### PR TITLE
chore(todo): mark 5 sketch TODOs Blocked with architectural-gap findings

### DIFF
--- a/_project/TODO/main/planning/write-primitives-sketch-clickhouse-and-storage-metrics.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-clickhouse-and-storage-metrics.yaml
@@ -2,10 +2,52 @@ id: write-primitives-sketch-clickhouse-and-storage-metrics
 title: "Write Primitives: ClickHouse-native sketch variants + storage-size validation for headline ★ ops"
 worktree: main
 priority: Medium-High
-status: "Not Started"
+status: "Blocked"
 category: "Core Functionality"
 
 description: |
+  ## BLOCKED — implementation attempt 2026-05-02 (PR #133)
+
+  Two architectural gaps in write_primitives surfaced when this TODO
+  was attempted; both must be resolved before the catalog work below
+  can land cross-engine. Findings captured as blind-spot files:
+
+    - `_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md`
+      `validation_queries[]` are sent raw to `connection.execute()`
+      with no per-platform override mechanism. The 3 ★ headline ops
+      use DuckDB-only `datasketch_*` syntax in their validation_query
+      bodies, so any ClickHouse `write_sql` override would fail
+      validation immediately (the validation runs DuckDB SQL on
+      ClickHouse and crashes). Resolving requires extending
+      `WriteOperation.validation_queries[]` schema + `loader.py` +
+      `_run_operation_validation` to support
+      `validation_query.platform_overrides`. All three files are in
+      `scope_limit.do_not_modify` for this TODO.
+
+    - `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`
+      The DuckDB community datasketches extension at the version
+      BenchBox installs (commit `2e38607` for v1.3.2) does not export
+      `datasketch_theta` or `datasketch_frequent_items`. 4/8 sketch
+      ops fail end-to-end on a clean develop install today,
+      contradicting PR #114's smoke-verification claim — the upstream
+      build appears to have been rebuilt without the families.
+      Resolving needs vendoring the extension binary or
+      switching the broken ops to `datasketch_hll` substitution.
+
+  Spike findings that DO survive: the chDB local verification of
+  `uniqState`/`uniqMerge`, `quantileTDigestState`/`quantileTDigestMerge(0.5)`,
+  and `topKState(8)`/`topKMerge(8)` was confirmed end-to-end. Storage
+  sizes were observed empirically (theta merged state ~60KB, KLL
+  ~3.5KB, topK ~317B) — these would inform w5 bounds when implementation
+  resumes. The catalog work in the work[] block is otherwise still
+  the correct shape.
+
+  Re-attempt after the fix-class TODO covering both gaps lands; add
+  a `deps.needs:` edge from this TODO to the new fix TODO at that
+  point. Keep this TODO's scope_limit unchanged.
+
+  ## Original description
+
   Two coordinated expansions to the `sketch` category that landed in
   PR #112:
 

--- a/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
@@ -1,11 +1,62 @@
 id: write-primitives-sketch-cloud-verification
-title: "Write Primitives sketch: cloud verification of Snowflake / BigQuery / Databricks platform_overrides"
+title: "Write Primitives sketch: cloud verification of Snowflake / BigQuery / Databricks / Redshift platform_overrides"
 worktree: main
 priority: Medium
-status: "Not Started"
+status: "Blocked"
 category: "Verification"
 
 description: |
+  ## BLOCKED — additional finding 2026-05-02 (PR #133, PR #134)
+
+  This TODO is blocked on TWO things, only one of which is the
+  originally-stated cloud-credential gap:
+
+  **(1) Cloud credentials still missing** — the original blocker.
+  Snowflake / BigQuery / Databricks / Redshift creds have not become
+  available locally yet.
+
+  **(2) validation_query no-per-platform-override architectural gap.**
+  Surfaced during the ClickHouse implementation attempt 2026-05-02:
+
+    - `_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md`
+
+  The existing 3 ★ headline sketch ops use DuckDB-only `datasketch_*`
+  syntax in their `validation_query` bodies. Even when cloud creds
+  arrive, the cloud `write_sql` overrides will succeed on the cloud
+  engines — but the validation_query that runs immediately after will
+  raise an "unknown function" exception because the DuckDB sketch
+  function names don't exist on Snowflake / BigQuery / Databricks /
+  Redshift. The op will be marked FAILED despite the persist+merge
+  having actually worked. Cloud verification cannot give a clean
+  signal until validation_query supports per-platform overrides.
+
+  Per-engine scope additions also needed:
+
+    - **Redshift**: PR #134 added 4 HLL-substitution overrides for
+      Redshift (DDL, theta-style insert, theta-style merge, drop).
+      These weren't in the original cloud-verification scope but
+      should be picked up here when creds become available.
+      Tolerance bounds for the merged HLL distinct estimate were
+      authored against DataSketches Theta and may need re-tuning to
+      absorb HLL++ bias — see PR #134 description for the
+      conservative starting bounds.
+    - **ClickHouse Cloud / Snowflake**: same fix-class TODO that
+      unblocks the validation_query gap will also unblock the
+      ClickHouse-native `-State`/`-Merge` overrides (TODO
+      `write-primitives-sketch-clickhouse-and-storage-metrics`),
+      and that TODO's overrides should land before this one runs
+      end-to-end on ClickHouse Cloud.
+
+  Resolution path:
+    1. Fix-class TODO for validation_query.platform_overrides lands.
+    2. Cloud creds for at least one of the four cloud engines
+       become available.
+    3. This TODO runs on each available engine, expanding to cover
+       Redshift's new HLL ops and (once their TODO lands)
+       ClickHouse-native variants.
+
+  ## Original description
+
   The merged write_primitives sketch category shipped with
   `platform_overrides` for Snowflake, BigQuery, and Databricks
   written from documented function names but **never executed against

