### PR TITLE
chore(workflow): integrate PR-gated develop with auto-merge + worktree tooling

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,45 @@
+---
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(make:*), Bash(uv:*)
+description: BenchBox PR workflow — preflight, push, open PR vs develop, enable auto-merge
+---
+
+## Context
+
+- Branch: !`git branch --show-current`
+- Status: !`git status --short`
+- Last commit: !`git log -1 --oneline`
+- Ahead/behind develop: !`git rev-list --left-right --count origin/develop...HEAD 2>/dev/null || echo "(no origin/develop)"`
+
+## Your task
+
+This is the BenchBox-specific PR workflow. `develop` is PR-gated (CI must pass:
+`lint` + `test (ubuntu-latest, 3.12)`; linear history; squash-only). The goal
+is to land a green PR with one command and walk away — auto-merge handles the
+rest.
+
+Execute the following in order, stopping on the first failure:
+
+1. **Refuse if on `develop` or `main`.** If `git branch --show-current` returns
+   one of those, stop and tell the user to switch to a feature branch (offer
+   `make worktree-add BRANCH=<name>`).
+
+2. **If there are uncommitted changes**, create a single conventional commit
+   (`feat:`/`fix:`/`docs:`/`test:`/`chore:`/`ci:`/`refactor:` prefix) summarizing
+   them. Stage explicitly by path — never `git add -A`. Include the standard
+   `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer.
+   If pre-commit hooks rewrite files, re-stage and commit again (do NOT use
+   `--amend`; create a new commit).
+
+3. **Run `make pr-preflight`** to mirror the CI gate locally. If it fails, fix
+   the root cause and loop back to step 2. Do NOT bypass with `--no-verify`.
+
+4. **Run `make pr-open`** — pushes the branch, opens a PR vs `develop` with
+   `gh pr create --fill`, and enables `gh pr merge --auto --squash`.
+
+5. **Print the PR URL** and a one-line summary of what auto-merge will do
+   ("will squash-merge once `lint` + `test (ubuntu-latest, 3.12)` go green").
+   Do NOT poll for CI completion — auto-merge handles it.
+
+You have the capability to call multiple tools in a single response. Call them
+all in one message wherever the calls are independent. Do not narrate
+intermediate steps unless you hit a blocker that needs the user's input.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,18 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      # Mirror the CI gate locally so PR pushes don't need to discover lint
+      # failures via the network roundtrip. ruff-format is enforced via the
+      # ruff-format hook below at commit time, so pre-push only re-checks
+      # `ruff check` (catches anything bypassed with --no-verify on commit)
+      # plus the fast test lane.
+      - id: pr-preflight-fast-tests
+        name: pr-preflight (fast tests, mirrors CI)
+        entry: uv run -- python -m pytest -m fast -q
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
       # Warn-only duplicate-code gate. Manual stage so it doesn't slow
       # every commit (pylint over benchbox/ takes ~60s). Run with
       # `pre-commit run duplicate-code-warn --all-files --hook-stage manual`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ No credentials in repo; use env vars or `.env` (gitignored); redact secrets in l
 Conventional Commits (feat:, fix:, docs:, test:). PRs link issues, include tests + docs. CI: ruff + typecheck + tests via `make test-ci`.
 Single repo (`origin` → `joeharris76/BenchBox`); two long-lived branches: `develop` (dev work) and `main` (release-only). Dev PRs target `develop`, squash-merge. Releases go through the version-branch flow (`make release-prepare VERSION=X.Y.Z` cuts `vX.Y.Z` from develop, squash-merge to main, tag, then `make release-rebase-develop`). Full runbook: `docs/operations/release-guide.md`.
 
+**`develop` is PR-gated** (no direct push). Required checks: `lint` + `test (ubuntu-latest, 3.12)`. Linear history; squash-only; 0 reviewer approvals required (self-merge is fine).
+
+**One-shot flow**: from a feature branch run `make pr-preflight && make pr-open`. Preflight runs ruff + fast tests (mirrors CI). `pr-open` pushes, opens the PR vs `develop`, and enables `gh pr merge --auto --squash` so the PR lands the moment CI goes green. Don't poll. The pre-push hook `pr-preflight-fast-tests` (in `.pre-commit-config.yaml`) re-runs the fast lane automatically — activate once with `pre-commit install`.
+
+**Worktrees for parallel branches**: keep `~/Developer/BenchBox/` on `develop` permanently; `make worktree-add BRANCH=fix/foo` creates `../BenchBox.fix-foo/` off `origin/develop`. `cd` in, `uv sync --group dev`, work, run `make pr-open` from inside. After auto-merge, `make worktree-prune` sweeps the worktree (looks for branches gone on origin). Three branches in flight = three worktrees, no stash thrash.
+
+**In Claude Code**: the project-local `/pr` slash command (`.claude/commands/pr.md`) is the canonical wrapper — it commits, preflights, pushes, opens, and enables auto-merge in one shot. Prefer it over the user-global `/commit-push-pr` plugin; that one targets `main` by default and doesn't enable auto-merge.
+
 ## Planning & TODOs
 Layout: `_project/TODO/{worktree}/{phase}/{item}.yaml`; completed → `_project/DONE/`. Stable `id` = filename slug.
 Flat `work[]` with `needs` edges (not nested tasks.phases). Inter-item deps: `deps.needs: [slug-ids]`. Deferred work in separate `deferred[]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,27 @@ during the single-repo migration).
   release-only.
 - **Dev PRs**: feature branch off `develop` → PR → squash-merge to
   `develop`. Required CI: `lint` + `test (ubuntu-latest, 3.12)`.
