### PR TITLE
chore(todo): harden Step 3a path-based CI skip plan

### DIFF
--- a/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
@@ -25,8 +25,9 @@ description: |
   Designed-together follow-up: Step 3a (`dev-loop-step-3a-path-based-ci-skip`)
   closes the remaining waste where doc-only / TODO-only PRs still trigger
   the post-Step-3 PR-tier jobs unnecessarily. Step 3 narrows the matrix;
-  Step 3a adds a `ci-required` umbrella that skips PR-tier entirely for
-  non-code paths. Read both before implementing either.
+  Step 3a adds a required-check umbrella that skips Python fast tests for
+  safe content-only paths while preserving targeted content validation.
+  Read both before implementing either.
 
 deps:
   needs:

--- a/_project/TODO/main/planning/dev-loop-step-3a-path-based-ci-skip.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-3a-path-based-ci-skip.yaml
@@ -1,5 +1,5 @@
 id: dev-loop-step-3a-path-based-ci-skip
-title: "Dev-loop simplification — Step 3a: path-based CI skip for non-code PRs"
+title: "Dev-loop simplification — Step 3a: path-based CI skip for content-only PRs"
 worktree: main
 priority: High
 status: Not Started
@@ -17,148 +17,198 @@ description: |
   of waste are unnecessary; nothing in those PRs could possibly affect
   the test suite.
 
-  Approach: introduce a single always-running `ci-required` umbrella job
-  that detects whether the PR's diff contains code via
-  `dorny/paths-filter` (or an equivalent step), then dispatches to the
-  Step-3 PR-tier jobs only when code paths changed. For non-code PRs,
-  the umbrella reports green in <60 seconds and the PR is mergeable.
+  Approach: introduce a single always-reporting required check
+  (`ci-required-result`) that classifies the PR's diff, runs a cheap
+  content guard for content-only PRs, and dispatches the Step-3 code
+  PR-tier (`lint`/type + Ubuntu 3.12 fast tests) only when code paths
+  changed. For TODO/blog/agent-doc-only PRs, the required check should
+  report green in <60 seconds without running Python fast tests.
 
-  Branch protection contract: the umbrella becomes the single required
-  status check. Subordinate jobs (`lint`, `test`) gain `if:` conditions
-  on the filter outputs but no longer need to be required, because their
-  pass/fail is rolled up into the umbrella. This preserves the merge gate
-  while eliminating the doc-only waste.
+  Branch protection contract: `ci-required-result` becomes the required
+  status check on develop. Any jobs whose failures should block merge
+  must be in the same workflow dependency graph as the result job, because
+  GitHub Actions `needs:` cannot aggregate jobs from separate workflows.
+  The current `lint.yml` workflow therefore moves its develop PR gate
+  under the umbrella. Leave `lint.yml` for main/push/manual use, or for
+  non-required reporting only.
 
   Single PR via `make pr-open`. Independently shippable AFTER Step 3
   lands (the required-checks list this depends on is established there).
 
 deps:
   needs:
+    - dev-loop-step-1-local-loop-cleanup
     - dev-loop-step-3-ci-rebalance-and-strict-base-off
 
 work:
   - id: w1
-    summary: "Define the path-filter ruleset (code vs non-code)"
+    summary: "Define a fail-closed path-filter ruleset"
     status: pending
     notes: |
-      Decide what counts as a "code path" that requires the full PR-tier
-      CI to run. Initial split, to be locked in this work unit:
+      Decide what is explicitly safe to treat as content-only. The rule is
+      fail-closed: a PR can skip code CI only when EVERY changed path is in
+      the safe content-only allowlist. Any path outside that allowlist is a
+      code/infra path and runs the full post-Step-3 PR-tier.
 
-      Code paths (run full PR-tier):
-        - `benchbox/**`
-        - `tests/**`
-        - `scripts/**`
-        - `_binaries/**` (TPC binaries — affect data generation)
-        - `pyproject.toml`, `uv.lock`
-        - `Makefile`
-        - `.github/workflows/**`
-        - `.pre-commit-config.yaml`
-        - `_project/scripts/**` (TODO scripts; if these break, validation breaks)
-
-      Non-code paths (skip PR-tier; umbrella greens immediately):
+      Safe content-only paths (skip Python fast tests; run content guard):
         - `_project/TODO/**`, `_project/DONE/**`
         - `_project/blind-spots/**`
         - `_project/decisions/**`
         - `_project/handoffs/**`
+        - `_project/notes/**`, `_project/research/**`, `_project/planning/**`
         - `_blog/**`
-        - `docs/**`
+        - `docs/**` ONLY if the content guard includes docs validation for
+          develop PRs; `docs.yml` currently runs PR checks for `main`, not
+          `develop`, so do not rely on it as-is.
         - `*.md` at repo root (README.md, CONTRIBUTING.md, etc.)
         - `CLAUDE.md`, `AGENTS.md`
