### PR TITLE
chore(todo): file UAT-20260502 corpus-integration + methodology-remediation TODOs

### DIFF
--- a/_project/TODO/main/planning/results-explorer-uat-corpus-integrate-validated-bundles.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-corpus-integrate-validated-bundles.yaml
@@ -1,0 +1,206 @@
+id: results-explorer-uat-corpus-integrate-validated-bundles
+title: "Integrate the UAT-20260502 validated corpus into results-data"
+worktree: main
+priority: "High"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+deps:
+  needs:
+  - results-explorer-uat-defect-normalized-cost-unavailable-bundles
+  - results-explorer-uat-defect-zero-query-timing-bundles
+  - results-explorer-uat-defect-flightdata-sf1-corpus-integrity
+  - results-explorer-uat-defect-partial-success-exit-contract
+
+description: |
+  The 2026-05-02 UAT sweep produced a 376-bundle local submission package
+  at `~/Developer/benchmark_runs/submissions/uat_20260502/` and a
+  validator-clean 205-bundle subset at
+  `~/Developer/benchmark_runs/submissions/uat_20260502_valid/`. Per the W5
+  completion record, **no upstream submission was performed** — the agent
+  intentionally stopped at local staging because 188 bundle errors and
+  171 failing bundles clustered around two corpus-integrity defects.
+
+  Those defects have since been fixed and merged (PRs #141 normalized-cost,
+  #143 zero-query-timing, #145 flightdata SF1, #142 partial-success exit
+  contract). The validator-clean subset is now likely a strict undercount
+  of what could be integrated, because some bundles previously failing on
+  contract issues should now validate cleanly against the fixed contracts.
+
+  This TODO performs the careful review the original UAT deferred:
+  re-validate the full staged package against current contracts, audit the
+  resulting clean set for corpus-quality balance (no platform/scale
+  over-representation, no telemetry pathologies), integrate the reviewed
+  bundles into `results-data/`, and open a `published-results` PR. The
+  source data is the existing UAT corpus on the local volume — this TODO
+  must NOT regenerate benchmark runs.
+
+  This work makes the corpus expansion goal of the UAT actually deliver:
+  the explorer's cross-scale comparison views are only meaningful when
+  there are enough cells per (platform, benchmark) at SF=0.01/0.1/1.0 to
+  compare against. Today the validator-clean snapshot has DataFusion 68 /
+  Polars 41 / PySpark 34 / SQLite 28 / Spark 25 / DuckDB 9 across 51
+  cohorts; the post-fix re-validation should improve those counts.
+
+work:
+- id: w1
+  summary: "Re-validate the staged 376-bundle package against current contracts"
+  status: pending
+  notes: |
+    The staged package lives at
+    `~/Developer/benchmark_runs/submissions/uat_20260502/`. Run
+    `uv run -- python scripts/validate_submission.py
+    ~/Developer/benchmark_runs/submissions/uat_20260502/` and capture the
+    new error / warning rate. Expect significant improvement vs the
+    original W5 log (`submission_validation_20260502.log`,
+    188 errors / 212 warnings) because PRs #141, #142, #143, #145 fixed
+    the dominant failure clusters.
+
+    Record the new totals and per-cluster breakdown to
+    `~/Developer/benchmark_runs/logs/uat_20260502/submission_validation_revalidate_$(date +%Y%m%d).log`.
+    Cross-reference each remaining failure against the 14 defect TODOs to
+    confirm none of them are still-open clusters that should have been
+    fixed; if so, surface the regression rather than silently excluding
+    the bundle.
+
+- id: w2
+  summary: "Audit the validator-clean set for corpus-quality balance"
+  needs: [w1]
+  status: pending
+  notes: |
+    Build a coverage matrix from the now-clean bundle set:
+      - cells per (platform, benchmark, scale)
+      - count of (platform, benchmark) pairs with all three SF rungs
+        (0.01, 0.1, 1.0) present — this is the cross-scale comparison
+        surface the explorer needs
+      - duplicate detection: same (platform, benchmark, scale, mode)
+        with multiple bundles
+      - telemetry sanity spot-checks: any zero or near-zero query timings
+        that survived #143; any cost contracts in unexpected states
+    Document the matrix and the bundles intentionally excluded from
+    integration (e.g., dup-from-retry, debug-only mode, suspicious timing).
+    This audit is the deliverable of the "carefully review" half of the
+    user's request and must not be skipped.
+
+- id: w3
+  summary: "Stage the reviewed bundles into a results-data working tree"
+  needs: [w2]
+  status: pending
+  notes: |
+    Copy the reviewed bundles into `results-data/bundles/` preserving the
+    per-bundle manifest layout introduced by PR #95
+    (`fix(results): support per-bundle published manifests`). Do not
+    overwrite existing curated entries — collisions should be surfaced
+    and resolved per-bundle rather than blindly preferring the new
+    submission. Trust labels: community-submission unless the bundle was
+    produced by a maintainer-run platform under maintainer-controlled
+    environment, in which case maintainer-curated. Do not invent new
+    trust labels.
+
+- id: w4
+  summary: "Open a draft published-results PR and confirm contract CI passes"
+  needs: [w3]
+  status: pending
+  notes: |
+    Open the PR vs `published-results` (not `develop`, not `main`) as
+    **draft**, per project convention for corpus changes. The hosted
+    validator and per-bundle contract CI must be green before flipping to
+    ready-for-review. Do not enable auto-merge — published-results PRs
+    get human review.
+
+- id: w5
+  summary: "Verify explorer ingests the new corpus locally before flipping the PR ready"
+  needs: [w4]
+  status: pending
+  notes: |
+    Run `benchbox explorer build --data-dir results-data/ --output
+    /tmp/explorer-corpus-check/data` and exercise the resulting snapshot
+    via the static test server and Playwright smoke
+    (results-explorer/scripts/serve-browser-tests.mjs). Specifically
+    cover the cross-scale comparison view for at least 3 (platform,
+    benchmark) pairs that now have all three SF rungs — this is the
+    surface the original UAT under-tested, see blind-spot finding
+    `2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md`.
+
+verification:
+- description: "Re-validation of the full staged package shows materially fewer failures than the original W5 log."
+  command: "uv run -- python scripts/validate_submission.py ~/Developer/benchmark_runs/submissions/uat_20260502/"
+  expected_output: "error count materially lower than 188; remaining failures all map to known still-open defect clusters"
+- description: "Per-bundle contract validator passes against results-data after staging."
+  command: "uv run -- python scripts/validate_submission.py results-data/bundles"
+  expected_output: "0 errors"
+- description: "Explorer build ingests the new corpus and the cross-scale comparison view renders for at least 3 (platform, benchmark) pairs."
+  command: "manual"
+  expected_output: "screenshots captured under explorer_uat verification logs"
+
+must_preserve:
+- "Existing curated entries in results-data/ remain in place and unmodified."
+- "Trust label semantics (community-submission vs maintainer-curated) are not collapsed or invented."
+- "Per-bundle manifest schema established by PR #95 — no schema drift."
+- "The original W5 staging directory and matrix_summary.tsv are not modified — they remain the audit-trail anchor."
+
+approach: |
+  Treat this as a corpus-curation task, not a benchmarking task. The
+  source is the existing UAT corpus on disk; do NOT re-run benchmarks
+  to refresh data. Lean on the existing validators
+  (`scripts/validate_submission.py`) and explorer build pipeline rather
+  than writing new integration tooling. Land the audit matrix as a
+  markdown file under `_project/handoffs/` so the curation reasoning is
+  reviewable, not buried in commit messages.
+
+anti_patterns:
+- "DO NOT regenerate or re-run benchmarks during this task -- because re-running invalidates the audit trail tying bundles to the 2026-05-02 sweep -- use the existing on-disk submission package as the source of truth."
+- "DO NOT commit the full 376-bundle set blindly because the validator now passes -- because some failures encode platform-level signals worth keeping visible -- review per-bundle and document exclusions."
+- "DO NOT enable auto-merge on the published-results PR -- because corpus changes get human review, not the auto-merge backstop -- open as draft and flip to ready manually."
+- "DO NOT modify benchbox/, results-explorer/, or scripts/ to make a bundle pass -- because that conflates curation with engineering -- if a bundle still fails, exclude it and file a defect TODO."
+
+scope_limit:
+  only_modify:
+  - "results-data/"
+  - "_project/TODO/main/planning/results-explorer-uat-corpus-integrate-validated-bundles.yaml"
+  - "_project/handoffs/results-explorer-uat-corpus-integration-*.md"
+  do_not_modify:
+  - "benchbox/"
+  - "results-explorer/"
+  - "scripts/"
+  - "_binaries/"
+
+success_metrics:
+- "At least 80% of validator-clean reviewed bundles land in results-data/ via a merged published-results PR."
+- "Cross-scale comparison view (SF=0.01/0.1/1.0) renders for >=3 (platform, benchmark) pairs after integration."
+- "Audit matrix document filed under _project/handoffs/ that maps every staged bundle to keep / exclude with rationale."
+- "Hosted validator and per-bundle contract CI green on the published-results PR before flipping to ready-for-review."
+
+open_questions:
+- "Does the post-fix re-validation reveal still-open defect clusters that the 14 follow-up TODOs missed? If so, file a new defect TODO before integrating around them."
+- "Should the integration prefer the validator-clean 205-bundle subset (already on disk) or rebuild from the full 376-bundle set after re-validation? Default: rebuild from the full set so newly-validating bundles are picked up, but spot-check the 205 subset for parity first."
+- "Do any of the 51 cohorts have so few cells post-curation that they should be excluded entirely rather than published as sparse rows? Decide a per-cohort minimum cell count before staging."
+
+deferred:
+- summary: "Cloud-platform corpus integration (Snowflake / BigQuery / Redshift / Athena / Databricks)"
+  reason: "The 2026-05-02 sweep was local-only by design; cloud rows are the scope of a separate `results-explorer-uat-cloud-corpus` if/when the explorer's cloud-facet surface is ready to be tested under load."
+- summary: "Throughput-phase corpus expansion"
+  reason: "The sweep only ran load,power phases. Throughput bundles belong in a separate sweep and are out of scope here."
+
+metadata:
+  tags:
+  - uat
+  - corpus-curation
+  - results-data
+  - submission-flow
+  - published-results
+  estimated_effort: "Medium (1 session if re-validation is clean; 2 if it surfaces new defect clusters)"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Realises the corpus-expansion half of the original UAT — the explorer's
+    cross-scale and cross-platform comparison views are only meaningful
+    when there's a real published corpus to back them.
+  user_impact: |
+    External users see a richer, scale-laddered corpus in the explorer,
+    not the curated single-scale set that exists today.
+  technical_debt: |
+    Closes the loop on the 2026-05-02 UAT — without this step, the sweep's
+    most expensive output (388 captured result paths) sits unused on a
+    local volume and decays toward irrelevance.

