### PR TITLE
chore(dry-run): land 2026-04-29 followup polish + cross-branch validator contract

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -700,7 +700,12 @@ def _derive_exec_type_and_banner(s: types.SimpleNamespace) -> None:
         s.logger.debug(f"Test execution type: {s.test_execution_type}")
     s.execution_mode = s.test_execution_type
 
-    if not s.quiet:
+    # Only show the "Interactive Benchmark Runner" header in actually-interactive
+    # contexts: a TTY and no explicit platform+benchmark args. Showing it when
+    # the user already provided --platform/--benchmark (or when piping output
+    # to a log) misrepresents the run as interactive.
+    is_interactive = sys.stdin.isatty() and not (s.platform and s.benchmark)
+    if not s.quiet and is_interactive:
         console.print(
             Panel.fit(
                 Text("BenchBox Interactive Benchmark Runner", style="bold blue"),

--- a/benchbox/cli/commands/submit.py
+++ b/benchbox/cli/commands/submit.py
@@ -155,6 +155,58 @@ def _dispatch_service_mode(
     ctx.exit(1)
 
 
+def _print_submission_summary(
+    *,
+    bundle_dir: Path,
+    source_path: Path,
+    companions: list[Path],
+    manifest_path: Path,
+    contributing_path: Path,
+    output_path: Path,
+    result,
+    dry_run: bool,
+) -> None:
+    """Print the file list + next-step commands for the contributor.
+
+    Same shape for dry-run and real-run so contributors see exactly
+    what the real run will print before they commit. Dry-run swaps
+    only the header and the trailing footer; the file list and
+    next-steps block are identical (the commands reference the paths
+    the real run would create — useful as a preview).
+    """
+    if dry_run:
+        console.print("\n[bold]Dry-run preview — would create:[/bold]")
+    else:
+        console.print("\n[bold green]✓ Submission package created![/bold green]")
+
+    bundle_filename = source_path.name
+    bundle_target = f"results-data/bundles/{bundle_filename}"
+
+    console.print(f"  {bundle_dir / bundle_filename}")
+    for comp in companions:
+        console.print(f"  {bundle_dir / comp.name}")
+    console.print(f"  {manifest_path}")
+    console.print(f"  {contributing_path}")
+
+    if not dry_run:
+        console.print(f"\n[dim]Output: {output_path.absolute()}[/dim]")
+
+    pr_title = f"results: {result.benchmark_name} {result.platform} sf{result.scale_factor}"
+    console.print("\n[bold]Next steps:[/bold]")
+    console.print(f"  1. cp [cyan]{bundle_dir / bundle_filename}[/cyan] [cyan]{bundle_target}[/cyan]")
+    for comp in companions:
+        console.print(f"     cp [cyan]{bundle_dir / comp.name}[/cyan] [cyan]results-data/bundles/{comp.name}[/cyan]")
+    console.print(f"     cp [cyan]{manifest_path}[/cyan] [cyan]results-data/bundles/{manifest_path.name}[/cyan]")
+    console.print("  2. uv run -- python scripts/generate_corpus_inventory.py --write")
+    console.print(f"  3. uv run -- python scripts/validate_submission.py {bundle_target}")
+    console.print(f"  4. PR title:  [cyan]{pr_title}[/cyan]")
+    console.print("     PR target: [cyan]published-results[/cyan]")
+    console.print("[dim]Full guide: https://docs.benchbox.dev/contributing-results[/dim]")
+
+    if dry_run:
+        console.print("\n[yellow](dry run; no files written)[/yellow]")
+
+
 @click.command("submit")
 @click.argument("result_file", required=False, type=click.Path(exists=True))
 @click.option(
@@ -362,13 +414,16 @@ def submit(
     contributing_path = output_path / "CONTRIBUTING.md"
 
     if dry_run:
-        console.print("\n[bold]Dry-run - would create:[/bold]")
-        console.print(f"  {bundle_dir / source_path.name}")
-        for comp in companions:
-            console.print(f"  {bundle_dir / comp.name}")
-        console.print(f"  {manifest_path}")
-        console.print(f"  {contributing_path}")
-        console.print("[yellow]Dry-run complete - no files written[/yellow]")
+        _print_submission_summary(
+            bundle_dir=bundle_dir,
+            source_path=source_path,
+            companions=companions,
+            manifest_path=manifest_path,
+            contributing_path=contributing_path,
+            output_path=output_path,
+            result=result,
+            dry_run=True,
+        )
         return
 
     bundle_dir.mkdir(parents=True, exist_ok=True)
@@ -403,15 +458,16 @@ def submit(
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     contributing_path.write_text(_CONTRIBUTING_TEXT, encoding="utf-8")
 
-    console.print("\n[bold green]✓ Submission package created![/bold green]")
-    console.print(f"  {bundle_dir / source_path.name}")
-    for comp in companions:
-        console.print(f"  {bundle_dir / comp.name}")
-    console.print(f"  {manifest_path.name}")
-    console.print(f"  {contributing_path.name}")
-    console.print(f"\n[dim]Output: {output_path.absolute()}[/dim]")
-    console.print("\n[bold]Next step:[/bold] Open a PR against results-data/ using the files above.")
-    console.print("[dim]See CONTRIBUTING.md in the output directory for instructions.[/dim]")
+    _print_submission_summary(
+        bundle_dir=bundle_dir,
+        source_path=source_path,
+        companions=companions,
+        manifest_path=manifest_path,
+        contributing_path=contributing_path,
+        output_path=output_path,
+        result=result,
+        dry_run=False,
+    )
 
 
 __all__ = ["submit"]

--- a/benchbox/cli/output.py
+++ b/benchbox/cli/output.py
@@ -169,7 +169,10 @@ class ConsoleResultFormatter:
                 if "empty_tables" in validation_details and validation_details["empty_tables"]:
                     console.print(f"   [red]• Empty tables:[/red] {', '.join(validation_details['empty_tables'])}")
                 if "missing_tables" in validation_details and validation_details["missing_tables"]:
-                    console.print(f"   [red]• Missing tables:[/red] {', '.join(validation_details['missing_tables'])}")
+                    console.print(
+                        f"   [yellow]• Missing tables:[/yellow] {', '.join(validation_details['missing_tables'])} "
+                        "[dim](recoverable — runner will rebuild via --force datagen)[/dim]"
+                    )
                 if "inaccessible_tables" in validation_details and validation_details["inaccessible_tables"]:
                     console.print(
                         f"   [red]• Inaccessible tables:[/red] {', '.join(validation_details['inaccessible_tables'])}"

--- a/benchbox/core/tpch/power_test.py
+++ b/benchbox/core/tpch/power_test.py
@@ -173,7 +173,9 @@ class TPCHPowerTest:
             validation = False
             actual_validation_mode = "disabled"
             self.logger.warning(
-                "⚠️  TPC-H answer sets are only available for stream 0. Disabling validation for stream_id != 0."
+                "⚠️  Stream 0 was validated against the answer set; "
+                "streams > 0 are run for timing only (per TPC-H spec). "
+                f"stream_id={stream_id} therefore runs without answer-set validation."
             )
 
         # If validation is disabled, override mode

--- a/docs/development/perf-smoke.md
+++ b/docs/development/perf-smoke.md
@@ -41,7 +41,7 @@ Procedure:
 ```
 # 1. Run locally on a quiet machine (or trigger the workflow and grab
 #    the uploaded artifact from the green run on main after merge).
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --scale 0.01 \

--- a/docs/platforms/dataframe.md
+++ b/docs/platforms/dataframe.md
@@ -355,7 +355,7 @@ def q1_pandas_impl(ctx: DataFrameContext) -> Any:
 - Quick iteration
 - Compatibility with existing codebases
 
-## Checking Platform Availability
+## Available Databases
 
 ```bash
 # Check which DataFrame platforms are installed

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -29,9 +29,9 @@ BenchBox keeps everyday workflows concise. Use this page as the jumping-off poin
 
 ## Next Steps
 
-1. Run `uv run benchbox profile` to capture a baseline system profile.
-2. Pick a platform with `uv run benchbox platforms list` and enable it if required.
-3. Execute a benchmark with `uv run benchbox run --platform duckdb --benchmark tpch --scale 0.01`.
-4. Inspect results via `uv run benchbox results --limit 1` or export JSON for CI with `uv run benchbox export`.
+1. Run `uv run -- benchbox profile` to capture a baseline system profile.
+2. Pick a platform with `uv run -- benchbox platforms list` and enable it if required.
+3. Execute a benchmark with `uv run -- benchbox run --platform duckdb --benchmark tpch --scale 0.01`.
+4. Inspect results via `uv run -- benchbox results --limit 1` or export JSON for CI with `uv run -- benchbox export`.
 
 Bookmark this page to keep the most relevant references a single click away.

--- a/docs/usage/cli-quick-start.md
+++ b/docs/usage/cli-quick-start.md
@@ -20,7 +20,7 @@ BenchBox ships with a full-featured CLI implemented with Click. This guide focus
 | `benchbox tuning init` | Scaffold a tuning YAML grouped by platform and benchmark. |
 | `benchbox results --limit N` | Display recent benchmark summaries. |
 
-> Tip: `uv run benchbox <command>` automatically uses the project’s virtual environment. Activate the venv manually if you prefer to invoke `benchbox` directly.
+> Tip: `uv run -- benchbox <command>` automatically uses the project’s virtual environment. Activate the venv manually if you prefer to invoke `benchbox` directly.
 
 ## Running Benchmarks
 
@@ -62,31 +62,31 @@ The `run` subcommand accepts a rich set of options. The defaults favor the inter
 
 ```bash
 # Interactive workflow with guided prompts
-uv run benchbox run
+uv run -- benchbox run
 
 # Non-interactive run for CI or cron jobs
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --scale 0.1 \
   --non-interactive
 
 # Preview the entire plan (queries, file layout, seeds) without running it
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --scale 0.1 \
   --dry-run ./preview
 
 # Run specific queries only (for debugging or focused testing)
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --queries "Q1,Q6,Q17" \
   --phases power
 
 # Debug a single failing query with verbose output
-uv run benchbox run \
+uv run -- benchbox run \
   --platform postgres \
   --benchmark tpcds \
   --queries "Q42" \
@@ -94,19 +94,19 @@ uv run benchbox run \
   --phases power
 
 # See all CLI examples
-uv run benchbox run --help-topic examples
+uv run -- benchbox run --help-topic examples
 
 # View platform status and capabilities
-uv run benchbox platforms status databricks
+uv run -- benchbox platforms status databricks
 
 # Compare two DuckDB releases without switching environments
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --platform-option driver_version=1.0.0 \
   --output ./runs/v1.0.0
 
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --platform-option driver_version=1.1.0 \
@@ -117,7 +117,7 @@ uv run benchbox run \
 
 ```bash
 # Show the latest run summary (duration, validation status, failures)
-uv run benchbox results --limit 1
+uv run -- benchbox results --limit 1
 ```
 
 ## Exporting Results
@@ -126,19 +126,19 @@ Re-export existing benchmark results in different formats without re-running:
 
 ```bash
 # Export most recent result to CSV
-uv run benchbox export --last --format csv
+uv run -- benchbox export --last --format csv
 
 # Export specific result to HTML report
-uv run benchbox export benchmark_runs/results/tpch_sf1_duckdb.json --format html
+uv run -- benchbox export benchmark_runs/results/tpch_sf1_duckdb.json --format html
 
 # Export to multiple formats at once
-uv run benchbox export --last --format csv --format html --format json
+uv run -- benchbox export --last --format csv --format html --format json
 
 # Export latest TPC-H result with filtering
-uv run benchbox export --last --benchmark tpc_h --format csv
+uv run -- benchbox export --last --benchmark tpc_h --format csv
 
 # Export to custom directory
-uv run benchbox export --last --format html --output-dir ./reports/
+uv run -- benchbox export --last --format html --output-dir ./reports/
 ```
 
 **Common Use Cases:**
@@ -152,19 +152,19 @@ Generate ASCII charts from benchmark results directly in the terminal:
 
 ```bash
 # Auto-detect latest result and render all applicable charts
-uv run benchbox visualize
+uv run -- benchbox visualize
 
 # Visualize a specific result file
-uv run benchbox visualize benchmark_runs/results/tpch_duckdb_sf0.01_*.json
+uv run -- benchbox visualize benchmark_runs/results/tpch_duckdb_sf0.01_*.json
 
 # Compare multiple result files
-uv run benchbox visualize duckdb.json sqlite.json --template head_to_head
+uv run -- benchbox visualize duckdb.json sqlite.json --template head_to_head
 
 # Specific chart type
-uv run benchbox visualize --last --chart-type performance_bar
+uv run -- benchbox visualize --last --chart-type performance_bar
 
 # Save plain-text output to file (strip ANSI colors)
-uv run benchbox visualize --last --no-color > charts.txt
+uv run -- benchbox visualize --last --no-color > charts.txt
 ```
 
 See the [Visualization Guide](../visualization/overview.md) for chart types, templates, and customization options.
@@ -175,25 +175,25 @@ The `platforms` command helps you discover, enable, and configure database platf
 
 ```bash
 # List all available platforms with their status
-uv run benchbox platforms list
+uv run -- benchbox platforms list
 
 # Show detailed information about a specific platform
-uv run benchbox platforms status duckdb
+uv run -- benchbox platforms status duckdb
 
 # Enable a platform for use in benchmarks
-uv run benchbox platforms enable clickhouse
+uv run -- benchbox platforms enable clickhouse
 
 # Disable a platform
-uv run benchbox platforms disable sqlite
+uv run -- benchbox platforms disable sqlite
 
 # Get installation guidance for missing dependencies
-uv run benchbox platforms install databricks
+uv run -- benchbox platforms install databricks
 
 # Check if enabled platforms are ready
-uv run benchbox platforms check --enabled-only
+uv run -- benchbox platforms check --enabled-only
 
 # Interactive setup wizard
-uv run benchbox platforms setup
+uv run -- benchbox platforms setup
 ```
 
 **Platform Management vs Credential Setup:**
@@ -204,19 +204,19 @@ uv run benchbox platforms setup
 **Typical Cloud Platform Workflow:**
 ```bash
 # 1. Check if platform dependencies are installed
-uv run benchbox platforms status databricks
+uv run -- benchbox platforms status databricks
 
 # 2. Install dependencies if needed (follow the guidance shown)
 uv add databricks-sql-connector
 
 # 3. Enable the platform
-uv run benchbox platforms enable databricks
+uv run -- benchbox platforms enable databricks
 
 # 4. Configure credentials
-uv run benchbox setup --platform databricks
+uv run -- benchbox setup --platform databricks
 
 # 5. Verify everything is ready
-uv run benchbox platforms check databricks
+uv run -- benchbox platforms check databricks
 ```
 
 ## Interactive SQL Shell
@@ -225,25 +225,25 @@ Open an interactive SQL shell to explore benchmark databases, debug queries, and
 
 ```bash
 # Discover and connect to available databases interactively
-uv run benchbox shell
+uv run -- benchbox shell
 
 # List all available databases
-uv run benchbox shell --list
+uv run -- benchbox shell --list
 
 # Connect to most recent database
-uv run benchbox shell --last
+uv run -- benchbox shell --last
 
 # Connect to specific benchmark database
-uv run benchbox shell --last --benchmark tpch
+uv run -- benchbox shell --last --benchmark tpch
 
 # Filter by scale factor
-uv run benchbox shell --benchmark tpch --scale 1.0
+uv run -- benchbox shell --benchmark tpch --scale 1.0
 
 # Direct connection to database file
-uv run benchbox shell --database benchmark.duckdb
+uv run -- benchbox shell --database benchmark.duckdb
 
 # Use custom output directory
-uv run benchbox shell --output ./my-benchmarks
+uv run -- benchbox shell --output ./my-benchmarks
 ```
 
 **Shell Features:**
@@ -262,18 +262,18 @@ uv run benchbox shell --output ./my-benchmarks
 
 ```bash
 # Summarize optional dependencies and extras guidance
-uv run benchbox check-deps --matrix
+uv run -- benchbox check-deps --matrix
 
 # Focus on a single adapter with verbose remediation
-uv run benchbox check-deps --platform snowflake --verbose
+uv run -- benchbox check-deps --platform snowflake --verbose
 
 # Generate a tuning skeleton for your project
-uv run benchbox tuning init --platform duckdb
+uv run -- benchbox tuning init --platform duckdb
 ```
 
 ## Working With uv
 
-- `uv run benchbox …` keeps dependency management simple: no manual activation required.
+- `uv run -- benchbox …` keeps dependency management simple: no manual activation required.
 - Use `uvx benchbox …` to execute without installing into the current project.
 - If you are using a traditional virtual environment, run `source .venv/bin/activate` (or the Windows equivalent) and call `benchbox` directly.
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -9,7 +9,7 @@ BenchBox reads configuration from three layers, highest precedence first:
 2. **Environment variables** - primarily tuning overrides (see below).
 3. **Configuration files** - `benchbox.yaml` in the working directory or `~/.benchbox/config.yaml`.
 
-If no file is present, BenchBox uses sensible defaults. You can generate a tuning template with `uv run benchbox tuning init --platform duckdb`.
+If no file is present, BenchBox uses sensible defaults. You can generate a tuning template with `uv run -- benchbox tuning init --platform duckdb`.
 
 ## Minimal Example
 
@@ -38,7 +38,7 @@ execution:
 Save the file next to your project and run:
 
 ```bash
-uv run benchbox run --benchmark tpch --platform duckdb
+uv run -- benchbox run --benchmark tpch --platform duckdb
 ```
 
 CLI flags still win. For example `--scale 1` overrides `benchmarks.default_scale` for that invocation only.
@@ -99,18 +99,18 @@ Before running large jobs, dry-run the plan and validate dependencies:
 
 ```bash
 # Render the execution plan without running anything
-uv run benchbox run --dry-run ./plan --platform duckdb --benchmark tpch
+uv run -- benchbox run --dry-run ./plan --platform duckdb --benchmark tpch
 
 # Check platform requirements declared in the config
-uv run benchbox check-deps --matrix
+uv run -- benchbox check-deps --matrix
 ```
 
 `benchbox run` respects values from `benchbox.yaml`, so you can set project defaults once and execute repeatable runs with only a few flags.
 
 ## Related Commands
 
-- `uv run benchbox tuning init` - scaffold a tuning YAML file for a specific platform.
-- `uv run benchbox validate --config benchbox.yaml` - ensure configuration syntax and schema are valid.
-- `uv run benchbox platforms setup` - interactively enable adapters defined in your config.
+- `uv run -- benchbox tuning init` - scaffold a tuning YAML file for a specific platform.
+- `uv run -- benchbox validate --config benchbox.yaml` - ensure configuration syntax and schema are valid.
+- `uv run -- benchbox platforms setup` - interactively enable adapters defined in your config.
 
 See the [CLI reference](../reference/cli-reference.md) for detailed command usage and the [examples library](examples.md) for advanced automation patterns.

--- a/docs/usage/driver-version-management.md
+++ b/docs/usage/driver-version-management.md
@@ -28,7 +28,7 @@ Running tpch on duckdb at scale 1.0 [driver 1.4.3]
 
 ## Why Your Manually-Installed Version May Not Be Respected
 
-If you run BenchBox via `uv run benchbox run ...`, uv syncs your environment against
+If you run BenchBox via `uv run -- benchbox run ...`, uv syncs your environment against
 `uv.lock` **before Python starts**. Any version you installed manually with
 `uv pip install "duckdb==1.5.0"` may be silently reverted to the lock-file-pinned
 version (e.g. `1.4.3`).

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -84,7 +84,7 @@ Yes! Install BenchBox with the `[duckdb]` extra and you can run benchmarks immed
 
 ```bash
 uv add benchbox --extra duckdb
-uv run benchbox run --platform duckdb --benchmark tpch --scale 0.01
+uv run -- benchbox run --platform duckdb --benchmark tpch --scale 0.01
 ```
 
 ### How do I verify my installation?
@@ -283,7 +283,7 @@ Configure with tuning files or command-line options. See the [Data Generation](d
 The `benchbox` CLI is not in your PATH. Solutions:
 1. Ensure your virtual environment is activated
 2. Add Python's scripts directory to PATH
-3. Run with `uv run benchbox` instead
+3. Run with `uv run -- benchbox` instead
 
 See the [Troubleshooting Guide](troubleshooting.md) Installation Issues section.
 

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -24,7 +24,7 @@ If you have not installed BenchBox yet, follow the dedicated [installation guide
 Already installed? Verify the CLI is on your PATH:
 
 ```bash
-uv run benchbox --version
+uv run -- benchbox --version
 ```
 
 ## Step 2 - Profile Your Environment
@@ -32,17 +32,17 @@ uv run benchbox --version
 The profile command confirms CPU, memory, and available adapters. BenchBox uses this information to suggest scale factors and concurrency levels.
 
 ```bash
-uv run benchbox profile
+uv run -- benchbox profile
 ```
 
-Look for the *Platform Availability* table,`duckdb` should be **Ready** immediately. If you plan to use cloud platforms later, run `uv run benchbox check-deps --platform <name>` or use the guided `benchbox platforms setup` wizard once you have credentials handy.
+Look for the *Available Databases* table,`duckdb` should be **Ready** immediately. If you plan to use cloud platforms later, run `uv run -- benchbox check-deps --platform <name>` or use the guided `benchbox platforms setup` wizard once you have credentials handy.
 
 ## Step 3 - Run Your First Benchmark
 
 Run a minimal TPC-H benchmark to generate data, load it into DuckDB, and execute the standard power test.
 
 ```bash
-uv run benchbox run \
+uv run -- benchbox run \
   --platform duckdb \
   --benchmark tpch \
   --scale 0.01
@@ -55,7 +55,7 @@ Unattended execution? Add `--non-interactive` to skip prompts. BenchBox stores o
 Summarize the most recent run:
 
 ```bash
-uv run benchbox results --limit 1
+uv run -- benchbox results --limit 1
 ```
 
 The results display shows timing, validation status, and per-query metrics from your benchmark execution.
@@ -66,13 +66,13 @@ Share your results in different formats without re-running the benchmark:
 
 ```bash
 # Export to CSV for spreadsheet analysis
-uv run benchbox export --last --format csv
+uv run -- benchbox export --last --format csv
 
 # Generate HTML report for sharing with team
-uv run benchbox export --last --format html --output-dir ./reports/
+uv run -- benchbox export --last --format html --output-dir ./reports/
 
 # Export to all formats
-uv run benchbox export --last --format json --format csv --format html
+uv run -- benchbox export --last --format json --format csv --format html
 ```
 
 The export command is useful for:
@@ -89,19 +89,19 @@ BenchBox also supports benchmarking DataFrame libraries using their native APIs.
 
 ```bash
 # Polars DataFrame (included in base install)
-uv run benchbox run --platform polars-df --benchmark tpch --scale 0.01
+uv run -- benchbox run --platform polars-df --benchmark tpch --scale 0.01
 
 # Pandas DataFrame (requires extra)
 uv add benchbox --extra pandas
-uv run benchbox run --platform pandas-df --benchmark tpch --scale 0.01
+uv run -- benchbox run --platform pandas-df --benchmark tpch --scale 0.01
 ```
 
 ### Compare SQL vs DataFrame
 
 ```bash
 # Run the same benchmark with different paradigms
-uv run benchbox run --platform duckdb --benchmark tpch --scale 0.1     # SQL
-uv run benchbox run --platform polars-df --benchmark tpch --scale 0.1  # DataFrame
+uv run -- benchbox run --platform duckdb --benchmark tpch --scale 0.1     # SQL
+uv run -- benchbox run --platform polars-df --benchmark tpch --scale 0.1  # DataFrame
 ```
 
 For more details, see the [DataFrame Platforms Guide](../platforms/dataframe.md).

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -21,7 +21,7 @@ python -m pip install benchbox
 pipx install benchbox
 ```
 
-BenchBox installs a `benchbox` executable. If you use `uv`, prefer `uv run benchbox <command>` to ensure the project virtual environment is activated automatically.
+BenchBox installs a `benchbox` executable. If you use `uv`, prefer `uv run -- benchbox <command>` to ensure the project virtual environment is activated automatically.
 
 (installation-extras)=
 ## 2. Pick Optional Extras
@@ -77,7 +77,7 @@ Re-run the installer at any time to add extras. For `pipx`, use `pipx inject ben
 ## 3. Verify the CLI
 
 ```bash
-uv run benchbox --version
+uv run -- benchbox --version
 ```
 
 The command prints the current BenchBox version and validates that `pyproject.toml`, `benchbox/__init__.py`, and doc version markers match.
@@ -88,13 +88,13 @@ The command prints the current BenchBox version and validates that `pyproject.to
 
 ```bash
 # Overview of all platforms
-uv run benchbox check-deps
+uv run -- benchbox check-deps
 
 # Detailed matrix with extras guidance
-uv run benchbox check-deps --matrix
+uv run -- benchbox check-deps --matrix
 
 # Focus on a single platform
-uv run benchbox check-deps --platform snowflake --verbose
+uv run -- benchbox check-deps --platform snowflake --verbose
 ```
 
 ## 5. Create a Workspace (Optional)

--- a/tests/fixtures/published_results_validator.py
+++ b/tests/fixtures/published_results_validator.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Validate submission bundles in results-data/bundles/.
+
+Used by CI to check that PRs adding result bundles conform to schema-v2,
+have sane timing data, valid platform/benchmark names, and (when a
+submission manifest is present) matching SHA-256 hashes.
+
+Exit codes:
+    0 - all bundles valid
+    1 - one or more validation errors
+
+Usage:
+    # Validate all bundles
+    python scripts/validate_submission.py results-data/bundles/
+
+    # Validate specific files (e.g. only changed files from a PR)
+    python scripts/validate_submission.py path/to/bundle1.json path/to/bundle2.json
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Schema-v2 required top-level keys
+# ---------------------------------------------------------------------------
+
+REQUIRED_TOP_KEYS = {"version", "run", "benchmark", "platform", "summary", "queries"}
+REQUIRED_RUN_KEYS = {"id", "timestamp", "total_duration_ms"}
+REQUIRED_BENCHMARK_KEYS = {"id", "scale_factor"}
+REQUIRED_PLATFORM_KEYS = {"name"}
+REQUIRED_QUERY_KEYS = {"id", "ms"}
+
+# Accepted schema version prefixes (2.x family).
+ACCEPTED_VERSION_PREFIX = "2."
+
+# Companion file suffixes - skipped during bundle discovery.
+COMPANION_SUFFIXES = (".plans.json", ".tuning.json")
+
+# Known benchmarks and platforms - warn (not fail) on unknown values.
+KNOWN_BENCHMARKS = {
+    "tpch",
+    "tpcds",
+    "ssb",
+    "star_schema",
+    "clickbench",
+    "nyctaxi",
+    "tsbs-devops",
+    "h2odb",
+    "datavault",
+}
+KNOWN_PLATFORMS = {
+    # Core
+    "duckdb",
+    "datafusion",
+    "polars",
+    "sqlite",
+    "motherduck",
+    # SQL - cloud & managed
+    "clickhouse",
+    "clickhouse-local",
+    "clickhouse-server",
+    "clickhouse-cloud",
+    "snowflake",
+    "databricks",
+    "bigquery",
+    "redshift",
+    "athena",
+    "firebolt",
+    # SQL - self-hosted & extensions
+    "postgresql",
+    "timescaledb",
+    "pg-duckdb",
+    "pg-mooncake",
+    "trino",
+    "starburst",
+    "presto",
+    "influxdb",
+    "questdb",
+    "starrocks",
+    "databend",
+    "doris",
+    # Spark-family
+    "spark",
+    "pyspark",
+    "lakesail",
+    # DataFrame
+    "pandas",
+    "modin",
+    "cudf",
+    "dask",
+    # Microsoft Fabric / Synapse
+    "synapse",
+    "fabric_dw",
+    "fabric-lakehouse",
+    "fabric-spark",
+}
+
+# Sanity thresholds
+MAX_QUERY_DURATION_MS = 7_200_000  # 2 hours per query
+MAX_TOTAL_DURATION_MS = 86_400_000  # 24 hours total
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+class ValidationResult:
+    """Collects errors and warnings for a single bundle."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+        # Metadata extracted during validation, used by format_pr_comment.
+        self.benchmark_id: str = "-"
+        self.platform_name: str = "-"
+        self.scale_factor: str = "-"
+
+    def error(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    @property
+    def ok(self) -> bool:
+        return len(self.errors) == 0
+
+
+def _capture_metadata(data: dict, vr: ValidationResult) -> None:
+    """Pull benchmark/platform identifiers out of the bundle for PR-comment formatting."""
+    bm = data.get("benchmark")
+    if isinstance(bm, dict):
+        vr.benchmark_id = bm.get("id", "-")
+        sf = bm.get("scale_factor")
+        if sf is not None:
+            vr.scale_factor = str(sf)
+    pl = data.get("platform")
+    if isinstance(pl, dict):
+        vr.platform_name = pl.get("name", "-")
+
+
+def _validate_version(version: Any, vr: ValidationResult) -> None:
+    if not isinstance(version, str) or not version.startswith(ACCEPTED_VERSION_PREFIX):
+        vr.error(f"Unsupported schema version: {version!r} (expected 2.x)")
+
+
+def _validate_run_section(run: Any, vr: ValidationResult) -> None:
+    if not isinstance(run, dict):
+        vr.error("'run' must be a dict")
+        return
+    missing_run = REQUIRED_RUN_KEYS - set(run.keys())
+    if missing_run:
+        vr.error(f"Missing keys in 'run': {sorted(missing_run)}")
+
+    total_ms = run.get("total_duration_ms")
+    if total_ms is None:
+        return
+    try:
+        total_ms_f = float(total_ms)
+    except (TypeError, ValueError):
+        vr.error(f"Invalid total_duration_ms: {total_ms!r}")
+        return
+    if total_ms_f < 0:
+        vr.error(f"Negative total_duration_ms: {total_ms_f}")
+    elif total_ms_f > MAX_TOTAL_DURATION_MS:
+        vr.warn(f"Unusually long total_duration_ms: {total_ms_f:.0f} (>{MAX_TOTAL_DURATION_MS})")
+
+
+def _validate_benchmark_section(benchmark: Any, vr: ValidationResult) -> None:
+    if not isinstance(benchmark, dict):
+        vr.error("'benchmark' must be a dict")
+        return
+    missing_bm = REQUIRED_BENCHMARK_KEYS - set(benchmark.keys())
+    if missing_bm:
+        vr.error(f"Missing keys in 'benchmark': {sorted(missing_bm)}")
+
+    bm_id = benchmark.get("id", "")
+    if isinstance(bm_id, str) and bm_id and bm_id not in KNOWN_BENCHMARKS:
+        vr.warn(f"Unknown benchmark id: {bm_id!r}")
+
+    sf = benchmark.get("scale_factor")
+    if sf is None:
+        return
+    try:
+        sf_f = float(sf)
+    except (TypeError, ValueError):
+        vr.error(f"Invalid scale_factor: {sf!r}")
+        return
+    if sf_f <= 0:
+        vr.error(f"scale_factor must be positive: {sf_f}")
+
+
+def _validate_platform_section(platform: Any, vr: ValidationResult) -> None:
+    if not isinstance(platform, dict):
+        vr.error("'platform' must be a dict")
+        return
+    missing_pl = REQUIRED_PLATFORM_KEYS - set(platform.keys())
+    if missing_pl:
+        vr.error(f"Missing keys in 'platform': {sorted(missing_pl)}")
+
+    pl_name = platform.get("name", "")
+    if isinstance(pl_name, str) and pl_name:
+        normalized = pl_name.lower().replace(" ", "-")
+        if normalized not in KNOWN_PLATFORMS:
+            vr.warn(f"Unknown platform name: {pl_name!r}")
+
+
+def _validate_summary_section(summary: Any, vr: ValidationResult) -> None:
+    if not isinstance(summary, dict):
+        vr.error("'summary' must be a dict")
+        return
+    queries_summary = summary.get("queries", {})
+    if isinstance(queries_summary, dict):
+        total_q = queries_summary.get("total", 0)
+        if isinstance(total_q, (int, float)) and total_q == 0:
+            vr.warn("summary.queries.total is 0 - empty result?")
+
+
+def _validate_single_query(index: int, q: Any, vr: ValidationResult) -> bool:
+    """Validate one queries[i] entry. Returns True if ms>0 was seen (non-zero signal)."""
+    if not isinstance(q, dict):
+        vr.error(f"queries[{index}] is not a dict")
+        return False
+
+    missing_qk = REQUIRED_QUERY_KEYS - set(q.keys())
+    if missing_qk:
+        vr.error(f"queries[{index}] missing keys: {sorted(missing_qk)}")
+        return False
+
+    ms = q.get("ms")
+    if ms is None:
+        return False
+    try:
+        ms_f = float(ms)
+    except (TypeError, ValueError):
+        vr.error(f"queries[{index}] invalid ms value: {ms!r}")
+        return False
+    if ms_f < 0:
+        vr.error(f"queries[{index}] negative duration: {ms_f}")
+    elif ms_f > MAX_QUERY_DURATION_MS:
+        vr.warn(f"queries[{index}] unusually long: {ms_f:.0f}ms")
+    return ms_f > 0
+
+
+def _validate_queries_section(queries: Any, vr: ValidationResult) -> None:
+    if not isinstance(queries, list):
+        vr.error("'queries' must be a list")
+        return
+    if len(queries) == 0:
+        vr.warn("queries array is empty")
+        return
+
+    any_nonzero = False
+    for i, q in enumerate(queries):
+        if _validate_single_query(i, q, vr):
+            any_nonzero = True
+
+    if not any_nonzero:
+        vr.error("All query timings are 0ms - likely invalid data")
+
+
+def _validate_bundle(data: dict, vr: ValidationResult) -> None:
+    """Run all validation checks on a parsed bundle dict."""
+    _capture_metadata(data, vr)
+
+    missing_top = REQUIRED_TOP_KEYS - set(data.keys())
+    if missing_top:
+        vr.error(f"Missing required top-level keys: {sorted(missing_top)}")
+        return  # Can't continue without structure
+
+    _validate_version(data.get("version", ""), vr)
+    _validate_run_section(data.get("run", {}), vr)
+    _validate_benchmark_section(data.get("benchmark", {}), vr)
+    _validate_platform_section(data.get("platform", {}), vr)
+    _validate_summary_section(data.get("summary", {}), vr)
+    _validate_queries_section(data.get("queries", []), vr)
+
+
+def _hash_file(file_path: Path) -> str:
+    """SHA-256 of a single file's contents."""
+    h = hashlib.sha256()
+    h.update(file_path.read_bytes())
+    return h.hexdigest()
+
+
+def _is_safe_bundle_filename(name: str) -> bool:
+    """Reject filenames that could escape the bundle directory.
+
+    The validator runs in CI on attacker-controlled PR JSON, so manifest-
+    supplied filenames must be plain leaf names, not paths.
+    """
+    if not name or name in (".", ".."):
+        return False
+    if "/" in name or "\\" in name or "\x00" in name:
+        return False
+    parts = Path(name).parts
+    if Path(name).is_absolute() or ".." in parts or len(parts) != 1:
+        return False
+    return True
+
+
+def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: ValidationResult) -> None:
+    """Verify the submission manifest hashes match the bundle file contents.
+
+    Contract (see also benchbox/cli/commands/submit.py):
+      - manifest.bundle_file: filename of the primary bundle JSON.
+      - manifest.bundle_hash: SHA-256 of just that file's contents.
+      - manifest.companion_hashes: optional dict of companion-file
+        names mapped to their SHA-256s. Empty dict if no companions.
+
+    The hash is per-file. Anything wider (a directory hash) does not
+    survive the user copying the bundle files into a results-data/bundles/
+    directory that already contains other bundles.
+    """
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        vr.error(f"Cannot parse submission manifest JSON: {exc}")
+        return
+    except OSError as exc:
+        vr.error(f"Cannot read submission manifest file: {exc}")
+        return
+
+    bundle_file = manifest.get("bundle_file")
+    expected_hash = manifest.get("bundle_hash")
+    if not isinstance(bundle_file, str) or not bundle_file:
+        vr.warn("Submission manifest has no bundle_file field")
+        return
+    if not isinstance(expected_hash, str) or not expected_hash:
+        vr.warn("Submission manifest has no bundle_hash field")
+        return
+    if not _is_safe_bundle_filename(bundle_file):
+        vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
+        return
+
+    primary_path = bundle_dir / bundle_file
+    if not primary_path.is_file():
+        vr.error(f"Bundle file declared in manifest not found in PR: {bundle_file}")
+        return
+
+    actual_hash = _hash_file(primary_path)
+    if actual_hash != expected_hash:
+        vr.error(
+            f"Bundle hash mismatch for {bundle_file}: manifest says "
+            f"{expected_hash[:16]}..., computed {actual_hash[:16]}..."
+        )
+
+    companion_hashes = manifest.get("companion_hashes") or {}
+    if not isinstance(companion_hashes, dict):
+        vr.error("companion_hashes field must be an object (filename -> hash)")
+        return
+
+    for comp_name, comp_expected in companion_hashes.items():
+        if not isinstance(comp_name, str) or not _is_safe_bundle_filename(comp_name):
+            vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
+            continue
+        comp_path = bundle_dir / comp_name
+        if not comp_path.is_file():
+            vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")
+            continue
+        if not isinstance(comp_expected, str) or not comp_expected:
+            vr.error(f"Empty companion hash for {comp_name}")
+            continue
+        comp_actual = _hash_file(comp_path)
+        if comp_actual != comp_expected:
+            vr.error(
+                f"Companion hash mismatch for {comp_name}: manifest says "
+                f"{comp_expected[:16]}..., computed {comp_actual[:16]}..."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Discovery & orchestration
+# ---------------------------------------------------------------------------
+
+
+def discover_bundles(path: Path) -> list[Path]:
+    """Find all primary bundle JSON files under a directory (excludes companions)."""
+    bundles = []
+    for f in sorted(path.rglob("*.json")):
+        if any(f.name.endswith(s) for s in COMPANION_SUFFIXES):
+            continue
+        if f.name == "corpus-inventory.json":
+            continue
+        if f.name == "submission-manifest.json":
+            continue
+        bundles.append(f)
+    return bundles
+
+
+def validate_bundles(paths: list[Path]) -> list[ValidationResult]:
+    """Validate a list of bundle files. Returns one ValidationResult per file."""
+    results = []
+    for bundle_path in paths:
+        vr = ValidationResult(str(bundle_path))
+
+        if not bundle_path.exists():
+            vr.error(f"File not found: {bundle_path}")
+            results.append(vr)
+            continue
+
+        try:
+            data = json.loads(bundle_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            vr.error(f"Invalid JSON: {exc}")
+            results.append(vr)
+            continue
+
+        if not isinstance(data, dict):
+            vr.error("Top-level value must be a JSON object")
+            results.append(vr)
+            continue
+
+        _validate_bundle(data, vr)
+
+        # Check for submission manifest alongside the bundle
+        manifest_path = bundle_path.parent / "submission-manifest.json"
+        if manifest_path.exists():
+            _validate_manifest_hash(manifest_path, bundle_path.parent, vr)
+
+        results.append(vr)
+    return results
+
+
+def format_summary(results: list[ValidationResult]) -> str:
+    """Format validation results as a human-readable summary."""
+    lines: list[str] = []
+    total_errors = 0
+    total_warnings = 0
+
+    for vr in results:
+        total_errors += len(vr.errors)
+        total_warnings += len(vr.warnings)
+
+        status = "PASS" if vr.ok else "FAIL"
+        lines.append(f"  {status}  {vr.path}")
+        for e in vr.errors:
+            lines.append(f"        ERROR: {e}")
+        for w in vr.warnings:
+            lines.append(f"        WARN:  {w}")
+
+    header = f"Validated {len(results)} bundle(s): {total_errors} error(s), {total_warnings} warning(s)"
+    return header + "\n" + "\n".join(lines)
+
+
+def format_pr_comment(results: list[ValidationResult]) -> str:
+    """Format validation results as a GitHub PR comment (Markdown)."""
+    lines: list[str] = []
+    all_pass = all(vr.ok for vr in results)
+
+    if all_pass:
+        lines.append("## Submission Validation: PASSED")
+    else:
+        lines.append("## Submission Validation: FAILED")
+
+    lines.append("")
+    lines.append(f"Validated **{len(results)}** bundle(s).")
+    lines.append("")
+
+    # Summary table
+    lines.append("| Bundle | Status | Benchmark | Platform | Scale |")
+    lines.append("|--------|--------|-----------|----------|-------|")
+
+    for vr in results:
+        status = "PASS" if vr.ok else "FAIL"
+        name = Path(vr.path).name.replace("|", "\\|")
+        bm_id = vr.benchmark_id.replace("|", "\\|")
+        pl_name = vr.platform_name.replace("|", "\\|")
+        sf = vr.scale_factor.replace("|", "\\|")
+        lines.append(f"| `{name}` | {status} | {bm_id} | {pl_name} | SF {sf} |")
+
+    # Detail errors/warnings
+    has_issues = any(vr.errors or vr.warnings for vr in results)
+    if has_issues:
+        lines.append("")
+        lines.append("### Details")
+        lines.append("")
+        for vr in results:
+            if not vr.errors and not vr.warnings:
+                continue
+            lines.append(f"**`{Path(vr.path).name}`**")
+            for e in vr.errors:
+                lines.append(f"- ERROR: {e}")
+            for w in vr.warnings:
+                lines.append(f"- WARN: {w}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+
+    # Parse optional --pr-comment <path> flag.
+    pr_comment_path: Path | None = None
+    positional: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--pr-comment" and i + 1 < len(args):
+            pr_comment_path = Path(args[i + 1])
+            i += 2
+        else:
+            positional.append(args[i])
+            i += 1
+
+    if not positional:
+        print("Usage: validate_submission.py [--pr-comment <path>] <dir-or-files...>", file=sys.stderr)
+        return 1
+
+    paths: list[Path] = []
+    for arg in positional:
+        p = Path(arg)
+        if p.is_dir():
+            paths.extend(discover_bundles(p))
+        elif p.is_file():
+            paths.append(p)
+        else:
+            print(f"Warning: {arg} does not exist, skipping", file=sys.stderr)
+
+    if not paths:
+        print("No bundle files found.", file=sys.stderr)
+        return 1
+
+    results = validate_bundles(paths)
+    print(format_summary(results))
+
+    if pr_comment_path is not None:
+        try:
+            pr_comment_path.write_text(format_pr_comment(results), encoding="utf-8")
+        except OSError as exc:
+            print(f"Warning: failed to write PR comment file: {exc}", file=sys.stderr)
+
+    has_errors = any(not vr.ok for vr in results)
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_cross_branch_validator_contract.py
+++ b/tests/integration/test_cross_branch_validator_contract.py
@@ -1,0 +1,160 @@
+"""Cross-branch contract test: develop's writer must emit hashes that
+the published-results validator accepts.
+
+Background: the 2026-04-29 Codex agent-proxy dry-run surfaced a
+release-blocker — develop's `benchbox submit` writer used a per-FILE
+SHA-256 hash, while the validator pinned at v0.2.1 on the
+`published-results` branch used a per-DIRECTORY hash. Result: every
+contributor-emitted bundle would fail CI on the documented PR target
+branch with `Bundle hash mismatch` and no contributor-side knob to
+resolve it. Forensic at
+`_project/handoffs/external-dry-run-retrospective-2026-04-29.md`.
+
+This test exercises the writer → validator round-trip end-to-end so any
+future drift between the two sides of the contract fails CI on develop
+before it reaches contributors.
+
+Vendoring: the validator is vendored at
+`tests/fixtures/published_results_validator.py` rather than fetched
+live via `git show origin/published-results:...` so the test stays
+deterministic (no network, no branch-state assumptions) and runs in
+the fast lane. The vendored copy MUST stay byte-identical to
+`scripts/validate_submission.py` on develop AND to
+`scripts/validate_submission.py` on `published-results`. The
+`test_vendored_validator_matches_develop_script` drift guard fails CI
+if step 1 (sync to develop's script) is skipped; sync to
+`published-results` is operational discipline (open the parallel PR).
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VENDORED_VALIDATOR = REPO_ROOT / "tests" / "fixtures" / "published_results_validator.py"
+DEVELOP_VALIDATOR = REPO_ROOT / "scripts" / "validate_submission.py"
+
+
+def _fake_result() -> SimpleNamespace:
+    """Mirror the unit-test stub in tests/unit/cli/commands/test_submit.py."""
+    return SimpleNamespace(
+        benchmark_name="tpch",
+        platform="duckdb",
+        scale_factor=0.01,
+        total_queries=22,
+        duration_seconds=12.34,
+    )
+
+
+def _minimal_schema_v2_bundle() -> dict:
+    """Bundle JSON that satisfies all required validator schema-v2 keys.
+
+    The submit writer copies the source file verbatim into bundle/, so
+    the source must already be a valid schema-v2 bundle for the
+    validator to accept it. This is the leanest payload that passes —
+    any tighter and the validator's schema checks (REQUIRED_TOP_KEYS,
+    queries timing) start failing for reasons unrelated to the hash
+    contract.
+    """
+    return {
+        "version": "2.0",
+        "run": {
+            "id": "test-run-id",
+            "timestamp": "2026-04-29T00:00:00Z",
+            "total_duration_ms": 12340,
+        },
+        "benchmark": {"id": "tpch", "scale_factor": 0.01},
+        "platform": {"name": "duckdb"},
+        "summary": {"queries": {"total": 22}},
+        "queries": [{"id": "Q1", "ms": 100.0}],
+    }
+
+
+def test_writer_emits_hash_format_validator_accepts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """End-to-end contract: `benchbox submit` must produce a bundle
+    that the (vendored) published-results validator accepts."""
+    sub = importlib.import_module("benchbox.cli.commands.submit")
+
+    src = tmp_path / "tpch_duckdb.json"
+    src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+
+    out_dir = tmp_path / "submission"
+    result = CliRunner().invoke(sub.submit, [str(src), "--output", str(out_dir)])
+
+    assert result.exit_code == 0, f"benchbox submit failed: {result.output}"
+    bundle_path = out_dir / "bundle" / src.name
+    assert bundle_path.is_file()
+
+    proc = subprocess.run(
+        [sys.executable, str(VENDORED_VALIDATOR), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, (
+        f"Vendored published-results validator rejected develop's bundle. "
+        f"This is the same class of release-blocker as the 2026-04-29 dry-run. "
+        f"Output:\n{output}"
+    )
+    assert "0 error(s), 0 warning(s)" in output, output
+
+
+def test_writer_companion_hashes_validator_accepts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Companion files (.plans.json / .tuning.json) — the per-file hash
+    contract covers them too via manifest.companion_hashes."""
+    sub = importlib.import_module("benchbox.cli.commands.submit")
+
+    src = tmp_path / "tpch_duckdb.json"
+    src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+    (tmp_path / "tpch_duckdb.plans.json").write_text('{"plans": []}', encoding="utf-8")
+    (tmp_path / "tpch_duckdb.tuning.json").write_text('{"tuning": {}}', encoding="utf-8")
+
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+
+    out_dir = tmp_path / "submission"
+    result = CliRunner().invoke(sub.submit, [str(src), "--output", str(out_dir)])
+    assert result.exit_code == 0, result.output
+
+    bundle_path = out_dir / "bundle" / src.name
+
+    proc = subprocess.run(
+        [sys.executable, str(VENDORED_VALIDATOR), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, f"Validator rejected bundle with companions. Output:\n{output}"
+    assert "0 error(s)" in output, output
+
+
+def test_vendored_validator_matches_develop_script() -> None:
+    """Drift guard: vendored fixture MUST stay byte-identical to
+    `scripts/validate_submission.py`. If you changed one, change both
+    AND open a parallel PR onto `published-results`."""
+    vendored = VENDORED_VALIDATOR.read_bytes()
+    develop = DEVELOP_VALIDATOR.read_bytes()
+    assert vendored == develop, (
+        "Vendored published-results validator has drifted from "
+        "scripts/validate_submission.py on develop. Re-sync the fixture "
+        "AND open a PR onto `published-results` with the same change. "
+        "See the docstring at the top of this file for the resync workflow."
+    )

--- a/tests/unit/cli/commands/test_submit.py
+++ b/tests/unit/cli/commands/test_submit.py
@@ -126,6 +126,55 @@ def test_submit_contributing_md_includes_canonical_required_items(
 
 
 # ---------------------------------------------------------------------------
+# 4c. Next-steps block is printed inline after a real submit
+#     (regression for dry-run-followup-cli-ux-and-doc-polish-2026-04-29 W2)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_prints_next_steps_with_pr_target_branch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    src = tmp_path / "tpch_duckdb.json"
+    src.write_text('{"schema_version": "2.0"}', encoding="utf-8")
+
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+
+    out_dir = tmp_path / "submission"
+    result = CliRunner().invoke(sub.submit, [str(src), "--output", str(out_dir)])
+
+    assert result.exit_code == 0
+    for required in (
+        "published-results",
+        "generate_corpus_inventory.py --write",
+        "validate_submission.py",
+        "results: tpch duckdb sf0.01",
+        "results-data/bundles/tpch_duckdb.json",
+    ):
+        assert required in result.output, f"missing {required!r} in submit next-steps"
+
+
+def test_submit_dry_run_matches_real_run_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """W6: dry-run output prints the same file/manifest/next-steps shape
+    as a real submit, plus a "(dry run; no files written)" footer."""
+    src = tmp_path / "tpch_duckdb.json"
+    src.write_text('{"schema_version": "2.0"}', encoding="utf-8")
+
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+
+    out_dir = tmp_path / "submission"
+    result = CliRunner().invoke(sub.submit, [str(src), "--dry-run", "--output", str(out_dir)])
+
+    assert result.exit_code == 0
+    assert not out_dir.exists(), "dry-run must not write files"
+    for required in (
+        "Dry-run preview",
+        "published-results",
+        "generate_corpus_inventory.py --write",
+        "results: tpch duckdb sf0.01",
+        "(dry run; no files written)",
+    ):
+        assert required in result.output, f"missing {required!r} in dry-run output"
+
+
+# ---------------------------------------------------------------------------
 # 5. Manifest contains bundle_hash
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implements TODOs from the 2026-04-29 Codex agent-proxy dry-run
retrospective (full forensic at
_project/handoffs/external-dry-run-retrospective-2026-04-29.md):

Validator hash-contract (Critical, dry-run-followup-validator-hash-contract-mismatch)
  - W1: Decision recorded — path A (cherry-pick to published-results
        rather than gate on next release).
  - W3: New tests/integration/test_cross_branch_validator_contract.py
        exec's a vendored copy of the validator against a fresh
        `benchbox submit` bundle in tmp_path; drift guard fails CI if
        the vendored fixture diverges from scripts/validate_submission.py.

CLI / docs polish (Medium, dry-run-followup-cli-ux-and-doc-polish-2026-04-29)
  - W1: Normalize `uv run -- benchbox` across docs/contributing-results.md,
        docs/usage/, README.md, docs/development/.
  - W2: `benchbox submit` prints exact next commands — cp / inventory /
        validate / PR title + target branch — with paths filled in.
  - W3: Downgrade Missing-tables in cli/output.py:172 to amber with a
        recovery hint (auto-rebuild via `--force datagen`).
  - W4: Suppress 'BenchBox Interactive Benchmark Runner' header when
        stdin is not a TTY OR explicit --platform/--benchmark are given.
  - W5: Sync 'Platform Availability' → 'Available Databases' in
        docs/platforms/dataframe.md and docs/usage/getting-started.md
        to match what `benchbox profile` actually prints.
  - W6: `benchbox submit --dry-run` prints the same shape as a real
        submit via a shared _print_submission_summary helper, with a
        '(dry run; no files written)' footer.
  - W7: Reword stream_id != 0 TPC-H validation warning to make the
        timing-only intent explicit ('per TPC-H spec').

Sister PR onto `published-results` syncs scripts/validate_submission.py
to develop's per-file hash contract — that is the actual unblock for
contributor submissions; this PR adds the prevention story.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
