### PR TITLE
fix(paths): honor BENCHBOX_OUTPUT_DIR for datagen, databases, and dataframe-cache roots

### DIFF
--- a/benchbox/cli/config.py
+++ b/benchbox/cli/config.py
@@ -836,8 +836,15 @@ class DirectoryManager:
     """Manages BenchBox directory structure and file organization."""
 
     def __init__(self, base_dir: Optional[str] = None):
-        """Initialize directory manager with configurable base directory."""
-        self.base_dir = Path(base_dir or "benchmark_runs")
+        """Initialize directory manager with configurable base directory.
+
+        When ``base_dir`` is omitted, the root is resolved via
+        :func:`resolve_benchmark_runs_dir`, which honors
+        ``BENCHBOX_OUTPUT_DIR`` and falls back to ``Path.cwd() / "benchmark_runs"``.
+        """
+        from benchbox.utils.path_utils import resolve_benchmark_runs_dir
+
+        self.base_dir = Path(base_dir) if base_dir else resolve_benchmark_runs_dir()
         self.results_dir = self.base_dir / "results"
         self.datagen_dir = self.base_dir / "datagen"
         self.databases_dir = self.base_dir / "databases"

--- a/benchbox/cli/platform_defaults.py
+++ b/benchbox/cli/platform_defaults.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from typing import Any
 
 from benchbox.cli.platform_hooks import (
@@ -14,6 +13,7 @@ from benchbox.cli.platform_hooks import (
 )
 from benchbox.core.platform_registry import PlatformInfo, PlatformRegistry
 from benchbox.core.schemas import DatabaseConfig
+from benchbox.utils.path_utils import resolve_benchmark_runs_dir
 
 
 def _parse_clickhouse_mode(value: str) -> str:
@@ -99,7 +99,7 @@ def _register_clickhouse() -> None:
         name = info.display_name if info else "ClickHouse"
         # Ensure local mode has a sensible default path
         if options.get("deployment_mode") == "local" and not options.get("data_path"):
-            db_dir = Path.cwd() / "benchmark_runs" / "databases"
+            db_dir = resolve_benchmark_runs_dir() / "databases"
             db_dir.mkdir(parents=True, exist_ok=True)
             options["data_path"] = str(db_dir / "clickhouse_local.chdb")
         driver_package = info.driver_package if info else None
@@ -139,7 +139,7 @@ def _register_clickhouse_local() -> None:
     ) -> DatabaseConfig:
         name = info.display_name if info else "ClickHouse Local"
         if not options.get("data_path"):
-            db_dir = Path.cwd() / "benchmark_runs" / "databases"
+            db_dir = resolve_benchmark_runs_dir() / "databases"
             db_dir.mkdir(parents=True, exist_ok=True)
             options["data_path"] = str(db_dir / "clickhouse_local.chdb")
         driver_package = info.driver_package if info else "chdb"
@@ -284,7 +284,7 @@ def _register_sqlite() -> None:
         overrides: dict[str, Any],
         info: PlatformInfo | None,
     ) -> DatabaseConfig:
-        db_dir = Path.cwd() / "benchmark_runs" / "databases"
+        db_dir = resolve_benchmark_runs_dir() / "databases"
         db_dir.mkdir(parents=True, exist_ok=True)
         base_name = options.get("database_name") or "benchbox"
         db_path = db_dir / f"{base_name}.db"

