### PR TITLE
chore(todo): file UAT framework TODO + script/driver-drift blind-spot

### DIFF
--- a/_project/TODO/main/planning/uat-framework-tests-uat-runner.yaml
+++ b/_project/TODO/main/planning/uat-framework-tests-uat-runner.yaml
@@ -1,0 +1,536 @@
+id: uat-framework-tests-uat-runner
+title: "UAT framework: consolidate stress + sweep machinery into tests/uat/"
+worktree: main
+priority: "Medium"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+deps:
+  needs:
+  - uat-template-validator-clean-rate-runner
+  - uat-template-success-metric-terminal-state-and-gating
+
+description: |
+  Closes the **script/driver-drift** gap that
+  `_project/specs/uat-methodology-blind-spot-remediation.md` deliberately
+  scoped out. The methodology spec resolved three blind-spot findings
+  about *how UAT TODOs are authored and reviewed*; this TODO resolves
+  a different gap about *how UAT machinery is built and reused*.
+
+  ## The gap
+
+  Today there are two parallel surfaces for matrix-shape execution:
+
+    1. `scripts/local_stress_test.sh` -- 600-line bash. Single scale per
+       benchmark, no cleanup, no validation, no scale-ladder. Purpose:
+       verify "does it run?" across the (platform, benchmark) matrix.
+
+    2. The 2026-05-02 UAT driver -- bespoke, hand-rolled, lives only as
+       `~/Developer/benchmark_runs/logs/uat_20260502/` artifacts plus
+       the retrospective. Re-invented timeout-wrapper (the script
+       already had one), scale-ladder, reuse-aware cleanup, matrix
+       summary TSV, submission packaging, validator subset filtering,
+       explorer build, Playwright smoke. Not reusable; the next sweep
+       will reinvent again.
+
+  Recorded:
+  `_project/blind-spots/2026-05-03-130000-stress-script-uat-driver-drift.md`.
+
+  ## What this TODO does
+
+  Builds a single Python framework under `tests/uat/` (tracked, not in
+  `_project/`), exposed via `make uat-*` operator targets (no
+  `benchbox` user-CLI surface change). Composable phases driven by
+  YAML configs under `tests/uat/configs/`:
+
+    - preflight (disk, docker, noisy-neighbor scan)
+    - enumerate (registry-driven matrix with min/max scale enforcement)
+    - execute (scale-ladder + early-stop + reuse-aware cleanup)
+    - validate (calls `scripts/uat_validator_rollup.py` from
+      `uat-template-validator-clean-rate-runner`)
+    - package (uses `submit_terminal_state` vocab from
+      `uat-template-success-metric-terminal-state-and-gating`)
+    - explorer-smoke (build + Playwright; optional)
+    - report (TSV roll-up + cross-scale coverage assertion)
+
+  Stress testing is the degenerate config (one scale, one platform
+  group, no validate/package/explorer phases).
+
+  ## Adversarial framing -- strongest case for not doing this
+
+  Per the methodology-spec author's recommendation: "convention plus a
+  small wrap-script is sufficient; framework adds engineering cost
+  without proportional benefit." Counter: the stress script IS the
+  framework that already exists; it just lacks half the phases. Either
+  we evolve it (this TODO) or accept that the next UAT reinvents the
+  same machinery a third time. The bash script's readability argument
+  weakened post-2026-05-02 because the sweep author had to read the
+  script for knowledge anyway, and still re-invented its timeout
+  wrapper.
+
+  Per blind-spot finding `2026-05-03-084354-stress-test-self-bias`:
+  this section may itself be proposer-biased. Independent review at
+  W1 (spec) is the mitigation; the spec is the explicit user-approval
+  gate before any code lands.
+
+  ## What this TODO does NOT do
+
+    - Methodology / TODO-template work -- owned by the two
+      `uat-template-*` deps. This TODO consumes their outputs.
+    - Cloud-platform UAT -- deferred (separate TODO if needed).
+    - Throughput-phase coverage -- deferred (separate sweep).
+    - Removing `scripts/local_stress_test.sh` -- W11 documents the
+      migration path but does not delete; deprecation is a separate
+      decision after adoption proves out.
+    - `benchbox uat` CLI subcommand -- explicitly out of scope; UAT
+      is a project-developer concern, `benchbox` is a project-user
+      concern.
+
+work:
+- id: w1
+  summary: "Spec the framework: tests/uat/ layout, YAML schema, phase contract, Make-target naming"
+  status: pending
+  notes: |
+    Output: `_project/specs/uat-framework.md`. This is a HARD
+    user-approval gate; no Python lands until the spec is reviewed
+    and approved.
+
+    Sections required:
+      1. Reframe -- the script/driver-drift gap; why this is separate
+         from the methodology spec.
+      2. tests/uat/ Python package layout (tree diagram naming every
+         file: matrix.py, runner.py, phases/, configs/, README.md).
+      3. YAML config schema with every field documented (platforms,
+         benchmarks, scales, ladder rules, cleanup policy, phases
+         enabled, submit_terminal_state vocab, validator_clean_rate
+         floor, cross_scale_coverage_min_pairs, per-run timeout).
+      4. Make-target naming and invocation contract.
+      5. Migration plan for `scripts/local_stress_test.sh` (default:
+         leave untouched; document delegation as opt-in for W11).
+      6. Replay artifact spec (tests/uat/configs/uat-2026-05-02.yaml).
+      7. Open questions for the user (independently reviewable).
+      8. Adversarial framing -- "strongest argument against each design
+         choice" subsection per finding 084354.
+      9. tests/uat/configs/ content policy (frozen replays vs
+         editable templates).
+  coverage_checklist:
+  - id: tests_uat_layout
+    description: "Spec names every file in tests/uat/ with its responsibility"
+    evidence_required: "Section 2 contains a tree diagram of the proposed layout"
+  - id: yaml_schema_complete
+    description: "Spec's YAML schema covers every phase-relevant config field"
+    evidence_required: "Section 3 lists each field with type, default, validation rule"
+  - id: adversarial_framing
+    description: "Strongest case against each major design choice surfaced explicitly"
+    evidence_required: "Section 8 contains one paragraph per major design choice"
+
+- id: w2
+  summary: "Lift shared matrix machinery from bash to tests/uat/matrix.py"
+  needs: [w1]
+  status: pending
+  notes: |
+    Translate the following from `scripts/local_stress_test.sh` to
+    Python in `tests/uat/matrix.py`:
+      - `get_platform_port` (lines 142-161) -> dict
+      - `get_platform_extra_opts` (lines 164-173) -> dict
+      - `get_platform_cli_flags` (lines 187-192) -> dict
+      - `get_platform_uv_extra` (lines 548-555) -> dict
+      - `tcp_probe`, `platform_is_reachable` (lines 197-227) ->
+        socket-based with same sentinel-cache semantics
+      - timeout wrapper (lines 90-123, 359-429) -> signal-based;
+        replaces the perl fallback path with native Python
+      - registry enumeration (lines 232-263) -> direct import from
+        `benchbox.core.benchmark_registry` (no eval; the bash version
+        already imports via `python -c`)
+      - benchmark scale resolution honouring min_scale and max_scale
+        (the bash script honours min_scale via `BENCHMARK_SMOKE_SCALES`
+        but does not enforce max_scale on `--scale` override -- fix
+        in the Python port)
+
+    `scripts/local_stress_test.sh` is NOT modified in this work unit.
+    The Python module becomes importable; bash continues to use its
+    embedded copies. The W11 decision is whether/how to delegate.
+
+    Add `tests/uat/test_matrix.py` with fast-test coverage of the
+    port map, extra opts, scale resolution, and tcp_probe (mocked
+    socket).
+
+- id: w3
+  summary: "tests/uat/runner.py + make uat-cell PLATFORM=X BENCHMARK=Y SCALE=Z"
+  needs: [w2]
+  status: pending
+  notes: |
+    Single-cell execution. `subprocess.run` invokes `benchbox run`
+    with timeout. Captures stdout+stderr to a per-run log file under
+    `~/Developer/benchmark_runs/logs/uat_<YYYYMMDD>/`. Extracts the
+    result-JSON path from log output (port the regex from
+    `scripts/local_stress_test.sh` line 478).
+
+    Make target signature:
+      make uat-cell PLATFORM=duckdb BENCHMARK=tpch SCALE=0.01
+
+    Feature parity with `scripts/local_stress_test.sh --platform X
+    --benchmark Y` for single-scale invocations. Add a fast test that
+    asserts the result-path extraction matches the bash script's
+    output for a fixture log.
+
+- id: w4
+  summary: "make uat-execute CONFIG=uat.yaml: scale-ladder + early-stop + reuse-aware cleanup"
+  needs: [w3]
+  status: pending
+  notes: |
+    Implements the matrix-execution mechanics the 2026-05-02 W3
+    hand-rolled:
+      - per-(platform, benchmark) scale ladder, configurable rungs
+      - early-stop on previous-rung failure
+      - early-stop on previous-rung wall-clock > N seconds (default 180,
+        per UAT W3 line 196)
+      - per-cell hard timeout (default 600s, per UAT W3 line 203)
+      - reuse-aware database cleanup: preserve `~/Developer/
+        benchmark_runs/datagen/` while later platforms can reuse;
+        prune `~/Developer/benchmark_runs/databases/` only at safe
+        boundaries (no remaining cell in current platform/source
+        group can consume the loaded DB)
+      - sentinel file at sweep start (`.sweep_start`) for `find
+        -newer` queries
+      - sequential platform execution; parallel platforms are
+        explicitly forbidden in code comments referencing UAT W3 line
+        222 ("concurrent runs contaminate timings")
+
+    Add a fast test that exercises ladder pruning logic via injected
+    fake-elapsed values (does not actually run benchmarks).
+
+- id: w5
+  summary: "make uat-validate: invoke scripts/uat_validator_rollup.py per cell"
+  needs: [w4]
+  status: pending
+  notes: |
+    INTEGRATION work, not reimplementation. The
+    `scripts/uat_validator_rollup.py` helper from
+    `uat-template-validator-clean-rate-runner` is the source of truth
+    for validation; this phase invokes it as a subprocess and consumes
+    the resulting TSV. If that helper has not yet landed when this
+    work unit is picked up, surface the dep blocker to the user
+    rather than reimplementing.
+
+    No changes to `scripts/uat_validator_rollup.py` itself; the
+    framework consumes it via its public CLI.
+
+- id: w6
+  summary: "make uat-package: read submit_terminal_state from YAML"
+  needs: [w5]
+  status: pending
+  notes: |
+    YAML field `submit_terminal_state` uses the four-word vocabulary
+    established by `uat-template-success-metric-terminal-state-and-gating`:
+      - `local-stage`: invoke `benchbox submit --output ...`
+      - `cloud-uploaded`: invoke `benchbox submit --service ...`
+      - `draft-pr`: open PR vs `published-results`, do NOT enable
+        auto-merge
+      - `merged-to-published-results`: open PR vs `published-results`,
+        enable auto-merge
+
+    Default: `local-stage`. The YAML field is required when the
+    `package` phase is enabled; no inference from evidence (this
+    eliminates the 2026-05-02 W5 ambiguity that motivated Finding 3).
+
+- id: w7
+  summary: "make uat-explorer-smoke: build + Playwright"
+  needs: [w6]
+  status: pending
+  notes: |
+    Reuses `benchbox explorer build` and `results-explorer/scripts/
+    serve-browser-tests.mjs` exactly as the 2026-05-02 W6 did. UATs
+    that don't have explorer scope skip this phase via the YAML
+    `phases:` list.
+
+    No reimplementation of the explorer build; this phase wraps
+    existing tooling.
+
+- id: w8
+  summary: "make uat-report: TSV roll-up + optional cross-scale coverage assertion"
+  needs: [w7]
+  status: pending
+  notes: |
+    Outputs:
+      - `matrix_summary.tsv` with columns: platform, benchmark, scale,
+        status, elapsed_s, log_path, result_path, validator_status
+      - per-platform and per-benchmark validator-clean-rate footer
+      - cross-scale coverage report (count of (platform, benchmark)
+        pairs with all configured rungs present and validator-clean)
+      - if YAML sets `cross_scale_coverage_min_pairs: N`, the report
+        exits non-zero when count < N (OPTIONAL TOOLING TEETH for
+        Finding 1; default OFF; spec recommended convention only)
+
+    Format mirrors the 2026-05-02 retrospective's `matrix_summary.tsv`
+    so historical comparisons are straightforward. The cross-scale
+    assertion is opt-in per the methodology spec's Finding 1 scoping.
+
+- id: w9
+  summary: "make uat-sweep CONFIG=...; make uat-stress (canned preset)"
+  needs: [w8]
+  status: pending
+  notes: |
+    `make uat-sweep CONFIG=path/uat.yaml` chains preflight ->
+    enumerate -> execute -> validate -> package -> explorer-smoke ->
+    report based on the YAML's `phases:` list.
+
+    `make uat-stress` is a canned preset config with one scale, no
+    validate/package/explorer phases -- feature parity with
+    `scripts/local_stress_test.sh` for the stress-test use case.
+    Accepts the same `PLATFORM=`, `BENCHMARK=`, `SCALE=` env vars
+    as today's bash script for muscle-memory continuity.
+
+- id: w10
+  summary: "tests/uat/configs/uat-2026-05-02.yaml replay + structural-parity assertion"
+  needs: [w9]
+  status: pending
+  notes: |
+    Encode the 2026-05-02 sweep parameters as a FROZEN replay config
+    (immutable historical record; per W1 spec policy decision, new
+    sweep configs are cloned from this template, not edited in
+    place).
+
+    Assertion: dry-run mode produces a TSV with the same columns and
+    equivalent row count (within scale-ladder pruning tolerance) as
+    `~/Developer/benchmark_runs/logs/uat_20260502/matrix_summary.tsv`.
+    Wall-clock match is impossible; structural parity is the bar.
+
+    Add a slow-marked test (`@pytest.mark.slow`) that runs the dry
+    sweep and asserts the structural parity. Marked slow because it
+    walks the full matrix even without invoking benchbox; not in
+    fast-test default.
+
+- id: w11
+  summary: "Documentation + scripts/local_stress_test.sh decision"
+  needs: [w10]
+  status: pending
+  notes: |
+    Output:
+      - `docs/operations/uat-framework.md` -- operator guide
+      - `tests/uat/README.md` -- developer guide
+      - Update `CLAUDE.md` Pre-approved Commands section with the new
+        `make uat-*` entries (only those new entries; no other edits)
+
+    `scripts/local_stress_test.sh` decision:
+      - Default: leave untouched. Document `make uat-stress` as the
+        preferred path. Keep the bash script for users with muscle
+        memory; this TODO does not deprecate.
+      - User may opt to refactor the bash script to delegate to
+        `make uat-stress` -- explicit user approval required at W11.
+      - Removal is OUT OF SCOPE here. A separate deprecation TODO
+        files only after `make uat-stress` proves adoption across
+        two-plus subsequent uses.
+
+verification:
+- description: "Spec exists and has been user-approved"
+  command: "test -f _project/specs/uat-framework.md"
+  expected_output: "file exists; user approval recorded in W1 commit message or chat"
+- description: "make uat-cell runs successfully for at least one (platform, benchmark, scale) cell"
+  command: "make uat-cell PLATFORM=duckdb BENCHMARK=tpch SCALE=0.01"
+  expected_output: "exit 0; result JSON path printed"
+- description: "make uat-stress provides feature parity for the stress use case"
+  command: "make uat-stress PLATFORM=duckdb BENCHMARK=tpch"
+  expected_output: "exit 0 with the same set of result paths scripts/local_stress_test.sh would produce for the same inputs"
+- description: "make uat-sweep dry-run against the 2026-05-02 replay config produces structurally-parallel TSV"
+  command: "make uat-sweep CONFIG=tests/uat/configs/uat-2026-05-02.yaml DRY_RUN=1"
+  expected_output: "matrix_summary.tsv with same columns and equivalent row count to the historical retrospective"
+- description: "Fast tests still pass"
+  command: "uv run -- python -m pytest -m fast -q"
+  expected_output: "all selected tests pass"
+- description: "scripts/local_stress_test.sh unchanged unless W11 explicitly delegates it"
+  command: "git diff origin/develop -- scripts/local_stress_test.sh"
+  expected_output: "no diff (default W11 outcome) OR a thin-delegation wrapper change explicitly approved"
+- description: "User CLI surface unchanged"
+  command: "git diff origin/develop -- benchbox/cli/"
+  expected_output: "no diff"
+
+must_preserve:
+- "scripts/local_stress_test.sh continues to work as today's stress entrypoint until W11 explicitly migrates it -- because muscle memory is widespread and breaking this surface mid-framework-build invalidates the no-disruption promise"
+- "benchbox user-facing CLI surface unchanged -- because UAT is dev tooling, not user surface; no benchbox uat subcommand, no new top-level commands"
+- "scripts/validate_submission.py contract and exit codes unchanged -- because the validator is the source of truth; the framework wraps via uat_validator_rollup.py only"
+- "scripts/uat_validator_rollup.py public CLI unchanged once it lands -- because that helper is owned by uat-template-validator-clean-rate-runner; the framework is a consumer"
+- "_project/TODO_SCHEMA.yaml and _project/TODO_ENTRY_TEMPLATE.yaml unchanged -- because schema/template work is owned by uat-template-success-metric-terminal-state-and-gating"
+- "results-data/ and origin/published-results corpus untouched -- because the framework dispatches submission, it does not curate corpus content"
+- "Sequential platform execution discipline -- because UAT W3 line 222 explicitly forbids parallel platforms (timing contamination); code comments must reference this"
+
+approach: |
+  Spec-first. W1 is a HARD user-approval gate: no Python lands until
+  `_project/specs/uat-framework.md` is reviewed and approved. This
+  mirrors the methodology-remediation approach (W4 design gate before
+  W5 implementation files).
+
+  Vertical slices. Each work unit ships a runnable Make target with
+  fast-test coverage before the next unit starts. W2-W3 establish
+  the core (matrix machinery + single-cell runner); W4-W7 add phases;
+  W8 reports; W9 orchestrates; W10 replays history; W11 documents.
+  One PR per work unit; no monolithic delivery.
+
+  Reuse aggressively:
+    - `benchbox.core.benchmark_registry` (already imported via
+      `python -c` from the bash script)
+    - `scripts/uat_validator_rollup.py` (from validator-clean-rate
+      TODO)
+    - `benchbox submit` and `benchbox explorer build` (existing CLI)
+    - `results-explorer/scripts/serve-browser-tests.mjs` (Playwright)
+
+  Don't reuse:
+    - `scripts/local_stress_test.sh` case statements as-is. Translate
+      to canonical Python form in `tests/uat/matrix.py`. The bash
+      script may opt in to delegate (W11 user choice) but that is
+      not the default path.
+
+  YAML configs live under `tests/uat/configs/` (tracked). Runtime
+  artifacts (logs, bundles, TSVs) live under
+  `~/Developer/benchmark_runs/uat_<date>/` (off-tree, as today).
+
+anti_patterns:
+- "DO NOT add a `benchbox uat` CLI subcommand -- because UAT is dev tooling, not user surface, and the package shipped on PyPI shouldn't carry sweep machinery -- expose via `make uat-*` targets only."
+- "DO NOT reimplement validator wrapping -- because uat-template-validator-clean-rate-runner ships scripts/uat_validator_rollup.py for exactly this purpose -- the framework's validate phase invokes that helper as a subprocess."
+- "DO NOT bundle methodology / TODO-template scope into this framework -- because Findings 1/2/3 have their own TODOs and a merged spec -- this TODO is about machinery drift only."
+- "DO NOT modify benchbox/ source -- because the framework consumes benchbox as a library only, and platform/runner code is user-CLI territory -- import and subprocess only."
+- "DO NOT remove scripts/local_stress_test.sh in this TODO -- because muscle memory is widespread and the W1 spec must explicitly authorise any deprecation cycle -- leave or thin-delegate; never delete in this TODO."
+- "DO NOT run platforms in parallel under uat-execute -- because concurrent runs contaminate timings and corrupt the corpus (UAT W3 line 222) -- preserve the sequential discipline; document the anti-pattern in code comments referencing the source line."
+- "DO NOT default cross_scale_coverage_min_pairs to enabled -- because the methodology spec scoped Finding 1 as convention-only and tooling teeth are opt-in -- the YAML field defaults off; sweep authors enable explicitly."
+- "DO NOT skip the W1 spec gate -- because this TODO has 11 work units and an approved spec is the only reliable user-review point at this scale -- no Python lands until the spec is approved by the user."
+- "DO NOT include UAT machinery in _project/scripts/ -- because the user has explicitly directed UAT to live in tests/ to avoid the mostly-untracked _project/ tree -- tests/uat/ is the only acceptable home."
+- "DO NOT proceed past W4 if scripts/uat_validator_rollup.py has not landed -- because that helper is the source of truth for validation and reimplementing it would orphan the validator-clean-rate TODO -- surface the dep blocker to the user instead."
+
+scope_limit:
+  only_modify:
+  - "tests/uat/"
+  - "tests/uat/configs/"
+  - "Makefile"
+  - "_project/specs/uat-framework.md"
+  - "_project/handoffs/uat-framework-*.md"
+  - "_project/TODO/main/planning/uat-framework-tests-uat-runner.yaml"
+  - "_project/TODO/main/active/uat-framework-tests-uat-runner.yaml"
+  - "_project/DONE/main/active/uat-framework-tests-uat-runner.yaml"
+  - "docs/operations/uat-framework.md"
+  - "CLAUDE.md"
+  do_not_modify:
+  - "benchbox/"
+  - "results-explorer/"
+  - "results-data/"
+  - "scripts/validate_submission.py"
+  - "scripts/uat_validator_rollup.py"
+  - "scripts/local_stress_test.sh"
+  - "_project/TODO_SCHEMA.yaml"
+  - "_project/TODO_ENTRY_TEMPLATE.yaml"
+  - "_project/specs/uat-methodology-blind-spot-remediation.md"
+  - "_binaries/"
+  - "tests/integration/"
+  - "tests/e2e/"
+  - "tests/performance/"
+  - "tests/system/"
+  - "tests/unit/"
+
+success_metrics:
+- "Single Python framework at tests/uat/ replaces the ad-hoc UAT-driver pattern; the next sweep author writes a YAML config under tests/uat/configs/ rather than a procedural TODO."
+- "make uat-stress provides feature parity with scripts/local_stress_test.sh for stress-test use cases (same PLATFORM/BENCHMARK/SCALE inputs produce the same result paths)."
+- "make uat-sweep against tests/uat/configs/uat-2026-05-02.yaml produces structurally-parallel output to the historical 2026-05-02 retrospective (same columns, equivalent row count within ladder-pruning tolerance)."
+- "scripts/local_stress_test.sh remains usable as today's stress entrypoint for the duration of this TODO; migration to make uat-stress is opt-in for users."
+- "Spec at _project/specs/uat-framework.md is user-approved before any Python in tests/uat/ lands."
+- "Each work unit lands in its own PR with fast-test coverage; no monolithic delivery."
+- "Validator-clean rate, terminal-state vocab, and (opt-in) cross-scale coverage assertion are first-class framework features sourced from the existing uat-template-* TODOs (no duplication)."
+- "Submission terminal state: local-stage (no upstream action; framework runs locally; published-results PRs are a separate downstream concern owned by results-explorer-uat-corpus-integrate-validated-bundles for the historical 2026-05-02 corpus)."
+
+deferred:
+- summary: "Retiring scripts/local_stress_test.sh entirely"
+  reason: "Out of scope -- W11 documents the migration path but does not delete the script. A separate deprecation TODO files only after make uat-stress proves adoption across two-plus subsequent UAT uses."
+- summary: "Cloud-platform UAT support (Snowflake / BigQuery / Redshift / Athena / Databricks / ClickHouse Cloud)"
+  reason: "Scope of a separate `uat-framework-cloud-platforms` TODO if/when the explorer's cloud-facet surface is ready to be tested under load. Local-only is sufficient for the first iteration; matches the 2026-05-02 sweep scope."
+- summary: "Throughput-phase support"
+  reason: "The 2026-05-02 sweep ran load,power only and the spec does not require throughput. Adding throughput multiplies wall-clock cost; deferred until the local UAT proves valuable."
+- summary: "Tooling enforcement of `gating: true` open_questions in todo_cli.py"
+  reason: "Owned by a future TODO if the convention proves insufficient. This framework respects the convention via YAML schema, not by enforcing TODO authoring conventions."
+- summary: "Pytest-style invocation of UAT phases"
+  reason: "tests/uat/ is a Python package, not a pytest test directory. The framework runs as a script with side effects; pytest is a poor fit for orchestration. The fast tests added in W2/W3/W4 ARE pytest, but they cover unit-level logic (port maps, ladder pruning) not full phase invocation."
+- summary: "Reformat scripts/local_stress_test.sh to import from tests/uat/matrix.py"
+  reason: "Drift-reducing but invasive; defaults to W11 deferral. Sweep author may opt into this with explicit user approval, but this TODO does not require it."
+- summary: "Migration of older bash entrypoints (other scripts/*.sh stress / smoke wrappers)"
+  reason: "Out of scope. This TODO addresses the local_stress_test.sh / UAT-driver drift only."
+
+metadata:
+  tags:
+  - uat
+  - framework
+  - testing
+  - tooling
+  - methodology
+  - spec-first
+  estimated_effort: "Large (5-7 sessions across 11 work units; W1 spec is the user-approval gate)"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Eliminates the bash-script-vs-bespoke-driver drift the 2026-05-02
+    sweep exposed. Future sweep authors write a YAML config; the
+    framework provides scale-ladder, cleanup, validation, packaging,
+    and reporting as composable phases. Reduces wall-clock and
+    cognitive cost per UAT and increases consistency across sweeps.
+  user_impact: |
+    Indirect: more reliable UAT output -> fewer regressions reaching
+    the explorer -> better external-user experience. No direct
+    CLI-surface impact on benchbox users.
+  technical_debt: |
+    Closes the script-drift blind-spot (recorded in
+    `_project/blind-spots/2026-05-03-130000-stress-script-uat-driver-drift.md`)
+    and turns a recurring re-invention pattern into a library plus
+    config artifact. The deps on the two `uat-template-*` TODOs
+    ensure they don't become orphan helpers.
+
+context_sections:
+  "Relationship to the methodology spec": |
+    `_project/specs/uat-methodology-blind-spot-remediation.md` resolves
+    *how UAT TODOs are authored* (cross-scale convention,
+    validator-clean-rate metric, terminal-state vocab plus gating
+    questions). It deliberately scoped out the question of *how UAT
+    machinery is built and reused*. This TODO addresses the
+    machinery question. The two specs are siblings, not competitors.
+    The two `uat-template-*` TODOs spawned by the methodology spec
+    are deps of this TODO -- their outputs become framework building
+    blocks.
+  "Relationship to scripts/local_stress_test.sh": |
+    The bash script is the existing-but-incomplete framework. It has
+    half the phases (matrix enumeration, per-platform extras, TCP
+    probe, timeout wrapper, result-JSON extraction, registry-driven
+    benchmark lists). It lacks the other half (scale-ladder,
+    reuse-aware cleanup, validation, packaging, explorer smoke,
+    structured report). This TODO completes the framework in Python
+    and makes the bash script's machinery a peer (delegating
+    optional) rather than a parallel surface (drifting inevitable).
+    The bash script is preserved for the duration of this TODO; W11
+    documents the migration path without forcing it.
+  "Why tests/uat/ and not _project/scripts/uat/": |
+    Per user direction (2026-05-03): `_project/` is a mixed
+    dev-private tree (handoffs, blind-spots, audits, baselines);
+    critical machinery must live in tracked, version-controlled
+    directories. `tests/` is the natural sibling for test-flavored
+    infrastructure -- `integration/`, `e2e/`, `performance/`,
+    `system/`, `validation/`, `parity/`, `contracts/` already live
+    there. UAT is structurally a test category -- long,
+    side-effect-heavy, multi-platform.
+  "Why no benchbox CLI subcommand": |
+    Per user direction (2026-05-03): UAT is a project-developer
+    concern, benchbox is a project-user concern. Adding `benchbox uat`
+    would bloat the user CLI surface and ship dev-only sweep machinery
+    on PyPI. `make` targets are the developer entrypoint for
+    everything else in this repo (`worktree-*`, `blind-spots-*`,
+    `pr-*`, `dev-loop-metrics`); UAT joins the same pattern.
+  "Self-bias risk in this TODO's adversarial framing": |
+    Per blind-spot finding `2026-05-03-084354-stress-test-self-bias`:
+    self-designed adversarial framing tends to under-weight failure
+    modes the proposer didn't already consider. The W1 spec gate
+    requires an independent reviewer (the user) precisely to mitigate
+    this; the description's "strongest case for not doing this"
+    paragraph is a starting point, not a substitute for outside
+    review.
+
+open_questions:
+- "tests/uat/ vs tests/uat_runner/ for the package directory name -- prefer tests/uat/ for brevity; flag if existing tests/ naming has a precedent the spec should align with."
+- "Should the W1 spec require independent reviewer beyond the user, given finding 084354 (self-bias risk in stress-tests)? Default: user reviews and the spec includes adversarial framing per the finding to mitigate; promote to multi-reviewer review only if the spec proves contentious."
+- "Should make uat-stress eventually replace scripts/local_stress_test.sh, or coexist indefinitely? Default: coexist; W11 documents the choice and a separate deprecation TODO files only after make uat-stress proves adoption."
+- "tests/uat/configs/uat-2026-05-02.yaml -- frozen replay (immutable historical record) or starting template (editable)? Default: frozen replay; new sweep configs cloned from it. Confirm before W10."
+- "submit_terminal_state default for stress preset: should make uat-stress have NO package phase (so terminal-state is undefined) or emit local-stage by default? Default: stress preset omits the package phase entirely so terminal-state is irrelevant for stress runs."
+- "Should W2's matrix.py port the eval-based registry-loader pattern (current bash) or use direct Python imports (cleaner)? Default: direct imports; the bash script's eval pattern was a workaround for shell limits and Python has no equivalent constraint."

