### PR TITLE
chore(validator): restore symlink rejection + tighten missing-field warnings

### DIFF
--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -328,19 +328,35 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
         vr.error(f"Cannot read submission manifest file: {exc}")
         return
 
+    # Surface ALL missing required fields in one pass so a contributor
+    # whose manifest is missing both `bundle_file` and `bundle_hash`
+    # sees both warnings instead of having to fix-and-retry one at a time.
     bundle_file = manifest.get("bundle_file")
     expected_hash = manifest.get("bundle_hash")
+    missing_fields: list[str] = []
     if not isinstance(bundle_file, str) or not bundle_file:
-        vr.warn("Submission manifest has no bundle_file field")
-        return
+        missing_fields.append("bundle_file")
     if not isinstance(expected_hash, str) or not expected_hash:
-        vr.warn("Submission manifest has no bundle_hash field")
+        missing_fields.append("bundle_hash")
+    if missing_fields:
+        for field in missing_fields:
+            vr.warn(f"Submission manifest has no {field} field")
         return
+
     if not _is_safe_bundle_filename(bundle_file):
         vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
         return
 
     primary_path = bundle_dir / bundle_file
+    # Symlink defense: the validator runs on PR-supplied content, so a
+    # malicious symlink (committed via a crafted git tree) could redirect
+    # the hash to attacker-chosen bytes outside the bundle. Reject before
+    # is_file() — is_file() follows symlinks. The writer (benchbox submit)
+    # uses shutil.copy2, which copies file contents not symlinks, so any
+    # symlink in a submitted bundle is suspicious by construction.
+    if primary_path.is_symlink():
+        vr.error(f"Bundle file is a symlink, not a regular file: {bundle_file} (symlinks not allowed)")
+        return
     if not primary_path.is_file():
         vr.error(f"Bundle file declared in manifest not found in PR: {bundle_file}")
         return
@@ -362,6 +378,9 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
             vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
             continue
         comp_path = bundle_dir / comp_name
+        if comp_path.is_symlink():
+            vr.error(f"Companion file is a symlink, not a regular file: {comp_name} (symlinks not allowed)")
+            continue
         if not comp_path.is_file():
             vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")
             continue

--- a/tests/fixtures/published_results_validator.py
+++ b/tests/fixtures/published_results_validator.py
@@ -328,19 +328,35 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
         vr.error(f"Cannot read submission manifest file: {exc}")
         return
 
+    # Surface ALL missing required fields in one pass so a contributor
+    # whose manifest is missing both `bundle_file` and `bundle_hash`
+    # sees both warnings instead of having to fix-and-retry one at a time.
     bundle_file = manifest.get("bundle_file")
     expected_hash = manifest.get("bundle_hash")
+    missing_fields: list[str] = []
     if not isinstance(bundle_file, str) or not bundle_file:
-        vr.warn("Submission manifest has no bundle_file field")
-        return
+        missing_fields.append("bundle_file")
     if not isinstance(expected_hash, str) or not expected_hash:
-        vr.warn("Submission manifest has no bundle_hash field")
+        missing_fields.append("bundle_hash")
+    if missing_fields:
+        for field in missing_fields:
+            vr.warn(f"Submission manifest has no {field} field")
         return
+
     if not _is_safe_bundle_filename(bundle_file):
         vr.error(f"Unsafe bundle_file in manifest: {bundle_file!r} (must be a plain filename)")
         return
 
     primary_path = bundle_dir / bundle_file
+    # Symlink defense: the validator runs on PR-supplied content, so a
+    # malicious symlink (committed via a crafted git tree) could redirect
+    # the hash to attacker-chosen bytes outside the bundle. Reject before
+    # is_file() — is_file() follows symlinks. The writer (benchbox submit)
+    # uses shutil.copy2, which copies file contents not symlinks, so any
+    # symlink in a submitted bundle is suspicious by construction.
+    if primary_path.is_symlink():
+        vr.error(f"Bundle file is a symlink, not a regular file: {bundle_file} (symlinks not allowed)")
+        return
     if not primary_path.is_file():
         vr.error(f"Bundle file declared in manifest not found in PR: {bundle_file}")
         return
