### PR TITLE
fix(read-primitives): address variant comparability review

### DIFF
--- a/_project/DONE/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/DONE/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -2,7 +2,8 @@ id: ensure-read-primitives-variant-comparability
 title: "Ensure read_primitives query variants are meaningfully comparable"
 worktree: main
 priority: High
-status: In Progress
+status: Completed
+completed_date: "2026-04-29"
 category: Testing and Quality Assurance
 description: |
   Previous review found that `read_primitives` platform variants can diverge enough
@@ -39,7 +40,7 @@ work:
 - id: w6
   summary: "Update read_primitives catalog docs and skip reference to require comparable variants or skip_on"
   needs: [w3, w4]
-  status: pending
+  status: done
 
 deferred:
 - summary: "Expose query comparability metadata in CLI output and persisted result artifacts"

--- a/_project/DONE/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/DONE/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -46,6 +46,10 @@ deferred:
 - summary: "Expose query comparability metadata in CLI output and persisted result artifacts"
   reason: "The first implementation should fix benchmark correctness at the catalog/test layer; CLI/result-report integration
     can follow once the contract shape stabilizes."
+- summary: "Expand runtime parity coverage for retained read_primitives variants not covered by the first local parity suite"
+  reason: "The first pass targets the highest-risk families. Follow-up coverage should include array_unnest (clickhouse,
+    bigquery), array_agg_simple (clickhouse), struct_construction (clickhouse), list_transform (clickhouse), and the duckdb/clickhouse
+    paths of map_construction so retained variants do not drift silently."
 
 files_affected:
   modified:

--- a/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -31,7 +31,7 @@ work:
 - id: w4
   summary: "Fix or skip semi-structured variants with nested-shape risk: JSON, arrays, structs, maps, and lambda/list operations"
   needs: [w2]
-  status: pending
+  status: done
 - id: w5
   summary: "Add focused runtime parity tests for risky read_primitives families against DuckDB reference at SF=0.01"
   needs: [w3, w4]

--- a/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -35,7 +35,7 @@ work:
 - id: w5
   summary: "Add focused runtime parity tests for risky read_primitives families against DuckDB reference at SF=0.01"
   needs: [w3, w4]
-  status: pending
+  status: done
 - id: w6
   summary: "Update read_primitives catalog docs and skip reference to require comparable variants or skip_on"
   needs: [w3, w4]

--- a/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -27,7 +27,7 @@ work:
   summary: "Fix or skip scalar and capability-divergent variants: fulltext, window_moving_frame, statistical_percentiles,
     timeseries_trend_analysis, and any_value"
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Fix or skip semi-structured variants with nested-shape risk: JSON, arrays, structs, maps, and lambda/list operations"
   needs: [w2]

--- a/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -22,7 +22,7 @@ work:
 - id: w2
   summary: "Add static comparability linting for base/variant output columns, nested shape, row identity, and measured capability"
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Fix or skip scalar and capability-divergent variants: fulltext, window_moving_frame, statistical_percentiles,
     timeseries_trend_analysis, and any_value"

--- a/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
+++ b/_project/TODO/main/active/ensure-read-primitives-variant-comparability.yaml
@@ -1,0 +1,118 @@
+id: ensure-read-primitives-variant-comparability
+title: "Ensure read_primitives query variants are meaningfully comparable"
+worktree: main
+priority: High
+status: In Progress
+category: Testing and Quality Assurance
+description: |
+  Previous review found that `read_primitives` platform variants can diverge enough
+  to produce misleading cross-platform benchmark signals. Q75/json_aggregates exposed
+  the issue: matching column names and successful execution are not enough when the
+  nested output shape or measured capability differs.
+
+  Apply the policy that every active platform variant must be meaningfully comparable
+  to the base query. If a platform can only express a related-but-not-equivalent
+  operation, skip that query on that platform rather than keeping it in cross-platform
+  benchmark scoring.
+
+work:
+- id: w1
+  summary: "Add result_contract metadata support to the read_primitives catalog model and loader"
+  status: done
+- id: w2
+  summary: "Add static comparability linting for base/variant output columns, nested shape, row identity, and measured capability"
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Fix or skip scalar and capability-divergent variants: fulltext, window_moving_frame, statistical_percentiles,
+    timeseries_trend_analysis, and any_value"
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix or skip semi-structured variants with nested-shape risk: JSON, arrays, structs, maps, and lambda/list operations"
+  needs: [w2]
+  status: pending
+- id: w5
+  summary: "Add focused runtime parity tests for risky read_primitives families against DuckDB reference at SF=0.01"
+  needs: [w3, w4]
+  status: pending
+- id: w6
+  summary: "Update read_primitives catalog docs and skip reference to require comparable variants or skip_on"
+  needs: [w3, w4]
+  status: pending
+
+deferred:
+- summary: "Expose query comparability metadata in CLI output and persisted result artifacts"
+  reason: "The first implementation should fix benchmark correctness at the catalog/test layer; CLI/result-report integration
+    can follow once the contract shape stabilizes."
+
+files_affected:
+  modified:
+  - "benchbox/core/read_primitives/catalog/loader.py"
+  - "benchbox/core/read_primitives/catalog/__init__.py"
+  - "benchbox/core/read_primitives/catalog/queries.yaml"
+  - "benchbox/core/primitives/catalog/loader.py"
+  - "docs/development/read-primitives-catalog.md"
+  - "docs/development/read-primitives-skips-reference.md"
+  added:
+  - "tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py"
+  - "tests/integration/validation/test_read_primitives_variant_parity.py"
+
+must_preserve:
+- "Catalog variants remain final target SQL and continue to bypass SQLGlot retranslation in ReadPrimitivesBenchmark.get_queries()."
+- "Existing skip_on behavior continues to exclude unsupported queries without counting them as failures."
+- "Runnable but non-equivalent variants are skipped rather than retained as benchmark-comparable queries."
+
+approach: |
+  Start with the shared query catalog loader because read_primitives uses the
+  generic query catalog path. Add result contract parsing in a backward-compatible
+  way, then enforce the stricter contract only for read_primitives queries with
+  variants or high-risk nested/semi-structured outputs.
+
+  Use the existing variant tests in tests/unit/core/read_primitives as the local
+  pattern. Keep the first implementation focused on read_primitives; do not
+  generalize the policy to metadata_primitives or ai_primitives unless needed for
+  shared loader compatibility.
+
+anti_patterns:
+- "DO NOT keep related-but-not-equivalent fallbacks as comparable variants - because they produce misleading benchmark signals
+  - use semantics-preserving SQL or skip_on instead."
+- "DO NOT rely only on column-name equality - because nested JSON/array/struct shape can diverge behind identical aliases
+  - validate declared result_contract metadata."
+- "DO NOT rewrite variants through SQLGlot - because existing platform variants are authored as final target SQL - preserve
+  the current bypass behavior."
+- "DO NOT broaden runtime parity tests to live cloud platforms in this item - because credentials and live_integration approvals
+  are separate concerns - keep runtime checks local/optional."
+
+verification:
+- description: "Catalog loader and existing variant behavior still pass"
+  command: "uv run -- python -m pytest tests/unit/core/read_primitives/test_catalog_loader.py tests/unit/core/read_primitives/test_query_manager_variants.py
+    tests/unit/core/read_primitives/test_benchmark_variants.py -q"
+  expected_output: "all tests pass"
+- description: "New static comparability contracts pass"
+  command: "uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py -q"
+  expected_output: "all tests pass"
+- description: "Focused runtime parity tests pass or skip cleanly for missing optional engines"
+  command: "uv run -- python -m pytest tests/integration/validation/test_read_primitives_variant_parity.py -q"
+  expected_output: "tests pass; optional engines may skip when unavailable"
+- description: "TODO graph remains valid after this item is created"
+  command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+  expected_output: "no cycles or dangling dependencies"
+
+scope_limit:
+  do_not_modify:
+  - "benchbox/core/metadata_primitives/catalog/queries.yaml"
+  - "benchbox/core/ai_primitives/catalog/queries.yaml"
+  - "benchbox/core/runner/"
+  - "benchbox/cli/"
+
+metadata:
+  tags: ["read-primitives", "validation", "query-variants", "benchmark-integrity"]
+  estimated_effort: "Medium-Large"
+  created_date: "2026-04-29"
+
+success_metrics:
+- "Every read_primitives variant either satisfies a declared comparability contract or is skipped for that platform."
+- "Known divergent variants from the review are fixed or skipped."
+- "Static tests prevent future base/variant output shape drift."
+- "Focused runtime parity tests cover the highest-risk query families."

--- a/benchbox/core/primitives/catalog/loader.py
+++ b/benchbox/core/primitives/catalog/loader.py
@@ -15,10 +15,35 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from importlib import resources
+from inspect import Parameter, signature
 from typing import Any
 
 import yaml
