### PR TITLE
feat/uat template terminal state

### DIFF
--- a/_project/DONE/main/active/uat-template-success-metric-terminal-state-and-gating.yaml
+++ b/_project/DONE/main/active/uat-template-success-metric-terminal-state-and-gating.yaml
@@ -2,8 +2,9 @@ id: uat-template-success-metric-terminal-state-and-gating
 title: "Add submission terminal-state vocab + open_questions gating schema relaxation"
 worktree: main
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
 category: "Testing and Quality Assurance"
+completed_date: "2026-05-03"
 
 description: |
   Closes the remediation for blind-spot finding
@@ -75,7 +76,7 @@ work:
 - id: w3
   summary: "Optional retrofit of external-contributor-submission-dry-run"
   needs: [w2]
-  status: pending
+  status: done
   notes: |
     Add to `_project/TODO/main/planning/external-contributor-submission-dry-run.yaml`:
 

--- a/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
+++ b/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
@@ -134,6 +134,9 @@ verification:
   command: "git log published-results --format='%s' | grep -i 'community'"
   expected_output: "at least one merge commit referencing the contribution"
 
+success_metrics:
+- "Submission terminal state: merged-to-published-results (PR opened, CI green, merge complete)"
+
 must_preserve:
 - The contributor's autonomy - no real-time hand-holding during the dry-run.
 - Production review rigor - if the submission has defects, it is asked to be fixed, not silently merged.

--- a/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
+++ b/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
@@ -57,7 +57,7 @@ work:
 - id: w2
   summary: "Template additions: terminal-state vocab + validator-clean rate + coverage_checklist examples"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
     Update `_project/TODO_ENTRY_TEMPLATE.yaml` per the spec's §3
     "Template diff preview" exactly. Specifically:

--- a/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
+++ b/_project/TODO/main/planning/uat-template-success-metric-terminal-state-and-gating.yaml
@@ -31,7 +31,7 @@ description: |
 work:
 - id: w1
   summary: "Schema relaxation: open_questions oneOf [string, object]"
-  status: pending
+  status: done
   notes: |
     Update `_project/TODO_SCHEMA.yaml` `open_questions` to:
 
@@ -109,7 +109,8 @@ verification:
   expected_output: "all files valid"
 
 must_preserve:
-- "Backwards compatibility: existing string-form `open_questions` entries continue to validate (the schema becomes oneOf string|object, not object-only)."
+- "Backwards compatibility: existing string-form `open_questions` entries continue to validate (the schema becomes oneOf string|object,
+  not object-only)."
 - "All currently-tracked TODOs in `_project/TODO/` and `_project/DONE/` continue to validate without modification."
 - "Template structure: comments stay terse; snippets remain copy-pastable."
 
@@ -121,9 +122,12 @@ approach: |
   edits.
 
 anti_patterns:
-- "DO NOT add `additionalProperties: false` to the new object form — because we explicitly want forward-compatibility for future fields like `resolved_with` — leave additionalProperties at its default (true)."
-- "DO NOT enforce `gating: true` runtime semantics in todo_cli.py — because the spec scopes that to a future TODO if reviewer attention proves insufficient — this TODO is template + schema only."
-- "DO NOT bundle in the coverage_checklist tooling change — because Finding 1 was approved as convention-only — that lives behind a separate (currently un-filed) TODO if a future UAT shows the convention drifting."
+- "DO NOT add `additionalProperties: false` to the new object form — because we explicitly want forward-compatibility for
+  future fields like `resolved_with` — leave additionalProperties at its default (true)."
+- "DO NOT enforce `gating: true` runtime semantics in todo_cli.py — because the spec scopes that to a future TODO if reviewer
+  attention proves insufficient — this TODO is template + schema only."
+- "DO NOT bundle in the coverage_checklist tooling change — because Finding 1 was approved as convention-only — that lives
+  behind a separate (currently un-filed) TODO if a future UAT shows the convention drifting."
 
 scope_limit:
   only_modify:
