### PR TITLE
fix/codex pr review followups week 2026 05 01

### DIFF
--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -325,8 +325,8 @@ jobs:
              ($pr.mergedAt // null) as $merged_at |
              (if $post_merge_red == "true" then
                 ([($jobs.jobs // [])[] |
-                  select((.name == "lint" or .name == "fast-test") and .conclusion == "failure") |
-                  .completed_at] | max // null)
+                  select((.name == "lint" or .name == "fast-test") and .conclusion == "failure" and .completed_at != null) |
+                  .completed_at] | min // null)
               else null end) as $red_at |
              {
                merged_at: $merged_at,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+        run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
       - name: Classify changed paths
         id: classify
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+        run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/Makefile
+++ b/Makefile
@@ -1030,7 +1030,7 @@ worktree-claim-attempt:
 		git -C "$$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue; \
 		[ -f "$$wt/.benchbox/claim_in_progress" ] && continue; \
 		branch=$$(git -C "$$wt" symbolic-ref -q --short HEAD 2>/dev/null || true); \
-		status=$$(git -C "$$wt" status --porcelain); \
+		status=$$(git -C "$$wt" status --porcelain --untracked-files=normal | grep -vE '^\?\? \.benchbox(/|$$)' || true); \
 		[ -z "$$branch" ] && [ -z "$$status" ] || continue; \
 		marker="$$wt/.benchbox/claim_in_progress"; \
 		mkdir -p "$$wt/.benchbox"; \

--- a/Makefile
+++ b/Makefile
@@ -1018,9 +1018,14 @@ worktree-claim-attempt:
 			git -C "$$wt" checkout --detach origin/develop >/dev/null 2>&1 || true; \
 			git -C "$$wt" branch -D "$(BRANCH)" >/dev/null 2>&1 || true; \
 			echo "claim of $$pool failed; slot returned to detached origin/develop" >&2; \
+			marker=""; \
 		fi; \
 	}; \
-	trap cleanup EXIT INT TERM; \
+	on_int() { cleanup; exit 130; }; \
+	on_term() { cleanup; exit 143; }; \
+	trap cleanup EXIT; \
+	trap on_int INT; \
+	trap on_term TERM; \
 	POOL_REPO=$$($(POOL_REPO_CMD)); \
 	i=1; \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ POOL_MIN_FREE_KB ?= 5000000
 # variable so the four pool-management targets share a single source of
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
+BENCHBOX_TEST_LOCK_PATH = $(shell uv run -- python -c 'import os; from pathlib import Path; lock_dir = os.environ.get("BENCHBOX_TEST_LOCK_DIR"); base_dir = Path(lock_dir).expanduser() if lock_dir else Path.home() / ".benchbox"; print(base_dir / "test.lock")')
 
 .PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status dev-loop-metrics worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex
 
@@ -56,9 +57,9 @@ test-fast:
 	uv run -- python -m pytest -m "fast and not (slow or stress or resource_heavy or live_integration)" --tb=short
 
 test-unlock:
-	@LOCK_DIR="$${BENCHBOX_TEST_LOCK_DIR:-$$HOME/.benchbox}"; \
-	echo "Removing stale BenchBox test lock at $$LOCK_DIR/test.lock..."; \
-	rm -f "$$LOCK_DIR/test.lock"
+	@LOCK_PATH="$(BENCHBOX_TEST_LOCK_PATH)"; \
+	echo "Removing stale BenchBox test lock at $$LOCK_PATH..."; \
+	rm -f "$$LOCK_PATH"
 	@echo "Lock cleared."
 
 test-medium:

--- a/Makefile
+++ b/Makefile
@@ -1061,6 +1061,12 @@ worktree-release-locked:
 	branch=$$(git branch --show-current); \
 	test -n "$$branch" || { echo "Refusing: this pool worktree is already detached/free."; exit 1; }; \
 	case "$$branch" in develop|main) echo "Refusing to release protected branch $$branch."; exit 1 ;; esac; \
+	dirty=$$(git status --porcelain --untracked-files=normal | grep -vE '^\?\? \.benchbox(/|$$)' || true); \
+	if [ -n "$$dirty" ] && [ "$(FORCE)" != "1" ]; then \
+		echo "Refusing to release dirty pool worktree $$top. Review changes or rerun with FORCE=1."; \
+		echo "$$dirty"; \
+		exit 1; \
+	fi; \
 	if [ "$(FORCE)" != "1" ]; then \
 		state=$$(gh pr view "$$branch" --json state --jq .state 2>/dev/null || true); \
 		[ "$$state" = "MERGED" ] || { echo "Refusing: PR for $$branch is not MERGED; open or close PR first, or rerun with FORCE=1."; exit 1; }; \

--- a/_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -2,7 +2,8 @@ id: codex-pr-review-followups-week-2026-05-01
 title: "Address unresolved Codex PR review follow-ups from the week ending 2026-05-01"
 worktree: main
 priority: High
-status: In Progress
+status: Completed
+completed_date: "2026-05-01"
 category: Testing and Quality Assurance
 
 description: |
@@ -343,7 +344,7 @@ work:
   - id: w14
     summary: "Re-audit stale Codex threads after fixes and record which ones are closed"
     needs: [w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13]
-    status: pending
+    status: done
     notes: |
       Re-run the PR thread scan for `chatgpt-codex-connector` on the same
       merge window and record which comments are now fixed, stale, or still

--- a/_project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml
+++ b/_project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml
@@ -445,7 +445,14 @@ verification:
     command: "grep -cE 'needs: \\[.*code-lint|code-lint:|ci-required-result:' .github/workflows/test.yml .github/workflows/pr.yml 2>/dev/null | awk -F: '{s+=$2}END{print s}'"
     expected_output: ">= 2"
   - description: "Branch-protection required check is the umbrella, not the subordinate jobs"
-    command: "gh api repos/joeharris76/BenchBox/rulesets/15611785 --jq '[.rules[] | select(.type == \"required_status_checks\") | .parameters.required_status_checks[]?.context]'"
+    command: |
+      repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+      found=0
+      for ruleset_id in $(gh api "repos/${repo}/rulesets" --jq '.[] | select(.target == "branch" and ((.conditions.ref_name.include // []) | any(. == "refs/heads/develop"))) | .id'); do
+        found=1
+        gh api "repos/${repo}/rulesets/${ruleset_id}" --jq '[.rules[] | select(.type == "required_status_checks") | .parameters.required_status_checks[]?.context]'
+      done
+      test "$found" = "1"
     expected_output: "list contains 'ci-required-result' and does NOT contain bare 'lint' or 'test (ubuntu-latest, 3.12)'"
   - description: "Smoke-test decision record proves content-only skip, code fallback, unknown fallback, and gitignore handling"
     command: "grep -cE 'TODO.only|docs/|under 60 seconds|unknown.*full|gitignore|code-lint|code-test|content guard' _project/decisions/dev-loop-path-filter-smoke-test-*.md"

--- a/_project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml
+++ b/_project/DONE/main/planning/dev-loop-step-0-verify-assumptions.yaml
@@ -80,7 +80,8 @@ work:
         - Count PRs where that gap > 30 min AND statusCheckRollup has
           >= 2 distinct startedAt timestamps for the same check name
           (proxy for re-CI after a base push)
-      Secondary signal (lower confidence): `gh pr list --json comments`
+      Secondary signal (lower confidence): run
+      `gh pr list --state merged --base develop --limit 50 --json number,comments`
       and grep PR comments for explicit `pr-refresh`, `make pr-refresh`,
       or `merged develop into branch`. Use only as corroboration.
 

--- a/_project/DONE/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
+++ b/_project/DONE/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml
@@ -236,7 +236,12 @@ verification:
     command: "gh api repos/joeharris76/BenchBox/branches/develop/protection --jq '.required_status_checks' 2>/dev/null || echo classic-protection-not-configured"
     expected_output: "classic-protection-not-configured OR no broader/strict required checks"
   - description: "Routine develop PR Tests workflow no longer queues broad non-required lanes"
-    command: "branch=$(git branch --show-current); run_id=$(gh run list --workflow test.yml --branch \"$branch\" --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId'); gh run view \"$run_id\" --json jobs --jq '[.jobs[] | select(.conclusion != \"skipped\") | .name] | sort[]'"
+    command: |
+      branch=$(git branch --show-current)
+      pr_base=$(gh pr view "$branch" --json baseRefName --jq .baseRefName)
+      [ "$pr_base" = "develop" ] || { echo "PR for $branch targets $pr_base, not develop"; exit 1; }
+      run_id=$(gh run list --workflow test.yml --branch "$branch" --event pull_request --limit 1 --json databaseId --jq '.[0].databaseId')
+      gh run view "$run_id" --json jobs --jq '[.jobs[] | select(.conclusion != "skipped") | .name] | sort[]'
     expected_output: "Only non-skipped required/lightweight develop PR job names, plus any explicitly documented lightweight umbrella/content jobs"
   - description: "Nightly/manual workflow exists and is active for broad validation"
     command: "gh workflow list --json name,state,path --jq '.[] | select((.name | test(\"nightly|Nightly\")) or (.path | test(\"nightly\")))'"

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -288,7 +288,7 @@ work:
 
   - id: w12
     summary: "Make Step 3 job-count verification select develop-targeted PR runs"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #67, P2, `_project/TODO/main/planning/dev-loop-step-3-ci-rebalance-and-strict-base-off.yaml`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -2,7 +2,7 @@ id: codex-pr-review-followups-week-2026-05-01
 title: "Address unresolved Codex PR review follow-ups from the week ending 2026-05-01"
 worktree: main
 priority: High
-status: Identified
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -34,7 +34,7 @@ description: |
 work:
   - id: w1
     summary: "Make blind-spot frontmatter stamping replace complete YAML nodes"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #59, P2, `_project/scripts/sweep_blind_spots.py`
@@ -465,7 +465,7 @@ anti_patterns:
 
 verification:
   - description: "This TODO item validates cleanly"
-    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/codex-pr-review-followups-week-2026-05-01.yaml"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml"
     expected_output: "Validation passes with no schema or DAG errors"
   - description: "TODO dependency graph remains valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -102,7 +102,7 @@ work:
 
   - id: w4
     summary: "Ignore expected `.benchbox` scratch files when claiming free pool slots"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #73, P2, `Makefile`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -79,7 +79,7 @@ work:
 
   - id: w3
     summary: "Refuse `worktree-release` on dirty pool worktrees unless forced"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #73, P1, `Makefile`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -124,7 +124,7 @@ work:
 
   - id: w5
     summary: "Make INT/TERM claim-trap handling exit nonzero after cleanup"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #78, P1, `Makefile`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -187,7 +187,7 @@ work:
 
   - id: w8
     summary: "Record first failed post-merge job completion as red-detection time"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #81, P2, `.github/workflows/develop-post-merge.yml`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -238,7 +238,7 @@ work:
 
   - id: w10
     summary: "Allow `benchbox auth login` to prompt even when an env token is set"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #93, P2, `benchbox/cli/commands/auth.py`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -314,7 +314,7 @@ work:
 
   - id: w13
     summary: "Scope Step 0 secondary-probe `gh pr list --json comments` query"
-    status: pending
+    status: done
     notes: |
       Source review comment (newly tracked — was acknowledged in inventory
       but not assigned to a work unit in the prior revision):

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -57,7 +57,7 @@ work:
 
   - id: w2
     summary: "Expand BENCHBOX_TEST_LOCK_DIR consistently in `make test-unlock`"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #71, P2, `Makefile`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -145,7 +145,7 @@ work:
 
   - id: w6
     summary: "Correct Step 5 measurement-window start description in TODO"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #70, P2, `_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -206,7 +206,7 @@ work:
 
   - id: w9
     summary: "Handle persistent results-explorer snapshot mismatch without an infinite spinner"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #86, P1, `results-explorer/src/pages/Home.tsx`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -168,7 +168,7 @@ work:
 
   - id: w7
     summary: "Convert Step 5 `last_updated` to ISO date-time as schema expects"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #83, P2, `_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml`

--- a/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
+++ b/_project/TODO/main/active/codex-pr-review-followups-week-2026-05-01.yaml
@@ -263,7 +263,7 @@ work:
 
   - id: w11
     summary: "Remove hard-coded repository ruleset ID from Step 3a verification"
-    status: pending
+    status: done
     notes: |
       Source review comment:
         - PR #80, P2, `_project/DONE/main/active/dev-loop-step-3a-path-based-ci-skip.yaml`

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -236,7 +236,7 @@ metadata:
   due_date: "2026-05-30"
   step3a_merged_at: "2026-04-30T20:36:27Z"
   step4_merged_at: "2026-04-30T21:33:45Z"
-  last_updated: "2026-04-30"
+  last_updated: "2026-05-01T15:29:14Z"
 
 impact:
   business_value: |

--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -30,21 +30,25 @@ deps:
 
 work:
   - id: w1
-    summary: "Wait for 30 calendar days post-Step-4-merge before starting w2"
+    summary: "Wait for 30 calendar days after Step 3a and Step 4 have both merged before starting w2"
     status: in_progress
     notes: |
-      The measurement window is 30 days of normal usage AFTER Step 4
-      lands. Prior data is contaminated by the old workflow. Mark this
-      TODO Blocked until that date.
+      The measurement window is 30 days of normal usage AFTER both
+      Step 3a and Step 4 have landed. Prior data is contaminated by the
+      old workflow. Mark this TODO Blocked until that date.
 
-      To start the timer: when Step 4 PR merges, comment on this TODO
-      with the merge date and update `metadata.due_date` to merge_date
-      + 30 days.
+      To start the timer: when both Step 3a and Step 4 PRs have merged,
+      set the window start timestamp to the later of `step3a_merged_at`
+      and `step4_merged_at`, comment on this TODO with the merge dates,
+      and update `metadata.due_date` to start_date + 30 calendar days.
 
       Implementation record (2026-04-30):
+        - Step 3a PR #80 merged to `develop` at `2026-04-30T20:36:27Z`.
         - Step 4 PR #81 merged to `develop` at `2026-04-30T21:33:45Z`.
-        - Set `metadata.due_date` to `2026-05-30` for the 30 calendar
-          day measurement window.
+        - Step 4 is the later prerequisite, so the measurement window
+          starts at `2026-04-30T21:33:45Z`.
+        - Set `metadata.due_date` to `2026-05-30`; the existing date
+          remains correct because Step 4 merged after Step 3a.
         - Set this TODO status to `Blocked` and left W1 `in_progress`
           until the due date. No code or workflow changes are allowed
           during the measurement window.
@@ -230,6 +234,7 @@ metadata:
   estimated_effort: "Small (2-3h after the 30-day wait)"
   created_date: "2026-04-30"
   due_date: "2026-05-30"
+  step3a_merged_at: "2026-04-30T20:36:27Z"
   step4_merged_at: "2026-04-30T21:33:45Z"
   last_updated: "2026-04-30"
 

--- a/_project/audits/codex-thread-rescan-week-2026-05-01.md
+++ b/_project/audits/codex-thread-rescan-week-2026-05-01.md
@@ -1,0 +1,85 @@
+# Codex Thread Rescan - Week Ending 2026-05-01
+
+Rescan date: 2026-05-01
+
+Scope:
+
+- PR range: #19 through #94.
+- API source: `gh api repos/joeharris76/BenchBox/pulls/<pr>/comments`.
+- Author filter: `chatgpt-codex-connector[bot]`.
+- Current result: 27 inline review comments across 18 PRs.
+
+The original TODO inventory listed 26 comments. The current API scan also
+returns PR #72, which is stale against the current repository state and is
+recorded below as already-fixed/no-current-action.
+
+## Resolved By w1-w13
+
+| PR | Thread | Current disposition | Fix |
+| --- | --- | --- | --- |
+| #59 | [Replace full YAML node when stamping frontmatter fields](https://github.com/joeharris76/BenchBox/pull/59#discussion_r3164438197) | Fixed by replacing the full top-level YAML node and adding a malformed-sequence regression. | [6e54796f0](https://github.com/joeharris76/BenchBox/commit/6e54796f0) |
+| #67 | [Scope secondary PR comment probe to merged develop PRs](https://github.com/joeharris76/BenchBox/pull/67#discussion_r3168098547) | Fixed by scoping the Step 0 secondary probe to merged `develop` PRs with a bounded limit. | [cb22fae6b](https://github.com/joeharris76/BenchBox/commit/cb22fae6b) |
+| #67 | [Restrict PR-tier job-count check to develop-targeted runs](https://github.com/joeharris76/BenchBox/pull/67#discussion_r3168098551) | Fixed by adding a `baseRefName == develop` guard before selecting the PR workflow run. | [8ddbbf673](https://github.com/joeharris76/BenchBox/commit/8ddbbf673) |
+| #70 | [Start Step 5 window after both Step 4 and Step 3a land](https://github.com/joeharris76/BenchBox/pull/70#discussion_r3168890227) | Fixed by documenting the later-of Step 3a and Step 4 merge timestamps; Step 4 remains later, so `2026-05-30` stays correct. | [bcb6f347e](https://github.com/joeharris76/BenchBox/commit/bcb6f347e) |
+| #71 | [Expand BENCHBOX_TEST_LOCK_DIR before removing test.lock](https://github.com/joeharris76/BenchBox/pull/71#discussion_r3169224322) | Fixed by resolving the Make target lock path through the same expanduser-equivalent logic as pytest. | [fe393e748](https://github.com/joeharris76/BenchBox/commit/fe393e748) |
+| #73 | [Guard against dirty worktree before forced release reset](https://github.com/joeharris76/BenchBox/pull/73#discussion_r3169372557) | Fixed by refusing dirty `worktree-release` without `FORCE=1` and adding a staged-change regression. | [42fa9e119](https://github.com/joeharris76/BenchBox/commit/42fa9e119) |
+| #73 | [Treat `.benchbox` as ignorable when claiming free pool slots](https://github.com/joeharris76/BenchBox/pull/73#discussion_r3169372563) | Fixed by filtering harmless `.benchbox/` scratch paths while keeping `claim_in_progress` blocking. | [a8fcbcb10](https://github.com/joeharris76/BenchBox/commit/a8fcbcb10) |
+| #78 | [Exit on INT/TERM in claim trap](https://github.com/joeharris76/BenchBox/pull/78#discussion_r3170491244) | Fixed by splitting EXIT cleanup from INT/TERM handlers that clean up and exit nonzero. | [ec356e1db](https://github.com/joeharris76/BenchBox/commit/ec356e1db) |
+| #80 | [Avoid hard-coding repository ruleset IDs](https://github.com/joeharris76/BenchBox/pull/80#discussion_r3170714532) | Fixed by resolving current-repo develop-targeting rulesets dynamically before reading required checks. | [3a2c983a8](https://github.com/joeharris76/BenchBox/commit/3a2c983a8) |
+| #81 | [Record first failing completion as red detection time](https://github.com/joeharris76/BenchBox/pull/81#discussion_r3170954637) | Fixed by using the earliest non-null failed lint/fast-test completion timestamp and adding a jq fixture. | [465cdb506](https://github.com/joeharris76/BenchBox/commit/465cdb506) |
+| #83 | [Restore `last_updated` to a full date-time value](https://github.com/joeharris76/BenchBox/pull/83#discussion_r3171491441) | Fixed by changing Step 5 metadata to a full ISO date-time. | [9904ce52e](https://github.com/joeharris76/BenchBox/commit/9904ce52e) |
+| #86 | [Handle persistent snapshot mismatch without infinite spinner](https://github.com/joeharris76/BenchBox/pull/86#discussion_r3171854306) | Fixed by keeping the one-shot retry and rendering a recoverable error after a persistent mismatch; strict cold-load row counts were restored with `toHaveCount`. | [d362529f2](https://github.com/joeharris76/BenchBox/commit/d362529f2) |
+| #93 | [Permit `auth login` to prompt even with env token set](https://github.com/joeharris76/BenchBox/pull/93#discussion_r3172049089) | Fixed by making `auth login` use the explicit prompt/store path while leaving env precedence intact elsewhere. | [6fd915bec](https://github.com/joeharris76/BenchBox/commit/6fd915bec) |
+
+## Already-Fixed By Earlier Merges
+
+| PR | Thread | Current disposition |
+| --- | --- | --- |
+| #56 | [Normalize date keys before sorting findings list](https://github.com/joeharris76/BenchBox/pull/56#discussion_r3163448331) | Already fixed: `cmd_list()` sorts through `fmt_date(...)`, and listing mixed quoted/unquoted YAML dates is covered by `test_sweep_list_handles_mixed_yaml_date_scalars`. |
+| #64 | [Match gitignore rules with gitignore semantics](https://github.com/joeharris76/BenchBox/pull/64#discussion_r3164775959) | Already fixed: `.github/workflows/gitignore-lint.yml` uses `git check-ignore -z -v --no-index --stdin`. |
+| #64 | [Verify reused PR base before enabling auto-merge](https://github.com/joeharris76/BenchBox/pull/64#discussion_r3164775961) | Already fixed: `make pr-open` reuses only open PRs matching `--base develop --head "$CURRENT"`. |
+| #66 | [Query merge-queue eligibility from a real merge-queue signal](https://github.com/joeharris76/BenchBox/pull/66#discussion_r3167971492) | Already fixed: Step 0 no longer aliases merge-queue feasibility to `.has_issues`. |
+| #66 | [Fix invalid Python syntax in lock-path verification command](https://github.com/joeharris76/BenchBox/pull/66#discussion_r3167971500) | Already fixed: the Step 1 command no longer contains the invalid conditional import expression. |
+| #66 | [Use a supported JSON field when listing workflow runs](https://github.com/joeharris76/BenchBox/pull/66#discussion_r3167971503) | Already fixed: Step 3 lists run IDs with `gh run list` and fetches job details with `gh run view`. |
+| #66 | [Remove machine-specific Makefile path from verification](https://github.com/joeharris76/BenchBox/pull/66#discussion_r3167971507) | Already fixed: Step 6 no longer references `/Users/joe/Developer/BenchBox/Makefile`. |
+| #70 | [Preserve content-guard failure when exiting aggregator](https://github.com/joeharris76/BenchBox/pull/70#discussion_r3168890222) | Already fixed: current `ci-required-result` exits immediately on content-guard failure instead of letting later output reset the status. |
+| #72 | [Handle single-workflow path when counting grep matches](https://github.com/joeharris76/BenchBox/pull/72#discussion_r3169133012) | No current action: both `.github/workflows/test.yml` and `.github/workflows/pr.yml` exist, and the three affected verification commands currently return `3`, `2`, and `3`. |
+| #75 | [Replace non-portable ERR trap in claim rollback](https://github.com/joeharris76/BenchBox/pull/75#discussion_r3170340636) | Already fixed: `worktree-claim-attempt` uses POSIX `EXIT` / `INT` / `TERM` traps, not a bash-only `ERR` trap. |
+| #75 | [Remove 200-item cap from PR state lookup](https://github.com/joeharris76/BenchBox/pull/75#discussion_r3170340639) | Already fixed: pool status and sweep use `--limit 1000` plus per-branch fallback behavior. |
+| #76 | [Replace non-POSIX ERR trap in claim recipe](https://github.com/joeharris76/BenchBox/pull/76#discussion_r3170399355) | Already fixed by the same POSIX trap migration noted for PR #75. |
+| #76 | [Remove fixed PR list cap from stale sweep lookup](https://github.com/joeharris76/BenchBox/pull/76#discussion_r3170399359) | Already fixed by the same `--limit 1000` pool status/sweep update noted for PR #75. |
+| #79 | [Include deleted files in path classifier diff](https://github.com/joeharris76/BenchBox/pull/79#discussion_r3170617850) | Already fixed: `scripts/path_filter_decision.py` uses `--diff-filter=ACDMRT`, including deletions. |
+
+## Still Actionable
+
+No current Codex inline review thread from the #19-#94 rescan remains
+actionable after w1-w13 and the earlier merges above.
+
+## Blind-Spot Cross-Check
+
+| Finding | Status | Audit disposition |
+| --- | --- | --- |
+| `2026-04-29-143205-react-key-collision-class` | open | Out of scope for this Codex-thread sweep; it concerns dashboard React key collision review, not the PR #19-#94 Codex inline threads. |
+| `2026-04-30-114719-separable-dev-loop-decisions` | open | Out of scope; it is a planning-framework note for dev-loop TODO design. Step 5/6 decision-gate work already carries the relevant separation. |
+| `2026-04-30-114720-pr-ci-cost-leverage` | open | Out of scope; it is a dev-loop planning metric note, already represented by Step 3/Step 5 measurement TODOs. |
+| `2026-04-30-114721-global-test-lock-cpu-protection` | open | Out of scope; w2 fixed `test-unlock` path expansion without changing the global-lock policy this finding protects. |
+| `2026-04-30-114722-queue-single-point-failure` | open | Out of scope until Step 6 is activated; Step 5 still gates whether queue infrastructure is built. |
+| `2026-04-30-114723-queue-dwell-contract` | open | Out of scope until Step 6 is activated; Step 5 measurement remains the decision gate. |
+| `2026-04-30-114724-post-merge-safety-tension` | open | Out of scope; this is a Step 4/Step 6 architecture tension, not an unresolved Codex inline comment. |
+| `2026-04-30-143500-pool-disk-accounting` | actioned | Folded into prior worktree-pool follow-up work; no additional action for this sweep. |
+| `2026-04-30-143501-four-worktree-creation-paths` | actioned | Partially actioned with remaining deprecation cleanup tracked separately; no Codex-thread action here. |
+| `2026-04-30-143502-half-claimed-state-invisible` | actioned | Folded into prior pool status/claim marker work; w4/w5 preserve marker behavior and signal cleanup. |
+| `2026-04-30-143503-no-pool-stale-sweep` | actioned | Folded into existing stale-sweep/pool status work; no additional action for this sweep. |
+| `2026-04-30-143504-gh-failure-vs-no-pr` | actioned | Folded into existing pool status unknown-state handling; no additional action for this sweep. |
+| `2026-04-30-143505-pool-lock-claim-only` | actioned | Folded into existing broader pool lock coverage; no additional action for this sweep. |
+| `2026-04-30-214358-pool-size-not-codified-as-contract` | open | Out of scope; it is a separate pool invariant hardening idea and remains open as a blind-spot. |
+| `2026-04-30-214359-claim-orchestrator-false-failure` | open | Still actionable but already filed as a blind-spot. This session reproduced the symptom when the first claim printed `WORKTREE_PATH` but `make` exited nonzero; promote separately if it becomes current sprint work. |
+| `2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades` | open | Folded into this sweep. w9 restored strict cold-load row-count assertions with `toHaveCount` and this audit adds the requested blind-spot cross-check step. |
+
+Notes:
+
+- The blind-spot file names referenced inside
+  `2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades`
+  for `103000`, `103001`, and `103002` are not present in this worktree.
+- No new TODO was created from this audit because the only still-actionable
+  non-Codex item is already tracked as an open blind-spot.

--- a/_project/scripts/sweep_blind_spots.py
+++ b/_project/scripts/sweep_blind_spots.py
@@ -222,9 +222,18 @@ def render_scalar_field(field: str, value: str) -> str:
 
 def replace_frontmatter_field(raw: str, field: str, value: str) -> str:
     line = render_scalar_field(field, value)
-    pattern = re.compile(rf"(?m)^{re.escape(field)}:.*$")
-    if pattern.search(raw):
-        return pattern.sub(line, raw, count=1)
+    field_re = re.compile(rf"^{re.escape(field)}\s*:")
+    lines = raw.splitlines()
+    for start, existing in enumerate(lines):
+        if not field_re.match(existing):
+            continue
+        end = start + 1
+        while end < len(lines):
+            next_line = lines[end]
+            if next_line and not next_line[0].isspace():
+                break
+            end += 1
+        return "\n".join([*lines[:start], line, *lines[end:]])
     return raw.rstrip() + f"\n{line}"
 
 

--- a/benchbox/cli/commands/auth.py
+++ b/benchbox/cli/commands/auth.py
@@ -12,6 +12,7 @@ from benchbox.cli.submit_auth import (
     get_submission_auth_status,
     normalize_service_url,
     refresh_submission_token,
+    resolve_submission_token,
 )
 
 
@@ -66,7 +67,7 @@ def login(ctx: click.Context, service_url: str, token: str | None, token_stdin: 
     store = SubmissionAuthStore()
     try:
         if token is None:
-            refresh_submission_token(service_url, store=store)
+            resolve_submission_token(service_url, prompt=True, force_refresh=True, store=store)
         else:
             store.save_token(service_url, token)
     except SubmissionAuthError as exc:

--- a/results-explorer/e2e/failures/platform-index-cold-load.spec.ts
+++ b/results-explorer/e2e/failures/platform-index-cold-load.spec.ts
@@ -14,7 +14,7 @@ const EXPECTED_ROWS_BY_PLATFORM: Record<string, number> = {
 };
 
 async function expectExactPlatformRows(page: Page, expected: number) {
-  await expect.poll(() => page.locator("table tbody tr").count(), { timeout: 20_000 }).toBe(expected);
+  await expect(page.locator("table tbody tr")).toHaveCount(expected, { timeout: 20_000 });
   await expect(page.getByText(/No results found for platform/i)).not.toBeVisible();
 }
 

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -24,6 +24,7 @@ export function Home(_: RoutableProps) {
   const [metaLeaderboard, setMetaLeaderboard] = useState<MetaLeaderboardData | null>(null);
   const [metaLeaderboardLoaded, setMetaLeaderboardLoaded] = useState(false);
   const retriedEmptyResults = useRef(false);
+  const [emptyResultsRetryFinished, setEmptyResultsRetryFinished] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [benchmarkFilters, setBenchmarkFilters] = useUrlState<string[]>("bm", EMPTY_STRING_ARRAY, arraySerde);
   const [scaleFilters, setScaleFilters] = useUrlState<string[]>("sf", EMPTY_STRING_ARRAY, arraySerde);
@@ -67,6 +68,7 @@ export function Home(_: RoutableProps) {
   // makes future investigation possible by surfacing the exact mismatch
   // in browser DevTools without needing to re-run the audit setup.
   const hasInconsistentEmptySnapshot = results !== null && results.length === 0 && metaLeaderboard !== null;
+  const hasPersistentInconsistentEmptySnapshot = hasInconsistentEmptySnapshot && emptyResultsRetryFinished;
 
   useEffect(() => {
     if (!hasInconsistentEmptySnapshot || retriedEmptyResults.current) return;
@@ -80,10 +82,16 @@ export function Home(_: RoutableProps) {
     }
     listResults()
       .then((rows) => {
-        if (!cancelled) setResults(rows);
+        if (!cancelled) {
+          setResults(rows);
+          setEmptyResultsRetryFinished(true);
+        }
       })
       .catch((err: unknown) => {
-        if (!cancelled) setError(errMsg(err));
+        if (!cancelled) {
+          setEmptyResultsRetryFinished(true);
+          setError(errMsg(err));
+        }
       });
     return () => {
       cancelled = true;
@@ -172,6 +180,14 @@ export function Home(_: RoutableProps) {
   ]);
 
   if (error) return <ErrorMessage message={error} />;
+  if (hasPersistentInconsistentEmptySnapshot) {
+    return (
+      <ErrorMessage
+        title="Results snapshot incomplete"
+        message="The results table loaded empty while leaderboard metadata is present. Reload the page to retry the DuckDB snapshot load."
+      />
+    );
+  }
   if (!results || !metaLeaderboardLoaded || hasInconsistentEmptySnapshot) {
     return <LoadingSpinner message="Loading results..." />;
   }

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -255,6 +255,33 @@ describe("Home", () => {
     expect(screen.queryByText("No leaderboard cells match the current filters.")).toBeNull();
   });
 
+  it("renders a recoverable error when the empty result snapshot persists after retry", async () => {
+    let resultCalls = 0;
+
+    vi.mocked(queryRows).mockImplementation(async (sql: string) => {
+      const s = String(sql).replace(/\s+/g, " ").trim();
+      if (s.startsWith("SELECT * FROM bench.results")) {
+        resultCalls += 1;
+        return [];
+      }
+      if (s.startsWith("SELECT platform_id, platform, avg_rank, n_cohorts FROM bench.meta_leaderboard")) {
+        return META_LEADERBOARD_ROWS;
+      }
+      if (s.startsWith("SELECT * FROM bench.cohort_metadata")) {
+        return COHORT_ROWS;
+      }
+      return [];
+    });
+
+    render(<Home />);
+
+    await waitFor(() => expect(resultCalls).toBe(2));
+    expect(screen.getByText("Results snapshot incomplete")).toBeTruthy();
+    expect(screen.getByText(/Reload the page to retry the DuckDB snapshot load/)).toBeTruthy();
+    expect(screen.queryByText("Loading results...")).toBeNull();
+    expect(screen.queryByText("Recent Results")).toBeNull();
+  });
+
   it("treats a benchmark chip click as isolate-not-exclude from the default all state", async () => {
     render(<Home />);
     await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());

--- a/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
+++ b/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
@@ -9,6 +9,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.fast,
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
+++ b/tests/integration/worktree/test_worktree_claim_benchbox_scratch.py
@@ -1,0 +1,113 @@
+"""Regression tests for retained worktree claim slot selection."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    run(["git", "init"], path)
+    run(["git", "config", "user.email", "test@example.com"], path)
+    run(["git", "config", "user.name", "BenchBox Test"], path)
+    (path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    run(["git", "add", ".gitignore", "README.md"], path)
+    run(["git", "commit", "-m", "initial"], path)
+
+
+def create_origin_with_develop(tmp_path: Path) -> Path:
+    seed = tmp_path / "seed"
+    origin = tmp_path / "origin.git"
+    init_repo(seed)
+    run(["git", "branch", "-M", "develop"], seed)
+    run(["git", "init", "--bare", str(origin)], tmp_path)
+    run(["git", "remote", "add", "origin", str(origin)], seed)
+    run(["git", "push", "-u", "origin", "develop"], seed)
+    return origin
+
+
+def test_worktree_claim_ignores_untracked_benchbox_scratch(tmp_path: Path) -> None:
+    origin = create_origin_with_develop(tmp_path)
+    main = tmp_path / "BenchBox"
+    pool_parent = tmp_path / "pool"
+    pool_parent.mkdir()
+    pool = pool_parent / "BenchBox.pool-01"
+    run(["git", "clone", str(origin), str(main)], tmp_path)
+    run(["git", "clone", str(origin), str(pool)], tmp_path)
+    run(["git", "checkout", "--detach", "origin/develop"], pool)
+    (pool / ".venv").mkdir()
+    (pool / ".venv" / "pyvenv.cfg").write_text("home = test\n", encoding="utf-8")
+    (pool / ".benchbox" / "cache").mkdir(parents=True)
+    (pool / ".benchbox" / "cache" / "scratch").write_text("scratch\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "make",
+            "-f",
+            str(REPO_ROOT / "Makefile"),
+            "-s",
+            "worktree-claim-attempt",
+            "BRANCH=feature/scratch-ok",
+            "POOL_SIZE=1",
+            f"WORKTREE_POOL_PARENT={pool_parent}",
+        ],
+        cwd=main,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"WORKTREE_PATH={pool.resolve()}" in result.stdout
+    assert run(["git", "branch", "--show-current"], pool).stdout.strip() == "feature/scratch-ok"
+    assert (pool / ".benchbox" / "cache" / "scratch").exists()
+
+
+def test_worktree_claim_keeps_claim_marker_blocking(tmp_path: Path) -> None:
+    origin = create_origin_with_develop(tmp_path)
+    main = tmp_path / "BenchBox"
+    pool_parent = tmp_path / "pool"
+    pool_parent.mkdir()
+    pool = pool_parent / "BenchBox.pool-01"
+    run(["git", "clone", str(origin), str(main)], tmp_path)
+    run(["git", "clone", str(origin), str(pool)], tmp_path)
+    run(["git", "checkout", "--detach", "origin/develop"], pool)
+    (pool / ".venv").mkdir()
+    (pool / ".venv" / "pyvenv.cfg").write_text("home = test\n", encoding="utf-8")
+    (pool / ".benchbox").mkdir()
+    (pool / ".benchbox" / "claim_in_progress").write_text("pid=1\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            "make",
+            "-f",
+            str(REPO_ROOT / "Makefile"),
+            "-s",
+            "worktree-claim-attempt",
+            "BRANCH=feature/blocked",
+            "POOL_SIZE=1",
+            f"WORKTREE_POOL_PARENT={pool_parent}",
+        ],
+        cwd=main,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "WORKTREE_PATH=" not in result.stdout
+    assert run(["git", "branch", "--show-current"], pool).stdout.strip() == ""

--- a/tests/integration/worktree/test_worktree_claim_signal_exit.py
+++ b/tests/integration/worktree/test_worktree_claim_signal_exit.py
@@ -11,6 +11,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.fast,
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/integration/worktree/test_worktree_claim_signal_exit.py
+++ b/tests/integration/worktree/test_worktree_claim_signal_exit.py
@@ -1,0 +1,98 @@
+"""Regression tests for retained worktree claim signal handling."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    run(["git", "init"], path)
+    run(["git", "config", "user.email", "test@example.com"], path)
+    run(["git", "config", "user.name", "BenchBox Test"], path)
+    (path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    run(["git", "add", ".gitignore", "README.md"], path)
+    run(["git", "commit", "-m", "initial"], path)
+
+
+def create_origin_with_develop(tmp_path: Path) -> Path:
+    seed = tmp_path / "seed"
+    origin = tmp_path / "origin.git"
+    init_repo(seed)
+    run(["git", "branch", "-M", "develop"], seed)
+    run(["git", "init", "--bare", str(origin)], tmp_path)
+    run(["git", "remote", "add", "origin", str(origin)], seed)
+    run(["git", "push", "-u", "origin", "develop"], seed)
+    return origin
+
+
+def test_worktree_claim_int_trap_exits_nonzero_after_cleanup(tmp_path: Path) -> None:
+    real_git = shutil.which("git")
+    assert real_git is not None
+    origin = create_origin_with_develop(tmp_path)
+    main = tmp_path / "BenchBox"
+    pool_parent = tmp_path / "pool"
+    pool_parent.mkdir()
+    pool = pool_parent / "BenchBox.pool-01"
+    run(["git", "clone", str(origin), str(main)], tmp_path)
+    run(["git", "clone", str(origin), str(pool)], tmp_path)
+    run(["git", "checkout", "--detach", "origin/develop"], pool)
+    (pool / ".venv").mkdir()
+    (pool / ".venv" / "pyvenv.cfg").write_text("home = test\n", encoding="utf-8")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    git_wrapper = bin_dir / "git"
+    git_wrapper.write_text(
+        f"""#!/bin/sh
+if [ "$1" = "-C" ] && [ "$3" = "reset" ]; then
+  kill -INT "$PPID"
+  exit 0
+fi
+exec "{real_git}" "$@"
+""",
+        encoding="utf-8",
+    )
+    git_wrapper.chmod(0o755)
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        [
+            "make",
+            "-f",
+            str(REPO_ROOT / "Makefile"),
+            "-s",
+            "worktree-claim-attempt",
+            "BRANCH=feature/signal-test",
+            "POOL_SIZE=1",
+            f"WORKTREE_POOL_PARENT={pool_parent}",
+        ],
+        cwd=main,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "WORKTREE_PATH=" not in result.stdout
+    assert "claim of pool-01 failed; slot returned to detached origin/develop" in result.stderr
+    assert not (pool / ".benchbox" / "claim_in_progress").exists()
+    assert run(["git", "branch", "--show-current"], pool).stdout.strip() == ""
+    assert run(["git", "branch", "--list", "feature/signal-test"], pool).stdout.strip() == ""

--- a/tests/integration/worktree/test_worktree_release_dirty_guard.py
+++ b/tests/integration/worktree/test_worktree_release_dirty_guard.py
@@ -1,0 +1,60 @@
+"""Regression tests for retained worktree release safety."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def init_feature_repo(path: Path) -> None:
+    path.mkdir()
+    run(["git", "init"], path)
+    run(["git", "config", "user.email", "test@example.com"], path)
+    run(["git", "config", "user.name", "BenchBox Test"], path)
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    run(["git", "add", "README.md"], path)
+    run(["git", "commit", "-m", "initial"], path)
+    run(["git", "checkout", "-b", "feature/dirty-release"], path)
+
+
+def test_worktree_release_refuses_staged_changes_before_pr_lookup(tmp_path: Path) -> None:
+    repo = tmp_path / "BenchBox.pool-01"
+    init_feature_repo(repo)
+    (repo / "dirty.txt").write_text("do not discard\n", encoding="utf-8")
+    run(["git", "add", "dirty.txt"], repo)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text("#!/bin/sh\necho gh should not be called >&2\nexit 99\n", encoding="utf-8")
+    gh.chmod(0o755)
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+
+    result = subprocess.run(
+        ["make", "-f", str(REPO_ROOT / "Makefile"), "-s", "worktree-release-locked"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Refusing to release dirty pool worktree" in result.stdout
+    assert "A  dirty.txt" in result.stdout
+    assert "gh should not be called" not in result.stderr
+    branch = run(["git", "branch", "--show-current"], repo).stdout.strip()
+    assert branch == "feature/dirty-release"

--- a/tests/integration/worktree/test_worktree_release_dirty_guard.py
+++ b/tests/integration/worktree/test_worktree_release_dirty_guard.py
@@ -10,6 +10,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.fast,
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/tests/unit/cli/commands/test_auth.py
+++ b/tests/unit/cli/commands/test_auth.py
@@ -141,6 +141,23 @@ def test_auth_command_login_status_logout_do_not_print_token(
     assert "cli-secret" not in logout.output
 
 
+def test_auth_login_prompt_stores_token_when_environment_token_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BENCHBOX_SUBMIT_TOKEN", "env-token")
+    fake = FakeKeyring()
+    monkeypatch.setattr(submit_auth, "_load_keyring", lambda: fake)
+    runner = CliRunner()
+
+    result = runner.invoke(auth_cmd.auth, ["login"], input="prompt-secret\n")
+
+    assert result.exit_code == 0, result.output
+    assert "credentials saved" in result.output.lower()
+    assert "prompt-secret" not in result.output
+    username = submit_auth.normalize_service_url(submit_auth.DEFAULT_SERVICE_URL)
+    assert fake.get_password(submit_auth.KEYRING_SERVICE_NAME, username) == "prompt-secret"
+
+
 def test_auth_command_registered_on_root_cli() -> None:
     from benchbox.cli.main import cli
 

--- a/tests/unit/scripts/test_blind_spot_tools.py
+++ b/tests/unit/scripts/test_blind_spot_tools.py
@@ -174,6 +174,43 @@ The reason.
     assert "status: dismissed" in text
 
 
+def test_stamp_frontmatter_replaces_sequence_shaped_status_node(tmp_path: Path) -> None:
+    stem = "2026-04-29-120006-sequence-status"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(
+        f"""---
+id: {stem}
+date: 2026-04-29
+status:
+  - open
+finding_kind: other
+review_context: "unit test"
+todo_id: null
+---
+
+# Test Finding
+
+## Finding
+The finding.
+
+## Why this matters
+The reason.
+
+## Suggested next steps
+- [ ] Do the thing.
+""",
+        encoding="utf-8",
+    )
+    _data, raw, body = sweep_blind_spots.split_frontmatter(path.read_text(encoding="utf-8"))
+
+    sweep_blind_spots.stamp_frontmatter(path, raw, body, "dismissed", None)
+
+    data, raw, _body = sweep_blind_spots.split_frontmatter(path.read_text(encoding="utf-8"))
+    assert data["status"] == "dismissed"
+    assert raw.splitlines().count("status: dismissed") == 1
+    assert "  - open" not in raw
+
+
 def test_append_triage_log_inserts_before_next_section(tmp_path: Path) -> None:
     path = tmp_path / "finding.md"
     path.write_text(

--- a/tests/unit/test_standardized_test_commands.py
+++ b/tests/unit/test_standardized_test_commands.py
@@ -131,6 +131,23 @@ class TestMakefileCommands:
         for target in expected_targets:
             assert target in makefile_content, f"Makefile should contain target: {target}"
 
+    def test_makefile_test_unlock_expands_user_lock_dir(self):
+        env = {**subprocess.os.environ, "BENCHBOX_TEST_LOCK_DIR": "~/tmp/benchbox-lock-probe"}
+
+        result = subprocess.run(
+            ["make", "-n", "--no-print-directory", "test-unlock"],
+            cwd=Path.cwd(),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        expected_path = str(Path.home() / "tmp" / "benchbox-lock-probe" / "test.lock")
+        assert result.returncode == 0, result.stderr
+        assert expected_path in result.stdout
+        assert "~/tmp/benchbox-lock-probe/test.lock" not in result.stdout
+
     def test_makefile_test_all_splits_parallel_and_serial_lanes_explicitly(self):
         makefile_content = (Path.cwd() / "Makefile").read_text()
 

--- a/tests/unit/workflows/test_develop_post_merge_metrics.py
+++ b/tests/unit/workflows/test_develop_post_merge_metrics.py
@@ -1,0 +1,83 @@
+"""Tests for develop-post-merge metrics jq behavior."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RED_AT_JQ = r"""
+if $post_merge_red == "true" then
+  ([($jobs.jobs // [])[] |
+    select((.name == "lint" or .name == "fast-test") and .conclusion == "failure" and .completed_at != null) |
+    .completed_at] | min // null)
+else null end
+"""
+
+
+def run_red_at_jq(jobs: dict, post_merge_red: str = "true") -> str | None:
+    jq = shutil.which("jq")
+    if jq is None:
+        pytest.skip("jq is required for workflow metrics fixture tests")
+    result = subprocess.run(
+        [
+            jq,
+            "-n",
+            "--argjson",
+            "jobs",
+            json.dumps(jobs),
+            "--arg",
+            "post_merge_red",
+            post_merge_red,
+            RED_AT_JQ,
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_failed_post_merge_jobs_use_earliest_completion_timestamp() -> None:
+    jobs = {
+        "jobs": [
+            {
+                "name": "fast-test",
+                "conclusion": "failure",
+                "completed_at": "2026-05-01T10:10:00Z",
+            },
+            {
+                "name": "lint",
+                "conclusion": "failure",
+                "completed_at": "2026-05-01T10:03:00Z",
+            },
+            {
+                "name": "docs",
+                "conclusion": "failure",
+                "completed_at": "2026-05-01T09:55:00Z",
+            },
+            {
+                "name": "lint",
+                "conclusion": "failure",
+                "completed_at": None,
+            },
+        ]
+    }
+
+    assert run_red_at_jq(jobs) == "2026-05-01T10:03:00Z"
+
+
+def test_workflow_metrics_expression_uses_min_not_max() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml").read_text(encoding="utf-8")
+
+    assert ".completed_at] | min // null" in workflow
+    assert ".completed_at] | max // null" not in workflow

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -1,0 +1,24 @@
+"""Guardrails for the develop PR path classifier workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_pr_path_classifier_fetches_base_history_for_merge_base() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8")
+    base_fetch = 'git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"'
+
+    # The classifier uses `git diff origin/develop...HEAD`; a depth-1 base fetch
+    # on GitHub's synthetic PR merge ref can leave no merge base available.
+    assert '--depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"' not in workflow
+    assert workflow.count(base_fetch) == 2


### PR DESCRIPTION
- **fix: replace blind-spot frontmatter nodes**
- **fix: expand test unlock lock directory**
- **fix: refuse dirty worktree release**
- **fix: ignore pool claim scratch files**
- **fix: stop pool claim after signals**
- **docs: clarify dev loop measurement start**
- **docs: normalize step 5 metadata timestamp**
- **fix: record earliest develop red failure**
- **fix: surface persistent explorer snapshot mismatch**
- **fix: let auth login prompt with env token**
- **docs: make step 3a ruleset check dynamic**
- **docs: guard step 3 PR run base**
- **docs: scope step 0 PR comment probe**
- **docs: record codex thread rescan**
- **test: mark worktree regressions fast**
