### PR TITLE
chore(blind-spots): capture two findings from worktree-pool docs review

### DIFF
--- a/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
+++ b/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
@@ -1,0 +1,53 @@
+---
+id: 2026-04-30-214358-pool-size-not-codified-as-contract
+date: 2026-04-30
+status: open
+finding_kind: missed-axis
+review_context: "/docs review of dev-loop worktree pool / chore/worktree-pool-docs-review / PR #84"
+related_paths:
+  - Makefile
+  - docs/operations/dev-loop-worktree-pool.md
+  - _project/DONE/main/planning/dev-loop-step-2-worktree-pool.yaml
+suggested_sweep: "consider adding `make worktree-pool-check` that asserts count == POOL_SIZE, every slot is in a known-good state (no `aborted`, no `missing`, no orphaned `pool.lock`); decide whether to gate it on release or leave purely advisory"
+todo_id: null
+---
+
+# Pool size of 10 is convention, not a contract
+
+## Finding
+
+`POOL_SIZE = 10` lives only as a Makefile default and a documented
+expectation in CLAUDE.md / AGENTS.md / the new operations guide. There
+is no test, lint, or release-gate target that fails if a slot goes
+missing, an extra slot appears, or `POOL_SIZE` is changed away from 10
+without a coordinated update of the docs. `worktree-pool-status` would
+*surface* a `missing` slot but does not exit non-zero on it — so a
+silent drift can persist indefinitely between sessions.
+
+The dev-loop-step-2 spec's `must_preserve` invariants (idempotent init,
+atomic claim, retained `.venv/`) are guarded by behavior, but the
+**count and presence of slots** is not.
+
+## Why this matters
+
+The pool model only delivers its value (predictable session start, no
+churn, retained venvs) when all 10 slots are present and in a known
+state. Silent drift — a slot manually removed, a stale `pool.lock`, a
+half-claimed `.benchbox/claim_in_progress` marker on a "free" slot —
+degrades the system gracefully and invisibly: claims still succeed
+against fewer slots, and the symptom only surfaces under contention.
+
+Making the pool a checked invariant (rather than convention + visual
+inspection of `pool-status`) would let the system fail fast when drift
+happens, instead of failing slow under load.
+
+## Suggested next steps
+- [ ] Decide whether the pool count is worth codifying as a contract,
+      or whether `pool-status` visibility is sufficient.
+- [ ] If yes: add `make worktree-pool-check` — exit non-zero on any of
+      `count != POOL_SIZE`, slot in `aborted` / `missing`, orphaned
+      `pool.lock` older than the lock timeout. Use it as a pre-release
+      sanity check or a periodic local cron, not a PR-CI blocker.
+- [ ] If no: write a one-line note in the operations doc that the count
+      is "by convention, run `pool-status` to inspect" — so future
+      readers don't assume it's enforced.

--- a/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
+++ b/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
@@ -1,0 +1,72 @@
+---
+id: 2026-04-30-214359-claim-orchestrator-false-failure
+date: 2026-04-30
+status: open
+finding_kind: bug-class
+review_context: "/docs review of dev-loop worktree pool / chore/worktree-pool-docs-review — observed during make worktree-claim BRANCH=chore/worktree-pool-docs-review"
+related_paths:
+  - Makefile
+suggested_sweep: "trace `worktree-claim-attempt` exit-status flow; the first attempt printed `WORKTREE_PATH=...` (success indicator) yet `worktree-claim-locked` fell through to the auto-sweep retry path"
+todo_id: null
+---
+
+# `worktree-claim` orchestrator triggers retry path after a successful first attempt
+
+## Finding
+
+A successful first-pass `worktree-claim` (which printed
+`WORKTREE_PATH=/Users/joe/Developer/BenchBox.pool-03` and switched the
+slot to the requested feature branch) was followed by:
+
+```
+No free pool worktree on first pass — auto-sweeping stale slots...
+skip pool-01: dirty (branch=fix/results-explorer-qa-pass2)
+skip pool-02: dirty (branch=fix/dev-loop-classifier-runbook)
+skip pool-03: PR not merged (state=none)
+Swept 0 pool slot(s).
+fatal: a branch named 'chore/worktree-pool-docs-review' already exists
+claim of pool-04 failed; slot returned to detached origin/develop
+make[2]: *** [worktree-claim-attempt] Error 128
+```
+
+The orchestrator (`worktree-claim-locked`) interpreted the first
+`worktree-claim-attempt` as having failed, ran `worktree-pool-sweep-stale`,
+then attempted a second claim — which collided with the branch the first
+(actually-successful) attempt created. Final exit code from the make
+target was non-zero even though the slot is correctly claimed. The pool
+ended in the right state (pool-03 on the branch, clean tree), but:
+
+1. The user (and any wrapping automation) sees a non-zero exit and
+   error noise after a successful claim.
+2. The second attempt's "branch already exists" rollback (`claim of
+   pool-04 failed; slot returned to detached origin/develop`) is
+   wasted IO.
+3. CI scripts or shell pipelines that key off make's exit code will
+   treat the success as a failure.
+
+## Why this matters
+
+`worktree-claim` is the canonical entry point for every agent and
+maintainer session start. A flaky exit code on the most-used target
+erodes trust in the auto-sweep retry behavior — the next time it
+*does* legitimately retry, the operator may assume the prior run
+"already worked" and skip investigation.
+
+The bug class is "orchestrator misreads a child make target's success
+signal." The same pattern likely exists in any other Make target that
+dispatches a sub-make and inspects only the exit code (e.g.
+`worktree-pool-sweep-stale-locked`).
+
+## Suggested next steps
+- [ ] Reproduce: run `make worktree-claim BRANCH=<new>` against a pool
+      with at least one free slot; capture the first
+      `worktree-claim-attempt`'s exit status explicitly.
+- [ ] Compare: is `worktree-claim-attempt` returning non-zero on
+      success because of a trailing `uv sync` or `pre-commit install`
+      step that exited with a warning? Or is the silent
+      `$(MAKE) -s` swallowing stdout but propagating an inner error?
+- [ ] Fix the exit-status path so the first attempt's success
+      short-circuits the orchestrator cleanly. The user-visible
+      contract is "WORKTREE_PATH=… printed → claim succeeded → exit 0".
+- [ ] Add a regression test that asserts `make worktree-claim BRANCH=…`
+      exits 0 on a fresh free pool.


### PR DESCRIPTION
Both surfaced while writing docs/operations/dev-loop-worktree-pool.md:

- Pool size of 10 is convention, not a contract: no test/lint/release
  gate fails on slot drift. `pool-status` only surfaces it visually.
- `worktree-claim` orchestrator triggers the auto-sweep retry path
  after a successful first attempt — observed claiming pool-03 for
  this branch. Final state was correct but exit code was non-zero
  and "branch already exists" noise was emitted.

File-first capture per blind-spots/README.md; sweep-time triage will
decide whether either becomes a TODO.
