### PR TITLE
chore(blind-spots): capture sketch-TODO architectural blockers

### DIFF
--- a/_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md
+++ b/_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md
@@ -1,0 +1,85 @@
+---
+id: 2026-05-02-155448-validation-query-no-per-platform-override
+date: 2026-05-02
+status: open
+finding_kind: framework-gap
+review_context: "TODO write-primitives-sketch-clickhouse-and-storage-metrics implementation attempt"
+related_paths:
+  - benchbox/core/write_primitives/catalog/loader.py
+  - benchbox/core/write_primitives/benchmark.py
+  - benchbox/core/write_primitives/catalog/operations.yaml
+suggested_sweep: "Audit every write_primitives op whose validation_query uses dialect-specific syntax (datasketch_*, theta_sketch_*, KLL_QUANTILES.*, APPROX_TOP_K_*, HLL_COMBINE, etc.) — those validation_queries cannot succeed on engines other than the one whose syntax was used to author them. Likely false-PASS or hard-FAIL across the cloud overrides for the 8 sketch ops + any future ops that follow the same pattern."
+todo_id: null
+---
+
+# Write-Primitives validation_query Has No Per-Platform Override
+
+## Finding
+
+`WriteOperation.validation_queries[]` are sent **raw** to
+`connection.execute(val_sql)` with no per-platform override mechanism — the
+loader (`loader.py`) defines `ValidationQuery` as a single SQL string, and the
+runner (`benchmark.py:_run_operation_validation`) does not call any dialect
+translator before executing.
+
+Meanwhile `WriteOperation.platform_overrides` *does* let `write_sql` differ
+per engine. So the existing 8 sketch ops have ClickHouse/Snowflake/Databricks/
+BigQuery `write_sql` variants but a single DuckDB-syntax `validation_query`.
+On every non-DuckDB engine, the validation step will raise an "unknown
+function" exception and mark the op FAILED.
+
+This is structurally invisible today because:
+
+- Cloud overrides for these ops have never been verified end-to-end (cloud
+  credentials gap, deferred to `write-primitives-sketch-cloud-verification`).
+- `clickhouse: null` skips the op entirely, so validation is never attempted.
+
+The TODO `write-primitives-sketch-clickhouse-and-storage-metrics` would have
+been the first PR to actually run a sketch-merge validation_query on a
+non-DuckDB engine (chDB), which surfaced this gap immediately. Even a perfect
+ClickHouse `write_sql` override fails because the validation_query
+`SELECT datasketch_theta_estimate(datasketch_theta(user_sketch))...` is
+DuckDB-only syntax.
+
+## Why this matters
+
+Three downstream TODOs depend on this gap being closed first or worked
+around:
+
+- `write-primitives-sketch-clickhouse-and-storage-metrics` (this finding's
+  origin) — w3 + w5 cannot be implemented in operations.yaml alone.
+- `write-primitives-sketch-cloud-verification` — when Snowflake/BigQuery/
+  Databricks credentials become available, cloud runs will fail validation
+  even though the writes succeed.
+- `write-primitives-sketch-pyspark-dataframe-surface` — DataFrame mode has
+  its own validation contract path; SQL-mode equivalents would hit this
+  same wall.
+
+PR #114 added scalar-bounds enforcement to gate ops at validation time,
+which made this gap actually break ClickHouse runs (previously it would
+have silently returned wrong values).
+
+## Suggested next steps
+
+- [ ] Promote to a fix-class TODO: extend `ValidationQuery` schema +
+      loader + runner to support `validation_query.platform_overrides`,
+      mirroring the existing `write_sql.platform_overrides` shape.
+- [ ] Once the override mechanism lands, unblock the four sketch TODOs
+      and add an explicit dependency edge from each to the new fix TODO.
+- [ ] Audit existing 8 sketch ops' validation_queries: confirm
+      DuckDB-syntax-only assumption was intentional and document the
+      cross-engine gap inline alongside the cloud platform_overrides.
+- [ ] Consider whether sqlglot dialect translation in
+      `_run_operation_validation` would be a smaller-blast alternative
+      (probably no — sketch function names are semantic, not syntactic,
+      mappings).
+
+## Why it didn't get caught earlier
+
+- PR #112 + #114 reviewers smoke-verified on DuckDB only ("DuckDB SF=0.01:
+  theta 14836.89 ∈ [14000, 16000]" — note: this no longer reproduces; see
+  related blind-spot on the datasketches extension drift).
+- The cloud `write_sql` overrides shipped with the assumption that
+  validation would just-work, but the existing validation_query SQL bodies
+  (`datasketch_*` family) are non-portable.
+- The sketch TODOs all share the same author and the same blind spot.

