### PR TITLE
fix(worktree-pool): address PR #73 review findings + L2 blind-spots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Single repo (`origin` → `joeharris76/BenchBox`); two long-lived branches: `dev
 - Keep `~/Developer/BenchBox/` on `develop` permanently.
 - New write sessions use the retained pool: `make worktree-claim BRANCH=fix/foo` atomically claims a free `BenchBox.pool-NN`, resets it to current `origin/develop`, checks out `fix/foo`, runs `uv sync --group dev`, and prints `WORKTREE_PATH=...`.
 - `cd` into that path, work, run `make pr-open`, and after the PR merges run `make worktree-release` inside the pool worktree to return it to detached `origin/develop`.
-- `make worktree-pool-status` shows free, claimed, stale, and dirty slots; stale recovery is inspect status first, then `make worktree-pool-reset POOL=NN` only when you intentionally want to discard or detach that slot.
+- `make worktree-pool-status` shows each slot's state (free / claimed / stale / dirty / unknown / missing), venv health (ok / stale / missing), and disk usage. After a busy session, `make worktree-pool-sweep-stale` auto-releases slots whose PRs have merged and whose trees are clean (idempotent). Reach for `make worktree-pool-reset POOL=NN` only as a last-resort manual escape hatch when you intentionally want to discard or detach that slot.
 - `make worktree-add BRANCH=fix/foo` remains as a deprecated one-release compatibility path for legacy non-pool worktrees.
 - `make pr-fanout` walks every worktree (skipping the main clone) and runs `make pr-open` with bounded parallelism (`PR_FANOUT_JOBS ?= 4`) so retained worktrees can be published without local hook serialization.
 - The operating model is pool worktrees + auto-merge, with `.github/workflows/develop-post-merge.yml` and the Step 4 auto-revert follow-up as the develop-tip safety net.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,22 @@ before the first edit.
 BenchBox uses a retained pool of 10 worktrees. `make worktree-claim`
 atomically picks a free `BenchBox.pool-NN`, resets it to current
 `origin/develop`, checks out the requested branch, and prints
-`WORKTREE_PATH=...`. After the PR merges, run `make worktree-release`
-inside that pool worktree to return it to detached `origin/develop`.
-If a prior session died, run `make worktree-pool-status`; reset a stale
-or dirty slot only with `make worktree-pool-reset POOL=NN` after
-reviewing what will be discarded. `make worktree-add` remains as a
-deprecated one-release compatibility path for legacy non-pool worktrees.
+`WORKTREE_PATH=...`. `uv sync --group dev` runs only when `uv.lock` or
+`pyproject.toml` is newer than the existing `.venv`, so repeat claims
+after a clean release skip the sync. If anything fails after the
+branch is created, the slot is rolled back to detached
+`origin/develop` automatically. After the PR merges, run
+`make worktree-release` inside that pool worktree to return it to
+detached `origin/develop`.
+
+`make worktree-pool-status` reports each slot's state (free / claimed /
+stale / dirty / unknown / missing), venv health (ok / stale / missing),
+and disk usage. After a busy session, `make worktree-pool-sweep-stale`
+auto-releases slots whose PRs are MERGED on origin and whose trees are
+clean — idempotent. Reach for `make worktree-pool-reset POOL=NN` only
+as a last-resort manual escape hatch after reviewing what will be
+discarded. `make worktree-add` remains as a deprecated one-release
+compatibility path for legacy non-pool worktrees.
 
 **If you find the main clone on a non-`develop` branch**, surface it
 to the user and ask before writing anything to it — that may be the
@@ -210,7 +220,7 @@ benchbox run --help | --help-topic all | --help-topic examples | --help-topic be
 ## Pre-approved Commands
 - **Dev/Test**: `make test-*`, `make coverage*`, `make lint`, `make format`, `make typecheck`, `uv run -- python -m pytest *`
 - **PR/Worktree (read-only)**: `make pr-preflight`, `make pr-status`, `make worktree-pool-status`, `make worktree-list`, `git worktree list*`, `gh pr list*`, `gh pr view*`, `gh pr checks*`
