### PR TITLE
chore(todo): create dev-loop simplification 6-step plan with decision gates

### DIFF
--- a/_project/TODO/main/planning/dev-loop-step-0-verify-assumptions.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-0-verify-assumptions.yaml
@@ -1,0 +1,163 @@
+id: dev-loop-step-0-verify-assumptions
+title: "Dev-loop simplification — Step 0: verify assumptions before changing anything"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Decision-gate item that precedes Steps 1-4 of the dev-loop simplification
+  plan. The plan rests on three load-bearing assumptions: (a) "Require
+  branches to be up to date before merging" is enabled on `develop`,
+  (b) PR-tier CI on `develop` is heavier than necessary, (c) native
+  GitHub Merge Queue is unavailable on this user-owned repo.
+
+  This TODO produces a written decision record. If any assumption is
+  wrong, downstream TODOs (Step 1-4) must be re-planned BEFORE shipping.
+
+  No commits are produced by this TODO except the decision record itself.
+
+  Context (for future readers): see `_project/blind-spots/` for the L2
+  audit findings that motivated the dev-loop simplification, captured
+  in Step 1.
+
+work:
+  - id: w1
+    summary: "Check classic branch protection on develop for `strict: true`"
+    status: pending
+    notes: |
+      Run: `gh api repos/joeharris76/BenchBox/branches/develop/protection
+      --jq '.required_status_checks'` and record the value of `strict`.
+      If strict is already false, the staleness diagnosis is wrong and
+      Step 3.4 (disable strict-base) is a no-op. Re-plan before Step 3.
+
+  - id: w2
+    summary: "Check GitHub rulesets targeting develop for required-checks and strict-base"
+    status: pending
+    notes: |
+      Required checks may be encoded in a ruleset, not in classic
+      branch protection. Run: `gh api repos/joeharris76/BenchBox/rulesets`
+      and inspect each ruleset that targets `develop`. Record:
+        - Ruleset names targeting develop
+        - Required status checks per ruleset
+        - Whether `require_branches_up_to_date` is set in any of them
+      The Step 3.4 toggle must be applied wherever it's encoded.
+
+  - id: w3
+    summary: "Audit current PR-tier CI cost on develop"
+    status: pending
+    notes: |
+      Read `.github/workflows/test.yml` `on:` block; identify which jobs
+      run on `pull_request` to develop. Cross-reference with recent run
+      durations: `gh run list --workflow test.yml --branch develop --limit 20
+      --json conclusion,startedAt,updatedAt,name`. Record P50/P95 CI
+      duration on develop PRs today. This is the baseline that Step 3.1
+      (cut to lint + Ubuntu 3.12 fast tests) reduces.
+
+  - id: w4
+    summary: "Audit develop-post-merge.yml health"
+    status: pending
+    notes: |
+      Run: `gh run list --workflow develop-post-merge.yml --branch develop
+      --limit 30 --json conclusion`. Record current red/green ratio. If
+      already noisy, Step 4 needs to handle false positives carefully.
+    needs: [w3]
+
+  - id: w5
+    summary: "Estimate actual pr-refresh / staleness pain rate"
+    status: pending
+    notes: |
+      Inspect last 50 merged PRs for refresh-loop indicators:
+        - `gh pr list --state merged --base develop --limit 50 --json title,labels,comments,mergedAt`
+        - grep recent shell history / commit messages for `pr-refresh`
+        - look for "rebase" or "merge develop" comments on PRs
+      Record an estimated rate (PRs that hit refresh / total). If it's
+      under 5%, the queue is overkill even if Step 4 metrics later say
+      otherwise — Step 6 should reflect that.
+
+  - id: w6
+    summary: "Confirm native GitHub Merge Queue availability"
+    status: pending
+    notes: |
+      Run: `gh api repos/joeharris76/BenchBox --jq '{visibility, owner_type:
+      .owner.type, allow_merge_commit, merge_queue: .has_issues}'`.
+      Native MQ requires public org-owned, or private org-owned on
+      Enterprise Cloud. User-owned repos do not qualify. Record the
+      finding so Step 6 picks the right path (native vs steward) without
+      re-investigation.
+
+  - id: w7
+    summary: "Write decision record at _project/decisions/dev-loop-verification-2026-04-30.md"
+    status: pending
+    needs: [w1, w2, w3, w4, w5, w6]
+    notes: |
+      Single markdown file with: timestamp, raw outputs of w1-w6,
+      conclusions, and explicit GO/NO-GO/RE-PLAN signal for each of
+      Steps 1-4. Future agents read this before starting any downstream
+      step.
+
+verification:
+  - description: "Decision record exists and contains all six findings"
+    command: "test -f _project/decisions/dev-loop-verification-2026-04-30.md && grep -cE '^## (W[1-6]|Conclusion)' _project/decisions/dev-loop-verification-2026-04-30.md"
+    expected_output: ">= 7"
+  - description: "Decision record explicitly addresses each downstream step"
+    command: "grep -cE 'Step [1-6]:' _project/decisions/dev-loop-verification-2026-04-30.md"
+    expected_output: ">= 4"
+
+must_preserve:
+  - "No code or workflow changes during this step — verification only"
+  - "All API outputs recorded verbatim, not paraphrased — future agents may need the raw values"
+
+approach: |
+  Pure read-only investigation. Run `gh api` calls in sequence,
+  paste raw JSON into the decision record, then write conclusions.
+  Do not modify branch protection, rulesets, or any workflow during
+  this TODO. The single artifact is a markdown file documenting
+  what is true today.
+
+anti_patterns:
+  - "DO NOT begin Step 1-4 work in parallel with this TODO — because the verification may invalidate downstream plans — wait for the GO signal in the decision record"
+  - "DO NOT skip w2 (rulesets) — because GitHub repos commonly encode protection in rulesets rather than classic branch protection — checking only one surface gives a false answer"
+  - "DO NOT paraphrase API responses in the decision record — because future re-plans need raw values — paste verbatim JSON"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/dev-loop-verification-2026-04-30.md (new file, the decision record)"
+  do_not_modify:
+    - ".github/workflows/"
+    - "Makefile"
+    - "CLAUDE.md"
+    - "AGENTS.md"
+    - "Any branch protection or ruleset settings"
+
+deferred:
+  - summary: "Acting on the findings (Steps 1-4 implementation)"
+    reason: "Each downstream step is a separate TODO with its own scope and verification"
+
+metadata:
+  tags:
+    - dev-loop
+    - verification
+    - decision-gate
+  estimated_effort: "Small (20-30 min, no commits beyond decision record)"
+  created_date: "2026-04-30"
+
+impact:
+  business_value: |
+    Prevents shipping the wrong fix. The dev-loop simplification plan
+    rests on assumptions about current branch-protection and CI shape;
+    if any are wrong, downstream steps need to change before they ship.
+    20 min of verification avoids 4-8 hours of re-work.
+  technical_debt: |
+    Produces a durable decision record at _project/decisions/. Same
+    pattern as ADRs — captures WHY the subsequent steps are shaped
+    the way they are, useful when revisiting in 6 months.
+
+success_metrics:
+  - "Decision record committed to develop within 1 day of starting"
+  - "Each of Steps 1-4 has an explicit GO/NO-GO/RE-PLAN signal in the record"
+  - "Raw API outputs preserved for future re-evaluation"
+
+open_questions:
+  - "Should the decision record also capture branch protection on `main` for symmetry, or is develop-only sufficient?"
+  - "If w1/w2 reveal strict-base is already off, do we still ship Steps 1-2 (still useful) or pause the whole plan?"

