### PR TITLE
chore(todo): add results-explorer UAT multi-scale corpus sweep

### DIFF
--- a/_project/TODO/main/planning/results-explorer-uat-multi-scale-corpus-sweep.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-multi-scale-corpus-sweep.yaml
@@ -1,0 +1,391 @@
+id: results-explorer-uat-multi-scale-corpus-sweep
+title: "Results Explorer UAT: multi-scale, multi-platform corpus sweep"
+worktree: main
+priority: "Medium-High"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+deps:
+  needs:
+    - explorer-leaderboard-first-identity-unification
+    - explorer-selection-facets-coverage-at-scale
+    - explorer-performance-perceived-latency
+    - explorer-facet-model-environment-contract-refactor
+    - explorer-mobile-density-responsive-tables
+    - results-complete-execution-environment-capture
+
+description: |
+  Run a structured UAT sweep that simultaneously (a) expands the published
+  results corpus across scales 0.01, 0.1, and 1.0 for every viable local
+  platform/benchmark pair, and (b) evaluates the improved Results Explorer
+  and the results submission flow using the corpus produced by the sweep.
+
+  The runs are the means; the explorer/submission UAT is the deliverable.
+  The corpus is what makes cross-scale comparison views meaningful for the
+  first time, so this work must run *after* the in-flight explorer and
+  environment-capture changes have landed -- otherwise the UAT findings
+  will be against the wrong target. Defer until the listed deps are
+  Completed.
+
+  Operating bar: act like a first-time external user, not an implementer.
+  Capture every rough edge, even the small ones. Fixes for those edges
+  belong in separate follow-up TODOs filed at the end -- this item only
+  observes, runs, submits, and reports.
+
+work:
+  - id: w1
+    summary: "Pre-flight: confirm a quiet local environment"
+    status: pending
+    notes: |
+      Before any run, verify the host is not contaminated by other
+      memory/CPU intensive processes. Noisy neighbors invalidate timings
+      and corrupt the corpus.
+        - `ps -Ao pid,pcpu,pmem,rss,comm | sort -k3 -nr | head -30`
+          Look for: prior benchmark sessions, browsers with heavy tabs,
+          video calls, IDE indexers (JetBrains scanning), `mds_stores`
+          (Spotlight reindex), `backupd` (Time Machine), background AI
+          processes.
+        - `docker ps` -- stop any leftover `benchbox-*` containers from
+          aborted prior runs (they collide on ports).
+        - Check Docker Desktop's memory ceiling. The local stress script
+          flags Velox specifically as memory-constrained at the
+          Docker Desktop ~11.7 GB ceiling; record the actual ceiling.
+        - `df -h ~/Developer/benchmark_runs` -- abort and surface to the
+          user if less than ~50 GB free; SF=1 datagen for some
+          benchmarks costs tens of GB.
+        - Confirm `BENCHBOX_OUTPUT_DIR` (default
+          `~/Developer/benchmark_runs`).
+      If anything is contaminated, surface specific process/container
+      names to the user before starting. Do not "just proceed" and do
+      not reflexively kill processes you did not start.
+
+  - id: w2
+    summary: "Build the run matrix from the registry (do not hardcode)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Read `scripts/local_stress_test.sh` for *knowledge*; do not invoke
+      it. It is the authoritative source for:
+        - platform groupings (FAST_NATIVE, FAST_DOCKER, SLOW_NATIVE,
+          SLOW_DOCKER, DF_PLATFORMS)
+        - SQL-only benchmarks (`SQL_ONLY_BENCHMARKS`)
+        - per-platform port maps (`get_platform_port`) for TCP probing
+        - per-platform `--platform-option` overrides
+          (`get_platform_extra_opts`) -- pass these through on every
+          invocation for that platform
+        - per-platform CLI flags (`get_platform_cli_flags`) -- notably
+          velox needs `--iterations 1`
+        - per-platform uv extras (`get_platform_uv_extra`) --
+          `clickhouse-local`, `singlestore`, `influxdb` require
+          `uv run --extra <name> -- benchbox run ...`; all others use
+          `--no-sync`.
+      Then enumerate benchmarks live from the registry:
+        uv run --no-sync -- python -c "
+        from benchbox.core.benchmark_registry import (
+            BENCHMARK_METADATA, get_benchmarks_by_category, get_categories,
+        )
+        import json
+        print(json.dumps({
+            c: list(get_benchmarks_by_category(c).keys())
+            for c in get_categories()
+        }, indent=2))
+        print('SQL-only:', [
+            i for i, m in BENCHMARK_METADATA.items()
+            if not m.get('supports_dataframe', True)
+        ])
+        print('Min/max scales:', {
+            i: (m.get('min_scale'), m.get('max_scale'))
+            for i, m in BENCHMARK_METADATA.items()
+        })
+        "
+      Respect each benchmark's `min_scale`/`max_scale`: skip 0.01, 0.1,
+      or 1.0 rungs that fall outside the supported range. TPC-DS subscale
+      (SF<1) requires the patched dsdgen bundled with BenchBox -- this
+      is supported, just be aware.
+
+  - id: w3
+    summary: "Execute the scale ladder with hard 10-minute per-run cap"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each viable (platform, benchmark) pair, run the scale ladder
+      0.01 -> 0.1 -> 1.0. Stop ascending the ladder for that pair as
+      soon as any of the following is true:
+        - the previous scale failed (don't waste time on a larger scale
+          of a broken pair);
+        - the previous scale took longer than ~3 minutes wall-clock
+          (10x scale typically means >=10x time; the next rung will
+          likely blow the 10-minute cap);
+        - the next scale violates the benchmark's metadata constraints.
+      Hard cap each invocation at 10 minutes wall-clock with a real
+      timeout (`timeout 600 ...` or `gtimeout 600 ...`). A run that hits
+      the cap is "deferred -- too slow at this scale", not a failure to
+      investigate.
+
+      Invocation template (adapt per platform):
+        timeout 600 uv run [--no-sync | --extra <extra>] -- \
+          benchbox run \
+            --platform <p> --benchmark <b> --scale <sf> \
+            --phases load,power --non-interactive \
+            [--platform-option ...]    # from get_platform_extra_opts
+            [--iterations 1]           # velox only
+
+      Capture stdout+stderr per run to a per-run log file under
+      `~/Developer/benchmark_runs/logs/uat_<YYYYMMDD>/<platform>_<benchmark>_<sf>.log`.
+      Record the result JSON path printed in the run output (matches
+      `.../benchmark_runs/results/.*\.json`).
+
+      Run platforms sequentially, never in parallel. Concurrent platform
+      runs contaminate each other's timings, defeating the
+      corpus-quality goal of this exercise.
+
+  - id: w4
+    summary: "Failure triage: fix trivia, log everything else"
+    needs: [w3]
+    status: pending
+    notes: |
+      When a run fails, classify in this order. Do NOT spend more than
+      ~5 minutes per failure on the first two buckets before deferring.
+
+      1. Trivially fixable config/syntax -> fix and rerun once. Examples:
+         wrong port option, missing
+         `--platform-option password=`, wrong uv extra, stale Docker
+         container holding the port, missing image
+         (`docker compose pull`), benchmark name typo, an obvious flag
+         rename surfaced by `benchbox run --help`. Note the fix in the
+         report so the team can decide whether default config or the
+         stress script needs an upstream change.
+
+      2. Environmental (Docker memory, disk full, port collision,
+         license/credential prompt for a cloud platform) -> log clearly
+         with the specific signal, stop attempting that platform, move
+         on.
+
+      3. Anything else (engine crash, query semantic error, validation
+         mismatch, dialect translation bug, datagen failure, segfault,
+         OOM at small scale) -> DO NOT INVESTIGATE. Log
+         platform/benchmark/scale, the failing phase, the last ~30 lines
+         of the log, and a one-line hypothesis. These become follow-up
+         engineering TODOs in w7.
+
+      The agent is explicitly NOT authorized to modify benchmark
+      queries, dialect adapters, datagen code, or platform
+      implementations to make a run pass. The corpus is only valuable
+      if it reflects real platform behavior.
+
+  - id: w5
+    summary: "Submit results through the BenchBox submission flow"
+    needs: [w3]
+    status: pending
+    notes: |
+      Discover the exact submission entrypoint yourself. Likely
+      candidates: `benchbox submit`, `benchbox results`,
+      `benchbox explore`, MCP tools (`get_results`, `analyze_results`,
+      `generate_chart`, `suggest_charts`). Check `benchbox --help` and
+      the MCP tool list. The submission target is the
+      `published-results` branch (per project convention), not main.
+
+      For each result you submit, act as a first-time user, not an
+      implementer. Capture in the report:
+        - submission flow friction: confusing prompts, unclear
+          validation errors, missing confirmation, ambiguous "did it
+          work?" signal, file-path gotchas, anything that would
+          frustrate an external contributor;
+        - the cross-reference of the agent-proxy dry-runs already
+          performed (see `external-contributor-submission-dry-run`
+          updates 2026-04-28 / 2026-04-29) and whether the issues they
+          surfaced still reproduce.
+
+  - id: w6
+    summary: "Exercise the Results Explorer against the new corpus"
+    needs: [w5]
+    status: pending
+    notes: |
+      Once the new SF=0.01/0.1/1.0 corpus is published, exercise the
+      Results Explorer end-to-end against it. Capture defects with
+      severity (blocker / major / minor / nit), reproduction steps,
+      observed vs expected, and the result file(s) that trigger the
+      issue.
+
+      Specifically test the surfaces these in-flight TODOs are touching
+      (so the UAT validates them under real corpus pressure rather than
+      against fixture data):
+        - leaderboard-first identity unification: skeleton tokens, Home
+          first-render geometry;
+        - selection-facets coverage-at-scale: facet completeness at
+          SF=1 corpus shape;
+        - perceived-latency: cold load, first leaderboard, query
+          response, pagination, table rendering;
+        - facet-model environment-contract refactor: filtering by
+          runtime type, container vs cloud vs embedded, region/compute
+          shape -- needs the `results-complete-execution-environment-capture`
+          fields populated;
+        - mobile density / responsive tables.
+
+      Defects you would NOT have found without a multi-scale
+      multi-platform corpus are the highest-signal findings -- call
+      them out separately. Cross-scale comparison UX (SF=0.01 vs 0.1
+      vs 1.0 for the same platform/benchmark) is the headline thing
+      this corpus enables; does the explorer let you actually see it
+      cleanly?
+
+  - id: w7
+    summary: "Write report, file follow-up TODOs, retire run logs"
+    needs: [w4, w5, w6]
+    status: pending
+    notes: |
+      Produce a single report (delivered in chat to the user) with:
+        1. Run matrix summary -- table of (platform x scale) cells per
+           benchmark with status: passed, failed-fixed, failed-deferred,
+           timed-out, skipped-unreachable, skipped-min-scale.
+        2. Submitted results -- count and list of paths/IDs that
+           landed in the corpus.
+        3. Fixes applied during the run (the "trivially fixable"
+           bucket) -- one bullet each with the exact change. These are
+           candidate small PRs.
+        4. Deferred failures (the "anything else" bucket) -- one bullet
+           each with platform/benchmark/scale, failing phase,
+           hypothesis, log path. File one follow-up TODO per cluster
+           under
+           `_project/TODO/main/planning/results-explorer-uat-defect-*.yaml`
+           (one TODO per defect cluster, not one per run).
+        5. Explorer & submission UAT findings -- severity-grouped list.
+           This is the most important section. File one follow-up TODO
+           per defect cluster.
+        6. Environment notes -- pre-run state, anything killed,
+           anything the harness should automate.
+
+      Save the run logs directory
+      (`~/Developer/benchmark_runs/logs/uat_<YYYYMMDD>/`) for ~30 days,
+      then prune. Do not check logs into the repo.
+
+verification:
+  - description: "Run logs directory exists with at least one log per attempted (platform, benchmark, scale) cell."
+    command: "ls ~/Developer/benchmark_runs/logs/uat_*/ 2>/dev/null | wc -l"
+    expected_output: ">= number of attempted runs"
+  - description: "At least the smoke ladder for DuckDB succeeds and produces submittable result JSONs."
+    command: "find ~/Developer/benchmark_runs/results -name 'duckdb_*.json' -newer ~/Developer/benchmark_runs/logs/uat_* | head"
+    expected_output: "result JSONs present for duckdb at SF=0.01/0.1/1.0 across the TPC and primitives benchmarks"
+  - description: "Follow-up defect TODOs exist for every Explorer/Submission finding above 'nit' severity."
+    command: "ls _project/TODO/main/planning/results-explorer-uat-defect-*.yaml 2>/dev/null"
+    expected_output: "one yaml per defect cluster"
+  - description: "Final UAT report delivered to user covering all six required sections."
+    command: "manual"
+    expected_output: "report contains: matrix, submitted, fixes, deferred, explorer findings, environment notes"
+
+must_preserve:
+  - "Real platform behavior in the corpus -- no source modifications to make a benchmark pass."
+  - "Methodology integrity -- runs sequential, no parallel platforms, hard 10-minute cap honored."
+  - "Existing local environment state -- agent does not kill processes it did not start without user approval."
+  - "Trust label distinction -- any submitted result keeps the appropriate community/maintainer label."
+  - "User autonomy -- pre-flight contamination is surfaced to the user, not silently 'cleaned up'."
+
+approach: |
+  This is a UAT item, not an engineering item. Run scope is bounded by
+  the 10-minute-per-run cap and the scale-ladder early-stop rules; do
+  not chase a long tail of slow benchmarks. Use the local stress
+  script as a knowledge source, not an entrypoint -- the BenchBox CLI
+  is the system under test for both the runs and the submission flow,
+  so invoking the script would defeat the UAT purpose.
+
+  Defer until the listed `deps.needs` items are Completed. Running
+  this against a moving explorer or before the environment-capture
+  fields land would produce findings against the wrong target and
+  waste the corpus. When picking up this TODO, first re-verify the
+  deps are in fact Completed and update this approach if the dep set
+  has shifted.
+
+anti_patterns:
+  - "DO NOT invoke `scripts/local_stress_test.sh` -- because this is a UAT of the BenchBox CLI itself, and using the script would skip the surface under test -- read the script for knowledge only and call `benchbox run` directly."
+  - "DO NOT modify benchmark queries, dialect adapters, datagen code, or platform implementations to make failing runs pass -- because the corpus is only valuable if it reflects real platform behavior -- log the failure as deferred and move on."
+  - "DO NOT investigate deep failures during the sweep -- because every minute spent on one engine crash is a minute the rest of the matrix sits idle -- triage in <=5 minutes per failure, then defer to a follow-up TODO."
+  - "DO NOT run platforms in parallel to save wall-clock -- because concurrent runs contaminate timings and corrupt the corpus -- run sequentially, accept the wall-clock cost."
+  - "DO NOT chase the long tail of slow benchmarks past the 10-minute cap -- because the goal is broad coverage at smoke scales, not full-corpus runs -- timing-out a cell is a valid 'deferred' outcome."
+  - "DO NOT pre-judge explorer findings as too small to file -- because rough edges are the deliverable here -- nits go in the report, doc/UX changes get a TODO."
+  - "DO NOT silently kill processes the agent did not start during pre-flight -- because they may be the user's in-progress work -- surface them and ask first."
+
+scope_limit:
+  only_modify:
+    - "_project/TODO/main/planning/results-explorer-uat-defect-*.yaml"
+    - "_project/handoffs/results-explorer-uat-retrospective-*.md"
+  do_not_modify:
+    - "benchbox/"
+    - "results-explorer/"
+    - "scripts/local_stress_test.sh"
+    - "results-data/"
+    - "_binaries/"
+
+context_sections:
+  "Why this is gated by other TODOs": |
+    The point of the sweep is to evaluate the *improved* Results
+    Explorer and the *normalized* execution-environment capture. The
+    dependency list pins to those in-flight items so the UAT lands
+    against the right target. Running this prematurely produces
+    findings that are stale before they are read.
+  "Relationship to existing dry-run TODOs": |
+    `external-contributor-submission-dry-run` is a Phase 2 single-human
+    dry-run focused on the contributor submission *experience*. This
+    TODO is broader and complementary: a multi-platform multi-scale
+    sweep that produces the corpus needed to UAT the *explorer* under
+    realistic load. Findings from one should cross-reference findings
+    from the other rather than duplicate them.
+  "Why scales 0.01, 0.1, 1.0 specifically": |
+    Three rungs spanning 100x is enough to test the explorer's
+    cross-scale comparison views and to expose `min_scale`/`max_scale`
+    boundary handling, while the early-stop rule prevents the sweep
+    from running forever. Using a denser ladder (e.g. 0.01, 0.05, 0.1,
+    0.5, 1.0) does not produce qualitatively new explorer findings and
+    burns local time.
+
+metadata:
+  tags:
+    - uat
+    - results-explorer
+    - submission-flow
+    - corpus-expansion
+    - multi-scale
+    - multi-platform
+  estimated_effort: "Large (1-2 sessions; runs are wall-clock heavy)"
+  created_date: "2026-05-02"
+
+impact:
+  business_value: |
+    Surfaces explorer and submission-flow defects that only appear with
+    a real multi-scale multi-platform corpus, before broader public
+    promotion exposes those defects to external contributors. Expands
+    the published corpus at the same time, which is independently
+    useful for the explorer's cross-scale comparison views.
+  user_impact: |
+    Users see a wider, scale-ladder corpus in the explorer and a
+    submission flow that has been hardened against the rough edges
+    found by the sweep.
+  technical_debt: |
+    Generates a backlog of small follow-up TODOs targeting the exact
+    failure modes that broke during real local runs -- those become
+    candidate small PRs that reduce friction for everyone running
+    BenchBox locally.
+
+success_metrics:
+  - "Run matrix completed for >=80% of viable (platform, benchmark, scale) cells under the 10-minute cap."
+  - "Result JSONs successfully submitted via the BenchBox submission flow for the successful cells."
+  - "At least one severity-graded report covering submission and explorer UX is delivered to the user."
+  - "Every above-nit finding has a follow-up TODO filed under `_project/TODO/main/planning/results-explorer-uat-defect-*.yaml`."
+  - "Trivial-fix bucket is documented well enough that the team can decide which fixes promote into upstream config or stress-script changes."
+
+open_questions:
+  - "When this TODO is picked up, are all listed `deps.needs` items actually Completed, or has the dep set shifted? Re-verify before running -- a moving target invalidates the corpus."
+  - "Should the agent attempt cloud platforms (Snowflake/BigQuery/Redshift/Athena/Databricks/etc.) at SF=0.01 only, or skip them entirely? Skipping is the safer default -- credentials and cost make them unsuitable for a local UAT sweep -- but the explorer's cloud-facet rendering can only be tested with cloud rows in the corpus."
+  - "Does the agent need permission to publish results, or should it stage submissions as draft PRs against `published-results` for human review? Draft-PR is the safer default."
+  - "Should the agent's run logs (~/Developer/benchmark_runs/logs/uat_*) be referenced from the retrospective, or compressed into a single artifact for handoff?"
+
+deferred:
+  - summary: "Cloud platform UAT (Snowflake, BigQuery, Redshift, Athena, Databricks, ClickHouse Cloud, Firebolt)"
+    reason: "Out of scope for a local sweep; credentials, cost, and tenant-side variability make these unsuitable here. File a separate `results-explorer-uat-cloud-corpus` if/when the explorer's cloud-facet surface is ready to be tested under load."
+  - summary: "Throughput phase coverage"
+    reason: "This sweep runs `--phases load,power` only. Throughput adds a multiplicative wall-clock cost that the 10-minute cap cannot absorb at SF>=0.1. Consider after the load/power UAT lands and the explorer's throughput rendering is ready to be tested."
+  - summary: "Validation = full / strict comparisons"
+    reason: "Default validation is sufficient for a UAT corpus. Strict validation produces additional failure modes that belong in a dedicated correctness sweep, not this UX-focused one."
+  - summary: "Larger scale rungs (SF >= 10)"
+    reason: "Scale ladder is intentionally capped at SF=1.0 to fit the 10-minute-per-run budget. SF=10 belongs in a perf-focused sweep on dedicated hardware, not a local UAT."
+  - summary: "Implementing the fixes the sweep produces"
+    reason: "This TODO observes, runs, submits, and reports. Each above-nit finding becomes its own follow-up TODO with its own scope -- mixing observation and implementation muddied the existing dry-run TODO retrospectives and that lesson applies here."


### PR DESCRIPTION
Captures the deferred plan to run scales 0.01/0.1/1.0 across every
viable local platform/benchmark pair and UAT the improved Results
Explorer + submission flow against the resulting corpus. Gated on the
in-flight explorer and execution-environment-capture TODOs so the UAT
lands against the right target.