@@ -146,11 +150,14 @@ success_metrics:
 
 deferred:
 - summary: "`gating: true` runtime enforcement in todo_cli.py done"
-  reason: "Spec §2 Finding 3 scopes this to a future follow-up if reviewer attention proves insufficient. Premature tooling adds false-positive risk (defensible exceptions get blocked)."
+  reason: "Spec §2 Finding 3 scopes this to a future follow-up if reviewer attention proves insufficient. Premature tooling
+    adds false-positive risk (defensible exceptions get blocked)."
 - summary: "Coverage checklist tooling enforcement"
-  reason: "Finding 1 was approved as convention-only per the W4 design. File separately if a future UAT shows the convention drifting."
+  reason: "Finding 1 was approved as convention-only per the W4 design. File separately if a future UAT shows the convention
+    drifting."
 - summary: "_project/UAT_TEMPLATE.yaml subtemplate extraction"
-  reason: "Q4 in the design defaulted to wait. Promote per-TODO conventions into a subtemplate after the next two UATs prove their cost/benefit."
+  reason: "Q4 in the design defaulted to wait. Promote per-TODO conventions into a subtemplate after the next two UATs prove
+    their cost/benefit."
 
 metadata:
   tags:

--- a/_project/TODO_ENTRY_TEMPLATE.yaml
+++ b/_project/TODO_ENTRY_TEMPLATE.yaml
@@ -51,6 +51,13 @@ work:
     needs: [w2, w3]
     status: pending
     notes: "<Optional implementation notes>"
+    # OPTIONAL - for work units with cross-cutting deliverables only.
+    # Pairs a specific exercise with the evidence the final report must
+    # produce. Reviewer convention; no tooling enforcement.
+    # coverage_checklist:
+    #   - id: <slug>
+    #     description: "<what to exercise>"
+    #     evidence_required: "<what the final report must show>"
 
 # Items that are known but explicitly out of scope
 deferred:
@@ -168,10 +175,24 @@ deps:
 success_metrics:
   - "<Measurable success criterion 1>"
   - "<Measurable success criterion 2>"
+  # For submission-flow UATs, name the intended terminal state explicitly
+  # using one of the four-word vocab terms below. Avoids ambiguity when
+  # an agent later infers terminal state from evidence rather than intent.
+  # - "Submission terminal state: <local-stage|cloud-uploaded|draft-pr|merged-to-published-results>"
+  # For corpus-shaped UATs only (>1 captured bundle): track the rate at
+  # which W3-passed cells produce bundles that pass validate_submission.py.
+  # - "Validator-clean rate: >=X% of W3-passed cells pass scripts/validate_submission.py"
 
 open_questions:
   - "<Unresolved question 1?>"
   - "<Unresolved question 2?>"
+  # Object form for gating questions whose resolution changes a deliverable.
+  # `affects` links to the success_metric or work unit at risk; reviewer
+  # attention is the enforcement model (no runtime gate in todo_cli.py done).
+  # - question: "<Object form for gating questions>"
+  #   gating: true
+  #   affects: ["<w-id> success_metric: <which one>"]
+  #   default: "<safe default if unresolved>"
 
 research_value:
   hypothesis: |

--- a/_project/TODO_SCHEMA.yaml
+++ b/_project/TODO_SCHEMA.yaml
@@ -304,7 +304,22 @@ properties:
     type: array
     description: "Unresolved questions or uncertainties"
     items:
-      type: string
+      oneOf:
+        - type: string
+        - type: object
+          required: [question]
+          properties:
+            question:
+              type: string
+            gating:
+              type: boolean
+            affects:
+              type: array
+              items: { type: string }
+            default:
+              type: string
+            resolved_with:
+              type: string
 
   commits:
     type: array


### PR DESCRIPTION
- **feat(todo-schema): allow object-form open_questions for gating**
- **docs(todo-template): add commented snippets for UAT methodology conventions**
- **feat(todo-uat): retrofit external-contributor-dry-run with terminal-state metric**
