### PR TITLE
chore: remove unused grpcio core deps + delete 6 obsolete release-tooling tests

### DIFF
--- a/_project/scripts/dependency_audit/guarded_optional_allowlist.yaml
+++ b/_project/scripts/dependency_audit/guarded_optional_allowlist.yaml
@@ -42,21 +42,3 @@ cupy:
 cuml:
   reason: "CUDA ML library; used in RAPIDS paths. Not declared in pyproject.toml; pulled transitively via cudf."
   extras_group: "extras:cudf"
-
-# --------------------------------------------------------------------------
-# gRPC stack - declared in core dependencies for cloud SDK compatibility
-# (databricks-sdk, snowflake-connector-python, google-cloud-* SDKs use grpc
-# transitively). Pinning grpcio/grpcio-status at the top level avoids ABI
-# mismatch when those SDKs lazily import grpc.
-#
-# TODO: revisit during dependency cleanup - if no cloud SDK in the install
-# matrix actually requires these pins anymore, remove them from
-# pyproject.toml dependencies.
-# --------------------------------------------------------------------------
-grpcio:
-  reason: "Top-level pin for ABI compatibility with cloud SDKs (databricks-sdk, snowflake, gcs) that use grpc transitively. No direct benchbox/ import site."
-  extras_group: "core"
-
-grpcio-status:
-  reason: "Companion to grpcio for SDK status-code handling. No direct benchbox/ import site; required transitively by cloud SDKs."
-  extras_group: "core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,10 @@ dependencies = [
     "pyarrow>=21.0.0,<25.0.0",
     "numpy>=1.24.0",
     "zstandard>=0.20.0",
-    "grpcio>=1.48.1",
-    "grpcio-status>=1.48.1",
+    # grpcio / grpcio-status are NOT declared at the core level. They are
+    # pulled in transitively by optional cloud / connectivity extras
+    # (e.g. influxdb3-python, snowflake, databricks-sdk, pyspark[connect]).
+    # Users without those extras don't pay the grpc weight.
 ]
 
 [tool.setuptools]

--- a/tests/unit/release/test_workflow.py
+++ b/tests/unit/release/test_workflow.py
@@ -102,93 +102,13 @@ jobs:
     return tmp_path
 
 
