### PR TITLE
feat(blind-spots): centralized capture for blind-spot audit findings

### DIFF
--- a/.claude/commands/blind-spot.md
+++ b/.claude/commands/blind-spot.md
@@ -1,0 +1,86 @@
+---
+allowed-tools: Bash(date:*), Bash(uv:*), Bash(make:*), Write, Edit, Read
+description: Record a blind-spot audit finding to _project/blind-spots/ (file-first capture)
+---
+
+## Context
+
+- Branch: !`git branch --show-current`
+- Date/time: !`date +%Y-%m-%d-%H%M%S`
+- Open findings: !`ls _project/blind-spots/*.md 2>/dev/null | grep -v README | wc -l | tr -d ' '`
+
+## Your task
+
+The user wants to record a blind-spot audit finding. Follow the protocol in
+`_project/blind-spots/README.md` exactly. Do **not** invent a different shape.
+
+1. **Pick the slug.** From the user's description (the part after `/blind-spot`),
+   derive a 3–6 word kebab-case slug capturing the *class*, not the *instance*.
+   Example: "react keys collide on platform name" → `react-key-collision-class`.
+   If the user gave nothing, ask one short clarifying question and stop.
+
+2. **Compose the filename.** Use the timestamp from the Context block above:
+   `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`. Filename stem must equal
+   the `id` field in the frontmatter.
+
+3. **Write the file** using this exact frontmatter schema. Required fields are
+   `id`, `date`, `status` (always `open` at write time), `finding_kind`, and
+   `review_context`. Optional: `related_paths`, `suggested_sweep`, `todo_id`.
+
+   ```yaml
+   ---
+   id: <filename stem>
+   date: <YYYY-MM-DD>
+   status: open
+   finding_kind: <framework-gap | bug-class | missed-axis | scope-creep | assumption | other>
+   review_context: "<one line: which review / branch / agent surfaced this>"
+   related_paths:
+     - <repo-relative path>
+   suggested_sweep: "<one-line hint for the sweep step>"
+   todo_id: null
+   ---
+   ```
+
+   Body shape:
+
+   ```markdown
+   # <Title — one line, no jargon>
+
+   ## Finding
+   <verbatim audit text from the review — copy/paste, don't paraphrase>
+
+   ## Why this matters
+   <one short paragraph on the lesson, not the instance>
+
+   ## Suggested next steps
+   - [ ] <concrete action 1>
+   - [ ] <concrete action 2>
+   ```
+
+4. **Validate** the new file:
+
+   ```
+   uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py _project/blind-spots/<filename>
+   ```
+
+   If validation fails, fix the frontmatter and re-run. Do not commit a
+   malformed finding.
+
+5. **Report** to the user with one line and a quote of the body:
+
+   ```
+   Recorded: _project/blind-spots/<filename>.md
+
+   <body content>
+   ```
+
+   Do not commit unless the user asks. The file lives on the current branch;
+   it'll ride along with whatever PR is in flight.
+
+## Notes
+
+- Findings are **observations**, not actionable TODOs. Promotion-to-TODO is a
+  sweep-step decision (`make blind-spots-sweep`), not a write-step decision.
+- Keep the body short. Long context belongs in a TODO or audit doc.
+- Never hand-edit `_project/blind-spots/_indexes/` — there is no checked-in
+  index by design (avoids merge collisions). Reports are regenerated on demand.

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ _sources/tpc-h/dbgen/dbgen_x86_64
 !_project/handoffs/
 !_project/notes/
 !_project/research/
+!_project/blind-spots/
 !_project/TODO_SCHEMA.yaml
 !_project/PROJECT_TODO.md
 !_project/PROJECT_TODO.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,16 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
+      # Validate any blind-spot finding files staged in this commit.
+      # Each finding is its own markdown file with strict YAML frontmatter;
+      # see _project/blind-spots/README.md for the protocol.
+      - id: blind-spot-validate
+        name: blind-spot frontmatter validation
+        entry: uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py
+        language: system
+        files: ^_project/blind-spots/.*\.md$
+        exclude: ^_project/blind-spots/README\.md$
+
       # Warn-only duplicate-code gate. Manual stage so it doesn't slow
       # every commit (pylint over benchbox/ takes ~60s). Run with
       # `pre-commit run duplicate-code-warn --all-files --hook-stage manual`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,28 @@ during the single-repo migration).
   (`_project/`, `_blog/`, agent configs, etc.) live only on develop by
   design. Full runbook: `docs/operations/release-guide.md`.
 
