### PR TITLE
fix(write_primitives): PR #112 review followups — runtime bound enforcement + Snowflake/BigQuery overrides

### DIFF
--- a/benchbox/core/write_primitives/README.md
+++ b/benchbox/core/write_primitives/README.md
@@ -24,8 +24,8 @@ Following the **primitives benchmark pattern**, this benchmark:
 
 ## Benchmark Statistics
 
-- **Total Operations**: 117 (113 baseline + 8 sketch — TRANSACTION ops moved to transaction_primitives)
-- **Categories**: 7 (INSERT, UPDATE, DELETE, BULK_LOAD, MERGE, DDL, SKETCH)
+- **Total Operations**: 117 (109 baseline + 8 sketch — TRANSACTION ops moved to transaction_primitives)
+- **Categories**: 7 (INSERT 12, UPDATE 15, DELETE 14, BULK_LOAD 36, MERGE 20, DDL 12, SKETCH 8)
 - **Data Formats**: CSV, Parquet (uncompressed, gzip, zstd, snappy, bzip2)
 - **Scale Factors**: Flexible (0.01 to 10.0+)
 - **Platform Support**: All platforms via dialect translation + platform-specific overrides

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -106,8 +106,16 @@ class OperationResult:
     skip_reason: Optional[str] = None
 
 
-def _check_validation_query(val_query: Any, actual_rows: int) -> bool:
-    """Check whether a validation query passes based on expected row criteria."""
+def _check_validation_query(val_query: Any, actual_rows: int, val_result: list | None = None) -> bool:
+    """Check whether a validation query passes based on expected row or scalar-value criteria.
+
+    Three validation modes (mutually exclusive at load time — see catalog loader):
+    - expected_rows: exact row-count match
+    - expected_rows_min/max: row-count range
+    - expected_value_min/max: scalar value from row[0][0] must fall in [min, max].
+      Used by approximate-aggregate sketch ops where a single tolerance-bounded
+      number certifies correctness without strict cross-engine equality.
+    """
     expected_rows = val_query.expected_rows
     if expected_rows is not None:
         return actual_rows == expected_rows
@@ -115,6 +123,17 @@ def _check_validation_query(val_query: Any, actual_rows: int) -> bool:
         min_val = val_query.expected_rows_min if val_query.expected_rows_min is not None else 0
         max_val = val_query.expected_rows_max if val_query.expected_rows_max is not None else float("inf")
         return min_val <= actual_rows <= max_val
+    if (
+        getattr(val_query, "expected_value_min", None) is not None
+        and getattr(val_query, "expected_value_max", None) is not None
+    ):
+        if not val_result or not val_result[0]:
+            return False
+        try:
+            scalar = float(val_result[0][0])
+        except (TypeError, ValueError):
+            return False
+        return val_query.expected_value_min <= scalar <= val_query.expected_value_max
     return True
 
 
@@ -911,7 +930,7 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             val_sql = self._replace_placeholders(val_query.sql)
             val_result = connection.execute(val_sql).fetchall()
             actual_rows = len(val_result)
-            passed = _check_validation_query(val_query, actual_rows)
+            passed = _check_validation_query(val_query, actual_rows, val_result)
             validation_passed = validation_passed and passed
 
             validation_results.append(

--- a/benchbox/core/write_primitives/catalog/operations.yaml
+++ b/benchbox/core/write_primitives/catalog/operations.yaml
@@ -2987,7 +2987,7 @@ operations:
         );
         INSERT INTO sketch_ops_topk
         SELECT MOD(l_orderkey, 8),
-               APPROX_TOP_K_ACCUMULATE(l_shipmode, 8)
+               APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)
         FROM lineitem GROUP BY MOD(l_orderkey, 8);
       bigquery: null  # No native top-K accumulator function
       clickhouse: null
@@ -2999,7 +2999,7 @@ operations:
   # ★ HEADLINE TEST — theta_union merge + estimate
   - id: sketch_query_theta_union_merge
     category: sketch
-    description: ★ Headline — populate theta sketches per partition, then merge across all partitions in a single query and emit an approximate distinct count (compare to aggregation_distinct in read_primitives)
+    description: ★ Headline — populate theta sketches per partition, then merge across all partitions in a single query and emit an approximate distinct count (compare to aggregation_distinct in read_primitives). BigQuery substitutes HLL_COUNT for Theta (no native Theta surface) — the persist + merge + requery shape is identical, but the underlying sketch family differs.
     requires_setup: false
     write_sql: |
       INSTALL datasketches FROM community;