-@pytest.mark.skip(
-    reason=(
-        "Obsolete under the two-branch single-repo migration: HOLD_BACK_PATHS no "
-        "longer contains benchbox/release/ etc.; those live on develop and main "
-        "and are curated out of the wheel via pyproject + MANIFEST.in instead of "
-        "via prepare_public_release(). Removed in Phase 6."
-    )
-)
-def test_prepare_public_release_strips_holdbacks(temp_source: Path, tmp_path: Path) -> None:
-    target = tmp_path / "public"
-
-    prepare_public_release(
-        source=temp_source,
-        target=target,
-        version="0.1.0",
-        clean=True,
-        init_git=False,
-    )
-
-    # ensure benchbox copied
-    assert (target / "benchbox/__init__.py").exists()
-    # ensure hold back paths removed
-    assert not (target / "benchbox/release").exists()
-    assert not (target / "benchbox/core/explorer_pipeline").exists()
-    assert not (target / "benchbox/cli/commands/explorer.py").exists()
-    assert not (target / "scripts/prepare_release.py").exists()
-    assert not (target / "tests/unit/core/explorer_pipeline").exists()
-    assert not (target / "tests/unit/release").exists()
-    assert not (target / "tests/unit/test_xdist_safety.py").exists()
-    assert not (target / ".github/workflows/results-explorer-browser.yml").exists()
-    assert not (target / "docs/development/results-explorer-brand-ownership.md").exists()
-    assert not (target / "docs/development/results-explorer-browser-testing.md").exists()
-
-    # Note: README no longer sanitized - public releases use the full README
-    # Only pyproject is sanitized
-    assert (target / "README.md").read_text(encoding="utf-8") == "Private README\n"
-    assert (target / "pyproject.toml").read_text(encoding="utf-8") == "[project]\nname='benchbox'\n"
-    cli_init = (target / "benchbox/cli/commands/__init__.py").read_text(encoding="utf-8")
-    assert "explorer_group" not in cli_init
-    test_workflow = (target / ".github/workflows/test.yml").read_text(encoding="utf-8")
-    assert "hashFiles('results-explorer/package.json')" in test_workflow
-    assert "_benchbox_pytest_xdist_safety" not in (target / "pytest.ini").read_text(encoding="utf-8")
-    assert "_benchbox_pytest_xdist_safety" not in (target / "pytest-ci.ini").read_text(encoding="utf-8")
-
-    # gitignore written
-    assert (target / ".gitignore").exists()
-
-    # timestamps normalized (file exists implies utime run)
-    assert (target / "RELEASE_VERSION").read_text(encoding="utf-8").strip() == "0.1.0"
-
-
-@pytest.mark.skip(
-    reason=(
-        "Obsolete under the two-branch single-repo migration: "
-        "_benchbox_pytest_xdist_safety.py is now in ALLOWED_ROOT_FILES (dev tooling "
-        "ships on develop). Removed in Phase 6."
-    )
-)
-def test_prepare_public_release_no_clean(temp_source: Path, tmp_path: Path) -> None:
-    target = tmp_path / "public"
-    target.mkdir()
-    (target / "old.txt").write_text("remove me\n", encoding="utf-8")
-    (target / "_benchbox_pytest_xdist_safety.py").write_text("stale helper\n", encoding="utf-8")
-    (target / "results-explorer").mkdir()
-    (target / "results-explorer/package.json").write_text("{}\n", encoding="utf-8")
-    (target / "dist").mkdir()
-    (target / "dist/existing.whl").write_text("wheel\n", encoding="utf-8")
-    (target / "build").mkdir()
-    (target / "build/artifact.txt").write_text("artifact\n", encoding="utf-8")
-    (target / "benchbox.egg-info").mkdir()
-    (target / "benchbox.egg-info/PKG-INFO").write_text("metadata\n", encoding="utf-8")
-
-    prepare_public_release(
-        source=temp_source,
-        target=target,
-        version="0.1.0",
-        clean=False,
-    )
-
-    # stale root files should be removed, but expected build artifacts preserved
-    assert not (target / "old.txt").exists()
-    assert not (target / "_benchbox_pytest_xdist_safety.py").exists()
-    assert not (target / "results-explorer").exists()
-    assert (target / "dist/existing.whl").exists()
-    assert (target / "build/artifact.txt").exists()
-    assert (target / "benchbox.egg-info/PKG-INFO").exists()
-    assert (target / "benchbox").exists()
+# Tests for prepare_public_release()'s old "strip hold-backs" semantics were
+# removed in 2026-04 as part of the two-branch single-repo migration. Under
+# the new architecture HOLD_BACK_PATHS only excludes per-user agent configs
+# (.claude / .codex / .gemini); maintainer-only paths like benchbox/release/
+# live on develop and on main, with wheel/sdist exclusions handled by
+# pyproject.toml + MANIFEST.in instead. The release-prepare flow uses git rm
+# directly on the version branch (see Makefile release-prepare target).
 
 
 def test_prepare_public_release_includes_extra_files(temp_source: Path, tmp_path: Path) -> None:

--- a/tests/unit/test_release_exclusion_invariants.py
+++ b/tests/unit/test_release_exclusion_invariants.py
@@ -89,33 +89,6 @@ def _pattern_to_path(pattern: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Layer A: HOLD_BACK_PATHS
-# ---------------------------------------------------------------------------
-class TestHoldBackPaths:
-    """Validate HOLD_BACK_PATHS entries in workflow.py."""
-
-    @pytest.mark.skip(
-        reason=(
-            "Obsolete under the two-branch single-repo migration: HOLD_BACK_PATHS now "
-            "lists per-user agent configs that are tracked on private but absent on "
-            "develop. The path-existence invariant no longer holds across branches. "
-            "Removed entirely in Phase 6."
-        )
-    )
-    def test_hold_back_paths_target_existing_paths(self):
-        """Every HOLD_BACK_PATHS entry must resolve to a real file or directory."""
-        from benchbox.release.workflow import HOLD_BACK_PATHS
-
-        for rel_path in HOLD_BACK_PATHS:
-            candidates = [REPO_ROOT / rel_path]
-            if "/" not in rel_path:
-                candidates.append(BENCHBOX_DIR / rel_path)
-            assert any(path.exists() for path in candidates), (
-                f"HOLD_BACK_PATHS entry '{rel_path}' does not exist. Remove or update it."
-            )
-
-
-# ---------------------------------------------------------------------------
 # Layer B: pyproject.toml [tool.setuptools.packages.find] exclude
 # ---------------------------------------------------------------------------
 class TestPyprojectExcludes:
@@ -144,30 +117,6 @@ class TestPyprojectExcludes:
                     f"Setuptools package excludes only work on packages (directories). "
                     f"Use MANIFEST.in 'exclude' for individual files."
                 )
