### PR TITLE
chore(todo): refine dev-loop guardrails per quality review

### DIFF
--- a/_project/TODO/main/planning/dev-loop-step-0-verify-assumptions.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-0-verify-assumptions.yaml
@@ -67,24 +67,45 @@ work:
     summary: "Estimate actual pr-refresh / staleness pain rate"
     status: pending
     notes: |
-      Inspect last 50 merged PRs for refresh-loop indicators:
-        - `gh pr list --state merged --base develop --limit 50 --json title,labels,comments,mergedAt`
-        - grep recent shell history / commit messages for `pr-refresh`
-        - look for "rebase" or "merge develop" comments on PRs
-      Record an estimated rate (PRs that hit refresh / total). If it's
-      under 5%, the queue is overkill even if Step 4 metrics later say
-      otherwise — Step 6 should reflect that.
+      Use a concrete proxy rather than free-text grep. For the last 50
+      merged PRs targeting develop, compute the gap between the last
+      successful CI run start and the PR merge time. A gap > 30 minutes
+      with intervening pushes is a strong signal of a strict-base re-CI
+      cycle (the PR was green, develop advanced, CI re-ran):
+        - `gh pr list --state merged --base develop --limit 50 \
+            --json number,mergedAt,headRefOid,labels,statusCheckRollup`
+        - For each PR, compute `merged_at - last_successful_check_started_at`
+          across `statusCheckRollup` entries
+        - Count PRs where that gap > 30 min AND statusCheckRollup has
+          >= 2 distinct startedAt timestamps for the same check name
+          (proxy for re-CI after a base push)
+      Secondary signal (lower confidence): `gh pr list --json comments`
+      and grep PR comments for explicit `pr-refresh`, `make pr-refresh`,
+      or `merged develop into branch`. Use only as corroboration.
+
+      Record:
+        - Strict-base re-CI rate (primary proxy, %)
+        - Explicit pr-refresh mentions (secondary, count)
+      If the primary proxy is < 5%, the queue is overkill even if Step 4
+      metrics later say otherwise — Step 6 should reflect that.
 
   - id: w6
     summary: "Confirm native GitHub Merge Queue availability"
     status: pending
     notes: |
-      Run: `gh api repos/joeharris76/BenchBox --jq '{visibility, owner_type:
-      .owner.type, allow_merge_commit, merge_queue: .has_issues}'`.
-      Native MQ requires public org-owned, or private org-owned on
-      Enterprise Cloud. User-owned repos do not qualify. Record the
-      finding so Step 6 picks the right path (native vs steward) without
-      re-investigation.
+      Run: `gh api repos/joeharris76/BenchBox --jq '{visibility,
+      owner_type: .owner.type, owner_login: .owner.login,
+      full_name, default_branch, private}'`. Also inspect the branch
+      protection / ruleset surfaces from w1/w2 for any native merge-queue
+      rule. Do NOT infer merge-queue availability from unrelated repo
+      fields such as `.has_issues`; that field only says whether Issues
+      are enabled.
+
+      Native MQ generally requires org-owned repos (with plan-dependent
+      availability for private repos). User-owned repos should be treated
+      as "native MQ unavailable" unless GitHub's protection/ruleset API
+      shows merge-queue rules can be applied. Record the evidence so Step 6
+      picks the right path (native vs steward) without re-investigation.
 
   - id: w7
     summary: "Write decision record at _project/decisions/dev-loop-verification-2026-04-30.md"
@@ -124,11 +145,12 @@ scope_limit:
   only_modify:
     - "_project/decisions/dev-loop-verification-2026-04-30.md (new file, the decision record)"
   do_not_modify:
-    - ".github/workflows/"
-    - "Makefile"
-    - "CLAUDE.md"
-    - "AGENTS.md"
-    - "Any branch protection or ruleset settings"
+    - ".github/workflows/test.yml (Step 3 owns this)"
+    - ".github/workflows/develop-post-merge.yml (Step 4 owns this)"
+    - ".github/workflows/release.yml (audited but not edited)"
+    - "Makefile (no edits — read-only investigation)"
+    - "CLAUDE.md, AGENTS.md (no edits — Steps 1-4 update these)"
+    - "GitHub branch protection / rulesets (Step 0 reads via gh api; never PATCH)"
 
 deferred:
   - summary: "Acting on the findings (Steps 1-4 implementation)"

--- a/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
@@ -57,9 +57,10 @@ work:
       Read `tests/conftest.py` and locate the lock acquisition logic
       (currently `~/.benchbox/test.lock`). Do NOT change the default —
       a global lock is what prevents 10 concurrent xdist runs from
-      melting the workstation. Add an env var override:
-        `lock_dir = os.environ.get("BENCHBOX_TEST_LOCK_DIR",
-                                   os.path.expanduser("~/.benchbox"))`
+      saturating the workstation. Add an env-var-aware helper, e.g.
+      `_get_test_lock_path()`, that returns:
+        `Path(os.environ.get("BENCHBOX_TEST_LOCK_DIR",
+                             Path.home() / ".benchbox")) / "test.lock"`
       Update `Makefile` `test-unlock` target to honor the same env var.
       Update `tests/README.md:257` area to document the override and
       explain WHY the default stays global.
@@ -109,10 +110,10 @@ work:
 
 verification:
   - description: "All pre-push hooks no-op when BENCHBOX_PREPUSH is unset"
-    command: "BENCHBOX_PREPUSH= pre-commit run --hook-stage pre-push --all-files 2>&1 | grep -cE '(Skipped|Passed)'"
+    command: "BENCHBOX_PREPUSH= uv run -- pre-commit run --hook-stage pre-push --all-files 2>&1 | grep -cE '(Skipped|Passed)'"
     expected_output: "matches the count of pre-push hooks in .pre-commit-config.yaml"
   - description: "Pre-push hooks execute when BENCHBOX_PREPUSH=1"
-    command: "BENCHBOX_PREPUSH=1 pre-commit run pr-preflight-fast-tests --hook-stage pre-push --all-files 2>&1 | tail -3"
+    command: "BENCHBOX_PREPUSH=1 uv run -- pre-commit run pr-preflight-fast-tests --hook-stage pre-push --all-files 2>&1 | tail -3"
     expected_output: "hook runs (success or expected failure on uncommitted state); does not skip"
   - description: "pr-fanout default parallelism is 4"
     command: "grep -E '^PR_FANOUT_JOBS \\?= ' Makefile"
@@ -121,8 +122,8 @@ verification:
     command: "BENCHBOX_TEST_LOCK_DIR=/tmp/bb-lock-test uv run -- python -m pytest -m fast -q tests/unit/ -x 2>&1 | tail -5 && ls /tmp/bb-lock-test/test.lock"
     expected_output: "lock file present at /tmp/bb-lock-test/test.lock; tests run normally"
   - description: "Default test lock still uses ~/.benchbox/"
-    command: "uv run -- python -c \"import os; from tests.conftest import _LOCK_PATH if False else None; print(os.path.expanduser('~/.benchbox/test.lock'))\""
-    expected_output: "/Users/joe/.benchbox/test.lock or equivalent home-dir path"
+    command: "uv run -- python -c \"from pathlib import Path; from tests.conftest import _get_test_lock_path; print(_get_test_lock_path() == Path.home() / '.benchbox' / 'test.lock')\""
+    expected_output: "True"
   - description: "Stale guidance removed from agent-facing docs"
     command: "grep -cE '(Drain one at a time|One PR per file area|Sequential by design)' CLAUDE.md AGENTS.md"
     expected_output: "0"
@@ -154,7 +155,6 @@ approach: |
 
 anti_patterns:
   - "DO NOT localize the test lock to per-worktree by default — because 10 concurrent xdist runs (auto-workers) would exhaust CPU and produce timing-flake — keep global default and offer override only"
-  - "DO NOT bundle worktree-pool work into this PR — because that's Step 2 with its own scope and verification — ship the local-loop changes alone"
   - "DO NOT remove pr-refresh target in this PR — because branch protection still requires up-to-date until Step 3 lands — that target stays useful until then"
   - "DO NOT skip the blind-spot capture (w5) — because the protocol explicitly requires file-first capture and this is the natural home — they are 6 small files"
 
@@ -168,9 +168,11 @@ scope_limit:
     - "AGENTS.md (manual-coordination paragraphs)"
     - "_project/blind-spots/2026-04-30-*.md (6 new files)"
   do_not_modify:
-    - ".github/workflows/ (that's Step 3 and Step 4)"
-    - "Makefile worktree-* targets (that's Step 2)"
-    - "Branch protection or rulesets (that's Step 3)"
+    - ".github/workflows/test.yml (Step 3 owns this)"
+    - ".github/workflows/develop-post-merge.yml (Step 4 owns this)"
+    - "Makefile worktree-add, worktree-prune, worktree-pool-* targets (Step 2 owns these)"
+    - "Makefile pr-refresh target (Step 3 deprecates this; here it stays)"
+    - "GitHub branch protection / rulesets (Step 3 manual deployment)"
 
 metadata:
   tags:

--- a/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-1-local-loop-cleanup.yaml
@@ -73,8 +73,14 @@ work:
         - "Drain one at a time, oldest first" (and surrounding pr-refresh prose)
         - "One PR per file area at a time"
         - "Sequential by design" notes around pr-fanout
+        - Any claim that the pre-push hook reruns the fast lane
+          automatically on every push
       Replace with a one-paragraph summary of the new model: pool
       worktrees + auto-merge + post-merge auto-revert as safety net.
+      Update the pre-push-hook guidance to say expensive pre-push hooks
+      are opt-in via `BENCHBOX_PREPUSH=1`; `make pr-preflight` is the
+      explicit local gate for humans/agents that want the fast lane before
+      pushing.
       Note that this paragraph will be expanded by Steps 2 and 4 once
       those land; here, just remove the now-incorrect guidance.
 
@@ -125,8 +131,11 @@ verification:
     command: "uv run -- python -c \"from pathlib import Path; from tests.conftest import _get_test_lock_path; print(_get_test_lock_path() == Path.home() / '.benchbox' / 'test.lock')\""
     expected_output: "True"
   - description: "Stale guidance removed from agent-facing docs"
-    command: "grep -cE '(Drain one at a time|One PR per file area|Sequential by design)' CLAUDE.md AGENTS.md"
+    command: "grep -cE '(Drain one at a time|One PR per file area|Sequential by design|pre-push hook.*runs the fast lane|re-runs the fast lane automatically)' CLAUDE.md AGENTS.md"
     expected_output: "0"
+  - description: "Agent docs say pre-push fast lane is opt-in and pr-preflight is explicit"
+    command: "grep -cE 'BENCHBOX_PREPUSH=1|pre-push hooks.*opt-in|make pr-preflight.*explicit|explicit.*make pr-preflight' CLAUDE.md AGENTS.md"
+    expected_output: ">= 2"
   - description: "Six blind-spot findings recorded"
     command: "ls _project/blind-spots/2026-04-30-*.md | wc -l"
     expected_output: "6"
@@ -164,8 +173,8 @@ scope_limit:
     - "Makefile (pr-fanout target only)"
     - "tests/conftest.py (lock-path logic only)"
     - "tests/README.md (around line 257)"
-    - "CLAUDE.md (manual-coordination paragraphs)"
-    - "AGENTS.md (manual-coordination paragraphs)"
+    - "CLAUDE.md (manual-coordination and pre-push hook paragraphs)"
+    - "AGENTS.md (manual-coordination and pre-push hook paragraphs)"
     - "_project/blind-spots/2026-04-30-*.md (6 new files)"
   do_not_modify:
     - ".github/workflows/test.yml (Step 3 owns this)"

--- a/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
@@ -6,18 +6,37 @@ status: Not Started
 category: Core Functionality
 
 description: |
-  Replace the create-and-destroy worktree model with a fixed pool of 10
-  worktrees retained indefinitely. New agent sessions claim an available
-  worktree, update it from current `develop`, work there until merge,
-  then release it back to the pool.
+  Replace the create-and-destroy worktree model with a retained pool of
+  worktrees. Default pool size is 10 (`POOL_SIZE ?= 10`), but the targets
+  must keep the size configurable so the workstation can be tuned without
+  editing Makefile logic. New agent sessions claim an available worktree,
+  update it from current `develop`, work there until merge, then release
+  it back to the pool.
 
-  This formalizes how concurrent agents share the workstation. The pool
-  size of 10 is a hard cap that bounds the parallelism (which is also
-  why Step 1 keeps the test lock global — even with the pool bounded,
-  10 concurrent xdist runs would saturate the machine).
+  This formalizes how concurrent agents share the workstation. The default
+  size of 10 bounds routine parallelism (which is also why Step 1 keeps
+  the test lock global — even with the pool bounded, 10 concurrent xdist
+  runs would saturate the machine).
 
-  Single PR via `make pr-open`. After merge, run `make worktree-pool-init`
-  on the workstation as a one-time bootstrap.
+  Single PR via `make pr-open`.
+
+  ## Post-merge runbook (not part of the PR diff)
+
+  After this PR merges to develop, perform on Joe's workstation:
+
+    make worktree-pool-init
+
+  Then verify:
+    - 10 worktrees present at `BenchBox.pool-01..10`
+    - Each is detached at `origin/develop` and clean
+    - Each has `.venv/` populated
+    - `make worktree-pool-status` shows all 10 free
+    - Each free worktree is detached at `origin/develop`, NOT on the
+      local `develop` branch
+
+  Tracked as a follow-up checklist item in the PR description, not as a
+  work unit, because the work unit DAG is for code changes that can be
+  marked done by `todo-cli done <slug> <work-id>` against a commit.
 
 deps:
   needs:
@@ -25,25 +44,34 @@ deps:
 
 work:
   - id: w1
-    summary: "Add make worktree-pool-init target — creates pool-01..10 from develop"
+    summary: "Add make worktree-pool-init target — creates pool-01..POOL_SIZE from develop"
     status: pending
     notes: |
-      One-time bootstrap. Creates `BenchBox.pool-01` through
-      `BenchBox.pool-10` as siblings of the main clone, each on
-      `develop`, each with `uv sync --group dev` run, each with
-      `pre-commit install`. Idempotent: if a pool-NN worktree already
-      exists, leave it alone (do not touch its branch state).
+      One-time bootstrap. Add `POOL_SIZE ?= 10` and
+      `WORKTREE_POOL_PARENT ?= ..` so verification can create disposable
+      pools outside the normal sibling paths. With defaults, creates
+      `BenchBox.pool-01` through `BenchBox.pool-10` as siblings of the
+      main clone, each in detached HEAD at `origin/develop`, each with
+      `uv sync --group dev` run, each with `pre-commit install`.
+      Idempotent: if a pool-NN worktree already exists, leave it alone
+      (do not touch its branch state).
       Print summary table at end: pool-NN | path | branch.
 
   - id: w2
-    summary: "Add make worktree-claim BRANCH=<name> — atomic claim under flock"
+    summary: "Add make worktree-claim BRANCH=<name> — atomic claim under portable lock"
     status: pending
     notes: |
-      Selects the first **Free** pool worktree (HEAD on `develop`,
-      working tree clean, no local feature branch beyond `develop`).
+      Selects the first **Free** pool worktree (detached HEAD exactly at
+      `origin/develop`, working tree clean, no local feature branch
+      checked out). Pool worktrees must not check out the local `develop`
+      branch because the main clone keeps `develop` checked out and Git
+      does not allow the same branch in multiple worktrees.
       Steps:
-        1. Acquire flock on `<main-clone>/.git/pool.lock` (timeout 30s)
-        2. Iterate pool-01..10; first match is "Free"
+        1. Acquire a portable file lock on `<main-clone>/.git/pool.lock`
+           (timeout 30s). Use `lockf` on macOS, `flock` on Linux if
+           available, or a tiny Python helper using `fcntl.flock` so the
+           target works on Joe's macOS workstation and CI.
+        2. Iterate pool-01..POOL_SIZE; first match is "Free"
         3. In that worktree: `git fetch origin`, `git reset --hard
            origin/develop`, `git checkout -b $BRANCH`, `uv sync --group dev`
         4. Release flock
@@ -63,7 +91,7 @@ work:
         2. Verify PR for this branch is in MERGED state via
            `gh pr view --json state` (refuse if not, with explicit
            "open or close PR first" message; FORCE=1 escapes)
-        3. `git checkout develop`
+        3. `git checkout --detach origin/develop`
         4. `git fetch origin`
         5. `git reset --hard origin/develop`
         6. `git branch -D <feature-branch>` (the one just released)
@@ -77,8 +105,8 @@ work:
     notes: |
       Prints table with columns: pool-NN | path | branch | state |
       claim_age. State is one of:
-        - free: HEAD on develop, working tree clean, no untracked files
-                outside expected (`.benchbox/`, `.venv/`, etc.)
+        - free: detached HEAD at origin/develop, working tree clean, no
+                untracked files outside expected (`.benchbox/`, `.venv/`, etc.)
         - claimed: HEAD on a non-develop branch
         - stale: claimed branch has been merged upstream (gh pr view
                  returns MERGED) but worktree still on the branch
@@ -139,33 +167,21 @@ work:
       worktrees only; pool worktrees are released via `worktree-release`.
     needs: [w1]
 
-  - id: w9
-    summary: "Run worktree-pool-init on Joe's workstation post-merge"
-    status: pending
-    needs: [w1, w2, w3, w4, w5, w6, w7, w8]
-    notes: |
-      One-time runbook step after the PR lands. Verify:
-        - 10 worktrees present at BenchBox.pool-01..10
-        - Each on develop, clean
-        - Each has .venv/ populated
-        - `make worktree-pool-status` shows all 10 free
-      Track in PR description as a follow-up checklist item.
-
 verification:
   - description: "make worktree-pool-init creates 10 worktrees idempotently"
