### PR TITLE
docs(meta): sweep three /code review blind-spots into a checklist update

### DIFF
--- a/_project/DONE/main/active/code-review-checklist-additions-for-spec-docs.yaml
+++ b/_project/DONE/main/active/code-review-checklist-additions-for-spec-docs.yaml
@@ -1,0 +1,169 @@
+id: code-review-checklist-additions-for-spec-docs
+title: "Add proposal/spec-doc checks to the /code review checklist"
+worktree: main
+priority: "Medium"
+status: "Completed"
+category: "Documentation"
+completed_date: "2026-05-03"
+
+description: |
+  Promotes three meta blind-spot findings produced *during* the
+  2026-05-03 review of the UAT methodology remediation work — findings
+  about how proposals/spec docs were reviewed, not about the source
+  UAT — into a single update to the `/code` review skill.
+
+  Source findings (all currently `status: open` in
+  `_project/blind-spots/`):
+
+  1. `2026-05-03-083859-proposals-doc-decidability-gap` — proposals
+     reviewed via the five-axis rubric can pass on Correctness /
+     Readability while still failing the user-facing function: each
+     user-facing choice should ship with a default, a consequence, and
+     a recommendation, not just a question.
+
+  2. `2026-05-03-084354-stress-test-self-bias` — when the proposer also
+     designs the stress-test, "all proposals survive" reads as
+     validation but is closer to a sanity check. Reviews of stress-test
+     handoffs should require a "strongest argument against each
+     proposal" subsection (or split designer/reviewer roles).
+
+  3. `2026-05-03-084923-spec-approval-ergonomics` — specs with a
+     user-approval gate should declare the response shape (yes/no per
+     question, defaults, partial-acceptance cascades). Reviewers should
+     flag specs that ask questions without an approval protocol.
+
+  Implementation surface: a single new "Reviewing proposals/spec docs"
+  section appended to `~/.claude/skills/references/five-axis-review.md`
+  with three checklist items. The skill file lives in the user-global
+  `~/.claude/` directory and so the actual content edit ships outside
+  any BenchBox PR; the BenchBox PR carries only the TODO record and
+  the three blind-spot frontmatter triage updates.
+
+work:
+- id: w1
+  summary: "Add a 'decidability check' item for proposals/spec docs"
+  status: done
+  notes: |
+    Append to `~/.claude/skills/references/five-axis-review.md` (under a
+    new "Reviewing proposals/spec docs" subsection) a bullet that says:
+    "for each user-facing choice, the doc should state a default, a
+    consequence, and a recommendation — conditional phrasing without a
+    default pushes the decision back onto the user."
+
+    Then promote the source blind-spot:
+      uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py \
+        triage 2026-05-03-083859-proposals-doc-decidability-gap \
+        --action promote --todo-id code-review-checklist-additions-for-spec-docs
+
+- id: w2
+  summary: "Add a 'self-bias guard' item for stress-test sections"
+  needs: [w1]
+  status: done
+  notes: |
+    Add a sibling bullet under the same "Reviewing proposals/spec docs"
+    subsection: "when a proposals doc includes a stress-test that
+    concludes 'all proposals survive', flag the self-grading risk and
+    require either (a) a 'strongest argument against each proposal'
+    subsection in the same doc, or (b) an independent reviewer for the
+    stress-test step."
+
+    Then promote:
+      uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py \
+        triage 2026-05-03-084354-stress-test-self-bias \
+        --action promote --todo-id code-review-checklist-additions-for-spec-docs
+
+- id: w3
+  summary: "Add an 'approval ergonomics' item for specs with user-approval gates"
+  needs: [w1]
+  status: done
+  notes: |
+    Add the third bullet: "specs with a user-approval gate must declare
+    the response shape — yes/no per question, what 'accept defaults'
+    selects, how partial acceptance cascades into downstream
+    parameterised work — before reaching the open-questions section."
+
+    Then promote:
+      uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py \
+        triage 2026-05-03-084923-spec-approval-ergonomics \
+        --action promote --todo-id code-review-checklist-additions-for-spec-docs
+
+verification:
+- description: "All three blind-spots reach merged-to-todo status with todo_id set"
+  command: "uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py list --status merged-to-todo
+    | grep -c code-review-checklist-additions-for-spec-docs"
+  expected_output: ">= 3"
+- description: "Skill file gained a 'Reviewing proposals/spec docs' subsection"
+  command: "grep -c 'Reviewing proposals/spec docs' ~/.claude/skills/references/five-axis-review.md"
+  expected_output: ">= 1"
+
+must_preserve:
+- "The five existing axes (Correctness, Readability, Architecture, Security, Performance) and their bullets — the new section
+  is additive."
+- "The Severity Classification, Change Sizing, and Rules sections at the bottom of `five-axis-review.md`."
+- "Existing blind-spot bodies — only `status` and `todo_id` (and the `## Triage log` entry) may change during promotion."
+
+approach: |
+  Single bundled PR for the planning artifacts (TODO file + three
+  blind-spot triage updates). The skill file edit lives in the
+  user-global `~/.claude/` directory; do that edit alongside the
+  BenchBox commits but expect it not to land via the PR.
+
+  Promotion via `sweep_blind_spots.py triage --action promote
+  --todo-id <slug>` only updates frontmatter `status` / `todo_id` and
+  appends a `## Triage log` entry — it does not author the TODO.
+
+anti_patterns:
+- "DO NOT split into three separate TODOs — because each finding produces a one-bullet edit to the same skill file — bundling
+  avoids three PRs reviewing nearly-identical changes."
+- "DO NOT generalise the proposals/spec checks into a sixth axis — because the five axes are stable and broadly applicable
+  to code, while these checks apply specifically to proposals/spec docs — keep them in their own subsection."
+- "DO NOT bundle the skill file edit into the BenchBox PR diff — because the skill file lives outside the repo — the BenchBox
+  PR ships only the TODO and triage updates."
+
+scope_limit:
+  only_modify:
+  - "_project/TODO/main/planning/code-review-checklist-additions-for-spec-docs.yaml"
+  - "_project/DONE/main/active/code-review-checklist-additions-for-spec-docs.yaml"
+  - "_project/blind-spots/2026-05-03-083859-proposals-doc-decidability-gap.md"
+  - "_project/blind-spots/2026-05-03-084354-stress-test-self-bias.md"
+  - "_project/blind-spots/2026-05-03-084923-spec-approval-ergonomics.md"
+  do_not_modify:
+  - "benchbox/"
+  - "results-explorer/"
+  - "scripts/"
+  - "_project/specs/"
+  - "_project/handoffs/"
+
+success_metrics:
+- "Three open meta blind-spot findings reach `merged-to-todo` with the TODO slug recorded."
+- "`/code` review skill gains a proposals/spec-docs subsection with three checklist items."
+- "No new axis is added to the five-axis rubric; the additions live in their own subsection."
+
+deferred:
+- summary: "Generalise the proposals/spec checks into a sixth axis of the rubric"
+  reason: "Premature generalisation. The five axes are stable; these checks apply only to proposals/spec docs. Promote to
+    a sixth axis only if the subsection grows past three or four items and starts to show structural patterns of its own."
+- summary: "Tooling enforcement (e.g., a /code linter that flags spec docs missing an approval protocol)"
+  reason: "Convention + reviewer attention is the proposed enforcement model, mirroring the parent UAT methodology spec's
+    approach. Tooling is a lever to pull only if a future review shows the convention drifting."
+
+metadata:
+  tags:
+  - meta
+  - code-review
+  - skill-checklist
+  - blind-spots
+  estimated_effort: "Small"
+  created_date: "2026-05-03"
+
+impact:
+  business_value: |
+    Closes the loop on a class of review-framework gaps: the five-axis
+    rubric is sized for code, not for spec/proposal docs that have a
+    user-approval gate. Adding three small checks turns these gaps from
+    recurrent oversights into a checklist item.
+  user_impact: |
+    Indirect. Future spec docs reaching the user are more likely to
+    arrive with default + consequence + recommendation per question and
+    a declared approval protocol, reducing the user's cost to act on
+    them.

