### PR TITLE
feat(uat-methodology): w5 file 2 implementation TODOs + triage source blind-spots

### DIFF
--- a/_project/DONE/main/active/results-explorer-uat-methodology-blind-spot-remediation.yaml
+++ b/_project/DONE/main/active/results-explorer-uat-methodology-blind-spot-remediation.yaml
@@ -2,7 +2,8 @@ id: results-explorer-uat-methodology-blind-spot-remediation
 title: "Plan: address the three UAT-20260502 methodology blind spots before the next sweep"
 worktree: main
 priority: "Medium-High"
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-05-03"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -113,7 +114,7 @@ work:
 - id: w5
   summary: "After approval, file implementation TODOs and triage the blind-spot files"
   needs: [w4]
-  status: pending
+  status: done
   notes: |
     File one TODO per accepted remediation under
     `_project/TODO/main/planning/`. Slug each so the link to the

--- a/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
+++ b/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
@@ -1,0 +1,174 @@
+id: uat-template-success-metric-terminal-state-and-gating
+title: "Add submission terminal-state vocab + open_questions gating schema relaxation"
+worktree: main
+priority: "Medium"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  Closes the remediation for blind-spot finding
+  `2026-05-03-081922-uat-submit-success-metric-ambiguity` per the
+  approved design document at
+  `_project/specs/uat-methodology-blind-spot-remediation.md`.
+
+  Bundles three small edits that share a single PR surface:
+    1. Schema relaxation: `TODO_SCHEMA.yaml` `open_questions` items
+       become `oneOf [string, object]` (backwards-compatible — existing
+       string-form questions still validate).
+    2. Template additions: `_project/TODO_ENTRY_TEMPLATE.yaml` learns
+       three example snippets — terminal-state vocabulary in
+       `success_metrics`, validator-clean-rate metric, and
+       per-work-unit `coverage_checklist` block.
+    3. Optional retrofit: `external-contributor-submission-dry-run`
+       gets a one-line terminal-state addition to its `success_metrics`
+       (its `verification` block already names "PR is merged"
+       unambiguously, but the explicit success-metric line is the
+       remediation Finding 3 prescribes for in-flight UATs).
+
+  Spec §2 Finding 3, §3 template/schema diff preview, §6 implementation
+  TODO 2 contain the full rationale and the exact YAML to apply.
+
+work:
+- id: w1
+  summary: "Schema relaxation: open_questions oneOf [string, object]"
+  status: pending
+  notes: |
+    Update `_project/TODO_SCHEMA.yaml` `open_questions` to:
+
+      open_questions:
+        type: array
+        description: "Unresolved questions or uncertainties"
+        items:
+          oneOf:
+            - type: string
+            - type: object
+              required: [question]
+              properties:
+                question: { type: string }
+                gating: { type: boolean }
+                affects: { type: array, items: { type: string } }
+                default: { type: string }
+                resolved_with: { type: string }
+
+    Verify: `validate_todo.py` continues to pass on every existing TODO
+    in `_project/TODO/` and `_project/DONE/`. Add a new fixture or unit
+    test that confirms the object form validates.
+
+- id: w2
+  summary: "Template additions: terminal-state vocab + validator-clean rate + coverage_checklist examples"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update `_project/TODO_ENTRY_TEMPLATE.yaml` per the spec's §3
+    "Template diff preview" exactly. Specifically:
+      - In the `work[]` example, add a commented `coverage_checklist:`
+        block scoped to "OPTIONAL — for work units with cross-cutting
+        deliverables only".
+      - In the `success_metrics` example, add commented examples for
+        the four-word terminal-state vocab and the validator-clean
+        rate (with a "corpus-shaped UATs only" guard).
+      - In the `open_questions` example, add a commented object-form
+        gating question after the existing string-form example.
+    Keep template comments concise; readers should be able to copy
+    snippets without untangling dense prose.
+
+- id: w3
+  summary: "Optional retrofit of external-contributor-submission-dry-run"
+  needs: [w2]
+  status: pending
+  notes: |
+    Add to `_project/TODO/main/planning/external-contributor-submission-dry-run.yaml`:
+
+      success_metrics:
+      - "Submission terminal state: merged-to-published-results (PR opened, CI green, merge complete)"
+
+    No other edits to that file. The existing `verification` block
+    already implies this terminal state; the success_metric makes it
+    explicit. If the user prefers to skip the retrofit, drop this work
+    unit; the rest of the TODO stands.
+
+verification:
+- description: "Schema accepts object-form open_questions"
+  command: |
+    cat > /tmp/uat_test_oq.yaml <<'EOF'
+    title: "Test"
+    worktree: main
+    priority: Low
+    status: "Not Started"
+    description: "Test that the schema relaxation works."
+    open_questions:
+    - "Legacy string"
+    - question: "Object form"
+      gating: true
+      affects: ["w1"]
+    EOF
+    uv run --project _project/scripts -- python _project/scripts/validate_todo.py /tmp/uat_test_oq.yaml
+  expected_output: "✅ valid"
+- description: "Existing TODOs still validate"
+  command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all"
+  expected_output: "all files valid"
+
+must_preserve:
+- "Backwards compatibility: existing string-form `open_questions` entries continue to validate (the schema becomes oneOf string|object, not object-only)."
+- "All currently-tracked TODOs in `_project/TODO/` and `_project/DONE/` continue to validate without modification."
+- "Template structure: comments stay terse; snippets remain copy-pastable."
+
+approach: |
+  Implement w1 first (schema), regression-test against the full TODO
+  corpus, then w2 (template additions), then w3 (retrofit if accepted).
+  The schema change is the only non-additive piece and so carries the
+  regression risk; everything else is purely additive comment/example
+  edits.
+
+anti_patterns:
+- "DO NOT add `additionalProperties: false` to the new object form — because we explicitly want forward-compatibility for future fields like `resolved_with` — leave additionalProperties at its default (true)."
+- "DO NOT enforce `gating: true` runtime semantics in todo_cli.py — because the spec scopes that to a future TODO if reviewer attention proves insufficient — this TODO is template + schema only."
+- "DO NOT bundle in the coverage_checklist tooling change — because Finding 1 was approved as convention-only — that lives behind a separate (currently un-filed) TODO if a future UAT shows the convention drifting."
+
+scope_limit:
+  only_modify:
+  - "_project/TODO_SCHEMA.yaml"
+  - "_project/TODO_ENTRY_TEMPLATE.yaml"
+  - "_project/scripts/validate_todo.py"  # only if a regression test is added
+  - "_project/scripts/tests/"  # if a fixture/unit test lands here
+  - "_project/TODO/main/planning/external-contributor-submission-dry-run.yaml"
+  do_not_modify:
+  - "benchbox/"
+  - "results-explorer/"
+  - "scripts/"
+  - "_project/DONE/"
+
+success_metrics:
+- "Schema accepts object-form `open_questions` items; string form still validates."
+- "Template demonstrates the three new conventions with copy-pastable snippets."
+- "If retrofit accepted: `external-contributor-submission-dry-run` names its terminal state explicitly in `success_metrics`."
+- "All existing TODO/DONE files continue to validate."
+
+deferred:
+- summary: "`gating: true` runtime enforcement in todo_cli.py done"
+  reason: "Spec §2 Finding 3 scopes this to a future follow-up if reviewer attention proves insufficient. Premature tooling adds false-positive risk (defensible exceptions get blocked)."
+- summary: "Coverage checklist tooling enforcement"
+  reason: "Finding 1 was approved as convention-only per the W4 design. File separately if a future UAT shows the convention drifting."
+- summary: "_project/UAT_TEMPLATE.yaml subtemplate extraction"
+  reason: "Q4 in the design defaulted to wait. Promote per-TODO conventions into a subtemplate after the next two UATs prove their cost/benefit."
+
+metadata:
+  tags:
+  - uat
+  - methodology
+  - submission-flow
+  - schema
+  - templates
+  estimated_effort: "Small"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Removes ambiguity from submission-flow success metrics, reducing the
+    chance of a future agent inferring the wrong terminal state from
+    evidence rather than authorisation. Schema relaxation enables
+    structured `gating: true` questions whose `affects:` link makes
+    deliverable-changing questions visible at completion review.
+  user_impact: |
+    Indirect: future UAT outcomes more clearly align with what was
+    actually authorised.