+## Review workflow — blind-spot capture (mandatory)
+
+When you produce a **Blind-Spot Audit (L2)** during any review (ultrareview,
+`/review`, ad-hoc code review, research, planning), you MUST:
+
+1. **Write the finding to disk first** at
+   `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`, using the frontmatter
+   schema and body shape in `_project/blind-spots/README.md`.
+2. **Then** quote the finding in your chat reply, prefixed with one line:
+   `Recorded: _project/blind-spots/<file>.md`.
+
+Do not skip the file write because the finding "feels minor" — sweep-time
+triage is where dismissals belong, not write-time. Findings printed only in
+chat get lost; file-first capture is what makes the L2 audit habit pay off.
+
+Sweep / triage findings with `make blind-spots-{list,report,sweep}`. Promotion
+to a TODO is a sweep-step decision, not a write-step decision. See
+`_project/blind-spots/README.md` for the full protocol.
+
+The `/blind-spot` slash command (`.claude/commands/blind-spot.md`) wraps the
+file-first capture flow when you want to record one explicitly outside a review.
+
 ## Commands
 
 | Task | Command |
@@ -95,4 +117,5 @@ benchbox run --help | --help-topic all | --help-topic examples | --help-topic be
 - **Python**: `uv tree`, `uv pip list`, `uv pip show*`, `uv export`, `uv run -- python -c*`, `uv run -- python -m*`
 - **TPC**: `timeout 30s _binaries/tpc-{h,ds}/<platform>/dsdgen*`, `timeout 60s _binaries/tpc-{h,ds}/<platform>/dsqgen*`
 - **TODO**: `uv run --project _project/scripts -- python _project/scripts/todo_cli.py list*|show*|stats|ready|next*|done*|check-graph`, `uv run --project _project/scripts -- python _project/scripts/validate_todo.py*`, `uv run _project/scripts/generate_indexes.py`, `uv run _project/scripts/migrate_todo_format.py*`
+- **Blind-spots**: `make blind-spots-list`, `make blind-spots-report`, `make blind-spots-sweep`, `uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py *`, `uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py *`
 - **System**: `ps*`, `uname*`, `whoami`, `pwd`, `env | grep*`

--- a/Makefile
+++ b/Makefile
@@ -712,7 +712,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-open pr-status worktree-add worktree-list worktree-prune todo-reindex
+.PHONY: pr-preflight pr-open pr-status worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
 
 # Mirror the CI gate locally before pushing. Catches ~all CI failures
 # without the network roundtrip. Delegates to ci-lint so the local
@@ -780,6 +780,16 @@ worktree-prune:
 			fi; \
 		done
 	@git worktree prune
+
+# Blind-spot finding triage (file-first capture; see _project/blind-spots/README.md).
+blind-spots-list:
+	@uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py list
+
+blind-spots-report:
+	@uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py report
+
+# Alias: 'sweep' as the verb users will reach for; report is the v1 sweep view.
+blind-spots-sweep: blind-spots-report
 
 # Help
 help:
@@ -887,6 +897,11 @@ help:
 	@echo "  make worktree-add BRANCH=name  Create a worktree off origin/develop at ../BenchBox.<name>"
 	@echo "  make worktree-list   List active worktrees"
 	@echo "  make worktree-prune  Remove worktrees whose branches are gone on origin (post-merge cleanup)"
+	@echo ""
+	@echo "Blind-Spot Findings (see _project/blind-spots/README.md):"
+	@echo "  make blind-spots-list   List open findings (one row each)"
+	@echo "  make blind-spots-report Counts by status + kind, oldest open first"
+	@echo "  make blind-spots-sweep  Alias for blind-spots-report"
 	@echo ""
 	@echo "Release Workflow (2-command flow; see docs/operations/release-guide.md):"
 	@echo "  make release-cut VERSION=X.Y.Z      Cut v\$$VERSION off develop, bump + changelog + curate, push, open PR vs main"