-        - `.gitignore`, `.gitattributes` (small risk; mark as code if it
-          ever causes a surprise)
+
+      Examples that MUST run full PR-tier (non-exhaustive; unknown paths
+      also run full PR-tier):
+        - `benchbox/**`, `tests/**`, `scripts/**`, `examples/**`
+        - `landing/**`, `results-data/**`, `results-explorer/**`, `docker/**`
+        - `_binaries/**`, `_sources/**`
+        - `_project/scripts/**`, `_project/config/**`, `_project/compat/**`
+        - `pyproject.toml`, `uv.lock`, `Makefile`
+        - `.github/workflows/**`, `.pre-commit-config.yaml`
+        - `.claude/commands/**` (slash-command behavior affects agents)
+        - `.gitignore`, `.gitattributes` (repo behavior and tracked-file
+          conflict guardrails; `.gitignore` also has gitignore-lint)
 
       Edge case: a single PR that touches BOTH categories runs full
-      PR-tier (failsafe). The filter is "any code path changed → full
-      run", not "majority of paths".
+      PR-tier (failsafe). The filter is "all paths safe → skip code CI";
+      anything else runs code CI.
 
       Document the ruleset in `.github/workflows/_paths.yml` (a reusable
-      filter file referenced by the umbrella) so it has a single source
-      of truth.
+      filter file referenced by the umbrella and local helper) so it has
+      a single source of truth.
 
   - id: w2
-    summary: "Add ci-required umbrella job to the PR-tier workflow"
+    summary: "Add ci-required umbrella, content guard, and gated code jobs"
     status: pending
     needs: [w1]
     notes: |
       Edit the workflow that runs on `pull_request` to develop (Step 3
       may have split test.yml; if so, edit the new pr-tier workflow;
-      otherwise edit test.yml). Add a job named `ci-required` that:
-        1. Always runs (no `if:` condition).
-        2. Uses `dorny/paths-filter@v3` (pinned by SHA) to compute
-           `code-changed: true|false` from the ruleset in `_paths.yml`.
-        3. If `code-changed == false`: outputs `decision: skip` and
-           reports success. End of job.
-        4. If `code-changed == true`: outputs `decision: full`. The
-           subordinate jobs (`lint`, `test`) gate their `if:` on this
-           output and run normally.
-        5. The umbrella's final step `needs:` the subordinate jobs (when
-           they were dispatched) and reports their aggregate status.
-           If `decision: skip`, the umbrella succeeds without waiting.
+      otherwise edit test.yml). Add:
+
+        - `ci-paths`: always runs, checks out the PR, uses
+          `dorny/paths-filter@<pinned-sha>` (not `@v3`) or the shared helper
+          to emit:
+            - `safe-content-only: true|false`
+            - `needs-code-ci: true|false`
+            - `changed-paths` / optional debug summary
+            - optional metric line/artifact: content-only?, skipped code
+              CI?, estimated runner minutes saved (for Step 5)
+        - `content-guard`: runs when a PR contains safe content paths. This
+          is intentionally cheap and targeted: TODO YAML validation,
+          markdown/YAML hygiene, docs validation for `docs/**` develop PRs,
+          and gitignore-lint if `.gitignore` is ever routed through this
+          workflow. It must catch the kind of markdown/YAML errors that
+          mattered on PR #66/#67.
+        - `code-lint`: the post-Step-3 lint/type gate, gated on
+          `needs-code-ci == 'true'`.
+        - `code-test`: Ubuntu 3.12 fast tests, gated on
+          `needs-code-ci == 'true'`.
+        - `ci-required-result`: always runs, aggregates all of the above,
+          and is the required check name.
+
+      Do not try to aggregate the existing `.github/workflows/lint.yml`
+      `lint` job from `ci-required-result`: `needs:` cannot cross workflow
+      boundaries. Move/duplicate the required develop PR lint/type gate
+      into the umbrella workflow before making `ci-required-result` the
+      sole required check. Leave `lint.yml` for main/push/manual surfaces
+      or non-required reporting only.
+
+      Required behavior:
+        1. `ci-paths` and `ci-required-result` always run (no `if:`
+           condition on those jobs).
+        2. Content-only PRs run `content-guard`, skip `code-lint` and
+           `code-test`, and pass only if `content-guard` succeeds.
+        3. Code/infra/unknown-path PRs run `content-guard` as applicable
+           plus `code-lint` and `code-test`.
+        4. If `needs-code-ci == true`, `ci-required-result` fails unless
+           both `code-lint` and `code-test` succeeded.
+        5. If `needs-code-ci == false`, `ci-required-result` fails unless
+           `content-guard` succeeded or no content guard was needed.
 
       Concrete shape (sketch):
 
         jobs:
-          ci-required:
+          ci-paths:
             runs-on: ubuntu-latest
             outputs:
-              code-changed: ${{ steps.filter.outputs.code }}
+              needs-code-ci: ${{ steps.classify.outputs.needs-code-ci }}
+              safe-content-only: ${{ steps.classify.outputs.safe-content-only }}
             steps:
               - uses: actions/checkout@v4
