### PR TITLE
chore(todo): plans for sketch-function benchmark expansion + blind-spot capture

### DIFF
--- a/_project/TODO/main/planning/read-primitives-approximate-aggregate-queries.yaml
+++ b/_project/TODO/main/planning/read-primitives-approximate-aggregate-queries.yaml
@@ -1,0 +1,260 @@
+id: read-primitives-approximate-aggregate-queries
+title: "Read Primitives: add approximate-aggregate query coverage (HLL distinct, KLL/T-Digest quantile, Top-K)"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  The `read_primitives` benchmark catalog (153 queries) has zero approximate-
+  aggregate coverage today. The two existing queries that gesture toward
+  approximation are misleading: `intrinsic_appx_median` is named "appx" but
+  uses exact `PERCENTILE_CONT(0.5)`, and `statistical_percentiles` is also
+  exact. There are no approximate distinct-count, approximate-quantile, or
+  top-K queries.
+
+  This TODO adds 4 new query IDs + 1 rename to give cross-engine coverage of
+  the one-shot approximate-aggregate path that every modern OLAP engine
+  exposes (Databricks `approx_*`, Snowflake `APPROX_*`, BigQuery `APPROX_*`
+  / `HLL_COUNT.*` / `KLL_QUANTILES.*`, DuckDB `approx_*`, ClickHouse
+  `uniq` / `quantileTDigest` / `topK`, Redshift `APPROXIMATE …`).
+
+  Scoped deliberately to *single-query* approximate aggregates. Sketch
+  persistence and merge across queries are NOT in scope here — see the
+  blind-spot finding referenced below and the companion
+  `write-primitives-sketch-persistence-category` TODO.
+
+context_sections:
+  "Background and Motivation": |
+    Triggered by evaluation of the Databricks "Approximate Answers, Exact
+    Decisions" blog post (2026-04-29) which announced KLL / Theta / Top-K /
+    Tuple sketch families. The function-by-function competitor parity
+    research showed broad cross-engine support for one-shot approximate
+    aggregates, so adding them to `read_primitives` is straightforward
+    catalog work.
+
+    The harder half of that announcement (sketch persistence, mergeable
+    artifacts across time/partitions) does NOT fit `read_primitives`'
+    single-query execution model — that gap is captured in the blind-spot
+    finding and addressed by a separate `write_primitives` TODO.
+
+  "Cross-Platform Function Reference": |
+    Captured in the documentation work unit (w5) — the table that maps
+    `approx_count_distinct` / `approx_percentile` / `approx_top_k` across
+    Databricks, Snowflake, BigQuery, DuckDB, ClickHouse, and Redshift, with
+    per-engine result-shape notes (e.g., BigQuery `APPROX_TOP_COUNT`
+    returns ARRAY<STRUCT> while others return ARRAY of values; Redshift
+    has no top-K).
+
+  "Blind-Spot Audit Reference": |
+    See `_project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md`.
+    This TODO addresses the framework gap *by scoping out* — it commits to
+    aggregate-only queries so that sketch persistence is not silently
+    smuggled in. Triage promotion of the blind-spot finding will happen
+    when the companion `write-primitives-sketch-persistence-category`
+    TODO lands; this TODO is referenced as a contributing resolver.
+
+work:
+  - id: w1
+    summary: "Add 5 query catalog entries for approximate aggregates with per-dialect variants"
+    status: pending
+    notes: |
+      In `benchbox/core/read_primitives/catalog/queries.yaml`, add:
+        - `approx_count_distinct_simple` (companion to `aggregation_distinct`)
+        - `approx_count_distinct_groupby` (companion to `aggregation_distinct_groupby`)
+        - `approx_quantile_groupby` (REPLACES misnamed `intrinsic_appx_median`)
+        - `approx_quantiles_array` (companion to `statistical_percentiles`)
+        - `approx_top_k_lineitem` (new capability — top-K)
+      Each must declare `result_contract.capability` with an
+      `approximate_*` name so the cross-dialect comparator does not apply
+      strict value equality. Use existing `variants:` blocks per engine for
+      function-name divergence (e.g., ClickHouse `quantileTDigest(0.5)(x)`,
+      BigQuery `APPROX_QUANTILES(x, 100)[OFFSET(50)]`, Redshift
+      `APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY x)`).
+      `approx_top_k_lineitem` should `skip_on: [redshift]`.
+
+  - id: w2
+    summary: "Retire historical guard for renamed query in variant_contracts.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      `benchbox/core/read_primitives/variant_contracts.py:48-51` has a
+      "historical guard" entry for `intrinsic_appx_median` in
+      `_HIGH_RISK_QUERY_IDS`. Once w1 renames that query to
+      `approx_quantile_groupby`, retire the guard entry (the new query is
+      already covered by being in the `statistical` category, which is in
+      `_HIGH_RISK_CATEGORIES`).
+
+  - id: w3
+    summary: "Run cross-engine validation; tune skip_on lists empirically"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      Run `benchbox run --platform <p> --benchmark read_primitives
+      --queries approx_*` against duckdb, datafusion, clickhouse,
+      and (where credentials available) snowflake/bigquery/databricks/
+      redshift. Where a query fails for an unfixable reason, add a tight
+      `skip_on:` rather than a per-platform variant. Document each skip
+      with a one-line comment in the YAML.
+
+  - id: w4
+    summary: "Run variant_contracts checker and pytest fast tests"
+    needs: [w3]
+    status: pending
+    notes: |
+      `uv run -- python -m pytest tests/unit/read_primitives -q -m fast`
+      and the static variant-contracts check
+      (`uv run -- python -m pytest tests/unit/read_primitives/test_variant_contracts.py -q`)
+      must both pass with the new entries. Result-contract column lists
+      must match between base SQL and every variant.
+
+  - id: w5
+    summary: "Write cross-platform comparison documentation in benchmark help-topic and README"
+    needs: [w3]
+    status: pending
+    notes: |
+      Capture the function-by-function cross-platform table from the
+      research in user-facing docs. Depends on w3 because the empirical
+      skip_on lists tuned in w3 must be reflected accurately in the docs.
+
+        - Add `docs/benchmarks/read-primitives-approximate-functions.md`
+          with the engine-by-function table (Databricks / Snowflake /
+          BigQuery / DuckDB / ClickHouse / Redshift columns × distinct /
+          percentile / top-K rows), result-shape divergences (BQ struct vs
+          array), and explicit "single-query only — not sketch persistence"
+          framing.
+        - Surface the doc from CLI help. The wiring depends on how
+          `--help-topic benchmarks` is composed today — start by reading
+          `benchbox/cli/help_topics.py` (or equivalent) and either: (a)
+          extend the benchmarks help-topic body with a "approximate
+          aggregate queries" section that references the doc path, or
+          (b) add a link from `read_primitives` benchmark help text.
+          DO NOT assume markdown files in `docs/benchmarks/` auto-surface.
+        - Cross-link to the companion `write_primitives` sketch
+          documentation when it exists.
+
+  - id: w6
+    summary: "Add changelog entry under unreleased"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Terse user-facing bullet under unreleased:
+      "read_primitives: add approximate-aggregate query coverage
+      (`approx_count_distinct_*`, `approx_quantile*`, `approx_top_k_*`).
+      `intrinsic_appx_median` renamed to `approx_quantile_groupby`."
+
+deferred:
+  - summary: "Theta-sketch set algebra queries (union/intersect/difference across filtered streams)"
+    reason: "Engine support too thin (Databricks, Snowflake DataSketches UDAFs, ClickHouse uniqTheta only). Skip lists would be longer than the SQL."
+  - summary: "Tuple-sketch queries (distinct + metric aggregation)"
+    reason: "Databricks-native + Snowflake DataSketches UDAFs only. Not portable enough for a primitive."
+  - summary: "Accuracy validation (paired exact/approximate queries with tolerance)"
+    reason: "Out of scope: read_primitives measures latency, not approximation error. Belongs in a future approximation-quality benchmark if pursued."
+  - summary: "Sketch persistence / merge / requery"
+    reason: "Single-query benchmark cannot test cross-query persistence. Captured by the companion write-primitives-sketch-persistence-category TODO."
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - read-primitives
+    - approximate-aggregates
+    - benchmark-catalog
+    - sketches
+  estimated_effort: "1-2 days"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Closes a real gap in benchmark coverage: no engine in BenchBox today
+    has its approximate-aggregate path measured, even though every
+    benchmarked engine implements one and vendors compete on it.
+  user_impact: |
+    Users get cross-engine latency numbers for the approximate path that
+    is the realistic substitute for `COUNT(DISTINCT)` / `PERCENTILE_CONT`
+    on production-scale data. Documentation explains which functions map
+    where so users can interpret skips.
+  technical_debt: |
+    Retires a misleading query name (`intrinsic_appx_median` was exact,
+    not approximate) and the corresponding historical-guard entry in
+    variant_contracts.py.
+
+files_affected:
+  modified:
+    - benchbox/core/read_primitives/catalog/queries.yaml
+    - benchbox/core/read_primitives/variant_contracts.py
+    - CHANGELOG.md
+  added:
+    - docs/benchmarks/read-primitives-approximate-functions.md
+
+must_preserve:
+  - "All 153 existing read_primitives queries continue to load via ReadPrimitivesQueryManager and produce identical SQL output."
+  - "variant_contracts.collect_variant_contract_issues() returns zero issues for the full updated catalog."
+  - "Existing skip_on lists for unrelated queries are not modified."
+  - "result_contract loader continues to enforce column-name equality between base SQL and variants."
+
+approach: |
+  Pure catalog YAML work plus one Python guard removal. Each new query
+  declares result_contract.capability with an `approximate_*` name —
+  the cross-dialect validator already treats `capability` as the
+  correctness anchor, so approximate values won't false-fail value
+  equality.
+
+  For per-dialect divergence, prefer `variants:` blocks (existing
+  pattern in `statistical_correlation` etc.) over inline branching.
+  Where an engine truly lacks the function (Redshift top-K), use
+  `skip_on: [redshift]` — same pattern as the 12 existing skipped
+  queries.
+
+  The misnamed `intrinsic_appx_median` rename is intentionally a hard
+  rename, not an alias — the YAML id changes, the historical-guard
+  entry retires, and the changelog notes the breaking name change.
+
+anti_patterns:
+  - "DO NOT add sketch persistence / write-then-read patterns here — because read_primitives runs queries in isolation with no shared state — handled by the companion write-primitives-sketch-persistence-category TODO."
+  - "DO NOT use exact value equality in result_contract for approximate queries — because approximate aggregates are non-deterministic across engines and even across runs — declare capability with an `approximate_*` prefix so the validator skips strict equality."
+  - "DO NOT rename intrinsic_appx_median without retiring the historical_guard entry in variant_contracts.py:48-51 — because the guard was added precisely as a placeholder for this rename — leaving it stale defeats its purpose."
+  - "DO NOT introduce ClickHouse-specific function-name variants for approximate aggregates that are already covered by sqlglot dialect translation — because the existing translation pipeline handles common rewrites — only add an explicit variant when sqlglot demonstrably fails."
+  - "DO NOT silently broaden scope to add Theta/Tuple sketches — because cross-engine coverage is too thin and skip lists would dominate the YAML — explicitly deferred."
+
+verification:
+  - description: "All read_primitives unit tests pass with new catalog"
+    command: "uv run -- python -m pytest tests/unit/read_primitives -q"
+    expected_output: "all tests pass, no failures"
+  - description: "Static variant-contract checker reports no issues"
+    command: "uv run -- python -m pytest tests/unit/read_primitives/test_variant_contracts.py -q"
+    expected_output: "all tests pass"
+  - description: "DuckDB smoke run executes the new approximate queries"
+    command: "uv run -- benchbox run --platform duckdb --benchmark read_primitives --scale 0.01 --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby,approx_quantiles_array,approx_top_k_lineitem"
+    expected_output: "all 5 queries complete with non-null results, no skips on duckdb"
+  - description: "Help-topic body references the new approximate-functions guidance (exact wiring chosen in w5)"
+    command: "uv run -- benchbox run --help-topic benchmarks 2>&1 | grep -iE 'approx|approximate-functions'"
+    expected_output: "output references the new approximate-aggregate guidance — either by inlining the section or linking to docs/benchmarks/read-primitives-approximate-functions.md"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/read_primitives/catalog/queries.yaml
+    - benchbox/core/read_primitives/variant_contracts.py
+    - tests/unit/read_primitives/
+    - docs/benchmarks/read-primitives-approximate-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/read_primitives/benchmark.py
+    - benchbox/core/read_primitives/schema.py
+    - benchbox/core/read_primitives/generator.py
+    - benchbox/core/write_primitives/
+
+success_metrics:
+  - "5 new approximate-aggregate queries (4 added, 1 renamed) execute end-to-end on at least DuckDB and one cloud engine"
+  - "Zero variant_contracts violations across the updated catalog"
+  - "Cross-platform function reference doc landed and linked from help-topic"
+  - "Changelog entry under unreleased"
+  - "Blind-spot finding 2026-05-02-084332 explicitly references this TODO as a contributing resolver"
+
+open_questions:
+  - "Should we apply tolerance-based result equivalence even for approximate queries, or stick with capability-only validation? (Current proposal: capability-only.)"
+  - "Is `quantileTDigest` accurate enough on TPC-H lineitem at SF=0.01 to give stable cross-engine numbers, or do we need a higher floor SF for the approximate-quantile queries specifically?"

