### PR TITLE
fix/explorer chart correctness navigation

### DIFF
--- a/_project/DONE/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/DONE/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -2,7 +2,7 @@ id: explorer-chart-correctness-and-navigation
 title: "Explorer: chart correctness, log-scale latency encoding, and chart navigation"
 worktree: main
 priority: High
-status: "In Progress"
+status: "Completed"
 category: "Data Visualization"
 
 deps:
@@ -139,6 +139,7 @@ metadata:
     - accessibility
   estimated_effort: "Large (3-5 days)"
   created_date: "2026-05-01"
+completed_date: "2026-05-02"
 
 impact:
   business_value: |

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -20,7 +20,12 @@ description: |
 work:
   - id: w1
     summary: "Audit chart registry and group charts by analytical question"
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/chartRegistry.ts"
+      - "results-explorer/src/components/ChartPanel.tsx"
+      - "results-explorer/src/__tests__/chartRegistry.meta.test.ts"
+      - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
     notes: |
       In `results-explorer/src/lib/chartRegistry.ts` and ChartPanel, replace the
       flat 10+ chip list with grouped tabs or segmented controls:

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -2,7 +2,7 @@ id: explorer-chart-correctness-and-navigation
 title: "Explorer: chart correctness, log-scale latency encoding, and chart navigation"
 worktree: main
 priority: High
-status: "Not Started"
+status: "In Progress"
 category: "Data Visualization"
 
 deps:
@@ -101,7 +101,14 @@ work:
   - id: w6
     summary: "Add high-contrast and reduced-color paths for heatmaps"
     needs: [w5]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/MetaLeaderboard.tsx"
+      - "results-explorer/src/components/QueryHeatmap.tsx"
+      - "results-explorer/src/index.css"
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+      - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
     notes: |
       MetaLeaderboard and QueryHeatmap should have text/value labels sufficient
       for interpretation without relying only on color. Add or preserve
@@ -141,17 +148,21 @@ files_affected:
   modified:
     - "results-explorer/src/lib/chartRegistry.ts"
     - "results-explorer/src/lib/chartMath.ts"
+    - "results-explorer/src/lib/queryLabels.ts"
     - "results-explorer/src/components/ChartPanel.tsx"
     - "results-explorer/src/components/PowerBar.tsx"
     - "results-explorer/src/components/TimeSeries.tsx"
     - "results-explorer/src/components/QueryHeatmap.tsx"
     - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/index.css"
     - "results-explorer/src/pages/BenchmarkIndex.tsx"
     - "results-explorer/src/pages/PlatformIndex.tsx"
     - "results-explorer/src/__tests__/chartRegistry.meta.test.ts"
     - "results-explorer/src/__tests__/chartTheme.test.ts"
     - "results-explorer/src/__tests__/parity/chartMath.parity.test.ts"
     - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
     - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
 
 must_preserve:
@@ -187,6 +198,7 @@ scope_limit:
     - "results-explorer/src/lib/chartMath.ts"
     - "results-explorer/src/lib/queryLabels.ts"
     - "results-explorer/src/components/"
+    - "results-explorer/src/index.css"
     - "results-explorer/src/pages/BenchmarkIndex.tsx"
     - "results-explorer/src/pages/PlatformIndex.tsx"
     - "results-explorer/src/__tests__/"

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -68,11 +68,19 @@ work:
   - id: w4
     summary: "Split platform trend charts by cohort or metric"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/pages/PlatformIndex.tsx"
+      - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
     notes: |
       Carry forward the critical defect fix: trend charts must not mix
       benchmark/scale/phase cohorts. Render cohort-specific small multiples or
       require a selected cohort before showing the time series.
+
+      Already satisfied by `explorer-critical-results-ux-defects` w3/w6 on the
+      current base: `buildTrendCohorts` groups by benchmark, scale factor,
+      phase, and primary metric, and `PlatformIndex.test.tsx` asserts TPC-H and
+      SSB trend points do not cross cohort sections.
 
   - id: w5
     summary: "Add natural query sorting and explicit query labels in heatmaps and tables"

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -84,7 +84,15 @@ work:
 
   - id: w5
     summary: "Add natural query sorting and explicit query labels in heatmaps and tables"
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/queryLabels.ts"
+      - "results-explorer/src/components/QueryHeatmap.tsx"
+      - "results-explorer/src/components/QueryHistogram.tsx"
+      - "results-explorer/src/components/RankTable.tsx"
+      - "results-explorer/src/__tests__/queryLabels.test.ts"
+      - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+      - "results-explorer/src/components/__tests__/charts.smoke.test.tsx"
     notes: |
       Query IDs should sort Q1, Q2, ..., Q10 rather than lexicographic 1, 10,
       11, ..., 2. Labels should preserve benchmark-specific prefixes where
@@ -177,6 +185,7 @@ scope_limit:
   only_modify:
     - "results-explorer/src/lib/chartRegistry.ts"
     - "results-explorer/src/lib/chartMath.ts"
+    - "results-explorer/src/lib/queryLabels.ts"
     - "results-explorer/src/components/"
     - "results-explorer/src/pages/BenchmarkIndex.tsx"
     - "results-explorer/src/pages/PlatformIndex.tsx"

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -118,11 +118,18 @@ work:
   - id: w7
     summary: "Add chart math and rendering tests for scale, sorting, and labels"
     needs: [w2, w3, w4, w5, w6]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
     notes: |
       Extend chartMath and component tests for log-scale mapping, label
       collision behavior, cohort-split trend data, natural query sort, and
       heatmap accessible names/values.
+
+      Existing W2-W6 commits cover log-scale chart math, ChartPanel log-scale
+      rendering, collision-aware value label placement, cohort-split trend
+      rendering, natural query sort, and MetaLeaderboard heatmap values. W7
+      closes the remaining exact accessible-name assertion for QueryHeatmap.
 
 metadata:
   tags:

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -56,7 +56,10 @@ work:
   - id: w3
     summary: "Fix label overlap in SSB/star_schema performance bar charts"
     needs: [w2]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/ChartPanel.tsx"
+      - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
     notes: |
       The audited SSB Performance Bar showed labels crowding near the origin.
       Implement collision-aware label placement: outside labels when space is

--- a/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
+++ b/_project/TODO/main/planning/explorer-chart-correctness-and-navigation.yaml
@@ -41,7 +41,12 @@ work:
   - id: w2
     summary: "Use log-scale or ratio-based encoding for latency bars where values span orders of magnitude"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/chartMath.ts"
+      - "results-explorer/src/components/ChartPanel.tsx"
+      - "results-explorer/src/__tests__/chartMath.scale.test.ts"
+      - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
     notes: |
       Update PowerBar/ChartPanel latency views so linear bars do not compress
       faster engines against a slow outlier. Use log scale for latency magnitude