--- a/_project/TODO/main/planning/uat-template-validator-clean-rate-runner.yaml
+++ b/_project/TODO/main/planning/uat-template-validator-clean-rate-runner.yaml
@@ -1,0 +1,146 @@
+id: uat-template-validator-clean-rate-runner
+title: "Add validator-clean-rate runner step + roll-up TSV for sweep-shape UATs"
+worktree: main
+priority: "Medium"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  Promotes the validator-clean rate from a manual reconciliation step
+  (which the 2026-05-02 sweep author had to do by hand) into a
+  first-class runner output for any sweep-shape UAT. Closes the
+  remediation for blind-spot finding
+  `2026-05-03-081921-uat-invalid-bundle-rate-not-tracked` per the
+  approved design document.
+
+  Background and rationale: see
+  `_project/specs/uat-methodology-blind-spot-remediation.md` §2 Finding 2
+  and §6 implementation TODO 1.
+
+  The 2026-05-02 sweep packaged 376 bundles; `scripts/validate_submission.py`
+  rejected 171 (45%). The discrepancy between the W3 pass count (434) and
+  the W5 validator-clean count (205) had no slot in the rubric and was
+  buried in §"W5 Submission Flow" of the retrospective. This TODO
+  formalises the per-platform / per-benchmark roll-up so future sweep
+  authors get the rate as a first-class artifact rather than as a
+  reconciliation chore.
+
+work:
+- id: w1
+  summary: "Decide implementation surface: runner step inside benchbox vs post-sweep helper script"
+  status: pending
+  notes: |
+    Two viable shapes:
+      a. New phase / option on `benchbox run` that emits a per-cell
+         validator status alongside the existing result JSON.
+      b. Standalone post-sweep helper at `scripts/uat_validator_rollup.py`
+         that walks a sweep's results directory, runs
+         `scripts/validate_submission.py` per bundle, and emits a TSV.
+    Default recommendation: (b). The existing `validate_submission.py`
+    is already the validator; wrapping it in a helper avoids touching
+    `benchbox run` and keeps the runner step out of the platform code
+    path. Option (a) is over-engineered given the sweep cadence.
+    Surface to the user only if (b) turns out to need invasive changes.
+
+- id: w2
+  summary: "Implement the helper and TSV format"
+  needs: [w1]
+  status: pending
+  notes: |
+    Inputs: sweep results dir (e.g.,
+    `~/Developer/benchmark_runs/results/`) plus optional sweep window
+    via `--newer <sentinel-file>` (mirrors the 2026-05-02 W3 sentinel
+    pattern at `~/Developer/benchmark_runs/logs/uat_*/.sweep_start`).
+
+    Output TSV columns:
+      platform | benchmark | scale | result_path | validator_status |
+      error_count | warning_count | first_error
+    Plus a footer line with overall counts: total / clean / per-platform
+    rate / per-benchmark rate.
+
+    `validator_status` values: `clean | error | warning_only | refused-by-cli`.
+    The fourth covers TPC-DS subscale / nonstandard refusals; the
+    helper must distinguish them from real validation errors.
+
+- id: w3
+  summary: "Add a fast unit test using fixture bundles"
+  needs: [w2]
+  status: pending
+  notes: |
+    Fixtures: a small dir with one valid bundle, one
+    normalized-cost-error bundle, one zero-timing-error bundle. Assert
+    the TSV roll-up reports exactly 1/3 clean rate and the per-bundle
+    error categorisation.
+
+- id: w4
+  summary: "Document in docs/operations/uat-methodology.md (or similar) plus a CLAUDE.md note"
+  needs: [w2]
+  status: pending
+  notes: |
+    Short docs entry: when to run, what the TSV columns mean, how to
+    read the per-platform rate. Add a one-line CLAUDE.md note pointing
+    sweep-shape UAT authors at this helper.
+
+verification:
+- description: "Helper exists and runs against a small fixture set."
+  command: "uv run -- python scripts/uat_validator_rollup.py tests/fixtures/uat_rollup --output -"
+  expected_output: "TSV with one row per fixture bundle plus footer counts"
+- description: "Fast unit test passes."
+  command: "uv run -- python -m pytest tests/unit/scripts/test_uat_validator_rollup.py -q"
+  expected_output: "all pass"
+
+must_preserve:
+- "`scripts/validate_submission.py` behaviour and exit codes — the helper wraps it, doesn't replace it."
+- "Existing sweep workflows that don't opt in (no breaking change to `benchbox run`)."
+
+approach: |
+  Wrap, don't replace. `scripts/validate_submission.py` already does the
+  bundle validation; this TODO adds an aggregator that walks a directory
+  and rolls up its output into a TSV. Default invocation should match
+  the manual reconciliation the 2026-05-02 sweep author did
+  (`submission_validation_20260502.log`).
+
+anti_patterns:
+- "DO NOT modify `benchbox run` — because the runner step is meant to be opt-in for sweep-shape UATs only — implement as a standalone helper script."
+- "DO NOT change `scripts/validate_submission.py` — because the validator contract is the source of truth — wrap it via subprocess or import its public API."
+- "DO NOT add a new dependency — because the existing scripts dir is dependency-light — stick to stdlib + what's already imported."
+
+scope_limit:
+  only_modify:
+  - "scripts/uat_validator_rollup.py"
+  - "tests/unit/scripts/test_uat_validator_rollup.py"
+  - "tests/fixtures/uat_rollup/"
+  - "docs/operations/uat-methodology.md"
+  - "CLAUDE.md"
+  do_not_modify:
+  - "benchbox/"
+  - "scripts/validate_submission.py"
+  - "results-explorer/"
+
+success_metrics:
+- "Helper produces a per-cell + footer TSV consumable by the W7 author of any future sweep-shape UAT."
+- "Per-platform / per-benchmark validator-clean rates surface as headline numbers, not buried in a sub-section of the retrospective."
+- "Fast unit test verifies error categorisation against fixture bundles."
+
+deferred:
+- summary: "Pre-submission validation gate inside `benchbox run`"
+  reason: "Discussed in the spec; out of scope here. Adding it would change run-time behaviour and risks producing different W3 pass counts than the historical baseline. File separately if the runner step proves insufficient."
+
+metadata:
+  tags:
+  - uat
+  - methodology
+  - submission-flow
+  - tooling
+  estimated_effort: "Small"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Closes the loop on the 2026-05-02 finding that headline W3 success
+    counts overstated corpus health by ~2x. Makes the same discrepancy
+    visible at sweep time for every future UAT.
+  user_impact: |
+    Indirect: more reliable corpus signals lead to more reliable
+    explorer demos and a more honest set of numbers in user-facing
+    artifacts.

