### PR TITLE
docs(contributing): land Cowork agent-proxy dry-run retrospective + 6 follow-up TODOs

### DIFF
--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:29.230133'
+generated_at: '2026-04-28T16:27:37.850051'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-category.yaml
+++ b/_project/DONE/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T07:38:12.087779'
+generated_at: '2026-04-28T09:46:29.230133'
 total_categories: 81
 categories:
   '"Bug Fixes & Reliability"':

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:29.230317'
+generated_at: '2026-04-28T16:27:37.850270'
 total_items: 787
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-priority.yaml
+++ b/_project/DONE/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T07:38:12.087988'
+generated_at: '2026-04-28T09:46:29.230317'
 total_items: 787
 priorities:
   Critical:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:29.230488'
+generated_at: '2026-04-28T16:27:37.850476'
 total_items: 787
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/by-status.yaml
+++ b/_project/DONE/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T07:38:12.088182'
+generated_at: '2026-04-28T09:46:29.230488'
 total_items: 787
 statuses:
   In Progress:

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T07:38:12.087413'
+generated_at: '2026-04-28T09:46:29.229788'
 total_items: 787
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/DONE/_indexes/master.yaml
+++ b/_project/DONE/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:29.229788'
+generated_at: '2026-04-28T16:27:37.849625'
 total_items: 787
 items:
 - id: interactive-wizard-dry-run-support

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-28T07:38:10.000388'
-total_categories: 12
+generated_at: '2026-04-28T09:46:27.216831'
+total_categories: 13
 categories:
   Architecture & Refactoring:
     count: 1
@@ -46,7 +46,7 @@ categories:
       priority: Low
       status: Not Started
   Core Functionality:
-    count: 2
+    count: 5
     items:
     - id: add-third-benchmark-cohort-to-corpus
       file: TODO/main/planning/add-third-benchmark-cohort-to-corpus.yaml
@@ -58,6 +58,39 @@ categories:
       title: Integrate BenchBox CLI submission flow and service authentication
       priority: Medium-High
       status: In Progress
+    - id: dry-run-followup-package-canonical-contributing
+      file: TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+      title: Make benchbox submit's packaged CONTRIBUTING.md match docs/contributing-results.md
+      priority: High
+      status: Not Started
+    - id: dry-run-followup-manifest-filename-convention
+      file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+      title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+      priority: Medium
+      status: Not Started
+    - id: dry-run-followup-submitted-by-flag
+      file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+      title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+      priority: Medium
+      status: Not Started
+  Documentation:
+    count: 3
+    items:
+    - id: dry-run-followup-broken-getting-started-link
+      file: TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+      title: Add a docs linkcheck rule so broken relative links can't regress
+      priority: Low
+      status: Not Started
+    - id: dry-run-followup-bundle-table-conditionals
+      file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+      title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
+      priority: Low
+      status: Not Started
+    - id: dry-run-followup-uv-fallback-and-schema-key
+      file: TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+      title: 'Local-validation block: document non-uv fallback and schema-version key name'
+      priority: Low
+      status: Not Started
   Performance:
     count: 1
     items:

--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:27.216831'
+generated_at: '2026-04-28T16:27:35.934099'
 total_categories: 13
 categories:
   Architecture & Refactoring:
@@ -85,7 +85,7 @@ categories:
       file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
       title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
       priority: Low
-      status: Not Started
+      status: Identified
     - id: dry-run-followup-uv-fallback-and-schema-key
       file: TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
       title: 'Local-validation block: document non-uv fallback and schema-version key name'

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:27.216849'
+generated_at: '2026-04-28T16:27:35.934120'
 total_items: 35
 priorities:
   High:
@@ -122,7 +122,7 @@ priorities:
       file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
       title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
       category: Documentation
-      status: Not Started
+      status: Identified
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,9 +1,14 @@
-generated_at: '2026-04-28T07:38:10.000407'
-total_items: 29
+generated_at: '2026-04-28T09:46:27.216849'
+total_items: 35
 priorities:
   High:
-    count: 3
+    count: 4
     items:
+    - id: dry-run-followup-package-canonical-contributing
+      file: TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+      title: Make benchbox submit's packaged CONTRIBUTING.md match docs/contributing-results.md
+      category: Core Functionality
+      status: Not Started
     - id: motherduck-cloud-features
       file: TODO/platform-expansion/planning/motherduck-cloud-features.yaml
       title: MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control
@@ -43,7 +48,7 @@ priorities:
       category: Core Functionality
       status: In Progress
   Medium:
-    count: 7
+    count: 9
     items:
     - id: ballista-distributed-adapter
       file: TODO/platform-expansion/planning/ballista-distributed-adapter.yaml
@@ -65,6 +70,11 @@ priorities:
       title: Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL
       category: Performance
       status: Identified
+    - id: dry-run-followup-manifest-filename-convention
+      file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+      title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+      category: Core Functionality
+      status: Not Started
     - id: single-repo-migration-phase-8-first-post-migration-release
       file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
       title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'
@@ -80,8 +90,13 @@ priorities:
       title: Validate tpc-tuning.json z-ordering recommendations and integrate or discard
       category: Testing and Quality Assurance
       status: Not Started
+    - id: dry-run-followup-submitted-by-flag
+      file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+      title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+      category: Core Functionality
+      status: Not Started
   Low:
-    count: 14
+    count: 17
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -98,6 +113,16 @@ priorities:
       title: Add SiriusDB (GPU-Native SQL Engine) Platform Adapter
       category: Platform Expansion
       status: Not Started
+    - id: dry-run-followup-broken-getting-started-link
+      file: TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+      title: Add a docs linkcheck rule so broken relative links can't regress
+      category: Documentation
+      status: Not Started
+    - id: dry-run-followup-bundle-table-conditionals
+      file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+      title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
+      category: Documentation
+      status: Not Started
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure
@@ -112,6 +137,11 @@ priorities:
       file: TODO/benchmark-expansion/planning/github-archive-benchmark.yaml
       title: GitHub Archive Benchmark - Developer Activity Analytics Workload
       category: Benchmark Development
+      status: Not Started
+    - id: dry-run-followup-uv-fallback-and-schema-key
+      file: TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+      title: 'Local-validation block: document non-uv fallback and schema-version key name'
+      category: Documentation
       status: Not Started
     - id: review-dependency-upper-bounds-quarterly
       file: TODO/main/planning/review-dependency-upper-bounds-quarterly.yaml

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,5 +1,5 @@
-generated_at: '2026-04-28T07:38:10.000418'
-total_items: 29
+generated_at: '2026-04-28T09:46:27.216858'
+total_items: 35
 statuses:
   In Progress:
     count: 3
@@ -20,7 +20,7 @@ statuses:
       priority: High
       category: Release Tooling
   Not Started:
-    count: 25
+    count: 31
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -47,6 +47,11 @@ statuses:
       title: Add SiriusDB (GPU-Native SQL Engine) Platform Adapter
       priority: Low
       category: Platform Expansion
+    - id: dry-run-followup-broken-getting-started-link
+      file: TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+      title: Add a docs linkcheck rule so broken relative links can't regress
+      priority: Low
+      category: Documentation
     - id: add-third-benchmark-cohort-to-corpus
       file: TODO/main/planning/add-third-benchmark-cohort-to-corpus.yaml
       title: Add a third benchmark cohort (TPC-DS or ClickBench) to the public corpus
@@ -57,6 +62,11 @@ statuses:
       title: Automate the Phase 3 promotion-metrics quarterly cadence
       priority: Medium
       category: Tooling
+    - id: dry-run-followup-bundle-table-conditionals
+      file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+      title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
+      priority: Low
+      category: Documentation
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure
@@ -82,11 +92,26 @@ statuses:
       title: Graduate Firefox and WebKit @smoke CI jobs to blocking gates
       priority: Medium-High
       category: Testing and Quality Assurance
+    - id: dry-run-followup-uv-fallback-and-schema-key
+      file: TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+      title: 'Local-validation block: document non-uv fallback and schema-version key name'
+      priority: Low
+      category: Documentation
+    - id: dry-run-followup-package-canonical-contributing
+      file: TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+      title: Make benchbox submit's packaged CONTRIBUTING.md match docs/contributing-results.md
+      priority: High
+      category: Core Functionality
     - id: motherduck-cloud-features
       file: TODO/platform-expansion/planning/motherduck-cloud-features.yaml
       title: MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control
       priority: High
       category: Platform Expansion
