### PR TITLE
chore(make): add worktree-pool-check invariant assertion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,7 +259,7 @@ benchbox run --help | --help-topic all | --help-topic examples | --help-topic be
 
 ## Pre-approved Commands
 - **Dev/Test**: `make test-*`, `make coverage*`, `make lint`, `make format`, `make typecheck`, `uv run -- python -m pytest *`
-- **PR/Worktree (read-only)**: `make pr-preflight`, `make pr-preflight-fast-tests`, `make pr-content-guard *`, `make pr-status`, `make dev-loop-metrics`, `make worktree-pool-status`, `make worktree-list`, `git worktree list*`, `gh pr list*`, `gh pr view*`, `gh pr checks*`
+- **PR/Worktree (read-only)**: `make pr-preflight`, `make pr-preflight-fast-tests`, `make pr-content-guard *`, `make pr-status`, `make dev-loop-metrics`, `make worktree-pool-status`, `make worktree-pool-check`, `make worktree-list`, `git worktree list*`, `gh pr list*`, `gh pr view*`, `gh pr checks*`
 - **PR/Worktree (write — feature/pool worktrees only)**: `make pr-open`, `make pr-fanout`, `make pr-refresh`, `make worktree-claim BRANCH=*`, `make worktree-release`, `make worktree-pool-sweep-stale`, `git push -u origin chore/*`, `git push -u origin fix/*`, `git push -u origin feat/*`, `git push -u origin docs/*`, `git push origin chore/*`, `git push origin fix/*`, `git push origin feat/*`, `git push origin docs/*`, `gh pr create --fill*`, `gh pr merge --auto --squash*`
   - **Manual/admin escape hatches, not broad auto-allow**: `make worktree-pool-init`, `make worktree-pool-reset POOL=NN`, `make worktree-prune`
   - **Never auto-allowed**: `git push * develop`, `git push * main`, `git push --force*`, `gh pr create --base main*`. These remain prompt-on-use.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ POOL_MIN_FREE_KB ?= 5000000
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status dev-loop-metrics worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -748,7 +748,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status dev-loop-metrics worktree-pool-init worktree-pool-status worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
+.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
 
 # Mirror the CI gate locally before pushing. Catches ~all CI failures
 # without the network roundtrip. Delegates to ci-lint so the local
@@ -1183,6 +1183,64 @@ worktree-pool-status:
 		printf '  Check \`gh auth status\` and \`gh api rate_limit\` to recover.\n'; \
 	fi
 
