### PR TITLE
fix/explorer selection facets coverage

### DIFF
--- a/_project/DONE/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/DONE/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -2,7 +2,8 @@ id: explorer-selection-facets-coverage-at-scale
 title: "Explorer: selection-oriented facets and coverage signals for large public corpus"
 worktree: main
 priority: High
-status: "Not Started"
+status: Completed
+completed_date: "2026-05-02"
 category: "Core Functionality"
 
 deps:

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -190,7 +190,10 @@ work:
   - id: w12
     summary: "Add regression tests for URL persistence, coverage labels, and no-penalty ranking"
     needs: [w7, w8, w9, w10, w11]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+      - "results-explorer/src/pages/__tests__/Home.test.tsx"
     notes: |
       Tests should cover:
         - URL state restores all primary facets.

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -59,7 +59,10 @@ work:
   - id: w3
     summary: "Migrate BenchmarkIndex page to shared facet model"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/pages/BenchmarkIndex.tsx"
+      - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
     notes: |
       Same migration shape as w2; restrict default facets to those meaningful
       for a single-benchmark page (scale_factor, phase, platform, tuning_mode,

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -173,7 +173,14 @@ work:
   - id: w11
     summary: "Add pagination/limit behavior for tables that can grow to thousands of rows"
     needs: [w2, w3, w4, w5]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/pages/BenchmarkIndex.tsx"
+      - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+      - "results-explorer/src/pages/PlatformIndex.tsx"
+      - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
+      - "results-explorer/src/pages/Query.tsx"
+      - "results-explorer/src/pages/__tests__/Query.test.tsx"
     notes: |
       Audit each migrated page's table renderer for unbounded row rendering.
       Add a default LIMIT (e.g. 200) plus "Show more" controls. Keep the result

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -147,7 +147,10 @@ work:
   - id: w9
     summary: "Add coverage-aware empty states and reset affordances"
     needs: [w6, w7]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/pages/Home.tsx"
+      - "results-explorer/src/pages/__tests__/Home.test.tsx"
     notes: |
       If a filter combination has no rows, show which facet combination removed
       all results and offer "Clear scale factor", "Clear platform", and

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -118,7 +118,13 @@ work:
   - id: w7
     summary: "Represent missing cohort coverage explicitly in MetaLeaderboard and benchmark matrices"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/MetaLeaderboard.tsx"
+      - "results-explorer/src/components/QueryHeatmap.tsx"
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+      - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
     notes: |
       In MetaLeaderboard, missing platform/cohort cells should render as a muted
       "No run" state with a tooltip explaining that missing coverage is not

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -103,7 +103,10 @@ work:
   - id: w6
     summary: "Add FacetRail desktop component and FacetDrawer mobile shell"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/FacetRail.tsx"
+      - "results-explorer/src/components/__tests__/FacetRail.test.tsx"
     notes: |
       THIS ITEM OWNS the FacetDrawer component. The downstream
       `explorer-mobile-density-responsive-tables` item styles the drawer for

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -44,7 +44,12 @@ work:
   - id: w2
     summary: "Migrate Home page to shared facet model"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/facetModel.ts"
+      - "results-explorer/src/lib/duckdbQueries.ts"
+      - "results-explorer/src/pages/Home.tsx"
+      - "results-explorer/src/pages/__tests__/Home.test.tsx"
     notes: |
       Replace Home-local filter state with `useFacetState()`. URL must round-trip
       benchmark, scale_factor, phase, platform, deployment_class, cost_status.

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -160,7 +160,10 @@ work:
   - id: w10
     summary: "Audit duckdbQueries/queryFilters for expensive scans and add memoization"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/duckdbQueries.ts"
+      - "results-explorer/src/lib/__tests__/duckdbQueries.test.ts"
     notes: |
       Review `results-explorer/src/lib/duckdbQueries.ts` and `queryFilters.ts`
       for full scans on every filter change and repeated COUNT/DISTINCT calls.

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -72,7 +72,12 @@ work:
   - id: w4
     summary: "Migrate PlatformIndex page to shared facet model"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/duckdbQueries.ts"
+      - "results-explorer/src/lib/__tests__/duckdbQueries.test.ts"
+      - "results-explorer/src/pages/PlatformIndex.tsx"
+      - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
     notes: |
       Default facets: benchmark, scale_factor, phase, deployment_class,
       cloud_provider, cloud_region, cost_status, date_window. Preserve cohort

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -86,7 +86,16 @@ work:
   - id: w5
     summary: "Migrate Compare and Query pages to shared facet model"
     needs: [w1]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/facetModel.ts"
+      - "results-explorer/src/lib/__tests__/facetModel.test.ts"
+      - "results-explorer/src/lib/queryFilters.ts"
+      - "results-explorer/src/lib/__tests__/queryFilters.test.ts"
+      - "results-explorer/src/pages/Compare.tsx"
+      - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+      - "results-explorer/src/pages/Query.tsx"
+      - "results-explorer/src/pages/__tests__/Query.test.tsx"
     notes: |
       Compare uses facets to bound the candidate-result picker. Query Workbench
       surfaces facets as starter-query toggles plus a column picker hint.

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -25,7 +25,10 @@ description: |
 work:
   - id: w1
     summary: "Define shared facet model and URL contract in lib/facetModel.ts"
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/lib/facetModel.ts"
+      - "results-explorer/src/lib/__tests__/facetModel.test.ts"
     notes: |
       Add `results-explorer/src/lib/facetModel.ts` exporting:
         - a `FacetKey` union (benchmark, scale_factor, phase, platform,

--- a/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
+++ b/_project/TODO/main/planning/explorer-selection-facets-coverage-at-scale.yaml
@@ -134,7 +134,10 @@ work:
   - id: w8
     summary: "Change aggregate labels to 'Avg rank over covered cohorts' and expose coverage denominator"
     needs: [w7]
-    status: pending
+    status: done
+    owned_files:
+      - "results-explorer/src/components/MetaLeaderboard.tsx"
+      - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
     notes: |
       The label must make the no-penalty coverage policy explicit. Tooltips
       should say: "Missing cohorts are not scored; coverage is shown separately."

--- a/results-explorer/src/components/FacetRail.tsx
+++ b/results-explorer/src/components/FacetRail.tsx
@@ -1,0 +1,208 @@
+import { useMemo, useState } from "preact/hooks";
+
+export interface FacetOption {
+  value: string;
+  label: string;
+  count?: number;
+  disabled?: boolean;
+}
+
+export interface FacetGroup {
+  key: string;
+  label: string;
+  options: FacetOption[];
+  selected: string[];
+  searchable?: boolean;
+  emptyLabel?: string;
+}
+
+export interface ActiveFacetChip {
+  key: string;
+  label: string;
+  onClear?: () => void;
+}
+
+export interface FacetRailProps {
+  groups: FacetGroup[];
+  resultCount: number;
+  activeChips?: ActiveFacetChip[];
+  onToggle: (groupKey: string, value: string) => void;
+  onReset: () => void;
+}
+
+export interface FacetDrawerProps extends FacetRailProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function FacetRail({ groups, resultCount, activeChips = [], onToggle, onReset }: FacetRailProps) {
+  return (
+    <aside class="space-y-3" aria-label="Result facets">
+      <FacetSummary resultCount={resultCount} activeChips={activeChips} onReset={onReset} />
+      {groups.map((group) => (
+        <FacetGroupSection key={group.key} group={group} onToggle={onToggle} />
+      ))}
+    </aside>
+  );
+}
+
+export function FacetDrawer({
+  groups,
+  resultCount,
+  activeChips = [],
+  onToggle,
+  onReset,
+  open,
+  onOpenChange,
+}: FacetDrawerProps) {
+  return (
+    <div class="space-y-3" aria-label="Mobile result facets">
+      <button
+        type="button"
+        class="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-sm shadow-sm"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+      >
+        <span class="font-medium text-gray-900">Filters</span>
+        <span class="text-xs text-gray-500">{resultCount.toLocaleString()} results</span>
+      </button>
+      {activeChips.length > 0 && (
+        <ActiveChipStrip activeChips={activeChips} onReset={onReset} compact />
+      )}
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Filter results"
+          class="rounded-lg border border-gray-200 bg-white p-3 shadow-lg"
+        >
+          <FacetRail
+            groups={groups}
+            resultCount={resultCount}
+            activeChips={activeChips}
+            onToggle={onToggle}
+            onReset={onReset}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FacetSummary({
+  resultCount,
+  activeChips,
+  onReset,
+}: {
+  resultCount: number;
+  activeChips: ActiveFacetChip[];
+  onReset: () => void;
+}) {
+  return (
+    <section class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-sm font-semibold text-gray-900">Filters</h2>
+          <p class="mt-1 text-xs text-gray-500">{resultCount.toLocaleString()} matching results</p>
+        </div>
+        <button type="button" class="text-xs font-medium text-brand-700 hover:text-brand-900" onClick={onReset}>
+          Reset
+        </button>
+      </div>
+      {activeChips.length > 0 && <ActiveChipStrip activeChips={activeChips} onReset={onReset} />}
+    </section>
+  );
+}
+
+function ActiveChipStrip({
+  activeChips,
+  onReset,
+  compact = false,
+}: {
+  activeChips: ActiveFacetChip[];
+  onReset: () => void;
+  compact?: boolean;
+}) {
+  return (
+    <div class={compact ? "flex flex-wrap gap-2" : "mt-3 flex flex-wrap gap-2"}>
+      {activeChips.map((chip) => (
+        <button
+          key={chip.key}
+          type="button"
+          class="rounded-full bg-brand-50 px-3 py-1 text-xs font-medium text-brand-700 hover:bg-brand-100"
+          onClick={chip.onClear ?? onReset}
+        >
+          {chip.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FacetGroupSection({
+  group,
+  onToggle,
+}: {
+  group: FacetGroup;
+  onToggle: (groupKey: string, value: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const options = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (needle === "") return group.options;
+    return group.options.filter(
+      (option) =>
+        option.label.toLowerCase().includes(needle) || option.value.toLowerCase().includes(needle),
+    );
+  }, [group.options, search]);
+
+  return (
+    <section class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div class="mb-3 flex items-center justify-between gap-2">
+        <h3 class="text-sm font-semibold text-gray-900">{group.label}</h3>
+        {group.selected.length > 0 && (
+          <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+            {group.selected.length}
+          </span>
+        )}
+      </div>
+      {group.searchable && (
+        <label class="mb-3 block">
+          <span class="sr-only">Search {group.label}</span>
+          <input
+            type="search"
+            class="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm"
+            placeholder={`Search ${group.label.toLowerCase()}`}
+            value={search}
+            onInput={(event) => setSearch((event.currentTarget as HTMLInputElement).value)}
+          />
+        </label>
+      )}
+      {options.length === 0 ? (
+        <p class="text-sm text-gray-400">{group.emptyLabel ?? "No facet values"}</p>
+      ) : (
+        <div class="space-y-2">
+          {options.map((option) => {
+            const checked = group.selected.includes(option.value);
+            return (
+              <label key={option.value} class="flex items-center justify-between gap-2 text-sm text-gray-600">
+                <span class="inline-flex min-w-0 items-center gap-2">
+                  <input
+                    type="checkbox"
+                    aria-label={option.label}
+                    checked={checked}
+                    disabled={option.disabled}
+                    onChange={() => onToggle(group.key, option.value)}
+                  />
+                  <span class="truncate">{option.label}</span>
+                </span>
+                {option.count !== undefined && (
+                  <span class="shrink-0 text-xs text-gray-400">{option.count.toLocaleString()}</span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/results-explorer/src/components/MetaLeaderboard.tsx
+++ b/results-explorer/src/components/MetaLeaderboard.tsx
@@ -28,14 +28,15 @@ const MODE_LABELS: Record<MetaLeaderboardMode, string> = {
   ranks: "Ranks",
   speedup: "Speedup",
 };
+const AVG_RANK_LABEL = "Avg rank over covered cohorts";
+const COVERAGE_POLICY_COPY = "Missing cohorts are not scored; coverage is shown separately.";
 const SORT_LABELS: Record<MetaLeaderboardSort, string> = {
-  avg_rank: "Avg rank",
+  avg_rank: AVG_RANK_LABEL,
   coverage: "Coverage",
   best_rank: "Best cohort",
   recent_activity: "Recent",
 };
-const MISSING_COHORT_TITLE =
-  "No published run for this cohort. Missing cohorts are not counted in average rank.";
+const MISSING_COHORT_TITLE = `No published run for this cohort. ${COVERAGE_POLICY_COPY}`;
 
 export function MetaLeaderboard({
   data,
@@ -219,9 +220,9 @@ export function MetaLeaderboard({
               <th
                 scope="col"
                 class="table-th whitespace-nowrap text-gray-700"
-                title="Average rank across visible cohorts"
+                title={`Average rank over cohorts where the platform has a published run. ${COVERAGE_POLICY_COPY}`}
               >
-                Avg rank
+                {AVG_RANK_LABEL}
               </th>
             </tr>
           </thead>
@@ -243,7 +244,7 @@ export function MetaLeaderboard({
                     </a>
                     <span
                       class="rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[11px] font-medium text-gray-500"
-                      title="Covered cohorts in the current leaderboard view"
+                      title={`Covered cohorts in the current leaderboard view. ${COVERAGE_POLICY_COPY}`}
                     >
                       {platform.n_cohorts}/{cohorts.length} cohorts
                     </span>
@@ -303,8 +304,20 @@ export function MetaLeaderboard({
                     </td>
                   );
                 })}
-                <td class="table-td text-center font-mono font-semibold text-gray-700">
-                  {platform.avg_rank !== null ? platform.avg_rank.toFixed(1) : <span class="text-gray-300">-</span>}
+                <td
+                  class="table-td text-center font-mono font-semibold text-gray-700"
+                  title={`${AVG_RANK_LABEL}: ${platform.n_cohorts}/${cohorts.length}. ${COVERAGE_POLICY_COPY}`}
+                >
+                  {platform.avg_rank !== null ? (
+                    <>
+                      <span>{platform.avg_rank.toFixed(1)}</span>
+                      <span class="mt-0.5 block text-[11px] font-normal text-gray-400">
+                        over {platform.n_cohorts}/{cohorts.length}
+                      </span>
+                    </>
+                  ) : (
+                    <span class="text-gray-300">No score</span>
+                  )}
                 </td>
               </tr>
             ))}
@@ -323,7 +336,7 @@ export function MetaLeaderboard({
           </p>
           <p>
             <strong>Ranks</strong> keeps the original meta-leaderboard contract: 1 = best in the
-            cohort, and missing cohorts are excluded from average-rank math.
+            cohort. {COVERAGE_POLICY_COPY}
           </p>
           <p>
             <strong>Speedup</strong> normalizes every cell to the cohort best, where 1.00x is
@@ -387,7 +400,7 @@ function describeCell(
   mode: MetaLeaderboardMode,
 ): string {
   if (!rank) {
-    return `${platform.platform} has no published run for ${cohort.label}. Missing cohorts are not counted in average rank.`;
+    return `${platform.platform} has no published run for ${cohort.label}. ${COVERAGE_POLICY_COPY}`;
   }
   const text = cellText(rank, cohort, mode);
   return `${platform.platform} ${MODE_LABELS[mode].toLowerCase()} for ${cohort.label}: ${text}`;

--- a/results-explorer/src/components/MetaLeaderboard.tsx
+++ b/results-explorer/src/components/MetaLeaderboard.tsx
@@ -6,6 +6,13 @@ import { fmtGeomean, fmtScore, humanizeBenchmark } from "@/utils";
 import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
 
 export type MetaLeaderboardMode = "times" | "ranks" | "speedup";
+type MetaLeaderboardSort = "avg_rank" | "coverage" | "best_rank" | "recent_activity";
+
+interface MetaResultMetadata {
+  trust_label: string;
+  validation_status?: string | null;
+  run_date?: string | null;
+}
 
 interface MetaLeaderboardProps {
   data: MetaLeaderboardData;
@@ -13,7 +20,7 @@ interface MetaLeaderboardProps {
   onModeChange: (mode: MetaLeaderboardMode) => void;
   cohortHref?: (cohort: MetaCohort) => string;
   platformHref?: (platformId: string) => string;
-  resultMetadataById?: ReadonlyMap<string, { trust_label: string; validation_status?: string | null }>;
+  resultMetadataById?: ReadonlyMap<string, MetaResultMetadata>;
 }
 
 const MODE_LABELS: Record<MetaLeaderboardMode, string> = {
@@ -21,6 +28,14 @@ const MODE_LABELS: Record<MetaLeaderboardMode, string> = {
   ranks: "Ranks",
   speedup: "Speedup",
 };
+const SORT_LABELS: Record<MetaLeaderboardSort, string> = {
+  avg_rank: "Avg rank",
+  coverage: "Coverage",
+  best_rank: "Best cohort",
+  recent_activity: "Recent",
+};
+const MISSING_COHORT_TITLE =
+  "No published run for this cohort. Missing cohorts are not counted in average rank.";
 
 export function MetaLeaderboard({
   data,
@@ -34,6 +49,7 @@ export function MetaLeaderboard({
   const gridRef = useRef<HTMLTableElement>(null);
   const [focusPos, setFocusPos] = useState({ row: 0, col: 0 });
   const [announcement, setAnnouncement] = useState("");
+  const [sortKey, setSortKey] = useState<MetaLeaderboardSort>("avg_rank");
 
   const columnMins = useMemo(() => {
     const mins = new Map<string, number | null>();
@@ -45,6 +61,14 @@ export function MetaLeaderboard({
     }
     return mins;
   }, [cohorts, mode, platforms]);
+
+  const sortedPlatforms = useMemo(
+    () =>
+      [...platforms].sort((a, b) =>
+        comparePlatforms(a, b, sortKey, cohorts, resultMetadataById),
+      ),
+    [cohorts, platforms, resultMetadataById, sortKey],
+  );
 
   if (platforms.length === 0 || cohorts.length === 0) return null;
 
@@ -59,7 +83,7 @@ export function MetaLeaderboard({
         nextCol = Math.max(colIdx - 1, 0);
         break;
       case "ArrowDown":
-        nextRow = Math.min(rowIdx + 1, platforms.length - 1);
+        nextRow = Math.min(rowIdx + 1, sortedPlatforms.length - 1);
         break;
       case "ArrowUp":
         nextRow = Math.max(rowIdx - 1, 0);
@@ -74,7 +98,7 @@ export function MetaLeaderboard({
         nextRow = 0;
         break;
       case "PageDown":
-        nextRow = platforms.length - 1;
+        nextRow = sortedPlatforms.length - 1;
         break;
       case "Enter":
       case " ": {
@@ -82,7 +106,7 @@ export function MetaLeaderboard({
         // Activation matches the row's mouse-click target (platform page), so
         // keyboard and pointer paths navigate to the same destination. The
         // column's cohort link is reachable via Tab on the header row.
-        const platform = platforms[rowIdx];
+        const platform = sortedPlatforms[rowIdx];
         if (platform) route(platformHref(platform.platform_id));
         return;
       }
@@ -119,21 +143,49 @@ export function MetaLeaderboard({
             Absolute values, ranks, or speedup-vs-cohort-best across the visible cohorts.
           </p>
         </div>
-        <div class="flex overflow-hidden rounded-md border border-gray-300 text-sm">
-          {(["times", "ranks", "speedup"] as const).map((value) => (
-            <button
-              key={value}
-              class={`px-3 py-1.5 ${
-                mode === value
-                  ? "bg-brand-600 text-white"
-                  : "bg-white text-gray-600 hover:bg-gray-50"
-              }`}
-              onClick={() => onModeChange(value)}
-              aria-pressed={mode === value}
-            >
-              {MODE_LABELS[value]}
-            </button>
-          ))}
+        <div class="flex flex-wrap items-center gap-2">
+          <div
+            role="group"
+            class="flex overflow-hidden rounded-md border border-gray-300 text-sm"
+            aria-label="Sort leaderboard"
+          >
+            {(Object.keys(SORT_LABELS) as MetaLeaderboardSort[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                class={`px-3 py-1.5 ${
+                  sortKey === value
+                    ? "bg-gray-900 text-white"
+                    : "bg-white text-gray-600 hover:bg-gray-50"
+                }`}
+                onClick={() => setSortKey(value)}
+                aria-pressed={sortKey === value}
+              >
+                {SORT_LABELS[value]}
+              </button>
+            ))}
+          </div>
+          <div
+            role="group"
+            class="flex overflow-hidden rounded-md border border-gray-300 text-sm"
+            aria-label="Display mode"
+          >
+            {(["times", "ranks", "speedup"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                class={`px-3 py-1.5 ${
+                  mode === value
+                    ? "bg-brand-600 text-white"
+                    : "bg-white text-gray-600 hover:bg-gray-50"
+                }`}
+                onClick={() => onModeChange(value)}
+                aria-pressed={mode === value}
+              >
+                {MODE_LABELS[value]}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
@@ -174,23 +226,32 @@ export function MetaLeaderboard({
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
-            {platforms.map((platform, rowIdx) => (
+            {sortedPlatforms.map((platform, rowIdx) => (
               <tr
                 key={platform.platform_id}
                 class="cursor-pointer hover:bg-gray-50"
                 onClick={() => route(platformHref(platform.platform_id))}
               >
                 <td class="table-td sticky left-0 z-10 bg-white font-medium text-gray-900">
-                  <a
-                    href={platformHref(platform.platform_id)}
-                    class="no-underline hover:text-brand-600"
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    {platform.platform}
-                  </a>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <a
+                      href={platformHref(platform.platform_id)}
+                      class="no-underline hover:text-brand-600"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {platform.platform}
+                    </a>
+                    <span
+                      class="rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-[11px] font-medium text-gray-500"
+                      title="Covered cohorts in the current leaderboard view"
+                    >
+                      {platform.n_cohorts}/{cohorts.length} cohorts
+                    </span>
+                  </div>
                 </td>
                 {cohorts.map((cohort, colIdx) => {
                   const rank = platform.ranks[cohort.key];
+                  const missing = rank === undefined;
                   const shadeMetric = cellShadeMetric(rank, mode, cohort);
                   const minInCol = columnMins.get(cohort.key) ?? null;
                   const hue = shadeMetric !== null ? colorForCell(shadeMetric, minInCol) : null;
@@ -206,7 +267,10 @@ export function MetaLeaderboard({
                       aria-colindex={colIdx + 1}
                       aria-rowindex={rowIdx + 1}
                       aria-label={text}
-                      class={`table-td text-center font-mono ${active ? "ring-2 ring-brand-500 ring-inset" : ""}`}
+                      title={missing ? MISSING_COHORT_TITLE : undefined}
+                      class={`table-td text-center font-mono ${
+                        missing ? "bg-gray-50 text-gray-400" : ""
+                      } ${active ? "ring-2 ring-brand-500 ring-inset" : ""}`}
                       style={{
                         backgroundColor: hue !== null ? `hsl(${hue} 72% 93%)` : undefined,
                       }}
@@ -287,7 +351,7 @@ function renderCellValue(
   cohort: MetaCohort,
   mode: MetaLeaderboardMode,
 ) {
-  if (!rank) return <span class="text-gray-300">-</span>;
+  if (!rank) return <span class="text-gray-400">No run</span>;
   const text = cellText(rank, cohort, mode);
   if (mode === "ranks") {
     return (
@@ -322,7 +386,93 @@ function describeCell(
   rank: MetaRank | undefined,
   mode: MetaLeaderboardMode,
 ): string {
-  if (!rank) return `${platform.platform} did not run ${cohort.label}`;
+  if (!rank) {
+    return `${platform.platform} has no published run for ${cohort.label}. Missing cohorts are not counted in average rank.`;
+  }
   const text = cellText(rank, cohort, mode);
   return `${platform.platform} ${MODE_LABELS[mode].toLowerCase()} for ${cohort.label}: ${text}`;
+}
+
+function comparePlatforms(
+  a: MetaPlatform,
+  b: MetaPlatform,
+  sortKey: MetaLeaderboardSort,
+  cohorts: MetaCohort[],
+  resultMetadataById?: ReadonlyMap<string, MetaResultMetadata>,
+): number {
+  const byName = () => a.platform.localeCompare(b.platform);
+
+  if (sortKey === "coverage") {
+    return (
+      b.n_cohorts - a.n_cohorts ||
+      compareNullableNumber(a.avg_rank, b.avg_rank, "asc") ||
+      byName()
+    );
+  }
+
+  if (sortKey === "best_rank") {
+    return (
+      compareNullableNumber(bestRank(a), bestRank(b), "asc") ||
+      compareNullableNumber(a.avg_rank, b.avg_rank, "asc") ||
+      byName()
+    );
+  }
+
+  if (sortKey === "recent_activity") {
+    const aDate = latestRunDate(a, cohorts, resultMetadataById);
+    const bDate = latestRunDate(b, cohorts, resultMetadataById);
+    return compareNullableString(aDate, bDate, "desc") || byName();
+  }
+
+  return compareNullableNumber(a.avg_rank, b.avg_rank, "asc") || byName();
+}
+
+function bestRank(platform: MetaPlatform): number | null {
+  const ranks = Object.values(platform.ranks)
+    .map((rank) => rank.rank)
+    .filter((rank): rank is number => Number.isFinite(rank));
+  return ranks.length > 0 ? Math.min(...ranks) : null;
+}
+
+function latestRunDate(
+  platform: MetaPlatform,
+  cohorts: MetaCohort[],
+  resultMetadataById?: ReadonlyMap<string, MetaResultMetadata>,
+): string | null {
+  if (!resultMetadataById) return null;
+
+  let latest: string | null = null;
+  for (const cohort of cohorts) {
+    for (const result of cohort.platforms ?? []) {
+      if (result.platform_id !== platform.platform_id) continue;
+      const runDate = resultMetadataById.get(result.result_id)?.run_date;
+      if (!runDate) continue;
+      if (latest === null || runDate.localeCompare(latest) > 0) {
+        latest = runDate;
+      }
+    }
+  }
+  return latest;
+}
+
+function compareNullableNumber(
+  a: number | null,
+  b: number | null,
+  direction: "asc" | "desc",
+): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return direction === "asc" ? a - b : b - a;
+}
+
+function compareNullableString(
+  a: string | null,
+  b: string | null,
+  direction: "asc" | "desc",
+): number {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return direction === "asc" ? a.localeCompare(b) : b.localeCompare(a);
 }

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -386,7 +386,7 @@ export function QueryHeatmap({
                             ? `${fmtMs(ms)}, fastest in column`
                             : `${fmtMs(ms)}, ${ratio.toFixed(1)}× fastest in column`
                           : fmtMs(ms)
-                        : "no data";
+                        : `No published query run for ${row.platform} ${qid}`;
 
                     const isFocused = focusPos.row === rowIdx && focusPos.col === colIdx;
 
@@ -405,14 +405,15 @@ export function QueryHeatmap({
                         data-cell={`${rowIdx}-${colIdx}`}
                         tabIndex={isFocused ? 0 : -1}
                         class={`table-td whitespace-nowrap text-right font-mono focus:outline focus:outline-2 focus:outline-brand-500 ${
-                          hue !== null ? "heatmap-cell" : ms === null ? "text-gray-400" : ""
+                          hue !== null ? "heatmap-cell" : ms === null ? "bg-gray-50 text-gray-400" : ""
                         }`}
                         style={cellStyle}
                         aria-label={ariaLabel}
+                        title={ms === null ? "No published run for this query/platform cell." : undefined}
                         onKeyDown={(e) => handleCellKey(e as KeyboardEvent, rowIdx, colIdx)}
                         onFocus={() => setAnnouncement(`${qid}: ${ariaLabel}`)}
                       >
-                        {ms !== null ? fmtMs(ms) : "-"}
+                        {ms !== null ? fmtMs(ms) : "No run"}
                       </td>
                     );
                   })}

--- a/results-explorer/src/components/__tests__/FacetRail.test.tsx
+++ b/results-explorer/src/components/__tests__/FacetRail.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen, within } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import { FacetDrawer, FacetRail, type FacetGroup } from "@/components/FacetRail";
+
+const GROUPS: FacetGroup[] = [
+  {
+    key: "benchmark",
+    label: "Benchmark",
+    selected: ["tpch"],
+    options: [
+      { value: "tpch", label: "TPC-H", count: 12 },
+      { value: "clickbench", label: "ClickBench", count: 4 },
+    ],
+  },
+  {
+    key: "platform",
+    label: "Platform",
+    selected: [],
+    searchable: true,
+    options: [
+      { value: "duckdb", label: "DuckDB", count: 8 },
+      { value: "sqlite", label: "SQLite", count: 3 },
+    ],
+  },
+];
+
+describe("FacetRail", () => {
+  it("renders active chips, counts, searchable groups, and reset", () => {
+    const onToggle = vi.fn();
+    const onReset = vi.fn();
+
+    render(
+      <FacetRail
+        groups={GROUPS}
+        resultCount={16}
+        activeChips={[{ key: "benchmark:tpch", label: "TPC-H" }]}
+        onToggle={onToggle}
+        onReset={onReset}
+      />,
+    );
+
+    expect(screen.getByText("16 matching results")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "TPC-H" }));
+    expect(onReset).toHaveBeenCalled();
+
+    const platformSection = screen.getByRole("heading", { name: "Platform" }).closest("section")!;
+    fireEvent.input(within(platformSection).getByRole("searchbox"), { target: { value: "duck" } });
+    expect(within(platformSection).getByText("DuckDB")).toBeTruthy();
+    expect(within(platformSection).queryByText("SQLite")).toBeNull();
+
+    fireEvent.click(within(platformSection).getByRole("checkbox"));
+    expect(onToggle).toHaveBeenCalledWith("platform", "duckdb");
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(onReset).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("FacetDrawer", () => {
+  it("shows a closed summary and opens the facet dialog", () => {
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <FacetDrawer
+        groups={GROUPS}
+        resultCount={16}
+        activeChips={[{ key: "benchmark:tpch", label: "TPC-H" }]}
+        onToggle={vi.fn()}
+        onReset={vi.fn()}
+        open={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Filters/ })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("dialog", { name: "Filter results" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Filters/ }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <FacetDrawer
+        groups={GROUPS}
+        resultCount={16}
+        activeChips={[{ key: "benchmark:tpch", label: "TPC-H" }]}
+        onToggle={vi.fn()}
+        onReset={vi.fn()}
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+    expect(screen.getByRole("dialog", { name: "Filter results" })).toBeTruthy();
+  });
+});

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -212,6 +212,74 @@ describe("MetaLeaderboard", () => {
     expect(rowOrder()[0]).toContain("DuckDB");
   });
 
+  it("keeps avg-rank sorting over covered cohorts instead of penalizing missing coverage", () => {
+    const data: MetaLeaderboardData = {
+      ...DATA,
+      cohorts: [
+        DATA.cohorts[0]!,
+        {
+          ...DATA.cohorts[0]!,
+          key: "tpch-sf0.1-power",
+          benchmark: "tpch",
+          label: "TPC-H SF0.1",
+          href: "/results/tpch/",
+          platform_count: 2,
+          platforms: [
+            {
+              platform_id: "duckdb",
+              platform: "DuckDB",
+              result_id: "r3",
+              rank: 2,
+              metric_value: 30,
+              speedup_vs_best: 0.5,
+              primary_metric: "display_geomean_ms",
+              primary_order: "asc" as const,
+            },
+          ],
+        },
+      ],
+      platforms: [
+        {
+          platform_id: "duckdb",
+          platform: "DuckDB",
+          ranks: {
+            ...DATA.platforms[0]!.ranks,
+            "tpch-sf0.1-power": {
+              rank: 2,
+              total: 2,
+              metric_value: 30,
+              speedup_vs_best: 0.5,
+            },
+          },
+          avg_rank: 1.5,
+          n_cohorts: 2,
+        },
+        {
+          platform_id: "polars",
+          platform: "Polars",
+          ranks: {
+            "clickbench-sf0.1-power": {
+              rank: 1,
+              total: 2,
+              metric_value: 8,
+              speedup_vs_best: 1,
+            },
+          },
+          avg_rank: 1,
+          n_cohorts: 1,
+        },
+      ],
+    };
+    const { container } = render(<MetaLeaderboard data={data} mode="ranks" onModeChange={vi.fn()} />);
+    const rowOrder = () =>
+      Array.from(container.querySelectorAll("tbody tr")).map((row) => row.textContent ?? "");
+
+    expect(rowOrder()[0]).toContain("Polars");
+    expect(rowOrder()[0]).toContain("1.0");
+    expect(rowOrder()[0]).toContain("over 1/2");
+    expect(rowOrder()[0]).toContain("No run");
+  });
+
 
   it("renders null when platforms list is empty", () => {
     const { container } = render(

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -198,15 +198,17 @@ describe("MetaLeaderboard", () => {
     const rowOrder = () =>
       Array.from(container.querySelectorAll("tbody tr")).map((row) => row.textContent ?? "");
 
-    expect(screen.getByRole("button", { name: "Avg rank" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Avg rank over covered cohorts" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByRole("button", { name: "Best cohort" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Recent" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Avg rank over covered cohorts" })).toBeTruthy();
     expect(rowOrder()[0]).toContain("Polars");
 
     fireEvent.click(screen.getByRole("button", { name: "Coverage" }));
 
     expect(screen.getByRole("button", { name: "Coverage" }).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByText("2/2 cohorts")).toBeTruthy();
+    expect(screen.getByText("over 2/2")).toBeTruthy();
     expect(rowOrder()[0]).toContain("DuckDB");
   });
 
@@ -241,10 +243,11 @@ describe("MetaLeaderboard", () => {
     render(<MetaLeaderboard data={dataWithNa} mode="ranks" onModeChange={vi.fn()} />);
     expect(screen.getByText("No run")).toBeTruthy();
     expect(screen.getByText("0/1 cohorts")).toBeTruthy();
+    expect(screen.getByText("No score")).toBeTruthy();
     const missingCell = screen.getByRole("gridcell", {
-      name: /Polars has no published run for ClickBench SF0\.1\. Missing cohorts are not counted in average rank\./,
+      name: /Polars has no published run for ClickBench SF0\.1\. Missing cohorts are not scored; coverage is shown separately\./,
     });
-    expect(missingCell.getAttribute("title")).toContain("Missing cohorts are not counted");
+    expect(missingCell.getAttribute("title")).toContain("Missing cohorts are not scored");
   });
 
   it("formats avg_rank with 2 decimal places", () => {

--- a/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
+++ b/results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx
@@ -125,6 +125,91 @@ describe("MetaLeaderboard", () => {
     expect(screen.getByText("loose")).toBeTruthy();
   });
 
+  it("shows coverage counts and can sort by covered cohort count", () => {
+    const data: MetaLeaderboardData = {
+      ...DATA,
+      cohorts: [
+        DATA.cohorts[0]!,
+        {
+          ...DATA.cohorts[0]!,
+          key: "tpch-sf0.1-power",
+          benchmark: "tpch",
+          label: "TPC-H SF0.1",
+          href: "/results/tpch/",
+          platform_count: 2,
+          platforms: [
+            {
+              platform_id: "duckdb",
+              platform: "DuckDB",
+              result_id: "r3",
+              rank: 2,
+              metric_value: 30,
+              speedup_vs_best: 0.5,
+              primary_metric: "display_geomean_ms",
+              primary_order: "asc" as const,
+            },
+            {
+              platform_id: "polars",
+              platform: "Polars",
+              result_id: "r4",
+              rank: 1,
+              metric_value: 15,
+              speedup_vs_best: 1,
+              primary_metric: "display_geomean_ms",
+              primary_order: "asc" as const,
+            },
+          ],
+        },
+      ],
+      platforms: [
+        {
+          platform_id: "duckdb",
+          platform: "DuckDB",
+          ranks: {
+            ...DATA.platforms[0]!.ranks,
+            "tpch-sf0.1-power": {
+              rank: 2,
+              total: 2,
+              metric_value: 30,
+              speedup_vs_best: 0.5,
+            },
+          },
+          avg_rank: 1.5,
+          n_cohorts: 2,
+        },
+        DATA.platforms[1]!,
+        {
+          platform_id: "polars",
+          platform: "Polars",
+          ranks: {
+            "tpch-sf0.1-power": {
+              rank: 1,
+              total: 2,
+              metric_value: 15,
+              speedup_vs_best: 1,
+            },
+          },
+          avg_rank: 1,
+          n_cohorts: 1,
+        },
+      ],
+    };
+    const { container } = render(<MetaLeaderboard data={data} mode="ranks" onModeChange={vi.fn()} />);
+    const rowOrder = () =>
+      Array.from(container.querySelectorAll("tbody tr")).map((row) => row.textContent ?? "");
+
+    expect(screen.getByRole("button", { name: "Avg rank" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Best cohort" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Recent" })).toBeTruthy();
+    expect(rowOrder()[0]).toContain("Polars");
+
+    fireEvent.click(screen.getByRole("button", { name: "Coverage" }));
+
+    expect(screen.getByRole("button", { name: "Coverage" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText("2/2 cohorts")).toBeTruthy();
+    expect(rowOrder()[0]).toContain("DuckDB");
+  });
+
 
   it("renders null when platforms list is empty", () => {
     const { container } = render(
@@ -139,7 +224,7 @@ describe("MetaLeaderboard", () => {
     expect(screen.getByText("2/2")).toBeTruthy();
   });
 
-  it("shows em-dash for platform missing a cohort rank entry", () => {
+  it("shows explicit no-run copy for a platform missing a cohort rank entry", () => {
     const dataWithNa = {
       ...DATA,
       platforms: [
@@ -148,14 +233,18 @@ describe("MetaLeaderboard", () => {
           platform_id: "polars",
           platform: "Polars",
           ranks: {},
-          avg_rank: null as unknown as number,
+          avg_rank: null,
           n_cohorts: 0,
         },
       ],
     };
     render(<MetaLeaderboard data={dataWithNa} mode="ranks" onModeChange={vi.fn()} />);
-    const dashes = screen.getAllByText("-");
-    expect(dashes.length).toBeGreaterThan(0);
+    expect(screen.getByText("No run")).toBeTruthy();
+    expect(screen.getByText("0/1 cohorts")).toBeTruthy();
+    const missingCell = screen.getByRole("gridcell", {
+      name: /Polars has no published run for ClickBench SF0\.1\. Missing cohorts are not counted in average rank\./,
+    });
+    expect(missingCell.getAttribute("title")).toContain("Missing cohorts are not counted");
   });
 
   it("formats avg_rank with 2 decimal places", () => {

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -3,7 +3,7 @@
  *
  * Cases:
  *   (a) Known timings produce stable color hue values
- *   (b) Null cells render "-" with aria-label="no data"
+ *   (b) Null cells render "No run" with an explicit missing-run aria-label
  *   (c) Single-platform matrix degrades gracefully (no heat coloring)
  *   (d) Empty platforms list shows empty-state message
  *
@@ -136,10 +136,10 @@ describe("QueryHeatmap rendering", () => {
   });
 
   // -----------------------------------------------------------------------
-  // (b) Null cells render "-"
+  // (b) Null cells render "No run"
   // -----------------------------------------------------------------------
 
-  it("null timing cell renders em-dash with no-data aria-label", () => {
+  it("null timing cell renders no-run copy with a missing-run aria-label", () => {
     const summary = makeSummary({
       platforms: [
         {
@@ -166,9 +166,10 @@ describe("QueryHeatmap rendering", () => {
       ],
     });
     const { container } = render(<QueryHeatmap summary={summary} />);
-    const cells = container.querySelectorAll('[aria-label="no data"]');
+    const cells = container.querySelectorAll('[aria-label="No published query run for DuckDB Q2"]');
     expect(cells.length).toBeGreaterThan(0);
-    expect(cells[0]?.textContent).toBe("-");
+    expect(cells[0]?.textContent).toBe("No run");
+    expect(cells[0]?.getAttribute("title")).toBe("No published run for this query/platform cell.");
   });
 
   // -----------------------------------------------------------------------

--- a/results-explorer/src/lib/__tests__/duckdbQueries.test.ts
+++ b/results-explorer/src/lib/__tests__/duckdbQueries.test.ts
@@ -34,6 +34,14 @@ describe("duckdbQueries - SQL targets and parameters", () => {
     expect(params).toBeUndefined();
   });
 
+  it("listResults accepts a parameterized facet WHERE clause", async () => {
+    mockedQueryRows.mockResolvedValueOnce([]);
+    await listResults({ sql: "WHERE benchmark IN (?)", params: ["tpch"] });
+    const [sql, params] = mockedQueryRows.mock.calls[0]!;
+    expect(sql).toContain("WHERE benchmark IN (?)");
+    expect(params).toEqual(["tpch"]);
+  });
+
   it("getResultDetailMetrics returns the single matching row or null", async () => {
     mockedQueryRows.mockResolvedValueOnce([{ result_id: "r1" }]);
     const row = await getResultDetailMetrics("r1");
@@ -86,6 +94,9 @@ describe("duckdbQueries - SQL targets and parameters", () => {
     expect(sql).toMatch(/COALESCE\(br\.phase, r\.test_type, 'power'\) AS phase/);
     expect(sql).toMatch(/br\.primary_metric/);
     expect(sql).toMatch(/validation_status/);
+    expect(sql).toMatch(/normalized_cost_usd/);
+    expect(sql).toMatch(/cloud_provider/);
+    expect(sql).toMatch(/storage_format/);
     expect(sql).not.toMatch(/WHERE/);
     expect(params).toBeUndefined();
   });

--- a/results-explorer/src/lib/__tests__/duckdbQueries.test.ts
+++ b/results-explorer/src/lib/__tests__/duckdbQueries.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/db", () => ({
 
 import { queryRows } from "@/db";
 import {
+  clearDuckdbQueryCachesForTests,
   listResults,
   getResultDetailMetrics,
   getQueryDisplayTimings,
@@ -23,6 +24,7 @@ const mockedQueryRows = vi.mocked(queryRows);
 
 beforeEach(() => {
   mockedQueryRows.mockReset();
+  clearDuckdbQueryCachesForTests();
 });
 
 describe("duckdbQueries - SQL targets and parameters", () => {
@@ -124,6 +126,28 @@ describe("duckdbQueries - SQL targets and parameters", () => {
     const [sql] = mockedQueryRows.mock.calls[0]!;
     expect(sql).toMatch(/FROM bench\.meta_leaderboard/);
     expect(sql).toMatch(/ORDER BY avg_rank NULLS LAST/);
+  });
+
+  it("memoizes stable metadata helper reads for the current snapshot", async () => {
+    const rows = [{ platform_id: "duckdb", platform: "DuckDB", avg_rank: 1, n_cohorts: 2 }];
+    mockedQueryRows.mockResolvedValueOnce(rows);
+
+    const first = await getMetaLeaderboard();
+    const second = await getMetaLeaderboard();
+
+    expect(first).toBe(second);
+    expect(mockedQueryRows).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts failed metadata helper reads so a retry can recover", async () => {
+    mockedQueryRows.mockRejectedValueOnce(new Error("snapshot not ready"));
+    await expect(getMetaLeaderboard()).rejects.toThrow("snapshot not ready");
+
+    const rows = [{ platform_id: "duckdb", platform: "DuckDB", avg_rank: 1, n_cohorts: 2 }];
+    mockedQueryRows.mockResolvedValueOnce(rows);
+
+    await expect(getMetaLeaderboard()).resolves.toEqual(rows);
+    expect(mockedQueryRows).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/results-explorer/src/lib/__tests__/facetModel.test.ts
+++ b/results-explorer/src/lib/__tests__/facetModel.test.ts
@@ -90,6 +90,14 @@ describe("facet URL contract", () => {
     expect(readFacetParam(params, "benchmark")).toEqual(["tpch", "ssb"]);
     expect(readFacetParam(params, "date_window")).toBe("30d");
   });
+
+  it("treats legacy all sentinel values as default selections", () => {
+    const params = new URLSearchParams("phase=all&tuning=all&trust=all");
+
+    expect(readFacetParam(params, "phase")).toEqual([]);
+    expect(readFacetParam(params, "tuning_mode")).toEqual([]);
+    expect(readFacetParam(params, "trust_tier")).toEqual([]);
+  });
 });
 
 describe("facetsToWhereClause", () => {
@@ -118,6 +126,7 @@ describe("facetsToWhereClause", () => {
     expect(sql).toContain("benchmark IN (?)");
     expect(sql).toContain("scale_factor IN (?)");
     expect(sql).toContain("test_type IN (?)");
+    expect(sql).toContain("(platform IN (?) OR platform_id IN (?))");
     expect(sql).toContain("(cloud_provider IS NOT NULL OR cost_status = ?)");
     expect(sql).toContain("COALESCE(instance_type, warehouse_size, cluster_size) IN (?)");
     expect(sql).toContain("run_date >= ?");
@@ -125,6 +134,7 @@ describe("facetsToWhereClause", () => {
       "tpch",
       0.01,
       "power",
+      "DuckDB",
       "DuckDB",
       "sql",
       "default",
@@ -142,5 +152,12 @@ describe("facetsToWhereClause", () => {
 
   it("returns an empty clause for default facets", () => {
     expect(facetsToWhereClause()).toEqual({ sql: "", params: [] });
+  });
+
+  it("preserves the legacy untuned tuning sentinel as NULL tuning mode", () => {
+    const { sql, params } = facetsToWhereClause({ tuning_mode: ["untuned", "auto"] });
+
+    expect(sql).toContain("(tuning_mode IN (?) OR tuning_mode IS NULL)");
+    expect(params).toEqual(["auto"]);
   });
 });

--- a/results-explorer/src/lib/__tests__/facetModel.test.ts
+++ b/results-explorer/src/lib/__tests__/facetModel.test.ts
@@ -7,6 +7,7 @@ import {
   FACET_URL_SERDES,
   facetsToWhereClause,
   readFacetParam,
+  useFacetField,
   type FacetKey,
   type FacetState,
 } from "@/lib/facetModel";
@@ -97,6 +98,14 @@ describe("facet URL contract", () => {
     expect(readFacetParam(params, "phase")).toEqual([]);
     expect(readFacetParam(params, "tuning_mode")).toEqual([]);
     expect(readFacetParam(params, "trust_tier")).toEqual([]);
+  });
+
+  it("can mount one shared facet without canonicalizing unrelated aliases", () => {
+    window.history.replaceState(null, "", "/?warehouse_size=MEDIUM");
+
+    const { result } = renderHook(() => useFacetField("benchmark"));
+    expect(result.current[0]).toEqual([]);
+    expect(new URL(window.location.href).searchParams.get("warehouse_size")).toBe("MEDIUM");
   });
 });
 

--- a/results-explorer/src/lib/__tests__/facetModel.test.ts
+++ b/results-explorer/src/lib/__tests__/facetModel.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook } from "@testing-library/preact";
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  DEFAULT_FACETS,
+  FACET_KEYS,
+  FACET_URL_KEYS,
+  FACET_URL_SERDES,
+  facetsToWhereClause,
+  readFacetParam,
+  type FacetKey,
+  type FacetState,
+} from "@/lib/facetModel";
+import { useUrlState, type UrlSerde } from "@/lib/useUrlState";
+
+const SAMPLE_VALUES: { [K in FacetKey]: FacetState[K] } = {
+  benchmark: ["tpch", "star_schema"],
+  scale_factor: ["0.01", "1"],
+  phase: ["power", "throughput"],
+  platform: ["DuckDB", "ClickHouse"],
+  execution_mode: ["sql"],
+  tuning_mode: ["default", "tuned"],
+  trust_tier: ["maintainer-run"],
+  validation_status: ["exact", "loose"],
+  deployment_class: ["cloud", "local"],
+  cloud_provider: ["aws", "gcp"],
+  cloud_region: ["us-east-1"],
+  instance_or_warehouse: ["m6i.large", "MEDIUM"],
+  storage_format: ["parquet"],
+  cost_status: ["normalized"],
+  date_window: "90d",
+};
+
+function clearSearch() {
+  window.history.replaceState(null, "", "/");
+}
+
+function renderFacetUrlState(key: FacetKey) {
+  return renderHook(() =>
+    useUrlState<unknown>(
+      FACET_URL_KEYS[key],
+      DEFAULT_FACETS[key],
+      FACET_URL_SERDES[key] as UrlSerde<unknown>,
+    ),
+  );
+}
+
+describe("facet URL contract", () => {
+  beforeEach(() => {
+    clearSearch();
+  });
+
+  it("defines every expected facet key", () => {
+    expect(FACET_KEYS).toStrictEqual([
+      "benchmark",
+      "scale_factor",
+      "phase",
+      "platform",
+      "execution_mode",
+      "tuning_mode",
+      "trust_tier",
+      "validation_status",
+      "deployment_class",
+      "cloud_provider",
+      "cloud_region",
+      "instance_or_warehouse",
+      "storage_format",
+      "cost_status",
+      "date_window",
+    ]);
+  });
+
+  for (const key of FACET_KEYS) {
+    it(`round-trips ${key} through useUrlState`, () => {
+      const sample = SAMPLE_VALUES[key];
+      const first = renderFacetUrlState(key);
+
+      act(() => {
+        first.result.current[1](sample);
+      });
+      first.unmount();
+
+      const second = renderFacetUrlState(key);
+      expect(second.result.current[0]).toEqual(sample);
+    });
+  }
+
+  it("reads legacy aliases while preserving the new canonical key", () => {
+    const params = new URLSearchParams("bm=tpch,ssb&date_window=30d");
+
+    expect(readFacetParam(params, "benchmark")).toEqual(["tpch", "ssb"]);
+    expect(readFacetParam(params, "date_window")).toBe("30d");
+  });
+});
+
+describe("facetsToWhereClause", () => {
+  it("builds a parameterized WHERE clause for core, deployment, and cost facets", () => {
+    const { sql, params } = facetsToWhereClause(
+      {
+        benchmark: ["tpch"],
+        scale_factor: ["0.01", "not-a-number"],
+        phase: ["power"],
+        platform: ["DuckDB"],
+        execution_mode: ["sql"],
+        tuning_mode: ["default"],
+        trust_tier: ["maintainer-run"],
+        validation_status: ["exact"],
+        deployment_class: ["cloud", "local"],
+        cloud_provider: ["aws"],
+        cloud_region: ["us-east-1"],
+        instance_or_warehouse: ["MEDIUM"],
+        storage_format: ["parquet"],
+        cost_status: ["normalized"],
+        date_window: "30d",
+      },
+      { now: new Date("2026-05-02T00:00:00.000Z") },
+    );
+
+    expect(sql).toContain("benchmark IN (?)");
+    expect(sql).toContain("scale_factor IN (?)");
+    expect(sql).toContain("test_type IN (?)");
+    expect(sql).toContain("(cloud_provider IS NOT NULL OR cost_status = ?)");
+    expect(sql).toContain("COALESCE(instance_type, warehouse_size, cluster_size) IN (?)");
+    expect(sql).toContain("run_date >= ?");
+    expect(params).toEqual([
+      "tpch",
+      0.01,
+      "power",
+      "DuckDB",
+      "sql",
+      "default",
+      "maintainer-run",
+      "exact",
+      "not_applicable_local",
+      "aws",
+      "us-east-1",
+      "MEDIUM",
+      "parquet",
+      "normalized",
+      "2026-04-02T00:00:00.000Z",
+    ]);
+  });
+
+  it("returns an empty clause for default facets", () => {
+    expect(facetsToWhereClause()).toEqual({ sql: "", params: [] });
+  });
+});

--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -182,6 +182,31 @@ export interface MetaLeaderboardRow {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const RESULTS_SNAPSHOT_PATH = "/results/data/results.duckdb";
+const snapshotQueryCache = new Map<string, Promise<unknown>>();
+
+function currentSnapshotCacheKey(): string {
+  if (typeof window === "undefined") return RESULTS_SNAPSHOT_PATH;
+  return new URL(RESULTS_SNAPSHOT_PATH, window.location.origin).href;
+}
+
+function memoizedSnapshotQuery<T>(key: string, loader: () => Promise<T>): Promise<T> {
+  const cacheKey = `${currentSnapshotCacheKey()}\u0000${key}`;
+  const cached = snapshotQueryCache.get(cacheKey);
+  if (cached) return cached as Promise<T>;
+
+  const promise = loader().catch((error: unknown) => {
+    snapshotQueryCache.delete(cacheKey);
+    throw error;
+  });
+  snapshotQueryCache.set(cacheKey, promise);
+  return promise;
+}
+
+export function clearDuckdbQueryCachesForTests() {
+  snapshotQueryCache.clear();
+}
+
 export async function listResults(where: FacetWhereClause = { sql: "", params: [] }): Promise<ResultRow[]> {
   const sql = `SELECT * FROM bench.results ${where.sql} ORDER BY run_date DESC`;
   return where.params.length > 0 ? queryRows<ResultRow>(sql, where.params) : queryRows<ResultRow>(sql);
@@ -371,6 +396,17 @@ export async function getBenchmarkSummaryFromDuckDB(
   scaleFactor: number,
   phase: string,
 ): Promise<BenchmarkSummary | null> {
+  return memoizedSnapshotQuery(
+    `benchmark-summary:${benchmark}\u0000${scaleFactor}\u0000${phase}`,
+    () => loadBenchmarkSummaryFromDuckDB(benchmark, scaleFactor, phase),
+  );
+}
+
+async function loadBenchmarkSummaryFromDuckDB(
+  benchmark: string,
+  scaleFactor: number,
+  phase: string,
+): Promise<BenchmarkSummary | null> {
   const [rankingRows, cellRows] = await Promise.all([
     getBenchmarkRanking(benchmark, scaleFactor, phase),
     getBenchmarkMatrixCells(benchmark, scaleFactor, phase),
@@ -464,6 +500,13 @@ export async function getBenchmarkSummaryFromDuckDB(
 }
 
 export async function getPlatformIndexRows(platformId?: string): Promise<PlatformIndexRowRow[]> {
+  return memoizedSnapshotQuery(
+    `platform-index:${platformId ?? "*"}`,
+    () => loadPlatformIndexRows(platformId),
+  );
+}
+
+function loadPlatformIndexRows(platformId?: string): Promise<PlatformIndexRowRow[]> {
   const sql =
     "SELECT" +
     " r.result_id," +
@@ -507,26 +550,31 @@ export async function getPlatformIndexRows(platformId?: string): Promise<Platfor
   if (platformId === undefined) {
     return queryRows<PlatformIndexRowRow>(`${sql} ORDER BY r.run_date DESC`);
   }
-  return queryRows<PlatformIndexRowRow>(
-    `${sql} WHERE r.platform_id = ? ORDER BY r.run_date DESC`,
-    [platformId],
-  );
+  return queryRows<PlatformIndexRowRow>(`${sql} WHERE r.platform_id = ? ORDER BY r.run_date DESC`, [platformId]);
 }
 
 export async function getCohort(cohortKey: string): Promise<CohortMetadataRow[]> {
-  return queryRows<CohortMetadataRow>(
-    "SELECT * FROM bench.cohort_metadata" +
-      " WHERE cohort_key = ?" +
-      " ORDER BY rank NULLS LAST, platform_id, result_id",
-    [cohortKey],
+  return memoizedSnapshotQuery(
+    `cohort:${cohortKey}`,
+    () =>
+      queryRows<CohortMetadataRow>(
+        "SELECT * FROM bench.cohort_metadata" +
+          " WHERE cohort_key = ?" +
+          " ORDER BY rank NULLS LAST, platform_id, result_id",
+        [cohortKey],
+      ),
   );
 }
 
 export async function getMetaLeaderboard(): Promise<MetaLeaderboardRow[]> {
-  return queryRows<MetaLeaderboardRow>(
-    "SELECT platform_id, platform, avg_rank, n_cohorts" +
-      " FROM bench.meta_leaderboard" +
-      " ORDER BY avg_rank NULLS LAST, platform_id",
+  return memoizedSnapshotQuery(
+    "meta-leaderboard",
+    () =>
+      queryRows<MetaLeaderboardRow>(
+        "SELECT platform_id, platform, avg_rank, n_cohorts" +
+          " FROM bench.meta_leaderboard" +
+          " ORDER BY avg_rank NULLS LAST, platform_id",
+      ),
   );
 }
 
@@ -545,6 +593,10 @@ export async function getMetaLeaderboard(): Promise<MetaLeaderboardRow[]> {
  * stable regardless of variant ordering on disk.
  */
 export async function getMetaLeaderboardData(): Promise<MetaLeaderboard | null> {
+  return memoizedSnapshotQuery("meta-leaderboard-data", loadMetaLeaderboardData);
+}
+
+async function loadMetaLeaderboardData(): Promise<MetaLeaderboard | null> {
   const [platformRows, cohortRows] = await Promise.all([
     queryRows<MetaLeaderboardRow>(
       "SELECT platform_id, platform, avg_rank, n_cohorts" +

--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -9,6 +9,7 @@
  */
 
 import { queryRows } from "@/db";
+import type { FacetWhereClause } from "@/lib/facetModel";
 import type {
   BenchmarkSummary,
   CostDeploymentFields,
@@ -181,8 +182,11 @@ export interface MetaLeaderboardRow {
 // Helpers
 // ---------------------------------------------------------------------------
 
-export async function listResults(): Promise<ResultRow[]> {
-  return queryRows<ResultRow>("SELECT * FROM bench.results ORDER BY run_date DESC");
+export async function listResults(where: FacetWhereClause = { sql: "", params: [] }): Promise<ResultRow[]> {
+  return queryRows<ResultRow>(
+    `SELECT * FROM bench.results ${where.sql} ORDER BY run_date DESC`,
+    where.params,
+  );
 }
 
 export async function getResultDetailMetrics(resultId: string): Promise<ResultDetailMetricsRow | null> {

--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -183,10 +183,8 @@ export interface MetaLeaderboardRow {
 // ---------------------------------------------------------------------------
 
 export async function listResults(where: FacetWhereClause = { sql: "", params: [] }): Promise<ResultRow[]> {
-  return queryRows<ResultRow>(
-    `SELECT * FROM bench.results ${where.sql} ORDER BY run_date DESC`,
-    where.params,
-  );
+  const sql = `SELECT * FROM bench.results ${where.sql} ORDER BY run_date DESC`;
+  return where.params.length > 0 ? queryRows<ResultRow>(sql, where.params) : queryRows<ResultRow>(sql);
 }
 
 export async function getResultDetailMetrics(resultId: string): Promise<ResultDetailMetricsRow | null> {
@@ -487,6 +485,21 @@ export async function getPlatformIndexRows(platformId?: string): Promise<Platfor
     " r.execution_mode," +
     " r.compliance_class," +
     " r.cost_usd," +
+    " r.normalized_cost_usd," +
+    " r.cost_model_version," +
+    " r.cost_model_source," +
+    " r.cost_scope," +
+    " r.cost_status," +
+    " r.billing_unit," +
+    " r.pricing_region," +
+    " r.cloud_provider," +
+    " r.cloud_region," +
+    " r.instance_type," +
+    " r.warehouse_size," +
+    " r.node_count," +
+    " r.cluster_size," +
+    " r.storage_format," +
+    " r.storage_tier," +
     " COALESCE(br.primary_metric, CASE WHEN r.power_score IS NOT NULL THEN 'power_score' ELSE 'display_geomean_ms' END)" +
     " AS primary_metric" +
     " FROM bench.results r" +

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import type { UrlSerde } from "@/lib/useUrlState";
 
 export const FACET_KEYS = [
@@ -46,6 +47,13 @@ export type PartialFacetState = Partial<{
 export interface FacetWhereClause {
   sql: string;
   params: unknown[];
+}
+
+export interface UseFacetStateResult {
+  facets: FacetState;
+  where: FacetWhereClause;
+  setFacet: <K extends FacetKey>(key: K, value: FacetState[K]) => void;
+  resetFacets: () => void;
 }
 
 export const DEFAULT_FACETS: FacetState = {
@@ -101,6 +109,7 @@ const DATE_WINDOW_DAYS: Record<Exclude<DateWindowFacet, "all">, number> = {
   "90d": 90,
   "365d": 365,
 };
+const LEGACY_ALL_SENTINEL_KEYS = new Set<FacetKey>(["phase", "tuning_mode", "trust_tier"]);
 
 const multiValueSerde: UrlSerde<string[]> = {
   encode: (values) => normalizeStringList(values).join(","),
@@ -132,22 +141,29 @@ export const FACET_URL_SERDES = {
 
 export function normalizeFacetState(input: PartialFacetState = {}): FacetState {
   return {
-    benchmark: normalizeStringList(input.benchmark ?? DEFAULT_FACETS.benchmark),
-    scale_factor: normalizeStringList(input.scale_factor ?? DEFAULT_FACETS.scale_factor),
-    phase: normalizeStringList(input.phase ?? DEFAULT_FACETS.phase),
-    platform: normalizeStringList(input.platform ?? DEFAULT_FACETS.platform),
-    execution_mode: normalizeStringList(input.execution_mode ?? DEFAULT_FACETS.execution_mode),
-    tuning_mode: normalizeStringList(input.tuning_mode ?? DEFAULT_FACETS.tuning_mode),
-    trust_tier: normalizeStringList(input.trust_tier ?? DEFAULT_FACETS.trust_tier),
-    validation_status: normalizeStringList(input.validation_status ?? DEFAULT_FACETS.validation_status),
-    deployment_class: normalizeStringList(input.deployment_class ?? DEFAULT_FACETS.deployment_class),
-    cloud_provider: normalizeStringList(input.cloud_provider ?? DEFAULT_FACETS.cloud_provider),
-    cloud_region: normalizeStringList(input.cloud_region ?? DEFAULT_FACETS.cloud_region),
-    instance_or_warehouse: normalizeStringList(
+    benchmark: normalizeFacetList("benchmark", input.benchmark ?? DEFAULT_FACETS.benchmark),
+    scale_factor: normalizeFacetList("scale_factor", input.scale_factor ?? DEFAULT_FACETS.scale_factor),
+    phase: normalizeFacetList("phase", input.phase ?? DEFAULT_FACETS.phase),
+    platform: normalizeFacetList("platform", input.platform ?? DEFAULT_FACETS.platform),
+    execution_mode: normalizeFacetList("execution_mode", input.execution_mode ?? DEFAULT_FACETS.execution_mode),
+    tuning_mode: normalizeFacetList("tuning_mode", input.tuning_mode ?? DEFAULT_FACETS.tuning_mode),
+    trust_tier: normalizeFacetList("trust_tier", input.trust_tier ?? DEFAULT_FACETS.trust_tier),
+    validation_status: normalizeFacetList(
+      "validation_status",
+      input.validation_status ?? DEFAULT_FACETS.validation_status,
+    ),
+    deployment_class: normalizeFacetList(
+      "deployment_class",
+      input.deployment_class ?? DEFAULT_FACETS.deployment_class,
+    ),
+    cloud_provider: normalizeFacetList("cloud_provider", input.cloud_provider ?? DEFAULT_FACETS.cloud_provider),
+    cloud_region: normalizeFacetList("cloud_region", input.cloud_region ?? DEFAULT_FACETS.cloud_region),
+    instance_or_warehouse: normalizeFacetList(
+      "instance_or_warehouse",
       input.instance_or_warehouse ?? DEFAULT_FACETS.instance_or_warehouse,
     ),
-    storage_format: normalizeStringList(input.storage_format ?? DEFAULT_FACETS.storage_format),
-    cost_status: normalizeStringList(input.cost_status ?? DEFAULT_FACETS.cost_status),
+    storage_format: normalizeFacetList("storage_format", input.storage_format ?? DEFAULT_FACETS.storage_format),
+    cost_status: normalizeFacetList("cost_status", input.cost_status ?? DEFAULT_FACETS.cost_status),
     date_window: DATE_WINDOWS.has(input.date_window as DateWindowFacet)
       ? (input.date_window as DateWindowFacet)
       : DEFAULT_FACETS.date_window,
@@ -162,7 +178,93 @@ export function readFacetParam<K extends FacetKey>(
   const fallback = defaultFacetValue(key);
   if (raw === null) return fallback;
   const serde = FACET_URL_SERDES[key] as unknown as UrlSerde<FacetState[K]>;
-  return serde.decode(raw) ?? fallback;
+  const decoded = serde.decode(raw);
+  return decoded === null ? fallback : normalizeFacetValue(key, decoded);
+}
+
+export function useFacetState(): UseFacetStateResult {
+  const [benchmark, setBenchmark] = useFacetUrlState("benchmark");
+  const [scaleFactor, setScaleFactor] = useFacetUrlState("scale_factor");
+  const [phase, setPhase] = useFacetUrlState("phase");
+  const [platform, setPlatform] = useFacetUrlState("platform");
+  const [executionMode, setExecutionMode] = useFacetUrlState("execution_mode");
+  const [tuningMode, setTuningMode] = useFacetUrlState("tuning_mode");
+  const [trustTier, setTrustTier] = useFacetUrlState("trust_tier");
+  const [validationStatus, setValidationStatus] = useFacetUrlState("validation_status");
+  const [deploymentClass, setDeploymentClass] = useFacetUrlState("deployment_class");
+  const [cloudProvider, setCloudProvider] = useFacetUrlState("cloud_provider");
+  const [cloudRegion, setCloudRegion] = useFacetUrlState("cloud_region");
+  const [instanceOrWarehouse, setInstanceOrWarehouse] = useFacetUrlState("instance_or_warehouse");
+  const [storageFormat, setStorageFormat] = useFacetUrlState("storage_format");
+  const [costStatus, setCostStatus] = useFacetUrlState("cost_status");
+  const [dateWindow, setDateWindow] = useFacetUrlState("date_window");
+
+  const facets = useMemo<FacetState>(
+    () => ({
+      benchmark,
+      scale_factor: scaleFactor,
+      phase,
+      platform,
+      execution_mode: executionMode,
+      tuning_mode: tuningMode,
+      trust_tier: trustTier,
+      validation_status: validationStatus,
+      deployment_class: deploymentClass,
+      cloud_provider: cloudProvider,
+      cloud_region: cloudRegion,
+      instance_or_warehouse: instanceOrWarehouse,
+      storage_format: storageFormat,
+      cost_status: costStatus,
+      date_window: dateWindow,
+    }),
+    [
+      benchmark,
+      cloudProvider,
+      cloudRegion,
+      costStatus,
+      dateWindow,
+      deploymentClass,
+      executionMode,
+      instanceOrWarehouse,
+      phase,
+      platform,
+      scaleFactor,
+      storageFormat,
+      trustTier,
+      tuningMode,
+      validationStatus,
+    ],
+  );
+  const where = useMemo(() => facetsToWhereClause(facets), [facets]);
+
+  function setFacet<K extends FacetKey>(key: K, value: FacetState[K]) {
+    const setters = {
+      benchmark: setBenchmark,
+      scale_factor: setScaleFactor,
+      phase: setPhase,
+      platform: setPlatform,
+      execution_mode: setExecutionMode,
+      tuning_mode: setTuningMode,
+      trust_tier: setTrustTier,
+      validation_status: setValidationStatus,
+      deployment_class: setDeploymentClass,
+      cloud_provider: setCloudProvider,
+      cloud_region: setCloudRegion,
+      instance_or_warehouse: setInstanceOrWarehouse,
+      storage_format: setStorageFormat,
+      cost_status: setCostStatus,
+      date_window: setDateWindow,
+    } satisfies { [Facet in FacetKey]: (next: FacetState[Facet]) => void };
+    (setters[key] as (next: FacetState[K]) => void)(value);
+  }
+
+  function resetFacets() {
+    for (const key of FACET_KEYS) {
+      setFacet(key, defaultFacetValue(key));
+    }
+  }
+
+  return { facets, where, setFacet, resetFacets };
 }
 
 export function facetsToWhereClause(
@@ -176,9 +278,9 @@ export function facetsToWhereClause(
   addListClause("benchmark", facets.benchmark, clauses, params);
   addNumericListClause("scale_factor", facets.scale_factor, clauses, params);
   addListClause("test_type", facets.phase, clauses, params);
-  addListClause("platform", facets.platform, clauses, params);
+  addPlatformClause(facets.platform, clauses, params);
   addListClause("execution_mode", facets.execution_mode, clauses, params);
-  addListClause("tuning_mode", facets.tuning_mode, clauses, params);
+  addNullableSentinelClause("tuning_mode", facets.tuning_mode, "untuned", clauses, params);
   addListClause("trust_label", facets.trust_tier, clauses, params);
   addListClause("validation_status", facets.validation_status, clauses, params);
   addDeploymentClause(facets.deployment_class, clauses, params);
@@ -209,9 +311,80 @@ function normalizeStringList(values: readonly string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
 }
 
+function normalizeFacetList(key: FacetKey, values: readonly string[]): string[] {
+  const normalized = normalizeStringList(values);
+  if (!LEGACY_ALL_SENTINEL_KEYS.has(key)) return normalized;
+  return normalized.filter((value) => value !== "all");
+}
+
+function normalizeFacetValue<K extends FacetKey>(key: K, value: FacetState[K]): FacetState[K] {
+  if (!Array.isArray(value)) return value;
+  return normalizeFacetList(key, value) as FacetState[K];
+}
+
+function useFacetUrlState<K extends FacetKey>(key: K): [FacetState[K], (value: FacetState[K]) => void] {
+  const [value, setValueRaw] = useState<FacetState[K]>(() => initialFacetValue(key));
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    writeFacetParam(key, readFacetParam(new URLSearchParams(window.location.search), key));
+  }, [key]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    function onPopState() {
+      setValueRaw(readFacetParam(new URLSearchParams(window.location.search), key));
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [key]);
+
+  const setValue = useCallback(
+    (next: FacetState[K]) => {
+      setValueRaw(next);
+      writeFacetParam(key, next);
+    },
+    [key],
+  );
+
+  return [value, setValue];
+}
+
+function initialFacetValue<K extends FacetKey>(key: K): FacetState[K] {
+  if (typeof window === "undefined") return defaultFacetValue(key);
+  return readFacetParam(new URLSearchParams(window.location.search), key);
+}
+
 function defaultFacetValue<K extends FacetKey>(key: K): FacetState[K] {
   const value = DEFAULT_FACETS[key];
   return (Array.isArray(value) ? [...value] : value) as FacetState[K];
+}
+
+function writeFacetParam<K extends FacetKey>(key: K, value: FacetState[K]) {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  const originalSearch = params.toString();
+  const urlKey = FACET_URL_KEYS[key];
+  const aliases = FACET_URL_ALIASES[key] ?? [];
+  const serde = FACET_URL_SERDES[key] as unknown as UrlSerde<FacetState[K]>;
+  const encoded = serde.encode(value);
+  const encodedDefault = serde.encode(defaultFacetValue(key));
+
+  for (const alias of aliases) {
+    params.delete(alias);
+  }
+  if (encoded === "" || encoded === encodedDefault) {
+    params.delete(urlKey);
+  } else {
+    params.set(urlKey, encoded);
+  }
+  if (params.toString() !== originalSearch) replaceSearch(params);
+}
+
+function replaceSearch(params: URLSearchParams) {
+  const newSearch = params.toString();
+  const search = newSearch.length > 0 ? `?${newSearch}` : "";
+  history.replaceState(null, "", `${window.location.pathname}${search}${window.location.hash}`);
 }
 
 function findFirstParam(params: URLSearchParams, keys: readonly string[]): string | null {
@@ -243,6 +416,33 @@ function addNumericListClause(
   if (numericValues.length === 0) return;
   clauses.push(`${column} IN (${numericValues.map(() => "?").join(", ")})`);
   params.push(...numericValues);
+}
+
+function addPlatformClause(values: readonly string[], clauses: string[], params: unknown[]) {
+  if (values.length === 0) return;
+  const placeholders = values.map(() => "?").join(", ");
+  clauses.push(`(platform IN (${placeholders}) OR platform_id IN (${placeholders}))`);
+  params.push(...values, ...values);
+}
+
+function addNullableSentinelClause(
+  column: string,
+  values: readonly string[],
+  nullSentinel: string,
+  clauses: string[],
+  params: unknown[],
+) {
+  if (values.length === 0) return;
+  const concreteValues = values.filter((value) => value !== nullSentinel);
+  const subclauses: string[] = [];
+  if (concreteValues.length > 0) {
+    subclauses.push(`${column} IN (${concreteValues.map(() => "?").join(", ")})`);
+    params.push(...concreteValues);
+  }
+  if (values.includes(nullSentinel)) {
+    subclauses.push(`${column} IS NULL`);
+  }
+  if (subclauses.length > 0) clauses.push(`(${subclauses.join(" OR ")})`);
 }
 
 function addDeploymentClause(

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -267,6 +267,10 @@ export function useFacetState(): UseFacetStateResult {
   return { facets, where, setFacet, resetFacets };
 }
 
+export function useFacetField<K extends FacetKey>(key: K): [FacetState[K], (value: FacetState[K]) => void] {
+  return useFacetUrlState(key);
+}
+
 export function facetsToWhereClause(
   input: PartialFacetState = {},
   options: { now?: Date } = {},

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -1,0 +1,277 @@
+import type { UrlSerde } from "@/lib/useUrlState";
+
+export const FACET_KEYS = [
+  "benchmark",
+  "scale_factor",
+  "phase",
+  "platform",
+  "execution_mode",
+  "tuning_mode",
+  "trust_tier",
+  "validation_status",
+  "deployment_class",
+  "cloud_provider",
+  "cloud_region",
+  "instance_or_warehouse",
+  "storage_format",
+  "cost_status",
+  "date_window",
+] as const;
+
+export type FacetKey = (typeof FACET_KEYS)[number];
+export type DateWindowFacet = "all" | "30d" | "90d" | "365d";
+
+export interface FacetState {
+  benchmark: string[];
+  scale_factor: string[];
+  phase: string[];
+  platform: string[];
+  execution_mode: string[];
+  tuning_mode: string[];
+  trust_tier: string[];
+  validation_status: string[];
+  deployment_class: string[];
+  cloud_provider: string[];
+  cloud_region: string[];
+  instance_or_warehouse: string[];
+  storage_format: string[];
+  cost_status: string[];
+  date_window: DateWindowFacet;
+}
+
+export type PartialFacetState = Partial<{
+  [K in FacetKey]: FacetState[K];
+}>;
+
+export interface FacetWhereClause {
+  sql: string;
+  params: unknown[];
+}
+
+export const DEFAULT_FACETS: FacetState = {
+  benchmark: [],
+  scale_factor: [],
+  phase: [],
+  platform: [],
+  execution_mode: [],
+  tuning_mode: [],
+  trust_tier: [],
+  validation_status: [],
+  deployment_class: [],
+  cloud_provider: [],
+  cloud_region: [],
+  instance_or_warehouse: [],
+  storage_format: [],
+  cost_status: [],
+  date_window: "all",
+};
+
+export const FACET_URL_KEYS: Record<FacetKey, string> = {
+  benchmark: "benchmark",
+  scale_factor: "sf",
+  phase: "phase",
+  platform: "platform",
+  execution_mode: "execution",
+  tuning_mode: "tuning",
+  trust_tier: "trust",
+  validation_status: "validation",
+  deployment_class: "deployment",
+  cloud_provider: "cloud_provider",
+  cloud_region: "cloud_region",
+  instance_or_warehouse: "shape",
+  storage_format: "storage_format",
+  cost_status: "cost_status",
+  date_window: "window",
+};
+
+export const FACET_URL_ALIASES: Partial<Record<FacetKey, readonly string[]>> = {
+  benchmark: ["bm"],
+  scale_factor: ["scale_factor"],
+  execution_mode: ["execution_mode"],
+  trust_tier: ["trust_tier"],
+  validation_status: ["validation_status"],
+  deployment_class: ["deployment_class"],
+  instance_or_warehouse: ["instance_type", "warehouse_size"],
+  date_window: ["date_window"],
+};
+
+const DATE_WINDOWS = new Set<DateWindowFacet>(["all", "30d", "90d", "365d"]);
+const DATE_WINDOW_DAYS: Record<Exclude<DateWindowFacet, "all">, number> = {
+  "30d": 30,
+  "90d": 90,
+  "365d": 365,
+};
+
+const multiValueSerde: UrlSerde<string[]> = {
+  encode: (values) => normalizeStringList(values).join(","),
+  decode: (raw) => normalizeStringList(raw === "" ? [] : raw.split(",")),
+};
+
+const dateWindowSerde: UrlSerde<DateWindowFacet> = {
+  encode: (value) => value,
+  decode: (raw) => (DATE_WINDOWS.has(raw as DateWindowFacet) ? (raw as DateWindowFacet) : null),
+};
+
+export const FACET_URL_SERDES = {
+  benchmark: multiValueSerde,
+  scale_factor: multiValueSerde,
+  phase: multiValueSerde,
+  platform: multiValueSerde,
+  execution_mode: multiValueSerde,
+  tuning_mode: multiValueSerde,
+  trust_tier: multiValueSerde,
+  validation_status: multiValueSerde,
+  deployment_class: multiValueSerde,
+  cloud_provider: multiValueSerde,
+  cloud_region: multiValueSerde,
+  instance_or_warehouse: multiValueSerde,
+  storage_format: multiValueSerde,
+  cost_status: multiValueSerde,
+  date_window: dateWindowSerde,
+} satisfies { [K in FacetKey]: UrlSerde<FacetState[K]> };
+
+export function normalizeFacetState(input: PartialFacetState = {}): FacetState {
+  return {
+    benchmark: normalizeStringList(input.benchmark ?? DEFAULT_FACETS.benchmark),
+    scale_factor: normalizeStringList(input.scale_factor ?? DEFAULT_FACETS.scale_factor),
+    phase: normalizeStringList(input.phase ?? DEFAULT_FACETS.phase),
+    platform: normalizeStringList(input.platform ?? DEFAULT_FACETS.platform),
+    execution_mode: normalizeStringList(input.execution_mode ?? DEFAULT_FACETS.execution_mode),
+    tuning_mode: normalizeStringList(input.tuning_mode ?? DEFAULT_FACETS.tuning_mode),
+    trust_tier: normalizeStringList(input.trust_tier ?? DEFAULT_FACETS.trust_tier),
+    validation_status: normalizeStringList(input.validation_status ?? DEFAULT_FACETS.validation_status),
+    deployment_class: normalizeStringList(input.deployment_class ?? DEFAULT_FACETS.deployment_class),
+    cloud_provider: normalizeStringList(input.cloud_provider ?? DEFAULT_FACETS.cloud_provider),
+    cloud_region: normalizeStringList(input.cloud_region ?? DEFAULT_FACETS.cloud_region),
+    instance_or_warehouse: normalizeStringList(
+      input.instance_or_warehouse ?? DEFAULT_FACETS.instance_or_warehouse,
+    ),
+    storage_format: normalizeStringList(input.storage_format ?? DEFAULT_FACETS.storage_format),
+    cost_status: normalizeStringList(input.cost_status ?? DEFAULT_FACETS.cost_status),
+    date_window: DATE_WINDOWS.has(input.date_window as DateWindowFacet)
+      ? (input.date_window as DateWindowFacet)
+      : DEFAULT_FACETS.date_window,
+  };
+}
+
+export function readFacetParam<K extends FacetKey>(
+  params: URLSearchParams,
+  key: K,
+): FacetState[K] {
+  const raw = findFirstParam(params, [FACET_URL_KEYS[key], ...(FACET_URL_ALIASES[key] ?? [])]);
+  const fallback = defaultFacetValue(key);
+  if (raw === null) return fallback;
+  const serde = FACET_URL_SERDES[key] as unknown as UrlSerde<FacetState[K]>;
+  return serde.decode(raw) ?? fallback;
+}
+
+export function facetsToWhereClause(
+  input: PartialFacetState = {},
+  options: { now?: Date } = {},
+): FacetWhereClause {
+  const facets = normalizeFacetState(input);
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  addListClause("benchmark", facets.benchmark, clauses, params);
+  addNumericListClause("scale_factor", facets.scale_factor, clauses, params);
+  addListClause("test_type", facets.phase, clauses, params);
+  addListClause("platform", facets.platform, clauses, params);
+  addListClause("execution_mode", facets.execution_mode, clauses, params);
+  addListClause("tuning_mode", facets.tuning_mode, clauses, params);
+  addListClause("trust_label", facets.trust_tier, clauses, params);
+  addListClause("validation_status", facets.validation_status, clauses, params);
+  addDeploymentClause(facets.deployment_class, clauses, params);
+  addListClause("cloud_provider", facets.cloud_provider, clauses, params);
+  addListClause("cloud_region", facets.cloud_region, clauses, params);
+  addListClause(
+    "COALESCE(instance_type, warehouse_size, cluster_size)",
+    facets.instance_or_warehouse,
+    clauses,
+    params,
+  );
+  addListClause("storage_format", facets.storage_format, clauses, params);
+  addListClause("cost_status", facets.cost_status, clauses, params);
+
+  const cutoff = dateWindowCutoffIso(facets.date_window, options.now);
+  if (cutoff !== null) {
+    clauses.push("run_date >= ?");
+    params.push(cutoff);
+  }
+
+  return {
+    sql: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    params,
+  };
+}
+
+function normalizeStringList(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function defaultFacetValue<K extends FacetKey>(key: K): FacetState[K] {
+  const value = DEFAULT_FACETS[key];
+  return (Array.isArray(value) ? [...value] : value) as FacetState[K];
+}
+
+function findFirstParam(params: URLSearchParams, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = params.get(key);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function addListClause(
+  column: string,
+  values: readonly string[],
+  clauses: string[],
+  params: unknown[],
+) {
+  if (values.length === 0) return;
+  clauses.push(`${column} IN (${values.map(() => "?").join(", ")})`);
+  params.push(...values);
+}
+
+function addNumericListClause(
+  column: string,
+  values: readonly string[],
+  clauses: string[],
+  params: unknown[],
+) {
+  const numericValues = values.map((value) => Number(value)).filter((value) => Number.isFinite(value));
+  if (numericValues.length === 0) return;
+  clauses.push(`${column} IN (${numericValues.map(() => "?").join(", ")})`);
+  params.push(...numericValues);
+}
+
+function addDeploymentClause(
+  values: readonly string[],
+  clauses: string[],
+  params: unknown[],
+) {
+  const deploymentClauses: string[] = [];
+  const deploymentParams: unknown[] = [];
+
+  for (const value of values) {
+    if (value === "cloud") {
+      deploymentClauses.push("cloud_provider IS NOT NULL");
+    } else if (value === "local") {
+      deploymentClauses.push("cost_status = ?");
+      deploymentParams.push("not_applicable_local");
+    } else if (value === "unavailable") {
+      deploymentClauses.push("cost_status = ?");
+      deploymentParams.push("unavailable");
+    }
+  }
+
+  if (deploymentClauses.length === 0) return;
+  clauses.push(`(${deploymentClauses.join(" OR ")})`);
+  params.push(...deploymentParams);
+}
+
+function dateWindowCutoffIso(value: DateWindowFacet, now = new Date()): string | null {
+  if (value === "all") return null;
+  const days = DATE_WINDOW_DAYS[value];
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -23,6 +23,8 @@ interface BenchmarkIndexProps extends RoutableProps {
 
 type ViewMode = "matrix" | "ranks" | "list";
 type BenchmarkListSortKey = "platform" | "scale_factor" | "run_date" | "power_score" | "display_geomean_ms" | "query_count";
+const TABLE_RENDER_LIMIT = 200;
+const TABLE_RENDER_INCREMENT = 200;
 
 const TRUST_LABEL_ABBREV: Record<string, string> = {
   "maintainer-run": "Maintainer",
@@ -629,6 +631,7 @@ function ListTable({
     key: "display_geomean_ms",
     direction: "asc",
   });
+  const [visibleLimit, setVisibleLimit] = useState(TABLE_RENDER_LIMIT);
   const benchmarkResults = results.filter((r) => r.benchmark === benchmark);
 
   const byScale = benchmarkResults.filter((r) => String(r.scale_factor) === scaleFactor);
@@ -636,6 +639,28 @@ function ListTable({
   const filtered = byScale
     .filter((row) => matchesFacetFields(row, facets))
     .sort((a, b) => compareListRows(a, b, sort));
+  const visibleRows = filtered.slice(0, visibleLimit);
+
+  useEffect(() => {
+    setVisibleLimit(TABLE_RENDER_LIMIT);
+  }, [
+    benchmark,
+    scaleFactor,
+    facets.platform,
+    facets.execution_mode,
+    facets.tuning_mode,
+    facets.trust_tier,
+    facets.validation_status,
+    facets.deployment_class,
+    facets.cloud_provider,
+    facets.cloud_region,
+    facets.instance_or_warehouse,
+    facets.storage_format,
+    facets.cost_status,
+    facets.date_window,
+    sort.key,
+    sort.direction,
+  ]);
 
   function toggleSort(key: BenchmarkListSortKey) {
     setSort((prev) =>
@@ -674,6 +699,9 @@ function ListTable({
 
   return (
     <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div class="border-b border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+        Showing {visibleRows.length.toLocaleString()} of {filtered.length.toLocaleString()} results for SF {scaleFactor}
+      </div>
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -737,11 +765,22 @@ function ListTable({
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100 bg-white">
-          {filtered.map((r) => (
+          {visibleRows.map((r) => (
             <BenchmarkRow key={r.result_id} entry={r} />
           ))}
         </tbody>
       </table>
+      {visibleRows.length < filtered.length && (
+        <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 text-center">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            onClick={() => setVisibleLimit((limit) => limit + TABLE_RENDER_INCREMENT)}
+          >
+            Show more results
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -1,11 +1,11 @@
 import type { ComponentChildren } from "preact";
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useMemo, useState } from "preact/hooks";
 import type { RoutableProps } from "preact-router";
-import type { BenchmarkSummary, SortDirection, SortState } from "@/types";
+import type { BenchmarkSummary, PlatformRow, SortDirection, SortState } from "@/types";
 import type { ResultRow } from "@/lib/duckdbQueries";
 import { getBenchmarkSummaryFromDuckDB, listResults } from "@/lib/duckdbQueries";
 import { humanizeBenchmark, isKnownBenchmark, fmtScore, fmtGeomean, errMsg, complianceLabel } from "@/utils";
-import { useUrlState, stringSerde } from "@/lib/useUrlState";
+import { facetsToWhereClause, useFacetState, type DateWindowFacet, type FacetState } from "@/lib/facetModel";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { Breadcrumb } from "@/components/Breadcrumb";
@@ -44,13 +44,40 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
   const [error, setError] = useState<string | null>(null);
 
   // Filter state - URL-synced so views are shareable.
-  const [_sfRaw, setSfRaw] = useUrlState<string>("sf", "", stringSerde);
-  const setScaleFilter = (v: string | null) => setSfRaw(v ?? "");
-  const [phaseFilter, setPhaseFilter] = useUrlState<string>("phase", "power", stringSerde);
-  const [tuningFilter, setTuningFilter] = useUrlState<string>("tuning", "all", stringSerde);
-  // Trust filter: null = "all tiers shown". When set, contains the set of
-  // trust_labels to include. Defaults to showing everything.
-  const [trustFilter, setTrustFilter] = useState<Set<string> | null>(null);
+  const { facets, setFacet } = useFacetState();
+  const requestedSf = singleFacetValue(facets.scale_factor);
+  const phaseFilter = singleFacetValue(facets.phase) ?? "power";
+  const tuningFilter = singleFacetValue(facets.tuning_mode) ?? "all";
+  const trustFilter = facets.trust_tier.length === 0 ? null : new Set(facets.trust_tier);
+  const benchmarkResultWhere = useMemo(
+    () =>
+      facetsToWhereClause({
+        ...facets,
+        benchmark: benchmark ? [benchmark] : [],
+        scale_factor: [],
+        phase: [],
+        tuning_mode: [],
+        trust_tier: [],
+      }),
+    [
+      benchmark,
+      facets.cloud_provider,
+      facets.cloud_region,
+      facets.cost_status,
+      facets.date_window,
+      facets.deployment_class,
+      facets.execution_mode,
+      facets.instance_or_warehouse,
+      facets.platform,
+      facets.storage_format,
+      facets.validation_status,
+    ],
+  );
+
+  const setScaleFilter = (value: string | null) => setFacet("scale_factor", value ? [value] : []);
+  const setPhaseFilter = (value: string) => setFacet("phase", value === "power" ? [] : [value]);
+  const setTuningFilter = (value: string) => setFacet("tuning_mode", value === "all" ? [] : [value]);
+  const setTrustFilter = (value: Set<string> | null) => setFacet("trust_tier", value ? [...value].sort() : []);
 
   // View: matrix (default), ranks, or list
   const [viewMode, setViewMode] = useState<ViewMode>("matrix");
@@ -64,7 +91,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
 
   useEffect(() => {
     let cancelled = false;
-    listResults()
+    listResults(benchmarkResultWhere)
       .then((r) => {
         if (!cancelled) setResults(r);
       })
@@ -74,7 +101,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [benchmarkResultWhere]);
 
   // Derive available scale factors and phases from the loaded rows.
   const benchmarkResults = results?.filter((r) => r.benchmark === benchmark) ?? [];
@@ -86,15 +113,15 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
   ].sort((a, b) => Number(a) - Number(b));
 
   const scaleFilter: string | null =
-    _sfRaw !== "" && scaleFactors.includes(_sfRaw) ? _sfRaw : null;
+    requestedSf !== null && scaleFactors.includes(requestedSf) ? requestedSf : null;
 
   // Set defaults once manifest loads.
   const effectiveSf = scaleFilter ?? scaleFactors[0] ?? "0.01";
 
   useEffect(() => {
-    if (!results || scaleFactors.length === 0 || _sfRaw === "" || _sfRaw === effectiveSf) return;
-    setSfRaw(effectiveSf);
-  }, [_sfRaw, effectiveSf, results, scaleFactors.length, setSfRaw]);
+    if (!results || scaleFactors.length === 0 || requestedSf === null || requestedSf === effectiveSf) return;
+    setScaleFilter(effectiveSf);
+  }, [effectiveSf, requestedSf, results, scaleFactors.length]);
 
   // Phases available for the *current* scale factor only - prevents requesting
   // a phase+SF combination that has no artifact (e.g. "power" for SF 0.01
@@ -180,6 +207,20 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         />
       );
     }
+    if (hasActiveBenchmarkResultFacets(facets)) {
+      return (
+        <div class="mx-auto max-w-7xl px-4 py-24 text-center sm:px-6 lg:px-8">
+          <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: humanizeBenchmark(benchmark) }]} />
+          <h1 class="mt-6 text-3xl font-bold text-gray-900">{humanizeBenchmark(benchmark)}</h1>
+          <p class="mt-4 text-lg text-gray-600">
+            No published results match the selected filters for {humanizeBenchmark(benchmark)}.
+          </p>
+          <a href={`/results/${benchmark}/`} class="mt-6 inline-block btn btn-primary no-underline">
+            Clear filters
+          </a>
+        </div>
+      );
+    }
     return (
       <div class="mx-auto max-w-7xl px-4 py-24 text-center sm:px-6 lg:px-8">
         <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: humanizeBenchmark(benchmark) }]} />
@@ -225,18 +266,14 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
     ? {
         ...summaryWithResultMetadata,
         platforms: summaryWithResultMetadata.platforms.filter((p) => {
-          if (tuningFilter !== "all" && p.tuning_mode !== tuningFilter) return false;
-          if (trustFilter !== null && !trustFilter.has(p.trust_label)) return false;
-          return true;
+          return matchesFacetFields(p, facets);
         }),
       }
     : null;
   const historicalEntries = benchmarkResults.filter((result) => {
     if (String(result.scale_factor) !== effectiveSf) return false;
     if ((result.test_type ?? "power") !== effectivePhase) return false;
-    if (tuningFilter !== "all" && result.tuning_mode !== tuningFilter) return false;
-    if (trustFilter !== null && !trustFilter.has(result.trust_label)) return false;
-    return true;
+    return matchesFacetFields(result, facets);
   });
 
   // Build the Compare URL from selected result_ids.
@@ -455,7 +492,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
 
       {/* List view (mobile-friendly fallback) */}
       {viewMode === "list" && (
-        <ListTable benchmark={benchmark} results={results} scaleFactor={effectiveSf} tuningFilter={tuningFilter} trustFilter={trustFilter} />
+        <ListTable benchmark={benchmark} results={results} scaleFactor={effectiveSf} facets={facets} />
       )}
 
       {filteredSummary && viewMode !== "list" && (
@@ -496,6 +533,84 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Shared facet helpers for benchmark-scoped row and platform filtering.
+// ---------------------------------------------------------------------------
+
+function singleFacetValue(values: string[]): string | null {
+  return values.length === 1 ? (values[0] ?? null) : null;
+}
+
+function hasActiveBenchmarkResultFacets(facets: FacetState): boolean {
+  return (
+    facets.platform.length > 0 ||
+    facets.execution_mode.length > 0 ||
+    facets.validation_status.length > 0 ||
+    facets.deployment_class.length > 0 ||
+    facets.cloud_provider.length > 0 ||
+    facets.cloud_region.length > 0 ||
+    facets.instance_or_warehouse.length > 0 ||
+    facets.storage_format.length > 0 ||
+    facets.cost_status.length > 0 ||
+    facets.date_window !== "all"
+  );
+}
+
+function matchesFacetFields(row: ResultRow | PlatformRow, facets: FacetState): boolean {
+  if (!matchesPlatformFacet(row, facets.platform)) return false;
+  if (!matchesOptionalFilter(row.execution_mode, facets.execution_mode)) return false;
+  if (!matchesTuningFacet(row, facets.tuning_mode)) return false;
+  if (!matchesMultiFilter(row.trust_label, facets.trust_tier)) return false;
+  if (!matchesOptionalFilter(row.validation_status, facets.validation_status)) return false;
+  if (!matchesDeploymentFacet(row, facets.deployment_class)) return false;
+  if (!matchesOptionalFilter(row.cloud_provider, facets.cloud_provider)) return false;
+  if (!matchesOptionalFilter(row.cloud_region, facets.cloud_region)) return false;
+  if (!matchesOptionalFilter(rowShape(row), facets.instance_or_warehouse)) return false;
+  if (!matchesOptionalFilter(row.storage_format, facets.storage_format)) return false;
+  if (!matchesOptionalFilter(row.cost_status, facets.cost_status)) return false;
+  return matchesDateWindow(row.run_date, facets.date_window);
+}
+
+function matchesMultiFilter(value: string, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(value);
+}
+
+function matchesOptionalFilter(value: string | null | undefined, selected: string[]): boolean {
+  return selected.length === 0 || (value !== null && value !== undefined && selected.includes(value));
+}
+
+function matchesPlatformFacet(row: ResultRow | PlatformRow, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(row.platform) || selected.includes(row.platform_id);
+}
+
+function matchesTuningFacet(row: ResultRow | PlatformRow, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(row.tuning_mode ?? "untuned");
+}
+
+function matchesDeploymentFacet(row: ResultRow | PlatformRow, selected: string[]): boolean {
+  if (selected.length === 0) return true;
+  const deployment = rowDeploymentClass(row);
+  return deployment !== null && selected.includes(deployment);
+}
+
+function rowDeploymentClass(row: ResultRow | PlatformRow): string | null {
+  if (row.cloud_provider) return "cloud";
+  if (row.cost_status === "not_applicable_local") return "local";
+  if (row.cost_status === "unavailable") return "unavailable";
+  return null;
+}
+
+function rowShape(row: ResultRow | PlatformRow): string | null {
+  return row.instance_type ?? row.warehouse_size ?? row.cluster_size ?? null;
+}
+
+function matchesDateWindow(runDate: string, windowValue: DateWindowFacet): boolean {
+  if (windowValue === "all") return true;
+  const days = Number(windowValue.replace("d", ""));
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return new Date(runDate).getTime() >= cutoff;
+}
+
+// ---------------------------------------------------------------------------
 // List view - sorted table of all result rows for the benchmark
 // ---------------------------------------------------------------------------
 
@@ -503,14 +618,12 @@ function ListTable({
   benchmark,
   results,
   scaleFactor,
-  tuningFilter,
-  trustFilter,
+  facets,
 }: {
   benchmark: string;
   results: ResultRow[];
   scaleFactor: string;
-  tuningFilter: string;
-  trustFilter: Set<string> | null;
+  facets: FacetState;
 }) {
   const [sort, setSort] = useState<SortState<BenchmarkListSortKey>>({
     key: "display_geomean_ms",
@@ -520,13 +633,9 @@ function ListTable({
 
   const byScale = benchmarkResults.filter((r) => String(r.scale_factor) === scaleFactor);
 
-  const tuningFiltered =
-    tuningFilter === "all" ? byScale : byScale.filter((r) => r.tuning_mode === tuningFilter);
-
-  const trustFiltered =
-    trustFilter === null ? tuningFiltered : tuningFiltered.filter((r) => trustFilter.has(r.trust_label));
-
-  const filtered = [...trustFiltered].sort((a, b) => compareListRows(a, b, sort));
+  const filtered = byScale
+    .filter((row) => matchesFacetFields(row, facets))
+    .sort((a, b) => compareListRows(a, b, sort));
 
   function toggleSort(key: BenchmarkListSortKey) {
     setSort((prev) =>

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -147,7 +147,9 @@ export function Compare(_: RoutableProps) {
     if (!hasLongForm) return;
     toShortIds(ids)
       .then((shortIds) => {
-        history.replaceState(null, "", `/results/compare?ids=${shortIds.join(",")}`);
+        const params = new URLSearchParams(window.location.search);
+        params.set("ids", shortIds.join(","));
+        history.replaceState(null, "", `/results/compare?${params.toString()}`);
       })
       .catch(() => {
         /* silently skip - non-critical */

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -13,10 +13,17 @@ import { SkeletonBlock } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { MetaLeaderboard } from "@/components/MetaLeaderboard";
 import type { MetaLeaderboardMode } from "@/components/MetaLeaderboard";
-import { arraySerde, stringSerde, useUrlState } from "@/lib/useUrlState";
+import {
+  FACET_KEYS,
+  FACET_URL_KEYS,
+  useFacetState,
+  type DateWindowFacet,
+  type FacetKey,
+  type FacetState,
+} from "@/lib/facetModel";
+import { stringSerde, useUrlState } from "@/lib/useUrlState";
 import { useDocumentTitle } from "@/lib/useDocumentTitle";
 
-const EMPTY_STRING_ARRAY: string[] = [];
 const SUPPORTED_BENCHMARK_COUNT = new Set(Object.values(BENCHMARK_LABELS)).size;
 
 export function Home(_: RoutableProps) {
@@ -27,23 +34,31 @@ export function Home(_: RoutableProps) {
   const retriedEmptyResults = useRef(false);
   const [emptyResultsRetryFinished, setEmptyResultsRetryFinished] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [benchmarkFilters, setBenchmarkFilters] = useUrlState<string[]>("bm", EMPTY_STRING_ARRAY, arraySerde);
-  const [scaleFilters, setScaleFilters] = useUrlState<string[]>("sf", EMPTY_STRING_ARRAY, arraySerde);
-  const [phaseFilter, setPhaseFilter] = useUrlState<string>("phase", "all", stringSerde);
-  const [tuningFilter, setTuningFilter] = useUrlState<string>("tuning", "all", stringSerde);
-  const [trustFilter, setTrustFilter] = useUrlState<string>("trust", "all", stringSerde);
-  const [dateWindow, setDateWindow] = useUrlState<string>("window", "all", stringSerde);
+  const { facets, where: facetWhere, setFacet } = useFacetState();
   const [modeRaw, setModeRaw] = useUrlState<string>("mode", "times", stringSerde);
+  const benchmarkFilters = facets.benchmark;
+  const scaleFilters = facets.scale_factor;
+  const phaseFilter = singleFacetValue(facets.phase);
+  const tuningFilter = singleFacetValue(facets.tuning_mode);
+  const trustFilter = singleFacetValue(facets.trust_tier);
+  const dateWindow = facets.date_window;
 
   useEffect(() => {
     let cancelled = false;
-    listResults()
+    listResults(facetWhere)
       .then((rows) => {
         if (!cancelled) setResults(rows);
       })
       .catch((err: unknown) => {
         if (!cancelled) setError(errMsg(err));
       });
+    return () => {
+      cancelled = true;
+    };
+  }, [facetWhere]);
+
+  useEffect(() => {
+    let cancelled = false;
     getMetaLeaderboardData()
       .then((data) => {
         if (!cancelled) {
@@ -59,7 +74,7 @@ export function Home(_: RoutableProps) {
     };
   }, []);
 
-  // Cold-load mitigation (N5 in pass-2 review): listResults() can briefly
+  // Cold-load mitigation (N5 in pass-2 review): unfiltered listResults() can briefly
   // resolve to [] on a cold DuckDB-WASM attach while the meta-leaderboard
   // succeeds, which would otherwise paint "0 Results / 0 Benchmarks /
   // 0 Platforms" before the real corpus arrives. Retrying once is a
@@ -68,7 +83,8 @@ export function Home(_: RoutableProps) {
   // (c) shared initPromise in db.ts is the trigger. The diagnostic log
   // makes future investigation possible by surfacing the exact mismatch
   // in browser DevTools without needing to re-run the audit setup.
-  const hasInconsistentEmptySnapshot = results !== null && results.length === 0 && metaLeaderboard !== null;
+  const hasInconsistentEmptySnapshot =
+    facetWhere.sql === "" && results !== null && results.length === 0 && metaLeaderboard !== null;
   const hasPersistentInconsistentEmptySnapshot = hasInconsistentEmptySnapshot && emptyResultsRetryFinished;
 
   useEffect(() => {
@@ -81,7 +97,7 @@ export function Home(_: RoutableProps) {
         metaLeaderboard?.cohorts?.length ?? 0,
       );
     }
-    listResults()
+    listResults(facetWhere)
       .then((rows) => {
         if (!cancelled) {
           setResults(rows);
@@ -97,7 +113,7 @@ export function Home(_: RoutableProps) {
     return () => {
       cancelled = true;
     };
-  }, [hasInconsistentEmptySnapshot]);
+  }, [facetWhere, hasInconsistentEmptySnapshot]);
 
   const resultById = useMemo(
     () => new Map((results ?? []).map((result) => [result.result_id, result])),
@@ -127,7 +143,7 @@ export function Home(_: RoutableProps) {
 
       return (cohort.platforms ?? []).some((row) => {
         const result = resultById.get(row.result_id);
-        return result !== undefined && matchesEntryFilters(result, tuningFilter, trustFilter, dateWindow);
+        return result !== undefined && matchesEntryFacets(result, facets);
       });
     });
 
@@ -139,7 +155,7 @@ export function Home(_: RoutableProps) {
             if (!visibleCohortKeys.has(cohortKey)) return false;
             const resultId = cohortPlatformIndex.get(cohortKey)?.get(platform.platform_id);
             const result = resultId ? resultById.get(resultId) : undefined;
-            return result !== undefined && matchesEntryFilters(result, tuningFilter, trustFilter, dateWindow);
+            return result !== undefined && matchesEntryFacets(result, facets);
           }),
         ) as Record<string, MetaRank>;
 
@@ -171,13 +187,11 @@ export function Home(_: RoutableProps) {
   }, [
     benchmarkFilters,
     cohortPlatformIndex,
-    dateWindow,
+    facets,
     metaLeaderboard,
     phaseFilter,
     resultById,
     scaleFilters,
-    trustFilter,
-    tuningFilter,
   ]);
 
   if (error) return <ErrorMessage message={error} />;
@@ -223,18 +237,14 @@ export function Home(_: RoutableProps) {
     const params = new URLSearchParams();
     params.set("sf", String(cohort.scale_factor));
     params.set("phase", cohort.phase);
-    if (tuningFilter !== "all") params.set("tuning", tuningFilter);
-    if (trustFilter !== "all") params.set("trust", trustFilter);
-    if (dateWindow !== "all") params.set("window", dateWindow);
+    appendFacetParams(params, facets, new Set(["benchmark", "scale_factor", "phase"]));
     const query = params.toString();
     return `/results/${cohort.benchmark}/${query ? `?${query}` : ""}`;
   }
 
   function buildPlatformHref(platformId: string): string {
     const params = new URLSearchParams();
-    if (tuningFilter !== "all") params.set("tuning", tuningFilter);
-    if (trustFilter !== "all") params.set("trust", trustFilter);
-    if (dateWindow !== "all") params.set("window", dateWindow);
+    appendFacetParams(params, facets, new Set(["platform"]));
     const query = params.toString();
     return `/results/p/${platformId}/${query ? `?${query}` : ""}`;
   }
@@ -261,7 +271,7 @@ export function Home(_: RoutableProps) {
                   allLabel="All benchmarks"
                   options={benchmarkOptions}
                   current={benchmarkFilters}
-                  onSelect={(value) => setBenchmarkFilters(value === "all" ? [] : [value])}
+                  onSelect={(value) => setFacet("benchmark", value === "all" ? [] : [value])}
                   format={(value) => humanizeBenchmark(value)}
                 />
                 <MultiSelectFilter
@@ -269,14 +279,14 @@ export function Home(_: RoutableProps) {
                   allLabel="All scales"
                   options={scaleOptions}
                   current={scaleFilters}
-                  onSelect={(value) => setScaleFilters(value === "all" ? [] : [value])}
+                  onSelect={(value) => setFacet("scale_factor", value === "all" ? [] : [value])}
                   format={(value) => `SF ${value}`}
                 />
                 <SelectFilter
                   label="Phase"
                   options={["all", ...phaseOptions]}
                   current={phaseFilter}
-                  onSelect={setPhaseFilter}
+                  onSelect={(value) => setFacet("phase", value === "all" ? [] : [value])}
                   format={(value) => (value === "all" ? "All phases" : value)}
                 />
                 <CoverageSummary />
@@ -291,21 +301,21 @@ export function Home(_: RoutableProps) {
                     label="Tuning"
                     options={tuningOptions}
                     current={tuningFilter}
-                    onSelect={setTuningFilter}
+                    onSelect={(value) => setFacet("tuning_mode", value === "all" ? [] : [value])}
                     format={(value) => (value === "all" ? "All tuning" : value)}
                   />
                   <SingleFilterGroup
                     label="Trust"
                     options={trustOptions}
                     current={trustFilter}
-                    onSelect={setTrustFilter}
+                    onSelect={(value) => setFacet("trust_tier", value === "all" ? [] : [value])}
                     format={(value) => (value === "all" ? "All trust tiers" : value)}
                   />
                   <SingleFilterGroup
                     label="Date window"
                     options={["all", "30d", "90d", "365d"]}
                     current={dateWindow}
-                    onSelect={setDateWindow}
+                    onSelect={(value) => setFacet("date_window", toDateWindowFacet(value))}
                     format={(value) => (value === "all" ? "All time" : `Last ${value}`)}
                   />
                 </div>
@@ -499,27 +509,83 @@ function SkeletonSelect({ label }: { label: string }) {
   );
 }
 
-function matchesEntryFilters(
-  entry: ResultRow,
-  tuningFilter: string,
-  trustFilter: string,
-  dateWindow: string,
-): boolean {
-  if (tuningFilter !== "all" && (entry.tuning_mode ?? "untuned") !== tuningFilter) return false;
-  if (trustFilter !== "all" && entry.trust_label !== trustFilter) return false;
-  return matchesDateWindow(entry.run_date, dateWindow);
+function appendFacetParams(params: URLSearchParams, facets: FacetState, omit: ReadonlySet<FacetKey>) {
+  for (const key of FACET_KEYS) {
+    if (omit.has(key)) continue;
+    const value = facets[key];
+    if (Array.isArray(value)) {
+      if (value.length > 0) params.set(FACET_URL_KEYS[key], value.join(","));
+    } else if (value !== "all") {
+      params.set(FACET_URL_KEYS[key], value);
+    }
+  }
 }
 
-function matchesDateWindow(runDate: string, windowValue: string): boolean {
+function singleFacetValue(values: string[]): string {
+  return values.length === 1 ? (values[0] ?? "all") : "all";
+}
+
+function toDateWindowFacet(value: string): DateWindowFacet {
+  if (value === "30d" || value === "90d" || value === "365d") return value;
+  return "all";
+}
+
+function matchesEntryFacets(entry: ResultRow, facets: FacetState): boolean {
+  if (!matchesMultiFilter(entry.benchmark, facets.benchmark)) return false;
+  if (!matchesMultiFilter(String(entry.scale_factor), facets.scale_factor)) return false;
+  if (!matchesOptionalFilter(entry.test_type, facets.phase)) return false;
+  if (!matchesPlatformFacet(entry, facets.platform)) return false;
+  if (!matchesOptionalFilter(entry.execution_mode, facets.execution_mode)) return false;
+  if (!matchesTuningFacet(entry, facets.tuning_mode)) return false;
+  if (!matchesMultiFilter(entry.trust_label, facets.trust_tier)) return false;
+  if (!matchesOptionalFilter(entry.validation_status, facets.validation_status)) return false;
+  if (!matchesDeploymentFacet(entry, facets.deployment_class)) return false;
+  if (!matchesOptionalFilter(entry.cloud_provider, facets.cloud_provider)) return false;
+  if (!matchesOptionalFilter(entry.cloud_region, facets.cloud_region)) return false;
+  if (!matchesOptionalFilter(entryShape(entry), facets.instance_or_warehouse)) return false;
+  if (!matchesOptionalFilter(entry.storage_format, facets.storage_format)) return false;
+  if (!matchesOptionalFilter(entry.cost_status, facets.cost_status)) return false;
+  return matchesDateWindow(entry.run_date, facets.date_window);
+}
+
+function matchesDateWindow(runDate: string, windowValue: DateWindowFacet): boolean {
   if (windowValue === "all") return true;
   const days = Number(windowValue.replace("d", ""));
-  if (Number.isNaN(days)) return true;
   const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
   return new Date(runDate).getTime() >= cutoff;
 }
 
 function matchesMultiFilter(value: string, selected: string[]): boolean {
   return selected.length === 0 || selected.includes(value);
+}
+
+function matchesOptionalFilter(value: string | null | undefined, selected: string[]): boolean {
+  return selected.length === 0 || (value !== null && value !== undefined && selected.includes(value));
+}
+
+function matchesPlatformFacet(entry: ResultRow, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(entry.platform) || selected.includes(entry.platform_id);
+}
+
+function matchesTuningFacet(entry: ResultRow, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(entry.tuning_mode ?? "untuned");
+}
+
+function matchesDeploymentFacet(entry: ResultRow, selected: string[]): boolean {
+  if (selected.length === 0) return true;
+  const deployment = entryDeploymentClass(entry);
+  return deployment !== null && selected.includes(deployment);
+}
+
+function entryDeploymentClass(entry: ResultRow): string | null {
+  if (entry.cloud_provider) return "cloud";
+  if (entry.cost_status === "not_applicable_local") return "local";
+  if (entry.cost_status === "unavailable") return "unavailable";
+  return null;
+}
+
+function entryShape(entry: ResultRow): string | null {
+  return entry.instance_type ?? entry.warehouse_size ?? entry.cluster_size ?? null;
 }
 
 function normalizedCostValue(entry: ResultRow): number | null {

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -34,7 +34,7 @@ export function Home(_: RoutableProps) {
   const retriedEmptyResults = useRef(false);
   const [emptyResultsRetryFinished, setEmptyResultsRetryFinished] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { facets, where: facetWhere, setFacet } = useFacetState();
+  const { facets, where: facetWhere, setFacet, resetFacets } = useFacetState();
   const [modeRaw, setModeRaw] = useUrlState<string>("mode", "times", stringSerde);
   const benchmarkFilters = facets.benchmark;
   const scaleFilters = facets.scale_factor;
@@ -210,8 +210,14 @@ export function Home(_: RoutableProps) {
   const mode: MetaLeaderboardMode =
     modeRaw === "ranks" || modeRaw === "speedup" ? modeRaw : "times";
   const benchmarks = [...new Set(results.map((result) => result.benchmark))].sort();
-  const platformIdToName = new Map(results.map((result) => [result.platform_id, result.platform]));
+  const platformIdToName = new Map(
+    (metaLeaderboard?.platforms ?? []).map((platform) => [platform.platform_id, platform.platform]),
+  );
+  for (const result of results) {
+    platformIdToName.set(result.platform_id, result.platform);
+  }
   const platformIds = [...new Set(results.map((result) => result.platform_id))].sort();
+  const activeFacetSummaries = summarizeActiveFacets(facets, platformIdToName);
   const benchmarkOptions = metaLeaderboard
     ? [...new Set(metaLeaderboard.cohorts.map((cohort) => cohort.benchmark))].sort()
     : [];
@@ -338,9 +344,14 @@ export function Home(_: RoutableProps) {
         )}
 
         {filteredMetaLeaderboard && filteredMetaLeaderboard.cohorts.length === 0 && (
-          <section class="mb-12 rounded-lg border border-dashed border-gray-300 bg-white p-10 text-center text-gray-400">
-            No leaderboard cells match the current filters.
-          </section>
+          <CoverageEmptyState
+            activeFacets={activeFacetSummaries}
+            canClearScale={scaleFilters.length > 0}
+            canClearPlatform={facets.platform.length > 0}
+            onClearScale={() => setFacet("scale_factor", [])}
+            onClearPlatform={() => setFacet("platform", [])}
+            onReset={resetFacets}
+          />
         )}
 
         {filteredMetaLeaderboard && <FlywheelStrip />}
@@ -507,6 +518,143 @@ function SkeletonSelect({ label }: { label: string }) {
       <SkeletonBlock className="h-9 w-full bb-skeleton-dark" />
     </div>
   );
+}
+
+interface ActiveFacetSummary {
+  key: FacetKey;
+  label: string;
+  value: string;
+}
+
+const FACET_LABELS: Record<FacetKey, string> = {
+  benchmark: "Benchmark",
+  scale_factor: "Scale factor",
+  phase: "Phase",
+  platform: "Platform",
+  execution_mode: "Execution",
+  tuning_mode: "Tuning",
+  trust_tier: "Trust",
+  validation_status: "Validation",
+  deployment_class: "Deployment",
+  cloud_provider: "Cloud provider",
+  cloud_region: "Cloud region",
+  instance_or_warehouse: "Instance / warehouse",
+  storage_format: "Storage format",
+  cost_status: "Cost status",
+  date_window: "Date window",
+};
+
+function CoverageEmptyState({
+  activeFacets,
+  canClearScale,
+  canClearPlatform,
+  onClearScale,
+  onClearPlatform,
+  onReset,
+}: {
+  activeFacets: ActiveFacetSummary[];
+  canClearScale: boolean;
+  canClearPlatform: boolean;
+  onClearScale: () => void;
+  onClearPlatform: () => void;
+  onReset: () => void;
+}) {
+  return (
+    <section
+      aria-labelledby="coverage-empty-title"
+      class="mb-12 rounded-lg border border-dashed border-gray-300 bg-white p-8 text-gray-600"
+    >
+      <div class="mx-auto max-w-3xl text-center">
+        <h2 id="coverage-empty-title" class="text-lg font-semibold text-gray-900">
+          No leaderboard cells match the current filters
+        </h2>
+        <p class="mt-2 text-sm text-gray-500">
+          The current facet combination removed every published cohort cell.
+        </p>
+      </div>
+
+      {activeFacets.length > 0 ? (
+        <dl
+          aria-label="Active filters removing leaderboard cells"
+          class="mx-auto mt-5 grid max-w-3xl gap-2 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {activeFacets.map((facet) => (
+            <div key={facet.key} class="rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-left">
+              <dt class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{facet.label}</dt>
+              <dd class="mt-1 text-sm font-medium text-gray-700">{facet.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p class="mt-5 text-center text-sm text-gray-500">
+          No active facets are applied; the public corpus has no leaderboard cohorts for this view.
+        </p>
+      )}
+
+      <div class="mt-5 flex flex-wrap justify-center gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={onClearScale}
+          disabled={!canClearScale}
+        >
+          Clear scale factor
+        </button>
+        <button
+          type="button"
+          class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={onClearPlatform}
+          disabled={!canClearPlatform}
+        >
+          Clear platform
+        </button>
+        <button
+          type="button"
+          class="rounded-md border border-brand-600 bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700"
+          onClick={onReset}
+        >
+          Reset all
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function summarizeActiveFacets(
+  facets: FacetState,
+  platformIdToName: ReadonlyMap<string, string>,
+): ActiveFacetSummary[] {
+  const summaries: ActiveFacetSummary[] = [];
+  for (const key of FACET_KEYS) {
+    const value = facets[key];
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      summaries.push({
+        key,
+        label: FACET_LABELS[key],
+        value: value.map((item) => formatFacetValue(key, item, platformIdToName)).join(", "),
+      });
+    } else if (value !== "all") {
+      summaries.push({
+        key,
+        label: FACET_LABELS[key],
+        value: formatFacetValue(key, value, platformIdToName),
+      });
+    }
+  }
+  return summaries;
+}
+
+function formatFacetValue(
+  key: FacetKey,
+  value: string,
+  platformIdToName: ReadonlyMap<string, string>,
+): string {
+  if (key === "benchmark") return humanizeBenchmark(value);
+  if (key === "scale_factor") return `SF ${value}`;
+  if (key === "platform") return platformIdToName.get(value) ?? value;
+  if (key === "date_window") return value === "all" ? "All time" : `Last ${value}`;
+  return value.split("_").join(" ");
 }
 
 function appendFacetParams(params: URLSearchParams, facets: FacetState, omit: ReadonlySet<FacetKey>) {

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "preact/hooks";
-import { useUrlState, stringSerde } from "@/lib/useUrlState";
 import type { RoutableProps } from "preact-router";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 import { getPlatformIndexRows } from "@/lib/duckdbQueries";
+import { useFacetState, type DateWindowFacet, type FacetState } from "@/lib/facetModel";
 import { humanizeBenchmark, fmtScore, fmtGeomean, errMsg } from "@/utils";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
@@ -31,7 +31,9 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const [rows, setRows] = useState<PlatformIndexRowRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [tuningFilter, setTuningFilter] = useUrlState<string>("tuning", "all", stringSerde);
+  const { facets, setFacet } = useFacetState();
+  const tuningFilter = singleFacetValue(facets.tuning_mode) ?? "all";
+  const setTuningFilter = (value: string) => setFacet("tuning_mode", value === "all" ? [] : [value]);
   // Default: geomean_ms ascending (fastest first), nulls last. The empty-state
   // ordering is observable behaviour — must_preserve in the parent TODO.
   const [sort, setSort] = useState<SortState<PlatformSortKey>>({
@@ -72,8 +74,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     ...new Set(allPlatformResults.map((r) => r.tuning_mode).filter((m): m is string => m !== null)),
   ].sort();
 
-  const platformResultsRaw =
-    tuningFilter === "all" ? allPlatformResults : allPlatformResults.filter((r) => r.tuning_mode === tuningFilter);
+  const platformResultsRaw = allPlatformResults.filter((row) => matchesPlatformIndexFacets(row, facets));
   const trendCohorts = buildTrendCohorts(platformResultsRaw);
 
   const platformResults = [...platformResultsRaw].sort((a, b) => {
@@ -178,7 +179,11 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
       </div>
 
       {platformResults.length === 0 ? (
-        <p class="text-gray-500">No results found for platform: {platformDisplayName}.</p>
+        <p class="text-gray-500">
+          {allPlatformResults.length > 0 && hasActivePlatformResultFacets(facets)
+            ? `No results match the selected filters for platform: ${platformDisplayName}.`
+            : `No results found for platform: ${platformDisplayName}.`}
+        </p>
       ) : (
         <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
           <table class="min-w-full divide-y divide-gray-200">
@@ -283,6 +288,82 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
       )}
     </div>
   );
+}
+
+function singleFacetValue(values: string[]): string | null {
+  return values.length === 1 ? (values[0] ?? null) : null;
+}
+
+function hasActivePlatformResultFacets(facets: FacetState): boolean {
+  return (
+    facets.benchmark.length > 0 ||
+    facets.scale_factor.length > 0 ||
+    facets.phase.length > 0 ||
+    facets.execution_mode.length > 0 ||
+    facets.tuning_mode.length > 0 ||
+    facets.trust_tier.length > 0 ||
+    facets.validation_status.length > 0 ||
+    facets.deployment_class.length > 0 ||
+    facets.cloud_provider.length > 0 ||
+    facets.cloud_region.length > 0 ||
+    facets.instance_or_warehouse.length > 0 ||
+    facets.storage_format.length > 0 ||
+    facets.cost_status.length > 0 ||
+    facets.date_window !== "all"
+  );
+}
+
+function matchesPlatformIndexFacets(row: PlatformIndexRowRow, facets: FacetState): boolean {
+  if (!matchesMultiFilter(row.benchmark, facets.benchmark)) return false;
+  if (!matchesMultiFilter(String(row.scale_factor), facets.scale_factor)) return false;
+  if (!matchesOptionalFilter(row.phase, facets.phase)) return false;
+  if (!matchesOptionalFilter(row.execution_mode, facets.execution_mode)) return false;
+  if (!matchesTuningFacet(row, facets.tuning_mode)) return false;
+  if (!matchesMultiFilter(row.trust_label, facets.trust_tier)) return false;
+  if (!matchesOptionalFilter(row.validation_status, facets.validation_status)) return false;
+  if (!matchesDeploymentFacet(row, facets.deployment_class)) return false;
+  if (!matchesOptionalFilter(row.cloud_provider, facets.cloud_provider)) return false;
+  if (!matchesOptionalFilter(row.cloud_region, facets.cloud_region)) return false;
+  if (!matchesOptionalFilter(rowShape(row), facets.instance_or_warehouse)) return false;
+  if (!matchesOptionalFilter(row.storage_format, facets.storage_format)) return false;
+  if (!matchesOptionalFilter(row.cost_status, facets.cost_status)) return false;
+  return matchesDateWindow(row.run_date, facets.date_window);
+}
+
+function matchesMultiFilter(value: string, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(value);
+}
+
+function matchesOptionalFilter(value: string | null | undefined, selected: string[]): boolean {
+  return selected.length === 0 || (value !== null && value !== undefined && selected.includes(value));
+}
+
+function matchesTuningFacet(row: PlatformIndexRowRow, selected: string[]): boolean {
+  return selected.length === 0 || selected.includes(row.tuning_mode ?? "untuned");
+}
+
+function matchesDeploymentFacet(row: PlatformIndexRowRow, selected: string[]): boolean {
+  if (selected.length === 0) return true;
+  const deployment = rowDeploymentClass(row);
+  return deployment !== null && selected.includes(deployment);
+}
+
+function rowDeploymentClass(row: PlatformIndexRowRow): string | null {
+  if (row.cloud_provider) return "cloud";
+  if (row.cost_status === "not_applicable_local") return "local";
+  if (row.cost_status === "unavailable") return "unavailable";
+  return null;
+}
+
+function rowShape(row: PlatformIndexRowRow): string | null {
+  return row.instance_type ?? row.warehouse_size ?? row.cluster_size ?? null;
+}
+
+function matchesDateWindow(runDate: string, windowValue: DateWindowFacet): boolean {
+  if (windowValue === "all") return true;
+  const days = Number(windowValue.replace("d", ""));
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return new Date(runDate).getTime() >= cutoff;
 }
 
 function buildTrendCohorts(rows: PlatformIndexRowRow[]): TrendCohort[] {

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -19,6 +19,8 @@ interface PlatformIndexProps extends RoutableProps {
 
 type PlatformSortKey = "benchmark" | "scale_factor" | "run_date" | "power_score" | "geomean_ms";
 type TrendMetric = "power_score" | "display_geomean_ms";
+const TABLE_RENDER_LIMIT = 200;
+const TABLE_RENDER_INCREMENT = 200;
 
 interface TrendCohort {
   key: string;
@@ -31,6 +33,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const [rows, setRows] = useState<PlatformIndexRowRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [visibleLimit, setVisibleLimit] = useState(TABLE_RENDER_LIMIT);
   const { facets, setFacet } = useFacetState();
   const tuningFilter = singleFacetValue(facets.tuning_mode) ?? "all";
   const setTuningFilter = (value: string) => setFacet("tuning_mode", value === "all" ? [] : [value]);
@@ -60,6 +63,28 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    setVisibleLimit(TABLE_RENDER_LIMIT);
+  }, [
+    platform,
+    facets.benchmark,
+    facets.scale_factor,
+    facets.phase,
+    facets.execution_mode,
+    facets.tuning_mode,
+    facets.trust_tier,
+    facets.validation_status,
+    facets.deployment_class,
+    facets.cloud_provider,
+    facets.cloud_region,
+    facets.instance_or_warehouse,
+    facets.storage_format,
+    facets.cost_status,
+    facets.date_window,
+    sort.key,
+    sort.direction,
+  ]);
 
   if (error) return <ErrorMessage message={error} />;
   if (!rows) return <LoadingSpinner message="Loading results..." />;
@@ -97,6 +122,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     if (bv === null) return -1;
     return dir * (av - bv);
   });
+  const visiblePlatformResults = platformResults.slice(0, visibleLimit);
 
   function toggleSort(key: PlatformSortKey) {
     setSort((prev) =>
@@ -186,6 +212,12 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
         </p>
       ) : (
         <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <div class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+            <span>
+              Showing {visiblePlatformResults.length.toLocaleString()} of {platformResults.length.toLocaleString()} results
+            </span>
+            {selected.size > 0 && <span>{selected.size.toLocaleString()} selected for compare</span>}
+          </div>
           <table class="min-w-full divide-y divide-gray-200">
             <thead class="bg-gray-50">
               <tr>
@@ -252,7 +284,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-100 bg-white">
-              {platformResults.map((r) => (
+              {visiblePlatformResults.map((r) => (
                 <PlatformRow
                   key={r.result_id}
                   entry={r}
@@ -262,6 +294,17 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
               ))}
             </tbody>
           </table>
+          {visiblePlatformResults.length < platformResults.length && (
+            <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 text-center">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                onClick={() => setVisibleLimit((limit) => limit + TABLE_RENDER_INCREMENT)}
+              >
+                Show more results
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -38,6 +38,8 @@ const DEFAULT_COLUMNS = [
   "geomean_ms",
   "trust_label",
 ];
+const TABLE_RENDER_LIMIT = 200;
+const TABLE_RENDER_INCREMENT = 200;
 
 export function Query(_: RoutableProps) {
   useDocumentTitle("Query · BenchBox Results");
@@ -73,6 +75,8 @@ export function Query(_: RoutableProps) {
   const [sqlRows, setSqlRows] = useState<ResultRow[]>([]);
   const [sqlError, setSqlError] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [visibleResultLimit, setVisibleResultLimit] = useState(TABLE_RENDER_LIMIT);
+  const [visibleSqlLimit, setVisibleSqlLimit] = useState(TABLE_RENDER_LIMIT);
   const rowLimitMode = rowLimitRaw === "all" ? "all" : "default";
   const rowLimit = rowLimitMode === "all" ? UNLIMITED_ROW_LIMIT : DEFAULT_ROW_LIMIT;
 
@@ -117,6 +121,16 @@ export function Query(_: RoutableProps) {
     [visibleColumns],
   );
   const activeFilters = useMemo(() => applySchemaFilterSupport(filters, schema), [filters, schema]);
+  const visibleRows = rows.slice(0, visibleResultLimit);
+  const visibleSqlRows = sqlRows.slice(0, visibleSqlLimit);
+
+  useEffect(() => {
+    setVisibleResultLimit(TABLE_RENDER_LIMIT);
+  }, [activeFilters, queryColumns, rowLimit, sort]);
+
+  useEffect(() => {
+    setVisibleSqlLimit(TABLE_RENDER_LIMIT);
+  }, [sqlRows]);
 
   useEffect(() => {
     if (rowLimitRaw === "default" || rowLimitRaw === "all") return;
@@ -502,6 +516,12 @@ export function Query(_: RoutableProps) {
             <LoadingSpinner message="Querying results.duckdb..." />
           ) : (
             <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+              <div class="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+                <span>
+                  Showing {visibleRows.length.toLocaleString()} of {rows.length.toLocaleString()} returned rows
+                </span>
+                <span>Query limit: {rowLimitMode === "all" ? "all" : DEFAULT_ROW_LIMIT.toLocaleString()}</span>
+              </div>
               <table class="min-w-full divide-y divide-gray-200">
                 <thead class="bg-gray-50">
                   <tr>
@@ -515,7 +535,7 @@ export function Query(_: RoutableProps) {
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-100 bg-white">
-                  {rows.map((row) => (
+                  {visibleRows.map((row) => (
                     <tr key={String(row.result_id)} class="hover:bg-gray-50">
                       {visibleColumns.map((column) => (
                         <td key={column} class="table-td">
@@ -530,16 +550,18 @@ export function Query(_: RoutableProps) {
                     </tr>
                   ))}
                 </tbody>
-                {rowLimitMode === "all" && (
-                  <tfoot class="border-t border-gray-200 bg-gray-50">
-                    <tr>
-                      <td class="table-td text-sm text-gray-500" colSpan={visibleColumns.length + 1}>
-                        Showing all returned rows: {rows.length.toLocaleString()}
-                      </td>
-                    </tr>
-                  </tfoot>
-                )}
               </table>
+              {visibleRows.length < rows.length && (
+                <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 text-center">
+                  <button
+                    type="button"
+                    class="btn btn-secondary"
+                    onClick={() => setVisibleResultLimit((limit) => limit + TABLE_RENDER_INCREMENT)}
+                  >
+                    Show more results
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -560,6 +582,9 @@ export function Query(_: RoutableProps) {
               </div>
               {sqlRows.length > 0 && (
                 <div class="overflow-hidden rounded-lg border border-gray-200">
+                  <div class="border-b border-gray-200 bg-white px-4 py-3 text-sm text-gray-500">
+                    Showing {visibleSqlRows.length.toLocaleString()} of {sqlRows.length.toLocaleString()} SQL rows
+                  </div>
                   <table class="min-w-full divide-y divide-gray-200">
                     <thead class="bg-gray-50">
                       <tr>
@@ -571,7 +596,7 @@ export function Query(_: RoutableProps) {
                       </tr>
                     </thead>
                     <tbody class="divide-y divide-gray-100 bg-white">
-                      {sqlRows.map((row, index) => (
+                      {visibleSqlRows.map((row, index) => (
                         <tr key={index}>
                           {sqlColumns.map((column) => (
                             <td key={column} class="table-td">
@@ -582,6 +607,17 @@ export function Query(_: RoutableProps) {
                       ))}
                     </tbody>
                   </table>
+                  {visibleSqlRows.length < sqlRows.length && (
+                    <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 text-center">
+                      <button
+                        type="button"
+                        class="btn btn-secondary"
+                        onClick={() => setVisibleSqlLimit((limit) => limit + TABLE_RENDER_INCREMENT)}
+                      >
+                        Show more SQL rows
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -15,6 +15,7 @@ import {
   type QuerySort,
 } from "@/lib/queryFilters";
 import { getTableSchema, type SchemaColumn } from "@/lib/duckdbSchema";
+import { useFacetField, type DateWindowFacet } from "@/lib/facetModel";
 import { STARTER_QUERY_CATEGORIES, starterQueriesByCategory, type StarterQueryCategory } from "@/lib/starterQueries";
 import { useDocumentTitle } from "@/lib/useDocumentTitle";
 
@@ -40,34 +41,27 @@ const DEFAULT_COLUMNS = [
 
 export function Query(_: RoutableProps) {
   useDocumentTitle("Query · BenchBox Results");
-  const [benchmarks, setBenchmarks] = useUrlState<string[]>("benchmark", EMPTY_STRING_ARRAY, arraySerde);
-  const [platforms, setPlatforms] = useUrlState<string[]>("platform", EMPTY_STRING_ARRAY, arraySerde);
-  const [scaleFactors, setScaleFactors] = useUrlState<string[]>("sf", EMPTY_STRING_ARRAY, arraySerde);
-  const [tuningModes, setTuningModes] = useUrlState<string[]>("tuning", EMPTY_STRING_ARRAY, arraySerde);
-  const [trustTiers, setTrustTiers] = useUrlState<string[]>("trust", EMPTY_STRING_ARRAY, arraySerde);
-  const [validationStatuses, setValidationStatuses] = useUrlState<string[]>(
-    "validation",
-    EMPTY_STRING_ARRAY,
-    arraySerde,
-  );
-  const [costStatuses, setCostStatuses] = useUrlState<string[]>("cost_status", EMPTY_STRING_ARRAY, arraySerde);
+  const [benchmarks, setBenchmarks] = useFacetField("benchmark");
+  const [platforms, setPlatforms] = useFacetField("platform");
+  const [scaleFactors, setScaleFactors] = useFacetField("scale_factor");
+  const [tuningModes, setTuningModes] = useFacetField("tuning_mode");
+  const [trustTiers, setTrustTiers] = useFacetField("trust_tier");
+  const [validationStatuses, setValidationStatuses] = useFacetField("validation_status");
+  const [costStatuses, setCostStatuses] = useFacetField("cost_status");
   const [costModelVersions, setCostModelVersions] = useUrlState<string[]>(
     "cost_model",
     EMPTY_STRING_ARRAY,
     arraySerde,
   );
-  const [cloudProviders, setCloudProviders] = useUrlState<string[]>(
-    "cloud_provider",
-    EMPTY_STRING_ARRAY,
-    arraySerde,
-  );
-  const [cloudRegions, setCloudRegions] = useUrlState<string[]>("cloud_region", EMPTY_STRING_ARRAY, arraySerde);
+  const [cloudProviders, setCloudProviders] = useFacetField("cloud_provider");
+  const [cloudRegions, setCloudRegions] = useFacetField("cloud_region");
   const [instanceTypes, setInstanceTypes] = useUrlState<string[]>("instance_type", EMPTY_STRING_ARRAY, arraySerde);
   const [warehouseSizes, setWarehouseSizes] = useUrlState<string[]>("warehouse_size", EMPTY_STRING_ARRAY, arraySerde);
-  const [storageFormats, setStorageFormats] = useUrlState<string[]>("storage_format", EMPTY_STRING_ARRAY, arraySerde);
+  const [storageFormats, setStorageFormats] = useFacetField("storage_format");
   const [rowLimitRaw, setRowLimitRaw] = useUrlState<string>("limit", "default", stringSerde);
   const [hasCost, setHasCost] = useUrlState<string>("has_cost", "all", stringSerde);
-  const [dateWindow, setDateWindow] = useUrlState<string>("window", "all", stringSerde);
+  const [dateWindow, setDateWindowFacet] = useFacetField("date_window");
+  const setDateWindow = (value: string) => setDateWindowFacet(toDateWindowFacet(value));
   const [schema, setSchema] = useState<SchemaColumn[]>([]);
   const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
   const [rows, setRows] = useState<ResultRow[]>([]);
@@ -98,7 +92,7 @@ export function Query(_: RoutableProps) {
       warehouseSizes,
       storageFormats,
       hasCost: hasCost === "yes" || hasCost === "no" ? hasCost : "all",
-      dateWindow: dateWindow === "30d" || dateWindow === "90d" || dateWindow === "365d" ? dateWindow : "all",
+      dateWindow,
     }),
     [
       benchmarks,
@@ -688,6 +682,11 @@ function applySchemaFilterSupport(filters: QueryFilterState, schema: SchemaColum
     warehouseSizes: columns.has("warehouse_size") ? filters.warehouseSizes : [],
     storageFormats: columns.has("storage_format") ? filters.storageFormats : [],
   };
+}
+
+function toDateWindowFacet(value: string): DateWindowFacet {
+  if (value === "30d" || value === "90d" || value === "365d") return value;
+  return "all";
 }
 
 function StarterQueries({ onSelect }: { onSelect: (sql: string) => void }) {

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/db", () => ({
 }));
 
 import { queryRows } from "@/db";
+import { clearDuckdbQueryCachesForTests } from "@/lib/duckdbQueries";
 import { BenchmarkIndex } from "@/pages/BenchmarkIndex";
 
 // ---------------------------------------------------------------------------
@@ -267,6 +268,7 @@ function defaultImpl(rows: typeof RESULT_ROWS, rankings: typeof RANKING_ROWS, ce
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearDuckdbQueryCachesForTests();
   window.history.replaceState(null, "", "/results/tpch/");
   vi.mocked(queryRows).mockImplementation(defaultImpl(RESULT_ROWS, RANKING_ROWS, CELL_ROWS));
 });
@@ -391,6 +393,30 @@ describe("BenchmarkIndex", () => {
     expect(getRenderedResultOrder(container)).toEqual(["r1", "r2"]);
     fireEvent.click(screen.getByRole("button", { name: /Geomean/ }));
     expect(getRenderedResultOrder(container)).toEqual(["r2", "r1"]);
+  });
+
+  it("list view caps rendered rows and expands them with Show more", async () => {
+    const manyRows = Array.from({ length: 205 }, (_, index) => ({
+      ...RESULT_ROWS[0]!,
+      result_id: `r-list-${index}`,
+      platform: `DuckDB ${index}`,
+      platform_id: `duckdb-${index}`,
+      display_geomean_ms: index + 1,
+      geomean_ms: index + 1,
+    }));
+    vi.mocked(queryRows).mockImplementation(defaultImpl(manyRows, RANKING_ROWS, CELL_ROWS));
+
+    const { container } = render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => screen.getAllByText("DuckDB"));
+    fireEvent.click(screen.getByText("List"));
+
+    await waitFor(() => expect(screen.getByText("Showing 200 of 205 results for SF 0.1")).toBeTruthy());
+    expect(getRenderedResultOrder(container)).toHaveLength(200);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more results" }));
+
+    expect(getRenderedResultOrder(container)).toHaveLength(205);
+    expect(screen.getByText("Showing 205 of 205 results for SF 0.1")).toBeTruthy();
   });
 
   // -----------------------------------------------------------------------

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -52,6 +52,14 @@ const RESULT_ROWS = [
     test_type: "power",
     validation_status: "exact",
     cost_usd: null,
+    normalized_cost_usd: 1.25,
+    cost_status: "normalized",
+    cost_scope: "compute_only",
+    cost_model_version: "2026.05.0",
+    cloud_provider: "aws",
+    cloud_region: "us-east-1",
+    warehouse_size: "MEDIUM",
+    storage_format: "parquet",
     compliance_class: null,
     is_ranking_eligible: true,
     has_plans: false,
@@ -80,6 +88,14 @@ const RESULT_ROWS = [
     test_type: "power",
     validation_status: "loose",
     cost_usd: null,
+    normalized_cost_usd: null,
+    cost_status: "not_applicable_local",
+    cost_scope: null,
+    cost_model_version: null,
+    cloud_provider: null,
+    cloud_region: null,
+    warehouse_size: null,
+    storage_format: null,
     compliance_class: null,
     is_ranking_eligible: false,
     has_plans: false,
@@ -108,6 +124,14 @@ const RANKING_ROWS = [
     display_geomean_ms: 10,
     sample_geomean_ms: 12,
     cost_usd: null,
+    normalized_cost_usd: 1.25,
+    cost_status: "normalized",
+    cost_scope: "compute_only",
+    cost_model_version: "2026.05.0",
+    cloud_provider: "aws",
+    cloud_region: "us-east-1",
+    warehouse_size: "MEDIUM",
+    storage_format: "parquet",
     primary_metric: "power_score",
     primary_order: "desc",
     rank: 1,
@@ -136,6 +160,14 @@ const RANKING_ROWS = [
     display_geomean_ms: 200,
     sample_geomean_ms: 220,
     cost_usd: null,
+    normalized_cost_usd: null,
+    cost_status: "not_applicable_local",
+    cost_scope: null,
+    cost_model_version: null,
+    cloud_provider: null,
+    cloud_region: null,
+    warehouse_size: null,
+    storage_format: null,
     primary_metric: "power_score",
     primary_order: "desc",
     rank: 2,
@@ -234,6 +266,7 @@ function defaultImpl(rows: typeof RESULT_ROWS, rankings: typeof RANKING_ROWS, ce
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   window.history.replaceState(null, "", "/results/tpch/");
   vi.mocked(queryRows).mockImplementation(defaultImpl(RESULT_ROWS, RANKING_ROWS, CELL_ROWS));
 });
@@ -298,6 +331,37 @@ describe("BenchmarkIndex", () => {
     expect(receiptLinks[0]?.getAttribute("href")).toBe("/results/r/r1#run-receipt");
     expect(screen.getByText("exact")).toBeTruthy();
     expect(screen.getByText("loose")).toBeTruthy();
+  });
+
+  it("restores benchmark URL facets without letting cohort facets block option recovery", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/results/tpch/?sf=0.1&phase=power&platform=duckdb&deployment=cloud&cost_status=normalized",
+    );
+
+    render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => screen.getAllByText("DuckDB"));
+
+    expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0);
+    expect(screen.queryByText("SQLite")).toBeNull();
+
+    const resultCall = vi
+      .mocked(queryRows)
+      .mock.calls.find(([sql]) => String(sql).replace(/\s+/g, " ").trim().startsWith("SELECT * FROM bench.results WHERE"));
+    const resultSql = String(resultCall?.[0]);
+    expect(resultSql).toContain("benchmark IN (?)");
+    expect(resultSql).toContain("(platform IN (?) OR platform_id IN (?))");
+    expect(resultSql).toContain("cloud_provider IS NOT NULL");
+    expect(resultSql).toContain("cost_status IN (?)");
+    expect(resultSql).not.toContain("scale_factor IN (?)");
+    expect(resultSql).not.toContain("test_type IN (?)");
+    expect(resultCall?.[1]).toEqual(["tpch", "duckdb", "duckdb", "normalized"]);
+
+    const rankingCalls = vi.mocked(queryRows).mock.calls.filter(([sql]) =>
+      String(sql).replace(/\s+/g, " ").includes("FROM bench.benchmark_rankings"),
+    );
+    expect(rankingCalls[rankingCalls.length - 1]?.[1]).toEqual(["tpch", 0.1, "power"]);
   });
 
   // -----------------------------------------------------------------------

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/lib/duckdbQueries", async () => {
   };
 });
 
-import { getDetailResult, getPrimaryMetricForBenchmark, resolveShortId } from "@/lib/duckdbQueries";
+import { getDetailResult, getPrimaryMetricForBenchmark, resolveShortId, toShortIds } from "@/lib/duckdbQueries";
 import { Compare } from "@/pages/Compare";
 
 // ---------------------------------------------------------------------------
@@ -206,6 +206,26 @@ describe("Compare", () => {
     expect(getPrimaryMetricForBenchmark).toHaveBeenCalledWith("tpch");
     const labels = screen.getAllByText(/Power score/i);
     expect(labels.length).toBeGreaterThan(0);
+  });
+
+  it("preserves facet URL params when canonicalizing long compare IDs", async () => {
+    setupUrl(["tpch-duckdb-long-id", "tpch-sqlite-long-id"], {
+      benchmark: "tpch",
+      cost_status: "normalized",
+    });
+    vi.mocked(resolveShortId).mockImplementation((id) =>
+      Promise.resolve(id.includes("duckdb") ? "r1" : "r2"),
+    );
+    vi.mocked(toShortIds).mockResolvedValue(["short1", "short2"]);
+
+    render(<Compare />);
+
+    await waitFor(() =>
+      expect(new URL(window.location.href).searchParams.get("ids")).toBe("short1,short2"),
+    );
+    const params = new URL(window.location.href).searchParams;
+    expect(params.get("benchmark")).toBe("tpch");
+    expect(params.get("cost_status")).toBe("normalized");
   });
 
   it("shows a secondary Geomean row when power_score is primary", async () => {

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -35,6 +35,14 @@ const RESULT_ROWS = [
     test_type: "power",
     validation_status: "exact",
     cost_usd: 1.1,
+    normalized_cost_usd: 1.1,
+    cost_status: "normalized",
+    cost_scope: "compute_only",
+    cost_model_version: "2026.05.0",
+    cloud_provider: "aws",
+    cloud_region: "us-east-1",
+    warehouse_size: "MEDIUM",
+    storage_format: "parquet",
     compliance_class: null,
     is_ranking_eligible: true,
     has_plans: false,
@@ -63,6 +71,14 @@ const RESULT_ROWS = [
     test_type: "power",
     validation_status: "exact",
     cost_usd: 2.3,
+    normalized_cost_usd: null,
+    cost_status: "not_applicable_local",
+    cost_scope: null,
+    cost_model_version: null,
+    cloud_provider: null,
+    cloud_region: null,
+    warehouse_size: null,
+    storage_format: null,
     compliance_class: null,
     is_ranking_eligible: true,
     has_plans: false,
@@ -91,6 +107,14 @@ const RESULT_ROWS = [
     test_type: "power",
     validation_status: "exact",
     cost_usd: 5.5,
+    normalized_cost_usd: 5.5,
+    cost_status: "normalized",
+    cost_scope: "compute_only",
+    cost_model_version: "2026.05.0",
+    cloud_provider: "gcp",
+    cloud_region: "us-central1",
+    warehouse_size: "LARGE",
+    storage_format: "parquet",
     compliance_class: null,
     is_ranking_eligible: true,
     has_plans: false,
@@ -186,6 +210,7 @@ function expectDocumentOrder(first: Element, second: Element) {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
   window.history.replaceState(null, "", "/results/");
   vi.mocked(queryRows).mockImplementation(async (sql: string) => {
     const s = String(sql).replace(/\s+/g, " ").trim();
@@ -397,6 +422,40 @@ describe("Home", () => {
       expect(within(grid).getByRole("link", { name: "ClickBench SF0.1" })).toBeTruthy();
       expect(within(grid).queryByRole("link", { name: "TPC-H SF1" })).toBeNull();
     });
+  });
+
+  it("restores canonical URL facets and applies them to the Home result query", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/results/?benchmark=clickbench&sf=0.1&phase=power&platform=DuckDB&deployment=cloud&cost_status=normalized",
+    );
+
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+
+    const grid = screen.getByRole("grid", { name: "Cross-benchmark leaderboard" });
+    expect(within(grid).getByText("DuckDB")).toBeTruthy();
+    expect(within(grid).queryByText("SQLite")).toBeNull();
+    expect(within(grid).queryByRole("link", { name: "TPC-H SF1" })).toBeNull();
+
+    const resultCall = vi
+      .mocked(queryRows)
+      .mock.calls.find(([sql]) => String(sql).replace(/\s+/g, " ").trim().startsWith("SELECT * FROM bench.results WHERE"));
+    expect(String(resultCall?.[0])).toContain("benchmark IN (?)");
+    expect(String(resultCall?.[0])).toContain("scale_factor IN (?)");
+    expect(String(resultCall?.[0])).toContain("test_type IN (?)");
+    expect(String(resultCall?.[0])).toContain("(platform IN (?) OR platform_id IN (?))");
+    expect(String(resultCall?.[0])).toContain("cloud_provider IS NOT NULL");
+    expect(String(resultCall?.[0])).toContain("cost_status IN (?)");
+    expect(resultCall?.[1]).toEqual(["clickbench", 0.1, "power", "DuckDB", "DuckDB", "normalized"]);
+
+    const cohortLink = within(grid).getByRole("link", { name: "ClickBench SF0.1" }) as HTMLAnchorElement;
+    expect(cohortLink.getAttribute("href")).toContain("sf=0.1");
+    expect(cohortLink.getAttribute("href")).toContain("phase=power");
+    expect(cohortLink.getAttribute("href")).toContain("platform=DuckDB");
+    expect(cohortLink.getAttribute("href")).toContain("deployment=cloud");
+    expect(cohortLink.getAttribute("href")).toContain("cost_status=normalized");
   });
 
   it("surfaces leaderboard receipt links with trust and validation metadata", async () => {

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -6,6 +6,7 @@ vi.mock("@/db", () => ({
 }));
 
 import { queryRows } from "@/db";
+import { clearDuckdbQueryCachesForTests } from "@/lib/duckdbQueries";
 import { Home } from "@/pages/Home";
 
 /**
@@ -211,6 +212,7 @@ function expectDocumentOrder(first: Element, second: Element) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearDuckdbQueryCachesForTests();
   window.history.replaceState(null, "", "/results/");
   vi.mocked(queryRows).mockImplementation(async (sql: string) => {
     const s = String(sql).replace(/\s+/g, " ").trim();
@@ -482,6 +484,32 @@ describe("Home", () => {
     expect(cohortLink.getAttribute("href")).toContain("platform=DuckDB");
     expect(cohortLink.getAttribute("href")).toContain("deployment=cloud");
     expect(cohortLink.getAttribute("href")).toContain("cost_status=normalized");
+  });
+
+  it("restores URL facet aliases while keeping coverage labels visible", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/results/?bm=clickbench&scale_factor=0.1&trust_tier=maintainer-run",
+    );
+
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+
+    await waitFor(() => {
+      const params = new URL(window.location.href).searchParams;
+      expect(params.get("benchmark")).toBe("clickbench");
+      expect(params.get("sf")).toBe("0.1");
+      expect(params.get("trust")).toBe("maintainer-run");
+      expect(params.get("bm")).toBeNull();
+      expect(params.get("scale_factor")).toBeNull();
+      expect(params.get("trust_tier")).toBeNull();
+    });
+
+    const grid = screen.getByRole("grid", { name: "Cross-benchmark leaderboard" });
+    expect(within(grid).getByRole("columnheader", { name: "Avg rank over covered cohorts" })).toBeTruthy();
+    expect(within(grid).getByText("1/1 cohorts")).toBeTruthy();
+    expect(within(grid).getByText("over 1/1")).toBeTruthy();
   });
 
   it("surfaces leaderboard receipt links with trust and validation metadata", async () => {

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -424,6 +424,32 @@ describe("Home", () => {
     });
   });
 
+  it("shows active facet combination and targeted reset actions when filters remove all coverage", async () => {
+    window.history.replaceState(null, "", "/results/?sf=999&platform=duckdb");
+
+    render(<Home />);
+
+    const emptyState = await screen.findByRole("region", {
+      name: "No leaderboard cells match the current filters",
+    });
+    expect(within(emptyState).getByText("Scale factor")).toBeTruthy();
+    expect(within(emptyState).getByText("SF 999")).toBeTruthy();
+    expect(within(emptyState).getByText("Platform")).toBeTruthy();
+    expect(within(emptyState).getByText("DuckDB")).toBeTruthy();
+    expect(within(emptyState).getByRole("button", { name: "Clear scale factor" })).toBeTruthy();
+    expect(within(emptyState).getByRole("button", { name: "Clear platform" })).toBeTruthy();
+    expect(within(emptyState).getByRole("button", { name: "Reset all" })).toBeTruthy();
+
+    fireEvent.click(within(emptyState).getByRole("button", { name: "Clear scale factor" }));
+
+    await waitFor(() => {
+      expect(new URLSearchParams(window.location.search).get("sf")).toBeNull();
+      expect(screen.queryByRole("region", { name: "No leaderboard cells match the current filters" })).toBeNull();
+    });
+    expect(new URLSearchParams(window.location.search).get("platform")).toBe("duckdb");
+    expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy();
+  });
+
   it("restores canonical URL facets and applies them to the Home result query", async () => {
     window.history.replaceState(
       null,

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -42,13 +42,35 @@ function makeRow(overrides: Partial<PlatformIndexRowRow> = {}): PlatformIndexRow
     execution_mode: null,
     compliance_class: null,
     cost_usd: null,
+    normalized_cost_usd: null,
+    cost_status: "not_applicable_local",
+    cost_scope: null,
+    cost_model_version: null,
+    cloud_provider: null,
+    cloud_region: null,
+    warehouse_size: null,
+    storage_format: null,
     primary_metric: "display_geomean_ms",
     ...overrides,
   };
 }
 
 const ROWS: PlatformIndexRowRow[] = [
-  makeRow({ result_id: "r-tpch-fast", benchmark: "tpch", run_date: "2026-04-03", power_score: 5000, geomean_ms: 5 }),
+  makeRow({
+    result_id: "r-tpch-fast",
+    benchmark: "tpch",
+    run_date: "2026-04-03",
+    power_score: 5000,
+    geomean_ms: 5,
+    normalized_cost_usd: 1.25,
+    cost_status: "normalized",
+    cost_scope: "compute_only",
+    cost_model_version: "2026.05.0",
+    cloud_provider: "aws",
+    cloud_region: "us-east-1",
+    warehouse_size: "MEDIUM",
+    storage_format: "parquet",
+  }),
   makeRow({ result_id: "r-ssb-mid", benchmark: "star_schema", run_date: "2026-04-01", power_score: 3000, geomean_ms: 15 }),
   makeRow({ result_id: "r-tpch-slow", benchmark: "tpch", run_date: "2026-04-02", power_score: 1000, geomean_ms: 50 }),
   makeRow({ result_id: "r-null-geo", benchmark: "tpch", run_date: "2026-04-04", power_score: null, geomean_ms: null }),
@@ -64,6 +86,8 @@ function getRowOrder(container: ParentNode): string[] {
 
 describe("PlatformIndex - sortable table headers", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, "", "/results/p/duckdb/");
     vi.mocked(getPlatformIndexRows).mockResolvedValue(ROWS);
   });
 
@@ -131,6 +155,21 @@ describe("PlatformIndex - sortable table headers", () => {
     // Click again; direction flips.
     fireEvent.click(screen.getByRole("button", { name: /Benchmark/ }));
     expect(benchTh?.getAttribute("aria-sort")).toBe("descending");
+  });
+
+  it("restores platform page URL facets for benchmark, cohort, deployment, and cost filters", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/results/p/duckdb/?benchmark=tpch&sf=0.1&phase=power&deployment=cloud&cost_status=normalized",
+    );
+
+    const { container } = render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    expect(getRowOrder(container)).toEqual(["r-tpch-fast"]);
+    expect(screen.queryByText("SSB")).toBeNull();
+    expect(screen.queryByTestId("r-tpch-slow")).toBeNull();
   });
 
   it("splits trend charts by benchmark, scale, phase, and primary metric", async () => {

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -235,6 +235,31 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(screen.getAllByText("exact").length).toBeGreaterThan(0);
   });
 
+  it("caps rendered platform rows and expands them with Show more", async () => {
+    vi.mocked(getPlatformIndexRows).mockResolvedValue(
+      Array.from({ length: 205 }, (_, index) =>
+        makeRow({
+          result_id: `r-many-${index}`,
+          benchmark: "tpch",
+          geomean_ms: index + 1,
+          display_geomean_ms: index + 1,
+          run_date: `2026-04-${String((index % 28) + 1).padStart(2, "0")}`,
+        }),
+      ),
+    );
+
+    const { container } = render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    expect(screen.getByText("Showing 200 of 205 results")).toBeTruthy();
+    expect(getRowOrder(container)).toHaveLength(200);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more results" }));
+
+    expect(getRowOrder(container)).toHaveLength(205);
+    expect(screen.getByText("Showing 205 of 205 results")).toBeTruthy();
+  });
+
   it("splits platform trend charts by comparable benchmark cohorts", async () => {
     vi.mocked(getPlatformIndexRows).mockResolvedValue([
       makeRow({

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -211,6 +211,30 @@ describe("Query", () => {
     });
   });
 
+  it("reads shared facet aliases and rewrites them to canonical query params", async () => {
+    window.history.replaceState(null, "", "/results/query?bm=clickbench&scale_factor=0.1&trust_tier=maintainer-run");
+
+    render(<Query />);
+    await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));
+
+    await waitFor(() => {
+      const params = new URL(window.location.href).searchParams;
+      expect(params.get("benchmark")).toBe("clickbench");
+      expect(params.get("sf")).toBe("0.1");
+      expect(params.get("trust")).toBe("maintainer-run");
+      expect(params.get("bm")).toBeNull();
+      expect(params.get("scale_factor")).toBeNull();
+      expect(params.get("trust_tier")).toBeNull();
+    });
+
+    const selectCalls = vi.mocked(queryRows).mock.calls.filter(([sql]) => isDefaultResultSelect(sql));
+    const latest = String(selectCalls.at(-1)?.[0]);
+    expect(latest).toContain("benchmark IN (?)");
+    expect(latest).toContain("scale_factor IN (?)");
+    expect(latest).toContain("trust_label IN (?)");
+    expect(selectCalls.at(-1)?.[1]).toEqual(["clickbench", 0.1, "maintainer-run"]);
+  });
+
   it("keeps hidden result IDs available for row actions without showing the column", async () => {
     render(<Query />);
     await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -309,7 +309,8 @@ describe("Query", () => {
       const selectCalls = vi.mocked(queryRows).mock.calls.filter(([sql]) => isDefaultResultSelect(sql));
       expect(selectCalls.at(-1)?.[0]).toContain(`LIMIT ${UNLIMITED_ROW_LIMIT}`);
     });
-    expect(screen.getByText("Showing all returned rows: 2")).toBeTruthy();
+    expect(screen.getByText("Showing 2 of 2 returned rows")).toBeTruthy();
+    expect(screen.getByText("Query limit: all")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /^Default$/ }));
 


### PR DESCRIPTION
- **feat(explorer): define shared facet model**
- **feat(explorer): migrate home facets to shared model**
- **feat(explorer): migrate benchmark facets to shared model**
- **feat(explorer): migrate platform facets to shared model**
- **feat(explorer): migrate query facets to shared model**
- **feat(explorer): add facet rail components**
- **feat(explorer): show missing coverage in matrices**
- **feat(explorer): clarify covered-cohort ranking labels**
- **feat(explorer): add coverage-aware empty state**
- **perf(explorer): memoize stable DuckDB metadata**
- **feat(explorer): cap large table rendering**
- **test(explorer): cover coverage facet regressions**
- **chore(todo): complete explorer selection facets**
