### PR TITLE
chore(blind-spots): sweep 2026-05-02 — close 4, refresh 9 actionable

### DIFF
--- a/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
+++ b/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
@@ -39,8 +39,26 @@ call-site of a generalizable defect.
 
 - [ ] Add a "bug-class blast radius" check to the review framework, used
       when the finding is structural rather than behavioral.
-- [ ] Sweep all chart components for React keys derived from
-      non-uniqueness-guaranteed fields (platform name, query id, etc.)
-      and convert to composite or stable IDs.
+- [ ] Sweep all chart components under `results-explorer/src/components/`
+      for React keys derived from non-uniqueness-guaranteed fields
+      (platform name, query id, etc.) and convert to composite or stable
+      IDs. Live candidates: `DivergingBarChart` (`<g key={queryId}>`),
+      `RankTable` (`<tr key={qid}>`), `QueryHeatmap` (`<… key={qid}>` /
+      `<… key={row.result_id}>`), `StackedPhase`, `CostScatter`. Use
+      `git grep "key={" results-explorer/src/components/` as the seed.
 - [ ] When a sweep is done, link the resulting TODO/PR back here and
       flip `status:` to `merged-to-todo`.
+
+## Triage log
+
+- 2026-05-02: verified actionable. The reviewed components moved from
+  `benchbox/dashboard/charts/` to `results-explorer/src/components/`
+  (the `benchbox/dashboard/` tree no longer exists). The two cited
+  files now carry explicit comments warning against
+  `key={date}` (TimeSeries.tsx:36-37) and `key={platform}`
+  (PercentileLadder.tsx:23) collisions, so the *original* instances
+  are mitigated. The broader bug-class sweep across all chart
+  components has NOT been performed — `git grep "key={"
+  results-explorer/src/components/` returns ~30 hits including
+  `key={queryId}` / `key={qid}` patterns whose uniqueness is not
+  obvious without per-call analysis.

--- a/_project/blind-spots/2026-04-30-114719-separable-dev-loop-decisions.md
+++ b/_project/blind-spots/2026-04-30-114719-separable-dev-loop-decisions.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114719-separable-dev-loop-decisions
 date: 2026-04-30
-status: open
+status: actioned
 finding_kind: framework-gap
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -23,3 +23,7 @@ Bundling local-loop friction fixes with release-grade gating changes can make a 
 ## Suggested next steps
 - [ ] During dev-loop TODO review, split local ergonomics, CI policy, and release policy into separate decisions.
 - [ ] Re-check any queue or gating plan against the Step 0 decision record before implementation.
+
+## Triage log
+
+- 2026-05-02: actioned — Sweep 2026-05-02: dev-loop plan was split into Steps 0-6 (verify/local/pool/CI-rebalance/strict-base/post-merge/measurement/queue-gate) per the advice. Local ergonomics, CI policy, and release policy each own a separate TODO; Step 6 queue gate is explicitly Blocked on Step 5 measurement. Rule embedded as project structure.

--- a/_project/blind-spots/2026-04-30-114720-pr-ci-cost-leverage.md
+++ b/_project/blind-spots/2026-04-30-114720-pr-ci-cost-leverage.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114720-pr-ci-cost-leverage
 date: 2026-04-30
-status: open
+status: actioned
 finding_kind: missed-axis
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -22,3 +22,7 @@ Reviewing only branch protection misses the separate cost of non-required jobs t
 ## Suggested next steps
 - [ ] In Step 3, distinguish required status checks from all PR-triggered workflow jobs.
 - [ ] Preserve a before/after CI-duration baseline so the rebalancing outcome is measurable.
+
+## Triage log
+
+- 2026-05-02: actioned — Sweep 2026-05-02: PR CI rebalance shipped. .github/workflows/pr.yml is the required lightweight 'Develop PR' gate with path-based classification (ci-paths job + .ci-paths/, content-only PRs skip Python tests); broader OS/Python/security/integration/parity coverage runs on schedule via .github/workflows/nightly.yml. Required vs non-required job split done in dev-loop-step-3 + step-3a (both Done). Before/after measurement is tracked separately in dev-loop-step-5-measurement-window (Blocked, in 30-day window).

