### PR TITLE
fix/results explorer normalized cost unavailable

### DIFF
--- a/_project/DONE/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
+++ b/_project/DONE/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
@@ -2,8 +2,9 @@ id: results-explorer-uat-defect-normalized-cost-unavailable-bundles
 title: "UAT defect: submitted bundles emit cost totals with unavailable cost status"
 worktree: main
 priority: "High"
-status: "In Progress"
+status: "Completed"
 category: "Core Functionality"
+completed_date: "2026-05-03"
 
 description: |
   W5 full-package validation rejected many bundles because `cost.total_usd` was

--- a/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
+++ b/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
@@ -40,7 +40,15 @@ work:
 - id: w2
   summary: "Align bundle export with the hosted-results cost contract"
   needs: [w1]
-  status: pending
+  status: done
+  notes: |
+    Implemented in `benchbox/core/results/schema.py`.
+    `_add_cost_section()` now emits the legacy direct `cost.total_usd`
+    only when normalized-cost metadata has an available value and an
+    accepted status (`normalized` or `not_applicable_local`). Bundles
+    with `normalized_cost.cost_status="unavailable"` retain the explicit
+    unavailable normalized-cost block but no longer emit an incompatible
+    direct cost total.
 - id: w3
   summary: "Add export/submission validation regression coverage"
   needs: [w2]

--- a/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
+++ b/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
@@ -2,7 +2,7 @@ id: results-explorer-uat-defect-normalized-cost-unavailable-bundles
 title: "UAT defect: submitted bundles emit cost totals with unavailable cost status"
 worktree: main
 priority: "High"
-status: "Not Started"
+status: "In Progress"
 category: "Core Functionality"
 
 description: |
@@ -14,7 +14,29 @@ description: |
 work:
 - id: w1
   summary: "Trace normalized-cost emission for local and unavailable-cost results"
-  status: pending
+  status: done
+  notes: |
+    W1 trace result (2026-05-03):
+      - Cost calculation is already producing the correct unavailable
+        normalized-cost payload. `CostCalculator.calculate_normalized_benchmark_cost`
+        returns `cost_status="unavailable"` and omits
+        `normalized_cost_usd` when cloud pricing metadata is defaulted or
+        missing; this is covered in
+        `tests/unit/core/cost/test_calculator.py` and
+        `tests/unit/core/cost/test_integration.py`.
+      - The incompatible direct total is added during schema-v2 export.
+        `benchbox/core/results/schema.py::_add_cost_section()` copies
+        `result.cost_summary["total_cost"]` into `payload["cost"]["total_usd"]`
+        without checking normalized-cost availability. The hosted
+        validator rejects that shape when `normalized_cost.cost_status`
+        is `unavailable`.
+      - W2 owned implementation file:
+        `benchbox/core/results/schema.py`.
+      - W3 owned test file:
+        `tests/unit/test_results_exporter.py`.
+      - Validator behavior should remain unchanged in
+        `scripts/validate_submission.py`; it is correctly rejecting the
+        invalid shape and is not owned by this fix.
 - id: w2
   summary: "Align bundle export with the hosted-results cost contract"
   needs: [w1]
@@ -37,7 +59,8 @@ must_preserve:
 - "Local results remain visibly cost-unavailable rather than pretending to be zero-cost cloud runs."
 
 anti_patterns:
-- "DO NOT set unavailable costs to 0 USD -- because that creates false leaderboard semantics -- omit totals or mark them using the explicit unavailable payload."
+- "DO NOT set unavailable costs to 0 USD -- because that creates false leaderboard semantics -- omit totals or mark them using
+  the explicit unavailable payload."
 
 metadata:
   tags: [uat, submission, normalized-cost]

--- a/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
+++ b/_project/TODO/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
@@ -52,7 +52,7 @@ work:
 - id: w3
   summary: "Add export/submission validation regression coverage"
   needs: [w2]