--- a/_project/blind-spots/2026-05-03-130000-stress-script-uat-driver-drift.md
+++ b/_project/blind-spots/2026-05-03-130000-stress-script-uat-driver-drift.md
@@ -1,0 +1,61 @@
+---
+id: 2026-05-03-130000-stress-script-uat-driver-drift
+date: 2026-05-03
+status: open
+finding_kind: framework-gap
+review_context: "code review of scripts/local_stress_test.sh against the 2026-05-02 UAT retrospective"
+related_paths:
+  - scripts/local_stress_test.sh
+  - _project/handoffs/results-explorer-uat-retrospective-20260502.md
+  - _project/specs/uat-methodology-blind-spot-remediation.md
+suggested_sweep: "fold the matrix-execution machinery (timeout wrapper, scale-ladder, reuse-aware cleanup, sentinel TSV, validation, packaging, explorer smoke) into a single tracked Python framework so future sweeps configure rather than reinvent"
+todo_id: null
+---
+
+# Stress script and bespoke UAT drivers reinvent the same machinery in parallel
+
+## Finding
+
+`scripts/local_stress_test.sh` and the 2026-05-02 UAT driver are two
+parallel surfaces for matrix-shape execution that drift. The bash script
+already ships timeout/gtimeout/perl fallback, registry enumeration,
+per-platform port maps, per-platform `--platform-option` tables,
+per-platform CLI flags, per-platform uv-extra mapping, TCP probing with
+sentinel cache, and result-JSON path extraction. The 2026-05-02 UAT W3
+hand-rolled a Perl-based timeout wrapper (the script already has this),
+plus scale-ladder pruning, reuse-aware database cleanup, a
+matrix-summary TSV, validator subset filtering, submission packaging
+exit-code interpretation, explorer build orchestration, and Playwright
+smoke — none of which the bash script has, none of which is reusable
+because they live only as ad-hoc artifacts under
+`~/Developer/benchmark_runs/logs/uat_20260502/` and the retrospective.
+
+The methodology-remediation spec at
+`_project/specs/uat-methodology-blind-spot-remediation.md` deliberately
+scoped this question out. It addresses *how UAT TODOs are authored* —
+cross-scale convention, validator-clean-rate metric, terminal-state
+vocab. It does not address *how UAT machinery is built*. The drift
+between `scripts/local_stress_test.sh` and the next bespoke UAT driver
+is a separate gap.
+
+## Why this matters
+
+Each future UAT pays the re-invention tax. The 2026-05-02 sweep author
+documented building a Perl timeout wrapper, scale-ladder logic, and
+reuse-aware cleanup from scratch — work that either could have been
+contributed back to the bash script (drift-reducing but inadequate for
+the broader phase set) or could have lived in a tracked Python
+framework (drift-preventing). Neither happened, so the next sweep
+inherits the same starting point and pays the tax again.
+
+A second-order effect: the spec's recommended `scripts/uat_validator_rollup.py`
+helper (Finding 2 deliverable) becomes an orphan if no framework
+consumes it as a phase. Filing helpers without a runner that composes
+them encourages each sweep to invent its own composition.
+
+## Suggested next steps
+
+- [ ] Build a tracked Python UAT framework under `tests/uat/` that hosts the matrix-execution machinery as composable phases (preflight, enumerate, execute with scale-ladder + cleanup, validate via the rollup helper, package with explicit terminal state, explorer smoke, report).
+- [ ] Expose the framework via `make uat-*` targets — keep the user CLI surface (`benchbox`) unchanged.
+- [ ] Encode the 2026-05-02 sweep parameters as a frozen replay config (`tests/uat/configs/uat-2026-05-02.yaml`) and assert structural parity with the historical retrospective.
+- [ ] Document the migration path for `scripts/local_stress_test.sh` (leave alone, thin-delegate, or retire) without forcing a deprecation cycle in the framework's first delivery.