+    - id: dry-run-followup-manifest-filename-convention
+      file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+      title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+      priority: Medium
+      category: Core Functionality
     - id: review-dependency-upper-bounds-quarterly
       file: TODO/main/planning/review-dependency-upper-bounds-quarterly.yaml
       title: Quarterly review of dependency upper bounds
@@ -148,6 +173,11 @@ statuses:
       title: Wikipedia Pageviews Benchmark - Web Traffic Analytics Workload
       priority: Low
       category: Benchmark Development
+    - id: dry-run-followup-submitted-by-flag
+      file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+      title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+      priority: Medium
+      category: Core Functionality
   Identified:
     count: 1
     items:

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:27.216858'
+generated_at: '2026-04-28T16:27:35.934131'
 total_items: 35
 statuses:
   In Progress:
@@ -20,7 +20,7 @@ statuses:
       priority: High
       category: Release Tooling
   Not Started:
-    count: 31
+    count: 30
     items:
     - id: databend-3-mode-local-server-cloud
       file: TODO/main/planning/databend-3-mode-local-server-cloud.yaml
@@ -62,11 +62,6 @@ statuses:
       title: Automate the Phase 3 promotion-metrics quarterly cadence
       priority: Medium
       category: Tooling
-    - id: dry-run-followup-bundle-table-conditionals
-      file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
-      title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
-      priority: Low
-      category: Documentation
     - id: future-ideas-backlog
       file: TODO/main/planning/future-ideas-backlog.yaml
       title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure
@@ -179,8 +174,13 @@ statuses:
       priority: Medium
       category: Core Functionality
   Identified:
-    count: 1
+    count: 2
     items:
+    - id: dry-run-followup-bundle-table-conditionals
+      file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+      title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
+      priority: Low
+      category: Documentation
     - id: enable-duckdb-wasm-http-range-reads-for-registered-urls
       file: TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
       title: Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,6 +1,23 @@
-generated_at: '2026-04-28T07:38:10.000356'
-total_items: 29
+generated_at: '2026-04-28T09:46:27.216794'
+total_items: 35
 items:
+- id: dry-run-followup-package-canonical-contributing
+  file: TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+  title: Make benchbox submit's packaged CONTRIBUTING.md match docs/contributing-results.md
+  worktree: main
+  category: Core Functionality
+  priority: High
+  status: Not Started
+  tags:
+  - results
+  - submit
+  - cli
+  - contributor-experience
+  - dry-run-followup
+  estimated_effort: Small
+  work_total: 1
+  work_done: 0
+  work_ready: 1
 - id: motherduck-cloud-features
   file: TODO/platform-expansion/planning/motherduck-cloud-features.yaml
   title: MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control
@@ -94,6 +111,36 @@ items:
   work_total: 17
   work_done: 0
   work_ready: 17
+- id: dry-run-followup-broken-getting-started-link
+  file: TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+  title: Add a docs linkcheck rule so broken relative links can't regress
+  worktree: main
+  category: Documentation
+  priority: Low
+  status: Not Started
+  tags:
+  - docs
+  - ci
+  - dry-run-followup
+  estimated_effort: Small
+  work_total: 3
+  work_done: 0
+  work_ready: 1
+- id: dry-run-followup-bundle-table-conditionals
+  file: TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+  title: Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table
+  worktree: main
+  category: Documentation
+  priority: Low
+  status: Not Started
+  tags:
+  - docs
+  - contributor-experience
+  - dry-run-followup
+  estimated_effort: Trivial
+  work_total: 2
+  work_done: 0
+  work_ready: 1
 - id: future-ideas-backlog
   file: TODO/main/planning/future-ideas-backlog.yaml
   title: Future Ideas Backlog - Specialized Benchmarks and Infrastructure
@@ -150,6 +197,21 @@ items:
   work_total: 18
   work_done: 0
   work_ready: 18
+- id: dry-run-followup-uv-fallback-and-schema-key
+  file: TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+  title: 'Local-validation block: document non-uv fallback and schema-version key name'
+  worktree: main
+  category: Documentation
+  priority: Low
+  status: Not Started
+  tags:
+  - docs
+  - contributor-experience
+  - dry-run-followup
+  estimated_effort: Trivial
+  work_total: 2
+  work_done: 0
+  work_ready: 2
 - id: review-dependency-upper-bounds-quarterly
   file: TODO/main/planning/review-dependency-upper-bounds-quarterly.yaml
   title: Quarterly review of dependency upper bounds
@@ -350,6 +412,22 @@ items:
   work_ready: 1
   needs:
   - implement-results-explorer-browser-functional-tests
+- id: dry-run-followup-manifest-filename-convention
+  file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+  title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+  worktree: main
+  category: Core Functionality
+  priority: Medium
+  status: Not Started
+  tags:
+  - results
+  - submit
+  - tooling
+  - dry-run-followup
+  estimated_effort: Medium
+  work_total: 4
+  work_done: 0
+  work_ready: 1
 - id: single-repo-migration-phase-8-first-post-migration-release
   file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
   title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'
@@ -390,6 +468,23 @@ items:
   - cleanup
   estimated_effort: Small
   work_total: 4
+  work_done: 0
+  work_ready: 1
+- id: dry-run-followup-submitted-by-flag
+  file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+  title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+  worktree: main
+  category: Core Functionality
+  priority: Medium
+  status: Not Started
+  tags:
+  - results
+  - submit
+  - cli
+  - contributor-experience
+  - dry-run-followup
+  estimated_effort: Small
+  work_total: 3
   work_done: 0
   work_ready: 1
 - id: add-hypothesis-property-tests

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T09:46:27.216794'
+generated_at: '2026-04-28T16:27:35.934069'
 total_items: 35
 items:
 - id: dry-run-followup-package-canonical-contributing
@@ -15,7 +15,7 @@ items:
   - contributor-experience
   - dry-run-followup
   estimated_effort: Small
-  work_total: 1
+  work_total: 3
   work_done: 0
   work_ready: 1
 - id: motherduck-cloud-features
@@ -132,7 +132,7 @@ items:
   worktree: main
   category: Documentation
   priority: Low
-  status: Not Started
+  status: Identified
   tags:
   - docs
   - contributor-experience
@@ -428,6 +428,8 @@ items:
   work_total: 4
   work_done: 0
   work_ready: 1
+  needs:
+  - dry-run-followup-package-canonical-contributing
 - id: single-repo-migration-phase-8-first-post-migration-release
   file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
   title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'
@@ -487,6 +489,8 @@ items:
   work_total: 3
   work_done: 0
   work_ready: 1
+  needs:
+  - dry-run-followup-package-canonical-contributing
 - id: add-hypothesis-property-tests
   file: TODO/main/planning/add-hypothesis-property-tests.yaml
   title: Add Hypothesis property-based tests for pure-function invariants

--- a/_project/TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
@@ -58,7 +58,9 @@ verification:
     expected_output: "exit 0"
 
 must_preserve:
-  - "The contributor-facing link from contributing-results.md to the Getting Started guide continues to resolve"
+  - "Existing relative links in `docs/` that currently resolve continue to resolve (no false positives from a poorly-tuned linkcheck config)"
+  - "Docs CI total wall-clock stays within the existing budget (linkcheck added as a parallel job, not serialized after the slow build)"
+  - "External-link 404s remain advisory, not blocking -- a third-party link rotting should not block a docs PR"
 
 anti_patterns:
   - "DO NOT whitelist the originally-broken path to make linkcheck pass -- because that defeats the purpose of adding the check"