+
+
+@dataclass(frozen=True)
+class ResultColumnContract:
+    """Contract for one projected query-result column."""
+
+    name: str
+    type_class: str = "scalar"
+    order_sensitive: bool = False
+
+
+@dataclass(frozen=True)
+class ResultContract:
+    """Machine-readable result shape and capability contract for query variants."""
+
+    columns: tuple[ResultColumnContract, ...]
+    row_identity: tuple[str, ...] = ()
+    capability: str | None = None
+
+
+_RESULT_CONTRACT_KEYS = {"columns", "row_identity", "capability"}
+_RESULT_COLUMN_CONTRACT_KEYS = {"name", "type_class", "order_sensitive"}
+_RESULT_TYPE_CLASSES = {"scalar", "json", "array", "struct", "map"}
 
 
 def load_operations_catalog(
@@ -176,6 +201,7 @@ def load_query_catalog(
         raise error_class(f"{label} query catalog must define a 'queries' list")
 
     queries: dict[str, Any] = {}
+    build_query_accepts_result_contract = _callable_accepts_keyword(build_query, "result_contract")
 
     for index, entry in enumerate(raw_entries):
         if not isinstance(entry, dict):
@@ -207,17 +233,171 @@ def load_query_catalog(
 
         variants = _parse_variants(entry, query_id, error_class)
         skip_on = _parse_skip_on(entry, query_id, error_class)
+        result_contract = _parse_result_contract(entry, query_id, error_class)
+
+        query_kwargs = {
+            "id": query_id,
+            "category": category,
+            "sql": raw_sql,
+            "description": description,
+            "variants": variants,
+            "skip_on": skip_on,
+        }
+        if build_query_accepts_result_contract:
+            query_kwargs["result_contract"] = result_contract
+        elif result_contract is not None:
+            raise error_class(
+                f"Catalog entry '{query_id}' declares result_contract, but this query model does not support it"
+            )
 
         queries[query_id] = build_query(
-            id=query_id,
-            category=category,
-            sql=raw_sql,
-            description=description,
-            variants=variants,
-            skip_on=skip_on,
+            **query_kwargs,
         )
 
     return build_catalog(version=version, queries=queries)
+
+
+def _callable_accepts_keyword(callable_obj: Any, keyword: str) -> bool:
+    """Return whether *callable_obj* can be called with *keyword*."""
+    try:
+        parameters = signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(parameter.kind == Parameter.VAR_KEYWORD or parameter.name == keyword for parameter in parameters)
+
+
+def _parse_result_contract(
+    entry: dict[str, Any],
+    query_id: str,
+    error_class: type[RuntimeError],
+) -> ResultContract | None:
+    """Parse optional result-shape contract metadata from a query entry."""
+    raw_contract = entry.get("result_contract")
+    if raw_contract is None:
+        return None
+
+    if not isinstance(raw_contract, dict):
+        raise error_class(f"Catalog entry '{query_id}' has invalid 'result_contract'; expected mapping")
+
+    unknown_keys = set(raw_contract) - _RESULT_CONTRACT_KEYS
+    if unknown_keys:
+        unknown = ", ".join(sorted(unknown_keys))
+        raise error_class(f"Catalog entry '{query_id}' result_contract has unknown field(s): {unknown}")
+
+    raw_columns = raw_contract.get("columns")
+    if not isinstance(raw_columns, list) or not raw_columns:
+        raise error_class(f"Catalog entry '{query_id}' result_contract.columns must be a non-empty list")
+
+    columns = tuple(
+        _parse_result_column_contract(column, query_id, index, error_class) for index, column in enumerate(raw_columns)
+    )
+    row_identity = _parse_result_contract_row_identity(
+        raw_contract,
+        query_id,
+        {column.name for column in columns},
+        error_class,
+    )
+    capability = _parse_optional_contract_string(raw_contract, "capability", query_id, error_class)
+
+    return ResultContract(columns=columns, row_identity=row_identity, capability=capability)
+
+
+def _parse_result_column_contract(
+    raw_column: Any,
+    query_id: str,
+    index: int,
+    error_class: type[RuntimeError],
+) -> ResultColumnContract:
+    """Parse one result_contract column entry."""
+    if isinstance(raw_column, str):
+        name = raw_column.strip()
+        if not name:
+            raise error_class(f"Catalog entry '{query_id}' result_contract column {index} must be non-empty")
+        return ResultColumnContract(name=name)
+
+    if not isinstance(raw_column, dict):
+        raise error_class(f"Catalog entry '{query_id}' result_contract column {index} must be a string or mapping")
+
+    unknown_keys = set(raw_column) - _RESULT_COLUMN_CONTRACT_KEYS
+    if unknown_keys:
+        unknown = ", ".join(sorted(unknown_keys))
+        raise error_class(f"Catalog entry '{query_id}' result_contract column {index} has unknown field(s): {unknown}")
+
+    name = _parse_contract_string_field(raw_column, "name", query_id, index, error_class)
+    type_class = raw_column.get("type_class", "scalar")
+    if not isinstance(type_class, str) or not type_class.strip():
+        raise error_class(
+            f"Catalog entry '{query_id}' result_contract column '{name}' type_class must be a non-empty string"
+        )
+    type_class = type_class.lower().strip()
+    if type_class not in _RESULT_TYPE_CLASSES:
+        allowed = ", ".join(sorted(_RESULT_TYPE_CLASSES))
+        raise error_class(
+            f"Catalog entry '{query_id}' result_contract column '{name}' type_class must be one of: {allowed}"
+        )
+
+    order_sensitive = raw_column.get("order_sensitive", False)
+    if not isinstance(order_sensitive, bool):
+        raise error_class(
+            f"Catalog entry '{query_id}' result_contract column '{name}' order_sensitive must be a boolean"
+        )
+
+    return ResultColumnContract(name=name, type_class=type_class, order_sensitive=order_sensitive)
+
+
+def _parse_result_contract_row_identity(
+    raw_contract: dict[str, Any],
+    query_id: str,
+    column_names: set[str],
+    error_class: type[RuntimeError],
+) -> tuple[str, ...]:
+    """Parse and validate result_contract.row_identity."""
+    raw_row_identity = raw_contract.get("row_identity", [])
+    if raw_row_identity is None:
+        return ()
+    if not isinstance(raw_row_identity, list):
+        raise error_class(f"Catalog entry '{query_id}' result_contract.row_identity must be a list")
+
+    row_identity = []
+    for index, column_name in enumerate(raw_row_identity):
+        if not isinstance(column_name, str) or not column_name.strip():
+            raise error_class(
+                f"Catalog entry '{query_id}' result_contract.row_identity entry {index} must be a non-empty string"
+            )
+        normalized = column_name.strip()
+        if normalized not in column_names:
+            raise error_class(
+                f"Catalog entry '{query_id}' result_contract.row_identity references unknown column '{normalized}'"
+            )
+        row_identity.append(normalized)
+    return tuple(row_identity)
+
+
+def _parse_contract_string_field(
+    payload: dict[str, Any],
+    field: str,
+    query_id: str,
+    index: int,
+    error_class: type[RuntimeError],
+) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise error_class(f"Catalog entry '{query_id}' result_contract column {index} must include non-empty '{field}'")
+    return value.strip()
+
+
+def _parse_optional_contract_string(
+    payload: dict[str, Any],
+    field: str,
+    query_id: str,
+    error_class: type[RuntimeError],
+) -> str | None:
+    value = payload.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise error_class(f"Catalog entry '{query_id}' result_contract.{field} must be a non-empty string")
+    return value.strip()
 
 
 # ---------------------------------------------------------------------------
@@ -367,6 +547,8 @@ def _parse_skip_on(
 
 
 __all__ = [
+    "ResultColumnContract",
+    "ResultContract",
     "load_operations_catalog",
     "load_query_catalog",
 ]

--- a/benchbox/core/read_primitives/catalog/__init__.py
+++ b/benchbox/core/read_primitives/catalog/__init__.py
@@ -1,10 +1,14 @@
 """Read Primitives query catalog utilities."""
 
+from benchbox.core.primitives.catalog.loader import ResultColumnContract, ResultContract
+
 from .loader import PrimitiveCatalog, PrimitiveQuery, PrimitivesCatalogError, load_primitives_catalog
 
 __all__ = [
     "PrimitiveCatalog",
     "PrimitiveQuery",
     "PrimitivesCatalogError",
+    "ResultColumnContract",
+    "ResultContract",
     "load_primitives_catalog",
 ]

--- a/benchbox/core/read_primitives/catalog/loader.py
+++ b/benchbox/core/read_primitives/catalog/loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from importlib import resources as _resources
 
-from benchbox.core.primitives.catalog.loader import load_query_catalog
+from benchbox.core.primitives.catalog.loader import ResultContract, load_query_catalog
 
 CATALOG_FILENAME = "queries.yaml"
 # Backward compatibility for tests that monkeypatch loader.resources.files.
@@ -26,6 +26,7 @@ class PrimitiveQuery:
     description: str | None = None
     variants: dict[str, str] | None = None  # dialect -> SQL mapping
     skip_on: list[str] | None = None  # list of dialects to skip this query on
+    result_contract: ResultContract | None = None
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,7 @@ __all__ = [
     "PrimitiveCatalog",
     "PrimitiveQuery",
     "PrimitivesCatalogError",
+    "ResultContract",
     "load_primitives_catalog",
     "resources",
 ]

--- a/benchbox/core/read_primitives/catalog/queries.yaml
+++ b/benchbox/core/read_primitives/catalog/queries.yaml
@@ -970,7 +970,7 @@ queries:
     FROM part
     WHERE MATCH(p_name, p_comment) AGAINST ('STEEL COPPER' IN NATURAL LANGUAGE MODE)
     LIMIT 100;
-  skip_on: [clickhouse, datafusion, duckdb, redshift]
+  skip_on: [bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake]
 - id: fulltext_boolean_search
   category: fulltext
   sql: |2
@@ -985,7 +985,7 @@ queries:
     WHERE MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE)
     ORDER BY relevance_score DESC
     LIMIT 50;
-  skip_on: [clickhouse, datafusion, duckdb, redshift]
+  skip_on: [bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake]
 - id: fulltext_phrase_search
   category: fulltext
   sql: |2
@@ -999,7 +999,7 @@ queries:
     FROM supplier
     WHERE MATCH(s_comment) AGAINST ('"Customer Complaints"' IN BOOLEAN MODE)
     ORDER BY phrase_match_score DESC;
-  skip_on: [clickhouse, datafusion, duckdb, redshift]
+  skip_on: [bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake]
 - id: statistical_percentiles
   category: statistical
   sql: |2
@@ -2827,6 +2827,25 @@ queries:
         type_class: array
         order_sensitive: true
   variants:
+    duckdb: |2
+
+      SELECT
+          o_orderkey,
+          ARRAY_AGG(
+              struct_pack(
+                  l_linenumber := l_linenumber,
+                  l_partkey := l_partkey,
+                  l_quantity := l_quantity,
+                  l_extendedprice := l_extendedprice
+              )
+              ORDER BY l_linenumber
+          ) as line_items
+      FROM orders o
+      JOIN lineitem l ON o.o_orderkey = l.l_orderkey
+      WHERE o_orderdate = DATE '1995-03-15'
+      GROUP BY o_orderkey
+      ORDER BY o_orderkey
+      LIMIT 50;
     clickhouse: |2
 
       SELECT

--- a/benchbox/core/read_primitives/catalog/queries.yaml
+++ b/benchbox/core/read_primitives/catalog/queries.yaml
@@ -813,6 +813,16 @@ queries:
     FROM lineitem
     WHERE l_orderkey <= 10000
     ORDER BY l_orderkey, price_rank;
+  result_contract:
+    capability: window_rank_distribution
+    columns:
+      - l_orderkey
+      - l_partkey
+      - l_quantity
+      - l_extendedprice
+      - price_rank
+      - quantity_percentile
+      - price_distribution
   variants:
     clickhouse: |2
 
@@ -913,24 +923,38 @@ queries:
 
     -- Create JSON array and object with JSON aggregate functions
     SELECT
+        p_brand,
         JSON_ARRAYAGG(p_name) as part_names,
         JSON_OBJECTAGG(p_partkey, p_retailprice) as part_prices,
         COUNT(*) as part_count
     FROM part
     WHERE p_type LIKE '%STEEL%'
     GROUP BY p_brand
+    ORDER BY p_brand
     LIMIT 100;
+  result_contract:
+    capability: json_array_object_aggregation
+    row_identity: [p_brand]
+    columns:
+      - p_brand
+      - name: part_names
+        type_class: json
+      - name: part_prices
+        type_class: json
+      - part_count
   variants:
     duckdb: |2
 
       -- DuckDB uses JSON_GROUP_ARRAY and JSON_GROUP_OBJECT instead
       SELECT
+          p_brand,
           JSON_GROUP_ARRAY(p_name) as part_names,
           JSON_GROUP_OBJECT(p_partkey, p_retailprice) as part_prices,
           COUNT(*) as part_count
       FROM part
       WHERE p_type LIKE '%STEEL%'
       GROUP BY p_brand
+      ORDER BY p_brand
       LIMIT 100;
   skip_on: [datafusion, redshift]
 - id: fulltext_simple_search
@@ -2214,17 +2238,28 @@ queries:
     FROM partsupp
     GROUP BY ps_suppkey
     HAVING COUNT(*) <= 10
+    ORDER BY ps_suppkey
     LIMIT 100;
+  result_contract:
+    capability: ordered_array_aggregation
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - name: supplied_parts
+        type_class: array
+        order_sensitive: true
+      - part_count
   variants:
     clickhouse: |2
 
       SELECT
           ps_suppkey,
-          groupArray(ps_partkey) as supplied_parts,
+          arraySort(groupArray(ps_partkey)) as supplied_parts,
           COUNT(*) as part_count
       FROM partsupp
       GROUP BY ps_suppkey
       HAVING COUNT(*) <= 10
+      ORDER BY ps_suppkey
       LIMIT 100;
   skip_on: [redshift]
 - id: array_agg_distinct
@@ -2237,12 +2272,20 @@ queries:
         ARRAY_AGG(DISTINCT c_nationkey ORDER BY c_nationkey) as nation_keys
     FROM customer
     GROUP BY c_mktsegment;
+  result_contract:
+    capability: ordered_distinct_array_aggregation
+    row_identity: [c_mktsegment]
+    columns:
+      - c_mktsegment
+      - name: nation_keys
+        type_class: array
+        order_sensitive: true
   variants:
     clickhouse: |2
 
       SELECT
           c_mktsegment,
-          groupUniqArray(c_nationkey) as nation_keys
+          arraySort(groupUniqArray(c_nationkey)) as nation_keys
       FROM customer
       GROUP BY c_mktsegment;
   skip_on: [redshift]
@@ -2263,6 +2306,12 @@ queries:
         ps_suppkey,
         UNNEST(parts) as part_key
     FROM supplier_parts;
+  result_contract:
+    capability: array_unnest
+    row_identity: [ps_suppkey, part_key]
+    columns:
+      - ps_suppkey
+      - part_key
   variants:
     bigquery: |2
 
@@ -2309,7 +2358,14 @@ queries:
         ps_suppkey,
         ARRAY_CONTAINS(parts, 100) as has_part_100
     FROM supplier_parts
+    ORDER BY ps_suppkey
     LIMIT 100;
+  result_contract:
+    capability: array_membership_predicate
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - has_part_100
   variants:
     duckdb: |2
 
@@ -2324,6 +2380,7 @@ queries:
           ps_suppkey,
           list_contains(parts, 100) as has_part_100
       FROM supplier_parts
+      ORDER BY ps_suppkey
       LIMIT 100;
     clickhouse: |2
 
@@ -2338,6 +2395,7 @@ queries:
           ps_suppkey,
           has(parts, 100) as has_part_100
       FROM supplier_parts
+      ORDER BY ps_suppkey
       LIMIT 100;
     bigquery: |2
 
@@ -2352,24 +2410,9 @@ queries:
           ps_suppkey,
           100 IN UNNEST(parts) as has_part_100
       FROM supplier_parts
+      ORDER BY ps_suppkey
       LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          ps_suppkey,
-          MAX(CASE WHEN ps_partkey = 100 THEN 1 ELSE 0 END) = 1 as has_part_100
-      FROM partsupp
-      GROUP BY ps_suppkey
-      LIMIT 100;
-    redshift: |2
-
-      -- Redshift has no native array type; use a scalar membership test
-      SELECT
-          ps_suppkey,
-          MAX(CASE WHEN ps_partkey = 100 THEN 1 ELSE 0 END) = 1 as has_part_100
-      FROM partsupp
-      GROUP BY ps_suppkey
-      LIMIT 100;
+  skip_on: [datafusion, redshift]
 - id: array_length
   category: array
   sql: |2
@@ -2386,8 +2429,14 @@ queries:
         ps_suppkey,
         CARDINALITY(parts) as num_parts
     FROM supplier_parts
-    ORDER BY num_parts DESC
+    ORDER BY num_parts DESC, ps_suppkey
     LIMIT 100;
+  result_contract:
+    capability: array_cardinality
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - num_parts
   variants:
     duckdb: |2
 
@@ -2402,7 +2451,7 @@ queries:
           ps_suppkey,
           len(parts) as num_parts
       FROM supplier_parts
-      ORDER BY num_parts DESC
+      ORDER BY num_parts DESC, ps_suppkey
       LIMIT 100;
     clickhouse: |2
 
@@ -2417,27 +2466,9 @@ queries:
           ps_suppkey,
           length(parts) as num_parts
       FROM supplier_parts
-      ORDER BY num_parts DESC
+      ORDER BY num_parts DESC, ps_suppkey
       LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          ps_suppkey,
-          COUNT(*) as num_parts
-      FROM partsupp
-      GROUP BY ps_suppkey
-      ORDER BY num_parts DESC
-      LIMIT 100;
-    redshift: |2
-
-      -- Redshift has no native array type; count parts directly
-      SELECT
-          ps_suppkey,
-          COUNT(*) as num_parts
-      FROM partsupp
-      GROUP BY ps_suppkey
-      ORDER BY num_parts DESC
-      LIMIT 100;
+  skip_on: [datafusion, redshift]
 - id: array_slice
   category: array
   sql: |2
@@ -2455,7 +2486,16 @@ queries:
         o_custkey,
         ARRAY_SLICE(prices, 1, 3) as top_3_orders
     FROM order_prices
+    ORDER BY o_custkey
     LIMIT 100;
+  result_contract:
+    capability: ordered_array_slice
+    row_identity: [o_custkey]
+    columns:
+      - o_custkey
+      - name: top_3_orders
+        type_class: array
+        order_sensitive: true
   variants:
     duckdb: |2
 
@@ -2471,6 +2511,7 @@ queries:
           o_custkey,
           prices[1:3] as top_3_orders
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
     clickhouse: |2
 
@@ -2486,6 +2527,7 @@ queries:
           o_custkey,
           arraySlice(prices, 1, 3) as top_3_orders
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
   skip_on: [redshift]
 - id: array_min_max
@@ -2505,7 +2547,15 @@ queries:
         ARRAY_MIN(prices) as min_order,
         ARRAY_MAX(prices) as max_order
     FROM order_prices
+    ORDER BY o_custkey
     LIMIT 100;
+  result_contract:
+    capability: array_min_max
+    row_identity: [o_custkey]
+    columns:
+      - o_custkey
+      - min_order
+      - max_order
   variants:
     duckdb: |2
 
@@ -2521,6 +2571,7 @@ queries:
           list_min(prices) as min_order,
           list_max(prices) as max_order
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
     clickhouse: |2
 
@@ -2536,27 +2587,9 @@ queries:
           arrayMin(prices) as min_order,
           arrayMax(prices) as max_order
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          o_custkey,
-          MIN(o_totalprice) as min_order,
-          MAX(o_totalprice) as max_order
-      FROM orders
-      GROUP BY o_custkey
-      LIMIT 100;
-    redshift: |2
-
-      -- Redshift has no native array type; compute min/max directly
-      SELECT
-          o_custkey,
-          MIN(o_totalprice) as min_order,
-          MAX(o_totalprice) as max_order
-      FROM orders
-      GROUP BY o_custkey
-      LIMIT 100;
-  skip_on: [bigquery]
+  skip_on: [bigquery, datafusion, redshift]
 - id: array_sort
   category: array
   sql: |2
@@ -2573,7 +2606,16 @@ queries:
         p_brand,
         ARRAY_SORT(sizes) as sorted_sizes
     FROM part_sizes
+    ORDER BY p_brand
     LIMIT 50;
+  result_contract:
+    capability: array_sort
+    row_identity: [p_brand]
+    columns:
+      - p_brand
+      - name: sorted_sizes
+        type_class: array
+        order_sensitive: true
   variants:
     duckdb: |2
 
@@ -2588,6 +2630,7 @@ queries:
           p_brand,
           list_sort(sizes) as sorted_sizes
       FROM part_sizes
+      ORDER BY p_brand
       LIMIT 50;
     clickhouse: |2
 
@@ -2602,6 +2645,7 @@ queries:
           p_brand,
           arraySort(sizes) as sorted_sizes
       FROM part_sizes
+      ORDER BY p_brand
       LIMIT 50;
   skip_on: [bigquery, redshift]
 - id: array_distinct
@@ -2620,7 +2664,15 @@ queries:
         l_orderkey,
         ARRAY_DISTINCT(modes) as unique_modes
     FROM ship_modes
+    ORDER BY l_orderkey
     LIMIT 100;
+  result_contract:
+    capability: distinct_array_values
+    row_identity: [l_orderkey]
+    columns:
+      - l_orderkey
+      - name: unique_modes
+        type_class: array
   variants:
     duckdb: |2
 
@@ -2635,6 +2687,7 @@ queries:
           l_orderkey,
           list_distinct(modes) as unique_modes
       FROM ship_modes
+      ORDER BY l_orderkey
       LIMIT 100;
     clickhouse: |2
 
@@ -2649,16 +2702,9 @@ queries:
           l_orderkey,
           arrayDistinct(modes) as unique_modes
       FROM ship_modes
+      ORDER BY l_orderkey
       LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          l_orderkey,
-          ARRAY_AGG(DISTINCT l_shipmode) as unique_modes
-      FROM lineitem
-      GROUP BY l_orderkey
-      LIMIT 100;
-  skip_on: [bigquery, redshift]
+  skip_on: [bigquery, datafusion, redshift]
 
 # ============================================================================
 # STRUCT type operations - composite data types
@@ -2675,7 +2721,16 @@ queries:
         c_acctbal
     FROM customer
     WHERE c_nationkey = 1
+    ORDER BY c_custkey
     LIMIT 100;
+  result_contract:
+    capability: positional_struct_construction
+    row_identity: [c_custkey]
+    columns:
+      - c_custkey
+      - name: contact_info
+        type_class: struct
+      - c_acctbal
   variants:
     clickhouse: |2
 
@@ -2685,6 +2740,7 @@ queries:
           c_acctbal
       FROM customer
       WHERE c_nationkey = 1
+      ORDER BY c_custkey
       LIMIT 100;
     duckdb: |2
 
@@ -2694,6 +2750,7 @@ queries:
           c_acctbal
       FROM customer
       WHERE c_nationkey = 1
+      ORDER BY c_custkey
       LIMIT 100;
   skip_on: [redshift]
 - id: struct_access
@@ -2714,7 +2771,15 @@ queries:
         info.balance
     FROM customer_info
     WHERE info.balance > 5000
+    ORDER BY c_custkey
     LIMIT 100;
+  result_contract:
+    capability: struct_field_access
+    row_identity: [c_custkey]
+    columns:
+      - c_custkey
+      - name
+      - balance
   variants:
     clickhouse: |2
 
@@ -2731,6 +2796,7 @@ queries:
           info.3 as balance
       FROM customer_info
       WHERE info.3 > 5000
+      ORDER BY c_custkey
       LIMIT 100;
   skip_on: [redshift]
 - id: array_of_struct
@@ -2748,17 +2814,30 @@ queries:
     JOIN lineitem l ON o.o_orderkey = l.l_orderkey
     WHERE o_orderdate = DATE '1995-03-15'
     GROUP BY o_orderkey
+    ORDER BY o_orderkey
     LIMIT 50;
+  result_contract:
+    capability: ordered_array_of_structs
+    row_identity: [o_orderkey]
+    columns:
+      - o_orderkey
+      - name: line_items
+        type_class: array
+        order_sensitive: true
   variants:
     clickhouse: |2
 
       SELECT
           o_orderkey,
-          groupArray(tuple(l_linenumber, l_partkey, l_quantity, l_extendedprice)) as line_items
+          arraySort(
+              x -> x.1,
+              groupArray(tuple(l_linenumber, l_partkey, l_quantity, l_extendedprice))
+          ) as line_items
       FROM orders o
       JOIN lineitem l ON o.o_orderkey = l.l_orderkey
       WHERE o_orderdate = '1995-03-15'
       GROUP BY o_orderkey
+      ORDER BY o_orderkey
       LIMIT 50;
   skip_on: [redshift]
 
@@ -2778,7 +2857,15 @@ queries:
         ) as part_costs
     FROM partsupp
     WHERE ps_suppkey <= 10
-    GROUP BY ps_suppkey;
+    GROUP BY ps_suppkey
+    ORDER BY ps_suppkey;
+  result_contract:
+    capability: map_construction
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - name: part_costs
+        type_class: map
   variants:
     duckdb: |2
 
@@ -2789,7 +2876,8 @@ queries:
           ) as part_costs
       FROM partsupp
       WHERE ps_suppkey <= 10
-      GROUP BY ps_suppkey;
+      GROUP BY ps_suppkey
+      ORDER BY ps_suppkey;
     datafusion: |2
 
       SELECT
@@ -2800,7 +2888,8 @@ queries:
           ) as part_costs
       FROM partsupp
       WHERE ps_suppkey <= 10
