### PR TITLE
chore(todo): bump 2 dry-run followup items to Medium-High

### DIFF
--- a/_project/TODO/_indexes/by-category.yaml
+++ b/_project/TODO/_indexes/by-category.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T18:04:33.405849'
+generated_at: '2026-04-28T19:49:03.533802'
 total_categories: 13
 categories:
   Architecture & Refactoring:
@@ -66,12 +66,12 @@ categories:
     - id: dry-run-followup-manifest-filename-convention
       file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
       title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
-      priority: Medium
+      priority: Medium-High
       status: Not Started
     - id: dry-run-followup-submitted-by-flag
       file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
       title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
-      priority: Medium
+      priority: Medium-High
       status: Not Started
   Documentation:
     count: 3

--- a/_project/TODO/_indexes/by-priority.yaml
+++ b/_project/TODO/_indexes/by-priority.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T18:04:33.405869'
+generated_at: '2026-04-28T19:49:03.533821'
 total_items: 36
 priorities:
   High:
@@ -30,7 +30,7 @@ priorities:
       category: Release Tooling
       status: In Progress
   Medium-High:
-    count: 4
+    count: 6
     items:
     - id: add-hypothesis-property-tests
       file: TODO/main/planning/add-hypothesis-property-tests.yaml
@@ -52,8 +52,18 @@ priorities:
       title: Integrate BenchBox CLI submission flow and service authentication
       category: Core Functionality
       status: In Progress
+    - id: dry-run-followup-manifest-filename-convention
+      file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+      title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+      category: Core Functionality
+      status: Not Started
+    - id: dry-run-followup-submitted-by-flag
+      file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+      title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+      category: Core Functionality
+      status: Not Started
   Medium:
-    count: 9
+    count: 7
     items:
     - id: ballista-distributed-adapter
       file: TODO/platform-expansion/planning/ballista-distributed-adapter.yaml
@@ -75,11 +85,6 @@ priorities:
       title: Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL
       category: Performance
       status: Identified
-    - id: dry-run-followup-manifest-filename-convention
-      file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
-      title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
-      category: Core Functionality
-      status: Not Started
     - id: single-repo-migration-phase-8-first-post-migration-release
       file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
       title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'
@@ -94,11 +99,6 @@ priorities:
       file: TODO/main/planning/validate-and-integrate-tpc-tuning-json.yaml
       title: Validate tpc-tuning.json z-ordering recommendations and integrate or discard
       category: Testing and Quality Assurance
-      status: Not Started
-    - id: dry-run-followup-submitted-by-flag
-      file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
-      title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
-      category: Core Functionality
       status: Not Started
   Low:
     count: 17

--- a/_project/TODO/_indexes/by-status.yaml
+++ b/_project/TODO/_indexes/by-status.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T18:04:33.405879'
+generated_at: '2026-04-28T19:49:03.533832'
 total_items: 36
 statuses:
   In Progress:
@@ -110,7 +110,7 @@ statuses:
     - id: dry-run-followup-manifest-filename-convention
       file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
       title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
-      priority: Medium
+      priority: Medium-High
       category: Core Functionality
     - id: review-dependency-upper-bounds-quarterly
       file: TODO/main/planning/review-dependency-upper-bounds-quarterly.yaml
@@ -176,7 +176,7 @@ statuses:
     - id: dry-run-followup-submitted-by-flag
       file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
       title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
-      priority: Medium
+      priority: Medium-High
       category: Core Functionality
   Identified:
     count: 2

--- a/_project/TODO/_indexes/master.yaml
+++ b/_project/TODO/_indexes/master.yaml
@@ -1,4 +1,4 @@
-generated_at: '2026-04-28T18:04:33.405811'
+generated_at: '2026-04-28T19:49:03.533770'
 total_items: 36
 items:
 - id: release-flow-dry-run-rc1
@@ -430,24 +430,6 @@ items:
   work_ready: 1
   needs:
   - implement-results-explorer-browser-functional-tests