--- a/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
@@ -1,0 +1,200 @@
+id: dev-loop-step-1-local-loop-cleanup
+title: "Dev-loop simplification — Step 1: opt-in pre-push, bounded fanout, conservative test lock"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  First implementation step of the dev-loop simplification plan. Removes
+  local-loop friction so agents can push and run `pr-fanout` without
+  hook serialization, while preserving the global test lock that protects
+  the workstation from concurrent xdist storms.
+
+  This step also captures the consolidated L2 blind-spot findings from
+  the four-round merge-loop audit to `_project/blind-spots/`, satisfying
+  the protocol-debt accumulated during the planning rounds.
+
+  Single PR via `make pr-open`. Independently shippable; no dependency
+  on Steps 2-4 landing first.
+
+deps:
+  needs:
+    - dev-loop-step-0-verify-assumptions
+
+work:
+  - id: w1
+    summary: "Gate all expensive pre-push hooks behind BENCHBOX_PREPUSH=1"
+    status: pending
+    notes: |
+      Audit `.pre-commit-config.yaml` for every hook with `stages:
+      [pre-push]`. Currently includes at minimum:
+        - `pr-preflight-fast-tests`
+        - `timing-policy-fast-lane`
+      Wrap each entry's command in a guard:
+        `if [ "$BENCHBOX_PREPUSH" = "1" ]; then <existing-cmd>; else exit 0; fi`
+      Or use the `args` / `entry` pattern that pre-commit supports.
+      Default behavior: hooks no-op unless env var is set. `make
+      pr-preflight` remains the explicit human-facing invocation
+      (does not depend on the env var).
+
+  - id: w2
+    summary: "Make pr-fanout bounded-parallel with PR_FANOUT_JOBS=4 default"
+    status: pending
+    notes: |
+      Change `pr-fanout` target in `Makefile` from sequential to parallel.
+      Add `PR_FANOUT_JOBS ?= 4` near the top. Use `xargs -P "$(PR_FANOUT_JOBS)"`
+      or GNU `parallel -j "$(PR_FANOUT_JOBS)"` to fan out
+      `make pr-open` calls across worktrees. Drop the
+      "Sequential by design" comment block. Document the env var in
+      the help target.
+    needs: [w1]
+
+  - id: w3
+    summary: "Keep global test lock; add BENCHBOX_TEST_LOCK_DIR override"
+    status: pending
+    notes: |
+      Read `tests/conftest.py` and locate the lock acquisition logic
+      (currently `~/.benchbox/test.lock`). Do NOT change the default —
+      a global lock is what prevents 10 concurrent xdist runs from
+      melting the workstation. Add an env var override:
+        `lock_dir = os.environ.get("BENCHBOX_TEST_LOCK_DIR",
+                                   os.path.expanduser("~/.benchbox"))`
+      Update `Makefile` `test-unlock` target to honor the same env var.
+      Update `tests/README.md:257` area to document the override and
+      explain WHY the default stays global.
+
+  - id: w4
+    summary: "Strip manual-coordination guidance from CLAUDE.md and AGENTS.md"
+    status: pending
+    notes: |
+      Remove from both files:
+        - "Drain one at a time, oldest first" (and surrounding pr-refresh prose)
+        - "One PR per file area at a time"
+        - "Sequential by design" notes around pr-fanout
+      Replace with a one-paragraph summary of the new model: pool
+      worktrees + auto-merge + post-merge auto-revert as safety net.
+      Note that this paragraph will be expanded by Steps 2 and 4 once
+      those land; here, just remove the now-incorrect guidance.
+
+  - id: w5
+    summary: "Capture consolidated L2 blind-spot findings to _project/blind-spots/"
+    status: pending
+    notes: |
+      Six findings from the four-round merge-loop audit (2026-04-30 session):
+        1. Original plan bundled "stop babysitting PRs" with "promote
+           develop to release-grade gating" — separable decisions
+        2. PR CI on develop is already heavy today; reducing it is the
+           highest-leverage standalone move
+        3. Test-lock localization is not a pure win at scale; the global
+           lock has a real CPU-protection job (10 worktrees × xdist auto)
+        4. A queue creates a single point of failure with no analog in
+           current setup
+        5. Dwell time silently changes the agent contract (5 min today
+           vs hours under a queue)
+        6. develop-post-merge.yml is the actual safety net; queue plan
+           kept it as belt-and-suspenders without resolving the tension
+      One file per finding under `_project/blind-spots/2026-04-30-HHMMSS-<slug>.md`
+      using the frontmatter schema from `_project/blind-spots/README.md`.
+
+  - id: w6
+    summary: "Run validation locally and open the PR"
+    status: pending
+    needs: [w1, w2, w3, w4, w5]
+    notes: |
+      Run `make lint format typecheck`, then
+      `BENCHBOX_PREPUSH=1 make pr-preflight` to confirm the opt-in path
+      still works. Then `make pr-open`. Do NOT enable the new env var
+      globally; the point is that absence-of-var is the new default.
+
+verification:
+  - description: "All pre-push hooks no-op when BENCHBOX_PREPUSH is unset"
+    command: "BENCHBOX_PREPUSH= pre-commit run --hook-stage pre-push --all-files 2>&1 | grep -cE '(Skipped|Passed)'"
+    expected_output: "matches the count of pre-push hooks in .pre-commit-config.yaml"
+  - description: "Pre-push hooks execute when BENCHBOX_PREPUSH=1"
+    command: "BENCHBOX_PREPUSH=1 pre-commit run pr-preflight-fast-tests --hook-stage pre-push --all-files 2>&1 | tail -3"
+    expected_output: "hook runs (success or expected failure on uncommitted state); does not skip"
+  - description: "pr-fanout default parallelism is 4"
+    command: "grep -E '^PR_FANOUT_JOBS \\?= ' Makefile"
+    expected_output: "PR_FANOUT_JOBS ?= 4"
+  - description: "Test lock honors BENCHBOX_TEST_LOCK_DIR override"
+    command: "BENCHBOX_TEST_LOCK_DIR=/tmp/bb-lock-test uv run -- python -m pytest -m fast -q tests/unit/ -x 2>&1 | tail -5 && ls /tmp/bb-lock-test/test.lock"
+    expected_output: "lock file present at /tmp/bb-lock-test/test.lock; tests run normally"
+  - description: "Default test lock still uses ~/.benchbox/"
+    command: "uv run -- python -c \"import os; from tests.conftest import _LOCK_PATH if False else None; print(os.path.expanduser('~/.benchbox/test.lock'))\""
+    expected_output: "/Users/joe/.benchbox/test.lock or equivalent home-dir path"
+  - description: "Stale guidance removed from agent-facing docs"
+    command: "grep -cE '(Drain one at a time|One PR per file area|Sequential by design)' CLAUDE.md AGENTS.md"
+    expected_output: "0"
+  - description: "Six blind-spot findings recorded"
+    command: "ls _project/blind-spots/2026-04-30-*.md | wc -l"
+    expected_output: "6"
+
+must_preserve:
+  - "Existing test runtime when BENCHBOX_PREPUSH is set — no functional change to the hook itself"
+  - "Global test lock as the DEFAULT — agents that don't set the env var continue to be CPU-protected"
+  - "make pr-preflight as a working manual command (it is the human-facing escape hatch)"
+  - "Existing pr-fanout output structure (one section per worktree) — only parallelism changes, not the report shape"
+
+approach: |
+  Order the work units to minimize risk: hooks first (w1) is the
+  load-bearing change; fanout (w2) depends on hooks being opt-in;
+  lock (w3) is independent but read tests/README.md:257 first to
+  understand the existing rationale; docs (w4) reflect the new
+  reality; blind-spots (w5) are the protocol-debt cleanup; PR (w6)
+  ships everything as one cohesive unit.
+
+  For w1, prefer wrapping hook commands in `bash -c` with the env-var
+  guard — it's smaller than rewriting hook definitions and easier to
+  revert if something breaks.
+
+  For w2, the `xargs -P` approach is simpler than GNU parallel
+  (parallel may not be installed). Keep the per-worktree output
+  prefixed with the worktree name so logs remain readable.
+
+anti_patterns:
+  - "DO NOT localize the test lock to per-worktree by default — because 10 concurrent xdist runs (auto-workers) would exhaust CPU and produce timing-flake — keep global default and offer override only"
+  - "DO NOT bundle worktree-pool work into this PR — because that's Step 2 with its own scope and verification — ship the local-loop changes alone"
+  - "DO NOT remove pr-refresh target in this PR — because branch protection still requires up-to-date until Step 3 lands — that target stays useful until then"
+  - "DO NOT skip the blind-spot capture (w5) — because the protocol explicitly requires file-first capture and this is the natural home — they are 6 small files"
+
+scope_limit:
+  only_modify:
+    - ".pre-commit-config.yaml"
+    - "Makefile (pr-fanout target only)"
+    - "tests/conftest.py (lock-path logic only)"
+    - "tests/README.md (around line 257)"
+    - "CLAUDE.md (manual-coordination paragraphs)"
+    - "AGENTS.md (manual-coordination paragraphs)"
+    - "_project/blind-spots/2026-04-30-*.md (6 new files)"
+  do_not_modify:
+    - ".github/workflows/ (that's Step 3 and Step 4)"
+    - "Makefile worktree-* targets (that's Step 2)"
+    - "Branch protection or rulesets (that's Step 3)"
+
+metadata:
+  tags:
+    - dev-loop
+    - pre-commit
+    - test-infrastructure
+    - blind-spots
+  estimated_effort: "Small (1h)"
+  created_date: "2026-04-30"
+
+impact:
+  user_impact: |
+    Agents push faster and pr-fanout no longer serializes. Workstation
+    stays CPU-protected because the global test lock remains. Six
+    audit findings from this planning round get archived where future
+    sessions can find them.
+  technical_debt: |
+    Reduces protocol drift (blind-spot capture). Removes incorrect
+    documentation that would mislead future agents.
+
+success_metrics:
+  - "PR lands as single squash-merge to develop"
+  - "Subsequent agent sessions push without local hook delay"
+  - "Six blind-spot findings reachable via `make blind-spots-list`"
+
+open_questions:
+  - "Should `make pr-preflight` print a hint when BENCHBOX_PREPUSH is unset, or stay silent? (Suggest: silent — agents shouldn't be nagged about a feature they're not using.)"

