### PR TITLE
fix(pr33): address post-merge review follow-ups

### DIFF
--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T19:59:32.612795'
+generated_at: '2026-04-27T20:56:17.966775'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T19:59:32.612984'
+generated_at: '2026-04-27T20:56:17.967006'
 total_items: 787
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T19:59:32.613167'
+generated_at: '2026-04-27T20:56:17.967193'
 total_items: 787
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T19:59:32.612467'
+generated_at: '2026-04-27T20:56:17.966380'
 total_items: 787
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T19:59:30.756408'
-total_categories: 11
+generated_at: '2026-04-27T20:56:29.970598'
+total_categories: 12
 categories:
   Architecture & Refactoring:
     count: 1
@@ -173,5 +173,13 @@ categories:
     - id: validate-and-integrate-tpc-tuning-json
       file: TODO/main/planning/validate-and-integrate-tpc-tuning-json.yaml
       title: Validate tpc-tuning.json z-ordering recommendations and integrate or discard
+      priority: Medium
+      status: Not Started
+  Tooling:
+    count: 1
+    items:
+    - id: automate-phase2-metrics-quarterly-cadence
+      file: TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
+      title: Automate the Phase 3 promotion-metrics quarterly cadence
       priority: Medium
       status: Not Started

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T19:59:30.756425'
-total_items: 28
+generated_at: '2026-04-27T20:56:29.970612'
+total_items: 29
 priorities:
   High:
     count: 4
@@ -43,7 +43,7 @@ priorities:
       category: Testing and Quality Assurance
       status: Not Started
   Medium:
-    count: 6
+    count: 7
     items:
     - id: ballista-distributed-adapter
       file: TODO/platform-expansion/planning/ballista-distributed-adapter.yaml
@@ -55,6 +55,11 @@ priorities:
       title: Address follow-up findings from timing-policy pre-commit split review
       category: Testing & Quality
       status: In Progress
+    - id: automate-phase2-metrics-quarterly-cadence
+      file: TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
+      title: Automate the Phase 3 promotion-metrics quarterly cadence
+      category: Tooling
+      status: Not Started
     - id: enable-duckdb-wasm-http-range-reads-for-registered-urls
       file: TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
       title: Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T19:59:30.756435'
-total_items: 28
+generated_at: '2026-04-27T20:56:29.970621'
+total_items: 29
 statuses:
   In Progress:
     count: 3
@@ -20,7 +20,7 @@ statuses:
       priority: High
       category: Release Tooling
   Not Started:
-    count: 24
+    count: 25
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -52,6 +52,11 @@ statuses:
       title: Add a third benchmark cohort (TPC-DS or ClickBench) to the public corpus
       priority: Medium-High
       category: Core Functionality
+    - id: automate-phase2-metrics-quarterly-cadence
+      file: TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
+      title: Automate the Phase 3 promotion-metrics quarterly cadence
+      priority: Medium
+      category: Tooling
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-27T19:59:30.756380'
-total_items: 28
+generated_at: '2026-04-27T20:56:29.970567'
+total_items: 29
 items:
 - id: integrate-benchbox-cli-submit-and-service-auth
   file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
@@ -16,7 +16,7 @@ items:
   - api
   estimated_effort: Large
   work_total: 8
-  work_done: 2
+  work_done: 3
   work_ready: 1
   needs:
   - define-results-platform-product-and-launch-strategy
@@ -334,6 +334,24 @@ items:
   work_total: 3
   work_done: 1
   work_ready: 2
+- id: automate-phase2-metrics-quarterly-cadence
+  file: TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
+  title: Automate the Phase 3 promotion-metrics quarterly cadence
+  worktree: main
+  category: Tooling
+  priority: Medium
+  status: Not Started
+  tags:
+  - phase-3
+  - metrics
+  - automation
+  - ci
+  estimated_effort: Small
+  work_total: 5
+  work_done: 0
+  work_ready: 1
+  needs:
+  - define-phase-3-promotion-metrics
 - id: enable-duckdb-wasm-http-range-reads-for-registered-urls
   file: TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
   title: Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL

--- a/_project/TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
+++ b/_project/TODO/main/planning/automate-phase2-metrics-quarterly-cadence.yaml
@@ -1,0 +1,144 @@
+id: automate-phase2-metrics-quarterly-cadence
+title: "Automate the Phase 3 promotion-metrics quarterly cadence"
+worktree: main
+priority: Medium
+status: Not Started
+category: Tooling
+deps:
+  needs:
+    - define-phase-3-promotion-metrics
+description: |
+  `scripts/phase2_metrics.py` (landed 2026-04-27) computes the six
+  Phase 2 → Phase 3 promotion metrics on demand and writes a markdown
+  handoff. The script is sound, but the **cadence depends on a human
+  remembering to run it quarterly** — the same failure mode the metrics
+  were introduced to prevent.
+
+  This TODO closes the loop: machine-readable output, automatic diff
+  against the previous review, and a scheduled CI hook so the report is
+  produced on the first Monday of each quarter without intervention.
+
+  Surfaced by the post-merge review of PR #33 (commit d6daac8c5).
+
+work:
+  - id: w1
+    summary: "Add `--format json` to phase2_metrics for automation consumers"
+    status: pending
+    notes: |
+      Today the script always emits markdown. Add `--format {markdown,json}`
+      and emit a JSON object with: generated_at, repo, base_branch,
+      results: [{name, value, breached, threshold, note}],
+      extraction_triggers: [...]. Markdown remains the default. The JSON
+      shape is what the diff-vs-last-review step (w2) and the scheduled
+      check (w3) consume.
+
+  - id: w2
+    summary: "Compute diff vs the most recent prior review"
+    needs: [w1]
+    status: pending
+    notes: |
+      Walk `_project/handoffs/phase-3-review-*.md` (or the JSON sidecars
+      from w1), pick the most recent before today, and append a "Trend
+      vs <date>" section to the report — per metric, value-then vs
+      value-now, plus a status-change column (ok→BREACHED, etc.).
+      The "two consecutive quarters" hysteresis rule in
+      `_project/analysis/phase-3-promotion-metrics.md` is the primary
+      consumer of this signal — surface it explicitly so the reviewer
+      doesn't have to diff manually.
+
+  - id: w3
+    summary: "Add a GitHub Actions workflow that runs the script quarterly"
+    needs: [w1]
+    status: pending
+    notes: |
+      `.github/workflows/phase3-promotion-review.yml` runs on a cron of
+      `0 9 1 1,4,7,10 *` (first day of Jan/Apr/Jul/Oct, 09:00 UTC) and
+      `workflow_dispatch`. Step 1: `uv run python scripts/phase2_metrics.py
+      --output _project/handoffs/phase-3-review-$(date +%Y-%m-%d).md`.
+      Step 2: open a PR titled `chore(phase-3): quarterly promotion review
+      <date>` with the handoff committed. The maintainer reviews the PR
+      and writes the one-paragraph interpretation per metric per the
+      procedure in `phase-3-promotion-metrics.md`, then merges or rejects.
+      No auto-merge — the human-judgment paragraph is the point.
+
+  - id: w4
+    summary: "Add `--exit-non-zero-on-breach` for ad-hoc CI gating"
+    needs: [w1]
+    status: pending
+    notes: |
+      Optional flag for users who want to wire this into a non-quarterly
+      check (e.g., a weekly cron during a high-throughput period). Off by
+      default — the canonical use is quarterly review where the report is
+      always generated regardless of breach state.
+
+  - id: w5
+    summary: "Document the automation in phase-3-promotion-metrics.md"
+    needs: [w3]
+    status: pending
+    notes: |
+      Update `_project/analysis/phase-3-promotion-metrics.md` "Review
+      Cadence and Procedure" section: replace step 2 ("Run the metrics
+      script") with "Review the auto-generated PR titled <title-pattern>"
+      and document the manual fallback (`workflow_dispatch` if the cron
+      misses).
+
+metadata:
+  tags:
+    - phase-3
+    - metrics
+    - automation
+    - ci
+  estimated_effort: "Small"
+  created_date: "2026-04-27"
+
+impact:
+  business_value: |
+    Removes the human-memory dependency from the Phase 3 promotion
+    decision. The metrics fire on a calendar, not when someone happens
+    to remember — which is the point of having metrics at all.
+  user_impact: |
+    Maintainer-facing only. End users never see this.
+  technical_debt: |
+    Closes the operational gap flagged in the post-merge review of
+    PR #33. Without this, the metrics doc is aspirational, not load-
+    bearing.
+
+must_preserve:
+  - "Markdown output remains the default (the existing handoff file format)"
+  - "Read-only: no GitHub writes from the metrics script itself; the workflow opens a PR but does not auto-merge"
+  - "The decision rule (two thresholds, two consecutive quarters) stays in `_project/analysis/phase-3-promotion-metrics.md`, not the script"
+
+approach: |
+  Build w1 (JSON output) first since w2 and w3 both depend on it. w3
+  (the workflow) is the load-bearing piece — w2 and w4 are conveniences
+  that the workflow can adopt incrementally.
+
+anti_patterns:
+  - "DO NOT auto-promote the Phase 3 design TODOs from the workflow -- because the human-judgment paragraph per metric is the safeguard against false-positive promotion -- only generate the report"
+  - "DO NOT run the workflow on every push -- because the cadence is what gives the metrics meaning -- quarterly + manual dispatch is correct"
+
+verification:
+  - description: "JSON output validates as JSON"
+    command: "uv run python scripts/phase2_metrics.py --format json | python -c 'import json,sys; json.load(sys.stdin)'"
+    expected_output: ""
+  - description: "Workflow file exists and the cron is correct"
+    command: "grep -c 'cron:.*1 1,4,7,10' .github/workflows/phase3-promotion-review.yml"
+    expected_output: "1"
+  - description: "Diff section appears when at least two reviews exist"
+    command: "uv run python scripts/phase2_metrics.py | grep -c 'Trend vs'"
+    expected_output: ">= 1"
+
+files_affected:
+  modified:
+    - "scripts/phase2_metrics.py"
+    - "_project/analysis/phase-3-promotion-metrics.md"
+    - "tests/unit/scripts/test_phase2_metrics.py"
+  added:
+    - ".github/workflows/phase3-promotion-review.yml"
+
+scope_limit:
+  only_modify:
+    - "scripts/"
+    - ".github/workflows/"
+    - "_project/analysis/"
+    - "tests/unit/scripts/"