-    command: "make worktree-pool-init && ls -d ../BenchBox.pool-* | wc -l && make worktree-pool-init"
-    expected_output: "10 (first run) and second run completes without error"
+    command: "tmp=$(mktemp -d); WORKTREE_POOL_PARENT=$tmp POOL_SIZE=2 make worktree-pool-init && find \"$tmp\" -maxdepth 1 -type d -name 'BenchBox.pool-*' | wc -l && WORKTREE_POOL_PARENT=$tmp POOL_SIZE=2 make worktree-pool-init; for wt in \"$tmp\"/BenchBox.pool-*; do git worktree remove --force \"$wt\" >/dev/null 2>&1 || true; done; rm -rf \"$tmp\""
+    expected_output: "2 (first run) and second run completes without error; disposable worktrees are removed"
   - description: "worktree-claim refuses invalid branch names"
     command: "make worktree-claim BRANCH=bad-name 2>&1 | grep -c 'must match'"
     expected_output: ">= 1"
   - description: "worktree-claim selects an available pool worktree"
-    command: "make worktree-claim BRANCH=chore/test-pool-claim 2>&1 | grep -E 'WORKTREE_PATH=.*pool-[0-9]+'"
+    command: "tmp=$(mktemp -d); WORKTREE_POOL_PARENT=$tmp POOL_SIZE=1 make worktree-pool-init >/dev/null && WORKTREE_POOL_PARENT=$tmp POOL_SIZE=1 make worktree-claim BRANCH=chore/test-pool-claim 2>&1 | tee /tmp/bb-pool-claim.out | grep -E 'WORKTREE_PATH=.*pool-[0-9]+'; wt=$(sed -n 's/^WORKTREE_PATH=//p' /tmp/bb-pool-claim.out); git worktree remove --force \"$wt\" >/dev/null 2>&1 || true; git branch -D chore/test-pool-claim >/dev/null 2>&1 || true; rm -rf \"$tmp\" /tmp/bb-pool-claim.out"
     expected_output: "WORKTREE_PATH=<absolute path containing pool-NN>"
   - description: "worktree-pool-status reports all pool worktrees"
     command: "make worktree-pool-status 2>&1 | grep -cE '^pool-[0-9]+'"
     expected_output: "10"
   - description: "Concurrent claims do not race"
-    command: "for i in 1 2 3; do (make worktree-claim BRANCH=chore/race-test-$i &); done; wait; make worktree-pool-status | grep -cE 'chore/race-test-' && make worktree-pool-status | sort -u"
+    command: "tmp=$(mktemp -d); WORKTREE_POOL_PARENT=$tmp POOL_SIZE=3 make worktree-pool-init >/dev/null; for i in 1 2 3; do (WORKTREE_POOL_PARENT=$tmp POOL_SIZE=3 make worktree-claim BRANCH=chore/race-test-$i >\"$tmp/out-$i\" 2>&1 &); done; wait; cat \"$tmp\"/out-* | grep -E '^WORKTREE_PATH=' | sort -u | wc -l; for wt in \"$tmp\"/BenchBox.pool-*; do git worktree remove --force \"$wt\" >/dev/null 2>&1 || true; done; for i in 1 2 3; do git branch -D chore/race-test-$i >/dev/null 2>&1 || true; done; rm -rf \"$tmp\""
     expected_output: "3 distinct claims, each on a different pool-NN worktree"
   - description: "worktree-prune skips pool worktrees"
     command: "make worktree-prune 2>&1 | grep -c 'Skipping pool worktree'"
@@ -186,13 +202,17 @@ approach: |
   (w4) and reset (w5) are operational tooling, then docs (w6) and
   deprecation (w7-w8) update the rest of the surface.
 
-  Use `flock` (via `flock(1)` on Linux/macOS) for atomic claim. Lock
-  file at `<main-clone>/.git/pool.lock`. Single shared lock across all
-  pool worktrees — claim is fast (seconds) so contention is fine.
+  Use a portable lock wrapper for atomic claim. `flock(1)` is not present
+  on the macOS workstation, so the Makefile cannot assume it. Prefer
+  `lockf` on macOS, `flock` on Linux when available, or a small Python
+  helper that calls `fcntl.flock`. Lock file stays at
+  `<main-clone>/.git/pool.lock`. Single shared lock across all pool
+  worktrees — claim is fast (seconds) so contention is fine.
 
   For state detection in worktree-pool-status:
-    - free: `git rev-parse --abbrev-ref HEAD` == "develop" AND
-            `git status --porcelain` is empty AND no extra branches
+    - free: `git symbolic-ref -q --short HEAD` is empty AND
+            `git rev-parse HEAD` == `git rev-parse origin/develop` AND
+            `git status --porcelain` is empty
     - claimed: not on develop, working tree may or may not be clean
     - stale: claimed AND `gh pr view --json state` returns MERGED
     - dirty: claimed AND `git status --porcelain` non-empty
@@ -202,10 +222,11 @@ approach: |
 
 anti_patterns:
   - "DO NOT auto-reap stale claims — because an agent crash mid-session may leave valuable uncommitted work — surface as 'stale' in status, require explicit `worktree-pool-reset` to free"
-  - "DO NOT skip flock on claim selection — because two concurrent agents racing to claim would both pick pool-01 and one would clobber the other's branch — atomic selection is required"
+  - "DO NOT skip portable locking on claim selection — because two concurrent agents racing to claim would both pick pool-01 and one would clobber the other's branch — atomic selection is required"
   - "DO NOT delete pool-NN worktrees in worktree-prune — because the pool is the contract — prune is for legacy non-pool worktrees only"
   - "DO NOT remove make worktree-add in this PR — because in-flight work in non-pool worktrees needs continuity — deprecate-with-notice now, remove next release"
   - "DO NOT hardcode pool size to 10 — because the workstation may want a different cap — read POOL_SIZE ?= 10 from the environment"
+  - "DO NOT check out the local develop branch in pool worktrees — because the main clone owns develop and Git forbids the same branch in multiple worktrees — use detached origin/develop as the Free state"
 
 scope_limit:
   only_modify:
@@ -214,10 +235,12 @@ scope_limit:
     - "AGENTS.md (Session start / Worktree section)"
     - ".gitignore (add .git/pool.lock if needed)"
   do_not_modify:
-    - ".github/workflows/ (Step 3 and Step 4 territory)"
-    - "tests/ (test lock is Step 1)"
-    - ".pre-commit-config.yaml (Step 1)"
-    - "Branch protection or rulesets (Step 3)"
+    - ".github/workflows/test.yml (Step 3 owns this)"
+    - ".github/workflows/develop-post-merge.yml (Step 4 owns this)"
+    - "tests/conftest.py (Step 1 owns the test-lock helper)"
+    - ".pre-commit-config.yaml (Step 1 owns pre-push gating)"
+    - "Makefile pr-* targets (Steps 1 and 3 own these)"
+    - "GitHub branch protection / rulesets (Step 3 manual deployment)"
 
 deferred:
   - summary: "Auto-update of pool worktrees while idle (background pull of develop)"

--- a/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-2-worktree-pool.yaml
@@ -139,6 +139,16 @@ work:
       `worktree-pool-reset POOL=NN` if needed).
       Note that `make worktree-add` remains as a deprecated alias for
       one release with a stderr deprecation notice.
+
+      Update Claude-specific pre-approved command buckets in CLAUDE.md:
+        - Read-only: `make worktree-pool-status`, `make worktree-list`,
+          `git worktree list*`
+        - Write, feature/pool worktrees only: `make worktree-claim
+          BRANCH=...`, `make worktree-release`
+        - Manual/admin escape hatches, not broad auto-allow:
+          `make worktree-pool-init`, `make worktree-pool-reset POOL=NN`
+      AGENTS.md should describe the same lifecycle in prose even though it
+      does not have Claude's pre-approved-command table.
     needs: [w2, w3, w4]
 
   - id: w7
@@ -189,6 +199,12 @@ verification:
   - description: "worktree-add prints deprecation notice"
     command: "make worktree-add BRANCH=chore/legacy-test 2>&1 | grep -c 'DEPRECATED'"
     expected_output: ">= 1"
+  - description: "Claude command permissions list new pool commands explicitly"
+    command: "grep -cE 'worktree-claim|worktree-release|worktree-pool-status|worktree-pool-init|worktree-pool-reset' CLAUDE.md"
+    expected_output: ">= 5"
+  - description: "Agent-facing docs describe claim/release pool lifecycle"
+    command: "grep -cE 'worktree-claim|worktree-release|worktree-pool-status|worktree-pool-reset' CLAUDE.md AGENTS.md"
+    expected_output: ">= 8"
 
 must_preserve:
   - "Existing make worktree-add target keeps working — only adds deprecation notice; do not break legacy non-pool worktree workflows mid-session"
@@ -231,7 +247,7 @@ anti_patterns:
 scope_limit:
   only_modify:
     - "Makefile (worktree-* targets only)"
