### PR TITLE
docs: SQLGlot ADR + blog post 11 follow-up corrections

### DIFF
--- a/_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md
+++ b/_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md
@@ -12,7 +12,7 @@ status: draft
 
 > SQLGlot is the foundation, not the finished house. This post is the punchlist of what we still had to build.
 
-**TL;DR**: BenchBox runs benchmarks across 36 SQL platforms. SQLGlot does the transpilation heavy lifting, and the recent mypyc work makes it dramatically faster, but real cross-engine portability needs about 2,500 lines of additional infrastructure on top: dialect normalization, post-generation fixups, engine-aware semantic rewrites, a 19-platform DDL rewrite registry, hand-written query overrides where translation cannot deliver, and a SQL-to-DataFrame layer that SQLGlot does not address. We catalog the seven categories of work with file paths and concrete examples.
+**TL;DR**: BenchBox runs benchmarks across 36 SQL platforms. SQLGlot does the transpilation heavy lifting, and the recent mypyc work makes it dramatically faster, but real cross-engine portability needs a substantial additional layer on top: dialect normalization, post-generation fixups, engine-aware semantic rewrites, a 19-platform DDL rewrite registry, hand-written query overrides where translation cannot deliver, and a SQL-to-DataFrame facade for engines that do not speak SQL. We catalog the seven categories of work with file paths and concrete examples.
 
 ---
 
@@ -24,6 +24,8 @@ That promise is built on cross-dialect SQL translation, and SQLGlot[^1] is the o
 
 Last week the SQLGlot team at Fivetran shipped a milestone[^2]: they compiled SQLGlot's hot Python with mypyc and got a roughly 5x parser speedup, 2.5x generator speedup, and 2x optimizer speedup while keeping the pure-Python path intact as a fallback. For a project that translates tens of thousands of TPC-DS queries on every release, this is a meaningful improvement, and worth saying out loud. Our experience with SQLGlot is overwhelmingly positive; without it, BenchBox would not exist as a multi-platform tool.
 
+We have not yet rigorously measured SQLGlot's share of the BenchBox runtime budget, so we treat the mypyc speedups as an opportunity rather than a quantified need. Worth flagging up front so the rest of the post is not read as "we have benchmarked this and have nothing to add."
+
 The Fivetran post closes with: "It has never been faster or easier to translate between different SQL dialects so that you can use different query engines." The first half of that sentence is unambiguously true. The second half is where our experience can add nuance. Running the same benchmark on different query engines is *partly* about transpilation, and *partly* about everything else. This post is what "everything else" looked like for us.
 
 ## How we got here: starting simple, ending with a registry