--- a/_project/TODO/main/planning/write-primitives-sketch-persistence-category.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-persistence-category.yaml
@@ -1,0 +1,354 @@
+id: write-primitives-sketch-persistence-category
+title: "Write Primitives: add `sketch` category for persist/merge/requery DataSketches lifecycle"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  Adds a new `sketch` category to `write_primitives` that exercises the
+  *persistence and merge* half of the modern approximate-analytics story:
+  building Apache DataSketches sketches in one query, persisting them as
+  a binary column, then merging and re-querying them in a later query.
+
+  This is the differentiated capability that vendors (Databricks, Snowflake
+  via DATASKETCHES_*, BigQuery via KLL_QUANTILES.* / HLL_COUNT.*, Spark)
+  compete on — "store sketches as columns, merge across time/partition,
+  requery in milliseconds". The DataSketches binary format is genuinely
+  cross-engine portable across Databricks / Snowflake / BigQuery / Spark
+  (all built on the DataSketches C++/Java/WASM core), so this is a real
+  cross-vendor benchmark, not a Databricks-only test.
+
+  This TODO is the *resolution* of the framework gap captured in the
+  blind-spot finding 2026-05-02-084332: `read_primitives` cannot test
+  cross-query sketch persistence because it runs queries in isolation;
+  `write_primitives` already has the structural primitives (write phase,
+  validation read phase, staging-table schema, platform_overrides) needed
+  to test the persist/merge/requery loop end-to-end.
+
+context_sections:
+  "Background and Motivation": |
+    Triggered by evaluation of the Databricks "Approximate Answers, Exact
+    Decisions" blog post (2026-04-29). The headline claim of that post is
+    NOT that one-shot approximate aggregates are faster than exact ones
+    (true on every engine for a decade) but that **sketches are storable,
+    mergeable, requeryable artifacts** with millisecond merge across
+    partitioned data. The `*_accumulate` / `*_combine` / `*_estimate`
+    function trios are what enables this.
+
+    Aggregate-only sketch queries are being added to `read_primitives` in
+    a companion TODO (`read-primitives-approximate-aggregate-queries`).
+    That covers the boring half of the announcement. This TODO covers the
+    actually-differentiated half.
+
+  "Cross-Platform Sketch Storage Reference": |
+    Captured in the documentation work unit (w6). The table maps
+    sketch family × engine × column-type × function-name across the four
+    engines that share the DataSketches binary format (Databricks,
+    Snowflake `DATASKETCHES_*`, BigQuery, Spark) plus the engines with
+    incompatible-but-comparable models (ClickHouse `AggregateFunction`
+    state, Redshift `HLLSKETCH` HLL-only, DuckDB datasketches community
+    extension).
+
+  "Engine Coverage Honest Accounting": |
+    First-pass support targets Databricks, Snowflake, BigQuery only —
+    these share the DataSketches binary format and have first-class or
+    DataSketches-UDAF coverage of all three sketch families (Theta /
+    KLL / Top-K).
+
+    DataFusion has no DML, so all sketch-write ops skip there (consistent
+    with existing 62-skip pattern).
+
+    ClickHouse uses `-State`/`-Merge` combinators with its own
+    serialization — comparable algorithmically but NOT binary-compatible
+    with DataSketches. Native ClickHouse variants are explicitly deferred
+    to a follow-up to keep this TODO scoped.
+
+    Redshift `HLLSKETCH` is HLL-only; KLL and Top-K skip on Redshift.
+
+  "Blind-Spot Audit Reference": |
+    See `_project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md`.
+    This TODO IS the resolution of that finding. When this TODO ships,
+    promote the blind-spot to `merged-to-todo` status with this slug as
+    the linked todo_id (work unit w8).
+
+work:
+  - id: w1
+    summary: "Add BINARY column type and per-engine type aliasing in dialect translation"
+    status: pending
+    notes: |
+      `benchbox/core/write_primitives/schema.py` does not currently use
+      BINARY/VARBINARY columns. Add type-mapping support in the DDL
+      translation layer:
+        - Databricks: `BINARY`
+        - Snowflake: `BINARY`
+        - BigQuery: `BYTES`
+        - DuckDB: `BLOB` (where datasketches extension loaded)
+        - Redshift: `HLLSKETCH` for HLL family only; skip elsewhere
+      Use the existing platform-override pattern. Verify the translation
+      covers CREATE TABLE and INSERT...SELECT.
+
+  - id: w2
+    summary: "Add SKETCH_OPS_* staging tables in schema.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Two new staging tables, dedicated to sketch ops to avoid mixing
+      sketch columns into existing staging tables:
+        - `sketch_ops_daily_users` (activity_date DATE, region VARCHAR(25),
+          user_sketch BINARY, rev_sketch BINARY)
+        - `sketch_ops_topk` (shard_id INTEGER, topk_sketch BINARY)
+      Wire into TABLES export and `get_all_staging_tables_sql`. Update
+      the data generator if any seed data is required (likely none —
+      sketches are populated by the benchmark INSERT...SELECT itself).
+
+  - id: w3
+    summary: "Extend validation contract with expected_value_min/max for approximate scalars"
+    needs: [w1]
+    status: pending
+    notes: |
+      Today validation queries assert `expected_rows`,
+      `expected_rows_min/max`, or column counts. Sketch read queries
+      return approximate scalar estimates that need tolerance-based
+      validation. Add `expected_value_min` / `expected_value_max` fields
+      to the validation_query schema in
+      `benchbox/core/write_primitives/catalog/loader.py`. Keep semantics
+      narrow: a single numeric value from the first row's first column
+      must fall in [min, max]. Don't silently accept the field on
+      ops that have no corresponding scalar; validate at load time.
+
+  - id: w4
+    summary: "Add 8 sketch operations to operations.yaml"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      In `benchbox/core/write_primitives/catalog/operations.yaml` add
+      `category: sketch` with these ops:
+        - sketch_ddl_create_persistent_table  (DDL with BINARY columns)
+        - sketch_insert_theta_per_partition   (theta_sketch_agg, GROUP BY date)
+        - sketch_insert_kll_per_partition     (kll_sketch_agg over l_extendedprice)
+        - sketch_insert_topk_per_shard        (approx_top_k_accumulate)
+        - sketch_query_theta_union_merge      ★ HEADLINE TEST — theta_union_agg + estimate vs aggregation_distinct
+        - sketch_query_kll_quantiles_merge    ★ HEADLINE TEST — kll merge + get_quantile vs statistical_percentiles
+        - sketch_query_topk_combine           ★ HEADLINE TEST — approx_top_k_combine + estimate
+        - sketch_drop_persistent_table        (cleanup)
+      Each op declares platform_overrides for Databricks/Snowflake/
+      BigQuery first-class, with `null` skips for ClickHouse / DataFusion /
+      Redshift (except HLL-only Redshift cover if w1 added it). Use
+      tolerance-based expected_value_min/max for the ★ headline tests.
+
+  - id: w5
+    summary: "Empirically tune validation tolerances against real engines"
+    needs: [w4]
+    status: pending
+    notes: |
+      Run the new sketch ops on duckdb (with extension if loaded), and
+      where credentials available on databricks / snowflake / bigquery.
+      For each ★ headline test, observe the cross-run distribution of the
+      approximate scalar at SF=0.01 and SF=0.1, then set
+      expected_value_min/max wide enough to never false-fail but tight
+      enough to catch a real regression (e.g., a sketch becoming a no-op).
+      Document chosen tolerances in inline YAML comments referencing the
+      observation runs.
+
+  - id: w6
+    summary: "Run write_primitives unit tests and operation contract checks"
+    needs: [w5]
+    status: pending
+    notes: |
+      `uv run -- python -m pytest tests/unit/write_primitives -q -m fast`
+      must pass. Catalog loader must accept the new validation kind and
+      reject malformed expected_value_min/max combinations. New BINARY
+      column type translates correctly per engine. Verify cleanup_sql
+      DROP works on every supported engine.
+
+  - id: w7
+    summary: "Write cross-platform sketch documentation in benchmark help-topic and README"
+    needs: [w4]
+    status: pending
+    notes: |
+      Capture the cross-platform sketch-storage table in user-facing docs:
+        - Add `docs/benchmarks/write-primitives-sketch-functions.md` with:
+          * Sketch family × engine support matrix (Theta / KLL / Top-K /
+            Tuple rows × Databricks / Snowflake / BigQuery / DuckDB /
+            ClickHouse / Redshift / DataFusion columns)
+          * Per-engine column-type mapping (BINARY / BYTES / HLLSKETCH /
+            BLOB / AggregateFunction)
+          * DataSketches binary portability statement (which 4 engines
+            share format)
+          * Explicit "headline test" callouts on the three ★ ops so users
+            know which numbers to compare to read_primitives baselines
+          * Why ClickHouse and Redshift have narrower coverage (separate
+            algorithmic models, not engine deficiency)
+        - Add the same table to the `write_primitives/README.md` under a
+          new "Sketch persistence operations" section.
+        - Reference it from `benchbox run --help-topic benchmarks`.
+        - Cross-link to the companion `read_primitives` approximate-
+          functions doc.
+
+  - id: w8
+    summary: "Promote blind-spot finding 2026-05-02-084332 to merged-to-todo"
+    needs: [w4]
+    status: pending
+    notes: |
+      Run:
+      `uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage 2026-05-02-084332-read-primitives-cant-test-sketch-persistence --action promote --todo-id write-primitives-sketch-persistence-category`
+      This sets the blind-spot status to merged-to-todo and links it to
+      this TODO. Note the read_primitives companion TODO is also a
+      contributing resolver (it scopes out persistence on the read side);
+      reference it in the triage log entry that gets appended to the
+      blind-spot file.
+
+  - id: w9
+    summary: "Add changelog entry under unreleased"
+    needs: [w6, w7]
+    status: pending
+    notes: |
+      Terse user-facing bullet:
+      "write_primitives: add `sketch` category exercising DataSketches
+      Theta / KLL / Top-K persist + merge + requery on Databricks,
+      Snowflake, BigQuery."
+
+deferred:
+  - summary: "ClickHouse-native sketch variants using -State / -Merge combinators"
+    reason: "ClickHouse uses its own serialization (uniqState / quantileTDigestState / topKState) that is not binary-compatible with DataSketches. Adding ClickHouse-native variants is valuable but is a scope expansion that should land as a follow-up TODO once the DataSketches-portable core works."
+  - summary: "Cross-engine sketch portability test (write on engine A, query on engine B)"
+    reason: "Genuinely interesting but requires two-engine orchestration that BenchBox doesn't have today. Out of scope for first cut."
+  - summary: "Tuple sketch ops (distinct + metric)"
+    reason: "Databricks-native + Snowflake DataSketches UDAFs only. Same portability calculus as the read_primitives Tuple deferral."
+  - summary: "Audit other vendor announcements for the same single-query-vs-persistent-artifact mismatch"
+    reason: "Captured as the third bullet in the blind-spot finding's suggested next steps. This is a process/review-skill update, not a benchmark code change. Should be raised as a separate TODO if pursued."
+
+deps:
+  needs:
+    - read-primitives-approximate-aggregate-queries
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - benchmark-catalog
+    - datasketches
+    - persistence
+    - blind-spot-resolution
+  estimated_effort: "1-2 days"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Tests the actual differentiated claim of the modern approximate-
+    analytics story (persist + merge + requery), not just the boring
+    one-shot half. Three vendors (Databricks, Snowflake, BigQuery)
+    actively compete on this; BenchBox should measure it.
+  user_impact: |
+    Users see millisecond-merge claims validated (or not) at scale,
+    on real engines, with tolerance-based correctness rather than
+    point-equality. Documentation explains which engines share the
+    DataSketches binary format and which use comparable-but-distinct
+    sketch models, so skip patterns don't read as engine criticism.
+  technical_debt: |
+    Resolves blind-spot finding 2026-05-02-084332 (framework gap).
+    Adds BINARY column type to write_primitives, which other future
+    write workflows (e.g., feature-store-style metadata) can reuse.
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/README.md
+    - CHANGELOG.md
+    - _project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md
+  added:
+    - docs/benchmarks/write-primitives-sketch-functions.md
+
+must_preserve:
+  - "All 113 existing write_primitives operations execute identically — no behavior changes to insert/update/delete/bulk_load/merge/ddl/transaction categories."
+  - "Existing STAGING_TABLES exports (INSERT_OPS_*, UPDATE_OPS_*, DELETE_OPS_*, MERGE_OPS_*) remain unchanged in shape."
+  - "Catalog loader continues to accept all existing validation_query shapes (expected_rows, expected_rows_min/max, column counts)."
+  - "Existing platform_overrides skip patterns (DataFusion DML skips, Starrocks skips) continue to work."
+  - "Per-op cleanup_sql still runs after each op — sketch ops MUST clean up their persistent tables to keep the benchmark idempotent."
+
+approach: |
+  Build the work in vertical slices following SHARED/slicing-framework.md:
+    Slice 1 (w1+w2):  schema + types — verify CREATE TABLE works per engine
+    Slice 2 (w3):     validation contract extension — verify loader accepts new shape
+    Slice 3 (w4):     8 ops added — verify each runs end-to-end on duckdb
+    Slice 4 (w5+w6):  empirical tolerances + tests — verify ★ headline
+                      tests catch synthetic regressions
+    Slice 5 (w7+w8+w9): docs + blind-spot promotion + changelog
+
+  For per-engine SQL divergence use existing platform_overrides pattern
+  (operations.yaml is full of these). Don't introduce a new variant
+  mechanism. Match the verbosity of existing ops — terse `description:`
+  field, multi-statement `write_sql:` blocks where useful.
+
+  For the BINARY column type, prefer extending the existing dialect-
+  translation pipeline over adding a one-off sketch-column path —
+  BINARY is generally useful and other future workflows will benefit.
+
+  The three ★ headline tests are the ones that validate the "merge in
+  milliseconds" claim. Their validation contracts must be comparison-
+  ready: same query semantics as the corresponding read_primitives exact
+  query (aggregation_distinct, statistical_percentiles), so users can
+  cross-reference latency numbers.
+
+anti_patterns:
+  - "DO NOT mix sketch columns into existing staging tables (INSERT_OPS_*, etc.) — because that risks regressing the 113 existing ops via type-system surprises — add dedicated SKETCH_OPS_* tables."
+  - "DO NOT make sketch ops depend on each other across operations.yaml entries — because the benchmark runner treats each op as independent and idempotent — keep each op fully self-contained (create table, populate sketches, query, drop)."
+  - "DO NOT chase exact-value validation on approximate sketch reads — because sketches are non-deterministic across engines and runs — use the new tolerance-based expected_value_min/max."
+  - "DO NOT add ClickHouse-native (-State/-Merge) variants in the first pass — because they use a different binary format and would dilute focus from the cross-engine DataSketches portability claim — explicitly deferred."
+  - "DO NOT advertise this benchmark as testing approximation accuracy — because it tests latency under approximate semantics, not error magnitude — call this out in the docs."
+  - "DO NOT expand the blind-spot finding to other vendor announcement types in this TODO — because that scope creep belongs in a separate process/review-skill update — captured as the third deferred item."
+  - "DO NOT promote the blind-spot to `actioned` (closed) — because the framework gap is partially mitigated, not eliminated; future evaluations of similar persistence-flavored announcements (vector indexes, materialized aggregates) still need the same execution-model-fit check — promote to `merged-to-todo` linked to this slug."
+
+verification:
+  - description: "All write_primitives unit tests pass with new ops + validation contract"
+    command: "uv run -- python -m pytest tests/unit/write_primitives -q"
+    expected_output: "all tests pass, including new sketch op coverage"
+  - description: "Catalog loader rejects malformed expected_value_min/max"
+    command: "uv run -- python -m pytest tests/unit/write_primitives/test_catalog_loader.py -q"
+    expected_output: "loader-validation tests pass; bad min/max combos surfaced as schema errors"
+  - description: "DuckDB end-to-end runs all sketch ops (with datasketches extension)"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_*"
+    expected_output: "all sketch ops complete; ★ headline tests return values within configured tolerances; cleanup leaves no residual tables"
+  - description: "Static blind-spot validator passes for the promoted finding"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py _project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md"
+    expected_output: "OK — frontmatter valid with status: merged-to-todo and todo_id: write-primitives-sketch-persistence-category"
+  - description: "Help-topic surfaces the new sketch-functions docs"
+    command: "uv run -- benchbox run --help-topic benchmarks | grep -i sketch"
+    expected_output: "output references write-primitives-sketch-functions.md or equivalent guidance"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/README.md
+    - tests/unit/write_primitives/
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - _project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/write_primitives/dataframe_operations.py
+    - benchbox/core/write_primitives/generator.py
+    - benchbox/core/write_primitives/operations.py
+    - benchbox/core/read_primitives/
+    - benchbox/core/tpch/
+
+success_metrics:
+  - "8 new sketch ops execute end-to-end on at least one supported engine (DuckDB-with-extension is acceptable for the merge tests)"
+  - "Three ★ headline tests measurably outperform their exact counterparts on partitioned data, validating the millisecond-merge claim"
+  - "Cross-platform sketch documentation landed and linked from help-topic + README"
+  - "Blind-spot finding 2026-05-02-084332 promoted to merged-to-todo with this slug as todo_id"
+  - "Zero regressions in existing 113 write_primitives ops"
+  - "Changelog entry under unreleased"
+
+open_questions:
+  - "Which engine is the canonical baseline for tolerance-tuning? Proposal: DuckDB-with-extension since it's locally reproducible. But the differentiated claim is multi-cloud, so cloud engines should also inform tolerances."
+  - "Should the sketch_query_theta_union_merge op explicitly compare against aggregation_distinct's measured time and report a ratio, or just report its own time and let users cross-reference? Current proposal: report own time only; comparison is the user's job."
+  - "Does adding BINARY/BYTES column type translation break any non-write benchmark that reuses the same dialect-translation pipeline? Needs spot-check during w1."

