### PR TITLE
chore(todo): refine 9 explorer review TODOs with deps, splits, and pinned budgets

### DIFF
--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -1,0 +1,162 @@
+id: explorer-chart-correctness-and-navigation
+title: "Explorer: chart correctness, log-scale latency encoding, and chart navigation"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Data Visualization"
+
+deps:
+  needs:
+    - explorer-critical-results-ux-defects
+
+description: |
+  Fix visualization choices that currently reduce trust or legibility in the
+  Results Explorer. Database benchmark latency often spans orders of magnitude,
+  so linear bar charts can compress meaningful differences and cause labels to
+  overlap. Chart navigation also exposes too many tiny chart chips without an
+  analytical hierarchy. The goal is to make charts answer clear questions:
+  overview, per-query behavior, distribution, cost, trend, and rank.
+
+work:
+  - id: w1
+    summary: "Audit chart registry and group charts by analytical question"
+    status: pending
+    notes: |
+      In `results-explorer/src/lib/chartRegistry.ts` and ChartPanel, replace the
+      flat 10+ chip list with grouped tabs or segmented controls:
+        - Overview
+        - Per-query
+        - Distribution
+        - Cost
+        - Trend
+        - Rank
+      Each group should show at most the relevant chart controls for the current
+      page/data shape.
+
+  - id: w2
+    summary: "Use log-scale or ratio-based encoding for latency bars where values span orders of magnitude"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update PowerBar/ChartPanel latency views so linear bars do not compress
+      faster engines against a slow outlier. Use log scale for latency magnitude
+      or speedup-vs-best where comparison is the point. Axis labels must disclose
+      log scale when used.
+
+  - id: w3
+    summary: "Fix label overlap in SSB/star_schema performance bar charts"
+    needs: [w2]
+    status: pending
+    notes: |
+      The audited SSB Performance Bar showed labels crowding near the origin.
+      Implement collision-aware label placement: outside labels when space is
+      insufficient, minimum label gutter, and tooltip fallback for narrow bars.
+
+  - id: w4
+    summary: "Split platform trend charts by cohort or metric"
+    needs: [w1]
+    status: pending
+    notes: |
+      Carry forward the critical defect fix: trend charts must not mix
+      benchmark/scale/phase cohorts. Render cohort-specific small multiples or
+      require a selected cohort before showing the time series.
+
+  - id: w5
+    summary: "Add natural query sorting and explicit query labels in heatmaps and tables"
+    status: pending
+    notes: |
+      Query IDs should sort Q1, Q2, ..., Q10 rather than lexicographic 1, 10,
+      11, ..., 2. Labels should preserve benchmark-specific prefixes where
+      present (`Q1`, `q01`, `query_001`) rather than bare ambiguous numerals.
+
+  - id: w6
+    summary: "Add high-contrast and reduced-color paths for heatmaps"
+    needs: [w5]
+    status: pending
+    notes: |
+      MetaLeaderboard and QueryHeatmap should have text/value labels sufficient
+      for interpretation without relying only on color. Add or preserve
+      color-blind-safe sequential palettes and reduced-color rendering where
+      supported by CSS/media queries.
+
+  - id: w7
+    summary: "Add chart math and rendering tests for scale, sorting, and labels"
+    needs: [w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Extend chartMath and component tests for log-scale mapping, label
+      collision behavior, cohort-split trend data, natural query sort, and
+      heatmap accessible names/values.
+
+metadata:
+  tags:
+    - explorer
+    - charts
+    - visualization
+    - accessibility
+  estimated_effort: "Large (3-5 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Makes leaderboard charts credible to technical users and reduces avoidable
+    objections about misleading scale or mixed metrics.
+  user_impact: |
+    Users can see meaningful latency differences, identify per-query outliers,
+    and navigate charts by question instead of scanning a long chip list.
+  technical_debt: |
+    Centralizes chart categorization and scale decisions in the chart registry
+    and math helpers.
+
+files_affected:
+  modified:
+    - "results-explorer/src/lib/chartRegistry.ts"
+    - "results-explorer/src/lib/chartMath.ts"
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/components/PowerBar.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/__tests__/chartRegistry.meta.test.ts"
+    - "results-explorer/src/__tests__/chartTheme.test.ts"
+    - "results-explorer/src/__tests__/parity/chartMath.parity.test.ts"
+    - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
+    - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+
+must_preserve:
+  - "Chart registry remains the single source for chart availability and chart metadata."
+  - "Benchmark ranking order continues to come from pipeline-emitted primary_metric/primary_order, not frontend guesses."
+  - "Charts remain readable when only one platform/result is present."
+  - "Heatmaps remain keyboard navigable and retain existing role/grid accessibility behavior."
+
+approach: |
+  Start by making chart intent explicit in registry metadata, then update
+  ChartPanel navigation. Treat log scale and speedup as distinct encodings:
+  log scale for magnitude across orders of magnitude, speedup when the user is
+  asking relative winner/loser questions. Test chart math separately from Preact
+  rendering so scale regressions are easy to catch.
+
+anti_patterns:
+  - "DO NOT use linear latency bars when one slow outlier collapses the rest of the field - because users cannot compare fast platforms - use log scale or speedup encoding with clear labels."
+  - "DO NOT mix cohorts in trend charts - because benchmark/scale geomeans are not one metric - split by cohort."
+  - "DO NOT rely on color alone in heatmaps - because color perception and print/screenshot contexts vary - keep visible values and accessible names."
+  - "DO NOT present every chart as an equal chip - because users need analytical hierarchy - group charts by question."
+
+verification:
+  - description: "Frontend typecheck and chart tests pass."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "All chart registry, chart math, heatmap, and ChartPanel tests pass."
+  - description: "Production build succeeds."
+    command: "cd results-explorer && npm run build"
+    expected_output: "Vite build completes without chart-related warnings or errors."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/lib/chartRegistry.ts"
+    - "results-explorer/src/lib/chartMath.ts"
+    - "results-explorer/src/components/"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/__tests__/"

--- a/_project/TODO/main/planning/explorer-compare-decision-summary.yaml
+++ b/_project/TODO/main/planning/explorer-compare-decision-summary.yaml
@@ -1,0 +1,153 @@
+id: explorer-compare-decision-summary
+title: "Explorer: summary-led compare workflow with cohort guardrails"
+worktree: main
+priority: "Medium-High"
+status: "Not Started"
+category: "Core Functionality"
+
+deps:
+  needs:
+    - explorer-run-receipt-methodology-disclosure
+    - results-normalized-cost-contract-cloud-facets
+
+description: |
+  Improve the compare workflow so it answers the top-line question before
+  presenting charts. A benchmark user comparing two or more result bundles needs
+  an immediate conclusion such as "Polars is faster on 22/22 queries and 3.65x
+  faster by geomean" plus clear warnings when the selected runs are not directly
+  comparable. This builds on the existing sticky compare bar and compare route.
+
+work:
+  - id: w1
+    summary: "Add compare decision summary computed from selected results"
+    status: pending
+    notes: |
+      At the top of Compare.tsx, render a compact summary:
+        - winner by primary cohort metric
+        - geomean difference or power-score ratio
+        - per-query wins/losses/ties
+        - p50/p90/p99 comparison when present
+        - cost/performance delta when normalized cost is present
+      The copy should be generated from data, not hand-written per benchmark.
+
+  - id: w2
+    summary: "Move diff table ahead of secondary charts"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a dense query-level diff table immediately after the summary:
+      query ID, baseline latency, candidate latency, ratio, absolute delta,
+      status, and optional cost/phase context. Charts should follow this table,
+      not precede it.
+
+  - id: w3
+    summary: "Add explicit baseline controls for multi-result comparisons"
+    needs: [w1]
+    status: pending
+    notes: |
+      Let the user choose baseline result from a segmented/select control.
+      Default to the first URL id for backwards compatibility. Ratios and
+      diverging bars should update without changing selected result membership.
+
+  - id: w4
+    summary: "Render cohort guardrails before claims"
+    needs: [w1]
+    status: pending
+    notes: |
+      Consumes the ComparabilityReceipt component owned by
+      `explorer-run-receipt-methodology-disclosure` w3 — this work unit does
+      NOT define the receipt's API or styling, only its placement and the
+      severity rules that flow into it. If selected results differ in
+      benchmark, scale factor, phase, tuning mode, validation status, platform
+      version, driver version, cost model, or major environment fields, show
+      warnings before the summary. For severe mismatch (different benchmark or
+      scale), label the comparison "Not directly comparable" and suppress
+      winner language.
+
+  - id: w5
+    summary: "Improve compare tray metadata and URL shareability"
+    status: pending
+    notes: |
+      Sticky compare bars in BenchmarkIndex and PlatformIndex should show
+      platform, benchmark, scale, phase, date, trust, and short id for selected
+      rows. Preserve current URL ids, but prefer short ids where available for
+      shareability.
+
+  - id: w6
+    summary: "Add tests for summary math, baseline selection, and guardrails"
+    needs: [w1, w2, w3, w4, w5]
+    status: pending
+    notes: |
+      Extend Compare.test.tsx with same-cohort, mismatched-cohort, missing-query,
+      multi-result, and baseline-switch cases. Include no-cost and normalized
+      cost cases once cost fields are available.
+
+metadata:
+  tags:
+    - explorer
+    - compare
+    - decision-support
+    - guardrails
+  estimated_effort: "Medium-Large (2-4 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Makes compare pages tweetable and decision-oriented, while protecting
+    BenchBox from overclaiming across incompatible result bundles.
+  user_impact: |
+    Users get the conclusion, the evidence table, and the caveats in that order.
+  technical_debt: |
+    Encapsulates comparison math and guardrails so compare behavior is not
+    scattered across chart components.
+
+files_affected:
+  modified:
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/ComparabilityBanner.tsx"
+    - "results-explorer/src/components/DivergingBarChart.tsx"
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+  added:
+    - "results-explorer/src/components/CompareSummary.tsx"
+    - "results-explorer/src/components/QueryDiffTable.tsx"
+    - "results-explorer/src/lib/compareSummary.ts"
+    - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+
+must_preserve:
+  - "Existing `/results/compare?ids=...` URLs continue to load."
+  - "The sticky compare bar remains available from benchmark and platform pages."
+  - "Compare still supports more than two selected results."
+  - "Warnings do not prevent users from inspecting mismatched selections; they prevent unsupported winner claims."
+
+approach: |
+  Build compare summary math in a testable library first, then render it in
+  Compare.tsx. Keep guardrails separate from summary claims so a severe mismatch
+  can suppress winner language while still showing raw rows. Move the diff table
+  above charts because it is the most information-dense evidence for platform
+  selection.
+
+anti_patterns:
+  - "DO NOT claim a winner across different benchmark/scale/phase cohorts - because that is not a valid comparison - show a mismatch warning and raw evidence only."
+  - "DO NOT make charts the first compare artifact - because users need the conclusion and per-query evidence first - lead with summary and diff table."
+  - "DO NOT force pairwise-only compare - because users may compare several variants - make baseline selection explicit."
+
+verification:
+  - description: "Frontend typecheck and compare tests pass."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "Compare summary, guardrail, and baseline tests pass."
+  - description: "Manual compare smoke."
+    command: "cd results-explorer && npm run dev"
+    expected_output: "A same-cohort compare URL shows summary + diff table; a mismatched compare URL shows guardrails before any winner language."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/"
+    - "results-explorer/src/lib/"
+    - "results-explorer/src/pages/__tests__/Compare.test.tsx"

--- a/_project/TODO/main/planning/explorer-critical-results-ux-defects.yaml
+++ b/_project/TODO/main/planning/explorer-critical-results-ux-defects.yaml
@@ -1,0 +1,154 @@
+id: explorer-critical-results-ux-defects
+title: "Explorer: fix critical result-browser defects found in design audit"
+worktree: main
+priority: Critical
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  Fix the correctness defects found while auditing the BenchBox Results Explorer
+  before layering on larger visual and IA changes. These issues directly break
+  navigation or misrepresent benchmark data:
+
+  - Query Workbench default `View ->` links can navigate to `/results/r/undefined`
+    because the default visible column set omits `result_id` while the row action
+    reads `row.result_id`.
+  - Result detail methodology can label sample count as query scope, e.g. showing
+    "Query scope: 88 queries" on a page whose timing section has 22 logical
+    queries and 88 individual samples.
+  - Platform page "Performance Trend" can mix unrelated benchmark/scale cohorts
+    such as SSB SF0.01, SSB SF0.1, TPC-H SF0.01, and TPC-H SF0.1 into one
+    geomean trend line, which implies a single longitudinal metric where none
+    exists.
+
+work:
+  - id: w1
+    summary: "Make Query Workbench row actions independent of visible result_id column"
+    status: pending
+    notes: |
+      In results-explorer/src/pages/Query.tsx, ensure `result_id` is always
+      available for row actions even when not visible. Preferred fix: keep
+      `result_id` in the SELECT projection as a hidden key and render only the
+      user-selected columns. Add a regression test where DEFAULT_COLUMNS omits
+      `result_id` but the "View" link still points to `/results/r/{id}`.
+
+  - id: w2
+    summary: "Correct Result Detail methodology copy to distinguish logical queries from samples"
+    status: pending
+    notes: |
+      In results-explorer/src/pages/ResultDetail.tsx and/or
+      MethodologyDisclosure, source logical query scope from `detail.query_count`
+      or `detail.display_timings.length`, and sample count from
+      `detail.queries.length`. The UI should say, for example, "22 queries,
+      88 measurement samples" rather than "88 queries" when samples are the
+      larger number.
+
+  - id: w3
+    summary: "Stop Platform page trend chart from combining different cohorts into one time series"
+    status: pending
+    notes: |
+      In results-explorer/src/pages/PlatformIndex.tsx and
+      results-explorer/src/components/TimeSeries.tsx call sites, group trend
+      data by `(benchmark, scale_factor, phase, primary_metric)` before drawing.
+      Either render cohort-specific small multiples or require an explicit cohort
+      selector. Do not plot mixed cohorts on one y-axis.
+
+  - id: w4
+    summary: "Add Query Workbench regression test for default row link without visible result_id"
+    needs: [w1]
+    status: pending
+    notes: |
+      Extend Query.test.tsx with a case where DEFAULT_COLUMNS omits `result_id`
+      but the rendered "View" link still resolves to `/results/r/{id}`. Commit
+      with the w1 fix so navigation is locked in by the same change.
+
+  - id: w5
+    summary: "Add Result Detail regression test for separate query and sample counts"
+    needs: [w2]
+    status: pending
+    notes: |
+      Extend ResultDetail.test.tsx or MethodologyDisclosure.test.tsx to assert
+      "queries" and "measurement samples" render as distinct counts when sample
+      count exceeds logical query count. Commit with the w2 fix.
+
+  - id: w6
+    summary: "Add Platform trend regression test against mixed cohorts"
+    needs: [w3]
+    status: pending
+    notes: |
+      Extend PlatformIndex.test.tsx with rows from at least two distinct
+      `(benchmark, scale_factor)` cohorts and assert the trend renderer either
+      splits cohorts into small multiples or refuses to render a single merged
+      line. Commit with the w3 fix.
+
+metadata:
+  tags:
+    - explorer
+    - audit-followup
+    - correctness
+    - navigation
+  estimated_effort: "Medium (1 day)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Removes trust-damaging defects before the explorer is promoted as a public
+    leaderboard surface.
+  user_impact: |
+    Users can navigate from the workbench reliably and are not shown misleading
+    methodology or trend data.
+  technical_debt: |
+    Adds regression coverage around defects that are likely to recur as result
+    tables and chart inputs become more configurable.
+
+files_affected:
+  modified:
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/MethodologyDisclosure.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/pages/__tests__/Query.test.tsx"
+    - "results-explorer/src/pages/__tests__/ResultDetail.test.tsx"
+    - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
+    - "results-explorer/src/components/__tests__/MethodologyDisclosure.test.tsx"
+
+must_preserve:
+  - "Query Workbench column picker continues to control visible table columns."
+  - "Query Workbench CSV/JSON export continues to emit exactly the columns the user has selected (no extra hidden `result_id`); the projection-only fix keeps `result_id` available to row actions without leaking into export output."
+  - "Existing Result Detail route `/results/r/{result_id}` remains unchanged."
+  - "Platform trend charts remain available, but only for comparable cohorts."
+
+approach: |
+  Fix each defect in the smallest owning component first, then add tests around
+  the observable behavior. For Query Workbench, avoid making `result_id` visible
+  by default just to fix navigation; separate row identity from displayed
+  columns. For Result Detail, audit all methodology labels that mention query
+  scope so the copy cannot reuse sample-count terminology. For Platform trend,
+  use the existing ranking/cohort fields already emitted by
+  `bench.benchmark_rankings` rather than inventing a frontend-only cohort key.
+
+anti_patterns:
+  - "DO NOT hide the Query Workbench View link when result_id is not visible - because navigation is a core row action - carry row identity separately from displayed columns."
+  - "DO NOT label measurement samples as queries - because that overstates benchmark breadth - show logical queries and samples as separate counts."
+  - "DO NOT normalize mixed benchmark/scale rows into a single trend line - because geomean values are cohort-relative - split by cohort or force a cohort selector."
+
+verification:
+  - description: "Frontend typecheck and unit tests pass."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "TypeScript and Vitest pass, including new regressions for workbench links, methodology counts, and platform trend grouping."
+  - description: "Production explorer bundle still builds."
+    command: "cd results-explorer && npm run build"
+    expected_output: "Vite production build completes without errors."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/MethodologyDisclosure.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/lib/queryFilters.ts"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/src/components/__tests__/"

--- a/_project/TODO/main/planning/explorer-leaderboard-first-identity-unification.yaml
+++ b/_project/TODO/main/planning/explorer-leaderboard-first-identity-unification.yaml
@@ -1,0 +1,199 @@
+id: explorer-leaderboard-first-identity-unification
+title: "Explorer: unify Results Explorer and benchbox.dev into a leaderboard-first product identity"
+worktree: main
+priority: High
+status: "Not Started"
+category: "User Experience"
+
+description: |
+  Redesign the Results Explorer front door and shell so it feels like part of
+  the BenchBox product rather than a separate light dashboard. The user clarified
+  that the primary audience is benchmark users choosing a database, while the
+  leaderboard browser must remain attention-grabbing because it feeds the
+  submission flywheel. The target frame is therefore:
+
+  "BenchBox Database Leaderboards: reproducible rankings for choosing OLAP
+  platforms by workload, scale, deployment, and normalized cost."
+
+  This item covers identity, first impression, first-viewport density, and the
+  shared BenchBox narrative. It should preserve the existing home
+  MetaLeaderboard work, but make it the first meaningful content rather than
+  burying it below generic hero/stat chrome.
+
+work:
+  - id: w1
+    summary: "Extract shared BenchBox brand tokens from landing page into explorer theme variables"
+    status: pending
+    notes: |
+      Read-only audit of `landing/` (tokens are extracted into the explorer;
+      `landing/` itself is not edited in this work). Add the following CSS
+      custom properties to `results-explorer/src/index.css`:
+        - surfaces: `--bb-bg-primary`, `--bb-bg-panel`, `--bb-bg-elevated`
+        - text: `--bb-fg-primary`, `--bb-fg-muted`, `--bb-fg-inverse`
+        - borders: `--bb-border-default`, `--bb-border-subtle`
+        - accent: `--bb-accent`, `--bb-accent-hover`
+        - status: `--bb-status-success`, `--bb-status-warning`,
+          `--bb-status-danger`
+        - code surfaces: `--bb-code-bg`, `--bb-code-fg`
+        - typography: `--bb-font-sans`, `--bb-font-mono`, plus type-scale
+          tokens `--bb-text-xs|sm|base|lg|xl|2xl`.
+      Chart palettes stay in their own `--bb-chart-*` namespace and must not
+      be aliased to brand tokens. Where landing and the existing explorer dark
+      theme disagree, defer to landing for chrome and to the explorer for
+      chart/data encodings.
+
+  - id: w2
+    summary: "Replace generic explorer header with shared global BenchBox navigation plus explorer subnav"
+    needs: [w1]
+    status: pending
+    notes: |
+      In results-explorer/src/components/Layout.tsx, add a compact global nav
+      matching benchbox.dev: BenchBox wordmark/name, Docs, Blog, Results, GitHub,
+      and primary submit/run CTA. Below it, keep explorer-specific navigation
+      for Leaderboards, Benchmarks, Platforms, Compare, and Query. Results should
+      be visibly active when on `/results/`.
+
+  - id: w3
+    summary: "Rewrite Home first viewport around a live leaderboard, not a brochure hero"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      In results-explorer/src/pages/Home.tsx, first viewport should contain:
+        - H1: "BenchBox Database Leaderboards"
+        - supporting line: "Reproducible OLAP benchmark rankings by workload,
+          scale, deployment, and normalized cost."
+        - one dense cohort selector row: benchmark, scale factor, phase,
+          deployment/cost coverage.
+        - the MetaLeaderboard table immediately visible above the fold.
+      Use a dark technical band or code-led surface from benchbox.dev only as
+      framing; do not let decorative copy push the leaderboard down.
+
+  - id: w4
+    summary: "Clarify supported vs published corpus stats in the home proof strip"
+    needs: [w3]
+    status: pending
+    notes: |
+      Replace ambiguous stat cards with explicit labels such as:
+        - "22 supported benchmarks"
+        - "N public result bundles"
+        - "N platforms with public results"
+        - "PR-validated corpus"
+      Avoid implying every supported benchmark has public leaderboard coverage.
+      If a value is unavailable from DuckDB metadata, compute it from existing
+      manifest/cohort tables or label it as "supported" rather than "published".
+
+  - id: w5
+    summary: "Add Run -> Compare -> Submit flywheel affordance without reducing data density"
+    needs: [w3]
+    status: pending
+    notes: |
+      Add a compact three-step strip or inline CTA cluster near the leaderboard:
+      "Run a benchmark", "Compare your result", "Submit a bundle". Each should
+      link to the existing docs/submission flow where available. This should be
+      secondary to the leaderboard, not a marketing section.
+
+  - id: w6
+    summary: "Define skeleton tokens and Home/Layout loading states"
+    needs: [w1, w3]
+    status: pending
+    notes: |
+      This item OWNS the skeleton design system: token names, animation,
+      sizing scale, and the Home + Layout consumers. The downstream
+      `explorer-performance-perceived-latency` item then applies the same
+      skeletons to MetaLeaderboard/BenchmarkIndex/Query/Compare without
+      redesigning them. Replace generic spinner-only states on Home and the
+      shell with dense skeletons that reserve final table geometry. Loading
+      should communicate that a static DuckDB snapshot is initializing,
+      without blocking the brand/header render.
+
+  - id: w7
+    summary: "Add automated DOM-order tests for first-viewport leaderboard hierarchy"
+    needs: [w2, w3, w4, w5]
+    status: pending
+    notes: |
+      Replace any reliance on manual smoke with mechanical assertions in
+      `Home.test.tsx` and `Layout.test.tsx`:
+        - The MetaLeaderboard region appears before any "Recent Results" or
+          submission CTA region in DOM order (`compareDocumentPosition` /
+          `getAllByRole` index check).
+        - The H1 text is exactly "BenchBox Database Leaderboards".
+        - Global nav exposes Docs, Blog, Results, GitHub, and the run/submit
+          CTA; the Results entry is visibly active when the route is `/`.
+        - Stat cards use explicit `supported` / `published` labels (no
+          ambiguous "benchmarks" copy).
+      These assertions back the manual browser smoke described under
+      `verification`; the DOM-order guarantee is what stops a future visual
+      edit from regressing first-impression hierarchy.
+
+metadata:
+  tags:
+    - explorer
+    - design-audit
+    - identity
+    - leaderboard
+    - landing-page-parity
+  estimated_effort: "Large (3-5 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Turns the explorer into a credible public acquisition surface while keeping
+    the leaderboard attention loop that attracts submissions.
+  user_impact: |
+    A benchmark user can understand within five seconds that BenchBox ranks
+    database platforms by reproducible workload evidence, and can immediately
+    start comparing platforms.
+  technical_debt: |
+    Establishes shared identity primitives instead of one-off Tailwind styling
+    scattered across page components.
+
+files_affected:
+  modified:
+    - "results-explorer/src/components/Layout.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/components/LoadingSpinner.tsx"
+    - "results-explorer/src/index.css"
+    - "results-explorer/src/pages/__tests__/Home.test.tsx"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+  added:
+    - "results-explorer/src/components/BrandShell.tsx"
+    - "results-explorer/src/components/__tests__/BrandShell.test.tsx"
+
+must_preserve:
+  - "The existing `/results/`, `/results/{benchmark}/`, `/results/p/{platform_id}/`, `/results/r/{result_id}`, `/results/compare`, and `/results/query` routes remain stable."
+  - "The MetaLeaderboard keeps Times/Ranks/Speedup modes and URL-backed filters from the completed home leaderboard work."
+  - "Recent Results remains accessible, but not ahead of the primary leaderboard on the home page."
+  - "Chart color encodings remain data-driven and accessible; brand colors must not become categorical chart colors by default."
+
+approach: |
+  Treat benchbox.dev as the source of brand expression and the explorer as the
+  data-dense product surface. Start by extracting the shared shell/tokens, then
+  rearrange Home so leaderboard data appears before submission/list chrome. Use
+  density from llm-stats for the table treatment, but keep BenchBox's code-first
+  credibility from the landing page. Test DOM order and labels so later visual
+  edits cannot regress the first-impression hierarchy.
+
+anti_patterns:
+  - "DO NOT build a marketing landing page inside `/results/` - because users came for benchmark answers - make the leaderboard the first usable screen."
+  - "DO NOT copy LLM leaderboard language such as model/provider/token throughput - because BenchBox benchmarks database platforms - translate labels to platform, workload, latency, throughput, load time, and cost."
+  - "DO NOT use a single dark/purple palette across charts and brand chrome - because data encodings need semantic contrast - keep brand tokens and chart tokens separate."
+  - "DO NOT hide submission CTAs entirely - because leaderboard attention feeds the submission flywheel - place them as compact secondary affordances near the data."
+
+verification:
+  - description: "Frontend typecheck, unit tests, and production build pass."
+    command: "cd results-explorer && npm run typecheck && npm test && npm run build"
+    expected_output: "All commands pass with new Home/Layout coverage."
+  - description: "Manual browser smoke at desktop and mobile widths."
+    command: "cd results-explorer && npm run dev"
+    expected_output: "`/results/` shows BenchBox Database Leaderboards, global nav, cohort filters, and the leaderboard in the first viewport at desktop; mobile shows headline, compact controls, and leaderboard entry before Recent Results."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/index.css"
+    - "results-explorer/src/pages/__tests__/Home.test.tsx"
+    - "results-explorer/src/components/__tests__/"
+  do_not_modify:
+    - "landing/"  # tokens are extracted into the explorer; landing itself is not edited

--- a/_project/TODO/main/planning/explorer-mobile-density-responsive-tables.yaml
+++ b/_project/TODO/main/planning/explorer-mobile-density-responsive-tables.yaml
@@ -1,0 +1,177 @@
+id: explorer-mobile-density-responsive-tables
+title: "Explorer: mobile-responsive dense leaderboard, filters, and charts"
+worktree: main
+priority: "Medium-High"
+status: "Not Started"
+category: "User Experience"
+
+deps:
+  needs:
+    - explorer-leaderboard-first-identity-unification
+    - explorer-selection-facets-coverage-at-scale
+    - explorer-chart-correctness-and-navigation
+
+description: |
+  Make the Results Explorer usable below 768px without simply stacking all
+  filters before all data. The audit found that the mobile first viewport can
+  show hero/stat/submission chrome before the leaderboard, benchmark heatmaps can
+  clip horizontally, and Query Workbench filters can dominate the screen before
+  users see any rows. The mobile design should preserve the leaderboard-first
+  identity while adapting dense tables into scrollable, card, or tabular
+  patterns with explicit affordances.
+
+work:
+  - id: w1
+    summary: "Define responsive breakpoint tokens and table-vs-card decision rule"
+    status: pending
+    notes: |
+      Add `--bb-bp-mobile`, `--bb-bp-tablet`, `--bb-bp-desktop` to
+      `index.css` (consistent with the brand tokens added by the upstream
+      identity unification work). Document the rule "use horizontal table
+      scroll above the mobile breakpoint when the table has a stable sticky
+      first column; below it, fall back to compact platform cards" once, in
+      a CSS comment near the breakpoint tokens. No page edits.
+
+  - id: w2
+    summary: "Apply mobile DOM order on Home: headline, cohort summary, leaderboard, then chrome"
+    needs: [w1]
+    status: pending
+    notes: |
+      At 390px width, the Home page must render in this DOM order: headline,
+      active cohort/filter summary, first leaderboard rows (or the compact
+      ResponsiveDataTable card variant), and only after that any Recent
+      Results or submission CTA strip. Pull leaderboard ordering from the
+      desktop rules established in `explorer-leaderboard-first-identity-
+      unification` w7 — do not redefine them.
+
+  - id: w3
+    summary: "Style the FacetDrawer for narrow widths"
+    status: pending
+    notes: |
+      The FacetDrawer COMPONENT is owned by `explorer-selection-facets-
+      coverage-at-scale` w6. This work unit ONLY adds narrow-width styling
+      (full-screen sheet behavior, swipe-to-dismiss optional, focus trap when
+      open). It must not change the drawer's prop shape or the facet model.
+
+  - id: w4
+    summary: "Add closed-state summary chip strip and live result count to drawer trigger"
+    needs: [w3]
+    status: pending
+    notes: |
+      The drawer trigger button shows active filter chips and live result
+      count BEFORE the user opens it. Result count comes from the same
+      `facetsToWhereClause` count query the desktop rail uses; do not run a
+      separate count query just for the mobile trigger.
+
+  - id: w5
+    summary: "Make benchmark matrices and heatmaps responsive without silent clipping"
+    status: pending
+    notes: |
+      QueryHeatmap/benchmark matrices should use sticky row labels, stable cell
+      dimensions, and an explicit horizontal overflow affordance. On very narrow
+      screens, provide a list/card fallback grouped by platform with query
+      outliers and aggregate metric.
+
+  - id: w6
+    summary: "Put Query Workbench results before deep filter controls on mobile"
+    needs: [w4]
+    status: pending
+    notes: |
+      Query page mobile order should be: title/result count, active filters,
+      table rows or SQL panel tabs, then full filters in a drawer. The default
+      should not require scrolling past every facet before seeing data.
+
+  - id: w7
+    summary: "Make chart controls wrap into stable segmented controls at small widths"
+    status: pending
+    notes: |
+      Chart group controls should remain tappable and not overflow. Use icon or
+      short labels where necessary, with accessible names. Do not let chart chips
+      resize the chart area on selection.
+
+  - id: w8
+    summary: "Add Playwright responsive assertions (not just screenshots) for DOM order, density, and overflow"
+    needs: [w2, w4, w5, w6, w7]
+    status: pending
+    notes: |
+      Mechanical assertions, not screenshot-only smokes. For `/results/`,
+      `/results/star_schema/?phase=standard`, `/results/query`, and
+      `/results/compare?ids=...`, at 390px AND 1440px:
+        - Headline + cohort summary + first leaderboard row are within the
+          first 800px of scroll on desktop and within the first 1200px on
+          mobile (use `boundingBox().y`).
+        - At 1440px, MetaLeaderboard renders >= 8 rows above the fold (desktop
+          density assertion — fails if mobile responsive rules accidentally
+          truncate the desktop layout).
+        - QueryHeatmap container reports `scrollWidth > clientWidth` ⇒ a
+          visible scroll-hint element exists in the DOM.
+        - FacetDrawer trigger shows the live result count attribute before the
+          drawer is opened.
+      Screenshots stay as a secondary regression net.
+
+metadata:
+  tags:
+    - explorer
+    - mobile
+    - responsive
+    - density
+  estimated_effort: "Medium-Large (2-4 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Keeps public leaderboard links usable when shared socially or opened on
+    mobile devices.
+  user_impact: |
+    Users can scan winners, filters, and top differences without fighting a
+    desktop table squeezed into a phone viewport.
+  technical_debt: |
+    Establishes reusable responsive patterns for dense data surfaces instead of
+    page-by-page overflow fixes.
+
+files_affected:
+  modified:
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/index.css"
+  added:
+    - "results-explorer/src/components/MobileFilterDrawer.tsx"
+    - "results-explorer/src/components/ResponsiveDataTable.tsx"
+    - "results-explorer/e2e/responsive.spec.ts"
+
+must_preserve:
+  - "Desktop density does not regress: at 1440px, MetaLeaderboard renders at least 8 rows above the fold (asserted by w8 Playwright check)."
+  - "Keyboard navigation and accessible labels remain available for tables, drawers, and charts."
+  - "URL state remains the source of active filters across responsive layouts (no mobile-only state shadow)."
+  - "Horizontal scroll, where used, is explicit and keeps row/header context visible (sticky first column + visible scroll-hint element)."
+  - "FacetDrawer prop API and the underlying facet model from `explorer-selection-facets-coverage-at-scale` w6 are not modified by this work."
+
+approach: |
+  Implement responsive primitives once, then use them on Home, BenchmarkIndex,
+  Query, and Compare. Start with CSS/layout and DOM ordering before adding new
+  components. Validate with Playwright at representative widths because visual
+  regressions here are hard to catch with unit tests alone.
+
+anti_patterns:
+  - "DO NOT put all filters above all data on mobile - because it hides the leaderboard answer - show active filters and result count first, full filters in a drawer."
+  - "DO NOT silently clip heatmaps - because users cannot tell more columns exist - add sticky labels and visible overflow affordance or a card fallback."
+  - "DO NOT reduce desktop table density to solve mobile - because desktop is the primary analysis surface - use responsive variants."
+
+verification:
+  - description: "Frontend typecheck, unit tests, and build pass."
+    command: "cd results-explorer && npm run typecheck && npm test && npm run build"
+    expected_output: "All commands pass after responsive component changes."
+  - description: "Responsive Playwright smoke passes."
+    command: "cd results-explorer && npm run test:e2e:chromium"
+    expected_output: "Chromium e2e tests pass at configured desktop and mobile viewports."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/"
+    - "results-explorer/e2e/"
+    - "results-explorer/playwright.config.ts"

--- a/_project/TODO/main/planning/explorer-performance-perceived-latency.yaml
+++ b/_project/TODO/main/planning/explorer-performance-perceived-latency.yaml
@@ -1,0 +1,157 @@
+id: explorer-performance-perceived-latency
+title: "Explorer: DuckDB-WASM load performance and perceived-latency hardening"
+worktree: main
+priority: "Medium-High"
+status: "Not Started"
+category: "Performance"
+
+deps:
+  needs:
+    - explorer-leaderboard-first-identity-unification
+    - explorer-selection-facets-coverage-at-scale
+
+description: |
+  Improve the performance feel of the static DuckDB-WASM explorer as the corpus
+  grows. The audit called out cold-load, query response, loading skeletons, and
+  pagination behavior as risks. This item focuses on perceived latency and
+  runtime cost, not visual redesign: initialize predictably, avoid avoidable
+  repeated scans, keep table rendering bounded, and instrument the expensive
+  paths so regressions are visible.
+
+work:
+  - id: w1
+    summary: "Measure DuckDB-WASM cold load and first meaningful leaderboard render"
+    status: pending
+    notes: |
+      Add lightweight browser performance marks around DB initialization in
+      `results-explorer/src/db.ts`, first Home leaderboard data resolution, and
+      first rendered table/chart. Log only in development or expose a debug panel
+      behind an explicit flag so production UI stays clean.
+
+  - id: w2
+    summary: "Apply identity-owned skeletons to MetaLeaderboard, BenchmarkIndex, Query, and Compare"
+    status: pending
+    notes: |
+      Skeleton TOKENS and the Home/Layout skeleton treatment are owned by
+      `explorer-leaderboard-first-identity-unification` w6. This work unit
+      only consumes those tokens to reserve final-geometry skeletons for
+      MetaLeaderboard, benchmark matrices, Query Workbench rows, and Compare
+      summary. Do not redefine skeleton primitives here; if a new skeleton
+      shape is needed, add it to the upstream identity work and consume it.
+
+  - id: w3
+    summary: "Bound large table rendering with pagination, limits, or virtualization"
+    status: pending
+    notes: |
+      Query Workbench already has default/unlimited row limit. Audit all table
+      surfaces for unbounded rendering and add explicit limits where corpus
+      growth can create thousands of rows. Show visible result counts and
+      "show more" affordances rather than rendering everything by default.
+
+  - id: w4
+    summary: "Batch or cache facet/count queries that repeat across pages"
+    status: pending
+    notes: |
+      Review `duckdbQueries.ts`, `queryFilters.ts`, Home, BenchmarkIndex,
+      PlatformIndex, and Query for repeated COUNT/DISTINCT queries. Cache stable
+      metadata for the lifetime of the loaded DuckDB snapshot and invalidate
+      only when filters change.
+
+  - id: w5
+    summary: "Add Playwright performance smoke with concrete budgets"
+    needs: [w1, w3, w4]
+    status: pending
+    notes: |
+      Provisional budgets, measured against the generated fixture corpus on a
+      GitHub Actions Ubuntu runner with the project's standard Chromium build:
+        - DuckDB-WASM cold init (`db-init` performance mark): P50 < 4000 ms,
+          P95 < 6000 ms
+        - First Home leaderboard data resolved (`leaderboard-data-ready`):
+          P50 < 1500 ms after `db-init`, P95 < 2500 ms
+        - First leaderboard render (`leaderboard-rendered`):
+          P50 < 500 ms after `leaderboard-data-ready`, P95 < 1000 ms
+        - First Query Workbench paint with default DEFAULT_COLUMNS:
+          P50 < 600 ms, P95 < 1200 ms after `db-init`
+      Run the smoke 10 times, fail on the P95 threshold, surface the P50 in
+      the test report. Tolerance is built into the gap between P50 and P95;
+      no extra slack. If a budget is genuinely wrong the fix is to revise it
+      in this file with rationale, not to widen tolerance silently.
+
+  - id: w6
+    summary: "Add fixture determinism guard"
+    needs: [w5]
+    status: pending
+    notes: |
+      `npm run test:e2e:fixtures` already generates fixtures. Add a check
+      that re-running fixture generation produces byte-identical output (or
+      a documented allow-list of timestamp fields), so the perf smoke is
+      not measuring regenerated fixtures with shifting row counts.
+
+metadata:
+  tags:
+    - explorer
+    - performance
+    - duckdb-wasm
+    - perceived-latency
+  estimated_effort: "Medium (2-3 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Keeps the public explorer feeling credible and responsive as public result
+    bundles scale from dozens to hundreds or thousands.
+  user_impact: |
+    Users see useful structure quickly during cold load and avoid browser jank
+    while filtering or opening large result tables.
+  technical_debt: |
+    Adds performance instrumentation and bounded rendering patterns before
+    large-corpus behavior becomes a production incident.
+
+files_affected:
+  modified:
+    - "results-explorer/src/db.ts"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/lib/queryFilters.ts"
+    - "results-explorer/src/components/LoadingSpinner.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+  added:
+    - "results-explorer/src/lib/performanceMarks.ts"
+    - "results-explorer/e2e/performance.spec.ts"
+
+must_preserve:
+  - "DuckDB-WASM remains loaded client-side from the static explorer bundle."
+  - "Production UI does not show debug timing unless explicitly enabled."
+  - "Query Workbench retains an intentional unlimited mode for users who request it."
+  - "Generated browser fixtures remain deterministic."
+
+approach: |
+  Measure first, then optimize the specific hot paths. Prefer simple memoization,
+  query batching, and bounded rendering before adding complex virtualization.
+  Use skeletons to improve perceived performance even when cold-load time cannot
+  be eliminated.
+
+anti_patterns:
+  - "DO NOT optimize by removing methodology/trust data from the first page - because trust context is part of the product - optimize queries and rendering instead."
+  - "DO NOT render every row by default just because DuckDB can return it - because DOM rendering is the likely bottleneck - use limits and explicit expansion."
+  - "DO NOT add noisy production console timing - because public visitors should not see debug instrumentation - gate it."
+
+verification:
+  - description: "Frontend typecheck, tests, fixture generation, and build pass."
+    command: "cd results-explorer && npm run typecheck && npm test && npm run test:e2e:fixtures && npm run build"
+    expected_output: "All commands pass with performance instrumentation and bounded rendering."
+  - description: "Performance smoke passes within budgets defined in w5."
+    command: "cd results-explorer && npm run test:e2e:chromium"
+    expected_output: "Chromium performance smoke passes; P95 budgets in w5 are met or exceeded with margin. Test output reports both P50 and P95 for each mark."
+  - description: "Fixture generation is deterministic across two consecutive runs."
+    command: "cd results-explorer && npm run test:e2e:fixtures && cp -r dist-fixtures dist-fixtures.first && npm run test:e2e:fixtures && diff -r dist-fixtures dist-fixtures.first"
+    expected_output: "No diff (or diff limited to a documented allow-list of timestamp fields)."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/"
+    - "results-explorer/e2e/"
+    - "results-explorer/scripts/"

--- a/_project/TODO/main/planning/explorer-run-receipt-methodology-disclosure.yaml
+++ b/_project/TODO/main/planning/explorer-run-receipt-methodology-disclosure.yaml
@@ -1,0 +1,155 @@
+id: explorer-run-receipt-methodology-disclosure
+title: "Explorer: prominent run receipt and methodology disclosure"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Result Integrity"
+
+description: |
+  Add a trust-forward "Run Receipt" pattern to result detail, compare, and
+  leaderboard surfaces. The hostile-reader test for database benchmarks is
+  straightforward: a vendor will attack hardware, version pinning, validation,
+  tuning, cost normalization, and query scope before accepting the ranking.
+  Today much of that context is either low in the page, collapsed, inconsistently
+  labeled, or absent from compare/leaderboard contexts.
+
+  The design goal is not more prose. It is an auditable receipt: command,
+  benchmark/scale/phase, platform and driver version, environment, validation,
+  tuning, cost model, artifact IDs, bundle link, and eventually plan artifacts.
+
+work:
+  - id: w1
+    summary: "Design and implement compact RunReceipt component for result detail"
+    status: pending
+    notes: |
+      Add `results-explorer/src/components/RunReceipt.tsx`. It should render a
+      dense two-column receipt with sections:
+        - Workload: benchmark, scale factor, phase/test type, query count,
+          sample count.
+        - Platform: platform, platform version, driver version, execution mode,
+          tuning mode/hash.
+        - Environment: OS, arch, CPU count, memory, Python.
+        - Integrity: trust label, visibility, validation status, compliance
+          class, ranking eligibility.
+        - Artifacts: result ID, short ID if available, bundle download, plans
+          availability, reproduce command if available.
+        - Cost: normalized cost status/model/scope once available.
+
+  - id: w2
+    summary: "Promote methodology from lower-page disclosure to above-the-fold trust panel"
+    needs: [w1]
+    status: pending
+    notes: |
+      On ResultDetail, place RunReceipt adjacent to or immediately below the
+      primary metric summary. MethodologyDisclosure can remain for deeper text,
+      but the receipt must be visible before charts/timing tables on desktop and
+      reachable before raw samples on mobile.
+
+  - id: w3
+    summary: "Add compare-page comparability receipt for selected result set"
+    needs: [w1]
+    status: pending
+    notes: |
+      THIS ITEM OWNS the ComparabilityReceipt component. The downstream
+      `explorer-compare-decision-summary` item consumes it (its w4 cohort
+      guardrails render through this component) but does not redefine its
+      API. In Compare.tsx, render a compact comparability strip showing which
+      fields are identical across selected runs and which differ: benchmark,
+      scale factor, phase, date window, platform versions, driver versions,
+      tuning, validation, cost model, environment. Differences are explicit
+      warnings, not buried in row metadata.
+
+  - id: w4
+    summary: "Surface methodology links from leaderboard rows and benchmark matrices"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add small trust/receipt affordances to row headers or result links in
+      MetaLeaderboard, BenchmarkIndex, and PlatformIndex: trust badge,
+      validation status, and quick link to the result detail receipt. Keep it
+      compact enough for dense tables.
+
+  - id: w5
+    summary: "Prepare execution-plan affordance without requiring public plans in this phase"
+    needs: [w1]
+    status: pending
+    notes: |
+      If `has_plans` is true, show "Plans available" linking to the future plan
+      viewer/download route if present. If false, show "Plans not published" in
+      the receipt. Do not implement a full plan viewer in this TODO.
+
+  - id: w6
+    summary: "Add tests for receipt labels, count semantics, and compare warnings"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Tests should assert that query count and sample count are separate, bundle
+      links render, validation/trust fields render, and compare warnings appear
+      when selected runs differ in benchmark/scale/tuning/environment.
+
+metadata:
+  tags:
+    - explorer
+    - methodology
+    - trust
+    - reproducibility
+  estimated_effort: "Medium-Large (2-4 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Makes public rankings harder to dismiss and gives vendors/contributors a
+    clear path to reproduce or challenge a result constructively.
+  user_impact: |
+    Users can decide whether a benchmark result is relevant and trustworthy
+    without hunting through raw JSON or collapsed methodology text.
+  technical_debt: |
+    Centralizes methodology rendering in reusable components instead of spreading
+    trust copy across pages.
+
+files_affected:
+  modified:
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/MethodologyDisclosure.tsx"
+    - "results-explorer/src/components/TrustBadge.tsx"
+    - "results-explorer/src/types.ts"
+  added:
+    - "results-explorer/src/components/RunReceipt.tsx"
+    - "results-explorer/src/components/ComparabilityReceipt.tsx"
+    - "results-explorer/src/components/__tests__/RunReceipt.test.tsx"
+    - "results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx"
+
+must_preserve:
+  - "Existing MethodologyDisclosure tests continue to pass or are migrated to the new receipt/disclosure split."
+  - "Bundle download URLs and result detail URLs remain stable."
+  - "TrustBadge semantics remain consistent across home, benchmark, platform, compare, and detail pages."
+  - "Execution plans remain a follow-on; this item only exposes availability/status."
+
+approach: |
+  Build the receipt as a reusable display component fed by existing DetailResult
+  fields. Add compare-specific aggregation separately so one result receipt does
+  not grow conditional compare logic. Keep the visual treatment compact:
+  12-13px labels, 13-14px values, strong section labels, no paragraph-heavy
+  methodology in the primary surface.
+
+anti_patterns:
+  - "DO NOT bury hardware/version/tuning/cost context below charts - because these are the first things a skeptical database engineer will attack - show a receipt near the primary metrics."
+  - "DO NOT add long methodology prose to leaderboard rows - because it destroys density - use badges and links there, full receipt on detail."
+  - "DO NOT imply plans are public when `has_plans` is false - because execution plans are a follow-on phase - show explicit unavailable status."
+
+verification:
+  - description: "Frontend typecheck and component/page tests pass."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "All tests pass, including RunReceipt and ComparabilityReceipt coverage."
+  - description: "Manual detail and compare smoke."
+    command: "cd results-explorer && npm run dev"
+    expected_output: "`/results/r/{id}` shows Run Receipt above timing tables; `/results/compare?ids=...` shows comparability warnings before detailed charts."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/"
+    - "results-explorer/src/components/"
+    - "results-explorer/src/types.ts"

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -1,0 +1,233 @@
+id: explorer-selection-facets-coverage-at-scale
+title: "Explorer: selection-oriented facets and coverage signals for large public corpus"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Core Functionality"
+
+deps:
+  needs:
+    - explorer-leaderboard-first-identity-unification
+
+description: |
+  Reframe the explorer from "pick a benchmark and browse rows" toward
+  "which platform should I pick for this workload at this scale and deployment
+  shape" while preserving the leaderboard browser. The public corpus is expected
+  to grow to hundreds or thousands of result bundles, so the current filters and
+  tables need scalable faceting, coverage disclosure, and URL-persistent state.
+
+  Missing benchmark coverage must not penalize cross-benchmark ranking, per
+  product direction, but missing coverage must be visually obvious. A platform's
+  aggregate should therefore be "average rank over covered cohorts" with
+  coverage badges and missing cells, not a zero/last-place penalty.
+
+work:
+  - id: w1
+    summary: "Define shared facet model and URL contract in lib/facetModel.ts"
+    status: pending
+    notes: |
+      Add `results-explorer/src/lib/facetModel.ts` exporting:
+        - a `FacetKey` union (benchmark, scale_factor, phase, platform,
+          execution_mode, tuning_mode, trust_tier, validation_status,
+          deployment_class, cloud_provider, cloud_region, instance_or_warehouse,
+          storage_format, cost_status, date_window)
+        - per-key URL serializer/parser pairs that round-trip through
+          `useUrlState`
+        - a `FacetState` type and a single `facetsToWhereClause` helper
+      Add `lib/__tests__/facetModel.test.ts` covering URL round-trip for every
+      key. No page edits in this unit; downstream units consume the model.
+
+  - id: w2
+    summary: "Migrate Home page to shared facet model"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace Home-local filter state with `useFacetState()`. URL must round-trip
+      benchmark, scale_factor, phase, platform, deployment_class, cost_status.
+      Leaderboard query consumes `facetsToWhereClause`. No new UI components;
+      this is a state-layer migration only.
+
+  - id: w3
+    summary: "Migrate BenchmarkIndex page to shared facet model"
+    needs: [w1]
+    status: pending
+    notes: |
+      Same migration shape as w2; restrict default facets to those meaningful
+      for a single-benchmark page (scale_factor, phase, platform, tuning_mode,
+      validation_status, deployment_class, cloud_provider, cost_status,
+      date_window).
+
+  - id: w4
+    summary: "Migrate PlatformIndex page to shared facet model"
+    needs: [w1]
+    status: pending
+    notes: |
+      Default facets: benchmark, scale_factor, phase, deployment_class,
+      cloud_provider, cloud_region, cost_status, date_window. Preserve cohort
+      grouping introduced by `explorer-critical-results-ux-defects` w3.
+
+  - id: w5
+    summary: "Migrate Compare and Query pages to shared facet model"
+    needs: [w1]
+    status: pending
+    notes: |
+      Compare uses facets to bound the candidate-result picker. Query Workbench
+      surfaces facets as starter-query toggles plus a column picker hint.
+
+  - id: w6
+    summary: "Add FacetRail desktop component and FacetDrawer mobile shell"
+    needs: [w1]
+    status: pending
+    notes: |
+      THIS ITEM OWNS the FacetDrawer component. The downstream
+      `explorer-mobile-density-responsive-tables` item styles the drawer for
+      narrow widths but does not redefine its API. Desktop renders FacetRail
+      (grouped facets, counts, search-within-platforms, active-chip strip,
+      one-click reset). Mobile renders FacetDrawer with a closed-state summary
+      showing active chips and live result count.
+
+  - id: w7
+    summary: "Represent missing cohort coverage explicitly in MetaLeaderboard and benchmark matrices"
+    needs: [w1]
+    status: pending
+    notes: |
+      In MetaLeaderboard, missing platform/cohort cells should render as a muted
+      "No run" state with a tooltip explaining that missing coverage is not
+      counted in average rank. Add coverage badges like "7/12 cohorts" and sort
+      controls for avg rank, coverage, best cohort, and recent activity.
+
+  - id: w8
+    summary: "Change aggregate labels to 'Avg rank over covered cohorts' and expose coverage denominator"
+    needs: [w7]
+    status: pending
+    notes: |
+      The label must make the no-penalty coverage policy explicit. Tooltips
+      should say: "Missing cohorts are not scored; coverage is shown separately."
+      Avoid generic "overall rank" copy unless it is mathematically a complete
+      cohort set.
+
+  - id: w9
+    summary: "Add coverage-aware empty states and reset affordances"
+    needs: [w6, w7]
+    status: pending
+    notes: |
+      If a filter combination has no rows, show which facet combination removed
+      all results and offer "Clear scale factor", "Clear platform", and
+      "Reset all" actions. If a platform lacks coverage in a selected cohort,
+      show "No published run for this cohort" rather than a blank cell.
+
+  - id: w10
+    summary: "Audit duckdbQueries/queryFilters for expensive scans and add memoization"
+    needs: [w1]
+    status: pending
+    notes: |
+      Review `results-explorer/src/lib/duckdbQueries.ts` and `queryFilters.ts`
+      for full scans on every filter change and repeated COUNT/DISTINCT calls.
+      Memoize stable metadata for the lifetime of the loaded DuckDB snapshot
+      and invalidate only when the underlying snapshot URL changes.
+
+  - id: w11
+    summary: "Add pagination/limit behavior for tables that can grow to thousands of rows"
+    needs: [w2, w3, w4, w5]
+    status: pending
+    notes: |
+      Audit each migrated page's table renderer for unbounded row rendering.
+      Add a default LIMIT (e.g. 200) plus "Show more" controls. Keep the result
+      count and selected cohort count visible at all times so users see what
+      they are paging through.
+
+  - id: w12
+    summary: "Add regression tests for URL persistence, coverage labels, and no-penalty ranking"
+    needs: [w7, w8, w9, w10, w11]
+    status: pending
+    notes: |
+      Tests should cover:
+        - URL state restores all primary facets.
+        - Missing cohorts render as missing coverage, not rank penalty.
+        - Average rank uses only covered cohorts and displays denominator.
+        - Empty state offers specific reset actions.
+
+metadata:
+  tags:
+    - explorer
+    - faceting
+    - coverage
+    - scalability
+    - product-ia
+  estimated_effort: "Large (4-6 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Makes the public leaderboard durable as the corpus grows, without losing
+    the simple attention-grabbing ranking surface.
+  user_impact: |
+    Benchmark users can narrow results by workload/deployment constraints and
+    see whether a platform's strong rank is broad coverage or a narrow cohort.
+  technical_debt: |
+    Consolidates filter semantics and URL state instead of each page developing
+    incompatible facet behavior.
+
+files_affected:
+  modified:
+    - "results-explorer/src/lib/useUrlState.ts"
+    - "results-explorer/src/lib/queryFilters.ts"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+  added:
+    - "results-explorer/src/components/FacetRail.tsx"
+    - "results-explorer/src/components/CoverageBadge.tsx"
+    - "results-explorer/src/lib/facetModel.ts"
+
+must_preserve:
+  - "Existing benchmark, platform, compare, result detail, and query URLs remain backwards compatible."
+  - "Missing coverage does not lower a platform's average rank."
+  - "Ranking eligibility rules from `benchbox.core.explorer_pipeline.models` remain the source of official-vs-visible distinction."
+  - "The Query Workbench continues to allow raw SQL for users who need escape-hatch analysis."
+
+approach: |
+  Start with a shared facet model and URL contract, then migrate pages one at a
+  time. Keep the main leaderboard dense by showing active filters as compact
+  chips and pushing long option lists into a rail/drawer. Coverage should be a
+  first-class metric adjacent to rank, not an explanatory footnote. Use DuckDB
+  aggregation for counts and coverage so the browser does not compute large
+  result sets in JavaScript.
+
+anti_patterns:
+  - "DO NOT compute coverage by treating missing cells as worst rank - because product direction says missing coverage is not penalized - show coverage separately."
+  - "DO NOT create page-specific names for the same facet - because URLs and mental models will diverge - use a shared facet model."
+  - "DO NOT render thousands of table rows eagerly - because the corpus will grow - paginate, limit, or virtualize before client-side rendering."
+  - "DO NOT hide reset controls in an empty state - because filtered no-results states are common in faceted search - surface targeted clears."
+
+verification:
+  - description: "Frontend typecheck and tests pass."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "All existing and new facet/coverage tests pass."
+  - description: "Browser build succeeds against generated DuckDB fixtures."
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build"
+    expected_output: "Fixture generation, fixture verification, and Vite build complete without errors."
+  - description: "Visible metrics parity remains canonical with Python."
+    command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline/test_visible_metrics_registry.py -q"
+    expected_output: "Registry parity test passes — every facet/metric exposed in the explorer is sourced from the Python pipeline contract, not the TypeScript code."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/lib/"
+    - "results-explorer/src/components/"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/lib/__tests__/"
+    - "benchbox/core/explorer_pipeline/"
+    - "tests/unit/core/explorer_pipeline/"
+    - "_project/planning/visible_metrics.yaml"

--- a/_project/TODO/main/planning/results-normalized-cost-contract-cloud-facets.yaml
+++ b/_project/TODO/main/planning/results-normalized-cost-contract-cloud-facets.yaml
@@ -1,0 +1,206 @@
+id: results-normalized-cost-contract-cloud-facets
+title: "Results pipeline: normalized cost contract and cloud deployment facets"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Result Integrity"
+
+description: |
+  Make cost usable for ranking, filtering, and trust. Product direction is that
+  cost must be normalized by BenchBox and not supplied directly by submitters.
+  Cloud region, instance/warehouse shape, storage, and pricing model facets must
+  be captured in benchmark results and filterable in the explorer.
+
+  Current UI evidence shows an inconsistent cost story: Query Workbench can
+  report "Has cost yes(...)" when `cost_usd` is present, while benchmark chart
+  copy can still say no cost data is available; local/self-hosted rows may
+  appear as `0` even though the comparison needs to distinguish "normalized
+  zero cloud compute cost" from "no normalized cost model available."
+
+work:
+  - id: w1
+    summary: "Define normalized cost data classes and Python contract test fixture"
+    status: pending
+    notes: |
+      In `benchbox/core/cost/models.py`, add a `NormalizedCost` data class with
+      the canonical fields:
+        - `normalized_cost_usd: Decimal`
+        - `cost_model_version: str` (e.g. `"2026.05.0"`)
+        - `cost_model_source: str` (e.g. `"benchbox.core.cost.pricing"`)
+        - `cost_scope: Literal["compute_only", "compute_plus_storage"]`
+        - `cost_status: Literal["normalized", "not_applicable_local", "unavailable"]`
+        - `billing_unit: str`
+        - `pricing_region: str`
+      Add a `DeploymentMetadata` block with `cloud_provider`, `cloud_region`,
+      `instance_type`, `warehouse_size`, `node_count`, `cluster_size`,
+      `storage_format`, `storage_tier`. Add
+      `tests/unit/core/explorer_pipeline/test_normalized_cost_contract.py`
+      with fixtures covering all three cost statuses. No transformer/DuckDB
+      wiring in this unit.
+
+  - id: w2
+    summary: "Document cost_usd compatibility decision (alias vs hard migrate)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Locks the open decision in `must_preserve`. RECOMMENDED resolution:
+      retain `cost_usd` as a read-only deprecated alias populated from
+      `normalized_cost_usd` when `cost_status == "normalized"` and `cost_scope
+      == "compute_only"`, and `None` otherwise. Document the decision in the
+      `NormalizedCost` docstring and in
+      `test_normalized_cost_contract.py::test_cost_usd_alias_behavior`. If the
+      user prefers a hard break instead, replace this work unit with a
+      migration of every `cost_usd` consumer in the same PR.
+
+  - id: w3
+    summary: "Wire normalized cost through bundle reader and explorer pipeline transformer"
+    needs: [w1]
+    status: pending
+    notes: |
+      Touch `benchbox/core/explorer_pipeline/models.py` and `transformer.py`.
+      The transformer must emit either a populated `NormalizedCost` block or
+      an explicit `cost_status="unavailable"` row; no implicit nulls or
+      partially-populated cost objects. Extend pipeline tests to cover all
+      three cost statuses.
+
+  - id: w4
+    summary: "Wire normalized cost through DuckDB builder and visible metrics registry"
+    needs: [w3]
+    status: pending
+    notes: |
+      Touch `benchbox/core/explorer_pipeline/duckdb_builder.py` and
+      `_project/planning/visible_metrics.yaml`. Add parity tests so every
+      visible cost/deployment field is either a raw bundle copy or a
+      documented derived value with a canonical Python reference. Update
+      `test_visible_metrics_registry.py` accordingly.
+
+  - id: w5
+    summary: "Integrate normalized cost with existing benchbox.core.cost calculators"
+    needs: [w1]
+    status: pending
+    notes: |
+      Reuse `benchbox/core/cost/models.py`, `calculator.py`, and `pricing.py`.
+      Cost should be computed from measured usage/resource configuration plus
+      BenchBox pricing tables, not from arbitrary submitter-supplied totals.
+      Add validation errors or warnings when a cloud run lacks the provider,
+      region, warehouse/instance, or billing-unit metadata required to normalize.
+
+  - id: w6
+    summary: "Add cloud/deployment facets to explorer filters and Query Workbench"
+    needs: [w4]
+    status: pending
+    notes: |
+      Add filters for cloud provider, region, instance/warehouse shape, storage
+      format, cost status, and cost model version. Query Workbench should expose
+      these columns in schema/column picker and starter queries. Cost filters
+      should distinguish `normalized`, `not_applicable_local`, and `unavailable`.
+
+  - id: w7
+    summary: "Update cost visualizations to use normalized cost and disclose model version"
+    needs: [w4]
+    status: pending
+    notes: |
+      Update `CostScatter`, benchmark pages, compare pages, and home leaderboard
+      metrics so any cost chart labels axes as normalized USD with scope and
+      model version. When no normalized cost exists, empty-state copy should
+      say which metadata is missing, not just "No cost data available."
+
+  - id: w8
+    summary: "Add submission validation that rejects user-supplied public leaderboard cost totals"
+    needs: [w5]
+    status: pending
+    notes: |
+      Public submissions should provide resource/deployment metadata; BenchBox
+      computes normalized cost. Add validator tests using fixtures that attempt
+      to submit `cost.total_usd` directly without normalized-cost provenance.
+
+  - id: w9
+    summary: "Backfill or explicitly mark existing public fixtures by cost status"
+    needs: [w4, w7]
+    status: pending
+    notes: |
+      Existing rows should not silently appear as comparable normalized cost if
+      the metadata is missing. Backfill local rows as `not_applicable_local`
+      where valid, and cloud rows as `unavailable` until enough metadata exists.
+
+metadata:
+  tags:
+    - cost
+    - explorer
+    - cloud
+    - result-schema
+    - trust
+  estimated_effort: "Large (5-8 days)"
+  created_date: "2026-05-01"
+
+impact:
+  business_value: |
+    Enables credible price/performance ranking and cloud-region filtering, which
+    are central to database selection decisions.
+  user_impact: |
+    Users can compare latency and cost without guessing whether a number is
+    submitter-supplied, local-zero, or normalized by BenchBox.
+  technical_debt: |
+    Replaces an overloaded `cost_usd` field with an auditable cost model and
+    explicit deployment facets.
+
+files_affected:
+  modified:
+    - "benchbox/core/cost/models.py"
+    - "benchbox/core/cost/calculator.py"
+    - "benchbox/core/cost/pricing.py"
+    - "benchbox/core/explorer_pipeline/models.py"
+    - "benchbox/core/explorer_pipeline/transformer.py"
+    - "benchbox/core/explorer_pipeline/duckdb_builder.py"
+    - "_project/planning/visible_metrics.yaml"
+    - "results-explorer/src/types.ts"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/lib/queryFilters.ts"
+    - "results-explorer/src/components/CostScatter.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+  added:
+    - "tests/unit/core/explorer_pipeline/test_normalized_cost_contract.py"
+    - "results-explorer/src/components/CostModelBadge.tsx"
+
+must_preserve:
+  - "Existing result bundles without normalized cost continue to load with explicit unavailable status."
+  - "Local/self-hosted platforms are not shown as cloud-cost comparable unless the cost scope explains what is included."
+  - "Visible metrics parity remains Python-canonical; TypeScript must not become the cost reference implementation."
+  - "Existing `cost_usd` consumers keep working through the read-only alias defined in w2 (alias is `None` outside `compute_only` normalized cost). Decision is locked in w2 before downstream wiring begins."
+
+approach: |
+  Start with the data contract, because UI cost work is not trustworthy until
+  normalized provenance is present. Reuse the existing cost package and pricing
+  version constants. In the explorer, prefer new fields and label every cost
+  chart with model version and scope. Treat missing cost as a status, not as
+  null-only UI absence.
+
+anti_patterns:
+  - "DO NOT accept submitter-supplied total cost as leaderboard cost - because vendors can manipulate it - compute normalized cost from resource metadata and BenchBox pricing tables."
+  - "DO NOT collapse zero local compute cost and missing cloud cost into the same value - because users will misread price/performance - use explicit cost_status."
+  - "DO NOT hardcode regional prices in the frontend - because pricing provenance belongs in `benchbox.core.cost` - surface only emitted model fields."
+  - "DO NOT change cost rankings without visible methodology copy - because cost is high-stakes for vendor comparison - show model version and scope near every cost metric."
+
+verification:
+  - description: "Python cost and explorer pipeline tests pass."
+    command: "uv run -- python -m pytest tests/unit/core/cost tests/unit/core/explorer_pipeline -q"
+    expected_output: "All cost and explorer pipeline tests pass, including normalized cost contract coverage."
+  - description: "Frontend typecheck and tests pass with normalized cost fields."
+    command: "cd results-explorer && npm run typecheck && npm test"
+    expected_output: "TypeScript and Vitest pass with new cost facets and cost-status states."
+  - description: "Visible metric registry remains valid."
+    command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline/test_visible_metrics_registry.py -q"
+    expected_output: "Visible metrics registry test passes for all added cost/deployment fields."
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/cost/"
+    - "benchbox/core/explorer_pipeline/"
+    - "tests/unit/core/cost/"
+    - "tests/unit/core/explorer_pipeline/"
+    - "results-explorer/src/"
+    - "_project/planning/visible_metrics.yaml"
+
+open_questions:
+  - "Should normalized storage cost be included in the first release or deferred behind compute-only cost with explicit scope?"
+  - "What canonical pricing region should be used for cross-cloud default comparisons when a user has not selected a region?"


### PR DESCRIPTION
Apply review findings to the 9 planning TODOs created from the explorer
design audit:

- Add inter-item deps.needs edges so the natural ordering (critical defects
  -> identity -> facets -> run-receipt -> chart-correctness -> compare-summary
  -> mobile-density -> performance) is machine-readable.
- Split oversized work units in the facets, normalized-cost, and
  mobile-density items so each unit is a 1-4h slice with its own commit.
- Resolve cross-TODO component-overlap ambiguities: facet drawer is owned
  by the facets item (mobile only styles it), ComparabilityReceipt is owned
  by run-receipt (compare-summary consumes it), skeleton tokens are owned by
  identity unification (perceived-latency consumes them).
- Convert manual browser smokes to mechanical Playwright/DOM-order
  assertions on identity unification and mobile density.
- Pin concrete P50/P95 budgets on the perceived-latency smoke and add a
  fixture-determinism guard.
- Tighten must_preserve lines that pointed at vague "established contracts"
  or "either/or" decisions; lock the cost_usd alias choice.
- Tighten scope_limit on the facets item from "results-explorer/src/" to
  specific subdirectories; mark landing/ as do_not_modify on the identity
  item.

Validation: all 9 files pass todo-validate; check-graph reports no
dependency cycles or dangling references across 44 items;
make pr-preflight passes (21336 tests, 5 skipped).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