### PR DESCRIPTION
The 2026-05-03 methodology spec at
`_project/specs/uat-methodology-blind-spot-remediation.md` resolved
three blind-spots about *how UAT TODOs are authored* but deliberately
scoped out the question of *how UAT machinery is built and reused*.

Files two artifacts that close the latter gap:

1. `_project/blind-spots/2026-05-03-130000-stress-script-uat-driver-drift.md`
   — records the framework-gap: `scripts/local_stress_test.sh` and the
   bespoke 2026-05-02 UAT driver are parallel surfaces that re-invent
   the same machinery (timeout wrapper, scale-ladder, reuse-aware
   cleanup, sentinel TSV).

2. `_project/TODO/main/planning/uat-framework-tests-uat-runner.yaml`
   — comprehensive TODO that builds a Python framework under
   `tests/uat/` (tracked, sibling to other test categories) exposed
   via `make uat-*` targets. No `benchbox` user-CLI surface change.
   11 work units; W1 is a hard user-approval spec gate.

Deps on the two existing `uat-template-*` TODOs (both still in
planning) — the framework consumes their outputs as building blocks
so they don't become orphan helpers. Explicit anti-pattern: do not
reimplement the validator-clean-rate runner; invoke
`scripts/uat_validator_rollup.py` once it lands.

Includes adversarial framing per finding 084354 (stress-test
self-bias): the "strongest case for not doing this" paragraph
acknowledges proposer bias and points to W1 user review as the
mitigation.
