### PR TITLE
chore(todo): plan write_primitives sketch expansion (1 recommended + 4 deferred)

### DIFF
--- a/_project/TODO/main/planning/write-primitives-sketch-clickhouse-and-storage-metrics.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-clickhouse-and-storage-metrics.yaml
@@ -1,0 +1,334 @@
+id: write-primitives-sketch-clickhouse-and-storage-metrics
+title: "Write Primitives: ClickHouse-native sketch variants + storage-size validation for headline ★ ops"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  Two coordinated expansions to the `sketch` category that landed in
+  PR #112:
+
+  - **A. ClickHouse-native sketch variants** using `-State` / `-Merge`
+    aggregate combinators. Currently every sketch op skips on ClickHouse
+    via `null` `platform_overrides`. ClickHouse's sketch model is
+    algorithmically comparable to DataSketches but uses its own binary
+    serialisation (not portable to Theta/KLL/Top-K bytes), so the
+    columns must use parameterised `AggregateFunction(...)` types
+    rather than the BINARY surface used elsewhere. This was explicitly
+    deferred in the merged write_primitives TODO with the rationale
+    "valuable but a scope expansion that should land as a follow-up
+    once the DataSketches-portable core works." That core has now
+    shipped; this TODO is the resolution.
+
+  - **B. Storage-size validation** on the three ★ headline ops. Today
+    every sketch op measures only latency. Adding `LENGTH(sketch_column)`
+    aggregate validations gives users the byte-cost side of the
+    "millisecond merge" claim: how much storage are partitioned
+    sketches consuming, and how much smaller does the merged sketch
+    get? Uses the existing `expected_value_min/max` runtime contract
+    added in PR #114 — no schema changes needed.
+
+  Bundled because both expansions complete the cross-engine sketch
+  story: A adds ClickHouse to the matrix; B makes every existing
+  sketch op more analytically useful by surfacing the cost dimension
+  alongside latency.
+
+context_sections:
+  "ClickHouse Sketch Surface": |
+    ClickHouse's sketch APIs are aggregate-function combinators rather
+    than first-class function families. The pattern is:
+      - Build:  `<agg>State(col)` returns `AggregateFunction(<agg>, T)`
+      - Merge:  `<agg>Merge(state)` returns the final scalar/array
+      - Or call `<agg>` directly as an aggregate over previously-built
+        states (uniqMerge over uniqState columns, etc.)
+
+    Verified locally with chDB 26.x:
+      - Theta-equivalent: `uniqState(x)` / `uniqMerge(s)` ✓
+      - KLL-equivalent:   `quantileTDigestState(x)` / `quantileTDigestMerge(0.5)(s)`
+      - Top-K-equivalent: `topKState(8)(x)` / `topKMerge(8)(s)`
+
+    Storage column types are parameterised:
+      - `AggregateFunction(uniq, UInt64)` for theta-equivalent
+      - `AggregateFunction(quantileTDigest(0.5), Float64)` for KLL-equivalent
+      - `AggregateFunction(topK(8), String)` for top-K-equivalent
+
+    This means each ClickHouse override emits its own CREATE TABLE
+    DDL — the BINARY translator can't be reused. That's fine; the
+    overrides already include their own DDL.
+
+  "Storage-Size Validation Methodology": |
+    DuckDB exposes raw sketch byte length via `octet_length(sketch)`
+    or `length(sketch::BLOB)`. Empirically observed sizes at SF=0.01:
+      - Theta merged sketch: ~16KB (default lg_k=12 = 4096 entries)
+      - KLL merged sketch:   ~3KB  (default k=200)
+      - Frequent-items merged sketch: ~600 bytes (lg_max_map_size=8)
+
+    The validation approach: for each ★ headline op, add a second
+    `validation_query` that computes `octet_length()` on the merged
+    sketch and asserts it falls in `[expected_value_min,
+    expected_value_max]` — wide enough to absorb minor encoding
+    drift, tight enough to flag a sketch becoming a no-op (size 0)
+    or unbounded.
+
+  "Why This Bundles Cleanly": |
+    Both A and B touch only `operations.yaml` for the ClickHouse
+    overrides + new validation queries; A optionally touches the
+    cross-platform doc with a ClickHouse column type table. Neither
+    requires schema.py / loader.py / benchmark.py changes — the
+    runtime infrastructure already supports both paths. Two separate
+    PRs would duplicate the doc + changelog work; one PR with seven
+    commits walks reviewers through the additions cleanly.
+
+work:
+  - id: w1
+    summary: "Add ClickHouse override for sketch_ddl_create_persistent_table"
+    status: pending
+    notes: |
+      The current override is `clickhouse: null`. Replace with a real
+      DDL block that creates a table with `AggregateFunction(uniq,
+      UInt64)` columns for the theta-style sketches. Pattern:
+
+        CREATE TABLE sketch_ops_daily_users (
+          activity_date Date,
+          region String,
+          user_sketch AggregateFunction(uniq, UInt64),
+          rev_sketch AggregateFunction(uniq, UInt64)
+        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
+
+      Verify against chDB locally: the validation query
+      `SELECT COUNT(*) FROM information_schema.tables WHERE
+      table_name = 'sketch_ops_daily_users'` should return 1.
+
+  - id: w2
+    summary: "Add ClickHouse overrides for the 3 sketch_insert_* ops"
+    needs: [w1]
+    status: pending
+    notes: |
+      For each insert op, add a `clickhouse:` override that uses the
+      `-State` combinator:
+
+        sketch_insert_theta_per_partition:
+          INSERT INTO sketch_ops_daily_users
+          SELECT l_shipdate, l_returnflag,
+                 uniqState(l_orderkey),
+                 uniqState(toUInt64(l_extendedprice))
+          FROM lineitem GROUP BY l_shipdate, l_returnflag;
+
+        sketch_insert_kll_per_partition:
+          (creates its own sketch_ops_kll_partitions with
+          AggregateFunction(quantileTDigest(0.5), Float64), uses
+          quantileTDigestState(toFloat64(l_extendedprice)))
+
+        sketch_insert_topk_per_shard:
+          (creates sketch_ops_topk with
+          AggregateFunction(topK(8), String), uses topKState(8))
+
+      Also handle the cast issue: ClickHouse rejects Decimal for these
+      aggregates — wrap in toFloat64() / toUInt64() per type.
+
+  - id: w3
+    summary: "Add ClickHouse overrides for the 3 ★ sketch_query_* merge ops"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each headline op, add a `clickhouse:` override that uses the
+      `-Merge` combinator:
+
+        sketch_query_theta_union_merge:
+          SELECT uniqMerge(user_sketch) AS distinct_orders
+          FROM sketch_ops_daily_users;
+
+        sketch_query_kll_quantiles_merge:
+          SELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price
+          FROM sketch_ops_kll_partitions;
+
+        sketch_query_topk_combine:
+          SELECT length(topKMerge(8)(topk_sketch)) AS frequent_count
+          FROM sketch_ops_topk;
+
+      Validation bounds (expected_value_min/max) must be re-tuned
+      empirically against ClickHouse — uniq's HyperLogLog estimator
+      produces different bias than DataSketches Theta. Document the
+      observed values inline alongside the existing DuckDB bounds.
+
+  - id: w4
+    summary: "Add ClickHouse override for sketch_drop_persistent_table"
+    needs: [w1]
+    status: pending
+    notes: |
+      Trivial: just `DROP TABLE IF EXISTS sketch_ops_daily_users` and
+      then `CREATE TABLE ... DROP TABLE` for the measurement op.
+
+  - id: w5
+    summary: "Add storage-size validation_queries to the 3 ★ headline ops"
+    status: pending
+    notes: |
+      For each of `sketch_query_theta_union_merge`,
+      `sketch_query_kll_quantiles_merge`, `sketch_query_topk_combine`,
+      add a second validation_query that computes `octet_length()` (or
+      ClickHouse equivalent: `length()`) on the merged sketch and
+      asserts the byte count falls in observed bounds.
+
+      Empirical observations to inform initial bounds (run on DuckDB
+      SF=0.01 first; ClickHouse may differ once w3 lands):
+        - theta merged sketch: observed ~16KB → bounds [4000, 32000]
+        - KLL merged sketch:   observed ~3KB  → bounds [1000, 8000]
+        - topk merged sketch:  observed ~600B → bounds [200, 2000]
+
+      The validation is an additional `validation_query`, not a
+      replacement — the existing scalar-bounds query stays.
+
+  - id: w6
+    summary: "Update cross-platform sketch docs with ClickHouse column types and storage-size methodology"
+    needs: [w3, w5]
+    status: pending
+    notes: |
+      In `docs/benchmarks/write-primitives-sketch-functions.md`:
+        - Add a row for ClickHouse to the function-name reference
+          tables (theta / KLL / top-K) using uniq* / quantileTDigest* /
+          topK* names.
+        - Update the "Per-engine column type" table: ClickHouse now
+          uses `AggregateFunction(...)` parameterised types (different
+          model from BINARY-portable). Note explicitly that this is
+          comparable algorithmically but NOT binary-compatible with
+          DataSketches.
+        - Add a "Storage-size methodology" section documenting the
+          octet_length validation approach and the observed bounds
+          per family.
+        - Reflect the ClickHouse addition in the headline-tests
+          cross-reference table.
+
+  - id: w7
+    summary: "Add changelog entry under unreleased"
+    needs: [w4, w6]
+    status: pending
+    notes: |
+      Two terse user-facing bullets:
+      "write_primitives sketch: add ClickHouse-native variants
+      (uniqState/uniqMerge, quantileTDigestState/Merge, topKState/Merge)
+      using the AggregateFunction column model."
+      "write_primitives sketch: add storage-size validation
+      (octet_length) on the three ★ headline ops alongside existing
+      scalar-bounds validation."
+
+deferred:
+  - summary: "ClickHouse `quantileTDigestWeighted` for weighted quantile sketches"
+    reason: "Adds weighted-quantile coverage but is a niche capability not paralleled in DataSketches KLL. Defer until weighted-quantile becomes a stated cross-engine requirement."
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - clickhouse
+    - storage-size
+    - benchmark-catalog
+  estimated_effort: "1-2 days"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Closes the largest current sketch-op skip gap: ClickHouse skips on
+    all 8 sketch ops today, leaving the cross-engine matrix incomplete
+    on a major OLAP engine. Storage-size validation adds a missing
+    dimension — every sketch op currently measures only latency, but
+    cost-per-byte is the other half of the persistence-vs-recompute
+    tradeoff users actually care about.
+  user_impact: |
+    Users running BenchBox on ClickHouse get sketch-persistence numbers
+    they can compare to Databricks / Snowflake / DuckDB rather than a
+    skip status. All users get byte-cost metrics on the headline tests
+    so they can answer "is the millisecond merge worth the extra
+    storage?" rather than just "is the merge fast?"
+  technical_debt: |
+    Resolves the "ClickHouse-native sketch variants" deferred item from
+    the merged write_primitives TODO. Adds a precedent for non-BINARY
+    sketch storage types (parameterised AggregateFunction columns)
+    that future work — e.g. ClickHouse Theta UDAF if it ships — can
+    extend.
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+
+must_preserve:
+  - "All 117 existing write_primitives operations execute identically — no behavior changes to the existing Databricks/Snowflake/BigQuery overrides or the DuckDB base SQL."
+  - "The 8 existing sketch ops continue to pass on DuckDB SF=0.01 with their current scalar-bounds validation contracts."
+  - "Catalog loader continues to accept the augmented ★ ops with two validation_queries each (existing scalar-bounds + new storage-size bounds)."
+  - "Per-op cleanup_sql still runs after each op — the ClickHouse-native variants must clean up their AggregateFunction-typed tables."
+
+approach: |
+  Pure operations.yaml work for w1-w5 — no Python or schema.py
+  changes. The runtime infrastructure (BINARY type translator,
+  validation contract loader, expected_value_min/max enforcement) all
+  shipped in PR #112 / #114; this TODO uses them.
+
+  For ClickHouse, each op gets a self-contained override that creates
+  its own AggregateFunction-typed table, populates with -State, queries
+  with -Merge, and drops. Same per-op self-contained pattern as the
+  DuckDB base SQL. The BINARY column type translator is not touched —
+  ClickHouse's parameterised column types don't fit that abstraction
+  and shouldn't be forced into it.
+
+  For storage-size validation, append a second validation_query to
+  each ★ headline op. The existing scalar-bounds query stays; the new
+  one uses octet_length and the same expected_value_min/max contract.
+  Loader-side validation already enforces both queries.
+
+  Docs and changelog land last, after the live ClickHouse runs confirm
+  the empirical bounds (w5 → w6 → w7 chain).
+
+anti_patterns:
+  - "DO NOT try to make ClickHouse `AggregateFunction(...)` columns binary-portable to DataSketches — because the serialisation formats are genuinely incompatible (different hash families, different layouts) — document the model difference in the docs and treat them as algorithmically-comparable, not byte-compatible."
+  - "DO NOT extend the BINARY → dialect type translator with a ClickHouse special-case — because parameterised AggregateFunction types depend on the aggregate name AND the input column type, so a single column-type translation can't express them — emit the CREATE TABLE inline in each ClickHouse override."
+  - "DO NOT reuse DuckDB's storage-size bounds for ClickHouse — because uniq's HyperLogLog++ encoding produces meaningfully different sizes vs DataSketches Theta — observe ClickHouse sizes empirically in w5 and document both side-by-side."
+  - "DO NOT collapse the existing scalar-bounds validation_query when adding the storage-size one — because they validate different correctness invariants (estimate quality vs storage hygiene) and a single query can't cover both — append, don't replace."
+  - "DO NOT skip the empirical-tolerance step for ClickHouse — because hash-family differences make value bounds non-trivially different from DuckDB — observe the values at SF=0.01 over multiple runs and document the chosen tolerances inline."
+
+verification:
+  - description: "All write_primitives unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/core/write_primitives -q"
+    expected_output: "all tests pass, including catalog_loader tests for the augmented validation_queries"
+  - description: "DuckDB end-to-end re-run of all 8 sketch ops (regression check; storage-size validation now active)"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table"
+    expected_output: "8/8 pass; both scalar-bounds and storage-size validations green on the 3 ★ ops"
+  - description: "ClickHouse local end-to-end run of all 8 sketch ops (now using -State/-Merge variants)"
+    command: "uv run -- benchbox run --platform clickhouse-local --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table"
+    expected_output: "8/8 pass on ClickHouse local; previously 0/8 (all skipped via null overrides)"
+  - description: "Help-topic still references the sketch docs (no regression)"
+    command: "uv run -- benchbox run --help-topic benchmarks 2>&1 | grep -i sketch"
+    expected_output: "output references docs/benchmarks/write-primitives-sketch-functions.md"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/write_primitives/dataframe_operations.py
+    - benchbox/core/write_primitives/generator.py
+    - benchbox/core/write_primitives/operations.py
+    - benchbox/core/read_primitives/
+
+success_metrics:
+  - "All 8 sketch ops execute end-to-end on ClickHouse local (chDB) — was 0/8 (all skipped)"
+  - "Three ★ headline ops gain a second validation_query for storage-size bounds (octet_length) on every supporting engine"
+  - "Cross-platform sketch docs add ClickHouse rows to the function-name and column-type reference tables, plus a Storage-size methodology section"
+  - "DuckDB regression: all 8 sketch ops still pass with the augmented validation contract"
+  - "Changelog entries under unreleased for both ClickHouse coverage and storage-size validation"
+
+open_questions:
+  - "Should ClickHouse storage-size bounds be wider than DuckDB's to absorb the HyperLogLog++ vs Theta encoding-size difference, or should we document the observed delta as a feature (showing users the cost-per-byte difference)? Lean: document the delta; same bounds shape, different observed values per engine."
+  - "Does ClickHouse's `quantileTDigestMerge(0.5)(state)` apply the quantile parameter at merge time or at state-build time? Spike during w3 — affects whether the state-builder needs to know the target quantile in advance."
+  - "Should we add an optional `expected_storage_max` field to OperationResult to track sketch storage in result JSON (vs only validating it)? Out of scope for this TODO; consider as a follow-up if storage tracking becomes a stated metric."

--- a/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
@@ -1,0 +1,287 @@
+id: write-primitives-sketch-cloud-verification
+title: "Write Primitives sketch: cloud verification of Snowflake / BigQuery / Databricks platform_overrides"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Verification"
+
+description: |
+  The merged write_primitives sketch category shipped with
+  `platform_overrides` for Snowflake, BigQuery, and Databricks
+  written from documented function names but **never executed against
+  real cloud engines**. Cloud credentials weren't available locally
+  during the original implementation, and the hard-block protocol
+  permitted DuckDB-with-extension coverage as the merge-test
+  acceptance criterion.
+
+  This TODO is the verification follow-up: when cloud credentials
+  become available, run each sketch op against each cloud engine and
+  reconcile any discrepancies between the documented function names
+  / signatures and the actual engine behavior.
+
+  Implicitly **blocked on credential availability** — this is not
+  ready-to-implement until BenchBox has working credentials for at
+  least one of Snowflake / BigQuery / Databricks. Captured here so the
+  follow-up is tracked and the verification plan is preserved.
+
+context_sections:
+  "Specific Items to Verify": |
+    Per the post-merge code review of PR #112:
+
+    Snowflake:
+      - DATASKETCHES_THETA_ACCUMULATE / _COMBINE / _ESTIMATE function
+        names (vs DATASKETCHES_HLL_* or DATASKETCHES_QUANTILE_KLL_*
+        — the actual function-name-spacing in current Snowflake docs
+        needs confirmation).
+      - APPROX_TOP_K_ACCUMULATE second arg semantics: PR #114 corrected
+        from `8` to `1024` based on docs ("counters", not K). Cloud
+        run is the ground-truth verification.
+      - APPROX_TOP_K_ESTIMATE return type: ARRAY of pairs vs
+        ARRAY<STRUCT> — affects ARRAY_SIZE handling.
+
+    BigQuery:
+      - HLL_COUNT.INIT / .MERGE / .EXTRACT — these are Theta
+        substitutions, not native Theta (BigQuery has no Theta
+        surface). Confirm the substitution still produces a
+        meaningful distinct-count via the merge path.
+      - KLL_QUANTILES.INIT_INT64 / .MERGE_POINT_INT64 — confirm the
+        INT64 specialization is the right choice vs FLOAT64 for
+        l_extendedprice (DECIMAL upcast).
+      - sketch_insert_topk_per_shard / sketch_query_topk_combine
+        currently `null` for BigQuery (no native top-K accumulator).
+        Confirm: is APPROX_TOP_COUNT actually missing the
+        accumulate/combine triplet, or is there a path we missed?
+
+    Databricks:
+      - theta_sketch_agg / theta_union_agg / theta_sketch_estimate —
+        verify these are first-class (DataSketches Spark integration
+        ships in Databricks Runtime by default).
+      - kll_sketch_agg / kll_sketch_estimate_quantile — Databricks-
+        specific function names that diverge from open-source Spark's
+        percentile_approx; confirm the override is correct.
+      - approx_top_k_accumulate / _combine / _estimate — Spark 4.1+
+        (Databricks Runtime bumps Spark version on its own cadence;
+        confirm the runtime version BenchBox targets has these).
+
+  "What Verification Looks Like": |
+    For each cloud engine with creds:
+      1. Run all 8 sketch ops at SF=0.01 on a small warehouse / job /
+         cluster.
+      2. Confirm 8/8 pass (with the new runtime expected_value_min/max
+         bounds enforced).
+      3. Re-tune bounds if the engine produces meaningfully different
+         estimates than DuckDB observed (HLL++ vs DataSketches Theta
+         have different bias profiles; KLL t-digest vs Greenwald-
+         Khanna are different algorithms).
+      4. Update the inline tolerance comments with engine-name
+         annotations (e.g. "DuckDB: 14836; Snowflake observed 15012").
+      5. If any function signature in the override is wrong, fix it
+         and document the discrepancy in the cross-platform doc.
+
+    Each engine's verification is a separate WU and produces its own
+    PR — do NOT bundle (failures on one engine shouldn't block the
+    others from landing).
+
+work:
+  - id: w1
+    summary: "Snowflake: live verification of all 8 sketch ops; reconcile any function-signature discrepancies"
+    status: pending
+    notes: |
+      Run sketch ops on a small Snowflake warehouse (XS or smaller is
+      fine for SF=0.01). Confirm 8/8 pass with the existing override
+      SQL. If DATASKETCHES_THETA_* function names diverge from current
+      Snowflake docs, update the override and document the corrected
+      signature in the cross-platform doc.
+
+      Critical-path checks:
+        - APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024) produces a sketch
+          that combines correctly via APPROX_TOP_K_COMBINE.
+        - DATASKETCHES_THETA_ACCUMULATE handles the INTEGER cast for
+          l_extendedprice without precision loss.
+        - kll_sketch_agg's quantile-estimate handles the merged
+          sketch correctly (Snowflake uses different KLL bindings
+          than the C++ DataSketches library).
+
+      Output: per-op result JSON committed somewhere appropriate
+      (or summarised in the PR description); inline tolerance comments
+      updated with Snowflake observations.
+
+  - id: w2
+    summary: "BigQuery: live verification of 6 sketch ops (skip topk pair); confirm HLL substitution behavior"
+    status: pending
+    notes: |
+      Run 6 sketch ops (skip the 2 topk ops which have `bigquery: null`)
+      on a real BigQuery project. Confirm HLL_COUNT.INIT / .MERGE
+      semantics produce the expected distinct count via the persist+
+      merge loop.
+
+      Critical-path checks:
+        - HLL_COUNT.INIT(x) produces a BYTES sketch that round-trips
+          through table storage.
+        - HLL_COUNT.MERGE(sketch_column) implicitly merges across rows
+          (no separate ACCUMULATE step needed in BigQuery — verify
+          this matches our override structure).
+        - KLL_QUANTILES.INIT_INT64 + MERGE_POINT_INT64 produces the
+          expected median for l_extendedprice (note the INT64 cast —
+          may lose decimal precision; confirm the median is still
+          meaningful).
+
+      Also revisit: is there actually a top-K accumulator in BigQuery
+      that we missed? APPROX_TOP_COUNT is documented as one-shot, but
+      check for any newer functions.
+
+  - id: w3
+    summary: "Databricks: live verification of all 8 sketch ops on Databricks Runtime"
+    status: pending
+    notes: |
+      Run sketch ops on a small Databricks warehouse / SQL endpoint
+      / cluster. Critical-path checks:
+        - theta_sketch_agg vs hll_sketch_agg: Databricks' DataSketches
+          integration may default to one or the other; confirm the
+          override matches the function actually available in the
+          target DBR.
+        - approx_top_k_accumulate availability depends on DBR Spark
+          version; if DBR is < Spark 4.1 equivalent, the topk ops will
+          fail with "function not found" — guard with a runtime
+          version check or accept the fail and skip.
+        - Photon path: are sketch UDAFs Photonised? If not, expect
+          slower latency than the SQL claims would suggest.
+
+  - id: w4
+    summary: "Update operations.yaml inline comments with verified-against-runtime-version notes"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      For each engine that completed verification, append a one-line
+      comment to its platform_overrides block noting the runtime
+      version and date verified (e.g. "# Snowflake: verified
+      2026-MM-DD against driver 3.x.y, function names confirmed").
+
+      This makes future regressions easier to triage — if an op breaks
+      after a Snowflake driver upgrade, the comment shows when it
+      last worked.
+
+  - id: w5
+    summary: "Update cross-platform sketch docs per-engine verification matrix"
+    needs: [w4]
+    status: pending
+    notes: |
+      Replace the current "untested cloud overrides" footnote in
+      `docs/benchmarks/write-primitives-sketch-functions.md` with a
+      per-engine status: which engines verified, which dates, which
+      function-name discrepancies were corrected, which expected_value
+      bounds were re-tuned per engine.
+
+  - id: w6
+    summary: "Add changelog entry under unreleased"
+    needs: [w5]
+    status: pending
+    notes: |
+      Terse user-facing bullet:
+      "write_primitives sketch: verified against {Snowflake,
+      BigQuery, Databricks} in cloud — reconciled function-signature
+      drift and re-tuned expected_value bounds per engine. See docs."
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - verification
+    - snowflake
+    - bigquery
+    - databricks
+    - cloud
+  estimated_effort: "1-2 days (per cloud engine; in parallel)"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Closes the largest known gap in PR #112's verification: cloud
+    overrides written from documented function names but never
+    actually executed. Cloud-engine sketch numbers are the headline
+    use case for the persist + merge + requery story (Databricks /
+    Snowflake / BigQuery vendors competing on this), so unverified
+    overrides are a real liability — users may run them and hit
+    function-not-found or signature-drift errors.
+  user_impact: |
+    Cloud users get sketch ops that have actually been run on their
+    engines. Tolerance bounds reflect the engine's real bias profile,
+    not DuckDB-derived numbers that may false-fail.
+  technical_debt: |
+    Resolves the "cloud verification pending" footnote in the docs and
+    in the merged TODO's PR description. Establishes the per-engine
+    runtime-version-pinned-comment pattern for future cloud-verified
+    catalog entries.
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+
+must_preserve:
+  - "Existing DuckDB sketch ops continue to pass with their current scalar-bounds validation contracts (cloud-tuning re-tunes per-engine bounds, not the DuckDB ones)."
+  - "ClickHouse sketch ops (added by `write-primitives-sketch-clickhouse-and-storage-metrics` if landed first) continue to pass — cloud verification doesn't touch ClickHouse."
+
+approach: |
+  Run each cloud verification in its own work unit / PR — failures on
+  one engine shouldn't block the others. For each engine: get creds
+  set up, run the 8 sketch ops, observe results, reconcile any
+  discrepancies, commit the corrected overrides and per-engine
+  tolerance bounds.
+
+  Tolerance bounds may need to be re-tuned per engine — this is the
+  same methodology used in the original PR #112 w5 (empirical
+  observation + wide-enough-to-not-false-fail, tight-enough-to-catch-
+  no-op). Document the engine name alongside the observed value in
+  the inline comment.
+
+  Function-signature corrections are landing-blockers for that engine
+  (the override is wrong if it doesn't run); document them prominently
+  in the PR.
+
+anti_patterns:
+  - "DO NOT bundle multi-engine verification into a single PR — because failures on one engine should not block the others — one PR per engine, each with its own w1/w2/w3 work unit."
+  - "DO NOT keep DuckDB-derived expected_value bounds for cloud engines that produce meaningfully different estimates — because that would false-fail healthy cloud sketches — re-tune per engine and document the per-engine values inline."
+  - "DO NOT loosen DuckDB bounds to accommodate cloud bias — because DuckDB's tighter bounds are a real correctness signal — keep DuckDB bounds tight and add per-engine bounds as separate annotations."
+  - "DO NOT silently drop overrides that fail — because the failure indicates a function-signature drift that future readers should know about — fix the override or remove it with a documented `# verified missing on $engine` comment."
+
+verification:
+  - description: "Snowflake: 8 sketch ops execute end-to-end with engine-tuned tolerance bounds"
+    command: "uv run -- benchbox run --platform snowflake --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table"
+    expected_output: "8/8 pass; per-engine bounds enforced"
+  - description: "BigQuery: 6 sketch ops execute (skip topk pair which is null on bigquery)"
+    command: "uv run -- benchbox run --platform bigquery --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_drop_persistent_table"
+    expected_output: "6/6 pass"
+  - description: "Databricks: 8 sketch ops execute end-to-end on a small DBR"
+    command: "uv run -- benchbox run --platform databricks --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table"
+    expected_output: "8/8 pass (or topk ops skip cleanly if DBR < Spark 4.1)"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/read_primitives/
+
+success_metrics:
+  - "All 8 sketch ops pass on at least one cloud engine (Snowflake OR BigQuery OR Databricks)"
+  - "Inline operations.yaml comments document verified-against-runtime-version per engine"
+  - "Cross-platform docs replace 'untested cloud overrides' footnote with per-engine status matrix"
+  - "Per-engine expected_value tolerance bounds documented inline alongside DuckDB defaults"
+  - "Changelog entry under unreleased per engine verified"
+
+open_questions:
+  - "Which cloud engine should be verified first when creds become available? Lean: Snowflake (DataSketches integration is well-documented); Databricks second (Databricks-Connect path adds complexity)."
+  - "Should cloud-engine bounds be re-tuned per cloud REGION too (eu-west-1 vs us-east-1 may have different driver versions)? Probably not for SF=0.01 — defer to a region-specific TODO if regional drift becomes a real source of false-fails."
+  - "Is there a cheap CI path for re-verifying cloud overrides on a schedule (e.g. monthly), or does this remain an opportunistic check whenever creds are around? Out of scope for this TODO; consider as a separate ops/CI item."

--- a/_project/TODO/main/planning/write-primitives-sketch-duckdb-cpc-req-families.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-duckdb-cpc-req-families.yaml
@@ -1,0 +1,211 @@
+id: write-primitives-sketch-duckdb-cpc-req-families
+title: "Write Primitives sketch: add DuckDB-only CPC and REQ sketch families"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  The DuckDB `datasketches` community extension exposes additional
+  sketch families beyond the Theta / KLL / Frequent-Items trio that
+  the merged write_primitives sketch category covers:
+
+  - **CPC** (Compressed Probabilistic Counting): an HLL-family
+    alternative with **smaller serialized size** at the cost of
+    slower update/merge. Functions: `datasketch_cpc(x)`,
+    `datasketch_cpc_estimate(sk)`, `datasketch_cpc_union(s1, s2)`,
+    `datasketch_cpc_lower_bound`, `datasketch_cpc_upper_bound`.
+  - **REQ** (Relative Error Quantile): an alternative quantile sketch
+    with **relative-error guarantees** (vs KLL's normalised-rank
+    error). Functions: `datasketch_req(k, x)`, `datasketch_req_quantile`,
+    `datasketch_req_rank`, `datasketch_req_cdf`, etc.
+
+  Both are DuckDB-only at the SQL surface today — no other engine in
+  BenchBox's matrix exposes them. This TODO adds DuckDB-scoped sketch
+  ops for each family so users can compare CPC vs Theta storage cost
+  and REQ vs KLL accuracy/latency in a single benchmark run.
+
+  Captured as a deferred item from the post-merge expansion review
+  (sibling to `write-primitives-sketch-clickhouse-and-storage-metrics`).
+  Lower priority because it's single-engine — does not extend the
+  cross-vendor matrix.
+
+context_sections:
+  "Why DuckDB-Only Is OK Here": |
+    The merged sketch ops shipped with BigQuery / Snowflake / Databricks
+    overrides only because those engines all share the DataSketches
+    binary format (CPC and REQ are part of the same Apache DataSketches
+    library, so they would also share the format if any cloud engine
+    surfaces them via UDFs). Today none do. Adding DuckDB-only ops
+    documents the local-extension story without misrepresenting the
+    cross-vendor support — every other engine gets a `null` override
+    and skips cleanly.
+
+  "Storage-Cost Story": |
+    The interesting CPC vs Theta comparison is **storage size**, not
+    estimate accuracy (both are HLL-family with similar error). If
+    `write-primitives-sketch-clickhouse-and-storage-metrics` lands first,
+    this TODO inherits the storage-size validation methodology and adds
+    side-by-side CPC vs Theta storage numbers in the docs.
+
+work:
+  - id: w1
+    summary: "Add 4 sketch_cpc_* ops (DDL, insert, query merge, drop) following the existing theta-op pattern"
+    status: pending
+    notes: |
+      Mirror the structure of the theta op family:
+        sketch_cpc_create_persistent_table  (BLOB column, like the
+                                             theta DDL but a separate
+                                             table to avoid mixing)
+        sketch_cpc_insert_per_partition     (datasketch_cpc(x) per partition)
+        sketch_cpc_query_union_merge        (datasketch_cpc_estimate(
+                                             datasketch_cpc(sk))) — but
+                                             note datasketch_cpc_union is
+                                             scalar, not aggregate; verify
+                                             whether a fold-aggregate exists
+                                             or use the same trick that
+                                             worked for theta (passing
+                                             sketch column to the build agg)
+        sketch_cpc_drop_persistent_table
+
+      All other engines: `clickhouse: null`, `datafusion: null`, etc.
+      Snowflake / BigQuery / Databricks have no native CPC surface.
+
+  - id: w2
+    summary: "Add 4 sketch_req_* ops following the KLL-op pattern"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror the structure of the KLL op family:
+        sketch_req_create_persistent_table
+        sketch_req_insert_per_partition     (datasketch_req(k, x))
+        sketch_req_query_quantile_merge     (datasketch_req_quantile)
+        sketch_req_drop_persistent_table
+
+      Verify the merge pattern works the same way as KLL — the
+      `datasketch_req` aggregate may or may not accept its own sketch
+      type as input for fold-merge. If not, document the limitation
+      and emit a comment in the op explaining the workaround.
+
+      Validation bounds on the merge ★ op should be empirically
+      observed at SF=0.01 (same methodology as the existing KLL op).
+
+  - id: w3
+    summary: "Update cross-platform sketch docs with CPC and REQ family rows"
+    needs: [w2]
+    status: pending
+    notes: |
+      Extend `docs/benchmarks/write-primitives-sketch-functions.md`:
+        - Add CPC and REQ rows to the family × engine support matrix.
+          All cloud engines and ClickHouse / DataFusion / Redshift
+          show "—" for these — only DuckDB ext supports.
+        - Add a side-by-side storage-size row comparing Theta vs CPC
+          (both HLL-family) and KLL vs REQ (both quantile-family) on
+          DuckDB SF=0.01.
+        - Note explicitly that CPC and REQ are part of Apache
+          DataSketches — they're "binary-portable in principle" but
+          no cloud engine surfaces them today.
+
+  - id: w4
+    summary: "Add changelog entry under unreleased"
+    needs: [w3]
+    status: pending
+    notes: |
+      Terse user-facing bullet:
+      "write_primitives sketch: add DuckDB-only CPC (alternative HLL,
+      smaller serialized size) and REQ (relative-error quantile)
+      sketch families. Other engines skip — see docs."
+
+deferred:
+  - summary: "Tuple sketches (distinct + metric aggregation)"
+    reason: "Databricks-native + Snowflake DataSketches UDAFs only. Same portability calculus as the merged TODO's deferred Tuple item — no DuckDB-extension support today."
+
+deps:
+  needs:
+    - write-primitives-sketch-clickhouse-and-storage-metrics
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - duckdb
+    - cpc
+    - req
+    - benchmark-catalog
+  estimated_effort: "0.5-1 day"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Surfaces sketch-family choice as a benchmark dimension users can
+    measure: CPC vs Theta storage tradeoff, REQ vs KLL accuracy/latency
+    tradeoff. Both are real production decisions (CPC is recommended
+    when sketch-storage cost dominates; REQ when relative error matters
+    more than rank error).
+  user_impact: |
+    Users running BenchBox on DuckDB get a richer sketch-tuning surface
+    without any other engine being affected. Cloud users see "—" rows
+    in the docs explaining the gap.
+  technical_debt: |
+    Demonstrates the per-engine sketch-family expansion path for future
+    work (e.g. when ClickHouse adds Theta UDAFs natively, or when
+    cloud engines surface CPC/REQ).
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+
+must_preserve:
+  - "All existing 117 write_primitives operations (including the 8 sketch ops) execute identically — no behavior changes to existing entries."
+  - "New CPC / REQ ops are additive; their validation contracts use the same expected_value_min/max shape introduced in PR #112."
+
+approach: |
+  Pure operations.yaml work. Mirror the theta and KLL op families one
+  for one. All non-DuckDB platform_overrides are `null` (no cloud
+  surface today). Validation tolerances are empirically observed
+  during w1/w2 against DuckDB SF=0.01.
+
+  If `write-primitives-sketch-clickhouse-and-storage-metrics` has
+  landed first, reuse its octet_length storage-size validation pattern
+  for the CPC vs Theta comparison story in w3 docs.
+
+anti_patterns:
+  - "DO NOT write Snowflake / BigQuery / Databricks overrides for CPC or REQ — because no cloud engine surfaces these families today — leave as `null` and document the gap."
+  - "DO NOT mix CPC ops into the existing theta-op family (e.g. as variants of the same op id) — because they have different storage / merge characteristics and benchmarking them as the same op would obscure the comparison — separate `sketch_cpc_*` op family."
+
+verification:
+  - description: "All write_primitives unit tests pass with new ops"
+    command: "uv run -- python -m pytest tests/unit/core/write_primitives -q"
+    expected_output: "all tests pass"
+  - description: "DuckDB end-to-end: new CPC ops execute"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_cpc_create_persistent_table,sketch_cpc_insert_per_partition,sketch_cpc_query_union_merge,sketch_cpc_drop_persistent_table"
+    expected_output: "4/4 pass; merge query value within tuned bounds"
+  - description: "DuckDB end-to-end: new REQ ops execute"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_req_create_persistent_table,sketch_req_insert_per_partition,sketch_req_query_quantile_merge,sketch_req_drop_persistent_table"
+    expected_output: "4/4 pass; merge quantile value within tuned bounds"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/read_primitives/
+
+success_metrics:
+  - "8 new DuckDB-only sketch ops (4 CPC + 4 REQ) execute end-to-end at SF=0.01"
+  - "Cross-platform docs add CPC and REQ family rows with explicit DuckDB-only annotation"
+  - "Side-by-side storage-size comparison Theta vs CPC documented (depends on storage-metrics TODO landing first)"
+  - "Changelog entry under unreleased"
+
+open_questions:
+  - "Does `datasketch_cpc` aggregate accept its own sketch type as a fold-merge input (like datasketch_theta does)? Verify in w1 — affects how the union ★ op is structured."
+  - "Should CPC and REQ ops use a shared persistent table with theta/KLL (one mega-sketch table) or separate tables per family (current design)? Lean separate — keeps ops self-contained and makes per-family DROP cleanup obvious."