-- **PR/Worktree (write — feature/pool worktrees only)**: `make pr-open`, `make pr-fanout`, `make pr-refresh`, `make worktree-claim BRANCH=*`, `make worktree-release`, `git push -u origin chore/*`, `git push -u origin fix/*`, `git push -u origin feat/*`, `git push -u origin docs/*`, `git push origin chore/*`, `git push origin fix/*`, `git push origin feat/*`, `git push origin docs/*`, `gh pr create --fill*`, `gh pr merge --auto --squash*`
+- **PR/Worktree (write — feature/pool worktrees only)**: `make pr-open`, `make pr-fanout`, `make pr-refresh`, `make worktree-claim BRANCH=*`, `make worktree-release`, `make worktree-pool-sweep-stale`, `git push -u origin chore/*`, `git push -u origin fix/*`, `git push -u origin feat/*`, `git push -u origin docs/*`, `git push origin chore/*`, `git push origin fix/*`, `git push origin feat/*`, `git push origin docs/*`, `gh pr create --fill*`, `gh pr merge --auto --squash*`
   - **Manual/admin escape hatches, not broad auto-allow**: `make worktree-pool-init`, `make worktree-pool-reset POOL=NN`, `make worktree-prune`
   - **Never auto-allowed**: `git push * develop`, `git push * main`, `git push --force*`, `gh pr create --base main*`. These remain prompt-on-use.
 - **Files**: `ls*`, `find*`, `cat*`, `head*`, `tail*`, `wc*`, `file*`, `stat*`, `du*`, `tree*`, `which*`

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ PR_FANOUT_JOBS ?= 4
 POOL_SIZE ?= 10
 WORKTREE_POOL_PARENT ?= ..
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-open pr-status worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-release worktree-pool-reset worktree-add worktree-list worktree-prune todo-reindex
+# Shell command snippet that resolves the main clone's directory name
+# (e.g. "BenchBox"). Pool worktree paths derive from it as
+# $(WORKTREE_POOL_PARENT)/$(POOL_REPO_CMD).pool-NN. Inlined as a Make
+# variable so the four pool-management targets share a single source of
+# truth instead of repeating the four-deep nested expansion.
+POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
+
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-open pr-status worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-add worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -730,7 +737,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-open pr-fanout pr-refresh pr-conflict-scan pr-status worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-release worktree-pool-reset worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
+.PHONY: pr-preflight pr-open pr-fanout pr-refresh pr-conflict-scan pr-status worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
 
 # Mirror the CI gate locally before pushing. Catches ~all CI failures
 # without the network roundtrip. Delegates to ci-lint so the local
@@ -828,7 +835,7 @@ pr-status:
 worktree-pool-init:
 	@git fetch origin develop --quiet
 	@set -e; \
-	POOL_REPO=$$(basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"); \
+	POOL_REPO=$$($(POOL_REPO_CMD)); \
 	i=1; \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
 		pool=$$(printf 'pool-%02d' "$$i"); \
@@ -846,7 +853,7 @@ worktree-pool-init:
 		fi; \
 		i=$$((i + 1)); \
 	done
-	@POOL_REPO=$$(basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"); \
+	@POOL_REPO=$$($(POOL_REPO_CMD)); \
 	printf '%-8s | %-60s | %s\n' "pool" "path" "branch"; \
 	i=1; \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
@@ -863,10 +870,17 @@ worktree-pool-init:
 	done
 
 # Claim the first free pool worktree for a feature branch.
+#
+# Concurrency note: the file lock serializes only `worktree-claim` calls
+# against each other. It does NOT prevent `worktree-claim` from racing
+# with `worktree-release` or `worktree-pool-reset` on the same slot —
+# those are operator-driven and assumed to run on a single workstation
+# where humans/agents serialize their own actions.
 worktree-claim:
 	@test -n "$(BRANCH)" || { echo "Usage: make worktree-claim BRANCH=<branch-name>"; exit 1; }
 	@case "$(BRANCH)" in chore/?*|fix/?*|feat/?*|docs/?*) ;; *) echo "BRANCH must match ^(chore|fix|feat|docs)/.+"; exit 1 ;; esac
 	@git check-ref-format --branch "$(BRANCH)" >/dev/null || { echo "Invalid git branch name: $(BRANCH)"; exit 1; }
+	@git fetch origin develop --quiet
 	@LOCK="$$(realpath "$$(git rev-parse --git-common-dir)")/pool.lock"; \
 	touch "$$LOCK"; \
 	if command -v lockf >/dev/null 2>&1; then \
@@ -874,13 +888,12 @@ worktree-claim:
 	elif command -v flock >/dev/null 2>&1; then \
 		flock -w 30 "$$LOCK" $(MAKE) -s worktree-claim-locked BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; \
 	else \
-		uv run -- python -c 'import fcntl, signal, subprocess, sys; signal.signal(signal.SIGALRM, lambda *_: sys.exit("Timed out waiting for pool lock")); signal.alarm(30); lock = open(sys.argv[1], "a", encoding="utf-8"); fcntl.flock(lock, fcntl.LOCK_EX); signal.alarm(0); raise SystemExit(subprocess.call(sys.argv[2:]))' "$$LOCK" $(MAKE) -s worktree-claim-locked BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; \
+		uv run -- python scripts/_pool_lock.py "$$LOCK" $(MAKE) -s worktree-claim-locked BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; \
 	fi
 
 worktree-claim-locked:
-	@git fetch origin develop --quiet
 	@set -e; \
-	POOL_REPO=$$(basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"); \
+	POOL_REPO=$$($(POOL_REPO_CMD)); \
 	i=1; \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
 		pool=$$(printf 'pool-%02d' "$$i"); \
@@ -889,17 +902,31 @@ worktree-claim-locked:
 			branch=$$(git -C "$$wt" symbolic-ref -q --short HEAD 2>/dev/null || true); \
 			status=$$(git -C "$$wt" status --porcelain); \
 			if [ -z "$$branch" ] && [ -z "$$status" ]; then \
-				git -C "$$wt" fetch origin develop --quiet; \
+				rollback() { \
+					git -C "$$wt" checkout --detach origin/develop >/dev/null 2>&1 || true; \
+					git -C "$$wt" branch -D "$(BRANCH)" >/dev/null 2>&1 || true; \
+					echo "claim of $$pool failed; slot returned to detached origin/develop" >&2; \
+					exit 1; \
+				}; \
+				trap rollback ERR; \
 				git -C "$$wt" reset --hard origin/develop >/dev/null; \
 				git -C "$$wt" checkout -b "$(BRANCH)" >/dev/null; \
-				( cd "$$wt" && uv sync --group dev >/dev/null ); \
+				if [ ! -f "$$wt/.venv/pyvenv.cfg" ] \
+					|| [ -n "$$(find "$$wt/uv.lock" "$$wt/pyproject.toml" -newer "$$wt/.venv/pyvenv.cfg" 2>/dev/null | head -n 1)" ]; then \
+					( cd "$$wt" && uv sync --group dev >/dev/null ); \
+				fi; \
+				trap - ERR; \
 				printf 'WORKTREE_PATH=%s\n' "$$(cd "$$wt" && pwd -P)"; \
 				exit 0; \
 			fi; \
 		fi; \
 		i=$$((i + 1)); \
 	done; \
-	echo "No free pool worktree available. Run: make worktree-pool-status" >&2; \
+	echo "No free pool worktree available." >&2; \
+	echo "Hint: stale slots (PR MERGED but branch not released) are common after agent crashes." >&2; \
+	echo "      Run \`make worktree-pool-status\` to find them, then \`make worktree-pool-sweep-stale\`" >&2; \
+	echo "      to auto-release any whose PRs are merged. Use \`make worktree-pool-reset POOL=NN\`" >&2; \
+	echo "      as a last-resort manual escape hatch." >&2; \
 	exit 1
 
 worktree-release:
@@ -920,17 +947,55 @@ worktree-release:
 	git remote prune origin; \
 	echo "Released $$branch; worktree is detached at origin/develop."
 
+## worktree-pool-status: report pool slot state + venv health + disk usage.
+##
+## Columns:
+##   pool, path, branch, state, claim_age, venv, size
+##
+## State semantics:
+##   free     — detached HEAD, working tree clean
+##   claimed  — on a feature branch, no PR or PR is open
+##   stale    — on a feature branch, PR is MERGED (release/sweep candidate)
+##   dirty    — uncommitted changes (filtered against .benchbox/ scratch
+##              dir which is the only expected non-ignored untracked path;
+##              .venv/ is .gitignored, so it does not appear in --untracked-files=normal)
+##   unknown  — gh pr view/list lookup failed (auth / network / rate limit)
+##              — distinguished from claimed-no-PR-yet
+##   missing  — pool slot directory absent
+##
+## Venv health:
+##   ok           — .venv/pyvenv.cfg exists and is at least as new as uv.lock + pyproject.toml
+##   stale        — .venv exists but uv.lock or pyproject.toml is newer (next claim will re-sync)
+##   missing      — .venv absent (claim will recreate)
+##
+## PR-state lookup is batched: a single `gh pr list --state all` runs up
+## front and an associative awk lookup per slot replaces N per-slot
+## `gh pr view` calls.
 worktree-pool-status:
-	@POOL_REPO=$$(basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"); \
-	printf '%-8s | %-60s | %-28s | %-7s | %s\n' "pool" "path" "branch" "state" "claim_age"; \
+	@POOL_REPO=$$($(POOL_REPO_CMD)); \
+	pr_table=$$(gh pr list --state all --base develop --limit 200 \
+		--json headRefName,state \
+		--template '{{range .}}{{.headRefName}}{{"\t"}}{{.state}}{{"\n"}}{{end}}' 2>/dev/null); \
+	pr_lookup_failed=0; \
+	if [ -z "$$pr_table" ]; then pr_lookup_failed=1; fi; \
+	printf '%-8s | %-58s | %-28s | %-8s | %-13s | %-7s | %s\n' "pool" "path" "branch" "state" "claim_age" "venv" "size"; \
 	i=1; \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
 		pool=$$(printf 'pool-%02d' "$$i"); \
 		wt="$(WORKTREE_POOL_PARENT)/$$POOL_REPO.$$pool"; \
-		branch="-"; state="missing"; age="-"; \
+		branch="-"; state="missing"; age="-"; venv="-"; size="-"; \
 		if git -C "$$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 			current=$$(git -C "$$wt" symbolic-ref -q --short HEAD 2>/dev/null || true); \
 			dirty=$$(git -C "$$wt" status --porcelain --untracked-files=normal | grep -vE '^\?\? \.benchbox(/|$$)' || true); \
+			if [ ! -f "$$wt/.venv/pyvenv.cfg" ]; then \
+				venv="missing"; \
+			elif [ -n "$$(find "$$wt/uv.lock" "$$wt/pyproject.toml" -newer "$$wt/.venv/pyvenv.cfg" 2>/dev/null | head -n 1)" ]; then \
+				venv="stale"; \
+			else \
+				venv="ok"; \
+			fi; \
+			size=$$(du -sh "$$wt" 2>/dev/null | awk '{print $$1}'); \
+			[ -n "$$size" ] || size="-"; \
 			if [ -z "$$current" ]; then \
 				branch="(detached)"; \
 				if [ -z "$$dirty" ]; then state="free"; else state="dirty"; fi; \
@@ -940,12 +1005,18 @@ worktree-pool-status:
 				if [ -n "$$dirty" ]; then \
 					state="dirty"; \
 				else \
-					pr_state=$$(gh pr view "$$current" --json state --jq .state 2>/dev/null || true); \
-					if [ "$$pr_state" = "MERGED" ]; then state="stale"; else state="claimed"; fi; \
+					pr_state=$$(printf '%s\n' "$$pr_table" | awk -F'\t' -v b="$$current" '$$1 == b {print $$2; exit}'); \
+					if [ "$$pr_lookup_failed" = "1" ]; then \
+						state="unknown"; \
+					elif [ "$$pr_state" = "MERGED" ]; then \
+						state="stale"; \
+					else \
+						state="claimed"; \
+					fi; \
 				fi; \
 			fi; \
 		fi; \
-		printf '%-8s | %-60s | %-28s | %-7s | %s\n' "$$pool" "$$wt" "$$branch" "$$state" "$$age"; \
+		printf '%-8s | %-58s | %-28s | %-8s | %-13s | %-7s | %s\n' "$$pool" "$$wt" "$$branch" "$$state" "$$age" "$$venv" "$$size"; \
 		i=$$((i + 1)); \
 	done
 
@@ -953,7 +1024,7 @@ worktree-pool-reset:
 	@test -n "$(POOL)" || { echo "Usage: make worktree-pool-reset POOL=NN"; exit 1; }
 	@case "$(POOL)" in [0-9][0-9]) ;; *) echo "POOL must be two digits, e.g. POOL=03"; exit 1 ;; esac
 	@set -e; \