+## worktree-pool-check: assert pool invariants and exit non-zero on drift.
+##
+## Fails if:
+##   - any slot directory is missing (count < POOL_SIZE)
+##   - extra `pool-NN` directories exist beyond POOL_SIZE in WORKTREE_POOL_PARENT
+##   - any slot is in `aborted` state (.benchbox/claim_in_progress survived)
+##
+## NOT a PR-CI gate. Intended use:
+##   - pre-release sanity check (catch drift before cutting a release)
+##   - periodic local cron / agent-loop hook
+##
+## Performance: avoids the gh PR lookup that worktree-pool-status uses, so
+## it is fast and safe to run frequently. Runs read-only — never mutates.
+##
+## See `_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md`.
+worktree-pool-check:
+	@POOL_REPO=$$($(POOL_REPO_CMD)); \
+	violations=""; \
+	missing_count=0; \
+	aborted_count=0; \
+	i=1; \
+	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
+		pool=$$(printf 'pool-%02d' "$$i"); \
+		wt="$(WORKTREE_POOL_PARENT)/$$POOL_REPO.$$pool"; \
+		if ! git -C "$$wt" rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+			violations="$$violations  - $$pool: missing ($$wt is not a git worktree)\n"; \
+			missing_count=$$((missing_count + 1)); \
+		elif [ -f "$$wt/.benchbox/claim_in_progress" ]; then \
+			marker_age=$$(date -u -r "$$wt/.benchbox/claim_in_progress" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?"); \
+			violations="$$violations  - $$pool: aborted (claim_in_progress marker present, mtime $$marker_age)\n"; \
+			aborted_count=$$((aborted_count + 1)); \
+		fi; \
+		i=$$((i + 1)); \
+	done; \
+	extras=""; \
+	for wt in "$(WORKTREE_POOL_PARENT)/$$POOL_REPO."pool-*; do \
+		[ -d "$$wt" ] || continue; \
+		base=$$(basename "$$wt"); \
+		num=$${base##*pool-}; \
+		case "$$num" in [0-9][0-9]) ;; *) continue ;; esac; \
+		num_dec=$$(expr "$$num" + 0); \
+		if [ "$$num_dec" -gt "$(POOL_SIZE)" ]; then \
+			extras="$$extras  - $$base (number > POOL_SIZE=$(POOL_SIZE))\n"; \
+		fi; \
+	done; \
+	if [ -n "$$extras" ]; then \
+		violations="$$violations  Extra pool slots beyond POOL_SIZE:\n$$extras"; \
+	fi; \
+	if [ -n "$$violations" ]; then \
+		printf 'Pool invariant check FAILED (POOL_SIZE=%s):\n' "$(POOL_SIZE)" >&2; \
+		printf '%b' "$$violations" >&2; \
+		printf 'Recover with `make worktree-pool-status` to inspect, then\n' >&2; \
+		printf '`make worktree-pool-reset POOL=NN` (last resort) or\n' >&2; \
+		printf '`make worktree-pool-init` to recreate missing slots.\n' >&2; \
+		exit 1; \
+	fi; \
+	printf 'Pool invariant check OK: %d slot(s), no aborted markers.\n' "$(POOL_SIZE)"
+
 worktree-pool-reset:
 	@test -n "$(POOL)" || { echo "Usage: make worktree-pool-reset POOL=NN"; exit 1; }
 	@case "$(POOL)" in [0-9][0-9]) ;; *) echo "POOL must be two digits, e.g. POOL=03"; exit 1 ;; esac
@@ -1470,6 +1528,7 @@ help:
 	@echo "  make worktree-claim BRANCH=name   Claim a free pool slot for a feature branch"
 	@echo "  make worktree-release             Inside a pool worktree: return to detached origin/develop after PR merges"
 	@echo "  make worktree-pool-status         Show pool slot state, venv health, and disk usage"
+	@echo "  make worktree-pool-check          Assert pool invariants (count, aborted slots) — exit non-zero on drift"
 	@echo "  make worktree-pool-sweep-stale    Auto-release pool slots whose PRs have merged"
 	@echo "  make worktree-pool-disk-clean     Drop pytest/mypy/ruff/coverage caches from pool slots (preserves .venv)"
 	@echo "  make worktree-pool-reset POOL=NN  Manual escape hatch for stuck pool slots"

--- a/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
+++ b/_project/blind-spots/2026-04-30-214358-pool-size-not-codified-as-contract.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-214358-pool-size-not-codified-as-contract
 date: 2026-04-30
-status: open
+status: actioned
 finding_kind: missed-axis
 review_context: "/docs review of dev-loop worktree pool / chore/worktree-pool-docs-review / PR #84"
 related_paths:
@@ -61,3 +61,4 @@ happens, instead of failing slow under load.
   reports state non-fatally (today's run shows `pool-01` dirty for
   26h, several `claimed` for hours; would not be flagged by a check
   target). The decision (codify vs document) is still owed.
+- 2026-05-02: actioned — Sweep 2026-05-02: added make worktree-pool-check target — exits non-zero on (a) any slot directory missing, (b) any slot with surviving .benchbox/claim_in_progress marker (aborted state), (c) any extra pool-NN slot beyond POOL_SIZE. Read-only, no gh calls so cheap; not a PR-CI gate. Documented as 'pre-release sanity check or periodic local cron' in the recipe header, in docs/operations/dev-loop-worktree-pool.md, and added to CLAUDE.md pre-approved read-only commands. Regression tests in tests/integration/worktree/test_worktree_pool_check.py cover the four contract clauses (healthy / missing / aborted / extras).