-  status: pending
+  status: done
 
 verification:
 - description: "Submission validator accepts a local no-cost bundle without cost totals."

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -574,11 +574,20 @@ def _add_cost_section(payload: dict[str, Any], result: BenchmarkResults) -> None
         if isinstance(normalized_cost, dict):
             payload["normalized_cost"] = normalized_cost
         cost_block: dict[str, Any] = {}
-        if "total_cost" in result.cost_summary:
+        if "total_cost" in result.cost_summary and _normalized_cost_allows_direct_total(normalized_cost):
             cost_block["total_usd"] = result.cost_summary["total_cost"]
         cost_block["model"] = result.cost_summary.get("cost_model", "estimated")
         if cost_block:
             payload["cost"] = cost_block
+
+
+def _normalized_cost_allows_direct_total(normalized_cost: Any) -> bool:
+    """Return True when legacy direct cost totals can satisfy the public contract."""
+    if not isinstance(normalized_cost, dict):
+        return False
+    if normalized_cost.get("cost_status") not in {"normalized", "not_applicable_local"}:
+        return False
+    return normalized_cost.get("normalized_cost_usd") is not None
 
 
 def _add_execution_section(payload: dict[str, Any], result: BenchmarkResults, driver_metadata: dict[str, Any]) -> None:

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -16,11 +16,39 @@ from benchbox.core.results.models import (
     SetupPhase,
     TableCreationStats,
 )
+from scripts.validate_submission import ValidationResult, _validate_bundle
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
 ]
+
+
+def _minimal_result(platform: str) -> BenchmarkResults:
+    return BenchmarkResults(
+        benchmark_name="TPCH",
+        platform=platform,
+        scale_factor=0.01,
+        execution_id=f"cost-{platform}",
+        timestamp=datetime(2026, 5, 3),
+        duration_seconds=1.0,
+        total_queries=1,
+        successful_queries=1,
+        failed_queries=0,
+        query_results=[{"query_id": "Q1", "execution_time_ms": 1, "rows_returned": 1, "status": "SUCCESS"}],
+    )
+
+
+def _export_payload(tmp_path, result: BenchmarkResults) -> dict:
+    exported = ResultExporter(output_dir=tmp_path, anonymize=False).export_result(result, formats=["json"])
+    with open(exported["json"], encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _assert_submission_valid(payload: dict) -> None:
+    vr = ValidationResult("export")
+    _validate_bundle(payload, vr)
+    assert vr.ok, vr.errors
 
 
 def test_exporter_serializes_execution_phases(tmp_path):
@@ -87,6 +115,24 @@ def test_exporter_serializes_execution_phases(tmp_path):
     assert payload["platform"]["name"] == "duckdb"
     # Successful phases won't create errors
     assert "errors" not in payload
+
+
+def test_exporter_omits_direct_total_for_unavailable_normalized_cost(tmp_path):
+    payload = _export_payload(tmp_path, _minimal_result("snowflake"))
+
+    assert payload["normalized_cost"]["cost_status"] == "unavailable"
+    assert payload["normalized_cost"]["normalized_cost_usd"] is None
+    assert "total_usd" not in payload.get("cost", {})
+    _assert_submission_valid(payload)
+
+
+def test_exporter_preserves_local_zero_total_with_normalized_provenance(tmp_path):
+    payload = _export_payload(tmp_path, _minimal_result("duckdb"))
+
+    assert payload["normalized_cost"]["cost_status"] == "not_applicable_local"
+    assert payload["normalized_cost"]["normalized_cost_usd"] == "0"
+    assert payload["cost"]["total_usd"] == 0
+    _assert_submission_valid(payload)
 
 
 def test_exporter_rejects_unsupported_type(tmp_path, caplog) -> None:


### PR DESCRIPTION
- **chore(todo): trace normalized cost export defect**
- **fix(results): omit unavailable direct cost totals**
- **test(results): cover unavailable normalized cost exports**
- **chore(todo): complete normalized cost export defect**