-
-
-# ---------------------------------------------------------------------------
-# Layer C: MANIFEST.in prune directives
-# ---------------------------------------------------------------------------
-class TestManifestPrunes:
-    """Validate MANIFEST.in prune directives."""
-
-    @pytest.mark.skip(
-        reason=(
-            "Obsolete under the two-branch single-repo migration: MANIFEST.in carries "
-            "defence-in-depth prunes for paths that exist on private (e.g. .claude/, "
-            "_project/) but are curated out of develop or main. The 'must exist' "
-            "invariant no longer holds. Removed entirely in Phase 6."
-        )
-    )
-    def test_prune_targets_are_existing_directories(self):
-        """Every MANIFEST.in 'prune' target must be a real directory."""
-        for prune_path in _load_manifest_prunes():
-            full_path = REPO_ROOT / prune_path
-            assert full_path.is_dir(), (
-                f"MANIFEST.in 'prune {prune_path}' targets a path that is not a "
-                f"directory (or doesn't exist). Remove or update it."
-            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_release_sync.py
+++ b/tests/unit/test_release_sync.py
@@ -159,50 +159,6 @@ class TestGetSyncableFiles:
         db_files = [p for p in result if "databases" in str(p)]
         assert len(db_files) == 0, f"Found database files: {db_files}"
 
-    @pytest.mark.skip(
-        reason=(
-            "Obsolete under the two-branch single-repo migration: benchbox/release/ "
-            "and benchbox/core/explorer_pipeline are no longer in HOLD_BACK_PATHS — "
-            "they live on develop and on main (just curated out of the wheel). "
-            "Removed entirely in Phase 6."
-        )
-    )
-    def test_excludes_hold_back_paths_across_repo_roots(self, tmp_path: Path):
-        """Explorer hold-backs should be excluded from syncable files everywhere."""
-        (tmp_path / "benchbox/release").mkdir(parents=True)
-        (tmp_path / "benchbox/release/sync.py").write_text("# private\n")
-        (tmp_path / "benchbox/core/explorer_pipeline").mkdir(parents=True)
-        (tmp_path / "benchbox/core/explorer_pipeline/__init__.py").write_text("# private\n")
-        (tmp_path / "benchbox/cli/commands").mkdir(parents=True)
-        (tmp_path / "benchbox/cli/commands/explorer.py").write_text("# private\n")
-        (tmp_path / "scripts").mkdir()
-        (tmp_path / "scripts/prepare_release.py").write_text("# private\n")
-        (tmp_path / "tests/unit/core/explorer_pipeline").mkdir(parents=True)
-        (tmp_path / "tests/unit/core/explorer_pipeline/test_private.py").write_text("# private\n")
-        (tmp_path / "tests/unit/release").mkdir(parents=True)
-        (tmp_path / "tests/unit/release/test_workflow.py").write_text("# private\n")
-        (tmp_path / "tests/unit/test_xdist_safety.py").write_text("# private\n")
-        (tmp_path / "docs/development").mkdir(parents=True)
-        (tmp_path / "docs/development/results-explorer-brand-ownership.md").write_text("# private\n")
-        (tmp_path / "docs/development/results-explorer-browser-testing.md").write_text("# private\n")
-        (tmp_path / ".github/workflows").mkdir(parents=True)
-        (tmp_path / ".github/workflows/results-explorer-browser.yml").write_text("name: explorer\n")
-        (tmp_path / "README.md").write_text("# public\n")
-
-        result = get_syncable_files(tmp_path)
-
-        assert Path("README.md") in result
-        assert Path("benchbox/release/sync.py") not in result
-        assert Path("benchbox/core/explorer_pipeline/__init__.py") not in result
-        assert Path("benchbox/cli/commands/explorer.py") not in result
-        assert Path("scripts/prepare_release.py") not in result
-        assert Path("tests/unit/core/explorer_pipeline/test_private.py") not in result
-        assert Path("tests/unit/release/test_workflow.py") not in result
-        assert Path("tests/unit/test_xdist_safety.py") not in result
-        assert Path("docs/development/results-explorer-brand-ownership.md") not in result
-        assert Path("docs/development/results-explorer-browser-testing.md") not in result
-        assert Path(".github/workflows/results-explorer-browser.yml") not in result
-
 
 class TestCompareRepos:
     """Test compare_repos() function."""
@@ -741,21 +697,21 @@ class TestExclusionConstants:
         """Test that DOCS_DIR_EXCLUDES includes _build."""
         assert "_build" in DOCS_DIR_EXCLUDES
 
-    @pytest.mark.skip(
-        reason=(
-            "Obsolete under the two-branch single-repo migration: CLAUDE.md / "
-            "AGENTS.md / GEMINI.md are project-shared agent instructions on develop "
-            "(curated out at release time, but still in ALLOWED_ROOT_FILES so the "
-            "develop-tree sync includes them). Per-user agent state under .claude/ "
-            ".codex/ .gemini/ stays excluded via HOLD_BACK_PATHS. Removed in Phase 6."
-        )
-    )
-    def test_claude_and_codex_not_in_allowed_roots(self):
-        """Test that .claude, .codex, CLAUDE.md, AGENTS.md are excluded from public release."""
-        assert ".claude" not in ALLOWED_ROOT_FILES
-        assert ".codex" not in ALLOWED_ROOT_FILES
-        assert "CLAUDE.md" not in ALLOWED_ROOT_FILES
-        assert "AGENTS.md" not in ALLOWED_ROOT_FILES
+    def test_per_user_agent_dirs_in_hold_back(self):
+        """HOLD_BACK_PATHS must keep per-user agent config dirs (.claude, .codex, .gemini) off public.
+
+        Replaces the legacy invariant that asserted .claude / .codex / CLAUDE.md
+        were absent from ALLOWED_ROOT_FILES. Under the two-branch migration,
+        CLAUDE.md / AGENTS.md / GEMINI.md are project-shared agent instructions
+        on develop (curated out at release time but tracked on develop), while
+        .claude/ / .codex/ / .gemini/ are per-user state and stay in
+        HOLD_BACK_PATHS so the curated public tree never includes them.
+        """
+        from benchbox.release.workflow import HOLD_BACK_PATHS
+
+        assert ".claude" in HOLD_BACK_PATHS
+        assert ".codex" in HOLD_BACK_PATHS
+        assert ".gemini" in HOLD_BACK_PATHS
 
     def test_forbidden_patterns_includes_data_files(self):
         """Test that FORBIDDEN_PATTERNS includes data file extensions."""

--- a/uv.lock
+++ b/uv.lock
@@ -318,8 +318,6 @@ version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "grpcio" },
-    { name = "grpcio-status" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "packaging" },
@@ -764,8 +762,6 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'cloud'", specifier = ">=2.0.0" },
     { name = "google-cloud-storage", marker = "extra == 'cloud-spark'", specifier = ">=2.0.0" },
     { name = "google-cloud-storage", marker = "extra == 'cloud-spark-gcp'", specifier = ">=2.0.0" },