-    - "CLAUDE.md (Session start section)"
+    - "CLAUDE.md (Session start, Worktrees, and Pre-approved Commands sections)"
     - "AGENTS.md (Session start / Worktree section)"
     - ".gitignore (add .git/pool.lock if needed)"
   do_not_modify:

--- a/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
@@ -91,7 +91,10 @@ work:
           critical toggle that eliminates stale-PR refresh)
         - Keep `enforce_admins: true` if currently set
       Record the before/after JSON in the PR description for audit.
-      This is a manual deployment step; not in the PR diff.
+      This is a manual deployment step; not in the PR diff. If Step 0
+      found required checks in GitHub rulesets rather than classic branch
+      protection, patch the ruleset instead and record the ruleset name,
+      rule id, required checks, and strict-base flag before/after.
     needs: [w2]
 
   - id: w6
@@ -120,7 +123,7 @@ work:
 
 verification:
   - description: "PR-tier CI on develop runs only lint and Ubuntu 3.12 fast tests"
-    command: "gh run list --workflow test.yml --branch develop --event pull_request --limit 1 --json jobs --jq '.[].jobs | length'"
+    command: "run_id=$(gh run list --workflow test.yml --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId'); gh run view \"$run_id\" --json jobs --jq '.jobs | length'"
     expected_output: "<= 3 jobs (lint, type, fast-test)"
   - description: "Full matrix runs on nightly schedule"
     command: "gh workflow list --json name,state | jq '.[] | select(.name | test(\"nightly|Nightly\"))'"
@@ -129,11 +132,14 @@ verification:
     command: "grep -cE 'matrix:|os: \\[ubuntu-latest, macos-latest, windows-latest\\]' .github/workflows/release.yml .github/workflows/test.yml"
     expected_output: ">= 1"
   - description: "Strict-base is off on develop branch protection"
-    command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.strict'"
-    expected_output: "false"
-  - description: "Required checks list contains only lightweight jobs"
-    command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.contexts | length'"
-    expected_output: "<= 3"
+    command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.strict' 2>/dev/null || echo classic-protection-not-configured"
+    expected_output: "false OR classic-protection-not-configured; ruleset strict check below must also pass"
+  - description: "Rulesets targeting develop do not require strict-base"
+    command: "gh api repos/joeharris76/BenchBox/rulesets --jq '[.[] | select((.conditions.ref_name.include // []) | any(. == \"refs/heads/develop\" or . == \"~DEFAULT_BRANCH\")) | .rules[]? | select(.type == \"required_status_checks\") | (.parameters.strict_required_status_checks_policy // false)] | all(. == false)'"
+    expected_output: "true"
+  - description: "Required checks list contains only lightweight jobs across protection surfaces"
+    command: "classic=$(gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '(.required_status_checks.contexts // []) | length' 2>/dev/null || echo 0); rulesets=$(gh api repos/joeharris76/BenchBox/rulesets --jq '[.[] | select((.conditions.ref_name.include // []) | any(. == \"refs/heads/develop\" or . == \"~DEFAULT_BRANCH\")) | .rules[]? | select(.type == \"required_status_checks\") | .parameters.required_status_checks[]?.context] | length'); test $((classic + rulesets)) -le 3 && echo ok"
+    expected_output: "ok"
   - description: "make pr-refresh prints deprecation notice"
     command: "make -n pr-refresh 2>&1 | grep -c 'DEPRECATED' || make pr-refresh 2>&1 | head -3 | grep -c 'DEPRECATED'"
     expected_output: ">= 1"
@@ -172,14 +178,16 @@ scope_limit:
     - ".github/workflows/test.yml"
     - ".github/workflows/nightly.yml (new)"
     - ".github/workflows/release.yml (audit + comment-only)"
-    - "Makefile (pr-refresh deprecation notice)"
+    - "Makefile (pr-refresh deprecation notice only)"
     - "CLAUDE.md (pr-refresh paragraph)"
     - "AGENTS.md (pr-refresh paragraph)"
   do_not_modify:
-    - ".github/workflows/develop-post-merge.yml (Step 4)"
-    - "Makefile worktree-* targets (Step 2)"
-    - ".pre-commit-config.yaml (Step 1)"
-    - "Test code (no test changes; only CI orchestration)"
+    - ".github/workflows/develop-post-merge.yml (Step 4 owns this)"
+    - ".github/workflows/lint.yml (only edit if a required PR-tier check moves; otherwise leave alone)"
+    - "Makefile worktree-add, worktree-claim, worktree-pool-*, worktree-release targets (Step 2 owns these)"
+    - "Makefile pr-fanout, pr-open targets (Step 1 owns these)"
+    - ".pre-commit-config.yaml (Step 1 owns pre-push gating)"
+    - "tests/ (no test changes; only CI orchestration)"
 
 deferred:
   - summary: "Native GitHub Merge Queue migration"

--- a/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
@@ -98,7 +98,7 @@ work:
     needs: [w2]
 
   - id: w6
-    summary: "Deprecate make pr-refresh and update CLAUDE.md/AGENTS.md"
+    summary: "Deprecate make pr-refresh and update CLAUDE.md/AGENTS.md CI guidance"
     status: pending
     notes: |
       With strict-base off, pr-refresh is no longer routine. Modify
@@ -108,6 +108,16 @@ work:
       Remove pr-refresh from the routine workflow paragraphs in
       CLAUDE.md ("PR/Worktree (write — feature branches only)" still
       lists it as escape hatch but not as routine).
+
+      Update the agent-facing CI prose in both CLAUDE.md and AGENTS.md:
+        - Develop PRs now run only lightweight required checks: lint/type
+          plus Ubuntu 3.12 fast tests.
+        - Full OS/Python matrix, integration/table-format/package/parity,
+          and PySpark validation moved to nightly/workflow_dispatch.
+        - `main` PRs and tag releases remain release-grade and must keep
+          full validation.
+        - Agents should not wait for nightly before ordinary develop PRs;
+          nightly failures are surfaced separately by `incident:nightly-red`.
     needs: [w5]
 
   - id: w7
@@ -143,6 +153,9 @@ verification:
   - description: "make pr-refresh prints deprecation notice"
     command: "make -n pr-refresh 2>&1 | grep -c 'DEPRECATED' || make pr-refresh 2>&1 | head -3 | grep -c 'DEPRECATED'"
     expected_output: ">= 1"
+  - description: "Agent docs describe light develop CI, nightly matrix, and release-grade main"
+    command: "grep -cE 'lightweight|required checks|nightly|full.*matrix|release-grade|tag releases|main PR' CLAUDE.md AGENTS.md"
+    expected_output: ">= 6"
 
 must_preserve:
   - "Full matrix + package + release validation remains REQUIRED for main PRs and tag releases — Step 3 only changes develop, not main"
@@ -179,8 +192,8 @@ scope_limit:
     - ".github/workflows/nightly.yml (new)"
     - ".github/workflows/release.yml (audit + comment-only)"
     - "Makefile (pr-refresh deprecation notice only)"
-    - "CLAUDE.md (pr-refresh paragraph)"
-    - "AGENTS.md (pr-refresh paragraph)"
+    - "CLAUDE.md (pr-refresh and CI guidance paragraphs)"
+    - "AGENTS.md (pr-refresh and CI guidance paragraphs)"
   do_not_modify:
     - ".github/workflows/develop-post-merge.yml (Step 4 owns this)"
     - ".github/workflows/lint.yml (only edit if a required PR-tier check moves; otherwise leave alone)"

--- a/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
@@ -63,18 +63,31 @@ work:
     summary: "Emit per-PR dev-loop metrics as workflow artifact"
     status: pending
     notes: |
-      Add a `metrics` job that runs on every successful merge to develop.
-      Computes and writes JSON artifact:
+      Add a `metrics` job that runs with `if: always()` for every push to
+      develop, so both green and red post-merge runs emit a machine-readable
+      record. Computes and writes JSON artifact:
         {
           "merged_at": "<ISO-8601>",
           "pr_number": N,
           "pr_open_to_merged_seconds": N,
           "post_merge_red": false,
-          "conflict_on_merge": <bool from PR labels>,
+          "develop_red_detected_at": null,
+          "auto_revert_pr_opened_at": null,
+          "time_to_revert_pr_seconds": null,
+          "next_green_develop_run_at": null,
+          "time_to_recover_red_seconds": null,
+          "conflict_on_merge": <bool from PR labels/comments>,
+          "orphaned_failed_pr": false,
           "ci_runner_minutes": N
         }
-      Artifact retention: 90 days (covers the Step 5 measurement window).
-      One file per merge. Step 5 aggregates these.
+      On failure, the auto-revert job should update or emit the same shape
+      with `post_merge_red: true`, `develop_red_detected_at`, and
+      `auto_revert_pr_opened_at`. `next_green_develop_run_at` and
+      `time_to_recover_red_seconds` may be null at artifact creation time;
+      `make dev-loop-metrics` must fill them by scanning later successful
+      develop-post-merge runs. Artifact retention: 90 days (covers the
+      Step 5 measurement window). One file per merge. Step 5 aggregates
+      these records plus the explicit PR audit sources named there.
 
   - id: w4
     summary: "Document the new failure flow in CLAUDE.md and AGENTS.md"