-      GROUP BY ps_suppkey;
+      GROUP BY ps_suppkey
+      ORDER BY ps_suppkey;
     clickhouse: |2
 
       SELECT
@@ -2811,7 +2900,8 @@ queries:
           ) as part_costs
       FROM partsupp
       WHERE ps_suppkey <= 10
-      GROUP BY ps_suppkey;
+      GROUP BY ps_suppkey
+      ORDER BY ps_suppkey;
   skip_on: [bigquery, redshift]
 - id: map_access
   category: map
@@ -2833,7 +2923,15 @@ queries:
         part_costs['1'] as cost_for_part_1,
         part_costs['5'] as cost_for_part_5
     FROM supplier_costs
+    ORDER BY ps_suppkey
     LIMIT 10;
+  result_contract:
+    capability: map_key_access
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - cost_for_part_1
+      - cost_for_part_5
   variants:
     datafusion: |2
 
@@ -2853,6 +2951,7 @@ queries:
           MAP_EXTRACT(part_costs, '1')[1] as cost_for_part_1,
           MAP_EXTRACT(part_costs, '5')[1] as cost_for_part_5
       FROM supplier_costs
+      ORDER BY ps_suppkey
       LIMIT 10;
   skip_on: [bigquery, redshift]
 - id: map_keys_values
@@ -2874,7 +2973,17 @@ queries:
         ps_suppkey,
         MAP_KEYS(part_costs) as part_ids,
         MAP_VALUES(part_costs) as costs
-    FROM supplier_costs;
+    FROM supplier_costs
+    ORDER BY ps_suppkey;
+  result_contract:
+    capability: map_keys_values
+    row_identity: [ps_suppkey]
+    columns:
+      - ps_suppkey
+      - name: part_ids
+        type_class: array
+      - name: costs
+        type_class: array
   variants:
     datafusion: |2
 
@@ -2893,7 +3002,8 @@ queries:
           ps_suppkey,
           MAP_KEYS(part_costs) as part_ids,
           MAP_VALUES(part_costs) as costs
-      FROM supplier_costs;
+      FROM supplier_costs
+      ORDER BY ps_suppkey;
     clickhouse: |2
 
       WITH supplier_costs AS (
@@ -2911,7 +3021,8 @@ queries:
           ps_suppkey,
           mapKeys(part_costs) as part_ids,
           mapValues(part_costs) as costs
-      FROM supplier_costs;
+      FROM supplier_costs
+      ORDER BY ps_suppkey;
   skip_on: [bigquery, redshift]
 
 # ============================================================================
@@ -2934,7 +3045,15 @@ queries:
         p_brand,
         TRANSFORM(prices, x -> x * 1.1) as prices_with_tax
     FROM part_prices
+    ORDER BY p_brand
     LIMIT 50;
+  result_contract:
+    capability: array_lambda_transform
+    row_identity: [p_brand]
+    columns:
+      - p_brand
+      - name: prices_with_tax
+        type_class: array
   variants:
     duckdb: |2
 
@@ -2949,6 +3068,7 @@ queries:
           p_brand,
           list_transform(prices, x -> x * 1.1) as prices_with_tax
       FROM part_prices
+      ORDER BY p_brand
       LIMIT 50;
     clickhouse: |2
 
@@ -2963,29 +3083,9 @@ queries:
           p_brand,
           arrayMap(x -> x * 1.1, prices) as prices_with_tax
       FROM part_prices
+      ORDER BY p_brand
       LIMIT 50;
-    datafusion: |2
-
-      WITH part_prices AS (
-          SELECT
-              p_brand,
-              ARRAY_AGG(p_retailprice) as prices
-          FROM part
-          GROUP BY p_brand
-      ),
-      exploded AS (
-          SELECT
-              p_brand,
-              UNNEST(prices) as price
-          FROM part_prices
-      )
-      SELECT
-          p_brand,
-          ARRAY_AGG(price * 1.1) as prices_with_tax
-      FROM exploded
-      GROUP BY p_brand
-      LIMIT 50;
-  skip_on: [bigquery, redshift]
+  skip_on: [bigquery, datafusion, redshift]
 - id: list_filter
   category: lambda
   sql: |2
@@ -3002,7 +3102,15 @@ queries:
         o_custkey,
         FILTER(prices, x -> x > 100000) as large_orders
     FROM order_prices
+    ORDER BY o_custkey
     LIMIT 100;
+  result_contract:
+    capability: array_lambda_filter
+    row_identity: [o_custkey]
+    columns:
+      - o_custkey
+      - name: large_orders
+        type_class: array
   variants:
     duckdb: |2
 
@@ -3017,6 +3125,7 @@ queries:
           o_custkey,
           list_filter(prices, x -> x > 100000) as large_orders
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
     clickhouse: |2
 
@@ -3031,30 +3140,9 @@ queries:
           o_custkey,
           arrayFilter(x -> x > 100000, prices) as large_orders
       FROM order_prices
+      ORDER BY o_custkey
       LIMIT 100;
-    datafusion: |2
-
-      WITH order_prices AS (
-          SELECT
-              o_custkey,
-              ARRAY_AGG(o_totalprice) as prices
-          FROM orders
-          GROUP BY o_custkey
-      ),
-      exploded AS (
-          SELECT
-              o_custkey,
-              UNNEST(prices) as price
-          FROM order_prices
-      )
-      SELECT
-          o_custkey,
-          ARRAY_AGG(price) as large_orders
-      FROM exploded
-      WHERE price > 100000
-      GROUP BY o_custkey
-      LIMIT 100;
-  skip_on: [bigquery, redshift]
+  skip_on: [bigquery, datafusion, redshift]
 - id: list_reduce
   category: lambda
   sql: |2
@@ -3071,7 +3159,14 @@ queries:
         l_orderkey,
         REDUCE(qtys, 0, (acc, x) -> acc + x) as total_qty
     FROM quantities
+    ORDER BY l_orderkey
     LIMIT 100;
+  result_contract:
+    capability: array_lambda_reduce
+    row_identity: [l_orderkey]
+    columns:
+      - l_orderkey
+      - total_qty
   variants:
     duckdb: |2
 
@@ -3086,6 +3181,7 @@ queries:
           l_orderkey,
           list_reduce(qtys, (acc, x) -> acc + x) as total_qty
       FROM quantities
+      ORDER BY l_orderkey
       LIMIT 100;
     clickhouse: |2
 
@@ -3100,29 +3196,9 @@ queries:
           l_orderkey,
           arrayReduce('sum', qtys) as total_qty
       FROM quantities
+      ORDER BY l_orderkey
       LIMIT 100;
-    datafusion: |2
-
-      WITH quantities AS (
-          SELECT
-              l_orderkey,
-              ARRAY_AGG(l_quantity) as qtys
-          FROM lineitem
-          GROUP BY l_orderkey
-      ),
-      exploded AS (
-          SELECT
-              l_orderkey,
-              UNNEST(qtys) as qty
-          FROM quantities
-      )
-      SELECT
-          l_orderkey,
-          SUM(qty) as total_qty
-      FROM exploded
-      GROUP BY l_orderkey
-      LIMIT 100;
-  skip_on: [bigquery, redshift]
+  skip_on: [bigquery, datafusion, redshift]
 
 # ============================================================================
 # ASOF JOIN - time series fuzzy temporal lookups
@@ -3145,7 +3221,16 @@ queries:
         AND l.l_shipdate >= o.o_orderdate
     WHERE l.l_shipdate >= DATE '1995-01-01'
       AND l.l_shipdate < DATE '1995-02-01'
+    ORDER BY l.l_orderkey, l.l_shipdate
     LIMIT 100;
+  result_contract:
+    capability: asof_temporal_join
+    columns:
+      - l_orderkey
+      - l_shipdate
+      - o_orderdate
+      - o_totalprice
+      - days_to_ship
   variants:
     snowflake: |2
 
@@ -3161,23 +3246,9 @@ queries:
           ON l.l_orderkey = o.o_orderkey
       WHERE l.l_shipdate >= DATE '1995-01-01'
         AND l.l_shipdate < DATE '1995-02-01'
+      ORDER BY l.l_orderkey, l.l_shipdate
       LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          l.l_orderkey,
-          l.l_shipdate,
-          o.o_orderdate,
-          o.o_totalprice,
-          l.l_shipdate - o.o_orderdate as days_to_ship
-      FROM lineitem l
-      ASOF JOIN orders o
-          MATCH_CONDITION (l.l_shipdate >= o.o_orderdate)
-          ON l.l_orderkey = o.o_orderkey
-      WHERE l.l_shipdate >= DATE '1995-01-01'
-        AND l.l_shipdate < DATE '1995-02-01'
-      LIMIT 100;
-  skip_on: [bigquery, databricks, redshift]
+  skip_on: [bigquery, datafusion, databricks, redshift]
 
 # ============================================================================
 # PIVOT/UNPIVOT operations - row-to-column and column-to-row transformations
@@ -3384,7 +3455,15 @@ queries:
     SELECT l_orderkey, l_returnflag, l_quantity,
            RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank
     FROM lineitem
-    QUALIFY RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) <= 5;
+    QUALIFY RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) <= 5
+    ORDER BY l_returnflag, qty_rank, l_orderkey;
+  result_contract:
+    capability: qualify_rank_filter
+    columns:
+      - l_orderkey
+      - l_returnflag
+      - l_quantity
+      - qty_rank
   variants:
     datafusion: |2
 
@@ -3394,7 +3473,8 @@ queries:
                  RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank
           FROM lineitem
       ) ranked
-      WHERE qty_rank <= 5;
+      WHERE qty_rank <= 5
+      ORDER BY l_returnflag, qty_rank, l_orderkey;
     redshift: |2
 
       -- Redshift QUALIFY with RANK requires subquery workaround
@@ -3404,7 +3484,8 @@ queries:
                  RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank
           FROM lineitem
       ) ranked
-      WHERE qty_rank <= 5;
+      WHERE qty_rank <= 5
+      ORDER BY l_returnflag, qty_rank, l_orderkey;
 
 - id: window_sum
   category: window

--- a/benchbox/core/read_primitives/catalog/queries.yaml
+++ b/benchbox/core/read_primitives/catalog/queries.yaml
@@ -449,15 +449,7 @@ queries:
         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l_quantity) as median_quantity
     FROM lineitem
     GROUP BY l_shipmode;
-  variants:
-    clickhouse: |2
-
-      -- ClickHouse uses quantile(0.5)(col) instead of PERCENTILE_CONT WITHIN GROUP
-      SELECT
-          l_shipmode,
-          quantile(0.5)(l_quantity) as median_quantity
-      FROM lineitem
-      GROUP BY l_shipmode;
+  skip_on: [clickhouse]
 - id: intrinsic_to_date
   category: intrinsic
   sql: |2
@@ -864,27 +856,7 @@ queries:
     WHERE o_orderdate >= DATE '1995-01-01'
       AND o_orderdate < DATE '1996-01-01'
     ORDER BY o_orderdate;
-  variants:
-    clickhouse: |2
-
-      -- ClickHouse does not support RANGE BETWEEN INTERVAL ... PRECEDING; use ROWS BETWEEN instead
-      SELECT
-          o_orderkey,
-          o_orderdate,
-          o_totalprice,
-          AVG(o_totalprice) OVER (
-              ORDER BY o_orderdate
-              ROWS BETWEEN 5 PRECEDING AND CURRENT ROW
-          ) as moving_avg_6_orders,
-          SUM(o_totalprice) OVER (
-              ORDER BY o_orderdate
-              ROWS BETWEEN 30 PRECEDING AND CURRENT ROW
-          ) as monthly_running_total
-      FROM orders
-      WHERE o_orderdate >= toDate('1995-01-01')
-        AND o_orderdate < toDate('1996-01-01')
-      ORDER BY o_orderdate;
-  skip_on: [redshift]
+  skip_on: [clickhouse, redshift]
 - id: window_unbounded_frame
   category: window
   sql: |2
@@ -974,54 +946,7 @@ queries:
     FROM part
     WHERE MATCH(p_name, p_comment) AGAINST ('STEEL COPPER' IN NATURAL LANGUAGE MODE)
     LIMIT 100;
-  variants:
-    duckdb: |2
-
-      -- DuckDB doesn't support MATCH...AGAINST, use LIKE instead
-      SELECT
-          p_partkey,
-          p_name,
-          p_mfgr,
-          p_comment
-      FROM part
-      WHERE p_name LIKE '%STEEL%' OR p_name LIKE '%COPPER%'
-         OR p_comment LIKE '%STEEL%' OR p_comment LIKE '%COPPER%'
-      LIMIT 100;
-    datafusion: |2
-
-      SELECT
-          p_partkey,
-          p_name,
-          p_mfgr,
-          p_comment
-      FROM part
-      WHERE p_name LIKE '%STEEL%' OR p_name LIKE '%COPPER%'
-         OR p_comment LIKE '%STEEL%' OR p_comment LIKE '%COPPER%'
-      LIMIT 100;
-    redshift: |2
-
-      -- Redshift doesn't support MATCH...AGAINST, use LIKE instead
-      SELECT
-          p_partkey,
-          p_name,
-          p_mfgr,
-          p_comment
-      FROM part
-      WHERE p_name LIKE '%STEEL%' OR p_name LIKE '%COPPER%'
-         OR p_comment LIKE '%STEEL%' OR p_comment LIKE '%COPPER%'
-      LIMIT 100;
-    clickhouse: |2
-
-      -- ClickHouse doesn't support MATCH...AGAINST, use LIKE instead
-      SELECT
-          p_partkey,
-          p_name,
-          p_mfgr,
-          p_comment
-      FROM part
-      WHERE p_name LIKE '%STEEL%' OR p_name LIKE '%COPPER%'
-         OR p_comment LIKE '%STEEL%' OR p_comment LIKE '%COPPER%'
-      LIMIT 100;
+  skip_on: [clickhouse, datafusion, duckdb, redshift]
 - id: fulltext_boolean_search
   category: fulltext
   sql: |2
@@ -1036,50 +961,7 @@ queries:
     WHERE MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE)
     ORDER BY relevance_score DESC
     LIMIT 50;
-  variants:
-    duckdb: |2
-
-      -- DuckDB doesn't support MATCH...AGAINST, use LIKE with AND/NOT logic
-      SELECT
-          c_custkey,
-          c_name,
-          c_comment
-      FROM customer
-      WHERE c_comment LIKE '%BUILDING%'
-        AND c_comment NOT LIKE '%FURNITURE%'
-      LIMIT 50;
-    datafusion: |2
-
-      SELECT
-          c_custkey,
-          c_name,
-          c_comment
-      FROM customer
-      WHERE c_comment LIKE '%BUILDING%'
-        AND c_comment NOT LIKE '%FURNITURE%'
-      LIMIT 50;
-    redshift: |2
-
-      -- Redshift doesn't support MATCH...AGAINST, use LIKE with AND/NOT logic
-      SELECT
-          c_custkey,
-          c_name,
-          c_comment
-      FROM customer
-      WHERE c_comment LIKE '%BUILDING%'
-        AND c_comment NOT LIKE '%FURNITURE%'
-      LIMIT 50;
-    clickhouse: |2
-
-      -- ClickHouse doesn't support MATCH...AGAINST, use LIKE with AND/NOT logic
-      SELECT
-          c_custkey,
-          c_name,
-          c_comment
-      FROM customer
-      WHERE c_comment LIKE '%BUILDING%'
-        AND c_comment NOT LIKE '%FURNITURE%'
-      LIMIT 50;
+  skip_on: [clickhouse, datafusion, duckdb, redshift]
 - id: fulltext_phrase_search
   category: fulltext
   sql: |2
@@ -1093,46 +975,7 @@ queries:
     FROM supplier
     WHERE MATCH(s_comment) AGAINST ('"Customer Complaints"' IN BOOLEAN MODE)
     ORDER BY phrase_match_score DESC;
-  variants:
-    duckdb: |2
-
-      -- DuckDB doesn't support MATCH...AGAINST, use LIKE with exact phrase
-      SELECT
-          s_suppkey,
-          s_name,
-          s_comment
-      FROM supplier
-      WHERE s_comment LIKE '%Customer Complaints%'
-      ORDER BY s_suppkey;
-    datafusion: |2
-
-      SELECT
-          s_suppkey,
-          s_name,
-          s_comment
-      FROM supplier
-      WHERE s_comment LIKE '%Customer Complaints%'
-      ORDER BY s_suppkey;
-    redshift: |2
-
-      -- Redshift doesn't support MATCH...AGAINST, use LIKE with exact phrase
-      SELECT
-          s_suppkey,
-          s_name,
-          s_comment
-      FROM supplier
-      WHERE s_comment LIKE '%Customer Complaints%'
-      ORDER BY s_suppkey;
-    clickhouse: |2
-
-      -- ClickHouse doesn't support MATCH...AGAINST, use LIKE with exact phrase
-      SELECT
-          s_suppkey,
-          s_name,
-          s_comment
-      FROM supplier
-      WHERE s_comment LIKE '%Customer Complaints%'
-      ORDER BY s_suppkey;
+  skip_on: [clickhouse, datafusion, duckdb, redshift]
 - id: statistical_percentiles
   category: statistical
   sql: |2
