### PR TITLE
ci(docs): split deploy into its own gated job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,9 +40,6 @@ jobs:
   # Build HTML documentation with warnings as errors
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v4
@@ -181,9 +178,19 @@ jobs:
         with:
           path: site
 
+  # Deploy to GitHub Pages (main pushes only)
+  # Isolated as its own job so the github-pages environment protection
+  # rules don't gate the build job on PRs.
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4
 
   # Validate example files and documentation references


### PR DESCRIPTION
## Summary
- Splits the docs workflow's deploy step into a dedicated `deploy` job gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
- Removes the job-level `environment: github-pages` from `build` so the github-pages environment protection rule no longer fails the entire `build` job pre-flight on PRs.
- `deploy` runs only on `main` pushes, `needs: build`, and carries the `environment` block.

## Why
The `build` job was failing in 2 seconds with zero steps on every PR (e.g. run 25017174303). Cause: `environment: github-pages` at the job level — the env's branch policy allows only `main`, so PR runs were rejected pre-flight. Gating the deploy *step* with `if:` was insufficient because the env attached to the whole job.

## Test plan
- [x] YAML parses; jobs structure verified (`deploy` has `if`, `needs: build`, environment).
- [x] Confirmed no branch-protection / repo-ruleset required-status-check references the old `build` job (only `lint` and `test (ubuntu-latest, 3.12)` are required).
- [ ] Watch this PR's Documentation workflow: `build` should run all steps and pass; `deploy` should be skipped (not failed).
- [ ] After squash-merge to develop and eventual promotion to main, confirm `deploy` runs on main push and publishes Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)