### PR TITLE
chore(release): simplify dev loop + release flow (2-command flow + CI churn cuts)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,85 +2,21 @@
 
 ## Description
 
-Brief description of the changes in this PR.
+Brief description of the changes in this PR (the *what* and *why*).
 
 ## Type of Change
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring (no functional changes)
-- [ ] Test improvements
-
-## Related Issues
-
-Closes #(issue number)
-
-## Changes Made
-
--
--
--
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Refactor / chore
 
 ## Testing
 
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have run the existing test suite and all tests pass
-- [ ] I have tested this change with multiple database platforms (if applicable)
+How did you verify the change? Include the commands you ran (e.g.
+`make pr-preflight`, targeted `pytest`, manual smoke).
 
-### Test Commands Run
+## Notes
 
-```bash
-# List the test commands you ran
-make test-fast
-make lint
-make typecheck
-```
-
-## Platform Compatibility
-
-If this change affects platform compatibility, please test on:
-
-- [ ] DuckDB
-- [ ] Databricks (if cloud platform change)
-- [ ] BigQuery (if cloud platform change)
-- [ ] Snowflake (if cloud platform change)
-- [ ] Redshift (if cloud platform change)
-- [ ] ClickHouse (if applicable)
-
-## Documentation
-
-- [ ] I have updated the documentation accordingly
-- [ ] I have updated the CHANGELOG.md file
-- [ ] I have added docstrings to new functions/classes
-- [ ] I have updated CLI help text (if applicable)
-
-## Code Quality
-
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
-- [ ] I have removed any debug print statements
-
-## Performance
-
-If this change affects performance:
-
-- [ ] I have benchmarked the changes
-- [ ] Performance impact is documented
-- [ ] No significant performance regressions
-
-## Alpha Status Considerations
-
-Since BenchBox is in alpha status:
-
-- [ ] I understand that breaking changes are acceptable
-- [ ] I have considered the impact on existing users
-- [ ] API changes are documented in the changelog
-
-## Additional Notes
-
-Add any additional notes, concerns, or areas you'd like reviewers to focus on.
+Anything you want reviewers to focus on (risks, follow-ups, deferred work).

--- a/.github/RELEASE_PR_TEMPLATE.md
+++ b/.github/RELEASE_PR_TEMPLATE.md
@@ -1,9 +1,10 @@
 ## Release v<!-- bump version here -->
 
-This PR was opened by `make release-prepare VERSION=X.Y.Z` from `develop`.
-It cuts the release branch, drops maintainer paths (`_project/`, `_blog/`,
-agent configs, dev-tooling root files), and queues the change for a
-squash-merge into `main`. After merge, tag `main` to fire `release.yml`.
+This PR was opened by `make release-cut VERSION=X.Y.Z` from `develop`.
+It cuts the release branch, bumps the version sources, generates the
+CHANGELOG entry, drops maintainer paths (`_project/`, `_blog/`, agent
+configs, dev-tooling root files), and queues the change for a
+squash-merge into `main`.
 
 ### Reviewer checklist
 
@@ -16,18 +17,21 @@ squash-merge into `main`. After merge, tag `main` to fire `release.yml`.
 - [ ] No surprise file additions (the curation only *removes*)
 - [ ] CI is green on this branch (Tests + Lint workflows must pass)
 
-### After merge
+### After CI green
 
 ```bash
-git checkout main && git pull
-git tag vX.Y.Z && git push origin vX.Y.Z   # triggers .github/workflows/release.yml
-make release-rebase-develop VERSION=X.Y.Z   # rebase develop onto release-shaped main
+make release-finalize VERSION=X.Y.Z
 ```
 
-The `release.yml` workflow runs `check-ci-passed` → `dependency-bounds` →
-`build` (with `SOURCE_DATE_EPOCH` from the tag commit) → `publish` (PyPI
-trusted publisher) → `github-release` → `test-installation` (cross-platform
-pip install verification).
+`release-finalize` squash-merges this PR, fast-forwards `main`, tags
+`vX.Y.Z`, and pushes the tag — which fires `.github/workflows/release.yml`:
+`dependency-bounds` → `build` (with `SOURCE_DATE_EPOCH` from the tag
+commit) → `publish` (PyPI trusted publisher) → `github-release` →
+`test-installation` (cross-platform pip install verification).
+
+`develop` is intentionally NOT modified by `release-finalize`. Dev-only
+paths (`_project/`, `_blog/`, agent configs, etc.) live only on develop
+by design (per A3 in `_project/decisions/single-repo-migration.md`).
 
 If anything fails downstream, fix on a new branch, PR to `main`, squash-merge,
 and bump to the next patch version (PyPI rejects re-uploads of an existing

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
       - develop
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Dependency audit (no unused declarations)
         run: make audit-deps
+
+      - name: Release curation list drift check
+        run: uv run python scripts/check_release_curation.py

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -12,7 +12,10 @@ jobs:
   perf-smoke:
     # Skip when maintainer attaches the skip-perf-smoke label - reserved for
     # intentional baseline shifts or CI-runner flake triage.
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-perf-smoke') }}
+    # Also skip on Release v* PRs (curation + version bumps; nothing perf-affecting).
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'skip-perf-smoke')
+      && !startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,75 +12,10 @@ on:
         type: boolean
 
 jobs:
-  # Wait for CI workflows (Tests + Lint) to pass before building
-  check-ci-passed:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify CI workflows passed for this commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const sha = context.sha;
-
-            console.log(`Checking CI workflows for commit: ${sha}`);
-
-            const requiredWorkflows = ['test.yml', 'lint.yml'];
-            const maxWait = 30 * 60 * 1000;  // 30 minutes
-            const pollInterval = 30 * 1000;  // 30 seconds
-            let waited = 0;
-
-            while (waited < maxWait) {
-              const results = await Promise.all(
-                requiredWorkflows.map(async (workflow) => {
-                  const runs = await github.rest.actions.listWorkflowRuns({
-                    owner, repo,
-                    workflow_id: workflow,
-                    head_sha: sha,
-                  });
-                  return { workflow, run: runs.data.workflow_runs[0] };
-                })
-              );
-
-              let allComplete = true;
-              let anyFailed = false;
-              let failedWorkflow = null;
-
-              for (const { workflow, run } of results) {
-                if (!run) {
-                  console.log(`  ${workflow}: not found, waiting...`);
-                  allComplete = false;
-                } else if (run.status !== 'completed') {
-                  console.log(`  ${workflow}: ${run.status}...`);
-                  allComplete = false;
-                } else if (run.conclusion !== 'success') {
-                  console.log(`  ${workflow}: ${run.conclusion}`);
-                  anyFailed = true;
-                  failedWorkflow = { workflow, run };
-                } else {
-                  console.log(`  ${workflow}: passed`);
-                }
-              }
-
-              if (anyFailed) {
-                core.setFailed(`${failedWorkflow.workflow} ${failedWorkflow.run.conclusion}. See: ${failedWorkflow.run.html_url}`);
-                return;
-              }
-
-              if (allComplete) {
-                console.log(`\nAll CI workflows passed for ${sha}`);
-                return;
-              }
-
-              console.log(`\nWaiting... (${Math.round(waited/1000)}s elapsed)\n`);
-              await new Promise(r => setTimeout(r, pollInterval));
-              waited += pollInterval;
-            }
-
-            core.setFailed(`Timed out waiting for CI workflows after ${maxWait/60000} minutes`);
-
+  # Note: ruleset main-release-only gates the release-cut PR on lint + test
+  # before squash-merge to main, so the tag fired here has already been
+  # CI-validated. The previous check-ci-passed JS poller was redundant.
   dependency-bounds:
-    needs: check-ci-passed
     runs-on: ubuntu-latest
     outputs:
       report_path: ${{ steps.gate.outputs.report_path }}
@@ -117,7 +52,7 @@ jobs:
           retention-days: 90
 
   build:
-    needs: [check-ci-passed, dependency-bounds]
+    needs: dependency-bounds
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
       - develop
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -254,7 +257,9 @@ jobs:
   # CLI↔explorer visualization parity check.
   # Verifies that the checked-in JSON fixtures in tests/parity/fixtures/
   # match the current Python implementations, AND that the Vitest suite passes.
+  # Skipped on Release v* PRs (curation + version bumps don't change fixtures).
   parity:
+    if: ${{ !startsWith(github.event.pull_request.title, 'Release v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ No credentials in repo; use env vars or `.env` (gitignored); redact secrets in l
 
 ## Commits & PRs
 Conventional Commits (feat:, fix:, docs:, test:). PRs link issues, include tests + docs. CI: ruff + typecheck + tests via `make test-ci`.
-Single repo (`origin` → `joeharris76/BenchBox`); two long-lived branches: `develop` (dev work) and `main` (release-only). Dev PRs target `develop`, squash-merge. Releases go through the version-branch flow (`make release-prepare VERSION=X.Y.Z` cuts `vX.Y.Z` from develop, squash-merge to main, tag, then `make release-rebase-develop`). Full runbook: `docs/operations/release-guide.md`.
+Single repo (`origin` → `joeharris76/BenchBox`); two long-lived branches: `develop` (dev work) and `main` (release-only). Dev PRs target `develop`, squash-merge. Releases use a 2-command flow: `make release-cut VERSION=X.Y.Z` (cuts `vX.Y.Z` from develop, bumps version, generates changelog, curates dev-only paths, opens PR vs main) → `make release-finalize VERSION=X.Y.Z` (squash-merges, tags `main`, pushes the tag → `release.yml` publishes to PyPI). `develop` is intentionally not modified post-release. Full runbook: `docs/operations/release-guide.md`.
 
 **`develop` is PR-gated** (no direct push). Required checks: `lint` + `test (ubuntu-latest, 3.12)`. Linear history; squash-only; 0 reviewer approvals required (self-merge is fine).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,15 @@ during the single-repo migration).
   - `make worktree-prune` removes worktrees whose branches are gone
     upstream (post-merge cleanup). Pairs with auto-merge: PR merges →
     branch deleted on origin → next prune sweeps the worktree.
-- **Releases** (version-branch flow): on `develop`, run `make bump
-  VERSION=X.Y.Z` and `make changelog-draft VERSION=X.Y.Z`, then `make
-  release-prepare VERSION=X.Y.Z` cuts the `vX.Y.Z` branch with curated
-  tree → PR → squash-merge to `main` → tag `main` → `release.yml`
-  publishes to PyPI → `make release-rebase-develop VERSION=X.Y.Z`
-  rebases develop. Full runbook: `docs/operations/release-guide.md`.
+- **Releases** (2-command flow): on `develop`, `make release-cut
+  VERSION=X.Y.Z` cuts the `vX.Y.Z` branch, bumps version, drafts the
+  changelog (opens `$EDITOR`), curates dev-only paths, opens the PR vs
+  `main`, and sweeps prior `v*` branches. After CI green, `make
+  release-finalize VERSION=X.Y.Z` squash-merges the PR, tags `main`,
+  and pushes the tag → `release.yml` publishes to PyPI. **`develop` is
+  intentionally not modified post-release** — dev-only paths
+  (`_project/`, `_blog/`, agent configs, etc.) live only on develop by
+  design. Full runbook: `docs/operations/release-guide.md`.
 
 ## Commands
 

--- a/Makefile
+++ b/Makefile
@@ -412,8 +412,11 @@ ci-lint:
 	uv run ruff check .
 	uv run ruff format --check .
 	uv run ty check
-	uv run -- python _project/scripts/sync_codex_shared_skills.py check
 	$(MAKE) lint-markers
+	uv run -- python _project/scripts/sync_codex_shared_skills.py check
+	uv run -- python _project/scripts/timing_policy_check.py --strict
+	$(MAKE) compat-docs-check
+	$(MAKE) audit-deps
 	@echo "✅ CI lint checks passed"
 
 # CI test check - exact match for test.yml workflow (fast tests with coverage)
@@ -712,12 +715,10 @@ release-finalize:
 .PHONY: pr-preflight pr-open pr-status worktree-add worktree-list worktree-prune
 
 # Mirror the CI gate locally before pushing. Catches ~all CI failures
-# without the network roundtrip. Same checks as `lint` ruleset rule.
+# without the network roundtrip. Delegates to ci-lint so the local
+# preflight surface stays in sync with lint.yml automatically.
 pr-preflight:
-	@echo "==> ruff check"
-	@uv run ruff check .
-	@echo "==> ruff format --check"
-	@uv run ruff format --check .
+	@$(MAKE) ci-lint
 	@echo "==> fast tests"
 	@uv run -- python -m pytest -m fast -q
 

--- a/Makefile
+++ b/Makefile
@@ -655,21 +655,26 @@ release-cut:
 	@if [ -n "$$EDITOR" ]; then \
 		echo "==> Opening CHANGELOG.md in $$EDITOR for hand-curation"; \
 		$$EDITOR CHANGELOG.md; \
-	else \
+	elif [ -t 0 ]; then \
 		echo "==> EDITOR unset; skipping interactive CHANGELOG curation"; \
+	else \
+		echo "ERROR: EDITOR unset and no TTY — refusing to skip changelog curation in headless mode." >&2; exit 1; \
 	fi
-	@# Stage version-bump + changelog edits.
-	git add -A
-	@# Curation: drop develop-only paths from the release branch.
-	@# These are paths recorded in A3 of _project/decisions/single-repo-migration.md
-	@# as "develop only". Released wheels never carry these.
+	@# Curation FIRST so dev-only paths are never staged. Order matters: git rm
+	@# before git add ensures untracked files inside _project/ etc. don't end up
+	@# staged-for-add by a later git add.
+	@# Curation list: A3 of _project/decisions/single-repo-migration.md.
 	-git rm -rf _project _blog .claude .codex .gemini
 	-git rm -f .pre-commit-config.yaml _benchbox_pytest_xdist_safety.py todo.config.yaml skill-sync.yaml skill-sync.lock .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md
+	@# Stage only the files update_version.py + generate_changelog_entry.py write.
+	@# Explicit list (not `git add -A`) to avoid staging build/cache artifacts.
+	git add pyproject.toml benchbox/__init__.py landing/index.html README.md docs/README.md benchbox/utils/VERSION_MANAGEMENT.md CHANGELOG.md
 	git commit -m "Release v$(VERSION)"
 	git push -u origin v$(VERSION)
 	gh pr create --base main --head v$(VERSION) --title "Release v$(VERSION)" --body-file .github/RELEASE_PR_TEMPLATE.md
 	@# Option-c lifecycle: delete any prior v* branches on origin (loop sweeps stale entries).
-	@for br in $$(git ls-remote --heads origin 'v*' | awk '{print $$2}' | sed 's|refs/heads/||' | grep -v '^v$(VERSION)$$'); do \
+	@# Use grep -Fxv (literal, full-line match) so version strings with `.` aren't treated as regex.
+	@for br in $$(git ls-remote --heads origin 'v*' | awk '{print $$2}' | sed 's|refs/heads/||' | grep -Fxv "v$(VERSION)"); do \
 		echo "==> Deleting prior release branch on origin: $$br"; \
 		git push origin --delete "$$br" || true; \
 	done
@@ -686,7 +691,7 @@ release-finalize:
 	@test -n "$(VERSION)" || (echo "Usage: make release-finalize VERSION=X.Y.Z" && exit 1)
 	@PR=$$(gh pr list --base main --head v$(VERSION) --state open --json number --jq '.[0].number'); \
 	test -n "$$PR" || (echo "Error: no open PR found for v$(VERSION) → main" && exit 1); \
-	echo "==> Squash-merging PR #$$PR"; \
+	echo "==> Squash-merging PR #$$PR (ruleset main-release-only blocks merge if CI is not green)"; \
 	gh pr merge --squash "$$PR"
 	git fetch origin --tags
 	git checkout main

--- a/Makefile
+++ b/Makefile
@@ -881,4 +881,8 @@ help:
 	@echo "  make worktree-list   List active worktrees"
 	@echo "  make worktree-prune  Remove worktrees whose branches are gone on origin (post-merge cleanup)"
 	@echo ""
+	@echo "Release Workflow (2-command flow; see docs/operations/release-guide.md):"
+	@echo "  make release-cut VERSION=X.Y.Z      Cut v\$$VERSION off develop, bump + changelog + curate, push, open PR vs main"
+	@echo "  make release-finalize VERSION=X.Y.Z Squash-merge the release PR, tag main, push tag (fires release.yml)"
+	@echo ""
 	@echo "  make help            Show this help message"

--- a/Makefile
+++ b/Makefile
@@ -624,41 +624,42 @@ run-test:
 # These targets must be run from the public clone (origin -> joeharris76/BenchBox).
 # Do NOT invoke from the legacy private clone — it has no `origin` remote.
 #
-# Flow: develop -> v$(VERSION) -> (squash) main -> rebase develop -> v$(VERSION+1)
-# See docs/operations/release-guide.md and _project/decisions/single-repo-migration.md (A4).
+# Flow: develop -> v$(VERSION) -> (squash) main -> tag main -> release.yml publishes
+#   develop is intentionally NOT modified post-release. dev-only paths
+#   (_project/, _blog/, AGENTS.md, etc.) live on develop and are removed
+#   from the release branch by release-cut's curation step.
+#
+# See docs/operations/release-guide.md and _project/decisions/single-repo-migration.md.
 
-.PHONY: bump changelog-draft release-prepare release-rebase-develop
+.PHONY: release-cut release-finalize
 
-# Bump version in __init__.py, pyproject.toml, docs landing pages.
-# Usage: make bump VERSION=X.Y.Z
-bump:
-	@test -n "$(VERSION)" || (echo "Usage: make bump VERSION=X.Y.Z" && exit 1)
-	uv run python scripts/update_version.py --version $(VERSION) --update-pyproject
-
-# Draft a CHANGELOG.md entry from conventional commits since the last v* tag.
-# Auto-summarises with Claude CLI when available; falls back to raw bullets.
-# Usage: make changelog-draft VERSION=X.Y.Z
-changelog-draft:
-	@test -n "$(VERSION)" || (echo "Usage: make changelog-draft VERSION=X.Y.Z" && exit 1)
-	uv run python scripts/generate_changelog_entry.py --version $(VERSION)
-
-# Cut the release branch from develop, drop maintainer paths, push, open PR.
-# Pre-conditions enforced:
-#   - Currently on develop branch
-#   - Working tree clean
-#   - pyproject.toml version already matches $(VERSION) (run `make bump` first)
-# Usage: make release-prepare VERSION=X.Y.Z
-release-prepare:
-	@test -n "$(VERSION)" || (echo "Usage: make release-prepare VERSION=X.Y.Z" && exit 1)
+# Cut a release branch from develop in one shot:
+#   1. Create v$(VERSION) branch off develop (develop is not modified).
+#   2. On v$(VERSION): bump version sources (scripts/update_version.py).
+#   3. On v$(VERSION): generate CHANGELOG.md entry.
+#   4. $EDITOR opens CHANGELOG.md for hand-curation (skipped if EDITOR unset).
+#   5. Curate: git rm dev-only paths (per A3 in single-repo-migration.md).
+#   6. Commit "Release v$(VERSION)" (bump + changelog + curation in one squash-friendly commit).
+#   7. Push, open PR vs main.
+#   8. Sweep stale v* branches on origin (option-c lifecycle).
+# Pre-conditions: on develop, clean tree.
+# Usage: make release-cut VERSION=X.Y.Z
+release-cut:
+	@test -n "$(VERSION)" || (echo "Usage: make release-cut VERSION=X.Y.Z" && exit 1)
 	@[ "$$(git rev-parse --abbrev-ref HEAD)" = "develop" ] || (echo "Error: must be on develop branch" && exit 1)
 	@[ -z "$$(git status --porcelain)" ] || (echo "Error: working tree must be clean" && exit 1)
-	@grep -q '^version = "$(VERSION)"$$' pyproject.toml || (echo "Error: pyproject.toml version is not $(VERSION); run 'make bump VERSION=$(VERSION)' first" && exit 1)
 	git fetch origin
-	@# Anchor pre-release point on develop so the post-release rebase knows
-	@# which commits to drop from develop (everything up to this anchor was
-	@# squashed into the release commit; only later commits should replay).
-	git tag pre-release-v$(VERSION) develop
 	git checkout -b v$(VERSION) develop
+	uv run python scripts/update_version.py --version $(VERSION) --update-pyproject
+	uv run python scripts/generate_changelog_entry.py --version $(VERSION)
+	@if [ -n "$$EDITOR" ]; then \
+		echo "==> Opening CHANGELOG.md in $$EDITOR for hand-curation"; \
+		$$EDITOR CHANGELOG.md; \
+	else \
+		echo "==> EDITOR unset; skipping interactive CHANGELOG curation"; \
+	fi
+	@# Stage version-bump + changelog edits.
+	git add -A
 	@# Curation: drop develop-only paths from the release branch.
 	@# These are paths recorded in A3 of _project/decisions/single-repo-migration.md
 	@# as "develop only". Released wheels never carry these.
@@ -667,31 +668,34 @@ release-prepare:
 	git commit -m "Release v$(VERSION)"
 	git push -u origin v$(VERSION)
 	gh pr create --base main --head v$(VERSION) --title "Release v$(VERSION)" --body-file .github/RELEASE_PR_TEMPLATE.md
+	@# Option-c lifecycle: delete any prior v* branches on origin (loop sweeps stale entries).
+	@for br in $$(git ls-remote --heads origin 'v*' | awk '{print $$2}' | sed 's|refs/heads/||' | grep -v '^v$(VERSION)$$'); do \
+		echo "==> Deleting prior release branch on origin: $$br"; \
+		git push origin --delete "$$br" || true; \
+	done
 	@echo
 	@echo "Release PR opened. Next steps:"
-	@echo "  1. Review the PR. Confirm CHANGELOG.md is correct and curation looks right."
-	@echo "  2. Squash-merge the PR on GitHub."
-	@echo "  3. git checkout main && git pull && git tag v$(VERSION) && git push origin v$(VERSION)"
-	@echo "  4. Watch .github/workflows/release.yml run; verify PyPI publish."
-	@echo "  5. make release-rebase-develop VERSION=$(VERSION)"
+	@echo "  1. Review the PR diff; confirm CHANGELOG and curation are correct."
+	@echo "  2. Wait for CI green."
+	@echo "  3. make release-finalize VERSION=$(VERSION)"
 
-# After release-prepare's PR is squash-merged and tag pushed, rebase develop
-# onto main so the next dev cycle starts from the release-shaped state.
-# Usage: make release-rebase-develop VERSION=X.Y.Z
-release-rebase-develop:
-	@test -n "$(VERSION)" || (echo "Usage: make release-rebase-develop VERSION=X.Y.Z" && exit 1)
+# After release-cut's PR is approved and CI is green: squash-merge it,
+# tag main, push the tag (fires release.yml), and leave develop alone.
+# Usage: make release-finalize VERSION=X.Y.Z
+release-finalize:
+	@test -n "$(VERSION)" || (echo "Usage: make release-finalize VERSION=X.Y.Z" && exit 1)
+	@PR=$$(gh pr list --base main --head v$(VERSION) --state open --json number --jq '.[0].number'); \
+	test -n "$$PR" || (echo "Error: no open PR found for v$(VERSION) → main" && exit 1); \
+	echo "==> Squash-merging PR #$$PR"; \
+	gh pr merge --squash "$$PR"
 	git fetch origin --tags
-	@[ -n "$$(git tag -l v$(VERSION))" ] || (echo "Error: tag v$(VERSION) not found locally" && exit 1)
-	@[ -n "$$(git tag -l pre-release-v$(VERSION))" ] || (echo "Error: anchor tag pre-release-v$(VERSION) not found (was release-prepare run?)" && exit 1)
-	@git merge-base --is-ancestor v$(VERSION) origin/main || (echo "Error: tag v$(VERSION) is not on origin/main; squash-merge the release PR first" && exit 1)
-	git checkout develop
-	git pull --ff-only origin develop
-	git rebase --onto main pre-release-v$(VERSION) develop
-	git push --force-with-lease origin develop
-	git tag -d pre-release-v$(VERSION)
+	git checkout main
+	git pull --ff-only origin main
+	git tag v$(VERSION)
+	git push origin v$(VERSION)
 	@echo
-	@echo "develop rebased onto main."
-	@echo "Per option-c lifecycle: previous release branch (e.g. vPREV) can be deleted on the next release-prepare run."
+	@echo "Tag v$(VERSION) pushed; release.yml will publish to PyPI."
+	@echo "develop is intentionally unchanged — dev-only paths persist on develop."
 
 # =============================================================================
 # PR + worktree workflow

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:43.457427'
+generated_at: '2026-04-27T21:01:12.817306'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:20.421359'
+generated_at: '2026-04-27T21:10:43.356860'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:33.526181'
+generated_at: '2026-04-27T21:04:20.713596'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T15:06:34.102069'
+generated_at: '2026-04-27T20:24:56.781159'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:20.713596'
+generated_at: '2026-04-27T21:06:20.421359'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:53.685838'
+generated_at: '2026-04-27T21:16:43.565238'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:12.817306'
+generated_at: '2026-04-27T21:02:33.526181'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:56.781159'
+generated_at: '2026-04-27T20:53:43.457427'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:43.356860'
+generated_at: '2026-04-27T21:13:53.685838'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:16:43.565238'
+generated_at: '2026-04-28T09:25:56.220215'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':
@@ -3500,8 +3500,13 @@ categories:
       priority: Critical
       status: Completed
   Release Tooling:
-    count: 9
+    count: 10
     items:
+    - id: simplify-dev-loop-and-release-flow
+      file: DONE/main/active/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      priority: High
+      status: Completed
     - id: single-repo-migration-phase-0-audit
       file: DONE/main/planning/single-repo-migration-phase-0-audit.yaml
       title: 'Single-repo migration phase 0: gitleaks scan and content audit (working tree + _project/** history + divergence

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:20.421538'
+generated_at: '2026-04-27T21:10:43.357058'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:53.686044'
+generated_at: '2026-04-27T21:16:43.565559'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:33.526413'
+generated_at: '2026-04-27T21:04:20.714455'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:20.714455'
+generated_at: '2026-04-27T21:06:20.421538'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:12.817502'
+generated_at: '2026-04-27T21:02:33.526413'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T21:16:43.565559'
-total_items: 780
+generated_at: '2026-04-28T09:25:56.220393'
+total_items: 781
 priorities:
   Critical:
     count: 45
@@ -231,7 +231,7 @@ priorities:
       category: Benchmark Implementation - Critical Fixes
       status: Completed
   High:
-    count: 267
+    count: 268
     items:
     - id: standardize-primitives-tpc-h-data-sharing-manifest-reuse
       file: DONE/unknown/completed/standardize-primitives-tpc-h-data-sharing-manifest-reuse.yaml
@@ -1274,6 +1274,11 @@ priorities:
       file: DONE/main/planning/explorer-align-ranking-metric-with-tpc-standards.yaml
       title: Select ranking metric per benchmark family (power_score for TPC, geomean elsewhere)
       category: Core Functionality
+      status: Completed
+    - id: simplify-dev-loop-and-release-flow
+      file: DONE/main/active/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      category: Release Tooling
       status: Completed
     - id: single-repo-migration-phase-1-wheel-hygiene
       file: DONE/main/planning/single-repo-migration-phase-1-wheel-hygiene.yaml

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T15:06:34.102274'
+generated_at: '2026-04-27T20:24:56.781373'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:43.357058'
+generated_at: '2026-04-27T21:13:53.686044'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:43.457617'
+generated_at: '2026-04-27T21:01:12.817502'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:56.781373'
+generated_at: '2026-04-27T20:53:43.457617'
 total_items: 780
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:53.686238'
+generated_at: '2026-04-27T21:16:43.565835'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:12.817683'
+generated_at: '2026-04-27T21:02:33.526631'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:56.781568'
+generated_at: '2026-04-27T20:53:43.457801'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:20.421721'
+generated_at: '2026-04-27T21:10:43.357244'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T15:06:34.102467'
+generated_at: '2026-04-27T20:24:56.781568'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:43.457801'
+generated_at: '2026-04-27T21:01:12.817683'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T21:16:43.565835'
-total_items: 780
+generated_at: '2026-04-28T09:25:56.220559'
+total_items: 781
 statuses:
   In Progress:
     count: 2
@@ -266,7 +266,7 @@ statuses:
       priority: High
       category: Pre-Release High Priority Tasks (Should-Fix Before Release)
   Completed:
-    count: 729
+    count: 730
     items:
     - id: cli-test-coverage-enhancement-to-80
       file: DONE/unknown/planning/cli-test-coverage-enhancement-to-80.yaml
@@ -3180,6 +3180,11 @@ statuses:
       title: Simplify data generator and pipeline loading functions (complexity batch 5)
       priority: Medium
       category: Core Functionality
+    - id: simplify-dev-loop-and-release-flow
+      file: DONE/main/active/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      priority: High
+      category: Release Tooling
     - id: simplify-dataframe-extra-naming
       file: DONE/main/active/simplify-dataframe-extra-naming.yaml
       title: 'Simplify pyproject.toml extras: add plain-name aliases and unify DataFrame platform extras'

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:43.357244'
+generated_at: '2026-04-27T21:13:53.686238'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:33.526631'
+generated_at: '2026-04-27T21:04:20.716053'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:20.716053'
+generated_at: '2026-04-27T21:06:20.421721'
 total_items: 780
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:33.525765'
+generated_at: '2026-04-27T21:04:20.712482'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:12.816941'
+generated_at: '2026-04-27T21:02:33.525765'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:43.356513'
+generated_at: '2026-04-27T21:13:53.685430'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:53.685430'
+generated_at: '2026-04-27T21:16:43.564619'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:20.420999'
+generated_at: '2026-04-27T21:10:43.356513'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:20.712482'
+generated_at: '2026-04-27T21:06:20.420999'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:43.457099'
+generated_at: '2026-04-27T21:01:12.816941'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T15:06:34.101690'
+generated_at: '2026-04-27T20:24:56.780757'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T21:16:43.564619'
-total_items: 780
+generated_at: '2026-04-28T09:25:56.219895'
+total_items: 781
 items:
 - id: interactive-wizard-dry-run-support
   file: DONE/ux-improvements/planning/interactive-wizard-dry-run-support.yaml
@@ -4002,6 +4002,26 @@ items:
   work_ready: 0
   needs:
   - explorer-emit-benchmark-summary-artifact
+- id: simplify-dev-loop-and-release-flow
+  file: DONE/main/active/simplify-dev-loop-and-release-flow.yaml
+  title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+  worktree: main
+  category: Release Tooling
+  priority: High
+  status: Completed
+  tags:
+  - release
+  - dev-loop
+  - tooling
+  - simplification
+  estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
+  completed_date: '2026-04-28'
+  work_total: 11
+  work_done: 11
+  work_ready: 0
+  deferred_count: 2
+  needs:
+  - single-repo-migration-phase-4-test-release-with-new-flow
 - id: single-repo-migration-phase-1-wheel-hygiene
   file: DONE/main/planning/single-repo-migration-phase-1-wheel-hygiene.yaml
   title: 'Single-repo migration phase 1: pyproject.toml and MANIFEST.in excludes for clean wheel'

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:56.780757'
+generated_at: '2026-04-27T20:53:43.457099'
 total_items: 780
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/DONE/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -2,7 +2,8 @@ id: simplify-dev-loop-and-release-flow
 title: "Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug"
 worktree: main
 priority: High
-status: In Progress
+status: Completed
+completed_date: "2026-04-28"
 category: Release Tooling
 
 deps:
@@ -332,58 +333,6 @@ work:
 
     Estimated savings: ~25 CI-min per release PR (one perf-smoke
     leg + one parity leg).
-
-- id: w9
-  summary: "Dry-run on 0.3.0-rc.1 to validate the flow end-to-end"
-  needs: [w1, w2, w3, w4, w5, w6, w7, w8, w10, w11, w12]
-  status: pending
-  notes: |
-    The first real release after migration is the validation. Use
-    a pre-release tag so a botched dry-run isn't catastrophic
-    (PyPI accepts rc tags).
-
-    Procedure:
-      1. From a worktree on develop:
-         make release-cut VERSION=0.3.0-rc.1
-      2. Inspect PR diff:
-         gh pr diff <PR#> | head -200
-         Confirm: only curation removals + version bumps + changelog;
-         no surprise additions.
-      3. Inspect release branch tree:
-         git ls-tree -d --name-only origin/v0.3.0-rc.1
-         Confirm absent: _project, _blog, .claude, .codex, .gemini.
-      4. Wait for CI green on PR.
-      5. From develop worktree:
-         make release-finalize VERSION=0.3.0-rc.1
-      6. Verify develop unchanged:
-         git diff origin/develop develop  # empty
-      7. Verify dev-only paths preserved on develop:
-         test -d _project && test -d _blog && test -f AGENTS.md && \
-           test -f CLAUDE.md && test -f GEMINI.md && echo OK
-      8. Verify release.yml published:
-         gh run list --workflow=release.yml --limit 1 --json conclusion --jq '.[0].conclusion'
-         pip index versions benchbox 2>&1 | grep 0.3.0-rc.1
-      9. Verify previous v* branch deletion (no-op for first run
-         since v0.2.1 was a legacy two-repo release without a v*
-         branch):
-         git ls-remote --heads origin 'v*'
-         # Should show only refs/heads/v0.3.0-rc.1.
-     10. Verify CI optimizations (w10/w11/w12):
-         a. perf-smoke skipped on release PR (w12):
-            gh pr view <release-PR#> --json statusCheckRollup \
-              --jq '.statusCheckRollup[] | select(.name|test("perf-smoke|parity"))'
-            # Both should be absent (job didn't fire).
-         b. After release-finalize, no push-CI on develop (w10):
-            (Develop didn't change, so this is trivially true. Validate
-            on the next regular feature-PR squash-merge instead:
-            gh run list --workflow=test.yml --branch develop --event push --limit 1
-            # No run after the squash-merge SHA.)
-         c. concurrency cancellation (w11): force-push to a feature
-            branch during CI; the older lint/test runs show as
-            "cancelled" in the Actions UI.
-
-    If any step fails, the rc tag is the only artifact published;
-    fix and bump to rc.2.
 
 deferred:
 - summary: "Consolidate version sources from 6 to 2 (pyproject.toml + __init__.py)"

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:41.635330'
+generated_at: '2026-04-27T21:01:10.463253'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:51.676493'
+generated_at: '2026-04-27T21:16:40.625894'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:10.463253'
+generated_at: '2026-04-27T21:02:30.090691'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:16:40.625894'
+generated_at: '2026-04-28T09:25:54.350425'
 total_categories: 11
 categories:
   Architecture & Refactoring:
@@ -132,11 +132,11 @@ categories:
   Release Tooling:
     count: 4
     items:
-    - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
-      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+    - id: release-flow-dry-run-rc1
+      file: TODO/main/active/release-flow-dry-run-rc1.yaml
+      title: Dry-run release on 0.3.0-rc.1 to validate the 2-command flow end-to-end
       priority: High
-      status: In Progress
+      status: Not Started
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:18.522114'
+generated_at: '2026-04-27T21:10:41.524124'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:41.524124'
+generated_at: '2026-04-27T21:13:51.676493'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:54.790193'
+generated_at: '2026-04-27T20:53:41.635330'
 total_categories: 11
 categories:
   Architecture & Refactoring:
@@ -133,10 +133,10 @@ categories:
     count: 4
     items:
     - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
       title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
       priority: High
-      status: Not Started
+      status: In Progress
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:30.090691'
+generated_at: '2026-04-27T21:04:16.957737'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:16.957737'
+generated_at: '2026-04-27T21:06:18.522114'
 total_categories: 11
 categories:
   Architecture & Refactoring:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T15:06:32.171985'
+generated_at: '2026-04-27T20:24:54.790193'
 total_categories: 11
 categories:
   Architecture & Refactoring:
@@ -130,8 +130,13 @@ categories:
       priority: Low
       status: Not Started
   Release Tooling:
-    count: 3
+    count: 4
     items:
+    - id: simplify-dev-loop-and-release-flow
+      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      priority: High
+      status: Not Started
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:51.676513'
+generated_at: '2026-04-27T21:16:40.625917'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T15:06:32.172001'
-total_items: 33
+generated_at: '2026-04-27T20:24:54.790215'
+total_items: 34
 priorities:
   Critical:
     count: 1
@@ -10,7 +10,7 @@ priorities:
       category: Testing and Quality Assurance
       status: Not Started
   High:
-    count: 5
+    count: 6
     items:
     - id: design-results-ingest-storage-and-derived-read-model
       file: TODO/main/planning/design-results-ingest-storage-and-derived-read-model.yaml
@@ -31,6 +31,11 @@ priorities:
       file: TODO/main/planning/external-contributor-submission-dry-run.yaml
       title: Run a Phase 2 dry-run with one external trusted contributor
       category: Testing and Quality Assurance
+      status: Not Started
+    - id: simplify-dev-loop-and-release-flow
+      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      category: Release Tooling
       status: Not Started
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:54.790215'
+generated_at: '2026-04-27T20:53:41.635349'
 total_items: 34
 priorities:
   Critical:
@@ -33,10 +33,10 @@ priorities:
       category: Testing and Quality Assurance
       status: Not Started
     - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
       title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
       category: Release Tooling
-      status: Not Started
+      status: In Progress
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:30.090713'
+generated_at: '2026-04-27T21:04:16.957756'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:41.635349'
+generated_at: '2026-04-27T21:01:10.463290'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:16:40.625917'
+generated_at: '2026-04-28T09:25:54.350438'
 total_items: 34
 priorities:
   Critical:
@@ -17,6 +17,11 @@ priorities:
       title: Design results ingest, storage, and derived read-model architecture
       category: Core Functionality
       status: Not Started
+    - id: release-flow-dry-run-rc1
+      file: TODO/main/active/release-flow-dry-run-rc1.yaml
+      title: Dry-run release on 0.3.0-rc.1 to validate the 2-command flow end-to-end
+      category: Release Tooling
+      status: Not Started
     - id: integrate-benchbox-cli-submit-and-service-auth
       file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
       title: Integrate BenchBox CLI submission flow and service authentication
@@ -32,11 +37,6 @@ priorities:
       title: Run a Phase 2 dry-run with one external trusted contributor
       category: Testing and Quality Assurance
       status: Not Started
-    - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
-      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
-      category: Release Tooling
-      status: In Progress
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:18.522132'
+generated_at: '2026-04-27T21:10:41.524144'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:41.524144'
+generated_at: '2026-04-27T21:13:51.676513'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:10.463290'
+generated_at: '2026-04-27T21:02:30.090713'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:16.957756'
+generated_at: '2026-04-27T21:06:18.522132'
 total_items: 34
 priorities:
   Critical:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:18.522143'
+generated_at: '2026-04-27T21:10:41.524153'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:41.635359'
+generated_at: '2026-04-27T21:01:10.463313'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,26 +1,21 @@
-generated_at: '2026-04-27T21:16:40.625929'
+generated_at: '2026-04-28T09:25:54.350447'
 total_items: 34
 statuses:
   In Progress:
-    count: 3
+    count: 2
     items:
     - id: timing-policy-split-review-followups
       file: TODO/main/active/timing-policy-split-review-followups.yaml
       title: Address follow-up findings from timing-policy pre-commit split review
       priority: Medium
       category: Testing & Quality
-    - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
-      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
-      priority: High
-      category: Release Tooling
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'
       priority: High
       category: Release Tooling
   Not Started:
-    count: 30
+    count: 31
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -62,6 +57,11 @@ statuses:
       title: Design results ingest, storage, and derived read-model architecture
       priority: High
       category: Core Functionality
+    - id: release-flow-dry-run-rc1
+      file: TODO/main/active/release-flow-dry-run-rc1.yaml
+      title: Dry-run release on 0.3.0-rc.1 to validate the 2-command flow end-to-end
+      priority: High
+      category: Release Tooling
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:51.676524'
+generated_at: '2026-04-27T21:16:40.625929'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:30.090724'
+generated_at: '2026-04-27T21:04:16.957767'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,21 +1,26 @@
-generated_at: '2026-04-27T20:24:54.790226'
+generated_at: '2026-04-27T20:53:41.635359'
 total_items: 34
 statuses:
   In Progress:
-    count: 2
+    count: 3
     items:
     - id: timing-policy-split-review-followups
       file: TODO/main/active/timing-policy-split-review-followups.yaml
       title: Address follow-up findings from timing-policy pre-commit split review
       priority: Medium
       category: Testing & Quality
+    - id: simplify-dev-loop-and-release-flow
+      file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      priority: High
+      category: Release Tooling
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
       title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'
       priority: High
       category: Release Tooling
   Not Started:
-    count: 31
+    count: 30
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -122,11 +127,6 @@ statuses:
       title: Schedule a checkpoint to evaluate extracting results-data/ to its own repo
       priority: Low
       category: Core Functionality
-    - id: simplify-dev-loop-and-release-flow
-      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
-      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
-      priority: High
-      category: Release Tooling
     - id: single-repo-migration-phase-8-first-post-migration-release
       file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
       title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:16.957767'
+generated_at: '2026-04-27T21:06:18.522143'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:10.463313'
+generated_at: '2026-04-27T21:02:30.090724'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:41.524153'
+generated_at: '2026-04-27T21:13:51.676524'
 total_items: 34
 statuses:
   In Progress:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T15:06:32.172011'
-total_items: 33
+generated_at: '2026-04-27T20:24:54.790226'
+total_items: 34
 statuses:
   In Progress:
     count: 2
@@ -15,7 +15,7 @@ statuses:
       priority: High
       category: Release Tooling
   Not Started:
-    count: 30
+    count: 31
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -122,6 +122,11 @@ statuses:
       title: Schedule a checkpoint to evaluate extracting results-data/ to its own repo
       priority: Low
       category: Core Functionality
+    - id: simplify-dev-loop-and-release-flow
+      file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+      title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+      priority: High
+      category: Release Tooling
     - id: single-repo-migration-phase-8-first-post-migration-release
       file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
       title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T15:06:32.171948'
-total_items: 33
+generated_at: '2026-04-27T20:24:54.790158'
+total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
   file: TODO/main/planning/verify-ci-validation-workflow-end-to-end.yaml
@@ -97,6 +97,25 @@ items:
   - verify-ci-validation-workflow-end-to-end
   - verify-trust-badge-rendering-in-explorer
   - surface-contributor-onboarding-for-results
+- id: simplify-dev-loop-and-release-flow
+  file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+  title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
+  worktree: main
+  category: Release Tooling
+  priority: High
+  status: Not Started
+  tags:
+  - release
+  - dev-loop
+  - tooling
+  - simplification
+  estimated_effort: ~6h spread across 1-2 days
+  work_total: 9
+  work_done: 0
+  work_ready: 4
+  deferred_count: 2
+  needs:
+  - single-repo-migration-phase-4-test-release-with-new-flow
 - id: single-repo-migration-phase-4-test-release-with-new-flow
   file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
   title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:10:41.524094'
+generated_at: '2026-04-27T21:13:51.676460'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,8 +111,8 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 7
-  work_ready: 4
+  work_done: 10
+  work_ready: 1
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:16:40.625848'
+generated_at: '2026-04-28T09:25:54.350396'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -40,6 +40,24 @@ items:
   needs:
   - define-results-platform-product-and-launch-strategy
   - define-hosted-results-contract-and-governance-model
+- id: release-flow-dry-run-rc1
+  file: TODO/main/active/release-flow-dry-run-rc1.yaml
+  title: Dry-run release on 0.3.0-rc.1 to validate the 2-command flow end-to-end
+  worktree: main
+  category: Release Tooling
+  priority: High
+  status: Not Started
+  tags:
+  - release
+  - validation
+  - rc
+  - pypi
+  estimated_effort: ~1h interactive (release-cut to release-finalize), plus ~15 min release.yml CI wait
+  work_total: 6
+  work_done: 0
+  work_ready: 1
+  needs:
+  - simplify-dev-loop-and-release-flow
 - id: integrate-benchbox-cli-submit-and-service-auth
   file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
   title: Integrate BenchBox CLI submission flow and service authentication
@@ -97,25 +115,6 @@ items:
   - verify-ci-validation-workflow-end-to-end
   - verify-trust-badge-rendering-in-explorer
   - surface-contributor-onboarding-for-results
-- id: simplify-dev-loop-and-release-flow
-  file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
-  title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
-  worktree: main
-  category: Release Tooling
-  priority: High
-  status: In Progress
-  tags:
-  - release
-  - dev-loop
-  - tooling
-  - simplification
-  estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
-  work_total: 12
-  work_done: 11
-  work_ready: 1
-  deferred_count: 2
-  needs:
-  - single-repo-migration-phase-4-test-release-with-new-flow
 - id: single-repo-migration-phase-4-test-release-with-new-flow
   file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
   title: 'Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)'

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:04:16.957701'
+generated_at: '2026-04-27T21:06:18.522081'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,8 +111,8 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 5
-  work_ready: 6
+  work_done: 6
+  work_ready: 5
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:24:54.790158'
+generated_at: '2026-04-27T20:53:41.635288'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -98,21 +98,21 @@ items:
   - verify-trust-badge-rendering-in-explorer
   - surface-contributor-onboarding-for-results
 - id: simplify-dev-loop-and-release-flow
-  file: TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+  file: TODO/main/active/simplify-dev-loop-and-release-flow.yaml
   title: 'Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug'
   worktree: main
   category: Release Tooling
   priority: High
-  status: Not Started
+  status: In Progress
   tags:
   - release
   - dev-loop
   - tooling
   - simplification
-  estimated_effort: ~6h spread across 1-2 days
-  work_total: 9
-  work_done: 0
-  work_ready: 4
+  estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
+  work_total: 12
+  work_done: 2
+  work_ready: 6
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:06:18.522081'
+generated_at: '2026-04-27T21:10:41.524094'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,8 +111,8 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 6
-  work_ready: 5
+  work_done: 7
+  work_ready: 4
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:01:10.463184'
+generated_at: '2026-04-27T21:02:30.090646'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,7 +111,7 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 3
+  work_done: 4
   work_ready: 5
   deferred_count: 2
   needs:

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:02:30.090646'
+generated_at: '2026-04-27T21:04:16.957701'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,8 +111,8 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 4
-  work_ready: 5
+  work_done: 5
+  work_ready: 6
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:53:41.635288'
+generated_at: '2026-04-27T21:01:10.463184'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,8 +111,8 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 2
-  work_ready: 6
+  work_done: 3
+  work_ready: 5
   deferred_count: 2
   needs:
   - single-repo-migration-phase-4-test-release-with-new-flow

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T21:13:51.676460'
+generated_at: '2026-04-27T21:16:40.625848'
 total_items: 34
 items:
 - id: verify-ci-validation-workflow-end-to-end
@@ -111,7 +111,7 @@ items:
   - simplification
   estimated_effort: ~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)
   work_total: 12
-  work_done: 10
+  work_done: 11
   work_ready: 1
   deferred_count: 2
   needs:

--- a/_project/TODO/main/active/release-flow-dry-run-rc1.yaml
+++ b/_project/TODO/main/active/release-flow-dry-run-rc1.yaml
@@ -1,0 +1,272 @@
+id: release-flow-dry-run-rc1
+title: "Dry-run release on 0.3.0-rc.1 to validate the 2-command flow end-to-end"
+worktree: main
+priority: High
+status: Not Started
+category: Release Tooling
+
+deps:
+  needs:
+  - simplify-dev-loop-and-release-flow
+
+description: |
+  Split out from simplify-dev-loop-and-release-flow w9 (2026-04-28). The
+  parent TODO landed the new 2-command flow (release-cut /
+  release-finalize) plus the CI churn cuts (w10/w11/w12) and the
+  curation-drift guard (w7). This follow-up exercises the whole flow
+  end-to-end on a pre-release tag before any real X.Y.Z version goes
+  out.
+
+  Why a dry-run is necessary: the latent rebase-develop bug that the
+  parent TODO fixed only surfaces on a real release, so the only
+  validation gate is to actually cut + finalize a release. Using a
+  pre-release rc tag (PEP 440 normalized to 0.3.0rc1 on PyPI) means a
+  botched run isn't catastrophic — fix and bump to rc.2.
+
+  Hard prerequisites (must be true before invoking release-cut):
+    1. PR #34 (chore/todo-simplify-dev-loop) merged to develop, so the
+       new Make targets exist on develop.
+    2. Explicit user authorization — PyPI publishing is irreversible
+       and the tag is public.
+
+  Out of scope: the 0.3.0 GA cut. This TODO closes when 0.3.0-rc.1 has
+  validated the flow; bumping to 0.3.0 is a separate decision made by
+  the user once the rc is verified.
+
+work:
+- id: w1
+  summary: "Run release-cut VERSION=0.3.0-rc.1 from a develop worktree"
+  status: pending
+  notes: |
+    Prereq: get explicit user authorization first.
+
+    Procedure:
+      cd ~/Developer/BenchBox  # must be on develop, clean tree
+      git fetch origin && git checkout develop && git pull --ff-only
+      make worktree-add BRANCH=release-test-rc1  # optional isolation
+      cd ../BenchBox.release-test-rc1            # if using worktree
+      make release-cut VERSION=0.3.0-rc.1
+
+    Expected behavior:
+      - Cuts v0.3.0-rc.1 branch off develop.
+      - Bumps the 6 version sources via scripts/update_version.py.
+      - Generates CHANGELOG entry, opens $EDITOR for hand-curation.
+      - git rm's the dev-only paths (curation step).
+      - Commits "Release v0.3.0-rc.1" and pushes.
+      - Opens PR vs main with .github/RELEASE_PR_TEMPLATE.md body.
+      - Sweeps prior v* branches (no-op for first run since v0.2.1 was
+        a legacy two-repo release without a v* branch).
+
+- id: w2
+  summary: "Inspect PR diff and release branch tree before merging"
+  needs: [w1]
+  status: pending
+  notes: |
+    Procedure:
+      gh pr diff <PR#> | head -200
+      # Confirm: only curation removals + version bumps + changelog;
+      # no surprise additions.
+
+      git ls-tree -d --name-only origin/v0.3.0-rc.1
+      # Confirm absent: _project, _blog, .claude, .codex, .gemini.
+
+    Bail out (close PR, delete branch, fix root cause) if anything
+    unexpected lands on the release branch.
+
+- id: w3
+  summary: "Wait for CI green on the release PR"
+  needs: [w2]
+  status: pending
+  notes: |
+    Required checks per ruleset main-release-only: lint + test
+    (ubuntu-latest, 3.12). perf-smoke and parity should be SKIPPED
+    (validates w12 from the parent TODO).
+
+    Verification of w12: gh pr view <release-PR#> --json
+    statusCheckRollup --jq '.statusCheckRollup[] | select(.name |
+    test("perf-smoke|parity"))' should return empty (jobs didn't fire).
+
+- id: w4
+  summary: "Run release-finalize VERSION=0.3.0-rc.1"
+  needs: [w3]
+  status: pending
+  notes: |
+    Procedure:
+      cd ~/Developer/BenchBox  # main clone on develop
+      make release-finalize VERSION=0.3.0-rc.1
+
+    Expected behavior:
+      - Squash-merges the release PR (gh pr merge --squash).
+      - Fast-forwards main locally and tags v0.3.0-rc.1.
+      - Pushes the tag → fires release.yml.
+      - Leaves develop untouched.
+
+- id: w5
+  summary: "Verify post-release invariants"
+  needs: [w4]
+  status: pending
+  notes: |
+    Verification commands (all must pass):
+
+      # develop unchanged
+      git diff origin/develop develop  # empty
+
+      # dev-only paths preserved on develop
+      test -d _project && test -d _blog && test -f AGENTS.md && \
+        test -f CLAUDE.md && test -f GEMINI.md && echo OK
+
+      # main is curated
+      git ls-tree -d --name-only origin/main | \
+        grep -E '^(_project|_blog|\.claude|\.codex|\.gemini)$' | wc -l
+      # → 0
+
+      # release.yml succeeded
+      gh run list --workflow=release.yml --limit 1 --json conclusion \
+        --jq '.[0].conclusion'
+      # → success
+
+      # PyPI published (PEP 440 normalizes to 0.3.0rc1)
+      pip index versions benchbox 2>&1 | grep -cE '0\.3\.0(rc1|-rc\.1)'
+      # → at least 1
+
+      # GH release created
+      gh release view v0.3.0-rc.1
+
+      # Cross-platform install matrix passed
+      gh run view <release-run-id> --log | grep test-installation
+
+      # No leftover v* branches besides the new one
+      git ls-remote --heads origin 'v*'
+      # → only refs/heads/v0.3.0-rc.1
+
+- id: w6
+  summary: "Verify CI optimizations from parent TODO held up under real release"
+  needs: [w4]
+  status: pending
+  notes: |
+    Validates w10/w11/w12 in production conditions:
+
+    w10 (no push-CI on develop): develop didn't change during this
+    release, so trivially true here. Validate on the next regular
+    feature-PR squash-merge instead:
+      gh run list --workflow=test.yml --branch develop --event push \
+        --limit 1
+      # No run after the squash-merge SHA.
+
+    w11 (concurrency cancellation): force-push to a feature branch
+    during CI; the older lint/test runs show as "cancelled" in the
+    Actions UI. Can be exercised separately from this dry-run.
+
+    w12 (perf-smoke + parity skipped on Release v* PRs): already
+    checked in w3; record the observation here for the closeout.
+
+verification:
+- description: "release.yml succeeded after the dry-run"
+  command: "gh run list --workflow=release.yml --limit 1 --json conclusion --jq '.[0].conclusion'"
+  expected_output: "success"
+- description: "0.3.0-rc.1 published to PyPI (PyPI normalizes to 0.3.0rc1 per PEP 440)"
+  command: "pip index versions benchbox 2>&1 | grep -cE '0\\.3\\.0(rc1|-rc\\.1)'"
+  expected_output: "at least 1"
+- description: "develop unchanged after release-finalize"
+  command: "git diff origin/develop develop"
+  expected_output: "empty diff"
+- description: "Dev-only paths still present on develop"
+  command: "test -d _project && test -d _blog && test -f AGENTS.md && test -f CLAUDE.md && test -f GEMINI.md && echo OK"
+  expected_output: "OK"
+- description: "Main tree is curated"
+  command: "git ls-tree -d --name-only origin/main | grep -E '^(_project|_blog|\\.claude|\\.codex|\\.gemini)$' | wc -l"
+  expected_output: "0"
+- description: "Release v* PR did NOT trigger perf-smoke or parity (validates w12)"
+  command: "gh pr view <release-PR#> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name|test(\"perf-smoke|parity\"))'"
+  expected_output: "empty"
+
+must_preserve:
+- The PyPI trusted-publisher configuration on the BenchBox repo — release.yml's `publish` job depends on it; do not rotate or revoke during this dry-run.
+- The `v*` tag on main remains immutable — once pushed, never force-push or re-tag (PyPI rejects re-uploads of an existing version anyway).
+- Existing v0.1.0 / v0.2.0 / v0.2.1 tags on main stay intact.
+- develop's tree shape — the whole point of the parent TODO was to keep dev-only paths present on develop post-release.
+
+approach: |
+  This is a real release, not a simulation. Every step has external
+  side effects (PR opened, branch on origin, tag on main, PyPI
+  publish). Procedure:
+
+  1. Confirm PR #34 is merged to develop (the new Make targets must
+     exist on develop before invoking them).
+  2. Get explicit user go-ahead (PyPI is irreversible).
+  3. Run w1 (release-cut), then pause for w2 (manual diff inspection).
+  4. After w3 (CI green), run w4 (release-finalize).
+  5. Run w5 (post-release verification) immediately after the tag push
+     fires release.yml; wait for the workflow to complete.
+  6. Run w6 (CI-optimization verification) opportunistically — w12 is
+     verifiable during the dry-run; w10/w11 verify on the next regular
+     feature-PR cycle.
+
+  If any step fails, do NOT force-push or re-tag. Diagnose, fix on a
+  feature branch off develop, merge back, then bump to rc.2 and repeat.
+
+anti_patterns:
+- "DO NOT bump straight to 0.3.0 GA without the rc dry-run — because the latent rebase-develop bug only surfaces on a real release, and the parent TODO's whole reason for existing was to fix that bug. The rc is the validation gate."
+- "DO NOT force-push or re-tag if release.yml fails — because the tag is already public and PyPI rejects re-uploads of the same version. Bump to rc.2 instead."
+- "DO NOT skip w2 (manual diff inspection) — because the curation-drift guard catches missing entries on develop, but a release-cut bug or stale local state could still let an unexpected file land on main. The diff inspection is the last human check before merging."
+- "DO NOT modify develop during release-finalize — release-finalize was deliberately written to leave develop alone (per the parent TODO and the 2026-04-27 amendment to single-repo-migration.md)."
+- "DO NOT run release-cut from the main BenchBox/ working clone — convention is develop stays on develop. Use a worktree (../BenchBox.release-test-rc1/) or accept that you're temporarily on the v0.3.0-rc.1 branch in the main clone."
+
+scope_limit:
+  only_modify: []
+  do_not_modify:
+  - scripts/update_version.py
+  - scripts/generate_changelog_entry.py
+  - .github/workflows/release.yml
+  - .github/workflows/lint.yml
+  - .github/workflows/test.yml
+  - .github/workflows/perf-smoke.yml
+  - Makefile
+  - scripts/check_release_curation.py
+  notes: |
+    This TODO is purely an exercise of the existing flow. No code
+    changes are expected. The only files touched will be the release
+    branch's curation + version bumps, all done automatically by
+    release-cut. If a code change turns out to be needed mid-flow,
+    open a separate feature TODO + PR off develop and abort the rc.
+
+impact:
+  business_value: |
+    Validates that the simplified release flow (parent TODO) actually
+    works end-to-end on a real PyPI publish. Without this dry-run,
+    the first 0.3.0 GA release is itself the validation — too
+    risky given the parent TODO's claim of fixing a latent bug.
+  user_impact: |
+    The 0.3.0-rc.1 wheel becomes available on PyPI (`pip install
+    benchbox==0.3.0rc1`). Standard `pip install benchbox` users do
+    NOT get rc tags by default (--pre is required), so user impact
+    is limited to maintainers and explicit early adopters.
+  technical_debt: |
+    Closes the validation gate that simplify-dev-loop-and-release-flow
+    deferred. After this passes, single-repo-migration-phase-4 can be
+    marked complete and phase-8 (first 0.3.0 GA release) can proceed.
+
+files_affected:
+  modified: []
+  added: []
+  removed: []
+
+metadata:
+  created_date: "2026-04-28"
+  estimated_effort: "~1h interactive (release-cut to release-finalize), plus ~15 min release.yml CI wait"
+  tags:
+  - release
+  - validation
+  - rc
+  - pypi
+
+success_metrics:
+- "v0.3.0-rc.1 dry-run completes end-to-end: PR opened, CI green, squash-merged, tagged, PyPI publish succeeds, GH release created, cross-OS install matrix passes."
+- "After dry-run, develop tree is unchanged (`git diff origin/develop develop` is empty) AND all dev-only paths (_project/, _blog/, AGENTS.md, etc.) are still present on develop."
+- "main tree after dry-run contains zero dev-only paths."
+- "Release PR shows perf-smoke and parity as not-fired (validates w12 of parent TODO)."
+- "Previous v* branch sweep ran (no-op for first run)."
+
+open_questions:
+- "After rc.1 validates, is 0.3.0 GA the right next step or should we cut another rc? Decide based on the rc.1 outcome."
+- "Should we add a smoke-test step to run `pip install benchbox==0.3.0rc1 && benchbox --version` from a clean venv as part of release-finalize verification? Currently relies on release.yml's test-installation matrix."

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -162,7 +162,7 @@ work:
 
 - id: w6
   summary: "Tighten ruleset allowed_merge_methods to ['squash'] on main + develop rulesets"