-- id: dry-run-followup-manifest-filename-convention
-  file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
-  title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
-  worktree: main
-  category: Core Functionality
-  priority: Medium
-  status: Not Started
-  tags:
-  - results
-  - submit
-  - tooling
-  - dry-run-followup
-  estimated_effort: Medium
-  work_total: 4
-  work_done: 0
-  work_ready: 1
-  needs:
-  - dry-run-followup-package-canonical-contributing
 - id: single-repo-migration-phase-8-first-post-migration-release
   file: TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
   title: 'Single-repo migration phase 8: cut the first release after deletion and docs cleanup'
@@ -490,25 +472,6 @@ items:
   work_total: 4
   work_done: 0
   work_ready: 1
-- id: dry-run-followup-submitted-by-flag
-  file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
-  title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
-  worktree: main
-  category: Core Functionality
-  priority: Medium
-  status: Not Started
-  tags:
-  - results
-  - submit
-  - cli
-  - contributor-experience
-  - dry-run-followup
-  estimated_effort: Small
-  work_total: 3
-  work_done: 0
-  work_ready: 1
-  needs:
-  - dry-run-followup-package-canonical-contributing
 - id: add-hypothesis-property-tests
   file: TODO/main/planning/add-hypothesis-property-tests.yaml
   title: Add Hypothesis property-based tests for pure-function invariants
@@ -587,6 +550,43 @@ items:
   - define-results-platform-product-and-launch-strategy
   - define-hosted-results-contract-and-governance-model
   - design-results-ingest-storage-and-derived-read-model
+- id: dry-run-followup-manifest-filename-convention
+  file: TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+  title: Per-bundle manifest filenames to avoid PR collision in results-data/bundles/
+  worktree: main
+  category: Core Functionality
+  priority: Medium-High
+  status: Not Started
+  tags:
+  - results
+  - submit
+  - tooling
+  - dry-run-followup
+  estimated_effort: Medium
+  work_total: 4
+  work_done: 0
+  work_ready: 1
+  needs:
+  - dry-run-followup-package-canonical-contributing
+- id: dry-run-followup-submitted-by-flag
+  file: TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+  title: 'benchbox submit: warn on empty submitted_by, add --submitted-by override'
+  worktree: main
+  category: Core Functionality
+  priority: Medium-High
+  status: Not Started
+  tags:
+  - results
+  - submit
+  - cli
+  - contributor-experience
+  - dry-run-followup
+  estimated_effort: Small
+  work_total: 3
+  work_done: 0
+  work_ready: 1
+  needs:
+  - dry-run-followup-package-canonical-contributing
 - id: generalize-database-table-reuse-detection
   file: TODO/main/planning/generalize-database-table-reuse-detection.yaml
   title: Generalize benchmark table reuse detection for managed databases

--- a/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-manifest-filename-convention.yaml
@@ -1,7 +1,7 @@
 id: dry-run-followup-manifest-filename-convention
 title: "Per-bundle manifest filenames to avoid PR collision in results-data/bundles/"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Core Functionality
 

--- a/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
+++ b/_project/TODO/main/planning/dry-run-followup-submitted-by-flag.yaml
@@ -1,7 +1,7 @@
 id: dry-run-followup-submitted-by-flag
 title: "benchbox submit: warn on empty submitted_by, add --submitted-by override"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Core Functionality
 


### PR DESCRIPTION
## Summary
- Promote `dry-run-followup-submitted-by-flag` and `dry-run-followup-manifest-filename-convention` from Medium → Medium-High.
- Both are direct follow-ups from the 2026-04-28 agent-proxy dry-run that produced the High-priority `dry-run-followup-package-canonical-contributing` lead. Clustering them at adjacent priority signals they should land as a coherent batch before the next external (human) dry-run.
- Distribution: Medium-High band moves from 4 → 6 (target 5–10); High stays at 5 (top of band).

## Test plan
- [ ] CI lint passes
- [ ] CI test (ubuntu-latest, 3.12) passes
- [ ] No code change — TODO YAML + auto-generated indexes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)