--- a/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
+++ b/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
@@ -22,3 +22,15 @@ Removing the global lock by default can shift pain from blocked pushes to CPU sa
 ## Suggested next steps
 - [ ] Track whether developers actually need `BENCHBOX_TEST_LOCK_DIR` outside isolated debug sessions.
 - [ ] Keep the default lock global unless measurement shows concurrent xdist runs are safe.
+
+## Triage log
+
+- 2026-05-02: verified actionable (advice still load-bearing). Default
+  lock path remains `$HOME/.benchbox/test.lock`
+  (`tests/conftest.py:_get_test_lock_path`, `Makefile:test-unlock`). The
+  override knob `BENCHBOX_TEST_LOCK_DIR` is still opt-in and now
+  expanduser-correct on both sides (codex w2 / commit fe393e748). No
+  measurement of concurrent-xdist safety has been collected yet, so the
+  rule "keep default global" is preserved by inertia rather than
+  evidence — the survey/measurement work item below is still owed.
+  Re-evaluate when dev-loop-step-5-measurement-window completes.

--- a/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
+++ b/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
@@ -22,3 +22,15 @@ Replacing decentralized auto-merge with a queue can make one local process or wo
 ## Suggested next steps
 - [ ] Require an explicit failure-mode analysis before adding a steward queue.
 - [ ] Prefer native GitHub features if they become available and meet the repository's ownership constraints.
+
+## Triage log
+
+- 2026-05-02: verified actionable (advice still load-bearing). The
+  decentralized auto-merge model is live (`auto-merge-on-open.yml` +
+  `develop-post-merge.yml` are both shipped). The queue itself is
+  intentionally NOT built — `dev-loop-step-6-queue-decision-gate.yaml`
+  is `Blocked` on `dev-loop-step-5-measurement-window`, with explicit
+  Path A (native MQ) vs Path B (steward) handoff. If Step 5 returns
+  BUILD QUEUE, this finding's failure-mode-analysis requirement is
+  the gate that must clear before any steward implementation TODO
+  unblocks.

--- a/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
+++ b/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
@@ -23,3 +23,14 @@ Agents can walk away after auto-merge only because the current dwell time is sho
 ## Suggested next steps
 - [ ] Treat dwell-time targets as part of any queue acceptance criteria.
 - [ ] Update agent handoff guidance if queue dwell becomes materially longer than current CI time.
+
+## Triage log
+
+- 2026-05-02: verified actionable. Dwell time on `develop` PRs is
+  still short by design (auto-merge + lightweight `pr.yml` gate;
+  `make dev-loop-metrics` measures PR-to-merge P50/P95). The agent
+  contract in CLAUDE.md ("walk away — don't poll") still holds.
+  This finding becomes load-bearing only when Step 5 measurement
+  surfaces dwell-time symptoms that justify Step 6 (queue); at that
+  point the dwell-target acceptance criteria below must be folded
+  into the queue spec before any implementation TODO ships.

--- a/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
+++ b/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
@@ -22,3 +22,16 @@ If the post-merge workflow is the real protection layer, adding a queue may dupl
 ## Suggested next steps
 - [ ] In Step 4, define the exact failure that post-merge auto-revert handles.
 - [ ] Do not add a queue unless Step 5 metrics show a separate pre-merge ordering problem.
