### PR TITLE
test(coverage): w10 — spark adapter 80%

### DIFF
--- a/tests/unit/platforms/test_spark_coverage.py
+++ b/tests/unit/platforms/test_spark_coverage.py
@@ -1,0 +1,1229 @@
+"""Coverage-boosting unit tests for benchbox.platforms.spark.SparkAdapter.
+
+Target: reach ≥80% coverage on benchbox/platforms/spark.py.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_pyspark():
+    """Provide a fully-mocked PySpark environment.
+
+    Returns (MockSparkSessionClass, mock_spark_session_instance).
+    """
+    mock_session = MagicMock()
+    mock_builder = MagicMock()
+    mock_builder.master.return_value = mock_builder
+    mock_builder.config.return_value = mock_builder
+    mock_builder.enableHiveSupport.return_value = mock_builder
+    mock_builder.getOrCreate.return_value = mock_session
+
+    mock_session.version = "3.5.0"
+    mock_session.catalog.listDatabases.return_value = []
+    mock_session.sql.return_value = MagicMock()
+
+    mock_class = MagicMock()
+    mock_class.builder = mock_builder
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "pyspark": MagicMock(__version__="3.5.0"),
+            "pyspark.sql": MagicMock(SparkSession=mock_class),
+            "pyspark.sql.types": MagicMock(
+                StructType=MagicMock(),
+                StructField=MagicMock(),
+                StringType=MagicMock(),
+                IntegerType=MagicMock(),
+                LongType=MagicMock(),
+                DoubleType=MagicMock(),
+                DecimalType=MagicMock(),
+                DateType=MagicMock(),
+            ),
+        },
+    ):
+        yield mock_class, mock_session
+
+
+# ---------------------------------------------------------------------------
+# __init__ config variants
+# ---------------------------------------------------------------------------
+
+
+class TestSparkAdapterInit:
+    """Branch coverage for __init__ parameter handling."""
+
+    def test_yarn_master(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(master="yarn")
+        assert a.master == "yarn"
+
+    def test_k8s_master(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(master="k8s://https://k8s-api:6443")
+        assert a.master == "k8s://https://k8s-api:6443"
+
+    def test_spark_connect_master(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(master="sc://host:15002")
+        assert a.master == "sc://host:15002"
+
+    def test_warehouse_dir_set(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(warehouse_dir="/tmp/warehouse")
+        assert a.warehouse_dir == "/tmp/warehouse"
+
+    def test_executor_cores_explicit_zero(self, mock_pyspark):
+        """executor_cores=0 is not None so should be kept (edge case)."""
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(executor_cores=0)
+        assert a.executor_cores == 0
+
+    def test_adaptive_disabled(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(adaptive_enabled=False)
+        assert a.adaptive_enabled is False
+
+    def test_enable_hive_true(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(enable_hive=True)
+        assert a.enable_hive is True
+
+    def test_disable_cache_false(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(disable_cache=False)
+        assert a.disable_cache is False
+
+    def test_num_executors_set(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(num_executors=8)
+        assert a.num_executors == 8
+
+    def test_spark_config_extra(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        extra = {"spark.custom.key": "value"}
+        a = SparkAdapter(spark_config=extra)
+        assert a.spark_config == extra
+
+    def test_broadcast_threshold_set(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(broadcast_threshold=128)
+        assert a.broadcast_threshold == 128
+
+    def test_staging_root_set(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(staging_root="/tmp/staging")
+        assert a.staging_root == "/tmp/staging"
+
+
+# ---------------------------------------------------------------------------
+# _get_spark_conf branches
+# ---------------------------------------------------------------------------
+
+
+class TestGetSparkConf:
+    """Branch coverage for _get_spark_conf()."""
+
+    def test_aqe_disabled(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(adaptive_enabled=False)
+        conf = a._get_spark_conf()
+        assert "spark.sql.adaptive.enabled" not in conf
+
+    def test_aqe_enabled(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(adaptive_enabled=True)
+        conf = a._get_spark_conf()
+        assert conf["spark.sql.adaptive.enabled"] == "true"
+        assert conf["spark.sql.adaptive.coalescePartitions.enabled"] == "true"
+        assert conf["spark.sql.adaptive.skewJoin.enabled"] == "true"
+
+    def test_broadcast_threshold_in_conf(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(broadcast_threshold=64)
+        conf = a._get_spark_conf()
+        assert conf["spark.sql.autoBroadcastJoinThreshold"] == "64"
+
+    def test_broadcast_threshold_none_absent(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        conf = a._get_spark_conf()
+        assert "spark.sql.autoBroadcastJoinThreshold" not in conf
+
+    def test_num_executors_in_conf(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(num_executors=4)
+        conf = a._get_spark_conf()
+        assert conf["spark.executor.instances"] == "4"
+
+    def test_num_executors_none_absent(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        conf = a._get_spark_conf()
+        assert "spark.executor.instances" not in conf
+
+    def test_warehouse_dir_in_conf(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(warehouse_dir="/data/warehouse")
+        conf = a._get_spark_conf()
+        assert conf["spark.sql.warehouse.dir"] == "/data/warehouse"
+
+    def test_warehouse_dir_none_absent(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        conf = a._get_spark_conf()
+        assert "spark.sql.warehouse.dir" not in conf
+
+    def test_disable_cache_true(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(disable_cache=True)
+        conf = a._get_spark_conf()
+        assert conf["spark.sql.inMemoryColumnarStorage.enabled"] == "false"
+
+    def test_disable_cache_false_absent(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(disable_cache=False)
+        conf = a._get_spark_conf()
+        assert "spark.sql.inMemoryColumnarStorage.enabled" not in conf
+
+    def test_delta_extensions(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="delta")
+        conf = a._get_spark_conf()
+        assert "io.delta.sql.DeltaSparkSessionExtension" in conf["spark.sql.extensions"]
+        assert "DeltaCatalog" in conf["spark.sql.catalog.spark_catalog"]
+
+    def test_iceberg_extensions(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="iceberg")
+        conf = a._get_spark_conf()
+        assert "IcebergSparkSessionExtensions" in conf["spark.sql.extensions"]
+        assert "SparkSessionCatalog" in conf["spark.sql.catalog.spark_catalog"]
+        assert conf["spark.sql.catalog.spark_catalog.type"] == "hive"
+
+    def test_parquet_no_extensions(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+        conf = a._get_spark_conf()
+        assert "spark.sql.extensions" not in conf
+
+    def test_extra_spark_config_merged(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        extra = {"spark.custom.setting": "custom_value"}
+        a = SparkAdapter(spark_config=extra)
+        conf = a._get_spark_conf()
+        assert conf["spark.custom.setting"] == "custom_value"
+
+
+# ---------------------------------------------------------------------------
+# create_connection branches
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConnection:
+    """Branch coverage for create_connection()."""
+
+    def test_create_connection_basic(self, mock_pyspark):
+        """create_connection creates a session and USEs the database."""
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="bench_db")
+        # Patch handle_existing_database and also the module-level SparkSession reference,
+        # since when the spark module is first imported without pyspark the variable is None.
+        with (
+            patch.object(a, "handle_existing_database"),
+            patch("benchbox.platforms.spark.SparkSession", mock_class),
+        ):
+            a.database_was_reused = False
+            mock_session.catalog.listDatabases.return_value = []
+            conn = a.create_connection()
+
+        assert conn is mock_session
+        assert a._spark_session is mock_session
+
+    def test_create_connection_with_hive_support(self, mock_pyspark):
+        """enable_hive=True calls enableHiveSupport() on the builder."""
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(enable_hive=True)
+        with (
+            patch.object(a, "handle_existing_database"),
+            patch("benchbox.platforms.spark.SparkSession", mock_class),
+        ):
+            a.database_was_reused = False
+            mock_session.catalog.listDatabases.return_value = []
+            a.create_connection()
+
+        mock_class.builder.enableHiveSupport.assert_called()
+
+    def test_create_connection_database_reused(self, mock_pyspark):
+        """When database_was_reused=True, CREATE DATABASE is skipped."""
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="existing_db")
+        with (
+            patch.object(a, "handle_existing_database"),
+            patch("benchbox.platforms.spark.SparkSession", mock_class),
+        ):
+            a.database_was_reused = True
+            a.create_connection()
+
+        # Verify CREATE DATABASE was not called
+        sql_calls = [str(c) for c in mock_session.sql.call_args_list]
+        assert not any("CREATE DATABASE" in c.upper() for c in sql_calls)
+
+    def test_create_connection_database_already_exists(self, mock_pyspark):
+        """When database exists, skip CREATE DATABASE but still USE it."""
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="existing_db")
+        # Pretend the db exists
+        db_mock = MagicMock()
+        db_mock.name = "existing_db"
+        mock_session.catalog.listDatabases.return_value = [db_mock]
+        with (
+            patch.object(a, "handle_existing_database"),
+            patch("benchbox.platforms.spark.SparkSession", mock_class),
+        ):
+            a.database_was_reused = False
+            a.create_connection()
+
+        sql_calls = [str(c) for c in mock_session.sql.call_args_list]
+        assert not any("CREATE DATABASE" in c.upper() for c in sql_calls)
+        assert any("USE" in c.upper() for c in sql_calls)
+
+    def test_create_connection_failure_propagates(self, mock_pyspark):
+        """Session creation failure is re-raised."""
+        mock_class, mock_session = mock_pyspark
+        mock_class.builder.getOrCreate.side_effect = RuntimeError("spark down")
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        with (
+            patch.object(a, "handle_existing_database"),
+            patch("benchbox.platforms.spark.SparkSession", mock_class),
+        ):
+            a.database_was_reused = False
+            with pytest.raises(RuntimeError, match="spark down"):
+                a.create_connection()
+
+
+# ---------------------------------------------------------------------------
+# check_server_database_exists
+# ---------------------------------------------------------------------------
+
+
+class TestCheckServerDatabaseExists:
+    """Branch coverage for check_server_database_exists()."""
+
+    def test_no_session_returns_false(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        assert a._spark_session is None
+        assert a.check_server_database_exists() is False
+
+    def test_database_found(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="mydb")
+        a._spark_session = mock_session
+        db = MagicMock()
+        db.name = "mydb"
+        mock_session.catalog.listDatabases.return_value = [db]
+        assert a.check_server_database_exists() is True
+
+    def test_database_not_found(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="missing")
+        a._spark_session = mock_session
+        db = MagicMock()
+        db.name = "other"
+        mock_session.catalog.listDatabases.return_value = [db]
+        assert a.check_server_database_exists() is False
+
+    def test_exception_returns_false(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="mydb")
+        a._spark_session = mock_session
+        mock_session.catalog.listDatabases.side_effect = Exception("catalog error")
+        assert a.check_server_database_exists() is False
+
+    def test_custom_database_in_kwargs(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="default")
+        a._spark_session = mock_session
+        db = MagicMock()
+        db.name = "custom"
+        mock_session.catalog.listDatabases.return_value = [db]
+        assert a.check_server_database_exists(database="custom") is True
+
+
+# ---------------------------------------------------------------------------
+# drop_database
+# ---------------------------------------------------------------------------
+
+
+class TestDropDatabase:
+    """Branch coverage for drop_database()."""
+
+    def test_drop_existing_database(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="mydb")
+        a._spark_session = mock_session
+
+        # Pretend database exists
+        db = MagicMock()
+        db.name = "mydb"
+        mock_session.catalog.listDatabases.return_value = [db]
+
+        a.drop_database()
+
+        drop_calls = [str(c) for c in mock_session.sql.call_args_list]
+        assert any("DROP DATABASE" in c.upper() and "mydb" in c for c in drop_calls)
+
+    def test_drop_nonexistent_database_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="gone")
+        a._spark_session = None  # no session → check returns False
+
+        # Should not raise
+        a.drop_database()
+        mock_session.sql.assert_not_called()
+
+    def test_drop_invalid_identifier_raises(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        with pytest.raises(ValueError, match="Invalid database identifier"):
+            a.drop_database(database="bad; DROP TABLE users")
+
+    def test_drop_sql_error_raises_runtime(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(database="mydb")
+        a._spark_session = mock_session
+        db = MagicMock()
+        db.name = "mydb"
+        mock_session.catalog.listDatabases.return_value = [db]
+        mock_session.sql.side_effect = Exception("drop failed")
+
+        with pytest.raises(RuntimeError, match="Failed to drop Spark database"):
+            a.drop_database()
+
+
+# ---------------------------------------------------------------------------
+# create_schema
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSchema:
+    """Branch coverage for create_schema()."""
+
+    def _make_benchmark(self):
+        bench = MagicMock()
+        bench.get_schema_sql.return_value = (
+            "CREATE TABLE orders (id INT, amount DECIMAL);\nCREATE TABLE lineitem (id INT, qty INT);"
+        )
+        return bench
+
+    def test_create_schema_basic(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+        bench = self._make_benchmark()
+        with patch.object(a, "_create_schema_with_tuning", return_value=bench.get_schema_sql()):
+            elapsed = a.create_schema(bench, mock_session)
+
+        assert elapsed >= 0
+        assert mock_session.sql.call_count >= 2
+
+    def test_create_schema_table_already_exists(self, mock_pyspark):
+        """When sql() raises 'already exists', table is dropped and recreated."""
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+        bench = self._make_benchmark()
+
+        # Raise "already exists" only for the very first CREATE TABLE call;
+        # all subsequent calls (DROP TABLE, re-CREATE, second table) succeed.
+        already_raised = {"done": False}
+
+        def side_effect(stmt):
+            if "CREATE TABLE" in stmt.upper() and not already_raised["done"]:
+                already_raised["done"] = True
+                raise Exception("Table already exists")
+            return MagicMock()
+
+        mock_session.sql.side_effect = side_effect
+
+        with patch.object(a, "_create_schema_with_tuning", return_value=bench.get_schema_sql()):
+            a.create_schema(bench, mock_session)
+
+        # DROP TABLE IF EXISTS should have been called at least once
+        drop_calls = [c for c in mock_session.sql.call_args_list if "DROP TABLE" in str(c).upper()]
+        assert len(drop_calls) >= 1
+
+    def test_create_schema_non_exists_error_propagates(self, mock_pyspark):
+        """Non-'already exists' exceptions propagate."""
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        bench = self._make_benchmark()
+        mock_session.sql.side_effect = Exception("syntax error")
+
+        with patch.object(a, "_create_schema_with_tuning", return_value="CREATE TABLE bad;"):
+            with pytest.raises(Exception, match="syntax error"):
+                a.create_schema(bench, mock_session)
+
+    def test_create_schema_delta_format(self, mock_pyspark):
+        """Delta format adds USING DELTA to CREATE TABLE."""
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="delta")
+        bench = self._make_benchmark()
+
+        with patch.object(a, "_create_schema_with_tuning", return_value=bench.get_schema_sql()):
+            a.create_schema(bench, mock_session)
+
+        all_sqls = [str(c) for c in mock_session.sql.call_args_list]
+        assert any("USING DELTA" in s.upper() for s in all_sqls)
+
+    def test_create_schema_iceberg_format(self, mock_pyspark):
+        """Iceberg format adds USING ICEBERG to CREATE TABLE."""
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="iceberg")
+        bench = self._make_benchmark()
+
+        with patch.object(a, "_create_schema_with_tuning", return_value=bench.get_schema_sql()):
+            a.create_schema(bench, mock_session)
+
+        all_sqls = [str(c) for c in mock_session.sql.call_args_list]
+        assert any("USING ICEBERG" in s.upper() for s in all_sqls)
+
+
+# ---------------------------------------------------------------------------
+# _optimize_table_definition
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeTableDefinition:
+    """Branch coverage for _optimize_table_definition()."""
+
+    def test_non_create_returns_unchanged(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        stmt = "INSERT INTO orders VALUES (1, 2)"
+        assert a._optimize_table_definition(stmt) == stmt
+
+    def test_removes_existing_using_clause(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+        stmt = "CREATE TABLE t (id INT) USING ORC"
+        result = a._optimize_table_definition(stmt)
+        # Should replace with PARQUET
+        assert "USING PARQUET" in result.upper()
+
+    def test_orc_format(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="orc")
+        stmt = "CREATE TABLE t (id INT)"
+        result = a._optimize_table_definition(stmt)
+        assert "USING ORC" in result.upper()
+
+    def test_no_closing_paren_no_using(self, mock_pyspark):
+        """Statements without ')' should not get USING appended."""
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+        stmt = "CREATE TABLE t AS SELECT 1"
+        result = a._optimize_table_definition(stmt)
+        assert "USING" not in result.upper()
+
+
+# ---------------------------------------------------------------------------
+# get_query_plan
+# ---------------------------------------------------------------------------
+
+
+class TestGetQueryPlan:
+    """Branch coverage for get_query_plan()."""
+
+    def test_plan_returned(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_df = MagicMock()
+        row1 = MagicMock()
+        row1.__getitem__ = lambda self, i: "== Physical Plan ==\nHashJoin"
+        mock_df.collect.return_value = [row1]
+        mock_session.sql.return_value = mock_df
+
+        plan = a.get_query_plan(mock_session, "SELECT * FROM t")
+        assert isinstance(plan, str)
+        assert "EXPLAIN EXTENDED" in mock_session.sql.call_args[0][0].upper()
+
+    def test_plan_error_returns_string(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_session.sql.side_effect = Exception("explain failed")
+
+        plan = a.get_query_plan(mock_session, "SELECT * FROM t")
+        assert "Could not get query plan" in plan
+
+
+# ---------------------------------------------------------------------------
+# test_connection
+# ---------------------------------------------------------------------------
+
+
+class TestTestConnection:
+    """Branch coverage for test_connection()."""
+
+    def test_connection_success(self, mock_pyspark):
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        mock_df = MagicMock()
+        mock_df.collect.return_value = [(1,)]
+        mock_session.sql.return_value = mock_df
+
+        a = SparkAdapter()
+        with patch("benchbox.platforms.spark.SparkSession", mock_class):
+            result = a.test_connection()
+
+        assert result is True
+        mock_session.stop.assert_called()
+
+    def test_connection_failure(self, mock_pyspark):
+        mock_class, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        mock_class.builder.getOrCreate.side_effect = Exception("cannot connect")
+
+        a = SparkAdapter()
+        with patch("benchbox.platforms.spark.SparkSession", mock_class):
+            result = a.test_connection()
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# get_platform_info
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlatformInfo:
+    """Branch coverage for get_platform_info()."""
+
+    def test_platform_info_with_connection(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        # Simulate a SparkContext with getConf
+        mock_conf = MagicMock()
+        mock_conf.get.side_effect = lambda k: f"val:{k}"
+        mock_sc = MagicMock()
+        mock_sc.getConf.return_value = mock_conf
+        mock_sc.applicationId = "app-123"
+        mock_session.sparkContext = mock_sc
+
+        a = SparkAdapter(master="local[4]")
+        info = a.get_platform_info(connection=mock_session)
+
+        assert info["platform_version"] == mock_session.version
+        assert info["connection_mode"] == "local"
+
+    def test_platform_info_connection_error_handled(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        # Make spark.version attribute access raise to exercise the error path
+        type(mock_session).version = PropertyMock(side_effect=AttributeError("no version"))
+
+        a = SparkAdapter()
+        info = a.get_platform_info(connection=mock_session)
+        # Error is swallowed; platform_version key must still be present
+        assert "platform_version" in info
+
+    def test_platform_info_no_connection_returns_none_version(self, mock_pyspark):
+        """When connection=None, platform_version is None."""
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(master="local[2]")
+        info = a.get_platform_info(connection=None)
+        assert info["platform_version"] is None
+        assert info["connection_mode"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# configure_for_benchmark
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureForBenchmark:
+    """Branch coverage for configure_for_benchmark()."""
+
+    def test_olap_sets_aqe(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.configure_for_benchmark(mock_session, "tpch")
+
+        conf_calls = [str(c) for c in mock_session.conf.set.call_args_list]
+        assert any("adaptive.enabled" in c for c in conf_calls)
+
+    def test_tpcds_sets_cbo(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.configure_for_benchmark(mock_session, "tpcds")
+
+        conf_calls = [str(c) for c in mock_session.conf.set.call_args_list]
+        assert any("cbo.enabled" in c for c in conf_calls)
+
+    def test_unknown_benchmark_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.configure_for_benchmark(mock_session, "unknown")
+        # No conf.set calls for non-OLAP type
+        mock_session.conf.set.assert_not_called()
+
+    def test_conf_set_exception_warning(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_session.conf.set.side_effect = Exception("read-only conf")
+        # Should not propagate
+        a.configure_for_benchmark(mock_session, "olap")
+
+
+# ---------------------------------------------------------------------------
+# generate_tuning_clause — delta sorting branch
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTuningClause:
+    """Additional branches for generate_tuning_clause()."""
+
+    def test_sorting_with_delta_generates_cluster_by(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="delta")
+
+        mock_col = MagicMock()
+        mock_col.name = "l_shipdate"
+        mock_col.order = 1
+
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = True
+        mock_tuning.table_name = "lineitem"
+
+        from benchbox.core.tuning.interface import TuningType
+
+        mock_tuning.get_columns_by_type.side_effect = lambda t: [mock_col] if t == TuningType.SORTING else []
+
+        clause = a.generate_tuning_clause(mock_tuning)
+        assert "CLUSTER BY" in clause
+        assert "l_shipdate" in clause
+
+    def test_sorting_without_delta_no_cluster_by(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+
+        mock_col = MagicMock()
+        mock_col.name = "col1"
+        mock_col.order = 1
+
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = True
+        mock_tuning.table_name = "t"
+
+        from benchbox.core.tuning.interface import TuningType
+
+        mock_tuning.get_columns_by_type.side_effect = lambda t: [mock_col] if t == TuningType.SORTING else []
+
+        clause = a.generate_tuning_clause(mock_tuning)
+        assert "CLUSTER BY" not in clause
+
+    def test_no_tuning_returns_empty(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = False
+        assert a.generate_tuning_clause(mock_tuning) == ""
+
+    def test_none_tuning_returns_empty(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        assert a.generate_tuning_clause(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# apply_table_tunings
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTableTunings:
+    """Branch coverage for apply_table_tunings()."""
+
+    def test_no_tuning_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.apply_table_tunings(None, mock_session)
+        mock_session.sql.assert_not_called()
+
+    def test_delta_zorder_applied(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="delta")
+
+        mock_col = MagicMock()
+        mock_col.name = "l_shipdate"
+        mock_col.order = 1
+
+        from benchbox.core.tuning.interface import TuningType
+
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = True
+        mock_tuning.table_name = "lineitem"
+        mock_tuning.get_columns_by_type.side_effect = lambda t: [mock_col] if t == TuningType.SORTING else []
+
+        a.apply_table_tunings(mock_tuning, mock_session)
+
+        sql_calls = [str(c) for c in mock_session.sql.call_args_list]
+        assert any("OPTIMIZE" in c.upper() and "ZORDER" in c.upper() for c in sql_calls)
+
+    def test_delta_zorder_error_continues(self, mock_pyspark):
+        """Z-ORDER failure should log a warning, not raise."""
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="delta")
+        mock_session.sql.side_effect = Exception("OPTIMIZE not available")
+
+        mock_col = MagicMock()
+        mock_col.name = "col1"
+        mock_col.order = 1
+
+        from benchbox.core.tuning.interface import TuningType
+
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = True
+        mock_tuning.table_name = "t"
+        mock_tuning.get_columns_by_type.side_effect = lambda t: [mock_col] if t == TuningType.SORTING else []
+
+        # Should not raise
+        a.apply_table_tunings(mock_tuning, mock_session)
+
+    def test_parquet_partition_columns_logged(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(table_format="parquet")
+
+        mock_col = MagicMock()
+        mock_col.name = "region"
+        mock_col.order = 1
+
+        from benchbox.core.tuning.interface import TuningType
+
+        mock_tuning = MagicMock()
+        mock_tuning.has_any_tuning.return_value = True
+        mock_tuning.table_name = "nation"
+        mock_tuning.get_columns_by_type.side_effect = lambda t: [mock_col] if t == TuningType.PARTITIONING else []
+
+        # Should not raise; logging only for parquet partitioning
+        a.apply_table_tunings(mock_tuning, mock_session)
+
+
+# ---------------------------------------------------------------------------
+# apply_unified_tuning
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUnifiedTuning:
+    """Branch coverage for apply_unified_tuning()."""
+
+    def test_none_config_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        # Should not raise
+        a.apply_unified_tuning(None, mock_session)
+
+    def test_applies_platform_optimizations(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        mock_platform_cfg = MagicMock()
+        mock_platform_cfg.spark = {"sql.shuffle.partitions": "100"}
+
+        mock_config = MagicMock()
+        mock_config.platform_optimizations = mock_platform_cfg
+        mock_config.primary_keys = None
+        mock_config.foreign_keys = None
+        mock_config.table_tunings = {}
+
+        with patch.object(a, "apply_constraint_configuration"):
+            with patch.object(a, "apply_platform_optimizations") as mock_apply:
+                a.apply_unified_tuning(mock_config, mock_session)
+                mock_apply.assert_called_once_with(mock_platform_cfg, mock_session)
+
+    def test_applies_table_tunings(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        mock_table_tuning = MagicMock()
+        mock_table_tuning.has_any_tuning.return_value = False
+
+        mock_config = MagicMock()
+        mock_config.platform_optimizations = None
+        mock_config.primary_keys = None
+        mock_config.foreign_keys = None
+        mock_config.table_tunings = {"orders": mock_table_tuning}
+
+        with patch.object(a, "apply_constraint_configuration"):
+            a.apply_unified_tuning(mock_config, mock_session)
+
+        mock_table_tuning.has_any_tuning.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# apply_platform_optimizations
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPlatformOptimizations:
+    """Branch coverage for apply_platform_optimizations()."""
+
+    def test_none_config_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.apply_platform_optimizations(None, mock_session)
+        mock_session.conf.set.assert_not_called()
+
+    def test_spark_config_applied(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        mock_platform_cfg = MagicMock()
+        mock_platform_cfg.spark = {"sql.shuffle.partitions": "400"}
+
+        a.apply_platform_optimizations(mock_platform_cfg, mock_session)
+
+        mock_session.conf.set.assert_called_with("spark.sql.shuffle.partitions", "400")
+
+    def test_no_spark_attr_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        mock_platform_cfg = MagicMock(spec=[])  # no spark attribute
+        a.apply_platform_optimizations(mock_platform_cfg, mock_session)
+        mock_session.conf.set.assert_not_called()
+
+    def test_conf_set_error_continues(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        mock_platform_cfg = MagicMock()
+        mock_platform_cfg.spark = {"bad.key": "value"}
+        mock_session.conf.set.side_effect = Exception("read-only")
+
+        # Should not raise
+        a.apply_platform_optimizations(mock_platform_cfg, mock_session)
+
+
+# ---------------------------------------------------------------------------
+# apply_constraint_configuration
+# ---------------------------------------------------------------------------
+
+
+class TestApplyConstraintConfiguration:
+    """Branch coverage for apply_constraint_configuration()."""
+
+    def test_pk_enabled_logs(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        pk = MagicMock()
+        pk.enabled = True
+        fk = MagicMock()
+        fk.enabled = False
+
+        # Should not raise
+        a.apply_constraint_configuration(pk, fk, mock_session)
+
+    def test_fk_enabled_logs(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+
+        pk = MagicMock()
+        pk.enabled = False
+        fk = MagicMock()
+        fk.enabled = True
+
+        a.apply_constraint_configuration(pk, fk, mock_session)
+
+    def test_both_none_noop(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.apply_constraint_configuration(None, None, mock_session)
+
+
+# ---------------------------------------------------------------------------
+# close_connection
+# ---------------------------------------------------------------------------
+
+
+class TestCloseConnection:
+    """Branch coverage for close_connection()."""
+
+    def test_stop_called_and_session_cleared(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a._spark_session = mock_session
+        a.close_connection(mock_session)
+
+        mock_session.stop.assert_called_once()
+        assert a._spark_session is None
+
+    def test_none_connection_noop(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.close_connection(None)
+
+    def test_stop_exception_swallowed(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_session.stop.side_effect = Exception("stop failed")
+        a.close_connection(mock_session)
+
+
+# ---------------------------------------------------------------------------
+# _get_existing_tables
+# ---------------------------------------------------------------------------
+
+
+class TestGetExistingTables:
+    def test_returns_table_names(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        t1 = MagicMock()
+        t1.name = "Orders"
+        t2 = MagicMock()
+        t2.name = "LineItem"
+        mock_session.catalog.listTables.return_value = [t1, t2]
+
+        tables = a._get_existing_tables(mock_session)
+        assert "orders" in tables
+        assert "lineitem" in tables
+
+    def test_exception_returns_empty(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_session.catalog.listTables.side_effect = Exception("no catalog")
+
+        tables = a._get_existing_tables(mock_session)
+        assert tables == []
+
+
+# ---------------------------------------------------------------------------
+# analyze_table
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeTable:
+    def test_analyze_table_executes_sql(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        a.analyze_table(mock_session, "Orders")
+
+        sql_calls = [str(c) for c in mock_session.sql.call_args_list]
+        assert any("ANALYZE TABLE" in c.upper() and "orders" in c.lower() for c in sql_calls)
+
+    def test_analyze_table_exception_handled(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter()
+        mock_session.sql.side_effect = Exception("permission denied")
+        # Should not raise
+        a.analyze_table(mock_session, "orders")
+
+
+# ---------------------------------------------------------------------------
+# from_config
+# ---------------------------------------------------------------------------
+
+
+class TestFromConfig:
+    def test_explicit_database_preserved(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        config = {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+            "database": "my_custom_db",
+        }
+        a = SparkAdapter.from_config(config)
+        assert a.database == "my_custom_db"
+
+    def test_database_generated_when_absent(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        config = {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+        }
+        a = SparkAdapter.from_config(config)
+        assert a.database  # non-empty
+
+    def test_all_core_keys_passed(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        config = {
+            "benchmark": "tpch",
+            "scale_factor": 1.0,
+            "master": "spark://host:7077",
+            "app_name": "MyApp",
+            "deploy_mode": "client",
+            "driver_memory": "16g",
+            "executor_memory": "32g",
+            "executor_cores": 8,
+            "num_executors": 20,
+        }
+        a = SparkAdapter.from_config(config)
+        assert a.master == "spark://host:7077"
+        assert a.app_name == "MyApp"
+        assert a.driver_memory == "16g"
+        assert a.num_executors == 20
+
+    def test_optional_keys_passed(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        config = {
+            "benchmark": "tpcds",
+            "scale_factor": 10.0,
+            "table_format": "delta",
+            "enable_hive": True,
+            "adaptive_enabled": False,
+            "shuffle_partitions": 400,
+            "broadcast_threshold": 128,
+        }
+        a = SparkAdapter.from_config(config)
+        assert a.table_format == "delta"
+        assert a.enable_hive is True
+        assert a.adaptive_enabled is False
+        assert a.shuffle_partitions == 400


### PR DESCRIPTION
## Summary

- Add `tests/unit/platforms/test_spark_coverage.py` with 89 fast unit tests targeting `benchbox/platforms/spark.py`
- Achieves **86% line+branch coverage** on `spark.py` (target: ≥80%)

## Coverage areas

- `__init__`: all config variants (YARN, K8s, Spark Connect master, warehouse, hive, cache, executors)
- `_get_spark_conf`: AQE on/off, broadcast threshold, num_executors, warehouse dir, disable_cache, Delta/Iceberg/Parquet extensions, extra spark_config merge
- `create_connection`: basic, Hive support, database reused skip, database already exists skip, failure propagation
- `check_server_database_exists`: no session, found, not found, exception, custom database kwarg
- `drop_database`: existing, nonexistent noop, invalid identifier, SQL error
- `create_schema`: basic, "already exists" drop-and-recreate recovery, non-exists error propagation, Delta/Iceberg formats
- `_optimize_table_definition`: non-CREATE passthrough, existing USING clause replacement, ORC/no-paren edge cases
- `get_query_plan`: success and error paths
- `test_connection`: success and failure
- `get_platform_info`: with connection, error handling, no-connection returns None
- `configure_for_benchmark`: OLAP/TPC-H/TPC-DS, unknown type noop, conf.set exception
- `generate_tuning_clause`: Delta CLUSTER BY, non-Delta no CLUSTER BY, None/empty tuning
- `apply_table_tunings`: no tuning noop, Delta Z-ORDER, Z-ORDER error recovery, partition logging
- `apply_unified_tuning` / `apply_platform_optimizations` / `apply_constraint_configuration`
- `from_config`: explicit database, auto-generated database, all core+optional keys

## Test plan

- [x] `uv run -- python -m pytest tests/unit/platforms/test_spark_coverage.py -m fast -q -n 0` → 89 passed
- [x] `uv run -- python -m pytest -m fast -q` → 16395 passed, 66 skipped (no regressions)
- [x] Coverage measurement: 86% on `benchbox/platforms/spark.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)