--- a/_project/blind-spots/2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md
+++ b/_project/blind-spots/2026-05-03-081920-uat-cross-scale-deliverable-not-guarded.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-03-081920-uat-cross-scale-deliverable-not-guarded
 date: 2026-05-03
-status: open
+status: actioned
 finding_kind: framework-gap
 review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W6 cross-scale UX deliverable)"
 related_paths:
@@ -40,3 +40,7 @@ final report explicitly answers, not a prose ask the agent might honor.
 - [ ] For the next UAT, add an enumerated cross-scale checklist (e.g. "for at least 3 platforms, open the same benchmark at SF=0.01/0.1/1.0 and capture cross-scale comparison findings") to W6 work unit notes.
 - [ ] Update `_project/TODO_ENTRY_TEMPLATE.yaml` (or a UAT-specific subtemplate) so headline deliverables are declared as `success_metrics` entries with measurable coverage commands, not prose-only goals.
 - [ ] Audit other in-flight UAT-style TODOs (e.g. `external-contributor-submission-dry-run`) for the same pattern and decide whether to retrofit explicit coverage checklists.
+
+## Triage log
+
+- 2026-05-03: actioned — Convention-only remediation captured in _project/specs/uat-methodology-blind-spot-remediation.md §2 Finding 1; per W4 user approval, no follow-up TODO needed (coverage_checklist is convention only).