--- a/_project/TODO/main/planning/write-primitives-sketch-duckdb-cpc-req-families.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-duckdb-cpc-req-families.yaml
@@ -2,10 +2,36 @@ id: write-primitives-sketch-duckdb-cpc-req-families
 title: "Write Primitives sketch: add DuckDB-only CPC and REQ sketch families"
 worktree: main
 priority: Medium
-status: "Not Started"
+status: "Blocked"
 category: "Core Functionality"
 
 description: |
+  ## BLOCKED — transitively blocked via `write-primitives-sketch-clickhouse-and-storage-metrics`
+
+  The dep edge in `deps.needs:` points at the ClickHouse + storage-
+  metrics TODO. That TODO is itself Blocked (PR #133, 2026-05-02) on
+  two write_primitives architectural gaps:
+
+    - validation_query has no per-platform override mechanism
+      (`_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md`)
+    - DuckDB community datasketches extension at the version BenchBox
+      installs has dropped the theta + frequent-items families
+      (`_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`)
+
+  This TODO additionally hits the second blocker directly: the
+  CPC/REQ family ops here would call `datasketch_cpc` and
+  `datasketch_req` against a community extension build that we
+  cannot reliably resolve via `INSTALL datasketches FROM community`
+  today. Both gaps need a fix-class TODO before any sketch work in
+  the matrix can land cross-engine.
+
+  Resolution path: same fix-class TODO that unblocks
+  `write-primitives-sketch-clickhouse-and-storage-metrics` will
+  unblock this TODO too. Re-attempt after that lands; keep the
+  scope_limit and work[] block unchanged.
+
+  ## Original description
+
   The DuckDB `datasketches` community extension exposes additional
   sketch families beyond the Theta / KLL / Frequent-Items trio that
   the merged write_primitives sketch category covers:

--- a/_project/TODO/main/planning/write-primitives-sketch-parameter-sweeps.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-parameter-sweeps.yaml
@@ -2,10 +2,38 @@ id: write-primitives-sketch-parameter-sweeps
 title: "Write Primitives sketch: parameter-sweep variants for sketch tuning surface (lg_k, k, lg_max_map_size)"
 worktree: main
 priority: Low
-status: "Not Started"
+status: "Blocked"
 category: "Core Functionality"
 
 description: |
+  ## BLOCKED — transitively blocked via `write-primitives-sketch-clickhouse-and-storage-metrics`
+
+  The dep edge in `deps.needs:` points at the ClickHouse + storage-
+  metrics TODO. That TODO is itself Blocked (PR #133, 2026-05-02) on
+  two write_primitives architectural gaps:
+
+    - validation_query has no per-platform override mechanism
+      (`_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md`)
+    - DuckDB community datasketches extension at the version BenchBox
+      installs has dropped the theta + frequent-items families
+      (`_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`)
+
+  Parameter sweeps multiply the number of (op × engine × parameter)
+  cells that have to validate end-to-end. Until both upstream gaps
+  are resolved, the parameter-sweep variants would expand the
+  blast-radius of the existing failures rather than measure anything
+  useful — every cell that depends on a broken-extension function
+  name or a non-portable validation_query would fail in the same
+  way. The size of the sweep makes it especially worth waiting for
+  the underlying architecture to be solid before adding axes.
+
+  Resolution path: same fix-class TODO that unblocks
+  `write-primitives-sketch-clickhouse-and-storage-metrics` will
+  unblock this TODO too. Re-attempt after that lands; keep the
+  scope_limit and work[] block unchanged.
+
+  ## Original description
+
   The merged sketch ops use one default parameter value per sketch
   family — Theta lg_k=12 (4096 entries), KLL k=200, Top-K
   lg_max_map_size=8 (256 entries). These defaults trade size,

--- a/_project/TODO/main/planning/write-primitives-sketch-pyspark-dataframe-surface.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-pyspark-dataframe-surface.yaml
@@ -2,10 +2,46 @@ id: write-primitives-sketch-pyspark-dataframe-surface
 title: "Write Primitives sketch: add PySpark-only DataFrame surface for sketch persist + merge"
 worktree: main
 priority: Medium
-status: "Not Started"
+status: "Blocked"
 category: "Core Functionality"
 
 description: |
+  ## BLOCKED — w1 research spike 2026-05-02 (PR #136)
+
+  w1's research spike confirmed BenchBox's DataFrame execution model
+  has no extension point for sketch-shaped ops. Finding captured as:
+
+    - `_project/blind-spots/2026-05-02-163132-write-primitives-dataframe-execution-model-no-sketch-shape.md`
+
+  `benchbox/core/write_primitives/dataframe_operations.py` exposes a
+  closed `WriteOperationType` enum (INSERT, BULK_LOAD, UPDATE, DELETE,
+  MERGE, TRANSACTION) routed through the row-level maintenance
+  interface. Sketch persistence is structurally different (per-group
+  HLL state build, persist, merge, extract scalar) and does not fit
+  any existing op type.
+
+  The TODO's own anti-pattern is the explicit hard-block trigger:
+  > "DO NOT extend BenchBox's DataFrame execution model beyond what
+  > dataframe_operations.py already supports — because that's a
+  > structural change with broader scope implications — surface the
+  > need to the user before extending."
+
+  Resolution requires a fix-class TODO that adds aggregate-state op
+  shape support: likely `WriteOperationType.AGGREGATE_PERSIST` and
+  `WriteOperationType.AGGREGATE_MERGE` with a build-fn / merge-fn /
+  extract-fn registration similar to read_primitives' existing
+  `expression_impl` / `pandas_impl` pattern. That extension would
+  also unlock potential ClickHouse / Polars / DataFusion sketch ops
+  later, plus any future aggregate-state-persistence benchmark
+  category (materialised views, summary tables, ML feature stores).
+
+  Re-attempt after the fix-class TODO covering that gap lands; add a
+  `deps.needs:` edge from this TODO to the new fix TODO at that point.
+  Keep w2-w5 work specifications below unchanged — they remain the
+  correct shape once the model accepts aggregate-state ops.
+
+  ## Original description
+
   The merged write_primitives sketch category exposes the persist +
   merge + requery loop only on the SQL surface (8 ops). PySpark is
   the only DataFrame engine in BenchBox's matrix with a comparable


### PR DESCRIPTION
## Summary

Updates 5 sketch TODOs from "Not Started" to "Blocked" with explicit
findings + blind-spot pointers gathered during the sketch / approximate-
aggregate implementation run on 2026-05-02 (PRs #133–#136). Each TODO
gets a "BLOCKED" section prepended to its description naming the
relevant blind-spot file, summarizing the gap, and pointing at the
resolution path. Original description, work[] block, and scope_limit
are preserved unchanged so the implementation shape stays correct for
re-attempt once the upstream architecture fixes land.

| TODO | Blocker(s) |
|---|---|
| `write-primitives-sketch-clickhouse-and-storage-metrics` | validation_query no per-platform override + DuckDB extension drift |
| `write-primitives-sketch-pyspark-dataframe-surface` | DataFrame execution-model has no aggregate-state op shape |
| `write-primitives-sketch-duckdb-cpc-req-families` | transitively via the ClickHouse TODO + direct hit on extension drift |
| `write-primitives-sketch-parameter-sweeps` | transitively via the ClickHouse TODO |
| `write-primitives-sketch-cloud-verification` | original cred gap PLUS validation_query no per-platform override (cloud overrides will fail validation even when writes succeed); title expanded to include Redshift since PR #134 added 4 HLL overrides |

## Test plan

- [x] All 5 yaml files pass `validate_todo.py`
- [x] `make pr-preflight` passes (no code paths touched; TODO YAML lane runs)
- [x] Indexes regenerated (no content change since planning/ vs done/ unchanged)
- [ ] Auto-merge picks up after CI