### PR TITLE
chore(audits): codex weekly-sweep template with blind-spot cross-check

### DIFF
--- a/_project/audits/codex-weekly-sweep-template.md
+++ b/_project/audits/codex-weekly-sweep-template.md
@@ -1,0 +1,184 @@
+# Weekly Codex PR-Review Sweep — Template
+
+A reusable checklist for the recurring "Codex PR-review follow-ups for week
+ending YYYY-MM-DD" TODOs. Built from the
+`codex-pr-review-followups-week-2026-05-01` execution and extended with the
+two axes the original sweep template missed (captured in blind-spot
+`_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md`).
+
+## When to use this template
+
+Run a sweep weekly (or whenever a backlog of `chatgpt-codex-connector[bot]`
+inline review threads has accumulated on merged PRs). Each sweep produces:
+
+1. A new TODO at
+   `_project/TODO/main/planning/codex-pr-review-followups-week-YYYY-MM-DD.yaml`
+2. A rescan audit at
+   `_project/audits/codex-thread-rescan-week-YYYY-MM-DD.md` listing
+   resolved-by-this-TODO, already-fixed-by-earlier-merges, and
+   still-actionable threads
+3. Optional cross-links from in-window blind-spots filed under
+   `_project/blind-spots/YYYY-MM-DD-*` to the TODO
+
+## Required scope axes
+
+The frame "unresolved Codex review threads from PRs #N–#M" is good at
+catching what Codex flagged-and-was-never-resolved, but blind to several
+adjacent failure modes. **All five axes below are mandatory** — skip any
+one of them only with an explicit `out-of-scope:` line citing why.
+
+### Axis 1 — Codex inline threads (the canonical scan)
+
+```bash
+# Discover merged PRs in the review window.
+START_DATE=YYYY-MM-DD  # the Monday before the sweep window
+END_DATE=YYYY-MM-DD    # the Sunday closing the window
+
+git log --since="$START_DATE 00:00:00 -0400" --until="$END_DATE 23:59:59 -0400" \
+  --merges --grep '#[0-9]\+' --pretty='%H %s' origin/develop
+
+# For each merged PR, list its inline review comments.
+gh api repos/joeharris76/BenchBox/pulls/<PR>/comments \
+  --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]")'
+```
+
+Bucket each comment as **Fixed (link the commit)**, **Already fixed by
+earlier merge (link that merge)**, or **Still actionable (becomes a w-unit
+in the TODO)**.
+
+### Axis 2 — In-window blind-spot findings
+
+`_project/blind-spots/YYYY-MM-DD-*.md` may have been filed during the same
+review window by `/code review`, `/blind-spot`, or other paths. Codex
+threads will not surface these — they came from local agents.
+
+```bash
+# Findings filed during the review window.
+ls _project/blind-spots/${START_DATE:0:7}-* 2>/dev/null
+
+# Or, more precisely, all findings whose `date:` frontmatter falls in window.
+make blind-spots-list
+```
+
+For each in-window finding:
+
+- Cross-link it from the TODO's `description:` or relevant `w-unit notes:`.
+- If the finding maps to a w-unit (e.g. a test was loosened in a PR Codex
+  also commented on), add a `must_not_do:` line connecting them so a
+  future agent picking up the w-unit cannot land the fix without
+  addressing the blind-spot.
+- If the finding is out-of-window or unrelated, mention it explicitly
+  ("blind-spot 2026-MM-DD-foo is out-of-scope: process change tracked
+  separately").
+
+The 2026-05-01 sweep added the `do not fix Home.tsx without restoring
+strict cold-load row counts` rule to its `must_not_do` list precisely
+because cross-linking the blind-spot caught the regression-coverage
+downgrade Codex itself never flagged.
+
+### Axis 3 — Tests weakened in the window
+
+Codex flags individual lines, not coverage downgrades. A PR can land a fix
+that simultaneously loosens an assertion that was guarding the same
+failure mode. The bug class is "assertion-loosening alongside fix lands
+without a guard"; the original scan template had no axis for it.
+
+```bash
+# Source: the same merge range as Axis 1.
+git log --since="$START_DATE" --until="$END_DATE" -p \
+  --diff-filter=M --pretty='format:%H %s' origin/develop \
+  -- '*.spec.ts' '*.spec.tsx' '*test*.py' 'tests/' \
+  | rg -B 5 -A 5 'toHaveCount\(.*\) ->|\.length\) ?=>|count.*>\s*0|expect\(.*\)\.toBeGreaterThan\(0\)|assert.*> 0'
+```
+
+Patterns to flag (non-exhaustive — extend as new patterns surface):
+
+- Replacing `expect(X).toHaveCount(N)` / `assertEqual(len(...), N)` with
+  `count > 0` / `length > 0` / `assertGreater(..., 0)`.
+- Removing strict-equal mocks/fixtures and replacing them with
+  fixture-DB polling (loses the byte-for-byte regression guarantee).
+- Deleting a regression test entirely with no replacement (search for
+  `removed test` / `unused test` / `flake` justification on the PR).
+- Loosening `expect(..., {timeout: T1})` to `expect(..., {timeout: T2 > T1})`
+  by an order of magnitude (often masks intermittent regressions).
+
+For each match: if Codex did not flag it, file a w-unit OR a blind-spot
+finding pointing at the diff. Do not silently accept "the team
+simplified" without confirming the regression mode the original test
+guarded is still covered.
+
+### Axis 4 — Codex threads that were "marked resolved" without a fix
+
+Codex's resolved-state in GitHub is unreliable: a contributor can resolve
+a thread by replying or by clicking the resolve button, even if the code
+was never changed. A thread that GitHub reports as resolved but for which
+no commit in the window matches the fix description is a candidate for a
+w-unit. The 2026-05-01 sweep used a manual cross-check; the next sweep
+should script it:
+
+```bash
+gh api repos/joeharris76/BenchBox/pulls/<PR>/comments \
+  --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | {id, body, path, original_position, original_commit_id}'
+
+# Then: for each thread, search the merged-PR diff for content that
+# matches the comment's path/anchor; if nothing changed in the comment's
+# vicinity AND the thread is reported resolved, it's a phantom-resolution.
+```
+
+### Axis 5 — DONE-item verification commands that drifted
+
+If the review window includes commits that touched a path or tool an
+older DONE-item used in its `verification:` block (e.g. a script that
+got renamed or an API that changed shape), the verification command may
+silently no-op or fail. The 2026-05-01 policy decision below is
+inherited:
+
+> Historical DONE-item verification commands are kept executable. If a
+> Codex finding identifies a portability or correctness defect in a
+> DONE-item verification block, fix it in place. Rationale: those
+> commands serve as runnable documentation of how the policy was
+> confirmed, so anyone re-verifying the historical decision (forks,
+> recreated rulesets, future audits) needs them to work.
+
+## TODO file shape
+
+Use `_project/TODO_ENTRY_TEMPLATE.yaml` as the base. The conventional
+fields for a Codex sweep TODO:
+
+- `id: codex-pr-review-followups-week-YYYY-MM-DD`
+- `title: "Address unresolved Codex PR review follow-ups from the week ending YYYY-MM-DD"`
+- `worktree: main`
+- `priority: High`
+- `category: Testing and Quality Assurance`
+- `description:` — number of merged PRs scanned, number of Codex comments
+  found, the policy decision quoted from Axis 5, AND a paragraph noting
+  which in-window blind-spots were folded in vs out-of-scope (Axis 2).
+- `work:` — one w-unit per still-actionable thread; one
+  `summary: "Re-run the Codex thread scan and produce the rescan audit"`
+  unit at the end whose `notes:` block lists the required audit sections.
+- `must_not_do:` — must include cross-links from any folded-in
+  blind-spots so the rule travels with the work.
+- `verification:` — must include checks for each w-unit AND a check that
+  the rescan audit file exists with the three required sections.
+
+## Rescan audit shape
+
+`_project/audits/codex-thread-rescan-week-YYYY-MM-DD.md` is the
+per-sweep public record. Required sections:
+
+1. `## Resolved By w1-wN` — one row per fixed thread, link to the
+   commit that fixed it.
+2. `## Already-Fixed By Earlier Merges` — one row per stale-but-OK
+   thread, link to the merge that already fixed it.
+3. `## Still Actionable` — one row per thread that needs a w-unit
+   (should be empty after the sweep TODO completes).
+
+## Closing the loop
+
+When the TODO completes:
+
+- Triage the cross-linked blind-spots — typically `--action actioned`
+  with a one-line reason citing the TODO id.
+- Mention the rescan audit file in the TODO's `final_notes:` block.
+- If new patterns surfaced for Axis 3 (test-weakening) that this
+  template did not list, add them here so the next sweep starts wider.

--- a/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
+++ b/_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades
 date: 2026-05-01
-status: open
+status: actioned
 finding_kind: framework-gap
 review_context: "/todo review of codex-pr-review-followups-week-2026-05-01"
 related_paths:
@@ -101,3 +101,4 @@ never flagged the test downgrade in the first place.
   template — there is no `_project/templates/` directory and no
   weekly-sweep template to amend. Verified actionable for the
   framework-gap dimension only.
+- 2026-05-02: actioned — Sweep 2026-05-02: created _project/audits/codex-weekly-sweep-template.md with all five required scope axes. Axis 2 (in-window blind-spot cross-check) and Axis 3 (tests weakened in the window — with concrete grep patterns for assertion-loosening like toHaveCount->count>0, fixture-DB polling replacing strict mocks, etc.) were the gaps the original frame missed. Future weekly Codex sweeps copy from this template and skip an axis only with an explicit out-of-scope citation. The 2026-05-01 sweep already executed Axis 2 manually (cold-load coverage cross-link in must_not_do); template now codifies the practice. (Note: `_project/prompts/` is gitignored, so the template lives in `_project/audits/` alongside the per-week rescan files.)


### PR DESCRIPTION
The 2026-05-01 codex-pr-review-followups TODO executed cleanly but the
sweep frame missed two axes that surfaced as blind-spots:

  1. In-window blind-spots filed by /code review or /blind-spot were
     not cross-linked. The cold-load coverage downgrade
     (2026-05-01-103002) had to be manually wired into the TODO's
     must_not_do list to keep the row-count restoration from getting
     dropped alongside the Home.tsx fix.
  2. "Tests weakened in this window" had no scan axis. Codex flags
     individual lines, not coverage downgrades — a PR can land a fix
     and simultaneously loosen the assertion that was guarding the
     same failure mode (which is exactly what PR #86 did before the
     follow-up restoration).

This template documents all five required axes (Codex inline threads,
in-window blind-spots, tests-weakened patterns, phantom-resolved
threads, and DONE-item verification drift) plus the TODO and rescan
audit shapes so the next weekly sweep starts from a wider frame. Lives
in `_project/audits/` (the natural sibling of the per-week rescan
files) since `_project/prompts/` is gitignored.

Resolves blind-spot
2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.