--- a/_project/TODO/main/planning/write-primitives-sketch-parameter-sweeps.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-parameter-sweeps.yaml
@@ -1,0 +1,214 @@
+id: write-primitives-sketch-parameter-sweeps
+title: "Write Primitives sketch: parameter-sweep variants for sketch tuning surface (lg_k, k, lg_max_map_size)"
+worktree: main
+priority: Low
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  The merged sketch ops use one default parameter value per sketch
+  family — Theta lg_k=12 (4096 entries), KLL k=200, Top-K
+  lg_max_map_size=8 (256 entries). These defaults trade size,
+  accuracy, and update speed in fixed proportions. Real users tune
+  these for their workload — bigger k = better accuracy + larger
+  storage + slower merge.
+
+  This TODO adds parameter-sweep variants of the existing sketch ops
+  so the benchmark surfaces the sketch-tuning tradeoff directly:
+  measure storage size, build latency, merge latency, and estimate
+  error across 3 parameter values per family.
+
+  Captured as a deferred item from the post-merge expansion review.
+  Lower priority because it's a tuning-analysis dimension rather than
+  a coverage gap — the existing default-parameter ops already
+  validate the persist+merge claim; sweeps just refine the analysis.
+
+context_sections:
+  "Parameter Ranges to Sweep": |
+    Theta (lg_k controls hash entries):
+      - lg_k=10 → 1024 entries  (~5KB serialized; ~3.1% RSE)
+      - lg_k=12 → 4096 entries  (~16KB; ~1.6% RSE) ← current default
+      - lg_k=14 → 16384 entries (~64KB; ~0.8% RSE)
+
+    KLL (k controls retained items):
+      - k=100  (~1.5KB; ~1.65% normalized rank error)
+      - k=200  (~3KB;   ~1.33%) ← current default
+      - k=1000 (~15KB;  ~0.59%)
+
+    Frequent Items (lg_max_map_size controls bucket count):
+      - lg_max_map_size=6  → 64 buckets   (~256B)
+      - lg_max_map_size=8  → 256 buckets  (~600B) ← current default
+      - lg_max_map_size=10 → 1024 buckets (~2KB)
+
+    Sweep adds 6 new ops total (3 per family × 2 non-default values).
+    Top-K only sweeps 2 because lg_max_map_size=6 is too small for
+    TPC-H lineitem's 7 distinct shipmodes (would saturate).
+
+  "Why DuckDB-First": |
+    DuckDB datasketches extension parameter signatures match the
+    Apache DataSketches C++ defaults exactly — sweeps are a 1-line
+    change per op. Snowflake / BigQuery / Databricks have similar
+    parameter knobs but with different defaults and signatures
+    (e.g. Snowflake APPROX_TOP_K's `counters` vs DataSketches'
+    lg_max_map_size). Cloud overrides for parameter sweeps are out of
+    scope — single-engine sweep on DuckDB is enough to demonstrate
+    the tradeoff; cloud users can tune at their end.
+
+work:
+  - id: w1
+    summary: "Add 2 sketch_query_theta_union_merge variants at lg_k=10 and lg_k=14"
+    status: pending
+    notes: |
+      Mirror the existing `sketch_query_theta_union_merge` with two
+      new ops: `sketch_query_theta_union_merge_lgk10` and `_lgk14`.
+      Each builds with the corresponding lg_k parameter, persists,
+      merges, validates the distinct count is in tolerance bounds.
+
+      The bounds at lg_k=10 will be wider (higher RSE → more variance)
+      and at lg_k=14 will be tighter — observe empirically and
+      document inline.
+
+  - id: w2
+    summary: "Add 2 sketch_query_kll_quantiles_merge variants at k=100 and k=1000"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror `sketch_query_kll_quantiles_merge` with `_k100` and
+      `_k1000` variants. Bounds reflect the relative accuracy: k=100
+      median estimate may drift further from true; k=1000 should be
+      tighter.
+
+  - id: w3
+    summary: "Add 2 sketch_query_topk_combine variants at lg_max_map_size=8 and 10 (skip 6 — too small for TPC-H)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror `sketch_query_topk_combine` with `_lgmm8` (current
+      default; explicit variant for sweep symmetry) and `_lgmm10`.
+      Both should still report 7 frequent items deterministically
+      (lineitem has 7 distinct shipmodes); the difference shows up in
+      build/merge latency and storage size, not the estimate count.
+
+  - id: w4
+    summary: "Update cross-platform sketch docs with parameter-sweep methodology and observed numbers"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      Add a "Parameter sweeps" section to
+      `docs/benchmarks/write-primitives-sketch-functions.md`:
+        - Why this dimension matters (the size / accuracy / latency
+          tradeoff is real and workload-dependent).
+        - Sweep parameter ranges per family with
+          DataSketches-recommended bounds.
+        - Observed numbers at SF=0.01 on DuckDB:
+          storage size, build latency, merge latency per parameter
+          value. Side-by-side bar charts (textcharts) optional.
+        - Cloud parameter mapping guidance: how to translate
+          DataSketches lg_k to Snowflake / Databricks equivalent
+          knobs (different defaults, different scales).
+
+  - id: w5
+    summary: "Add changelog entry under unreleased"
+    needs: [w4]
+    status: pending
+    notes: |
+      Terse user-facing bullet:
+      "write_primitives sketch: add parameter-sweep variants
+      (sketch_query_*_merge_{lgk10,lgk14,k100,k1000,lgmm8,lgmm10})
+      for tuning analysis on DuckDB. Cloud parameter-knob mapping
+      guidance in docs."
+
+deferred:
+  - summary: "Cloud-engine parameter-sweep overrides"
+    reason: "Each cloud engine has different parameter knobs and defaults; sweeping all 3 families × 3 values × 3 cloud engines = 27 new overrides per family. Out of proportion with the analytical value. DuckDB-only sweep is enough to demonstrate the tradeoff; cloud users tune at their end with vendor-specific knobs."
+
+deps:
+  needs:
+    - write-primitives-sketch-clickhouse-and-storage-metrics
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - tuning
+    - duckdb
+    - benchmark-catalog
+  estimated_effort: "0.5 day"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Surfaces sketch tuning as a benchmark dimension users can measure
+    rather than guess. The size/accuracy tradeoff is real and
+    workload-dependent — having BenchBox numbers for the trade
+    points lets users pick parameters confidently.
+  user_impact: |
+    Users can read the docs to see "lg_k=10 saves 11KB per partition
+    at the cost of 1.5x estimate error" and decide whether the saving
+    matters for their workload — without having to set up the sweep
+    themselves.
+  technical_debt: |
+    None. Pure additive ops with no schema or runtime changes. Reuses
+    the existing storage-size validation infrastructure (depends on
+    `write-primitives-sketch-clickhouse-and-storage-metrics` landing
+    first to inherit that methodology).
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+
+must_preserve:
+  - "Existing sketch_query_theta_union_merge / _kll_quantiles_merge / _topk_combine ops execute identically — sweep variants are net-new ops with distinct IDs."
+  - "Validation contracts on sweep variants use the same expected_value_min/max + expected_storage_min/max shape as the default ops."
+
+approach: |
+  Pure operations.yaml work. For each new variant:
+    - Copy the default op's write_sql; change the parameter literal.
+    - Re-tune expected_value_min/max empirically against DuckDB
+      (RSE / accuracy is parameter-dependent).
+    - Re-tune storage-size bounds to match the new parameter value.
+    - Add a one-line description noting the parameter delta.
+  All non-DuckDB platform_overrides are `null` — sweeps are
+  DuckDB-only by design.
+
+anti_patterns:
+  - "DO NOT add cloud-engine overrides for sweep variants — because each cloud has its own parameter mapping (Snowflake counters vs DataSketches lg_max_map_size, etc.) and 27 new overrides are out of proportion with the value — DuckDB-only sweep, cloud guidance in docs only."
+  - "DO NOT sweep with extreme values that wouldn't be used in production (e.g. lg_k=4 = 16 entries) — because the resulting estimates would be useless and the bounds would be impossible to set meaningfully — stick to DataSketches-recommended ranges."
+  - "DO NOT collapse sweep variants into a single parameterised op — because BenchBox treats each op as a discrete measurement unit and parameterising would require runtime parameter-injection plumbing — separate ops per parameter value."
+
+verification:
+  - description: "All write_primitives unit tests pass with new sweep variants"
+    command: "uv run -- python -m pytest tests/unit/core/write_primitives -q"
+    expected_output: "all tests pass"
+  - description: "DuckDB end-to-end: theta lg_k sweep variants execute"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_query_theta_union_merge_lgk10,sketch_query_theta_union_merge_lgk14"
+    expected_output: "2/2 pass; storage size at lg_k=10 < default < lg_k=14 as observed"
+  - description: "DuckDB end-to-end: KLL k sweep variants execute"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_query_kll_quantiles_merge_k100,sketch_query_kll_quantiles_merge_k1000"
+    expected_output: "2/2 pass; storage size at k=100 < default < k=1000"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/read_primitives/
+
+success_metrics:
+  - "6 new sketch parameter-sweep ops (2 theta + 2 KLL + 2 topk) execute end-to-end on DuckDB SF=0.01"
+  - "Cross-platform docs gain a Parameter sweeps section with observed storage / latency / accuracy numbers per parameter value"
+  - "Cloud parameter-knob mapping guidance documented (no new overrides)"
+  - "Changelog entry under unreleased"
+
+open_questions:
+  - "Is there a cleaner way to label sweep variants than `_lgk10` / `_lgk14` suffix? Lean: keep the suffix — explicit and grep-friendly. Reconsider if the catalog gets cluttered with dozens of sweep variants."
+  - "Should the storage-size bounds for sweep variants be tuned to a single observation or to the bound family (e.g., lg_k=10 should be ~25% of lg_k=12 size)? Lean: empirical per-variant bounds with inline rationale comments — same pattern as the default ops."

