### PR TITLE
test(ci): tampered-bundle hash mismatch (will be closed)

### DIFF
--- a/results-data/bundles/submission-manifest.json
+++ b/results-data/bundles/submission-manifest.json
@@ -1,0 +1,12 @@
+{
+  "submission_tool_version": "benchbox/0.2.1",
+  "submitted_at": "2026-04-27T23:24:40.000353+00:00",
+  "bundle_file": "tpch_sf001_duckdb_sql_20260427_192436_a64d36db.json",
+  "bundle_hash": "e5821554c491fd52e48474ba5dd1cd64d7482d02f400329455edffb47cecbd10",
+  "benchmark": "TPC-H",
+  "platform": "DuckDB",
+  "scale_factor": 0.01,
+  "phase": 2,
+  "submission_path": "PR-based",
+  "submitted_by": "Joe Harris"
+}

--- a/results-data/bundles/tpch_sf001_duckdb_sql_20260427_192436_a64d36db.json
+++ b/results-data/bundles/tpch_sf001_duckdb_sql_20260427_192436_a64d36db.json
@@ -1,0 +1,234 @@
+{
+  "version": "2.1",
+  "run": {
+    "id": "a64d36db",
+    "timestamp": "2026-04-27T19:24:36.114066",
+    "total_duration_ms": 250,
+    "query_time_ms": 36,
+    "iterations": 3,
+    "streams": 3
+  },
+  "benchmark": {
+    "id": "tpch",
+    "name": "TPC-H",
+    "scale_factor": 0.01,
+    "test_type": "power"
+  },
+  "platform": {
+    "name": "DuckDB",
+    "version": "1.4.4",
+    "client_version": "1.4.4",
+    "config": {
+      "execution_mode": "sql",
+      "connection_mode": "file",
+      "database_path": "/Users/joe/Developer/BenchBox/.claude/worktrees/results-explorer-todos/benchmark_runs/databases/tpch_sf001/tpch_sf001_notuning_noconstraints.duckdb",
+      "memory_limit": "12GB",
+      "enable_progress_bar": false,
+      "result_cache_enabled": false,
+      "driver_version_actual": "1.4.4",
+      "driver_runtime_strategy": "current-process",
+      "driver_version_resolved": "1.4.4",
+      "driver_package": "duckdb",
+      "driver_runtime_python_executable": "/Users/joe/.local/share/uv/tools/benchbox/bin/python3"
+    },
+    "driver_actual_version": "1.4.4",
+    "driver_package": "duckdb",
+    "driver_resolved_version": "1.4.4",
+    "driver_runtime_strategy": "current-process"
+  },
+  "config": {
+    "compression": {
+      "type": "zstd",
+      "level": null
+    },
+    "phases": [
+      "power"
+    ],
+    "query_subset": [
+      "1",
+      "6"
+    ],
+    "mode": "sql"
+  },
+  "summary": {
+    "queries": {
+      "total": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    "timing": {
+      "total_ms": 36,
+      "avg_ms": 6.0,
+      "min_ms": 5,
+      "max_ms": 7,
+      "geometric_mean_ms": 5.9,
+      "stdev_ms": 0.9
+    },
+    "data": {
+      "rows_loaded": 86805
+    },
+    "validation": "passed",
+    "tpc_metrics": {
+      "power_at_size": 5641.783973382945
+    }
+  },
+  "phases": {
+    "data_generation": {
+      "status": "SUCCESS",
+      "duration_ms": 0
+    },
+    "schema_creation": {
+      "status": "SUCCESS",
+      "duration_ms": 0
+    },
+    "data_loading": {
+      "status": "SUCCESS",
+      "duration_ms": 0
+    },
+    "validation": {
+      "status": "PASSED",
+      "duration_ms": 50
+    },
+    "power_test": {
+      "status": "COMPLETED",
+      "duration_ms": 67
+    },
+    "throughput_test": {
+      "status": "NOT_RUN"
+    }
+  },
+  "queries": [
+    {
+      "id": "1",
+      "ms": 22.001,
+      "rows": 1,
+      "iter": 0,
+      "stream": 0,
+      "run_type": "warmup",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "6",
+      "ms": 6,
+      "rows": 1,
+      "iter": 0,
+      "stream": 0,
+      "run_type": "warmup",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "1",
+      "ms": 7,
+      "rows": 1,
+      "iter": 1,
+      "stream": 1,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "6",
+      "ms": 5,
+      "rows": 1,
+      "iter": 1,
+      "stream": 1,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "1",
+      "ms": 6,
+      "rows": 1,
+      "iter": 2,
+      "stream": 2,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "6",
+      "ms": 6,
+      "rows": 1,
+      "iter": 2,
+      "stream": 2,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "1",
+      "ms": 7,
+      "rows": 1,
+      "iter": 3,
+      "stream": 3,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    },
+    {
+      "id": "6",
+      "ms": 5,
+      "rows": 1,
+      "iter": 3,
+      "stream": 3,
+      "run_type": "measurement",
+      "status": "SUCCESS"
+    }
+  ],
+  "tables": {
+    "customer": {
+      "rows": 1500
+    },
+    "lineitem": {
+      "rows": 60175
+    },
+    "nation": {
+      "rows": 25
+    },
+    "orders": {
+      "rows": 15000
+    },
+    "part": {
+      "rows": 2000
+    },
+    "partsupp": {
+      "rows": 8000
+    },
+    "region": {
+      "rows": 5
+    },
+    "supplier": {
+      "rows": 100
+    }
+  },
+  "cost": {
+    "total_usd": 0,
+    "model": "actual"
+  },
+  "execution": {
+    "entry_point": "cli",
+    "timestamp": "2026-04-27T19:24:35.838974",
+    "compression": {
+      "type": "zstd"
+    },
+    "mode": "sql",
+    "driver_package": "duckdb",
+    "driver_version_resolved": "1.4.4",
+    "driver_version_actual": "1.4.4",
+    "driver_runtime_strategy": "current-process",
+    "driver_runtime_python_executable": "/Users/joe/.local/share/uv/tools/benchbox/bin/python3",
+    "query_subset": [
+      "1",
+      "6"
+    ]
+  },
+  "environment": {
+    "os": "Darwin 25.4.0",
+    "arch": "arm64",
+    "python": "3.12.11",
+    "cpu_count": 10,
+    "memory_gb": 16,
+    "machine_id": "machine_45d1a3ef31a1728d"
+  },
+  "export": {
+    "timestamp": "2026-04-27T19:24:36.130051",
+    "tool": "benchbox-exporter",
+    "anonymized": true
+  }
+}


### PR DESCRIPTION
Test PR for `verify-ci-validation-workflow-end-to-end` w3.

This PR mutates the bundle file AFTER the manifest hash was computed (queries[0].ms: 22 → 22.001). Expected: workflow rejects with a hash-mismatch error citing the offending file path.

**Will be closed without merging.**

Tracking under TODO `verify-ci-validation-workflow-end-to-end`.