--- a/benchbox/cli/tuning.py
+++ b/benchbox/cli/tuning.py
@@ -198,8 +198,10 @@ def _prompt_save_config(config: UnifiedTuningConfiguration, platform: str, bench
     default_filename = f"{platform}_{benchmark}_tuned.yaml"
 
     # Ensure benchmark_runs directory exists
-    benchmark_runs_dir = Path("benchmark_runs")
-    benchmark_runs_dir.mkdir(exist_ok=True)
+    from benchbox.utils.path_utils import resolve_benchmark_runs_dir
+
+    benchmark_runs_dir = resolve_benchmark_runs_dir()
+    benchmark_runs_dir.mkdir(parents=True, exist_ok=True)
 
     # Default save path in benchmark_runs/
     default_path = benchmark_runs_dir / default_filename

--- a/benchbox/utils/path_utils.py
+++ b/benchbox/utils/path_utils.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from benchbox.core.runtime_paths import (
+    DEFAULT_BENCHMARK_RUNS_ROOT,
+    resolve_benchmark_runs_root,
+)
 from benchbox.utils.scale_factor import format_scale_factor
 
 
@@ -24,6 +28,19 @@ def get_default_data_directory() -> Path:
     return Path.cwd() / "data"
 
 
+def resolve_benchmark_runs_dir() -> Path:
+    """Return the resolved ``benchmark_runs/`` root.
+
+    Honors ``BENCHBOX_OUTPUT_DIR``; otherwise anchors the historical
+    ``benchmark_runs`` default to :func:`Path.cwd` so callers using the result
+    for filesystem operations get an absolute path.
+    """
+    root = resolve_benchmark_runs_root(env=os.environ)
+    if root == DEFAULT_BENCHMARK_RUNS_ROOT:
+        return Path.cwd() / DEFAULT_BENCHMARK_RUNS_ROOT
+    return root
+
+
 def get_benchmark_runs_datagen_path(
     benchmark_name: str,
     scale_factor: float,
@@ -34,18 +51,18 @@ def get_benchmark_runs_datagen_path(
     Args:
         benchmark_name: Normalized benchmark identifier (e.g., "tpch").
         scale_factor: Scale factor used for data generation.
-        base_dir: Optional override for the benchmark_runs root. When omitted,
-            uses ``Path.cwd() / "benchmark_runs" / "datagen"`` which mirrors
-            :class:`BaseBenchmark` defaults.
+        base_dir: Optional override for the datagen root. When omitted, the
+            root is resolved via :func:`resolve_benchmark_runs_dir` so
+            ``BENCHBOX_OUTPUT_DIR`` redirects datagen output alongside results.
 
     Returns:
-        Path pointing to ``benchmark_runs/datagen/{benchmark_name}_{sf}`` where
+        Path pointing to ``<root>/datagen/{benchmark_name}_{sf}`` where
         ``sf`` is rendered via :func:`format_scale_factor`.
     """
 
-    base_dir = Path(base_dir) if base_dir is not None else Path.cwd() / "benchmark_runs" / "datagen"
+    base = Path(base_dir) if base_dir is not None else resolve_benchmark_runs_dir() / "datagen"
     sf_fragment = format_scale_factor(scale_factor)
-    return base_dir / f"{benchmark_name}_{sf_fragment}"
+    return base / f"{benchmark_name}_{sf_fragment}"
 
 
 def get_benchmark_runs_databases_path(
@@ -58,35 +75,30 @@ def get_benchmark_runs_databases_path(
     Args:
         benchmark_name: Normalized benchmark identifier (e.g., "tpch").
         scale_factor: Scale factor used for data generation.
-        base_dir: Optional override for the databases root. When omitted,
-            uses ``Path.cwd() / "benchmark_runs" / "databases"``.
+        base_dir: Optional override for the databases root. When omitted, the
+            root is resolved via :func:`resolve_benchmark_runs_dir` so
+            ``BENCHBOX_OUTPUT_DIR`` redirects local DB artifacts alongside
+            results.
 
     Returns:
-        Path pointing to ``benchmark_runs/databases/{benchmark_name}_{sf}`` where
+        Path pointing to ``<root>/databases/{benchmark_name}_{sf}`` where
         ``sf`` is rendered via :func:`format_scale_factor`.
     """
-    base_dir = Path(base_dir) if base_dir is not None else Path.cwd() / "benchmark_runs" / "databases"
+    base = Path(base_dir) if base_dir is not None else resolve_benchmark_runs_dir() / "databases"
     sf_fragment = format_scale_factor(scale_factor)
-    return base_dir / f"{benchmark_name}_{sf_fragment}"
+    return base / f"{benchmark_name}_{sf_fragment}"
 
 
 def get_benchmark_runs_dataframe_path(base_dir: str | Path | None = None) -> Path:
     """Get the canonical benchmark_runs/datagen directory for DataFrame cached data.
 
-    DataFrame cached data now lives alongside SQL datagen output under the
-    unified ``benchmark_runs/datagen/`` directory, enabling efficient reuse of
-    generated data across execution modes.
-
-    Args:
-        base_dir: Optional override for the datagen root. When omitted,
-            uses ``Path.cwd() / "benchmark_runs" / "datagen"``.
-
-    Returns:
-        Path pointing to ``benchmark_runs/datagen/``.
+    DataFrame cached data lives alongside SQL datagen output under the unified
+    ``<root>/datagen/`` directory, enabling efficient reuse of generated data
+    across execution modes. The root honors ``BENCHBOX_OUTPUT_DIR``.
     """
     if base_dir is not None:
         return Path(base_dir)
-    return Path.cwd() / "benchmark_runs" / "datagen"
+    return resolve_benchmark_runs_dir() / "datagen"
 
 
 def get_results_path(benchmark_name: str, timestamp: str, base_dir: str | Path | None = None) -> Path:

--- a/scripts/local_stress_test.sh
+++ b/scripts/local_stress_test.sh
@@ -25,7 +25,8 @@ Options:
                                 Uses timeout(1)/gtimeout(1) when available,
                                 otherwise falls back to perl(1).
   --log-dir <dir>               Directory for captured stdout/stderr logs
-                                (default: benchmark_runs/logs)
+                                (default: \$BENCHBOX_OUTPUT_DIR/logs, falling back to
+                                ~/Developer/benchmark_runs/logs)
   --skip-unavailable            Skip platforms that fail a pre-flight connectivity check
                                 instead of counting them as failures
   -h, --help                    Show this help
@@ -47,6 +48,14 @@ EOF
   exit 1
 }
 
+# ---- BenchBox runs root ----
+# All datagen, database, log, and result files land under this root. The
+# framework reads BENCHBOX_OUTPUT_DIR to redirect benchmark_runs/{datagen,
+# databases,results,charts}; we export it here and anchor LOG_DIR to the
+# same root so a single env var controls every artifact path.
+: "${BENCHBOX_OUTPUT_DIR:=$HOME/Developer/benchmark_runs}"
+export BENCHBOX_OUTPUT_DIR
+
 # ---- args ----
 SCALE_OVERRIDE=""
 PHASES="load,power"
@@ -56,7 +65,7 @@ BENCHMARK_FILTER=""
 BENCHMARK_GROUP="all"
 COMPRESSION=""
 PER_BENCHMARK_TIMEOUT="0"
-LOG_DIR="benchmark_runs/logs"
+LOG_DIR="$BENCHBOX_OUTPUT_DIR/logs"
 SKIP_UNAVAILABLE=0
 
 while [[ $# -gt 0 ]]; do
@@ -461,9 +470,12 @@ run_benchmark() {
   local elapsed=$(( SECONDS - t0 ))
 
   if [[ "$rc" -eq 0 ]]; then
-    # Extract result JSON path from log if present.
+    # Extract result JSON path from log if present. Match either a relative
+    # benchmark_runs/results/... path (legacy) or an absolute path under
+    # $BENCHBOX_OUTPUT_DIR/results/... so the script works regardless of where
+    # the runs root lives.
     local result_path
-    result_path=$(grep -oE 'benchmark_runs/results/[^[:space:]]+\.json' "$log_file" | tail -1 || true)
+    result_path=$(grep -oE '(/[^[:space:]]+/)?benchmark_runs/results/[^[:space:]]+\.json' "$log_file" | tail -1 || true)
     if [[ -n "$result_path" ]]; then
       echo "done (${elapsed}s) → $result_path"
     else

--- a/tests/unit/cli/test_config_coverage.py
+++ b/tests/unit/cli/test_config_coverage.py
@@ -72,6 +72,17 @@ def test_load_config_raises_when_validation_fails(tmp_path: Path, monkeypatch: p
         cfg.load_config(config_file=config_path, validate=True)
 
 
+def test_directory_manager_honors_output_dir_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``DirectoryManager()`` (no base_dir) should resolve via BENCHBOX_OUTPUT_DIR."""
+    custom_root = tmp_path / "custom_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(custom_root))
+    dm = cfg.DirectoryManager()
+    assert dm.base_dir == custom_root
+    assert dm.results_dir == custom_root / "results"
+    assert dm.datagen_dir == custom_root / "datagen"
+    assert dm.databases_dir == custom_root / "databases"
+
+
 def test_directory_manager_paths_and_cleanup(tmp_path: Path) -> None:
     dm = cfg.DirectoryManager(base_dir=str(tmp_path / "runs"))
     assert dm.results_dir.exists() and dm.datagen_dir.exists() and dm.databases_dir.exists()

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -14,9 +14,11 @@ import pytest
 from benchbox.utils.path_utils import (
     ensure_directory,
     get_benchmark_runs_databases_path,
+    get_benchmark_runs_dataframe_path,
     get_benchmark_runs_datagen_path,
     get_default_data_directory,
     get_results_path,
+    resolve_benchmark_runs_dir,
 )
 
 pytestmark = [
@@ -324,8 +326,8 @@ class TestPathUtilsIntegration:
             default_dir = get_default_data_directory()
             assert default_dir == custom_data_dir
 
-            # Note: get_benchmark_runs_datagen_path uses benchmark_runs/datagen by default, not env var
-            # Only get_results_path (via get_default_data_directory) uses env var
+            # get_results_path consumes BENCHBOX_DATA_DIR via get_default_data_directory.
+            # (BENCHBOX_OUTPUT_DIR is the runs-root override; covered separately below.)
             results_path = get_results_path("ssb", "20250115_150000")  # No base_dir specified
 
             # Verify results path uses environment variable
@@ -362,7 +364,10 @@ class TestGetBenchmarkRunsDatabasesPath:
 
     def test_default_databases_path(self):
         """Default path should use benchmark_runs/databases under cwd."""
-        with patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")),
+        ):
             result = get_benchmark_runs_databases_path("tpch", 1.0)
         assert result == Path("/repo/benchmark_runs/databases/tpch_sf1")
 
@@ -370,3 +375,55 @@ class TestGetBenchmarkRunsDatabasesPath:
         """Custom base dir should be used directly."""
         result = get_benchmark_runs_databases_path("tpcds", 0.01, "/tmp/base")
         assert result == Path("/tmp/base/tpcds_sf001")
+
+
+class TestBenchboxOutputDirRedirection:
+    """BENCHBOX_OUTPUT_DIR redirects datagen, databases, and dataframe-cache roots."""
+
+    def test_datagen_path_honors_output_dir(self, tmp_path):
+        custom_root = tmp_path / "runs"
+        with patch.dict(os.environ, {"BENCHBOX_OUTPUT_DIR": str(custom_root)}):
+            result = get_benchmark_runs_datagen_path("tpch", 1.0)
+        assert result == custom_root / "datagen" / "tpch_sf1"
+
+    def test_databases_path_honors_output_dir(self, tmp_path):
+        custom_root = tmp_path / "runs"
+        with patch.dict(os.environ, {"BENCHBOX_OUTPUT_DIR": str(custom_root)}):
+            result = get_benchmark_runs_databases_path("tpcds", 0.01)
+        assert result == custom_root / "databases" / "tpcds_sf001"
+
+    def test_dataframe_path_honors_output_dir(self, tmp_path):
+        custom_root = tmp_path / "runs"
+        with patch.dict(os.environ, {"BENCHBOX_OUTPUT_DIR": str(custom_root)}):
+            result = get_benchmark_runs_dataframe_path()
+        assert result == custom_root / "datagen"
+
+    def test_explicit_base_dir_overrides_env(self, tmp_path):
+        """An explicit base_dir takes precedence over BENCHBOX_OUTPUT_DIR."""
+        env_root = tmp_path / "from_env"
+        explicit = tmp_path / "from_arg"
+        with patch.dict(os.environ, {"BENCHBOX_OUTPUT_DIR": str(env_root)}):
+            result = get_benchmark_runs_databases_path("tpch", 1.0, explicit)
+        assert result == explicit / "tpch_sf1"
+
+    def test_resolve_benchmark_runs_dir_expands_user(self, tmp_path, monkeypatch):
+        """``~`` in the env var is expanded so callers get an absolute path."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", "~/runs")
+        assert resolve_benchmark_runs_dir() == tmp_path / "runs"
+
+    def test_resolve_benchmark_runs_dir_falls_back_to_cwd(self):
+        """When no env var is set, fall back to cwd-anchored default."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")),
+        ):
+            assert resolve_benchmark_runs_dir() == Path("/repo/benchmark_runs")
+
+    def test_empty_env_var_falls_back_to_cwd(self):
+        """An empty BENCHBOX_OUTPUT_DIR value should not override the default."""
+        with (
+            patch.dict(os.environ, {"BENCHBOX_OUTPUT_DIR": ""}),
+            patch("benchbox.utils.path_utils.Path.cwd", return_value=Path("/repo")),
+        ):
+            assert resolve_benchmark_runs_dir() == Path("/repo/benchmark_runs")

--- a/tests/unit/utils/test_path_utils.py
+++ b/tests/unit/utils/test_path_utils.py
@@ -408,7 +408,10 @@ class TestBenchboxOutputDirRedirection:
 
     def test_resolve_benchmark_runs_dir_expands_user(self, tmp_path, monkeypatch):
         """``~`` in the env var is expanded so callers get an absolute path."""
+        # Path.expanduser() consults HOME on POSIX and USERPROFILE on Windows
+        # (ntpath.expanduser ignores HOME); set both so the test is portable.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", "~/runs")
         assert resolve_benchmark_runs_dir() == tmp_path / "runs"
 


### PR DESCRIPTION
BENCHBOX_OUTPUT_DIR previously only redirected results/charts via runtime_paths;
datagen, local DB artifacts, dataframe cache, DirectoryManager defaults, and
the tuning-save default still hard-coded Path.cwd() / "benchmark_runs", so
setting the env var split outputs across two roots.

Centralize on a new resolve_benchmark_runs_dir() helper in path_utils that
calls runtime_paths.resolve_benchmark_runs_root(env=os.environ) and falls back
to Path.cwd() / "benchmark_runs". Wire every default path through it:
get_benchmark_runs_{datagen,databases,dataframe}_path, the three database-dir
sites in cli/platform_defaults.py, DirectoryManager, and cli/tuning.py.

scripts/local_stress_test.sh defaults BENCHBOX_OUTPUT_DIR to
\$HOME/Developer/benchmark_runs (overridable), pins LOG_DIR under it, and
broadens the result-discovery regex to match absolute paths.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