@@ -34,7 +36,7 @@ We did not set out to build SQL infrastructure. We set out to call `sqlglot.tran
 
 **Layer 2: A centralized wrapper** at `benchbox/utils/dialect_utils.py`. Once we hit the second post-generation regex fixup, we centralized. Today this layer normalizes 8 dialects with no SQLGlot entry to their nearest peer (mostly `postgres`) and applies four generic post-generation fixups that affect multiple dialects.
 
-**Layer 3: Per-platform query transformers.** When a single platform's quirks were too platform-specific for the wrapper, we extracted them: a ClickHouse transformer for case folding and division safety, a 450-line QuestDB rewriter for syntax gaps, a DataFusion transformer for engine-semantic query rewrites.
+**Layer 3: Per-platform query transformers.** When a single platform's quirks were too platform-specific for the wrapper, we extracted them: a ClickHouse transformer for case folding and division safety, a dedicated QuestDB rewriter for syntax gaps, a DataFusion transformer for engine-semantic query rewrites.
 
 **Layer 4: A SQL compatibility registry** under `benchbox/sql_compat/`. When the per-platform code grew structure of its own, we built explicit rule families: `ddl_optimize/` for DDL semantics across 19 platforms, `query_source/` for hand-written platform-specific queries, `query_adapter/` for post-translation query rewrites, `schema_emit/` for schema generation rules, `benchmark_gate/` for platform-by-benchmark compatibility checks, plus an `inventory.py` and `registry.py` for governance.
 
@@ -78,7 +80,7 @@ Three platforms required dedicated transformer modules.
 
 The TPC-DS Q23 and Q87 case is worth telling. ClickHouse rejects derived tables without aliases, so we wrote an AST visitor that walks the parsed query and injects `AS _sqN` on every unaliased subquery. The visitor was correct in isolation. On real queries, it corrupted Q23 (it pulled the GROUP BY clause out of a subquery boundary) and Q87 (it injected aliases inside `EXCEPT/INTERSECT`, where they are not allowed). We disabled the rewriter and shipped a session setting instead (`joined_subquery_requires_alias=0`). The lesson, which we will return to, is that even with full AST control, the safe move was to abandon the rewrite and twist the engine knob.
 
-**QuestDB** (`platforms/questdb_rewriter.py`, about 450 lines) is a post-AST rewriter for:
+**QuestDB** (`platforms/questdb_rewriter.py`) is a dedicated post-AST rewriter for:
 
 - Implicit comma joins, converted to explicit `INNER JOIN ... ON` (every TPC-H, TPC-DS, and SSB query, since the legacy specs use comma joins)
 - `INTERVAL` arithmetic, converted to `dateadd('d', n, ts)` (TPC-H Q1, Q4, Q6, Q17, and others)
@@ -103,6 +105,8 @@ DataFusion has a SQLGlot dialect entry. SQLGlot translates four TPC-H queries in
 | Q20 | Nested correlated IN: incorrect join cardinality | Extract to CTEs with explicit joins |
 
 Critical framing: these are engine planner semantics, not SQLGlot bugs in any strict sense. But the user-visible failure mode for someone using SQLGlot to run their workload across engines is "I transpiled and got wrong results." A syntactic transpiler structurally cannot catch this; the SQL is well-formed in both dialects, the bug lives in the target engine's planner. Someone has to know which query *shapes* trigger which engine bugs, and write a rewrite that produces the same answer through a different shape. Today, every team that hits these issues discovers them privately. We discovered ours by validating BenchBox results against TPC-H reference answers and watching four queries fail validation while running.
+
+You could push back on this position: if SQLGlot's pitch is portability across engines, and the engines have known bugs that break portability, isn't that within scope for SQLGlot to ship rewrite recipes for? It is a fair argument. We do not adopt the position because we think SQLGlot's job is dialect-correct emission, and an engine-bug registry is a different artifact: it could live alongside SQLGlot, in a sidecar project, or in project-specific layers like ours. We would happily contribute to such an artifact if one emerges. The structural argument is not "SQLGlot should never know about engine bugs"; it is "knowing about engine bugs is a separable concern from translating SQL between dialects."
 
 ### 5. DDL semantics, across 19 platforms
 
@@ -139,13 +143,13 @@ This is a category, not a one-off. Every benchmark we ship has a few queries whe
 
 Half of BenchBox's targets are DataFrame engines: Polars, Pandas, DataFusion's Python frontend, PySpark, Dask, Modin, cuDF, LakeSail. SQLGlot does not address translating SQL into Polars expressions, which is a different problem from translating SQL into more SQL.
 
-Our `platforms/dataframe/unified_frame.py` is about 2,200 lines of SQL-shaped facade over per-engine DataFrame APIs, with bespoke parsing of DataFusion's expression AST for aggregate arithmetic. Polars' own SQL frontend was tried and removed earlier in BenchBox's history; "fundamental limitations" is the note we left ourselves.
+Our `platforms/dataframe/unified_frame.py` is the SQL-shaped facade over per-engine DataFrame APIs, with bespoke parsing of DataFusion's expression AST for aggregate arithmetic. It is the largest single file in our cross-platform layer (about 4,200 lines), which surprised us, and is part of why we treat DataFrame translation as a separate problem from SQL translation. Polars' own SQL frontend was tried and removed earlier in BenchBox's history; "fundamental limitations" is the note we left ourselves.
 
 This is not a SQLGlot gap; it is the boundary of what a SQL transpiler is for. But it is worth flagging for anyone shopping for a "SQL portability layer." Transpilation only takes you to engines that speak SQL.
 
 ## What we learned
 
-**1. "Supported dialects" is a one-bit signal that needs more bits.** SQLGlot's "34 dialects" is accurate as a count. It is less useful as a maturity signal. The Postgres support is rock-solid. The Doris support emits `VARCHAR` to `STRING` in a way that breaks key columns. A per-dialect maturity matrix (A-grade tested, best effort, parser-only) would be transformative for production users. We would happily contribute test cases for the dialects we exercise heavily.
+**1. "Supported dialects" is a one-bit signal that needs more bits.** SQLGlot's "34 dialects" is accurate as a count. It is less useful as a maturity signal. The Postgres support is rock-solid. The Doris support emits `VARCHAR` to `STRING` in a way that breaks key columns. A per-dialect maturity matrix (A-grade tested, best effort, parser-only) would be transformative for production users. We would happily contribute test cases for the dialects we exercise heavily, and bug fixes in dialect generators where we have isolated reproductions; this is our standing position on upstreaming, regardless of whatever else lands in our own layer.
 
 **2. Engine-semantic bugs are the most dangerous category.** The DataFusion TPC-H rewrites are not in any "transpilation correctness" framework's failure list, because the transpilation is correct. The engine's planner is the proximate cause of the wrong answer. Yet the user-visible failure mode is "I transpiled and got wrong results." A community-maintained registry of "this query shape produces wrong results on engine X version >= Y," with rewrite recipes, would help every team that hits these. Today every team rediscovers them privately.
 
@@ -191,19 +195,19 @@ We would love to hear about gaps you have hit in your own SQLGlot-based projects
 
 The patterns described here are taken from the BenchBox codebase as of v0.2.1, with additional details verified against:
 
-- SQLGlot main branch as of May 2026
+- SQLGlot pinned `>=20.0.0,<31.0.0` in `pyproject.toml`; resolved version in `uv.lock` was 30.6.0 at time of writing
 - DataFusion versions current to the BenchBox v0.2.1 platform matrix
 - ClickHouse Cloud and self-hosted 25.x
 - QuestDB 9.3.4
 - Doris 2.1.x
 
-The line counts cited (450 lines for the QuestDB rewriter, 2,200 for `unified_frame.py`, 19 DDL rewrite modules) are file-level counts from `wc -l` on the listed paths. The dialect coverage gap (8 platforms with no SQLGlot entry) is from `dialect_utils.normalize_dialect_for_sqlglot`. The DataFusion silent-corruption queries (Q11, Q16, Q18, Q20) are documented in `datafusion_query_transformer.py` with the rewrite recipes.
+The 19 DDL rewrite modules under `benchbox/sql_compat/rules/ddl_optimize/` and the dialect coverage gap (8 platforms with no SQLGlot entry, normalized by `dialect_utils.normalize_dialect_for_sqlglot`) are verifiable directly in the listed paths. The DataFusion silent-corruption queries (Q11, Q16, Q18, Q20) are documented in `datafusion_query_transformer.py` with the rewrite recipes inline.
 
 ## Limitations
 
 - This post catalogs *what we built*, not the full set of SQLGlot gaps a different project might hit. Workloads with heavy DDL automation, ETL with stored procedure translation, or live query rewriting against a SaaS warehouse will have a different list.
 - The "categories" framing is post-hoc; the code grew organically. A team starting today with the same platform list might land on a different decomposition.
-- Engine versions matter. Some of the silent-corruption cases on DataFusion may resolve in future planner releases. We re-validate on each platform upgrade.
+- Engine versions matter. Some of the silent-corruption cases on DataFusion may resolve in future planner releases, at which point the rewrite becomes a candidate for retirement: we run the rewrite-bypass version against TPC-H reference answers, and remove the rule only if validation passes. Retirement is opt-in; we do not auto-retire.
 
 ---
 

--- a/_blog/building-benchbox/outlines/11-what-we-built-on-top-of-sqlglot.md
+++ b/_blog/building-benchbox/outlines/11-what-we-built-on-top-of-sqlglot.md
@@ -2,7 +2,7 @@
 
 > SQLGlot is the foundation, not the finished house. This post is the punchlist of what we still had to build.
 
-**TL;DR**: BenchBox runs benchmarks across 36 SQL platforms. SQLGlot does the transpilation heavy lifting (and the recent mypyc work makes it dramatically faster), but real cross-engine portability needs ~2,500 lines of additional infrastructure: dialect normalization, post-generation fixups, engine-aware semantic rewrites, a 19-platform DDL rewrite registry, hand-written query overrides where translation can't deliver, and a SQL-to-DataFrame layer that SQLGlot doesn't address. We catalog the gaps with file paths and concrete examples.
+**TL;DR**: BenchBox runs benchmarks across 36 SQL platforms. SQLGlot does the transpilation heavy lifting (and the recent mypyc work makes it dramatically faster), but real cross-engine portability needs a substantial additional layer: dialect normalization, post-generation fixups, engine-aware semantic rewrites, a 19-platform DDL rewrite registry, hand-written query overrides where translation can't deliver, and a SQL-to-DataFrame facade for engines that don't speak SQL. We catalog the gaps with file paths and concrete examples.
 
 ---
 
@@ -68,7 +68,7 @@ tags: [benchbox, sqlglot, sql, transpilation, dialects, dataframe, architecture,
 
 **Layer 3: Per-platform query transformers**. When a single platform's quirks were too platform-specific for the wrapper, we extracted them:
 - `clickhouse/query_transformer.py` (case folding, division safety, type casts)
-- `questdb_rewriter.py` (450 lines of post-AST rewrites)
+- `questdb_rewriter.py` (dedicated post-AST rewrites)
 - `datafusion_query_transformer.py` (engine-semantic query rewrites)
 
 **Layer 4: A SQL compatibility registry** (`benchbox/sql_compat/`). When the per-platform code grew structure, we built explicit rule families:
@@ -126,7 +126,7 @@ Three platforms required dedicated transformer modules.
 - DECIMAL division-by-zero NULL wrapping
 - TPC-DS Q23/Q87 subquery aliasing: we tried AST injection, it corrupted GROUP BY in Q23 and aliases inside `EXCEPT/INTERSECT` in Q87. We fell back to a session setting (`joined_subquery_requires_alias=0`) because the AST rewrite was unsafe.
 
-**QuestDB** (`platforms/questdb_rewriter.py`, ~450 lines):
+**QuestDB** (`platforms/questdb_rewriter.py`):
 - Implicit comma joins -> explicit `INNER JOIN ... ON` (every TPC-H, TPC-DS, SSB query)
 - `INTERVAL` arithmetic -> `dateadd('d', n, ts)` (TPC-H Q1, Q4, Q6, Q17)
 - `SUBSTRING(s FROM p FOR l)` -> `substring(s, p, l)`
@@ -188,7 +188,7 @@ Same pattern in `nyctaxi_variants.py`, `coffeeshop_variants.py`, `tpcdi_variants
 
 Half of BenchBox's targets are DataFrame engines: Polars, Pandas, DataFusion-Python, PySpark, Dask, Modin, cuDF, LakeSail. SQLGlot doesn't address translating SQL into Polars expressions; that's a different problem.
 