-    { name = "grpcio", specifier = ">=1.48.1" },
-    { name = "grpcio-status", specifier = ">=1.48.1" },
     { name = "influxdb3-python", marker = "extra == 'all'", specifier = ">=0.10.0" },
     { name = "influxdb3-python", marker = "extra == 'influxdb'", specifier = ">=0.10.0" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0" },


### PR DESCRIPTION
Resolves the two minor TODOs left from the Phase 5 closure:

## 1. grpcio / grpcio-status removed from core dependencies

Verified via `uv tree` and grep that grpcio is **not directly imported anywhere** in benchbox core. It was pulled in transitively by optional cloud / connectivity extras (influxdb3-python, snowflake-connector-python, databricks-sdk, pyspark[connect]) and the top-level pin was redundant.

- Removed `grpcio>=1.48.1` and `grpcio-status>=1.48.1` from pyproject.toml main dependencies.
- Removed the matching allowlist entries (no longer declared, so no allowlist needed).
- Replaced with a comment explaining where grpcio comes from when it IS needed.
- `uv lock` re-resolved to the same 303 packages (grpc still pulled transitively for relevant extras).
- Dependency audit: 0 violations.
- Users without cloud extras no longer pay grpcio's install weight.

## 2. Six obsolete release-tooling test methods deleted

These were marked `@pytest.mark.skip` during Phase 5 closure with TODO-Phase-6 reasons. Promoted that deletion forward instead of carrying the skips:

- `test_release_exclusion_invariants.py::TestHoldBackPaths::test_hold_back_paths_target_existing_paths` — path-existence invariant moot when HOLD_BACK_PATHS is just per-user agent configs.
- `test_release_exclusion_invariants.py::TestManifestPrunes::test_prune_targets_are_existing_directories` — defence-in-depth prunes can target paths that exist on private but not on develop.
- `test_release_sync.py::TestGetSyncableFiles::test_excludes_hold_back_paths_across_repo_roots` — `benchbox/release/`, explorer paths, etc. no longer in HOLD_BACK_PATHS.
- `test_release_sync.py::TestExclusionConstants::test_claude_and_codex_not_in_allowed_roots` — replaced by a positive invariant: per-user dirs (.claude/.codex/.gemini) ARE in HOLD_BACK_PATHS. CLAUDE.md/AGENTS.md/GEMINI.md are intentionally in ALLOWED_ROOT_FILES (project-shared instructions on develop).
- `release/test_workflow.py::test_prepare_public_release_strips_holdbacks` and `test_prepare_public_release_no_clean` — `prepare_public_release()`'s strip-holdbacks behaviour is no longer how releases are curated; the Makefile release-prepare target uses git rm directly.

Tests + lint local verification clean: 78/78 release tests pass with 0 skips; full fast suite 21,396 passed.