--- a/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
@@ -1,0 +1,257 @@
+id: dev-loop-step-2-worktree-pool
+title: "Dev-loop simplification — Step 2: fixed pool of 10 retained worktrees with claim/release"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Replace the create-and-destroy worktree model with a fixed pool of 10
+  worktrees retained indefinitely. New agent sessions claim an available
+  worktree, update it from current `develop`, work there until merge,
+  then release it back to the pool.
+
+  This formalizes how concurrent agents share the workstation. The pool
+  size of 10 is a hard cap that bounds the parallelism (which is also
+  why Step 1 keeps the test lock global — even with the pool bounded,
+  10 concurrent xdist runs would saturate the machine).
+
+  Single PR via `make pr-open`. After merge, run `make worktree-pool-init`
+  on the workstation as a one-time bootstrap.
+
+deps:
+  needs:
+    - dev-loop-step-0-verify-assumptions
+
+work:
+  - id: w1
+    summary: "Add make worktree-pool-init target — creates pool-01..10 from develop"
+    status: pending
+    notes: |
+      One-time bootstrap. Creates `BenchBox.pool-01` through
+      `BenchBox.pool-10` as siblings of the main clone, each on
+      `develop`, each with `uv sync --group dev` run, each with
+      `pre-commit install`. Idempotent: if a pool-NN worktree already
+      exists, leave it alone (do not touch its branch state).
+      Print summary table at end: pool-NN | path | branch.
+
+  - id: w2
+    summary: "Add make worktree-claim BRANCH=<name> — atomic claim under flock"
+    status: pending
+    notes: |
+      Selects the first **Free** pool worktree (HEAD on `develop`,
+      working tree clean, no local feature branch beyond `develop`).
+      Steps:
+        1. Acquire flock on `<main-clone>/.git/pool.lock` (timeout 30s)
+        2. Iterate pool-01..10; first match is "Free"
+        3. In that worktree: `git fetch origin`, `git reset --hard
+           origin/develop`, `git checkout -b $BRANCH`, `uv sync --group dev`
+        4. Release flock
+        5. Print: `WORKTREE_PATH=<absolute-path>`
+      Refuses (exit 1) if pool is fully claimed; suggests
+      `make worktree-pool-status` to investigate.
+      Refuses if BRANCH is empty or doesn't match `^(chore|fix|feat|docs)/.+`.
+    needs: [w1]
+
+  - id: w3
+    summary: "Add make worktree-release — verify merged, return to develop"
+    status: pending
+    notes: |
+      Run from inside a pool worktree (refuses if cwd is not a pool-NN
+      path). Steps:
+        1. Identify current branch
+        2. Verify PR for this branch is in MERGED state via
+           `gh pr view --json state` (refuse if not, with explicit
+           "open or close PR first" message; FORCE=1 escapes)
+        3. `git checkout develop`
+        4. `git fetch origin`
+        5. `git reset --hard origin/develop`
+        6. `git branch -D <feature-branch>` (the one just released)
+        7. `git remote prune origin`
+      Worktree returns to **Free** state.
+    needs: [w1]
+
+  - id: w4
+    summary: "Add make worktree-pool-status — tabular state listing"
+    status: pending
+    notes: |
+      Prints table with columns: pool-NN | path | branch | state |
+      claim_age. State is one of:
+        - free: HEAD on develop, working tree clean, no untracked files
+                outside expected (`.benchbox/`, `.venv/`, etc.)
+        - claimed: HEAD on a non-develop branch
+        - stale: claimed branch has been merged upstream (gh pr view
+                 returns MERGED) but worktree still on the branch
+        - dirty: claimed with uncommitted changes — needs review
+      claim_age is `git log -1 --format=%ar` of the most recent commit
+      on the current branch (or "—" for free).
+    needs: [w1]
+
+  - id: w5
+    summary: "Add make worktree-pool-reset POOL=NN — manual escape hatch"
+    status: pending
+    notes: |
+      Forcibly returns pool-NN to Free state. Refuses if working tree
+      has uncommitted changes UNLESS `FORCE=1` is set. Even with FORCE,
+      prints what it's about to discard and requires interactive
+      confirmation (read -p). Useful when an agent died mid-session
+      leaving the worktree in an inconsistent state.
+    needs: [w1]
+
+  - id: w6
+    summary: "Update Session-start docs in CLAUDE.md and AGENTS.md"
+    status: pending
+    notes: |
+      Replace the existing "Session start" instructions:
+        - Old: `make worktree-add BRANCH=<type>/<short-slug>`
+        - New: `make worktree-claim BRANCH=<type>/<short-slug>`
+      Add a paragraph explaining the pool model: 10 worktrees,
+      retained indefinitely, claim/release lifecycle. Document the
+      Stale recovery flow (run `worktree-pool-status`, then
+      `worktree-pool-reset POOL=NN` if needed).
+      Note that `make worktree-add` remains as a deprecated alias for
+      one release with a stderr deprecation notice.
+    needs: [w2, w3, w4]
+
+  - id: w7
+    summary: "Mark worktree-add as deprecated alias of worktree-claim"
+    status: pending
+    notes: |
+      `worktree-add` keeps current semantics but prints to stderr:
+      "DEPRECATED: use `make worktree-claim BRANCH=...` instead. The
+      pool model retains worktrees rather than creating new ones.
+      `worktree-add` will be removed in the next release." Then
+      proceeds normally. Pool-NN worktrees are never created via
+      worktree-add; they only come from worktree-pool-init.
+    needs: [w2]
+
+  - id: w8
+    summary: "Update worktree-prune to skip pool-NN worktrees"
+    status: pending
+    notes: |
+      Pool worktrees are retained indefinitely; `worktree-prune` should
+      no longer be a routine end-of-session command. Modify the target
+      to:
+        1. Detect pool-NN paths and skip them
+        2. Print: "Skipping pool worktree pool-NN (retained)"
+        3. Continue pruning legacy non-pool worktrees as today
+      Update help text to note: `worktree-prune` is for legacy
+      worktrees only; pool worktrees are released via `worktree-release`.
+    needs: [w1]
+
+  - id: w9
+    summary: "Run worktree-pool-init on Joe's workstation post-merge"
+    status: pending
+    needs: [w1, w2, w3, w4, w5, w6, w7, w8]
+    notes: |
+      One-time runbook step after the PR lands. Verify:
+        - 10 worktrees present at BenchBox.pool-01..10
+        - Each on develop, clean
+        - Each has .venv/ populated
+        - `make worktree-pool-status` shows all 10 free
+      Track in PR description as a follow-up checklist item.
+
+verification:
+  - description: "make worktree-pool-init creates 10 worktrees idempotently"
+    command: "make worktree-pool-init && ls -d ../BenchBox.pool-* | wc -l && make worktree-pool-init"
+    expected_output: "10 (first run) and second run completes without error"
+  - description: "worktree-claim refuses invalid branch names"
+    command: "make worktree-claim BRANCH=bad-name 2>&1 | grep -c 'must match'"
+    expected_output: ">= 1"
+  - description: "worktree-claim selects an available pool worktree"
+    command: "make worktree-claim BRANCH=chore/test-pool-claim 2>&1 | grep -E 'WORKTREE_PATH=.*pool-[0-9]+'"
+    expected_output: "WORKTREE_PATH=<absolute path containing pool-NN>"
+  - description: "worktree-pool-status reports all pool worktrees"
+    command: "make worktree-pool-status 2>&1 | grep -cE '^pool-[0-9]+'"
+    expected_output: "10"
+  - description: "Concurrent claims do not race"
+    command: "for i in 1 2 3; do (make worktree-claim BRANCH=chore/race-test-$i &); done; wait; make worktree-pool-status | grep -cE 'chore/race-test-' && make worktree-pool-status | sort -u"
+    expected_output: "3 distinct claims, each on a different pool-NN worktree"
+  - description: "worktree-prune skips pool worktrees"
+    command: "make worktree-prune 2>&1 | grep -c 'Skipping pool worktree'"
+    expected_output: ">= 0 (skips logged for any pool worktrees on develop)"
+  - description: "worktree-add prints deprecation notice"
+    command: "make worktree-add BRANCH=chore/legacy-test 2>&1 | grep -c 'DEPRECATED'"
+    expected_output: ">= 1"
+
+must_preserve:
+  - "Existing make worktree-add target keeps working — only adds deprecation notice; do not break legacy non-pool worktree workflows mid-session"
+  - "Pool worktrees retain their .venv/ across release/claim cycles — uv sync only runs at claim time after a fetch, and only if pyproject.toml/uv.lock changed"
+  - "Atomic claim semantics — two concurrent `make worktree-claim` calls must always pick different pool-NN worktrees, never collide"
+  - "make worktree-pool-init is idempotent — re-running must not destroy or reset existing pool worktrees"
+
+approach: |
+  Build the targets in dependency order: pool-init (w1) is foundational,
+  then claim (w2) and release (w3) are the core lifecycle, then status
+  (w4) and reset (w5) are operational tooling, then docs (w6) and
+  deprecation (w7-w8) update the rest of the surface.
+
+  Use `flock` (via `flock(1)` on Linux/macOS) for atomic claim. Lock
+  file at `<main-clone>/.git/pool.lock`. Single shared lock across all
+  pool worktrees — claim is fast (seconds) so contention is fine.
+
+  For state detection in worktree-pool-status:
+    - free: `git rev-parse --abbrev-ref HEAD` == "develop" AND
+            `git status --porcelain` is empty AND no extra branches
+    - claimed: not on develop, working tree may or may not be clean
+    - stale: claimed AND `gh pr view --json state` returns MERGED
+    - dirty: claimed AND `git status --porcelain` non-empty
+
+  Refer to existing `make worktree-add` and `make worktree-prune`
+  targets for patterns; reuse their git-worktree command structure.
+
+anti_patterns:
+  - "DO NOT auto-reap stale claims — because an agent crash mid-session may leave valuable uncommitted work — surface as 'stale' in status, require explicit `worktree-pool-reset` to free"
+  - "DO NOT skip flock on claim selection — because two concurrent agents racing to claim would both pick pool-01 and one would clobber the other's branch — atomic selection is required"
+  - "DO NOT delete pool-NN worktrees in worktree-prune — because the pool is the contract — prune is for legacy non-pool worktrees only"
+  - "DO NOT remove make worktree-add in this PR — because in-flight work in non-pool worktrees needs continuity — deprecate-with-notice now, remove next release"
+  - "DO NOT hardcode pool size to 10 — because the workstation may want a different cap — read POOL_SIZE ?= 10 from the environment"
+
+scope_limit:
+  only_modify:
+    - "Makefile (worktree-* targets only)"
+    - "CLAUDE.md (Session start section)"
+    - "AGENTS.md (Session start / Worktree section)"
+    - ".gitignore (add .git/pool.lock if needed)"
+  do_not_modify:
+    - ".github/workflows/ (Step 3 and Step 4 territory)"
+    - "tests/ (test lock is Step 1)"
+    - ".pre-commit-config.yaml (Step 1)"
+    - "Branch protection or rulesets (Step 3)"
+
+deferred:
+  - summary: "Auto-update of pool worktrees while idle (background pull of develop)"
+    reason: "Reasonable enhancement but out of scope; claim already updates at claim-time. Revisit if pool-status shows worktrees consistently lagging develop."
+  - summary: "Per-worktree resource quotas (CPU/memory limits)"
+    reason: "Pool size of 10 + global test lock is sufficient for now. Add only if metrics in Step 5 show resource-contention failures."
+
+metadata:
+  tags:
+    - dev-loop
+    - worktree
+    - infrastructure
+    - makefile
+  estimated_effort: "Medium (2h)"
+  created_date: "2026-04-30"
+
+impact:
+  user_impact: |
+    New session start is one command (`make worktree-claim BRANCH=...`)
+    and the worktree is updated to current develop automatically. No
+    create/destroy churn. End-of-session is `make worktree-release`,
+    a no-op on the filesystem (worktree stays, just returns to
+    develop). Concurrent agents can't race-claim the same worktree.
+  technical_debt: |
+    Reduces "stale worktree" debt (where pruning lagged because no one
+    ran `make worktree-prune` end-of-session). Replaces with explicit
+    pool-status visibility.
+
+success_metrics:
+  - "Concurrent claims (3+ simultaneous) always select distinct worktrees"
+  - "Pool worktrees survive multiple claim/release cycles without state corruption"
+  - "Subsequent agent sessions report 'session start' as one command, not three"
+
+open_questions:
+  - "Should pool-NN worktrees share a venv or each have their own? (Plan: each their own — uv handles this fine, isolation is cheap.)"
+  - "Should we cap concurrent test runs to less than 10 even with the pool? (Defer to Step 5 measurement; the global test lock is the safety valve.)"
+  - "What happens if the user has uncommitted work in the main clone when running pool-init? (Plan: pool-init only operates on sibling paths; main clone is untouched.)"