-  status: pending
+  status: done
   notes: |
     Current state (from `gh api repos/joeharris76/BenchBox/rulesets`):
       - 15611783 main-release-only: allowed_merge_methods=[merge,squash,rebase]

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -102,7 +102,7 @@ work:
 
 - id: w3
   summary: "Widen `pr-preflight` to mirror full `ci-lint` surface"
-  status: pending
+  status: done
   notes: |
     Current pr-preflight (Makefile:707–713) runs only:
       ruff check, ruff format --check, fast tests

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -190,7 +190,7 @@ work:
 - id: w7
   summary: "Add curation-drift CI guard: scripts/check_release_curation.py wired into lint.yml"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
     Risk: dev-only path list (5 dirs + 13 files) drifts as new
     dev-only files are added to develop without being added to the

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -224,7 +224,7 @@ work:
 - id: w8
   summary: "Update docs and templates to the new 2-command flow"
   needs: [w1, w2, w4]
-  status: pending
+  status: done
   notes: |
     Edits:
       - .github/RELEASE_PR_TEMPLATE.md: replace `make

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -251,7 +251,7 @@ work:
 - id: w10
   summary: "Drop redundant push-CI on develop (lint.yml + test.yml)"
   needs: [w5]
-  status: pending
+  status: done
   notes: |
     After a feature PR squash-merges, GitHub creates a new SHA on
     develop and re-fires lint.yml + test.yml on identical content
@@ -276,7 +276,7 @@ work:
 
 - id: w11
   summary: "Add concurrency cancel-in-progress to lint.yml + test.yml"
-  status: pending
+  status: done
   notes: |
     Pattern already in use on perf-smoke.yml and
     results-explorer-browser.yml. When a PR is force-pushed during
@@ -306,7 +306,7 @@ work:
 - id: w12
   summary: "Skip perf-smoke and parity on release PRs"
   needs: [w5]
-  status: pending
+  status: done
   notes: |
     Release PRs (title starts with `Release v`) touch only curation
     removals + version bumps + changelog. Nothing perf-affecting

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -142,7 +142,7 @@ work:
 
 - id: w5
   summary: "Workflow trims: drop check-ci-passed from release.yml; remove v* push trigger from lint.yml + test.yml"
-  status: pending
+  status: done
   notes: |
     .github/workflows/release.yml:
       - Delete entire `check-ci-passed` job (lines 16–80, the JS poller).

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -124,7 +124,7 @@ work:
 - id: w4
   summary: "Delete obsolete release Make targets and update help text"
   needs: [w1, w2]
-  status: pending
+  status: done
   notes: |
     Remove from Makefile:
       - bump (line ~634)

--- a/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/active/simplify-dev-loop-and-release-flow.yaml
@@ -2,7 +2,7 @@ id: simplify-dev-loop-and-release-flow
 title: "Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Release Tooling
 
 deps:
@@ -58,7 +58,7 @@ description: |
 work:
 - id: w1
   summary: "Add `release-cut VERSION=X.Y.Z` Make target (cut + curate + bump + changelog + open PR + delete prev v*)"
-  status: pending
+  status: done
   notes: |
     Replace the existing release-prepare target. Differences from
     release-prepare:
@@ -87,7 +87,7 @@ work:
 - id: w2
   summary: "Add `release-finalize VERSION=X.Y.Z` Make target (squash-merge PR + tag + push + leave develop alone)"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
     Replace release-rebase-develop. Steps:
       1. gh pr list --base main --head v$(VERSION) → number → gh pr merge --squash
@@ -415,15 +415,21 @@ verification:
 
 must_preserve:
 - pr-open's auto-merge flow vs develop continues to work end-to-end (the /pr command and make pr-open are unchanged).
-- Worktree convention works unchanged (worktree-add/list/prune Make targets and the conventional ../BenchBox.<branch>/ path).
+- Worktree convention works unchanged (worktree-add/list/prune Make targets and the conventional ../BenchBox.<branch>/
+  path).
 - All 50+ test/coverage/docker/lint Make targets unchanged.
-- Pre-commit surface unchanged — 13 hooks across pre-commit/pre-push/manual stages still install via `pre-commit install`.
+- Pre-commit surface unchanged — 13 hooks across pre-commit/pre-push/manual stages still install via `pre-commit
+  install`.
 - Workflow file `published-results` flow (validate-submission.yml) untouched.
-- "Orthogonal workflows untouched — cross-platform-validation.yml, perf-smoke.yml, results-explorer-browser.yml, seed-corpus.yml, upload-answers.yml, docs.yml."
-- Released wheel still excludes _project/, _blog/, etc. (already enforced by pyproject.toml + MANIFEST.in; this TODO does not modify those exclusions).
+- "Orthogonal workflows untouched — cross-platform-validation.yml, perf-smoke.yml, results-explorer-browser.yml, seed-corpus.yml,
+  upload-answers.yml, docs.yml."
+- Released wheel still excludes _project/, _blog/, etc. (already enforced by pyproject.toml + MANIFEST.in; this TODO
+  does not modify those exclusions).
 - All 6 version sources stay in sync — `benchbox --version` consistency check continues to pass after every release.
-- Ruleset v-release-branches-minimal (15611787) stays at "non_fast_forward only"; w6 only tightens main and develop rulesets.
-- scripts/update_version.py and scripts/generate_changelog_entry.py untouched in their public surface; release-cut just calls them.
+- Ruleset v-release-branches-minimal (15611787) stays at "non_fast_forward only"; w6 only tightens main and develop
+  rulesets.
+- scripts/update_version.py and scripts/generate_changelog_entry.py untouched in their public surface; release-cut just
+  calls them.
 - The 9 pre-existing release commits on main (v0.1.0 through v0.2.1 tags) are not rewritten — no force-push to main.
 
 approach: |
@@ -454,15 +460,26 @@ approach: |
     - w9 (dry-run) last; it exercises every prior unit.
 
 anti_patterns:
-- "DO NOT reset develop to main in release-finalize — because develop carries dev-only paths (_project/, _blog/, agent configs) that don't exist on main; resetting would delete them on every release. The whole reason this TODO exists is to fix that latent bug."
-- "DO NOT squash-merge the version branch to main without curation first — because dev-only paths would land on main, polluting the canonical default-branch view and the released wheel. Curation is the `git rm` step inside release-cut."
-- "DO NOT consolidate the 6 version sources of truth — because user explicitly chose status quo on 2026-04-27 (decision #3); reducing the source list would silently break benchbox --version's cross-source consistency check."
-- "DO NOT skip the rc dry-run in w9 — because the latent rebase-develop bug only surfaces on a real release; w9 is the only validation gate before a real version goes out."
-- "DO NOT modify scripts/update_version.py or scripts/generate_changelog_entry.py — because they are already correct and outside the locked-in scope of this change; release-cut just invokes them."
-- "DO NOT add `merge` or `rebase` back to allowed_merge_methods on the rulesets — because the repo-wide setting is squash-only and the rulesets should match; w6 deliberately tightens, not relaxes."
-- "DO NOT mark single-repo-migration-phase-4 complete until this TODO's w9 passes — because phase-4 w7/w8 are subsumed here; closing phase-4 prematurely would lose the dependency edge that this TODO must precede phase-8 (first real post-migration release)."
-- "DO NOT remove `'v*'` from release.yml's tag trigger when doing w5 — because release.yml fires on tag push (v*), not branch push; only the branch-push trigger in lint.yml/test.yml is being trimmed."
-- "DO NOT delete the previous v* branch manually — because release-cut handles option-c deletion automatically; the make target is the single place that runs the deletion to keep the policy consistent."
+- "DO NOT reset develop to main in release-finalize — because develop carries dev-only paths (_project/, _blog/, agent configs)
+  that don't exist on main; resetting would delete them on every release. The whole reason this TODO exists is to fix that
+  latent bug."
+- "DO NOT squash-merge the version branch to main without curation first — because dev-only paths would land on main, polluting
+  the canonical default-branch view and the released wheel. Curation is the `git rm` step inside release-cut."
+- "DO NOT consolidate the 6 version sources of truth — because user explicitly chose status quo on 2026-04-27 (decision #3);
+  reducing the source list would silently break benchbox --version's cross-source consistency check."
+- "DO NOT skip the rc dry-run in w9 — because the latent rebase-develop bug only surfaces on a real release; w9 is the only
+  validation gate before a real version goes out."
+- "DO NOT modify scripts/update_version.py or scripts/generate_changelog_entry.py — because they are already correct and outside
+  the locked-in scope of this change; release-cut just invokes them."
+- "DO NOT add `merge` or `rebase` back to allowed_merge_methods on the rulesets — because the repo-wide setting is squash-only
+  and the rulesets should match; w6 deliberately tightens, not relaxes."
+- "DO NOT mark single-repo-migration-phase-4 complete until this TODO's w9 passes — because phase-4 w7/w8 are subsumed here;
+  closing phase-4 prematurely would lose the dependency edge that this TODO must precede phase-8 (first real post-migration
+  release)."
+- "DO NOT remove `'v*'` from release.yml's tag trigger when doing w5 — because release.yml fires on tag push (v*), not branch
+  push; only the branch-push trigger in lint.yml/test.yml is being trimmed."
+- "DO NOT delete the previous v* branch manually — because release-cut handles option-c deletion automatically; the make target
+  is the single place that runs the deletion to keep the policy consistent."
 
 scope_limit:
   only_modify:
@@ -561,10 +578,14 @@ metadata:
 
 success_metrics:
 - "Release flow is 2 commands (make release-cut + make release-finalize), down from 4."
-- "v0.3.0-rc.1 dry-run completes end-to-end: PR opened, CI green, squash-merged, tagged, PyPI publish succeeds, GH release created, cross-OS install matrix passes."
-- "After dry-run, develop tree is unchanged (git diff origin/develop develop is empty) AND all dev-only paths (_project/, _blog/, AGENTS.md, etc.) are still present on develop."
-- "main tree after dry-run contains zero dev-only paths (`git ls-tree -d --name-only origin/main | grep -E '_project|_blog|\\.claude'` returns nothing)."
-- "Curation-drift CI guard fails when a synthetic dev-only file is added to develop and not added to the release-cut curation list (validate by adding a test file in a throwaway branch)."
+- "v0.3.0-rc.1 dry-run completes end-to-end: PR opened, CI green, squash-merged, tagged, PyPI publish succeeds, GH release
+  created, cross-OS install matrix passes."
+- "After dry-run, develop tree is unchanged (git diff origin/develop develop is empty) AND all dev-only paths (_project/,
+  _blog/, AGENTS.md, etc.) are still present on develop."
+- "main tree after dry-run contains zero dev-only paths (`git ls-tree -d --name-only origin/main | grep -E '_project|_blog|\\\
+  .claude'` returns nothing)."
+- "Curation-drift CI guard fails when a synthetic dev-only file is added to develop and not added to the release-cut curation
+  list (validate by adding a test file in a throwaway branch)."
 - "Ruleset main-release-only and develop-squash-only return ['squash'] for allowed_merge_methods after w6."
 - "After w10: a feature PR squash-merge to develop produces zero new lint.yml + test.yml runs (only the PR-CI run remains)."
 - "After w11: force-pushing to a feature branch during CI cancels the prior lint.yml + test.yml runs (visible in Actions UI)."

--- a/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
@@ -49,6 +49,12 @@ description: |
   and phase-8 (first post-migration release) can proceed using the
   new flow.
 
+  Bundled in the same PR (per user direction 2026-04-27, Option A):
+  three CI churn reductions (w10/w11/w12). Net effect of the
+  simplification + opts: ~−110 CI-min per release cycle and ~−60
+  CI-min per merged feature PR vs status quo, while preserving all
+  required check signals.
+
 work:
 - id: w1
   summary: "Add `release-cut VERSION=X.Y.Z` Make target (cut + curate + bump + changelog + open PR + delete prev v*)"
@@ -242,9 +248,94 @@ work:
         release-cut. Do NOT rewrite history of the original
         document.
 
+- id: w10
+  summary: "Drop redundant push-CI on develop (lint.yml + test.yml)"
+  needs: [w5]
+  status: pending
+  notes: |
+    After a feature PR squash-merges, GitHub creates a new SHA on
+    develop and re-fires lint.yml + test.yml on identical content
+    that the PR-CI just proved green. Pure churn.
+
+    Edits:
+      .github/workflows/lint.yml `on.push.branches`:
+        Remove 'develop' (w5 already removes 'v*'; result is [main]).
+      .github/workflows/test.yml `on.push.branches`:
+        Same removal.
+
+    Keep `main` in push triggers — provides the "main is always
+    CI-green" signal that humans rely on as a badge / sanity check
+    (the deleted check-ci-passed poller no longer reads it, but
+    humans do).
+
+    Sequence after w5 to avoid editing the same `on.push.branches`
+    block twice in different commits.
+
+    Estimated savings: ~50 CI-min per merged feature PR (one full
+    lint+test cycle eliminated). At ~10 PRs/week, ~500 CI-min/week.
+
+- id: w11
+  summary: "Add concurrency cancel-in-progress to lint.yml + test.yml"
+  status: pending
+  notes: |
+    Pattern already in use on perf-smoke.yml and
+    results-explorer-browser.yml. When a PR is force-pushed during
+    CI (common during iteration), the in-flight run is superseded.
+
+    Add a top-level `concurrency:` block (NOT inside `on:` or
+    `jobs:`) to both:
+      .github/workflows/lint.yml:
+        concurrency:
+          group: lint-${{ github.ref }}
+          cancel-in-progress: true
+      .github/workflows/test.yml:
+        concurrency:
+          group: test-${{ github.ref }}
+          cancel-in-progress: true
+
+    No conflict with w5/w10 (different top-level key).
+
+    Estimated savings: bounded by force-push frequency; ~10–20%
+    of test.yml minutes during active iteration.
+
+    Risk note: if a required check is cancelled mid-flight on the
+    PR's last commit (no superseding push), GitHub may show the
+    PR as "checks pending" until the next push. Standard pattern;
+    the cancelled run only happens when a NEWER push exists.
+
+- id: w12
+  summary: "Skip perf-smoke and parity on release PRs"
+  needs: [w5]
+  status: pending
+  notes: |
+    Release PRs (title starts with `Release v`) touch only curation
+    removals + version bumps + changelog. Nothing perf-affecting
+    (perf-smoke); nothing fixture-affecting (parity job in
+    test.yml).
+
+    Edits:
+      .github/workflows/perf-smoke.yml — extend the existing `if:`
+      on the `perf-smoke` job (currently checks skip-perf-smoke
+      label):
+        if: |
+          !contains(github.event.pull_request.labels.*.name, 'skip-perf-smoke')
+          && !startsWith(github.event.pull_request.title, 'Release v')
+
+      .github/workflows/test.yml `parity` job — add `if:`:
+        if: ${{ !startsWith(github.event.pull_request.title, 'Release v') }}
+
+    The `Release v` title prefix is set by `release-cut` (see w1).
+    Don't depend on a label — release-cut doesn't apply one.
+
+    Sequence after w5 because both edit test.yml (different keys
+    but same file; serialize to avoid merge conflicts).
+
+    Estimated savings: ~25 CI-min per release PR (one perf-smoke
+    leg + one parity leg).
+
 - id: w9
   summary: "Dry-run on 0.3.0-rc.1 to validate the flow end-to-end"
-  needs: [w1, w2, w3, w4, w5, w6, w7, w8]
+  needs: [w1, w2, w3, w4, w5, w6, w7, w8, w10, w11, w12]
   status: pending
   notes: |
     The first real release after migration is the validation. Use
@@ -277,6 +368,19 @@ work:
          branch):
          git ls-remote --heads origin 'v*'
          # Should show only refs/heads/v0.3.0-rc.1.
+     10. Verify CI optimizations (w10/w11/w12):
+         a. perf-smoke skipped on release PR (w12):
+            gh pr view <release-PR#> --json statusCheckRollup \
+              --jq '.statusCheckRollup[] | select(.name|test("perf-smoke|parity"))'
+            # Both should be absent (job didn't fire).
+         b. After release-finalize, no push-CI on develop (w10):
+            (Develop didn't change, so this is trivially true. Validate
+            on the next regular feature-PR squash-merge instead:
+            gh run list --workflow=test.yml --branch develop --event push --limit 1
+            # No run after the squash-merge SHA.)
+         c. concurrency cancellation (w11): force-push to a feature
+            branch during CI; the older lint/test runs show as
+            "cancelled" in the Actions UI.
 
     If any step fails, the rc tag is the only artifact published;
     fix and bump to rc.2.
@@ -323,9 +427,12 @@ must_preserve:
 - The 9 pre-existing release commits on main (v0.1.0 through v0.2.1 tags) are not rewritten — no force-push to main.
 
 approach: |
-  Sequence: w1+w2+w3 (Make target work) → w4 (cleanup) → w5+w6+w7
-  (parallel: workflows / rulesets / curation guard) → w8 (docs catch
-  up to final names) → w9 (dry-run validates).
+  Sequence: w1+w2+w3 (Make target work) → w4 (cleanup) →
+  w5+w6+w7 (parallel: workflow trims / rulesets / curation guard) →
+  w10+w11+w12 (CI churn reductions; w10 and w12 sequence after w5
+  to avoid same-file conflicts on lint.yml / test.yml) →
+  w8 (docs catch up to final names) →
+  w9 (dry-run validates everything including the CI opts).
 
   Reuse strategy:
     - release-cut reuses scripts/update_version.py and
@@ -361,8 +468,9 @@ scope_limit:
   only_modify:
   - Makefile  # release-cut, release-finalize, pr-preflight; delete obsolete targets
   - .github/workflows/release.yml  # drop check-ci-passed
-  - .github/workflows/lint.yml  # remove v* push trigger; add curation-drift step
-  - .github/workflows/test.yml  # remove v* push trigger
+  - .github/workflows/lint.yml  # w5: remove v* push trigger; w7: add curation-drift step; w10: remove develop push trigger; w11: add concurrency
+  - .github/workflows/test.yml  # w5: remove v* push trigger; w10: remove develop push trigger; w11: add concurrency; w12: skip parity on Release v* PRs
+  - .github/workflows/perf-smoke.yml  # w12: skip on Release v* PRs
   - .github/RELEASE_PR_TEMPLATE.md  # update to release-finalize wording
   - .github/PULL_REQUEST_TEMPLATE.md  # slim
   - docs/operations/release-guide.md  # rewrite around 2 commands
@@ -376,7 +484,6 @@ scope_limit:
   - .pre-commit-config.yaml  # pre-commit surface unchanged
   - .github/workflows/docs.yml
   - .github/workflows/cross-platform-validation.yml
-  - .github/workflows/perf-smoke.yml
   - .github/workflows/results-explorer-browser.yml
   - .github/workflows/seed-corpus.yml
   - .github/workflows/upload-answers.yml
@@ -415,6 +522,12 @@ impact:
         from local preflight).
       - 4 obsolete Make targets (~120 lines total) replaced by 2
         (~60 lines total).
+      - Redundant push-CI on develop (w10): saves ~50 CI-min per
+        merged feature PR.
+      - Wasted in-flight CI runs on superseded force-pushes (w11):
+        saves ~10–20% of test.yml minutes during active iteration.
+      - perf-smoke + parity runs on release PRs (w12): saves ~25
+        CI-min per release PR.
     Adds:
       - One curation-drift CI guard (~40 lines) that prevents the
         same class of latent bug from recurring as new dev-only
@@ -426,6 +539,7 @@ files_affected:
   - .github/workflows/release.yml
   - .github/workflows/lint.yml
   - .github/workflows/test.yml
+  - .github/workflows/perf-smoke.yml
   - .github/RELEASE_PR_TEMPLATE.md
   - .github/PULL_REQUEST_TEMPLATE.md
   - docs/operations/release-guide.md
@@ -438,7 +552,7 @@ files_affected:
 
 metadata:
   created_date: "2026-04-27"
-  estimated_effort: "~6h spread across 1-2 days"
+  estimated_effort: "~7h spread across 1-2 days (6h flow + 1h CI churn opts w10/w11/w12)"
   tags:
   - release
   - dev-loop
@@ -452,6 +566,9 @@ success_metrics:
 - "main tree after dry-run contains zero dev-only paths (`git ls-tree -d --name-only origin/main | grep -E '_project|_blog|\\.claude'` returns nothing)."
 - "Curation-drift CI guard fails when a synthetic dev-only file is added to develop and not added to the release-cut curation list (validate by adding a test file in a throwaway branch)."
 - "Ruleset main-release-only and develop-squash-only return ['squash'] for allowed_merge_methods after w6."
+- "After w10: a feature PR squash-merge to develop produces zero new lint.yml + test.yml runs (only the PR-CI run remains)."
+- "After w11: force-pushing to a feature branch during CI cancels the prior lint.yml + test.yml runs (visible in Actions UI)."
+- "After w12: a Release v* PR shows perf-smoke and parity as not-fired in the status check rollup."
 
 open_questions:
 - "Does the curation-drift script need to also walk into _project/_archive/ or treat _project/ as opaque?"

--- a/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
@@ -62,9 +62,11 @@ work:
       - Opens $EDITOR on CHANGELOG.md after generation for hand-curation.
       - Drops the pre-release-vX.Y.Z anchor tag (no longer needed
         without rebase-develop).
-      - Adds option-c lifecycle: after pushing the new vX.Y.Z, look up
-        the previous v* branch on origin (sort -V), and `git push origin
-        --delete` it. The just-released tag remains on main.
+      - Adds option-c lifecycle: after pushing the new vX.Y.Z, list all
+        v* branches on origin except the new one and `git push origin
+        --delete` each (loop, not `tail -1`). The just-released tag
+        remains on main. Looping rather than taking the highest sweeps
+        any stale v* branches a hotfix path may have left behind.
 
     Curation list stays identical (Makefile lines 665–666):
       git rm -rf _project _blog .claude .codex .gemini
@@ -205,6 +207,14 @@ work:
       - name: Release curation list drift check
         run: uv run python scripts/check_release_curation.py
 
+    Sequencing safety: implement the script and run it locally against
+    the current develop tree FIRST. Confirm it exits 0 against the
+    real tree AND fails (exits non-zero) against a synthetic stray
+    file (touch a throwaway file at repo root not in the curation
+    list, re-run, confirm it fails). THEN add the lint.yml step in
+    the SAME commit. `lint` is a required status check; a buggy
+    script would block every PR repo-wide.
+
 - id: w8
   summary: "Update docs and templates to the new 2-command flow"
   needs: [w1, w2, w4]
@@ -221,8 +231,9 @@ work:
         Drop bump / changelog-draft / release-prepare /
         release-rebase-develop references. Add option-c
         auto-deletion behavior in release-cut.
-      - AGENTS.md: line 69 release paragraph rewrite.
-      - CLAUDE.md: "Git workflow" section release paragraph rewrite.
+      - AGENTS.md (project file at repo root): line 69 release paragraph rewrite.
+      - CLAUDE.md (project file at repo root, NOT the user-global
+        ~/.claude/CLAUDE.md): "Git workflow" section release paragraph rewrite.
       - _project/decisions/single-repo-migration.md: append an
         "Amendment 2026-04-27" section. Note: A4 step 6 (rebase
         develop) is replaced with "develop is not modified
@@ -282,9 +293,6 @@ deferred:
     lines as a reasonable middle. Further compression can wait.
 
 verification:
-- description: "release-cut dry-runs end-to-end without error (use a sandbox version)"
-  command: "make release-cut VERSION=0.0.0-sandbox && git checkout develop && git branch -D v0.0.0-sandbox && git push origin --delete v0.0.0-sandbox || true"
-  expected_output: "PR opened against main; sandbox cleanup OK"
 - description: "After dry-run release-finalize, develop tree is unchanged from origin/develop"
   command: "git diff origin/develop develop"
   expected_output: "empty diff"
@@ -297,8 +305,8 @@ verification:
 - description: "release.yml succeeded after the dry-run"
   command: "gh run list --workflow=release.yml --limit 1 --json conclusion --jq '.[0].conclusion'"
   expected_output: "success"
-- description: "0.3.0-rc.1 published to PyPI"
-  command: "pip index versions benchbox 2>&1 | grep -c '0.3.0-rc.1'"
+- description: "0.3.0-rc.1 published to PyPI (PyPI normalizes to 0.3.0rc1 per PEP 440)"
+  command: "pip index versions benchbox 2>&1 | grep -cE '0\\.3\\.0(rc1|-rc\\.1)'"
   expected_output: "at least 1"
 
 must_preserve:

--- a/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
+++ b/_project/TODO/main/planning/simplify-dev-loop-and-release-flow.yaml
@@ -1,0 +1,450 @@
+id: simplify-dev-loop-and-release-flow
+title: "Simplify dev loop + release flow: 2-command release, fix latent develop-rebase bug"
+worktree: main
+priority: High
+status: Not Started
+category: Release Tooling
+
+deps:
+  needs:
+  - single-repo-migration-phase-4-test-release-with-new-flow
+
+description: |
+  Replace the current 4-target release flow (bump / changelog-draft /
+  release-prepare / release-rebase-develop) with a 2-target flow
+  (release-cut / release-finalize), and fix a latent bug in the
+  current rebase-develop step that would lose dev-only paths
+  (_project/, _blog/, AGENTS.md, .pre-commit-config.yaml, etc.) from
+  develop on the first real release.
+
+  Root cause: develop and main carry DIFFERENT trees by design (per
+  _project/decisions/single-repo-migration.md A3 — develop has
+  maintainer scaffolding; main is release-only). The current
+  release-rebase-develop and the originally-proposed "reset develop to
+  main" both assume symmetric trees and would delete dev-only paths
+  from develop. Fix: develop is intentionally NOT modified
+  post-release; main's release squash adds nothing to develop's
+  content surface that isn't already there.
+
+  Locked-in decisions (from 2026-04-27 conversation with user):
+    1. Curation stays — dev-only paths dropped from main via git rm.
+    2. Develop never resets (verified: zero pre-2026 commits on develop).
+    3. Keep all 6 version sources of truth (pyproject.toml,
+       benchbox/__init__.py, landing/index.html, README.md,
+       docs/README.md, benchbox/utils/VERSION_MANAGEMENT.md).
+       update_version.py unchanged.
+    4. Drop check-ci-passed JS poller from release.yml (rulesets
+       already gate the version-branch PR on lint + test).
+    5. Tighten ruleset allowed_merge_methods to ["squash"] on main
+       and develop (currently allows merge/squash/rebase even though
+       repo-wide setting is squash-only).
+    6. Widen pr-preflight to mirror full ci-lint surface (ty check,
+       lint-markers, codex-skills-check, timing-policy,
+       compat-docs-check, audit-deps).
+    7. Option-c version-branch lifecycle: keep vX.Y.Z until next
+       release-cut runs, then auto-delete previous on origin.
+
+  This TODO subsumes single-repo-migration-phase-4 w7/w8 (which were
+  deferred). After this completes, phase-4 can be marked complete
+  and phase-8 (first post-migration release) can proceed using the
+  new flow.
+
+work:
+- id: w1
+  summary: "Add `release-cut VERSION=X.Y.Z` Make target (cut + curate + bump + changelog + open PR + delete prev v*)"
+  status: pending
+  notes: |
+    Replace the existing release-prepare target. Differences from
+    release-prepare:
+      - Folds `make bump` and `make changelog-draft` into a single command
+        (still calls scripts/update_version.py and
+        scripts/generate_changelog_entry.py — those scripts unchanged).
+      - Opens $EDITOR on CHANGELOG.md after generation for hand-curation.
+      - Drops the pre-release-vX.Y.Z anchor tag (no longer needed
+        without rebase-develop).
+      - Adds option-c lifecycle: after pushing the new vX.Y.Z, look up
+        the previous v* branch on origin (sort -V), and `git push origin
+        --delete` it. The just-released tag remains on main.
+
+    Curation list stays identical (Makefile lines 665–666):
+      git rm -rf _project _blog .claude .codex .gemini
+      git rm -f .pre-commit-config.yaml _benchbox_pytest_xdist_safety.py \
+                todo.config.yaml skill-sync.yaml skill-sync.lock \
+                .coveragerc_core .dockerignore .env.example .mcp.json \
+                AGENTS.md CLAUDE.md GEMINI.md
+
+    Pre-conditions: on develop, clean tree, fetched.
+    Post: `gh pr create --base main --head v$(VERSION) --title "Release v$(VERSION)" --body-file .github/RELEASE_PR_TEMPLATE.md`.
+
+- id: w2
+  summary: "Add `release-finalize VERSION=X.Y.Z` Make target (squash-merge PR + tag + push + leave develop alone)"
+  needs: [w1]
+  status: pending
+  notes: |
+    Replace release-rebase-develop. Steps:
+      1. gh pr list --base main --head v$(VERSION) → number → gh pr merge --squash
+      2. git fetch origin --tags
+      3. git checkout main && git pull --ff-only
+      4. git tag v$(VERSION) && git push origin v$(VERSION)  # fires release.yml
+      5. echo "develop is intentionally unchanged"
+
+    Critical: do NOT touch develop. Step 5 of the previous flow
+    (rebase or reset) deletes dev-only paths and is removed by this
+    TODO.
+
+- id: w3
+  summary: "Widen `pr-preflight` to mirror full `ci-lint` surface"
+  status: pending
+  notes: |
+    Current pr-preflight (Makefile:707–713) runs only:
+      ruff check, ruff format --check, fast tests
+    But lint.yml additionally runs:
+      ty check, lint-markers, codex-skills-check, timing-policy,
+      compat-docs-check, audit-deps
+    These can fail CI even when local pr-preflight passes.
+
+    New body:
+      pr-preflight:
+        @$(MAKE) ci-lint
+        @echo "==> fast tests"
+        @uv run -- python -m pytest -m fast -q
+
+    ci-lint already exists (Makefile:410–417) and runs the full lint
+    surface. Adds ~10s to local preflight; eliminates a class of
+    surprise CI failures.
+
+- id: w4
+  summary: "Delete obsolete release Make targets and update help text"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Remove from Makefile:
+      - bump (line ~634)
+      - changelog-draft (line ~641)
+      - release-prepare (line ~651)
+      - release-rebase-develop (line ~681)
+    Update .PHONY at top of file (line 4) and the .PHONY at line 630.
+    Update `make help` (line 768+) Release Workflow section to show
+    only release-cut and release-finalize.
+
+    Keep underlying scripts unchanged:
+      scripts/update_version.py
+      scripts/generate_changelog_entry.py
+    They are called inside release-cut.
+
+- id: w5
+  summary: "Workflow trims: drop check-ci-passed from release.yml; remove v* push trigger from lint.yml + test.yml"
+  status: pending
+  notes: |
+    .github/workflows/release.yml:
+      - Delete entire `check-ci-passed` job (lines 16–80, the JS poller).
+      - In `dependency-bounds`, change `needs: check-ci-passed` to
+        remove that needs entry (or set `needs: []`).
+      - In `build`, change `needs: [check-ci-passed, dependency-bounds]`
+        to `needs: dependency-bounds`.
+      Rationale: ruleset main-release-only already gates the
+      version-branch PR on lint + test. Poller is redundant.
+
+    .github/workflows/lint.yml:
+      - Remove `'v*'` from `on.push.branches` (line 8).
+    .github/workflows/test.yml:
+      - Same removal (line 8).
+      Rationale: release branches now exercise CI via their PR vs
+      main, not via push.
+
+- id: w6
+  summary: "Tighten ruleset allowed_merge_methods to ['squash'] on main + develop rulesets"
+  status: pending
+  notes: |
+    Current state (from `gh api repos/joeharris76/BenchBox/rulesets`):
+      - 15611783 main-release-only: allowed_merge_methods=[merge,squash,rebase]
+      - 15611785 develop-squash-only: allowed_merge_methods=[merge,squash,rebase]
+      - 15611787 v-release-branches-minimal: only blocks force-push (LEAVE ALONE)
+
+    Repo-wide setting is already squash-only
+    (squashMergeAllowed:true, mergeCommitAllowed:false,
+    rebaseMergeAllowed:false). Tighten the rulesets to match for
+    defense-in-depth.
+
+    Backup-then-update flow (idempotent):
+      gh api repos/joeharris76/BenchBox/rulesets/15611783 > /tmp/main-ruleset.json
+      gh api repos/joeharris76/BenchBox/rulesets/15611785 > /tmp/develop-ruleset.json
+      jq '.rules[0].parameters.allowed_merge_methods = ["squash"]' /tmp/main-ruleset.json \
+        | gh api repos/joeharris76/BenchBox/rulesets/15611783 --method PUT --input -
+      jq '.rules[0].parameters.allowed_merge_methods = ["squash"]' /tmp/develop-ruleset.json \
+        | gh api repos/joeharris76/BenchBox/rulesets/15611785 --method PUT --input -
+
+    Verify after with:
+      gh api repos/joeharris76/BenchBox/rulesets/15611783 \
+        --jq '.rules[0].parameters.allowed_merge_methods'
+      # → ["squash"]
+
+- id: w7
+  summary: "Add curation-drift CI guard: scripts/check_release_curation.py wired into lint.yml"
+  needs: [w1]
+  status: pending
+  notes: |
+    Risk: dev-only path list (5 dirs + 13 files) drifts as new
+    dev-only files are added to develop without being added to the
+    release-cut curation list. This would silently leak maintainer
+    scaffolding onto main on the next release.
+
+    Script (~40 lines):
+      1. Parse the `git rm` lines from the `release-cut` target in
+         Makefile to extract the curation list.
+      2. Parse the A3 main-only allowlist from
+         _project/decisions/single-repo-migration.md.
+      3. For every top-level path in the working tree on develop,
+         assert it is EITHER in the A3 main-only allowlist OR in the
+         curation list.
+      4. Fail with a clear message naming any unaccounted-for path
+         and recommending which list to add it to.
+
+    Wire into .github/workflows/lint.yml as one more step after the
+    existing `audit-deps` step:
+      - name: Release curation list drift check
+        run: uv run python scripts/check_release_curation.py
+
+- id: w8
+  summary: "Update docs and templates to the new 2-command flow"
+  needs: [w1, w2, w4]
+  status: pending
+  notes: |
+    Edits:
+      - .github/RELEASE_PR_TEMPLATE.md: replace `make
+        release-rebase-develop` with `make release-finalize`. Drop
+        the "rebase develop onto release-shaped main" sentence. Note
+        develop is intentionally unchanged post-release.
+      - .github/PULL_REQUEST_TEMPLATE.md: slim from 86 lines to ~20
+        (Description / Type / Testing / Notes).
+      - docs/operations/release-guide.md: rewrite around 2 commands.
+        Drop bump / changelog-draft / release-prepare /
+        release-rebase-develop references. Add option-c
+        auto-deletion behavior in release-cut.
+      - AGENTS.md: line 69 release paragraph rewrite.
+      - CLAUDE.md: "Git workflow" section release paragraph rewrite.
+      - _project/decisions/single-repo-migration.md: append an
+        "Amendment 2026-04-27" section. Note: A4 step 6 (rebase
+        develop) is replaced with "develop is not modified
+        post-release; dev-only paths persist on develop". A5
+        option-c deletion moves from manual to automatic in
+        release-cut. Do NOT rewrite history of the original
+        document.
+
+- id: w9
+  summary: "Dry-run on 0.3.0-rc.1 to validate the flow end-to-end"
+  needs: [w1, w2, w3, w4, w5, w6, w7, w8]
+  status: pending
+  notes: |
+    The first real release after migration is the validation. Use
+    a pre-release tag so a botched dry-run isn't catastrophic
+    (PyPI accepts rc tags).
+
+    Procedure:
+      1. From a worktree on develop:
+         make release-cut VERSION=0.3.0-rc.1
+      2. Inspect PR diff:
+         gh pr diff <PR#> | head -200
+         Confirm: only curation removals + version bumps + changelog;
+         no surprise additions.
+      3. Inspect release branch tree:
+         git ls-tree -d --name-only origin/v0.3.0-rc.1
+         Confirm absent: _project, _blog, .claude, .codex, .gemini.
+      4. Wait for CI green on PR.
+      5. From develop worktree:
+         make release-finalize VERSION=0.3.0-rc.1
+      6. Verify develop unchanged:
+         git diff origin/develop develop  # empty
+      7. Verify dev-only paths preserved on develop:
+         test -d _project && test -d _blog && test -f AGENTS.md && \
+           test -f CLAUDE.md && test -f GEMINI.md && echo OK
+      8. Verify release.yml published:
+         gh run list --workflow=release.yml --limit 1 --json conclusion --jq '.[0].conclusion'
+         pip index versions benchbox 2>&1 | grep 0.3.0-rc.1
+      9. Verify previous v* branch deletion (no-op for first run
+         since v0.2.1 was a legacy two-repo release without a v*
+         branch):
+         git ls-remote --heads origin 'v*'
+         # Should show only refs/heads/v0.3.0-rc.1.
+
+    If any step fails, the rc tag is the only artifact published;
+    fix and bump to rc.2.
+
+deferred:
+- summary: "Consolidate version sources from 6 to 2 (pyproject.toml + __init__.py)"
+  reason: |
+    User decision 2026-04-27 #3: keep at 6. Status quo.
+    Revisit only if version-bump friction becomes a maintenance
+    bottleneck.
+- summary: "Slim PULL_REQUEST_TEMPLATE.md aggressively"
+  reason: |
+    Lower priority than the release flow itself. w8 trims to ~20
+    lines as a reasonable middle. Further compression can wait.
+
+verification:
+- description: "release-cut dry-runs end-to-end without error (use a sandbox version)"
+  command: "make release-cut VERSION=0.0.0-sandbox && git checkout develop && git branch -D v0.0.0-sandbox && git push origin --delete v0.0.0-sandbox || true"
+  expected_output: "PR opened against main; sandbox cleanup OK"
+- description: "After dry-run release-finalize, develop tree is unchanged from origin/develop"
+  command: "git diff origin/develop develop"
+  expected_output: "empty diff"
+- description: "Dev-only paths still present on develop after release"
+  command: "test -d _project && test -d _blog && test -f AGENTS.md && test -f CLAUDE.md && test -f GEMINI.md && echo OK"
+  expected_output: "OK"
+- description: "Main tree is curated (no dev-only paths) after release"
+  command: "git ls-tree -d --name-only origin/main | grep -E '^(_project|_blog|\\.claude|\\.codex|\\.gemini)$' | wc -l"
+  expected_output: "0"
+- description: "release.yml succeeded after the dry-run"
+  command: "gh run list --workflow=release.yml --limit 1 --json conclusion --jq '.[0].conclusion'"
+  expected_output: "success"
+- description: "0.3.0-rc.1 published to PyPI"
+  command: "pip index versions benchbox 2>&1 | grep -c '0.3.0-rc.1'"
+  expected_output: "at least 1"
+
+must_preserve:
+- pr-open's auto-merge flow vs develop continues to work end-to-end (the /pr command and make pr-open are unchanged).
+- Worktree convention works unchanged (worktree-add/list/prune Make targets and the conventional ../BenchBox.<branch>/ path).
+- All 50+ test/coverage/docker/lint Make targets unchanged.
+- Pre-commit surface unchanged — 13 hooks across pre-commit/pre-push/manual stages still install via `pre-commit install`.
+- Workflow file `published-results` flow (validate-submission.yml) untouched.
+- "Orthogonal workflows untouched — cross-platform-validation.yml, perf-smoke.yml, results-explorer-browser.yml, seed-corpus.yml, upload-answers.yml, docs.yml."
+- Released wheel still excludes _project/, _blog/, etc. (already enforced by pyproject.toml + MANIFEST.in; this TODO does not modify those exclusions).
+- All 6 version sources stay in sync — `benchbox --version` consistency check continues to pass after every release.
+- Ruleset v-release-branches-minimal (15611787) stays at "non_fast_forward only"; w6 only tightens main and develop rulesets.
+- scripts/update_version.py and scripts/generate_changelog_entry.py untouched in their public surface; release-cut just calls them.
+- The 9 pre-existing release commits on main (v0.1.0 through v0.2.1 tags) are not rewritten — no force-push to main.
+
+approach: |
+  Sequence: w1+w2+w3 (Make target work) → w4 (cleanup) → w5+w6+w7
+  (parallel: workflows / rulesets / curation guard) → w8 (docs catch
+  up to final names) → w9 (dry-run validates).
+
+  Reuse strategy:
+    - release-cut reuses scripts/update_version.py and
+      scripts/generate_changelog_entry.py wholesale; they are
+      already correct.
+    - release-finalize is mostly `gh pr merge --squash` + `git tag`
+      + `git push`; no scripting needed.
+    - The curation list in release-cut is copied verbatim from
+      release-prepare (Makefile:665–666); do not invent new entries.
+    - The ruleset edit (w6) uses jq + gh api PUT, the standard
+      idempotent pattern for partial ruleset updates.
+
+  Sequencing reasoning:
+    - w1 before w2 because release-finalize references the PR opened
+      by release-cut.
+    - w4 (delete obsolete) after w1+w2 so we never have a window
+      where neither flow is callable.
+    - w8 (docs) after w4 so the names referenced are final.
+    - w9 (dry-run) last; it exercises every prior unit.
+
+anti_patterns:
+- "DO NOT reset develop to main in release-finalize — because develop carries dev-only paths (_project/, _blog/, agent configs) that don't exist on main; resetting would delete them on every release. The whole reason this TODO exists is to fix that latent bug."
+- "DO NOT squash-merge the version branch to main without curation first — because dev-only paths would land on main, polluting the canonical default-branch view and the released wheel. Curation is the `git rm` step inside release-cut."
+- "DO NOT consolidate the 6 version sources of truth — because user explicitly chose status quo on 2026-04-27 (decision #3); reducing the source list would silently break benchbox --version's cross-source consistency check."
+- "DO NOT skip the rc dry-run in w9 — because the latent rebase-develop bug only surfaces on a real release; w9 is the only validation gate before a real version goes out."
+- "DO NOT modify scripts/update_version.py or scripts/generate_changelog_entry.py — because they are already correct and outside the locked-in scope of this change; release-cut just invokes them."
+- "DO NOT add `merge` or `rebase` back to allowed_merge_methods on the rulesets — because the repo-wide setting is squash-only and the rulesets should match; w6 deliberately tightens, not relaxes."
+- "DO NOT mark single-repo-migration-phase-4 complete until this TODO's w9 passes — because phase-4 w7/w8 are subsumed here; closing phase-4 prematurely would lose the dependency edge that this TODO must precede phase-8 (first real post-migration release)."
+- "DO NOT remove `'v*'` from release.yml's tag trigger when doing w5 — because release.yml fires on tag push (v*), not branch push; only the branch-push trigger in lint.yml/test.yml is being trimmed."
+- "DO NOT delete the previous v* branch manually — because release-cut handles option-c deletion automatically; the make target is the single place that runs the deletion to keep the policy consistent."
+
+scope_limit:
+  only_modify:
+  - Makefile  # release-cut, release-finalize, pr-preflight; delete obsolete targets
+  - .github/workflows/release.yml  # drop check-ci-passed
+  - .github/workflows/lint.yml  # remove v* push trigger; add curation-drift step
+  - .github/workflows/test.yml  # remove v* push trigger
+  - .github/RELEASE_PR_TEMPLATE.md  # update to release-finalize wording
+  - .github/PULL_REQUEST_TEMPLATE.md  # slim
+  - docs/operations/release-guide.md  # rewrite around 2 commands
+  - AGENTS.md  # release paragraph
+  - CLAUDE.md  # Git workflow section
+  - _project/decisions/single-repo-migration.md  # append amendment, do not rewrite
+  - scripts/check_release_curation.py  # NEW, ~40 lines
+  do_not_modify:
+  - scripts/update_version.py  # keep at 6 version sources per decision #3
+  - scripts/generate_changelog_entry.py  # invoked unchanged by release-cut
+  - .pre-commit-config.yaml  # pre-commit surface unchanged
+  - .github/workflows/docs.yml
+  - .github/workflows/cross-platform-validation.yml
+  - .github/workflows/perf-smoke.yml
+  - .github/workflows/results-explorer-browser.yml
+  - .github/workflows/seed-corpus.yml
+  - .github/workflows/upload-answers.yml
+  - .github/workflows/validate-submission.yml
+  - pyproject.toml  # version source; only updated by update_version.py at release time
+  - benchbox/__init__.py  # version source; only updated by update_version.py at release time
+  - landing/index.html  # version badge; only updated by update_version.py at release time
+  - README.md  # version marker; only updated by update_version.py at release time
+  - docs/README.md  # version marker; only updated by update_version.py at release time
+  - benchbox/utils/VERSION_MANAGEMENT.md  # version marker; only updated by update_version.py at release time
+  notes: |
+    The 6 version-source files are listed under do_not_modify
+    because this TODO does not edit them directly; they are only
+    rewritten by scripts/update_version.py during release-cut at
+    release time. Listing them prevents accidental hand-edits during
+    the migration work.
+
+impact:
+  business_value: |
+    Reduces release-time cognitive load from 4 Make targets to 2,
+    and fixes a latent bug that would lose maintainer scaffolding
+    (decisions, TODOs, agent configs, blog drafts) from develop on
+    the first real post-migration release. Unblocks
+    single-repo-migration-phase-8 (first post-migration release)
+    by making the flow correct.
+  user_impact: |
+    No user-facing change. Released wheels are identical in shape;
+    PyPI versioning unchanged; CLI behavior unchanged. Internal-only
+    workflow simplification.
+  technical_debt: |
+    Removes:
+      - The latent rebase-develop bug (untested code path that
+        would lose dev-only paths).
+      - The redundant check-ci-passed JS poller in release.yml.
+      - The pr-preflight / lint.yml gap (5 lint checks were absent
+        from local preflight).
+      - 4 obsolete Make targets (~120 lines total) replaced by 2
+        (~60 lines total).
+    Adds:
+      - One curation-drift CI guard (~40 lines) that prevents the
+        same class of latent bug from recurring as new dev-only
+        files are added to develop.
+
+files_affected:
+  modified:
+  - Makefile
+  - .github/workflows/release.yml
+  - .github/workflows/lint.yml
+  - .github/workflows/test.yml
+  - .github/RELEASE_PR_TEMPLATE.md
+  - .github/PULL_REQUEST_TEMPLATE.md
+  - docs/operations/release-guide.md
+  - AGENTS.md
+  - CLAUDE.md
+  - _project/decisions/single-repo-migration.md
+  added:
+  - scripts/check_release_curation.py
+  removed: []
+
+metadata:
+  created_date: "2026-04-27"
+  estimated_effort: "~6h spread across 1-2 days"
+  tags:
+  - release
+  - dev-loop
+  - tooling
+  - simplification
+
+success_metrics:
+- "Release flow is 2 commands (make release-cut + make release-finalize), down from 4."
+- "v0.3.0-rc.1 dry-run completes end-to-end: PR opened, CI green, squash-merged, tagged, PyPI publish succeeds, GH release created, cross-OS install matrix passes."
+- "After dry-run, develop tree is unchanged (git diff origin/develop develop is empty) AND all dev-only paths (_project/, _blog/, AGENTS.md, etc.) are still present on develop."
+- "main tree after dry-run contains zero dev-only paths (`git ls-tree -d --name-only origin/main | grep -E '_project|_blog|\\.claude'` returns nothing)."
+- "Curation-drift CI guard fails when a synthetic dev-only file is added to develop and not added to the release-cut curation list (validate by adding a test file in a throwaway branch)."
+- "Ruleset main-release-only and develop-squash-only return ['squash'] for allowed_merge_methods after w6."
+
+open_questions:
+- "Does the curation-drift script need to also walk into _project/_archive/ or treat _project/ as opaque?"
+- "Should release-cut accept a --dry-run flag for paranoia? Or is the rc-tag dry-run procedure sufficient?"

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -174,6 +174,29 @@ dates).
 
 Phase 0 audit complete. Phase 1 (wheel hygiene) is now unblocked.
 
+## Amendment 2026-04-27 — 2-command release flow (A4 + A5 supersession)
+
+The 4-target release flow originally specified by A4 (`bump` →
+`changelog-draft` → `release-prepare` → `release-rebase-develop`) is
+replaced by a 2-target flow: `make release-cut` and `make
+release-finalize`. Two semantic changes accompany the consolidation:
+
+- **A4 step 6 (rebase develop) is removed.** `develop` is intentionally
+  NOT modified by `release-finalize`. Dev-only paths (`_project/`,
+  `_blog/`, agent configs, dev-tooling root files) live only on
+  `develop` by design (per A3); the release squash on `main` does not
+  add anything to develop's content surface that isn't already there.
+  The original A4 step 6 (`git rebase --onto main vX.Y.Z develop`)
+  would have deleted those dev-only paths from `develop` on every
+  release.
+- **A5 option-c deletion moves from manual to automatic.** The previous
+  `vX.Y.Z` branch on origin is auto-deleted by `release-cut` after the
+  new branch is pushed (loop sweeps any stale `v*` branches a hotfix
+  path may have left behind, not just the highest one).
+
+The 7-step A4 procedure block is preserved as historical record; the
+runbook of record is now `docs/operations/release-guide.md`.
+
 ## Amendment 2026-04-27 — A3 main-only allowlist extension
 
 The original A3 main-only enumeration omitted several top-level paths

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -173,3 +173,20 @@ dates).
    cleanup PR. Discuss after Phase 4 lands.
 
 Phase 0 audit complete. Phase 1 (wheel hygiene) is now unblocked.
+
+## Amendment 2026-04-27 — A3 main-only allowlist extension
+
+The original A3 main-only enumeration omitted several top-level paths
+that have always shipped on main but were never explicitly listed.
+Discovered while implementing the curation-drift CI guard
+(`scripts/check_release_curation.py`); the script enforces that every
+top-level tracked path is in either the main-only allowlist or the
+release-cut curation list.
+
+- **`main` only** (extension to A3): `docker/`, `quality/`, `results-data/`,
+  `results-explorer/`, `setup.cfg`, `setup.py`, `tox.ini`, `index.html`.
+
+These are all build/release/UI artefacts that belong on the released
+tree. They are therefore NOT in the release-cut curation list. This
+amendment is the source of truth for the script; the original A3 row
+remains unchanged.

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -4,59 +4,53 @@ BenchBox releases follow a **version-branch flow** on a single repo
 (`joeharris76/BenchBox`) with two long-lived branches: `develop` (dev work)
 and `main` (release-only). This guide is the maintainer runbook.
 
-## The flow
+## The flow (2 commands)
 
-Every release follows seven steps. The Makefile encapsulates the
-mechanical parts.
+```bash
+git checkout develop && git pull
+make release-cut VERSION=X.Y.Z
+# review the PR; wait for CI green
+make release-finalize VERSION=X.Y.Z
+```
 
-1. **Bump the version on `develop`**:
-   ```bash
-   git checkout develop && git pull
-   make bump VERSION=X.Y.Z
-   make changelog-draft VERSION=X.Y.Z   # optional helper
-   ```
-   Review the auto-drafted CHANGELOG entry, edit any awkward bullets,
-   then commit on `develop` (or open a "release prep" PR).
+That's the entire flow. The two Make targets do the rest.
 
-2. **Cut the release branch**:
-   ```bash
-   make release-prepare VERSION=X.Y.Z
-   ```
-   This creates `vX.Y.Z` from `develop`, drops develop-only paths
-   (`_project/`, `_blog/`, agent configs, dev tooling), commits a
-   `Release vX.Y.Z` commit, pushes, and opens a PR against `main`.
+### What `release-cut` does
 
-3. **Review the PR**. Confirm `CHANGELOG.md` is correct and the curation
-   diff looks like the expected release-shaped subset. CI must pass.
+1. Cuts a `vX.Y.Z` branch off `develop` (`develop` itself is never modified).
+2. Bumps the 6 version sources via `scripts/update_version.py` and generates
+   the CHANGELOG entry via `scripts/generate_changelog_entry.py`.
+3. Opens `$EDITOR` on `CHANGELOG.md` for hand-curation. (Headless mode:
+   refuses to skip the curation step rather than silently committing
+   raw output.)
+4. Curates the release branch — `git rm`'s the dev-only paths
+   (`_project/`, `_blog/`, agent configs, dev-tooling root files; full
+   list in the `release-cut:` Makefile target and gated by
+   `scripts/check_release_curation.py`).
+5. Commits a single `Release vX.Y.Z` commit on `vX.Y.Z`, pushes, and
+   opens a PR against `main`.
+6. Sweeps prior `v*` branches on origin (option-c lifecycle: keep until
+   superseded, then auto-delete on the next `release-cut`).
 
-4. **Squash-merge** the PR on GitHub. `main` now has one new
-   release-shaped commit.
+### What `release-finalize` does
 
-5. **Tag and push**:
-   ```bash
-   git checkout main && git pull
-   git tag vX.Y.Z && git push origin vX.Y.Z
-   ```
-   The tag push triggers `.github/workflows/release.yml`, which builds
-   the wheel and sdist with `SOURCE_DATE_EPOCH` from the tag commit,
-   verifies content, and publishes to PyPI via the trusted publisher.
-
-6. **Rebase `develop` onto `main`**:
-   ```bash
-   make release-rebase-develop VERSION=X.Y.Z
-   ```
-   This drops the commits that became the release squash, replaying
-   only post-release dev work onto the new release-shaped `main`.
-
-7. **(Next release)** delete the previous version branch when the next
-   `make release-prepare` runs (option-c lifecycle: branches stay alive
-   until superseded so a same-version hotfix can re-cut from them).
+1. Finds the open release PR for `vX.Y.Z` and squash-merges it. (Ruleset
+   `main-release-only` blocks the merge if `lint` or `test` aren't green;
+   no local poller is needed.)
+2. Fast-forwards `main` and tags `vX.Y.Z`.
+3. Pushes the tag — which fires `.github/workflows/release.yml`:
+   `dependency-bounds` → `build` (with `SOURCE_DATE_EPOCH` from the tag
+   commit) → `publish` (PyPI trusted publisher) → `github-release` →
+   `test-installation` (cross-platform pip install verification).
+4. Leaves `develop` untouched. Dev-only paths persist on develop by
+   design (per A3 in `_project/decisions/single-repo-migration.md`); the
+   release squash on `main` does not need to be replayed onto develop.
 
 ## Recovering from common failures
 
-- **Required CI fails on the release PR**: fix on a feature branch off
-  `develop`, PR back to `develop`, then re-run `make release-prepare`
-  (delete the stale `vX.Y.Z` branch first if needed).
+- **CI fails on the release PR**: fix on a feature branch off `develop`,
+  PR back to `develop`, then re-run `make release-cut` (the option-c
+  sweep will delete the stale `vX.Y.Z` branch automatically).
 - **Wheel content is wrong**: adjust `pyproject.toml` / `MANIFEST.in`
   excludes on `develop`, then cut a patch release. PyPI rejects
   re-uploads of an existing version, so always bump.
@@ -66,9 +60,12 @@ mechanical parts.
 
 ## Reference
 
-- Makefile targets: `bump`, `changelog-draft`, `release-prepare`,
-  `release-rebase-develop`.
+- Makefile targets: `release-cut`, `release-finalize`.
 - Workflow: `.github/workflows/release.yml`.
+- Curation drift guard: `scripts/check_release_curation.py` (runs in
+  `lint.yml` on every PR).
+- Version updater: `scripts/update_version.py`.
 - Changelog generator: `scripts/generate_changelog_entry.py`.
 - Architecture record: `_project/decisions/single-repo-migration.md`
-  (D5 / A4 / A5).
+  (D5 / A3 / A4 / A5, plus the 2026-04-27 amendment for the 2-command
+  flow and the develop-not-modified rule).

--- a/scripts/check_release_curation.py
+++ b/scripts/check_release_curation.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Curation-drift CI guard.
+
+Verifies that every top-level tracked path on develop is accounted for as
+either main-only (will land on the released main tree) or curated (will be
+git-rm'd from the release branch by `make release-cut`).
+
+Sources of truth:
+  - A3 main-only allowlist: _project/decisions/single-repo-migration.md
+    (the bullet under "**main only**" in the A3 row).
+  - Curation list: the `git rm -rf` / `git rm -f` lines inside the
+    `release-cut:` target in Makefile.
+
+Fails (exit 1) on any top-level path that appears in neither list, naming
+the offending paths and recommending which list to update.
+
+Run locally:
+    uv run python scripts/check_release_curation.py
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DECISION_DOC = REPO_ROOT / "_project" / "decisions" / "single-repo-migration.md"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+
+def parse_main_only_allowlist(doc: Path) -> set[str]:
+    """Extract backtick-quoted top-level paths from every "main only" bullet.
+
+    Picks up both the original A3 bullet and any later amendments that
+    extend the main-only list (matched by the same `**`main` only**:` marker).
+    """
+    text = doc.read_text(encoding="utf-8")
+    # Allow optional descriptive text after "main only" before the colon,
+    # e.g. "**`main` only** (extension to A3):" so amendments can extend
+    # the allowlist without changing the original A3 row.
+    matches = re.findall(
+        r"\*\*`main` only\*\*[^:\n]*:(.*?)(?=\n\s*-\s*\*\*|\n\n)",
+        text,
+        re.DOTALL,
+    )
+    if not matches:
+        sys.exit(f"ERROR: could not find any 'main only' bullet in {doc}")
+    paths: set[str] = set()
+    for body in matches:
+        paths.update(re.findall(r"`([^`]+)`", body))
+    # Strip trailing slashes; we compare against top-level tree entries.
+    return {p.rstrip("/") for p in paths}
+
+
+def parse_curation_list(makefile: Path) -> set[str]:
+    """Extract `git rm` paths from the `release-cut:` target body."""
+    text = makefile.read_text(encoding="utf-8")
+    match = re.search(
+        r"^release-cut:\s*\n((?:[ \t].*\n|\n)+)",
+        text,
+        re.MULTILINE,
+    )
+    if not match:
+        sys.exit(f"ERROR: could not find release-cut: target in {makefile}")
+    body = match.group(1)
+    paths: set[str] = set()
+    for line in body.splitlines():
+        # Match both `-git rm -rf <paths>` and `-git rm -f <paths>` (leading
+        # `-` is the Make convention for "ignore exit code").
+        rm_match = re.search(r"git rm (?:-rf|-f) (.+?)$", line.strip())
+        if not rm_match:
+            continue
+        paths.update(rm_match.group(1).split())
+    return paths
+
+
+def list_tracked_top_level() -> set[str]:
+    """Return the set of top-level tracked paths from `git ls-tree HEAD`."""
+    result = subprocess.run(
+        ["git", "ls-tree", "HEAD", "--name-only"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line for line in result.stdout.splitlines() if line}
+
+
+def main() -> int:
+    main_only = parse_main_only_allowlist(DECISION_DOC)
+    curated = parse_curation_list(MAKEFILE)
+    tracked = list_tracked_top_level()
+
+    accounted = main_only | curated
+    unaccounted = sorted(tracked - accounted)
+
+    if not unaccounted:
+        print(
+            f"OK: all {len(tracked)} top-level tracked paths are accounted for "
+            f"({len(main_only)} main-only, {len(curated)} curated)."
+        )
+        return 0
+
+    print("ERROR: the following top-level paths are not accounted for:")
+    for path in unaccounted:
+        print(f"  - {path}")
+    print()
+    print("Each unaccounted-for path must be added to ONE of:")
+    print("  (a) the A3 'main only' allowlist in _project/decisions/single-repo-migration.md (if it ships to main), OR")
+    print(
+        "  (b) the curation list in the release-cut: target in Makefile "
+        "(if it is dev-only and should be git-rm'd from the release branch)."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements TODO **simplify-dev-loop-and-release-flow** end-to-end except for w9 (the rc dry-run, which has to run from develop after this lands).

## Summary

- **Release flow (4 → 2 commands)**: replaces `bump` / `changelog-draft` / `release-prepare` / `release-rebase-develop` with `release-cut` / `release-finalize`. Fixes the latent rebase-develop bug that would have wiped dev-only paths from develop on the first real release.
- **`develop` is intentionally not modified post-release** — dev-only paths (`_project/`, `_blog/`, agent configs, etc.) live only on develop by design (per A3 in `_project/decisions/single-repo-migration.md`).
- **CI churn cuts (~−110 CI-min/release, ~−50 CI-min/PR)**:
  - drop the redundant check-ci-passed JS poller from `release.yml` (rulesets already gate the release PR on lint+test);
  - drop `'v*'` and `develop` from `lint.yml` / `test.yml` push triggers (PR-CI already covers them);
  - add cancel-in-progress concurrency to `lint.yml` / `test.yml`;
  - skip `perf-smoke` and `parity` on Release v* PRs (curation only — nothing perf-affecting or fixture-affecting).
- **Defence-in-depth**: tighten `main-release-only` and `develop-squash-only` rulesets to `allowed_merge_methods: ["squash"]` (matches repo-wide squash-only setting); new `scripts/check_release_curation.py` runs in `lint.yml` to catch any future drift between A3 main-only paths and the release-cut curation list.
- **Local preflight**: `pr-preflight` now mirrors the full `ci-lint` surface (timing-policy, compat-docs-check, audit-deps were missing).

## Work units

| ID | Subject |
|----|---------|
| w1 | Add `release-cut` Make target |
| w2 | Add `release-finalize` Make target |
| w3 | Widen `pr-preflight` to mirror full `ci-lint` surface |
| w4 | Add Release Workflow section to `make help` (obsolete targets removed in w1+w2) |
| w5 | Drop `check-ci-passed` from release.yml; remove `v*` push trigger from lint/test |
| w6 | Tighten ruleset `allowed_merge_methods` to `["squash"]` on main + develop rulesets |
| w7 | New `scripts/check_release_curation.py` + `lint.yml` step + A3 amendment |
| w8 | Drop `develop` from lint/test push triggers (paired with w5 same-file edit) |
| w9 | Add cancel-in-progress concurrency to lint.yml / test.yml |
| w10 | Skip perf-smoke + parity on Release v* PRs |
| w11 | Rewrite docs and templates to 2-command flow |
| w9 (deferred) | Dry-run on `0.3.0-rc.1` — has to run from develop after this lands |

(Numbering reflects YAML work IDs, not commit order. The TODO YAML on develop is the canonical breakdown.)

## Test plan

- [x] `make -n release-cut VERSION=0.3.0-rc.1` parses cleanly.
- [x] `make -n release-finalize VERSION=0.3.0-rc.1` parses cleanly.
- [x] `uv run python scripts/check_release_curation.py` exits 0 on the current develop tree (44 paths accounted for).
- [x] Synthetic stray file at repo root makes the curation guard exit 1 with a clear message.
- [x] All `gh api repos/joeharris76/BenchBox/rulesets/{15611783,15611785}` show `allowed_merge_methods: ["squash"]`.
- [x] All YAML workflows parse.
- [x] Pre-push hook (`pr-preflight-fast-tests`) passes.
- [ ] CI green on this PR (lint + test workflows).
- [ ] After this lands on develop: run `make release-cut VERSION=0.3.0-rc.1` from a develop worktree to exercise the end-to-end dry-run (w9). Procedure documented in the TODO yaml under `work[].id == w9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)