### PR TITLE
fix(validator): sync per-file hash contract with develop's writer

### DIFF
--- a/.github/workflows/validator-smoke.yml
+++ b/.github/workflows/validator-smoke.yml
@@ -38,7 +38,9 @@ jobs:
         run: python -m pip install --quiet pytest
 
       - name: Run validator smoke test
-        # `-c /dev/null` bypasses the repo-root pytest.ini, which references
-        # benchbox-internal plugins (xdist safety, pytest-benchmark) that
-        # aren't installed in this slim, standalone smoke-test environment.
-        run: python -m pytest -c /dev/null tests/test_validate_submission_smoke.py -v
+        # `-c /dev/null` bypasses the repo-root pytest.ini (benchbox-internal
+        # plugins like xdist/benchmark aren't installed here). `--noconftest`
+        # skips tests/conftest.py, which imports the full benchbox package
+        # (rich, polars, etc.) — overkill for a subprocess-driven validator
+        # smoke test on a slim runner.
+        run: python -m pytest -c /dev/null --noconftest tests/test_validate_submission_smoke.py -v

--- a/.github/workflows/validator-smoke.yml
+++ b/.github/workflows/validator-smoke.yml
@@ -38,4 +38,7 @@ jobs:
         run: python -m pip install --quiet pytest
 
       - name: Run validator smoke test
-        run: python -m pytest tests/test_validate_submission_smoke.py -v
+        # `-c /dev/null` bypasses the repo-root pytest.ini, which references
+        # benchbox-internal plugins (xdist safety, pytest-benchmark) that
+        # aren't installed in this slim, standalone smoke-test environment.
+        run: python -m pytest -c /dev/null tests/test_validate_submission_smoke.py -v

--- a/.github/workflows/validator-smoke.yml
+++ b/.github/workflows/validator-smoke.yml
@@ -1,0 +1,41 @@
+name: Validator Smoke
+
+# Standalone CI gate for `scripts/validate_submission.py` on this branch.
+# The repo-wide test.yml / lint.yml workflows only fire on PRs targeting
+# `main` / `develop`, and `validate-submission.yml` only fires when bundle
+# data changes. Without this workflow, a PR that edits *only* the
+# validator script (the typical sync-from-develop PR) would have no CI
+# gating at all on this branch.
+
+on:
+  pull_request:
+    branches:
+      - published-results
+    paths:
+      - "scripts/validate_submission.py"
+      - "tests/test_validate_submission_smoke.py"
+      - ".github/workflows/validator-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Validator round-trip smoke test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        # Standalone — no benchbox import needed, so we don't pay the
+        # cost of `uv sync --group dev`. Just pytest is enough.
+        run: python -m pip install --quiet pytest
+
+      - name: Run validator smoke test
+        run: python -m pytest tests/test_validate_submission_smoke.py -v

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -283,8 +283,42 @@ def _validate_bundle(data: dict, vr: ValidationResult) -> None:
     _validate_queries_section(data.get("queries", []), vr)
 
 
+def _hash_file(file_path: Path) -> str:
+    """SHA-256 of a single file's contents."""
+    h = hashlib.sha256()
+    h.update(file_path.read_bytes())
+    return h.hexdigest()
+
+
+def _is_safe_bundle_filename(name: str) -> bool:
+    """Reject filenames that could escape the bundle directory.
+
+    The validator runs in CI on attacker-controlled PR JSON, so manifest-
+    supplied filenames must be plain leaf names, not paths.
+    """
+    if not name or name in (".", ".."):
+        return False
+    if "/" in name or "\\" in name or "\x00" in name:
+        return False
+    parts = Path(name).parts
+    if Path(name).is_absolute() or ".." in parts or len(parts) != 1:
+        return False
+    return True
+
+
 def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: ValidationResult) -> None:
-    """Verify that the submission manifest hash matches the bundle directory contents."""
+    """Verify the submission manifest hashes match the bundle file contents.
+
+    Contract (see also benchbox/cli/commands/submit.py):
+      - manifest.bundle_file: filename of the primary bundle JSON.
+      - manifest.bundle_hash: SHA-256 of just that file's contents.
+      - manifest.companion_hashes: optional dict of companion-file
+        names mapped to their SHA-256s. Empty dict if no companions.
+
+    The hash is per-file. Anything wider (a directory hash) does not
+    survive the user copying the bundle files into a results-data/bundles/
+    directory that already contains other bundles.
+    """
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
@@ -294,28 +328,52 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
         vr.error(f"Cannot read submission manifest file: {exc}")
         return
 
+    bundle_file = manifest.get("bundle_file")
     expected_hash = manifest.get("bundle_hash")
+    if not isinstance(bundle_file, str) or not bundle_file:
+        vr.warn("Submission manifest has no bundle_file field")
+        return
     if not isinstance(expected_hash, str) or not expected_hash:
         vr.warn("Submission manifest has no bundle_hash field")
         return
+    if not _is_safe_bundle_filename(bundle_file):
+        vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
+        return
 