--- a/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
+++ b/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
@@ -1,0 +1,46 @@
+---
+id: 2026-04-29-143205-react-key-collision-class
+date: 2026-04-29
+status: open
+finding_kind: bug-class
+review_context: "ultrareview B4 / dashboard chart key collisions"
+related_paths:
+  - benchbox/dashboard/charts/TimeSeries.tsx
+  - benchbox/dashboard/charts/PercentileLadder.tsx
+suggested_sweep: "grep for React keys derived from non-unique fields across all chart components before declaring the class fixed"
+todo_id: null
+---
+
+# Symptom-vs-Class Axis Missing from 5-Axis Review Framework
+
+## Finding
+
+The five-axis framework misses one issue specific to symptom-vs-class fixes:
+whether the fix addresses the bug class or just the reported instance. B4 was
+reported on TimeSeries, but the underlying class is "React key uses a
+non-unique field that the dataset's batch nature can collide." That class
+shows up at least once more in PercentileLadder. Fixing only TimeSeries
+leaves the same defect ready to fire on the next dataset where two DuckDB
+rows share a platform name. C1 captures this; the framework's "Architecture"
+axis would have given a 9 if I hadn't widened the lens. Worth recording as a
+habit: when a key-collision bug surfaces, always sweep the file tree for
+sibling instances before declaring the class fixed.
+
+## Why this matters
+
+Reviews driven by a fixed-axis rubric will systematically under-weight
+defects whose blast radius is "this class of bug, anywhere it shows up"
+rather than "this file's behavior." A high score on the existing axes can
+co-exist with an entire class of bugs left intact in sibling files. This is
+not specific to React keys — it applies anywhere a fix targets a single
+call-site of a generalizable defect.
+
+## Suggested next steps
+
+- [ ] Add a "bug-class blast radius" check to the review framework, used
+      when the finding is structural rather than behavioral.
+- [ ] Sweep all chart components for React keys derived from
+      non-uniqueness-guaranteed fields (platform name, query id, etc.)
+      and convert to composite or stable IDs.
+- [ ] When a sweep is done, link the resulting TODO/PR back here and
+      flip `status:` to `merged-to-todo`.

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -1,0 +1,173 @@
+# Blind-Spot Findings
+
+Centralized capture for **blind-spot audit (L2)** findings produced during
+reviews — observations that *may* warrant action but haven't been triaged yet.
+
+This directory exists because audit findings printed only in chat get lost.
+Persisting each finding as its own file makes the backlog sweepable later
+without creating PR merge collisions.
+
+---
+
+## What goes here
+
+A finding belongs in this directory when it surfaces:
+
+- A **gap in a review framework** that was used (axis missing, dimension
+  the rubric can't capture).
+- A **bug class** behind a reported instance (the symptom was fixed, but
+  the underlying pattern probably exists elsewhere).
+- A **scope-creep flag** — work that wasn't requested but might be load-bearing.
+- An **assumption worth testing later** — something that was true at audit
+  time but might decay.
+- Anything else that came out of a Blind-Spot Audit (L2) section in a review.
+
+### What does NOT go here
+
+- Concrete actionable bugs with a clear owner → make a TODO.
+- Architectural decisions → `_project/decisions/` (ADRs).
+- Full reviews / audits → `_project/audits/`.
+- Random ideas / brainstorming → `_project/notes/`.
+
+If unsure, write the finding here. The sweep step is where dismissals happen,
+not the write step.
+
+---
+
+## File naming
+
+```
+YYYY-MM-DD-HHMMSS-<short-slug>.md
+```
+
+- The timestamp prefix gives total ordering and uniqueness — two parallel
+  reviews on two branches can never produce the same filename. **This is
+  what makes the directory merge-collision-safe.**
+- The slug is grep bait, kept short (3–6 words).
+
+Use the local clock; precision to the second is plenty.
+
+---
+
+## Frontmatter schema (required)
+
+Every finding file must start with YAML frontmatter matching this shape:
+
+```yaml
+---
+id: 2026-04-29-143205-react-key-collision-class   # = filename stem
+date: 2026-04-29                                  # ISO date
+status: open                                      # open | actioned | dismissed | merged-to-todo
+finding_kind: bug-class                           # framework-gap | bug-class | missed-axis | scope-creep | assumption | other
+review_context: "ultrareview B4 / chore/dashboard-keys"
+related_paths:
+  - benchbox/dashboard/charts/TimeSeries.tsx
+  - benchbox/dashboard/charts/PercentileLadder.tsx
+suggested_sweep: "grep for sibling key-collision instances before declaring class fixed"
+todo_id: null                                     # populated when promoted via sweep
+---
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | yes | Must equal filename without `.md` |
+| `date` | yes | ISO `YYYY-MM-DD` |
+| `status` | yes | One of: `open`, `actioned`, `dismissed`, `merged-to-todo` |
+| `finding_kind` | yes | One of: `framework-gap`, `bug-class`, `missed-axis`, `scope-creep`, `assumption`, `other` |
+| `review_context` | yes | Free-form: which review / branch / PR / agent surfaced this |
+| `related_paths` | optional | Repo-relative paths the finding touches |
+| `suggested_sweep` | optional | One-line hint for the sweep step |
+| `todo_id` | optional | Slug of the promoted TODO, populated by `sweep_blind_spots.py triage promote` |
+
+Anything else is rejected by `validate_blind_spot.py`. Keep frontmatter
+minimal — long context belongs in the body.
+
+---
+
+## Body shape
+
+Keep it short. These are seeds, not specs.
+
+```markdown
+# <Title — one line, no jargon>
+
+## Finding
+<verbatim audit text from the review — copy/paste, don't paraphrase>
+
+## Why this matters
+<one short paragraph on the lesson, not the instance>
+
+## Suggested next steps
+- [ ] <concrete action 1>
+- [ ] <concrete action 2>
+```
+
+---
+
+## How findings get written
+
+Project `CLAUDE.md` binds Claude Code's L2 audits to this directory:
+when an L2 audit is generated during any review, the audit is **written to
+disk first**, then quoted in the chat response. The chat output becomes a
+view of the persisted file, not a separate ephemeral artifact.
+
+Humans (and other agents) can also invoke the `/blind-spot` slash command
+to record one explicitly.
+
+---
+
+## How findings get triaged
+
+Sweep on demand:
+
+```bash
+make blind-spots-list                # all open findings (one row each)
+make blind-spots-report              # counts by status + kind, oldest open first
+make blind-spots-sweep               # alias for blind-spots-report
+```
+
+Direct script invocations:
+
+```bash
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py list --status open
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py show <id>
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action dismiss  --reason "..."
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action actioned [--reason "..."]
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action promote  --todo-id <todo-slug>
+```
+
+Triage outcomes (each stamps frontmatter and appends a one-line entry under
+`## Triage log` in the body):
+
+- **`dismiss`** — sets `status: dismissed`. Use when the finding doesn't
+  warrant action.
+- **`actioned`** — sets `status: actioned`. Use when a fix landed without
+  needing a separate TODO (e.g., handled inline during the same review).
+- **`promote`** — sets `status: merged-to-todo` and fills `todo_id`.
+  Authoring the TODO file itself is **your** job — use
+  `_project/TODO_ENTRY_TEMPLATE.yaml` and place it under
+  `_project/TODO/<worktree>/planning/<slug>.yaml`. The sweep script only
+  records the link; it does not generate TODO YAML.
+
+Findings stay in the directory after triage — they're a historical record of
+what was noticed, not a working queue. Use `status` filters to scope sweeps.
+
+---
+
+## Why this won't cause PR merge collisions
+
+There are exactly two ways markdown-in-git directories generate merge
+conflicts, and both are designed out:
+
+1. **Two branches editing the same file at the same offset** — avoided by
+   one-file-per-finding with timestamped names. Two parallel reviews produce
+   two filenames, not two diffs of one file.
+2. **Two branches editing a shared index** — avoided by *not checking in any
+   hand-maintained index*. The sweep produces transient reports, and TODO
+   promotion goes through the existing `todo_cli.py` infrastructure (which
+   already handles its own indexes via `generate_indexes.py`).
+
+The only file that gets edited in place after creation is the finding's own
+frontmatter `status:` line during triage. Triage happens serially on a single
+branch, so two people aren't dismissing the same finding from two PRs. If
+they ever did, the conflict is a 3-line YAML diff, trivial to resolve.

--- a/_project/scripts/sweep_blind_spots.py
+++ b/_project/scripts/sweep_blind_spots.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Triage and report on blind-spot findings.
+
+Subcommands::
+
+    list [--status STATUS] [--kind KIND]    Show matching findings (default: open).
+    show <id>                               Print one finding (frontmatter + body).
+    report                                  Counts by status + kind, oldest open first.
+    triage <id> --action ACTION [...]       Stamp frontmatter to record triage outcome.
+        --action dismiss --reason "..."
+        --action actioned [--reason "..."]
+        --action promote --todo-id <slug>
+
+Triage edits only the frontmatter and appends one line under a
+``## Triage log`` section. Triage does NOT author TODO files —
+``promote`` records the link to a TODO id you authored separately
+(see ``_project/TODO_ENTRY_TEMPLATE.yaml``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date as _date, datetime
+from pathlib import Path
+
+import yaml
+
+ALLOWED_STATUS = {"open", "actioned", "dismissed", "merged-to-todo"}
+ACTION_TO_STATUS = {
+    "dismiss": "dismissed",
+    "actioned": "actioned",
+    "promote": "merged-to-todo",
+}
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def find_blind_spots_dir(start: Path) -> Path:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        candidate = parent / "_project" / "blind-spots"
+        if candidate.is_dir():
+            return candidate
+    print("error: could not locate _project/blind-spots/", file=sys.stderr)
+    sys.exit(2)
+
+
+def split_frontmatter(text: str) -> tuple[dict, str, str]:
+    """Return (data, raw_frontmatter, body)."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        raise ValueError("file does not start with a YAML frontmatter block")
+    raw = m.group(1)
+    data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        raise ValueError("frontmatter must be a YAML mapping")
+    body = text[m.end() :]
+    return data, raw, body
+
+
+def load_findings(bs_dir: Path) -> list[tuple[Path, dict, str]]:
+    """Load every finding (skipping README). Returns [(path, data, body), ...]."""
+    out: list[tuple[Path, dict, str]] = []
+    for path in sorted(bs_dir.glob("*.md")):
+        if path.name == "README.md":
+            continue
+        try:
+            data, _raw, body = split_frontmatter(path.read_text(encoding="utf-8"))
+        except (ValueError, yaml.YAMLError) as exc:
+            print(f"warning: skipping {path.name}: {exc}", file=sys.stderr)
+            continue
+        out.append((path, data, body))
+    return out
+
+
+def find_one(bs_dir: Path, finding_id: str) -> tuple[Path, dict, str]:
+    candidate = bs_dir / f"{finding_id}.md"
+    if not candidate.exists():
+        print(f"error: no finding with id '{finding_id}'", file=sys.stderr)
+        sys.exit(2)
+    data, _raw, body = split_frontmatter(candidate.read_text(encoding="utf-8"))
+    return candidate, data, body
+
+
+def extract_title(body: str) -> str:
+    for line in body.splitlines():
+        line = line.strip()
+        if line.startswith("# "):
+            return line[2:].strip()
+    return "(untitled)"
+
+
+def fmt_date(value) -> str:
+    if isinstance(value, _date):
+        return value.isoformat()
+    return str(value)
+
+
+def cmd_list(bs_dir: Path, args: argparse.Namespace) -> int:
+    findings = load_findings(bs_dir)
+    findings.sort(key=lambda t: t[1].get("date", ""))
+
+    rows = []
+    for path, data, body in findings:
+        if args.status and data.get("status") != args.status:
+            continue
+        if args.kind and data.get("finding_kind") != args.kind:
+            continue
+        rows.append(
+            (
+                fmt_date(data.get("date", "????-??-??")),
+                data.get("status", "?"),
+                data.get("finding_kind", "?"),
+                data.get("id", path.stem),
+                extract_title(body),
+            )
+        )
+
+    if not rows:
+        filt = []
+        if args.status:
+            filt.append(f"status={args.status}")
+        if args.kind:
+            filt.append(f"kind={args.kind}")
+        suffix = f" matching {', '.join(filt)}" if filt else ""
+        print(f"no findings{suffix}.")
+        return 0
+
+    w_date = max(len(r[0]) for r in rows)
+    w_status = max(len(r[1]) for r in rows)
+    w_kind = max(len(r[2]) for r in rows)
+    w_id = max(len(r[3]) for r in rows)
+    for d, st, k, fid, title in rows:
+        print(f"{d:<{w_date}}  {st:<{w_status}}  {k:<{w_kind}}  {fid:<{w_id}}  {title}")
+    print(f"\n{len(rows)} finding(s).")
+    return 0
+
+
+def cmd_show(bs_dir: Path, args: argparse.Namespace) -> int:
+    path, data, body = find_one(bs_dir, args.id)
+    print(f"# {path.relative_to(bs_dir.parent.parent)}\n")
+    print("---")
+    print(yaml.safe_dump(data, sort_keys=False).rstrip())
+    print("---")
+    print(body.rstrip())
+    return 0
+
+
+def cmd_report(bs_dir: Path, args: argparse.Namespace) -> int:
+    findings = load_findings(bs_dir)
+    if not findings:
+        print("no findings recorded yet.")
+        return 0
+
+    by_status: dict[str, int] = {}
+    by_kind: dict[str, int] = {}
+    open_findings: list[tuple[str, dict, str]] = []
+    for path, data, body in findings:
+        st = str(data.get("status", "?"))
+        kn = str(data.get("finding_kind", "?"))
+        by_status[st] = by_status.get(st, 0) + 1
+        by_kind[kn] = by_kind.get(kn, 0) + 1
+        if st == "open":
+            open_findings.append((fmt_date(data.get("date", "")), data, body))
+
+    print(f"Total findings: {len(findings)}\n")
+
+    print("By status:")
+    for st in sorted(by_status):
+        print(f"  {st:<16} {by_status[st]:>4}")
+    print()
+
+    print("By finding_kind:")
+    for kn in sorted(by_kind):
+        print(f"  {kn:<16} {by_kind[kn]:>4}")
+    print()
+
+    if open_findings:
+        open_findings.sort(key=lambda t: t[0])
+        print(f"Oldest open ({min(args.top, len(open_findings))} of {len(open_findings)}):")
+        for d, data, body in open_findings[: args.top]:
+            print(f"  {d}  {data.get('id', '?')}  — {extract_title(body)}")
+    else:
+        print("No open findings.")
+
+    print("\nTriage with: sweep_blind_spots.py triage <id> --action {dismiss|actioned|promote} [...]")
+    return 0
+
+
+def stamp_frontmatter(path: Path, data: dict, body: str, new_status: str, todo_id: str | None) -> None:
+    """Rewrite the file with updated status (and optional todo_id)."""
+    data["status"] = new_status
+    if todo_id is not None:
+        data["todo_id"] = todo_id
+    new_raw = yaml.safe_dump(data, sort_keys=False).rstrip()
+    new_text = f"---\n{new_raw}\n---\n{body}"
+    path.write_text(new_text, encoding="utf-8")
+
+
+def append_triage_log(path: Path, line: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "\n## Triage log\n" in text:
+        # Append under existing section.
+        new_text = text.rstrip() + f"\n- {line}\n"
+    else:
+        new_text = text.rstrip() + f"\n\n## Triage log\n\n- {line}\n"
+    path.write_text(new_text, encoding="utf-8")
+
+
+def cmd_triage(bs_dir: Path, args: argparse.Namespace) -> int:
+    new_status = ACTION_TO_STATUS[args.action]
+    path, data, body = find_one(bs_dir, args.id)
+
+    if args.action == "promote":
+        if not args.todo_id:
+            print("error: --todo-id is required for --action promote", file=sys.stderr)
+            return 2
+        todo_id: str | None = args.todo_id
+        log_line = f"{datetime.now().date().isoformat()}: promoted to TODO `{todo_id}`"
+    else:
+        todo_id = None
+        reason = args.reason or ""
+        suffix = f" — {reason}" if reason else ""
+        log_line = f"{datetime.now().date().isoformat()}: {args.action}{suffix}"
+
+    stamp_frontmatter(path, data, body, new_status, todo_id)
+    append_triage_log(path, log_line)
+    print(f"OK   {path.relative_to(bs_dir.parent.parent)} → status={new_status}")
+    if todo_id:
+        print(f"     todo_id={todo_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sweep blind-spot findings.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="list findings")
+    p_list.add_argument("--status", choices=sorted(ALLOWED_STATUS), default="open")
+    p_list.add_argument("--kind", default=None)
+
+    p_show = sub.add_parser("show", help="show one finding")
+    p_show.add_argument("id")
+
+    p_report = sub.add_parser("report", help="aggregate report")
+    p_report.add_argument("--top", type=int, default=10, help="oldest-N to surface")
+
+    p_triage = sub.add_parser("triage", help="record a triage outcome")
+    p_triage.add_argument("id")
+    p_triage.add_argument("--action", choices=sorted(ACTION_TO_STATUS), required=True)
+    p_triage.add_argument("--reason", default=None)
+    p_triage.add_argument("--todo-id", dest="todo_id", default=None)
+
+    args = parser.parse_args()
+    bs_dir = find_blind_spots_dir(Path.cwd())
+
+    if args.cmd == "list":
+        return cmd_list(bs_dir, args)
+    if args.cmd == "show":
+        return cmd_show(bs_dir, args)
+    if args.cmd == "report":
+        return cmd_report(bs_dir, args)
+    if args.cmd == "triage":
+        return cmd_triage(bs_dir, args)
+    parser.print_help(sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_project/scripts/validate_blind_spot.py
+++ b/_project/scripts/validate_blind_spot.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Validate blind-spot finding files in _project/blind-spots/.
+
+Each finding is a markdown file with YAML frontmatter (delimited by ``---``
+lines). The frontmatter schema is small and strict — see
+``_project/blind-spots/README.md`` for the protocol.
+
+Usage::
+
+    uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py <path>
+    uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date as _date
+from pathlib import Path
+
+import yaml
+
+ALLOWED_STATUS = {"open", "actioned", "dismissed", "merged-to-todo"}
+ALLOWED_KIND = {
+    "framework-gap",
+    "bug-class",
+    "missed-axis",
+    "scope-creep",
+    "assumption",
+    "other",
+}
+REQUIRED_FIELDS = {"id", "date", "status", "finding_kind", "review_context"}
+OPTIONAL_FIELDS = {"related_paths", "suggested_sweep", "todo_id"}
+ALLOWED_FIELDS = REQUIRED_FIELDS | OPTIONAL_FIELDS
+
+# YYYY-MM-DD-HHMMSS-<slug>; slug is kebab-case, lowercase letters/digits.
+FILENAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9][a-z0-9-]*$")
+
+
+def parse_frontmatter(text: str) -> tuple[dict | None, list[str]]:
+    """Split a markdown file into (frontmatter_dict, errors).
+
+    Returns ``(None, [...])`` if the frontmatter block is missing or malformed.
+    """
+    errors: list[str] = []
+    if not text.startswith("---\n"):
+        return None, ["file must begin with a YAML frontmatter '---' line"]
+
+    # Find the closing fence on its own line.
+    body = text[4:]
+    end = body.find("\n---\n")
+    if end == -1:
+        # Allow trailing fence with no body after.
+        if body.endswith("\n---") or body.endswith("\n---\n"):
+            end = len(body) - 4
+        else:
+            return None, ["unterminated frontmatter block (no closing '---')"]
+
+    raw = body[:end]
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        return None, [f"frontmatter is not valid YAML: {exc}"]
+
+    if not isinstance(data, dict):
+        return None, ["frontmatter must be a YAML mapping"]
+    return data, errors
+
+
+def _check_id_and_filename(data: dict, file_path: Path) -> list[str]:
+    errors: list[str] = []
+    expected_id = file_path.stem
+    if "id" in data and data["id"] != expected_id:
+        errors.append(f"id '{data['id']}' must equal filename stem '{expected_id}'")
+    if not FILENAME_RE.match(expected_id):
+        errors.append(f"filename stem '{expected_id}' does not match YYYY-MM-DD-HHMMSS-<kebab-slug>")
+    return errors
+
+
+def _check_date(data: dict) -> list[str]:
+    if "date" not in data:
+        return []
+    d = data["date"]
+    if isinstance(d, _date):
+        return []
+    if isinstance(d, str):
+        try:
+            _date.fromisoformat(d)
+        except ValueError:
+            return [f"date '{d}' is not ISO YYYY-MM-DD"]
+        return []
+    return [f"date must be a string or date, got {type(d).__name__}"]
+
+
+def _check_enums(data: dict) -> list[str]:
+    errors: list[str] = []
+    if "status" in data and data["status"] not in ALLOWED_STATUS:
+        errors.append(f"status '{data['status']}' not in {sorted(ALLOWED_STATUS)}")
+    if "finding_kind" in data and data["finding_kind"] not in ALLOWED_KIND:
+        errors.append(f"finding_kind '{data['finding_kind']}' not in {sorted(ALLOWED_KIND)}")
+    return errors
+
+
+def _check_optional_shapes(data: dict) -> list[str]:
+    errors: list[str] = []
+    if "review_context" in data:
+        rc = data["review_context"]
+        if not isinstance(rc, str) or not rc.strip():
+            errors.append("review_context must be a non-empty string")
+    if "related_paths" in data and data["related_paths"] is not None:
+        rp = data["related_paths"]
+        if not isinstance(rp, list) or not all(isinstance(x, str) for x in rp):
+            errors.append("related_paths must be a list of strings (or null)")
+    if "suggested_sweep" in data:
+        ss = data["suggested_sweep"]
+        if ss is not None and not isinstance(ss, str):
+            errors.append("suggested_sweep must be a string or null")
+    if "todo_id" in data:
+        ti = data["todo_id"]
+        if ti is not None and not isinstance(ti, str):
+            errors.append("todo_id must be a string or null")
+    return errors
+
+
+def _check_status_invariants(data: dict) -> list[str]:
+    if data.get("status") == "merged-to-todo" and not data.get("todo_id"):
+        return ["status 'merged-to-todo' requires a non-empty todo_id"]
+    return []
+
+
+def validate_frontmatter(data: dict, file_path: Path) -> list[str]:
+    """Validate a frontmatter dict against the blind-spot schema."""
+    errors: list[str] = []
+    errors.extend(f"unknown field '{f}'" for f in sorted(set(data) - ALLOWED_FIELDS))
+    errors.extend(f"missing required field '{f}'" for f in sorted(REQUIRED_FIELDS - data.keys()))
+    errors.extend(_check_id_and_filename(data, file_path))
+    errors.extend(_check_date(data))
+    errors.extend(_check_enums(data))
+    errors.extend(_check_optional_shapes(data))
+    errors.extend(_check_status_invariants(data))
+    return errors
+
+
+def validate_file(file_path: Path) -> list[str]:
+    if not file_path.exists():
+        return [f"file not found: {file_path}"]
+    if file_path.suffix != ".md":
+        return [f"not a markdown file: {file_path}"]
+    if file_path.name == "README.md":
+        return []  # README is the protocol doc, not a finding
+
+    text = file_path.read_text(encoding="utf-8")
+    data, parse_errors = parse_frontmatter(text)
+    if data is None:
+        return parse_errors
+    return parse_errors + validate_frontmatter(data, file_path)
+
+
+def find_blind_spots_dir(start: Path) -> Path | None:
+    cur = start.resolve()
+    for parent in [cur, *cur.parents]:
+        candidate = parent / "_project" / "blind-spots"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate blind-spot finding files.")
+    parser.add_argument("paths", nargs="*", help="files or directories to validate")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="validate every finding under _project/blind-spots/",
+    )
+    args = parser.parse_args()
+
+    targets: list[Path] = []
+    if args.all:
+        bs_dir = find_blind_spots_dir(Path.cwd())
+        if bs_dir is None:
+            print("error: could not locate _project/blind-spots/", file=sys.stderr)
+            return 2
+        targets.extend(sorted(p for p in bs_dir.glob("*.md") if p.name != "README.md"))
+    for p in args.paths:
+        path = Path(p)
+        if path.is_dir():
+            targets.extend(sorted(q for q in path.glob("*.md") if q.name != "README.md"))
+        else:
+            targets.append(path)
+
+    if not targets:
+        parser.print_help(sys.stderr)
+        return 2
+
+    failed = 0
+    for path in targets:
+        errors = validate_file(path)
+        if errors:
+            failed += 1
+            print(f"FAIL {path}", file=sys.stderr)
+            for err in errors:
+                print(f"  - {err}", file=sys.stderr)
+        else:
+            print(f"OK   {path}")
+    if failed:
+        print(f"\n{failed} of {len(targets)} file(s) failed validation.", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(targets)} file(s) valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add _project/blind-spots/ with one-file-per-finding pattern, a strict
frontmatter schema, validator + pre-commit gate, and a sweep CLI for
triage (list / show / report / dismiss / actioned / promote-to-todo).
Project CLAUDE.md now binds Claude Code's L2 audits to a write-then-quote
protocol so findings can no longer be lost in chat.

The directory is merge-collision-safe by construction: timestamped
filenames mean parallel reviews on parallel branches always produce
distinct files, and there is no checked-in index to fight over —
reports are regenerated on demand. TODO promotion records the link
only; authoring the TODO file remains the user's job and reuses
_project/TODO_ENTRY_TEMPLATE.yaml.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