--- a/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
@@ -1,0 +1,222 @@
+id: dev-loop-step-3-ci-rebalance-and-strict-base-off
+title: "Dev-loop simplification — Step 3: light PR-tier CI on develop, heavy matrix to nightly, strict-base off"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The load-bearing change in the dev-loop simplification plan. Three
+  coupled adjustments that together eliminate stale-PR refresh churn
+  on `develop` while preserving release-grade validation on `main`:
+
+    1. Cut PR-tier CI on develop to lint + Ubuntu 3.12 fast tests
+    2. Move full OS/Python matrix + integration + parity to nightly
+    3. Disable "Require branches up to date before merging" on develop
+
+  Critically: full matrix + package + release validation REMAINS
+  required for `main` PRs and tag releases. Release confidence is
+  unchanged; only the routine `develop` PR experience is altered.
+
+  Single PR via `make pr-open`. The branch-protection toggle (3.4) is
+  applied via the GitHub UI or `gh api` separately and recorded in
+  the PR description as a manual deployment step.
+
+deps:
+  needs:
+    - dev-loop-step-0-verify-assumptions
+
+work:
+  - id: w1
+    summary: "Identify current required-checks for develop and the PR-tier job set in test.yml"
+    status: pending
+    notes: |
+      Re-read the Step 0 decision record (`_project/decisions/
+      dev-loop-verification-2026-04-30.md`) for w1/w2/w3 outputs.
+      Confirm exactly which jobs are listed as required vs which run
+      but don't block. The Step 3.1 surgery touches the required set;
+      non-required jobs can stay or move to nightly per cost analysis.
+
+  - id: w2
+    summary: "Cut develop PR-tier CI to lint + Ubuntu 3.12 fast tests"
+    status: pending
+    notes: |
+      Edit `.github/workflows/test.yml`. For the `pull_request` trigger
+      targeting develop:
+        - Keep: lint, type-check, Ubuntu-latest Python 3.12 fast test
+        - Move to nightly (or workflow_dispatch only): macOS, Windows,
+          Python 3.10/3.11/3.13, integration smoke, table-format,
+          package, parity, PySpark
+      Use a job-level `if: github.event_name != 'pull_request' ||
+      github.base_ref != 'develop'` for moved jobs, OR split into
+      two workflows (`pr.yml` minimal, `nightly.yml` full).
+      Branch-protection required-checks list updated in w5 below.
+    needs: [w1]
+
+  - id: w3
+    summary: "Add nightly.yml workflow (or schedule trigger on test.yml) running the full matrix"
+    status: pending
+    notes: |
+      Schedule `cron: '0 6 * * *'` (6am UTC, off-peak). On failure,
+      emit a workflow_run event that auto-opens an issue with label
+      `incident:nightly-red` containing the failing job name and run
+      URL. Use `workflow_dispatch` for manual re-runs. Reuse the same
+      job definitions moved out of PR-tier in w2.
+    needs: [w2]
+
+  - id: w4
+    summary: "Preserve full matrix + package validation on main PRs and tag releases"
+    status: pending
+    notes: |
+      Audit `.github/workflows/release.yml` and `test.yml` to ensure
+      that `pull_request` to `main` AND `push: tags: ['v*']` still
+      trigger:
+        - Full OS/Python matrix
+        - Package install validation
+        - Release-flow checks
+      Add a comment block in `release.yml` stating "DO NOT lighten
+      this — main is release-only; full validation is required here."
+      No functional change if these are already correct; the audit
+      step is the deliverable.
+
+  - id: w5
+    summary: "Update branch-protection required-checks list for develop"
+    status: pending
+    notes: |
+      Apply via `gh api -X PATCH repos/joeharris76/BenchBox/branches/
+      develop/protection` (or the equivalent ruleset PATCH) to:
+        - Reduce `required_status_checks.contexts` to just the lint
+          and Ubuntu 3.12 fast-test job names
+        - Set `required_status_checks.strict: false` (this is the
+          critical toggle that eliminates stale-PR refresh)
+        - Keep `enforce_admins: true` if currently set
+      Record the before/after JSON in the PR description for audit.
+      This is a manual deployment step; not in the PR diff.
+    needs: [w2]
+
+  - id: w6
+    summary: "Deprecate make pr-refresh and update CLAUDE.md/AGENTS.md"
+    status: pending
+    notes: |
+      With strict-base off, pr-refresh is no longer routine. Modify
+      target to print stderr: "DEPRECATED: strict-base is now off on
+      develop; pr-refresh is rarely needed. Use only as escape hatch
+      when explicitly required." Then proceed with current behavior.
+      Remove pr-refresh from the routine workflow paragraphs in
+      CLAUDE.md ("PR/Worktree (write — feature branches only)" still
+      lists it as escape hatch but not as routine).
+    needs: [w5]
+
+  - id: w7
+    summary: "Run lint + fast-test locally and open the PR"
+    status: pending
+    needs: [w1, w2, w3, w4, w5, w6]
+    notes: |
+      `make lint format typecheck`, `BENCHBOX_PREPUSH=1 make
+      pr-preflight`, then `make pr-open`. Manually apply the
+      branch-protection change (w5) AFTER the PR merges so the
+      workflow file changes are live before required-checks are
+      adjusted. Document the sequence in PR description.
+
+verification:
+  - description: "PR-tier CI on develop runs only lint and Ubuntu 3.12 fast tests"
+    command: "gh run list --workflow test.yml --branch develop --event pull_request --limit 1 --json jobs --jq '.[].jobs | length'"
+    expected_output: "<= 3 jobs (lint, type, fast-test)"
+  - description: "Full matrix runs on nightly schedule"
+    command: "gh workflow list --json name,state | jq '.[] | select(.name | test(\"nightly|Nightly\"))'"
+    expected_output: "nightly workflow exists and is active"
+  - description: "Main PRs and tag releases still run full matrix"
+    command: "grep -cE 'matrix:|os: \\[ubuntu-latest, macos-latest, windows-latest\\]' .github/workflows/release.yml .github/workflows/test.yml"
+    expected_output: ">= 1"
+  - description: "Strict-base is off on develop branch protection"
+    command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.strict'"
+    expected_output: "false"
+  - description: "Required checks list contains only lightweight jobs"
+    command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.contexts | length'"
+    expected_output: "<= 3"
+  - description: "make pr-refresh prints deprecation notice"
+    command: "make -n pr-refresh 2>&1 | grep -c 'DEPRECATED' || make pr-refresh 2>&1 | head -3 | grep -c 'DEPRECATED'"
+    expected_output: ">= 1"
+
+must_preserve:
+  - "Full matrix + package + release validation remains REQUIRED for main PRs and tag releases — Step 3 only changes develop, not main"
+  - "Existing required job names that downstream tooling references — confirm test runner integrations (status badges, code coverage) still find their checks"
+  - "develop-post-merge.yml unchanged in this step — Step 4 strengthens it; here we only rebalance PR-tier"
+  - "Existing pull_request job functionality when run via workflow_dispatch — moved-to-nightly jobs must still run successfully when manually invoked"
+
+approach: |
+  Sequence matters: ship the workflow changes first (w2, w3, w4) so
+  the lighter jobs exist and are reporting status BEFORE updating
+  required-checks (w5). If you flip required-checks first, develop
+  will be unmergeable until the workflow changes propagate.
+
+  Two-workflow split (test.yml for PR-tier, nightly.yml for matrix)
+  is cleaner than `if:` job conditions. Conditions create maintenance
+  surface — every new job needs the same condition copied. Splitting
+  files makes intent obvious.
+
+  For w5, read the existing branch-protection JSON first, redact and
+  archive it in the PR description, then PATCH only the changed fields.
+  Don't replace the whole protection blob — easy to lose unrelated
+  settings (e.g., enforce_admins, dismiss_stale_reviews).
+
+anti_patterns:
+  - "DO NOT also lighten main PR / tag-release CI — because main is release-only and full validation is required there — only develop's PR-tier changes"
+  - "DO NOT flip branch protection BEFORE the workflow changes land — because required checks reference job names that may not exist yet — sequence: workflows first, protection second"
+  - "DO NOT remove make pr-refresh in this PR — because rare-but-real conflict cases still need it — deprecate-with-notice now, remove next release after Step 5 measurement confirms it's unused"
+  - "DO NOT skip nightly issue automation (w3) — because moved-to-nightly jobs are now invisible without a clear failure signal — auto-issue is the replacement for PR-blocking"
+  - "DO NOT delete the develop-post-merge.yml workflow — because it becomes the safety net under relaxed strict-base — Step 4 strengthens it"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/test.yml"
+    - ".github/workflows/nightly.yml (new)"
+    - ".github/workflows/release.yml (audit + comment-only)"
+    - "Makefile (pr-refresh deprecation notice)"
+    - "CLAUDE.md (pr-refresh paragraph)"
+    - "AGENTS.md (pr-refresh paragraph)"
+  do_not_modify:
+    - ".github/workflows/develop-post-merge.yml (Step 4)"
+    - "Makefile worktree-* targets (Step 2)"
+    - ".pre-commit-config.yaml (Step 1)"
+    - "Test code (no test changes; only CI orchestration)"
+
+deferred:
+  - summary: "Native GitHub Merge Queue migration"
+    reason: "Step 6 territory, deferred until Step 5 measurement justifies it. Current repo is user-owned which likely precludes native MQ anyway."
+  - summary: "Self-hosted runner adoption"
+    reason: "Cost reduction is real but adds operational burden. Defer until runner-minutes metric in Step 5 shows it's worth it."
+
+metadata:
+  tags:
+    - dev-loop
+    - ci
+    - branch-protection
+    - workflows
+  estimated_effort: "Medium (1-2h including manual branch-protection edit)"
+  created_date: "2026-04-30"
+
+impact:
+  user_impact: |
+    PR-to-merged time on develop drops from minutes-to-hours (with
+    refresh churn) to single-digit minutes. Heavy regressions still
+    caught — just nightly instead of per-PR. Release confidence on
+    main unchanged.
+  business_value: |
+    Reduces runner minutes by N× (where N depends on the matrix size
+    cut). Frees agent time previously spent on pr-refresh. Lets the
+    pool of 10 worktrees actually deliver throughput instead of
+    serializing on stale-base CI re-runs.
+  technical_debt: |
+    Some technical debt added: heavy matrix bugs may be discovered
+    one day later (nightly) instead of on the PR. Step 4's auto-revert
+    is the mitigation for the rare case where this matters on develop.
+
+success_metrics:
+  - "P50 develop PR CI duration drops from current baseline (recorded in Step 0 w3) to under 5 minutes"
+  - "Zero pr-refresh invocations needed during routine workflow over the next 2 weeks post-merge"
+  - "Nightly workflow runs successfully each morning; failures auto-open issues with full context"
+
+open_questions:
+  - "Should the nightly workflow also run weekly/on-demand security scans, or keep those separate? (Plan: keep separate; security cadence is its own decision.)"
+  - "If a moved-to-nightly job depends on a develop-only secret, do we keep the secret available to nightly? (Yes — secrets are per-environment, not per-trigger.)"

