### PR TITLE
feat(sqlglot-upstream): repro harness, drafted issues, blog factual fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ _sources/tpc-h/dbgen/dbgen_x86_64
 !_project/research/
 !_project/blind-spots/
 !_project/specs/
+!_project/sqlglot-upstream/
 !_project/TODO_SCHEMA.yaml
 !_project/PROJECT_TODO.md
 !_project/PROJECT_TODO.yaml

--- a/_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md
+++ b/_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md
@@ -77,14 +77,14 @@ Three platforms required dedicated modules.
 
 The Q23/Q87 case is worth telling. We wrote an AST visitor to inject `AS _sqN` on every unaliased subquery, but it corrupted Q23 (pulled `GROUP BY` out of a subquery) and Q87 (injected aliases inside `EXCEPT/INTERSECT`). The fix that shipped was a session setting, `joined_subquery_requires_alias=0`. The lesson: even with full AST control, the safer move was to abandon the rewrite and use the session setting the engine already exposed.
 
-**QuestDB** (`platforms/questdb_rewriter.py`) is a dedicated post-AST rewriter for four constructs the SQLGlot dialect entry does not fully cover:
+**QuestDB** (`platforms/questdb_rewriter.py`) is a dedicated post-AST rewriter for four constructs SQLGlot's `postgres` output does not transform for QuestDB:
 
 - Implicit comma joins, converted to explicit `INNER JOIN ... ON`.
 - `INTERVAL` arithmetic, converted to `dateadd('d', n, ts)`.
 - `SUBSTRING(s FROM p FOR l)`, converted to `substring(s, p, l)`.
 - CTE column-alias lists, stripped.
 
-QuestDB has a SQLGlot dialect entry; the dialect entry does not cover what QuestDB 9.3.4 actually accepts. Without our rewriter, every TPC-H, TPC-DS, and SSB query fails before the first row.
+QuestDB is not in SQLGlot's dialect list (verified against `sqlglot==30.6.0`); we map it to `postgres` in `dialect_utils.normalize_dialect_for_sqlglot` and apply this rewriter on top. Without it, every TPC-H, TPC-DS, and SSB query fails before the first row on QuestDB 9.3.4.
 
 **DataFusion** is its own category, and it is the most expensive one we have.
 
@@ -92,7 +92,7 @@ QuestDB has a SQLGlot dialect entry; the dialect entry does not cover what Quest
 
 This is the category we worry about most. SQLGlot transpiles cleanly. The SQL executes. The results are wrong.
 
-DataFusion has a SQLGlot dialect entry. We observed that SQLGlot translates four TPC-H queries into syntactically valid DataFusion SQL that the engine runs to completion and returns the wrong answer for. These observations are pinned to the BenchBox `uv.lock` resolved version of the `datafusion` Python package (53.0.0); upstream planner work may resolve any of them in later releases.
+DataFusion is not in SQLGlot's dialect list either; we transpile to `postgres` and run the result on DataFusion. We observed that this `postgres`-targeted SQL is syntactically valid for DataFusion's parser and runs to completion, but four TPC-H queries return the wrong answer. These observations are pinned to the BenchBox `uv.lock` resolved version of the `datafusion` Python package (53.0.0); upstream planner work may resolve any of them in later releases.
 
 | TPC-H query | Issue (observed on DataFusion Python 53.0.0) | Our rewrite |
 |--------------|-------|-------------|