-    # Recompute hash using the same algorithm as benchbox submit.
-    # Exclude the manifest itself - it contains the hash so it can't be
-    # part of its own hash computation.
-    # Uses POSIX relative path (not just filename) to distinguish files
-    # in subdirectories - must match _compute_bundle_hash() in submit.py.
-    h = hashlib.sha256()
-    for file_path in sorted(bundle_dir.rglob("*")):
-        if file_path.is_symlink():
-            vr.error(f"Symlink detected in bundle: {file_path.name} - symlinks are not allowed")
-            continue
-        if file_path.is_file() and file_path.name != "submission-manifest.json":
-            h.update(file_path.relative_to(bundle_dir).as_posix().encode())
-            h.update(file_path.read_bytes())
-    actual_hash = h.hexdigest()
+    primary_path = bundle_dir / bundle_file
+    if not primary_path.is_file():
+        vr.error(f"Bundle file declared in manifest not found in PR: {bundle_file}")
+        return
 
+    actual_hash = _hash_file(primary_path)
     if actual_hash != expected_hash:
-        vr.error(f"Bundle hash mismatch: manifest says {expected_hash[:16]}..., computed {actual_hash[:16]}...")
+        vr.error(
+            f"Bundle hash mismatch for {bundle_file}: manifest says "
+            f"{expected_hash[:16]}..., computed {actual_hash[:16]}..."
+        )
+
+    companion_hashes = manifest.get("companion_hashes") or {}
+    if not isinstance(companion_hashes, dict):
+        vr.error("companion_hashes field must be an object (filename -> hash)")
+        return
+
+    for comp_name, comp_expected in companion_hashes.items():
+        if not isinstance(comp_name, str) or not _is_safe_bundle_filename(comp_name):
+            vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
+            continue
+        comp_path = bundle_dir / comp_name
+        if not comp_path.is_file():
+            vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")
+            continue
+        if not isinstance(comp_expected, str) or not comp_expected:
+            vr.error(f"Empty companion hash for {comp_name}")
+            continue
+        comp_actual = _hash_file(comp_path)
+        if comp_actual != comp_expected:
+            vr.error(
+                f"Companion hash mismatch for {comp_name}: manifest says "
+                f"{comp_expected[:16]}..., computed {comp_actual[:16]}..."
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -328,19 +328,35 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
         vr.error(f"Cannot read submission manifest file: {exc}")
         return
 
+    # Surface ALL missing required fields in one pass so a contributor
+    # whose manifest is missing both `bundle_file` and `bundle_hash`
+    # sees both warnings instead of having to fix-and-retry one at a time.
     bundle_file = manifest.get("bundle_file")
     expected_hash = manifest.get("bundle_hash")
+    missing_fields: list[str] = []
     if not isinstance(bundle_file, str) or not bundle_file:
-        vr.warn("Submission manifest has no bundle_file field")
-        return
+        missing_fields.append("bundle_file")
     if not isinstance(expected_hash, str) or not expected_hash:
-        vr.warn("Submission manifest has no bundle_hash field")
+        missing_fields.append("bundle_hash")
+    if missing_fields:
+        for field in missing_fields:
+            vr.warn(f"Submission manifest has no {field} field")
         return
+
     if not _is_safe_bundle_filename(bundle_file):
         vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
         return
 
     primary_path = bundle_dir / bundle_file
+    # Symlink defense: the validator runs on PR-supplied content, so a
+    # malicious symlink (committed via a crafted git tree) could redirect
+    # the hash to attacker-chosen bytes outside the bundle. Reject before
+    # is_file() — is_file() follows symlinks. The writer (benchbox submit)
+    # uses shutil.copy2, which copies file contents not symlinks, so any
+    # symlink in a submitted bundle is suspicious by construction.
+    if primary_path.is_symlink():
+        vr.error(f"Bundle file is a symlink, not a regular file: {bundle_file} (symlinks not allowed)")
+        return
     if not primary_path.is_file():
         vr.error(f"Bundle file declared in manifest not found in PR: {bundle_file}")
         return
@@ -362,6 +378,9 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
             vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
             continue
         comp_path = bundle_dir / comp_name
+        if comp_path.is_symlink():
+            vr.error(f"Companion file is a symlink, not a regular file: {comp_name} (symlinks not allowed)")
+            continue
         if not comp_path.is_file():
             vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")
             continue

--- a/tests/test_validate_submission_smoke.py
+++ b/tests/test_validate_submission_smoke.py
@@ -1,0 +1,136 @@
+"""Smoke test for `scripts/validate_submission.py` on the
+published-results branch.
+
+Why this exists: this branch's CI lanes (lint.yml, test.yml) only run on
+PRs to `develop` / `main`, and `validate-submission.yml` only fires when
+`results-data/bundles/**` changes. A PR that edits *only* the validator
+script (like the sister sync PR) would otherwise have no CI gating on
+this branch. This smoke test is wired into `.github/workflows/validator-smoke.yml`
+so changes to `scripts/validate_submission.py` are exercised end-to-end
+before merge.
+
+Standalone by design: no benchbox import — uses pytest + subprocess so
+it works on a stripped-down CI runner without the full benchbox dev
+environment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATOR = REPO_ROOT / "scripts" / "validate_submission.py"
+
+
+def _minimal_schema_v2_bundle() -> dict:
+    """Leanest payload that satisfies the validator's schema-v2 checks.
+
+    Mirrors the fixture in develop's
+    tests/integration/test_cross_branch_validator_contract.py so any
+    drift between the two sides surfaces visibly.
+    """
+    return {
+        "version": "2.0",
+        "run": {
+            "id": "smoke-test-run",
+            "timestamp": "2026-04-29T00:00:00Z",
+            "total_duration_ms": 12340,
+        },
+        "benchmark": {"id": "tpch", "scale_factor": 0.01},
+        "platform": {"name": "duckdb"},
+        "summary": {"queries": {"total": 22}},
+        "queries": [{"id": "Q1", "ms": 100.0}],
+    }
+
+
+def _write_bundle_with_manifest(bundle_dir: Path, bundle_filename: str = "tpch_duckdb.json") -> Path:
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = bundle_dir / bundle_filename
+    bundle_path.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+
+    manifest = {
+        "bundle_file": bundle_filename,
+        "bundle_hash": hashlib.sha256(bundle_path.read_bytes()).hexdigest(),
+        "companion_hashes": {},
+    }
+    (bundle_dir / "submission-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return bundle_path
+
+
+def _run_validator(bundle_path: Path, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def test_validator_accepts_valid_bundle(tmp_path: Path) -> None:
+    """Happy path: a valid schema-v2 bundle with a matching manifest passes."""
+    bundle_path = _write_bundle_with_manifest(tmp_path / "bundle")
+    proc = _run_validator(bundle_path, tmp_path)
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode == 0, f"Valid bundle was rejected:\n{output}"
+    assert "0 error(s), 0 warning(s)" in output, output
+
+
+def test_validator_rejects_hash_mismatch(tmp_path: Path) -> None:
+    """Negative path: a manifest whose bundle_hash doesn't match the
+    bundle's actual SHA-256 must be rejected."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_path = _write_bundle_with_manifest(bundle_dir)
+
+    manifest_path = bundle_dir / "submission-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # Tamper with the recorded hash so the validator's recomputation diverges.
+    manifest["bundle_hash"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    proc = _run_validator(bundle_path, tmp_path)
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"Tampered manifest was wrongly accepted:\n{output}"
+    assert "Bundle hash mismatch" in output, output
+
+
+def test_validator_rejects_symlinked_bundle(tmp_path: Path) -> None:
+    """Symlink defense: a bundle file that is actually a symlink must be
+    rejected even when the symlink target's bytes happen to match the
+    manifest hash. Without this check, a malicious PR could redirect the
+    hash computation through a symlink to attacker-chosen bytes."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+
+    real = tmp_path / "real_target.json"
+    real.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+
+    bundle_filename = "tpch_duckdb.json"
+    symlink_path = bundle_dir / bundle_filename
+    symlink_path.symlink_to(real)
+
+    manifest = {
+        "bundle_file": bundle_filename,
+        "bundle_hash": hashlib.sha256(real.read_bytes()).hexdigest(),
+        "companion_hashes": {},
+    }
+    (bundle_dir / "submission-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    proc = _run_validator(symlink_path, tmp_path)
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"Symlinked bundle was wrongly accepted:\n{output}"
+    assert "symlink" in output.lower(), output
+
+
+def test_validator_script_exists() -> None:
+    """Sanity: the validator script the rest of these tests exec actually
+    exists at the expected path. Catches accidental relocations early."""
+    assert VALIDATOR.is_file(), f"Validator script not found at {VALIDATOR}"


### PR DESCRIPTION
## Summary

- Sync `scripts/validate_submission.py` on this branch with develop's post-PR-#33 version (per-file SHA-256 + `companion_hashes`), replacing the v0.2.1-pinned per-directory hash.
- Resolves the release-blocker surfaced by the 2026-04-29 Codex agent-proxy dry-run: every contributor-emitted bundle was failing CI on this branch with `Bundle hash mismatch` and no contributor-side knob to resolve it.
- Sister PR onto develop (#49) adds `tests/integration/test_cross_branch_validator_contract.py` so CI catches future drift between the writer and validator.

Forensic and reproduction at `_project/handoffs/external-dry-run-retrospective-2026-04-29.md` (Appendix B). Tracks `dry-run-followup-validator-hash-contract-mismatch` W2.

## Test plan

- [x] Round-trip locally: `python3 scripts/validate_submission.py /Users/joe/Developer/BenchBox/submission/bundle/tpch_sf001_duckdb_sql_*.json` → `0 error(s), 0 warning(s)` (Codex's actual dry-run bundle).
- [ ] CI on this PR (Validate Submission workflow).
- [ ] After merge: contract test in #49 passes against the synced validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)