+
+## Triage log
+
+- 2026-05-02: verified actionable (architectural rule still load-bearing).
+  Step 4 is Done — `.github/workflows/develop-post-merge.yml` is the
+  declared safety net (revert PR labeled `incident:develop-red`, or
+  `incident:develop-red-revert-conflict` issue on conflict). Step 5
+  measurement is `Blocked`/in-progress (30-day window after Step 3a +
+  Step 4 merge), and Step 6 queue gate is explicitly blocked on Step 5.
+  The "do not add a queue unless Step 5 metrics show a pre-merge ordering
+  problem" rule is currently being respected by the planning DAG rather
+  than by enforcement; revisit after Step 5 publishes the go/no-go
+  decision record.

--- a/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
+++ b/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
@@ -51,3 +51,13 @@ happens, instead of failing slow under load.
 - [ ] If no: write a one-line note in the operations doc that the count
       is "by convention, run `pool-status` to inspect" — so future
       readers don't assume it's enforced.
+
+## Triage log
+
+- 2026-05-02: verified actionable. `make worktree-pool-check` does NOT
+  exist in the current Makefile (`grep -n worktree-pool Makefile`
+  shows `init`, `status`, `claim*`, `release*`, `reset*`,
+  `sweep-stale*`, `disk-clean` — no `check`). `worktree-pool-status`
+  reports state non-fatally (today's run shows `pool-01` dirty for
+  26h, several `claimed` for hours; would not be flagged by a check
+  target). The decision (codify vs document) is still owed.