-Our `platforms/dataframe/unified_frame.py` (~2,200 lines) is a SQL-shaped facade over per-engine DataFrame APIs. Polars' own SQL frontend was tried and removed: "fundamental limitations" in our notes. DataFusion's expression AST has to be parsed post-translation for aggregate arithmetic.
+Our `platforms/dataframe/unified_frame.py` (about 4,200 lines, the largest single file in the cross-platform layer) is a SQL-shaped facade over per-engine DataFrame APIs. Polars' own SQL frontend was tried and removed: "fundamental limitations" in our notes. DataFusion's expression AST has to be parsed post-translation for aggregate arithmetic.
 
 This isn't a SQLGlot gap; it's the boundary of what a SQL transpiler is for. But anyone shopping for "a SQL portability layer" should know it exists.
 
@@ -249,14 +249,14 @@ We'd love to hear about gaps you've hit in your own SQLGlot-based projects. Open
 ## Research Status
 
 - [x] Fivetran post (2026-05-01) reviewed for performance numbers and capability claims
-- [x] BenchBox SQL infrastructure audit (~2,500 lines across 7 categories, file paths verified)
+- [x] BenchBox SQL infrastructure audit covers seven categories with verified file paths
 - [x] DataFusion silent-corruption queries (Q11, Q16, Q18, Q20) confirmed in `datafusion_query_transformer.py`