@@ -1148,20 +991,18 @@ queries:
         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) as price_p95
     FROM lineitem
     GROUP BY l_returnflag, l_linestatus;
+  result_contract:
+    capability: exact_continuous_percentiles
+    row_identity: [l_returnflag, l_linestatus]
+    columns:
+      - l_returnflag
+      - l_linestatus
+      - record_count
+      - quantity_q1
+      - quantity_median
+      - quantity_q3
+      - price_p95
   variants:
-    clickhouse: |2
-
-      -- ClickHouse uses quantile(p)(col) instead of PERCENTILE_CONT WITHIN GROUP
-      SELECT
-          l_returnflag,
-          l_linestatus,
-          COUNT(*) as record_count,
-          quantile(0.25)(l_quantity) as quantity_q1,
-          quantile(0.5)(l_quantity) as quantity_median,
-          quantile(0.75)(l_quantity) as quantity_q3,
-          quantile(0.95)(l_extendedprice) as price_p95
-      FROM lineitem
-      GROUP BY l_returnflag, l_linestatus;
     redshift: |2
 
       -- Redshift supports PERCENTILE_CONT only as a window function, not aggregate
@@ -1174,6 +1015,7 @@ queries:
           PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_q3,
           PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) OVER (PARTITION BY l_returnflag, l_linestatus) as price_p95
       FROM lineitem;
+  skip_on: [clickhouse]
 - id: statistical_variance_stddev
   category: statistical
   sql: |2
@@ -1206,6 +1048,15 @@ queries:
     FROM lineitem
     WHERE l_shipdate >= DATE '1995-01-01'
       AND l_shipdate < DATE '1996-01-01';
+  result_contract:
+    capability: correlation_covariance_regression
+    columns:
+      - qty_price_correlation
+      - qty_discount_covariance
+      - tax_price_covariance
+      - price_qty_slope
+      - price_qty_intercept
+      - regression_r_squared
   variants:
     clickhouse: |2
 
@@ -1269,22 +1120,49 @@ queries:
   sql: |2
 
     -- Time series trend analysis with linear regression
