### PR TITLE
fix(test): allow negative fare_amount in nyctaxi trips structure check

### DIFF
--- a/tests/integration/test_nyctaxi_duckdb.py
+++ b/tests/integration/test_nyctaxi_duckdb.py
@@ -286,6 +286,7 @@ class TestNYCTaxiDataGeneration:
                 assert 0 < pickup_id <= 265
                 assert 0 < dropoff_id <= 265
 
-                # Amounts should be numeric
-                fare = float(row[header.index("fare_amount")])
-                assert fare >= 0
+                # Amounts should be numeric. Real NYC TLC trip data
+                # includes negative fare_amount values (refunds and
+                # adjustments), so assert numeric-ness only.
+                float(row[header.index("fare_amount")])


### PR DESCRIPTION
## Summary
- Real NYC TLC trip data includes negative `fare_amount` values (refunds, adjustments).
- The test asserted `fare >= 0` against a sampled row, which flakes on Windows when the sample includes one of those rows (e.g. -6.0).
- The `float()` cast already verifies the field is numeric — that matches the surrounding "Amounts should be numeric" comment intent.

## Why now
This was failing `integration-smoke (windows-latest, 3.12)` on PR #34. Not a required check but blocks GitHub auto-merge from firing.

## Test plan
- [x] Local: `uv run -- python -m pytest 'tests/integration/test_nyctaxi_duckdb.py::TestNYCTaxiDataGeneration::test_trips_data_structure' -m slow -v` → 1 passed
- [x] Local: `make pr-preflight` → 21217 passed, 6 skipped
- [ ] CI: lint + test (ubuntu-latest, 3.12) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)