### PR TITLE
ci(main-guardrail): reject non-release-branch PRs targeting main

### DIFF
--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -1,0 +1,31 @@
+name: Validate main PR base
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: validate-main-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate-base:
+    name: validate-base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-release-branch PRs to main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${HEAD_REF}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "Release branch '${HEAD_REF}' approved for merge into main."
+            exit 0
+          fi
+          echo "::error::Only release branches matching 'vX.Y.Z' (optionally with a '-suffix') may merge into main. Got '${HEAD_REF}'."
+          echo "::error::Open this PR against 'develop' instead, or cut a release branch via 'make release-cut VERSION=X.Y.Z'."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/validate-main-pr.yml` with a single `validate-base` job that fails when a PR targets `main` and the head branch isn't `^vX.Y.Z(-suffix)?$`.
- Closes the gap that allowed PR #24 to land directly on `main` (mis-targeted base).

## Follow-up after merge
- Add `validate-base` to ruleset `main-release-only` (id `15611783`) under `required_status_checks` so the rule is enforced for every PR-to-main going forward. PRs from stale branches that lack the workflow file will block on the missing check; PRs from `vX.Y.Z` heads will run and pass.

## Test plan
- [x] Regex unit-checked locally against `v0.2.2`, `v1.0.0`, `v0.2.2-rc1`, `v0.2.2-beta.1` (pass) and `chore/foo`, `main`, `feature/v1.0`, `v0.2`, `v0.2.2.1` (fail).
- [ ] After merge, add the check to the ruleset and verify the next non-release PR-to-main is blocked (would only happen on a real attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)