### PR TITLE
chore(todo): revise codex pr review followups todo with audit corrections

### DIFF
--- a/_project/TODO/main/planning/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/planning/codex-pr-review-followups-week-2026-05-01.yaml
@@ -1,0 +1,557 @@
+id: codex-pr-review-followups-week-2026-05-01
+title: "Address unresolved Codex PR review follow-ups from the week ending 2026-05-01"
+worktree: main
+priority: High
+status: Identified
+category: Testing and Quality Assurance
+
+description: |
+  Audit and fix the Codex web-agent review findings that were left on merged
+  PRs during the 2026-04-24 through 2026-05-01 commit window.
+
+  Source scan:
+    - Git range: `origin/develop` commits since `2026-04-24 00:00:00 -0400`.
+    - PR-numbered squash merges scanned: 68 merged PRs, #19 through #94 where
+      present in the commit subjects.
+    - Codex author matched: `chatgpt-codex-connector`.
+    - Inline Codex findings found: 26 comments across 17 merged PRs.
+
+  Not every unresolved GitHub thread still requires a code change. Several
+  comments were fixed in later PRs but remain unresolved/outdated on GitHub.
+  This TODO keeps the active work units focused on findings that still looked
+  unresolved against `origin/develop` at scan time, with enough source context
+  to re-check before editing.
+
+  Policy decision (resolves prior `open_questions` ambiguity): historical
+  DONE-item verification commands are kept executable. If a Codex finding
+  identifies a portability or correctness defect in a DONE-item verification
+  block, fix it in place. Rationale: those commands serve as runnable
+  documentation of how the policy was confirmed, so anyone re-verifying the
+  historical decision (forks, recreated rulesets, future audits) needs them
+  to work. This policy applies to w11, w12, and w13 below; future sweeps
+  inherit the same rule.
+
+work:
+  - id: w1
+    summary: "Make blind-spot frontmatter stamping replace complete YAML nodes"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #59, P2, `_project/scripts/sweep_blind_spots.py`
+        - https://github.com/joeharris76/BenchBox/pull/59#discussion_r3164438197
+
+      Finding: `replace_frontmatter_field()` replaces only the first line that
+      starts with `status:` or `todo_id:`. If a malformed finding has a block
+      or sequence-shaped value, triage can leave orphaned continuation lines
+      behind and make the markdown file unparsable.
+
+      Current evidence on `origin/develop`: lines 223-228 still use a
+      regex-line substitution over raw frontmatter. That preserves formatting
+      for normal scalar fields, but it does not replace the whole YAML node.
+
+      Recommended fix: parse the frontmatter into a YAML node tree or use a
+      safer text rewrite that can remove the full field block before inserting
+      the normalized scalar. Add a regression test that starts with
+      `status:\n  - open`, stamps `dismissed`, and verifies the result parses
+      and contains exactly scalar `status: dismissed`.
+
+  - id: w2
+    summary: "Expand BENCHBOX_TEST_LOCK_DIR consistently in `make test-unlock`"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #71, P2, `Makefile`
+        - https://github.com/joeharris76/BenchBox/pull/71#discussion_r3169224322
+
+      Finding: `tests/conftest.py` resolves `BENCHBOX_TEST_LOCK_DIR` with
+      `Path(...).expanduser()`, but `make test-unlock` removes
+      `$LOCK_DIR/test.lock` directly. If the environment variable contains a
+      literal `~/tmp`, pytest and the Make target disagree on the lock path.
+
+      Current evidence on `origin/develop`: `test-unlock` lines 58-61 still
+      set `LOCK_DIR="$${BENCHBOX_TEST_LOCK_DIR:-$$HOME/.benchbox}"` and run
+      `rm -f "$$LOCK_DIR/test.lock"` without expanduser-equivalent handling.
+
+      Recommended fix: resolve the lock directory through a tiny `uv run --`
+      Python one-liner or an existing helper so the Make target matches
+      `tests.conftest._get_test_lock_path()`. Add or update coverage for the
+      `BENCHBOX_TEST_LOCK_DIR=~/...` case.
+
+  - id: w3
+    summary: "Refuse `worktree-release` on dirty pool worktrees unless forced"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #73, P1, `Makefile`
+        - https://github.com/joeharris76/BenchBox/pull/73#discussion_r3169372557
+
+      Finding: `worktree-release-locked` detaches and hard-resets a pool
+      worktree after checking the PR is merged, but it does not first refuse
+      staged, unstaged, or non-ignored untracked changes. A user can lose local
+      edits when releasing a slot.
+
+      Current evidence on `origin/develop`: lines 1057-1072 perform
+      `git checkout --detach origin/develop` and `git reset --hard
+      origin/develop` without the dirty guard that `worktree-pool-reset-locked`
+      has at lines 1177-1183.
+
+      Recommended fix: before detach/reset, compute dirty state with the same
+      `.benchbox` exclusion used by pool status/reset. Refuse by default and
+      allow discard only with `FORCE=1`, preserving the existing PR-merged
+      safety check.
+
+  - id: w4
+    summary: "Ignore expected `.benchbox` scratch files when claiming free pool slots"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #73, P2, `Makefile`
+        - https://github.com/joeharris76/BenchBox/pull/73#discussion_r3169372563
+
+      Finding: `worktree-claim-attempt` treats any `git status --porcelain`
+      output as dirty, but pool status/reset already ignore expected
+      untracked `.benchbox/` scratch artifacts. A released slot with harmless
+      `.benchbox/*` files can become unclaimable.
+
+      Current evidence on `origin/develop`: line 1032 uses raw
+      `git status --porcelain`; line 1033 requires it to be empty. Other pool
+      commands filter `^\?\? \.benchbox(/|$)`.
+
+      Recommended fix: reuse the same filtered dirty check in
+      `worktree-claim-attempt`, while still treating
+      `.benchbox/claim_in_progress` as an aborted claim marker that must not
+      be ignored.
+
+  - id: w5
+    summary: "Make INT/TERM claim-trap handling exit nonzero after cleanup"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #78, P1, `Makefile`
+        - https://github.com/joeharris76/BenchBox/pull/78#discussion_r3170491244
+
+      Finding: the claim cleanup handler is registered for `EXIT INT TERM`,
+      but the handler does not exit when invoked by INT/TERM. In `/bin/sh`
+      implementations such as dash, the trap can swallow cancellation and let
+      the recipe continue or return success.
+
+      Current evidence on `origin/develop`: lines 1014-1022 define
+      `cleanup()` and install `trap cleanup EXIT INT TERM`; the function has no
+      signal-aware exit path.
+
+      Recommended fix: split cleanup from signal handling, or have the
+      INT/TERM trap run cleanup and then exit with a nonzero status. Keep the
+      recipe POSIX-sh compatible; do not reintroduce a bash-only `ERR` trap.
+
+  - id: w6
+    summary: "Correct Step 5 measurement-window start description in TODO"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #70, P2, `_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml`
+        - https://github.com/joeharris76/BenchBox/pull/70#discussion_r3168890227
+
+      Finding: Step 5 says the measurement window runs after Steps 1-4 plus
+      Step 3a, but w1 still says "post-Step-4-merge" and the notes start the
+      timer from Step 4 alone.
+
+      Current evidence on `origin/develop`: lines 33-42 still describe a
+      Step-4-only timer. In the actual merge order Step 3a landed before
+      Step 4, so the current `due_date: 2026-05-30` may still be valid;
+      verify before changing dates.
+
+      Recommended fix: update w1's summary and notes to define the start
+      timestamp as the later of Step 3a and Step 4 merge times. Confirm
+      whether the existing `2026-05-30` due date remains correct (compute
+      `max(step_3a_merged_at, step_4_merged_at) + 30 days`); only adjust
+      `due_date` if the math diverges.
+
+  - id: w7
+    summary: "Convert Step 5 `last_updated` to ISO date-time as schema expects"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #83, P2, `_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml`
+        - https://github.com/joeharris76/BenchBox/pull/83#discussion_r3171491441
+
+      Finding: `metadata.last_updated` is `2026-04-30`, but the TODO schema
+      expects a date-time value.
+
+      Current evidence on `origin/develop`: line 234 has
+      `last_updated: "2026-04-30"`. The repo convention elsewhere is full
+      ISO 8601 with `Z` (e.g. this TODO's own `2026-05-01T13:30:00Z`).
+
+      Recommended fix: change `last_updated` to a full ISO date-time stamped
+      at the time of edit. Independent of w6 — they happen to touch the same
+      file but have unrelated acceptance criteria.
+
+  - id: w8
+    summary: "Record first failed post-merge job completion as red-detection time"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #81, P2, `.github/workflows/develop-post-merge.yml`
+        - https://github.com/joeharris76/BenchBox/pull/81#discussion_r3170954637
+
+      Finding: the metrics job computes `develop_red_detected_at` using
+      `max` over failed lint/fast-test completion timestamps. If both fail,
+      this records the last failure and understates time to revert/recover.
+
+      Current evidence on `origin/develop`: lines 326-330 select failed
+      `lint`/`fast-test` jobs and use `.completed_at] | max // null`.
+
+      Recommended fix: use the earliest failed completion timestamp, e.g.
+      `min`, and add a local jq regression fixture with two failed jobs at
+      different completion times.
+
+  - id: w9
+    summary: "Handle persistent results-explorer snapshot mismatch without an infinite spinner"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #86, P1, `results-explorer/src/pages/Home.tsx`
+        - https://github.com/joeharris76/BenchBox/pull/86#discussion_r3171854306
+
+      Finding: when `listResults()` returns `[]` while meta-leaderboard data
+      is present, the Home page retries once. If the retry also returns empty,
+      `hasInconsistentEmptySnapshot` remains true and the page renders
+      `Loading results...` forever instead of surfacing a recoverable error or
+      empty-state message.
+
+      Current evidence on `origin/develop`: lines 60-76 implement a one-shot
+      retry, while lines 159-162 still render the loading spinner whenever
+      `hasInconsistentEmptySnapshot` is true.
+
+      Recommended fix: after the one retry has completed, render an
+      actionable error/empty state for persistent mismatch. Preserve the
+      transient retry path. Add a Home unit test in
+      `results-explorer/src/pages/__tests__/Home.test.tsx`.
+
+      Related blind-spot (separate regression on the same PR):
+        - `_project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md`
+        - PR #86 also weakened `platform-index-cold-load.spec.ts` from strict
+          row counts (`toHaveCount(4)` / `toHaveCount(2)`) to `count > 0`.
+          Whoever picks up w9 should restore strict assertions in the same
+          PR or open a follow-up — the cold-load partial-row regression is a
+          different failure mode than the Home empty-state and the loosened
+          assertion will not catch it.
+
+  - id: w10
+    summary: "Allow `benchbox auth login` to prompt even when an env token is set"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #93, P2, `benchbox/cli/commands/auth.py`
+        - https://github.com/joeharris76/BenchBox/pull/93#discussion_r3172049089
+
+      Finding: `auth.login()` calls `refresh_submission_token()` when
+      `--token` is omitted. That helper intentionally raises if
+      `BENCHBOX_SUBMIT_TOKEN` or `BENCHBOX_SERVICE_TOKEN` is active, so a user
+      cannot use the login prompt to bootstrap/update keyring credentials from
+      a shell that also has an environment token.
+
+      Current evidence on `origin/develop`: `auth.login()` calls
+      `refresh_submission_token()` for the prompt path; the helper in
+      `submit_auth.py` (`refresh_submission_token` and its env-token check)
+      still rejects active env tokens before prompting.
+
+      Recommended fix: keep env-token precedence and refresh safety for
+      non-login flows, but give `auth login` an explicit prompt/store path
+      that bypasses the env-token refresh guard. Add CLI coverage that sets
+      `BENCHBOX_SUBMIT_TOKEN`, runs `benchbox auth login` without `--token`,
+      and confirms the prompt value is saved.
+
+  - id: w11
+    summary: "Remove hard-coded repository ruleset ID from Step 3a verification"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #80, P2, `_project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml`
+        - https://github.com/joeharris76/BenchBox/pull/80#discussion_r3170714532
+
+      Finding: a DONE-item verification command calls
+      `gh api repos/joeharris76/BenchBox/rulesets/15611785`, which is
+      repository-instance-specific. Forks or recreated rulesets can make this
+      historical checklist fail even if the policy is configured correctly.
+
+      Current evidence on `origin/develop`: line 448 still hard-codes
+      `rulesets/15611785`.
+
+      Per the policy decision in `description` above, edit the DONE file
+      in place rather than closing as no-op.
+
+      Recommended fix: replace the command with a dynamic ruleset lookup that
+      filters for develop-targeting required status checks before asserting
+      `ci-required-result`. Pattern:
+      `gh api repos/{owner}/{repo}/rulesets --jq '.[] | select(.target == "branch" and (.conditions.ref_name.include // []) | any(. == "refs/heads/develop")) | .id'`
+      then pipe the resolved id back into the existing `--jq` extraction.
+
+  - id: w12
+    summary: "Make Step 3 job-count verification select develop-targeted PR runs"
+    status: pending
+    notes: |
+      Source review comment:
+        - PR #67, P2, `_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml`
+        - https://github.com/joeharris76/BenchBox/pull/67#discussion_r3168098551
+
+      Finding: the verification command for routine develop PR job count can
+      inspect the latest `pull_request` `test.yml` run for the current branch
+      without proving the run came from a PR targeting `develop`. A
+      main-targeted PR run could produce a false failure.
+
+      Current evidence on `origin/develop`: the item has moved to
+      `_project/DONE/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml`;
+      line 239 uses `gh run list --workflow test.yml --branch "$branch"
+      --event pull_request --limit 1` before `gh run view`.
+
+      Per the policy decision in `description` above, edit the DONE file
+      in place rather than closing as no-op.
+
+      Recommended fix: resolve the current branch's PR and assert
+      `baseRefName == develop` before selecting the run. Pattern:
+      `pr_base=$(gh pr view "$branch" --json baseRefName --jq .baseRefName); [ "$pr_base" = "develop" ] || { echo "PR for $branch targets $pr_base, not develop"; exit 1; }`
+      then proceed with the existing `gh run list ... --event pull_request`.
+
+  - id: w13
+    summary: "Scope Step 0 secondary-probe `gh pr list --json comments` query"
+    status: pending
+    notes: |
+      Source review comment (newly tracked — was acknowledged in inventory
+      but not assigned to a work unit in the prior revision):
+        - PR #67, P2, `_project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml`
+
+      Finding: the Step 0 secondary-signal probe runs
+      `gh pr list --json comments` without `--state`, `--base`, or `--limit`.
+      That scans the full PR history (open + closed + merged across all base
+      branches), which is slow on busy repos, returns a different population
+      than the primary probe (which is develop-merged-recent), and can
+      rate-limit the gh client mid-audit.
+
+      Current evidence on `origin/develop`: line 83 of
+      `_project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml`
+      still has the unscoped form.
+
+      Per the policy decision in `description` above, edit the DONE file
+      in place rather than closing as no-op.
+
+      Recommended fix: scope the secondary probe to match the primary probe's
+      population. Pattern:
+      `gh pr list --state merged --base develop --limit 50 --json number,comments`
+      then grep the comments payload for the `pr-refresh` / `make pr-refresh`
+      / `merged develop into branch` markers as today.
+
+  - id: w14
+    summary: "Re-audit stale Codex threads after fixes and record which ones are closed"
+    needs: [w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13]
+    status: pending
+    notes: |
+      Re-run the PR thread scan for `chatgpt-codex-connector` on the same
+      merge window and record which comments are now fixed, stale, or still
+      actionable. Do not mark a thread resolved only because it is outdated;
+      verify the current code or TODO text first.
+
+      Required output artifact (resolves prior ambiguity):
+        - Write findings to a new file under `_project/audits/` named
+          `codex-thread-rescan-week-2026-05-01.md`.
+        - File must contain three sections: (1) Resolved by w1-w13 (one row
+          per thread, link to commit/PR that fixed it), (2) Already-fixed by
+          earlier merges (one row per stale-but-ok thread, link to the merge
+          that fixed it), (3) Still actionable (one row per thread that
+          neither this TODO nor any earlier merge addressed — promote each
+          to a new TODO or blind-spot).
+        - Cross-check: diff `_project/blind-spots/` for entries dated within
+          2026-04-24 .. 2026-05-01 and either fold them into the audit or
+          mark out-of-scope with a one-line rationale. This addresses the
+          framework-gap finding in
+          `_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md`.
+
+      Findings that looked already fixed or stale during the 2026-05-01 scan:
+        - PR #56 date sorting: current code uses `fmt_date(...)` before
+          sorting/listing blind-spot dates.
+        - PR #64 gitignore semantics: current workflow uses
+          `git check-ignore -z -v --no-index --stdin`, not pathspec matching.
+        - PR #64 PR-base reuse: current `pr-open` reuses PRs only with
+          `gh pr list --base develop --head "$CURRENT"`.
+        - PR #66 Step 0 merge-queue signal: current TODO explicitly says not
+          to infer merge-queue availability from `.has_issues`.
+        - PR #66 Step 1 lock-path command: current verification uses valid
+          Python syntax.
+        - PR #66 Step 3 unsupported `gh run list --json jobs`: current
+          verification lists run IDs and uses `gh run view` for jobs.
+        - PR #66 Step 6 machine-specific Makefile path: current TODO no longer
+          references `/Users/joe/Developer/BenchBox/Makefile`.
+        - PR #70 content-guard aggregator exit: current `.github/workflows/pr.yml`
+          exits immediately on content-guard failure before content-only
+          success messages.
+        - PR #75 and PR #76 non-POSIX `ERR` trap: current claim path uses a
+          POSIX `EXIT INT TERM` trap, though w5 tracks the remaining signal
+          exit problem.
+        - PR #75 and PR #76 PR-list cap: current pool status/sweep use
+          `--limit 1000` plus per-branch fallback lookups.
+        - PR #79 deleted-file classifier: current diff filter is `ACDMRT`,
+          including deletions.
+
+metadata:
+  tags:
+    - codex-review
+    - pr-followup
+    - workflow
+    - worktree-pool
+    - results-explorer
+    - hosted-submit
+  estimated_effort: "Medium"
+  created_date: "2026-05-01"
+  last_updated: "2026-05-01T13:30:00Z"
+
+impact:
+  business_value: |
+    Converts unresolved Codex PR review feedback into a tracked, executable
+    backlog item instead of leaving high-signal review comments buried on
+    already-merged PRs.
+  user_impact: |
+    Reduces the risk of data loss in pool worktrees, stale test locks,
+    misleading dev-loop metrics, blocked hosted-login flows, and a stuck
+    results-explorer Home page.
+  technical_debt: |
+    Preserves the value of PR review by closing the loop on comments that
+    landed after auto-merge and by documenting which unresolved threads are
+    already fixed versus still actionable.
+
+files_affected:
+  modified:
+    - "_project/scripts/sweep_blind_spots.py"
+    - "tests/unit/scripts/test_blind_spot_tools.py"
+    - "Makefile"
+    - "_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml"
+    - "_project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml"
+    - "_project/DONE/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml"
+    - "_project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml"
+    - ".github/workflows/develop-post-merge.yml"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/__tests__/Home.test.tsx"
+    - "results-explorer/e2e/failures/platform-index-cold-load.spec.ts"
+    - "benchbox/cli/commands/auth.py"
+    - "benchbox/cli/submit_auth.py"
+    - "tests/unit/cli/commands/test_auth.py"
+  created:
+    - "_project/audits/codex-thread-rescan-week-2026-05-01.md"
+
+must_preserve:
+  - "`worktree-release` and `worktree-pool-reset` must not discard dirty pool worktrees without an explicit force path."
+  - "`worktree-claim` remains compatible with `/bin/sh` on Ubuntu/dash; do not reintroduce bash-only `ERR` traps."
+  - "The path classifier continues to include deleted files via `ACDMRT` and content-only deletion PRs keep the intended cheap guard path."
+  - "Results explorer Home keeps the transient empty-results retry, but persistent snapshot mismatch must not render an endless spinner."
+  - "Environment tokens remain the normal precedence for submit/auth resolution outside the explicit `auth login` prompt path."
+  - "TODO and DONE YAML edited by this work remains schema-valid and graph-valid."
+  - "DONE-item verification commands edited under this TODO remain executable on a clean fork (no hard-coded ruleset IDs, no repo-specific account paths)."
+
+approach: |
+  Treat each work unit as a small targeted fix. Before editing, reopen the
+  current `origin/develop` file and the linked GitHub review comment, then
+  confirm whether a newer commit already handled the issue. Prefer regression
+  tests around each behavior rather than broad rewrites.
+
+  For Makefile work, keep shell syntax POSIX-compatible unless the target
+  explicitly sets `SHELL` and all callers/tests are updated. For DONE-item
+  verification text, follow the policy in `description`: edit in place to
+  keep historical commands portable and runnable.
+
+anti_patterns:
+  - "DO NOT resolve or dismiss a GitHub review thread solely because it is outdated - because later commits may or may not have fixed it - verify current behavior first."
+  - "DO NOT switch the whole Makefile to bash to fix one trap - because these recipes currently run under `/bin/sh` on common Linux hosts - use POSIX shell patterns or justify a scoped shell change."
+  - "DO NOT remove the hosted-submit env-token guard globally - because CI and non-interactive submit flows depend on env-token precedence - add a login-specific prompt path instead."
+  - "DO NOT replace the results explorer retry with a generic empty state - because transient DuckDB snapshot ordering can recover on retry - keep one retry and handle only persistent mismatch differently."
+  - "DO NOT fix only the Home.tsx empty-state issue from PR #86 without also restoring strict row-count assertions in `platform-index-cold-load.spec.ts` - because the loosened `count > 0` assertion will not detect partial-row cold-load regressions, which is exactly the failure mode the original test was guarding."
+
+verification:
+  - description: "This TODO item validates cleanly"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/codex-pr-review-followups-week-2026-05-01.yaml"
+    expected_output: "Validation passes with no schema or DAG errors"
+  - description: "TODO dependency graph remains valid"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passes"
+  - description: "w1 - blind-spot frontmatter stamping regression test"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_blind_spot_tools.py -q"
+    expected_output: "All blind-spot tests pass, including the new block/sequence-shaped status field regression"
+  - description: "w2 - test-unlock honors BENCHBOX_TEST_LOCK_DIR with ~"
+    command: "BENCHBOX_TEST_LOCK_DIR='~/tmp/benchbox-lock-probe' make -n test-unlock | grep -F \"$HOME/tmp/benchbox-lock-probe/test.lock\""
+    expected_output: "Resolved lock path expands ~ to $HOME (exit 0)"
+  - description: "w3 - worktree-release refuses dirty trees without FORCE=1"
+    command: "uv run -- python -m pytest tests/integration/worktree/test_worktree_release_dirty_guard.py -q || echo 'test must be created by w3 implementation'"
+    expected_output: "New test exercises a pool worktree with staged changes and confirms release exits nonzero without FORCE=1"
+  - description: "w4 - .benchbox scratch files do not block claim"
+    command: "uv run -- python -m pytest tests/integration/worktree/test_worktree_claim_benchbox_scratch.py -q || echo 'test must be created by w4 implementation'"
+    expected_output: "New test seeds a free pool slot with .benchbox/foo and confirms claim succeeds"
+  - description: "w5 - INT/TERM trap exits nonzero"
+    command: "uv run -- python -m pytest tests/integration/worktree/test_worktree_claim_signal_exit.py -q || echo 'test must be created by w5 implementation'"
+    expected_output: "New test sends INT mid-claim under /bin/sh and confirms recipe exits nonzero with cleanup performed"
+  - description: "w6 / w7 - Step 5 TODO remains schema-valid after edits"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml"
+    expected_output: "Validation passes; last_updated is full ISO date-time; due_date is max(step_3a_merged_at, step_4_merged_at) + 30 days"
+  - description: "w8 - develop-post-merge metrics jq fixture for two failed jobs"
+    command: "uv run -- python -m pytest tests/unit/workflows/test_develop_post_merge_metrics.py -q || echo 'fixture test does not exist yet - w8 must create it'"
+    expected_output: "Two failed jobs at different completed_at produce develop_red_detected_at equal to the earlier timestamp"
+  - description: "w9 - Home.tsx persistent-mismatch unit test"
+    command: "cd results-explorer && npm run test -- src/pages/__tests__/Home.test.tsx"
+    expected_output: "Home tests pass; new test asserts persistent empty-results renders an actionable error/empty state, not a spinner"
+  - description: "w9 (related) - cold-load e2e restores strict row-count assertions"
+    command: "grep -E 'toHaveCount\\(' results-explorer/e2e/failures/platform-index-cold-load.spec.ts"
+    expected_output: "Test contains explicit toHaveCount(N) assertions, not just count > 0"
+  - description: "w10 - benchbox auth login prompt with env token set"
+    command: "uv run -- python -m pytest tests/unit/cli/commands/test_auth.py -q"
+    expected_output: "All auth tests pass; new test sets BENCHBOX_SUBMIT_TOKEN, runs auth login without --token, and confirms keyring stores prompted value"
+  - description: "w11 - Step 3a ruleset verification is repo-instance-agnostic"
+    command: "! grep -nE 'rulesets/[0-9]+' _project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml"
+    expected_output: "No matches (hard-coded numeric ruleset ID has been replaced by dynamic lookup); grep exit 1 inverted to 0"
+  - description: "w12 - Step 3 verification asserts develop-targeted PR base"
+    command: "grep -nE 'baseRefName' _project/DONE/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml"
+    expected_output: "baseRefName guard present before gh run list ... --event pull_request"
+  - description: "w13 - Step 0 secondary probe is scoped"
+    command: "grep -nE 'gh pr list[^|\\\\n]*--state[^|\\\\n]*--base develop' _project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml"
+    expected_output: "Secondary probe includes --state and --base develop filters"
+  - description: "w14 - rescan audit artifact exists with required sections"
+    command: "test -f _project/audits/codex-thread-rescan-week-2026-05-01.md && [ \"$(grep -cE '^## ' _project/audits/codex-thread-rescan-week-2026-05-01.md)\" -ge 3 ]"
+    expected_output: "File exists with at least three ## section headers (Resolved / Already-fixed / Still actionable)"
+
+context_sections:
+  "Review Inventory": |
+    Merged PRs with Codex inline review comments in the scan:
+      - #56: 1 comment, date sorting; appears addressed.
+      - #59: 1 comment, blind-spot frontmatter stamping; tracked by w1.
+      - #64: 2 comments, gitignore semantics and PR-base reuse; appear addressed.
+      - #66: 4 comments, dev-loop TODO command/verification quality; appear addressed.
+      - #67: 2 comments, Step 0 secondary probe and Step 3 run selection; Step 0 tracked by w13, Step 3 tracked by w12.
+      - #70: 2 comments, content-guard aggregator and Step 5 window start; Step 5 tracked by w6.
+      - #71: 1 comment, test lock path expansion; tracked by w2.
+      - #73: 2 comments, worktree-release dirty guard and `.benchbox` scratch files; tracked by w3 and w4.
+      - #75: 2 comments, ERR trap and PR cap; appear addressed or superseded by w5.
+      - #76: 2 comments, duplicate ERR trap and stale-sweep cap; appear addressed or superseded by w5.
+      - #78: 1 comment, INT/TERM trap exit; tracked by w5.
+      - #79: 1 comment, deleted-file path classifier; appears addressed.
+      - #80: 1 comment, hard-coded ruleset ID; tracked by w11.
+      - #81: 1 comment, red-detection timestamp; tracked by w8.
+      - #83: 1 comment, TODO `last_updated` schema format; tracked by w7.
+      - #86: 1 comment, results explorer infinite spinner; tracked by w9 (with cross-link to cold-load coverage downgrade blind-spot).
+      - #93: 1 comment, auth login prompt with env token; tracked by w10.
+
+success_metrics:
+  - "Every active Codex review finding in the scan is either fixed with a regression test or explicitly documented as no longer required."
+  - "No worktree-pool command can discard user changes without an explicit force path."
+  - "Dev-loop metrics and TODO metadata remain schema-valid and operationally accurate."
+  - "Results explorer Home surfaces persistent snapshot mismatch without an infinite loading state, AND the cold-load e2e test retains strict row-count assertions."
+  - "`benchbox auth login` can prompt and store credentials when env tokens are present, without changing env-token behavior for non-login flows."
+  - "DONE-item verification commands edited under this TODO are repo-instance-agnostic and runnable on a clean fork."
+  - "w14 produces `_project/audits/codex-thread-rescan-week-2026-05-01.md` with explicit cross-check against blind-spots filed in the same window."
+
+commits:
+  - "175a98d3b"
+  - "3c0ee11fa"
+  - "fd225974c"
+  - "2d43bf26f"
+  - "e0e0d9a3a"
+  - "92acd0021"
+  - "d8c8dd6eb"
+  - "83cff3a21"
+  - "855e7ebee"
+  - "d69cf2d08"
+  - "40bf1e376"

--- a/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
+++ b/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
@@ -1,0 +1,87 @@
+---
+id: 2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades
+date: 2026-05-01
+status: open
+finding_kind: framework-gap
+review_context: "/todo review of codex-pr-review-followups-week-2026-05-01"
+related_paths:
+  - _project/TODO/main/planning/codex-pr-review-followups-week-2026-05-01.yaml
+  - _project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md
+  - _project/blind-spots/2026-05-01-103000-hosted-submit-no-local-validate-preflight.md
+  - _project/blind-spots/2026-05-01-103001-published-results-validator-no-per-bundle-test.md
+  - results-explorer/e2e/failures/platform-index-cold-load.spec.ts
+suggested_sweep: "Before sweeping codex-followups w12, diff blind-spots filed in the same window and either fold them in, link them, or explicitly mark them out-of-scope. Add a 'review-window cross-check' step to the next weekly Codex sweep template."
+todo_id: codex-pr-review-followups-week-2026-05-01
+---
+
+# "Codex thread sweep" framework misses coverage downgrades and locally-filed blind-spots from the same window
+
+## Finding
+
+`codex-pr-review-followups-week-2026-05-01.yaml` frames itself as
+"unresolved Codex review threads from PRs #19-#94 → fix list". That
+frame is good at catching what Codex flagged-and-was-never-resolved,
+but blind to two adjacent failure modes:
+
+1. **Coverage downgrades from later PRs in the same window.** The
+   per-PR Codex thread scan reads each thread in isolation. If PR #N
+   adds a strict assertion and PR #N+M weakens it, no Codex thread
+   exists to follow because Codex didn't flag it. The local
+   blind-spot `2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md`
+   captures exactly this case for PR #86: row-count assertions in
+   `platform-index-cold-load.spec.ts` were loosened from
+   `toHaveCount(4)` / `toHaveCount(2)` to `count > 0`. The Codex
+   followups TODO has w8 for the Home.tsx empty-state issue from the
+   same PR, but does not surface that the regression test for the
+   *original* cold-load symptom got weaker.
+
+2. **Locally-filed blind-spots from the same review window are not
+   cross-linked.** Three blind-spots filed today
+   (`2026-05-01-103000`, `103001`, `103002`) cover hosted-submit
+   pre-flight, published-results validator, and the explorer
+   coverage downgrade — all from `/code review` on the same merge
+   window. The Codex sweep TODO is silent about them. A reader
+   working w8 won't discover the related cold-load coverage finding
+   unless they grep `_project/blind-spots/` independently.
+
+## Why the framework missed it
+
+The "Codex thread per PR" sweep template only iterates one source
+(GitHub inline review threads) and one author
+(`chatgpt-codex-connector`). It has no slot for:
+
+- Local human/agent review findings filed as blind-spots in the
+  same window.
+- Tests whose assertions weakened across the window.
+- "Reviewer was right, fix landed, but the fix subtly regressed an
+  adjacent test" — the kind of N+M chain that no single PR thread
+  can express.
+
+Because the rubric never asks "what else was filed about these PRs
+this week?", co-located but separately-tracked findings stay
+invisible.
+
+## Why this matters
+
+The cold-load partial-row regression is the exact failure mode the
+original e2e test was written to catch (per the pass-1 audit). If
+the Home.tsx fix in w8 lands without restoring the strict
+assertions, the next regression of that class slips past CI silently
+— and the Codex followups TODO will report "done" because Codex
+never flagged the test downgrade in the first place.
+
+## Suggested next steps
+
+1. Add a step to the next weekly Codex sweep that diffs
+   `_project/blind-spots/` for findings filed in the review window
+   and either folds them into the TODO or explicitly marks them
+   out-of-scope with a one-line rationale.
+2. For *this* TODO specifically, cross-link
+   `2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md`
+   from w8's notes so whoever picks up w8 knows the partial-row
+   regression test still needs restoration (separate fix from the
+   Home.tsx empty-state).
+3. Consider a longer-term rubric change: weekly review sweeps
+   should include "tests weakened in this window" as an explicit
+   axis, sourced from `git log -p -- '*.spec.ts' '*test*.py'` and
+   filtered for assertion-loosening patterns.


### PR DESCRIPTION
Address review findings from two-agent adversarial review of the
codex-pr-review-followups-week-2026-05-01 TODO:

- Add w13 for the previously-dropped PR #67 Step 0 secondary-probe
  finding (unscoped `gh pr list --json comments`); finding was
  acknowledged in inventory but not assigned to any work unit.
- Split prior w6 into w6 (Step 5 measurement-window start description)
  and w7 (Step 5 last_updated schema format) — they touched the same
  file but had unrelated acceptance criteria.
- Resolve the DONE-edit policy ambiguity in `description` so
  implementers know to fix DONE verification commands in place rather
  than close as no-op (applies to w11/w12/w13).
- Replace `open_questions` deferred decisions with concrete fixes and a
  policy statement; w14 (rescan) now has an explicit output artifact at
  `_project/audits/codex-thread-rescan-week-2026-05-01.md`.
- Backfill per-work-unit `verification` commands so all 14 units have a
  runnable check, not just w1/w8/w9.
- Drop drifted line numbers in w10 (auth.py) in favor of function names.
- Cross-link w9 (Home.tsx empty-state) to the cold-load coverage-
  downgrade blind-spot from PR #86 so whoever picks up w9 also restores
  the strict row-count e2e assertions.
- Renumber work units to satisfy `w[0-9]{1,3}` schema (no w6a/w6b).

Also files the L2 framework-gap blind-spot under
`_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md`
documenting that the Codex per-PR thread sweep is blind to coverage
downgrades and to locally-filed blind-spots in the same window.