-- [x] QuestDB rewriter line count and rewrite categories confirmed
+- [x] QuestDB rewriter scope (comma joins, INTERVAL arithmetic, SUBSTRING form, CTE column lists) confirmed
 - [x] 19 DDL rewrite modules enumerated under `sql_compat/rules/ddl_optimize/`
 - [x] H2O Q9 hand-written variants confirmed in `h2odb_variants.py`
 - [x] Subquery alias injection failure documented in `clickhouse_session_policy.py`
-- [x] DataFrame `unified_frame.py` line count (~2,200) confirmed
-- [ ] Verify exact line counts in draft via `wc -l` before publish
+- [x] DataFrame `unified_frame.py` is the dominant file in the layer (verified via `wc -l` at write time)
+- [x] SQLGlot pin recorded (`>=20.0.0,<31.0.0` in `pyproject.toml`; resolved 30.6.0 in `uv.lock`)
 - [ ] Confirm DataFusion engine version that triggers Q11/Q16/Q18/Q20 issues for citation
 
 ## Visual Elements for Draft

--- a/docs/development/adr/adr-sqlglot-use-and-non-use.md
+++ b/docs/development/adr/adr-sqlglot-use-and-non-use.md
@@ -31,10 +31,11 @@ release since. SQLGlot is excellent and the recent mypyc compilation work
 delivered meaningful speedups for our workload (parser ~5x, generator ~2.5x,
 optimizer ~2x).
 
