### PR TITLE
chore(todo): plan retirement of obsolete DuckDB GROUP BY ALL workaround

### DIFF
--- a/_project/TODO/main/planning/retire-sqlglot-duckdb-all-workaround.yaml
+++ b/_project/TODO/main/planning/retire-sqlglot-duckdb-all-workaround.yaml
@@ -1,0 +1,267 @@
+id: retire-sqlglot-duckdb-all-workaround
+title: "Retire obsolete _restore_group_order_by_all_keyword DuckDB workaround and update related docs"
+worktree: main
+priority: Medium
+status: Identified
+category: Code Quality
+
+description: |
+  The repro harness at `_project/sqlglot-upstream/repros/repro_all.py`
+  confirmed against `sqlglot==30.6.0` that SQLGlot's DuckDB generator now
+  preserves `GROUP BY ALL` and `ORDER BY ALL` as bare keywords even when
+  `identify=True` is set. This was previously a defect that BenchBox
+  worked around with `_restore_group_order_by_all_keyword` and
+  `_query_has_group_or_order_by_all` in `benchbox/utils/dialect_utils.py`,
+  invoked from two call sites:
+
+    1. `benchbox/utils/dialect_utils.translate_sql_query` (the central
+       wrapper).
+    2. `benchbox/platforms/base/dialect_translation.py` (a parallel
+       per-statement path that imports the same helpers).
+
+  Upstream fix: https://github.com/tobymao/sqlglot/pull/3756 (issue
+  https://github.com/tobymao/sqlglot/issues/3755). Verified by our
+  harness on 30.6.0; the `[PASS]` line in the harness output confirms
+  the bare-keyword form is preserved.
+
+  This TODO retires the workaround safely. Safe retirement requires
+  bumping our `sqlglot` floor in `pyproject.toml` to the first version
+  that includes #3756 - removing the code without that bump would silently
+  break users on older `sqlglot` releases who still have the underlying
+  defect. Our current pin is `sqlglot>=20.0.0,<31.0.0`.
+
+  Two artifacts that currently document the workaround as load-bearing
+  must be updated in the same PR:
+
+    - `_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md`
+      (post #11, currently in `drafts/`, not yet published). Section 2
+      "Post-generation fixups" lists `_restore_group_order_by_all_keyword`
+      in a three-row table. Update to remove that row, attribute the
+      retirement to upstream PR #3756, and reduce the post's "three fixes"
+      framing to two.
+    - `_project/sqlglot-upstream/README.md`. The verdict table and the
+      "Follow-up TODOs" section both reference this retirement.
+
+context_sections:
+  "Research findings": |
+    - Repro on `sqlglot==30.6.0` PASSES; SQLGlot output is
+      `SELECT "col1", "col2", SUM("col3") FROM "tbl" GROUP BY ALL`
+      (no double-quoted ALL inside the GROUP BY clause).
+    - Our existing post-fixup is therefore a no-op when the input has
+      `GROUP BY ALL` but is not on the path otherwise; it is dead code.
+    - `_query_has_group_or_order_by_all` is only called from
+      `_restore_group_order_by_all_keyword`'s gate; both functions
+      can be deleted together.
+    - There are two production call sites (see description).
+    - There are two test files referencing these helpers:
+      `tests/unit/utils/test_dialect_utils.py` and
+      `tests/unit/sql_compat/test_translate_sql_delegation.py`.
+
+  "Why this is Medium, not High": |
+    The code is harmless when running against modern `sqlglot`; this is
+    code-cleanliness, not a correctness fix. Schedule against contributor
+    bandwidth, not on a deadline. The blog post 11 is in `drafts/`,
+    so the documentation correction is not a public-facing emergency.
+
+work:
+  - id: w1
+    summary: "Identify the first sqlglot release containing PR #3756"
+    status: pending
+    notes: |
+      Read the sqlglot CHANGELOG / release notes / git tags around the
+      merge date of https://github.com/tobymao/sqlglot/pull/3756. Record
+      the first tagged release containing the fix in this TODO's
+      "Research findings" section, e.g. "first fix release: sqlglot
+      vX.Y.Z (YYYY-MM-DD)". This number drives w2.
+
+  - id: w2
+    summary: "Bump sqlglot floor in pyproject.toml and refresh uv.lock"
+    status: pending
+    needs: [w1]
+    notes: |
+      Update the `sqlglot` requirement in `pyproject.toml` from the
+      current `>=20.0.0,<31.0.0` to `>=<min-with-3756>,<31.0.0`. Run
+      `uv lock` to refresh `uv.lock`. Confirm the resolved version is
+      still `30.6.0` (no unintended downgrade or upgrade). Note in the
+      PR body that the floor bump is the safety predicate for w3.
+
+  - id: w3
+    summary: "Remove _restore_group_order_by_all_keyword and _query_has_group_or_order_by_all"
+    status: pending
+    needs: [w2]
+    notes: |
+      In `benchbox/utils/dialect_utils.py`:
+        - Delete the two helper functions.
+        - Delete the `if tgt == "duckdb" and _query_has_group_or_order_by_all(query): translated = _restore_group_order_by_all_keyword(translated)` branch
+          inside `translate_sql_query`.
+      In `benchbox/platforms/base/dialect_translation.py`:
+        - Drop the imports for the two helpers.
+        - Delete the `has_all = _query_has_group_or_order_by_all(sql)` branch
+          and its dependent `_restore_group_order_by_all_keyword(stmt)` call.
+      Leave the surrounding `translate_sql_query` flow control unchanged.
+
+  - id: w4
+    summary: "Prune dialect_utils unit tests; add regression test for GROUP/ORDER BY ALL"
+    status: pending
+    needs: [w3]
+    notes: |
+      In `tests/unit/utils/test_dialect_utils.py`:
+        - Remove tests that exercise `_query_has_group_or_order_by_all`
+          and `_restore_group_order_by_all_keyword` directly.
+        - Add a regression test that calls the public
+          `translate_sql_query` with `target_dialect="duckdb"`,
+          `identify=True`, and an input containing `GROUP BY ALL`.
+          Assert the output preserves the bare keyword and does NOT
+          contain `"ALL"`.
+      In `tests/unit/sql_compat/test_translate_sql_delegation.py`:
+        - Update the docstring/comment block on/near line 149 that
+          references the old workaround.
+
+  - id: w5
+    summary: "Live regression: TPC-H/TPC-DS/SSB on DuckDB SF 0.01"
+    status: pending
+    needs: [w4]
+    notes: |
+      Run `benchbox run --platform duckdb --benchmark tpch --scale 0.01
+      --validation full` and the equivalent for `tpcds` and `ssb`. All
+      runs must pass validation (or match the validation status they
+      had before the change). Capture the pre/post status in the PR
+      description. This is the load-bearing evidence that `--identify`
+      DuckDB output still works without the workaround in the full path.
+
+  - id: w6
+    summary: "Update blog post 11 and SQLGlot upstream README to reflect retirement"
+    status: pending
+    needs: [w5]
+    notes: |
+      In `_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md`:
+        - Section 2 "Post-generation fixups": remove the
+          `_restore_group_order_by_all_keyword` row from the table.
+        - Update the surrounding prose: "We carry three fixes" -> "We
+          carry two fixes". Add a one-sentence aside explaining that the
+          DuckDB ALL fix landed upstream in SQLGlot PR #3756 and the
+          workaround was retired.
+
+      In `_project/sqlglot-upstream/README.md`:
+        - Move row #1 in the verdict table out of "Action: Retire
+          workaround in BenchBox" and into "Action: Retired in PR <#>"
+          with the merge SHA / PR link.
+        - Remove the corresponding bullet from "Follow-up TODOs"
+          (`Retire _restore_group_order_by_all_keyword ...`) since the
+          work is captured by this TODO.
+        - Update the SQLGlot floor reference in the README if w2 changed it.
+
+deferred:
+  - summary: "Audit other DuckDB post-fix branches in dialect_utils.py for similar obsolescence"
+    reason: |
+      Out of scope. Each post-fix should be retired against its own
+      upstream-fix evidence. This TODO is scoped to the GROUP/ORDER BY
+      ALL workaround that the repro harness has already PASS-confirmed.
+
+  - summary: "Auto-retirement workflow (run repros on every sqlglot upgrade)"
+    reason: |
+      Worth considering as a separate process improvement. Out of scope
+      for this cleanup.
+
+metadata:
+  tags:
+    - sqlglot
+    - dialect-utils
+    - duckdb
+    - tech-debt
+    - documentation
+  estimated_effort: "Small (half-day)"
+  created_date: "2026-05-04"
+
+impact:
+  business_value: |
+    Removes ~25 lines of dead code and one branch of conditional logic
+    from a hot path (`translate_sql_query` is on every transpilation in
+    BenchBox). Reduces the "BenchBox-specific magic" surface area that
+    new contributors have to learn before they can confidently change
+    the dialect translation layer.
+  user_impact: |
+    None at runtime. Bumping the `sqlglot` floor narrows the supported
+    range. Communicate the floor bump in the next changelog entry.
+  technical_debt: |
+    Net reduction. Both call sites simplify. The blog post and upstream
+    README catch up with the repro evidence.
+
+files_affected:
+  modified:
+    - "benchbox/utils/dialect_utils.py"
+    - "benchbox/platforms/base/dialect_translation.py"
+    - "tests/unit/utils/test_dialect_utils.py"
+    - "tests/unit/sql_compat/test_translate_sql_delegation.py"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md"
+    - "_project/sqlglot-upstream/README.md"
+
+must_preserve:
+  - "translate_sql_query public signature unchanged (callers must not need updates)."
+  - "DuckDB TPC-H, TPC-DS, and SSB validation results match pre-change baseline at SF 0.01."
+  - "All other dialect branches in translate_sql_query (e.g. SQLite EXTRACT/INTERVAL fixups) untouched."
+  - "Other helpers in dialect_utils.py (fix_postgres_date_arithmetic, _fix_sqlite_unsupported_syntax, normalize_dialect_for_sqlglot) untouched."
+
+approach: |
+  Bump the floor before deleting the code. The floor bump is the
+  contract that lets us assume the upstream fix is present; without it,
+  users on older sqlglot would silently regress. After the bump and
+  delete, the live DuckDB regression on TPC-H/TPC-DS/SSB is the
+  load-bearing evidence the change is safe end-to-end. Documentation
+  edits land in the same PR so the public artifacts (blog draft,
+  upstream README) stay in sync with the code.
+
+anti_patterns:
+  - "DO NOT delete the workaround without bumping the sqlglot floor first - because users on the current floor (>=20.0.0) may be on a sqlglot version pre-#3756 and would silently produce broken DuckDB SQL."
+  - "DO NOT skip the live DuckDB regression in w5 - because unit tests on translate_sql_query do not exercise the full per-platform call path through dialect_translation.py."
+  - "DO NOT touch the SQLite or Postgres post-fix branches - because those are independently load-bearing per the repro harness FAIL results for items #2, #3 in the upstream prep."
+
+verification:
+  - description: "Repro harness still PASSes the DuckDB ALL case and continues to FAIL the other items"
+    command: "uv run --with sqlglot==30.6.0 python _project/sqlglot-upstream/repros/repro_all.py"
+    expected_output: "Item #1 reports [PASS]; items #2, #3, #5, #6 report [FAIL] (unchanged)"
+  - description: "dialect_utils unit tests pass after pruning"
+    command: "uv run -- python -m pytest tests/unit/utils/test_dialect_utils.py -v"
+    expected_output: "all tests pass; no references to removed helpers"
+  - description: "Full fast-test suite passes"
+    command: "uv run -- python -m pytest -m fast -q"
+    expected_output: "all tests pass, 0 failures"
+  - description: "Live DuckDB regression on TPC-H, TPC-DS, SSB at SF 0.01 with --validation full"
+    command: "benchbox run --platform duckdb --benchmark tpch --scale 0.01 --validation full && benchbox run --platform duckdb --benchmark tpcds --scale 0.01 --validation full && benchbox run --platform duckdb --benchmark ssb --scale 0.01 --validation full"
+    expected_output: "validation passes for every benchmark, results match pre-change baseline"
+  - description: "Blog post 11 reflects retirement"
+    command: "grep -c '_restore_group_order_by_all_keyword' _blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md"
+    expected_output: "0"
+  - description: "SQLGlot upstream README verdict reflects retirement"
+    command: "grep -A1 'Retire workaround in BenchBox' _project/sqlglot-upstream/README.md || true"
+    expected_output: "no remaining 'Retire workaround in BenchBox' status (replaced by 'Retired in PR ...')"
+
+scope_limit:
+  only_modify:
+    - "benchbox/utils/dialect_utils.py"
+    - "benchbox/platforms/base/dialect_translation.py"
+    - "tests/unit/utils/test_dialect_utils.py"
+    - "tests/unit/sql_compat/test_translate_sql_delegation.py"
+    - "pyproject.toml"
+    - "uv.lock"
+    - "_blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md"
+    - "_project/sqlglot-upstream/README.md"
+  do_not_modify:
+    - "benchbox/platforms/clickhouse/"
+    - "benchbox/platforms/questdb_rewriter.py"
+    - "benchbox/platforms/datafusion_query_transformer.py"
+    - "_project/sqlglot-upstream/issues/"
+    - "_project/sqlglot-upstream/repros/repro_all.py"
+
+success_metrics:
+  - "_restore_group_order_by_all_keyword and _query_has_group_or_order_by_all removed from benchbox/."
+  - "sqlglot floor in pyproject.toml bumped to the first release containing PR #3756."
+  - "DuckDB TPC-H/TPC-DS/SSB validation at SF 0.01 still passes."
+  - "Blog post 11 draft no longer lists the DuckDB ALL workaround."
+  - "_project/sqlglot-upstream/README.md verdict for item #1 reads 'Retired in PR <#>'."
+
+open_questions:
+  - "What is the first sqlglot release containing PR #3756? (Answered in w1.)"
+  - "Does any external benchbox extension package import _restore_group_order_by_all_keyword by name? (If yes, may need a deprecation shim instead of straight delete.)"


### PR DESCRIPTION
The repro harness in _project/sqlglot-upstream/repros/repro_all.py
confirmed against sqlglot==30.6.0 that SQLGlot's DuckDB generator now
preserves GROUP BY ALL / ORDER BY ALL as bare keywords even with
identify=True. Upstream PR https://github.com/tobymao/sqlglot/pull/3756
fixed this; our _restore_group_order_by_all_keyword post-fix is dead
code on currently pinned versions.

Add a TODO covering safe retirement: identify the first sqlglot release
containing #3756, bump the pyproject floor, remove the helpers from both
call sites (utils/dialect_utils.py and platforms/base/dialect_translation.py),
prune and rewrite the unit tests, run a live DuckDB regression on
TPC-H/TPC-DS/SSB SF 0.01, and update both the in-progress blog draft
and the SQLGlot upstream-prep README so the public-facing artifacts
match the new code.

Includes guardrails (must_preserve, anti-patterns, scope_limit,
verification commands) so an implementing agent does not accidentally
delete unrelated post-fix branches or skip the live DuckDB regression.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