--- a/_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md
+++ b/_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md
@@ -1,0 +1,80 @@
+---
+id: 2026-05-02-155524-duckdb-datasketches-extension-drift
+date: 2026-05-02
+status: open
+finding_kind: assumption
+review_context: "TODO write-primitives-sketch-clickhouse-and-storage-metrics implementation attempt"
+related_paths:
+  - benchbox/core/write_primitives/catalog/operations.yaml
+  - pyproject.toml
+suggested_sweep: "Pin or vendor a known-good datasketches community-extension build (e.g. ship the .duckdb_extension binary in _binaries/), or replace `datasketch_theta` / `datasketch_frequent_items` references with HLL family substitutes that the current extension actually exports. Add a CI smoke that calls `SELECT datasketch_theta(1)` to fail fast if a future extension rebuild drops the family again."
+todo_id: null
+---
+
+# DuckDB datasketches Community Extension Dropped theta + frequent-items Families
+
+## Finding
+
+The 4 sketch ops `sketch_insert_theta_per_partition`,
+`sketch_insert_topk_per_shard`, `sketch_query_theta_union_merge`,
+`sketch_query_topk_combine` reference `datasketch_theta` and
+`datasketch_frequent_items` aggregates that **do not exist** in the
+DuckDB community datasketches extension at the version BenchBox installs
+today (commit `2e38607` for DuckDB v1.3.2).
+
+PR #114's commit message explicitly claims smoke-verification:
+
+> "all 3 ★ headline sketch ops still return values within their tuned
+> bounds on DuckDB SF=0.01 (theta 14836.89 ∈ [14000, 16000]; ...)"
+
+That assertion was true on 2026-05-02 morning when PR #114 merged. As of
+2026-05-02 ~15:50, a fresh `INSTALL datasketches FROM community` (cache
+purged, version 2e38607 re-downloaded) returns the same build and the
+function family is absent: `Catalog Error: Scalar Function with name
+datasketch_theta does not exist! Did you mean "datasketch_tdigest"?`.
+
+`SELECT DISTINCT function_name FROM duckdb_functions() WHERE function_name
+ILIKE 'datasketch_%'` returns the families: `cpc`, `hll`, `kll`,
+`quantiles`, `req`, `tdigest`. No `theta`. No `frequent_items`.
+
+Either the upstream extension build for v1.3.2 was rebuilt without the
+theta + frequent-items families between PR #114 morning and this audit,
+or the smoke verification was performed against a different DuckDB
+version that BenchBox doesn't pin to.
+
+## Why this matters
+
+`benchbox run --platform duckdb --benchmark write_primitives --queries
+sketch_query_theta_union_merge` returns FAILED on develop today, and
+4/8 sketch ops fail end-to-end. This blocks the verification step of
+every write_primitives sketch TODO that asserts "8/8 pass on DuckDB"
+as a regression check.
+
+Combined with the sibling blind-spot
+(`2026-05-02-155448-validation-query-no-per-platform-override`), the
+TODO `write-primitives-sketch-clickhouse-and-storage-metrics` is
+hard-blocked: even if the ClickHouse-side overrides are added, the
+DuckDB regression check cannot pass and the validation infrastructure
+cannot reliably gate cross-engine ops.
+
+CI doesn't catch this because it doesn't currently exercise the sketch
+ops beyond loader unit tests. The community extensions are downloaded
+on-demand from a CDN and not vendored, so an upstream re-build silently
+changes BenchBox's behavior without any version bump or PR.
+
+## Suggested next steps
+
+- [ ] Add a fast smoke in CI that calls `SELECT datasketch_theta(1)` and
+      `SELECT datasketch_frequent_items(8, 'x')` against a fresh DuckDB
+      install — fails the build if either family is absent.
+- [ ] Decide between vendoring the community extension binary in
+      `_binaries/datasketches/` (control over version, larger artifact
+      tree) vs. switching the ops to families the upstream extension
+      reliably exports (`hll` substitution; closer to Redshift's
+      HLL-only ceiling).
+- [ ] File an upstream issue against the duckdb-community-extensions
+      datasketches build asking why the theta + frequent-items families
+      were dropped from the v1.3.2 build artifact, if confirmed.
+- [ ] Until resolved, treat any sketch-TODO verification step that
+      requires DuckDB execution of theta or topk ops as a known-fail;
+      do not block PRs on that specific check.


### PR DESCRIPTION
## Summary

Records two blind-spot findings surfaced while attempting TODO
`write-primitives-sketch-clickhouse-and-storage-metrics`. Both findings
hard-block that TODO and the sibling sketch TODOs (CPC/REQ families,
parameter sweeps, PySpark DataFrame surface, cloud verification).

### Finding 1: validation_query has no per-platform override

`validation_queries[]` SQL is sent raw to `connection.execute` with no
dialect translation, while `write_sql` does support `platform_overrides`.
The 3 ★ headline sketch ops use DuckDB-only `datasketch_*` syntax in
their validation_query bodies, so even a perfect ClickHouse `write_sql`
override fails — the validation runs DuckDB SQL on ClickHouse and
crashes. Same gap will surface on Snowflake / Databricks / BigQuery the
moment cloud verification runs.

`benchbox/core/write_primitives/catalog/loader.py` and
`benchbox/core/write_primitives/benchmark.py` would both need to change
to add `validation_query.platform_overrides`. Both are in
`scope_limit.do_not_modify` for the four sketch TODOs in flight.

### Finding 2: DuckDB datasketches extension dropped theta + frequent_items

The community datasketches extension at the version BenchBox installs
today (commit `2e38607` for DuckDB v1.3.2) does not export
`datasketch_theta` or `datasketch_frequent_items`. Existing
`sketch_insert_theta_per_partition`, `sketch_insert_topk_per_shard`,
`sketch_query_theta_union_merge`, `sketch_query_topk_combine` ops fail
on a clean develop install (4/8 sketch ops broken).

PR #114's commit message claims smoke verification passed on the morning
of 2026-05-02, so either the upstream extension build was rebuilt
without the families later that day, or the smoke ran against a
different DuckDB version than BenchBox pins to.

## Test plan

- [x] Both files validate against the blind-spot frontmatter pre-commit
- [x] `make pr-preflight` passes (no code paths touched)
- [x] Sweep candidate documented in each file's `suggested_sweep`