### PR TITLE
test(coverage): w18 — write-primitives benchmark 80%

### DIFF
--- a/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
+++ b/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
@@ -1,0 +1,1029 @@
+"""Coverage tests for WritePrimitivesBenchmark execution paths.
+
+Targets the uncovered lines in benchbox/core/write_primitives/benchmark.py to
+reach ≥80% coverage. Tests are isolated — all DB calls use MagicMock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchbox.core.write_primitives.benchmark import (
+    OperationResult,
+    WritePrimitivesBenchmark,
+    _check_validation_query,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_val_query(
+    expected_rows=None,
+    expected_rows_min=None,
+    expected_rows_max=None,
+):
+    return SimpleNamespace(
+        id="VQ_1",
+        sql="SELECT 1",
+        expected_rows=expected_rows,
+        expected_rows_min=expected_rows_min,
+        expected_rows_max=expected_rows_max,
+    )
+
+
+def _make_operation(
+    *,
+    write_sql="INSERT INTO t VALUES (1)",
+    platform_overrides=None,
+    requires_setup=False,
+    validation_queries=None,
+    cleanup_sql=None,
+    id="OP_1",
+    category="insert",
+):
+    return SimpleNamespace(
+        id=id,
+        write_sql=write_sql,
+        platform_overrides=platform_overrides or {},
+        requires_setup=requires_setup,
+        validation_queries=validation_queries or [],
+        cleanup_sql=cleanup_sql,
+        category=category,
+    )
+
+
+@pytest.fixture()
+def wp(tmp_path: Path) -> WritePrimitivesBenchmark:
+    return WritePrimitivesBenchmark(output_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _check_validation_query — module-level function
+# ---------------------------------------------------------------------------
+
+
+class TestCheckValidationQuery:
+    def test_exact_match_passes(self):
+        vq = _make_val_query(expected_rows=5)
+        assert _check_validation_query(vq, 5) is True
+
+    def test_exact_match_fails(self):
+        vq = _make_val_query(expected_rows=5)
+        assert _check_validation_query(vq, 3) is False
+
+    def test_min_max_both_present_passes(self):
+        vq = _make_val_query(expected_rows_min=2, expected_rows_max=10)
+        assert _check_validation_query(vq, 5) is True
+
+    def test_min_max_both_present_fails_below(self):
+        vq = _make_val_query(expected_rows_min=2, expected_rows_max=10)
+        assert _check_validation_query(vq, 1) is False
+
+    def test_min_max_both_present_fails_above(self):
+        vq = _make_val_query(expected_rows_min=2, expected_rows_max=10)
+        assert _check_validation_query(vq, 11) is False
+
+    def test_only_min_set_passes(self):
+        vq = _make_val_query(expected_rows_min=3)
+        assert _check_validation_query(vq, 100) is True
+
+    def test_only_min_set_fails(self):
+        vq = _make_val_query(expected_rows_min=3)
+        assert _check_validation_query(vq, 2) is False
+
+    def test_only_max_set_passes(self):
+        vq = _make_val_query(expected_rows_max=10)
+        assert _check_validation_query(vq, 5) is True
+
+    def test_only_max_set_fails(self):
+        vq = _make_val_query(expected_rows_max=10)
+        assert _check_validation_query(vq, 11) is False
+
+    def test_no_constraints_returns_true(self):
+        vq = _make_val_query()
+        assert _check_validation_query(vq, 999) is True
+
+
+# ---------------------------------------------------------------------------
+# WritePrimitivesBenchmark.__init__ (default output_dir branch)
+# ---------------------------------------------------------------------------
+
+
+class TestInitDefaultOutputDir:
+    def test_default_output_dir_uses_tpch_path(self, tmp_path):
+        with patch("benchbox.core.write_primitives.benchmark.get_benchmark_runs_datagen_path") as mock_path:
+            mock_path.return_value = tmp_path
+            bm = WritePrimitivesBenchmark()
+            mock_path.assert_called_once_with("tpch", 1.0)
+            assert str(bm.output_dir) == str(tmp_path)
+
+    def test_quiet_kwarg_is_consumed(self, tmp_path):
+        # quiet=True must not raise a duplicate-kwarg error
+        bm = WritePrimitivesBenchmark(output_dir=tmp_path, quiet=True)
+        assert bm is not None
+
+
+# ---------------------------------------------------------------------------
+# output_dir setter — propagation to data_generator
+# ---------------------------------------------------------------------------
+
+
+class TestOutputDirSetter:
+    def test_setter_updates_data_generator(self, tmp_path):
+        bm = WritePrimitivesBenchmark(output_dir=tmp_path)
+        new_dir = tmp_path / "newdir"
+        new_dir.mkdir()
+        bm.output_dir = new_dir
+        assert str(bm.data_generator.output_dir) == str(new_dir)
+
+    def test_setter_updates_tpch_generator_if_present(self, tmp_path):
+        bm = WritePrimitivesBenchmark(output_dir=tmp_path)
+        new_dir = tmp_path / "sub"
+        new_dir.mkdir()
+        # Ensure tpch_generator exists before exercising the branch
+        if hasattr(bm.data_generator, "tpch_generator"):
+            bm.output_dir = new_dir
+            assert str(bm.data_generator.tpch_generator.output_dir) == str(new_dir)
+
+
+# ---------------------------------------------------------------------------
+# generate_data
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateData:
+    def test_returns_list_of_paths(self, wp, tmp_path):
+        fake_tables = {"orders": tmp_path / "orders.tbl", "lineitem": tmp_path / "lineitem.tbl"}
+        with patch.object(wp.data_generator, "generate", return_value=fake_tables):
+            result = wp.generate_data()
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert wp.tables == fake_tables
+
+    def test_generates_subset_of_tables(self, wp, tmp_path):
+        fake_tables = {"orders": tmp_path / "orders.tbl"}
+        with patch.object(wp.data_generator, "generate", return_value=fake_tables):
+            result = wp.generate_data(tables=["orders"])
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# ensure_auxiliary_data_files
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureAuxiliaryDataFiles:
+    def test_no_op_when_files_exist(self, wp):
+        with patch.object(wp.data_generator, "check_bulk_load_files_exist", return_value=True):
+            wp.ensure_auxiliary_data_files()
+
+    def test_generates_when_files_missing_and_lock_acquired(self, wp, tmp_path):
+        wp.data_generator.files_dir = tmp_path / "aux"
+        with (
+            patch.object(wp.data_generator, "check_bulk_load_files_exist", return_value=False),
+            patch.object(wp.data_generator, "_acquire_bulk_load_lock", return_value=True),
+            patch.object(wp.data_generator, "generate_bulk_load_files", return_value=[tmp_path / "f.csv"]) as mock_gen,
+            patch.object(wp.data_generator, "_release_bulk_load_lock") as mock_release,
+        ):
+            wp.ensure_auxiliary_data_files()
+            mock_gen.assert_called_once()
+            mock_release.assert_called_once()
+
+    def test_skips_generation_when_lock_not_acquired(self, wp):
+        with (
+            patch.object(wp.data_generator, "check_bulk_load_files_exist", return_value=False),
+            patch.object(wp.data_generator, "_acquire_bulk_load_lock", return_value=False),
+            patch.object(wp.data_generator, "generate_bulk_load_files") as mock_gen,
+        ):
+            wp.ensure_auxiliary_data_files()
+            mock_gen.assert_not_called()
+
+    def test_handles_generation_exception(self, wp, tmp_path):
+        wp.data_generator.files_dir = tmp_path / "aux"
+        with (
+            patch.object(wp.data_generator, "check_bulk_load_files_exist", return_value=False),
+            patch.object(wp.data_generator, "_acquire_bulk_load_lock", return_value=True),
+            patch.object(wp.data_generator, "generate_bulk_load_files", side_effect=RuntimeError("disk full")),
+            patch.object(wp.data_generator, "_release_bulk_load_lock"),
+        ):
+            wp.ensure_auxiliary_data_files()
+
+    def test_skips_regeneration_when_another_process_generated(self, wp):
+        call_count = {"n": 0}
+
+        def check_files():
+            call_count["n"] += 1
+            return call_count["n"] > 1  # False on first call, True on second
+
+        with (
+            patch.object(wp.data_generator, "check_bulk_load_files_exist", side_effect=check_files),
+            patch.object(wp.data_generator, "_acquire_bulk_load_lock", return_value=True),
+            patch.object(wp.data_generator, "generate_bulk_load_files") as mock_gen,
+            patch.object(wp.data_generator, "_release_bulk_load_lock"),
+        ):
+            wp.ensure_auxiliary_data_files()
+            mock_gen.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _acquire_setup_lock
+# ---------------------------------------------------------------------------
+
+
+class TestAcquireSetupLock:
+    def test_datafusion_dialect_skips_lock(self, wp):
+        conn = MagicMock()
+        result = wp._acquire_setup_lock(conn, dialect="datafusion")
+        assert result is True
+        conn.execute.assert_not_called()
+
+    def test_fails_when_create_table_raises(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("permission denied")
+        result = wp._acquire_setup_lock(conn, dialect="standard")
+        assert result is False
+
+    def test_acquires_lock_on_first_try(self, wp):
+        conn = MagicMock()
+        # First execute creates the lock table (no exception)
+        # Second execute inserts the lock row (no exception)
+        conn.execute.return_value = MagicMock()
+        result = wp._acquire_setup_lock(conn, timeout_seconds=5, dialect="standard")
+        assert result is True
+
+    def test_returns_false_on_timeout(self, wp):
+        conn = MagicMock()
+        # create table succeeds but INSERT always fails with duplicate key
+        call_count = {"n": 0}
+
+        def side_effect(sql):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock()  # CREATE TABLE succeeds
+            raise Exception("duplicate key constraint violation")
+
+        conn.execute.side_effect = side_effect
+        # timeout=0 makes the while loop not execute
+        result = wp._acquire_setup_lock(conn, timeout_seconds=0, dialect="standard")
+        assert result is False
+
+    def test_unexpected_error_during_insert_returns_false(self, wp):
+        conn = MagicMock()
+        call_count = {"n": 0}
+
+        def side_effect(sql):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return MagicMock()  # CREATE TABLE succeeds
+            raise Exception("network error")  # Non-constraint error
+
+        conn.execute.side_effect = side_effect
+        result = wp._acquire_setup_lock(conn, timeout_seconds=5, dialect="standard")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _release_setup_lock
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseSetupLock:
+    def test_datafusion_dialect_is_noop(self, wp):
+        conn = MagicMock()
+        wp._release_setup_lock(conn, dialect="datafusion")
+        conn.execute.assert_not_called()
+
+    def test_executes_delete(self, wp):
+        conn = MagicMock()
+        wp._release_setup_lock(conn, dialect="standard")
+        conn.execute.assert_called_once()
+        assert "DELETE FROM" in conn.execute.call_args[0][0]
+
+    def test_handles_exception_gracefully(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("connection lost")
+        wp._release_setup_lock(conn, dialect="standard")
+
+
+# ---------------------------------------------------------------------------
+# _get_effective_write_sql
+# ---------------------------------------------------------------------------
+
+
+class TestGetEffectiveWriteSql:
+    def test_sql_override_takes_priority(self, wp):
+        op = _make_operation(write_sql="INSERT INTO a VALUES(1)")
+        sql, skip = wp._get_effective_write_sql(op, sql_override="INSERT INTO b VALUES(2)")
+        assert sql == "INSERT INTO b VALUES(2)"
+        assert skip is None
+
+    def test_platform_override_applied(self, wp):
+        op = _make_operation(
+            write_sql="INSERT INTO a VALUES(1)",
+            platform_overrides={"duckdb": "INSERT INTO duckdb_t VALUES(1)"},
+        )
+        sql, skip = wp._get_effective_write_sql(op, platform_key="duckdb")
+        assert sql == "INSERT INTO duckdb_t VALUES(1)"
+        assert skip is None
+
+    def test_none_override_returns_skip_reason(self, wp):
+        op = _make_operation(
+            write_sql="INSERT INTO a VALUES(1)",
+            platform_overrides={"datafusion": None},
+            id="OP_SKIP",
+        )
+        sql, skip = wp._get_effective_write_sql(op, platform_key="datafusion")
+        assert sql is None
+        assert skip is not None
+        assert "unsupported" in skip.lower()
+
+    def test_no_override_returns_write_sql(self, wp):
+        op = _make_operation(write_sql="INSERT INTO a VALUES(1)")
+        sql, skip = wp._get_effective_write_sql(op)
+        assert sql == "INSERT INTO a VALUES(1)"
+        assert skip is None
+
+
+# ---------------------------------------------------------------------------
+# _get_population_sql special cases
+# ---------------------------------------------------------------------------
+
+
+class TestGetPopulationSql:
+    def test_merge_ops_target(self, wp):
+        sql = wp._get_population_sql("merge_ops_target", "orders")
+        assert "merge_ops_target" in sql
+        assert "0.5" in sql
+
+    def test_merge_ops_source(self, wp):
+        sql = wp._get_population_sql("merge_ops_source", "orders")
+        assert "merge_ops_source" in sql
+        assert "0.5" in sql
+
+    def test_merge_ops_lineitem_target(self, wp):
+        sql = wp._get_population_sql("merge_ops_lineitem_target", "lineitem")
+        assert "merge_ops_lineitem_target" in sql
+
+    def test_ddl_truncate_target(self, wp):
+        sql = wp._get_population_sql("ddl_truncate_target", "orders")
+        assert "ddl_truncate_target" in sql
+        assert "o_orderkey" in sql
+
+    def test_generic_table_full_copy(self, wp):
+        sql = wp._get_population_sql("insert_ops_lineitem", "lineitem")
+        assert "SELECT * FROM" in sql
+
+
+# ---------------------------------------------------------------------------
+# _populate_staging_tables
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateStagingTables:
+    def test_skips_already_populated_table(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (100,)
+        status = wp._populate_staging_tables(conn, {"update_ops_orders": "orders"})
+        assert status["update_ops_orders"] == 100
+
+    def test_populates_empty_table(self, wp):
+        conn = MagicMock()
+        # COUNT(*) on staging = 0, COUNT(*) on source = 50, then COUNT(*) after insert = 50
+        call_count = {"n": 0}
+
+        def execute_side(sql):
+            call_count["n"] += 1
+            mock = MagicMock()
+            if call_count["n"] == 1:
+                mock.fetchone.return_value = (0,)  # staging count = 0
+            elif call_count["n"] == 2:
+                mock.fetchone.return_value = (50,)  # source count = 50
+            elif call_count["n"] == 4:
+                mock.fetchone.return_value = (50,)  # post-insert count
+            return mock
+
+        conn.execute.side_effect = execute_side
+        status = wp._populate_staging_tables(conn, {"update_ops_orders": "orders"})
+        assert status["update_ops_orders"] == 50
+
+    def test_skips_optional_table_when_source_missing(self, wp):
+        conn = MagicMock()
+        call_count = {"n": 0}
+
+        def execute_side(sql):
+            call_count["n"] += 1
+            mock = MagicMock()
+            if call_count["n"] == 1:
+                mock.fetchone.return_value = (0,)  # staging empty
+            else:
+                raise Exception("table does not exist")  # source missing
+            return mock
+
+        conn.execute.side_effect = execute_side
+        status = wp._populate_staging_tables(conn, {"delete_ops_supplier": "supplier"})
+        assert status["delete_ops_supplier"] == 0
+
+    def test_raises_when_required_source_missing(self, wp):
+        conn = MagicMock()
+        call_count = {"n": 0}
+
+        def execute_side(sql):
+            call_count["n"] += 1
+            mock = MagicMock()
+            if call_count["n"] == 1:
+                mock.fetchone.return_value = (0,)  # staging empty
+            else:
+                raise Exception("table does not exist")
+            return mock
+
+        conn.execute.side_effect = execute_side
+        with pytest.raises(RuntimeError, match="Cannot validate source table"):
+            wp._populate_staging_tables(conn, {"update_ops_orders": "orders"})
+
+    def test_raises_when_required_source_is_empty(self, wp):
+        conn = MagicMock()
+        call_count = {"n": 0}
+
+        def execute_side(sql):
+            call_count["n"] += 1
+            mock = MagicMock()
+            mock.fetchone.return_value = (0,)  # both staging and source empty
+            return mock
+
+        conn.execute.side_effect = execute_side
+        with pytest.raises(RuntimeError, match="is empty"):
+            wp._populate_staging_tables(conn, {"update_ops_orders": "orders"})
+
+
+# ---------------------------------------------------------------------------
+# setup()
+# ---------------------------------------------------------------------------
+
+
+class TestSetup:
+    def test_raises_when_required_table_missing(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("table not found")
+        with pytest.raises(RuntimeError, match="Required TPC-H table"):
+            wp.setup(conn)
+
+    def test_raises_when_lock_not_acquired(self, wp):
+        conn = MagicMock()
+        # Required tables check passes (SELECT 1 FROM orders / lineitem)
+        call_count = {"n": 0}
+
+        def execute_side(sql):
+            call_count["n"] += 1
+            if call_count["n"] <= 2:
+                return MagicMock()  # required table checks pass
+            raise Exception("permission denied")  # lock table create fails
+
+        conn.execute.side_effect = execute_side
+        with pytest.raises(RuntimeError, match="Could not acquire setup lock"):
+            wp.setup(conn)
+
+    def test_happy_path_returns_success_dict(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+
+        with (
+            patch.object(wp, "_acquire_setup_lock", return_value=True),
+            patch.object(wp, "_release_setup_lock"),
+            patch.object(wp, "_table_exists", return_value=False),
+            patch.object(wp, "_populate_staging_tables", return_value={}),
+        ):
+            result = wp.setup(conn)
+
+        assert result["success"] is True
+        assert "tables_created" in result
+
+    def test_force_drops_existing_tables(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0,)
+
+        with (
+            patch.object(wp, "_acquire_setup_lock", return_value=True),
+            patch.object(wp, "_release_setup_lock"),
+            patch.object(wp, "_table_exists", return_value=True),
+            patch.object(wp, "_populate_staging_tables", return_value={}),
+        ):
+            result = wp.setup(conn, force=True)
+
+        assert result["success"] is True
+        # DROP TABLE IF EXISTS should have been called for each staging table
+        drop_calls = [c for c in conn.execute.call_args_list if "DROP TABLE" in str(c)]
+        assert len(drop_calls) > 0
+
+    def test_datafusion_dialect_skips_lock_table(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+
+        with (
+            patch.object(wp, "_acquire_setup_lock", return_value=True),
+            patch.object(wp, "_release_setup_lock"),
+            patch.object(wp, "_table_exists", return_value=True),
+            patch.object(wp, "_populate_staging_tables", return_value={}),
+        ):
+            result = wp.setup(conn, dialect="datafusion")
+
+        assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# teardown()
+# ---------------------------------------------------------------------------
+
+
+class TestTeardown:
+    def test_drops_all_staging_tables(self, wp):
+        conn = MagicMock()
+        wp.teardown(conn)
+        calls = [str(c) for c in conn.execute.call_args_list]
+        drop_calls = [c for c in calls if "DROP TABLE" in c]
+        assert len(drop_calls) > 0
+
+    def test_handles_drop_exception_gracefully(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("permission denied")
+        wp.teardown(conn)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_auxiliary_files()
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupAuxiliaryFiles:
+    def test_removes_existing_dir(self, wp, tmp_path):
+        aux_dir = tmp_path / "write_primitives_auxiliary"
+        aux_dir.mkdir()
+        (aux_dir / "test.csv").write_text("data")
+        wp.data_generator.files_dir = aux_dir
+
+        wp.cleanup_auxiliary_files()
+        assert not aux_dir.exists()
+
+    def test_noop_when_dir_does_not_exist(self, wp, tmp_path):
+        aux_dir = tmp_path / "nonexistent_aux"
+        wp.data_generator.files_dir = aux_dir
+        wp.cleanup_auxiliary_files()
+
+    def test_handles_rmtree_exception(self, wp, tmp_path):
+        import shutil
+
+        aux_dir = tmp_path / "write_primitives_auxiliary"
+        aux_dir.mkdir()
+        wp.data_generator.files_dir = aux_dir
+
+        with patch.object(shutil, "rmtree", side_effect=OSError("permission denied")):
+            wp.cleanup_auxiliary_files()
+
+
+# ---------------------------------------------------------------------------
+# reset()
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_truncates_and_repopulates(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (10,)
+
+        with patch.object(wp, "_populate_staging_tables", return_value={}) as mock_pop:
+            wp.reset(conn)
+            mock_pop.assert_called_once()
+
+    def test_handles_truncate_exception(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("truncate not supported")
+
+        with patch.object(wp, "_populate_staging_tables", return_value={}):
+            wp.reset(conn)
+
+
+# ---------------------------------------------------------------------------
+# is_setup()
+# ---------------------------------------------------------------------------
+
+
+class TestIsSetup:
+    def test_returns_true_when_all_tables_populated(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (5,)
+        assert wp.is_setup(conn) is True
+
+    def test_returns_false_when_table_empty(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (0,)
+        assert wp.is_setup(conn) is False
+
+    def test_returns_false_on_exception(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("table not found")
+        assert wp.is_setup(conn) is False
+
+    def test_returns_false_when_fetchone_returns_none(self, wp):
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = None
+        assert wp.is_setup(conn) is False
+
+
+# ---------------------------------------------------------------------------
+# get_schema()
+# ---------------------------------------------------------------------------
+
+
+class TestGetSchema:
+    def test_returns_dict_with_tables(self, wp):
+        schema = wp.get_schema()
+        assert isinstance(schema, dict)
+        assert len(schema) > 0
+
+    def test_each_table_has_columns(self, wp):
+        schema = wp.get_schema()
+        for table_name, table_def in schema.items():
+            assert "columns" in table_def, f"{table_name} missing 'columns'"
+
+    def test_dialect_parameter_accepted(self, wp):
+        schema = wp.get_schema(dialect="snowflake")
+        assert isinstance(schema, dict)
+
+
+# ---------------------------------------------------------------------------
+# get_create_tables_sql()
+# ---------------------------------------------------------------------------
+
+
+class TestGetCreateTablesSql:
+    def test_returns_nonempty_string(self, wp):
+        sql = wp.get_create_tables_sql()
+        assert isinstance(sql, str)
+        assert len(sql) > 0
+
+    def test_includes_create_table_statements(self, wp):
+        sql = wp.get_create_tables_sql()
+        assert "CREATE TABLE" in sql.upper()
+
+    def test_accepts_dialect(self, wp):
+        sql = wp.get_create_tables_sql(dialect="snowflake")
+        assert "CREATE TABLE" in sql.upper()
+
+
+# ---------------------------------------------------------------------------
+# get_benchmark_info()
+# ---------------------------------------------------------------------------
+
+
+class TestGetBenchmarkInfo:
+    def test_returns_expected_keys(self, wp):
+        info = wp.get_benchmark_info()
+        assert "name" in info
+        assert "version" in info
+        assert "description" in info
+        assert "scale_factor" in info
+        assert "total_operations" in info
+        assert "categories" in info
+        assert "tables" in info
+        assert info["data_source"] == "tpch"
+
+    def test_total_operations_positive(self, wp):
+        info = wp.get_benchmark_info()
+        assert info["total_operations"] > 0
+
+
+# ---------------------------------------------------------------------------
+# get_query() and get_queries() and get_queries_by_category()
+# ---------------------------------------------------------------------------
+
+
+class TestQueryAccessors:
+    def test_get_query_returns_sql_string(self, wp):
+        op_id = next(iter(wp.get_all_operations()))
+        sql = wp.get_query(op_id)
+        assert isinstance(sql, str)
+        assert len(sql) > 0
+
+    def test_get_queries_returns_all(self, wp):
+        queries = wp.get_queries()
+        ops = wp.get_all_operations()
+        assert len(queries) == len(ops)
+
+    def test_get_queries_by_category_returns_subset(self, wp):
+        categories = wp.get_operation_categories()
+        if categories:
+            cat = categories[0]
+            result = wp.get_queries_by_category(cat)
+            assert isinstance(result, dict)
+            assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# execute_operation()
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteOperation:
+    def test_raises_on_none_connection(self, wp):
+        with pytest.raises(ValueError, match="Connection is None"):
+            wp.execute_operation("OP_1", None)
+
+    def test_raises_on_invalid_connection_type(self, wp):
+        with pytest.raises(ValueError, match="Invalid connection type"):
+            wp.execute_operation("OP_1", "not_a_connection")
+
+    def test_success_path_with_mock_operation(self, wp):
+        conn = MagicMock()
+        # execute returns object with rowcount
+        mock_result = MagicMock()
+        mock_result.rowcount = 10
+        mock_result.fetchall.return_value = [("row1",)]
+        conn.execute.return_value = mock_result
+
+        op = _make_operation(
+            id="INSERT_001",
+            write_sql="INSERT INTO t VALUES (1)",
+            validation_queries=[
+                _make_val_query(expected_rows=1),
+            ],
+        )
+
+        with patch.object(wp.operations_manager, "get_operation", return_value=op):
+            result = wp.execute_operation("INSERT_001", conn)
+
+        assert result.operation_id == "INSERT_001"
+        assert result.success is True
+        assert result.rows_affected == 10
+        assert result.write_duration_ms >= 0
+
+    def test_skipped_operation_when_none_sql(self, wp):
+        conn = MagicMock()
+        op = _make_operation(
+            id="SKIP_OP",
+            platform_overrides={"datafusion": None},
+            requires_setup=False,
+        )
+
+        with patch.object(wp.operations_manager, "get_operation", return_value=op):
+            result = wp.execute_operation("SKIP_OP", conn, platform_key="datafusion")
+
+        assert result.status == "SKIPPED"
+        assert result.success is True
+
+    def test_execute_raises_returns_failed_result(self, wp):
+        conn = MagicMock()
+        conn.execute.side_effect = Exception("SQL error")
+
+        op = _make_operation(id="FAIL_OP", requires_setup=False)
+        with patch.object(wp.operations_manager, "get_operation", return_value=op):
+            result = wp.execute_operation("FAIL_OP", conn)
+
+        assert result.success is False
+        assert result.status == "FAILED"
+        assert "FAIL_OP" in result.error
+
+    def test_auto_setup_when_required(self, wp):
+        conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 0
+        mock_result.fetchall.return_value = []
+        conn.execute.return_value = mock_result
+
+        op = _make_operation(id="SETUP_OP", requires_setup=True)
+
+        with (
+            patch.object(wp.operations_manager, "get_operation", return_value=op),
+            patch.object(wp, "is_setup", return_value=False),
+            patch.object(wp, "setup", return_value={"success": True}) as mock_setup,
+        ):
+            result = wp.execute_operation("SETUP_OP", conn)
+
+        mock_setup.assert_called_once()
+        assert result.success is True
+
+    def test_auto_setup_failure_raises(self, wp):
+        conn = MagicMock()
+        op = _make_operation(id="SETUP_FAIL", requires_setup=True)
+
+        with (
+            patch.object(wp.operations_manager, "get_operation", return_value=op),
+            patch.object(wp, "is_setup", return_value=False),
+            patch.object(wp, "setup", side_effect=RuntimeError("no TPC-H data")),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to initialize staging tables"):
+                wp.execute_operation("SETUP_FAIL", conn)
+
+    def test_cleanup_failure_captured_in_result(self, wp):
+        conn = MagicMock()
+        mock_result = MagicMock()
+        mock_result.rowcount = 5
+        mock_result.fetchall.return_value = []
+        conn.execute.return_value = mock_result
+
+        op = _make_operation(
+            id="CLEANUP_FAIL_OP",
+            cleanup_sql="DELETE FROM t",
+            requires_setup=False,
+        )
+
+        def execute_side(sql):
+            if sql == "DELETE FROM t":
+                raise Exception("cleanup error")
+            return mock_result
+
+        conn.execute.side_effect = execute_side
+
+        with patch.object(wp.operations_manager, "get_operation", return_value=op):
+            result = wp.execute_operation("CLEANUP_FAIL_OP", conn)
+
+        assert result.success is True  # write succeeded
+        assert result.cleanup_success is False
+        assert result.cleanup_warning is not None
+
+
+# ---------------------------------------------------------------------------
+# run_benchmark()
+# ---------------------------------------------------------------------------
+
+
+class TestRunBenchmark:
+    def test_runs_all_operations_by_default(self, wp):
+        conn = MagicMock()
+
+        fake_result = OperationResult(
+            operation_id="OP_1",
+            success=True,
+            write_duration_ms=1.0,
+            rows_affected=1,
+            validation_duration_ms=0.5,
+            validation_passed=True,
+            validation_results=[],
+            cleanup_duration_ms=0.1,
+            cleanup_success=True,
+        )
+
+        with patch.object(wp, "execute_operation", return_value=fake_result) as mock_exec:
+            results = wp.run_benchmark(conn)
+
+        assert len(results) == len(wp.get_all_operations())
+        assert mock_exec.call_count == len(wp.get_all_operations())
+
+    def test_runs_specific_operation_ids(self, wp):
+        conn = MagicMock()
+        op_ids = list(wp.get_all_operations().keys())[:2]
+
+        fake_result = OperationResult(
+            operation_id="OP",
+            success=True,
+            write_duration_ms=1.0,
+            rows_affected=1,
+            validation_duration_ms=0.5,
+            validation_passed=True,
+            validation_results=[],
+            cleanup_duration_ms=0.1,
+            cleanup_success=True,
+        )
+
+        with patch.object(wp, "execute_operation", return_value=fake_result) as mock_exec:
+            results = wp.run_benchmark(conn, operation_ids=op_ids)
+
+        assert len(results) == 2
+        assert mock_exec.call_count == 2
+
+    def test_runs_by_category(self, wp):
+        conn = MagicMock()
+        categories = wp.get_operation_categories()[:1]
+
+        fake_result = OperationResult(
+            operation_id="OP",
+            success=True,
+            write_duration_ms=1.0,
+            rows_affected=1,
+            validation_duration_ms=0.5,
+            validation_passed=True,
+            validation_results=[],
+            cleanup_duration_ms=0.1,
+            cleanup_success=True,
+        )
+
+        with patch.object(wp, "execute_operation", return_value=fake_result):
+            results = wp.run_benchmark(conn, categories=categories)
+
+        assert len(results) > 0
+
+
+# ---------------------------------------------------------------------------
+# DataFrame support methods
+# ---------------------------------------------------------------------------
+
+
+class TestDataFrameSupport:
+    def test_supports_dataframe_mode(self, wp):
+        assert wp.supports_dataframe_mode() is True
+
+    def test_skip_dataframe_data_loading(self, wp):
+        assert wp.skip_dataframe_data_loading() is True
+
+    def test_get_dataframe_operations_unknown_platform(self, wp):
+        result = wp.get_dataframe_operations("unknown-platform")
+        assert result is None
+
+    def test_get_dataframe_capabilities_none_for_unknown_platform(self, wp):
+        result = wp.get_dataframe_capabilities("unknown-platform")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# execute_dataframe_workload()
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDataframeWorkload:
+    def test_returns_list_with_error_on_exception(self, wp):
+        benchmark_config = SimpleNamespace(options={})
+
+        with patch.object(
+            wp,
+            "_execute_dataframe_sql_parity_workload",
+            side_effect=RuntimeError("DuckDB not available"),
+        ):
+            results = wp.execute_dataframe_workload(
+                ctx=None,
+                adapter=None,
+                benchmark_config=benchmark_config,
+            )
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert results[0]["status"] == "FAILED"
+        assert "DuckDB not available" in results[0]["error"]
+
+    def test_measurement_iterations_respected(self, wp):
+        # warmup_iterations uses "or 1" fallback so 0 still becomes 1; use 1 for warmup
+        benchmark_config = SimpleNamespace(options={"power_iterations": 2, "power_warmup_iterations": 1})
+        fake_rows = [{"query_id": "OP_1", "status": "SUCCESS", "execution_time_seconds": 0.1, "rows_returned": 5}]
+
+        with patch.object(wp, "_execute_dataframe_sql_parity_workload", return_value=fake_rows) as mock_exec:
+            results = wp.execute_dataframe_workload(
+                ctx=None,
+                adapter=None,
+                benchmark_config=benchmark_config,
+            )
+
+        # 1 warmup + 2 measurement = 3 calls
+        assert mock_exec.call_count == 3
+        measurement_rows = [r for r in results if r.get("run_type") == "measurement"]
+        assert len(measurement_rows) == 2
+
+    def test_warmup_iteration_included(self, wp):
+        benchmark_config = SimpleNamespace(options={"power_warmup_iterations": 1, "power_iterations": 1})
+        fake_rows = [{"query_id": "OP_1", "status": "SUCCESS", "execution_time_seconds": 0.1, "rows_returned": 5}]
+
+        with patch.object(wp, "_execute_dataframe_sql_parity_workload", return_value=fake_rows):
+            results = wp.execute_dataframe_workload(
+                ctx=None,
+                adapter=None,
+                benchmark_config=benchmark_config,
+            )
+
+        warmup_rows = [r for r in results if r.get("run_type") == "warmup"]
+        assert len(warmup_rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# _select_dataframe_operation_ids()
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDataframeOperationIds:
+    def test_returns_all_when_no_filter(self, wp):
+        ids = wp._select_dataframe_operation_ids(query_filter=None)
+        assert len(ids) == len(wp.get_all_operations())
+
+    def test_filters_by_op_id(self, wp):
+        all_ids = list(wp.get_all_operations().keys())
+        first_id = all_ids[0]
+        ids = wp._select_dataframe_operation_ids(query_filter={first_id})
+        assert first_id in ids
+        assert len(ids) == 1
+
+    def test_filters_by_q_prefixed_id(self, wp):
+        all_ids = list(wp.get_all_operations().keys())
+        first_id = all_ids[0]
+        ids = wp._select_dataframe_operation_ids(query_filter={f"Q{first_id}"})
+        assert first_id in ids
+
+    def test_empty_filter_returns_all(self, wp):
+        ids = wp._select_dataframe_operation_ids(query_filter=set())
+        assert len(ids) == len(wp.get_all_operations())


### PR DESCRIPTION
## Summary

- Adds 92 fast unit tests for `benchbox/core/write_primitives/benchmark.py`
- Raises coverage of that module from 39% → 90% (target was ≥80%)
- All tests are `pytest.mark.unit` + `pytest.mark.fast`; no DB connections required — all DB calls are mocked via `MagicMock`

## Key paths covered

- `_check_validation_query` — exact match, min/max range, unconstrained fallback
- `WritePrimitivesBenchmark.__init__` — default `output_dir` via `get_benchmark_runs_datagen_path`, `quiet` kwarg stripping
- `output_dir` setter — propagation to `data_generator` and nested `tpch_generator`
- `generate_data`, `ensure_auxiliary_data_files` — all lock/generate/exception branches
- `_acquire_setup_lock` / `_release_setup_lock` — datafusion no-op, happy path, timeout, unexpected error
- `_get_effective_write_sql` — override priority, platform override, None-skip, default passthrough
- `_get_population_sql` — all five special-case table names
- `_populate_staging_tables` — already-populated, empty populate, optional table skip, required-table errors
- `setup()` — missing table, lock failure, happy path, `force=True` drop, datafusion dialect
- `teardown()`, `reset()`, `is_setup()`, `cleanup_auxiliary_files()`
- `get_schema()`, `get_create_tables_sql()`, `get_benchmark_info()`
- `execute_operation()` — success, skip (None SQL), failure, auto-setup, cleanup failure
- `run_benchmark()` — all ops, by ID, by category
- `execute_dataframe_workload()` — exception path, warmup/measurement iterations
- `_select_dataframe_operation_ids()` — no filter, ID filter, Q-prefixed filter

## Test plan

- [x] `uv run -- python -m pytest tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py -m fast -q` — 92 passed
- [x] Coverage: `benchbox/core/write_primitives/benchmark.py` 90% (≥80% target met)
- [x] Full fast suite: 16,400 passed, 0 failures
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)