--- a/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
@@ -1,0 +1,230 @@
+id: dev-loop-step-4-post-merge-safety-net
+title: "Dev-loop simplification — Step 4: develop-post-merge auto-revert + dev-loop metrics"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Strengthens `develop-post-merge.yml` so that relaxing strict-base in
+  Step 3 has a credible safety net, not just a notification. When
+  develop goes red post-merge, the workflow automatically opens a revert
+  PR for the offending SHA (or an issue if revert conflicts), and emits
+  basic dev-loop metrics that feed Step 5's measurement window.
+
+  Sequence: this MUST land after Step 3 (relaxed strict-base), because
+  the auto-revert is the mitigation for the increased post-merge risk
+  introduced by Step 3.
+
+  Single PR via `make pr-open`.
+
+deps:
+  needs:
+    - dev-loop-step-3-ci-rebalance-and-strict-base-off
+
+work:
+  - id: w1
+    summary: "Set cancel-in-progress: false on develop-post-merge.yml"
+    status: pending
+    notes: |
+      Currently the workflow likely has a `concurrency:` block that
+      may cancel in-progress runs when a new push lands. Change:
+        concurrency:
+          group: develop-post-merge-${{ github.sha }}
+          cancel-in-progress: false
+      Group key on `github.sha` (not `github.ref`) so each landed SHA
+      gets its own concurrency lane and runs to completion. This is
+      necessary so fast-landing PRs don't cause the workflow to skip
+      checking intermediate SHAs.
+
+  - id: w2
+    summary: "Add auto-revert PR generation on red"
+    status: pending
+    notes: |
+      New job `auto-revert-on-failure` triggered by
+      `workflow_run.conclusion == 'failure'` (or as a continuation
+      job in the same workflow with `if: failure()`). Steps:
+        1. Identify the failing SHA (`github.sha` of the post-merge run)
+        2. Identify the PR that introduced the SHA via
+           `gh pr list --state merged --search "<sha>"`
+        3. Create branch `auto-revert/<short-sha>` from develop
+        4. `git revert --no-edit <sha>` (single SHA, no merge commits)
+        5. If revert succeeds: push branch, open PR with title
+           `Revert <pr-title> (#<pr-num>) — develop went red post-merge`,
+           body includes failing run URL + originating PR link, label
+           `incident:develop-red`, request review from PR author
+        6. If revert fails (conflict): open issue with same metadata,
+           label `incident:develop-red-revert-conflict`, no PR
+      Use `peter-evans/create-pull-request@v6` action or a small
+      gh-cli script.
+    needs: [w1]
+
+  - id: w3
+    summary: "Emit per-PR dev-loop metrics as workflow artifact"
+    status: pending
+    notes: |
+      Add a `metrics` job that runs on every successful merge to develop.
+      Computes and writes JSON artifact:
+        {
+          "merged_at": "<ISO-8601>",
+          "pr_number": N,
+          "pr_open_to_merged_seconds": N,
+          "post_merge_red": false,
+          "conflict_on_merge": <bool from PR labels>,
+          "ci_runner_minutes": N
+        }
+      Artifact retention: 90 days (covers the Step 5 measurement window).
+      One file per merge. Step 5 aggregates these.
+
+  - id: w4
+    summary: "Document the new failure flow in CLAUDE.md and AGENTS.md"
+    status: pending
+    notes: |
+      Add a section "If develop goes red":
+        - The post-merge workflow detects the failure within ~5 min
+        - It auto-opens a revert PR (label: incident:develop-red) OR
+          an issue if revert conflicts
+        - Original PR author gets review-requested on the revert
+        - Agents do NOT need to monitor CI proactively
+        - To repair: `make worktree-claim BRANCH=fix/<original-issue>`,
+          fix, resubmit
+      Replace any older "monitor your PR until green" guidance.
+    needs: [w2]
+
+  - id: w5
+    summary: "Add make dev-loop-metrics target for ad-hoc inspection"
+    status: pending
+    notes: |
+      `make dev-loop-metrics` downloads the last N (default 30) days
+      of metrics artifacts and prints a summary:
+        - P50/P95 PR-to-merged time
+        - Post-merge red rate
+        - Conflict rate
+        - Runner minutes total
+      Used by Step 5 reviewer (manual or scripted) to check thresholds.
+      Implementation: `gh run list --workflow develop-post-merge.yml
+      --json conclusion,databaseId | gh run download <id> -n metrics`,
+      then aggregate the JSON files.
+    needs: [w3]
+
+  - id: w6
+    summary: "Run smoke test against a known-bad SHA in a fork"
+    status: pending
+    needs: [w1, w2, w3, w4, w5]
+    notes: |
+      Before merging this PR, validate the auto-revert path end-to-end
+      in a fork: cherry-pick a commit that fails the post-merge tests,
+      push to a fork's develop, confirm the workflow opens a revert PR
+      with correct title/body/labels. If revert conflicts, confirm the
+      fallback issue is opened correctly.
+      Document the test in PR description.
+
+verification:
+  - description: "develop-post-merge.yml uses cancel-in-progress: false"
+    command: "grep -A 3 'concurrency:' .github/workflows/develop-post-merge.yml | grep -c 'cancel-in-progress: false'"
+    expected_output: ">= 1"
+  - description: "Auto-revert job exists in develop-post-merge.yml"
+    command: "grep -cE '(auto-revert|revert.*failure)' .github/workflows/develop-post-merge.yml"
+    expected_output: ">= 1"
+  - description: "Metrics job emits an artifact named 'metrics'"
+    command: "grep -cE 'name: metrics' .github/workflows/develop-post-merge.yml"
+    expected_output: ">= 1"
+  - description: "make dev-loop-metrics produces a non-empty summary"
+    command: "make dev-loop-metrics 2>&1 | grep -cE 'P50|P95|red rate|runner'"
+    expected_output: ">= 4"
+  - description: "Failure flow is documented in agent-facing docs"
+    command: "grep -cE 'incident:develop-red|auto-revert' CLAUDE.md AGENTS.md"
+    expected_output: ">= 2"
+  - description: "PR description includes fork-test evidence"
+    command: "echo 'manual check at review time'"
+    expected_output: "PR description references the fork-validation test"
+
+must_preserve:
+  - "Existing develop-post-merge.yml job definitions and their pass/fail signal — Step 4 ADDS auto-revert, does not replace existing checks"
+  - "Issue and PR labels are namespaced (incident:*) so they don't conflict with existing labels"
+  - "GITHUB_TOKEN scope: auto-revert needs `contents: write` and `pull-requests: write` — confirm permissions block in workflow declares these"
+  - "Metrics artifacts are JSON, not human-readable text — Step 5 aggregator depends on machine-parseable shape"
+
+approach: |
+  Build the workflow changes incrementally:
+    1. cancel-in-progress (w1) is a small, low-risk YAML edit
+    2. Auto-revert (w2) is the substantive change — use peter-evans/
+       create-pull-request@v6 (mature, well-tested) rather than rolling
+       a custom revert script
+    3. Metrics (w3) is independent of auto-revert; both can run in
+       parallel jobs in the same workflow
+    4. Make target (w5) is the human-facing surface for w3
+    5. Docs (w4) once the behavior is confirmed
+    6. Smoke test in fork (w6) BEFORE merging — auto-revert that
+       opens spurious PRs would be very noisy to roll back
+
+  For revert conflicts: the fallback to "open an issue" is intentional.
+  An auto-revert that conflicts probably means later commits depend on
+  the broken one, so a human needs to decide whether to revert the
+  whole stack or fix forward.
+
+  For metrics: keep it simple. JSON files in workflow artifacts, no
+  database, no service. Step 5 reads the last 30 days and aggregates.
+  If we end up wanting longer retention, push to a `metrics` orphan
+  branch instead — but that's a Step 5 decision, not Step 4.
+
+anti_patterns:
+  - "DO NOT auto-merge the revert PR — because a human should decide whether to revert vs fix-forward — open it but require manual approval"
+  - "DO NOT cancel-in-progress on develop-post-merge — because fast PR landings would skip safety checks on intermediate SHAs — every landed SHA must be verified independently"
+  - "DO NOT page or alert on every red — because the auto-revert PR IS the alert — over-paging trains agents to ignore the channel"
+  - "DO NOT chain to Step 5 work in this PR — because metrics emission is the deliverable here; aggregation/threshold-checking is Step 5 — keep the surface small"
+  - "DO NOT skip the fork smoke test (w6) — because a buggy auto-revert on production develop would be loud and embarrassing — 30 minutes in a fork is cheap insurance"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/develop-post-merge.yml"
+    - "Makefile (dev-loop-metrics target only)"
+    - "CLAUDE.md (failure flow section)"
+    - "AGENTS.md (failure flow section)"
+  do_not_modify:
+    - ".github/workflows/test.yml (Step 3 territory)"
+    - ".github/workflows/release.yml"
+    - "Branch protection rules (Step 3)"
+    - "Makefile worktree-* or pr-* targets (Steps 1-2)"
+
+deferred:
+  - summary: "Slack/Discord notifications on develop-red"
+    reason: "Out of scope; the auto-revert PR is the notification. Add only if Step 5 shows reverts are missed."
+  - summary: "Auto-merge of revert PRs after green CI"
+    reason: "Intentional human gate. A human decides revert vs fix-forward. Revisit if revert PRs accumulate unmerged."
+  - summary: "Metrics dashboard / Grafana"
+    reason: "JSON artifacts + make dev-loop-metrics is sufficient for Step 5. Build a dashboard only if the metrics become a routine inspection target."
+
+metadata:
+  tags:
+    - dev-loop
+    - ci
+    - safety-net
+    - metrics
+    - post-merge
+  estimated_effort: "Medium (1-2h including fork smoke test)"
+  created_date: "2026-04-30"
+
+impact:
+  user_impact: |
+    Agents stop monitoring CI proactively; if their PR breaks develop
+    they get review-requested on an auto-revert PR. The recovery loop
+    is explicit and fast (under 10 min from red to revert PR open),
+    not "hope someone notices."
+  business_value: |
+    Lets Step 3 (relaxed strict-base) be safe in production. Without
+    Step 4, Step 3 trades author babysitting for unbounded develop
+    breakage. Together they are the simplification.
+  technical_debt: |
+    Adds workflow complexity (a new job + revert action). Standard,
+    well-trodden pattern (peter-evans/create-pull-request is widely
+    used). Net debt: low.
+
+success_metrics:
+  - "P95 time-from-develop-red to revert-PR-open under 10 minutes"
+  - "Zero false-positive auto-revert PRs in the first 30 days post-merge (Step 5 verifies)"
+  - "Metrics artifacts present for >= 95% of merges (some merges may fail to emit due to runner issues; tolerate)"
+
+open_questions:
+  - "Should auto-revert PRs include a checklist for the original PR author (rerun tests, identify root cause, etc.) or stay minimal? (Plan: minimal body with run URL + originating PR link; checklist creates clutter.)"
+  - "If the metrics job fails, should it block the merge? (Plan: no — metrics are observability, not gates.)"

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -1,0 +1,183 @@
+id: dev-loop-step-5-measurement-window
+title: "Dev-loop simplification — Step 5: 30-day measurement window with queue decision thresholds"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Decision-gate item that decides whether Step 6 (queue) is needed.
+  Runs after Steps 1-4 have been merged for ~30 days. Aggregates the
+  metrics emitted by Step 4 against pre-defined thresholds and produces
+  a written go/no-go recommendation.
+
+  No code changes during the window itself; the deliverable is a
+  decision record. If all thresholds are below trigger, Step 6 is
+  cancelled and the simplification effort is closed. If one or more
+  trigger, Step 6 is unblocked.
+
+  This TODO is intentionally LOW-effort but HIGH-leverage — it prevents
+  building queue infrastructure for a problem that doesn't exist at
+  scale.
+
+deps:
+  needs:
+    - dev-loop-step-1-local-loop-cleanup
+    - dev-loop-step-2-worktree-pool
+    - dev-loop-step-3-ci-rebalance-and-strict-base-off
+    - dev-loop-step-4-post-merge-safety-net
+
+work:
+  - id: w1
+    summary: "Wait for 30 calendar days post-Step-4-merge before starting w2"
+    status: pending
+    notes: |
+      The measurement window is 30 days of normal usage AFTER Step 4
+      lands. Prior data is contaminated by the old workflow. Mark this
+      TODO Blocked until that date.
+
+      To start the timer: when Step 4 PR merges, comment on this TODO
+      with the merge date and update `metadata.due_date` to merge_date
+      + 30 days.
+
+  - id: w2
+    summary: "Aggregate dev-loop metrics for the 30-day window"
+    status: pending
+    needs: [w1]
+    notes: |
+      Run `make dev-loop-metrics WINDOW=30d` (added in Step 4 w5).
+      Capture output. If artifacts coverage is below 80% of merges
+      (i.e., emission failures), extend the window 7 days and retry.
+      Save raw aggregation to `_project/decisions/
+      dev-loop-measurement-<window-end>.md`.
+
+  - id: w3
+    summary: "Evaluate against queue-trigger thresholds"
+    status: pending
+    needs: [w2]
+    notes: |
+      Apply the trigger matrix from the plan:
+        | Metric                                | Trigger threshold |
+        | P95 PR open → merged                  | sustained > 1h    |
+        | Post-merge red rate on develop        | sustained > 5%    |
+        | Time-to-recover red develop (P95)     | > 30 min          |
+        | Cross-PR conflict repairs / week      | > 2/week          |
+        | Orphaned failed PRs (no resub <24h)   | any pattern       |
+        | Runner minutes total                  | budget signal     |
+      For each metric: PASS (below trigger) / FAIL (at or above).
+      "Sustained" means >= 70% of days in the window above threshold;
+      not just one outlier week.
+
+  - id: w4
+    summary: "Write decision record with go/no-go for Step 6"
+    status: pending
+    needs: [w3]
+    notes: |
+      Single markdown file appended to the measurement record from w2.
+      Sections:
+        - Window: <start> to <end>
+        - Per-metric PASS/FAIL with raw numbers
+        - Recommendation: BUILD QUEUE | DO NOT BUILD QUEUE | REASSESS
+        - If BUILD: which queue path (native vs steward), rationale
+          tied to Step 0 w6 finding
+        - If DO NOT BUILD: cancel Step 6 TODO, close the simplification
+          effort
+        - If REASSESS: extend window 30 days, identify which
+          measurements were ambiguous, and what would resolve them
+      Commit the record. Update Step 6 TODO status (unblock or close).
+
+  - id: w5
+    summary: "Update CLAUDE.md / AGENTS.md with measurement findings"
+    status: pending
+    needs: [w4]
+    notes: |
+      Add a one-paragraph "Dev-loop status (as of <date>)" note in
+      both files that documents:
+        - Whether the queue is being built or not
+        - Current P95 PR-to-merged time
+        - Current post-merge red rate
+      Future agents read this to understand the state of the merge
+      machinery without re-running the analysis.
+
+verification:
+  - description: "Measurement record exists with all six metrics evaluated"
+    command: "ls _project/decisions/dev-loop-measurement-*.md && grep -cE '^### (P95|Post-merge|Time-to-recover|Cross-PR|Orphaned|Runner)' _project/decisions/dev-loop-measurement-*.md"
+    expected_output: ">= 6"
+  - description: "Recommendation section is present and unambiguous"
+    command: "grep -cE '^Recommendation: (BUILD QUEUE|DO NOT BUILD QUEUE|REASSESS)' _project/decisions/dev-loop-measurement-*.md"
+    expected_output: "1"
+  - description: "Step 6 TODO status updated to reflect decision"
+    command: "grep -E '^status:' _project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml"
+    expected_output: "Either 'Not Started' (if BUILD), 'Blocked' (if REASSESS), or moved to DONE (if DO NOT BUILD)"
+
+must_preserve:
+  - "Steps 1-4 implementation untouched during measurement — no code changes during the window"
+  - "Existing dev-loop metrics emission — if Step 4 metrics break mid-window, fix forward; do not roll back"
+  - "Threshold definitions from this TODO — if measurement is ambiguous, use REASSESS rather than redefining thresholds post-hoc"
+
+approach: |
+  This is a deliberately low-effort TODO. The work is "wait, then look
+  at numbers and write down the answer." The goal is a forcing
+  function: without this gate, Step 6 might get built reflexively
+  ("we said we would") rather than because it's needed.
+
+  Be honest about what the metrics show. If the numbers are clearly
+  below threshold (e.g., P95 PR-to-merged is 8 minutes), DO NOT BUILD
+  is the correct call. If they're clearly above, BUILD. If they're
+  ambiguous, REASSESS — don't force a binary decision on noisy data.
+
+  For "sustained" interpretation: use 70% of days above threshold as
+  the rule. One bad week shouldn't trigger a queue; sustained pain
+  should. Adjust if 70% turns out wrong empirically.
+
+anti_patterns:
+  - "DO NOT shorten the measurement window because it feels long — because 30 days captures within-month variability (releases, vacations, etc.) that shorter windows miss — wait the full window"
+  - "DO NOT redefine thresholds during evaluation — because that's confirmation bias dressed as analysis — if thresholds were wrong, that's a separate REASSESS conclusion, not a silent edit"
+  - "DO NOT skip writing the decision record — because future re-evaluation needs to know what was decided and why — a verbal 'we measured and it was fine' loses information"
+  - "DO NOT begin Step 6 planning during the measurement window — because that primes the conclusion — wait for the data"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/dev-loop-measurement-*.md (new)"
+    - "_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml (status field only)"
+    - "CLAUDE.md (one paragraph)"
+    - "AGENTS.md (one paragraph)"
+  do_not_modify:
+    - "Any code or workflow file"
+    - "Branch protection or rulesets"
+    - "Step 1-4 implementation artifacts"
+
+deferred:
+  - summary: "Building infrastructure based on measurement findings"
+    reason: "That's Step 6, gated on this step's recommendation. Keeping the decision/build separation prevents 'might as well build it while I'm here.'"
+  - summary: "Long-term metrics retention beyond 90-day artifact window"
+    reason: "If measurement reveals we want continuous tracking, that's a follow-up. For Step 5, the 90-day artifact retention from Step 4 is sufficient."
+
+metadata:
+  tags:
+    - dev-loop
+    - measurement
+    - decision-gate
+  estimated_effort: "Small (2-3h after the 30-day wait)"
+  created_date: "2026-04-30"
+  due_date: "2026-06-15"
+
+impact:
+  business_value: |
+    Prevents building queue infrastructure for a non-problem.
+    Conservative estimate: queue infra is 2-3 days of work + ongoing
+    maintenance. If Steps 1-4 already solved the dev loop, a clean
+    DO NOT BUILD recommendation captures that win and closes the
+    effort.
+  technical_debt: |
+    Produces a durable decision record that future planning rounds
+    can reference. Same pattern as ADRs.
+
+success_metrics:
+  - "Decision record committed within 1 week of window end"
+  - "Recommendation is unambiguous (BUILD / DO NOT BUILD / REASSESS — not 'maybe')"
+  - "If REASSESS, the next-action triggers are explicit (extend X days, measure Y additionally)"
+
+open_questions:
+  - "If measurement reveals new thresholds are more meaningful than the originals, do we adopt them (REASSESS path) or stick with the locked thresholds for this evaluation? (Plan: stick. Adopt new thresholds only in a follow-up.)"
+  - "Who reviews the decision record before it's binding? (Plan: Joe reviews; this is a one-person org.)"