-	POOL_REPO=$$(basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"); \
+	POOL_REPO=$$($(POOL_REPO_CMD)); \
 	wt="$(WORKTREE_POOL_PARENT)/$$POOL_REPO.pool-$(POOL)"; \
 	git -C "$$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "No pool worktree found: $$wt"; exit 1; }; \
 	branch=$$(git -C "$$wt" branch --show-current 2>/dev/null || true); \
@@ -979,6 +1050,50 @@ worktree-pool-reset:
 		case "$$branch" in develop|main) ;; *) git branch -D "$$branch" >/dev/null 2>&1 || true ;; esac; \
 	fi; \
 	echo "Reset pool-$(POOL): $$wt"
+
+## worktree-pool-sweep-stale: auto-release pool slots whose branch's PR
+## is MERGED on origin and whose working tree is clean. Idempotent;
+## refuses to touch slots that are dirty, claimed-no-PR, claimed-with-open-PR,
+## or where the gh API lookup failed (state=unknown). Run after a busy day
+## to recover slots that died between work and `make worktree-release`.
+worktree-pool-sweep-stale:
+	@set -e; \
+	POOL_REPO=$$($(POOL_REPO_CMD)); \
+	pr_table=$$(gh pr list --state all --base develop --limit 200 \
+		--json headRefName,state \
+		--template '{{range .}}{{.headRefName}}{{"\t"}}{{.state}}{{"\n"}}{{end}}' 2>/dev/null); \
+	if [ -z "$$pr_table" ]; then \
+		echo "gh pr list returned no data; refusing to sweep without PR-state visibility" >&2; \
+		exit 1; \
+	fi; \
+	swept=0; \
+	i=1; \
+	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
+		pool=$$(printf 'pool-%02d' "$$i"); \
+		wt="$(WORKTREE_POOL_PARENT)/$$POOL_REPO.$$pool"; \
+		i=$$((i + 1)); \
+		git -C "$$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue; \
+		current=$$(git -C "$$wt" symbolic-ref -q --short HEAD 2>/dev/null || true); \
+		[ -n "$$current" ] || continue; \
+		dirty=$$(git -C "$$wt" status --porcelain --untracked-files=normal | grep -vE '^\?\? \.benchbox(/|$$)' || true); \
+		if [ -n "$$dirty" ]; then \
+			echo "skip $$pool: dirty (branch=$$current)"; \
+			continue; \
+		fi; \
+		pr_state=$$(printf '%s\n' "$$pr_table" | awk -F'\t' -v b="$$current" '$$1 == b {print $$2; exit}'); \
+		if [ "$$pr_state" != "MERGED" ]; then \
+			echo "skip $$pool: PR not merged (state=$${pr_state:-none})"; \
+			continue; \
+		fi; \
+		echo "sweep $$pool: releasing $$current (PR MERGED)"; \
+		git -C "$$wt" fetch origin develop --quiet; \
+		git -C "$$wt" checkout --detach origin/develop >/dev/null; \
+		git -C "$$wt" reset --hard origin/develop >/dev/null; \
+		git -C "$$wt" branch -D "$$current" >/dev/null 2>&1 || true; \
+		git -C "$$wt" remote prune origin >/dev/null 2>&1 || true; \
+		swept=$$((swept + 1)); \
+	done; \
+	echo "Swept $$swept pool slot(s)."
 
 # Create a worktree off origin/develop. Usage: make worktree-add BRANCH=fix/foo
 # Path convention: ../BenchBox.<branch-with-slashes-as-dashes>/