--- a/_project/blind-spots/2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md
+++ b/_project/blind-spots/2026-05-03-081921-uat-invalid-bundle-rate-not-tracked.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-03-081921-uat-invalid-bundle-rate-not-tracked
 date: 2026-05-03
-status: open
+status: merged-to-todo
 finding_kind: missed-axis
 review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W5 submission flow validation)"
 related_paths:
@@ -9,7 +9,7 @@ related_paths:
   - _project/DONE/main/active/results-explorer-uat-defect-normalized-cost-unavailable-bundles.yaml
   - _project/DONE/main/active/results-explorer-uat-defect-zero-query-timing-bundles.yaml
 suggested_sweep: "treat 'attempted-pass-but-validator-rejected' as its own corpus-quality metric and add it to UAT success_metrics with an explicit budget"
-todo_id: null
+todo_id: uat-template-validator-clean-rate-runner
 ---
 
 # UAT triaged failures per-cluster but never tracked the overall invalid-bundle rate as a methodology metric
@@ -43,3 +43,7 @@ language is failing to track what actually matters.
 - [ ] Add a "validator-clean rate" metric to UAT `success_metrics`: e.g. ">=80% of W3-passed cells produce bundles that pass `scripts/validate_submission.py`."
 - [ ] Capture the rate per-platform and per-benchmark in the W7 report — clusters with low validator-clean rates are higher-priority defect targets than clusters with low W3-pass rates.
 - [ ] Reconsider whether `--phases load,power` plus default validation is the right floor for a UAT corpus when so many bundles fail downstream contract validation; possibly add a pre-submission validator pass to W3 itself.