--- a/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
@@ -1,0 +1,256 @@
+id: dev-loop-step-6-queue-decision-gate
+title: "Dev-loop simplification — Step 6: queue (native MQ or steward) — DEFERRED until Step 5 justifies"
+worktree: main
+priority: Low
+status: Blocked
+
+description: |
+  Deferred queue implementation. Locked design decisions captured here
+  so that IF Step 5 measurement returns BUILD QUEUE, this work can
+  execute against a pre-agreed spec rather than re-designed from scratch.
+
+  Status starts as Blocked (on Step 5). Three resolution paths:
+    - Step 5 → DO NOT BUILD: this TODO moves to DONE with completion
+      note "queue not needed; closed by Step 5 measurement <date>"
+    - Step 5 → BUILD QUEUE: this TODO unblocks, status → Not Started,
+      work units below execute
+    - Step 5 → REASSESS: stays Blocked, deps point to next measurement
+
+  Critical guardrail: if this TODO unblocks, the design decisions in
+  the work units are LOCKED — they were debated extensively in the
+  planning rounds. Re-debating them at build time is out of scope.
+  Modify only if Step 5 measurement findings explicitly contradict
+  a specific decision (e.g., trust-lane assumption was wrong).
+
+deps:
+  needs:
+    - dev-loop-step-5-measurement-window
+
+work:
+  - id: w1
+    summary: "Confirm path: native GitHub Merge Queue vs BenchBox Merge Steward"
+    status: pending
+    notes: |
+      Re-read Step 0 w6 finding (native MQ availability) and Step 5
+      decision record. Path A (native MQ) requires repo to be
+      org-owned (and possibly Enterprise Cloud for private). Path B
+      (steward) is the fallback.
+
+      If Step 0 confirmed user-owned repo, Path B is mandatory unless
+      user has since transferred to an org. If org transfer is on the
+      table, evaluate it as a separate decision (one-time friction
+      vs ongoing steward maintenance).
+
+      Lock the choice in a sub-decision-record before w2.
+
+  - id: w2
+    summary: "PATH A — Enable native GitHub Merge Queue on develop"
+    status: pending
+    needs: [w1]
+    notes: |
+      ONLY if w1 selected Path A. Otherwise mark this w2 as skipped.
+      Steps:
+        1. Enable "Require merge queue" on develop branch protection
+        2. Add `merge_group:` trigger to lint.yml, test.yml (queue-tier
+           jobs), nightly is unaffected (it's scheduled, not PR-tied)
+        3. Reduce PR-required checks to only what should gate "is this
+           PR plausibly good" — keep Step 3's lighter set
+        4. Update make pr-open / pr-submit to call
+           `gh pr merge --auto --squash` (already does this on develop)
+        5. Update CLAUDE.md/AGENTS.md to describe the queue-managed flow
+
+  - id: w3
+    summary: "PATH B — Implement BenchBox Merge Steward as a single-concurrency workflow"
+    status: pending
+    needs: [w1]
+    notes: |
+      ONLY if w1 selected Path B. Workflow:
+        - Trigger: PR labeled `queue:ready` (set by pr-submit after
+          PR-tier CI passes)
+        - Concurrency: `group: benchbox-develop-integrator,
+          cancel-in-progress: false` — single-flight integrator
+        - Loop oldest-first by `queue:ready` label timestamp:
+            a. Reset to current origin/develop
+            b. Apply PR branch onto that tip (rebase or 3-way merge)
+            c. Run queue-tier checks against rebased SHA
+            d. Pass: push squash commit to develop, close PR, delete
+               branch
+            e. Conflict: label `queue:conflict`, comment with files,
+               continue to next PR
+            f. Test fail: label `queue:failed`, comment with job,
+               continue to next PR
+        - Each PR re-evaluates against the current develop tip;
+          staleness is impossible by construction
+      Use a narrow GitHub App (not a long-lived PAT) with permissions:
+      `contents: write`, `pull_requests: write`. App credentials in
+      org secrets.
+
+  - id: w4
+    summary: "Define queue-tier CI separately from PR-tier"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      Queue-tier CI is LIGHT, not heavy. Same as Step 3's PR-tier
+      (lint + Ubuntu 3.12 fast tests) — the queue's job is "rebase
+      and re-test against current base," not "release qualification."
+      Heavy validation stays in nightly.
+      For Path A: workflows that report to merge_group gate the queue.
+      For Path B: the steward runs the same lint+fast-test against
+      the rebased SHA before merging.
+
+  - id: w5
+    summary: "Add make pr-submit with hygiene checks (rename of pr-open semantics)"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      pr-submit is pr-open + queue handoff + hygiene:
+        - Refuse dirty worktree (`git status --porcelain` non-empty)
+        - Capture immutable head SHA at submission; if HEAD changes
+          after submit, requeue (Path B) or auto-cancel and resubmit
+          (Path A)
+        - Drafts skip the queue (do not add queue:ready label)
+        - PRs touching `.github/workflows/**` or steward source bypass
+          auto-queue and require manual review
+      Keep `make pr-open` as deprecated alias for one release.
+
+  - id: w6
+    summary: "Define trust lanes — agent PRs vs external contributor PRs"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      Two queue lanes (or two labels: `queue:trusted` vs
+      `queue:untrusted`):
+        - Trusted: PRs from project members / Joe / known agents.
+          Auto-queue on `queue:ready` label.
+        - Untrusted: PRs from external contributors. Require manual
+          `queue:approved` label from Joe before queueing. Steward
+          NEVER runs PR-controlled code (workflow files, scripts) with
+          elevated tokens — `pull_request_target` is forbidden in any
+          steward-related workflow.
+      Document the lane policy in CONTRIBUTING.md.
+
+  - id: w7
+    summary: "Define bounce ownership and retry budget"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      For PRs ejected from queue with `queue:conflict` or
+      `queue:failed`:
+        - Repair owner: original PR author (auto-assigned)
+        - Retry budget: 3 ejections per PR; on the 4th, label
+          `queue:abandoned` and require manual triage
+        - Stale-branch cleanup: PRs with `queue:abandoned` older than
+          14 days get auto-closed with a polite comment
+      Document in CLAUDE.md/AGENTS.md.
+
+  - id: w8
+    summary: "Smoke test in fork (Path B only) before enabling on develop"
+    status: pending
+    needs: [w3, w4, w5, w6, w7]
+    notes: |
+      For Path B: validate the steward workflow end-to-end in a fork
+      with a mix of clean PRs, conflicting PRs, and failing PRs.
+      Confirm:
+        - Single-flight: two `queue:ready` PRs land sequentially
+        - Conflict ejection: `queue:conflict` label and comment
+        - Test-fail ejection: `queue:failed` label and comment
+        - Trust lane: untrusted PR doesn't auto-queue
+      Document the test in PR description.
+
+verification:
+  - description: "Path A or Path B chosen with rationale recorded"
+    command: "grep -cE '^Selected path: (A|B) \\(' _project/decisions/dev-loop-queue-path-*.md"
+    expected_output: "1"
+  - description: "Queue-tier CI is light (not full matrix)"
+    command: "grep -cE 'merge_group|queue:ready' .github/workflows/*.yml | awk -F: '{s+=$2}END{print s}'"
+    expected_output: ">= 1 (Path A) or steward script references it"
+  - description: "make pr-submit refuses dirty worktree"
+    command: "cd $(mktemp -d) && git init && touch dirty && make -f /Users/joe/Developer/BenchBox/Makefile pr-submit BRANCH=test 2>&1 | grep -c 'dirty'"
+    expected_output: ">= 1"
+  - description: "Trust lanes documented in CONTRIBUTING.md"
+    command: "grep -cE 'queue:trusted|queue:untrusted|queue:approved' CONTRIBUTING.md"
+    expected_output: ">= 1"
+  - description: "Bounce/retry policy documented"
+    command: "grep -cE 'queue:abandoned|retry budget' CLAUDE.md AGENTS.md"
+    expected_output: ">= 1"
+
+must_preserve:
+  - "Step 3's lightweight PR-tier CI — the queue does not promote develop to release-grade gating"
+  - "Heavy validation stays in nightly — do not move it back to the queue path"
+  - "develop-post-merge.yml safety net (Step 4) remains active even with the queue — belt-and-suspenders is correct here because queue-tier CI runs against rebased SHA, not the post-merge SHA"
+  - "Existing pr-open semantics during deprecation period — don't break in-flight workflows mid-rollout"
+
+approach: |
+  Lock path selection (w1) FIRST. Everything else depends on the choice.
+  Path A is significantly simpler if available; Path B is a real
+  software project (workflow + bot creds + state machine).
+
+  For Path B specifically, do not roll a custom merge driver. Use
+  `git merge-tree` for conflict detection (already used by pr-open),
+  `gh pr merge --squash` for the actual merge, and the
+  peter-evans/create-pull-request action for any auxiliary PRs.
+
+  Trust lanes (w6) and bounce ownership (w7) are policy decisions
+  that benefit from being written down BEFORE the implementation.
+  If they emerge from rollout incidents, they encode the wrong
+  defaults.
+
+  Smoke test (w8) is mandatory for Path B because the steward writes
+  to develop. A buggy steward is louder than a buggy workflow change.
+
+anti_patterns:
+  - "DO NOT add full matrix to queue-tier CI — because that's exactly the over-engineering Steps 3-5 prevented — keep queue light, heavy stays nightly"
+  - "DO NOT use a long-lived PAT for the steward — because rotation burden and audit trail are worse than a GitHub App — use App with scoped permissions"
+  - "DO NOT skip trust lanes — because public repos with write-token bots are a known exfil vector — `pull_request_target` is forbidden anywhere in steward workflows"
+  - "DO NOT remove develop-post-merge.yml just because the queue runs queue-tier CI — because the queue-tier and post-merge are checking different SHAs (rebased vs landed) — both protect different failure modes"
+  - "DO NOT auto-queue PRs that modify workflows or steward source — because they could compromise the queue itself — manual review required for those"
+  - "DO NOT begin queue work without Step 5 saying BUILD — because Step 5 might say DO NOT BUILD — premature start wastes effort"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/ (new merge_group triggers if Path A; new steward.yml if Path B)"
+    - "Makefile (pr-submit target, deprecate pr-open)"
+    - "CLAUDE.md, AGENTS.md (queue flow, trust lanes, bounce policy)"
+    - "CONTRIBUTING.md (trust lanes, queue:approved process)"
+    - "_project/decisions/dev-loop-queue-path-*.md (new decision record)"
+  do_not_modify:
+    - "develop-post-merge.yml (Step 4 — keep as-is)"
+    - "test.yml or nightly.yml (Step 3 — keep as-is)"
+    - "Pool worktree targets (Step 2 — orthogonal)"
+
+deferred:
+  - summary: "Native MQ migration via org transfer"
+    reason: "Org transfer is a separate decision with broader implications (URLs, integrations, billing). If Step 5 says BUILD AND Step 6 w1 prefers Path A, escalate that decision separately."
+  - summary: "Queue dashboard / observability beyond labels"
+    reason: "Labels + comments are sufficient for one-person ops. Add dashboard if queue volume justifies it."
+
+metadata:
+  tags:
+    - dev-loop
+    - queue
+    - merge-queue
+    - steward
+    - deferred
+  estimated_effort: "Large (Path A: 1-2 days; Path B: 2-3 days)"
+  created_date: "2026-04-30"
+
+impact:
+  business_value: |
+    IF measurement justifies it, eliminates remaining merge contention
+    and provides hard guarantees about develop never being broken by
+    semantic conflicts. IF measurement does NOT justify it, the design
+    captured here is throwaway — but the gate prevents wasted work.
+  technical_debt: |
+    If built, adds significant infrastructure (Path A: GitHub config;
+    Path B: workflow + bot + state machine). All gated on data, so
+    debt only accrues when it's worth carrying.
+
+success_metrics:
+  - "Queue successfully serializes integration to develop with zero false-positive merges"
+  - "P95 queue dwell time stays under 30 minutes for trusted-lane PRs"
+  - "Zero successful exploits via PR-controlled steward code (untrusted lane proves out)"
+
+open_questions:
+  - "Should queue:abandoned auto-close after 14 days, or just label and let humans decide? (Plan: auto-close with polite comment; reduces backlog. Revisit if it closes valuable work.)"
+  - "Should the steward (Path B) run on schedule (every 5 min) or event-driven (label change)? (Plan: event-driven via label; schedule is a fallback for missed events.)"
+  - "If org transfer happens, do we still need Path B as a fallback? (Plan: no — native MQ replaces steward entirely. But keep the design document as historical reference.)"


### PR DESCRIPTION
Synthesized from a multi-round planning audit. Seven TODOs implementing
the agreed-on plan to simplify the merge loop without over-solving:

- Step 0 (decision gate): verify assumptions about strict-base, PR-tier
  CI cost, ruleset encoding, and native MQ availability before any
  downstream work; produces a decision record.
- Step 1: opt-in pre-push hooks, bounded pr-fanout, conservative test
  lock (kept global by default), and capture of consolidated L2
  blind-spot findings.
- Step 2: fixed pool of 10 worktrees with claim/release lifecycle and
  atomic claim under flock.
- Step 3: light PR-tier CI on develop (lint + Ubuntu 3.12 fast tests),
  full matrix moved to nightly, strict-base disabled — the load-bearing
  change. Main and tag releases keep full matrix unchanged.
- Step 4: develop-post-merge.yml safety net with cancel-in-progress=false,
  auto-revert PR generation, and dev-loop metrics emission.
- Step 5 (decision gate): 30-day measurement window with explicit
  thresholds for queue-trigger; produces go/no-go decision for Step 6.
- Step 6 (deferred): queue (native MQ or steward) with locked design
  decisions, blocked on Step 5.

Each TODO has guardrails (must_preserve, anti_patterns, scope_limit,
verification commands) and dependency edges so the CLI ready queue
walks them in correct order.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