-This ADR exists because, over the last 12 months, BenchBox accreted ~2,500
-lines of SQL infrastructure on top of SQLGlot: post-generation fixups, three
-per-platform query transformers, a 19-platform DDL rewrite registry, hand-
-written query overrides, a SQL-to-DataFrame facade, and the
+This ADR exists because, over the last 12 months, BenchBox accreted a
+substantial layer of SQL infrastructure on top of SQLGlot, organized into
+seven categories: dialect normalization, post-generation fixups, three
+per-platform query transformers, a 19-platform DDL rewrite registry,
+hand-written query overrides, a SQL-to-DataFrame facade, and the
 [`sql_compat` rule engine](adr-sql-compat-phase-aware-pipeline.md). The
 answer to "why do we need so much code on top of a transpiler?" has
 structural reasons rooted in what a SQL transpiler is and is not, and those
@@ -198,11 +199,18 @@ under [`benchbox/sql_compat/rules/ddl_optimize/`](../../../benchbox/sql_compat/r
 plus the per-adapter `_optimize_table_definition()` hook documented in the
 [phase-aware pipeline ADR](adr-sql-compat-phase-aware-pipeline.md).
 
-Fabric Warehouse is a documented exception: its `_optimize_table_definition`
-injects a schema-qualified table name from runtime adapter state, which is
-operational context (not DDL compatibility), so it is intentionally not in
-the registry. See the parent ADR's "Fabric Warehouse Decision" section for
-the full reasoning.
+Fabric Warehouse occupies a third path between "in the registry" and
+"not in the registry":
+[`fabric_dw_ddl_rewrites.py`](../../../benchbox/sql_compat/rules/ddl_optimize/fabric_dw_ddl_rewrites.py)
+registers a `governance_only=True` rule so `compat_lint` can audit that
+DDL rewriting is happening for the platform, but the runtime
+transformation lives in `FabricWarehouseAdapter._optimize_table_definition()`
+because the schema prefix it injects depends on runtime adapter state
+(the adapter's configured `self.schema`). The registry rule is the
+governance marker; the rewrite is operational. The parent ADR's
+"Fabric Warehouse Decision" section captures the original reasoning for
+keeping the runtime logic in the adapter; the governance-only rule was
+added afterwards as a `compat_lint` accountability hook.
 
 **Fallback**: Explicit DDL rewrite registered per platform. The rule engine
 applies the rewrite at the `ddl_optimize` phase before the DDL reaches the
@@ -350,10 +358,10 @@ tractable.
 
 ### Negative / Risks
 
-- The infrastructure on top of SQLGlot is 2,500+ lines and continues to
-  grow as we add platforms. Any contributor evaluating BenchBox's
-  cross-engine support has to read this ADR plus the phase-aware pipeline
-  ADR to understand the scope.
+- The infrastructure on top of SQLGlot covers seven categories and
+  continues to grow as we add platforms. Any contributor evaluating
+  BenchBox's cross-engine support has to read this ADR plus the
+  phase-aware pipeline ADR to understand the scope.
 - Engine version drift can re-open closed semantic-rewrite cases. If a
   DataFusion release fixes Q16 NULL semantics, our rewrite becomes
   redundant; we do not aggressively retire rewrites because the


### PR DESCRIPTION
Apply findings from /blog review of post 11 against the updated ADR.

Critical
- F3 (ADR): Correct the Fabric Warehouse claim. The previous
  "intentionally not in the registry" framing was wrong; Fabric DW has a
  governance_only=True rule in fabric_dw_ddl_rewrites.py that lets
  compat_lint audit the platform without shipping a static transformer.
  The runtime transformation lives in
  FabricWarehouseAdapter._optimize_table_definition() because the
  schema prefix it injects depends on adapter state. Document this
  third path between "in the registry" and "not in the registry".
- F1 (blog draft + outline): Drop the wrong unified_frame.py line count
  (~2,200) wherever it appeared and replace with the verified figure
  (about 4,200 lines, the largest single file in the cross-platform
  layer).
- F2 (blog TL;DR + ADR Context + ADR Negative): The "~2,500 lines"
  aggregate was internally inconsistent with the categories it
  enumerated (the DataFrame layer alone exceeds 2,500). Reframe as a
  qualitative "substantial additional layer" / "covers seven
  categories", letting the categorical structure carry the weight.

Lines-of-code de-emphasis (per user instruction: max 3 mentions per
location)
- ADR: now has one LoC mention (the verified 4,200-line DataFrame
  anchor in section 4). Removed two stale 2,500-line counts.
- Blog draft: now has one LoC mention (same DataFrame anchor).
  Removed three 2,200/2,500/450 references that were either wrong or
  unnecessary.
- Blog outline: now has one LoC mention. The remaining "2,200-2,800
  words" line is the YAML target_length for the post, not a
  lines-of-code claim.

High
- F4 (blog Test environment): Replace the imprecise "SQLGlot main
  branch as of May 2026" with the actual pin from pyproject.toml
  (>=20.0.0,<31.0.0) and the resolved uv.lock version (30.6.0). Matches
  the ADR's recorded baseline so an external reader can reproduce.
- F5 (blog Limitations): Add the retirement protocol the ADR records
  in its FailureMode section (run rewrite-bypass against TPC-H
  references, remove rule only if validation passes, opt-in).

Medium
- F6 (blog Introduction): Add the "we have not rigorously measured
  SQLGlot's share of the BenchBox runtime budget" caveat the ADR
  introduced, so the Fivetran speedup citation is not read as our
  benchmarked endorsement.
- F7 (blog section 4): Add the explicit steelman ("you could push back:
  if SQLGlot's pitch is portability...") and rebuttal that the ADR
  records, framing engine-bug rewrites as a separable concern from SQL
  translation.
- F8 (blog "What we learned" #1): Strengthen the upstream-contribution
  position from "we'd happily contribute test cases" to a clearer
  standing policy (test cases plus bug fixes in dialect generators
  where we have isolated reproductions).

Outline research-status checklist updated to drop stale per-file line
counts and add the SQLGlot pin to the verified-fact list.

Verified clean: max-1 LoC mentions per file, em-dash/en-dash, markdownlint.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