--- a/_project/TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-broken-getting-started-link.yaml
@@ -1,0 +1,84 @@
+id: dry-run-followup-broken-getting-started-link
+title: "Add a docs linkcheck rule so broken relative links can't regress"
+worktree: main
+priority: Low
+status: Not Started
+category: Documentation
+
+description: |
+  The agent-proxy dry-run on 2026-04-28 found that
+  `docs/contributing-results.md` Prerequisites #1 linked to
+  `getting-started.rst` at the wrong relative path (the file lives at
+  `docs/usage/getting-started.md`, not `docs/getting-started.rst`). The
+  link itself is patched in the same PR as the retrospective; this TODO
+  exists to add a docs linkcheck rule so the same shape of breakage
+  cannot regress.
+
+  See `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`
+  for the originating finding.
+
+work:
+  - id: w1
+    summary: "Audit current docs build for any existing linkcheck step"
+    status: pending
+    notes: |
+      Check `docs/Makefile` and any `make docs-*` targets, plus
+      `.github/workflows/docs.yml` if it exists, for a pre-existing
+      Sphinx linkcheck or markdown-link-check step. If one exists
+      and it didn't catch this regression, find out why (was the
+      file excluded? Did the broken link only resolve at build time
+      vs source time?).
+
+  - id: w2
+    summary: "Add markdown-link-check (or equivalent) to the docs CI"
+    needs: [w1]
+    status: pending
+    notes: |
+      If no linkcheck exists, add one. Suggested:
+      `markdown-link-check` run via `npx` in a docs CI job, scoped
+      to `docs/` and `_project/handoffs/`. Configure to fail the
+      job on broken relative links (HTTP 404s on external links can
+      stay advisory). Add an ignore-list file for known-flaky
+      external URLs.
+
+  - id: w3
+    summary: "Run the linkcheck against current docs and fix any other latent breakage"
+    needs: [w2]
+    status: pending
+    notes: |
+      First run will likely surface other broken links. Fix them in
+      the same PR or file follow-up TODOs per file scope.
+
+verification:
+  - description: "Linkcheck job exists and runs in docs CI"
+    command: "grep -rE 'markdown-link-check|sphinx-build.*linkcheck' .github/workflows/ | wc -l"
+    expected_output: ">= 1"
+  - description: "The originally-broken link resolves"
+    command: "test -f docs/usage/getting-started.md"
+    expected_output: "exit 0"
+
+must_preserve:
+  - "The contributor-facing link from contributing-results.md to the Getting Started guide continues to resolve"
+
+anti_patterns:
+  - "DO NOT whitelist the originally-broken path to make linkcheck pass -- because that defeats the purpose of adding the check"
+
+scope_limit:
+  only_modify:
+    - "docs/"
+    - ".github/workflows/"
+    - "package.json"
+
+metadata:
+  tags:
+    - docs
+    - ci
+    - dry-run-followup
+  estimated_effort: "Small"
+  created_date: "2026-04-28"
+
+impact:
+  technical_debt: |
+    Closes the regression-detection gap that let the broken link
+    survive long enough for a contributor (agent or human) to
+    encounter it.

--- a/_project/TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
@@ -2,10 +2,14 @@ id: dry-run-followup-bundle-table-conditionals
 title: "Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table"
 worktree: main
 priority: Low
-status: Not Started
+status: Identified
 category: Documentation
 
 description: |
+  **Status note:** marked `Identified` rather than `Not Started`
+  because `w1` requires a maintainer decision before any code or doc
+  edit can begin. Move to `Not Started` once the decision is recorded.
+
   `docs/contributing-results.md` Step 2 lists `<result>.plans.json` and
   `<result>.tuning.json` as bundle outputs gated on `(if captured)` /
   `(if used)`. Neither phrase is defined anywhere in the doc; nothing

--- a/_project/TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-bundle-table-conditionals.yaml
@@ -1,0 +1,74 @@
+id: dry-run-followup-bundle-table-conditionals
+title: "Clarify or drop the plans.json / tuning.json rows in the Step 2 bundle table"
+worktree: main
+priority: Low
+status: Not Started
+category: Documentation
+
+description: |
+  `docs/contributing-results.md` Step 2 lists `<result>.plans.json` and
+  `<result>.tuning.json` as bundle outputs gated on `(if captured)` /
+  `(if used)`. Neither phrase is defined anywhere in the doc; nothing
+  explains how a contributor opts into plan capture or applies tuning
+  before running. First-time contributors see the rows and wonder if
+  their bundle is incomplete because those files don't appear.
+
+  Decision needed: are plans/tuning files community-submittable, or
+  maintainer-only? Either explain the opt-in or drop the rows from
+  the contributor-facing doc and surface them in advanced docs only.
+
+  Surfaced by the agent-proxy dry-run on 2026-04-28
+  (see `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`).
+
+work:
+  - id: w1
+    summary: "Decide whether plans/tuning files are community-submittable"
+    status: pending
+    notes: |
+      Talk to the maintainer or check the validate-submission CI
+      behavior: does the workflow accept a community PR carrying a
+      plans.json / tuning.json sidecar? If yes -> document the
+      opt-in flags in Step 1. If no -> drop the rows from the
+      community-facing doc.
+
+  - id: w2
+    summary: "Apply the chosen change to docs/contributing-results.md"
+    needs: [w1]
+    status: pending
+    notes: |
+      If documenting opt-in: add a one-line sub-bullet under Step 1
+      naming the `benchbox run` flags that produce these files
+      (likely `--capture-plans` / `--tuning <path>` — verify against
+      the actual CLI). If dropping: remove the two rows and add a
+      brief note in `docs/operations/` for maintainers who need
+      these artifacts.
+
+verification:
+  - description: "Bundle table no longer contains undefined `(if captured)` / `(if used)` qualifiers"
+    command: "grep -cE '\\(if captured\\)|\\(if used\\)' docs/contributing-results.md"
+    expected_output: "0"
+
+must_preserve:
+  - "If plans/tuning files ARE community-submittable, the validate-submission CI continues to accept them"
+
+anti_patterns:
+  - "DO NOT leave the rows in with vague qualifiers -- because that is the failure mode this TODO exists to fix -- pick a path and apply it"
+
+scope_limit:
+  only_modify:
+    - "docs/contributing-results.md"
+    - "docs/operations/"
+
+metadata:
+  tags:
+    - docs
+    - contributor-experience
+    - dry-run-followup
+  estimated_effort: "Trivial"
+  created_date: "2026-04-28"
+
+impact:
+  business_value: |
+    Removes a doc ambiguity that makes contributors second-guess their
+    bundles. Tiny change, but it's exactly the kind of thing first-time
+    contributors notice.

--- a/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
@@ -1,0 +1,115 @@
+id: dry-run-followup-manifest-filename-convention
+title: "Per-bundle manifest filenames to avoid PR collision in results-data/bundles/"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  `benchbox submit` always writes the submission manifest as the literal
+  filename `submission-manifest.json` (constant
+  `SUBMISSION_MANIFEST_FILENAME` in
+  `benchbox/core/explorer_pipeline/pipeline.py:39`, also used in
+  `benchbox/cli/commands/submit.py:338`). The doc instruction is "copy
+  `submission/submission-manifest.json` alongside the bundle files" into
+  `results-data/bundles/`. `results-data/bundles/` currently contains
+  zero manifest files, but two community PRs landing in the same window
+  would conflict on the same filename. The doc names no convention for
+  resolving the collision.
+
+  Proposal: emit `<result_basename>.manifest.json` so the manifest's
+  filename inherits the bundle's uniqueness (timestamp + hash). Update
+  doc, in-bundle CONTRIBUTING.md, validators, and the inventory generator
+  if any of them filter by exact filename.
+
+  Surfaced by the agent-proxy dry-run on 2026-04-28
+  (see `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`).
+
+work:
+  - id: w1
+    summary: "Audit consumers of submission-manifest.json filename"
+    status: pending
+    notes: |
+      Grep for `submission-manifest.json` and `SUBMISSION_MANIFEST_FILENAME`
+      across:
+        - benchbox/cli/commands/submit.py (writer)
+        - benchbox/core/explorer_pipeline/pipeline.py (reader, trust-label resolver)
+        - scripts/validate_submission.py
+        - scripts/generate_corpus_inventory.py
+        - .github/workflows/validate-submission.yml (if it references the filename)
+      Document everywhere the filename is hard-coded so the rename is
+      atomic.
+
+  - id: w2
+    summary: "Rename to <bundle-stem>.manifest.json and update consumers"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update the writer to emit `<bundle_stem>.manifest.json`. Update
+      readers to resolve manifests by glob (`*.manifest.json`) rather
+      than by literal name. Update the inventory generator's filter
+      rules if it currently filters by exact filename.
+
+  - id: w3
+    summary: "Update docs (canonical + in-bundle) to reflect the new filename"
+    needs: [w2]
+    status: pending
+    notes: |
+      `docs/contributing-results.md` Step 2 / Step 3.3 both name the
+      file. The in-bundle CONTRIBUTING.md is being rewritten in
+      `dry-run-followup-package-canonical-contributing` — coordinate
+      so both land consistent.
+
+  - id: w4
+    summary: "Add a regression test for two consecutive submits"
+    needs: [w2]
+    status: pending
+    notes: |
+      Two consecutive `benchbox submit --output ./submission` calls
+      against different result files should not overwrite each other's
+      manifests. Test asserts both manifests exist after the second
+      call.
+
+verification:
+  - description: "Submit emits per-bundle manifest filenames"
+    command: "uv run -- benchbox submit --last --output /tmp/dry-run-mft && ls /tmp/dry-run-mft | grep -c '\\.manifest\\.json$'"
+    expected_output: "1"
+  - description: "Inventory generator resolves manifests by glob"
+    command: "grep -c 'manifest.json' scripts/generate_corpus_inventory.py"
+    expected_output: ">= 1"
+
+must_preserve:
+  - "The trust-label resolution path in `explorer_pipeline/pipeline.py` continues to find manifests for existing bundles"
+  - "Backwards-compat for any already-merged community submissions that used the old filename"
+
+anti_patterns:
+  - "DO NOT change the writer without updating every reader in the same PR -- because mid-flight readers will fail to find the manifest -- audit consumers first (w1)"
+  - "DO NOT silently break already-merged manifests in results-data/bundles/ -- because that erodes trust in already-published submissions -- if any exist with the old name, support both during a transition window"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/commands/submit.py"
+    - "benchbox/core/explorer_pipeline/pipeline.py"
+    - "scripts/validate_submission.py"
+    - "scripts/generate_corpus_inventory.py"
+    - "tests/"
+    - "docs/contributing-results.md"
+    - ".github/workflows/validate-submission.yml"
+
+metadata:
+  tags:
+    - results
+    - submit
+    - tooling
+    - dry-run-followup
+  estimated_effort: "Medium"
+  created_date: "2026-04-28"
+
+impact:
+  business_value: |
+    Removes a silent collision risk that scales with submission volume.
+    Today's near-zero manifest count masks the bug; it would surface
+    the moment two contributors submit the same week.
+  technical_debt: |
+    The hard-coded singleton filename is a load-bearing assumption that
+    the system has implicitly outgrown.