@@ -117,7 +130,10 @@ work:
       push to a fork's develop, confirm the workflow opens a revert PR
       with correct title/body/labels. If revert conflicts, confirm the
       fallback issue is opened correctly.
-      Document the test in PR description.
+      Document the test in PR description AND write
+      `_project/decisions/dev-loop-auto-revert-fork-test-<date>.md` with
+      fork repo, failing SHA, workflow run URL, revert PR URL or conflict
+      issue URL, and screenshots/CLI excerpts sufficient for review.
 
 verification:
   - description: "develop-post-merge.yml uses cancel-in-progress: false"
@@ -136,8 +152,8 @@ verification:
     command: "grep -cE 'incident:develop-red|auto-revert' CLAUDE.md AGENTS.md"
     expected_output: ">= 2"
   - description: "PR description includes fork-test evidence"
-    command: "echo 'manual check at review time'"
-    expected_output: "PR description references the fork-validation test"
+    command: "grep -cE 'Fork validation|failing SHA|revert PR|conflict issue|workflow run' _project/decisions/dev-loop-auto-revert-fork-test-*.md"
+    expected_output: ">= 4"
 
 must_preserve:
   - "Existing develop-post-merge.yml job definitions and their pass/fail signal — Step 4 ADDS auto-revert, does not replace existing checks"
@@ -181,11 +197,14 @@ scope_limit:
     - "Makefile (dev-loop-metrics target only)"
     - "CLAUDE.md (failure flow section)"
     - "AGENTS.md (failure flow section)"
+    - "_project/decisions/dev-loop-auto-revert-fork-test-*.md (new fork validation evidence)"
   do_not_modify:
-    - ".github/workflows/test.yml (Step 3 territory)"
-    - ".github/workflows/release.yml"
-    - "Branch protection rules (Step 3)"
-    - "Makefile worktree-* or pr-* targets (Steps 1-2)"
+    - ".github/workflows/test.yml (Step 3 owns this)"
+    - ".github/workflows/nightly.yml (Step 3 owns this)"
+    - ".github/workflows/release.yml (release CI is unchanged)"
+    - "Makefile worktree-add, worktree-claim, worktree-pool-*, worktree-release targets (Step 2 owns these)"
+    - "Makefile pr-open, pr-fanout, pr-refresh targets (Steps 1 and 3 own these)"
+    - "GitHub branch protection / rulesets (Step 3 owns these)"
 
 deferred:
   - summary: "Slack/Discord notifications on develop-red"

--- a/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-4-post-merge-safety-net.yaml
@@ -118,6 +118,10 @@ work:
       Implementation: `gh run list --workflow develop-post-merge.yml
       --json conclusion,databaseId | gh run download <id> -n metrics`,
       then aggregate the JSON files.
+      Document this target in CLAUDE.md and AGENTS.md near the post-merge
+      safety-net / dev-loop workflow text. In CLAUDE.md, add it to the
+      pre-approved read-only PR/Worktree or metrics bucket; the command
+      reads workflow artifacts through `gh` and does not mutate repo state.
     needs: [w3]
 
   - id: w6
@@ -148,6 +152,9 @@ verification:
   - description: "make dev-loop-metrics produces a non-empty summary"
     command: "make dev-loop-metrics 2>&1 | grep -cE 'P50|P95|red rate|runner'"
     expected_output: ">= 4"
+  - description: "dev-loop-metrics is documented for agents and pre-approved in CLAUDE.md"
+    command: "grep -cE 'dev-loop-metrics|P50|P95|post-merge red|runner minutes' CLAUDE.md AGENTS.md"
+    expected_output: ">= 3"
   - description: "Failure flow is documented in agent-facing docs"
     command: "grep -cE 'incident:develop-red|auto-revert' CLAUDE.md AGENTS.md"
     expected_output: ">= 2"
@@ -195,8 +202,8 @@ scope_limit:
   only_modify:
     - ".github/workflows/develop-post-merge.yml"
     - "Makefile (dev-loop-metrics target only)"
-    - "CLAUDE.md (failure flow section)"
-    - "AGENTS.md (failure flow section)"
+    - "CLAUDE.md (failure flow, dev-loop metrics, and Pre-approved Commands sections)"
+    - "AGENTS.md (failure flow and dev-loop metrics sections)"
     - "_project/decisions/dev-loop-auto-revert-fork-test-*.md (new fork validation evidence)"
   do_not_modify:
     - ".github/workflows/test.yml (Step 3 owns this)"

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -48,6 +48,21 @@ work:
       Run `make dev-loop-metrics WINDOW=30d` (added in Step 4 w5).
       Capture output. If artifacts coverage is below 80% of merges
       (i.e., emission failures), extend the window 7 days and retry.
+      Also capture the raw JSON summary if the target supports it
+      (`make dev-loop-metrics WINDOW=30d FORMAT=json`), because w3 needs
+      exact counts for threshold evaluation.
+
+      Metrics must combine:
+        - Step 4 metrics artifacts (PR open->merged, post-merge red,
+          time-to-revert-PR, time-to-recover, runner minutes)
+        - PR audit for the same window:
+          `gh pr list --state all --base develop --search "updated:>=<start>"`
+          and labels/comments containing `queue:conflict`,
+          `conflict`, `pr-refresh`, `auto-revert`, or
+          `incident:develop-red`
+        - Post-merge workflow runs:
+          `gh run list --workflow develop-post-merge.yml --created
+          <start>..<end> --json conclusion,createdAt,updatedAt,url`
       Save raw aggregation to `_project/decisions/
       dev-loop-measurement-<window-end>.md`.
 
@@ -67,6 +82,17 @@ work:
       For each metric: PASS (below trigger) / FAIL (at or above).
       "Sustained" means >= 70% of days in the window above threshold;
       not just one outlier week.
+
+      Data-source rules:
+        - Use Step 4 artifacts for PR open->merged, post-merge red,
+          time-to-revert-PR, time-to-recover, and runner minutes.
+        - Use the PR audit from w2 for cross-PR conflict repairs/week.
+        - Count orphaned failed PRs from PRs labeled/commented as failed,
+          conflicted, auto-reverted, or develop-red with no new commit,
+          review response, or replacement PR within 24h.
+        - If a metric cannot be computed because Step 4 did not emit the
+          required fields, mark REASSESS and create a follow-up to fix
+          metrics emission; do not silently drop the metric.
 
   - id: w4
     summary: "Write decision record with go/no-go for Step 6"
@@ -139,13 +165,15 @@ anti_patterns:
 scope_limit:
   only_modify:
     - "_project/decisions/dev-loop-measurement-*.md (new)"
-    - "_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml (status field only)"
+    - "_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml (status/deps only, or move to DONE if DO NOT BUILD)"
     - "CLAUDE.md (one paragraph)"
     - "AGENTS.md (one paragraph)"
   do_not_modify:
-    - "Any code or workflow file"
-    - "Branch protection or rulesets"
-    - "Step 1-4 implementation artifacts"
+    - ".github/workflows/test.yml, develop-post-merge.yml, nightly.yml, release.yml (no code changes during the measurement window)"
+    - "Makefile (no target changes during the window)"
+    - "tests/conftest.py (Step 1 helper stays as-is)"
+    - "GitHub branch protection / rulesets (no further changes during the window)"
+    - "_project/TODO/main/planning/dev-loop-step-{0,1,2,3,4}-*.yaml (Steps 1-4 implementations are frozen during measurement)"
 
 deferred:
   - summary: "Building infrastructure based on measurement findings"
@@ -160,7 +188,9 @@ metadata:
     - decision-gate
   estimated_effort: "Small (2-3h after the 30-day wait)"
   created_date: "2026-04-30"
-  due_date: "2026-06-15"
+  # due_date: TBD — set to (Step 4 merge_date + 30 days) when Step 4 lands.
+  # Leaving unset because Step 4's merge date is unknown at TODO creation;
+  # a fake-precise placeholder would mislead future readers.
 
 impact:
   business_value: |

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -135,6 +135,9 @@ verification:
   - description: "Step 6 TODO status updated to reflect decision"
     command: "grep -E '^status:' _project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml"
     expected_output: "Either 'Not Started' (if BUILD), 'Blocked' (if REASSESS), or moved to DONE (if DO NOT BUILD)"
+  - description: "Agent docs include current dev-loop status summary"
+    command: "grep -cE 'Dev-loop status \\(as of|P95 PR-to-merged|post-merge red rate|BUILD QUEUE|DO NOT BUILD QUEUE|REASSESS' CLAUDE.md AGENTS.md"
+    expected_output: ">= 3"
 
 must_preserve:
   - "Steps 1-4 implementation untouched during measurement — no code changes during the window"

--- a/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
@@ -82,6 +82,8 @@ work:
         4. Confirm `gh pr merge --auto --squash` remains the submission
            mechanism for develop PRs.
         5. Update CLAUDE.md/AGENTS.md to describe the queue-managed flow.
