### PR TITLE
fix(results): support per-bundle published manifests

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -38,6 +38,7 @@ jobs:
             | grep -v '\.plans\.json$' \
             | grep -v '\.tuning\.json$' \
             | grep -v 'corpus-inventory\.json$' \
+            | grep -v '\.manifest\.json$' \
             | grep -v 'submission-manifest\.json$' \
             || true)
           if [ -z "$CHANGED" ]; then

--- a/scripts/generate_corpus_inventory.py
+++ b/scripts/generate_corpus_inventory.py
@@ -17,6 +17,7 @@ INVENTORY_PATH = Path("results-data/corpus-inventory.json")
 SKIP_NAMES = {"corpus-inventory.json", "submission-manifest.json"}
 COMPANION_SUFFIXES = (".plans.json", ".tuning.json")
 SUBMISSION_MANIFEST = "submission-manifest.json"
+SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 COMMUNITY_TRUST_LABEL = "community-submission"
 DEFAULT_TRUST_LABEL = "maintainer-run"
 
@@ -26,7 +27,9 @@ def discover_bundles(bundles_dir: Path) -> list[Path]:
     return [
         path
         for path in sorted(bundles_dir.rglob("*.json"))
-        if path.name not in SKIP_NAMES and not any(path.name.endswith(s) for s in COMPANION_SUFFIXES)
+        if path.name not in SKIP_NAMES
+        and not any(path.name.endswith(s) for s in COMPANION_SUFFIXES)
+        and not path.name.endswith(SUBMISSION_MANIFEST_SUFFIX)
     ]
 
 
@@ -36,8 +39,15 @@ def _bundle_hash(bundle_path: Path) -> str:
 
 
 def _bundle_trust_label(bundle_path: Path) -> str:
-    """Resolve trust label using the established sidecar-presence contract."""
-    if (bundle_path.parent / SUBMISSION_MANIFEST).is_file():
+    """Resolve trust label using the established sidecar-presence contract.
+
+    Prefers the per-bundle name (`<stem>.manifest.json`); falls back to the
+    legacy singleton (`submission-manifest.json`) so already-merged
+    submissions keep their community label.
+    """
+    per_bundle = bundle_path.parent / f"{bundle_path.stem}{SUBMISSION_MANIFEST_SUFFIX}"
+    legacy = bundle_path.parent / SUBMISSION_MANIFEST
+    if per_bundle.is_file() or legacy.is_file():
         return COMMUNITY_TRUST_LABEL
     return DEFAULT_TRUST_LABEL
 

--- a/scripts/validate_submission.py
+++ b/scripts/validate_submission.py
@@ -11,10 +11,10 @@ Exit codes:
 
 Usage:
     # Validate all bundles
-    python scripts/validate_submission.py results-data/bundles/
+    uv run -- python scripts/validate_submission.py results-data/bundles/
 
     # Validate specific files (e.g. only changed files from a PR)
-    python scripts/validate_submission.py path/to/bundle1.json path/to/bundle2.json
+    uv run -- python scripts/validate_submission.py path/to/bundle1.json path/to/bundle2.json
 """
 
 from __future__ import annotations
@@ -40,6 +40,8 @@ ACCEPTED_VERSION_PREFIX = "2."
 
 # Companion file suffixes - skipped during bundle discovery.
 COMPANION_SUFFIXES = (".plans.json", ".tuning.json")
+SUBMISSION_MANIFEST_FILENAME = "submission-manifest.json"
+SUBMISSION_MANIFEST_SUFFIX = ".manifest.json"
 
 # Known benchmarks and platforms - warn (not fail) on unknown values.
 KNOWN_BENCHMARKS = {
@@ -49,9 +51,24 @@ KNOWN_BENCHMARKS = {
     "star_schema",
     "clickbench",
     "nyctaxi",
+    "flightdata",
     "tsbs-devops",
+    "tsbs_devops",
     "h2odb",
+    "amplab",
+    "coffeeshop",
+    "joinorder",
+    "tpch_skew",
+    "tpchavoc",
     "datavault",
+    "tpcdi",
+    "tpcds_obt",
+    "read_primitives",
+    "write_primitives",
+    "metadata_primitives",
+    "transaction_primitives",
+    "ai_primitives",
+    "vector_search",
 }
 KNOWN_PLATFORMS = {
     # Core
@@ -408,16 +425,23 @@ def discover_bundles(path: Path) -> list[Path]:
             continue
         if f.name == "corpus-inventory.json":
             continue
-        if f.name == "submission-manifest.json" or f.name.endswith(".manifest.json"):
+        if _is_submission_manifest_path(f):
             continue
         bundles.append(f)
     return bundles
+
+
+def _is_submission_manifest_path(path: Path) -> bool:
+    return path.name == SUBMISSION_MANIFEST_FILENAME or path.name.endswith(SUBMISSION_MANIFEST_SUFFIX)
 
 
 def validate_bundles(paths: list[Path]) -> list[ValidationResult]:
     """Validate a list of bundle files. Returns one ValidationResult per file."""
     results = []
     for bundle_path in paths:
+        if _is_submission_manifest_path(bundle_path):
+            continue
+
         vr = ValidationResult(str(bundle_path))
 
         if not bundle_path.exists():
@@ -441,8 +465,8 @@ def validate_bundles(paths: list[Path]) -> list[ValidationResult]:
 
         # Check for submission manifest alongside the bundle.
         # Prefer per-bundle name (<stem>.manifest.json), fall back to legacy.
-        per_bundle_manifest = bundle_path.parent / f"{bundle_path.stem}.manifest.json"
-        legacy_manifest = bundle_path.parent / "submission-manifest.json"
+        per_bundle_manifest = bundle_path.parent / f"{bundle_path.stem}{SUBMISSION_MANIFEST_SUFFIX}"
+        legacy_manifest = bundle_path.parent / SUBMISSION_MANIFEST_FILENAME
         manifest_path = (
             per_bundle_manifest
             if per_bundle_manifest.exists()


### PR DESCRIPTION
## Summary
- Exclude per-bundle `<stem>.manifest.json` files from changed-bundle workflow filtering.
- Teach the published corpus inventory generator to skip per-bundle manifests and apply the community trust label when either per-bundle or legacy manifests are present.
- Keep the published-results validator in sync with develop, including explicit manifest-path skipping and current benchmark IDs.

## Verification
- `uv run -- ruff check scripts/validate_submission.py scripts/generate_corpus_inventory.py`
- Per-bundle manifest validation/inventory repro: passed
- Workflow filter smoke: `sample.manifest.json` excluded, `sample.json` retained
- `git diff --check`