### PR TITLE
fix(explorer): harden React-key bug class at chart-data boundaries

### DIFF
--- a/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
+++ b/_project/blind-spots/2026-04-29-143205-react-key-collision-class.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-29-143205-react-key-collision-class
 date: 2026-04-29
-status: open
+status: actioned
 finding_kind: bug-class
 review_context: "ultrareview B4 / dashboard chart key collisions"
 related_paths:
@@ -62,3 +62,4 @@ call-site of a generalizable defect.
   results-explorer/src/components/` returns ~30 hits including
   `key={queryId}` / `key={qid}` patterns whose uniqueness is not
   obvious without per-call analysis.
+- 2026-05-02: actioned — Sweep 2026-05-02: hardened the bug class at two data-boundary sites. (1) sortQueryIds now deduplicates input — protects RankTable, QueryHeatmap (header + cell-row column iterations), and QueryHistogram against duplicate query_ids in the prop. (2) NormalizedSpeedupChart row iteration now uses composite key '{queryId}-{rowIdx}' because its 'queries' prop is not deduped at the boundary like sortQueryIds. New tests: queryLabels.test.ts dedup contract, NormalizedSpeedupChart.test.tsx duplicate-queryId rendering. Other potential sites audited and left as-is: DivergingBarChart (uses Map.entries() so deduped by construction), TimeSeries / PercentileLadder (already mitigated by prior review), components keying on result_id (unique per run by data definition).

--- a/results-explorer/src/__tests__/queryLabels.test.ts
+++ b/results-explorer/src/__tests__/queryLabels.test.ts
@@ -17,4 +17,18 @@ describe("query labels", () => {
     expect(queryDisplayLabel("q01")).toBe("q01");
     expect(queryDisplayLabel("query_001")).toBe("query_001");
   });
+
+  it("deduplicates duplicate query IDs so callers can use them as React keys", () => {
+    // Defensive contract: RankTable, QueryHeatmap, and QueryHistogram all
+    // iterate this output as React keys. A duplicate would collide.
+    expect(sortQueryIds(["Q3", "Q1", "Q1", "Q2", "Q3", "Q1"])).toStrictEqual([
+      "Q1",
+      "Q2",
+      "Q3",
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(sortQueryIds([])).toStrictEqual([]);
+  });
 });

--- a/results-explorer/src/components/NormalizedSpeedupChart.tsx
+++ b/results-explorer/src/components/NormalizedSpeedupChart.tsx
@@ -104,8 +104,12 @@ export function NormalizedSpeedupChart({ queries, results, baselineIdx }: Props)
           const barAreaW = drawWidth - LABEL_W - PADDING;
           const centerX = LABEL_W + toX(1, barAreaW);
 
+          // Composite key: the `queries` prop is not deduped at the boundary
+          // (unlike sortQueryIds), so a caller passing variant rows for the
+          // same queryId would collide on key={queryId}. The row index
+          // disambiguates within this iteration.
           return (
-            <g key={queryId} transform={`translate(0, ${y0})`}>
+            <g key={`${queryId}-${rowIdx}`} transform={`translate(0, ${y0})`}>
               <text
                 x={LABEL_W - 4}
                 y={rowHeight / 2 + 4}

--- a/results-explorer/src/components/__tests__/NormalizedSpeedupChart.test.tsx
+++ b/results-explorer/src/components/__tests__/NormalizedSpeedupChart.test.tsx
@@ -87,4 +87,29 @@ describe("NormalizedSpeedupChart", () => {
     // em-dash rendered for the null timing slot
     expect(screen.getByText("-")).toBeTruthy();
   });
+
+  // -----------------------------------------------------------------------
+  // Duplicate-queryId guard (blind-spot
+  //   _project/blind-spots/2026-04-29-143205-react-key-collision-class.md)
+  //
+  // The `queries` prop is not deduped at the boundary, so a caller passing
+  // variant rows for the same queryId could collide on key={queryId}. The
+  // composite key `${queryId}-${rowIdx}` keeps reconciliation stable.
+  // -----------------------------------------------------------------------
+
+  it("renders both rows when two queries share the same queryId", () => {
+    const queriesWithDuplicate = [
+      { queryId: "Q1", timings: [{ ms: 100, status: "pass" }, { ms: 50, status: "pass" }] },
+      { queryId: "Q1", timings: [{ ms: 200, status: "pass" }, { ms: 100, status: "pass" }] },
+    ];
+    const { container } = render(
+      <NormalizedSpeedupChart queries={queriesWithDuplicate} results={RESULTS} baselineIdx={0} />,
+    );
+    // Two distinct row groups should render — both Q1 entries plus the
+    // grid axis group. Per-row count: 2 query rows.
+    const queryRows = Array.from(container.querySelectorAll("text")).filter(
+      (el) => el.textContent === "Q1",
+    );
+    expect(queryRows.length).toBe(2);
+  });
 });

--- a/results-explorer/src/lib/queryLabels.ts
+++ b/results-explorer/src/lib/queryLabels.ts
@@ -7,8 +7,28 @@ export function compareQueryIds(a: string, b: string): number {
   return QUERY_ID_COLLATOR.compare(a, b) || a.localeCompare(b);
 }
 
+/**
+ * Sort and deduplicate query identifiers.
+ *
+ * Dedup is defensive: callers (RankTable, QueryHeatmap, QueryHistogram) use
+ * the result both for column ordering AND as React keys. A duplicate id in
+ * the input would produce React key collisions and break reconciliation,
+ * which is the bug class captured in
+ * `_project/blind-spots/2026-04-29-143205-react-key-collision-class.md`.
+ * Stable order on duplicates would not have helped there: only one of the
+ * duplicates can ever survive as a column, so the right answer is to drop
+ * the duplicates at the boundary rather than push composite-key gymnastics
+ * into every column-iterating component.
+ */
 export function sortQueryIds(queryIds: readonly string[]): string[] {
-  return [...queryIds].sort(compareQueryIds);
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const id of queryIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    unique.push(id);
+  }
+  return unique.sort(compareQueryIds);
 }
 
 export function queryDisplayLabel(queryId: string): string {


### PR DESCRIPTION
Two sites where the dataset's batch nature (variant tuning rows, joined
data) could produce duplicate query identifiers and collide on React
keys, breaking reconciliation:

  1. sortQueryIds now dedupes its input. Protects RankTable,
     QueryHeatmap (column header + per-row cell columns), and
     QueryHistogram, all of which use the result both for column
     ordering and as React keys.
  2. NormalizedSpeedupChart's row iteration uses composite key
     `${queryId}-${rowIdx}`. Its `queries` prop is not deduped at the
     boundary the way sortQueryIds is, so a caller passing variant
     rows for the same queryId would otherwise collide.

Sites audited and left unchanged because they are guaranteed unique by
data shape: DivergingBarChart (uses `Map.entries()` so deduped by
construction), TimeSeries and PercentileLadder (already mitigated by
prior review and explicitly commented), components keying on
`result_id` (unique per run by data definition).

Tests:
  - queryLabels.test.ts: dedup contract for sortQueryIds.
  - NormalizedSpeedupChart.test.tsx: duplicate-queryId rendering.

Resolves blind-spot
2026-04-29-143205-react-key-collision-class.