--- a/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
@@ -5,6 +5,10 @@ priority: Medium
 status: Not Started
 category: Core Functionality
 
+deps:
+  needs:
+    - dry-run-followup-package-canonical-contributing
+
 description: |
   `benchbox submit` always writes the submission manifest as the literal
   filename `submission-manifest.json` (constant

--- a/_project/TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
@@ -32,21 +32,57 @@ description: |
 
 work:
   - id: w1
-    summary: "Regenerate the in-bundle CONTRIBUTING.md from the canonical doc, or replace it with a checklist that points to the canonical URL"
+    summary: "Pick option A (regenerate from canonical doc at build time) or option B (static checklist + canonical URL)"
+    status: pending
+    notes: |
+      A vs B is a real architectural call:
+        - A: harder-to-drift but introduces a build-time read of
+          `docs/contributing-results.md` from `submit.py`. Requires
+          packaging the doc into the wheel or reading it relative to
+          the repo root.
+        - B: simpler; ships a checklist that names the four required
+          steps and points contributors to docs.benchbox.dev for the
+          full doc. Requires updating the checklist whenever the
+          canonical doc changes -- but the checklist is small and
+          stable.
+      Default recommendation: option B unless wheel-packaging the doc
+      is already cheap. Document the choice + rationale in a one-line
+      comment above `_CONTRIBUTING_TEXT` so future maintainers don't
+      re-litigate it.
+
+  - id: w2
+    summary: "Implement the chosen option in benchbox/cli/commands/submit.py"
+    needs: [w1]
     status: pending
     notes: |
       Touch `benchbox/cli/commands/submit.py` (`_CONTRIBUTING_TEXT`).
-      Either copy `docs/contributing-results.md` verbatim into the
-      bundle, or rewrite the stub to include: regenerate inventory,
-      target `published-results`, run `validate_submission.py` before
-      pushing, link to the canonical doc URL on docs.benchbox.dev.
-      Add a regression test that asserts the bundled file mentions
-      both `published-results` and `generate_corpus_inventory`.
+      The new file content MUST include all four:
+        - `published-results` as the PR base branch (not `main`)
+        - `generate_corpus_inventory.py --write` before commit
+        - `validate_submission.py` for local pre-push check
+        - canonical doc URL (https://docs.benchbox.dev/contributing-results
+          or wherever the canonical doc lives at land time)
+      Coordinate with `dry-run-followup-submitted-by-flag` and
+      `dry-run-followup-manifest-filename-convention` since both
+      will edit the same template after this lands.
+
+  - id: w3
+    summary: "Add a regression test asserting the in-bundle file mentions all four required items"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add to `tests/unit/cli/commands/test_submit.py`: run
+      `benchbox submit --last --output <tmp>` against a fixture result,
+      read the resulting CONTRIBUTING.md, assert presence of
+      `published-results`, `generate_corpus_inventory`,
+      `validate_submission`, and the canonical doc URL. The test
+      pins the contract independent of which option (A or B) was
+      chosen.
 
 verification:
-  - description: "Packaged CONTRIBUTING.md mentions published-results and inventory regeneration"
-    command: "grep -E 'published-results|generate_corpus_inventory' submission/CONTRIBUTING.md | wc -l"
-    expected_output: ">= 2"
+  - description: "Packaged CONTRIBUTING.md mentions all four required items"
+    command: "uv run -- benchbox submit --last --output /tmp/dry-run-canonical && grep -cE 'published-results|generate_corpus_inventory|validate_submission|docs\\.benchbox\\.dev' /tmp/dry-run-canonical/CONTRIBUTING.md"
+    expected_output: ">= 4"
   - description: "Submit unit tests still pass"
     command: "uv run -- python -m pytest tests/unit/cli/commands/test_submit.py -q"
     expected_output: "All tests pass"

--- a/_project/TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-package-canonical-contributing.yaml
@@ -1,0 +1,89 @@
+id: dry-run-followup-package-canonical-contributing
+title: "Make benchbox submit's packaged CONTRIBUTING.md match docs/contributing-results.md"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  `benchbox submit` writes a 16-line CONTRIBUTING.md into every submission
+  bundle (hardcoded as `_CONTRIBUTING_TEXT` at
+  `benchbox/cli/commands/submit.py:29-46`), and the CLI's "Next step"
+  message tells contributors to follow it. That file does NOT include
+  three steps the canonical `docs/contributing-results.md` requires:
+
+    1. Regenerate `corpus-inventory.json` before commit.
+    2. Target the `published-results` branch (not `main`).
+    3. Optionally validate the bundle locally with
+       `scripts/validate_submission.py`.
+
+  A contributor who reads only the in-bundle file will open a PR against
+  `main` with a stale inventory. CI catches it, but that's wasted
+  maintainer cycles and a worse first-time UX. Surfaced by the
+  agent-proxy dry-run on 2026-04-28
+  (see `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`).
+
+  Fix options (pick one):
+    A. Generate the in-bundle file from `docs/contributing-results.md`
+       at package-build time so the two cannot drift.
+    B. Replace the in-bundle file with a one-page checklist that points
+       to the canonical doc URL and lists the three required commands
+       inline.
+
+work:
+  - id: w1
+    summary: "Regenerate the in-bundle CONTRIBUTING.md from the canonical doc, or replace it with a checklist that points to the canonical URL"
+    status: pending
+    notes: |
+      Touch `benchbox/cli/commands/submit.py` (`_CONTRIBUTING_TEXT`).
+      Either copy `docs/contributing-results.md` verbatim into the
+      bundle, or rewrite the stub to include: regenerate inventory,
+      target `published-results`, run `validate_submission.py` before
+      pushing, link to the canonical doc URL on docs.benchbox.dev.
+      Add a regression test that asserts the bundled file mentions
+      both `published-results` and `generate_corpus_inventory`.
+
+verification:
+  - description: "Packaged CONTRIBUTING.md mentions published-results and inventory regeneration"
+    command: "grep -E 'published-results|generate_corpus_inventory' submission/CONTRIBUTING.md | wc -l"
+    expected_output: ">= 2"
+  - description: "Submit unit tests still pass"
+    command: "uv run -- python -m pytest tests/unit/cli/commands/test_submit.py -q"
+    expected_output: "All tests pass"
+
+must_preserve:
+  - "`benchbox submit --output` continues to package a self-contained bundle directory"
+  - "The CLI's existing 'Next step' message still points contributors at the in-bundle file"
+
+anti_patterns:
+  - "DO NOT silently keep the in-bundle template diverged from the canonical doc -- because that is the exact failure mode this TODO exists to fix -- regenerate at build time or include a clear pointer"
+  - "DO NOT remove the in-bundle file entirely -- because contributors offline / on planes still need a packaged copy of the steps -- ship a checklist + canonical URL instead"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/commands/submit.py"
+    - "tests/unit/cli/commands/test_submit.py"
+    - "docs/contributing-results.md"
+
+metadata:
+  tags:
+    - results
+    - submit
+    - cli
+    - contributor-experience
+    - dry-run-followup
+  estimated_effort: "Small"
+  created_date: "2026-04-28"
+
+impact:
+  business_value: |
+    Removes the silent footgun where contributors follow stale in-bundle
+    instructions and open wrong-target PRs with stale inventory. Saves
+    maintainer review cycles and improves first-time contributor UX.
+  user_impact: |
+    Community contributors get one consistent set of instructions
+    regardless of which file they read first.
+  technical_debt: |
+    Eliminates a duplicate-truth surface: today the in-bundle CONTRIBUTING.md
+    and `docs/contributing-results.md` can drift independently; only one
+    is exercised by CI.

--- a/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
@@ -5,6 +5,10 @@ priority: Medium
 status: Not Started
 category: Core Functionality
 
+deps:
+  needs:
+    - dry-run-followup-package-canonical-contributing
+
 description: |
   `docs/contributing-results.md` describes the submission manifest as
   containing a "contributor" field. The CLI does fall back to
@@ -70,7 +74,7 @@ must_preserve:
 
 anti_patterns:
   - "DO NOT make empty submitted_by a hard error -- because anonymous submissions are valid -- warn and continue"
-  - "DO NOT switch the default fallback from user.name to user.email -- because user.name has been the convention since the field was added -- changing it silently breaks existing reproducible workflows"
+  - "DO NOT change the default fallback source without updating the doc table in the same PR -- because contributors verifying their manifest will look for whichever field the doc names -- keep code and doc consistent"
 
 scope_limit:
   only_modify:

--- a/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
@@ -1,0 +1,99 @@
+id: dry-run-followup-submitted-by-flag
+title: "benchbox submit: warn on empty submitted_by, add --submitted-by override"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  `docs/contributing-results.md` describes the submission manifest as
+  containing a "contributor" field. The CLI does fall back to
+  `git config user.name` via `_get_git_username()` at
+  `benchbox/cli/commands/submit.py:49-60`, but when that returns empty
+  (no git user.name configured — e.g. fresh sandbox), the manifest's
+  `submitted_by` is silently set to `""` with no warning.
+
+  Two improvements:
+    1. Warn loudly when the fallback returns empty, telling the
+       contributor exactly how to set it.
+    2. Add `--submitted-by TEXT` for explicit override (CI, automation,
+       contributors who prefer not to set git config).
+
+  Surfaced by the agent-proxy dry-run on 2026-04-28
+  (see `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`).
+  The Cowork sandbox had no `git config user.name` set, which is what
+  triggered the silent-empty path that this TODO addresses.
+
+work:
+  - id: w1
+    summary: "Warn when _get_git_username returns empty and no --submitted-by was passed"
+    status: pending
+    notes: |
+      In the manifest-write path, if `submitted_by` would be empty,
+      print a warning to stderr: "submitted_by is empty — set
+      `git config user.name <name>` or pass --submitted-by NAME".
+      Do not fail the command; the empty field is a soft issue, not
+      a hard error.
+
+  - id: w2
+    summary: "Add --submitted-by TEXT flag and plumb into manifest write"
+    status: pending
+    needs: [w1]
+    notes: |
+      Add `--submitted-by TEXT` option to `benchbox submit`. Precedence:
+      explicit flag > `git config user.name` > empty (with warning).
+      Document in `docs/contributing-results.md` and in the in-bundle
+      CONTRIBUTING.md (which is being rewritten in
+      `dry-run-followup-package-canonical-contributing` — coordinate
+      the doc change there).
+
+  - id: w3
+    summary: "Add unit tests for the three precedence paths"
+    status: pending
+    needs: [w2]
+    notes: |
+      Test cases: (a) --submitted-by overrides git config, (b) git
+      config user.name is used when no flag, (c) warning is emitted
+      when both are empty. Mock `_get_git_username` for determinism.
+
+verification:
+  - description: "--submitted-by flag is in the help output"
+    command: "uv run -- benchbox submit --help | grep -c -- '--submitted-by'"
+    expected_output: "1"
+  - description: "Submit unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/cli/commands/test_submit.py -q"
+    expected_output: "All tests pass"
+
+must_preserve:
+  - "Existing `_get_git_username()` fallback behavior remains the default when no flag is passed"
+  - "The empty-submitted_by case stays a warning, not a hard failure -- some contributors may legitimately submit anonymously"
+
+anti_patterns:
+  - "DO NOT make empty submitted_by a hard error -- because anonymous submissions are valid -- warn and continue"
+  - "DO NOT switch the default fallback from user.name to user.email -- because user.name has been the convention since the field was added -- changing it silently breaks existing reproducible workflows"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/commands/submit.py"
+    - "tests/unit/cli/commands/test_submit.py"
+    - "docs/contributing-results.md"
+
+metadata:
+  tags:
+    - results
+    - submit
+    - cli
+    - contributor-experience
+    - dry-run-followup
+  estimated_effort: "Small"
+  created_date: "2026-04-28"
+
+impact:
+  business_value: |
+    Closes the silent-empty failure mode for `submitted_by` so the
+    manifest's contributor metadata is reliably populated, and gives
+    automated submission paths an explicit override.
+  user_impact: |
+    Contributors get a clear warning when their setup is missing the
+    git user.name, instead of producing a manifest with empty
+    contributor metadata they discover only post-PR.

--- a/_project/TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
@@ -1,0 +1,71 @@
+id: dry-run-followup-uv-fallback-and-schema-key
+title: "Local-validation block: document non-uv fallback and schema-version key name"
+worktree: main
+priority: Low
+status: Not Started
+category: Documentation
+
+description: |
+  Two small contributor-facing clarifications in
+  `docs/contributing-results.md`, both surfaced by the agent-proxy
+  dry-run on 2026-04-28
+  (see `_project/handoffs/external-dry-run-retrospective-2026-04-28.md`).
+
+  1. The "Running Validation Locally" block uses `uv run -- python …`
+     for every example. In environments where `uv` is not installed or
+     is slow to bootstrap a venv, plain `python scripts/validate_submission.py …`
+     works identically. Add a one-line "no uv? use python directly"
+     note. (Cowork's sandbox specifically hit a 45s `uv run` stall
+     and had to fall back to `python3` — a real-world contributor on
+     a constrained machine could hit the same.)
+
+  2. The "Quality Expectations" section says "Schema v2 format - only
+     the current schema version is accepted". The actual JSON key is
+     `version` (string, currently `"2.1"`), not `schema_version`. Name
+     the key explicitly so contributors can grep their bundle to
+     verify compliance.
+
+work:
+  - id: w1
+    summary: "Add a non-uv fallback note to Running Validation Locally"
+    status: pending
+    notes: |
+      Add a sentence: "If you don't have `uv`, replace `uv run -- python`
+      with `python` — the scripts have no uv-specific dependencies."
+      Place it once at the top of the local-validation block.
+
+  - id: w2
+    summary: "Name the version JSON key explicitly under Quality Expectations"
+    status: pending
+    notes: |
+      Change "Schema v2 format - only the current schema version is
+      accepted" to "Schema v2 format (top-level `version` field,
+      currently `\"2.1\"`)". Optionally add a one-line how-to:
+      `python3 -c "import json; print(json.load(open('bundle.json'))['version'])"`.
+
+verification:
+  - description: "Doc names the version key"
+    command: "grep -c 'version.*2\\.1\\|`version`' docs/contributing-results.md"
+    expected_output: ">= 1"
+  - description: "Doc mentions a non-uv fallback"
+    command: "grep -ciE 'without uv|no uv|don.t have uv' docs/contributing-results.md"
+    expected_output: ">= 1"
+
+scope_limit:
+  only_modify:
+    - "docs/contributing-results.md"
+
+metadata:
+  tags:
+    - docs
+    - contributor-experience
+    - dry-run-followup
+  estimated_effort: "Trivial"
+  created_date: "2026-04-28"
+
+impact:
+  user_impact: |
+    Two small clarifications that prevent contributors on constrained
+    environments from getting stuck on `uv run`, and stop anyone trying
+    to grep for `schema_version` in their bundle from concluding the
+    bundle is malformed.

--- a/_project/TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-uv-fallback-and-schema-key.yaml
@@ -44,12 +44,20 @@ work:
       `python3 -c "import json; print(json.load(open('bundle.json'))['version'])"`.
 
 verification:
-  - description: "Doc names the version key"
-    command: "grep -c 'version.*2\\.1\\|`version`' docs/contributing-results.md"
+  - description: "Doc names the top-level version JSON key explicitly"
+    command: "grep -cE 'top-level `version`|JSON key `version`|`version` field' docs/contributing-results.md"
     expected_output: ">= 1"
-  - description: "Doc mentions a non-uv fallback"
+  - description: "Doc mentions a non-uv fallback for the validation block"
     command: "grep -ciE 'without uv|no uv|don.t have uv' docs/contributing-results.md"
     expected_output: ">= 1"
+
+must_preserve:
+  - "The existing `uv run -- python` examples remain in the doc as the canonical invocation -- the fallback is added as an alternative, not a replacement"
+  - "The Quality Expectations section still names schema v2 as the accepted format"
+
+anti_patterns:
+  - "DO NOT remove the `uv run` examples in favor of plain `python` -- because most contributors do have uv and removing it would break the canonical Python tooling pattern -- add the fallback as an alternative line"
+  - "DO NOT name a different JSON key than the bundle actually emits -- because a contributor grepping their bundle should find what the doc says is there -- check a real bundle's top-level keys before naming one"
 
 scope_limit:
   only_modify:

--- a/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
+++ b/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
@@ -121,6 +121,7 @@ anti_patterns:
 - DO NOT pre-coach the contributor through the docs - because that hides the friction this dry-run exists to surface.
 - DO NOT skip the external recruit and use another maintainer - because every maintainer already shares the curse of knowledge.
 - DO NOT bundle defect fixes into this TODO - because mixing observation with implementation muddies the retrospective; file separate TODOs and keep this one focused on the dry-run experience.
+- DO NOT interpret a frictionless human dry-run as evidence the human run was unnecessary - because the agent-proxy run on 2026-04-28 already pre-fixed obvious friction via the dry-run-followup-* TODOs - frictionless from a human is success of the prep, not redundancy of the test, and confirms the docs are now where they need to be.
 
 scope_limit:
   only_modify:

--- a/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
+++ b/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
@@ -23,6 +23,17 @@ description: |
   captures friction points, and converts the friction list into actionable
   follow-up TODOs. Done before broader public promotion.
 
+  Update 2026-04-28: an agent-proxy dry-run was performed via Claude
+  Cowork as a doc-hardening pre-pass. It surfaced 11 friction items and
+  produced 6 follow-up TODOs (`dry-run-followup-*.yaml` in this
+  directory). See
+  `_project/handoffs/external-dry-run-retrospective-2026-04-28.md` for
+  the retrospective. The agent run does NOT close this TODO -- the
+  human dry-run (w1-w5) is still required because Cowork structurally
+  cannot exercise auth, push, PR open, CI validate, maintainer review,
+  trust-label apply, or explorer redeploy. The agent run reduces the
+  friction the eventual human contributor will hit.
+
 work:
 - id: w1
   summary: "Identify and recruit one external contributor"

--- a/_project/handoffs/external-dry-run-retrospective-2026-04-28.md
+++ b/_project/handoffs/external-dry-run-retrospective-2026-04-28.md
@@ -1,0 +1,196 @@
+# External Dry-Run Retrospective — 2026-04-28
+
+> Source: agent-proxy run via Claude Cowork (cold sandbox, no repo mounted,
+> no GitHub auth, no maintainer tooling). The parent TODO
+> `external-contributor-submission-dry-run` requires a *human* contributor
+> dry-run; this run is a doc-hardening pre-pass that surfaces friction the
+> human shouldn't have to discover. The TODO is **not closed** by this run.
+
+## Timeline
+
+- 13:20:53Z — Cloned `joeharris76/BenchBox` into `/tmp/BenchBox`. (First clone into the Cowork outputs mount failed on a `.git/config.lock` permission error; re-cloned into `/tmp` and proceeded. Sandbox quirk, not a doc issue.)
+- 13:21:02Z — Read `docs/contributing-results.md` cold. Spotted broken Prerequisites link (`getting-started.rst`) before doing anything else.
+- 13:21:30Z — `pip install benchbox` (sandbox is throwaway, `--break-system-packages`). Installed `benchbox 0.2.1`.
+- 13:21:55Z — Ran `benchbox run --platform duckdb --benchmark tpch --scale 0.01` exactly as the doc says. Failed: "Platform 'duckdb' is not available (missing dependencies)". CLI told me to install `benchbox[duckdb]`. The doc did not.
+- 13:22:00Z — `pip install "benchbox[duckdb]"`.
+- 13:22:05Z — Re-ran benchmark. Passed. Result written to `benchmark_runs/results/tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json` — note the filename shape (extra `_sql_` segment, hash suffix) does not match the doc's example `tpch_sf001_duckdb_20260401_120000.json`.
+- 13:22:18Z — `benchbox submit --last --dry-run`. Listed three files. Ran the real package: `benchbox submit --last --output ./submission`. Bundle, manifest, and a `CONTRIBUTING.md` were written.
+- 13:22:30Z — Read packaged `submission/CONTRIBUTING.md`. It disagrees with `docs/contributing-results.md` in three places (no inventory regeneration, no `published-results` branch target, no local-validation block).
+- 13:23:10Z — Inspected manifest: `submitted_by` is empty; the CLI never asked for a contributor and offers no flag to set one. The doc table promises a "contributor" field.
+- 13:23:30Z — Tried `uv run -- python scripts/validate_submission.py …` exactly as the doc says. Timed out at 45s. Switched to plain `python3 scripts/validate_submission.py …`. Passed in <1s.
+- 13:23:50Z — Pre-stage inventory check: `python3 scripts/generate_corpus_inventory.py --check` → OK (12 bundles).
+- 13:24:00Z — Followed Step 3.2/3.3: copied bundle and `submission-manifest.json` into `results-data/bundles/` (in my throwaway clone — would-have-pushed in user's clone).
+- 13:24:10Z — Re-ran `--check`. Failed exactly as the doc warns ("Missing from inventory: ..."). Ran `--write`. Inventory regenerated to 13 bundles, NOT 14 — the manifest file was silently filtered out. Behavior is undocumented.
+- 13:24:25Z — `--check` again. OK. Stop point: would-have-pushed and would-have-opened-PR. Logged in Appendix B.
+- 13:25:13Z — Compiled artifacts.
+
+## Environment caveats
+
+Cowork sandbox could not test:
+
+- **GitHub auth** of any kind (no `gh`, no token, no SSH agent).
+- **`git push`** to a fork or to the user's repo.
+- **`gh pr create`** / opening a PR via API.
+- **CI run of "Validate Submission"** — that workflow only fires on PR open. I ran the CI's underlying scripts (`validate_submission.py`, `generate_corpus_inventory.py`) directly, but the workflow file itself, the PR-comment posting path, and any GitHub-context glue went untested.
+- **Maintainer review / merge / docs CI rebuild** of `results-explorer` (Step 5).
+- **`pre-commit install`** — would write hooks into a clone that's about to be discarded.
+- **Trust-label assignment** in the explorer ("Community Submission") — that's a downstream rendering step.
+- **`uv run`** in this sandbox stalls past 45s on the validation script. May be sandbox CPU/network constraint, not a real-world contributor problem — flagging because the doc relies entirely on `uv run` for the local-validation block.
+
+## Friction items
+
+- **Step: Prerequisites #1 — broken relative link.** Expected: link to a Getting Started guide. Actual: `[Getting Started](getting-started.rst)` resolves to `docs/getting-started.rst`, which does not exist. There's `docs/usage/getting-started.md` and `docs/development/getting-started.rst`. Resolved by skipping (I already had pip available). Classification: **doc-fix**. *(Patched in the same PR as this retrospective.)*
+
+- **Step: Step 1 — `benchbox run --platform duckdb …`.** Expected: works after `pip install benchbox`. Actual: errors with "Platform 'duckdb' is not available (missing dependencies). Run uv pip install \"benchbox[duckdb]\" to install dependencies." The CLI message is good; the doc is silent on extras. Resolved by following the CLI hint. Classification: **doc-fix**. *(Patched in the same PR as this retrospective.)*
+
+- **Step: Step 1 — example filename in §1.** Expected: real result filenames look like `tpch_sf001_duckdb_20260401_120000.json` (the doc's example for the explicit `benchbox submit <path>` form). Actual: `tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json`. The `_sql_` mode suffix and the hash tail are not in the doc's example, so a contributor copy-pasting the second `benchbox submit` form has to translate. Resolved by using `--last`. Classification: **doc-fix**.
+
+- **Step: Step 2 — bundle table.** Expected: per the table, my bundle directory should contain `<result>.json`, `<result>.plans.json`, `<result>.tuning.json`, plus the manifest and the README. Actual: only `<result>.json`. The doc footnotes "(if captured)" / "(if used)" but never explains how a contributor would *opt in* to capture plans or apply tuning before running. The "if" rules out of nowhere. Resolved by ignoring. Classification: **doc-fix**.
+
+- **Step: Step 2 — packaged `CONTRIBUTING.md` disagrees with `docs/contributing-results.md`.** The file `benchbox submit` writes into the bundle is a 16-line stub. It does not mention: (a) regenerating `corpus-inventory.json` before commit, (b) targeting the `published-results` branch (it just says "open a pull request"), (c) the local validation block. A contributor who reads only the in-bundle file — which is what `submit` directs them to ("See CONTRIBUTING.md in the output directory for instructions") — will open a PR against `main` with a stale inventory. CI on the user side will then catch it; that's wasted round-trips. Classification: **tool-fix** (regenerate the in-bundle file from the canonical doc, or have `submit` print the canonical instructions).
+
+- **Step: Step 2 — manifest filename collision.** Doc instruction 3.3: "Copy `submission/submission-manifest.json` alongside the bundle files." The filename is generic. `results-data/bundles/` currently contains zero manifests. Two community PRs landing in the same window would write to the same filename. The doc never names the convention. Classification: **process-gap** (also a tool-fix candidate — emit `<result>.manifest.json` instead).
+
+- **Step: Step 2 — `submitted_by` is empty.** The doc table promises the manifest contains "contributor". My manifest's `submitted_by` field is an empty string. *Maintainer correction during review: the CLI does fall back to `git config user.name` via `_get_git_username()` at `submit.py:49-60`. The Cowork sandbox simply had no `user.name` set, so the fallback returned `""` silently with no warning.* Real failure mode: silent empty when the fallback misses, plus no override flag. Classification: **tool-fix** (warn loudly when the fallback returns empty, add `--submitted-by` override).
+
+- **Step: Step 3.5 — branch target ambiguity.** Doc says PR against `published-results` branch, but the in-bundle CONTRIBUTING.md does not, and `git remote show origin` shows `main` as HEAD. A contributor following GitHub defaults will target `main`. Doc could call out the branch more loudly (bold + first time it's mentioned); CLI could open the PR URL with the base preselected. Classification: **doc-fix** + **tool-fix**.
+
+- **Step: Step 4 — schema version key naming.** The doc calls bundles "schema-v2 result bundle". The JSON has no `schema_version` key. The actual key is `version: "2.1"`. The "Quality Expectations" section says "Schema v2 format - only the current schema version is accepted" without naming the key. Anyone trying to grep their JSON for compliance will look in the wrong place. Classification: **doc-fix**.
+
+- **Step: "Running Validation Locally" — `uv run` stall.** Expected: `uv run -- python scripts/validate_submission.py …` returns in seconds. Actual: timed out at the sandbox's 45s ceiling. Plain `python3 scripts/validate_submission.py …` returned in ~1s and passed. May be a Cowork-specific environment problem (uv warming a venv), but the doc gives no fallback. Classification: **cowork-can't-test** primarily, with a **doc-fix** suggestion (offer the `python` invocation as an alt for environments without uv).
+
+- **Step: Step 3.4 — manifest filtered silently from inventory.** After copying the bundle plus the manifest into `results-data/bundles/`, the inventory regenerator counted 13 (= 12 + 1), not 14. It silently dropped `submission-manifest.json`. That's probably the right behavior, but it's undocumented — a contributor seeing the count not match their file count will worry. Classification: **doc-fix**.
+
+## What worked / what didn't / what I'd change
+
+**What worked.** The CLI itself was the most polished surface. `benchbox run`'s missing-dependency error was clear and actionable. `benchbox submit --dry-run` showed exactly what would land. `validate_submission.py` and `generate_corpus_inventory.py --check`/`--write` did what the doc said they would. The benchmark itself ran clean on the smallest scale and produced a usable bundle.
+
+**What didn't.** The doc is the weak surface. Three independent friction points are caused by the doc lagging the CLI: the missing extras, the broken Prerequisites link, and the bundle-table claim about plans/tuning files that are gated on flags the doc never names. The packaged `CONTRIBUTING.md` is the worst single artifact — it's authoritative-looking and the CLI points the contributor at it, but it omits two of the four steps the canonical doc requires for the PR to merge cleanly.
+
+**What I'd change.** Make `benchbox submit` either (a) embed the canonical contributing-results.md verbatim into the bundle, or (b) print a one-screen checklist that includes `published-results` branch + inventory regeneration. Add a `--submitted-by` flag (default to `git config user.name`, warn on empty). Drop the "if captured / if used" rows from the bundle-table or move them to a footnote with a how-to. Fix the broken link.
+
+## Agent-vs-human caveat
+
+A human cold-running this would probably hit the missing-`[duckdb]`-extras error, give up for ten minutes assuming the install was broken, then either follow the CLI hint or post in Discussions. I pattern-matched on "missing dependencies" + the literal `uv pip install …` suggestion in the error and fixed it in seconds — agents are cheap on these. Conversely, a human reading the broken Prerequisites link would notice immediately ("404 — clearly a doc bug, file an issue, move on"); I almost ignored it because I had `pip` already and didn't *need* the page. Humans will also more readily read the in-bundle `CONTRIBUTING.md` and trust it as the latest source of truth, which is the worst place to put stale instructions. And a human is more likely to ask a maintainer "do I really PR against `published-results`? — that's unusual" before pushing, whereas an agent will just do whatever the doc says. Net: the friction items are real for both, but humans are more likely to file an issue and stop, agents more likely to grind through and never report.
+
+## Follow-ups filed
+
+Six follow-up TODOs landed alongside this retrospective in
+`_project/TODO/main/planning/`:
+
+- `dry-run-followup-package-canonical-contributing.yaml` (High)
+- `dry-run-followup-submitted-by-flag.yaml` (Medium)
+- `dry-run-followup-manifest-filename-convention.yaml` (Medium)
+- `dry-run-followup-bundle-table-conditionals.yaml` (Low)
+- `dry-run-followup-broken-getting-started-link.yaml` (Low — already
+  patched in this PR; YAML kept as the tracked record)
+- `dry-run-followup-uv-fallback-and-schema-key.yaml` (Low)
+
+The parent TODO `external-contributor-submission-dry-run` is **not
+closed**: the human contributor dry-run (w1–w5) is still required
+because Cowork structurally cannot exercise auth, push, PR open, CI
+validate, maintainer review, trust-label apply, or explorer redeploy.
+This run is a doc-hardening pre-pass that reduces friction for the
+human run.
+
+---
+
+## Appendix A — Bundle structural report
+
+Directory tree of `submission/`:
+
+```
+submission/
+├── CONTRIBUTING.md
+├── bundle
+│   └── tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json
+└── submission-manifest.json
+```
+
+`submission-manifest.json` contents:
+
+```json
+{
+  "submission_tool_version": "benchbox/0.2.1",
+  "submitted_at": "2026-04-28T13:22:25.715970+00:00",
+  "bundle_file": "tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json",
+  "bundle_hash": "927236b656b60931c69f23fa2e4888bd98e47e080bee6ae8092efc0f042d02e8",
+  "benchmark": "TPC-H",
+  "platform": "DuckDB",
+  "scale_factor": 0.01,
+  "phase": 2,
+  "submission_path": "PR-based",
+  "submitted_by": ""
+}
+```
+
+Bundle JSON top-level shape (`bundle/tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json`, 17,111 bytes):
+
+- Top-level keys: `version`, `run`, `benchmark`, `platform`, `config`, `summary`, `phases`, `queries`, `tables`, `cost`, `execution`, `environment`, `export`
+- `version: "2.1"` (note: not `schema_version`)
+- `run.id`: `a0be0851` (matches the filename suffix; this is a separate
+  run ID, not the manifest's `bundle_hash`)
+- `benchmark`: `{id: tpch, name: TPC-H, scale_factor: 0.01, test_type: power}`
+- `platform`: `{name: DuckDB, version: 1.5.2, …}`
+- `summary.queries`: `{total: 66, passed: 66, failed: 0}` — that's 22 queries × 3 measurement runs.
+- `summary.timing`: `{total_ms: 221, avg_ms: 3.3, min_ms: 1, max_ms: 5, p99_ms: 5}`
+- `queries` array length: 88 records (22 × (1 warm-up + 3 measurement)).
+- 22 distinct query IDs 1..22.
+
+`validate_submission.py` ran against this bundle and reported 0 error(s),
+0 warning(s). The doc never instructs contributors to record any hashes
+or row counts by hand; everything is auto-populated by `benchbox submit`.
+
+## Appendix B — "Would-have" command log
+
+Every command stopped at because of the auth/file-write boundary:
+
+```
+# Step 3.1 — Fork the BenchBox repo
+would have run: <browser action> open https://github.com/joeharris76/BenchBox → click Fork
+expected: a fork at <my-username>/BenchBox
+
+# Step 3.2 — Clone the fork and switch to a feature branch
+would have run: git clone git@github.com:<my-username>/BenchBox.git && cd BenchBox && git checkout -b results/tpch-duckdb-sf001-20260428
+expected: working tree on a new branch ready for the bundle copy
+
+# Step 3.2 — Copy bundle into results-data/bundles/
+would have run: cp /path/to/submission/bundle/tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json results-data/bundles/
+expected: one new file under results-data/bundles/
+
+# Step 3.3 — Copy submission-manifest.json
+would have run: cp /path/to/submission/submission-manifest.json results-data/bundles/
+expected: manifest sits next to the bundle file  [filename collision risk, see follow-up TODO]
+
+# Step 3.4 — Regenerate inventory
+would have run: uv run -- python scripts/generate_corpus_inventory.py --write
+expected: results-data/corpus-inventory.json bumped from 12 to 13 bundles  [verified via python3 invocation in /tmp clone — succeeded]
+
+# Step 3.5 — Commit
+would have run: git add results-data/bundles/tpch_sf001_duckdb_sql_20260428_132205_a0be0851.json results-data/bundles/submission-manifest.json results-data/corpus-inventory.json && git commit -m "results: tpch DuckDB sf0.01"
+expected: one commit with bundle + manifest + inventory delta
+
+# Step 3.5 — Push
+would have run: git push -u origin results/tpch-duckdb-sf001-20260428
+expected: branch published on the fork
+
+# Step 3.5 — Open PR
+would have run: gh pr create --repo joeharris76/BenchBox --base published-results --head <my-username>:results/tpch-duckdb-sf001-20260428 --title "results: tpch DuckDB sf0.01" --body "<auto>"
+expected: PR opened against the published-results branch (NOT main — see friction item)
+
+# Step 4 — CI Validate Submission
+would have run: <GitHub Actions> .github/workflows/validate-submission.yml triggered by PR open
+expected: schema-valid bundle, hash matches manifest, inventory in sync, summary comment posted on PR
+
+# Step 5 — Maintainer review and merge
+would have run: <maintainer action> review + Squash and merge
+expected: PR merged into published-results
+
+# Step 5 — Post-merge docs CI
+would have run: <GitHub Actions> docs CI rebuilds results-explorer with the new bundle
+expected: bundle visible in the explorer with "Community Submission" trust label
+
+# Optional — pre-commit hooks
+would have run: pre-commit install
+expected: future commits in this clone auto-check inventory drift  [skipped because the clone is throwaway; would run in user's clone]
+```

--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -4,7 +4,7 @@ Thank you for contributing to the BenchBox community results dataset! Community-
 
 ## Prerequisites
 
-1. **Install BenchBox** - follow the [Getting Started](getting-started.rst) guide
+1. **Install BenchBox** - follow the [Getting Started](usage/getting-started.md) guide
 2. **Run a benchmark** - you need a complete benchmark result to submit
 
 ## Step-by-Step Submission Flow
@@ -12,6 +12,8 @@ Thank you for contributing to the BenchBox community results dataset! Community-
 ### 1. Run a benchmark
 
 Run a complete benchmark suite (not a cherry-picked subset of queries):
+
+Install the platform extra first (e.g. `pip install "benchbox[duckdb]"`).
 
 ```bash
 benchbox run --platform duckdb --benchmark tpch --scale 0.01


### PR DESCRIPTION
## Summary

Lands the artifacts from a Claude Cowork agent-proxy cold-walk of `docs/contributing-results.md` (run on 2026-04-28) as a doc-hardening pre-pass for the parent TODO `external-contributor-submission-dry-run`.

The parent TODO is **not closed** by this PR — the human contributor dry-run is still required because Cowork structurally cannot exercise auth, push, PR open, CI validate, maintainer review, trust-label apply, or explorer redeploy. This run reduces the friction the eventual human contributor will hit.

## What lands

- **Retrospective:** `_project/handoffs/external-dry-run-retrospective-2026-04-28.md` — timeline, environment caveats, 11 friction items, agent-vs-human caveat, bundle structural report, "would-have" command log.
- **Six follow-up TODOs** in `_project/TODO/main/planning/`:
  - `dry-run-followup-package-canonical-contributing.yaml` (**High**) — the in-bundle CONTRIBUTING.md emitted by `benchbox submit` is hardcoded and diverges from `docs/contributing-results.md` in 3 load-bearing ways (no inventory regen, no `published-results` target, no local-validation block). Spot-checked against `submit.py:29-46` — confirmed real.
  - `dry-run-followup-submitted-by-flag.yaml` (Medium) — manifest's `submitted_by` is silently empty when `git config user.name` is unset; add warning + `--submitted-by` override.
  - `dry-run-followup-manifest-filename-convention.yaml` (Medium) — `submission-manifest.json` literal collides on concurrent PRs; rename to `<bundle-stem>.manifest.json`.
  - `dry-run-followup-bundle-table-conditionals.yaml` (Low) — undefined `(if captured)` / `(if used)` rows in the Step 2 bundle table.
  - `dry-run-followup-broken-getting-started-link.yaml` (Low) — add a docs linkcheck CI rule so the originally-broken link can't regress.
  - `dry-run-followup-uv-fallback-and-schema-key.yaml` (Low) — document non-uv fallback for the validation block; name the `version` JSON key explicitly.
- **Two trivial doc fixes** in `docs/contributing-results.md`:
  - Broken `getting-started.rst` link → `usage/getting-started.md`.
  - One-line "install the platform extra first" hint above the `benchbox run` example.
- **Parent TODO update:** description note pointing to the retrospective and explicitly stating the human dry-run is still required.

## Diagnosis correction during review

Cowork's `--submitted-by` stub claimed the manifest field has no fallback. Verified against `benchbox/cli/commands/submit.py:49-60`: the code DOES fall back to `git config user.name`, but returns `""` silently when unset. The follow-up TODO has been reframed accordingly (warn on empty + add override flag) instead of "add fallback."

## Test plan

- [x] `todo-validate` passes on all 6 new TODOs and the modified parent
- [x] `todo-index` regenerates indexes cleanly
- [x] `make pr-preflight` green (21217 passed, 6 skipped, 105s)
- [x] Doc fix verified: `getting-started.rst` link now resolves to `docs/usage/getting-started.md`
- [ ] Maintainer review of the 6 follow-up TODOs' framing before they're picked up