@@ -362,6 +378,9 @@ def _validate_manifest_hash(manifest_path: Path, bundle_dir: Path, vr: Validatio
             vr.error(f"Unsafe companion filename in manifest: {comp_name!r} (must be a plain filename)")
             continue
         comp_path = bundle_dir / comp_name
+        if comp_path.is_symlink():
+            vr.error(f"Companion file is a symlink, not a regular file: {comp_name} (symlinks not allowed)")
+            continue
         if not comp_path.is_file():
             vr.error(f"Companion file declared in manifest not found in PR: {comp_name}")
             continue

--- a/tests/integration/test_cross_branch_validator_contract.py
+++ b/tests/integration/test_cross_branch_validator_contract.py
@@ -28,6 +28,7 @@ if step 1 (sync to develop's script) is skipped; sync to
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import subprocess
@@ -144,6 +145,71 @@ def test_writer_companion_hashes_validator_accepts(monkeypatch: pytest.MonkeyPat
 
     assert proc.returncode == 0, f"Validator rejected bundle with companions. Output:\n{output}"
     assert "0 error(s)" in output, output
+
+
+def test_validator_rejects_symlinked_bundle(tmp_path: Path) -> None:
+    """Symlink defense: a bundle that resolves through a symlink must be
+    rejected by the validator regardless of whether the symlink target's
+    bytes happen to hash correctly. The validator runs on PR-supplied
+    content; without this check, a malicious PR could redirect the hash
+    computation to attacker-chosen bytes."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+
+    real = tmp_path / "real_target.json"
+    real.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+
+    # Symlink lives inside bundle_dir, points to a file outside it.
+    bundle_filename = "tpch_duckdb.json"
+    symlink_path = bundle_dir / bundle_filename
+    symlink_path.symlink_to(real)
+
+    # Manifest sits beside the bundle (where the validator discovers it
+    # via bundle_path.parent / "submission-manifest.json"). Hash matches
+    # the real target's bytes — the validator must reject *because of*
+    # the symlink, not because of a hash mismatch.
+    real_hash = hashlib.sha256(real.read_bytes()).hexdigest()
+    manifest = {
+        "bundle_file": bundle_filename,
+        "bundle_hash": real_hash,
+        "companion_hashes": {},
+    }
+    (bundle_dir / "submission-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(VENDORED_VALIDATOR), str(symlink_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    output = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0, f"Validator wrongly accepted a symlinked bundle. Output:\n{output}"
+    assert "symlink" in output.lower(), f"Expected a symlink-specific error. Output:\n{output}"
+
+
+def test_validator_surfaces_both_missing_manifest_fields(tmp_path: Path) -> None:
+    """Early-return UX: a manifest missing both bundle_file and bundle_hash
+    should warn about both in one pass, not just the first."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    bundle_path = bundle_dir / "tpch_duckdb.json"
+    bundle_path.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+    # Manifest is intentionally empty to exercise the both-fields-missing path.
+    # Sits beside the bundle where the validator discovers it.
+    (bundle_dir / "submission-manifest.json").write_text("{}", encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(VENDORED_VALIDATOR), str(bundle_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    output = proc.stdout + proc.stderr
+
+    # Both fields are missing — both warnings should surface in one pass.
+    assert "bundle_file" in output, output
+    assert "bundle_hash" in output, output
 
 
 def test_vendored_validator_matches_develop_script() -> None:


### PR DESCRIPTION
Addresses two findings from the review of #50 (the
published-results sister PR landing the per-file hash contract):

1. Symlink defense regression — develop's PR-#33 validator dropped
   the explicit `is_symlink()` rejection that lived in the prior
   per-directory hash code. Without it, a malicious PR including a
   committed symlink (rare but possible — git typically preserves
   them) could redirect the hash computation through the symlink to
   attacker-chosen bytes outside the bundle. Re-add the check
   inline for both the primary bundle path and each declared
   companion. New regression test
   test_validator_rejects_symlinked_bundle exec's the validator
   against a bundle whose primary path is a symlink to a real (and
   correctly-hashed) target — the validator must reject regardless
   of hash agreement.

2. Early-return UX — when a manifest was missing both `bundle_file`
   and `bundle_hash`, only the first warning surfaced because the
   first check returned eagerly. Collect both into a list and emit
   in one pass so the contributor fixes both at once. New test
   test_validator_surfaces_both_missing_manifest_fields covers it.

Vendored fixture re-synced (drift guard test
test_vendored_validator_matches_develop_script continues to pass —
verified locally). Sister PR onto `published-results` mirrors the
same script change so the contract stays byte-identical across
branches.

Tracks #50's review feedback. Forensic at
_project/handoffs/external-dry-run-retrospective-2026-04-29.md
(Appendix B) for the original incident.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