--- a/_project/TODO/main/planning/write-primitives-sketch-pyspark-dataframe-surface.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-pyspark-dataframe-surface.yaml
@@ -1,0 +1,235 @@
+id: write-primitives-sketch-pyspark-dataframe-surface
+title: "Write Primitives sketch: add PySpark-only DataFrame surface for sketch persist + merge"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  The merged write_primitives sketch category exposes the persist +
+  merge + requery loop only on the SQL surface (8 ops). PySpark is
+  the only DataFrame engine in BenchBox's matrix with a comparable
+  DataFrame-side sketch API:
+
+  - `pyspark.sql.functions.hll_sketch_agg(col)` (Spark 3.5+) — builds
+    DataSketches HLL state, returns BINARY column.
+  - `pyspark.sql.functions.hll_union_agg(col)` — merges HLL states.
+  - `pyspark.sql.functions.hll_sketch_estimate(col)` — extracts count.
+  - `pyspark.sql.functions.approx_top_k_accumulate(col)` (Spark 4.1+)
+    + `_combine` + `_estimate` — same triplet for top-K.
+  - `percentile_approx(col, p)` for KLL-equivalent (no separate
+    accumulate/combine triplet at the DataFrame layer).
+
+  This TODO adds a Spark-only DataFrame implementation of the sketch
+  ops, mirroring the SQL category's structure. It does NOT extend the
+  cross-engine matrix — Polars / DataFusion / Pandas / Modin / cuDF /
+  Dask have no DataFrame-layer sketch persistence today.
+
+  Captured as a deferred item from the post-merge expansion review and
+  the DataFrame approximate-aggregates research (TODO #121's deferred
+  list).
+
+context_sections:
+  "Why Single-Engine Showcase Is Worth Doing": |
+    The SQL sketch ops already work on PySpark via the Spark SQL
+    `theta_sketch_agg` / `hll_sketch_agg` UDAFs (assuming the
+    DataSketches UDAF library is loaded). Adding a DataFrame surface
+    is technically redundant for users who can write SQL. But:
+
+      - It demonstrates the BenchBox DataFrame execution-mode story
+        for sketches — currently zero DataFrame engines have any
+        sketch ops at all on the write side.
+      - It exercises the persist+merge claim in a different idiom
+        (DataFrame chaining vs SQL CTE) which has different
+        optimisation opportunities.
+      - PySpark Connect (and therefore Databricks Connect, Snowpark
+        Connect, etc.) inherits the surface — enabling future
+        cross-engine DataFrame comparisons if those engines ship the
+        equivalent DataSketches functions.
+
+  "Spark Version Floor Considerations": |
+    HLL sketches: Spark 3.5+. BenchBox's PySpark adapter currently
+    targets >= 3.5, so this is a soft floor.
+    Top-K accumulate/combine/estimate: Spark 4.1+. Many BenchBox-
+    supported PySpark deployments are on 3.5 / 4.0 — top-K ops must
+    guard with a runtime version check and skip cleanly on older
+    versions rather than failing.
+
+work:
+  - id: w1
+    summary: "Investigate write_primitives DataFrame execution model — confirm whether dataframe_operations.py has any prior art for sketch-style multi-step ops"
+    status: pending
+    notes: |
+      Read `benchbox/core/write_primitives/dataframe_operations.py` to
+      understand: (a) whether dataframe-mode write ops exist today;
+      (b) what the registration / dispatch pattern looks like; (c)
+      whether validation contracts are honored on the dataframe side
+      or only SQL. This is a research-first work unit — we may discover
+      that BenchBox's write_primitives DataFrame surface is structurally
+      different from read_primitives' (which uses the
+      DataFrameContext / expression_impl / pandas_impl pattern).
+
+      Output: a short doc note (in the TODO file or a scratch doc)
+      summarising what the implementation pattern needs to look like
+      for sketch ops.
+
+  - id: w2
+    summary: "Add PySpark dataframe_operations for HLL persist + merge (mirrors sketch_query_theta_union_merge)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Build a DataFrame-side equivalent of `sketch_query_theta_union_merge`:
+        - groupBy(date, region).agg(F.hll_sketch_agg("l_orderkey"))
+          to produce per-partition HLL sketches in a BINARY column.
+        - Persist (Delta or Parquet) — measure write latency.
+        - Read back, merge with F.hll_union_agg, estimate with
+          F.hll_sketch_estimate — measure merge+requery latency.
+      Include in the result_contract a tolerance-bounded distinct
+      count (re-tune empirically against PySpark; HLL++ vs DataSketches
+      HLL produce different bias).
+
+  - id: w3
+    summary: "Add PySpark dataframe_operations for top-K accumulate + combine (Spark 4.1+ guarded)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror `sketch_query_topk_combine` using
+      F.approx_top_k_accumulate("l_shipmode") /
+      F.approx_top_k_combine(sketch) / F.approx_top_k_estimate(sketch).
+
+      Runtime guard: if PySpark version < 4.1, skip the op cleanly with
+      an informative log message (do NOT raise) — the SQL sibling
+      handles this via platform_overrides; the DataFrame side needs an
+      equivalent check at op load time or at first-call.
+
+  - id: w4
+    summary: "Document the PySpark-only DataFrame sketch surface in cross-platform docs"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Extend `docs/benchmarks/write-primitives-sketch-functions.md`
+      with a "DataFrame surface" section noting:
+        - Only PySpark has DataFrame-side sketch persistence today
+          (HLL ≥ Spark 3.5, top-K ≥ Spark 4.1).
+        - Cross-link to the SQL sibling ops so users can compare
+          DataFrame-mode vs SQL-mode latency on the same engine.
+        - Note that other DataFrame engines (Polars, DataFusion, Dask)
+          have no sketch persistence path — re-evaluate when they
+          ship native equivalents (link to upstream issues).
+
+  - id: w5
+    summary: "Add changelog entry under unreleased"
+    needs: [w4]
+    status: pending
+    notes: |
+      Terse user-facing bullet:
+      "write_primitives sketch (DataFrame): add PySpark-only HLL
+      persist+merge ops (Spark 3.5+) and top-K accumulate+combine
+      ops (Spark 4.1+). Other DataFrame engines have no comparable
+      surface today — see docs."
+
+deferred:
+  - summary: "PySpark KLL DataFrame surface (state-builder + merge)"
+    reason: "Spark exposes percentile_approx as a one-shot aggregate but no DataFrame-layer accumulate/combine/estimate triplet for KLL. Wait until kll_sketch_agg ships at the DataFrame layer (currently SQL-UDAF-only via DataSketches Spark integration)."
+  - summary: "DataFrame-side storage-size validation for sketch persistence"
+    reason: "Storage-size methodology is being added in `write-primitives-sketch-clickhouse-and-storage-metrics` for the SQL surface. Once that lands, mirror it for the DataFrame surface — but do that as a follow-up, not in this TODO."
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - write-primitives
+    - sketches
+    - pyspark
+    - dataframe
+    - benchmark-catalog
+  estimated_effort: "1-2 days"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Activates the BenchBox DataFrame execution mode for write-side
+    sketch persistence on PySpark — currently zero DataFrame engines
+    in BenchBox's matrix have any sketch ops at all. Demonstrates the
+    Spark-DataSketches DataFrame story for users who prefer DataFrame
+    APIs to SQL.
+  user_impact: |
+    PySpark / Databricks DataFrame users get a DataFrame-mode equivalent
+    of the SQL sketch ops, comparable head-to-head. Other DataFrame
+    engines see "—" rows in the docs explaining the gap.
+  technical_debt: |
+    Establishes a precedent for DataFrame-side sketch ops that future
+    engines (when they ship sketch APIs at the DataFrame layer) can
+    extend. Validates that BenchBox's DataFrame execution model can
+    handle multi-step persist + merge workflows, not just single-pass
+    aggregates.
+
+files_affected:
+  modified:
+    - benchbox/core/write_primitives/dataframe_operations.py
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  added:
+    - tests/unit/core/write_primitives/test_dataframe_sketch_ops.py
+
+must_preserve:
+  - "All existing 117 SQL write_primitives operations execute identically — DataFrame additions are net-new and do not touch the SQL catalog."
+  - "PySpark adapter remains usable on Spark < 4.1 (top-K ops skip cleanly)."
+
+approach: |
+  Start with w1 as a research spike — read dataframe_operations.py
+  before designing. The pattern may differ from read_primitives'
+  expression_impl / pandas_impl split because write ops have
+  validation_queries + cleanup_sql phases that don't map cleanly to
+  DataFrame fluent APIs. If the existing pattern requires significant
+  extension, that itself becomes a scope question to surface back to
+  the user before continuing.
+
+  HLL ops first (Spark 3.5+ stable surface). Top-K ops second with the
+  version guard. KLL is deferred — Spark doesn't ship a DataFrame-
+  layer accumulate/combine triplet for KLL today.
+
+anti_patterns:
+  - "DO NOT mirror the 8 SQL sketch ops 1-for-1 in DataFrame mode — because the DataFrame fluent-API idiom doesn't match the SQL CTE idiom (e.g. CREATE TABLE + INSERT + SELECT in one op) — express each persist+merge cycle as its own DataFrame chain and document the mapping in w4 docs, not in op IDs."
+  - "DO NOT crash on Spark < 4.1 when top-K ops are invoked — because the BenchBox PySpark adapter is documented to support Spark 3.5+ — runtime-guard with a version check and skip cleanly with a logged reason."
+  - "DO NOT add KLL DataFrame ops in this TODO — because Spark's KLL surface is SQL-UDAF-only today and a DataFrame chain would need to fall back to percentile_approx (which is one-shot, defeats the persist+merge story) — explicit deferred item."
+  - "DO NOT extend BenchBox's DataFrame execution model beyond what dataframe_operations.py already supports — because that's a structural change with broader scope implications — surface the need to the user before extending."
+
+verification:
+  - description: "PySpark unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/core/write_primitives -q"
+    expected_output: "all tests pass, including new test_dataframe_sketch_ops.py"
+  - description: "PySpark live: HLL persist+merge DataFrame ops execute end-to-end"
+    command: "uv run -- benchbox run --platform pyspark --benchmark write_primitives --scale 0.01 --queries sketch_df_hll_persist_merge"
+    expected_output: "op completes; merged distinct estimate within tolerance bounds"
+  - description: "Top-K ops skip cleanly on Spark < 4.1 (if local Spark is older)"
+    command: "uv run -- benchbox run --platform pyspark --benchmark write_primitives --scale 0.01 --queries sketch_df_topk_accumulate_combine"
+    expected_output: "either passes (Spark 4.1+) or skips with a clear 'requires Spark 4.1+' log message — no crash"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/dataframe_operations.py
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - tests/unit/core/write_primitives/
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/read_primitives/
+
+success_metrics:
+  - "PySpark DataFrame-mode sketch ops (HLL persist+merge; top-K accumulate+combine) execute end-to-end at SF=0.01 on a local Spark"
+  - "Top-K ops skip cleanly on Spark < 4.1 with a clear log message"
+  - "Cross-platform docs document PySpark as the only DataFrame engine with sketch persistence today, with cross-link to the SQL sibling"
+  - "Changelog entry under unreleased"
+
+open_questions:
+  - "What's the existing dataframe_operations.py pattern? w1 is a research spike — implementation design depends on it. May surface a need to extend BenchBox's DataFrame execution model before this TODO can proceed."
+  - "Should Databricks Connect / Snowpark Connect be tested too, or is local PySpark coverage sufficient? Lean: local PySpark only for this TODO; cross-engine Connect verification is its own scope."
+  - "Spark 4.1 hasn't shipped GA at the time of this TODO's creation (2026-05). If 4.1 GA is delayed, the top-K work unit (w3) may need to be deferred or guarded behind a Spark master/preview build. Re-evaluate at implementation time."