+        6. Update CLAUDE.md pre-approved command buckets for any new
+           queue-facing commands or labels.
 
       Path B locked spec:
         1. Implement BenchBox Merge Steward as a single-concurrency
@@ -111,9 +113,19 @@ work:
           refuse dirty worktree, capture immutable head SHA, skip drafts,
           and bypass auto-queue for workflow/steward changes.
         - Keep `make pr-open` as a deprecated alias for one release.
+        - Update CLAUDE.md and AGENTS.md with the submitted/queued flow,
+          including when agents use `make pr-submit` vs deprecated
+          `make pr-open`, whether they should wait, and how queue
+          ejections are repaired.
+        - Update CLAUDE.md Pre-approved Commands so `make pr-submit`
+          and any safe queue-status commands are explicitly classified;
+          queue admin/reset commands must not be hidden in broad wildcards.
         - Define trusted vs untrusted lanes. Untrusted PRs require manual
           `queue:approved`; `pull_request_target` is forbidden in steward
           workflows.
+        - Update CONTRIBUTING.md with the external contributor path:
+          untrusted PRs require manual `queue:approved`; PR-controlled
+          workflow/steward changes bypass auto-queue.
         - Define bounce ownership and retry budget: original author owns
           `queue:conflict` / `queue:failed`; 3 ejections max, then
           `queue:abandoned`.
@@ -147,8 +159,8 @@ verification:
     command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); ! grep -qE 'ONLY if|mark this .* skipped|needs: \\[w2, w3\\]' \"$f\" && echo ok"
     expected_output: "ok"
   - description: "Common queue policy is present in generated TODO"
-    command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); grep -cE 'queue-tier|pr-submit|queue:approved|queue:abandoned|pull_request_target|develop-post-merge' \"$f\""
-    expected_output: ">= 6"
+    command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); grep -cE 'queue-tier|pr-submit|queue:approved|queue:abandoned|pull_request_target|develop-post-merge|CLAUDE.md|AGENTS.md|CONTRIBUTING.md|Pre-approved' \"$f\""
+    expected_output: ">= 10"
 
 must_preserve:
   - "Step 3's lightweight PR-tier CI — the queue does not promote develop to release-grade gating"

--- a/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
@@ -1,26 +1,32 @@
 id: dev-loop-step-6-queue-decision-gate
-title: "Dev-loop simplification — Step 6: queue (native MQ or steward) — DEFERRED until Step 5 justifies"
+title: "Dev-loop simplification — Step 6: queue implementation gate — DEFERRED until Step 5 justifies"
 worktree: main
-priority: Low
+priority: Medium-High
 status: Blocked
+category: Core Functionality
 
 description: |
-  Deferred queue implementation. Locked design decisions captured here
-  so that IF Step 5 measurement returns BUILD QUEUE, this work can
-  execute against a pre-agreed spec rather than re-designed from scratch.
+  Deferred queue gate and spec handoff. This TODO does NOT implement a
+  queue directly. If Step 5 measurement returns BUILD QUEUE, this item
+  chooses the viable path and creates exactly one follow-up implementation
+  TODO from the locked spec below:
+
+    - Path A: native GitHub Merge Queue
+    - Path B: BenchBox Merge Steward
+
+  This shape is intentional. The TODO work-unit graph only supports
+  `pending`, `in_progress`, and `done`, so mutually exclusive Path A/Path B
+  implementation units cannot live in the same flat DAG without deadlocking
+  downstream work. The generated follow-up TODO becomes the executable
+  implementation item; this gate records the path and prevents re-debating
+  settled design decisions.
 
   Status starts as Blocked (on Step 5). Three resolution paths:
-    - Step 5 → DO NOT BUILD: this TODO moves to DONE with completion
-      note "queue not needed; closed by Step 5 measurement <date>"
-    - Step 5 → BUILD QUEUE: this TODO unblocks, status → Not Started,
-      work units below execute
-    - Step 5 → REASSESS: stays Blocked, deps point to next measurement
-
-  Critical guardrail: if this TODO unblocks, the design decisions in
-  the work units are LOCKED — they were debated extensively in the
-  planning rounds. Re-debating them at build time is out of scope.
-  Modify only if Step 5 measurement findings explicitly contradict
-  a specific decision (e.g., trust-lane assumption was wrong).
+    - Step 5 -> DO NOT BUILD: this TODO moves to DONE with completion note
+      "queue not needed; closed by Step 5 measurement <date>"
+    - Step 5 -> BUILD QUEUE: this TODO unblocks, status -> Not Started,
+      work units below create the selected implementation TODO
+    - Step 5 -> REASSESS: stays Blocked, deps point to next measurement
 
 deps:
   needs:
@@ -28,199 +34,166 @@ deps:
 
 work:
   - id: w1
-    summary: "Confirm path: native GitHub Merge Queue vs BenchBox Merge Steward"
+    summary: "Confirm BUILD decision and choose native MQ vs steward"
     status: pending
     notes: |
-      Re-read Step 0 w6 finding (native MQ availability) and Step 5
-      decision record. Path A (native MQ) requires repo to be
-      org-owned (and possibly Enterprise Cloud for private). Path B
-      (steward) is the fallback.
+      Re-read Step 0 w6 finding (native MQ availability) and the Step 5
+      decision record. Path A (native MQ) requires repo/ruleset support for
+      GitHub Merge Queue. Path B (steward) is the fallback.
 
-      If Step 0 confirmed user-owned repo, Path B is mandatory unless
-      user has since transferred to an org. If org transfer is on the
-      table, evaluate it as a separate decision (one-time friction
-      vs ongoing steward maintenance).
-
-      Lock the choice in a sub-decision-record before w2.
+      If Step 0 confirmed user-owned repo and GitHub APIs still do not
+      expose merge-queue rules for this repo, Path B is mandatory unless
+      the user has since transferred the repo to an org. If org transfer
+      is on the table, evaluate it as a separate decision (one-time
+      friction vs ongoing steward maintenance), not inside implementation.
 
   - id: w2
-    summary: "PATH A — Enable native GitHub Merge Queue on develop"
+    summary: "Write queue path decision record"
     status: pending
     needs: [w1]
     notes: |
