### PR TITLE
chore(todo): downgrade hosted-submission item to Medium-High

### DIFF
--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:17.966775'
+generated_at: '2026-04-28T07:38:12.087779'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:17.967006'
+generated_at: '2026-04-28T07:38:12.087988'
 total_items: 787
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:17.967193'
+generated_at: '2026-04-28T07:38:12.088182'
 total_items: 787
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:17.966380'
+generated_at: '2026-04-28T07:38:12.087413'
 total_items: 787
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:29.970598'
+generated_at: '2026-04-28T07:38:10.000388'
 total_categories: 12
 categories:
   Architecture & Refactoring:
@@ -56,7 +56,7 @@ categories:
     - id: integrate-benchbox-cli-submit-and-service-auth
       file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
       title: Integrate BenchBox CLI submission flow and service authentication
-      priority: High
+      priority: Medium-High
       status: In Progress
   Performance:
     count: 1

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,14 +1,9 @@
-generated_at: '2026-04-27T20:56:29.970612'
+generated_at: '2026-04-28T07:38:10.000407'
 total_items: 29
 priorities:
   High:
-    count: 4
+    count: 3
     items:
-    - id: integrate-benchbox-cli-submit-and-service-auth
-      file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
-      title: Integrate BenchBox CLI submission flow and service authentication
-      category: Core Functionality
-      status: In Progress
     - id: motherduck-cloud-features
       file: TODO/platform-expansion/planning/motherduck-cloud-features.yaml
       title: MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control
@@ -25,7 +20,7 @@ priorities:
       category: Release Tooling
       status: In Progress
   Medium-High:
-    count: 3
+    count: 4
     items:
     - id: add-hypothesis-property-tests
       file: TODO/main/planning/add-hypothesis-property-tests.yaml
@@ -42,6 +37,11 @@ priorities:
       title: Graduate Firefox and WebKit @smoke CI jobs to blocking gates
       category: Testing and Quality Assurance
       status: Not Started
+    - id: integrate-benchbox-cli-submit-and-service-auth
+      file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
+      title: Integrate BenchBox CLI submission flow and service authentication
+      category: Core Functionality
+      status: In Progress
   Medium:
     count: 7
     items:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-27T20:56:29.970621'
+generated_at: '2026-04-28T07:38:10.000418'
 total_items: 29
 statuses:
   In Progress:
@@ -12,7 +12,7 @@ statuses:
     - id: integrate-benchbox-cli-submit-and-service-auth
       file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
       title: Integrate BenchBox CLI submission flow and service authentication
-      priority: High
+      priority: Medium-High
       category: Core Functionality
     - id: single-repo-migration-phase-4-test-release-with-new-flow
       file: TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,27 +1,6 @@
-generated_at: '2026-04-27T20:56:29.970567'
+generated_at: '2026-04-28T07:38:10.000356'
 total_items: 29
 items:
-- id: integrate-benchbox-cli-submit-and-service-auth
-  file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
-  title: Integrate BenchBox CLI submission flow and service authentication
-  worktree: main
-  category: Core Functionality
-  priority: High
-  status: In Progress
-  tags:
-  - results
-  - cli
-  - auth
-  - submission
-  - api
-  estimated_effort: Large
-  work_total: 8
-  work_done: 3
-  work_ready: 1
-  needs:
-  - define-results-platform-product-and-launch-strategy
-  - define-hosted-results-contract-and-governance-model
-  - design-results-ingest-storage-and-derived-read-model
 - id: motherduck-cloud-features
   file: TODO/platform-expansion/planning/motherduck-cloud-features.yaml
   title: MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control
@@ -470,6 +449,27 @@ items:
   work_ready: 2
   needs:
   - stabilize-webkit-browser-smoke-flake-under-parallel-workers
+- id: integrate-benchbox-cli-submit-and-service-auth
+  file: TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
+  title: Integrate BenchBox CLI submission flow and service authentication
+  worktree: main
+  category: Core Functionality
+  priority: Medium-High
+  status: In Progress
+  tags:
+  - results
+  - cli
+  - auth
+  - submission
+  - api
+  estimated_effort: Large
+  work_total: 8
+  work_done: 3
+  work_ready: 1
+  needs:
+  - define-results-platform-product-and-launch-strategy
+  - define-hosted-results-contract-and-governance-model
+  - design-results-ingest-storage-and-derived-read-model
 - id: generalize-database-table-reuse-detection
   file: TODO/main/planning/generalize-database-table-reuse-detection.yaml
   title: Generalize benchmark table reuse detection for managed databases

--- a/_project/TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
+++ b/_project/TODO/main/planning/integrate-benchbox-cli-submit-and-service-auth.yaml
@@ -1,7 +1,7 @@
 id: integrate-benchbox-cli-submit-and-service-auth
 title: "Integrate BenchBox CLI submission flow and service authentication"
 worktree: main
-priority: High
+priority: Medium-High
 status: In Progress
 category: Core Functionality
 deps:


### PR DESCRIPTION
## Summary
- Downgrades `integrate-benchbox-cli-submit-and-service-auth` from **High** to **Medium-High**.
- Phase 3 hosted submit/auth (w4–w8) is contingent on Phase 2 PR-submission volume exceeding manual review and on a hosted ingest API existing — neither is true today. The research/scaffolding (w1–w3) is already done.
- Surfaced during a prioritization pass over results-explorer / publishing TODOs.

## Test plan
- [x] `todo-validate` passes on the modified item
- [x] `todo-index` regenerates indexes cleanly