-    SELECT
+    WITH monthly_totals AS (
+      SELECT
         DATE_TRUNC('month', o_orderdate) as order_month,
         COUNT(*) as order_count,
         SUM(o_totalprice) as monthly_revenue,
         AVG(o_totalprice) as avg_order_value,
-        -- Linear trend calculation
-        REGR_SLOPE(SUM(o_totalprice), EXTRACT(EPOCH FROM o_orderdate)) as revenue_trend_slope,
-        -- Month-over-month growth
-        LAG(SUM(o_totalprice), 1) OVER (ORDER BY DATE_TRUNC('month', o_orderdate)) as prev_month_revenue,
-        (SUM(o_totalprice) - LAG(SUM(o_totalprice), 1) OVER (ORDER BY DATE_TRUNC('month', o_orderdate)))
-        / NULLIF(LAG(SUM(o_totalprice), 1) OVER (ORDER BY DATE_TRUNC('month', o_orderdate)), 0) * 100 as mom_growth_pct
-    FROM orders
-    WHERE o_orderdate >= DATE '1995-01-01'
-      AND o_orderdate < DATE '1997-01-01'
-    GROUP BY DATE_TRUNC('month', o_orderdate)
+        EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch
+      FROM orders
+      WHERE o_orderdate >= DATE '1995-01-01'
+        AND o_orderdate < DATE '1997-01-01'
+      GROUP BY DATE_TRUNC('month', o_orderdate)
+    ),
+    monthly_with_lag AS (
+      SELECT
+        order_month,
+        order_count,
+        monthly_revenue,
+        avg_order_value,
+        month_epoch,
+        LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue
+      FROM monthly_totals
+    )
+    SELECT
+      order_month,
+      order_count,
+      monthly_revenue,
+      avg_order_value,
+      REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,
+      prev_month_revenue,
+      (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct
+    FROM monthly_with_lag
     ORDER BY order_month;
+  result_contract:
+    capability: monthly_time_series_regression
+    row_identity: [order_month]
+    columns:
+      - order_month
+      - order_count
+      - monthly_revenue
+      - avg_order_value
+      - revenue_trend_slope
+      - prev_month_revenue
+      - mom_growth_pct
   variants:
     duckdb: |2
 
@@ -2158,6 +2036,13 @@ queries:
         COUNT(*) as customer_count
     FROM customer
     GROUP BY c_mktsegment;
+  result_contract:
+    capability: arbitrary_value_aggregate
+    row_identity: [c_mktsegment]
+    columns:
+      - c_mktsegment
+      - sample_customer
+      - customer_count
   variants:
     clickhouse: |2
 
@@ -2167,14 +2052,7 @@ queries:
           COUNT(*) as customer_count
       FROM customer
       GROUP BY c_mktsegment;
-    datafusion: |2
-
-      SELECT
-          c_mktsegment,
-          MIN(c_name) as sample_customer,
-          COUNT(*) as customer_count
-      FROM customer
-      GROUP BY c_mktsegment;
+  skip_on: [datafusion]
 - id: any_value_with_filter
   category: aggregation
   sql: |2
@@ -2187,6 +2065,14 @@ queries:
         COUNT(*) as nation_count
     FROM nation
     GROUP BY n_regionkey;
+  result_contract:
+    capability: arbitrary_value_aggregate
+    row_identity: [n_regionkey]
+    columns:
+      - n_regionkey
+      - sample_nation
+      - sample_comment
+      - nation_count
   variants:
     clickhouse: |2
 
@@ -2197,15 +2083,7 @@ queries:
           COUNT(*) as nation_count
       FROM nation
       GROUP BY n_regionkey;
-    datafusion: |2
-
-      SELECT
-          n_regionkey,
-          MIN(n_name) as sample_nation,
-          MIN(n_comment) as sample_comment,
-          COUNT(*) as nation_count
-      FROM nation
-      GROUP BY n_regionkey;
+  skip_on: [datafusion]
 
 # GROUP BY ALL - automatic grouping by all non-aggregate columns
 - id: groupby_all_simple

--- a/benchbox/core/read_primitives/catalog/queries.yaml
+++ b/benchbox/core/read_primitives/catalog/queries.yaml
@@ -2271,7 +2271,8 @@ queries:
         c_mktsegment,
         ARRAY_AGG(DISTINCT c_nationkey ORDER BY c_nationkey) as nation_keys
     FROM customer
-    GROUP BY c_mktsegment;
+    GROUP BY c_mktsegment
+    ORDER BY c_mktsegment;
   result_contract:
     capability: ordered_distinct_array_aggregation
     row_identity: [c_mktsegment]
@@ -2287,7 +2288,8 @@ queries:
           c_mktsegment,
           arraySort(groupUniqArray(c_nationkey)) as nation_keys
       FROM customer
-      GROUP BY c_mktsegment;
+      GROUP BY c_mktsegment
+      ORDER BY c_mktsegment;
   skip_on: [redshift]
 - id: array_unnest
   category: array
@@ -2831,7 +2833,12 @@ queries:
           o_orderkey,
           arraySort(
               x -> x.1,
-              groupArray(tuple(l_linenumber, l_partkey, l_quantity, l_extendedprice))
+              groupArray(
+                  CAST(
+                      (l_linenumber, l_partkey, l_quantity, l_extendedprice),
+                      'Tuple(l_linenumber Int32, l_partkey Int32, l_quantity Decimal(15,2), l_extendedprice Decimal(15,2))'
+                  )
+              )
           ) as line_items
       FROM orders o
       JOIN lineitem l ON o.o_orderkey = l.l_orderkey

--- a/benchbox/core/read_primitives/variant_contracts.py
+++ b/benchbox/core/read_primitives/variant_contracts.py
@@ -45,6 +45,8 @@ _HIGH_RISK_CATEGORIES = {
 _HIGH_RISK_QUERY_IDS = {
     "any_value_simple",
     "any_value_with_filter",
+    # Guard for future approximate-median variants: no active variant exists
+    # today, but any reintroduced variant must declare its comparability contract.
     "intrinsic_appx_median",
 }
 
@@ -74,7 +76,19 @@ def collect_variant_contract_issues(
             )
 
         issues.extend(_contract_metadata_issues(query_id, entry, base_columns, require_contracts=require_contracts))
-        issues.extend(_variant_projection_issues(query_id, variants, base_columns))
+        contract_columns = (
+            tuple(column.name for column in entry.result_contract.columns)
+            if entry.result_contract is not None
+            else None
+        )
+        issues.extend(
+            _variant_projection_issues(
+                query_id,
+                variants,
+                expected_columns=contract_columns or base_columns,
+                expected_source="result_contract" if contract_columns is not None else "base",
+            )
+        )
 
     return issues
 
@@ -148,7 +162,9 @@ def _contract_metadata_issues(
 def _variant_projection_issues(
     query_id: str,
     variants: dict[str, str],
-    base_columns: tuple[str, ...] | None,
+    *,
+    expected_columns: tuple[str, ...] | None,
+    expected_source: str,
 ) -> list[VariantContractIssue]:
     issues = []
     for dialect, sql in variants.items():
@@ -162,13 +178,13 @@ def _variant_projection_issues(
                     detail="Could not parse variant projection columns",
                 )
             )
-        elif base_columns is not None and variant_columns != base_columns:
+        elif expected_columns is not None and variant_columns != expected_columns:
             issues.append(
                 VariantContractIssue(
                     query_id=query_id,
                     dialect=dialect,
                     kind="column_mismatch",
-                    detail=f"base columns {base_columns!r} != variant columns {variant_columns!r}",
+                    detail=(f"{expected_source} columns {expected_columns!r} != variant columns {variant_columns!r}"),
                 )
             )
     return issues

--- a/benchbox/core/read_primitives/variant_contracts.py
+++ b/benchbox/core/read_primitives/variant_contracts.py
@@ -1,0 +1,203 @@
+"""Static checks for read_primitives query variant comparability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import sqlglot
+from sqlglot import exp
+
+if TYPE_CHECKING:
+    from benchbox.core.read_primitives.catalog import PrimitiveCatalog, PrimitiveQuery
+
+
+@dataclass(frozen=True)
+class VariantContractIssue:
+    """One static comparability issue for a base query or platform variant."""
+
+    query_id: str
+    dialect: str | None
+    kind: str
+    detail: str
+
+
+_DIALECT_READ = {
+    "bigquery": "bigquery",
+    "clickhouse": "clickhouse",
+    "duckdb": "duckdb",
+    "redshift": "redshift",
+    "snowflake": "snowflake",
+}
+
+_HIGH_RISK_CATEGORIES = {
+    "array",
+    "fulltext",
+    "json",
+    "lambda",
+    "map",
+    "statistical",
+    "struct",
+    "timeseries",
+    "window",
+}
+
+_HIGH_RISK_QUERY_IDS = {
+    "any_value_simple",
+    "any_value_with_filter",
+    "intrinsic_appx_median",
+}
+
+
+def collect_variant_contract_issues(
+    catalog: PrimitiveCatalog,
+    *,
+    require_contracts: bool = True,
+) -> list[VariantContractIssue]:
+    """Return static comparability issues for read_primitives platform variants."""
+    issues: list[VariantContractIssue] = []
+
+    for query_id, entry in catalog.queries.items():
+        variants = entry.variants or {}
+        if not variants:
+            continue
+
+        base_columns = extract_projection_names(entry.sql, dialect="duckdb")
+        if base_columns is None:
+            issues.append(
+                VariantContractIssue(
+                    query_id=query_id,
+                    dialect=None,
+                    kind="base_parse_error",
+                    detail="Could not parse base query projection columns",
+                )
+            )
+
+        issues.extend(_contract_metadata_issues(query_id, entry, base_columns, require_contracts=require_contracts))
+        issues.extend(_variant_projection_issues(query_id, variants, base_columns))
+
+    return issues
+
+
+def extract_projection_names(sql: str, *, dialect: str) -> tuple[str, ...] | None:
+    """Return top-level projection names for *sql*, or None when unsupported."""
+    try:
+        expression = sqlglot.parse_one(sql, read=_DIALECT_READ.get(dialect, "duckdb"))
+    except sqlglot.errors.SqlglotError:
+        return None
+
+    select = expression if isinstance(expression, exp.Select) else expression.find(exp.Select)
+    if select is None:
+        return None
+
+    projections = _resolve_star_wrapper_projections(select)
+    names = []
+    for projection in projections:
+        if isinstance(projection, exp.Star):
+            return None
+        name = projection.alias_or_name or projection.output_name
+        if not name:
+            return None
+        names.append(name)
+    return tuple(names)
+
+
+def _contract_metadata_issues(
+    query_id: str,
+    entry: PrimitiveQuery,
+    base_columns: tuple[str, ...] | None,
+    *,
+    require_contracts: bool,
+) -> list[VariantContractIssue]:
+    contract = entry.result_contract
+    if contract is None:
+        if require_contracts and _requires_result_contract(entry):
+            return [
+                VariantContractIssue(
+                    query_id=query_id,
+                    dialect=None,
+                    kind="missing_result_contract",
+                    detail="High-risk variant-bearing query must declare result_contract",
+                )
+            ]
+        return []
+
+    issues = []
+    contract_columns = tuple(column.name for column in contract.columns)
+    if base_columns is not None and contract_columns != base_columns:
+        issues.append(
+            VariantContractIssue(
+                query_id=query_id,
+                dialect=None,
+                kind="contract_column_mismatch",
+                detail=f"base columns {base_columns!r} != result_contract columns {contract_columns!r}",
+            )
+        )
+    if not contract.capability:
+        issues.append(
+            VariantContractIssue(
+                query_id=query_id,
+                dialect=None,
+                kind="missing_capability",
+                detail="result_contract must declare measured capability",
+            )
+        )
+    return issues
+
+
+def _variant_projection_issues(
+    query_id: str,
+    variants: dict[str, str],
+    base_columns: tuple[str, ...] | None,
+) -> list[VariantContractIssue]:
+    issues = []
+    for dialect, sql in variants.items():
+        variant_columns = extract_projection_names(sql, dialect=dialect)
+        if variant_columns is None:
+            issues.append(
+                VariantContractIssue(
+                    query_id=query_id,
+                    dialect=dialect,
+                    kind="variant_parse_error",
+                    detail="Could not parse variant projection columns",
+                )
+            )
+        elif base_columns is not None and variant_columns != base_columns:
+            issues.append(
+                VariantContractIssue(
+                    query_id=query_id,
+                    dialect=dialect,
+                    kind="column_mismatch",
+                    detail=f"base columns {base_columns!r} != variant columns {variant_columns!r}",
+                )
+            )
+    return issues
+
+
+def _resolve_star_wrapper_projections(select: exp.Select) -> list[exp.Expression]:
+    projections = list(select.expressions)
+    if len(projections) != 1 or not isinstance(projections[0], exp.Star):
+        return projections
+
+    from_clause = select.args.get("from_")
+    if from_clause is None:
+        return projections
+    source = from_clause.this
+    if not isinstance(source, exp.Subquery):
+        return projections
+
+    inner_select = source.this.find(exp.Select)
+    if inner_select is None:
+        return projections
+    return list(inner_select.expressions)
+
+
+def _requires_result_contract(entry: PrimitiveQuery) -> bool:
+    return entry.category in _HIGH_RISK_CATEGORIES or entry.id in _HIGH_RISK_QUERY_IDS
+
+
+__all__ = [
+    "VariantContractIssue",
+    "collect_variant_contract_issues",
+    "extract_projection_names",
+]

--- a/docs/development/read-primitives-catalog.md
+++ b/docs/development/read-primitives-catalog.md
@@ -4,7 +4,7 @@
 ```
 
 The Read Primitives benchmark queries now live outside Python source in
-`benchbox/core/primitives/catalog/queries.yaml`. This keeps the runtime module
+`benchbox/core/read_primitives/catalog/queries.yaml`. This keeps the runtime module
 small and makes it easier to audit or extend the workload.
 
 ## File layout
@@ -27,6 +27,8 @@ default to the `id` prefix.
 * `description` (optional) - free-form text for future tooling.
 * `variants` (optional) - dict mapping dialect names to platform-specific SQL.
 * `skip_on` (optional) - list of dialects where this query should be skipped.
+* `result_contract` (required for high-risk variant queries) - machine-readable
+  result shape and measured capability metadata.
 
 ## Platform-Specific Variants
 
@@ -42,29 +44,77 @@ Define alternative SQL for specific platforms using the `variants` field:
   sql: |-
     -- Standard SQL version (MySQL syntax)
     SELECT
+        p_brand,
         JSON_ARRAYAGG(p_name) as part_names,
-        JSON_OBJECTAGG(p_partkey, p_retailprice) as part_prices
+        JSON_OBJECTAGG(p_partkey, p_retailprice) as part_prices,
+        COUNT(*) as part_count
     FROM part
+    GROUP BY p_brand
+    ORDER BY p_brand
     LIMIT 100
+  result_contract:
+    capability: json_array_object_aggregation
+    row_identity: [p_brand]
+    columns:
+      - p_brand
+      - name: part_names
+        type_class: json
+      - name: part_prices
+        type_class: json
+      - part_count
   variants:
     duckdb: |-
       -- DuckDB uses different function names
       SELECT
+          p_brand,
           JSON_GROUP_ARRAY(p_name) as part_names,
-          JSON_GROUP_OBJECT(p_partkey, p_retailprice) as part_prices
+          JSON_GROUP_OBJECT(p_partkey, p_retailprice) as part_prices,
+          COUNT(*) as part_count
       FROM part
+      GROUP BY p_brand
+      ORDER BY p_brand
       LIMIT 100
 ```
 
 **When to use variants:**
 - Platform uses different function names (e.g., `JSON_ARRAYAGG` vs `JSON_GROUP_ARRAY`)
-- Platform requires different syntax for same functionality (e.g., `MATCH...AGAINST` vs `LIKE`)
+- Platform requires different syntax for the same functionality
 - Query needs structural changes but tests same capability (e.g., CTE to avoid nested aggregates)
+- Output columns, row identity, nested shape, and measured capability remain comparable
 
 **How it works:**
 1. When `get_query(query_id, dialect="duckdb")` is called, the query manager returns the DuckDB variant if it exists
 2. If no variant exists for the requested dialect, returns the base `sql` query
-3. Variant SQL goes through the same translation pipeline as base queries
+3. Variant SQL is authored as final target SQL; `ReadPrimitivesBenchmark.get_queries()` does not rerun it through SQLGlot
+
+### Result Contracts
+
+Every active variant in a high-risk family (`json`, `array`, `struct`, `map`,
+`lambda`, `window`, `statistical`, `timeseries`, `fulltext`, and selected scalar
+edge cases) must declare `result_contract`.
+
+```yaml
+result_contract:
+  capability: ordered_array_slice
+  row_identity: [o_custkey]
+  columns:
+    - o_custkey
+    - name: top_3_orders
+      type_class: array
+      order_sensitive: true
+```
+
+Contract fields:
+
+* `capability` - the database capability the query measures. Variants that
+  produce the same values by testing a different capability should be skipped.
+* `row_identity` - result columns that identify a row for cross-platform
+  alignment. If the query has `LIMIT`, order deterministically by this identity.
+* `columns` - projected columns in exact output order. Use mappings when a
+  nested type or order sensitivity matters.
+* `type_class` - one of `scalar`, `json`, `array`, `struct`, or `map`.
+* `order_sensitive` - set `true` when array/list order is part of the result
+  semantics.
 
 ### Skipping Queries
 
@@ -87,6 +137,9 @@ Some queries cannot be meaningfully tested on certain platforms due to data limi
 - Data quality issues make query meaningless (e.g., JSON functions on non-JSON data)
 - Platform fundamentally lacks required feature and no reasonable alternative exists
 - Query would always fail due to platform limitations, not bugs
+- Platform can only express a related-but-not-equivalent fallback, such as
+  full-text search rewritten as `LIKE`, approximate percentile substituted for
+  exact percentile, or array capability rewritten as a scalar aggregate
 
 For a complete reference of all current skips, their root causes, and instructions on how to re-enable them, see {doc}`read-primitives-skips-reference`.
 
@@ -98,13 +151,14 @@ For a complete reference of all current skips, their root causes, and instructio
 ### Best Practices
 
 **Prefer variants over skip_on:**
-- Only skip when no reasonable alternative exists
-- Most syntax differences can be handled with variants
+- Only skip when no comparable alternative exists
+- Most syntax differences can be handled with variants, but capability changes cannot
 
 **Keep variants semantically equivalent:**
 - Variants should test the same database capability
-- Results may differ slightly, but behavior should be comparable
+- Results must have comparable columns, nested shape, row identity, and ordering
 - Document why variant is needed in comments
+- Do not keep runnable but non-comparable fallbacks in benchmark scoring
 
 **Dialect names:**
 - Use lowercase: `duckdb`, `bigquery`, `snowflake`, `postgres`
@@ -112,9 +166,9 @@ For a complete reference of all current skips, their root causes, and instructio
 - Case-insensitive matching during query retrieval
 
 **Validation:**
-- Run benchmark with variant to ensure it works: `benchbox run --platform duckdb --benchmark read_primitives --scale 1`
-- Check success rate in results
-- Unit tests automatically validate catalog structure
+- Run static contracts: `uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py -q`
+- Run focused runtime parity: `uv run -- python -m pytest tests/integration/validation/test_read_primitives_variant_parity.py -q`
+- Run the platform query at SF=0.01 before removing a skip
 
 ### Example: Complex Variant (timeseries_trend_analysis)
 
@@ -164,18 +218,20 @@ This example shows:
 
    ```bash
    uv run -- python - <<'PY'
-   from benchbox.core.primitives.queries import PrimitivesQueryManager
+   from benchbox.core.read_primitives.queries import ReadPrimitivesQueryManager
 
-   manager = PrimitivesQueryManager()
+   manager = ReadPrimitivesQueryManager()
    print(f"queries: {len(manager.get_all_queries())}")
    print(f"categories: {manager.get_query_categories()}")
    PY
 
-   uv run -- python -m pytest tests/unit/primitives/test_query_catalog.py
+   uv run -- python -m pytest tests/unit/core/read_primitives/test_catalog_loader.py
+   uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
    ```
 
    The test suite exercises catalog parsing, duplicate detection, and category
-   filters.
+   filters. The contract suite also rejects active high-risk variants without
+   comparable result-shape metadata.
 3. Run the full test suite (`uv run -- python -m pytest`) before committing.
 
 ## Adding many queries

--- a/docs/development/read-primitives-skips-reference.md
+++ b/docs/development/read-primitives-skips-reference.md
@@ -8,7 +8,10 @@ This document is the authoritative reference for every `skip_on` entry in
 explains **why** the skip exists and **where to look** to determine whether the
 skip can be removed.
 
-There are currently **68 skipped query/platform pairs** across 6 platforms.
+As of 2026-04-29, there are **77 skipped query/target-dialect pairs** across 7
+target dialects. Deployment aliases inherit their adapter target dialects: for
+example, MotherDuck uses the DuckDB dialect skips, while ClickHouse local,
+server, and cloud deployments use the ClickHouse dialect skips.
 They fall into four root-cause classes:
 
 1. **Missing function**: the SQL function is simply absent from the platform's
@@ -39,9 +42,9 @@ They fall into four root-cause classes:
 | `array_slice` | redshift | Missing type | array |
 | `array_sort` | bigquery, redshift | Missing function | array |
 | `array_unnest` | redshift | Missing type | array |
-| `fulltext_boolean_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
-| `fulltext_phrase_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
-| `fulltext_simple_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
+| `fulltext_boolean_search` | bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake | Semantic gap | fulltext |
+| `fulltext_phrase_search` | bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake | Semantic gap | fulltext |
+| `fulltext_simple_search` | bigquery, clickhouse, datafusion, databricks, duckdb, redshift, snowflake | Semantic gap | fulltext |
 | `intrinsic_appx_median` | clickhouse | Semantic gap | intrinsic |
 | `json_aggregates` | datafusion, redshift | Missing function | json |
 | `json_extract_nested` | datafusion, redshift | Missing function | json |
@@ -218,7 +221,7 @@ semantics efficiently enough to be meaningful as a benchmark primitive.
 
 ---
 
-## Google BigQuery (10 queries skipped)
+## Google BigQuery (13 queries skipped)
 
 ### Array functions: `array_min_max`, `array_sort`, `array_distinct`
 
@@ -260,6 +263,18 @@ in the [BigQuery data types reference](https://cloud.google.com/bigquery/docs/re
 
 **Re-enable when**: `ASOF JOIN` appears in the
 [BigQuery JOIN reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#join_types).
+
+---
+
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: The base SQL uses MySQL `MATCH(...) AGAINST (...)`. BigQuery
+has `SEARCH` and text analyzers, but the syntax and scoring behavior are not a
+drop-in equivalent for MySQL natural-language, boolean, and phrase modes.
+
+**Re-enable when**: A BigQuery variant is written that preserves tokenization,
+boolean operators, phrase matching, and relevance-score semantics for the
+declared full-text capability.
 
 ---
 
@@ -414,7 +429,7 @@ frame, or a variant preserves the exact frame semantics.
 
 ---
 
-## Databricks (1 query skipped)
+## Databricks (4 queries skipped)
 
 ### `asof_join_basic`
 
@@ -424,6 +439,32 @@ available as a SQL clause.
 
 **Re-enable when**: `ASOF JOIN` appears in the
 [Databricks SQL reference](https://docs.databricks.com/sql/language-manual/sql-ref-syntax-qry-select-join.html).
+
+---
+
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: The base SQL uses MySQL `MATCH(...) AGAINST (...)`, which
+Databricks SQL does not support. `LIKE`, `contains`, or Spark text functions do
+not preserve MySQL full-text ranking, boolean operators, phrase matching, or
+index-backed search semantics.
+
+**Re-enable when**: Databricks SQL exposes comparable full-text search syntax or
+a verified variant can preserve the declared full-text result contract.
+
+---
+
+## Snowflake (3 queries skipped)
+
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: The base SQL uses MySQL `MATCH(...) AGAINST (...)`. Snowflake
+has text search functions, but they do not provide a direct equivalent for the
+MySQL natural-language, boolean, and phrase modes used by these primitives.
+
+**Re-enable when**: A Snowflake variant preserves the declared full-text
+capability, including boolean operators, phrase semantics, and relevance-score
+shape for scored queries.
 
 ---
 

--- a/docs/development/read-primitives-skips-reference.md
+++ b/docs/development/read-primitives-skips-reference.md
@@ -8,8 +8,8 @@ This document is the authoritative reference for every `skip_on` entry in
 explains **why** the skip exists and **where to look** to determine whether the
 skip can be removed.
 
-There are currently **26 skipped query/platform pairs** across 6 platforms.
-They fall into three root-cause classes:
+There are currently **68 skipped query/platform pairs** across 6 platforms.
+They fall into four root-cause classes:
 
 1. **Missing function**: the SQL function is simply absent from the platform's
    catalog and no semantics-preserving rewrite exists.
@@ -17,6 +17,8 @@ They fall into three root-cause classes:
    required by the query.
 3. **Data quality**: the TPC-H column used by the query (`o_comment`,
    `c_comment`) contains plain text, not the structured data the query expects.
+4. **Semantic gap**: a runnable fallback exists, but it would measure a related
+   capability rather than the query's declared `result_contract.capability`.
 
 ---
 
@@ -24,36 +26,45 @@ They fall into three root-cause classes:
 
 | Query ID | Skipped on | Root cause | Category |
 |----------|-----------|------------|----------|
-| `asof_join_basic` | bigquery, databricks, redshift | Missing syntax | timeseries |
+| `any_value_simple` | datafusion | Semantic gap | aggregation |
+| `any_value_with_filter` | datafusion | Semantic gap | aggregation |
+| `asof_join_basic` | bigquery, datafusion, databricks, redshift | Missing syntax | timeseries |
 | `array_agg_distinct` | redshift | Missing type | array |
 | `array_agg_simple` | redshift | Missing type | array |
-| `array_distinct` | bigquery, redshift | Missing function | array |
-| `array_min_max` | bigquery | Missing function | array |
+| `array_contains` | datafusion, redshift | Semantic gap / missing type | array |
+| `array_distinct` | bigquery, datafusion, redshift | Missing function / semantic gap | array |
+| `array_length` | datafusion, redshift | Semantic gap / missing type | array |
+| `array_min_max` | bigquery, datafusion, redshift | Missing function / semantic gap | array |
 | `array_of_struct` | redshift | Missing type | struct |
 | `array_slice` | redshift | Missing type | array |
 | `array_sort` | bigquery, redshift | Missing function | array |
 | `array_unnest` | redshift | Missing type | array |
+| `fulltext_boolean_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
+| `fulltext_phrase_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
+| `fulltext_simple_search` | clickhouse, datafusion, duckdb, redshift | Semantic gap | fulltext |
+| `intrinsic_appx_median` | clickhouse | Semantic gap | intrinsic |
 | `json_aggregates` | datafusion, redshift | Missing function | json |
 | `json_extract_nested` | datafusion, redshift | Missing function | json |
 | `json_extract_simple` | duckdb, datafusion, redshift | Data quality | json |
-| `list_filter` | bigquery, redshift | Missing function | lambda |
-| `list_reduce` | bigquery, redshift | Missing function | lambda |
-| `list_transform` | bigquery, redshift | Missing function | lambda |
+| `list_filter` | bigquery, datafusion, redshift | Missing function / semantic gap | lambda |
+| `list_reduce` | bigquery, datafusion, redshift | Missing function / semantic gap | lambda |
+| `list_transform` | bigquery, datafusion, redshift | Missing function / semantic gap | lambda |
 | `map_access` | bigquery, redshift | Missing type | map |
 | `map_construction` | bigquery, redshift | Missing type | map |
 | `map_keys_values` | bigquery, redshift | Missing type | map |
 | `pivot_basic` | clickhouse | Incompatible syntax | pivot |
 | `statistical_correlation` | redshift | Missing function | statistical |
+| `statistical_percentiles` | clickhouse | Semantic gap | statistical |
 | `struct_access` | redshift | Missing type | struct |
 | `struct_construction` | redshift | Missing type | struct |
 | `timeseries_trend_analysis` | redshift | Missing function | timeseries |
 | `unpivot_basic` | clickhouse | Incompatible syntax | pivot |
-| `window_moving_frame` | redshift | Semantic gap | window |
+| `window_moving_frame` | clickhouse, redshift | Semantic gap | window |
 | `window_running_sum` | redshift | Semantic gap | window |
 
 ---
 
-## Amazon Redshift (23 queries skipped)
+## Amazon Redshift (29 queries skipped)
 
 Redshift has the largest skip set because it predates many modern SQL extensions
 and has diverged significantly from PostgreSQL in the area of complex types.
@@ -104,20 +115,17 @@ specifically the `frame_clause` section describing `RANGE` offset types.
 
 ---
 
-### Array operations: 8 queries
+### Array operations: 9 queries
 
-`array_agg_simple`, `array_agg_distinct`, `array_unnest`, `array_slice`,
-`array_sort`, `array_distinct`, `array_of_struct`
+`array_agg_simple`, `array_agg_distinct`, `array_unnest`, `array_contains`,
+`array_length`, `array_slice`, `array_min_max`, `array_sort`, `array_distinct`
 
 **Why skipped**: Redshift does not have a native array type. `ARRAY_AGG`,
-`UNNEST`, `ARRAY_SLICE`, `ARRAY_SORT`, and `ARRAY_DISTINCT` all require an
-array column as input or produce one as output. There is no semantics-preserving
-rewrite that avoids materialising an array.
-
-Note: `array_min_max` is **not** skipped on Redshift; it has a Redshift variant
-that rewrites the query as a plain `MIN`/`MAX` aggregate, which is semantically
-equivalent for that specific test. The variant was viable because the query's
-intent is to find the extremes of a value set, not to manipulate an array object.
+`ARRAY_CONTAINS`, `CARDINALITY`, `UNNEST`, `ARRAY_SLICE`, `ARRAY_MIN`,
+`ARRAY_MAX`, `ARRAY_SORT`, and `ARRAY_DISTINCT` all require an array column as
+input or produce one as output. Redshift scalar rewrites such as `COUNT(*)`,
+`MIN`/`MAX`, or `CASE WHEN` can produce the same values for the current data,
+but they do not test the array capability declared in the query contract.
 
 **Re-enable when**: AWS adds native array type support to Redshift. Monitor:
 - [What's new in Amazon Redshift](https://aws.amazon.com/about-aws/whats-new/database/?whats-new-content.sort-by=item.additionalFields.postDateTime&whats-new-content.sort-order=desc&awsf.whats-new-product=product%23amazon-redshift)
@@ -126,7 +134,7 @@ intent is to find the extremes of a value set, not to manipulate an array object
 
 ---
 
-### Struct operations: `struct_construction`, `struct_access`
+### Struct operations: `struct_construction`, `struct_access`, `array_of_struct`
 
 **Why skipped**: Redshift has no `STRUCT(...)` constructor and does not support
 accessing struct fields via dot notation. The base queries and the `array_of_struct`
@@ -186,6 +194,19 @@ constraint, not a platform constraint.
 
 ---
 
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: Redshift can express coarse `LIKE` filters, but those do not
+preserve MySQL full-text tokenization, boolean operators, phrase matching, or
+relevance scores. Keeping the old `LIKE` variants would make Redshift look
+comparable while measuring a different capability.
+
+**Re-enable when**: Redshift exposes comparable full-text search syntax and the
+variant passes contract validation plus a live Redshift run for the declared
+result contract.
+
+---
+
 ### ASOF JOIN: `asof_join_basic`
 
 **Why skipped**: Redshift does not support `ASOF JOIN` syntax. No rewrite of
@@ -242,7 +263,7 @@ in the [BigQuery data types reference](https://cloud.google.com/bigquery/docs/re
 
 ---
 
-## Apache DataFusion (3 queries skipped)
+## Apache DataFusion (16 queries skipped)
 
 ### JSON functions: `json_extract_simple`, `json_extract_nested`, `json_aggregates`
 
@@ -266,7 +287,60 @@ in [DataFusion's function catalog](https://datafusion.apache.org/user-guide/sql/
 
 ---
 
-## DuckDB (1 query skipped)
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: DataFusion does not implement MySQL-style
+`MATCH(...) AGAINST (...)` full-text search. A `LIKE` rewrite runs, but it does
+not preserve ranking, boolean search operators, phrase matching, tokenization,
+or indexing behavior, so it would violate the full-text result contract.
+
+**Re-enable when**: DataFusion exposes full-text search syntax with comparable
+boolean and phrase semantics.
+
+---
+
+### Array and lambda semantic gaps
+
+`array_contains`, `array_length`, `array_min_max`, `array_distinct`,
+`list_transform`, `list_filter`, `list_reduce`
+
+**Why skipped**: DataFusion can express some value-equivalent rewrites using
+plain aggregates, `UNNEST`, or re-aggregation. Those rewrites do not exercise
+the same nested-array or higher-order lambda capability as the base query. The
+catalog keeps DataFusion's MAP variants because they use DataFusion MAP
+functions and pass the DuckDB-reference runtime parity test.
+
+**Re-enable when**: DataFusion supports the corresponding array and
+higher-order functions directly, or a variant can be written that exercises the
+same declared capability and passes
+`tests/integration/validation/test_read_primitives_variant_parity.py`.
+
+---
+
+### Arbitrary-value aggregate: `any_value_simple`, `any_value_with_filter`
+
+**Why skipped**: Rewriting `ANY_VALUE` to `MIN` makes the query deterministic
+but changes the capability from arbitrary representative aggregate to ordered
+minimum aggregate.
+
+**Re-enable when**: DataFusion supports `ANY_VALUE` or an equivalent arbitrary
+aggregate.
+
+---
+
+### ASOF JOIN: `asof_join_basic`
+
+**Why skipped**: The prior DataFusion variant used Snowflake-style
+`MATCH_CONDITION`, which is not a portable DataFusion syntax and could not be
+statically parsed for contract validation. No verified DataFusion SQL variant is
+currently retained.
+
+**Re-enable when**: DataFusion documents a SQL `ASOF JOIN` form that can express
+the query exactly and passes the DuckDB-reference parity test.
+
+---
+
+## DuckDB (4 queries skipped)
 
 ### `json_extract_simple`
 
@@ -280,7 +354,19 @@ with valid JSON. DuckDB fully supports `JSON_EXTRACT` and complex paths.
 
 ---
 
-## ClickHouse (2 queries skipped)
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: DuckDB does not implement MySQL-style
+`MATCH(...) AGAINST (...)` full-text semantics. `LIKE` rewrites were removed
+because they produce a different shape for scored queries and a different
+matching capability for every full-text query.
+
+**Re-enable when**: DuckDB exposes comparable full-text search syntax, including
+score/rank output for boolean and phrase queries.
+
+---
+
+## ClickHouse (8 queries skipped)
 
 ### `pivot_basic`, `unpivot_basic`
 
@@ -291,6 +377,40 @@ query structure that tests different capabilities than `PIVOT`/`UNPIVOT`.
 
 **Re-enable when**: Standard `PIVOT`/`UNPIVOT` clause syntax appears in the
 [ClickHouse SELECT reference](https://clickhouse.com/docs/en/sql-reference/statements/select).
+
+---
+
+### Full-text search: `fulltext_simple_search`, `fulltext_boolean_search`, `fulltext_phrase_search`
+
+**Why skipped**: ClickHouse string predicates can approximate parts of the
+filtering behavior, but they do not preserve MySQL full-text tokenization,
+boolean operators, phrase matching, or relevance scores.
+
+**Re-enable when**: ClickHouse exposes comparable full-text search semantics for
+these three query families.
+
+---
+
+### Percentile semantics: `intrinsic_appx_median`, `statistical_percentiles`
+
+**Why skipped**: ClickHouse `quantile` functions are approximate by default.
+The base queries declare exact continuous percentile/median capabilities.
+Running approximate percentiles against exact percentile queries would produce a
+misleading benchmark signal even when the query executes successfully.
+
+**Re-enable when**: A ClickHouse variant uses exact percentile functions with
+matching interpolation semantics and passes the runtime parity test.
+
+---
+
+### Window frame semantics: `window_moving_frame`
+
+**Why skipped**: The old ClickHouse variant replaced a date `RANGE` frame with a
+row-count `ROWS` frame. That changes results whenever order dates are sparse or
+duplicate.
+
+**Re-enable when**: ClickHouse supports the original interval-valued `RANGE`
+frame, or a variant preserves the exact frame semantics.
 
 ---
 
@@ -309,17 +429,17 @@ available as a SQL clause.
 
 ## Validation workflow
 
-Three assets work together to validate whether a skip is still needed and
+Five assets work together to validate whether a skip is still needed and
 whether removing it is safe. Understanding how they relate prevents both
 false confidence (unit test passes but live run fails) and unnecessary work
 (live run attempted before the catalog change is consistent).
 
 ```
-Reference doc          queries.yaml          Unit test             Live run
-─────────────          ────────────          ─────────             ────────
-Check URL         →    Remove skip_on    →   pytest passes    →    benchbox run passes
-condition met           (+ variant if         skip set matches      query returns rows,
-                         needed)              catalog reality       no SQL errors
+Reference doc      queries.yaml      Static/unit tests      Runtime parity      Platform run
+─────────────      ────────────      ────────────────       ──────────────      ────────────
+Check URL     →    Remove skip  →    contracts pass    →    DuckDB ref    →    benchbox run
+condition met       (+ variant)       skip set matches       matches local      passes
+                                      catalog reality        variant
 ```
 
 **Reference doc** (`docs/development/read-primitives-skips-reference.md`, this
@@ -333,16 +453,31 @@ change to `queries.yaml`:
 
 ```bash
 uv run -- python -m pytest tests/unit/core/read_primitives/test_benchmark_variants.py -q
+uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py -q
 ```
 
 A passing unit test means the catalog and the test expectations are internally
-consistent. It does **not** mean the SQL executes correctly on the platform.
+consistent and every active high-risk variant has a declared comparable shape.
+It does **not** mean the SQL executes correctly on the platform.
 
-**Live benchmark run** is the ground-truth check. Run it after the unit test
-passes:
+**Runtime parity test**
+(`tests/integration/validation/test_read_primitives_variant_parity.py`) is the
+credential-free check for local engines. It runs DuckDB SF=0.01 as the
+reference, then compares retained DataFusion and ClickHouse-local variants under
+the declared result contracts:
 
 ```bash
-benchbox run --platform <platform> --benchmark read_primitives --queries <query_id> --scale 0.01
+uv run -- python -m pytest tests/integration/validation/test_read_primitives_variant_parity.py -q
+```
+
+Optional engines may skip when their packages are unavailable. If an installed
+engine diverges, keep or restore `skip_on` until the variant is truly comparable.
+
+**Live benchmark run** is the ground-truth check. Run it after the unit test
+and runtime parity test pass:
+
+```bash
+uv run -- benchbox run --platform <platform> --benchmark read_primitives --queries <query_id> --scale 0.01
 ```
 
 A passing live run (non-empty result set, no SQL errors) is the definitive
@@ -371,12 +506,14 @@ it still fails, so the next maintainer has a complete picture.
 
    ```bash
    uv run -- python -m pytest tests/unit/core/read_primitives/test_benchmark_variants.py -q
+   uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py -q
+   uv run -- python -m pytest tests/integration/validation/test_read_primitives_variant_parity.py -q
    ```
 
 5. Run the live benchmark against the platform:
 
    ```bash
-   benchbox run --platform <platform> --benchmark read_primitives --queries <query_id> --scale 0.01
+   uv run -- benchbox run --platform <platform> --benchmark read_primitives --queries <query_id> --scale 0.01
    ```
 
 6. Confirm the query passes and produces a non-empty result set.

--- a/tests/integration/test_read_primitives_identify_regression.py
+++ b/tests/integration/test_read_primitives_identify_regression.py
@@ -39,9 +39,13 @@ class TestReadPrimitivesIdentifyRegression:
         # Get queries translated to DuckDB with identify=True (the default)
         translated_queries = benchmark.get_queries(dialect="duckdb")
 
-        # DuckDB should have all but the skipped json_extract_simple query
-        assert len(translated_queries) + 1 == len(base_queries), "Expected one DuckDB skip (json_extract_simple)"
-        assert "json_extract_simple" not in translated_queries, "Skipped query should not appear in translations"
+        # DuckDB skips queries that cannot preserve comparable semantics.
+        assert set(base_queries) - set(translated_queries) == {
+            "fulltext_simple_search",
+            "fulltext_boolean_search",
+            "fulltext_phrase_search",
+            "json_extract_simple",
+        }
 
         # Verify all translated queries are non-empty and contain SQL
         for query_id, query_sql in translated_queries.items():
@@ -80,9 +84,13 @@ class TestReadPrimitivesIdentifyRegression:
         base_queries = benchmark.get_queries()
         queries = benchmark.get_queries(dialect="duckdb")
 
-        # All non-skipped queries should translate successfully
-        assert len(queries) + 1 == len(base_queries), "All non-skipped queries should translate"
-        assert "json_extract_simple" not in queries, "json_extract_simple is skipped on DuckDB"
+        # All non-skipped queries should translate successfully.
+        assert set(base_queries) - set(queries) == {
+            "fulltext_simple_search",
+            "fulltext_boolean_search",
+            "fulltext_phrase_search",
+            "json_extract_simple",
+        }
 
         # Verify that common table names are quoted (these could be keywords in some dialects)
         # We're looking for patterns like "orders", "customer", etc.
@@ -164,7 +172,6 @@ class TestReadPrimitivesIdentifyRegression:
         # Test queries that have DuckDB variants
         variant_query_ids = [
             "json_aggregates",  # Has DuckDB variant
-            "fulltext_simple_search",  # Has DuckDB variant
             "timeseries_trend_analysis",  # Has DuckDB variant
         ]
 

--- a/tests/integration/validation/test_read_primitives_variant_parity.py
+++ b/tests/integration/validation/test_read_primitives_variant_parity.py
@@ -1,0 +1,290 @@
+"""Runtime parity checks for risky read_primitives platform variants."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from benchbox.core.read_primitives.benchmark import ReadPrimitivesBenchmark
+from benchbox.core.read_primitives.catalog import ResultContract, load_primitives_catalog
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.medium,
+]
+
+duckdb = pytest.importorskip("duckdb", reason="duckdb not installed")
+
+_TPCH_TABLES = (
+    "customer",
+    "lineitem",
+    "nation",
+    "orders",
+    "part",
+    "partsupp",
+    "region",
+    "supplier",
+)
+
+_DUCKDB_CONTRACT_SHAPE_QUERIES = (
+    "json_aggregates",
+    "array_agg_distinct",
+    "array_slice",
+    "array_distinct",
+    "struct_construction",
+    "array_of_struct",
+    "map_construction",
+    "list_filter",
+    "list_reduce",
+    "window_rank",
+)
+
+_DATAFUSION_VARIANT_QUERIES = (
+    "map_construction",
+    "map_access",
+    "map_keys_values",
+    "window_rank",
+)
+
+_CLICKHOUSE_VARIANT_QUERIES = (
+    "array_contains",
+    "array_length",
+    "array_min_max",
+    "array_agg_distinct",
+    "array_slice",
+    "array_sort",
+    "array_distinct",
+    "struct_access",
+    "array_of_struct",
+    "map_keys_values",
+    "list_filter",
+    "list_reduce",
+)
+
+
+@pytest.fixture(scope="session")
+def read_primitives_tpch_parquet_dir(tmp_path_factory):
+    """Generate TPC-H SF=0.01 Parquet data for local parity engines."""
+    data_dir = tmp_path_factory.mktemp("read_primitives_variant_tpch_sf001")
+    conn = duckdb.connect(":memory:")
+    try:
+        conn.execute("INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01)")
+        for table in _TPCH_TABLES:
+            conn.execute(f"COPY {table} TO '{data_dir / f'{table}.parquet'}' (FORMAT PARQUET)")
+    finally:
+        conn.close()
+    return data_dir
+
+
+@pytest.fixture(scope="session")
+def read_primitives_duckdb_conn(read_primitives_tpch_parquet_dir):
+    """DuckDB reference connection loaded from the shared SF=0.01 Parquet data."""
+    conn = duckdb.connect(":memory:")
+    for table in _TPCH_TABLES:
+        parquet_path = read_primitives_tpch_parquet_dir / f"{table}.parquet"
+        conn.execute(f"CREATE TABLE {table} AS SELECT * FROM read_parquet('{parquet_path}')")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="session")
+def read_primitives_queries_by_dialect():
+    benchmark = ReadPrimitivesBenchmark()
+    return {
+        "duckdb": benchmark.get_queries(dialect="duckdb"),
+        "datafusion": benchmark.get_queries(dialect="datafusion"),
+        "clickhouse": benchmark.get_queries(dialect="clickhouse"),
+    }
+
+
+@pytest.fixture(scope="session")
+def read_primitives_contracts():
+    return {
+        query_id: query.result_contract
+        for query_id, query in load_primitives_catalog().queries.items()
+        if query.result_contract is not None
+    }
+
+
+@pytest.fixture(scope="session")
+def datafusion_ctx(read_primitives_tpch_parquet_dir):
+    """DataFusion context registered with the same SF=0.01 Parquet tables."""
+    datafusion = pytest.importorskip("datafusion", reason="datafusion not installed")
+    ctx = datafusion.SessionContext()
+    for table in _TPCH_TABLES:
+        ctx.register_parquet(table, str(read_primitives_tpch_parquet_dir / f"{table}.parquet"))
+    return ctx
+
+
+@pytest.fixture(scope="session")
+def clickhouse_session(read_primitives_tpch_parquet_dir):
+    """ClickHouse-local session backed by the same SF=0.01 Parquet tables."""
+    pytest.importorskip("chdb", reason="chdb not installed")
+    from chdb import session as chdb_session
+
+    sess = chdb_session.Session()
+    sess.query("CREATE DATABASE IF NOT EXISTS tpch", "CSV")
+    sess.query("USE tpch", "CSV")
+
+    for table in _TPCH_TABLES:
+        parquet_path = read_primitives_tpch_parquet_dir / f"{table}.parquet"
+        sess.query(f"CREATE TABLE IF NOT EXISTS {table} ENGINE=File(Parquet, '{parquet_path}')", "CSV")
+
+    return sess
+
+
+def _duckdb_rows(conn: object, sql: str) -> list[tuple[Any, ...]]:
+    return [tuple(row) for row in conn.execute(sql).fetchall()]  # type: ignore[union-attr]
+
+
+def _datafusion_rows(ctx: object, sql: str) -> list[tuple[Any, ...]]:
+    batches = ctx.sql(sql).collect()  # type: ignore[attr-defined]
+    rows: list[tuple[Any, ...]] = []
+    for batch in batches:
+        for row_index in range(batch.num_rows):
+            rows.append(
+                tuple(batch.column(column_index)[row_index].as_py() for column_index in range(batch.num_columns))
+            )
+    return rows
+
+
+def _clickhouse_rows(sess: object, sql: str) -> list[tuple[Any, ...]]:
+    pyarrow = pytest.importorskip("pyarrow", reason="pyarrow not installed")
+    ipc = pytest.importorskip("pyarrow.ipc", reason="pyarrow.ipc not installed")
+
+    result = sess.query(sql, "Arrow")  # type: ignore[attr-defined]
+    if result.has_error():
+        raise RuntimeError(result.error_message())
+    table = ipc.open_file(pyarrow.BufferReader(result.bytes())).read_all()
+    return [tuple(row[name] for name in table.column_names) for row in table.to_pylist()]
+
+
+def _canonical_value(value: Any, *, order_sensitive: bool, type_class: str = "scalar") -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return str(value.normalize())
+    if isinstance(value, float):
+        return round(value, 10)
+    if isinstance(value, str):
+        stripped = value.rstrip()
+        if stripped.startswith(("[", "{")):
+            try:
+                return _canonical_value(json.loads(stripped), order_sensitive=order_sensitive, type_class="json")
+            except json.JSONDecodeError:
+                return stripped
+        return stripped
+    if type_class == "map":
+        if isinstance(value, dict):
+            items = value.items()
+        elif isinstance(value, (list, tuple)) and all(
+            isinstance(item, (list, tuple)) and len(item) == 2 for item in value
+        ):
+            items = value
+        else:
+            return value
+        return tuple(
+            sorted(
+                (
+                    str(_canonical_value(key, order_sensitive=True)),
+                    _canonical_value(cell, order_sensitive=True),
+                )
+                for key, cell in items
+            )
+        )
+    if isinstance(value, dict):
+        return tuple(
+            (str(key), _canonical_value(cell, order_sensitive=order_sensitive))
+            for key, cell in sorted(value.items(), key=lambda item: str(item[0]))
+        )
+    if isinstance(value, (list, tuple)):
+        items = [_canonical_value(cell, order_sensitive=True) for cell in value]
+        if not order_sensitive:
+            return tuple(sorted(items, key=repr))
+        return tuple(items)
+    return value
+
+
+def _canonical_rows(rows: list[tuple[Any, ...]], contract: ResultContract) -> list[tuple[Any, ...]]:
+    column_contracts = list(contract.columns)
+    canonical = [
+        tuple(
+            _canonical_value(
+                cell,
+                order_sensitive=column_contracts[index].order_sensitive,
+                type_class=column_contracts[index].type_class,
+            )
+            for index, cell in enumerate(row)
+        )
+        for row in rows
+    ]
+    if not contract.row_identity:
+        return canonical
+    identity_indexes = [index for index, column in enumerate(column_contracts) if column.name in contract.row_identity]
+    return sorted(canonical, key=lambda row: tuple(row[index] for index in identity_indexes))
+
+
+def _assert_shape_contract(rows: list[tuple[Any, ...]], contract: ResultContract) -> None:
+    assert rows, "Runtime parity queries should return at least one row at SF=0.01"
+    for row in rows:
+        assert len(row) == len(contract.columns)
+        for cell, column in zip(row, contract.columns):
+            if cell is None:
+                continue
+            if column.type_class == "json":
+                assert isinstance(
+                    _canonical_value(cell, order_sensitive=column.order_sensitive, type_class=column.type_class),
+                    (tuple, list),
+                )
+            elif column.type_class == "array":
+                assert isinstance(cell, (list, tuple))
+            elif column.type_class in {"struct", "map"}:
+                assert isinstance(cell, (dict, tuple))
+
+
+@pytest.mark.parametrize("query_id", _DUCKDB_CONTRACT_SHAPE_QUERIES)
+def test_duckdb_reference_outputs_satisfy_declared_contracts(
+    query_id,
+    read_primitives_duckdb_conn,
+    read_primitives_queries_by_dialect,
+    read_primitives_contracts,
+):
+    """DuckDB reference rows should expose parseable nested values for risky families."""
+    rows = _duckdb_rows(read_primitives_duckdb_conn, read_primitives_queries_by_dialect["duckdb"][query_id])
+
+    _assert_shape_contract(rows, read_primitives_contracts[query_id])
+
+
+@pytest.mark.parametrize("query_id", _DATAFUSION_VARIANT_QUERIES)
+def test_datafusion_variants_match_duckdb_reference(
+    query_id,
+    read_primitives_duckdb_conn,
+    datafusion_ctx,
+    read_primitives_queries_by_dialect,
+    read_primitives_contracts,
+):
+    """DataFusion variants retained in the catalog should match DuckDB reference rows."""
+    reference_rows = _duckdb_rows(read_primitives_duckdb_conn, read_primitives_queries_by_dialect["duckdb"][query_id])
+    comparison_rows = _datafusion_rows(datafusion_ctx, read_primitives_queries_by_dialect["datafusion"][query_id])
+    contract = read_primitives_contracts[query_id]
+
+    assert _canonical_rows(comparison_rows, contract) == _canonical_rows(reference_rows, contract)
+
+
+@pytest.mark.parametrize("query_id", _CLICKHOUSE_VARIANT_QUERIES)
+def test_clickhouse_variants_match_duckdb_reference(
+    query_id,
+    read_primitives_duckdb_conn,
+    clickhouse_session,
+    read_primitives_queries_by_dialect,
+    read_primitives_contracts,
+):
+    """ClickHouse-local variants retained in the catalog should match DuckDB reference rows."""
+    reference_rows = _duckdb_rows(read_primitives_duckdb_conn, read_primitives_queries_by_dialect["duckdb"][query_id])
+    comparison_rows = _clickhouse_rows(clickhouse_session, read_primitives_queries_by_dialect["clickhouse"][query_id])
+    contract = read_primitives_contracts[query_id]
+
+    assert _canonical_rows(comparison_rows, contract) == _canonical_rows(reference_rows, contract)