-              - uses: dorny/paths-filter@v3
+              - uses: dorny/paths-filter@<pinned-sha>
                 id: filter
                 with:
                   filters: .github/workflows/_paths.yml
+              - id: classify
+                run: scripts/path_filter_decision.sh
 
-          lint:
-            needs: ci-required
-            if: needs.ci-required.outputs.code-changed == 'true'
+          content-guard:
+            needs: ci-paths
+            if: needs.ci-paths.outputs.safe-content-only == 'true' ||
+                needs.ci-paths.outputs.needs-code-ci == 'true'
             ...
 
-          test:
-            needs: ci-required
-            if: needs.ci-required.outputs.code-changed == 'true'
+          code-lint:
+            needs: ci-paths
+            if: needs.ci-paths.outputs.needs-code-ci == 'true'
+            ...
+
+          code-test:
+            needs: ci-paths
+            if: needs.ci-paths.outputs.needs-code-ci == 'true'
             ...
 
           ci-required-result:
-            needs: [ci-required, lint, test]
+            needs: [ci-paths, content-guard, code-lint, code-test]
             if: always()
             runs-on: ubuntu-latest
             steps:
               - run: |
-                  if [ "${{ needs.ci-required.outputs.code-changed }}" = "false" ]; then
-                    echo "Doc-only PR — skipped code CI. Marking required check green."
+                  set -euo pipefail
+                  if [ "${{ needs.ci-paths.outputs.needs-code-ci }}" = "false" ]; then
+                    test "${{ needs.content-guard.result }}" = "success" ||
+                      test "${{ needs.content-guard.result }}" = "skipped"
+                    echo "Content-only PR — skipped Python code CI."
+                    exit $?
+                  fi
+                  if [ "${{ needs.code-lint.result }}" = "success" ] && \
+                     [ "${{ needs.code-test.result }}" = "success" ]; then
                     exit 0
                   fi
-                  if [ "${{ needs.lint.result }}" = "success" ] && \
-                     [ "${{ needs.test.result }}" = "success" ]; then
-                    exit 0
-                  fi
-                  echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }}"
+                  echo "code-lint=${{ needs.code-lint.result }} code-test=${{ needs.code-test.result }}"
                   exit 1
 
       The required check on develop branch protection becomes
-      `ci-required-result`, NOT `lint` or `test` directly.
+      `ci-required-result`, NOT bare `lint` or `test` directly, only after
+      the workflow has landed on develop.
 
   - id: w3
-    summary: "Update branch-protection required-checks list to use the umbrella"
+    summary: "Add the equivalent local skip in pr-preflight"
     status: pending
-    needs: [w2]
+    needs: [w1]
     notes: |
-      Apply via `gh api -X PATCH repos/joeharris76/BenchBox/branches/
-      develop/protection` (or the Step-0-found ruleset). Required
-      checks before this step (post-Step-3): `lint`, `test (ubuntu-latest, 3.12)`.
-      Required checks after this step: `ci-required-result`.
+      Step 1 made pre-push hooks opt-in via BENCHBOX_PREPUSH=1. When
+      humans/agents DO opt in (e.g. running `make pr-preflight`), the
+      fast-test lane still runs even on content-only changes — same waste,
+      just locally instead of in CI.
 
-      The lint and test jobs continue to run (when dispatched) and
-      report their own status, but they are no longer required gates;
-      the umbrella's aggregation is the gate.
+      Add a check at the top of `pr-preflight` and the
+      pr-preflight-fast-tests pre-commit hook that runs the same path
+      decision against `git diff --name-only origin/develop...HEAD`. If
+      no code paths matched, run the cheap content guard, print
+      "No code changes detected; skipping fast tests.", and skip only the
+      Python fast-test lane.
 
-      Sequencing: WORKFLOW CHANGES (w2) MUST LAND ON DEVELOP BEFORE
-      THIS BRANCH PROTECTION EDIT. Otherwise develop becomes unmergeable
-      because the new required check name doesn't exist yet. Document
-      the order in PR description (same pattern as Step 3 w5).
-
-      Record the before/after JSON in PR description for audit.
+      Reuse the path-filter ruleset from `.github/workflows/_paths.yml`
+      via a small helper (`scripts/path_filter_decision.sh` or Python if
+      YAML parsing is needed) so the rule lives in exactly one place.
 
   - id: w4
     summary: "Add a tiny test that proves the skip path works"
@@ -166,130 +216,170 @@ work:
     needs: [w2]
     notes: |
       In a fork or via `act` locally, simulate two PR diffs:
-        1. Touch only `_project/TODO/foo.yaml` — confirm `ci-required`
-           reports green in under 60 seconds, lint/test do not run.
-        2. Touch `benchbox/cli/run.py` — confirm full PR-tier runs as
+        1. Touch only `_project/TODO/foo.yaml` — confirm
+           `ci-required-result` reports green in under 60 seconds, the
+           content guard runs, and code-lint/code-test do not run.
+        2. Touch `docs/development/foo.md` — confirm docs/content
+           validation runs for develop PRs without Python fast tests.
+        3. Touch `benchbox/cli/run.py` — confirm full PR-tier runs as
            today and umbrella aggregates correctly.