--- a/_project/blind-spots/2026-05-03-083859-proposals-doc-decidability-gap.md
+++ b/_project/blind-spots/2026-05-03-083859-proposals-doc-decidability-gap.md
@@ -1,14 +1,14 @@
 ---
 id: 2026-05-03-083859-proposals-doc-decidability-gap
 date: 2026-05-03
-status: open
+status: merged-to-todo
 finding_kind: framework-gap
 review_context: "code review of W2 deliverable in TODO results-explorer-uat-methodology-blind-spot-remediation"
 related_paths:
   - _project/handoffs/uat-methodology-w2-proposals.md
   - _project/specs/uat-methodology-blind-spot-remediation.md
 suggested_sweep: "when reviewing proposals/spec docs, add a 'decidability' check beyond the five-axis code rubric: each open question needs a stated default, a stated consequence, and a clear yes-or-no path for the user."
-todo_id: null
+todo_id: code-review-checklist-additions-for-spec-docs
 ---
 
 # Five-axis code review framework misses decidability gaps in proposals docs
@@ -43,3 +43,7 @@ cheaply.
 - [ ] Patch the W2 proposals doc to recommend per-finding tooling vs convention rather than leaving it conditional.
 - [ ] When the W4 design document collates user decisions, ensure each one has default + consequence + recommendation, not just a question.
 - [ ] Consider promoting "decidability check for proposals/spec docs" into the `/code review` skill checklist.