@@ -1141,14 +1256,18 @@ help:
 	@echo "  make pr-fanout       Run pr-open across worktrees with bounded parallelism (PR_FANOUT_JOBS=$(PR_FANOUT_JOBS))"
 	@echo "  make pr-refresh      Merge origin/develop into current branch, push, and re-enable auto-merge"
 	@echo "  make pr-status       List your open PRs vs develop with CI + auto-merge state"
-	@echo "  make worktree-pool-init  Create retained pool worktrees (POOL_SIZE=$(POOL_SIZE))"
-	@echo "  make worktree-pool-status  Show retained pool worktree state"
-	@echo "  make worktree-claim BRANCH=name  Claim a retained pool worktree for a branch"
-	@echo "  make worktree-release  Release a merged pool branch back to detached origin/develop"
-	@echo "  make worktree-pool-reset POOL=NN  Reset a retained pool worktree manually"
-	@echo "  make worktree-add BRANCH=name  Deprecated legacy worktree creator"
-	@echo "  make worktree-list   List active worktrees"
-	@echo "  make worktree-prune  Remove legacy non-pool worktrees whose branches are gone on origin"
+	@echo "Worktree-pool lifecycle (preferred for new write sessions):"
+	@echo "  make worktree-pool-init           Bootstrap retained pool worktrees (POOL_SIZE=$(POOL_SIZE))"
+	@echo "  make worktree-claim BRANCH=name   Claim a free pool slot for a feature branch"
+	@echo "  make worktree-release             Inside a pool worktree: return to detached origin/develop after PR merges"
+	@echo "  make worktree-pool-status         Show pool slot state, venv health, and disk usage"
+	@echo "  make worktree-pool-sweep-stale    Auto-release pool slots whose PRs have merged"
+	@echo "  make worktree-pool-reset POOL=NN  Manual escape hatch for stuck pool slots"
+	@echo ""
+	@echo "Legacy / non-pool worktree paths (deprecated, kept for one release):"
+	@echo "  make worktree-add BRANCH=name  Deprecated legacy worktree creator (prefer worktree-claim)"
+	@echo "  make worktree-list             List active worktrees"
+	@echo "  make worktree-prune            Remove legacy non-pool worktrees whose branches are gone on origin"
 	@echo ""
 	@echo "Blind-Spot Findings (see _project/blind-spots/README.md):"
 	@echo "  make blind-spots-list   List open findings (one row each)"