--- a/tests/unit/core/read_primitives/test_benchmark_variants.py
+++ b/tests/unit/core/read_primitives/test_benchmark_variants.py
@@ -252,17 +252,21 @@ class TestBenchmarkWithActualCatalog:
         # Should have all queries (136 as of December 2025 with modern SQL features)
         assert len(queries) >= 136
 
-    def test_get_queries_with_duckdb_skips_one_query(self):
-        """Test DuckDB skips json_extract_simple (data quality issue)."""
+    def test_get_queries_with_duckdb_skips_known_non_comparable_queries(self):
+        """Test DuckDB skips queries that cannot be compared with base semantics."""
         benchmark = ReadPrimitivesBenchmark()
 
-        queries_no_dialect = benchmark.get_queries()
         queries_duckdb = benchmark.get_queries(dialect="duckdb")
 
         # json_extract_simple is skipped on DuckDB (TPC-H data contains plain text, not JSON)
-        # Total queries minus 1 for json_extract_simple
-        assert len(queries_no_dialect) >= 136
-        assert len(queries_duckdb) == len(queries_no_dialect) - 1
+        # Fulltext MATCH...AGAINST queries are skipped because LIKE fallbacks are not equivalent.
+        duckdb_skipped = {
+            "fulltext_simple_search",
+            "fulltext_boolean_search",
+            "fulltext_phrase_search",
+            "json_extract_simple",
+        }
+        assert duckdb_skipped.isdisjoint(queries_duckdb)
 
     def test_clickhouse_keeps_timeout_only_query_available(self):
         """Timeout-only ClickHouse queries should remain runnable unless truly unsupported."""
