### PR TITLE
fix(blind-spots): address review findings

### DIFF
--- a/.claude/commands/blind-spot.md
+++ b/.claude/commands/blind-spot.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(date:*), Bash(uv:*), Bash(make:*), Write, Edit, Read
+allowed-tools: Bash(date:*), Bash(git:*), Bash(ls:*), Bash(grep:*), Bash(wc:*), Bash(tr:*), Bash(test:*), Bash(uv:*), Bash(make:*), Write, Edit, Read
 description: Record a blind-spot audit finding to _project/blind-spots/ (file-first capture)
 ---
 
@@ -21,7 +21,8 @@ The user wants to record a blind-spot audit finding. Follow the protocol in
 
 2. **Compose the filename.** Use the timestamp from the Context block above:
    `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`. Filename stem must equal
-   the `id` field in the frontmatter.
+   the `id` field in the frontmatter. If that exact path already exists, append
+   a short numeric suffix before `.md` (`...-<slug>-2.md`, then `-3`, etc.).
 
 3. **Write the file** using this exact frontmatter schema. Required fields are
    `id`, `date`, `status` (always `open` at write time), `finding_kind`, and

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ _sources/tpc-h/dbgen/dbgen_x86_64
 # pure functions of the per-item _project/{TODO,DONE}/**/*.yaml files.
 _project/TODO/_indexes/
 _project/DONE/_indexes/