--- a/_project/analysis/phase-3-promotion-metrics.md
+++ b/_project/analysis/phase-3-promotion-metrics.md
@@ -25,7 +25,7 @@ requests is enough signal that the demand is real, not anecdotal.
 | # | Metric                                            | Source                                                    | Threshold                  | Implication if breached                                     |
 |---|---------------------------------------------------|-----------------------------------------------------------|----------------------------|-------------------------------------------------------------|
 | 1 | Merged community submissions / month (90d window) | `gh pr list --base published-results --state merged`      | ≥ 50 sustained for 3 mo    | PR review at scale; hosted ingest reduces maintainer toil   |
-| 2 | Median PR review latency (open → merge, hours)    | `gh pr list --base published-results --state merged --json` | > 72h median over 30d    | Reviewers are the bottleneck; async ingest would help       |
+| 2 | Median PR open→merge time, hours (proxy for review latency) | `gh pr list --base published-results --state merged --json` | > 72h median over 30d    | Reviewers are the bottleneck; async ingest would help       |
 | 3 | PR backlog (open against published-results > 7d)  | `gh pr list --base published-results --state open --json` | ≥ 5 sustained for 30d      | Queue is growing; signals chronic capacity gap              |
 | 4 | Distinct requests for private/unlisted results    | § Private/Unlisted, count distinct **Requester**          | ≥ 3 distinct requesters    | Public-only constraint blocks legitimate use cases          |
 | 5 | Submissions blocked by maintainer-only constraints | § Blocked-Maintainer, count entries (one per **Date**)    | ≥ 5 entries                | PR-mediated trust model is gating real contributions        |
@@ -66,7 +66,11 @@ other quantitative thresholds are calibrated against that:
 
 - **72h median latency**: at 50 PRs/mo (~12/wk), > 72h median means
   more than half the queue is older than the typical reviewer rotation
-  — a clear bottleneck.
+  — a clear bottleneck. M2 measures open→merge, so it includes draft
+  and author-iteration time; treat it as a coarse proxy for review-only
+  latency. If false-positive promotion is a concern, switch to
+  first-non-author-comment → merge once gh's `--json reviews` field is
+  the bottleneck check (not at calibration time).
 - **Backlog ≥ 5 for 30d**: with 50/mo throughput, a steady-state
   backlog of 5 is ~3 days of in-flight work, which is healthy. Sustained
   ≥ 5 *for 30 days* means the queue is not draining at the arrival rate.