--- a/_project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md
+++ b/_project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md
@@ -1,0 +1,61 @@
+---
+id: 2026-05-02-084332-read-primitives-cant-test-sketch-persistence
+date: 2026-05-02
+status: open
+finding_kind: framework-gap
+review_context: "ad-hoc research / Databricks sketch functions blog evaluation against read_primitives benchmark"
+related_paths:
+  - benchbox/core/read_primitives/catalog/queries.yaml
+  - benchbox/core/read_primitives/benchmark.py
+  - benchbox/core/read_primitives/variant_contracts.py
+suggested_sweep: "before adding sketch queries, decide whether read_primitives is the right home for sketch persistence/merge tests or whether a new benchmark (or write_primitives extension) should own them"
+todo_id: null
+---
+
+# read_primitives can score sketch *aggregates* but cannot exercise sketch *persistence*, which is the differentiated Databricks claim
+
+## Finding
+
+The standard "function-by-function competitor parity" framework I used to evaluate
+the Databricks sketch announcement under-weights what's actually novel about the
+post. The post's headline claim is not that approximate aggregates are faster
+than exact ones (that's been true on every engine for a decade), but that
+**sketches are storable, mergeable, requeryable artifacts** — "stored as columns
+in Delta tables", "merged across time windows and partitions", "merge the
+precomputed sketches in milliseconds". The `accumulate` / `combine` / `estimate`
+function trio is what enables this; the single-pass `theta_sketch_agg` /
+`approx_top_k` calls are the boring half of the announcement.
+
+`read_primitives` is structurally a single-query benchmark: each query in
+`catalog/queries.yaml` runs in isolation against TPC-H tables, with no facility
+to (a) write a sketch column to a persisted table, (b) read sketches back in a
+later query, or (c) merge sketches across partitions in a multi-query workflow.
+Adding `APPROX_QUANTILES` and `APPROX_COUNT_DISTINCT` queries here measures
+*aggregate latency*, which is largely uninteresting — the optimization the
+vendors are competing on is the persist/merge/requery loop.
+
+So a parity-table evaluation will conclude "yes, add the queries", and the
+benchmark will technically run, but the queries we add will not exercise the
+capability the post is actually announcing. This is a framework-gap: the
+evaluation rubric (function name → competitor function name → add or skip)
+doesn't have an axis for "does this benchmark's execution model fit the
+capability under test."
+
+## Why this matters
+
+Whenever a vendor announces something framed as "stored, mergeable,
+requeryable" — sketches, materialized aggregates, search indexes, vector
+indexes, incremental MVs, ML features — a single-query benchmark catalog
+cannot test the differentiated claim, only the trivial scalar-function
+half. Future evaluations should explicitly ask "does the benchmark's
+execution model fit the capability?" before mapping function names. The
+right home for cross-query sketch persistence may be a new benchmark
+(perhaps a `sketch_lifecycle` or `materialization` benchmark that writes
+sketch artifacts in one phase and queries them in a later phase) or an
+extension of `write_primitives` — not `read_primitives`.
+
+## Suggested next steps
+
+- [ ] Decide explicitly whether `read_primitives` adds *aggregate-only* sketch queries (cheap; runs everywhere; doesn't test the claim) or stays out of sketches entirely until a persistence-capable benchmark exists.
+- [ ] If we want to test the persistence/merge claim, scope a new benchmark or `write_primitives` extension with a two-phase shape: phase 1 writes sketch columns to a table, phase 2 merges/queries them.
+- [ ] Audit other recent vendor announcements we've evaluated against `read_primitives` for the same single-query/persistent-artifact mismatch.


### PR DESCRIPTION
Two new TODO plans triggered by evaluating Databricks' April 2026
"Approximate Answers, Exact Decisions" announcement against existing
benchmark coverage:

- read-primitives-approximate-aggregate-queries: 5 query catalog
  additions (incl. one rename) covering APPROX_COUNT_DISTINCT /
  APPROX_PERCENTILE / APPROX_TOP_K with per-dialect variants and
  cross-platform comparison docs. Explicitly scoped to one-shot
  aggregates only.
- write-primitives-sketch-persistence-category: new sketch category
  exercising DataSketches Theta/KLL/Top-K persist+merge+requery on
  Databricks/Snowflake/BigQuery (the engines that share the
  DataSketches binary format). Includes BINARY column type addition
  and tolerance-based validation contract extension.

Captured blind-spot finding 2026-05-02-084332 documenting the
framework gap that drove the split: read_primitives' single-query
execution model cannot test the sketch persistence claim, which is
the actual differentiated capability vendors compete on. The
write_primitives TODO is the resolution; promotion is wired into
its w8 work unit.

Both plans include user-facing documentation work units that
codify the cross-platform comparison tables produced during
research, so the function-name divergence and engine-coverage
tradeoffs become readable from `--help-topic benchmarks`.
