### PR TITLE
fix(results): make --paths pipeable; reject --submitted+--paths

### DIFF
--- a/_project/DONE/main/planning/results-explorer-uat-defect-submission-batch-path-affordances.yaml
+++ b/_project/DONE/main/planning/results-explorer-uat-defect-submission-batch-path-affordances.yaml
@@ -48,6 +48,17 @@ approach: |
   --output DIR` unchanged, and keep hosted submission behind explicit
   `--service`.
 
+outcome: |
+  Delivered exact-path discovery only via `benchbox results --paths`. Batch
+  hosted submission was deferred by design — hosted upload still requires an
+  explicit `--service` flag and one bundle at a time. The initial cut (PR #154)
+  emitted paths through the Rich console alongside the summary table, which
+  follow-up review flagged as not actually pipeable; addressed in
+  `fix/results-paths-pipeable-affordance` by writing paths as plain stdout
+  (one per line) with hint/overflow text on stderr, and by making `--paths`
+  mutually exclusive with `--submitted`. If batch hosted submission is wanted,
+  open a new TODO rather than reopening this one.
+
 scope_limit:
   only_modify:
   - "benchbox/cli/commands/results.py"

--- a/_project/blind-spots/2026-05-03-075857-cli-affordance-vs-pipeable-output.md
+++ b/_project/blind-spots/2026-05-03-075857-cli-affordance-vs-pipeable-output.md
@@ -1,0 +1,28 @@
+---
+id: 2026-05-03-075857-cli-affordance-vs-pipeable-output
+date: 2026-05-03
+status: actioned
+finding_kind: framework-gap
+review_context: "/code review of PR #154 (results-explorer-uat-defect-submission-batch-path-affordances)"
+related_paths:
+  - benchbox/cli/commands/results.py
+suggested_sweep: "When a CLI affordance is added to address a scripting/loop pain point, audit the output channel: is the new output cleanly pipeable (plain stdout, no decorations, no preamble) or just rendered alongside existing TTY-only output? Check other recent CLI additions for the same pattern."
+todo_id: null
+---
+
+# Five-axis review misses workflow-fit for CLI affordances driven by scripting pain
+
+## Finding
+The five-axis frame (Correctness, Readability, Architecture, Security, Performance) does not natively ask: "Does the new CLI output match the workflow that motivated the change?" PR #154 was justified by W5 needing to loop `benchbox submit` over 388 captured paths. The delivered `benchbox results --paths` *prints* those paths, but only after a Rich-formatted summary table, on the same `console` object that emits style markup. A contributor who tries the obvious next step — `benchbox results --paths | xargs -n1 benchbox submit` — has to grep past a table and strip color codes. The affordance technically exists; the *workflow* the UAT defect named is still broken.
+
+## Why this matters
+"Make X easier" UX changes need a workflow-fit axis distinct from the standard five. Correctness, readability, and architecture can all pass while the user's actual pipeline stays awkward. Whenever a CLI affordance is justified by a scripting/loop pain point, the review should explicitly verify the output is consumable by the scripts the user will actually write — plain stdout, no decorative preamble, no markup that bleeds through `tee`/`xargs`. Otherwise the PR ships a half-fix that looks complete in the test suite.
+
+## Suggested next steps
+- [ ] Sweep recent `benchbox <verb>` additions that emit "copyable" or "exportable" output (e.g., paths, IDs, URLs) and confirm each can be piped without grep filtering.
+- [ ] Decide whether to add a workflow-fit checklist item to the project review rubric for any change framed as "make scripting easier" (e.g., must demonstrate `<cmd> | xargs ...` works in the PR description).
+- [ ] If `benchbox results --paths` is updated, prefer `click.echo` (or `console.print(..., markup=False)` with no preamble when `--paths` is the only mode requested) so output round-trips through pipes cleanly.
+
+## Triage log
+
+- 2026-05-03: actioned — Fixed inline in fix/results-paths-pipeable-affordance — paths now write to plain stdout via click.echo, hint to stderr, mutually exclusive with --submitted.

--- a/benchbox/cli/commands/results.py
+++ b/benchbox/cli/commands/results.py
@@ -86,7 +86,11 @@ def _reconstruct_cli_command(
 @click.group("results", invoke_without_command=True)
 @click.option("--limit", type=int, default=10, help="Number of results to show")
 @click.option("--submitted", is_flag=True, help="Show hosted submission history")
-@click.option("--paths", is_flag=True, help="Print copyable result JSON paths for use with submit/export")
+@click.option(
+    "--paths",
+    is_flag=True,
+    help="Print copyable result JSON paths to stdout (suitable for piping to xargs)",
+)
 @click.pass_context
 def results(ctx, limit, submitted, paths):
     """Show exported benchmark results and execution history.
@@ -100,15 +104,17 @@ def results(ctx, limit, submitted, paths):
         benchbox results --paths      # Print exact result paths for benchbox submit
         benchbox results show-cli <file>  # Show CLI command to reproduce a run
     """
-    # If no subcommand is invoked, show results summary
-    if ctx.invoked_subcommand is None:
-        exporter = ResultExporter()
-        if submitted:
-            _show_submitted_results(exporter, limit=limit)
-        else:
-            exporter.show_results_summary()
-            if paths:
-                _show_result_paths(exporter, limit=limit)
+    if ctx.invoked_subcommand is not None:
+        return
+    if submitted and paths:
+        raise click.UsageError("--submitted and --paths are mutually exclusive")
+    exporter = ResultExporter()
+    if submitted:
+        _show_submitted_results(exporter, limit=limit)
+    elif paths:
+        _show_result_paths(exporter, limit=limit)
+    else:
+        exporter.show_results_summary()
 
 
 def _show_result_paths(exporter: ResultExporter, *, limit: int) -> None:
@@ -117,12 +123,19 @@ def _show_result_paths(exporter: ResultExporter, *, limit: int) -> None:
         return
 
     shown = records[:limit]
-    console.print(f"\n[bold]Result Paths ({len(shown)} shown)[/bold]")
     for record in shown:
         path = record.get("file")
         if path is not None:
-            console.print(str(path))
-    console.print("[dim]Use with: benchbox submit <path> --output ./submission[/dim]")
+            click.echo(str(path))
+    if len(records) > limit:
+        click.echo(
+            f"# Showing {len(shown)} of {len(records)}; use --limit to widen.",
+            err=True,
+        )
+    click.echo(
+        "# Use with: benchbox submit <path> --output ./submission",
+        err=True,
+    )
 
 
 def _show_submitted_results(exporter: ResultExporter, *, limit: int) -> None:

--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -40,6 +40,7 @@ Use `uv run -- benchbox submit` to create a submission package:
 uv run -- benchbox submit --last --output ./submission
 
 # Show exact result paths if you need to choose a specific run
+# (--paths writes one path per line to stdout, safe to pipe to xargs)
 uv run -- benchbox results --paths --limit 25
 
 # Or specify a result file directly

--- a/docs/reference/cli/results.md
+++ b/docs/reference/cli/results.md
@@ -105,9 +105,14 @@ Display exported benchmark results and execution history.
 - `--paths`: Print copyable primary result JSON paths for use with
   `benchbox submit`, `benchbox export`, or `benchbox results show-cli`
 
-`--paths` lists the primary schema-v2 result JSON files returned by the result
-history and excludes companion files such as `.plans.json`, `.tuning.json`, and
-hosted `.submission.json` sidecars.
+`--paths` writes one path per line to stdout (no Rich formatting, no preamble)
+so the output is safe to pipe into `xargs` or save with `tee`. Hint text and
+overflow notices are written to stderr. The list contains only primary
+schema-v2 result JSON files — companion files such as `.plans.json`,
+`.tuning.json`, and hosted `.submission.json` sidecars are excluded.
+
+`--paths` and `--submitted` are mutually exclusive: hosted submission history
+is a separate sidecar surface from local result discovery.
 
 ### Usage Examples
 
@@ -118,8 +123,11 @@ benchbox results
 # Show more results
 benchbox results --limit 25
 
-# Show exact result file paths accepted by submit/export
+# Show exact result file paths accepted by submit/export (one per line, pipeable)
 benchbox results --paths
+
+# Pipe into submit to package each result in turn
+benchbox results --paths --limit 100 | xargs -n1 -I{} benchbox submit {} --output ./submissions
 
 # Show hosted submissions and public URLs
 benchbox results --submitted

--- a/docs/reference/cli/submit.md
+++ b/docs/reference/cli/submit.md
@@ -140,9 +140,13 @@ uv run -- benchbox submit results/tpch_sf1_duckdb.json
 # Package the most recent result
 uv run -- benchbox submit --last
 
-# Print exact result paths, then package one result by path
+# Print exact result paths (one per line, pipeable), then package one result by path
 uv run -- benchbox results --paths
 uv run -- benchbox submit benchmark_runs/results/tpch_sf001_duckdb_20260401_120000.json --output ./submission
+
+# Or loop over every recent result
+uv run -- benchbox results --paths --limit 100 \
+  | xargs -n1 -I{} uv run -- benchbox submit {} --output ./submissions
 
 # Package the most recent TPC-H result
 uv run -- benchbox submit --last --benchmark tpch

--- a/tests/unit/cli/commands/test_results.py
+++ b/tests/unit/cli/commands/test_results.py
@@ -33,7 +33,7 @@ def test_results_group_without_subcommand_shows_summary(cli_runner, monkeypatch)
     exporter.show_results_summary.assert_called_once_with()
 
 
-def test_results_paths_prints_copyable_result_paths(cli_runner, monkeypatch, tmp_path):
+def test_results_paths_emits_pipeable_paths_to_stdout(cli_runner, monkeypatch, tmp_path):
     results_module = import_module("benchbox.cli.commands.results")
     result_a = tmp_path / "tpch_duckdb.json"
     result_b = tmp_path / "tpch_clickhouse.json"
@@ -46,24 +46,81 @@ def test_results_paths_prints_copyable_result_paths(cli_runner, monkeypatch, tmp
             ]
         ),
     )
-    prints = []
     monkeypatch.setattr(results_module, "ResultExporter", lambda: exporter)
-    monkeypatch.setattr(
-        results_module,
-        "console",
-        SimpleNamespace(print=lambda *args, **_kwargs: prints.extend(str(arg) for arg in args)),
-    )
 
     result = cli_runner.invoke(results, ["--paths", "--limit", "1"])
 
     assert result.exit_code == 0
-    exporter.show_results_summary.assert_called_once_with()
+    exporter.show_results_summary.assert_not_called()
     exporter.list_results.assert_called_once_with()
-    printed = "\n".join(prints)
-    assert "Result Paths (1 shown)" in printed
-    assert str(result_a) in printed
-    assert str(result_b) not in printed
-    assert "benchbox submit <path> --output ./submission" in printed
+    stdout_lines = result.stdout.splitlines()
+    assert stdout_lines == [str(result_a)]
+    assert "Showing 1 of 2" in result.stderr
+    assert "benchbox submit <path> --output ./submission" in result.stderr
+
+
+def test_results_paths_omits_overflow_hint_when_within_limit(cli_runner, monkeypatch, tmp_path):
+    results_module = import_module("benchbox.cli.commands.results")
+    result_a = tmp_path / "tpch_duckdb.json"
+    exporter = SimpleNamespace(
+        show_results_summary=MagicMock(),
+        list_results=MagicMock(return_value=[{"file": result_a, "timestamp": "2026-05-03T12:00:00"}]),
+    )
+    monkeypatch.setattr(results_module, "ResultExporter", lambda: exporter)
+
+    result = cli_runner.invoke(results, ["--paths", "--limit", "10"])
+
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == [str(result_a)]
+    assert "Showing" not in result.stderr
+
+
+def test_results_paths_emits_nothing_when_no_results(cli_runner, monkeypatch):
+    results_module = import_module("benchbox.cli.commands.results")
+    exporter = SimpleNamespace(
+        show_results_summary=MagicMock(),
+        list_results=MagicMock(return_value=[]),
+    )
+    monkeypatch.setattr(results_module, "ResultExporter", lambda: exporter)
+
+    result = cli_runner.invoke(results, ["--paths"])
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    exporter.show_results_summary.assert_not_called()
+
+
+def test_results_paths_emits_paths_with_rich_markup_chars_unescaped(cli_runner, monkeypatch, tmp_path):
+    """Path emission must not run through Rich markup; brackets in paths survive verbatim."""
+    results_module = import_module("benchbox.cli.commands.results")
+    tricky = tmp_path / "results [archive] / r.json"
+    exporter = SimpleNamespace(
+        show_results_summary=MagicMock(),
+        list_results=MagicMock(return_value=[{"file": tricky, "timestamp": "2026-05-03T12:00:00"}]),
+    )
+    monkeypatch.setattr(results_module, "ResultExporter", lambda: exporter)
+
+    result = cli_runner.invoke(results, ["--paths"])
+
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == [str(tricky)]
+
+
+def test_results_paths_and_submitted_are_mutually_exclusive(cli_runner, monkeypatch):
+    results_module = import_module("benchbox.cli.commands.results")
+    exporter = SimpleNamespace(
+        show_results_summary=MagicMock(),
+        list_results=MagicMock(),
+    )
+    monkeypatch.setattr(results_module, "ResultExporter", lambda: exporter)
+
+    result = cli_runner.invoke(results, ["--paths", "--submitted"])
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.stderr
+    exporter.show_results_summary.assert_not_called()
+    exporter.list_results.assert_not_called()
 
 
 def test_results_group_with_submitted_shows_submission_history(cli_runner, monkeypatch, tmp_path):


### PR DESCRIPTION
Address PR #154 review findings on `benchbox results --paths`:

- Emit paths as plain stdout via `click.echo` (one per line, no Rich
  preamble, markup-safe) so output is consumable by `xargs`/`tee`.
- Suppress the Rich summary table when `--paths` is set; previously a
  table was rendered first, defeating piping.
- Move hint text and the "Showing N of M; use --limit" overflow notice
  to stderr so stdout stays pure.
- Reject `--submitted --paths` with a `click.UsageError` instead of
  silently dropping `--paths` — the two surfaces are intentionally
  separate.
- Tests assert pipeable stdout, stderr hints, overflow notice,
  empty-records branch, markup-safe path emission, and mutual
  exclusion.
- Docs in `reference/cli/results.md`, `reference/cli/submit.md`, and
  `contributing-results.md` document the pipeable contract and add an
  `xargs` example.
- DONE TODO gains an `outcome:` block recording what was delivered and
  what was deferred.
- Blind-spot finding from the PR #154 review marked `actioned`.