+_project/blind-spots/_indexes/
 
 # Firebolt data and core data directories
 /firebolt-data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ When you produce a **Blind-Spot Audit (L2)** during any review (ultrareview,
 Do not skip the file write because the finding "feels minor" — sweep-time
 triage is where dismissals belong, not write-time. Findings printed only in
 chat get lost; file-first capture is what makes the L2 audit habit pay off.
+If a review response contains an L2 audit without a `Recorded:` pointer for
+each finding, treat the response as protocol drift and record the missing
+finding before continuing.
 
 Sweep / triage findings with `make blind-spots-{list,report,sweep}`. Promotion
 to a TODO is a sweep-step decision, not a write-step decision. See

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -40,12 +40,15 @@ not the write step.
 YYYY-MM-DD-HHMMSS-<short-slug>.md
 ```
 
-- The timestamp prefix gives total ordering and uniqueness — two parallel
-  reviews on two branches can never produce the same filename. **This is
-  what makes the directory merge-collision-safe.**
-- The slug is grep bait, kept short (3–6 words).
+- The timestamp prefix gives total ordering and practical uniqueness. If the
+  exact target path already exists (same second + same slug), append a short
+  numeric suffix such as `-2` before `.md`. **This is what makes the directory
+  merge-collision-safe.**
+- The slug is grep bait, kept short (3–6 words), lowercase kebab-case with no
+  empty segments or trailing hyphen.
 
-Use the local clock; precision to the second is plenty.
+Use the local clock; precision to the second is plenty when paired with the
+exists-before-write suffix rule.
 
 ---
 
@@ -75,9 +78,9 @@ todo_id: null                                     # populated when promoted via 
 | `status` | yes | One of: `open`, `actioned`, `dismissed`, `merged-to-todo` |
 | `finding_kind` | yes | One of: `framework-gap`, `bug-class`, `missed-axis`, `scope-creep`, `assumption`, `other` |
 | `review_context` | yes | Free-form: which review / branch / PR / agent surfaced this |
-| `related_paths` | optional | Repo-relative paths the finding touches |
-| `suggested_sweep` | optional | One-line hint for the sweep step |
-| `todo_id` | optional | Slug of the promoted TODO, populated by `sweep_blind_spots.py triage promote` |
+| `related_paths` | optional | Repo-relative paths the finding touches; list of strings or `null` |
+| `suggested_sweep` | optional | One-line hint for the sweep step; string or `null` |
+| `todo_id` | optional | Non-empty slug of the promoted TODO, populated by `sweep_blind_spots.py triage promote`; `null` while open |
 
 Anything else is rejected by `validate_blind_spot.py`. Keep frontmatter
 minimal — long context belongs in the body.
@@ -86,7 +89,8 @@ minimal — long context belongs in the body.
 
 ## Body shape
 
-Keep it short. These are seeds, not specs.
+Keep it short. These are seeds, not specs. `validate_blind_spot.py` enforces
+the top-level title plus the three required `##` sections below.
 
 ```markdown
 # <Title — one line, no jargon>
@@ -136,8 +140,8 @@ uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.p
 uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action promote  --todo-id <todo-slug>
 ```
 
-Triage outcomes (each stamps frontmatter and appends a one-line entry under
-`## Triage log` in the body):
+Triage outcomes (each updates only `status` / `todo_id` in frontmatter and
+appends a one-line entry under `## Triage log` in the body):
 
 - **`dismiss`** — sets `status: dismissed`. Use when the finding doesn't
   warrant action.
@@ -160,14 +164,16 @@ There are exactly two ways markdown-in-git directories generate merge
 conflicts, and both are designed out:
 
 1. **Two branches editing the same file at the same offset** — avoided by
-   one-file-per-finding with timestamped names. Two parallel reviews produce
-   two filenames, not two diffs of one file.
+   one-file-per-finding with timestamped names plus the exists-before-write
+   suffix rule. Two parallel reviews produce two filenames, not two diffs of
+   one file.
 2. **Two branches editing a shared index** — avoided by *not checking in any
    hand-maintained index*. The sweep produces transient reports, and TODO
    promotion goes through the existing `todo_cli.py` infrastructure (which
    already handles its own indexes via `generate_indexes.py`).
 
 The only file that gets edited in place after creation is the finding's own
-frontmatter `status:` line during triage. Triage happens serially on a single
-branch, so two people aren't dismissing the same finding from two PRs. If
-they ever did, the conflict is a 3-line YAML diff, trivial to resolve.
+frontmatter `status:` / `todo_id:` line during triage plus its own
+`## Triage log` section. Triage happens serially on a single branch, so two
+people aren't dismissing the same finding from two PRs. If they ever did, the
+conflict is a small finding-local diff, not a shared-index conflict.

--- a/_project/scripts/sweep_blind_spots.py
+++ b/_project/scripts/sweep_blind_spots.py
@@ -33,7 +33,15 @@ ACTION_TO_STATUS = {
     "actioned": "actioned",
     "promote": "merged-to-todo",
 }
-FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+FINDING_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9]+(?:-[a-z0-9]+)*$")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|\Z)", re.DOTALL)
+TRIAGE_LOG_HEADING_RE = re.compile(r"(?m)^## Triage log\s*$")
+SECTION_HEADING_RE = re.compile(r"(?m)^## .+$")
+
+
+def normalize_newlines(text: str) -> str:
+    """Normalize markdown line endings before parsing or rewriting."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
 def find_blind_spots_dir(start: Path) -> Path:
@@ -48,6 +56,7 @@ def find_blind_spots_dir(start: Path) -> Path:
 
 def split_frontmatter(text: str) -> tuple[dict, str, str]:
     """Return (data, raw_frontmatter, body)."""
+    text = normalize_newlines(text)
     m = FRONTMATTER_RE.match(text)
     if not m:
         raise ValueError("file does not start with a YAML frontmatter block")
@@ -74,13 +83,28 @@ def load_findings(bs_dir: Path) -> list[tuple[Path, dict, str]]:
     return out
 
 
-def find_one(bs_dir: Path, finding_id: str) -> tuple[Path, dict, str]:
-    candidate = bs_dir / f"{finding_id}.md"
+def find_one(bs_dir: Path, finding_id: str) -> tuple[Path, dict, str, str]:
+    if not FINDING_ID_RE.match(finding_id):
+        print(f"error: invalid finding id '{finding_id}'", file=sys.stderr)
+        sys.exit(2)
+
+    root = bs_dir.resolve()
+    candidate = (bs_dir / f"{finding_id}.md").resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        print(f"error: invalid finding id '{finding_id}'", file=sys.stderr)
+        sys.exit(2)
+
     if not candidate.exists():
         print(f"error: no finding with id '{finding_id}'", file=sys.stderr)
         sys.exit(2)
-    data, _raw, body = split_frontmatter(candidate.read_text(encoding="utf-8"))
-    return candidate, data, body
+    try:
+        data, raw, body = split_frontmatter(candidate.read_text(encoding="utf-8"))
+    except (ValueError, yaml.YAMLError) as exc:
+        print(f"error: finding '{finding_id}' is malformed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return candidate, data, raw, body
 
 
 def extract_title(body: str) -> str:
@@ -99,7 +123,7 @@ def fmt_date(value) -> str:
 
 def cmd_list(bs_dir: Path, args: argparse.Namespace) -> int:
     findings = load_findings(bs_dir)
-    findings.sort(key=lambda t: t[1].get("date", ""))
+    findings.sort(key=lambda t: fmt_date(t[1].get("date", "")))
 
     rows = []
     for path, data, body in findings:
@@ -110,9 +134,9 @@ def cmd_list(bs_dir: Path, args: argparse.Namespace) -> int:
         rows.append(
             (
                 fmt_date(data.get("date", "????-??-??")),
-                data.get("status", "?"),
-                data.get("finding_kind", "?"),
-                data.get("id", path.stem),
+                str(data.get("status", "?")),
+                str(data.get("finding_kind", "?")),
+                str(data.get("id", path.stem)),
                 extract_title(body),
             )
         )
@@ -138,7 +162,7 @@ def cmd_list(bs_dir: Path, args: argparse.Namespace) -> int:
 
 
 def cmd_show(bs_dir: Path, args: argparse.Namespace) -> int:
-    path, data, body = find_one(bs_dir, args.id)
+    path, data, _raw, body = find_one(bs_dir, args.id)
     print(f"# {path.relative_to(bs_dir.parent.parent)}\n")
     print("---")
     print(yaml.safe_dump(data, sort_keys=False).rstrip())
@@ -188,43 +212,72 @@ def cmd_report(bs_dir: Path, args: argparse.Namespace) -> int:
     return 0
 
 
-def stamp_frontmatter(path: Path, data: dict, body: str, new_status: str, todo_id: str | None) -> None:
-    """Rewrite the file with updated status (and optional todo_id)."""
-    data["status"] = new_status
+def render_scalar_field(field: str, value: str) -> str:
+    """Render one simple YAML scalar assignment without reformatting the block."""
+    rendered = yaml.safe_dump({field: value}, sort_keys=False, width=10_000).strip()
+    if "\n" in rendered:
+        raise ValueError(f"{field} must render as a single YAML line")
+    return rendered
+
+
+def replace_frontmatter_field(raw: str, field: str, value: str) -> str:
+    line = render_scalar_field(field, value)
+    pattern = re.compile(rf"(?m)^{re.escape(field)}:.*$")
+    if pattern.search(raw):
+        return pattern.sub(line, raw, count=1)
+    return raw.rstrip() + f"\n{line}"
+
+
+def stamp_frontmatter(path: Path, raw_frontmatter: str, body: str, new_status: str, todo_id: str | None) -> None:
+    """Rewrite only status/todo_id while preserving the rest of the frontmatter."""
+    new_raw = replace_frontmatter_field(raw_frontmatter, "status", new_status)
     if todo_id is not None:
-        data["todo_id"] = todo_id
-    new_raw = yaml.safe_dump(data, sort_keys=False).rstrip()
+        new_raw = replace_frontmatter_field(new_raw, "todo_id", todo_id)
     new_text = f"---\n{new_raw}\n---\n{body}"
     path.write_text(new_text, encoding="utf-8")
 
 
 def append_triage_log(path: Path, line: str) -> None:
-    text = path.read_text(encoding="utf-8")
-    if "\n## Triage log\n" in text:
-        # Append under existing section.
-        new_text = text.rstrip() + f"\n- {line}\n"
-    else:
+    text = normalize_newlines(path.read_text(encoding="utf-8"))
+    match = TRIAGE_LOG_HEADING_RE.search(text)
+    if match is None:
         new_text = text.rstrip() + f"\n\n## Triage log\n\n- {line}\n"
+    else:
+        next_section = SECTION_HEADING_RE.search(text, match.end())
+        insert_at = next_section.start() if next_section else len(text)
+        before = text[:insert_at].rstrip()
+        after = text[insert_at:].lstrip("\n")
+        if before.endswith("## Triage log"):
+            before += "\n"
+        new_text = f"{before}\n- {line}\n"
+        if after:
+            new_text += f"\n{after}"
     path.write_text(new_text, encoding="utf-8")
 
 
 def cmd_triage(bs_dir: Path, args: argparse.Namespace) -> int:
     new_status = ACTION_TO_STATUS[args.action]
-    path, data, body = find_one(bs_dir, args.id)
 
     if args.action == "promote":
+        if args.reason:
+            print("error: --reason cannot be combined with --action promote", file=sys.stderr)
+            return 2
         if not args.todo_id:
             print("error: --todo-id is required for --action promote", file=sys.stderr)
             return 2
         todo_id: str | None = args.todo_id
         log_line = f"{datetime.now().date().isoformat()}: promoted to TODO `{todo_id}`"
     else:
+        if args.todo_id:
+            print("error: --todo-id is only valid with --action promote", file=sys.stderr)
+            return 2
         todo_id = None
         reason = args.reason or ""
         suffix = f" — {reason}" if reason else ""
         log_line = f"{datetime.now().date().isoformat()}: {args.action}{suffix}"
 
-    stamp_frontmatter(path, data, body, new_status, todo_id)
+    path, _data, raw, body = find_one(bs_dir, args.id)
+    stamp_frontmatter(path, raw, body, new_status, todo_id)
     append_triage_log(path, log_line)
     print(f"OK   {path.relative_to(bs_dir.parent.parent)} → status={new_status}")
     if todo_id:

--- a/_project/scripts/validate_blind_spot.py
+++ b/_project/scripts/validate_blind_spot.py
@@ -35,44 +35,50 @@ OPTIONAL_FIELDS = {"related_paths", "suggested_sweep", "todo_id"}
 ALLOWED_FIELDS = REQUIRED_FIELDS | OPTIONAL_FIELDS
 
 # YYYY-MM-DD-HHMMSS-<slug>; slug is kebab-case, lowercase letters/digits.
-FILENAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9][a-z0-9-]*$")
+FILENAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9]+(?:-[a-z0-9]+)*$")
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|\Z)(.*)\Z", re.DOTALL)
+REQUIRED_BODY_HEADINGS = ("## Finding", "## Why this matters", "## Suggested next steps")
 
 
-def parse_frontmatter(text: str) -> tuple[dict | None, list[str]]:
-    """Split a markdown file into (frontmatter_dict, errors).
+def normalize_newlines(text: str) -> str:
+    """Normalize markdown line endings before frontmatter parsing."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def parse_frontmatter(text: str) -> tuple[dict | None, str, list[str]]:
+    """Split a markdown file into (frontmatter_dict, body, errors).
 
     Returns ``(None, [...])`` if the frontmatter block is missing or malformed.
     """
     errors: list[str] = []
+    text = normalize_newlines(text)
     if not text.startswith("---\n"):
-        return None, ["file must begin with a YAML frontmatter '---' line"]
+        return None, "", ["file must begin with a YAML frontmatter '---' line"]
 
-    # Find the closing fence on its own line.
-    body = text[4:]
-    end = body.find("\n---\n")
-    if end == -1:
-        # Allow trailing fence with no body after.
-        if body.endswith("\n---") or body.endswith("\n---\n"):
-            end = len(body) - 4
-        else:
-            return None, ["unterminated frontmatter block (no closing '---')"]
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return None, "", ["unterminated frontmatter block (no closing '---')"]
 
-    raw = body[:end]
+    raw = match.group(1)
     try:
         data = yaml.safe_load(raw)
     except yaml.YAMLError as exc:
-        return None, [f"frontmatter is not valid YAML: {exc}"]
+        return None, "", [f"frontmatter is not valid YAML: {exc}"]
 
     if not isinstance(data, dict):
-        return None, ["frontmatter must be a YAML mapping"]
-    return data, errors
+        return None, "", ["frontmatter must be a YAML mapping"]
+    return data, match.group(2), errors
 
 
 def _check_id_and_filename(data: dict, file_path: Path) -> list[str]:
     errors: list[str] = []
     expected_id = file_path.stem
-    if "id" in data and data["id"] != expected_id:
-        errors.append(f"id '{data['id']}' must equal filename stem '{expected_id}'")
+    if "id" in data:
+        value = data["id"]
+        if not isinstance(value, str) or not value.strip():
+            errors.append("id must be a non-empty string")
+        elif value != expected_id:
+            errors.append(f"id '{value}' must equal filename stem '{expected_id}'")
     if not FILENAME_RE.match(expected_id):
         errors.append(f"filename stem '{expected_id}' does not match YYYY-MM-DD-HHMMSS-<kebab-slug>")
     return errors
@@ -95,10 +101,18 @@ def _check_date(data: dict) -> list[str]:
 
 def _check_enums(data: dict) -> list[str]:
     errors: list[str] = []
-    if "status" in data and data["status"] not in ALLOWED_STATUS:
-        errors.append(f"status '{data['status']}' not in {sorted(ALLOWED_STATUS)}")
-    if "finding_kind" in data and data["finding_kind"] not in ALLOWED_KIND:
-        errors.append(f"finding_kind '{data['finding_kind']}' not in {sorted(ALLOWED_KIND)}")
+    if "status" in data:
+        status = data["status"]
+        if not isinstance(status, str):
+            errors.append(f"status must be a string, got {type(status).__name__}")
+        elif status not in ALLOWED_STATUS:
+            errors.append(f"status '{status}' not in {sorted(ALLOWED_STATUS)}")
+    if "finding_kind" in data:
+        kind = data["finding_kind"]
+        if not isinstance(kind, str):
+            errors.append(f"finding_kind must be a string, got {type(kind).__name__}")
+        elif kind not in ALLOWED_KIND:
+            errors.append(f"finding_kind '{kind}' not in {sorted(ALLOWED_KIND)}")
     return errors
 
 
@@ -116,15 +130,20 @@ def _check_optional_shapes(data: dict) -> list[str]:
         ss = data["suggested_sweep"]
         if ss is not None and not isinstance(ss, str):
             errors.append("suggested_sweep must be a string or null")
+        elif isinstance(ss, str) and "\n" in ss:
+            errors.append("suggested_sweep must be one line")
     if "todo_id" in data:
         ti = data["todo_id"]
         if ti is not None and not isinstance(ti, str):
             errors.append("todo_id must be a string or null")
+        elif isinstance(ti, str) and not ti.strip():
+            errors.append("todo_id must be non-empty when present")
     return errors
 
 
 def _check_status_invariants(data: dict) -> list[str]:
-    if data.get("status") == "merged-to-todo" and not data.get("todo_id"):
+    todo_id = data.get("todo_id")
+    if data.get("status") == "merged-to-todo" and not (isinstance(todo_id, str) and todo_id.strip()):
         return ["status 'merged-to-todo' requires a non-empty todo_id"]
     return []
 
@@ -142,6 +161,18 @@ def validate_frontmatter(data: dict, file_path: Path) -> list[str]:
     return errors
 
 
+def validate_body(body: str) -> list[str]:
+    """Validate the required short markdown body shape."""
+    errors: list[str] = []
+    lines = [line.strip() for line in body.splitlines()]
+    if not any(line.startswith("# ") and line[2:].strip() for line in lines):
+        errors.append("body must include a top-level '# <title>' heading")
+    for heading in REQUIRED_BODY_HEADINGS:
+        if heading not in lines:
+            errors.append(f"body must include '{heading}' section")
+    return errors
+
+
 def validate_file(file_path: Path) -> list[str]:
     if not file_path.exists():
         return [f"file not found: {file_path}"]
@@ -151,10 +182,10 @@ def validate_file(file_path: Path) -> list[str]:
         return []  # README is the protocol doc, not a finding
 
     text = file_path.read_text(encoding="utf-8")
-    data, parse_errors = parse_frontmatter(text)
+    data, body, parse_errors = parse_frontmatter(text)
     if data is None:
         return parse_errors
-    return parse_errors + validate_frontmatter(data, file_path)
+    return parse_errors + validate_frontmatter(data, file_path) + validate_body(body)
 
 
 def find_blind_spots_dir(start: Path) -> Path | None:

--- a/tests/unit/scripts/test_blind_spot_tools.py
+++ b/tests/unit/scripts/test_blind_spot_tools.py
@@ -1,0 +1,206 @@
+"""Tests for blind-spot finding validation and sweep tooling."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script(name: str):
+    path = REPO_ROOT / "_project" / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validate_blind_spot = _load_script("validate_blind_spot")
+sweep_blind_spots = _load_script("sweep_blind_spots")
+
+
+def _finding_text(
+    stem: str,
+    *,
+    status: str = "open",
+    date: str = "2026-04-29",
+    finding_kind: str = "other",
+    body: str | None = None,
+) -> str:
+    body = (
+        body
+        or """# Test Finding
+
+## Finding
+The finding.
+
+## Why this matters
+The reason.
+
+## Suggested next steps
+- [ ] Do the thing.
+"""
+    )
+    return f"""---
+id: {stem}
+date: {date}
+status: {status}
+finding_kind: {finding_kind}
+review_context: "unit test"
+related_paths: null
+suggested_sweep: null
+todo_id: null
+---
+
+{body}"""
+
+
+def _write_finding(bs_dir: Path, stem: str, **kwargs) -> Path:
+    bs_dir.mkdir(parents=True, exist_ok=True)
+    path = bs_dir / f"{stem}.md"
+    path.write_text(_finding_text(stem, **kwargs), encoding="utf-8")
+    return path
+
+
+def test_validator_reports_nested_enum_instead_of_traceback(tmp_path: Path) -> None:
+    stem = "2026-04-29-120000-nested-status"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(
+        _finding_text(stem).replace("status: open", "status:\n  - open"),
+        encoding="utf-8",
+    )
+
+    errors = validate_blind_spot.validate_file(path)
+
+    assert "status must be a string, got list" in errors
+
+
+def test_validator_accepts_crlf_frontmatter(tmp_path: Path) -> None:
+    stem = "2026-04-29-120001-crlf-frontmatter"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(_finding_text(stem).replace("\n", "\r\n"), encoding="utf-8")
+
+    assert validate_blind_spot.validate_file(path) == []
+
+
+def test_validator_rejects_frontmatter_only_files(tmp_path: Path) -> None:
+    stem = "2026-04-29-120002-frontmatter-only"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(
+        f"""---
+id: {stem}
+date: 2026-04-29
+status: open
+finding_kind: other
+review_context: "unit test"
+---
+""",
+        encoding="utf-8",
+    )
+
+    errors = validate_blind_spot.validate_file(path)
+
+    assert "body must include a top-level '# <title>' heading" in errors
+    assert "body must include '## Finding' section" in errors
+
+
+def test_sweep_list_handles_mixed_yaml_date_scalars(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    _write_finding(bs_dir, "2026-04-29-120003-unquoted-date")
+    _write_finding(bs_dir, "2026-04-29-120004-quoted-date", date='"2026-04-29"')
+
+    result = sweep_blind_spots.cmd_list(bs_dir, SimpleNamespace(status="open", kind=None))
+
+    assert result == 0
+    assert "2 finding(s)." in capsys.readouterr().out
+
+
+def test_find_one_rejects_path_traversal(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    bs_dir.mkdir(parents=True)
+
+    with pytest.raises(SystemExit) as exc:
+        sweep_blind_spots.find_one(bs_dir, "../audits/not-a-finding")
+
+    assert exc.value.code == 2
+    assert "invalid finding id" in capsys.readouterr().err
+
+
+def test_stamp_frontmatter_preserves_unrelated_formatting(tmp_path: Path) -> None:
+    stem = "2026-04-29-120005-preserve-format"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(
+        f"""---
+id: {stem}
+# keep this comment
+date: 2026-04-29
+status: open
+finding_kind: other
+review_context: "quoted context"
+todo_id: null
+---
+
+# Test Finding
+
+## Finding
+The finding.
+
+## Why this matters
+The reason.
+
+## Suggested next steps
+- [ ] Do the thing.
+""",
+        encoding="utf-8",
+    )
+    _data, raw, body = sweep_blind_spots.split_frontmatter(path.read_text(encoding="utf-8"))
+
+    sweep_blind_spots.stamp_frontmatter(path, raw, body, "dismissed", None)
+
+    text = path.read_text(encoding="utf-8")
+    assert "# keep this comment" in text
+    assert 'review_context: "quoted context"' in text
+    assert "status: dismissed" in text
+
+
+def test_append_triage_log_inserts_before_next_section(tmp_path: Path) -> None:
+    path = tmp_path / "finding.md"
+    path.write_text(
+        """# Test Finding
+
+## Triage log
+
+## Later notes
+
+Keep this content separate.
+""",
+        encoding="utf-8",
+    )
+
+    sweep_blind_spots.append_triage_log(path, "2026-04-29: actioned")
+
+    text = path.read_text(encoding="utf-8")
+    assert text.index("- 2026-04-29: actioned") < text.index("## Later notes")
+
+
+def test_triage_rejects_promote_reason_combo(tmp_path: Path) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    stem = "2026-04-29-120006-promote-reason"
+    path = _write_finding(bs_dir, stem)
+    args = SimpleNamespace(id=stem, action="promote", reason="because", todo_id="todo-slug")
+
+    result = sweep_blind_spots.cmd_triage(bs_dir, args)
+
+    assert result == 2
+    assert "status: open" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
Follow-up to PR #56 addressing the review findings before relying on blind-spot capture as review infrastructure.

Changes:
- Block path traversal and invalid IDs in `sweep_blind_spots.py`.
- Normalize CRLF frontmatter and mixed YAML date scalar handling.
- Type-check enum fields so nested YAML fails with validation errors instead of tracebacks.
- Preserve unrelated frontmatter formatting when triaging.
- Insert triage-log entries into the `## Triage log` section rather than appending blindly to EOF.
- Reject invalid triage option combinations.
- Document filename collision handling and protocol drift signals.
- Add focused fast unit coverage for validator and sweep edge cases.

Validation run locally in a fresh clone:
- `uv run -- python -m pytest tests/unit/scripts/test_blind_spot_tools.py -q -n 0`
- `uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py --all`
- `uv run -- python -m ruff check _project/scripts/validate_blind_spot.py _project/scripts/sweep_blind_spots.py tests/unit/scripts/test_blind_spot_tools.py`
- `uv run -- python -m ruff format --check _project/scripts/validate_blind_spot.py _project/scripts/sweep_blind_spots.py tests/unit/scripts/test_blind_spot_tools.py`