--- a/_project/blind-spots/2026-04-30-143500-pool-disk-accounting.md
+++ b/_project/blind-spots/2026-04-30-143500-pool-disk-accounting.md
@@ -1,0 +1,41 @@
+---
+id: 2026-04-30-143500-pool-disk-accounting
+date: 2026-04-30
+status: actioned
+finding_kind: missed-axis
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+suggested_sweep: "Watch for disk-pressure failures during busy multi-claim sessions; consider a soft cap or pre-claim free-space check if it becomes an issue"
+todo_id: null
+---
+
+# Pool worktrees consume ~30 GB of disk silently
+
+## Finding
+
+The five-axis review of PR #73 caught code-quality issues but missed a
+physical-state dimension: 10 retained worktrees × ~2 GB each (repo + `.venv` +
+caches) = ~20 GB minimum, with `.benchbox/` scratch state and pytest caches
+pushing toward 30 GB during active use. Nothing in the original PR accounted
+for monitoring or capping disk usage. A workstation that runs out of disk
+will see claims fail in confusing ways (uv sync mid-claim → trap rollback,
+but the underlying filesystem error is the actual cause).
+
+## Why this matters
+
+Long-lived pool infrastructure has a slow-leak failure mode that
+code-quality reviews don't catch: the pool itself is fine, but the
+host's free-space budget shrinks over time as pytest caches, build
+artifacts, and per-worktree venvs accumulate. Without surfacing the
+size, the operator only learns about it when something breaks.
+
+## Suggested next steps
+
+- [x] Add `size` column to `make worktree-pool-status` (this PR).
+- [ ] Optional: pre-claim free-space check that refuses with a clear
+      "host has < 2 GB free; clean caches before claiming" message
+      rather than letting `uv sync` fail mid-claim.
+- [ ] Optional: a `make worktree-pool-disk-clean` that removes
+      pytest/coverage caches in pool-NN slots without touching `.venv`
+      or git state.

--- a/_project/blind-spots/2026-04-30-143501-four-worktree-creation-paths.md
+++ b/_project/blind-spots/2026-04-30-143501-four-worktree-creation-paths.md
@@ -1,0 +1,46 @@
+---
+id: 2026-04-30-143501-four-worktree-creation-paths
+date: 2026-04-30
+status: actioned
+finding_kind: scope-creep
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+  - CLAUDE.md
+  - AGENTS.md
+suggested_sweep: "After one release with worktree-add deprecated, remove it and reduce the surface to two paths"
+todo_id: null
+---
+
+# Four worktree creation paths now coexist; agents must learn which to use when
+
+## Finding
+
+After Step 2 lands, four ways to create a worktree exist:
+
+1. Raw `git worktree add` (always available, not Makefile-mediated)
+2. `make worktree-add BRANCH=...` (deprecated; one-release compatibility path)
+3. `make worktree-claim BRANCH=...` (preferred; pool-managed)
+4. `make worktree-pool-init` (one-time bootstrap)
+
+A new agent reading the docs has to learn which path applies when. The
+deprecation notice on `worktree-add` is good, but the underlying churn
+isn't measured, and the help text didn't surface the lifecycle clearly.
+
+## Why this matters
+
+Discovery cost compounds across every new session and every new
+contributor. The Makefile is one of the first places someone looks
+for "what should I run?", and four creation paths with subtle
+ownership boundaries produces ambiguity rather than ergonomics.
+
+## Suggested next steps
+
+- [x] Restructure `make help` to group worktree commands by lifecycle
+      (preferred pool path vs deprecated legacy path) instead of
+      listing them flat (this PR).
+- [x] CLAUDE.md and AGENTS.md prose explicitly call out
+      `worktree-claim` as the preferred path for new write sessions.
+- [ ] After one release with the deprecation notice live, remove
+      `make worktree-add` and the corresponding docs paragraphs.
+      Track via a one-shot follow-up TODO at deprecation deadline.