--- a/results-explorer/src/__tests__/chartMath.scale.test.ts
+++ b/results-explorer/src/__tests__/chartMath.scale.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLatencyBarScale,
+  latencyScaleFraction,
+  latencyScaleTicks,
+} from "@/lib/chartMath";
+
+describe("latency bar scale", () => {
+  it("keeps compact latency ranges on a zero-based linear scale", () => {
+    const scale = buildLatencyBarScale([10, 20, 40]);
+
+    expect(scale?.mode).toBe("linear");
+    expect(scale?.domainMin).toBe(0);
+    expect(scale?.domainMax).toBe(40);
+    expect(latencyScaleFraction(20, scale!)).toBe(0.5);
+    expect(latencyScaleTicks(scale!)).toStrictEqual([0, 10, 20, 30, 40]);
+  });
+
+  it("switches to log scale when a slow outlier spans an order of magnitude", () => {
+    const scale = buildLatencyBarScale([10, 100, 1000]);
+
+    expect(scale?.mode).toBe("log");
+    expect(scale?.spanRatio).toBe(100);
+    expect(latencyScaleTicks(scale!)).toStrictEqual([10, 100, 1000]);
+
+    const fast = latencyScaleFraction(10, scale!);
+    const middle = latencyScaleFraction(100, scale!);
+    const slow = latencyScaleFraction(1000, scale!);
+
+    expect(fast).toBeGreaterThan(0);
+    expect(middle).toBeGreaterThan(fast!);
+    expect(middle).toBeLessThan(slow!);
+    expect(slow).toBe(1);
+  });
+
+  it("keeps sub-millisecond values visible on log scale", () => {
+    const scale = buildLatencyBarScale([0.01, 1]);
+
+    expect(scale?.mode).toBe("log");
+    expect(latencyScaleFraction(0.01, scale!)).toBeGreaterThan(0);
+    expect(latencyScaleFraction(1, scale!)).toBe(1);
+  });
+
+  it("ignores null, zero, and non-finite inputs when choosing a scale", () => {
+    const scale = buildLatencyBarScale([null, 0, Number.POSITIVE_INFINITY, 25]);
+
+    expect(scale).toMatchObject({
+      mode: "linear",
+      min: 25,
+      max: 25,
+      domainMin: 0,
+      domainMax: 25,
+      spanRatio: 1,
+    });
+  });
+});

--- a/results-explorer/src/__tests__/chartRegistry.meta.test.ts
+++ b/results-explorer/src/__tests__/chartRegistry.meta.test.ts
@@ -12,7 +12,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { CHART_REGISTRY, ALL_CHART_IDS, isValidChartId } from "@/lib/chartRegistry";
+import {
+  CHART_REGISTRY,
+  ALL_CHART_IDS,
+  CHART_QUESTION_GROUPS,
+  groupChartsByQuestion,
+  isValidChartId,
+} from "@/lib/chartRegistry";
 
 // Hard-coded canonical list from chart_types.py _CHART_SPECS (order matters).
 // chart_types.py is the SINGLE SOURCE OF TRUTH. This list must be kept in sync
@@ -66,5 +72,40 @@ describe("chartRegistry parity with chart_types.py", () => {
       const entry = CHART_REGISTRY.find((e) => e.id === id);
       expect(entry?.requires.requiresTwoResults, `${id} should requiresTwoResults`).toBe(true);
     }
+  });
+
+  it("assigns every chart to a known analytical question group", () => {
+    const groupIds = new Set(CHART_QUESTION_GROUPS.map((group) => group.id));
+
+    for (const entry of CHART_REGISTRY) {
+      expect(groupIds.has(entry.questionGroup), `${entry.id} has a known question group`).toBe(true);
+    }
+  });
+
+  it("groups charts by Explorer analytical question without changing registry order", () => {
+    const grouped = groupChartsByQuestion(CHART_REGISTRY);
+
+    expect(grouped.map((group) => group.label)).toStrictEqual([
+      "Overview",
+      "Per-query",
+      "Distribution",
+      "Cost",
+      "Trend",
+      "Rank",
+    ]);
+    expect(grouped.find((group) => group.id === "overview")?.charts.map((chart) => chart.id)).toStrictEqual([
+      "performance_bar",
+      "power_bar",
+      "summary_box",
+      "stacked_phase",
+      "sparkline_table",
+    ]);
+    expect(grouped.find((group) => group.id === "per_query")?.charts.map((chart) => chart.id)).toStrictEqual([
+      "query_heatmap",
+      "query_histogram",
+      "comparison_bar",
+      "diverging_bar",
+      "normalized_speedup",
+    ]);
   });
 });

--- a/results-explorer/src/__tests__/queryLabels.test.ts
+++ b/results-explorer/src/__tests__/queryLabels.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
+
+describe("query labels", () => {
+  it("sorts query IDs naturally without stripping benchmark-specific prefixes", () => {
+    expect(sortQueryIds(["Q10", "Q2", "Q1", "query_001", "q03"])).toStrictEqual([
+      "Q1",
+      "Q2",
+      "q03",
+      "Q10",
+      "query_001",
+    ]);
+  });
+
+  it("keeps the original query label for display", () => {
+    expect(queryDisplayLabel("Q1")).toBe("Q1");
+    expect(queryDisplayLabel("q01")).toBe("q01");
+    expect(queryDisplayLabel("query_001")).toBe("query_001");
+  });
+});

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -25,6 +25,11 @@ import { CDFChart } from "@/components/CDFChart";
 import { RankTable } from "@/components/RankTable";
 import { fmtGeomean, fmtScore } from "@/utils";
 import { paletteColor } from "@/lib/chartTheme";