@@ -459,6 +463,30 @@ class TestModernSQLFeatures:
         for qid in clickhouse_skipped:
             assert qid not in queries_clickhouse, f"ClickHouse should skip: {qid}"
 
+    def test_clickhouse_skips_non_comparable_scalar_fallbacks(self):
+        """ClickHouse should skip scalar rewrites that change the measured capability."""
+        benchmark = ReadPrimitivesBenchmark()
+        queries_clickhouse = benchmark.get_queries(dialect="clickhouse")
+
+        clickhouse_skipped = [
+            "intrinsic_appx_median",
+            "window_moving_frame",
+            "fulltext_simple_search",
+            "fulltext_boolean_search",
+            "fulltext_phrase_search",
+            "statistical_percentiles",
+        ]
+        for qid in clickhouse_skipped:
+            assert qid not in queries_clickhouse, f"ClickHouse should skip: {qid}"
+
+    def test_datafusion_skips_non_comparable_any_value_fallbacks(self):
+        """DataFusion should skip MIN fallbacks for arbitrary-value aggregate queries."""
+        benchmark = ReadPrimitivesBenchmark()
+        queries_datafusion = benchmark.get_queries(dialect="datafusion")
+
+        assert "any_value_simple" not in queries_datafusion
+        assert "any_value_with_filter" not in queries_datafusion
+
     def test_duckdb_uses_list_functions_for_arrays(self):
         """Test that DuckDB dialect uses list_* functions for array operations."""
         benchmark = ReadPrimitivesBenchmark()
@@ -488,6 +516,16 @@ class TestModernSQLFeatures:
 
         assert "statistical_correlation" not in queries_redshift
         assert "timeseries_trend_analysis" not in queries_redshift
+
+    def test_redshift_percentile_variant_preserves_group_cardinality(self):
+        """Redshift percentile window rewrite should still emit one row per base group."""
+        benchmark = ReadPrimitivesBenchmark()
+        queries_redshift = benchmark.get_queries(dialect="redshift")
+
+        percentile_sql = queries_redshift["statistical_percentiles"].upper()
+
+        assert "SELECT DISTINCT" in percentile_sql
+        assert "OVER (PARTITION BY" in percentile_sql
 
     def test_redshift_uses_scalar_fallback_for_array_contains(self):
         """Test Redshift keeps array_contains coverage via scalar membership logic."""

--- a/tests/unit/core/read_primitives/test_benchmark_variants.py
+++ b/tests/unit/core/read_primitives/test_benchmark_variants.py
@@ -527,18 +527,36 @@ class TestModernSQLFeatures:
         assert "SELECT DISTINCT" in percentile_sql
         assert "OVER (PARTITION BY" in percentile_sql
 
-    def test_redshift_uses_scalar_fallback_for_array_contains(self):
-        """Test Redshift keeps array_contains coverage via scalar membership logic."""
+    def test_redshift_skips_non_comparable_array_scalar_fallbacks(self):
+        """Redshift should skip array queries when only scalar rewrites are available."""
         benchmark = ReadPrimitivesBenchmark()
         queries_redshift = benchmark.get_queries(dialect="redshift")
 
-        array_contains_sql = queries_redshift.get("array_contains", "")
+        redshift_skipped = [
+            "array_contains",
+            "array_length",
+            "array_min_max",
+        ]
+        for qid in redshift_skipped:
+            assert qid not in queries_redshift, f"Redshift should skip: {qid}"
 
-        assert array_contains_sql
-        assert "CASE WHEN" in array_contains_sql.upper()
-        assert "MAX(" in array_contains_sql.upper()
-        assert "ARRAY_CONTAINS" not in array_contains_sql.upper()
-        assert "ARRAY_AGG" not in array_contains_sql.upper()
+    def test_datafusion_skips_non_comparable_semistructured_fallbacks(self):
+        """DataFusion should skip variants that do not exercise nested/list semantics."""
+        benchmark = ReadPrimitivesBenchmark()
+        queries_datafusion = benchmark.get_queries(dialect="datafusion")
+
+        datafusion_skipped = [
+            "array_contains",
+            "array_length",
+            "array_min_max",
+            "array_distinct",
+            "list_transform",
+            "list_filter",
+            "list_reduce",
+            "asof_join_basic",
+        ]
+        for qid in datafusion_skipped:
+            assert qid not in queries_datafusion, f"DataFusion should skip: {qid}"
 
     def test_duckdb_uses_row_for_struct(self):
         """Test that DuckDB dialect uses ROW() for struct construction."""

--- a/tests/unit/core/read_primitives/test_benchmark_variants.py
+++ b/tests/unit/core/read_primitives/test_benchmark_variants.py
@@ -268,6 +268,27 @@ class TestBenchmarkWithActualCatalog:
         }
         assert duckdb_skipped.isdisjoint(queries_duckdb)
 
+    def test_duckdb_array_of_struct_variant_preserves_inner_order(self):
+        """DuckDB reference SQL must sort line-item structs inside each aggregated array."""
+        benchmark = ReadPrimitivesBenchmark()
+
+        queries_duckdb = benchmark.get_queries(dialect="duckdb")
+        array_sql = queries_duckdb["array_of_struct"].lower()
+
+        assert "struct_pack" in array_sql
+        assert "order by l_linenumber" in array_sql
+
+    @pytest.mark.parametrize("dialect", ["bigquery", "databricks", "snowflake"])
+    def test_cloud_dialects_skip_mysql_fulltext_queries(self, dialect):
+        """MySQL MATCH...AGAINST full-text queries should not reach non-MySQL translators."""
+        benchmark = ReadPrimitivesBenchmark()
+
+        queries = benchmark.get_queries(dialect=dialect)
+
+        assert "fulltext_simple_search" not in queries
+        assert "fulltext_boolean_search" not in queries
+        assert "fulltext_phrase_search" not in queries
+
     def test_clickhouse_keeps_timeout_only_query_available(self):
         """Timeout-only ClickHouse queries should remain runnable unless truly unsupported."""
         benchmark = ReadPrimitivesBenchmark()
@@ -439,6 +460,9 @@ class TestModernSQLFeatures:
 
         # BigQuery should skip MAP, lambda, and some array functions
         bigquery_skipped = [
+            "fulltext_simple_search",
+            "fulltext_boolean_search",
+            "fulltext_phrase_search",
             "map_construction",
             "map_access",
             "map_keys_values",

--- a/tests/unit/core/read_primitives/test_catalog_loader.py
+++ b/tests/unit/core/read_primitives/test_catalog_loader.py
@@ -4,6 +4,8 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import importlib.resources
+
 import pytest
 
 from benchbox.core.read_primitives.catalog import (
@@ -18,6 +20,26 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
 ]
+
+
+@pytest.fixture
+def mock_catalog_yaml(monkeypatch, tmp_path):
+    """Patch importlib.resources.files() to return a temp query catalog."""
+
+    class MockPath:
+        def __init__(self, path):
+            self.path = path
+
+        def joinpath(self, name):
+            return self.path / name
+
+    def write(catalog_yaml: str):
+        catalog_file = tmp_path / "queries.yaml"
+        catalog_file.write_text(catalog_yaml)
+        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+        return catalog_file
+
+    return write
 
 
 class TestPrimitiveQueryDataclass:
@@ -80,7 +102,7 @@ class TestPrimitiveQueryDataclass:
 class TestCatalogLoaderResultContractParsing:
     """Test result_contract parsing from YAML."""
 
-    def test_load_query_with_result_contract(self, monkeypatch, tmp_path):
+    def test_load_query_with_result_contract(self, mock_catalog_yaml):
         """Test loading a query with typed result contract metadata."""
         catalog_yaml = """
 version: 1
@@ -97,22 +119,7 @@ queries:
           type_class: array
           order_sensitive: true
 """
-        catalog_file = tmp_path / "queries.yaml"
-        catalog_file.write_text(catalog_yaml)
-
-        import importlib.resources
-
-        class MockPath:
-            def __init__(self, path):
-                self.path = path
-
-            def joinpath(self, name):
-                return self.path / name
-
-            def open(self, *args, **kwargs):
-                return open(self.path / "queries.yaml", *args, **kwargs)
-
-        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+        mock_catalog_yaml(catalog_yaml)
 
         catalog = load_primitives_catalog()
         contract = catalog.queries["test_query"].result_contract
@@ -126,7 +133,7 @@ queries:
             capability="ordered_array_aggregate",
         )
 
-    def test_result_contract_columns_must_be_non_empty_list(self, monkeypatch, tmp_path):
+    def test_result_contract_columns_must_be_non_empty_list(self, mock_catalog_yaml):
         """Test result_contract.columns validation."""
         catalog_yaml = """
 version: 1
@@ -137,27 +144,12 @@ queries:
     result_contract:
       columns: []
 """
-        catalog_file = tmp_path / "queries.yaml"
-        catalog_file.write_text(catalog_yaml)
-
-        import importlib.resources
-
-        class MockPath:
-            def __init__(self, path):
-                self.path = path
-
-            def joinpath(self, name):
-                return self.path / name
-
-            def open(self, *args, **kwargs):
-                return open(self.path / "queries.yaml", *args, **kwargs)
-
-        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+        mock_catalog_yaml(catalog_yaml)
 
         with pytest.raises(PrimitivesCatalogError, match="result_contract.columns must be a non-empty list"):
             load_primitives_catalog()
 
-    def test_result_contract_rejects_unknown_row_identity_column(self, monkeypatch, tmp_path):
+    def test_result_contract_rejects_unknown_row_identity_column(self, mock_catalog_yaml):
         """Test row_identity must reference declared columns."""
         catalog_yaml = """
 version: 1
@@ -169,27 +161,12 @@ queries:
       columns: [result]
       row_identity: [missing]
 """
-        catalog_file = tmp_path / "queries.yaml"
-        catalog_file.write_text(catalog_yaml)
-
-        import importlib.resources
-
-        class MockPath:
-            def __init__(self, path):
-                self.path = path
-
-            def joinpath(self, name):
-                return self.path / name
-
-            def open(self, *args, **kwargs):
-                return open(self.path / "queries.yaml", *args, **kwargs)
-
-        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+        mock_catalog_yaml(catalog_yaml)
 
         with pytest.raises(PrimitivesCatalogError, match="row_identity references unknown column 'missing'"):
             load_primitives_catalog()
 
-    def test_result_contract_rejects_unknown_type_class(self, monkeypatch, tmp_path):
+    def test_result_contract_rejects_unknown_type_class(self, mock_catalog_yaml):
         """Test type_class validation."""
         catalog_yaml = """
 version: 1
@@ -202,22 +179,7 @@ queries:
         - name: result
           type_class: nested_blob
 """
-        catalog_file = tmp_path / "queries.yaml"
-        catalog_file.write_text(catalog_yaml)
-
-        import importlib.resources
-
-        class MockPath:
-            def __init__(self, path):
-                self.path = path
-
-            def joinpath(self, name):
-                return self.path / name
-
-            def open(self, *args, **kwargs):
-                return open(self.path / "queries.yaml", *args, **kwargs)
-
-        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+        mock_catalog_yaml(catalog_yaml)
 
         with pytest.raises(PrimitivesCatalogError, match="type_class must be one of"):
             load_primitives_catalog()

--- a/tests/unit/core/read_primitives/test_catalog_loader.py
+++ b/tests/unit/core/read_primitives/test_catalog_loader.py
@@ -6,7 +6,13 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 import pytest
 