--- a/_project/TODO/main/planning/results-explorer-uat-methodology-blind-spot-remediation.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-methodology-blind-spot-remediation.yaml
@@ -1,0 +1,241 @@
+id: results-explorer-uat-methodology-blind-spot-remediation
+title: "Plan: address the three UAT-20260502 methodology blind spots before the next sweep"
+worktree: main
+priority: "Medium-High"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  The 2026-05-03 code review of `results-explorer-uat-multi-scale-corpus-sweep`
+  produced a Blind-Spot Audit (L2) with three methodology findings,
+  captured under `_project/blind-spots/`:
+
+    1. `2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md`
+       — UAT framework declared a headline deliverable (cross-scale
+       comparison UX) but had no enforcement; the agent's W6 findings
+       drifted to easier surfaces.
+    2. `2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md`
+       — Triage classified failures per-cluster but never tracked the
+       overall "passed-but-validator-rejected" rate (~45% in this sweep)
+       as a methodology metric.
+    3. `2026-05-03-081922-uat-submit-success-metric-ambiguity.md`
+       — "Submitted via the BenchBox submission flow" conflated local
+       staging, draft PR, and merged-to-`published-results`; Open Question
+       Q3 sat in the deferred-resolution position when it actually gated
+       the W5 deliverable.
+
+  This TODO produces a **plan**, not the implementation. The deliverable
+  is a single design document covering each finding's root cause,
+  proposed template/process change, and verification mechanism, plus a
+  set of follow-up implementation TODOs filed once the plan is approved.
+
+  Producing the plan now (rather than implementing inline) follows the
+  precedent set by the parent UAT TODO itself, which observed and reported
+  but explicitly deferred fixes. The findings are about how UAT TODOs are
+  authored and verified — touching that surface without an explicit plan
+  risks scattershot template edits that don't actually close the gaps.
+
+work:
+- id: w1
+  summary: "Read the three blind-spot files and the parent UAT retrospective"
+  status: pending
+  notes: |
+    Inputs:
+      - `_project/blind-spots/2026-05-03-08192{0,1,2}-*.md`
+      - `_project/handoffs/results-explorer-uat-retrospective-20260502.md`
+      - `_project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml`
+      - `_project/TODO_ENTRY_TEMPLATE.yaml` (the surface most edits will
+        touch)
+      - `_project/TODO/main/planning/external-contributor-submission-dry-run.yaml`
+        (parallel UAT-style TODO that may share the success-metric
+        ambiguity)
+    Note any other in-flight UAT/dry-run TODOs that exhibit the same
+    patterns; they may need to be retrofitted by the implementation
+    TODOs filed in w5.
+
+- id: w2
+  summary: "Draft remediation proposals for each of the three findings"
+  needs: [w1]
+  status: pending
+  notes: |
+    For each finding, produce:
+      a. Root cause: what specifically in the UAT TODO format failed.
+      b. Proposed template change: concrete additions or restructurings to
+         `_project/TODO_ENTRY_TEMPLATE.yaml` or a new
+         `_project/UAT_TEMPLATE.yaml` subtemplate. Include exact YAML
+         snippets, not prose.
+      c. Verification mechanism: what the W7 final report or a new
+         pre-completion check must demonstrate. For finding 1, an
+         enumerated coverage checklist; for finding 2, a numeric
+         validator-clean-rate floor in success_metrics; for finding 3,
+         an explicit terminal-state declaration plus a `gating: true`
+         marker on open_questions that change success_metrics.
+      d. Migration plan: which existing TODOs are retrofitted vs left
+         as-is. Default to "retrofit only the active UAT/dry-run TODOs;
+         leave Completed ones alone."
+
+- id: w3
+  summary: "Stress-test the proposals against historical UATs"
+  needs: [w2]
+  status: pending
+  notes: |
+    For each proposal, replay against:
+      - the 2026-04-28 Cowork agent-proxy dry-run
+        (`_project/handoffs/external-dry-run-retrospective-2026-04-28.md`),
+      - the 2026-04-29 Codex agent-proxy dry-run
+        (`_project/handoffs/external-dry-run-retrospective-2026-04-29.md`),
+      - the 2026-05-02 sweep retrospective.
+    For each historical UAT, ask: would the proposed change have caught
+    the failure mode? Would it have generated false positives? Would the
+    template have been onerous to author? Document the answers — if any
+    proposal looks expensive vs prior UATs without a corresponding
+    benefit, drop it or simplify before w4.
+
+- id: w4
+  summary: "Compile the design document and route to user for approval"
+  needs: [w3]
+  status: pending
+  notes: |
+    Output file:
+      `_project/specs/uat-methodology-blind-spot-remediation.md`
+    Sections:
+      1. Executive summary (recommendation + main tradeoff).
+      2. Per-finding remediation (one section each, structured per w2).
+      3. Template diff preview (before/after of
+         `_project/TODO_ENTRY_TEMPLATE.yaml` if that's the surface
+         touched).
+      4. Migration plan + retrofit list.
+      5. Open questions for the user.
+      6. Implementation TODO list (titles only — files in w5).
+    Surface in chat for user review. Do not proceed to w5 until the user
+    explicitly approves; the plan is itself the deliverable.
+
+- id: w5
+  summary: "After approval, file implementation TODOs and triage the blind-spot files"
+  needs: [w4]
+  status: pending
+  notes: |
+    File one TODO per accepted remediation under
+    `_project/TODO/main/planning/`. Slug each so the link to the
+    originating finding is obvious (e.g.,
+    `uat-template-cross-scale-coverage-checklist`,
+    `uat-template-validator-clean-rate-metric`,
+    `uat-template-success-metric-terminal-state`).
+
+    Then update each blind-spot file via:
+      `uv run --project _project/scripts -- python
+       _project/scripts/sweep_blind_spots.py triage <id>
+       --action promote --todo-id <implementation-todo-slug>`
+
+    If the user rejects a remediation outright, mark that finding
+    `--action dismiss --reason "..."` instead.
+
+verification:
+- description: "Design document exists at the agreed location with all six required sections."
+  command: "test -f _project/specs/uat-methodology-blind-spot-remediation.md"
+  expected_output: "file exists"
+- description: "All three blind-spot files have status `merged-to-todo` (or `dismissed` for explicitly rejected ones)."
+  command: "uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py list --status open | grep -E '081920|081921|081922' || echo 'all triaged'"
+  expected_output: "all triaged"
+- description: "Implementation TODOs exist for each accepted remediation."
+  command: "ls _project/TODO/main/planning/uat-template-*.yaml 2>/dev/null"
+  expected_output: "one yaml per accepted remediation"
+
+must_preserve:
+- "Backwards compatibility of `_project/TODO_ENTRY_TEMPLATE.yaml` — any new fields are additive, optional, and ignored by older TODOs."
+- "Existing UAT TODO format used by other in-flight items (`external-contributor-submission-dry-run`, etc.) continues to validate unchanged unless explicitly retrofitted."
+- "The blind-spot directory protocol (`_project/blind-spots/README.md`) — triage uses the existing sweep script, not new tooling."
+
+approach: |
+  Treat this as a spec-before-code task. The plan IS the deliverable;
+  implementation goes in separate, narrower TODOs filed in w5. Lean on
+  existing project infrastructure (`_project/TODO_ENTRY_TEMPLATE.yaml`,
+  `_project/blind-spots/README.md`, `sweep_blind_spots.py`) rather than
+  proposing new tooling. Retrofit existing UATs only where the cost is
+  visibly less than the catch — bias toward "apply to next UAT, leave
+  Completed ones alone."
+
+  Use `_project/specs/` as the spec home (consistent with other
+  spec-style design docs). The /spec workflow under the todo skill
+  describes the structure; we are using it for a process change rather
+  than a feature, but the assumption-surfacing and human-review-gate
+  patterns apply.
+
+anti_patterns:
+- "DO NOT implement template edits during this TODO -- because the deliverable is the plan, and inline implementation muddies the user-review gate -- file separate implementation TODOs in w5."
+- "DO NOT collapse the three findings into a single homogeneous remediation -- because they have different shapes (deliverable enforcement / metric definition / policy resolution) -- preserve the per-finding structure through to w5."
+- "DO NOT propose new tooling unless the existing scripts genuinely cannot express the change -- because the project already has working blind-spot triage and TODO indexing -- prefer additive YAML conventions."
+- "DO NOT auto-promote findings without user approval -- because two of the three are policy-flavored (terminal state, gating questions) and need explicit human sign-off -- route through w4."
+
+scope_limit:
+  only_modify:
+  - "_project/specs/uat-methodology-blind-spot-remediation.md"
+  - "_project/TODO/main/planning/results-explorer-uat-methodology-blind-spot-remediation.yaml"
+  - "_project/TODO/main/planning/uat-template-*.yaml"
+  - "_project/blind-spots/2026-05-03-08192*.md"
+  - "_project/handoffs/uat-methodology-*.md"
+  do_not_modify:
+  - "_project/TODO_ENTRY_TEMPLATE.yaml"
+  - "_project/blind-spots/README.md"
+  - "benchbox/"
+  - "results-explorer/"
+  - "scripts/"
+
+success_metrics:
+- "Single design document delivered covering all three findings (root cause / proposal / verification / migration)."
+- "Each accepted remediation has a corresponding implementation TODO filed; each rejected one has a dismissal reason in the blind-spot triage log."
+- "All three blind-spot files have status `merged-to-todo` or `dismissed` after w5."
+- "Plan stress-tested against >=2 historical UATs and false-positive / cost concerns documented."
+
+open_questions:
+- "Should the cross-scale coverage checklist live as a free-form `notes` field on the W6 work unit, or as a structured `coverage_checklist:` block in the TODO schema? Free-form is cheaper; structured is enforceable by validate_todo.py."
+- "Where does the validator-clean-rate floor go — `success_metrics` (per-TODO) or a new project-wide UAT policy doc? Per-TODO is local; project-wide makes drift across sweeps harder."
+- "Do gating questions need a tooling change (e.g., todo_cli.py blocks `done` on unresolved gating questions) or is the convention enough? Convention-only is fastest; tooling enforces it."
+- "Is `_project/specs/` the right home, or should this go under `_project/decisions/` (ADR) or `docs/operations/`? Spec is closer to forward-looking; ADR is decision-of-record after the fact."
+
+deferred:
+- summary: "Implementing the accepted remediations"
+  reason: "Each accepted remediation gets its own narrow TODO in w5. Mixing planning and implementation here repeats the exact mistake the parent UAT avoided (and which the open dry-run TODOs document as a hard-won lesson)."
+- summary: "Retrofitting Completed UAT TODOs with the new conventions"
+  reason: "Default plan is to apply changes to the next UAT and to currently-active UAT-style TODOs only. Completed ones are historical record; rewriting them buys nothing and risks audit confusion."
+- summary: "Generalising the conventions beyond UAT TODOs (e.g., to all dry-run / observation TODOs)"
+  reason: "Out of scope until the UAT-specific changes have shipped and proved their cost/benefit. Premature generalisation is itself one of the patterns the blind-spots flag."
+
+metadata:
+  tags:
+  - uat
+  - methodology
+  - blind-spots
+  - process-improvement
+  - templates
+  estimated_effort: "Small-Medium (1 session for plan; w5 file-creation is mechanical)"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Increases the signal density of future UAT sweeps. A UAT that misses
+    its headline deliverable, overstates corpus health, or ends without
+    publication burns a session of wall-clock time for less than its full
+    value; closing those gaps once compounds across every future sweep.
+  user_impact: |
+    Indirect: external users see a more reliable corpus and a more
+    consistent submission story when the next UAT lands.
+  technical_debt: |
+    Closes the loop on the L2 audit produced by the 2026-05-03 review —
+    findings printed only in chat get lost; this TODO is the action half
+    of the file-first capture protocol.
+
+context_sections:
+  "Relationship to the parent UAT TODO": |
+    The parent TODO (`results-explorer-uat-multi-scale-corpus-sweep`) was
+    itself observation-only by design. Its W7 spawned 14 defect TODOs.
+    This TODO spawns the *methodology* counterparts of those defects —
+    not bugs in the explorer or submission flow, but bugs in how the UAT
+    was scoped and verified. Treating those as first-class is what makes
+    "observe, then plan" a reliable pattern instead of a coincidence.
+  "Why a separate plan TODO instead of inline edits": |
+    Two of the three findings are policy-flavored (success-metric
+    terminal state, gating-question convention). Editing the template
+    inline would lock those policies without a review gate — and they
+    affect every future TODO author, not just UAT ones. The user-review
+    step at w4 is load-bearing, not bureaucratic.