### PR DESCRIPTION
## Summary

Five new planning TODOs sweeping the post-merge expansion menu for the \`write_primitives\` sketch category (PR #112 sibling).

### Recommended (Tier 1 — implement next)
- **\`write-primitives-sketch-clickhouse-and-storage-metrics\`** (Medium-High, 7 work units)
  - ClickHouse-native \`-State\`/\`-Merge\` variants completing the cross-engine matrix
  - Storage-size validation on the 3 ★ headline ops via \`octet_length\` + the existing \`expected_value_min/max\` contract
  - Locally verifiable today (chDB + DuckDB regression)

### Deferred (Tier 2 — captured for future work)
- **\`write-primitives-sketch-duckdb-cpc-req-families\`** (Medium, 4 WUs) — DuckDB-only CPC + REQ sketch families. Depends on storage-metrics for the storage-cost story.
- **\`write-primitives-sketch-pyspark-dataframe-surface\`** (Medium, 5 WUs) — PySpark-only DataFrame-mode sketch persistence with \`hll_sketch_agg\`/\`hll_union_agg\` and Spark 4.1+ \`approx_top_k_*\`. Spike work unit first to investigate \`dataframe_operations.py\` model.
- **\`write-primitives-sketch-parameter-sweeps\`** (Low, 5 WUs) — \`lg_k\` / \`k\` / \`lg_max_map_size\` sweep variants for sketch tuning analysis on DuckDB. Depends on storage-metrics.
- **\`write-primitives-sketch-cloud-verification\`** (Medium, 6 WUs) — Live verification of Snowflake / BigQuery / Databricks overrides when creds become available. One PR per cloud engine; resolves the "untested cloud overrides" footnote from PR #112.

### Inter-item dependency graph

\`\`\`
storage-metrics (Tier 1)
    ├── duckdb-cpc-req-families
    └── parameter-sweeps

pyspark-dataframe-surface     (independent)
cloud-verification            (blocked on credential availability)
\`\`\`

### Anti-patterns flagged across the set
- DO NOT make ClickHouse \`AggregateFunction(...)\` columns binary-portable to DataSketches (different formats; document the model difference).
- DO NOT add cloud-engine overrides for sweep variants (27 new overrides for marginal value; DuckDB sweep is enough).
- DO NOT bundle multi-engine cloud verification into one PR (failures on one engine should not block others).
- DO NOT silently substitute cloud-engine bounds with DuckDB-derived values (different bias profiles; per-engine tuning required).
- DO NOT crash on Spark < 4.1 for top-K DataFrame ops (runtime-guard with version check, skip cleanly).

## Test plan

- [x] All 5 TODOs validate clean via \`validate_todo.py\`
- [x] \`todo_cli.py check-graph\` clean (43 items checked, no DAG cycles, no dangling refs)
- [x] \`todo_cli.py next\` resolves work-unit dependency edges as designed
- [ ] No code changes — implementation will be a series of separate PRs per TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)