+
+## Triage log
+
+- 2026-05-03: promoted to TODO `uat-template-validator-clean-rate-runner`

--- a/_project/blind-spots/2026-05-03-081922-uat-submit-success-metric-ambiguity.md
+++ b/_project/blind-spots/2026-05-03-081922-uat-submit-success-metric-ambiguity.md
@@ -1,13 +1,13 @@
 ---
 id: 2026-05-03-081922-uat-submit-success-metric-ambiguity
 date: 2026-05-03
-status: open
+status: merged-to-todo
 finding_kind: framework-gap
 review_context: "code review of completed TODO _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml (W5 success_metrics + open_questions Q3)"
 related_paths:
   - _project/DONE/main/active/results-explorer-uat-multi-scale-corpus-sweep.yaml
 suggested_sweep: "audit UAT/dry-run TODO templates for success_metrics that conflate local-staging with upstream-publication; require open_questions that gate work to be resolved before that work begins, not deferred"
-todo_id: null
+todo_id: uat-template-success-metric-terminal-state-and-gating
 ---
 
 # UAT success metric "submitted via the BenchBox submission flow" did not disambiguate local-staging from upstream-publication
@@ -48,3 +48,7 @@ that terminal state must be resolved before the relevant work unit starts.
 - [ ] Update `_project/TODO_ENTRY_TEMPLATE.yaml` so submission-related success metrics name a specific terminal state (local stage / draft PR / merged) rather than the verb "submit."
 - [ ] Add a TODO-author convention: any `open_questions` entry whose answer changes a `success_metrics` entry must be marked `gating: true` and resolved before the dependent work unit starts; non-gating questions stay deferable.
 - [ ] Sweep open UAT/dry-run TODOs for the "submitted via submission flow" pattern and disambiguate before they're picked up.
+
+## Triage log
+
+- 2026-05-03: promoted to TODO `uat-template-success-metric-terminal-state-and-gating`


### PR DESCRIPTION
Per user approval of all W4 design defaults:
- File uat-template-validator-clean-rate-runner (Finding 2): runner step
  + roll-up TSV for sweep-shape UATs.
- File uat-template-success-metric-terminal-state-and-gating (Finding 3):
  open_questions oneOf [string, object] schema relaxation, template
  example additions for terminal-state vocab + validator-clean rate +
  coverage_checklist, plus optional retrofit of
  external-contributor-submission-dry-run.
- Triage 081920 (cross-scale coverage) as actioned: Finding 1 is
  convention-only per the W4 design; the convention is captured in the
  spec, no implementation TODO needed.
- Promote 081921 -> uat-template-validator-clean-rate-runner.
- Promote 081922 -> uat-template-success-metric-terminal-state-and-gating.

Mark parent TODO results-explorer-uat-methodology-blind-spot-remediation
Completed; move to DONE.

Verification (all from parent TODO):
  V1: spec exists at _project/specs/...                          OK
  V2: blind-spots all triaged (081920|081921|081922 not in open) OK
  V3: implementation TODOs exist (uat-template-*.yaml)           OK
