### PR TITLE
chore: cleanup develop working tree leftovers

### DIFF
--- a/_project/blind-spots/2026-05-01-103000-hosted-submit-no-local-validate-preflight.md
+++ b/_project/blind-spots/2026-05-01-103000-hosted-submit-no-local-validate-preflight.md
@@ -1,0 +1,62 @@
+---
+id: 2026-05-01-103000-hosted-submit-no-local-validate-preflight
+date: 2026-05-01
+status: open
+finding_kind: scope-creep
+review_context: "/code review of PRs #86–#93 (results-platform push)"
+related_paths:
+  - benchbox/cli/commands/submit.py
+  - scripts/validate_submission.py
+  - tests/integration/test_hosted_submission.py
+suggested_sweep: "Decide whether `benchbox submit --service` should run validate_submission.py against the bundle before upload, matching the implicit contract of the --output flow."
+todo_id: null
+---
+
+# `benchbox submit --service` skips the local validator that `--output` flow benefits from
+
+## Finding
+
+The Phase 2 PR flow produces a bundle that contributors run through
+`scripts/validate_submission.py` before opening the PR (the README of the
+output dir tells them to). The Phase 3 hosted flow added in PR #93
+(`benchbox submit --service`) sends bytes to the API without first running
+the validator locally. The hosted service is presumed to validate
+server-side, but:
+
+- Contributors with bad bundles pay full upload latency before the
+  service tells them what's wrong.
+- A schema mismatch between the develop validator and the hosted
+  service's validator becomes invisible — the hosted service might
+  accept a bundle that `published-results` would later reject (or vice
+  versa) if the bundle is later mirrored into the PR corpus.
+- There is no end-to-end test asserting that the same bundle produced
+  by `submit` passes the develop validator AND the hosted service
+  validator. The cross-branch drift guard
+  (`test_vendored_validator_matches_develop_script`) only protects
+  develop ↔ published-results, not develop ↔ hosted service.
+
+## Why the five-axis review missed it
+
+The five axes (correctness/readability/architecture/security/perf)
+naturally evaluate per-PR code quality. They don't ask "does the path
+this code adds preserve invariants the other path establishes?" That's
+a *contract* axis — invisible unless you're holding the whole submission
+flow in your head.
+
+## Why this matters
+
+If hosted ingest validation drifts from `scripts/validate_submission.py`,
+contributors see "Hosted submission complete" but the bundle would fail
+when later mirrored to `published-results`. There is no warning or
+local pre-flight to catch this.
+
+## Suggested next steps
+
+Either:
+1. Run `validate_submission.py` against the bundle in the `--service`
+   path before upload (treat its errors as upload-blocking, warnings as
+   advisory), or
+2. Document explicitly that the hosted service is the sole source of
+   truth for `--service` validation and that develop's validator may
+   diverge — and add a contract test that asserts the hosted mock and
+   `validate_submission.py` accept/reject the same bundles.

--- a/_project/blind-spots/2026-05-01-103001-published-results-validator-no-per-bundle-test.md
+++ b/_project/blind-spots/2026-05-01-103001-published-results-validator-no-per-bundle-test.md
@@ -1,0 +1,58 @@
+---
+id: 2026-05-01-103001-published-results-validator-no-per-bundle-test
+date: 2026-05-01
+status: open
+finding_kind: bug-class
+review_context: "/code review of PR #87 (validator manifest compatibility) and PR #88 (closure)"
+related_paths:
+  - tests/integration/test_cross_branch_validator_contract.py
+  - tests/fixtures/published_results_validator.py
+  - scripts/validate_submission.py
+suggested_sweep: "Add a cross-branch contract test that exercises the per-bundle <stem>.manifest.json discovery path, mirroring the existing legacy submission-manifest.json coverage."
+todo_id: null
+---
+
+# Per-bundle manifest path landed without an integration test
+
+## Finding
+
+PR #87 added a code path to `scripts/validate_submission.py` (and the
+identical vendored fixture) that prefers `<bundle-stem>.manifest.json`
+over `submission-manifest.json` and skips `*.manifest.json` during bundle
+discovery. The PR shipped without an integration test exercising that
+new path:
+
+- `tests/integration/test_cross_branch_validator_contract.py` lines 168,
+  177, and 200 only set up `submission-manifest.json` (legacy).
+- The drift guard `test_vendored_validator_matches_develop_script`
+  passes because both files were updated in lockstep, but it doesn't
+  exercise the discovery preference.
+- PR #88's claim that "cross-branch contract test already exists" is
+  technically true — the file exists — but the new code path is not
+  covered.
+
+## Why the five-axis review missed it
+
+A "missing test" axis exists, but it tends to flag tests for *new*
+modules. When a single-file change extends an existing module that
+*already* has a test file, the natural assumption is "covered." The
+extra step — checking whether the existing test exercises the new
+branch — is easy to skip.
+
+## Why this matters
+
+If a future refactor breaks per-bundle discovery (or worse, regresses
+the discovery preference so legacy beats per-bundle), CI on develop will
+not notice. The hosted submit path now writes `<stem>.manifest.json`
+exclusively; if validator drift puts the legacy fallback ahead, hosted
+bundles mirrored into the PR corpus would fail with confusing errors.
+
+## Suggested next steps
+
+Add a `test_per_bundle_manifest_preferred_over_legacy` to
+`test_cross_branch_validator_contract.py`:
+
+1. Create a bundle dir with both `<stem>.manifest.json` (correct hash)
+   and `submission-manifest.json` (incorrect hash).
+2. Run the validator and assert it succeeds, proving per-bundle wins.
+3. Mirror the test for the per-bundle-only case.

