### PR TITLE
fix(make): worktree-claim orchestrator exits 0 on first-pass success

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -994,20 +994,26 @@ worktree-claim:
 # Orchestrator: try once, then auto-sweep stale slots, then try again.
 # The auto-sweep means routine pool exhaustion (forgotten releases) is
 # self-healing without operator intervention.
+#
+# The whole recipe runs in ONE shell (line continuations + a single `@`).
+# Each `@`-prefixed make recipe line otherwise spawns its own subshell, so
+# `if ... ; then exit 0; fi` would only exit that line's subshell — make
+# would happily continue to the auto-sweep retry path even after a
+# successful first attempt, falsely reporting failure to the caller.
 worktree-claim-locked:
 	@if $(MAKE) -s worktree-claim-attempt BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; then \
 		exit 0; \
-	fi
-	@echo "No free pool worktree on first pass — auto-sweeping stale slots..." >&2
-	@$(MAKE) -s worktree-pool-sweep-stale-locked POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)" >&2 || true
-	@if $(MAKE) -s worktree-claim-attempt BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; then \
+	fi; \
+	echo "No free pool worktree on first pass — auto-sweeping stale slots..." >&2; \
+	$(MAKE) -s worktree-pool-sweep-stale-locked POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)" >&2 || true; \
+	if $(MAKE) -s worktree-claim-attempt BRANCH="$(BRANCH)" POOL_SIZE="$(POOL_SIZE)" WORKTREE_POOL_PARENT="$(WORKTREE_POOL_PARENT)"; then \
 		exit 0; \
-	fi
-	@echo "Still no free pool worktree available after auto-sweep." >&2
-	@echo "Hint: dirty or claim-aborted slots are not auto-recovered (they may have valuable state)." >&2
-	@echo "      Run \`make worktree-pool-status\` to inspect, then \`make worktree-pool-reset POOL=NN\`" >&2
-	@echo "      as a last-resort manual escape hatch after reviewing what will be discarded." >&2
-	@exit 1
+	fi; \
+	echo "Still no free pool worktree available after auto-sweep." >&2; \
+	echo "Hint: dirty or claim-aborted slots are not auto-recovered (they may have valuable state)." >&2; \
+	echo "      Run \`make worktree-pool-status\` to inspect, then \`make worktree-pool-reset POOL=NN\`" >&2; \
+	echo "      as a last-resort manual escape hatch after reviewing what will be discarded." >&2; \
+	exit 1
 
 # Single-pass claim attempt. Iterates the pool once; on the first
 # detached, clean, non-claim-aborted slot, mutates it to the requested

--- a/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
+++ b/_project/blind-spots/2026-04-30-214359-claim-orchestrator-false-failure.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-214359-claim-orchestrator-false-failure
 date: 2026-04-30
-status: open
+status: actioned
 finding_kind: bug-class
 review_context: "/docs review of dev-loop worktree pool / chore/worktree-pool-docs-review — observed during make worktree-claim BRANCH=chore/worktree-pool-docs-review"
 related_paths:
@@ -83,3 +83,4 @@ dispatches a sub-make and inspects only the exit code (e.g.
   correct: pool-10 cleanly claimed on the requested branch, working
   tree clean. The bug class — orchestrator misreads child make
   target's success — is still live. Verified actionable.
+- 2026-05-02: actioned — Sweep 2026-05-02: fixed by chaining worktree-claim-locked recipe into a single shell with line continuations (the @-prefixed if/exit was running in a per-line subshell, so 'exit 0' exited only that subshell while make walked to the auto-sweep retry path). Added regression test tests/integration/worktree/test_worktree_claim_orchestrator_exit.py — verified it fails on the unfixed recipe and passes after the fix.

--- a/tests/integration/worktree/test_worktree_claim_orchestrator_exit.py
+++ b/tests/integration/worktree/test_worktree_claim_orchestrator_exit.py
@@ -1,0 +1,99 @@
+"""Regression test for worktree-claim orchestrator exit-status path.
+
+When `worktree-claim-attempt` succeeds on the first try, the
+`worktree-claim-locked` orchestrator must exit 0 cleanly and must NOT
+fall through to the auto-sweep retry branch. The bug class is "make
+recipe runs each `@` line in its own subshell, so `if ... then exit 0`
+exits the subshell but make still walks to the next line"; the fix is
+chaining the recipe into a single shell with line continuations.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    run(["git", "init"], path)
+    run(["git", "config", "user.email", "test@example.com"], path)
+    run(["git", "config", "user.name", "BenchBox Test"], path)
+    (path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    run(["git", "add", ".gitignore", "README.md"], path)
+    run(["git", "commit", "-m", "initial"], path)
+
+
+def create_origin_with_develop(tmp_path: Path) -> Path:
+    seed = tmp_path / "seed"
+    origin = tmp_path / "origin.git"
+    init_repo(seed)
+    run(["git", "branch", "-M", "develop"], seed)
+    run(["git", "init", "--bare", str(origin)], tmp_path)
+    run(["git", "remote", "add", "origin", str(origin)], seed)
+    run(["git", "push", "-u", "origin", "develop"], seed)
+    return origin
+
+
+def test_worktree_claim_orchestrator_first_attempt_success_exits_zero(tmp_path: Path) -> None:
+    """Successful first-pass claim must exit 0 without running auto-sweep."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+    origin = create_origin_with_develop(tmp_path)
+    main = tmp_path / "BenchBox"
+    pool_parent = tmp_path / "pool"
+    pool_parent.mkdir()
+    pool = pool_parent / "BenchBox.pool-01"
+    run(["git", "clone", str(origin), str(main)], tmp_path)
+    run(["git", "clone", str(origin), str(pool)], tmp_path)
+    run(["git", "checkout", "--detach", "origin/develop"], pool)
+    (pool / ".venv").mkdir()
+    (pool / ".venv" / "pyvenv.cfg").write_text("home = test\n", encoding="utf-8")
+
+    # The orchestrator recursively invokes $(MAKE) without -f, so the
+    # Makefile must be discoverable from cwd. Symlink the real Makefile
+    # and the scripts/ directory it depends on into the temp main clone.
+    (main / "Makefile").symlink_to(REPO_ROOT / "Makefile")
+    (main / "scripts").symlink_to(REPO_ROOT / "scripts")
+
+    result = subprocess.run(
+        [
+            "make",
+            "-s",
+            "worktree-claim-locked",
+            "BRANCH=feature/orchestrator-exit",
+            "POOL_SIZE=1",
+            f"WORKTREE_POOL_PARENT={pool_parent}",
+        ],
+        cwd=main,
+        env={**os.environ},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"orchestrator should exit 0 on first-pass success.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "WORKTREE_PATH=" in result.stdout
+    assert "No free pool worktree on first pass" not in result.stderr, (
+        "auto-sweep retry path must not fire after a successful first attempt"
+    )
+    assert "Still no free pool worktree available" not in result.stderr
+    assert run(["git", "branch", "--show-current"], pool).stdout.strip() == "feature/orchestrator-exit"


### PR DESCRIPTION
`worktree-claim-locked` ran each `@`-prefixed line in its own subshell,
so `if $(MAKE) -s worktree-claim-attempt ...; then exit 0; fi` would
exit only that subshell on success. Make then walked to the auto-sweep
retry path, ran sweep-stale, attempted a second claim that collided
with the branch the first attempt created, and exited the recipe with
non-zero — falsely reporting failure to callers even though the slot
was correctly claimed.

Fix: chain the recipe into a single shell using line continuations.
The `exit 0` on first-pass success now exits the whole recipe.

Added tests/integration/worktree/test_worktree_claim_orchestrator_exit.py
which fails on the unfixed recipe and passes after the fix (validated
by running the test against `git stash` of the change).

Resolves blind-spot
2026-04-30-214359-claim-orchestrator-false-failure.