--- a/_project/sqlglot-upstream/README.md
+++ b/_project/sqlglot-upstream/README.md
@@ -1,0 +1,66 @@
+# SQLGlot upstream contribution prep
+
+Drafted bug reports and a feature request for the SQLGlot project, plus the
+minimal reproducer harness that pins each defect to a specific SQLGlot
+version. **Nothing here has been filed upstream yet.** The drafts under
+`issues/` are intended for human review before opening on
+https://github.com/tobymao/sqlglot/issues.
+
+## Layout
+
+| Path | What it is |
+|------|------------|
+| `repros/repro_all.py` | Single-file Python harness covering all candidates; pinned to `sqlglot==30.6.0` |
+| `issues/02-sqlite-interval-date-arithmetic.md` | Drafted bug report (Tier A) |
+| `issues/03-sqlite-extract-not-lowered-to-strftime.md` | Drafted bug report (Tier B confirmed) |
+| `issues/05-mysql-percentile-cont-extra-case-decorator.md` | Drafted bug report (Tier A) |
+| `issues/06-questdb-dialect-feature-request.md` | Drafted feature request (Tier A) |
+
+## Run the harness
+
+```bash
+uv run --with sqlglot==30.6.0 python _project/sqlglot-upstream/repros/repro_all.py
+```
+
+Exit code is zero only if every defect has been resolved upstream; any
+remaining `FAIL` lines indicate the workaround in BenchBox is still load-bearing.
+
+## Current verdict (sqlglot 30.6.0)
+
+| # | Item | Tier | Repro result | BenchBox workaround | Action |
+|---|------|------|--------------|---------------------|--------|
+| 1 | DuckDB `GROUP/ORDER BY ALL` quoted under `identify=True` | B (verify) | **PASS** (no longer reproduces) | `dialect_utils._restore_group_order_by_all_keyword` | **Retire workaround in BenchBox.** Do not file. |
+| 2 | SQLite `DATE + INTERVAL` not lowered to date modifier | A | FAIL | `dialect_utils._fix_sqlite_unsupported_syntax` | File: `issues/02-sqlite-interval-date-arithmetic.md` |
+| 3 | SQLite `EXTRACT` not lowered to `STRFTIME` | B (verify) | FAIL | `dialect_utils._fix_sqlite_unsupported_syntax` | File: `issues/03-sqlite-extract-not-lowered-to-strftime.md` (refs prior #2592) |
+| 4 | Postgres `date + integer` not promoted to `INTERVAL` | D | n/a (AST-ambiguous) | `dialect_utils.fix_postgres_date_arithmetic` | Do not file. Keep as BenchBox pre-processor. |
+| 5 | MySQL `PERCENTILE_CONT` extra `CASE WHEN x IS NULL` decorator | A | FAIL | `h2odb_variants.MYSQL_Q9_SQL` | File: `issues/05-mysql-percentile-cont-extra-case-decorator.md` |
+| 6 | QuestDB dialect missing | A | FAIL (no dialect) | `platforms/questdb_rewriter.py` | File: `issues/06-questdb-dialect-feature-request.md` |
+| 7 | Netezza / Vertica missing | C | n/a (existing issues) | `dialect_utils.normalize_dialect_for_sqlglot` | Comment on existing tracker issues; no new issues. |
+
+## What's filed already upstream
+
+- Netezza: open feature requests
+  [#6040](https://github.com/tobymao/sqlglot/issues/6040),
+  [#1289](https://github.com/tobymao/sqlglot/issues/1289); failed PRs
+  [#7402](https://github.com/tobymao/sqlglot/pull/7402),
+  [#5637](https://github.com/tobymao/sqlglot/pull/5637).
+- Vertica: closed-without-merge PRs
+  [#7277](https://github.com/tobymao/sqlglot/pull/7277),
+  [#3351](https://github.com/tobymao/sqlglot/pull/3351),
+  [#3325](https://github.com/tobymao/sqlglot/pull/3325).
+- DuckDB `ORDER BY ALL` parsing: [#3755](https://github.com/tobymao/sqlglot/issues/3755) closed by [#3756](https://github.com/tobymao/sqlglot/pull/3756) (merged). Our repro confirms this fix also covers the `identify=True` case.
+- SQLite `EXTRACT`: prior [#2592](https://github.com/tobymao/sqlglot/issues/2592) (2023, closed without linked fix).
+
+## Pre-flight before filing
+
+1. Re-run the harness to confirm `FAIL` lines still reproduce on the latest published `sqlglot` version. Update the `sqlglot_version` frontmatter in each draft to match the version you reproduce against.
+2. Skim each draft for tone — they are written in a neutral, evidence-led voice; no advocacy, no project promotion beyond a single offer line.
+3. File one issue per draft. The drafts already include the harness URL so maintainers can run our repro against any version.
+4. After filing, set `filed: true` and add a `tracker_url:` line to each draft's frontmatter.
+
+## Follow-up TODOs (not part of this prep)
+
+- Retire `_restore_group_order_by_all_keyword` and its branch in `translate_sql_query` once we drop support for `sqlglot < 30.<release-where-#3756-landed>`. The PASS in our repro means this code is no longer load-bearing on currently pinned versions.
+- If maintainers accept the QuestDB dialect contribution offer, the
+  rewriter in `benchbox/platforms/questdb_rewriter.py` becomes the natural
+  starting point.

--- a/_project/sqlglot-upstream/issues/02-sqlite-interval-date-arithmetic.md
+++ b/_project/sqlglot-upstream/issues/02-sqlite-interval-date-arithmetic.md
@@ -1,0 +1,58 @@
+---
+sqlglot_version: 30.6.0
+status: drafted
+type: bug
+target_dialect: sqlite
+benchbox_workaround: benchbox/utils/dialect_utils.py:_fix_sqlite_unsupported_syntax
+filed: false
+---
+
+# Title
+
+SQLite generator emits `INTERVAL '...' DAY` for date arithmetic, but SQLite has no INTERVAL type
+
+# Body
+
+## Description
+
+When transpiling date arithmetic from `postgres` (or any dialect with `INTERVAL` support) to `sqlite`, SQLGlot emits the `INTERVAL` literal verbatim. SQLite has no `INTERVAL` keyword and rejects the resulting SQL. The canonical SQLite form for date arithmetic is the modifier-string variant of `DATE()`, `DATETIME()`, etc., e.g. `DATE('2025-01-01', '+5 days')`.
+
+## Reproducer
+
+```python
+import sqlglot
+
+sql = "SELECT DATE '2025-01-01' + INTERVAL '5' DAY"
+out = sqlglot.transpile(sql, read="postgres", write="sqlite")[0]
+print(out)
+```
+
+## Expected output
+
+Something equivalent to:
+
+```sql
+SELECT DATE('2025-01-01', '+5 days')
+```
+
+## Actual output (sqlglot 30.6.0)
+
+```sql
+SELECT DATE('2025-01-01') + INTERVAL '5' DAY
+```
+
+SQLite rejects this with `Parse error: near "INTERVAL"`.
+
+## Scope
+
+This affects all `INTERVAL '<n>' (DAY|MONTH|YEAR)` expressions when targeting SQLite, including TPC-H Q1, Q4, Q6, Q12, Q14, Q15, Q20 and broadly any analytical workload with date-bounded predicates.
+
+## Version
+
+- `sqlglot==30.6.0`
+- Python 3.12
+- Reproduced via the harness at https://github.com/joeharris76/BenchBox/blob/develop/_project/sqlglot-upstream/repros/repro_all.py
+
+## Notes
+
+BenchBox currently works around this with a regex post-processor (`_fix_sqlite_unsupported_syntax`). We are happy to contribute a fix or test case if helpful.

--- a/_project/sqlglot-upstream/issues/03-sqlite-extract-not-lowered-to-strftime.md
+++ b/_project/sqlglot-upstream/issues/03-sqlite-extract-not-lowered-to-strftime.md
@@ -1,0 +1,61 @@
+---
+sqlglot_version: 30.6.0
+status: drafted
+type: bug
+target_dialect: sqlite
+benchbox_workaround: benchbox/utils/dialect_utils.py:_fix_sqlite_unsupported_syntax
+filed: false
+prior_issue: https://github.com/tobymao/sqlglot/issues/2592
+---
+
+# Title
+
+SQLite generator does not lower `EXTRACT(... FROM date)` to `STRFTIME` (revisit of #2592)
+
+# Body
+
+## Description
+
+`EXTRACT(YEAR FROM d)` is left verbatim when the write dialect is `sqlite`. SQLite has no `EXTRACT` function — the canonical equivalent is `CAST(STRFTIME('%Y', d) AS INTEGER)` (and `'%m'`, `'%d'`, etc. for `MONTH` and `DAY`).
+
+A prior issue (https://github.com/tobymao/sqlglot/issues/2592, 2023) reported the same gap and was closed without a linked fix. This issue re-reports against `sqlglot==30.6.0` with a current minimal reproducer.
+
+## Reproducer
+
+```python
+import sqlglot
+
+sql = "SELECT EXTRACT(YEAR FROM d) FROM t"
+out = sqlglot.transpile(sql, read="postgres", write="sqlite")[0]
+print(out)
+```
+
+## Expected output
+
+Something equivalent to:
+
+```sql
+SELECT CAST(STRFTIME('%Y', d) AS INTEGER) FROM t
+```
+
+## Actual output (sqlglot 30.6.0)
+
+```sql
+SELECT EXTRACT(YEAR FROM d) FROM t
+```
+
+SQLite rejects this with `Parse error: near "FROM"`.
+
+## Scope
+
+`YEAR`, `MONTH`, `DAY` at minimum. Affects every TPC-H/TPC-DS query that uses `EXTRACT` against a date column when targeting SQLite.
+
+## Version
+
+- `sqlglot==30.6.0`
+- Python 3.12
+- Reproduced via the harness at https://github.com/joeharris76/BenchBox/blob/develop/_project/sqlglot-upstream/repros/repro_all.py
+
+## Notes
+
+BenchBox currently works around this with a regex post-processor (`_fix_sqlite_unsupported_syntax`). Happy to contribute a fix or test case.

--- a/_project/sqlglot-upstream/issues/05-mysql-percentile-cont-extra-case-decorator.md
+++ b/_project/sqlglot-upstream/issues/05-mysql-percentile-cont-extra-case-decorator.md
@@ -1,0 +1,62 @@
+---
+sqlglot_version: 30.6.0
+status: drafted
+type: bug
+target_dialect: mysql
+also_affects: singlestore
+benchbox_workaround: benchbox/sql_compat/rules/query_source/h2odb_variants.py
+filed: false
+related: https://github.com/tobymao/sqlglot/issues/3257
+---
+
+# Title
+
+MySQL generator decorates `PERCENTILE_CONT WITHIN GROUP (ORDER BY x)` with synthetic `CASE WHEN x IS NULL` clause that engines reject
+
+# Body
+
+## Description
+
+When the write dialect is `mysql`, SQLGlot adds a synthetic `CASE WHEN <col> IS NULL THEN 1 ELSE 0 END, <col>` to the `WITHIN GROUP (ORDER BY ...)` clause of `PERCENTILE_CONT`. The standard ANSI form should round-trip; the synthetic NULL-sort decorator is rejected by SingleStore's MySQL-compatible parser (and is not required by the SQL standard for the percentile expression).
+
+## Reproducer
+
+```python
+import sqlglot
+
+sql = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x) FROM t"
+out = sqlglot.transpile(sql, read="postgres", write="mysql")[0]
+print(out)
+```
+
+## Expected output
+
+```sql
+SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x) FROM t
+```
+
+## Actual output (sqlglot 30.6.0)
+
+```sql
+SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY CASE WHEN x IS NULL THEN 1 ELSE 0 END, x) FROM t
+```
+
+SingleStore (MySQL wire-protocol) responds with a parser error on the `CASE` inside `WITHIN GROUP`.
+
+## Scope
+
+`PERCENTILE_CONT` is a SQL standard ordered-set aggregate; this affects any analytical query using percentiles when the write dialect is `mysql`. In our corpus this surfaces in H2ODB Q9 and would surface in any benchmark or production query on SingleStore using `PERCENTILE_CONT`.
+
+## Where it likely originates
+
+`add_within_group_for_percentiles` (the rewrite rule referenced indirectly in https://github.com/tobymao/sqlglot/issues/3257) appears to be the source of the decorator. That issue covers a different downstream failure on Snowflake, but the underlying rule may be over-applying.
+
+## Version
+
+- `sqlglot==30.6.0`
+- Python 3.12
+- Reproduced via the harness at https://github.com/joeharris76/BenchBox/blob/develop/_project/sqlglot-upstream/repros/repro_all.py
+
+## Notes
+
+BenchBox currently bypasses SQLGlot for this query and ships a verbatim ANSI variant. Happy to contribute a fix or test case.

--- a/_project/sqlglot-upstream/issues/06-questdb-dialect-feature-request.md
+++ b/_project/sqlglot-upstream/issues/06-questdb-dialect-feature-request.md
@@ -1,0 +1,100 @@
+---
+sqlglot_version: 30.6.0
+status: drafted
+type: feature-request
+target_dialect: questdb
+benchbox_workaround: benchbox/platforms/questdb_rewriter.py
+filed: false
+---
+
+# Title
+
+Feature request: QuestDB dialect
+
+# Body
+
+## Background
+
+QuestDB (https://questdb.io/) is an open-source time-series + analytical engine with a SQL surface that is broadly Postgres-shaped but with several material divergences. As of `sqlglot==30.6.0` there is no `questdb` entry in `Dialects`. Targeting QuestDB by transpiling to `postgres` produces SQL that fails to parse on QuestDB 9.3.4 across every TPC-H, TPC-DS, and SSB query we run.
+
+```python
+from sqlglot.dialects.dialect import Dialect
+
+Dialect.get_or_raise("questdb")
+# ValueError: Unknown dialect 'questdb'
+```
+
+## Coverage gaps observed against QuestDB 9.3.4
+
+These are the four cases that BenchBox currently rewrites in
+`benchbox/platforms/questdb_rewriter.py` after a `postgres`-targeted transpile:
+
+### 1. Implicit comma joins → explicit `INNER JOIN ... ON`
+
+QuestDB does not accept implicit comma joins (`FROM a, b WHERE a.x = b.x`), despite documentation suggestions otherwise. Affects all 22 TPC-H queries, all 99 TPC-DS queries, all 13 SSB queries.
+
+```sql
+-- input
+SELECT l.l_orderkey, o.o_orderdate
+FROM lineitem l, orders o
+WHERE l.l_orderkey = o.o_orderkey
+  AND l.l_shipdate > DATE '1995-01-01'
+
+-- needs to become
+SELECT l.l_orderkey, o.o_orderdate
+FROM lineitem AS l
+INNER JOIN orders AS o ON l.l_orderkey = o.o_orderkey
+WHERE l.l_shipdate > DATE '1995-01-01'
+```
+
+### 2. `INTERVAL` arithmetic → `dateadd('d', n, expr)`
+
+QuestDB has no SQL standard `INTERVAL` expression. The native form is `dateadd('<unit>', <signed_n>, <expr>)`.
+
+```sql
+-- input
+CAST('1998-12-01' AS DATE) - INTERVAL '90' DAY
+
+-- needs to become
+dateadd('d', -90, CAST('1998-12-01' AS DATE))
+```
+
+### 3. `SUBSTRING(s FROM p FOR l)` → 3-argument form
+
+QuestDB accepts only the function-style 3-argument `substring(s, p, l)`.
+
+```sql
+-- input
+SUBSTRING(name FROM 1 FOR 3)
+
+-- needs to become
+substring(name, 1, 3)
+```
+
+### 4. CTE column-alias lists rejected
+
+QuestDB does not accept `WITH cte (col1, col2) AS (SELECT ...)`; the column list must be omitted.
+
+```sql
+-- input
+WITH x (a, b) AS (SELECT 1, 2) SELECT * FROM x
+
+-- needs to become
+WITH x AS (SELECT 1, 2) SELECT * FROM x
+```
+
+## Offer
+
+We have a working post-AST rewriter in `benchbox/platforms/questdb_rewriter.py` (about 21 KB) that handles these cases plus a bank of fixtures across TPC-H, TPC-DS, SSB, tpchavoc, and tpch_skew. We are happy to:
+
+- Contribute a `QuestDB` dialect class derived from `Postgres`, lifting the four transformations into the dialect's parser/generator.
+- Contribute the BenchBox query corpus as test fixtures.
+
+If the maintainers prefer to scope a first pass narrowly, items (1) and (2) cover the largest fraction of failures we see on real workloads.
+
+## Version
+
+- `sqlglot==30.6.0`
+- Python 3.12
+- QuestDB 9.3.4
+- Confirmed missing dialect via the harness at https://github.com/joeharris76/BenchBox/blob/develop/_project/sqlglot-upstream/repros/repro_all.py

--- a/_project/sqlglot-upstream/repros/repro_all.py
+++ b/_project/sqlglot-upstream/repros/repro_all.py
@@ -1,0 +1,134 @@
+"""Minimal reproducers for SQLGlot defects observed by BenchBox.
+
+Pinned to ``sqlglot==30.6.0`` (the version resolved by the BenchBox lockfile
+at the time the issues were drafted). Run with:
+
+    uv run --with sqlglot==30.6.0 python _project/sqlglot-upstream/repros/repro_all.py
+
+Each repro prints PASS / FAIL with the offending output. Tier A items are
+defects we plan to file. Tier B items must reproduce as FAIL on this version
+before we file; if they PASS on 30.6.0 the workaround is obsolete and we
+should remove it from BenchBox instead of filing upstream.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import sqlglot
+from sqlglot.dialects.dialect import Dialect
+
+
+def _section(title: str) -> None:
+    print()
+    print(f"=== {title} ===")
+
+
+def _result(label: str, passed: bool, detail: str) -> bool:
+    status = "PASS" if passed else "FAIL"
+    print(f"  [{status}] {label}")
+    print(f"        {detail}")
+    return passed
+
+
+def repro_1_duckdb_all_keyword() -> bool:
+    _section("Tier B #1: DuckDB GROUP/ORDER BY ALL quoted under identify=True")
+    sql = "SELECT col1, col2, SUM(col3) FROM tbl GROUP BY ALL"
+    out = sqlglot.transpile(sql, read="duckdb", write="duckdb", identify=True)[0]
+    print(f"  input : {sql}")
+    print(f"  output: {out}")
+    quoted = '"ALL"' in out or "`ALL`" in out
+    return _result(
+        "GROUP BY ALL preserved as bare keyword (no identifier quoting)",
+        passed=not quoted,
+        detail=f"detected double-quoted ALL in clause: {quoted}",
+    )
+
+
+def repro_2_sqlite_interval_arithmetic() -> bool:
+    _section("Tier A #2: SQLite INTERVAL date arithmetic")
+    sql = "SELECT DATE '2025-01-01' + INTERVAL '5' DAY"
+    out = sqlglot.transpile(sql, read="postgres", write="sqlite")[0]
+    print(f"  input : {sql}")
+    print(f"  output: {out}")
+    has_interval = "INTERVAL" in out.upper()
+    return _result(
+        "INTERVAL lowered to SQLite date modifier form",
+        passed=not has_interval,
+        detail=f"SQLite has no INTERVAL keyword. literal INTERVAL still present: {has_interval}",
+    )
+
+
+def repro_3_sqlite_extract() -> bool:
+    _section("Tier B #3: SQLite EXTRACT not lowered to STRFTIME")
+    sql = "SELECT EXTRACT(YEAR FROM d) FROM t"
+    out = sqlglot.transpile(sql, read="postgres", write="sqlite")[0]
+    print(f"  input : {sql}")
+    print(f"  output: {out}")
+    has_extract = "EXTRACT" in out.upper()
+    return _result(
+        "EXTRACT lowered to STRFTIME (or equivalent SQLite expression)",
+        passed=not has_extract,
+        detail=f"SQLite has no EXTRACT. literal EXTRACT still present: {has_extract}",
+    )
+
+
+def repro_5_mysql_percentile_cont_decorator() -> bool:
+    _section("Tier A #5: MySQL PERCENTILE_CONT decorated with extra CASE/NULL")
+    sql = "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x) FROM t"
+    out = sqlglot.transpile(sql, read="postgres", write="mysql")[0]
+    print(f"  input : {sql}")
+    print(f"  output: {out}")
+    upper = out.upper()
+    has_case = "CASE" in upper
+    has_null = "NULL" in upper
+    decorated = has_case and has_null
+    return _result(
+        "PERCENTILE_CONT round-trips without synthetic CASE/NULL decorator",
+        passed=not decorated,
+        detail=f"unwanted CASE+NULL decorator detected: {decorated}",
+    )
+
+
+def repro_6_questdb_dialect_missing() -> bool:
+    _section("Tier A #6: QuestDB has no SQLGlot dialect")
+    try:
+        Dialect.get_or_raise("questdb")
+        return _result(
+            "QuestDB dialect resolvable",
+            passed=True,
+            detail="Dialect.get_or_raise('questdb') succeeded — feature request may be obsolete",
+        )
+    except Exception as exc:
+        return _result(
+            "QuestDB dialect resolvable",
+            passed=False,
+            detail=f"Dialect.get_or_raise('questdb') raised: {type(exc).__name__}: {exc}",
+        )
+
+
+def main() -> int:
+    print(f"sqlglot version: {sqlglot.__version__}")
+    expected = "30.6.0"
+    if sqlglot.__version__ != expected:
+        print(f"WARNING: pinned to {expected}; running on {sqlglot.__version__}")
+
+    results = [
+        ("#1 duckdb-all-keyword (Tier B)", repro_1_duckdb_all_keyword()),
+        ("#2 sqlite-interval-arithmetic (Tier A)", repro_2_sqlite_interval_arithmetic()),
+        ("#3 sqlite-extract (Tier B)", repro_3_sqlite_extract()),
+        ("#5 mysql-percentile-cont (Tier A)", repro_5_mysql_percentile_cont_decorator()),
+        ("#6 questdb-dialect-missing (Tier A)", repro_6_questdb_dialect_missing()),
+    ]
+
+    _section("Summary (FAIL = defect reproduces; PASS = no longer reproduces)")
+    for label, passed in results:
+        marker = "PASS" if passed else "FAIL"
+        print(f"  [{marker}] {label}")
+
+    any_failed = any(not p for _, p in results)
+    return 1 if any_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Followup to PR #171 critique fixes. The research that was driven by the
post's SQLGlot framing surfaced two more findings beyond the critique
review:

1. Two factual errors in the blog draft. SQLGlot's dialect list (verified
   against `sqlglot==30.6.0` Dialects enum) does NOT contain QuestDB or
   DataFusion. The draft previously asserted both. Both passages now say
   the dialect is missing and we transpile to `postgres` and rewrite or
   live with engine-specific behavior on top.

2. A reproducible upstream-contribution backlog. Add
   `_project/sqlglot-upstream/` containing:
   - `repros/repro_all.py`: single-file harness pinned to sqlglot 30.6.0
     covering five candidate defects. Confirms 4 of 5 still reproduce on
     30.6.0; the DuckDB GROUP/ORDER BY ALL workaround is now obsolete and
     is queued for retirement in BenchBox.
   - `issues/02-sqlite-interval-date-arithmetic.md` (Tier A bug)
   - `issues/03-sqlite-extract-not-lowered-to-strftime.md` (Tier B
     confirmed; refs prior closed #2592)
   - `issues/05-mysql-percentile-cont-extra-case-decorator.md` (Tier A
     bug; the MySQL/SingleStore CASE/NULL decorator)
   - `issues/06-questdb-dialect-feature-request.md` (Tier A feature)
   - `README.md` indexing status, verdict, and pre-flight steps.

Issues are drafted but not filed upstream. Each draft tracks
`filed: false` in frontmatter; flip to `filed: true` after opening.

Add `!_project/sqlglot-upstream/` to `.gitignore` to follow the existing
allowlist pattern for `_project/` subdirectories.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