+- **One-shot PR flow** (the canonical path — use this, not bare git):
+  - From a feature branch: `make pr-preflight && make pr-open`. Opens
+    the PR vs `develop` with `gh pr create --fill` and enables
+    `gh pr merge --auto --squash` so it lands the moment CI is green.
+    Walk away — don't poll.
+  - In Claude Code, the project-local `/pr` slash command
+    (`.claude/commands/pr.md`) wraps this end-to-end (commit if needed,
+    preflight, push, open PR, enable auto-merge). Prefer `/pr` over the
+    user-global `/commit-push-pr` plugin in this repo — `/pr` targets
+    `develop`, runs preflight, and enables auto-merge.
+  - Pre-push hook (`pr-preflight-fast-tests` in `.pre-commit-config.yaml`)
+    runs the fast lane on every push. Activate once with `pre-commit install`.
+- **Worktrees** for parallel branches (the convention):
+  - `~/Developer/BenchBox/` stays on `develop`, always. Don't swap
+    branches in the main clone.
+  - `make worktree-add BRANCH=fix/foo` creates `../BenchBox.fix-foo/`
+    off `origin/develop` with branch `fix/foo` checked out. `cd` into it,
+    run `uv sync --group dev`, work, `make pr-open` from inside.
+  - `make worktree-prune` removes worktrees whose branches are gone
+    upstream (post-merge cleanup). Pairs with auto-merge: PR merges →
+    branch deleted on origin → next prune sweeps the worktree.
 - **Releases** (version-branch flow): on `develop`, run `make bump
   VERSION=X.Y.Z` and `make changelog-draft VERSION=X.Y.Z`, then `make
   release-prepare VERSION=X.Y.Z` cuts the `vX.Y.Z` branch with curated
@@ -65,8 +86,9 @@ benchbox run --help | --help-topic all | --help-topic examples | --help-topic be
 
 ## Pre-approved Commands
 - **Dev/Test**: `make test-*`, `make coverage*`, `make lint`, `make format`, `make typecheck`, `uv run -- python -m pytest *`
+- **PR/Worktree**: `make pr-preflight`, `make pr-status`, `make worktree-list`, `make worktree-prune`, `git worktree list*`, `gh pr list*`, `gh pr view*`, `gh pr checks*`
 - **Files**: `ls*`, `find*`, `cat*`, `head*`, `tail*`, `wc*`, `file*`, `stat*`, `du*`, `tree*`, `which*`