-from benchbox.core.read_primitives.catalog import PrimitiveQuery, PrimitivesCatalogError, load_primitives_catalog
+from benchbox.core.read_primitives.catalog import (
+    PrimitiveQuery,
+    PrimitivesCatalogError,
+    ResultColumnContract,
+    ResultContract,
+    load_primitives_catalog,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -30,6 +36,7 @@ class TestPrimitiveQueryDataclass:
         assert query.description is None
         assert query.variants is None
         assert query.skip_on is None
+        assert query.result_contract is None
 
     def test_primitive_query_with_variants(self):
         """Test PrimitiveQuery with dialect variants."""
@@ -55,6 +62,10 @@ class TestPrimitiveQueryDataclass:
             description="Test query description",
             variants={"duckdb": "SELECT 1 AS result"},
             skip_on=["sqlite"],
+            result_contract=ResultContract(
+                columns=(ResultColumnContract(name="result"),),
+                capability="scalar_projection",
+            ),
         )
         assert query.id == "test_query"
         assert query.category == "test"
@@ -62,6 +73,154 @@ class TestPrimitiveQueryDataclass:
         assert query.description == "Test query description"
         assert query.variants == {"duckdb": "SELECT 1 AS result"}
         assert query.skip_on == ["sqlite"]
+        assert query.result_contract is not None
+        assert query.result_contract.capability == "scalar_projection"
+
+
+class TestCatalogLoaderResultContractParsing:
+    """Test result_contract parsing from YAML."""
+
+    def test_load_query_with_result_contract(self, monkeypatch, tmp_path):
+        """Test loading a query with typed result contract metadata."""
+        catalog_yaml = """
+version: 1
+queries:
+  - id: test_query
+    category: test
+    sql: SELECT k, ARRAY_AGG(v ORDER BY v) AS values FROM t GROUP BY k
+    result_contract:
+      capability: ordered_array_aggregate
+      row_identity: [k]
+      columns:
+        - k
+        - name: values
+          type_class: array
+          order_sensitive: true
+"""
+        catalog_file = tmp_path / "queries.yaml"
+        catalog_file.write_text(catalog_yaml)
+
+        import importlib.resources
+
+        class MockPath:
+            def __init__(self, path):
+                self.path = path
+
+            def joinpath(self, name):
+                return self.path / name
+
+            def open(self, *args, **kwargs):
+                return open(self.path / "queries.yaml", *args, **kwargs)
+
+        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+
+        catalog = load_primitives_catalog()
+        contract = catalog.queries["test_query"].result_contract
+
+        assert contract == ResultContract(
+            columns=(
+                ResultColumnContract(name="k"),
+                ResultColumnContract(name="values", type_class="array", order_sensitive=True),
+            ),
+            row_identity=("k",),
+            capability="ordered_array_aggregate",
+        )
+
+    def test_result_contract_columns_must_be_non_empty_list(self, monkeypatch, tmp_path):
+        """Test result_contract.columns validation."""
+        catalog_yaml = """
+version: 1
+queries:
+  - id: test_query
+    category: test
+    sql: SELECT 1
+    result_contract:
+      columns: []
+"""
+        catalog_file = tmp_path / "queries.yaml"
+        catalog_file.write_text(catalog_yaml)
+
+        import importlib.resources
+
+        class MockPath:
+            def __init__(self, path):
+                self.path = path
+
+            def joinpath(self, name):
+                return self.path / name
+
+            def open(self, *args, **kwargs):
+                return open(self.path / "queries.yaml", *args, **kwargs)
+
+        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+
+        with pytest.raises(PrimitivesCatalogError, match="result_contract.columns must be a non-empty list"):
+            load_primitives_catalog()
+
+    def test_result_contract_rejects_unknown_row_identity_column(self, monkeypatch, tmp_path):
+        """Test row_identity must reference declared columns."""
+        catalog_yaml = """
+version: 1
+queries:
+  - id: test_query
+    category: test
+    sql: SELECT 1 AS result
+    result_contract:
+      columns: [result]
+      row_identity: [missing]
+"""
+        catalog_file = tmp_path / "queries.yaml"
+        catalog_file.write_text(catalog_yaml)
+
+        import importlib.resources
+
+        class MockPath:
+            def __init__(self, path):
+                self.path = path
+
+            def joinpath(self, name):
+                return self.path / name
+
+            def open(self, *args, **kwargs):
+                return open(self.path / "queries.yaml", *args, **kwargs)
+
+        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+
+        with pytest.raises(PrimitivesCatalogError, match="row_identity references unknown column 'missing'"):
+            load_primitives_catalog()
+
+    def test_result_contract_rejects_unknown_type_class(self, monkeypatch, tmp_path):
+        """Test type_class validation."""
+        catalog_yaml = """
+version: 1
+queries:
+  - id: test_query
+    category: test
+    sql: SELECT 1 AS result
+    result_contract:
+      columns:
+        - name: result
+          type_class: nested_blob
+"""
+        catalog_file = tmp_path / "queries.yaml"
+        catalog_file.write_text(catalog_yaml)
+
+        import importlib.resources
+
+        class MockPath:
+            def __init__(self, path):
+                self.path = path
+
+            def joinpath(self, name):
+                return self.path / name
+
+            def open(self, *args, **kwargs):
+                return open(self.path / "queries.yaml", *args, **kwargs)
+
+        monkeypatch.setattr(importlib.resources, "files", lambda pkg: MockPath(tmp_path))
+
+        with pytest.raises(PrimitivesCatalogError, match="type_class must be one of"):
+            load_primitives_catalog()
 
 
 class TestCatalogLoaderVariantParsing:

--- a/tests/unit/core/read_primitives/test_query_manager_variants.py
+++ b/tests/unit/core/read_primitives/test_query_manager_variants.py
@@ -197,8 +197,8 @@ class TestQueryManagerVariantIntegration:
             assert "MAP(" in query.upper()
             assert "MAP_FROM_ENTRIES" not in query.upper()
 
-        distinct_query = manager.get_query("array_distinct", dialect="datafusion")
-        assert "ARRAY_AGG(DISTINCT" in distinct_query.upper()
+        with pytest.raises(ValueError, match="not supported on dialect"):
+            manager.get_query("array_distinct", dialect="datafusion")
 
     def test_actual_catalog_datafusion_rewrites_for_known_failures(self):
         """DataFusion should use variants for known unsupported base functions."""

--- a/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
+++ b/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
@@ -1,0 +1,169 @@
+"""Static comparability checks for read_primitives query variants."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.read_primitives.catalog import (
+    PrimitiveCatalog,
+    PrimitiveQuery,
+    ResultColumnContract,
+    ResultContract,
+    load_primitives_catalog,
+)
+from benchbox.core.read_primitives.variant_contracts import (
+    VariantContractIssue,
+    collect_variant_contract_issues,
+    extract_projection_names,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def test_extract_projection_names_resolves_simple_select_star_wrapper():
+    """SELECT * wrapper variants should compare against the wrapped projection."""
+    sql = """
+    SELECT *
+    FROM (
+      SELECT
+        l_orderkey,
+        l_partkey,
+        DENSE_RANK() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice DESC) AS price_rank
+      FROM lineitem
+    ) t
+    ORDER BY l_orderkey, price_rank
+    """
+
+    assert extract_projection_names(sql, dialect="clickhouse") == ("l_orderkey", "l_partkey", "price_rank")
+
+
+def test_extract_projection_names_keeps_unrelated_select_star_as_unknown():
+    """SELECT * should not be resolved from an unrelated nested subquery."""
+    sql = """
+    SELECT *
+    FROM orders
+    WHERE EXISTS (
+      SELECT 1
+      FROM lineitem
+      WHERE l_orderkey = o_orderkey
+    )
+    """
+
+    assert extract_projection_names(sql, dialect="duckdb") is None
+
+
+def test_linter_detects_variant_column_mismatch():
+    """Static lint catches variants that project a different top-level shape."""
+    catalog = PrimitiveCatalog(
+        version=1,
+        queries={
+            "fulltext_boolean_search": PrimitiveQuery(
+                id="fulltext_boolean_search",
+                category="fulltext",
+                sql="SELECT c_custkey, c_name, relevance_score FROM customer",
+                variants={"duckdb": "SELECT c_custkey, c_name FROM customer"},
+                result_contract=ResultContract(
+                    columns=(
+                        ResultColumnContract("c_custkey"),
+                        ResultColumnContract("c_name"),
+                        ResultColumnContract("relevance_score"),
+                    ),
+                    capability="fulltext_boolean_rank",
+                ),
+            )
+        },
+    )
+
+    assert collect_variant_contract_issues(catalog, require_contracts=True) == [
+        VariantContractIssue(
+            query_id="fulltext_boolean_search",
+            dialect="duckdb",
+            kind="column_mismatch",
+            detail="base columns ('c_custkey', 'c_name', 'relevance_score') != variant columns ('c_custkey', 'c_name')",
+        )
+    ]
+
+
+def test_linter_requires_contract_for_high_risk_variant_query():
+    """High-risk variant families need explicit shape and capability metadata."""
+    catalog = PrimitiveCatalog(
+        version=1,
+        queries={
+            "json_aggregates": PrimitiveQuery(
+                id="json_aggregates",
+                category="json",
+                sql="SELECT JSON_ARRAYAGG(p_name) AS part_names FROM part",
+                variants={"duckdb": "SELECT JSON_GROUP_ARRAY(p_name) AS part_names FROM part"},
+            )
+        },
+    )
+
+    assert collect_variant_contract_issues(catalog, require_contracts=True) == [
+        VariantContractIssue(
+            query_id="json_aggregates",
+            dialect=None,
+            kind="missing_result_contract",
+            detail="High-risk variant-bearing query must declare result_contract",
+        )
+    ]
+
+
+def test_linter_detects_contract_column_mismatch_and_missing_capability():
+    """Contract metadata must match base projection names and declare capability."""
+    catalog = PrimitiveCatalog(
+        version=1,
+        queries={
+            "array_agg_simple": PrimitiveQuery(
+                id="array_agg_simple",
+                category="array",
+                sql="SELECT ps_suppkey, ARRAY_AGG(ps_partkey) AS supplied_parts FROM partsupp",
+                variants={"clickhouse": "SELECT ps_suppkey, groupArray(ps_partkey) AS supplied_parts FROM partsupp"},
+                result_contract=ResultContract(
+                    columns=(
+                        ResultColumnContract("ps_suppkey"),
+                        ResultColumnContract("parts", type_class="array"),
+                    ),
+                ),
+            )
+        },
+    )
+
+    issues = collect_variant_contract_issues(catalog, require_contracts=True)
+
+    assert issues == [
+        VariantContractIssue(
+            query_id="array_agg_simple",
+            dialect=None,
+            kind="contract_column_mismatch",
+            detail="base columns ('ps_suppkey', 'supplied_parts') != result_contract columns ('ps_suppkey', 'parts')",
+        ),
+        VariantContractIssue(
+            query_id="array_agg_simple",
+            dialect=None,
+            kind="missing_capability",
+            detail="result_contract must declare measured capability",
+        ),
+    ]
+
+
+def test_actual_catalog_static_linter_reports_known_current_drift():
+    """Current catalog drift is explicit until W3/W4 fix or skip those variants."""
+    issues = collect_variant_contract_issues(load_primitives_catalog(), require_contracts=False)
+
+    column_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "column_mismatch"}
+    parse_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "variant_parse_error"}
+
+    assert column_drift == {
+        ("fulltext_boolean_search", "clickhouse"),
+        ("fulltext_boolean_search", "datafusion"),
+        ("fulltext_boolean_search", "duckdb"),
+        ("fulltext_boolean_search", "redshift"),
+        ("fulltext_phrase_search", "clickhouse"),
+        ("fulltext_phrase_search", "datafusion"),
+        ("fulltext_phrase_search", "duckdb"),
+        ("fulltext_phrase_search", "redshift"),
+    }
+    assert parse_drift == {("asof_join_basic", "datafusion")}

--- a/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
+++ b/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
@@ -149,21 +149,12 @@ def test_linter_detects_contract_column_mismatch_and_missing_capability():
     ]
 
 
-def test_actual_catalog_static_linter_reports_known_current_drift():
-    """Current catalog drift is explicit until W3/W4 fix or skip those variants."""
+def test_actual_catalog_static_linter_reports_no_column_drift_after_scalar_skips():
+    """Catalog variants should not project different top-level columns after W3 scalar fixes."""
     issues = collect_variant_contract_issues(load_primitives_catalog(), require_contracts=False)
 
     column_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "column_mismatch"}
     parse_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "variant_parse_error"}
 
-    assert column_drift == {
-        ("fulltext_boolean_search", "clickhouse"),
-        ("fulltext_boolean_search", "datafusion"),
-        ("fulltext_boolean_search", "duckdb"),
-        ("fulltext_boolean_search", "redshift"),
-        ("fulltext_phrase_search", "clickhouse"),
-        ("fulltext_phrase_search", "datafusion"),
-        ("fulltext_phrase_search", "duckdb"),
-        ("fulltext_phrase_search", "redshift"),
-    }
+    assert column_drift == set()
     assert parse_drift == {("asof_join_basic", "datafusion")}

--- a/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
+++ b/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
@@ -82,7 +82,41 @@ def test_linter_detects_variant_column_mismatch():
             query_id="fulltext_boolean_search",
             dialect="duckdb",
             kind="column_mismatch",
-            detail="base columns ('c_custkey', 'c_name', 'relevance_score') != variant columns ('c_custkey', 'c_name')",
+            detail=(
+                "result_contract columns ('c_custkey', 'c_name', 'relevance_score') "
+                "!= variant columns ('c_custkey', 'c_name')"
+            ),
+        )
+    ]
+
+
+def test_linter_compares_variants_to_declared_contract_columns():
+    """A variant matching the declared contract should not be blamed for base SQL drift."""
+    catalog = PrimitiveCatalog(
+        version=1,
+        queries={
+            "array_agg_simple": PrimitiveQuery(
+                id="array_agg_simple",
+                category="array",
+                sql="SELECT ps_suppkey, ARRAY_AGG(ps_partkey) AS raw_parts FROM partsupp",
+                variants={"clickhouse": "SELECT ps_suppkey, groupArray(ps_partkey) AS supplied_parts FROM partsupp"},
+                result_contract=ResultContract(
+                    columns=(
+                        ResultColumnContract("ps_suppkey"),
+                        ResultColumnContract("supplied_parts", type_class="array"),
+                    ),
+                    capability="ordered_array_aggregation",
+                ),
+            )
+        },
+    )
+
+    assert collect_variant_contract_issues(catalog, require_contracts=True) == [
+        VariantContractIssue(
+            query_id="array_agg_simple",
+            dialect=None,
+            kind="contract_column_mismatch",
+            detail="base columns ('ps_suppkey', 'raw_parts') != result_contract columns ('ps_suppkey', 'supplied_parts')",
         )
     ]
 
@@ -145,6 +179,12 @@ def test_linter_detects_contract_column_mismatch_and_missing_capability():
             dialect=None,
             kind="missing_capability",
             detail="result_contract must declare measured capability",
+        ),
+        VariantContractIssue(
+            query_id="array_agg_simple",
+            dialect="clickhouse",
+            kind="column_mismatch",
+            detail="result_contract columns ('ps_suppkey', 'parts') != variant columns ('ps_suppkey', 'supplied_parts')",
         ),
     ]
 

--- a/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
+++ b/tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py
@@ -149,12 +149,6 @@ def test_linter_detects_contract_column_mismatch_and_missing_capability():
     ]
 
 
-def test_actual_catalog_static_linter_reports_no_column_drift_after_scalar_skips():
-    """Catalog variants should not project different top-level columns after W3 scalar fixes."""
-    issues = collect_variant_contract_issues(load_primitives_catalog(), require_contracts=False)
-
-    column_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "column_mismatch"}
-    parse_drift = {(issue.query_id, issue.dialect) for issue in issues if issue.kind == "variant_parse_error"}
-
-    assert column_drift == set()
-    assert parse_drift == {("asof_join_basic", "datafusion")}
+def test_actual_catalog_static_linter_reports_no_variant_contract_issues():
+    """Every active catalog variant must declare and satisfy a comparability contract."""
+    assert collect_variant_contract_issues(load_primitives_catalog(), require_contracts=True) == []


### PR DESCRIPTION
## Summary

- add result-contract metadata and static linting for read-primitives variant comparability
- skip non-comparable read-primitives variants consistently, including full-text queries on unsupported dialects
- add parity coverage for high-risk variants and address the review findings around array ordering, contract source-of-truth, docs drift, and test boilerplate

## Validation

- `uv run -- ruff format --check ...`
- `uv run -- ruff check ...`
- `uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py tests/unit/core/read_primitives/test_catalog_loader.py tests/unit/core/read_primitives/test_benchmark_variants.py tests/unit/core/read_primitives/test_query_manager_variants.py tests/integration/validation/test_read_primitives_variant_parity.py -q` (`111 passed`)
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`

Note: a prior full fast-suite run hit one transient local memory-gate failure in `tests/unit/core/runner/test_dataframe_runner.py::TestRunDataframeBenchmark::test_load_phase_uses_data_loader_preparation_pipeline`; rerunning that test passed.