--- a/benchbox/cli/commands/submit.py
+++ b/benchbox/cli/commands/submit.py
@@ -23,6 +23,9 @@ from benchbox.core.results.loader import (
 # Submission manifest phase - indicates the result schema generation (v2.0 = phase 2).
 _SUBMISSION_PHASE = 2
 
+_DEFAULT_SERVICE_URL = "https://api.benchbox.dev/v1"
+_VISIBILITY_CHOICES = ("public", "unlisted", "private")
+
 _CONTRIBUTING_TEXT = """\
 # Contributing a Benchmark Result
 
@@ -85,6 +88,16 @@ def _dispatch_service_mode(
     real upload + auth + status-polling flow is the work in
     `integrate-benchbox-cli-submit-and-service-auth` w4-w8 and lands
     once the hosted ingest API is available.
+
+    Hash contract for the dry-run: the values printed are SHA-256 of the
+    on-disk source files as-is. The Phase 2 PR-package path
+    (--output mode) hashes the same bytes after a `shutil.copy2` into
+    `bundle/`, so the hashes are byte-identical there. If a future
+    iteration of the real-upload path canonicalises (re-serialises) the
+    bundle JSON before sending, this dry-run hash will diverge from the
+    sent hash. In that case, hoist the canonicalisation step ahead of
+    `_compute_file_hash` here so the dry-run reports what the server
+    will actually receive.
     """
     bundle_size = source_path.stat().st_size
     bundle_hash = _compute_file_hash(source_path)
@@ -117,10 +130,6 @@ def _dispatch_service_mode(
         "  _project/analysis/phase-3-promotion-metrics.md."
     )
     ctx.exit(1)
-
-
-_DEFAULT_SERVICE_URL = "https://api.benchbox.dev/v1"
-_VISIBILITY_CHOICES = ("public", "unlisted", "private")
 
 
 @click.command("submit")

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -326,7 +326,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                     <th class="p-0" scope="col">
                       <button
                         type="button"
-                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0 font-inherit"
+                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
                         onClick={() => toggleSort("query_id")}
                       >
                         Query{sortArrow("query_id")}
@@ -335,7 +335,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                     <th class="p-0" scope="col">
                       <button
                         type="button"
-                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0 font-inherit"
+                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
                         onClick={() => toggleSort("display_ms")}
                       >
                         Median (ms){sortArrow("display_ms")}
@@ -344,7 +344,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                     <th class="p-0" scope="col">
                       <button
                         type="button"
-                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0 font-inherit"
+                        class="table-th block w-full text-left cursor-pointer select-none bg-transparent border-0"
                         onClick={() => toggleSort("sample_count")}
                       >
                         Samples{sortArrow("sample_count")}

--- a/scripts/phase2_metrics.py
+++ b/scripts/phase2_metrics.py
@@ -164,6 +164,9 @@ def metric_merged_volume(prs: list[dict] | GhError, now: datetime) -> MetricResu
         if merged is None:
             continue
         delta_days = (now - merged).days
+        if delta_days < 0:
+            # Future-dated mergedAt (clock skew or upstream API quirk).
+            continue
         if delta_days < 30:
             buckets[0] += 1
         elif delta_days < 60:
@@ -177,8 +180,9 @@ def metric_merged_volume(prs: list[dict] | GhError, now: datetime) -> MetricResu
 
 
 def metric_review_latency(prs: list[dict] | GhError, now: datetime) -> MetricResult:
-    name = f"Median PR review latency, hours (last {LATENCY_WINDOW_DAYS}d merged)"
+    name = f"Median PR open->merge time, hours (last {LATENCY_WINDOW_DAYS}d merged)"
     threshold = f"> {THRESH_LATENCY_HOURS}h"
+    note_def = "open->merge; includes draft + author-iteration time, so this over-reports strict review-only latency"
     if isinstance(prs, GhError):
         return MetricResult(name, "n/a", None, threshold, prs.message)
 
@@ -189,13 +193,16 @@ def metric_review_latency(prs: list[dict] | GhError, now: datetime) -> MetricRes
         created = _parse_iso(pr.get("createdAt"))
         if merged is None or created is None or merged < cutoff:
             continue
+        if merged < created:
+            # Defensive: skip nonsensical negative-duration rows.
+            continue
         latencies.append((merged - created).total_seconds() / 3600.0)
 
     if not latencies:
         return MetricResult(name, "0 PRs in window", False, threshold, "no data")
     median_h = statistics.median(latencies)
     breached = median_h > THRESH_LATENCY_HOURS
-    return MetricResult(name, f"{median_h:.1f}h (n={len(latencies)})", breached, threshold)
+    return MetricResult(name, f"{median_h:.1f}h (n={len(latencies)})", breached, threshold, note_def)
 
 
 def metric_backlog(prs: list[dict] | GhError, now: datetime) -> MetricResult:
@@ -313,6 +320,8 @@ def _trigger_q2_pr_volume(prs: list[dict] | GhError, now: datetime) -> MetricRes
         if merged is None:
             continue
         delta_days = (now - merged).days
+        if delta_days < 0:
+            continue
         bucket = delta_days // 30
         if 0 <= bucket < EXTRACTION_PR_VOLUME_MONTHS:
             buckets[bucket] += 1

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -290,6 +290,22 @@ def _hash_file(file_path: Path) -> str:
     return h.hexdigest()
 
 
+def _is_safe_bundle_filename(name: str) -> bool:
+    """Reject filenames that could escape the bundle directory.
+
+    The validator runs in CI on attacker-controlled PR JSON, so manifest-
+    supplied filenames must be plain leaf names, not paths.
+    """
+    if not name or name in (".", ".."):
+        return False
+    if "/" in name or "\\" in name or "\x00" in name:
+        return False
+    parts = Path(name).parts
+    if Path(name).is_absolute() or ".." in parts or len(parts) != 1:
+        return False
+    return True
+
+
 def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: ValidationResult) -> None:
     """Verify the submission manifest hashes match the bundle file contents.
 
@@ -320,6 +336,9 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
     if not isinstance(expected_hash, str) or not expected_hash:
         vr.warn("Submission manifest has no bundle_hash field")
         return
+    if not _is_safe_bundle_filename(bundle_file):
+        vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
+        return
 
     primary_path = bundle_dir / bundle_file
     if not primary_path.is_file():
@@ -339,6 +358,9 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
         return
 
     for comp_name, comp_expected in companion_hashes.items():
+        if not isinstance(comp_name, str) or not _is_safe_bundle_filename(comp_name):
+            vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
+            continue
         comp_path = bundle_dir / comp_name
         if not comp_path.is_file():
             vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")

--- a/tests/unit/scripts/test_phase2_metrics.py
+++ b/tests/unit/scripts/test_phase2_metrics.py
@@ -1,0 +1,281 @@
+"""Tests for scripts/phase2_metrics.py.
+
+Covers the parsing helpers and metric functions. The gh CLI is not
+exercised here — those code paths take a list[dict] | GhError and we
+inject both shapes directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from phase2_metrics import (
+    DATE_LINE_RE,
+    ORG_LINE_RE,
+    REQUESTER_LINE_RE,
+    SECTION_BLOCKED,
+    SECTION_ORG,
+    SECTION_PRIVATE,
+    GhError,
+    _count_distinct_lowercased,
+    _count_entries,
+    _glyph,
+    _split_sections,
+    _trigger_q1_size,
+    _trigger_q2_pr_volume,
+    metric_backlog,
+    metric_merged_volume,
+    metric_qualitative,
+    metric_review_latency,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+NOW = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _pr(merged_offset_days: float | None, created_offset_days: float | None = None) -> dict:
+    """Build a minimal gh-shaped PR dict.
+
+    `*_offset_days` is days BEFORE NOW (positive = past). None = field absent.
+    """
+    out: dict = {}
+    if merged_offset_days is not None:
+        out["mergedAt"] = (NOW - timedelta(days=merged_offset_days)).isoformat().replace("+00:00", "Z")
+    if created_offset_days is not None:
+        out["createdAt"] = (NOW - timedelta(days=created_offset_days)).isoformat().replace("+00:00", "Z")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Section parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSplitSections:
+    def test_extracts_sections_keyed_by_h2(self):
+        text = "# Title\n\n## Foo\n\nfoo body\n\n## Bar\n\nbar body\n"
+        sections = _split_sections(text)
+        assert "Foo" in sections and "Bar" in sections
+        assert "foo body" in sections["Foo"]
+        assert "bar body" in sections["Bar"]
+
+    def test_ignores_h1_and_h3(self):
+        text = "# H1\n## Real\nbody\n### Sub\nnope\n"
+        sections = _split_sections(text)
+        assert list(sections.keys()) == ["Real"]
+        assert "### Sub" in sections["Real"]  # h3 is content of the h2
+
+    def test_empty_text(self):
+        assert _split_sections("") == {}
+
+
+class TestCountDistinctLowercased:
+    def test_case_folds(self):
+        body = "**Requester**: Alice\n**Requester**: ALICE\n**Requester**: bob\n"
+        assert _count_distinct_lowercased(body, REQUESTER_LINE_RE) == 2
+
+    def test_strips_whitespace(self):
+        body = "**Requester**:  Alice   \n**Requester**: alice\n"
+        assert _count_distinct_lowercased(body, REQUESTER_LINE_RE) == 1
+
+    def test_ignores_blank_values(self):
+        body = "**Requester**: \n**Requester**: alice\n"
+        assert _count_distinct_lowercased(body, REQUESTER_LINE_RE) == 1
+
+    def test_orgs(self):
+        body = "**Organization**: AcmeCorp\n**Organization**: acmecorp\n**Organization**: Other\n"
+        assert _count_distinct_lowercased(body, ORG_LINE_RE) == 2
+
+    def test_no_matches(self):
+        assert _count_distinct_lowercased("nothing here", REQUESTER_LINE_RE) == 0
+
+
+class TestCountEntries:
+    def test_one_per_date_line(self):
+        body = "**Date**: 2026-04-01\n**Date**: 2026-04-02\n**Date**: 2026-04-02\n"
+        # Same date twice -> two entries (a heavy contributor blocked twice).
+        assert _count_entries(body) == 3
+
+    def test_no_dates(self):
+        assert _count_entries("no dates here") == 0
+
+    def test_rejects_malformed_dates(self):
+        # The regex requires YYYY-MM-DD; bare year or text is ignored.
+        body = "**Date**: 2026\n**Date**: yesterday\n**Date**: 2026-04-01\n"
+        assert _count_entries(body) == 1
+
+
+# ---------------------------------------------------------------------------
+# metric_qualitative
+# ---------------------------------------------------------------------------
+
+
+def _notes_with(section: str, body: str) -> str:
+    return f"# Notes\n\n## {section}\n\n{body}\n"
+
+
+class TestMetricQualitative:
+    def test_distinct_requesters_rule(self):
+        notes = _notes_with(SECTION_PRIVATE, "**Requester**: alice\n**Requester**: ALICE\n**Requester**: bob\n")
+        r = metric_qualitative(
+            notes, SECTION_PRIVATE, threshold=2, rule="distinct_requesters", label="Distinct requesters"
+        )
+        assert r.value == "2"
+        assert r.breached is True
+
+    def test_entry_count_rule(self):
+        notes = _notes_with(SECTION_BLOCKED, "**Date**: 2026-04-01\n**Date**: 2026-04-02\n")
+        r = metric_qualitative(notes, SECTION_BLOCKED, threshold=5, rule="entry_count", label="Entries")
+        assert r.value == "2"
+        assert r.breached is False
+
+    def test_distinct_orgs_rule(self):
+        notes = _notes_with(SECTION_ORG, "**Organization**: AcmeCorp\n**Organization**: acmecorp\n")
+        r = metric_qualitative(notes, SECTION_ORG, threshold=3, rule="distinct_orgs", label="Orgs")
+        assert r.value == "1"
+        assert r.breached is False
+
+    def test_missing_section_is_unmeasurable(self):
+        r = metric_qualitative("# empty\n", "Nope", threshold=1, rule="distinct_requesters", label="X")
+        assert r.value == "n/a"
+        assert r.breached is None
+        assert "missing" in r.note
+
+    def test_unknown_rule_is_unmeasurable(self):
+        notes = _notes_with(SECTION_PRIVATE, "**Requester**: alice\n")
+        r = metric_qualitative(notes, SECTION_PRIVATE, threshold=1, rule="not_a_rule", label="X")
+        assert r.value == "n/a"
+        assert r.breached is None
+
+
+# ---------------------------------------------------------------------------
+# Quantitative metrics
+# ---------------------------------------------------------------------------
+
+
+class TestMetricMergedVolume:
+    def test_buckets_by_30d_window(self):
+        prs = [
+            _pr(merged_offset_days=5),  # bucket 0
+            _pr(merged_offset_days=29),  # bucket 0
+            _pr(merged_offset_days=45),  # bucket 1
+            _pr(merged_offset_days=80),  # bucket 2
+            _pr(merged_offset_days=120),  # outside window
+        ]
+        r = metric_merged_volume(prs, NOW)
+        assert "2 / 1 / 1" in r.value
+
+    def test_future_dated_merge_skipped(self):
+        # mergedAt 1 day in the future -> negative delta_days -> must skip.
+        prs = [_pr(merged_offset_days=-1), _pr(merged_offset_days=5)]
+        r = metric_merged_volume(prs, NOW)
+        assert r.value.startswith("1 / 0 / 0")
+
+    def test_gh_error_unmeasurable(self):
+        r = metric_merged_volume(GhError("nope"), NOW)
+        assert r.value == "n/a"
+        assert r.breached is None
+        assert r.note == "nope"
+
+    def test_breached_requires_all_three_buckets(self):
+        # Threshold is 50/mo; this fails because only bucket 0 has 50.
+        prs = [_pr(merged_offset_days=10) for _ in range(50)]
+        r = metric_merged_volume(prs, NOW)
+        assert r.breached is False
+
+
+class TestMetricReviewLatency:
+    def test_computes_median_open_to_merge(self):
+        # PR1: 24h open->merge, PR2: 96h open->merge.
+        prs = [
+            _pr(merged_offset_days=1, created_offset_days=2),  # 24h
+            _pr(merged_offset_days=1, created_offset_days=5),  # 96h
+        ]
+        r = metric_review_latency(prs, NOW)
+        # median = 60h, below 72h threshold
+        assert "60.0h" in r.value
+        assert r.breached is False
+
+    def test_excludes_outside_30d_window(self):
+        prs = [_pr(merged_offset_days=45, created_offset_days=46)]
+        r = metric_review_latency(prs, NOW)
+        assert r.value == "0 PRs in window"
+
+    def test_skips_negative_duration_rows(self):
+        # createdAt after mergedAt is nonsensical; the helper must skip it.
+        prs = [_pr(merged_offset_days=2, created_offset_days=1)]
+        r = metric_review_latency(prs, NOW)
+        assert r.value == "0 PRs in window"
+
+    def test_note_calls_out_proxy_nature(self):
+        prs = [_pr(merged_offset_days=1, created_offset_days=2)]
+        r = metric_review_latency(prs, NOW)
+        assert "open->merge" in r.note
+
+
+class TestMetricBacklog:
+    def test_counts_only_aged(self):
+        prs = [
+            _pr(merged_offset_days=None, created_offset_days=1),  # too new
+            _pr(merged_offset_days=None, created_offset_days=10),  # aged
+            _pr(merged_offset_days=None, created_offset_days=20),  # aged
+        ]
+        # createdAt set, mergedAt absent -> open
+        r = metric_backlog(prs, NOW)
+        assert "2 (of 3 open)" in r.value
+        assert r.breached is False  # threshold is 5
+
+    def test_breached_at_threshold(self):
+        prs = [_pr(merged_offset_days=None, created_offset_days=10) for _ in range(5)]
+        r = metric_backlog(prs, NOW)
+        assert r.breached is True
+
+
+# ---------------------------------------------------------------------------
+# Extraction triggers
+# ---------------------------------------------------------------------------
+
+
+class TestQ1Size:
+    def test_under_threshold(self, tmp_path: Path):
+        (tmp_path / "f.txt").write_text("x" * 100)
+        r = _trigger_q1_size(tmp_path)
+        assert r.breached is False
+        assert "MB" in r.value
+
+    def test_missing_dir_unmeasurable(self, tmp_path: Path):
+        r = _trigger_q1_size(tmp_path / "does-not-exist")
+        assert r.value == "n/a"
+        assert r.breached is None
+
+
+class TestQ2PrVolume:
+    def test_future_dated_merge_skipped(self):
+        prs = [_pr(merged_offset_days=-1), _pr(merged_offset_days=5)]
+        r = _trigger_q2_pr_volume(prs, NOW)
+        # Most recent 30d gets the one valid PR; older buckets stay 0.
+        assert r.value.startswith("1 / 0 / 0")
+        assert r.breached is False
+
+
+# ---------------------------------------------------------------------------
+# Glyphs
+# ---------------------------------------------------------------------------
+
+
+class TestGlyph:
+    def test_breached_label(self):
+        assert _glyph(True) == "BREACHED"
+
+    def test_ok_label(self):
+        assert _glyph(False) == "ok"
+
+    def test_unmeasurable(self):
+        assert _glyph(None) == "?"

--- a/tests/unit/scripts/test_validate_submission.py
+++ b/tests/unit/scripts/test_validate_submission.py
@@ -294,6 +294,56 @@ class TestValidateManifestHash:
         assert not vr.ok
         assert any("Companion hash mismatch" in e and "result.plans.json" in e for e in vr.errors)
 
+    @pytest.mark.parametrize(
+        "unsafe_name",
+        [
+            "../escape.json",
+            "subdir/result.json",
+            "/etc/passwd",
+            "..",
+            "a\x00b.json",
+            "a\\b.json",
+        ],
+    )
+    def test_unsafe_bundle_filename_rejected(self, tmp_path: Path, unsafe_name: str):
+        """Manifest-supplied filenames must not escape the bundle directory."""
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        manifest = bundle_dir / "submission-manifest.json"
+        manifest.write_text(
+            json.dumps({"bundle_file": unsafe_name, "bundle_hash": "a" * 64}),
+            encoding="utf-8",
+        )
+
+        vr = ValidationResult("test")
+        _validate_manifest_hash(manifest, bundle_dir, vr)
+        assert not vr.ok
+        assert any("Unsafe bundle_file" in e for e in vr.errors)
+
+    def test_unsafe_companion_filename_rejected(self, tmp_path: Path):
+        """Companion-hash keys must also be plain filenames."""
+        bundle_dir = tmp_path / "bundle"
+        bundle_dir.mkdir()
+        bundle_file = bundle_dir / "result.json"
+        bundle_file.write_text(json.dumps(_minimal_bundle()), encoding="utf-8")
+
+        manifest = bundle_dir / "submission-manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "bundle_file": "result.json",
+                    "bundle_hash": self._hash_of(bundle_file),
+                    "companion_hashes": {"../escape.plans.json": "a" * 64},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        vr = ValidationResult("test")
+        _validate_manifest_hash(manifest, bundle_dir, vr)
+        assert not vr.ok
+        assert any("Unsafe companion filename" in e for e in vr.errors)
+
     def test_robust_when_corpus_already_populated(self, tmp_path: Path):
         """Sibling bundles in the directory must not affect validation.
 


### PR DESCRIPTION
Fixes the seven action items raised in the post-merge review of #33,
plus an operational follow-up TODO.

Security
- validate_submission.py: reject manifest-supplied bundle_file and
  companion_hashes keys that contain path separators, ".." segments,
  or absolute prefixes. The validator runs in CI on attacker-controlled
  PR JSON, so manifest-supplied filenames must be plain leaves.
- 6 parametrised tests cover ../, subdir/, /etc/passwd, "..", null
  bytes, and backslashes; one targeted test covers traversal through
  companion_hashes keys.

Correctness
- phase2_metrics.py: skip future-dated mergedAt rows (clock skew or
  upstream API quirk) in metric_merged_volume and _trigger_q2_pr_volume
  so they don't land in the most-recent 30d bucket.
- metric_review_latency: skip merged<created rows defensively, rename
  to "PR open->merge time" with a Note column documenting that the
  measurement includes draft + author-iteration time and over-reports
  strict review-only latency. The metrics doc gets the same caveat
  with a pointer to the gh `--json reviews` upgrade path if the
  current proxy ever produces false-positive promotion signals.

Tests
- New tests/unit/scripts/test_phase2_metrics.py covers _split_sections,
  _count_distinct_lowercased, _count_entries, metric_qualitative (all
  three rules + missing-section + unknown-rule), metric_merged_volume
  (buckets, future-date guard, gh-error path, breach rule),
  metric_review_latency (median, window cutoff, defensive skip, note),
  metric_backlog (counts + threshold), the extraction triggers, and
  _glyph. 32 tests, all fast.

Cleanup
- benchbox/cli/commands/submit.py: hoist _DEFAULT_SERVICE_URL and
  _VISIBILITY_CHOICES to module-top with the other module constants.
  Document the dry-run hash contract on _dispatch_service_mode so a
  future canonicalisation step in the live-upload flow surfaces the
  divergence risk explicitly.
- results-explorer/src/pages/ResultDetail.tsx: drop the non-existent
  `font-inherit` class from the three sortable header buttons. The
  class was undefined in the project's Tailwind config so it never
  emitted any CSS; Tailwind's preflight already resets button
  font-family to inherit, so the visual outcome is unchanged.

Follow-up
- New TODO automate-phase2-metrics-quarterly-cadence captures the
  operational gap surfaced by the review: today's metrics depend on a
  human remembering the quarterly cadence — the same failure mode the
  metrics were introduced to prevent. Five work units cover JSON
  output, diff-vs-prior-review, a scheduled GHA workflow, an opt-in
  --exit-non-zero-on-breach flag, and a doc update.

Verification
  uv run -- python -m pytest tests/unit/scripts/test_phase2_metrics.py \
    tests/unit/scripts/test_validate_submission.py \
    tests/unit/cli/commands/test_submit.py \
    tests/integration/test_submission_validation.py
  -> 94 passed
  uv run ruff check scripts/ benchbox/cli/commands/submit.py tests/unit/scripts/
  -> All checks passed
  uv run ty check scripts/phase2_metrics.py scripts/validate_submission.py \
    benchbox/cli/commands/submit.py
  -> All checks passed
  (cd results-explorer && npm run typecheck)
  -> tsc clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