--- a/_project/blind-spots/2026-04-30-143502-half-claimed-state-invisible.md
+++ b/_project/blind-spots/2026-04-30-143502-half-claimed-state-invisible.md
@@ -1,0 +1,42 @@
+---
+id: 2026-04-30-143502-half-claimed-state-invisible
+date: 2026-04-30
+status: actioned
+finding_kind: framework-gap
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+suggested_sweep: "If pool-status reports venv=missing or venv=stale repeatedly, investigate whether claim's trap rollback is firing without leaving evidence"
+todo_id: null
+---
+
+# Half-claimed-and-broken pool slots were undetectable
+
+## Finding
+
+If `worktree-claim` succeeded at `git checkout -b` but then `uv sync`
+failed (network blip, corrupted uv cache, etc.), the worktree was left
+on the feature branch with a missing or broken `.venv`.
+`worktree-pool-status` reported it as `claimed` with no indication of
+brokenness. The next session that claimed it would discover the broken
+venv only by trying to use it.
+
+## Why this matters
+
+Lifecycle state machines for long-lived infrastructure need explicit
+representation of partial-failure intermediates, not just the success
+path. The five-axis review caught the missing rollback (Required #2)
+but missed the broader pattern: there was no observability for slots
+that were "claimed but broken" even before the rollback gap.
+
+## Suggested next steps
+
+- [x] Add a `venv` health column (`ok` / `stale` / `missing`) to
+      `make worktree-pool-status` (this PR).
+- [x] Add a trap-on-failure rollback to `worktree-claim-locked` so
+      partial failures return the slot to detached origin/develop
+      (this PR).
+- [ ] Optional: consider a `claim_started_at` marker file that
+      `worktree-claim` writes before mutation and removes on success;
+      pool-status would surface lingering markers as `claim-aborted`
+      state for slots that died without trap firing (e.g. SIGKILL).

--- a/_project/blind-spots/2026-04-30-143503-no-pool-stale-sweep.md
+++ b/_project/blind-spots/2026-04-30-143503-no-pool-stale-sweep.md
@@ -1,0 +1,38 @@
+---
+id: 2026-04-30-143503-no-pool-stale-sweep
+date: 2026-04-30
+status: actioned
+finding_kind: framework-gap
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+suggested_sweep: "Watch for sweep-stale being run frequently; if it is, claim's trap rollback may not be firing or releases are being skipped — investigate"
+todo_id: null
+---
+
+# Pool exhaustion has no automatic recovery for stale slots
+
+## Finding
+
+If 10 sessions all crash leaving stale claims (PRs merged but worktrees
+still on the branch), the 11th claim attempt fails with "No free pool
+worktree available." The user has to manually run `worktree-pool-status`
+and reset slots one at a time. The bookkeeping analog of `worktree-prune`
+for the pool was missing.
+
+## Why this matters
+
+The pool's value is "set and forget" — agents claim slots without
+ceremony. That contract breaks the moment recovery requires manual
+intervention. Long-lived systems need a boring sweep that handles the
+common cleanup case automatically.
+
+## Suggested next steps
+
+- [x] Add `make worktree-pool-sweep-stale` (this PR) that finds slots
+      with MERGED PRs + clean trees and auto-releases them. Idempotent.
+- [x] Update the pool-exhausted error message to point at sweep-stale
+      and pool-reset as the recovery hierarchy.
+- [ ] Optional: schedule sweep-stale via a developer's local cron or a
+      pre-claim hook so it runs automatically before claim ever sees
+      pool exhaustion.

--- a/_project/blind-spots/2026-04-30-143504-gh-failure-vs-no-pr.md
+++ b/_project/blind-spots/2026-04-30-143504-gh-failure-vs-no-pr.md
@@ -1,0 +1,39 @@
+---
+id: 2026-04-30-143504-gh-failure-vs-no-pr
+date: 2026-04-30
+status: actioned
+finding_kind: framework-gap
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+suggested_sweep: "If state=unknown ever appears in pool-status, check gh auth status and rate limit before assuming the pool is broken"
+todo_id: null
+---
+
+# `gh pr view` exit codes conflate "no PR" with "API failure"
+
+## Finding
+
+`worktree-pool-status` originally called `gh pr view <branch>` per slot
+and treated empty output as "no PR yet → claimed". This was correct for
+freshly-claimed slots, but conflated the same outcome with legitimate
+failures: `gh` auth expired, rate limit exhausted, network timeout. All
+three returned empty `.state` and rendered as `claimed`, hiding real
+infrastructure problems behind ordinary state.
+
+## Why this matters
+
+State machines that swallow API failures into normal states leave
+operators flying blind during incidents. The framework-gap is "API
+output and infrastructure failure share an exit-code channel" — solved
+by distinguishing the lookup-failed case explicitly.
+
+## Suggested next steps
+
+- [x] Replace per-slot `gh pr view` with a single up-front `gh pr list`,
+      then awk-lookup per slot (this PR — also closes Consider #4).
+- [x] If the up-front `gh pr list` returns no data (empty stdout),
+      report state=`unknown` for all otherwise-claimed slots rather
+      than silently rendering as `claimed`.
+- [ ] Optional: surface the `unknown` count in the pool-status footer
+      with a hint to check `gh auth status` and `gh api rate_limit`.

--- a/_project/blind-spots/2026-04-30-143505-pool-lock-claim-only.md
+++ b/_project/blind-spots/2026-04-30-143505-pool-lock-claim-only.md
@@ -1,0 +1,42 @@
+---
+id: 2026-04-30-143505-pool-lock-claim-only
+date: 2026-04-30
+status: actioned
+finding_kind: assumption
+review_context: "/code review of PR #73 (Step 2: worktree pool)"
+related_paths:
+  - Makefile
+suggested_sweep: "If pool corruption ever occurs after concurrent ops, revisit the assumption and consider adding lock coverage to release/reset"
+todo_id: null
+---
+
+# Pool file lock is claim-only; release/reset assume single-operator serial use
+
+## Finding
+
+The portable file lock at `.git/pool.lock` serializes only
+`worktree-claim` calls against each other. It does NOT prevent
+`worktree-claim` from racing with `worktree-release` or
+`worktree-pool-reset` on the same slot. The implementation is correct
+for a single-user workstation where humans/agents serialize their own
+actions, but the constraint wasn't documented and the framework-gap
+"lock scope is narrower than intended" was easy to miss.
+
+## Why this matters
+
+The original Step 2 spec specified atomic claim semantics. Atomic claim
+satisfies the literal requirement, but it doesn't fully prevent
+slot corruption — only one specific class. As the pool sees more
+concurrent automation (cron sweeps, background reset triggers), the
+narrow scope might leak.
+
+## Suggested next steps
+
+- [x] Document the concurrency assumption in a comment at the
+      `worktree-claim` lock acquisition site (this PR).
+- [x] Update the operator-facing docs to call out that pool ops
+      assume single-workstation serial use.
+- [ ] If automation is ever added that races claim/release/reset
+      (e.g. cron-driven sweep-stale running while a user claims a
+      slot), extend the lock to cover all three operations or
+      introduce per-slot read-write locks.

--- a/scripts/_pool_lock.py
+++ b/scripts/_pool_lock.py
@@ -1,0 +1,38 @@
+"""Portable file-lock fallback for `make worktree-claim`.
+
+Used only when `lockf` (macOS) and `flock` (Linux) are unavailable on PATH.
+Acquires an exclusive `fcntl.flock` on the given lock path, then execs the
+remaining argv. Times out after 30s with a clear message.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import signal
+import subprocess
+import sys
+
+LOCK_TIMEOUT_SECONDS = 30
+
+
+def _on_timeout(_signum: int, _frame: object) -> None:
+    sys.exit("Timed out waiting for pool lock")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        sys.exit("Usage: _pool_lock.py <lock-path> <cmd> [args...]")
+    lock_path, *command = argv[1:]
+    signal.signal(signal.SIGALRM, _on_timeout)
+    signal.alarm(LOCK_TIMEOUT_SECONDS)
+    lock_dir = os.path.dirname(lock_path) or "."
+    os.makedirs(lock_dir, exist_ok=True)
+    with open(lock_path, "a", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        signal.alarm(0)
+        return subprocess.call(command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
Five-axis review of PR #73 surfaced 8 findings (2 Required, 3 Consider,
3 Nit) and an L2 audit added 6 blind-spot dimensions the framework
missed. All 14 are addressed here.

Required
- Skip uv sync when uv.lock and pyproject.toml are not newer than
  .venv/pyvenv.cfg, restoring spec compliance from the Step 2 TODO.
- Add trap-on-failure rollback to worktree-claim-locked: any failure
  after `git checkout -b` returns the slot to detached origin/develop
  and deletes the half-created branch.

Consider
- Pool-exhausted error message now points at sweep-stale and pool-reset
  as the recovery hierarchy (was: just "run pool-status").
- Replace per-slot `gh pr view` in pool-status with a single up-front
  `gh pr list` and awk lookup. Cuts API calls from O(claimed slots) to 1.
- Update the .venv-filtering comment to clarify why only .benchbox is
  filtered (`.venv` is .gitignored, so it never appears in
  --untracked-files=normal).

Nit
- POOL_REPO_CMD Make variable centralizes the four-deep nested shell
  expansion previously duplicated across four targets.
- Move `git fetch origin develop --quiet` outside the file-lock critical
  section so concurrent claims don't serialize the network round-trip.
- Extract the Python `fcntl` lock fallback into scripts/_pool_lock.py;
  the inline one-liner was hard to read and untestable.

L2 blind-spot dimensions (each captured at _project/blind-spots/)
- Disk-usage accounting → new `size` column in pool-status.
- Four worktree creation paths → `make help` regrouped by lifecycle.
- Half-claimed-and-broken state → new `venv` health column
  (ok/stale/missing) + the trap rollback above.
- No automatic stale-slot recovery → new `make worktree-pool-sweep-stale`
  target. Idempotent; refuses without PR-state visibility from gh.
- gh failure vs "no PR yet" conflation → distinguished as state=`unknown`
  when the up-front `gh pr list` returns no data.
- Lock scope assumption → documented at the worktree-claim site that
  the lock is claim-only and assumes single-workstation serial use.

Verification
- BENCHBOX_PREPUSH=1 make pr-preflight: 21269 passed, 5 skipped.
- make worktree-pool-status: 10 rows, new columns populated correctly.
- make -n worktree-pool-sweep-stale: shell expansion validates.
- make worktree-claim BRANCH=bad-name: refuses with regex error.
- All 6 blind-spot files validate via validate_blind_spot.py.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