--- a/docs/operations/dev-loop-worktree-pool.md
+++ b/docs/operations/dev-loop-worktree-pool.md
@@ -41,6 +41,7 @@ The minimum surface for routine work — start here.
 | Inside the slot, ship the work | `make pr-preflight && make pr-open` | Run the local lint + fast-test gate, push, open PR vs `develop`, enable squash auto-merge. Walk away — auto-merge lands it once CI is green. |
 | After the PR merges | `make worktree-release` | Detach the slot back to `origin/develop`, delete the local feature branch. Refuses unless the PR state is `MERGED` (use `FORCE=1` to escape — only when intentional). |
 | See pool state any time | `make worktree-pool-status` | Tabular: pool, path, branch, state, claim age, venv health, disk size. Read-only; safe to run during other operations. |
+| Assert pool invariants | `make worktree-pool-check` | Read-only; exits non-zero if any slot is missing, has a surviving `.benchbox/claim_in_progress` marker, or there are extra `pool-NN` directories beyond `POOL_SIZE`. Cheap (no `gh` calls); use as a pre-release sanity check or periodic local cron. |
 | Recover forgotten slots | `make worktree-pool-sweep-stale` | Auto-release every slot whose PR is `MERGED` and tree is clean. Idempotent; refuses dirty/claimed-no-PR/unknown slots. Auto-runs once before `worktree-claim` fails. |
 
 Pre-approved in Claude Code's user-global settings; agents can run them
@@ -160,6 +161,7 @@ local pre-push hook lock doesn't bottleneck it.
 | `make worktree-claim BRANCH=<type>/<slug>` | Claim a free slot atomically. `<type>` ∈ `chore\|fix\|feat\|docs`. |
 | `make worktree-release [FORCE=1]` | Release the current pool slot back to detached `origin/develop`. |
 | `make worktree-pool-status` | Read-only state listing for all slots. |
+| `make worktree-pool-check` | Read-only pool invariant assertion: exits non-zero on missing slots, surviving `.benchbox/claim_in_progress` markers, or extra slots beyond `POOL_SIZE`. No `gh` calls. |
 | `make worktree-pool-sweep-stale` | Auto-release MERGED-and-clean slots. |
 | `make worktree-pool-reset POOL=NN [FORCE=1]` | Per-slot manual escape hatch. |
 | `make worktree-pool-disk-clean` | Strip pytest/coverage/ruff caches across all slots. |

