### PR TITLE
docs: record Phase 5 w6 option-a (rename) supersedes initial option-b (symlink)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@
 ## Git workflow
 
 Single repo, single remote (`origin` → `joeharris76/BenchBox`). Working
-clone: `~/Developer/benchbox-public` (canonical path
-`/Users/joe/Developer/BenchBox` is a symlink).
+clone: `/Users/joe/Developer/BenchBox` (the canonical path; the old
+private clone was retired to `BenchBox.retired-20260427/` alongside it
+during the single-repo migration).
 
 - **Branches**: `develop` is the long-lived dev branch; `main` is
   release-only.

--- a/_project/DONE/main/planning/single-repo-migration-phase-5-repo-flip.yaml
+++ b/_project/DONE/main/planning/single-repo-migration-phase-5-repo-flip.yaml
@@ -12,10 +12,12 @@ amendment_2026-04-27: |
 
   Outcome:
   - joeharris76/benchbox-private archived (read-only on GitHub).
-  - /Users/joe/Developer/BenchBox renamed to BenchBox.retired-20260427/;
-    a symlink at /Users/joe/Developer/BenchBox now points at
-    ~/Developer/benchbox-public for shell-muscle-memory continuity (w6
-    option-b chosen).
+  - /Users/joe/Developer/BenchBox renamed to BenchBox.retired-20260427/.
+    Initially a symlink at /Users/joe/Developer/BenchBox pointed at
+    ~/Developer/benchbox-public (w6 option-b). Later on 2026-04-27 the
+    symlink was removed and ~/Developer/benchbox-public was renamed to
+    /Users/joe/Developer/BenchBox (w6 option-a) so the canonical path
+    is now a real directory, not a symlink.
   - Mirror backup at /tmp/benchbox-private-backup-20260427.git (147 MB)
     retained per the 60-day soak.
   - Three rulesets applied to joeharris76/BenchBox via gh api:


### PR DESCRIPTION
Tiny doc update to reflect the actual state of the dev locus path.

After Phase 5 landed, `/Users/joe/Developer/BenchBox` was a symlink pointing to `~/Developer/benchbox-public` (option-b from Phase 5 w6). Today (still 2026-04-27) the symlink was removed and `~/Developer/benchbox-public` was renamed to `/Users/joe/Developer/BenchBox` so the canonical path is a real directory (option-a from w6).

Updates:
- `CLAUDE.md`: Git workflow section now describes the canonical path as a real directory, not a symlink.
- `_project/DONE/main/planning/single-repo-migration-phase-5-repo-flip.yaml`: amendment_2026-04-27 outcome note records the symlink → rename progression.

No code or test changes.