### PR TITLE
chore(todo): plan Redshift maximum approximate-coverage expansion

### DIFF
--- a/_project/TODO/main/planning/redshift-maximum-approximate-coverage.yaml
+++ b/_project/TODO/main/planning/redshift-maximum-approximate-coverage.yaml
@@ -1,0 +1,445 @@
+id: redshift-maximum-approximate-coverage
+title: "Redshift: bring approximate-aggregate + sketch coverage to the natural HLL-only ceiling"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  Audit of Redshift's approximate-aggregate surface (2026-05-02)
+  found that BenchBox supports Redshift to maximum extent on **2 of 5**
+  new read_primitives approximate queries and **0 of 4** HLL-applicable
+  write_primitives sketch ops. Closable gap is **1 read variant + 4
+  write HLL variants** in a single catalog-only PR.
+
+  Redshift's complete approximate surface is **HLL-only**: no top-K, no
+  T-Digest, no KLL, no Theta, no CMS, no frequency-estimation
+  aggregate. The April 2026 "Top-K optimization" announcement was an
+  internal optimizer change for `ORDER BY … LIMIT N`, not a new
+  function family. So "maximum coverage" means: (a) every existing
+  query that maps to an HLL or `APPROXIMATE PERCENTILE_DISC` path runs
+  on Redshift; (b) the HLL persist + merge + requery loop is exercised
+  end-to-end; (c) ops that can't run on Redshift skip with explicit
+  rationale comments instead of bare `null`.
+
+  This TODO closes the gap. Verification end-to-end requires Redshift
+  credentials BenchBox doesn't currently have locally — the catalog
+  changes ship pre-cloud-verification with sqlglot static-parse
+  validation, then the cloud-verification TODO
+  (`write-primitives-sketch-cloud-verification`) picks up Redshift as
+  another engine to run when creds become available.
+
+context_sections:
+  "Redshift Approximate Surface (full inventory)": |
+    Verified against AWS Redshift docs (Aggregate functions index,
+    HyperLogLog functions, APPROXIMATE PERCENTILE_DISC) on 2026-05-02:
+
+      - APPROXIMATE COUNT(DISTINCT col) — HLL distinct, ~2% rel error.
+      - APPROXIMATE PERCENTILE_DISC(p) WITHIN GROUP (ORDER BY x)
+        — quantile-summary, ~0.5% rel error. GROUP BY result-set is
+        capped per node-type; oversize groups raise an error and need
+        fallback to exact PERCENTILE_CONT.
+      - HLL(col) — one-shot HLL distinct count returning BIGINT (lower-
+        level equivalent of APPROXIMATE COUNT(DISTINCT)).
+      - HLL_CREATE_SKETCH(col) — aggregate; returns HLLSKETCH per group.
+      - HLL_COMBINE(sketch_col) — aggregate; unions HLLSKETCH rows
+        into one merged sketch.
+      - HLL_COMBINE_SKETCHES(s1, s2[, s3…]) — scalar; pairwise/N-ary
+        union (useful for join-style sketch combinations).
+      - HLL_CARDINALITY(sketch) — scalar; extracts BIGINT estimate
+        from a sketch.
+      - HLLSKETCH data type — persistent sketch column. Fixed
+        logm=15; ~10–11 KB dense.
+
+    No top-K, no T-Digest, no KLL, no Theta, no CMS, no frequency-
+    estimation aggregate. UDF emulation would measure UDF dispatch,
+    not sketch perf — explicitly out of scope.
+
+  "HLLSKETCH Column Constraints (must respect)": |
+    HLLSKETCH columns have non-trivial DDL/query restrictions that
+    don't fit the BINARY-portable model used elsewhere:
+
+      - Cannot be DISTKEY / SORTKEY / PRIMARY KEY / FOREIGN KEY.
+      - Cannot appear in GROUP BY / ORDER BY / DISTINCT clauses.
+      - Fixed logm=15 (no precision tuning knob — the parameter-sweep
+        TODO does not apply to Redshift).
+      - JDBC/ODBC drivers return HLLSKETCH as VARCHAR JSON/Base64
+        (opaque text in driver result rows; validation paths must
+        treat as text, not binary).
+      - Not supported in Spectrum, Python UDFs.
+
+    Implications: query ops must GROUP BY a non-sketch column (e.g.
+    `region`); DDL must use DISTSTYLE EVEN (or AUTO), no SORTKEY on
+    sketch columns; storage-size validation needs to use LENGTH() on
+    the VARCHAR representation OR a Redshift-specific SQL escape.
+
+  "sqlglot Redshift Dialect Gaps": |
+    Verified locally against sqlglot 30.6.0:
+
+      - APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY x)
+        — ParseError at the `(` after PERCENTILE_DISC. The APPROXIMATE
+        qualifier on aggregates other than COUNT(DISTINCT) is not
+        modeled. Workaround: hand-written redshift: variant; bypass
+        sqlglot via the existing per-engine variant mechanism (same
+        approach used elsewhere when sqlglot's parser falls behind).
+      - APPROX_QUANTILE → passes through unchanged (silent breakage).
+        This is why approx_quantile_groupby currently skips on Redshift.
+      - APPROX_COUNT_DISTINCT → correctly rewritten to
+        APPROXIMATE COUNT(DISTINCT …). What lets the 2 distinct
+        queries support Redshift today.
+      - HLL, HLL_CREATE_SKETCH, HLL_COMBINE, HLL_COMBINE_SKETCHES,
+        HLL_CARDINALITY → all round-trip correctly as anonymous
+        functions. Safe to use in hand-written variants.
+      - CREATE TABLE (s HLLSKETCH) → parses + emits correctly.
+
+  "Why Per-Op DDL, Not Generic _BINARY_TYPE_BY_DIALECT": |
+    The existing `_BINARY_TYPE_BY_DIALECT` mapping in
+    `benchbox/core/write_primitives/schema.py` already maps
+    `BINARY → HLLSKETCH` for redshift, but no op activates this path
+    today. Tempting to wire it through; safer to leave it alone.
+
+    The mapping turns one logical BINARY into one dialect type, but
+    HLLSKETCH semantics differ enough (no DISTKEY/SORTKEY/GROUP BY)
+    that future ops touching the generic translator could silently
+    break on Redshift. Per-op explicit DDL in platform_overrides is
+    safer — each Redshift override states its own constraints in
+    plain SQL, no abstraction-leakage risk.
+
+work:
+  - id: w1
+    summary: "Add hand-written redshift: variant for approx_quantile_groupby using APPROXIMATE PERCENTILE_DISC"
+    status: pending
+    notes: |
+      In `benchbox/core/read_primitives/catalog/queries.yaml`,
+      add a `redshift:` entry under the existing `variants:` block of
+      `approx_quantile_groupby`:
+
+        redshift: |2
+
+          SELECT
+              l_shipmode,
+              APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY l_quantity) as median_quantity
+          FROM lineitem
+          GROUP BY l_shipmode;
+
+      Drop `redshift` from the existing `skip_on: [redshift, sqlite]`
+      list (leave sqlite). The variant_contracts checker will fail to
+      parse the variant via sqlglot — confirm the existing checker
+      gracefully accepts a variant_parse_error vs hard-failing the
+      catalog. If it hard-fails, the variant_contracts test needs an
+      allowlist entry for this specific Redshift parse limitation
+      (precedent: investigate during w1 — may need a follow-up
+      `# variant_contracts: allow-parse-failure(redshift)` marker if
+      no precedent exists).
+
+      l_shipmode has 7 distinct values, well under any per-node group
+      cap, so the GROUP BY size restriction doesn't apply here.
+
+  - id: w2
+    summary: "Add Redshift HLL DDL override for sketch_ddl_create_persistent_table"
+    status: pending
+    notes: |
+      In `benchbox/core/write_primitives/catalog/operations.yaml`,
+      replace the `redshift: null` for `sketch_ddl_create_persistent_table`
+      with:
+
+        redshift: |
+          DROP TABLE IF EXISTS sketch_ops_daily_users;
+          CREATE TABLE sketch_ops_daily_users (
+            activity_date DATE,
+            region VARCHAR(25),
+            user_sketch HLLSKETCH,
+            rev_sketch HLLSKETCH
+          )
+          DISTSTYLE EVEN;
+
+      Notes:
+        - DISTSTYLE EVEN required: HLLSKETCH cannot be DISTKEY/SORTKEY.
+        - No PRIMARY KEY: HLLSKETCH cannot be PK/FK either.
+        - This activates the previously-unused HLLSKETCH path on Redshift.
+
+      For the validation_query, the existing `SELECT COUNT(*) FROM
+      information_schema.tables WHERE table_name = 'sketch_ops_daily_users'`
+      should work as-is.
+
+  - id: w3
+    summary: "Add Redshift HLL insert override for sketch_insert_theta_per_partition (replaces theta with HLL)"
+    needs: [w2]
+    status: pending
+    notes: |
+      Replace `redshift: null` with:
+
+        redshift: |
+          DROP TABLE IF EXISTS sketch_ops_daily_users;
+          CREATE TABLE sketch_ops_daily_users (
+            activity_date DATE, region VARCHAR(25),
+            user_sketch HLLSKETCH, rev_sketch HLLSKETCH
+          ) DISTSTYLE EVEN;
+          INSERT INTO sketch_ops_daily_users
+          SELECT l_shipdate, l_returnflag,
+                 HLL_CREATE_SKETCH(l_orderkey),
+                 HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))
+          FROM lineitem
+          GROUP BY l_shipdate, l_returnflag;
+
+      This is the HLL equivalent of the theta-style persist op. The op
+      ID stays `sketch_insert_theta_per_partition` because the
+      benchmark measurement is "build a sketch per partition" — HLL is
+      Redshift's expression of that capability. Document the family
+      substitution in the cross-platform doc (w7).
+
+      The existing validation_query (`SELECT COUNT(*) as partitions
+      FROM sketch_ops_daily_users` with `expected_rows_min: 1`) works
+      unchanged.
+
+  - id: w4
+    summary: "Add Redshift HLL merge override for sketch_query_theta_union_merge ★ headline op"
+    needs: [w3]
+    status: pending
+    notes: |
+      Replace `redshift: null` with the HLL persist+merge+requery
+      lifecycle:
+
+        redshift: |
+          DROP TABLE IF EXISTS sketch_ops_daily_users;
+          CREATE TABLE sketch_ops_daily_users (
+            activity_date DATE, region VARCHAR(25),
+            user_sketch HLLSKETCH, rev_sketch HLLSKETCH
+          ) DISTSTYLE EVEN;
+          INSERT INTO sketch_ops_daily_users
+          SELECT l_shipdate, l_returnflag,
+                 HLL_CREATE_SKETCH(l_orderkey),
+                 HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))
+          FROM lineitem GROUP BY l_shipdate, l_returnflag;
+          SELECT HLL_CARDINALITY(HLL_COMBINE(user_sketch)) AS distinct_orders
+          FROM sketch_ops_daily_users;
+
+      For the validation_query, mirror the existing DuckDB
+      `theta_estimate_in_range` pattern — the SELECT returns the
+      merged distinct estimate; assert it falls in
+      [expected_value_min, expected_value_max].
+
+      Tolerance bounds: HLL++ (Redshift's implementation) produces
+      different bias than DataSketches Theta. Cannot tune empirically
+      without Redshift creds — set initial bounds wide
+      (e.g. [12000, 18000] vs DuckDB's [14000, 16000]) and document
+      "Redshift bounds initial estimate; re-tune in cloud-verification
+      TODO" inline. Same approach used for cloud overrides in PR #112.
+
+  - id: w5
+    summary: "Add Redshift DROP override for sketch_drop_persistent_table"
+    needs: [w2]
+    status: pending
+    notes: |
+      Trivial mirror of w2 with explicit DROP at the end:
+
+        redshift: |
+          DROP TABLE IF EXISTS sketch_ops_daily_users;
+          CREATE TABLE sketch_ops_daily_users (
+            activity_date DATE, region VARCHAR(25),
+            user_sketch HLLSKETCH, rev_sketch HLLSKETCH
+          ) DISTSTYLE EVEN;
+          DROP TABLE sketch_ops_daily_users;
+
+  - id: w6
+    summary: "Tighten skip-rationale comments on the 4 ops that legitimately stay null on Redshift"
+    needs: [w4]
+    status: pending
+    notes: |
+      For these ops, replace bare `redshift: null` with an explicit
+      rationale comment:
+        - sketch_insert_kll_per_partition:
+          `redshift: null  # Redshift has no KLL or T-Digest sketch family`
+        - sketch_insert_topk_per_shard:
+          `redshift: null  # Redshift has no top-K function family`
+        - sketch_query_kll_quantiles_merge:
+          `redshift: null  # Redshift has no KLL or T-Digest sketch family`
+        - sketch_query_topk_combine:
+          `redshift: null  # Redshift has no top-K function family`
+
+      Documentation hygiene: prevents the next reader re-asking
+      "could we add Redshift coverage for this op" because it's
+      already answered inline.
+
+  - id: w7
+    summary: "Update cross-platform sketch docs with Redshift HLL coverage and HLL-only ceiling"
+    needs: [w4, w6]
+    status: pending
+    notes: |
+      Two docs touched:
+
+      `docs/benchmarks/read-primitives-approximate-functions.md`:
+        - In the Single-quantile table, change Redshift from "(skipped)"
+          to "APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY x)
+          — YAML variant" with a footnote on the per-node GROUP BY size
+          cap.
+
+      `docs/benchmarks/write-primitives-sketch-functions.md`:
+        - In the family × engine support matrix: change Redshift from
+          "(skipped)" on Theta to "HLL substitution (HLL_CREATE_SKETCH /
+          HLL_COMBINE / HLL_CARDINALITY)" with a footnote explaining
+          HLL is Redshift's expression of distinct-counting persist+
+          merge.
+        - Confirm the per-engine column-type table still says
+          "Redshift: HLLSKETCH (HLL family only)" — it does, but
+          add the constraint annotations (cannot be DISTKEY/SORTKEY/
+          GROUP BY/etc.).
+        - Add a "Redshift HLL-only ceiling" subsection noting that
+          Redshift fundamentally lacks Theta / KLL / Top-K and thus
+          stays skipped on those sketch families. Pre-empts the
+          "why no top-K" question.
+
+  - id: w8
+    summary: "Add changelog entry under unreleased"
+    needs: [w7]
+    status: pending
+    notes: |
+      Two terse user-facing bullets:
+      "read_primitives: add Redshift variant for approx_quantile_groupby
+      using APPROXIMATE PERCENTILE_DISC. Was skipped (sqlglot parser gap)."
+      "write_primitives sketch: add Redshift HLL coverage for the 4
+      HLL-applicable ops (DDL, theta-style insert, theta-style merge,
+      drop) using HLL_CREATE_SKETCH / HLL_COMBINE / HLL_CARDINALITY.
+      KLL / Top-K ops stay skipped — Redshift has no equivalent."
+
+deferred:
+  - summary: "Native HLL(col) one-shot variant of approx_count_distinct_simple"
+    reason: "Functionally identical to APPROXIMATE COUNT(DISTINCT) which sqlglot already rewrites to. Adding HLL(col) explicitly would double-count the same code path without measuring anything different."
+  - summary: "HLL_COMBINE_SKETCHES scalar variant for join-style sketch combinations"
+    reason: "Useful for combining sketches across pre-aggregated tables via a join — but the current write_primitives shape is single-table partition-merge. Out of scope until a multi-table sketch op is added."
+  - summary: "sqlglot upstream PR for APPROXIMATE PERCENTILE_DISC parsing"
+    reason: "Nice-to-have; would eliminate the need for the hand-written w1 variant. Not blocking — per-engine variant works today. File as a separate sqlglot upstream issue if/when bandwidth allows."
+  - summary: "Activating the existing _BINARY_TYPE_BY_DIALECT[redshift] = HLLSKETCH translator path"
+    reason: "Per-op explicit DDL in platform_overrides is safer than the generic translator (HLLSKETCH semantic constraints don't fit the BINARY abstraction — DISTKEY / SORTKEY / GROUP BY restrictions). Leave the mapping in place as documentation but keep ops self-contained with explicit DDL."
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - redshift
+    - read-primitives
+    - write-primitives
+    - sketches
+    - approximate-aggregates
+    - hll
+  estimated_effort: "0.5-1 day catalog work + cloud verification when creds available"
+  created_date: "2026-05-02"
+  last_updated: "2026-05-02"
+
+impact:
+  business_value: |
+    Closes the largest known Redshift coverage gap on the new
+    approximate-aggregate + sketch surface. Currently Redshift runs
+    2/5 read approx queries and 0/4 HLL-applicable sketch ops. After
+    this TODO: 3/5 read approx queries (the only remaining skips are
+    ones Redshift fundamentally can't do) and 4/4 HLL-applicable
+    sketch ops. Cross-engine matrix is now complete to Redshift's
+    natural ceiling.
+  user_impact: |
+    Redshift users get end-to-end HLL persist + merge + requery
+    benchmark numbers comparable to other engines' Theta numbers
+    (acknowledging the family substitution in docs). The previously-
+    unused HLLSKETCH type translation gets exercised by real ops.
+  technical_debt: |
+    Resolves the "Redshift HLL-only" rationale that's currently
+    hand-waved across multiple null overrides. Establishes the
+    pattern for HLL-substitution overrides on other engines that
+    might be HLL-only in the future.
+
+files_affected:
+  modified:
+    - benchbox/core/read_primitives/catalog/queries.yaml
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/read-primitives-approximate-functions.md
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+
+must_preserve:
+  - "All 157 existing read_primitives queries continue to load and execute identically — the only change is dropping `redshift` from one skip_on list and adding one variant."
+  - "All 117 existing write_primitives operations execute identically — the only changes are 4 platform_overrides moving from null to a real SQL block, plus inline rationale comments on 4 still-null entries."
+  - "variant_contracts checker passes against the augmented Redshift variant for approx_quantile_groupby — may require an allowlist entry if sqlglot can't parse APPROXIMATE PERCENTILE_DISC, investigate during w1."
+  - "The existing _BINARY_TYPE_BY_DIALECT[redshift] = 'HLLSKETCH' mapping is NOT activated by any op (per-op explicit DDL is the chosen pattern); the mapping stays as documentation only."
+
+approach: |
+  Pure catalog-only work (operations.yaml + queries.yaml + 2 docs +
+  changelog). No Python, no schema.py, no loader.py, no benchmark.py
+  changes. Mirrors the structure of the ClickHouse-native expansion
+  TODO — same shape, different engine.
+
+  For the read_primitives variant (w1), use the existing per-engine
+  variant mechanism. If the variant_contracts checker can't parse
+  APPROXIMATE PERCENTILE_DISC, investigate whether the checker has a
+  parse-failure allowlist OR whether the variant should be guarded by
+  the same skip_on as before with a different mechanism (e.g., a
+  comment-based opt-out). w1's research output will determine the
+  right path.
+
+  For the write_primitives HLL ops (w2-w5), each Redshift override
+  emits its own self-contained DDL → INSERT → optional SELECT → DROP,
+  matching the existing DuckDB / Databricks / Snowflake / BigQuery
+  pattern. HLLSKETCH constraints (no DISTKEY/SORTKEY/PK/GROUP BY) are
+  expressed in the SQL itself, not factored into the BINARY translator.
+
+  Initial tolerance bounds for the HLL merge ★ op are estimates
+  (HLL++ vs DataSketches Theta have different bias profiles); cloud
+  verification re-tunes them. This matches the strategy used for the
+  cloud overrides in PR #112.
+
+  Documentation lands last (w7), after the ops are verified to parse
+  and load. Changelog (w8) is the final commit.
+
+anti_patterns:
+  - "DO NOT activate the existing _BINARY_TYPE_BY_DIALECT[redshift] = HLLSKETCH translator — because HLLSKETCH semantics (no DISTKEY/SORTKEY/PK/GROUP BY) don't fit the generic BINARY abstraction and silently breaking on Redshift in some other op would be very hard to debug — keep ops self-contained with explicit redshift: DDL."
+  - "DO NOT rename ops to reflect the HLL family substitution (e.g., sketch_insert_theta_per_partition → sketch_insert_hll_or_theta_per_partition) — because the op ID is the user-facing measurement key and changing it breaks cross-engine comparison — keep the ID as 'theta' and document the per-engine substitution in the cross-platform doc."
+  - "DO NOT attempt UDF emulation of top-K, KLL, T-Digest etc. on Redshift — because the resulting numbers would measure UDF dispatch overhead, not sketch performance, and would mislead cross-engine comparisons — let those ops stay skipped with explicit rationale comments."
+  - "DO NOT use HLLSKETCH columns in DISTKEY / SORTKEY / PRIMARY KEY / GROUP BY / ORDER BY / DISTINCT — because Redshift rejects all of these — DDL must use DISTSTYLE EVEN (or AUTO) and queries must group by a non-sketch column (e.g., region or activity_date)."
+  - "DO NOT tune Redshift expected_value_min/max bounds tightly without empirical observations — because HLL++ vs DataSketches bias differs and cloud-verification can't run locally — set initial bounds wide with a 'Redshift bounds initial estimate; re-tune in cloud-verification TODO' inline comment."
+
+verification:
+  - description: "All read_primitives unit tests pass with the new Redshift variant"
+    command: "uv run -- python -m pytest tests/unit/read_primitives tests/unit/core/read_primitives -q -m fast"
+    expected_output: "all tests pass; variant_contracts checker accepts (or explicitly allowlists) the APPROXIMATE PERCENTILE_DISC variant"
+  - description: "All write_primitives unit tests pass with augmented Redshift overrides"
+    command: "uv run -- python -m pytest tests/unit/core/write_primitives -q"
+    expected_output: "all tests pass, including catalog_loader tests with the 4 new Redshift overrides"
+  - description: "DuckDB regression: all 8 sketch ops still pass (no DuckDB-side changes expected)"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table"
+    expected_output: "8/8 pass on DuckDB"
+  - description: "DuckDB regression: 5 read_primitives approx queries still pass"
+    command: "uv run -- benchbox run --platform duckdb --benchmark read_primitives --scale 0.01 --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby,approx_quantiles_array,approx_top_k_lineitem"
+    expected_output: "5/5 pass on DuckDB"
+  - description: "Redshift cloud verification (BLOCKED — needs Redshift creds)"
+    command: "uv run -- benchbox run --platform redshift --benchmark write_primitives --scale 0.01 --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_query_theta_union_merge,sketch_drop_persistent_table"
+    expected_output: "4/4 pass on Redshift; merged distinct estimate within tuned bounds — REQUIRES creds, will land via the cloud-verification TODO when available"
+
+scope_limit:
+  only_modify:
+    - benchbox/core/read_primitives/catalog/queries.yaml
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/read-primitives-approximate-functions.md
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/schema.py
+    - benchbox/core/write_primitives/catalog/loader.py
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/read_primitives/variant_contracts.py
+    - benchbox/core/read_primitives/benchmark.py
+
+success_metrics:
+  - "approx_quantile_groupby drops `redshift` from skip_on; Redshift variant added using APPROXIMATE PERCENTILE_DISC"
+  - "4 write_primitives sketch ops (DDL, theta-style insert, theta-style merge, drop) gain Redshift HLL overrides activating the unused HLLSKETCH path"
+  - "4 still-null Redshift overrides (kll/topk pairs) gain explicit rationale comments instead of bare null"
+  - "Cross-platform docs reflect Redshift's HLL-only ceiling: covered where supportable, skipped with rationale where not"
+  - "Catalog loader and variant_contracts checker still pass; no regression in DuckDB end-to-end runs"
+  - "Changelog entries under unreleased for both read_primitives and write_primitives Redshift coverage"
+  - "Redshift cloud verification deferred to write-primitives-sketch-cloud-verification TODO when creds become available"
+
+open_questions:
+  - "Does the variant_contracts checker accept a variant that sqlglot can't parse, or does it hard-fail the catalog? Investigate in w1 — may need a parse-failure allowlist mechanism (precedent: how do existing variants on engines sqlglot doesn't support handle this today? e.g. datafusion has no sqlglot dialect but variants exist for it)."
+  - "Should HLLSKETCH return-type be checked specifically in the validation_query — JDBC/ODBC drivers return it as VARCHAR JSON/Base64, which means LENGTH() returns the encoded text length, not the binary length. Affects future storage-size validation if added."
+  - "Is initial bound [12000, 18000] for theta-merge on Redshift wide enough to absorb HLL++ bias? Acknowledge as estimate; cloud-verification re-tunes."
+  - "Could the cloud-verification TODO be extended to include Redshift even though Redshift wasn't explicitly listed in its initial scope? Lean: yes — same pattern (per-engine work unit, separate PR), Redshift just gets added as another engine to verify when creds are around."


### PR DESCRIPTION
## Summary

New planning TODO at \`_project/TODO/main/planning/redshift-maximum-approximate-coverage.yaml\` capturing the Redshift coverage audit findings.

**Today's coverage**: 2/5 read approx queries + 0/4 HLL-applicable write sketch ops.
**After this TODO**: 3/5 read approx queries + 4/4 HLL-applicable write sketch ops — Redshift's natural ceiling (HLL-only).

## What this closes

| Surface | Today | After |
|---|---|---|
| read_primitives \`approx_count_distinct_*\` | ✅ via sqlglot rewrite | unchanged |
| read_primitives \`approx_quantile_groupby\` | ❌ skipped (sqlglot parser gap) | ✅ hand-written variant w/ \`APPROXIMATE PERCENTILE_DISC\` |
| read_primitives \`approx_quantiles_array\` / \`approx_top_k_lineitem\` | ✅ correctly skipped (Redshift has neither) | unchanged |
| write_primitives sketch ops (8 total) | 0/8 (all \`redshift: null\`) | 4/8 active (DDL + theta-style insert + theta-style merge + drop using HLL); 4/8 stay null with explicit rationale comments |

## Critical implementation watch-outs (in \`context_sections\`)

- HLLSKETCH cannot be DISTKEY / SORTKEY / PRIMARY KEY / FOREIGN KEY / GROUP BY / ORDER BY / DISTINCT
- Fixed \`logm=15\` (no precision tuning — parameter-sweep TODO doesn't apply to Redshift)
- JDBC/ODBC drivers return HLLSKETCH as VARCHAR JSON/Base64 (opaque text)
- **DON'T** activate the generic \`_BINARY_TYPE_BY_DIALECT[redshift] = "HLLSKETCH"\` translator — per-op explicit DDL is safer (the BINARY abstraction doesn't fit HLLSKETCH's semantic constraints)

## Anti-patterns flagged

- DO NOT activate the generic translator (HLLSKETCH semantics don't fit BINARY abstraction)
- DO NOT rename ops to reflect family substitution (op IDs are user-facing measurement keys)
- DO NOT attempt UDF emulation of top-K / KLL on Redshift (would measure UDF dispatch, not sketch perf)
- DO NOT use HLLSKETCH columns in DISTKEY/SORTKEY/PK/GROUP BY (Redshift rejects)
- DO NOT tune Redshift bounds tightly without empirical observations (cloud-verification re-tunes)

## Verification

- Catalog work locally verifiable (DuckDB regression — no behaviour changes expected on DuckDB)
- Redshift cloud verification deferred to \`write-primitives-sketch-cloud-verification\` TODO when creds become available (same blocker as Snowflake/BigQuery/Databricks)

## Test plan

- [x] \`validate_todo.py\` passes
- [x] \`todo_cli.py check-graph\` clean (44 items, no DAG cycles, no dangling refs)
- [x] \`todo_cli.py next\` resolves w1 + w2 as ready, w3-w8 as blocked-by-deps
- [ ] No code changes — implementation is the TODO's own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)