+        4. Touch an unknown top-level path (e.g., `quality/example.txt`)
+           — confirm the classifier fails closed and runs full PR-tier.
+        5. Touch `.gitignore` — confirm full PR-tier or gitignore-lint is
+           included in the blocking aggregation.
       Document the test in `_project/decisions/dev-loop-path-filter-
       smoke-test-<date>.md` with workflow run URLs and timings.
 
   - id: w5
-    summary: "Apply equivalent local skip in pr-preflight for symmetry"
+    summary: "Document the umbrella in agent and contributor docs"
     status: pending
-    needs: [w1]
+    needs: [w2, w3]
     notes: |
-      Step 1 made pre-push hooks opt-in via BENCHBOX_PREPUSH=1. When
-      humans/agents DO opt in (e.g. running `make pr-preflight`), the
-      fast-test lane still runs even on doc-only changes — same waste,
-      just locally instead of in CI.
+      Update every place that currently hard-codes the old
+      `lint` + `test (ubuntu-latest, 3.12)` contract:
+        - `CLAUDE.md`
+        - `AGENTS.md`
+        - `CONTRIBUTING.md`
+        - `.claude/commands/pr.md`
 
-      Add a check at the top of `pr-preflight` (and the
-      pr-preflight-fast-tests pre-commit hook) that runs the same path
-      filter against `git diff --name-only origin/develop...HEAD`. If
-      no code paths matched, print "No code changes detected; skipping
-      fast tests." and exit 0.
-
-      Reuse the path-filter ruleset from `.github/workflows/_paths.yml`
-      via a small Python or shell helper at `scripts/_paths_filter.sh`
-      so the rule lives in exactly one place.
+      Required prose:
+        - Develop PRs report through `ci-required-result`.
+        - Content-only PRs run content validation and skip Python fast
+          tests.
+        - Code/infra/unknown-path PRs run the post-Step-3 lint/type +
+          Ubuntu 3.12 fast-test gate.
+        - The shared path ruleset is `.github/workflows/_paths.yml`.
+        - Local `make pr-preflight` uses the same classifier.
 
   - id: w6
-    summary: "Document the umbrella in CLAUDE.md / AGENTS.md"
+    summary: "Open and merge the workflow PR before touching branch protection"
     status: pending
-    needs: [w2]
-    notes: |
-      Add a short paragraph in both files under the CI-related guidance
-      from Step 3:
-        - "PRs that touch only docs/TODOs/blind-spots/decisions/blog
-          report green via the `ci-required` umbrella in <60s; full
-          PR-tier CI runs only when code paths (benchbox/, tests/, etc.)
-          change. The path ruleset is at .github/workflows/_paths.yml."
-      Note that this also applies locally to `make pr-preflight` so
-      agents don't see fast-tests on TODO-only commits anymore.
-
-  - id: w7
-    summary: "Open the PR after Step 3 has landed and required checks updated"
-    status: pending
-    needs: [w1, w2, w3, w4, w5, w6]
+    needs: [w1, w2, w3, w4, w5]
     notes: |
       `make lint format typecheck`; `BENCHBOX_PREPUSH=1 make pr-preflight`;
-      `make pr-open`. Apply branch-protection change (w3) AFTER the PR
-      merges (workflow changes need to be live first; same sequencing
-      as Step 3 w5).
+      `make pr-open`. The PR description must state that the branch
+      protection/ruleset edit happens AFTER this PR merges, because the
+      new required check name does not exist on develop until then.
 
-      In PR description: include before/after required-checks JSON,
-      smoke-test fork run URLs, and confirmation that PR #66/#67-style
-      doc-only PRs would now skip code CI entirely.
+      Include smoke-test fork run URLs and confirmation that PR
+      #66/#67-style TODO-only PRs would now skip Python code CI while
+      still running content validation.
+
+  - id: w7
+    summary: "Post-merge: update branch-protection required checks"
+    status: pending
+    needs: [w6]
+    notes: |
+      Apply via `gh api -X PATCH repos/joeharris76/BenchBox/branches/
+      develop/protection` (or the Step-0-found ruleset). Required
+      checks before this step (post-Step-3): `lint`, `test (ubuntu-latest, 3.12)`.
+      Required checks after this step: `ci-required-result`.
+
+      The workflow changes from w6 MUST already be on develop. Do not make
+      this branch-protection edit a prerequisite for opening or merging
+      the workflow PR.
+
+      Record the before/after JSON in `_project/decisions/
+      dev-loop-path-filter-smoke-test-<date>.md` or a follow-up decision
+      record for audit. Do not change strict-base, dismiss-stale-reviews,
+      enforce-admins, or review settings in this step.
 
 verification:
-  - description: "Path filter ruleset exists in workflows directory"
-    command: "test -f .github/workflows/_paths.yml && grep -cE '^(code|non_code|docs|todos):' .github/workflows/_paths.yml"
+  - description: "Path filter ruleset exists and has safe-content plus fail-closed code categories"
+    command: "test -f .github/workflows/_paths.yml && grep -cE 'safe[-_]?content|content[-_]?only|needs[-_]?code|code[-_]?ci|unknown' .github/workflows/_paths.yml"
     expected_output: ">= 1"
-  - description: "ci-required umbrella job is present in PR-tier workflow"
-    command: "grep -cE 'ci-required:|ci-required-result:' .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
+  - description: "ci-required umbrella/result jobs and content guard are present in PR-tier workflow"
+    command: "grep -cE 'ci-paths:|ci-required-result:|content-guard:' .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
+    expected_output: ">= 3"
+  - description: "Code jobs gate on the fail-closed classifier output"
+    command: "grep -cE \"if:.*needs\\.ci-paths\\.outputs\\.needs-code-ci.*true\" .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
     expected_output: ">= 2"
-  - description: "Subordinate jobs gate on the filter output"
-    command: "grep -cE \"if:.*needs\\.ci-required\\.outputs\\.code-changed\" .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
+  - description: "Develop PR lint/type failures are aggregated by the required result check"
+    command: "grep -cE 'needs: \\[.*code-lint|code-lint:|ci-required-result:' .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
     expected_output: ">= 2"
   - description: "Branch-protection required check is the umbrella, not the subordinate jobs"
     command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks.contexts' 2>/dev/null || gh api repos/joeharris76/BenchBox/rulesets --jq '[.[] | select((.conditions.ref_name.include // []) | any(. == \"refs/heads/develop\" or . == \"~DEFAULT_BRANCH\")) | .rules[]? | select(.type == \"required_status_checks\") | .parameters.required_status_checks[]?.context]'"
     expected_output: "list contains 'ci-required-result' and does NOT contain bare 'lint' or 'test (ubuntu-latest, 3.12)'"
-  - description: "Smoke-test decision record proves doc-only PR greens in <60s"
-    command: "grep -cE 'doc.only|TODO.only|under 60 seconds|skip path' _project/decisions/dev-loop-path-filter-smoke-test-*.md"
-    expected_output: ">= 2"
-  - description: "Local pr-preflight skips fast tests for doc-only diffs"
+  - description: "Smoke-test decision record proves content-only skip, code fallback, unknown fallback, and gitignore handling"
+    command: "grep -cE 'TODO.only|docs/|under 60 seconds|unknown.*full|gitignore|code-lint|code-test|content guard' _project/decisions/dev-loop-path-filter-smoke-test-*.md"
+    expected_output: ">= 6"
+  - description: "Local pr-preflight skips only fast tests for content-only diffs"
     command: "make pr-preflight 2>&1 | grep -cE 'No code changes detected|skipping fast tests' || echo 'requires a doc-only diff to demonstrate'"
     expected_output: ">= 1 when run on a doc-only branch; absent on a code-changed branch"
-  - description: "CLAUDE.md and AGENTS.md document the umbrella behavior"
-    command: "grep -cE 'ci-required|_paths\\.yml|umbrella|doc-only PR' CLAUDE.md AGENTS.md"
-    expected_output: ">= 2"
+  - description: "Agent and contributor docs document the new required check and path behavior"
+    command: "grep -cE 'ci-required-result|_paths\\.yml|content-only|path.*filter|skipping fast tests' CLAUDE.md AGENTS.md CONTRIBUTING.md .claude/commands/pr.md"
+    expected_output: ">= 4"
+  - description: "dorny/paths-filter is pinned by SHA, not the mutable v3 tag"
+    command: "! grep -R \"dorny/paths-filter@v3\" .github/workflows"
+    expected_output: "no matches"
 
 must_preserve:
-  - "Existing PR-tier job definitions from Step 3 — Step 3a wraps them, does not replace them"
+  - "Existing PR-tier code checks from Step 3 — Step 3a gates them, it does not remove lint/type or Ubuntu 3.12 fast tests for code/infra/unknown-path PRs"
   - "Branch-protection contract — required check always reports a status; the umbrella is the new required check, not a removal of all required checks"
-  - "Code-touching PRs continue to run full PR-tier CI as today (post-Step-3 narrowed) — the skip applies only when no code paths matched"
+  - "Content validation — content-only PRs skip Python fast tests but still run cheap TODO/markdown/docs hygiene relevant to the changed paths"
+  - "Fail-closed path behavior — unknown paths, .gitignore, .gitattributes, workflow/config/tooling changes run full PR-tier unless explicitly and safely reclassified"
+  - "Code-touching PRs continue to run full PR-tier CI as today (post-Step-3 narrowed) — the skip applies only when every changed path is in the safe content-only allowlist"
   - "Step 4's develop-post-merge.yml safety net is unchanged — post-merge auto-revert still runs on every landed SHA, doc-only or not"
   - "Single source of truth for the path ruleset — `_paths.yml` is referenced by both CI and local pr-preflight; do not duplicate the rules"
 
 approach: |
-  Two-file change at minimum: `.github/workflows/_paths.yml` (ruleset)
-  plus the PR-tier workflow that adds `ci-required` and
-  `ci-required-result`. Plus a small `scripts/_paths_filter.sh` for the
-  local equivalent (w5).
+  Minimum implementation surface: `.github/workflows/_paths.yml`
+  (ruleset), the PR-tier workflow (`test.yml` or `pr.yml`) that adds
+  `ci-paths`, `content-guard`, `code-lint`, `code-test`, and
+  `ci-required-result`, plus a small local helper for `make pr-preflight`
+  and the pre-push hook.
 
-  Use `dorny/paths-filter@v3` rather than rolling a custom diff parser:
+  Use `dorny/paths-filter@<pinned-sha>` rather than rolling a custom diff parser:
   it handles edge cases (renames, submodules, merge-commit diffs)
-  correctly. Pin to a SHA for supply-chain safety, not to `@v3`.
+  correctly. Pin to a SHA for supply-chain safety, not to `@v3`. If the
+  local helper needs to parse `_paths.yml`, prefer a small Python helper
+  over ad hoc shell parsing; the repo already standardizes on `uv run --`
+  for Python execution.
+
+  Required-check aggregation has one hard GitHub Actions constraint:
+  `needs:` only works inside one workflow. If the required `lint` gate
+  stays in `.github/workflows/lint.yml`, `ci-required-result` cannot
+  observe it. Move/duplicate the required develop PR lint/type work into
+  the umbrella workflow before making `ci-required-result` the only
+  required check.
 
   For the umbrella aggregation step, the explicit pass/fail script
   (rather than relying on `needs:` propagation alone) is intentional:
-  it makes the "doc-only is success" semantic visible in the workflow
+  it makes the "content-only can pass without Python tests" semantic visible in the workflow
   log, and it correctly handles the case where `needs.lint.result` is
   the literal string `"skipped"` (which evaluates truthy in some
   comparison contexts).
 
-  Sequence the rollout: workflow changes first (w2 → develop), THEN
-  branch-protection change (w3). Reverse order leaves develop
+  Sequence the rollout: workflow changes first (w6 merged to develop),
+  THEN branch-protection change (w7). Reverse order leaves develop
   unmergeable for whatever interval. Step 3 w5 used the same sequencing
   for the same reason.
 
 anti_patterns:
   - "DO NOT use top-level `paths:` / `paths-ignore:` filters on the workflow `on:` block — because GitHub treats workflows-not-run as 'pending' for required-checks, leaving the PR unmergeable — use job-level `if:` with an umbrella instead"
-  - "DO NOT skip lint on doc-only PRs — because markdown/YAML lint catches errors that ARE relevant to those PRs (e.g., the pre-commit hooks that ran on PR #66/#67 caught real issues) — keep lint inside the umbrella's full path or move it to its own always-run job"
+  - "DO NOT skip all validation on content-only PRs — because markdown/YAML/TODO/docs errors are relevant and PR #66/#67 surfaced exactly that class of issue — run a cheap content guard while skipping Python fast tests"
+  - "DO NOT classify unknown paths as non-code — because new top-level areas can affect builds/tests and a false green weakens branch protection — default unknown paths to full PR-tier"
+  - "DO NOT assume docs.yml protects develop docs PRs — because it currently triggers PR checks for main only — add develop content validation or classify docs/** as code"
+  - "DO NOT mark .gitignore or .gitattributes as safe content-only — because they affect repository behavior and tracked-file conflict guardrails — route them through full PR-tier or a blocking gitignore-lint aggregation"
+  - "DO NOT make ci-required-result the only required check while required lint remains isolated in lint.yml — because the result job cannot aggregate another workflow — move the develop PR lint gate under the umbrella first"
   - "DO NOT duplicate the path ruleset between CI and local pr-preflight — because they will drift and the local skip will lie to agents — share via `.github/workflows/_paths.yml` or a single shell helper"
   - "DO NOT pin `dorny/paths-filter@v3` by tag — because tags are mutable and a compromised release could exfil secrets — pin by SHA"
   - "DO NOT mark Makefile changes as non-code — because Makefile edits change developer-facing surface and have caused real regressions — keep Makefile in the code path list"
+  - "DO NOT apply branch-protection changes before the workflow PR lands — because the required check name will not exist on develop yet — merge workflow changes first, then patch branch protection/rulesets"
   - "DO NOT skip the smoke-test (w4) — because a buggy umbrella that always greens would make develop unprotected and you would not notice until something breaks — fork-test before enabling on develop"
 
 scope_limit:
   only_modify:
     - ".github/workflows/_paths.yml (new path-filter ruleset)"
-    - ".github/workflows/test.yml or .github/workflows/pr.yml (whichever Step 3 ended up with as PR-tier)"
-    - "scripts/_paths_filter.sh (new local helper)"
+    - ".github/workflows/test.yml or .github/workflows/pr.yml (whichever Step 3 ended up with as PR-tier; add umbrella/result/content/code jobs)"
+    - ".github/workflows/lint.yml (remove/disable duplicated develop PR trigger after its required gate moves under the umbrella, or leave as non-required reporting only)"
+    - "scripts/path_filter_decision.sh or scripts/path_filter_decision.py (new local helper)"
     - "Makefile (pr-preflight target — add path-filter shortcut)"
     - ".pre-commit-config.yaml (pr-preflight-fast-tests hook — add path-filter shortcut)"
     - "CLAUDE.md (umbrella + local skip paragraph)"
     - "AGENTS.md (umbrella + local skip paragraph)"
+    - "CONTRIBUTING.md (required-check and preflight prose)"
+    - ".claude/commands/pr.md (one-shot PR command summary)"
     - "_project/decisions/dev-loop-path-filter-smoke-test-*.md (smoke-test evidence)"
   do_not_modify:
     - ".github/workflows/develop-post-merge.yml (Step 4 owns this; post-merge runs on every SHA, doc-only or not)"
@@ -298,7 +388,7 @@ scope_limit:
     - "Makefile worktree-add, worktree-claim, worktree-pool-*, worktree-release targets (Step 2 owns these)"
     - "Makefile pr-fanout target (Step 1 owns this)"
     - "tests/ (no test changes; only CI orchestration and a tiny local helper)"
-    - "GitHub branch protection / rulesets — Step 3a w3 IS the rule edit, but the edit is to the required-checks list only; do not change strict-base, dismiss-stale-reviews, enforce-admins, etc."
+    - "GitHub branch protection / rulesets — Step 3a w7 IS the rule edit, but the edit is to the required-checks list only; do not change strict-base, dismiss-stale-reviews, enforce-admins, etc."
 
 deferred:
   - summary: "Path-based skip on Step 4 develop-post-merge.yml"
@@ -307,8 +397,8 @@ deferred:
     reason: "Nightly is scheduled, not PR-triggered. The 'doc-only' question doesn't apply — nightly runs the full matrix regardless of recent commits."
   - summary: "Cache the path-filter ruleset across steps for performance"
     reason: "Premature optimization. dorny/paths-filter completes in seconds; caching adds complexity for negligible gain."
-  - summary: "Per-path matrix dispatch (e.g., only run ubuntu tests for backend changes, only docs lint for docs changes)"
-    reason: "Bigger redesign than the umbrella. Revisit only if Step 5 metrics show it's worth the complexity."
+  - summary: "Per-path matrix dispatch beyond content-vs-code (e.g., only run explorer tests for results-explorer changes)"
+    reason: "Bigger redesign than the umbrella. Step 3a only separates safe content-only PRs from everything else. Revisit only if Step 5 metrics show it's worth the complexity."
 
 metadata:
   tags:
@@ -316,33 +406,34 @@ metadata:
     - ci
     - path-filter
     - cost-reduction
-  estimated_effort: "Small (1-2h after Step 3 lands)"
+  estimated_effort: "Medium (2-4h after Step 1 and Step 3 land, including smoke tests and branch-protection deployment)"
   created_date: "2026-04-30"
 
 impact:
   user_impact: |
-    Doc-only / TODO-only / blog-only PRs report green in under 60 seconds
-    instead of triggering the post-Step-3 PR-tier (lint + Ubuntu 3.12
-    fast tests). Local `make pr-preflight` mirrors the skip, so agents
-    no longer hit the test-lock collision pattern that bit the Step 1/2
-    drafts (PRs #66/#67 saw exactly this).
+    TODO-only / blog-only / agent-doc-only PRs report green in under
+    60 seconds after targeted content validation instead of triggering
+    the post-Step-3 Python fast-test lane. Local `make pr-preflight`
+    mirrors the skip, so agents no longer hit the test-lock collision
+    pattern that bit the Step 1/2 drafts (PRs #66/#67 saw exactly this).
   business_value: |
     Concrete runner-minute savings. Conservative estimate: half of recent
     PRs touched only `_project/**`, `docs/**`, or markdown — that's a
     50% reduction in PR-tier runner minutes on top of Step 3's matrix
     cut. Compounds over the measurement window in Step 5.
   technical_debt: |
-    One additional workflow file (`_paths.yml`) and one additional job
-    (`ci-required` umbrella). Standard pattern in many large repos
-    (rust-lang/rust, kubernetes/kubernetes use variations). Net debt:
-    low.
+    One additional path ruleset (`_paths.yml`), a small classifier helper,
+    and one required-result aggregation job. The complexity is justified
+    only because the design fails closed and keeps content validation in
+    place for content-only PRs. Net debt: low-to-medium.
 
 success_metrics:
-  - "P95 CI time on doc-only PRs drops from ~5 min (post-Step-3) to under 60 seconds"
+  - "P95 CI time on safe content-only PRs drops from ~5 min (post-Step-3) to under 60 seconds"
   - "Branch protection contract preserved: every PR has a single required check that always reports green or red"
   - "Zero false-positive merges where the umbrella greened despite a real code-path change being missed by the filter"
+  - "Content-only PRs still run targeted TODO/markdown/docs validation"
 
 open_questions:
-  - "Should `docs/**` count as code or non-code? (Plan: non-code; docs have their own validation in docs.yml. Revisit if a docs-rendered-from-code change ever ships and breaks something.)"
-  - "Should `.github/workflows/**` ever be considered non-code? (Plan: no — workflow changes can break CI silently and need full-run validation themselves.)"
-  - "Should the umbrella also write a metric (doc-only PR count, time saved) for Step 5? (Plan: yes if cheap; reuse the Step 4 metrics emission pattern. If it adds workflow complexity, defer.)"
+  - "Should `docs/**` be safe content-only after a develop content guard exists? (Plan: yes, but only after the guard is implemented and smoke-tested; otherwise classify docs/** as code.)"
+  - "Should `.github/workflows/**` ever be considered content-only? (Plan: no — workflow changes can break CI silently and need full-run validation themselves.)"
+  - "Should the umbrella write a metric (content-only PR count, code-CI skipped, estimated runner minutes saved) for Step 5? (Plan: yes if it is a simple log line or artifact; defer if it complicates the workflow.)"

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -7,9 +7,9 @@ category: Core Functionality
 
 description: |
   Decision-gate item that decides whether Step 6 (queue) is needed.
-  Runs after Steps 1-4 have been merged for ~30 days. Aggregates the
-  metrics emitted by Step 4 against pre-defined thresholds and produces
-  a written go/no-go recommendation.
+  Runs after Steps 1-4 plus Step 3a have been merged for ~30 days.
+  Aggregates the metrics emitted by Step 4 against pre-defined thresholds
+  and produces a written go/no-go recommendation.
 
   No code changes during the window itself; the deliverable is a
   decision record. If all thresholds are below trigger, Step 6 is
@@ -173,11 +173,11 @@ scope_limit:
     - "CLAUDE.md (one paragraph)"
     - "AGENTS.md (one paragraph)"
   do_not_modify:
-    - ".github/workflows/test.yml, develop-post-merge.yml, nightly.yml, release.yml (no code changes during the measurement window)"
+    - ".github/workflows/test.yml, pr.yml, develop-post-merge.yml, nightly.yml, release.yml (no code changes during the measurement window)"
     - "Makefile (no target changes during the window)"
     - "tests/conftest.py (Step 1 helper stays as-is)"
     - "GitHub branch protection / rulesets (no further changes during the window)"
-    - "_project/TODO/main/planning/dev-loop-step-{0,1,2,3,4}-*.yaml (Steps 1-4 implementations are frozen during measurement)"
+    - "_project/TODO/main/planning/dev-loop-step-{0,1,2,3,3a,4}-*.yaml (Steps 1-4 plus Step 3a implementations are frozen during measurement)"
 
 deferred:
   - summary: "Building infrastructure based on measurement findings"


### PR DESCRIPTION
## Summary

Hardens the Step 3a path-based CI skip plan based on follow-up review of the original Step 3a TODO that landed in PR #68. Three TODO files updated; no code changes.

### What changed

- **Step 3a**: from a broad "non-code skip" to a **fail-closed safe content-only classification**. The filter now skips Python fast tests only when *every* changed path is in an explicit content-only allowlist; any path outside that allowlist (including unknown paths) runs the full post-Step-3 PR-tier.
- **Content validation guard**: instead of skipping all validation for content-only PRs, a cheap targeted `content-guard` job runs (TODO YAML validation, markdown/YAML hygiene, docs validation, gitignore-lint as applicable) — catches the kind of markdown/YAML errors that mattered on PRs #66/#67.
- **Branch-protection sequencing**: explicitly documented that the workflow changes must land on develop before `ci-required-result` becomes the required check on develop branch protection. Reverse order leaves develop unmergeable.
- **Docs/config coverage**: implementation TODO now requires updating `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `.claude/commands/pr.md` so agents understand the umbrella-check behavior locally and remotely.
- **Cross-references**: Step 3 description forward-references 3a; Step 5 `deps.needs` includes 3a so the 30-day measurement window captures the runner-minute reduction.

### Files changed

- `_project/TODO/main/planning/dev-loop-step-3a-path-based-ci-skip.yaml`
- `_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml`
- `_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml`

### Validation

- \`uv run --project _project/scripts -- python _project/scripts/validate_todo.py\` passes for all three modified files.
- \`todo-cli check-graph\` passes (45 items, no cycles, no dangling refs).

## Test plan

- [x] Schema validation on all 3 TODO files
- [x] Dependency graph validation
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)