-- **Git**: `git status`, `git diff*`, `git log*`, `git show*`, `git branch*`, `git remote*`, `git config --list`
+- **Git**: `git status`, `git diff*`, `git log*`, `git show*`, `git branch*`, `git remote*`, `git config --list`, `git worktree list*`
 - **Python**: `uv tree`, `uv pip list`, `uv pip show*`, `uv export`, `uv run -- python -c*`, `uv run -- python -m*`
 - **TPC**: `timeout 30s _binaries/tpc-{h,ds}/<platform>/dsdgen*`, `timeout 60s _binaries/tpc-{h,ds}/<platform>/dsqgen*`
 - **TODO**: `uv run --project _project/scripts -- python _project/scripts/todo_cli.py list*|show*|stats|ready|next*|done*|check-graph`, `uv run --project _project/scripts -- python _project/scripts/validate_todo.py*`, `uv run _project/scripts/generate_indexes.py`, `uv run _project/scripts/migrate_todo_format.py*`

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # BenchBox Makefile
 # This makefile provides commands for building, testing and development
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json codex-skills-sync codex-skills-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json codex-skills-sync codex-skills-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-open pr-status worktree-add worktree-list worktree-prune
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -693,6 +693,77 @@ release-rebase-develop:
 	@echo "develop rebased onto main."
 	@echo "Per option-c lifecycle: previous release branch (e.g. vPREV) can be deleted on the next release-prepare run."
 
+# =============================================================================
+# PR + worktree workflow
+# Solo-dev develop is PR-gated (CI must be green; linear history; squash).
+# These targets collapse the PR roundtrip to one command and let multiple
+# branches stay live in parallel via worktrees.
+# =============================================================================
+
+.PHONY: pr-preflight pr-open pr-status worktree-add worktree-list worktree-prune
+
+# Mirror the CI gate locally before pushing. Catches ~all CI failures
+# without the network roundtrip. Same checks as `lint` ruleset rule.
+pr-preflight:
+	@echo "==> ruff check"
+	@uv run ruff check .
+	@echo "==> ruff format --check"
+	@uv run ruff format --check .
+	@echo "==> fast tests"
+	@uv run -- python -m pytest -m fast -q
+
+# Push current branch and open a PR against develop with auto-merge enabled.
+# Squash-merge happens automatically once `lint` + `test (ubuntu-latest, 3.12)`
+# go green. Refuses to run from develop/main.
+pr-open:
+	@CURRENT=$$(git branch --show-current); \
+	case "$$CURRENT" in \
+		develop|main) echo "Refusing to open PR from $$CURRENT — switch to a feature branch."; exit 1 ;; \
+	esac; \
+	git push -u origin "$$CURRENT" && \
+	URL=$$(gh pr create --base develop --fill --head "$$CURRENT") && \
+	echo "$$URL" && \
+	gh pr merge --auto --squash "$$URL"
+
+# Show PRs you have open against develop and their CI state.
+pr-status:
+	@gh pr list --author "@me" --base develop --json number,title,headRefName,statusCheckRollup,autoMergeRequest \
+		--template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}  auto-merge: {{if .autoMergeRequest}}enabled{{else}}OFF{{end}}{{"\n"}}  checks: {{range .statusCheckRollup}}{{.name}}={{.conclusion}} {{end}}{{"\n\n"}}{{end}}'
+
+# Create a worktree off origin/develop. Usage: make worktree-add BRANCH=fix/foo
+# Path convention: ../BenchBox.<branch-with-slashes-as-dashes>/
+# After: cd into the path, work, run `make pr-open` from inside.
+worktree-add:
+	@test -n "$(BRANCH)" || { echo "Usage: make worktree-add BRANCH=<branch-name>"; exit 1; }
+	@WTNAME=$$(echo "$(BRANCH)" | tr '/' '-'); \
+	WTPATH="../BenchBox.$$WTNAME"; \
+	test ! -e "$$WTPATH" || { echo "Path exists: $$WTPATH"; exit 1; }; \
+	git fetch origin develop --quiet && \
+	git worktree add -b "$(BRANCH)" "$$WTPATH" origin/develop && \
+	echo "" && \
+	echo "Worktree ready: $$WTPATH" && \
+	echo "Branch:        $(BRANCH) (based on origin/develop)" && \
+	echo "Next:          cd $$WTPATH && uv sync --group dev"
+
+worktree-list:
+	@git worktree list
+
+# Remove worktrees whose branches are gone on origin (already merged).
+# Pairs with auto-merge: PR merges → branch deleted → worktree pruned.
+worktree-prune:
+	@git fetch --prune --quiet
+	@git worktree list --porcelain | awk '/^worktree /{wt=$$2} /^branch /{br=$$2; print wt"|"br}' | \
+		while IFS='|' read -r wt br; do \
+			[ "$$wt" = "$$(git rev-parse --show-toplevel)" ] && continue; \
+			short=$${br#refs/heads/}; \
+			if ! git ls-remote --exit-code --heads origin "$$short" >/dev/null 2>&1; then \
+				echo "Removing worktree (branch gone on origin): $$wt [$$short]"; \
+				git worktree remove "$$wt" 2>/dev/null || git worktree remove --force "$$wt"; \
+				git branch -D "$$short" 2>/dev/null || true; \
+			fi; \
+		done
+	@git worktree prune
+
 # Help
 help:
 	@echo "BenchBox Makefile"
@@ -791,5 +862,13 @@ help:
 	@echo "  make docs-validate   Validate example references, syntax, and screenshot sync"
 	@echo "  make docs-images     Refresh generated visualization screenshots and sync docs/blog copies"
 	@echo "  make docs-check      Run all documentation checks (validate, linkcheck, build)"
+	@echo ""
+	@echo "PR Workflow & Worktrees:"
+	@echo "  make pr-preflight    Run lint + fast tests locally; mirrors CI gate"
+	@echo "  make pr-open         Push branch + open PR vs develop + enable auto-merge (squash)"
+	@echo "  make pr-status       List your open PRs vs develop with CI + auto-merge state"
+	@echo "  make worktree-add BRANCH=name  Create a worktree off origin/develop at ../BenchBox.<name>"
+	@echo "  make worktree-list   List active worktrees"
+	@echo "  make worktree-prune  Remove worktrees whose branches are gone on origin (post-merge cleanup)"
 	@echo ""
 	@echo "  make help            Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -725,10 +725,10 @@ pr-open:
 	echo "$$URL" && \
 	gh pr merge --auto --squash "$$URL"
 
-# Show PRs you have open against develop and their CI state.
+# Show open PRs against develop and their CI + auto-merge state.
 pr-status:
-	@gh pr list --author "@me" --base develop --json number,title,headRefName,statusCheckRollup,autoMergeRequest \
-		--template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}  auto-merge: {{if .autoMergeRequest}}enabled{{else}}OFF{{end}}{{"\n"}}  checks: {{range .statusCheckRollup}}{{.name}}={{.conclusion}} {{end}}{{"\n\n"}}{{end}}'
+	@gh pr list --base develop --state open --limit 20 --json number,title,headRefName,statusCheckRollup,autoMergeRequest \
+		--template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}  auto-merge: {{if .autoMergeRequest}}ON{{else}}OFF{{end}}{{"\n"}}  checks: {{range .statusCheckRollup}}{{.name}}={{.conclusion}} {{end}}{{"\n\n"}}{{end}}'
 
 # Create a worktree off origin/develop. Usage: make worktree-add BRANCH=fix/foo
 # Path convention: ../BenchBox.<branch-with-slashes-as-dashes>/