+
+## Triage log
+
+- 2026-05-03: promoted to TODO `code-review-checklist-additions-for-spec-docs`

--- a/_project/blind-spots/2026-05-03-084354-stress-test-self-bias.md
+++ b/_project/blind-spots/2026-05-03-084354-stress-test-self-bias.md
@@ -1,13 +1,13 @@
 ---
 id: 2026-05-03-084354-stress-test-self-bias
 date: 2026-05-03
-status: open
+status: merged-to-todo
 finding_kind: framework-gap
 review_context: "code review of W3 stress-test in TODO results-explorer-uat-methodology-blind-spot-remediation"
 related_paths:
   - _project/handoffs/uat-methodology-w3-stress-test.md
 suggested_sweep: "when stress-testing proposals against historical cases, separate the 'designer' and 'reviewer' roles, or explicitly include a 'strongest argument against each proposal' section to counter the natural survivorship bias."
-todo_id: null
+todo_id: code-review-checklist-additions-for-spec-docs
 ---
 
 # Self-designed stress-tests survive too easily — proposer bias
@@ -43,3 +43,7 @@ incident or a recurring shape.
 - [ ] Add a "strongest case against each proposal" subsection to the W3 stress-test doc (or fold into W4).
 - [ ] Consider promoting "adversarial framing or independent reviewer for stress-tests" into the /code review and /todo skill checklists.
 - [ ] Sweep recent specs/handoffs for stress-test sections that conclude with universal proposal survival; flag for re-review.
+
+## Triage log
+
+- 2026-05-03: promoted to TODO `code-review-checklist-additions-for-spec-docs`

--- a/_project/blind-spots/2026-05-03-084923-spec-approval-ergonomics.md
+++ b/_project/blind-spots/2026-05-03-084923-spec-approval-ergonomics.md
@@ -1,13 +1,13 @@
 ---
 id: 2026-05-03-084923-spec-approval-ergonomics
 date: 2026-05-03
-status: open
+status: merged-to-todo
 finding_kind: framework-gap
 review_context: "code review of W4 design document in TODO results-explorer-uat-methodology-blind-spot-remediation"
 related_paths:
   - _project/specs/uat-methodology-blind-spot-remediation.md
 suggested_sweep: "extend the /code review checklist for spec/proposal docs that have a user-approval gate to include 'approval ergonomics': what does the user do to accept, partially accept, reject; what cascades."
-todo_id: null
+todo_id: code-review-checklist-additions-for-spec-docs
 ---
 
 # Approval-gate specs need explicit approval protocols, not just open questions
@@ -42,3 +42,7 @@ as follows: ..." — closes the gap cheaply.
 
 - [ ] Add an "Approval protocol" preamble to W4's Section 5.
 - [ ] Consider adding "approval ergonomics" to the /code review checklist for proposal/spec docs with user-approval gates.
+
+## Triage log
+
+- 2026-05-03: promoted to TODO `code-review-checklist-additions-for-spec-docs`


### PR DESCRIPTION
Promotes three meta blind-spot findings produced during the 2026-05-03
review of the UAT methodology remediation work — all about how
proposals/spec docs were reviewed, not about the source UAT — into a
single bundled TODO with three w-units. Each w-unit corresponds to one
checklist addition under a new "Reviewing proposals/spec docs"
subsection in the user-global /code review skill (at
~/.claude/skills/references/five-axis-review.md):

  - decidability check: each user-facing choice must ship with a
    default, a consequence, and a recommendation
  - stress-test self-bias guard: "all proposals survive" without
    adversarial framing is a flag, not a passing grade
  - approval ergonomics: specs with a user-approval gate must declare
    the response shape before the open-questions section

Triage updates land in this PR (frontmatter status: merged-to-todo,
todo_id: code-review-checklist-additions-for-spec-docs on each of the
three blind-spot files). The skill file edit itself ships outside this
PR because ~/.claude/ lives outside the repo; the TODO scope_limit and
description name this explicitly.

All three w-units are marked done; the TODO file lands directly in
_project/DONE/main/active/ with completed_date 2026-05-03.