--- a/_project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md
+++ b/_project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md
@@ -1,0 +1,64 @@
+---
+id: 2026-05-01-103002-explorer-cold-load-test-coverage-weakened
+date: 2026-05-01
+status: open
+finding_kind: bug-class
+review_context: "/code review of PR #86 (Results Explorer QA pass 2)"
+related_paths:
+  - results-explorer/e2e/failures/platform-index-cold-load.spec.ts
+  - results-explorer/src/pages/Home.tsx
+suggested_sweep: "Restore strict row-count assertions for the cold-load regression, or document why polling-based assertions are sufficient."
+todo_id: null
+---
+
+# Cold-load regression test was loosened from strict row counts to "any rows"
+
+## Finding
+
+The pass-1 cold-load regression test
+(`platform-index-cold-load.spec.ts`) used to:
+
+1. Mock the production `results.duckdb` byte-for-byte via Playwright
+   route interception.
+2. Assert exact row counts: `await expect(page.locator("table tbody
+   tr")).toHaveCount(4)` for DuckDB and `2` for Polars.
+
+After PR #86 the test:
+
+1. Drops the route mocking entirely (now polls fixtures DB).
+2. Asserts only `count > 0`, no upper bound.
+3. Adds a guard against the empty-state copy.
+
+The pass-1 finding (`results-explorer-qa-pass1-fixes`) was specifically
+that *partial-row* loads occurred (some platforms had fewer rows than
+expected on cold-load). Asserting "any rows present" cannot detect a
+regression where, e.g., DuckDB renders 1 row instead of 4 — exactly the
+class of bug the original test was guarding.
+
+The pass-2 fix in `Home.tsx` (the inconsistent-empty-snapshot retry)
+addresses Home-level empty flashes, not PlatformIndex-level partial
+loads. So the loosened assertion is not justified by the fix landing
+elsewhere.
+
+## Why the five-axis review missed it
+
+The "what's done well" + "missing tests" frames don't have a slot for
+*regression-coverage downgrade*. The diff goes from 100 lines of strict
+test to 30 lines of permissive test, which reads as simplification.
+Without comparing the failure mode this test was originally written
+to catch, the reviewer accepts the diff as cleanup.
+
+## Why this matters
+
+A future cold-load partial-row regression — which is the one we
+actually had — would now slip past CI silently.
+
+## Suggested next steps
+
+Either:
+1. Restore the route-interception harness and exact row counts (treat
+   the simplification as a regression in coverage); or
+2. Update `_project/audits/results-explorer-qa-pass1-fixes.md` to
+   record the *test simplification rationale* — why the team decided
+   the fixture-DB assertion is sufficient — so the next reviewer can
+   tell loose-on-purpose from loose-by-accident.

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -213,3 +213,17 @@ These are all build/release/UI artefacts that belong on the released
 tree. They are therefore NOT in the release-cut curation list. This
 amendment is the source of truth for the script; the original A3 row
 remains unchanged.
+
+## Amendment 2026-05-01 — codecov config to main-only allowlist
+
+Adding `codecov.yml` (Codecov coverage thresholds and PR-comment
+suppression) as a new top-level path. CI workflows (`pr.yml`,
+`nightly.yml`, `test.yml`) reference `codecov/codecov-action@v4`, which
+loads this config on every coverage upload. The config is needed on
+both `develop` and the released `main` tree, so it goes in the
+main-only allowlist (not the release-cut curation list).
+
+- **`main` only** (extension to A3): `codecov.yml`.
+
+This amendment extends the 2026-04-27 amendment; both bullets are
+authoritative.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment: false   # no PR comments
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%   # small tolerance
+    patch:
+      default:
+        target: 80%     # enforce diff coverage


### PR DESCRIPTION
Move 4 files that were sitting in the develop working tree of the main
clone onto a proper branch.

- codecov.yml: required by codecov-action references in pr.yml,
  nightly.yml, and test.yml; never committed previously.
- 3 blind-spots from the 2026-05-01 PR #86-#93 review pass
  (hosted-submit-no-local-validate-preflight,
   published-results-validator-no-per-bundle-test,
   explorer-cold-load-test-coverage-weakened); heading normalised to
  "## Suggested next steps" to match the schema.

Items evaluated and intentionally NOT included:
- external-contributor-submission-dry-run.yaml mod (added a deps.needs
  reference to dry-run-followup-validator-hash-contract-mismatch).
  PR #88 deleted that target TODO when the bug was fixed; the dep is
  stale.
- codex-pr-review-followups-week-2026-05-01.yaml: develop's version
  (post-#97) is newer than the local copy.
- 2026-05-01-130000 blind-spot: develop's version is newer (heading
  already normalised).
- submission/ tree (CONTRIBUTING.md + bundle + manifest): dry-run
  scratch from the 2026-04-29 Codex pre-pass; never committed in any
  branch. Left on disk in the main clone for the user to relocate or
  delete.
- _project/scripts/uv.lock: regenerated lockfile.