### PR DESCRIPTION
`develop` is PR-gated (CI: lint + test (ubuntu-latest, 3.12); linear history;
squash-only). Reduce the friction of that gate to one command and let
multiple branches stay live in parallel via worktrees.

Adds:

- `make pr-preflight` — runs ruff check + ruff format --check + fast tests;
  mirrors the CI gate so PR pushes don't discover lint/test failures via the
  network roundtrip.
- `make pr-open` — pushes current branch, opens PR vs `develop` with
  `gh pr create --fill`, and enables `gh pr merge --auto --squash`. Refuses
  if run from `develop`/`main`.
- `make pr-status` — lists open PRs vs develop with CI + auto-merge state.
- `make worktree-add BRANCH=name` — creates `../BenchBox.<name>/` off
  `origin/develop` with the named branch checked out. Sibling-path convention
  matches existing `BenchBox.retired-20260427/`.
- `make worktree-list` / `make worktree-prune` — inventory + post-merge
  cleanup (sweeps worktrees whose branches are gone on origin).
- `.claude/commands/pr.md` — project-local `/pr` slash command wrapping the
  full flow (commit if needed → preflight → open → enable auto-merge).
  Supersedes the user-global `/commit-push-pr` plugin in this repo because
  that one targets `main` and doesn't enable auto-merge.
- `.pre-commit-config.yaml` — new `pr-preflight-fast-tests` hook on the
  pre-push stage. Activate once with `pre-commit install`.

Documents the workflow in AGENTS.md "Commits & PRs" and CLAUDE.md "Git
workflow"; pre-approves the read-only PR/worktree commands so they don't
trigger permission prompts.

Self-tested: preflight passes locally (21168 tests in 66s); `make pr-status`
correctly reports PR #25 state.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