+import {
+  buildLatencyBarScale,
+  latencyScaleFraction,
+  latencyScaleTicks,
+} from "@/lib/chartMath";
 
 interface ChartPanelProps {
   context: ChartContext;
@@ -360,7 +365,14 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
   const valueWidth = 72;
   const plotWidth = width - labelWidth - valueWidth;
   const totalHeight = topPadding + rows.length * rowHeight + axisHeight;
-  const maxValue = Math.max(...rows.map((row) => row.display_geomean_ms ?? 0));
+  const scale = buildLatencyBarScale(rows.map((row) => row.display_geomean_ms));
+  if (scale === null) return null;
+
+  const ticks = latencyScaleTicks(scale);
+  const scaleLabel =
+    scale.mode === "log"
+      ? "Geomean query time (log scale) - lower is faster"
+      : "Geomean query time (median-of-passing) - lower is faster";
 
   return (
     <div ref={containerRef} class="w-full overflow-x-auto">
@@ -368,10 +380,15 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
         width={width}
         height={totalHeight}
         role="img"
-        aria-label="Geomean performance comparison"
+        aria-label={
+          scale.mode === "log"
+            ? "Geomean performance comparison (log scale)"
+            : "Geomean performance comparison"
+        }
       >
         {rows.map((row, index) => {
-          const barWidth = ((row.display_geomean_ms ?? 0) / maxValue) * plotWidth;
+          const fraction = latencyScaleFraction(row.display_geomean_ms, scale) ?? 0;
+          const barWidth = fraction * plotWidth;
           const y = topPadding + index * rowHeight;
           const midY = y + rowHeight * 0.5;
           const barHeight = rowHeight * 0.55;
@@ -426,11 +443,11 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
             stroke="#d1d5db"
             strokeWidth={1}
           />
-          {[0, 0.25, 0.5, 0.75, 1].map((fraction) => {
+          {ticks.map((value) => {
+            const fraction = latencyScaleFraction(value, scale) ?? 0;
             const x = labelWidth + fraction * plotWidth;
-            const value = fraction * maxValue;
             return (
-              <g key={fraction}>
+              <g key={value}>
                 <line x1={x} y1={0} x2={x} y2={4} stroke="#9ca3af" strokeWidth={1} />
                 <text
                   x={x}
@@ -449,7 +466,7 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
             textAnchor="middle"
             style={{ fontSize: "10px", fill: "#9ca3af" }}
           >
-            Geomean query time (median-of-passing) - lower is faster
+            {scaleLabel}
           </text>
         </g>
       </svg>

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -40,6 +40,13 @@ interface CompareQueryRow {
   timings: ({ ms: number; status: "pass" } | null)[];
 }
 
+interface ValueLabelPlacement {
+  x: number;
+  textAnchor: "start" | "end";
+  fill: string;
+  placement: "outside" | "inside" | "gutter";
+}
+
 export function ChartPanel({ context }: ChartPanelProps) {
   const charts = useMemo(() => applicableCharts(context), [context]);
   const chartGroups = useMemo(() => groupChartsByQuestion(charts), [charts]);
@@ -362,8 +369,8 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
   const rowHeight = 36;
   const axisHeight = 32;
   const topPadding = 8;
-  const valueWidth = 72;
-  const plotWidth = width - labelWidth - valueWidth;
+  const valueLabelGutter = 96;
+  const plotWidth = width - labelWidth - valueLabelGutter;
   const totalHeight = topPadding + rows.length * rowHeight + axisHeight;
   const scale = buildLatencyBarScale(rows.map((row) => row.display_geomean_ms));
   if (scale === null) return null;
@@ -389,6 +396,14 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
         {rows.map((row, index) => {
           const fraction = latencyScaleFraction(row.display_geomean_ms, scale) ?? 0;
           const barWidth = fraction * plotWidth;
+          const renderedBarWidth = Math.max(2, barWidth);
+          const valueLabel = fmtGeomean(row.display_geomean_ms);
+          const valueLabelPlacement = placePerformanceValueLabel({
+            barWidth: renderedBarWidth,
+            plotWidth,
+            labelWidth,
+            valueText: valueLabel,
+          });
           const y = topPadding + index * rowHeight;
           const midY = y + rowHeight * 0.5;
           const barHeight = rowHeight * 0.55;
@@ -405,7 +420,7 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
               <rect
                 x={labelWidth}
                 y={midY - barHeight / 2}
-                width={Math.max(2, barWidth)}
+                width={renderedBarWidth}
                 height={barHeight}
                 fill={row.color}
                 opacity={0.85}
@@ -413,12 +428,25 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
               >
                 <title>{`${row.platform}: ${fmtGeomean(row.display_geomean_ms)}`}</title>
               </rect>
+              {valueLabelPlacement.placement === "gutter" && (
+                <line
+                  x1={labelWidth + renderedBarWidth + 4}
+                  y1={midY}
+                  x2={valueLabelPlacement.x - 5}
+                  y2={midY}
+                  stroke="#d1d5db"
+                  strokeWidth={1}
+                  strokeDasharray="2 2"
+                />
+              )}
               <text
-                x={labelWidth + barWidth + 6}
+                x={valueLabelPlacement.x}
                 y={midY + 4}
-                style={{ fontSize: "11px", fill: "#374151" }}
+                textAnchor={valueLabelPlacement.textAnchor}
+                data-value-placement={valueLabelPlacement.placement}
+                style={{ fontSize: "11px", fill: valueLabelPlacement.fill }}
               >
-                {fmtGeomean(row.display_geomean_ms)}
+                {valueLabel}
               </text>
               {index < rows.length - 1 && (
                 <line
@@ -472,6 +500,49 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
       </svg>
     </div>
   );
+}
+
+function placePerformanceValueLabel({
+  barWidth,
+  plotWidth,
+  labelWidth,
+  valueText,
+}: {
+  barWidth: number;
+  plotWidth: number;
+  labelWidth: number;
+  valueText: string;
+}): ValueLabelPlacement {
+  const labelGap = 6;
+  const labelPx = valueText.length * 6.5;
+  const plotRight = labelWidth + plotWidth;
+  const outsideX = labelWidth + barWidth + labelGap;
+  const outsideFits = outsideX + labelPx <= plotRight - labelGap;
+  if (outsideFits) {
+    return {
+      x: outsideX,
+      textAnchor: "start",
+      fill: "#374151",
+      placement: "outside",
+    };
+  }
+
+  const insideFits = barWidth >= labelPx + labelGap * 2;
+  if (insideFits) {
+    return {
+      x: labelWidth + barWidth - labelGap,
+      textAnchor: "end",
+      fill: "#ffffff",
+      placement: "inside",
+    };
+  }
+
+  return {
+    x: plotRight + labelGap,
+    textAnchor: "start",
+    fill: "#374151",
+    placement: "gutter",
+  };
 }
 
 function SummaryBoxPanel({

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -3,6 +3,7 @@ import type { BenchmarkSummary } from "@/types";
 import {
   applicableCharts,
   buildRenderableSummary,
+  groupChartsByQuestion,
   type ChartContext,
   type ChartHistoricalEntry,
   type ChartRegistryEntry,
@@ -36,6 +37,7 @@ interface CompareQueryRow {
 
 export function ChartPanel({ context }: ChartPanelProps) {
   const charts = useMemo(() => applicableCharts(context), [context]);
+  const chartGroups = useMemo(() => groupChartsByQuestion(charts), [charts]);
   const summary = useMemo(() => buildRenderableSummary(context), [context]);
   const historical = useMemo(
     () =>
@@ -87,13 +89,54 @@ export function ChartPanel({ context }: ChartPanelProps) {
   if (charts.length === 0) return null;
 
   const activeChart = charts.find((chart) => chart.id === activeId) ?? charts[0]!;
+  const activeGroup =
+    chartGroups.find((group) => group.charts.some((chart) => chart.id === activeChart.id)) ??
+    chartGroups[0]!;
+  const activeGroupCharts = activeGroup.charts;
   const showBaseline = context.kind === "compare" && (activeId === "normalized_speedup" || activeId === "diverging_bar");
+
+  const selectGroup = (group: (typeof chartGroups)[number]) => {
+    const nextChart =
+      group.charts.find((chart) => chart.id === activeId) ??
+      group.charts.find((chart) => chart.id === preferredId) ??
+      group.charts[0];
+    if (nextChart) setActiveId(nextChart.id);
+  };
 
   return (
     <section class="card">
-      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
         <h2 class="text-base font-semibold text-gray-900">Charts</h2>
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
+          {chartGroups.length > 1 && (
+            <div
+              class="flex flex-wrap gap-1 rounded-md border border-gray-200 bg-gray-50 p-1"
+              role="tablist"
+              aria-label="Chart question groups"
+            >
+              {chartGroups.map((group) => {
+                const selected = group.id === activeGroup.id;
+                return (
+                  <button
+                    key={group.id}
+                    role="tab"
+                    type="button"
+                    aria-selected={selected}
+                    aria-controls="chart-panel-chart"
+                    class={`rounded px-3 py-1.5 text-xs font-medium transition-colors ${
+                      selected
+                        ? "bg-white text-gray-900 shadow-sm"
+                        : "text-gray-600 hover:bg-white hover:text-gray-900"
+                    }`}
+                    onClick={() => selectGroup(group)}
+                    title={group.description}
+                  >
+                    {group.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
           {showBaseline && summary && summary.platforms.length > 1 && (
             <div class="flex items-center gap-2">
               <label class="text-xs text-gray-500" for="chart-panel-baseline">
@@ -113,34 +156,43 @@ export function ChartPanel({ context }: ChartPanelProps) {
               </select>
             </div>
           )}
-          <div class="flex flex-wrap gap-1">
-            {charts.map((chart) => (
-              <button
-                key={chart.id}
-                class={`rounded px-3 py-1 text-xs font-medium transition-colors ${
-                  activeChart.id === chart.id
-                    ? "bg-brand-600 text-white"
-                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                }`}
-                onClick={() => setActiveId(chart.id)}
-                aria-pressed={activeChart.id === chart.id}
-                title={chart.description}
-              >
-                {chart.title}
-              </button>
-            ))}
-          </div>
+          {activeGroupCharts.length > 1 && (
+            <div
+              class="flex flex-wrap justify-end gap-1"
+              role="group"
+              aria-label={`${activeGroup.label} charts`}
+            >
+              {activeGroupCharts.map((chart) => (
+                <button
+                  key={chart.id}
+                  type="button"
+                  class={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+                    activeChart.id === chart.id
+                      ? "bg-brand-600 text-white"
+                      : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                  }`}
+                  onClick={() => setActiveId(chart.id)}
+                  aria-pressed={activeChart.id === chart.id}
+                  title={chart.description}
+                >
+                  {chart.title}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
-      {renderChart(activeChart, {
-        context,
-        summary,
-        historical,
-        compareRows,
-        compareGroups,
-        baselineIdx,
-      })}
+      <div id="chart-panel-chart" role="tabpanel" aria-label={`${activeGroup.label} chart`}>
+        {renderChart(activeChart, {
+          context,
+          summary,
+          historical,
+          compareRows,
+          compareGroups,
+          baselineIdx,
+        })}
+      </div>
     </section>
   );
 }

--- a/results-explorer/src/components/MetaLeaderboard.tsx
+++ b/results-explorer/src/components/MetaLeaderboard.tsx
@@ -1,7 +1,8 @@
+import type { JSX } from "preact";
 import { useMemo, useRef, useState } from "preact/hooks";
 import { route } from "preact-router";
 import type { MetaCohort, MetaLeaderboard as MetaLeaderboardData, MetaPlatform, MetaRank } from "@/types";
-import { colorForCell } from "@/lib/chartMath";
+import { colorForCell, lightnessForCell } from "@/lib/chartMath";
 import { fmtGeomean, fmtScore, humanizeBenchmark } from "@/utils";
 import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
 
@@ -194,11 +195,19 @@ export function MetaLeaderboard({
                   const shadeMetric = cellShadeMetric(rank, mode, cohort);
                   const minInCol = columnMins.get(cohort.key) ?? null;
                   const hue = shadeMetric !== null ? colorForCell(shadeMetric, minInCol) : null;
+                  const lightness = shadeMetric !== null ? lightnessForCell(shadeMetric, minInCol) : null;
                   const active = focusPos.row === rowIdx && focusPos.col === colIdx;
                   const text = describeCell(platform, cohort, rank, mode);
                   const result = cohort.platforms?.find((row) => row.platform_id === platform.platform_id);
                   const metadata = result ? resultMetadataById?.get(result.result_id) : undefined;
                   const receiptHref = result ? `/results/r/${result.result_id}#run-receipt` : null;
+                  const cellStyle: JSX.CSSProperties | undefined =
+                    hue !== null
+                      ? ({
+                          "--cell-hue": String(hue),
+                          "--cell-lightness": lightness ?? "95%",
+                        } as JSX.CSSProperties)
+                      : undefined;
                   return (
                     <td
                       key={cohort.key}
@@ -206,10 +215,10 @@ export function MetaLeaderboard({
                       aria-colindex={colIdx + 1}
                       aria-rowindex={rowIdx + 1}
                       aria-label={text}
-                      class={`table-td text-center font-mono ${active ? "ring-2 ring-brand-500 ring-inset" : ""}`}
-                      style={{
-                        backgroundColor: hue !== null ? `hsl(${hue} 72% 93%)` : undefined,
-                      }}
+                      class={`table-td text-center font-mono ${
+                        hue !== null ? "meta-heatmap-cell" : ""
+                      } ${active ? "ring-2 ring-brand-500 ring-inset" : ""}`}
+                      style={cellStyle}
                       tabIndex={active ? 0 : -1}
                       data-cell={`${rowIdx}-${colIdx}`}
                       onFocus={() => {

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -3,7 +3,9 @@
  *
  * Renders a BenchmarkSummary as a heat-colored table where each cell shows
  * the canonical display_ms value for (platform, query), colored per column
- * using a log10(ratio-to-fastest) scale clamped at 10× (green → red).
+ * using a log10(ratio-to-fastest) scale clamped at 10×. The default CSS path
+ * uses a single-hue sequential palette, with grayscale lightness for reduced
+ * color / high-contrast contexts.
  *
  * Accessibility:
  *   - role="grid" on the table; role="gridcell" on data cells.

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -22,6 +22,7 @@ import type { JSX } from "preact";
 import type { BenchmarkSummary, PlatformRow, SortDirection, SortState } from "@/types";
 import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
 import { fmtMs, fmtScore, fmtGeomean, complianceLabel } from "@/utils";
+import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
 
 // ---------------------------------------------------------------------------
 // Color math - sourced from chartMath.ts (single source of truth for parity)
@@ -54,6 +55,7 @@ export function QueryHeatmap({
   highContrast = false,
 }: QueryHeatmapProps) {
   const { query_ids, platforms, ranking } = summary;
+  const sortedQueryIds = useMemo(() => sortQueryIds(query_ids), [query_ids]);
   const hasSelection = onSelectionChange !== undefined;
   const gridRef = useRef<HTMLTableElement>(null);
 
@@ -64,10 +66,10 @@ export function QueryHeatmap({
 
   // Per-column minimum: fastest time across all platforms for each query.
   // Memoized on `summary` to avoid recomputing the full matrix on every render
-  // (the for loop runs query_ids.length × platforms.length iterations).
+  // (the for loop runs sortedQueryIds.length × platforms.length iterations).
   const colMins = useMemo<Record<string, number | null>>(() => {
     const mins: Record<string, number | null> = {};
-    for (const qid of query_ids) {
+    for (const qid of sortedQueryIds) {
       const vals = platforms
         .map((p) => p.timings[qid] ?? null)
         // Exclude zero/null cells; sub-ms values round to 0 in some runners.
@@ -75,7 +77,7 @@ export function QueryHeatmap({
       mins[qid] = vals.length > 0 ? Math.min(...vals) : null;
     }
     return mins;
-  }, [summary]);
+  }, [platforms, sortedQueryIds]);
 
   // Determine primary display metric from the artifact's ranking config.
   const primaryMetric = ranking?.primary_metric ?? "display_geomean_ms";
@@ -180,7 +182,7 @@ export function QueryHeatmap({
     let nextCol = colIdx;
     switch (e.key) {
       case "ArrowRight":
-        nextCol = Math.min(colIdx + 1, query_ids.length - 1);
+        nextCol = Math.min(colIdx + 1, sortedQueryIds.length - 1);
         break;
       case "ArrowLeft":
         nextCol = Math.max(colIdx - 1, 0);
@@ -195,7 +197,7 @@ export function QueryHeatmap({
         nextCol = 0;
         break;
       case "End":
-        nextCol = query_ids.length - 1;
+        nextCol = sortedQueryIds.length - 1;
         break;
       default:
         return;
@@ -300,7 +302,7 @@ export function QueryHeatmap({
                   </button>
                 </th>
               )}
-              {query_ids.map((qid) => (
+              {sortedQueryIds.map((qid) => (
                 <th
                   key={qid}
                   role="columnheader"
@@ -311,9 +313,10 @@ export function QueryHeatmap({
                   <button
                     type="button"
                     class="table-th block w-full cursor-pointer select-none border-0 bg-transparent text-left font-mono"
+                    data-query-label={qid}
                     onClick={() => toggleSort(`query:${qid}`)}
                   >
-                    {qid}{sortArrow(`query:${qid}`)}
+                    {queryDisplayLabel(qid)}{sortArrow(`query:${qid}`)}
                     {sortAnnouncement(`query:${qid}`)}
                   </button>
                 </th>
@@ -372,7 +375,7 @@ export function QueryHeatmap({
                       {fmtGeomean(row.display_geomean_ms)}
                     </td>
                   )}
-                  {query_ids.map((qid, colIdx) => {
+                  {sortedQueryIds.map((qid, colIdx) => {
                     const ms = row.timings[qid] ?? null;
                     const minInCol = colMins[qid] ?? null;
                     const hue = suppressHeat ? null : colorForCell(ms, minInCol);
@@ -410,7 +413,7 @@ export function QueryHeatmap({
                         style={cellStyle}
                         aria-label={ariaLabel}
                         onKeyDown={(e) => handleCellKey(e as KeyboardEvent, rowIdx, colIdx)}
-                        onFocus={() => setAnnouncement(`${qid}: ${ariaLabel}`)}
+                        onFocus={() => setAnnouncement(`${queryDisplayLabel(qid)}: ${ariaLabel}`)}
                       >
                         {ms !== null ? fmtMs(ms) : "-"}
                       </td>

--- a/results-explorer/src/components/QueryHistogram.tsx
+++ b/results-explorer/src/components/QueryHistogram.tsx
@@ -11,6 +11,7 @@
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
 import { paletteColor } from "@/lib/chartTheme";
+import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
 
 const MAX_PER_PANEL = 33;
 const BAR_GAP = 3;
@@ -35,11 +36,12 @@ export function QueryHistogram({ summary }: Props) {
 
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
+  const sortedQueryIds = sortQueryIds(query_ids);
 
   // Split into panels
   const panels: string[][] = [];
-  for (let i = 0; i < query_ids.length; i += MAX_PER_PANEL) {
-    panels.push(query_ids.slice(i, i + MAX_PER_PANEL));
+  for (let i = 0; i < sortedQueryIds.length; i += MAX_PER_PANEL) {
+    panels.push(sortedQueryIds.slice(i, i + MAX_PER_PANEL));
   }
 
   function renderPanel(qids: string[], panelIdx: number) {
@@ -63,7 +65,7 @@ export function QueryHistogram({ summary }: Props) {
       <div key={panelIdx} class="mb-2">
         {panels.length > 1 && (
           <p class="text-[10px] text-gray-400 mb-0.5 ml-[44px]">
-            Queries {panelIdx * MAX_PER_PANEL + 1}-{Math.min((panelIdx + 1) * MAX_PER_PANEL, query_ids.length)}
+            Queries {panelIdx * MAX_PER_PANEL + 1}-{Math.min((panelIdx + 1) * MAX_PER_PANEL, sortedQueryIds.length)}
           </p>
         )}
         <svg
@@ -112,7 +114,7 @@ export function QueryHistogram({ summary }: Props) {
                         strokeDasharray="2,1"
                         opacity={0.5}
                       >
-                        <title>{`${p.platform} · ${qid}: no result`}</title>
+                        <title>{`${p.platform} · ${queryDisplayLabel(qid)}: no result`}</title>
                       </line>
                     );
                   }
@@ -126,7 +128,7 @@ export function QueryHistogram({ summary }: Props) {
                       fill={paletteColor(pi)}
                       fillOpacity={0.85}
                     >
-                      <title>{`${p.platform} · ${qid}: ${ms.toFixed(1)}ms`}</title>
+                      <title>{`${p.platform} · ${queryDisplayLabel(qid)}: ${ms.toFixed(1)}ms`}</title>
                     </rect>
                   );
                 })}
@@ -134,9 +136,10 @@ export function QueryHistogram({ summary }: Props) {
                   x={groupX + innerW / 2}
                   y={PADDING_TOP + CHART_H + 14}
                   textAnchor="middle"
+                  data-query-label={qid}
                   style={{ fontSize: "9px", fill: "#9ca3af" }}
                 >
-                  {qid.replace(/^[Qq]/, "")}
+                  {queryDisplayLabel(qid)}
                 </text>
               </g>
             );

--- a/results-explorer/src/components/RankTable.tsx
+++ b/results-explorer/src/components/RankTable.tsx
@@ -13,6 +13,7 @@
 import type { BenchmarkSummary } from "@/types";
 import { paletteColor } from "@/lib/chartTheme";
 import { computeRankTable } from "@/lib/chartMath";
+import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
 
 interface Props {
   summary: BenchmarkSummary;
@@ -27,14 +28,15 @@ function ordinal(n: number): string {
 export function RankTable({ summary }: Props) {
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
+  const sortedQueryIds = sortQueryIds(query_ids);
 
   const ranks = computeRankTable(
-    query_ids,
+    sortedQueryIds,
     platforms.map((p) => p.timings),
   );
 
   const winCounts = platforms.map((_, i) =>
-    query_ids.filter((qid) => ranks[qid]?.[i] === 1).length,
+    sortedQueryIds.filter((qid) => ranks[qid]?.[i] === 1).length,
   );
   const maxWins = Math.max(...winCounts);
 
@@ -64,10 +66,10 @@ export function RankTable({ summary }: Props) {
           </tr>
         </thead>
         <tbody>
-          {query_ids.map((qid) => (
+          {sortedQueryIds.map((qid) => (
             <tr key={qid} class="hover:bg-gray-50">
               <td class="px-2 py-1 border-b border-gray-100 text-gray-600 font-mono sticky left-0 bg-white">
-                {qid}
+                {queryDisplayLabel(qid)}
               </td>
               {platforms.map((_, i) => {
                 const r = ranks[qid]?.[i] ?? null;

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -195,6 +195,36 @@ describe("ChartPanel", () => {
     expect(screen.queryByRole("button", { name: "Sparkline Table" })).toBeNull();
   });
 
+  it("uses log scale for performance bars when latency spans an order of magnitude", () => {
+    const { container } = render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary: makeSummary({
+            platforms: [
+              makePlatformRow({ result_id: "fast", platform: "FastDB", display_geomean_ms: 10 }),
+              makePlatformRow({ result_id: "middle", platform: "MidDB", display_geomean_ms: 100 }),
+              makePlatformRow({ result_id: "slow", platform: "SlowDB", display_geomean_ms: 1000 }),
+            ],
+          }),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Performance Bar" }));
+
+    expect(screen.getByRole("img", { name: "Geomean performance comparison (log scale)" })).toBeTruthy();
+    expect(screen.getByText("Geomean query time (log scale) - lower is faster")).toBeTruthy();
+
+    const widths = Array.from(
+      container.querySelectorAll('svg[aria-label="Geomean performance comparison (log scale)"] rect'),
+    ).map((rect) => Number(rect.getAttribute("width")));
+    expect(widths).toHaveLength(3);
+    expect(widths[0]).toBeGreaterThan(2);
+    expect(widths[0]).toBeLessThan(widths[1]!);
+    expect(widths[1]!).toBeLessThan(widths[2]!);
+  });
+
   it("keeps the cost chart reachable so normalized-cost empty states are visible", () => {
     render(
       <ChartPanel

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -225,6 +225,35 @@ describe("ChartPanel", () => {
     expect(widths[1]!).toBeLessThan(widths[2]!);
   });
 
+  it("places performance labels away from cramped bar edges and keeps tooltip values", () => {
+    const { container } = render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary: makeSummary({
+            platforms: [
+              makePlatformRow({ result_id: "fast", platform: "FastDB", display_geomean_ms: 10 }),
+              makePlatformRow({ result_id: "slow", platform: "SlowDB", display_geomean_ms: 1000 }),
+            ],
+          }),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Performance Bar" }));
+
+    const valueLabels = Array.from(container.querySelectorAll("text[data-value-placement]"));
+    expect(valueLabels.map((label) => label.getAttribute("data-value-placement"))).toContain("outside");
+    expect(valueLabels.map((label) => label.getAttribute("data-value-placement"))).toContain("inside");
+    expect(
+      valueLabels.find((label) => label.textContent === "1000 ms")?.getAttribute("data-value-placement"),
+    ).toBe("inside");
+
+    const tooltips = Array.from(container.querySelectorAll("rect title")).map((title) => title.textContent);
+    expect(tooltips).toContain("FastDB: 10 ms");
+    expect(tooltips).toContain("SlowDB: 1000 ms");
+  });
+
   it("keeps the cost chart reachable so normalized-cost empty states are visible", () => {
     render(
       <ChartPanel

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -160,7 +160,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
 }
 
 describe("ChartPanel", () => {
-  it("renders summary charts from registry requirements", () => {
+  it("groups summary charts by analytical question", () => {
     render(
       <ChartPanel
         context={{
@@ -174,10 +174,25 @@ describe("ChartPanel", () => {
       />,
     );
 
+    expect(screen.getByRole("tablist", { name: "Chart question groups" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Overview" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toStrictEqual([
+      "Overview",
+      "Per-query",
+      "Distribution",
+      "Cost",
+      "Trend",
+      "Rank",
+    ]);
     expect(screen.getByRole("button", { name: "Sparkline Table" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Performance Trend" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Cost vs Performance Scatter" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Query Heatmap" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Comparison Bar" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Trend" }));
+
+    expect(screen.getByRole("tab", { name: "Trend" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("img", { name: "Geomean ms trend over time" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Sparkline Table" })).toBeNull();
   });
 
   it("keeps the cost chart reachable so normalized-cost empty states are visible", () => {
@@ -201,7 +216,7 @@ describe("ChartPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Cost vs Performance Scatter" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Cost" }));
 
     expect(screen.getByText(/No normalized cost data/)).toBeTruthy();
     expect(screen.getByText(/No row has cost_status=normalized/)).toBeTruthy();
@@ -233,6 +248,7 @@ describe("ChartPanel", () => {
     expect(screen.getByRole("button", { name: "Comparison Bar" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Normalized Speedup" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Query Heatmap" })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: "Per-query" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.queryByRole("button", { name: "Performance Trend" })).toBeNull();
   });
 
@@ -260,6 +276,7 @@ describe("ChartPanel", () => {
       />,
     );
 
+    fireEvent.click(screen.getByRole("tab", { name: "Overview" }));
     fireEvent.click(screen.getByRole("button", { name: "Summary Box" }));
     expect(screen.getByText("throughput")).toBeTruthy();
   });
@@ -275,7 +292,8 @@ describe("ChartPanel", () => {
     );
 
     expect(screen.getByRole("button", { name: "Query Histogram" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Rank Table" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("tab", { name: "Rank" }));
+    expect(screen.getByRole("table", { name: "Per-query platform rankings (1st = fastest)" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Normalized Speedup" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Performance Trend" })).toBeNull();
   });

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -96,6 +96,20 @@ describe("MetaLeaderboard", () => {
     expect(screen.getByText("0.50x")).toBeTruthy();
   });
 
+  it("renders interpretable heatmap cells without relying only on color", () => {
+    const { container } = render(
+      <MetaLeaderboard data={DATA} mode="times" onModeChange={vi.fn()} />,
+    );
+
+    const cells = container.querySelectorAll<HTMLElement>("[data-cell]");
+    expect(cells).toHaveLength(2);
+    expect(cells[0]?.textContent).toContain("10 ms");
+    expect(cells[0]?.getAttribute("aria-label")).toBe("DuckDB times for ClickBench SF0.1: 10 ms");
+    expect(cells[0]?.className).toContain("meta-heatmap-cell");
+    expect(cells[0]?.style.getPropertyValue("--cell-hue")).toBeTruthy();
+    expect(cells[0]?.style.getPropertyValue("--cell-lightness")).toBeTruthy();
+  });
+
   it("fires render-mode changes through the toggle buttons", () => {
     const onModeChange = vi.fn();
     render(<MetaLeaderboard data={DATA} mode="times" onModeChange={onModeChange} />);
@@ -124,7 +138,6 @@ describe("MetaLeaderboard", () => {
     expect(screen.getByText("exact")).toBeTruthy();
     expect(screen.getByText("loose")).toBeTruthy();
   });
-
 
   it("renders null when platforms list is empty", () => {
     const { container } = render(

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -101,6 +101,25 @@ describe("QueryHeatmap rendering", () => {
     expect(screen.getByRole("button", { name: /^Q2/ })).toBeTruthy();
   });
 
+  it("sorts query headers naturally while preserving explicit labels", () => {
+    const summary = makeSummary({
+      query_ids: ["Q10", "Q2", "Q1"],
+      platforms: [
+        {
+          ...makeSummary().platforms[0]!,
+          timings: { Q1: 10, Q2: 20, Q10: 100 },
+        },
+      ],
+    });
+    const { container } = render(<QueryHeatmap summary={summary} />);
+
+    const labels = Array.from(container.querySelectorAll("thead button[data-query-label]")).map(
+      (button) => button.getAttribute("data-query-label"),
+    );
+    expect(labels).toStrictEqual(["Q1", "Q2", "Q10"]);
+    expect(screen.getByRole("button", { name: /^Q10/ })).toBeTruthy();
+  });
+
   it("renders compact receipt links and validation status badges", () => {
     render(<QueryHeatmap summary={makeSummary()} />);
     const receiptLinks = screen.getAllByRole("link", { name: "Receipt →" }) as HTMLAnchorElement[];

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -156,6 +156,17 @@ describe("QueryHeatmap rendering", () => {
     }
   });
 
+  it("exposes exact timing and relative-to-fastest accessible names", () => {
+    const { container } = render(<QueryHeatmap summary={makeSummary()} />);
+    const fastest = container.querySelector<HTMLElement>('[data-cell="0-0"]');
+    const slowest = container.querySelector<HTMLElement>('[data-cell="1-0"]');
+
+    expect(fastest?.textContent).toBe("10 ms");
+    expect(fastest?.getAttribute("aria-label")).toBe("10 ms, fastest in column");
+    expect(slowest?.textContent).toBe("100 ms");
+    expect(slowest?.getAttribute("aria-label")).toBe("100 ms, 10.0× fastest in column");
+  });
+
   it("activates reduced-color class when high contrast is requested", () => {
     const { container } = render(<QueryHeatmap summary={makeSummary()} highContrast />);
     expect(container.firstElementChild?.className).toContain("heatmap-reduced-color");

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -144,14 +144,21 @@ describe("QueryHeatmap rendering", () => {
     expect(rowOrder()).toEqual(["r2", "r1"]);
   });
 
-  it("heatmap cells have --cell-hue style set for multi-platform summaries", () => {
+  it("heatmap cells keep visible values and color variables for multi-platform summaries", () => {
     const { container } = render(<QueryHeatmap summary={makeSummary()} />);
     const heatCells = container.querySelectorAll(".heatmap-cell");
     // DuckDB Q1 (fastest) and SQLite Q1 (10× slower) = 2 cells; Q2 similarly
     expect(heatCells.length).toBeGreaterThan(0);
     for (const cell of Array.from(heatCells)) {
       expect((cell as HTMLElement).style.getPropertyValue("--cell-hue")).toBeTruthy();
+      expect((cell as HTMLElement).style.getPropertyValue("--cell-lightness")).toBeTruthy();
+      expect(cell.textContent).not.toBe("");
     }
+  });
+
+  it("activates reduced-color class when high contrast is requested", () => {
+    const { container } = render(<QueryHeatmap summary={makeSummary()} highContrast />);
+    expect(container.firstElementChild?.className).toContain("heatmap-reduced-color");
   });
 
   // -----------------------------------------------------------------------

--- a/results-explorer/src/components/__tests__/charts.smoke.test.tsx
+++ b/results-explorer/src/components/__tests__/charts.smoke.test.tsx
@@ -181,6 +181,18 @@ describe("RankTable", () => {
     const ranks = Array.from(cells).map((c) => c.textContent);
     expect(ranks.filter((r) => r === "1st").length).toBe(2);
   });
+
+  it("sorts query rows naturally and preserves explicit labels", () => {
+    const summary = makeSummary({
+      query_ids: ["Q10", "Q2", "Q1"],
+      platforms: [makePlatform({ timings: { Q1: 10, Q2: 20, Q10: 100 } })],
+    });
+    const { container } = render(<RankTable summary={summary} />);
+    const labels = Array.from(container.querySelectorAll("tbody tr td:first-child")).map(
+      (cell) => cell.textContent,
+    );
+    expect(labels).toStrictEqual(["Q1", "Q2", "Q10"]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -226,6 +238,18 @@ describe("QueryHistogram", () => {
     const { container } = render(<QueryHistogram summary={summary} />);
     const svgs = container.querySelectorAll("svg");
     expect(svgs.length).toBeGreaterThan(1);
+  });
+
+  it("sorts query labels naturally and does not strip prefixes", () => {
+    const summary = makeSummary({
+      query_ids: ["Q10", "Q2", "Q1"],
+      platforms: [makePlatform({ timings: { Q1: 10, Q2: 20, Q10: 100 } })],
+    });
+    const { container } = render(<QueryHistogram summary={summary} />);
+    const labels = Array.from(container.querySelectorAll("text[data-query-label]")).map(
+      (label) => label.textContent,
+    );
+    expect(labels).toStrictEqual(["Q1", "Q2", "Q10"]);
   });
 });
 

--- a/results-explorer/src/index.css
+++ b/results-explorer/src/index.css
@@ -124,30 +124,36 @@
         min-height: var(--bb-skeleton-row-height);
     }
 
-    /* Heatmap cells: background driven by --cell-hue CSS custom property.
-     Using custom properties lets dark-mode and high-contrast media queries
-     override saturation/lightness without hard-coding color values here. */
-    .heatmap-cell {
-        background-color: hsl(var(--cell-hue) 55% 50% / 0.3);
-    }
-
-    /* Reduced-color / high-contrast mode: switch to grayscale lightness steps.
-     Activated by the .heatmap-reduced-color class (explicit user toggle) or
-     automatically by the prefers-contrast: more media query.
-     Note: must be two separate rules - a class selector cannot be comma-joined
-     with an @media at-rule in a single rule block. */
-    .heatmap-reduced-color .heatmap-cell {
-        background-color: hsl(0 0% var(--cell-lightness, 95%) / 0.75);
-    }
-    @media (prefers-contrast: more) {
-        .heatmap-cell {
-            background-color: hsl(0 0% var(--cell-lightness, 95%) / 0.75);
-        }
+    /* Heatmap cells use a single-hue sequential palette by default.
+     Components still emit --cell-hue for chart-math parity, while
+     --cell-lightness drives a color-blind-safer light-to-dark scale. */
+    .heatmap-cell,
+    .meta-heatmap-cell {
+        background-color: hsl(205 80% var(--cell-lightness, 92%) / 0.38);
     }
 
     @media (prefers-color-scheme: dark) {
-        .heatmap-cell {
-            background-color: hsl(var(--cell-hue) 60% 35% / 0.5);
+        .heatmap-cell,
+        .meta-heatmap-cell {
+            background-color: hsl(205 70% var(--cell-lightness, 72%) / 0.42);
+        }
+    }
+
+    /* Reduced-color / high-contrast mode switches to grayscale lightness steps.
+     Activated by the .heatmap-reduced-color class where an explicit user toggle
+     exists, or automatically by the prefers-contrast: more media query.
+     Note: must be two separate rules - a class selector cannot be comma-joined
+     with an @media at-rule in a single rule block. Keep these rules after the
+     dark-mode rule so high-contrast users do not lose the reduced-color path. */
+    .heatmap-reduced-color .heatmap-cell,
+    .heatmap-reduced-color .meta-heatmap-cell {
+        background-color: hsl(0 0% var(--cell-lightness, 95%) / 0.62);
+    }
+
+    @media (prefers-contrast: more) {
+        .heatmap-cell,
+        .meta-heatmap-cell {
+            background-color: hsl(0 0% var(--cell-lightness, 95%) / 0.62);
         }
     }
 

--- a/results-explorer/src/lib/chartMath.ts
+++ b/results-explorer/src/lib/chartMath.ts
@@ -17,6 +17,90 @@
 import { HEAT_MIN_RATIO, HEAT_MAX_RATIO } from "@/lib/chartTheme";
 
 // ---------------------------------------------------------------------------
+// Latency magnitude scale
+// Explorer-only SVG layout policy for lower-is-better latency bars. The CLI
+// ASCII bar chart remains linear; the browser switches to log scale when a slow
+// outlier would otherwise collapse faster platforms into unreadable slivers.
+// ---------------------------------------------------------------------------
+
+export const LATENCY_LOG_SCALE_THRESHOLD = 10;
+
+export type LatencyScaleMode = "linear" | "log";
+
+export interface LatencyBarScale {
+  mode: LatencyScaleMode;
+  min: number;
+  max: number;
+  domainMin: number;
+  domainMax: number;
+  spanRatio: number;
+}
+
+const LATENCY_LOG_DOMAIN_PAD = Math.sqrt(10);
+const LATENCY_LOG_TICKS_MS = [0.1, 1, 10, 100, 1000, 10000, 100000, 1000000];
+
+function log2Latency(ms: number): number {
+  return Math.log2(Math.max(ms, Number.MIN_VALUE));
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function buildLatencyBarScale(
+  values: (number | null)[],
+  logThreshold = LATENCY_LOG_SCALE_THRESHOLD,
+): LatencyBarScale | null {
+  const valid = values.filter((value): value is number =>
+    value !== null && value > 0 && Number.isFinite(value),
+  );
+  if (valid.length === 0) return null;
+
+  const min = Math.min(...valid);
+  const max = Math.max(...valid);
+  const spanRatio = max / min;
+  const mode: LatencyScaleMode = spanRatio >= logThreshold ? "log" : "linear";
+
+  if (mode === "linear") {
+    return { mode, min, max, domainMin: 0, domainMax: max, spanRatio };
+  }
+
+  return {
+    mode,
+    min,
+    max,
+    domainMin: min / LATENCY_LOG_DOMAIN_PAD,
+    domainMax: max,
+    spanRatio,
+  };
+}
+
+export function latencyScaleFraction(value: number | null, scale: LatencyBarScale): number | null {
+  if (value === null || !Number.isFinite(value)) return null;
+  if (scale.mode === "linear") {
+    if (value < 0 || scale.domainMax <= 0) return null;
+    return clamp01(value / scale.domainMax);
+  }
+  if (value <= 0) return null;
+
+  const logMin = log2Latency(scale.domainMin);
+  const logMax = log2Latency(scale.domainMax);
+  const logRange = logMax - logMin || 1;
+  return clamp01((log2Latency(value) - logMin) / logRange);
+}
+
+export function latencyScaleTicks(scale: LatencyBarScale): number[] {
+  if (scale.mode === "linear") {
+    return [0, 0.25, 0.5, 0.75, 1].map((fraction) => fraction * scale.domainMax);
+  }
+
+  const ticks = LATENCY_LOG_TICKS_MS.filter(
+    (ms) => ms >= scale.domainMin * 0.99 && ms <= scale.domainMax * 1.01,
+  );
+  return ticks.length >= 2 ? ticks : [scale.min, scale.max];
+}
+
+// ---------------------------------------------------------------------------
 // Heatmap color math
 // Python reference: benchbox/core/visualization/ascii/heatmap.py
 // (log10-ratio → hue mapping)

--- a/results-explorer/src/lib/chartRegistry.ts
+++ b/results-explorer/src/lib/chartRegistry.ts
@@ -55,15 +55,74 @@ export interface DataRequirements {
   requiresPercentileStats?: boolean;
 }
 
+export type ChartQuestionGroupId =
+  | "overview"
+  | "per_query"
+  | "distribution"
+  | "cost"
+  | "trend"
+  | "rank";
+
+export interface ChartQuestionGroup {
+  id: ChartQuestionGroupId;
+  label: string;
+  description: string;
+}
+
 export interface ChartRegistryEntry {
   /** Canonical ID - matches chart_types.py ALL_CHART_TYPES entry. */
   id: string;
   title: string;
   description: string;
+  /** Analytical question this chart answers in Explorer navigation. */
+  questionGroup: ChartQuestionGroupId;
   requires: DataRequirements;
   /** Python CLI equivalent chart type name (always === id). */
   cli_equivalent: string;
 }
+
+export interface ChartQuestionGroupWithCharts extends ChartQuestionGroup {
+  charts: ChartRegistryEntry[];
+}
+
+export const CHART_QUESTION_GROUPS: readonly ChartQuestionGroup[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    description: "Top-line metric summaries and phase composition",
+  },
+  {
+    id: "per_query",
+    label: "Per-query",
+    description: "Query-level comparisons and outlier views",
+  },
+  {
+    id: "distribution",
+    label: "Distribution",
+    description: "Latency spread and percentile shape",
+  },
+  {
+    id: "cost",
+    label: "Cost",
+    description: "Cost and performance tradeoffs",
+  },
+  {
+    id: "trend",
+    label: "Trend",
+    description: "Historical movement over time",
+  },
+  {
+    id: "rank",
+    label: "Rank",
+    description: "Per-query ranking tables",
+  },
+] as const;
+
+export const CHART_QUESTION_GROUP_BY_ID: Readonly<Record<ChartQuestionGroupId, ChartQuestionGroup>> =
+  Object.fromEntries(CHART_QUESTION_GROUPS.map((group) => [group.id, group])) as Record<
+    ChartQuestionGroupId,
+    ChartQuestionGroup
+  >;
 
 // ---------------------------------------------------------------------------
 // Registry - must stay in sync with chart_types.py _CHART_SPECS order
@@ -74,6 +133,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "performance_bar",
     title: "Performance Bar",
     description: "Bar chart comparing total runtime across platforms",
+    questionGroup: "overview",
     requires: { requiresSummary: true },
     cli_equivalent: "performance_bar",
   },
@@ -81,6 +141,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "power_bar",
     title: "Power@Size Bar",
     description: "Bar chart comparing TPC Power@Size metric across platforms (higher is better)",
+    questionGroup: "overview",
     requires: { requiresSummary: true, requiresPowerScore: true },
     cli_equivalent: "power_bar",
   },
@@ -88,6 +149,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "distribution_box",
     title: "Distribution Box Plot",
     description: "Box plot showing query execution time distribution",
+    questionGroup: "distribution",
     requires: { requiresSummary: true, requiresQueryTimings: true },
     cli_equivalent: "distribution_box",
   },
@@ -95,6 +157,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "query_heatmap",
     title: "Query Heatmap",
     description: "Heatmap comparing per-query execution times across platforms",
+    questionGroup: "per_query",
     requires: { requiresSummary: true, requiresQueryTimings: true },
     cli_equivalent: "query_heatmap",
   },
@@ -103,6 +166,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     title: "Query Histogram",
     description:
       "Vertical bar histogram showing latency per query (auto-splits for >33 queries)",
+    questionGroup: "per_query",
     requires: { requiresSummary: true, requiresQueryTimings: true },
     cli_equivalent: "query_histogram",
   },
@@ -110,6 +174,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "cost_scatter",
     title: "Cost vs Performance Scatter",
     description: "Scatter plot of normalized cost vs performance with cost-status empty states",
+    questionGroup: "cost",
     requires: { requiresSummary: true },
     cli_equivalent: "cost_scatter",
   },
@@ -117,6 +182,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "time_series",
     title: "Performance Trend",
     description: "Line chart showing performance trends over time",
+    questionGroup: "trend",
     requires: { requiresHistorical: true },
     cli_equivalent: "time_series",
   },
@@ -125,6 +191,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     title: "Comparison Bar",
     description:
       "Paired side-by-side bars comparing two runs per query with % change annotations",
+    questionGroup: "per_query",
     requires: { requiresTwoResults: true },
     cli_equivalent: "comparison_bar",
   },
@@ -133,6 +200,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     title: "Diverging Bar",
     description:
       "Centered-zero chart showing regression/improvement distribution sorted by magnitude",
+    questionGroup: "per_query",
     requires: { requiresTwoResults: true },
     cli_equivalent: "diverging_bar",
   },
@@ -141,6 +209,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     title: "Summary Box",
     description:
       "Bordered panel with aggregate stats (geo mean, total time, improved/regressed counts)",
+    questionGroup: "overview",
     requires: {},
     cli_equivalent: "summary_box",
   },
@@ -148,6 +217,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "percentile_ladder",
     title: "Percentile Ladder",
     description: "Percentile ladder chart (P50/P90/P95/P99) across platforms",
+    questionGroup: "distribution",
     requires: { requiresSummary: true, requiresPercentileStats: true },
     cli_equivalent: "percentile_ladder",
   },
@@ -155,6 +225,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "normalized_speedup",
     title: "Normalized Speedup",
     description: "Normalized speedup chart relative to a selected baseline platform",
+    questionGroup: "per_query",
     requires: { requiresTwoResults: true },
     cli_equivalent: "normalized_speedup",
   },
@@ -162,6 +233,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "stacked_phase",
     title: "Stacked Phase Breakdown",
     description: "Stacked phase breakdown chart across benchmark execution phases",
+    questionGroup: "overview",
     requires: { requiresSummary: true, requiresPhaseDurations: true },
     cli_equivalent: "stacked_phase",
   },
@@ -169,6 +241,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "sparkline_table",
     title: "Sparkline Table",
     description: "Compact sparkline table of key metrics across platforms",
+    questionGroup: "overview",
     requires: { requiresSummary: true },
     cli_equivalent: "sparkline_table",
   },
@@ -176,6 +249,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "cdf_chart",
     title: "CDF Chart",
     description: "Cumulative distribution chart of per-query execution latency",
+    questionGroup: "distribution",
     requires: { requiresSummary: true, requiresQueryTimings: true },
     cli_equivalent: "cdf_chart",
   },
@@ -183,6 +257,7 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     id: "rank_table",
     title: "Rank Table",
     description: "Per-query platform ranking table (1st=fastest)",
+    questionGroup: "rank",
     requires: { requiresSummary: true, requiresQueryTimings: true },
     cli_equivalent: "rank_table",
   },
@@ -427,4 +502,13 @@ export function applicableCharts(context: ChartContext): ChartRegistryEntry[] {
     if (requires.requiresPercentileStats && !capabilities.hasPercentileStats) return false;
     return true;
   });
+}
+
+export function groupChartsByQuestion(
+  charts: readonly ChartRegistryEntry[],
+): ChartQuestionGroupWithCharts[] {
+  return CHART_QUESTION_GROUPS.map((group) => ({
+    ...group,
+    charts: charts.filter((chart) => chart.questionGroup === group.id),
+  })).filter((group) => group.charts.length > 0);
 }

--- a/results-explorer/src/lib/queryLabels.ts
+++ b/results-explorer/src/lib/queryLabels.ts
@@ -1,0 +1,16 @@
+const QUERY_ID_COLLATOR = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
+
+export function compareQueryIds(a: string, b: string): number {
+  return QUERY_ID_COLLATOR.compare(a, b) || a.localeCompare(b);
+}
+
+export function sortQueryIds(queryIds: readonly string[]): string[] {
+  return [...queryIds].sort(compareQueryIds);
+}
+
+export function queryDisplayLabel(queryId: string): string {
+  return queryId;
+}

--- a/tests/unit/core/runner/test_dataframe_runner.py
+++ b/tests/unit/core/runner/test_dataframe_runner.py
@@ -261,7 +261,11 @@ class TestRunDataframeBenchmark:
 
         prepared = {"lineitem": tmp_path / "lineitem.parquet"}
 
-        with patch("benchbox.core.runner.dataframe_runner.DataFrameDataLoader") as loader_cls:
+        with (
+            patch("benchbox.core.runner.dataframe_runner.DataFrameDataLoader") as loader_cls,
+            patch("benchbox.core.runner.dataframe_runner.check_sufficient_memory") as mem_check,
+        ):
+            mem_check.return_value = MagicMock(is_safe=True)
             loader = loader_cls.return_value
             loader.prepare_benchmark_data.return_value = prepared
 


### PR DESCRIPTION
- **feat(explorer): group chart navigation by question**
- **fix(explorer): use log scale for wide latency bars**
- **fix(explorer): prevent performance bar label crowding**
- **chore(todo): mark trend cohort split complete**
- **fix(explorer): sort query labels naturally**
- **fix(explorer): add reduced-color heatmap paths**
- **test(explorer): cover heatmap accessible labels**
- **chore(todo): complete explorer chart navigation**
- **test(dataframe): mock memory check in load pipeline test**