-      ONLY if w1 selected Path A. Otherwise mark this w2 as skipped.
-      Steps:
-        1. Enable "Require merge queue" on develop branch protection
-        2. Add `merge_group:` trigger to lint.yml, test.yml (queue-tier
-           jobs), nightly is unaffected (it's scheduled, not PR-tied)
-        3. Reduce PR-required checks to only what should gate "is this
-           PR plausibly good" — keep Step 3's lighter set
-        4. Update make pr-open / pr-submit to call
-           `gh pr merge --auto --squash` (already does this on develop)
-        5. Update CLAUDE.md/AGENTS.md to describe the queue-managed flow
+      Create `_project/decisions/dev-loop-queue-path-<date>.md` with:
+        - Selected path: A or B
+        - Step 0 evidence used
+        - Step 5 BUILD QUEUE metrics that justified starting
+        - Why the unselected path was rejected
+        - Whether org transfer was considered and why it is/is not part
+          of the queue rollout
 
   - id: w3
-    summary: "PATH B — Implement BenchBox Merge Steward as a single-concurrency workflow"
+    summary: "Create exactly one selected-path implementation TODO"
     status: pending
-    needs: [w1]
+    needs: [w2]
     notes: |
-      ONLY if w1 selected Path B. Workflow:
-        - Trigger: PR labeled `queue:ready` (set by pr-submit after
-          PR-tier CI passes)
-        - Concurrency: `group: benchbox-develop-integrator,
-          cancel-in-progress: false` — single-flight integrator
-        - Loop oldest-first by `queue:ready` label timestamp:
-            a. Reset to current origin/develop
-            b. Apply PR branch onto that tip (rebase or 3-way merge)
-            c. Run queue-tier checks against rebased SHA
-            d. Pass: push squash commit to develop, close PR, delete
-               branch
-            e. Conflict: label `queue:conflict`, comment with files,
-               continue to next PR
-            f. Test fail: label `queue:failed`, comment with job,
-               continue to next PR
-        - Each PR re-evaluates against the current develop tip;
-          staleness is impossible by construction
-      Use a narrow GitHub App (not a long-lived PAT) with permissions:
-      `contents: write`, `pull_requests: write`. App credentials in
-      org secrets.
+      Create ONE of these files, not both:
+        - Path A: `_project/TODO/main/planning/dev-loop-step-6a-native-merge-queue.yaml`
+        - Path B: `_project/TODO/main/planning/dev-loop-step-6b-merge-steward.yaml`
+
+      The generated TODO must be a normal implementation item with flat
+      `work[]` units and no mutually exclusive branches.
+
+      Path A locked spec:
+        1. Enable "Require merge queue" on develop branch protection or
+           the ruleset that targets develop.
+        2. Add `merge_group:` trigger to the workflows that report
+           queue-tier checks.
+        3. Keep Step 3's lightweight PR-tier checks; queue-tier is also
+           light (lint + Ubuntu 3.12 fast tests), not release-grade.
+        4. Confirm `gh pr merge --auto --squash` remains the submission
+           mechanism for develop PRs.
+        5. Update CLAUDE.md/AGENTS.md to describe the queue-managed flow.
+
+      Path B locked spec:
+        1. Implement BenchBox Merge Steward as a single-concurrency
+           workflow triggered by `queue:ready`.
+        2. Concurrency group: `benchbox-develop-integrator`,
+           `cancel-in-progress: false`.
+        3. Loop oldest-first by `queue:ready` label timestamp.
+        4. For each PR: reset to current origin/develop, apply PR branch
+           onto that tip, run queue-tier checks, then merge or eject.
+        5. Conflict: label `queue:conflict`, comment with files, continue.
+        6. Test fail: label `queue:failed`, comment with job, continue.
+        7. Use a GitHub App with `contents: write` and
+           `pull_requests: write`; no long-lived PAT.
+        8. Smoke test in a fork with clean, conflicting, failing, and
+           untrusted PRs before enabling on develop.
 
   - id: w4
-    summary: "Define queue-tier CI separately from PR-tier"
+    summary: "Add common queue policy requirements to the selected TODO"
     status: pending
-    needs: [w2, w3]
+    needs: [w3]
     notes: |
-      Queue-tier CI is LIGHT, not heavy. Same as Step 3's PR-tier
-      (lint + Ubuntu 3.12 fast tests) — the queue's job is "rebase
-      and re-test against current base," not "release qualification."
-      Heavy validation stays in nightly.
-      For Path A: workflows that report to merge_group gate the queue.
-      For Path B: the steward runs the same lint+fast-test against
-      the rebased SHA before merging.
+      The selected implementation TODO must include these common work units
+      or guardrails:
+        - Queue-tier CI is light: lint + Ubuntu 3.12 fast tests only.
+          Heavy validation stays in nightly.
+        - Add `make pr-submit` as pr-open + queue handoff + hygiene:
+          refuse dirty worktree, capture immutable head SHA, skip drafts,
+          and bypass auto-queue for workflow/steward changes.
+        - Keep `make pr-open` as a deprecated alias for one release.
+        - Define trusted vs untrusted lanes. Untrusted PRs require manual
+          `queue:approved`; `pull_request_target` is forbidden in steward
+          workflows.
+        - Define bounce ownership and retry budget: original author owns
+          `queue:conflict` / `queue:failed`; 3 ejections max, then
+          `queue:abandoned`.
+        - Keep develop-post-merge.yml active as Step 4's safety net.
 
   - id: w5
-    summary: "Add make pr-submit with hygiene checks (rename of pr-open semantics)"
+    summary: "Validate the generated TODO and close this gate"
     status: pending
-    needs: [w2, w3]
+    needs: [w2, w3, w4]
     notes: |
-      pr-submit is pr-open + queue handoff + hygiene:
-        - Refuse dirty worktree (`git status --porcelain` non-empty)
-        - Capture immutable head SHA at submission; if HEAD changes
-          after submit, requeue (Path B) or auto-cancel and resubmit
-          (Path A)
-        - Drafts skip the queue (do not add queue:ready label)
-        - PRs touching `.github/workflows/**` or steward source bypass
-          auto-queue and require manual review
-      Keep `make pr-open` as deprecated alias for one release.
-
-  - id: w6
-    summary: "Define trust lanes — agent PRs vs external contributor PRs"
-    status: pending
-    needs: [w2, w3]
-    notes: |
-      Two queue lanes (or two labels: `queue:trusted` vs
-      `queue:untrusted`):
-        - Trusted: PRs from project members / Joe / known agents.
-          Auto-queue on `queue:ready` label.
-        - Untrusted: PRs from external contributors. Require manual
-          `queue:approved` label from Joe before queueing. Steward
-          NEVER runs PR-controlled code (workflow files, scripts) with
-          elevated tokens — `pull_request_target` is forbidden in any
-          steward-related workflow.
-      Document the lane policy in CONTRIBUTING.md.
-
-  - id: w7
-    summary: "Define bounce ownership and retry budget"
-    status: pending
-    needs: [w2, w3]
-    notes: |
-      For PRs ejected from queue with `queue:conflict` or
-      `queue:failed`:
-        - Repair owner: original PR author (auto-assigned)
-        - Retry budget: 3 ejections per PR; on the 4th, label
-          `queue:abandoned` and require manual triage
-        - Stale-branch cleanup: PRs with `queue:abandoned` older than
-          14 days get auto-closed with a polite comment
-      Document in CLAUDE.md/AGENTS.md.
-
-  - id: w8
-    summary: "Smoke test in fork (Path B only) before enabling on develop"
-    status: pending
-    needs: [w3, w4, w5, w6, w7]
-    notes: |
-      For Path B: validate the steward workflow end-to-end in a fork
-      with a mix of clean PRs, conflicting PRs, and failing PRs.
-      Confirm:
-        - Single-flight: two `queue:ready` PRs land sequentially
-        - Conflict ejection: `queue:conflict` label and comment
-        - Test-fail ejection: `queue:failed` label and comment
-        - Trust lane: untrusted PR doesn't auto-queue
-      Document the test in PR description.
+      Run strict validation on the generated TODO and `todo_cli.py
+      check-graph`. The generated TODO is the implementation item to work
+      next. This gate is complete once:
+        - Exactly one implementation TODO exists
+        - The decision record exists
+        - The generated TODO is valid, graph-safe, and has runnable
+          verification commands
+        - The unselected path is documented as rejected/deferred
 
 verification:
   - description: "Path A or Path B chosen with rationale recorded"
     command: "grep -cE '^Selected path: (A|B) \\(' _project/decisions/dev-loop-queue-path-*.md"
     expected_output: "1"
-  - description: "Queue-tier CI is light (not full matrix)"
-    command: "grep -cE 'merge_group|queue:ready' .github/workflows/*.yml | awk -F: '{s+=$2}END{print s}'"
-    expected_output: ">= 1 (Path A) or steward script references it"
-  - description: "make pr-submit refuses dirty worktree"
-    command: "cd $(mktemp -d) && git init && touch dirty && make -f /Users/joe/Developer/BenchBox/Makefile pr-submit BRANCH=test 2>&1 | grep -c 'dirty'"
-    expected_output: ">= 1"
-  - description: "Trust lanes documented in CONTRIBUTING.md"
-    command: "grep -cE 'queue:trusted|queue:untrusted|queue:approved' CONTRIBUTING.md"
-    expected_output: ">= 1"
-  - description: "Bounce/retry policy documented"
-    command: "grep -cE 'queue:abandoned|retry budget' CLAUDE.md AGENTS.md"
-    expected_output: ">= 1"
+  - description: "Exactly one selected-path implementation TODO exists"
+    command: "test \"$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml 2>/dev/null | wc -l | tr -d ' ')\" = \"1\" && echo ok"
+    expected_output: "ok"
+  - description: "Generated implementation TODO validates strictly"
+    command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); uv run --project _project/scripts -- python _project/scripts/validate_todo.py \"$f\" --strict"
+    expected_output: "valid"
+  - description: "Generated implementation TODO has no mutually exclusive DAG branches"
+    command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); ! grep -qE 'ONLY if|mark this .* skipped|needs: \\[w2, w3\\]' \"$f\" && echo ok"
+    expected_output: "ok"
+  - description: "Common queue policy is present in generated TODO"
+    command: "f=$(ls _project/TODO/main/planning/dev-loop-step-6[ab]-*.yaml); grep -cE 'queue-tier|pr-submit|queue:approved|queue:abandoned|pull_request_target|develop-post-merge' \"$f\""
+    expected_output: ">= 6"
 
 must_preserve:
   - "Step 3's lightweight PR-tier CI — the queue does not promote develop to release-grade gating"
   - "Heavy validation stays in nightly — do not move it back to the queue path"
-  - "develop-post-merge.yml safety net (Step 4) remains active even with the queue — belt-and-suspenders is correct here because queue-tier CI runs against rebased SHA, not the post-merge SHA"
-  - "Existing pr-open semantics during deprecation period — don't break in-flight workflows mid-rollout"
+  - "develop-post-merge.yml safety net from Step 4 remains active even with a queue"
+  - "Existing pr-open semantics during deprecation period — do not break in-flight workflows mid-rollout"
+  - "Only one path implementation TODO exists — no flat-DAG deadlock from mutually exclusive Path A/Path B work"
 
 approach: |
-  Lock path selection (w1) FIRST. Everything else depends on the choice.
-  Path A is significantly simpler if available; Path B is a real
-  software project (workflow + bot creds + state machine).
+  Lock path selection first, then generate the selected implementation TODO.
+  Do not put both implementations into this item's `work[]`; the local TODO
+  model cannot represent branch choice without a skipped status. If the
+  generated TODO needs to differ from the locked spec, cite the Step 5
+  measurement or Step 0 availability evidence that forced the change.
 