--- a/_project/blind-spots/2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md
+++ b/_project/blind-spots/2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md
@@ -1,0 +1,42 @@
+---
+id: 2026-05-03-081920-uat-cross-scale-deliverable-not-guarded
+date: 2026-05-03
+status: open
+finding_kind: framework-gap
+review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W6 cross-scale UX deliverable)"
+related_paths:
+  - _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml
+  - _project/handoffs/results-explorer-uat-retrospective-20260502.md
+suggested_sweep: "before the next UAT sweep, require an explicit cross-scale exercise checklist that the W6 report must check off, not just a free-form findings list"
+todo_id: null
+---
+
+# UAT framework declared a headline deliverable but never enforced that it was exercised
+
+## Finding
+
+W6's stated highest-signal goal was "defects you would NOT have found without
+a multi-scale multi-platform corpus" — i.e. cross-scale comparison UX. The
+four W6 findings are all minor/nit and none are about cross-scale views
+specifically. With only 9 DuckDB bundles surviving validation across 3
+scales, true cross-scale comparison was likely under-tested.
+
+## Why this matters
+
+UAT TODOs that declare a "headline deliverable" via prose but rely on the
+agent's free-form report to demonstrate coverage have no failsafe when the
+agent's exploration drifts to easier surfaces (mechanics, accessibility,
+mobile drawer) and away from the harder one. The report comes back full of
+real findings — they're just not findings against the headline axis. The
+absence is invisible in the W7 review because every section has content.
+
+This generalises beyond UAT. Any TODO whose value proposition rests on a
+specific cross-cutting surface (cross-scale, cross-platform, cross-region,
+cold-vs-warm, before-vs-after) needs an enumerated coverage checklist the
+final report explicitly answers, not a prose ask the agent might honor.
+
+## Suggested next steps
+
+- [ ] For the next UAT, add an enumerated cross-scale checklist (e.g. "for at least 3 platforms, open the same benchmark at SF=0.01/0.1/1.0 and capture cross-scale comparison findings") to W6 work unit notes.
+- [ ] Update `_project/TODO_ENTRY_TEMPLATE.yaml` (or a UAT-specific subtemplate) so headline deliverables are declared as `success_metrics` entries with measurable coverage commands, not prose-only goals.
+- [ ] Audit other in-flight UAT-style TODOs (e.g. `external-contributor-submission-dry-run`) for the same pattern and decide whether to retrofit explicit coverage checklists.