--- a/tests/integration/worktree/test_worktree_pool_check.py
+++ b/tests/integration/worktree/test_worktree_pool_check.py
@@ -1,0 +1,118 @@
+"""Regression tests for `make worktree-pool-check` invariant assertions.
+
+Verifies the contract documented in the recipe: exit non-zero if any slot
+is missing, aborted, or there are extras beyond POOL_SIZE; exit zero
+otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def run(cmd: list[str], cwd: Path, **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=cwd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir()
+    run(["git", "init"], path)
+    run(["git", "config", "user.email", "test@example.com"], path)
+    run(["git", "config", "user.name", "BenchBox Test"], path)
+    (path / ".gitignore").write_text(".venv/\n", encoding="utf-8")
+    (path / "README.md").write_text("test repo\n", encoding="utf-8")
+    run(["git", "add", ".gitignore", "README.md"], path)
+    run(["git", "commit", "-m", "initial"], path)
+
+
+def create_origin_with_develop(tmp_path: Path) -> Path:
+    seed = tmp_path / "seed"
+    origin = tmp_path / "origin.git"
+    init_repo(seed)
+    run(["git", "branch", "-M", "develop"], seed)
+    run(["git", "init", "--bare", str(origin)], tmp_path)
+    run(["git", "remote", "add", "origin", str(origin)], seed)
+    run(["git", "push", "-u", "origin", "develop"], seed)
+    return origin
+
+
+def setup_pool(tmp_path: Path, num_slots: int) -> tuple[Path, Path]:
+    """Create a main clone + `num_slots` pool worktrees on detached develop."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+    origin = create_origin_with_develop(tmp_path)
+    main = tmp_path / "BenchBox"
+    pool_parent = tmp_path / "pool"
+    pool_parent.mkdir()
+    run(["git", "clone", str(origin), str(main)], tmp_path)
+    for i in range(1, num_slots + 1):
+        slot = pool_parent / f"BenchBox.pool-{i:02d}"
+        run(["git", "clone", str(origin), str(slot)], tmp_path)
+        run(["git", "checkout", "--detach", "origin/develop"], slot)
+    return main, pool_parent
+
+
+def invoke_check(main: Path, pool_parent: Path, pool_size: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "make",
+            "-f",
+            str(REPO_ROOT / "Makefile"),
+            "-s",
+            "worktree-pool-check",
+            f"POOL_SIZE={pool_size}",
+            f"WORKTREE_POOL_PARENT={pool_parent}",
+        ],
+        cwd=main,
+        env={**os.environ},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_pool_check_passes_when_all_slots_present_and_clean(tmp_path: Path) -> None:
+    main, pool_parent = setup_pool(tmp_path, num_slots=2)
+    result = invoke_check(main, pool_parent, pool_size=2)
+    assert result.returncode == 0, result.stderr
+    assert "Pool invariant check OK" in result.stdout
+
+
+def test_pool_check_fails_when_slot_missing(tmp_path: Path) -> None:
+    main, pool_parent = setup_pool(tmp_path, num_slots=1)
+    result = invoke_check(main, pool_parent, pool_size=2)
+    assert result.returncode != 0
+    assert "missing" in result.stderr
+    assert "pool-02" in result.stderr
+
+
+def test_pool_check_fails_when_claim_in_progress_marker_present(tmp_path: Path) -> None:
+    main, pool_parent = setup_pool(tmp_path, num_slots=2)
+    marker = pool_parent / "BenchBox.pool-01" / ".benchbox" / "claim_in_progress"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("pid=99999 started=2026-05-02T00:00:00Z branch=feature/dead\n", encoding="utf-8")
+    result = invoke_check(main, pool_parent, pool_size=2)
+    assert result.returncode != 0
+    assert "aborted" in result.stderr
+    assert "pool-01" in result.stderr
+
+
+def test_pool_check_fails_when_extra_slot_beyond_pool_size(tmp_path: Path) -> None:
+    main, pool_parent = setup_pool(tmp_path, num_slots=3)
+    # POOL_SIZE=2 but pool-03 exists → extra slot.
+    result = invoke_check(main, pool_parent, pool_size=2)
+    assert result.returncode != 0
+    assert "Extra pool slots beyond POOL_SIZE" in result.stderr
+    assert "BenchBox.pool-03" in result.stderr


### PR DESCRIPTION
`POOL_SIZE = 10` was previously documented convention only — no target
failed if a slot went missing, an extra `pool-NN` directory appeared,
or a `.benchbox/claim_in_progress` marker survived. The new
`worktree-pool-check` target is read-only (no `gh` calls), so it is
cheap enough to run as a pre-release sanity check or a periodic local
cron without becoming a PR-CI gate.

Failure cases covered:
  - any slot directory missing (count < POOL_SIZE)
  - any slot in `aborted` state (claim_in_progress marker present)
  - extra pool-NN directories beyond POOL_SIZE

The pool.lock file is intrinsic (lockf/flock are OS-level locks
released on process exit, so the file always exists) and is not
checked. Documented in the recipe header, the operations guide, and
CLAUDE.md pre-approved read-only commands.

Regression tests in tests/integration/worktree/test_worktree_pool_check.py
cover all four contract clauses.

Resolves blind-spot
2026-04-30-214358-pool-size-not-codified-as-contract.