-  For Path B specifically, do not roll a custom merge driver. Use
-  `git merge-tree` for conflict detection (already used by pr-open),
-  `gh pr merge --squash` for the actual merge, and the
-  peter-evans/create-pull-request action for any auxiliary PRs.
-
-  Trust lanes (w6) and bounce ownership (w7) are policy decisions
-  that benefit from being written down BEFORE the implementation.
-  If they emerge from rollout incidents, they encode the wrong
-  defaults.
-
-  Smoke test (w8) is mandatory for Path B because the steward writes
-  to develop. A buggy steward is louder than a buggy workflow change.
+  Path A is significantly simpler if available. Path B is a real software
+  project (workflow + bot credentials + state machine) and needs fork smoke
+  testing before enabling on develop.
 
 anti_patterns:
+  - "DO NOT add both Path A and Path B implementation units to this TODO — because the flat work DAG cannot mark the unchosen path skipped — create exactly one selected-path TODO"
   - "DO NOT add full matrix to queue-tier CI — because that's exactly the over-engineering Steps 3-5 prevented — keep queue light, heavy stays nightly"
   - "DO NOT use a long-lived PAT for the steward — because rotation burden and audit trail are worse than a GitHub App — use App with scoped permissions"
-  - "DO NOT skip trust lanes — because public repos with write-token bots are a known exfil vector — `pull_request_target` is forbidden anywhere in steward workflows"
-  - "DO NOT remove develop-post-merge.yml just because the queue runs queue-tier CI — because the queue-tier and post-merge are checking different SHAs (rebased vs landed) — both protect different failure modes"
-  - "DO NOT auto-queue PRs that modify workflows or steward source — because they could compromise the queue itself — manual review required for those"
+  - "DO NOT skip trust lanes — because public repos with write-token automation are an exfiltration risk — `pull_request_target` is forbidden anywhere in steward workflows"
+  - "DO NOT remove develop-post-merge.yml just because the queue runs queue-tier CI — because queue-tier and post-merge check different SHAs — both protect different failure modes"
   - "DO NOT begin queue work without Step 5 saying BUILD — because Step 5 might say DO NOT BUILD — premature start wastes effort"
 
 scope_limit:
   only_modify:
-    - ".github/workflows/ (new merge_group triggers if Path A; new steward.yml if Path B)"
-    - "Makefile (pr-submit target, deprecate pr-open)"
-    - "CLAUDE.md, AGENTS.md (queue flow, trust lanes, bounce policy)"
-    - "CONTRIBUTING.md (trust lanes, queue:approved process)"
     - "_project/decisions/dev-loop-queue-path-*.md (new decision record)"
+    - "_project/TODO/main/planning/dev-loop-step-6a-native-merge-queue.yaml (new, Path A only)"
+    - "_project/TODO/main/planning/dev-loop-step-6b-merge-steward.yaml (new, Path B only)"
+    - "_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml (status/completion updates)"
   do_not_modify:
-    - "develop-post-merge.yml (Step 4 — keep as-is)"
-    - "test.yml or nightly.yml (Step 3 — keep as-is)"
-    - "Pool worktree targets (Step 2 — orthogonal)"
+    - ".github/workflows/test.yml, develop-post-merge.yml, nightly.yml, release.yml (implementation TODO territory)"
+    - "Makefile (implementation TODO will own pr-submit and queue handoff)"
+    - "CLAUDE.md, AGENTS.md, CONTRIBUTING.md (implementation TODO will own queue-flow docs and trust lanes)"
+    - "GitHub branch protection / rulesets (implementation TODO toggles merge-queue rule)"
+    - "tests/, .pre-commit-config.yaml (orthogonal to queue path selection)"
 
 deferred:
+  - summary: "Unselected queue implementation path"
+    reason: "Only one selected-path TODO should be created. The rejected path is documented in the decision record to avoid a deadlocked flat DAG."
   - summary: "Native MQ migration via org transfer"
-    reason: "Org transfer is a separate decision with broader implications (URLs, integrations, billing). If Step 5 says BUILD AND Step 6 w1 prefers Path A, escalate that decision separately."
+    reason: "Org transfer is a separate decision with broader implications (URLs, integrations, billing). If Step 5 says BUILD and Path A requires transfer, escalate that decision separately."
   - summary: "Queue dashboard / observability beyond labels"
     reason: "Labels + comments are sufficient for one-person ops. Add dashboard if queue volume justifies it."
 
@@ -231,26 +204,27 @@ metadata:
     - merge-queue
     - steward
     - deferred
-  estimated_effort: "Large (Path A: 1-2 days; Path B: 2-3 days)"
+    - decision-gate
+  estimated_effort: "Small (about 1h to choose path and generate selected implementation TODO)"
   created_date: "2026-04-30"
 
 impact:
   business_value: |
-    IF measurement justifies it, eliminates remaining merge contention
-    and provides hard guarantees about develop never being broken by
-    semantic conflicts. IF measurement does NOT justify it, the design
-    captured here is throwaway — but the gate prevents wasted work.
+    If measurement justifies queue work, this gate prevents wasted design
+    churn and creates a single executable implementation TODO. If
+    measurement does not justify it, the queue closes without adding
+    infrastructure.
   technical_debt: |
-    If built, adds significant infrastructure (Path A: GitHub config;
-    Path B: workflow + bot + state machine). All gated on data, so
-    debt only accrues when it's worth carrying.
+    Keeps path choice out of the flat work DAG. The queue itself, if built,
+    still adds infrastructure debt; this gate ensures that debt only accrues
+    when the data says it is worth carrying.
 
 success_metrics:
-  - "Queue successfully serializes integration to develop with zero false-positive merges"
-  - "P95 queue dwell time stays under 30 minutes for trusted-lane PRs"
-  - "Zero successful exploits via PR-controlled steward code (untrusted lane proves out)"
+  - "Exactly one selected-path implementation TODO is created"
+  - "Generated TODO validates strictly and has no impossible Path A/Path B dependencies"
+  - "Generated TODO preserves lightweight queue-tier CI, trust lanes, bounce policy, and Step 4 safety net"
 
 open_questions:
-  - "Should queue:abandoned auto-close after 14 days, or just label and let humans decide? (Plan: auto-close with polite comment; reduces backlog. Revisit if it closes valuable work.)"
-  - "Should the steward (Path B) run on schedule (every 5 min) or event-driven (label change)? (Plan: event-driven via label; schedule is a fallback for missed events.)"
-  - "If org transfer happens, do we still need Path B as a fallback? (Plan: no — native MQ replaces steward entirely. But keep the design document as historical reference.)"
+  - "Should queue:abandoned auto-close after 14 days, or just label and let humans decide? (Plan: include auto-close in generated TODO; revisit if it closes valuable work.)"
+  - "Should the steward (Path B) run on schedule or event-driven? (Plan: event-driven via label; schedule is fallback for missed events.)"
+  - "If org transfer happens, do we still need Path B as a fallback? (Plan: no; native MQ replaces steward entirely, but keep the decision record as history.)"


### PR DESCRIPTION
## Summary

Follow-up to PR #66 addressing all remaining findings from the adversarial quality review of the seven dev-loop simplification TODOs.

### Findings addressed

- **Directory-path `do_not_modify` entries** (rubric red flag): Steps 0, 1, 2, 3, 4, 5, 6 — replaced bare-directory bans with named files and Makefile targets, each annotated with the owning step.
- **Step 0 `w5` heuristic measurement**: replaced free-text grep over PR comments with a concrete strict-base re-CI proxy (gap between last successful check start and merge time, with multi-startedAt detection).
- **Step 1 scope-policing anti-pattern**: dropped the "DO NOT bundle worktree-pool work into this PR" entry — pure scope policing rather than learned-from-mistakes wisdom.
- **Step 2 `w9` runbook leakage**: deleted from `work[]` (a runbook step is not a code-change unit) and captured as a "Post-merge runbook" section in the description.
- **Step 5 speculative `due_date`**: removed the `2026-06-15` placeholder; left a comment explaining the policy ("set to merge_date + 30 days when Step 4 lands").
- **Step 6 misleading `priority: Low`**: changed to `Medium-High` (value-if-unblocked); `status: Blocked` continues to express "do not start now."

### Linter additions folded in

- Step 4 w5: dev-loop-metrics target now also gets documented in CLAUDE.md/AGENTS.md and added to the pre-approved read-only command bucket.
- Step 4 verification: new check that the metrics target is documented for agents.
- Step 5 verification: new check that CLAUDE.md/AGENTS.md include the dev-loop status summary.
- Step 6 w3/w4: Path A and B specs both now include CLAUDE.md / AGENTS.md / CONTRIBUTING.md / pre-approved-command-bucket updates as required artifacts of the implementation TODO.
- Step 6 verification: common-policy regex now also matches doc-surface keywords.

### Validation

- All 7 TODOs pass `validate_todo.py`.
- `todo-cli check-graph` passes (44 items, no cycles, no dangling refs).
- Ready queue still surfaces Step 0 first.

## Test plan

- [x] `validate_todo.py` for each of the 7 modified files
- [x] `todo-cli check-graph`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)