--- a/_project/blind-spots/2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md
+++ b/_project/blind-spots/2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md
@@ -1,0 +1,45 @@
+---
+id: 2026-05-03-081921-uat-invalid-bundle-rate-not-tracked
+date: 2026-05-03
+status: open
+finding_kind: missed-axis
+review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W5 submission flow validation)"
+related_paths:
+  - _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml
+  - _project/DONE/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
+  - _project/DONE/main/active/results-explorer-uat-defect-zero-query-timing-bundles.yaml
+suggested_sweep: "treat 'attempted-pass-but-validator-rejected' as its own corpus-quality metric and add it to UAT success_metrics with an explicit budget"
+todo_id: null
+---
+
+# UAT triaged failures per-cluster but never tracked the overall invalid-bundle rate as a methodology metric
+
+## Finding
+
+W5 full-package validation rejected 171 of 376 packaged bundles
+(~45 percent). The two corpus-integrity TODOs (#141 normalized-cost,
+#143 zero-query-timing) treat this as a contract/platform issue, but the
+rate itself suggests sweep configuration may have systematically produced
+unsubmittable results — that's a process finding worth surfacing separately.
+
+## Why this matters
+
+The UAT triage rubric (W4) classifies failures by exit/error class:
+trivially fixable, environmental, deferred-engineering. None of those buckets
+capture "the run technically passed but the artifact it produced cannot be
+submitted." That category is structurally different — it represents
+*silent corpus pollution*, where success is overcounted at run time and the
+real cost shows up only at validation time.
+
+When ~45% of "passed" cells produce unsubmittable bundles, the headline
+W3 success counts (434 passed of 527 attempted, ~82%) overstate corpus
+health by ~2x. Future UATs should treat the "passed-but-rejected" rate as
+its own first-class methodology metric with an explicit budget — both as a
+go/no-go gate before publication and as a signal that the success metric
+language is failing to track what actually matters.
+
+## Suggested next steps
+
+- [ ] Add a "validator-clean rate" metric to UAT `success_metrics`: e.g. ">=80% of W3-passed cells produce bundles that pass `scripts/validate_submission.py`."
+- [ ] Capture the rate per-platform and per-benchmark in the W7 report — clusters with low validator-clean rates are higher-priority defect targets than clusters with low W3-pass rates.
+- [ ] Reconsider whether `--phases load,power` plus default validation is the right floor for a UAT corpus when so many bundles fail downstream contract validation; possibly add a pre-submission validator pass to W3 itself.

--- a/_project/blind-spots/2026-05-03-081922-uat-submit-success-metric-ambiguity.md
+++ b/_project/blind-spots/2026-05-03-081922-uat-submit-success-metric-ambiguity.md
@@ -1,0 +1,50 @@
+---
+id: 2026-05-03-081922-uat-submit-success-metric-ambiguity
+date: 2026-05-03
+status: open
+finding_kind: framework-gap
+review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W5 success_metrics + open_questions Q3)"
+related_paths:
+  - _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml
+suggested_sweep: "audit UAT/dry-run TODO templates for success_metrics that conflate local-staging with upstream-publication; require open_questions that gate work to be resolved before that work begins, not deferred"
+todo_id: null
+---
+
+# UAT success metric "submitted via the BenchBox submission flow" did not disambiguate local-staging from upstream-publication
+
+## Finding
+
+The TODO success metric reads: "Result JSONs successfully submitted via the
+BenchBox submission flow for the successful cells." The agent's interpretation
+("submitted = packaged via `benchbox submit --output`") is reasonable but
+differs from a strict "landed in `published-results`" reading. Open
+Question Q3 (draft PR vs publish) was deferred rather than resolved.
+
+## Why this matters
+
+Two structurally different outcomes — local staging directory vs upstream
+PR vs merged-to-`published-results` branch — were collapsed into one
+sentence. This left the agent free to pick the lowest-risk reading
+(local stage), which was probably correct given the validation failures,
+but the TODO could not have *forced* a different choice if it mattered.
+
+More general lesson: an `open_questions` block whose answer materially
+changes the deliverable should not be a deferral mechanism. It either gates
+the work (resolve before starting) or it gets removed (not actually
+load-bearing). Q3 sat in the "deferred" position for a question that
+genuinely changed the W5 deliverable, and the result is that nobody
+explicitly authorised "stop at local staging." The agent inferred it from
+validation evidence, which is correct judgment but not policy.
+
+The same pattern appears (cf. `external-contributor-submission-dry-run`)
+in other submission-flow TODOs. The fix is templating: success metrics for
+submission flows should specify the exact terminal state ("merged to
+`published-results`" / "open draft PR vs `published-results`" / "local
+staging only — no upstream action") and `open_questions` that would change
+that terminal state must be resolved before the relevant work unit starts.
+
+## Suggested next steps
+
+- [ ] Update `_project/TODO_ENTRY_TEMPLATE.yaml` so submission-related success metrics name a specific terminal state (local stage / draft PR / merged) rather than the verb "submit."
+- [ ] Add a TODO-author convention: any `open_questions` entry whose answer changes a `success_metrics` entry must be marked `gating: true` and resolved before the dependent work unit starts; non-gating questions stay deferable.
+- [ ] Sweep open UAT/dry-run TODOs for the "submitted via submission flow" pattern and disambiguate before they're picked up.


### PR DESCRIPTION
Two follow-ups from the 2026-05-03 code review of
`results-explorer-uat-multi-scale-corpus-sweep`:

1. `results-explorer-uat-corpus-integrate-validated-bundles` (High):
   re-validate the staged 376-bundle UAT package against the now-fixed
   contracts (#141 normalized-cost, #142 partial-success, #143
   zero-query-timing, #145 flightdata SF1), audit the resulting
   validator-clean set for cross-scale balance, and integrate into
   `results-data/` via a draft `published-results` PR. Closes the loop
   on the corpus-expansion half of the original UAT, which intentionally
   stopped at local staging.

2. `results-explorer-uat-methodology-blind-spot-remediation` (Medium-High):
   produce a design document addressing three Blind-Spot Audit (L2)
   findings from the same review — headline-deliverable enforcement,
   validator-clean rate as a methodology metric, and submission-flow
   success-metric terminal-state ambiguity. Plan-only TODO; per-finding
   implementation TODOs filed after user approval.

Plus three blind-spot finding files captured per the file-first protocol
(`_project/blind-spots/README.md`):
- `2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md`
- `2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md`
- `2026-05-03-081922-uat-submit-success-metric-ambiguity.md`