@@ -3189,7 +3189,7 @@ operations:
         CREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BINARY);
         INSERT INTO sketch_ops_topk
         SELECT MOD(l_orderkey, 8),
-               APPROX_TOP_K_ACCUMULATE(l_shipmode, 8)
+               APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)
         FROM lineitem GROUP BY MOD(l_orderkey, 8);
         SELECT ARRAY_SIZE(APPROX_TOP_K_ESTIMATE(APPROX_TOP_K_COMBINE(topk_sketch))) AS frequent_count
         FROM sketch_ops_topk;

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -722,11 +722,20 @@ class TestCheckValidationQuery:
 
     pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
-    def _make_query(self, expected_rows=None, expected_rows_min=None, expected_rows_max=None):
+    def _make_query(
+        self,
+        expected_rows=None,
+        expected_rows_min=None,
+        expected_rows_max=None,
+        expected_value_min=None,
+        expected_value_max=None,
+    ):
         return SimpleNamespace(
             expected_rows=expected_rows,
             expected_rows_min=expected_rows_min,
             expected_rows_max=expected_rows_max,
+            expected_value_min=expected_value_min,
+            expected_value_max=expected_value_max,
         )
 
     def test_exact_match_passes(self):
@@ -774,6 +783,43 @@ class TestCheckValidationQuery:
 
         q = self._make_query()
         assert _check_validation_query(q, actual_rows=999) is True
+
+    def test_value_bounds_within_range_passes(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=14000, expected_value_max=16000)
+        assert _check_validation_query(q, actual_rows=1, val_result=[(14836.89,)]) is True
+
+    def test_value_bounds_below_range_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=14000, expected_value_max=16000)
+        assert _check_validation_query(q, actual_rows=1, val_result=[(0.0,)]) is False
+
+    def test_value_bounds_above_range_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=14000, expected_value_max=16000)
+        assert _check_validation_query(q, actual_rows=1, val_result=[(50000.0,)]) is False
+
+    def test_value_bounds_no_rows_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=14000, expected_value_max=16000)
+        assert _check_validation_query(q, actual_rows=0, val_result=[]) is False
+
+    def test_value_bounds_non_numeric_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=14000, expected_value_max=16000)
+        assert _check_validation_query(q, actual_rows=1, val_result=[("not a number",)]) is False
+
+    def test_value_bounds_integer_scalar_passes(self):
+        """Integer scalars (e.g. topk frequent_count = 7) coerce to float for the range check."""
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=6, expected_value_max=8)
+        assert _check_validation_query(q, actual_rows=1, val_result=[(7,)]) is True
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Follow-up PR addressing the review findings from #112 (which auto-merged before these landed). Four corrections, two commits:

- **Runtime enforcement of `expected_value_min/max`** — the loader-side parsing added in #112 was inert. Wire it into `_check_validation_query` so the field actually gates op success. Without this, a sketch op that returns 0 would still report PASS. 6 new unit tests cover in-range pass, below/above-range fail, no-rows fail, non-numeric fail, and integer-coerced pass.
- **Snowflake `APPROX_TOP_K_ACCUMULATE` second arg** — was `8` (semantically wrong; second arg is `counters`, the sketch internal map size, not K). Bumped to `1024` (Snowflake's documented default) in both `sketch_insert_topk_per_shard` and `sketch_query_topk_combine`. Pre-emptive fix before the first cloud run.
- **BigQuery Theta description softening** — `sketch_query_theta_union_merge` BigQuery override uses `HLL_COUNT.*` because BigQuery has no native Theta surface. Op description now notes this so users don't expect Theta semantics from BigQuery runs.
- **README op-count drift** — was "117 (113 baseline + 8 sketch)". 117 - 8 = 109 (the actual baseline after TRANSACTION ops moved out, per the per-category counter). Inline the per-category breakdown for unambiguous reference.

## Test plan

- [x] `make pr-preflight` (21390 passed, 5 skipped — was 21384 + 6 new runtime-enforcement tests)
- [x] DuckDB live: all 3 ★ headline sketch ops (`sketch_query_theta_union_merge` / `_kll_quantiles_merge` / `_topk_combine`) pass with bounds now actively enforced (theta 14836.89 ∈ [14000, 16000]; kll ~34000 ∈ [30000, 40000]; topk 7 ∈ [6, 8])
- [ ] Cloud verification of Snowflake override still pending creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)