--- a/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
+++ b/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
@@ -70,3 +70,16 @@ dispatches a sub-make and inspects only the exit code (e.g.
       contract is "WORKTREE_PATH=… printed → claim succeeded → exit 0".
 - [ ] Add a regression test that asserts `make worktree-claim BRANCH=…`
       exits 0 on a fresh free pool.
+
+## Triage log
+
+- 2026-05-02: reproduced during this very sweep. `make -s
+  worktree-claim BRANCH=chore/blind-spot-sweep` printed
+  `WORKTREE_PATH=/Users/joe/Developer/BenchBox.pool-10`, then ran the
+  auto-sweep retry path ("No free pool worktree on first pass —
+  auto-sweeping stale slots..."), `Swept 0 pool slot(s)`, and exited
+  the make target with `Error 1` / `Error 2` (`worktree-claim-attempt`
+  → `worktree-claim-locked` → `worktree-claim`). Final state was
+  correct: pool-10 cleanly claimed on the requested branch, working
+  tree clean. The bug class — orchestrator misreads child make
+  target's success — is still live. Verified actionable.

--- a/_project/blind-spots/2026-05-01-103000-hosted-submit-no-local-validate-preflight.md
+++ b/_project/blind-spots/2026-05-01-103000-hosted-submit-no-local-validate-preflight.md
@@ -60,3 +60,18 @@ Either:
    truth for `--service` validation and that develop's validator may
    diverge — and add a contract test that asserts the hosted mock and
    `validate_submission.py` accept/reject the same bundles.
+
+## Triage log
+
+- 2026-05-02: verified actionable; option (2) is partially landed,
+  contract test still owed. The "no local preflight" decision is now
+  recorded inline at `benchbox/cli/commands/submit.py:172-182` (the
+  `_dispatch_service_mode` docstring) with an explicit pointer back to
+  this finding. The path remains: contributors pay full upload latency
+  before the hosted service rejects a bad bundle. The contract test
+  asserting that the hosted mock and `validate_submission.py`
+  accept/reject the same bundles has NOT been written —
+  `tests/integration/` has no test joining
+  `test_hosted_submission.py` to `validate_submission.py`. Once that
+  contract test ships, fail-fast preflight (option 1) becomes the
+  obvious next move per the inline docstring.

--- a/_project/blind-spots/2026-05-01-103001-published-results-validator-no-per-bundle-test.md
+++ b/_project/blind-spots/2026-05-01-103001-published-results-validator-no-per-bundle-test.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-01-103001-published-results-validator-no-per-bundle-test
 date: 2026-05-01
-status: open
+status: actioned
 finding_kind: bug-class
 review_context: "/code review of PR #87 (validator manifest compatibility) and PR #88 (closure)"
 related_paths:
@@ -56,3 +56,7 @@ Add a `test_per_bundle_manifest_preferred_over_legacy` to
    and `submission-manifest.json` (incorrect hash).
 2. Run the validator and assert it succeeds, proving per-bundle wins.
 3. Mirror the test for the per-bundle-only case.
+
+## Triage log
+
+- 2026-05-02: actioned — Sweep 2026-05-02: tests/integration/test_cross_branch_validator_contract.py now contains test_validator_prefers_per_bundle_manifest_over_legacy (line 229) which asserts the validator prefers <stem>.manifest.json over submission-manifest.json when both are present, and test_validator_skips_per_bundle_manifest_during_discovery (line 269) which guards the discovery skip. Both run against the develop script and the vendored fixture, exercising the per-bundle code path the original PR #87 added.

--- a/_project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md
+++ b/_project/blind-spots/2026-05-01-103002-explorer-cold-load-test-coverage-weakened.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-01-103002-explorer-cold-load-test-coverage-weakened
 date: 2026-05-01
-status: open
+status: actioned
 finding_kind: bug-class
 review_context: "/code review of PR #86 (Results Explorer QA pass 2)"
 related_paths:
@@ -62,3 +62,7 @@ Either:
    record the *test simplification rationale* — why the team decided
    the fixture-DB assertion is sufficient — so the next reviewer can
    tell loose-on-purpose from loose-by-accident.
+
+## Triage log
+
+- 2026-05-02: actioned — Sweep 2026-05-02: results-explorer/e2e/failures/platform-index-cold-load.spec.ts now uses toHaveCount(EXPECTED_ROWS_BY_PLATFORM[platform]) (duckdb=5, polars=1) via expectExactPlatformRows(). The file's leading comment explicitly cites this blind-spot's failure mode ('PARTIAL rows... A count > 0 assertion would silently pass that regression'). Restored in PR #86 follow-up commit d362529f2 per codex-thread-rescan-week-2026-05-01.md.

--- a/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
+++ b/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
@@ -85,3 +85,19 @@ never flagged the test downgrade in the first place.
    should include "tests weakened in this window" as an explicit
    axis, sourced from `git log -p -- '*.spec.ts' '*test*.py'` and
    filtered for assertion-loosening patterns.
+
+## Triage log
+
+- 2026-05-02: partially actioned; rubric/template change still owed.
+  Step 2 landed inside
+  `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml`
+  — the TODO is `Completed`, w9 covers the Home.tsx persistent-mismatch
+  fix, and the file's `must_not_do` list explicitly forbids landing the
+  Home.tsx fix without restoring `toHaveCount` in
+  `platform-index-cold-load.spec.ts` (the row counts were restored;
+  see `2026-05-01-103002-...-coverage-weakened.md → actioned`). Step 1
+  (process change to next weekly sweep) and Step 3 (rubric axis "tests
+  weakened in this window") have NOT been encoded as a reusable
+  template — there is no `_project/templates/` directory and no
+  weekly-sweep template to amend. Verified actionable for the
+  framework-gap dimension only.


### PR DESCRIPTION
Triaged the 13 open blind-spot findings against current code:

- actioned (4):
  - 2026-04-30-114719-separable-dev-loop-decisions
  - 2026-04-30-114720-pr-ci-cost-leverage
  - 2026-05-01-103001-published-results-validator-no-per-bundle-test
  - 2026-05-01-103002-explorer-cold-load-test-coverage-weakened

- verified actionable (9): added a 2026-05-02 triage-log entry to each
  with current-state evidence (file paths, line refs, related TODO
  status) and refined next-step bullets where the original wording
  pointed at moved or renamed code. Status stays `open`; one finding
  (claim-orchestrator-false-failure) was reproduced live during this
  sweep on `make worktree-claim` for `chore/blind-spot-sweep`.

No code changes; documentation-only edits under `_project/blind-spots/`.
