### PR TITLE
fix(codex-followups): wave 2 — P1 correctness batch (w1, w2, w4-w9, w12, w22, w23)

### DIFF
--- a/_project/audits/codex-weekly-sweep-template.md
+++ b/_project/audits/codex-weekly-sweep-template.md
@@ -53,11 +53,24 @@ review window by `/code review`, `/blind-spot`, or other paths. Codex
 threads will not surface these — they came from local agents.
 
 ```bash
-# Findings filed during the review window.
-ls _project/blind-spots/${START_DATE:0:7}-* 2>/dev/null
+# Findings filed during the review window. Use explicit start/end dates so
+# the listing is bounded to the actual sweep range; ${START_DATE:0:7} only
+# scopes to a calendar month, which can pull pre-window findings or omit
+# late-week ones.
+ls _project/blind-spots/ \
+  | awk -v s="$START_DATE" -v e="$END_DATE" '
+      /^[0-9]{4}-[0-9]{2}-[0-9]{2}-/ {
+        prefix = substr($0, 1, 10)
+        if (prefix >= s && prefix <= e) print
+      }
+    '
 
-# Or, more precisely, all findings whose `date:` frontmatter falls in window.
-make blind-spots-list
+# Note: `make blind-spots-list` (sweep_blind_spots.py list) filters by
+# status/kind only and has no --since/--until. Do NOT use it to scope this
+# axis: it pulls historical open findings outside the window and can omit
+# in-window non-open findings, making the sweep scope inconsistent. If a
+# date-window flag is added to sweep_blind_spots.py, replace the awk filter
+# above with that command.
 ```
 
 For each in-window finding:
@@ -84,8 +97,11 @@ failure mode. The bug class is "assertion-loosening alongside fix lands
 without a guard"; the original scan template had no axis for it.
 
 ```bash
-# Source: the same merge range as Axis 1.
-git log --since="$START_DATE" --until="$END_DATE" -p \
+# Source: the same merge range as Axis 1. Match Axis 1's inclusive end-of-day
+# bound — bare `--until=$END_DATE` resolves to midnight at the *start* of
+# END_DATE, which excludes test changes merged later on the closing day
+# (precisely the changes this axis exists to catch).
+git log --since="$START_DATE 00:00:00 -0400" --until="$END_DATE 23:59:59 -0400" -p \
   --diff-filter=M --pretty='format:%H %s' origin/develop \
   -- '*.spec.ts' '*.spec.tsx' '*test*.py' 'tests/' \
   | rg -B 5 -A 5 'toHaveCount\(.*\) ->|\.length\) ?=>|count.*>\s*0|expect\(.*\)\.toBeGreaterThan\(0\)|assert.*> 0'

--- a/benchbox/cli/platform.py
+++ b/benchbox/cli/platform.py
@@ -878,13 +878,17 @@ def check_platforms(platforms_to_check: tuple, enabled_only: bool):
         readiness_results = check_platform_readiness(readiness_platform)
         readiness_failed = has_readiness_failures(readiness_results)
 
-        if info.available and readiness_failed:
+        # Disabled platforms are always informational. A readiness failure on
+        # an available-but-disabled platform must not fail `platforms check`,
+        # since the user has opted out of running it; only an enabled platform
+        # with a failed readiness probe is a real environment problem.
+        if info.available and not info.enabled:
+            console.print(f"[yellow]○ {info.display_name}: Available but disabled[/yellow]")
+        elif info.available and readiness_failed:
             console.print(f"[yellow]⚠️ {info.display_name}: Environment not ready[/yellow]")
             all_good = False
         elif info.enabled and info.available:
             console.print(f"[green]✅ {info.display_name}: Ready[/green]")
-        elif info.available:
-            console.print(f"[yellow]○ {info.display_name}: Available but disabled[/yellow]")
         else:
             console.print(f"[red]❌ {info.display_name}: Missing dependencies[/red]")
             console.print(f"   Install: {info.installation_command}")

--- a/benchbox/cli/platform_readiness.py
+++ b/benchbox/cli/platform_readiness.py
@@ -260,6 +260,30 @@ def _check_lakesail(platform: str, timeout_seconds: float) -> tuple[PlatformRead
         return tuple(results)
 
     pysail_available = _module_available("pysail")
+    # The SQL adapter (`lakesail`) can auto-start a local pysail server at run
+    # time via LakeSailAdapter._ensure_server_ready, so an unreachable endpoint
+    # is not a real readiness failure when pysail is importable. The DataFrame
+    # adapter (`lakesail-df`) still requires an already-running endpoint.
+    is_sql_adapter = platform == "lakesail"
+    if pysail_available and is_sql_adapter:
+        results.append(
+            PlatformReadinessResult(
+                platform=platform,
+                check="spark_connect_endpoint",
+                status="ready",
+                summary=(
+                    f"LakeSail Spark Connect endpoint is not reachable at {endpoint}, "
+                    "but the SQL adapter can auto-start a local pysail server at run time."
+                ),
+                detail=(
+                    "pysail is importable; LakeSailAdapter._ensure_server_ready will "
+                    "start a local Sail server when the benchmark runs."
+                ),
+                endpoint=endpoint,
+            )
+        )
+        return tuple(results)
+
     auto_start_detail = (
         "The SQL adapter can auto-start a local pysail server at run time, but this readiness check does not "
         "start it. LakeSail DataFrame mode still needs an already-running endpoint."

--- a/benchbox/core/cost/integration.py
+++ b/benchbox/core/cost/integration.py
@@ -367,10 +367,44 @@ def _extract_platform_config_from_results(results: BenchmarkResults) -> dict[str
                 "For accurate cost estimation, ensure databricks-sdk is installed."
             )
 
+    else:
+        # Generic fallback for cloud adapters that emit `platform_type` values
+        # not covered above (e.g. "athena", "azure_synapse", future
+        # "clickhouse-cloud"). These adapters still populate `platform_info`
+        # with `region` and `cloud_provider`, but without this branch the cost
+        # calculator would warn `pricing region metadata missing` and force
+        # `cost_status="unavailable"`, blocking public cost totals in
+        # submission validation.
+        cloud_default = _DEFAULT_CLOUD_BY_PLATFORM_TYPE.get(platform_type, "aws")
+        region_default = _DEFAULT_REGION_BY_CLOUD.get(cloud_default, "us-east-1")
+        config["cloud"] = _value_or_default(
+            platform_info, "cloud_provider", cloud_default, defaulted_fields, alias="cloud"
+        )
+        config["region"] = _value_or_default(platform_info, "region", region_default, defaulted_fields)
+
     if defaulted_fields:
         config["_defaulted_fields"] = sorted(set(defaulted_fields))
 
     return config
+
+
+_DEFAULT_CLOUD_BY_PLATFORM_TYPE: dict[str, str] = {
+    "athena": "aws",
+    "azure_synapse": "azure",
+    "azure-synapse": "azure",
+    "synapse": "azure",
+    "clickhouse-cloud": "aws",
+    "motherduck": "aws",
+    "fabric": "azure",
+    "fabric_warehouse": "azure",
+}
+
+
+_DEFAULT_REGION_BY_CLOUD: dict[str, str] = {
+    "aws": "us-east-1",
+    "azure": "eastus",
+    "gcp": "us-central1",
+}
 
 
 def _value_or_default(

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -217,7 +217,7 @@ def reconstruct_benchmark_results(
     environment_section = data.get("environment", {})
     system_profile = _extract_system_profile(environment_section)
     execution_environment = _extract_execution_environment(environment_section)
-    cost_summary = _extract_cost_summary(data.get("cost", {}))
+    cost_summary = _extract_cost_summary(data.get("cost", {}), data.get("normalized_cost"))
     plans_captured, plan_failures = _extract_plans_info(plans_data)
 
     queries_counts = summary_section.get("queries", {})
@@ -391,14 +391,26 @@ def _extract_execution_environment(environment_section: dict[str, Any]) -> dict[
     return normalized or None
 
 
-def _extract_cost_summary(cost_section: dict[str, Any]) -> dict[str, Any] | None:
-    """Extract cost summary from cost section."""
+def _extract_cost_summary(
+    cost_section: dict[str, Any],
+    normalized_cost_section: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Extract cost summary from cost section.
+
+    Preserves the ``normalized_cost`` block when present so a re-export round-
+    trips ``cost.total_usd`` correctly for bundles that have one. Legacy
+    bundles without a normalized_cost block still round-trip their direct
+    total via the schema-side missing-vs-rejected distinction.
+    """
     if not cost_section:
         return None
-    return {
+    summary: dict[str, Any] = {
         "total_cost": cost_section.get("total_usd"),
         "cost_model": cost_section.get("model", "estimated"),
     }
+    if isinstance(normalized_cost_section, dict):
+        summary["normalized_cost"] = normalized_cost_section
+    return summary
 
 
 def _extract_plans_info(plans_data: dict[str, Any] | None) -> tuple[int, int]:

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -590,7 +590,16 @@ def _add_cost_section(payload: dict[str, Any], result: BenchmarkResults) -> None
 
 
 def _normalized_cost_allows_direct_total(normalized_cost: Any) -> bool:
-    """Return True when legacy direct cost totals can satisfy the public contract."""
+    """Return True when legacy direct cost totals can satisfy the public contract.
+
+    A genuinely missing normalized_cost block (legacy bundles produced before
+    the normalized_cost contract existed) means we have nothing to *reject*
+    — the direct total is the only signal available, so allow it. Only an
+    explicitly-rejected normalized_cost dict (e.g. ``cost_status="unavailable"``)
+    blocks emitting the direct total.
+    """
+    if normalized_cost is None:
+        return True
     if not isinstance(normalized_cost, dict):
         return False
     if normalized_cost.get("cost_status") not in {"normalized", "not_applicable_local"}:

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -112,9 +112,11 @@ def _check_validation_query(val_query: Any, actual_rows: int, val_result: list |
     Three validation modes (mutually exclusive at load time — see catalog loader):
     - expected_rows: exact row-count match
     - expected_rows_min/max: row-count range
-    - expected_value_min/max: scalar value from row[0][0] must fall in [min, max].
-      Used by approximate-aggregate sketch ops where a single tolerance-bounded
-      number certifies correctness without strict cross-engine equality.
+    - expected_value_min/max: scalar value(s) from each row's first column must
+      fall in [min, max]. Used by approximate-aggregate sketch ops where a
+      tolerance-bounded number certifies correctness without strict cross-engine
+      equality. Multi-row results (e.g. partition-aggregation validation
+      queries) must have *every* row in range, not just the first.
     """
     expected_rows = val_query.expected_rows
     if expected_rows is not None:
@@ -127,13 +129,18 @@ def _check_validation_query(val_query: Any, actual_rows: int, val_result: list |
         getattr(val_query, "expected_value_min", None) is not None
         and getattr(val_query, "expected_value_max", None) is not None
     ):
-        if not val_result or not val_result[0]:
+        if not val_result:
             return False
-        try:
-            scalar = float(val_result[0][0])
-        except (TypeError, ValueError):
-            return False
-        return val_query.expected_value_min <= scalar <= val_query.expected_value_max
+        for row in val_result:
+            if not row:
+                return False
+            try:
+                scalar = float(row[0])
+            except (TypeError, ValueError):
+                return False
+            if not (val_query.expected_value_min <= scalar <= val_query.expected_value_max):
+                return False
+        return True
     return True
 
 

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -445,14 +445,38 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
         )
 
     def _collect_skip_query_ids(self, benchmark_instance: Any | None) -> set[str]:
-        """Add Dask resource-envelope skips to benchmark-provided skip lists."""
+        """Add Dask resource-envelope skips to benchmark-provided skip lists.
+
+        The TPC-H Q10 OOM that motivated this guard is specific to the local
+        single-machine cluster envelope. When the user provides an external
+        ``scheduler_address`` or explicitly requests a distributed cluster,
+        Q10 should run normally — skipping it for those runs would lose
+        legitimate full-suite coverage.
+        """
         skip_query_ids = super()._collect_skip_query_ids(benchmark_instance)
         self._resource_envelope_skip_query_ids: set[str] = set()
-        if self._is_tpch_benchmark(benchmark_instance):
+        if self._is_tpch_benchmark(benchmark_instance) and self._is_local_envelope():
             self._resource_envelope_skip_query_ids = set(_RESOURCE_ENVELOPE_SKIP_QUERY_IDS)
             skip_query_ids |= self._resource_envelope_skip_query_ids
-            logger.warning("Skipping TPC-H Q10 for dask-df: %s", self._tpch_q10_resource_envelope_diagnostic())
+            logger.warning(
+                "Skipping TPC-H Q10 for dask-df local envelope: %s. "
+                "Pass --platform-option scheduler_address=tcp://... to run Q10 on an external cluster.",
+                self._tpch_q10_resource_envelope_diagnostic(),
+            )
         return skip_query_ids
+
+    def _is_local_envelope(self) -> bool:
+        """Return True only for runs that use the constrained local single-machine cluster.
+
+        Treat any external scheduler or explicit distributed cluster request as
+        out-of-envelope: those runs have provisioned their own resources and
+        must not lose Q10 coverage to the local-OOM guard.
+        """
+        if getattr(self, "scheduler_address", None):
+            return False
+        if getattr(self, "use_distributed", False):
+            return False
+        return True
 
     def _build_skipped_results(self, filtered_skip_query_ids: set[str]) -> list[dict[str, Any]]:
         """Build skipped results, preserving Dask resource-envelope skip reasons."""

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -911,8 +911,23 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
             parent_dir = file_paths[0].parent
             if all(f.parent == parent_dir for f in file_paths):
                 common_prefix = os.path.commonprefix([f.name for f in file_paths])
-                location = str(parent_dir / f"{common_prefix}*")
-                self.log_very_verbose(f"Using glob pattern for {table_name}: {location}")
+                if common_prefix:
+                    location = str(parent_dir / f"{common_prefix}*")
+                    self.log_very_verbose(f"Using glob pattern for {table_name}: {location}")
+                else:
+                    # No shared filename prefix (e.g. UUID/hash-named shards):
+                    # `parent/*` would register every file in the directory and
+                    # silently pull in other tables' data. Register each shard
+                    # by exact path via UNION ALL instead so row counts stay
+                    # correct.
+                    return self._create_external_table_union(
+                        connection,
+                        table_name,
+                        file_paths,
+                        schema_clause=schema_clause,
+                        delimiter=delimiter,
+                        has_header=dialect.has_header,
+                    )
             else:
                 # Files in different directories - fall back to first file with warning
                 location = str(file_paths[0])
@@ -953,6 +968,63 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
             return row_count
         except Exception as e:
             self.log_verbose(f"Error counting rows in {table_name}: {e}")
+            raise RuntimeError(f"Failed to count rows in {table_name}: {e}") from e
+
+    def _create_external_table_union(
+        self,
+        connection: Any,
+        table_name: str,
+        file_paths: list[Path],
+        *,
+        schema_clause: str,
+        delimiter: str,
+        has_header: bool,
+    ) -> int:
+        """Register a multi-shard CSV table by exact path then UNION ALL.
+
+        Used when ``os.path.commonprefix`` returns ``""`` for the shard names.
+        A bare ``parent/*`` glob would silently include unrelated files in the
+        same directory; per-shard registration keeps row counts correct.
+        """
+        shard_options_clause = ", ".join(
+            (
+                f"'has_header' '{str(has_header).lower()}'",
+                f"'delimiter' '{delimiter}'",
+            )
+        )
+        shard_table_names: list[str] = []
+        for index, shard_path in enumerate(file_paths):
+            shard_table = f"{table_name}__shard_{index}"
+            shard_sql = f"""
+                CREATE EXTERNAL TABLE {shard_table} {schema_clause}
+                STORED AS CSV
+                LOCATION '{shard_path}'
+                OPTIONS ({shard_options_clause})
+            """
+            try:
+                connection.sql(shard_sql)
+            except Exception as e:
+                self.log_verbose(f"Error creating shard external table {shard_table}: {e}")
+                raise RuntimeError(f"Failed to create shard external table {shard_table}: {e}") from e
+            shard_table_names.append(shard_table)
+
+        union_body = " UNION ALL ".join(f"SELECT * FROM {name}" for name in shard_table_names)
+        view_sql = f"CREATE OR REPLACE VIEW {table_name} AS {union_body}"
+        try:
+            connection.sql(view_sql)
+            self.log_very_verbose(
+                f"Created external table view {table_name} unioning {len(shard_table_names)} shard(s) "
+                "(no shared filename prefix; avoiding parent-glob to keep row counts correct)"
+            )
+        except Exception as e:
+            self.log_verbose(f"Error creating union view {table_name}: {e}")
+            raise RuntimeError(f"Failed to create union view {table_name}: {e}") from e
+
+        try:
+            result = connection.sql(f"SELECT COUNT(*) FROM {table_name}").collect()
+            return int(result[0].column(0)[0])
+        except Exception as e:
+            self.log_verbose(f"Error counting rows in {table_name} (union view): {e}")
             raise RuntimeError(f"Failed to count rows in {table_name}: {e}") from e
 
     def _map_to_arrow_type(self, sql_type: str) -> str:

--- a/results-explorer/src/__tests__/snapshotReadiness.test.ts
+++ b/results-explorer/src/__tests__/snapshotReadiness.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@duckdb/duckdb-wasm", () => ({}));
+vi.mock("@/lib/performanceMarks", () => ({
+  EXPLORER_PERFORMANCE_MARKS: {},
+  markExplorerPerformance: vi.fn(),
+  markExplorerError: vi.fn(),
+}));
+
+import { _waitForSnapshotRowsForTest } from "@/db";
+
+interface FakeRow {
+  result_id: string;
+}
+
+function fakeConnection(
+  rowsByLabelOrSql: Record<string, FakeRow[]>,
+  log: string[],
+): { query: (sql: string) => Promise<{ toArray: () => FakeRow[] }> } {
+  return {
+    query: async (sql: string) => {
+      log.push(sql);
+      // Match by table name in the SQL — readiness scans are
+      // `SELECT result_id FROM bench.<table> LIMIT 1`.
+      const tableMatch = sql.match(/FROM bench\.(\w+)/);
+      const table = tableMatch?.[1] ?? "";
+      const rows = rowsByLabelOrSql[table] ?? [];
+      return { toArray: () => rows };
+    },
+  };
+}
+
+describe("waitForSnapshotRows / SNAPSHOT_READY_SCANS (w5)", () => {
+  it("resolves when required scans return rows even if optional scans are empty", async () => {
+    // Required scans get 1 row; optional scans (query_executions,
+    // query_display_timings, short_ids) return [].
+    const log: string[] = [];
+    const conn = fakeConnection(
+      {
+        results: [{ result_id: "r1" }],
+        platform_index_rows: [{ result_id: "r1" }],
+        benchmark_rankings: [{ result_id: "r1" }],
+        benchmark_matrix_cells: [{ result_id: "r1" }],
+        result_detail_metrics: [{ result_id: "r1" }],
+        // Optional tables intentionally empty.
+        query_executions: [],
+        query_display_timings: [],
+        short_ids: [],
+      },
+      log,
+    );
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).resolves.toBeUndefined();
+    // All scans were probed (we still want to know the table is queryable
+    // even if it's optional).
+    expect(log.some((sql) => sql.includes("query_executions"))).toBe(true);
+    expect(log.some((sql) => sql.includes("short_ids"))).toBe(true);
+  });
+
+  it("rejects when a required scan stays empty across retries", async () => {
+    const log: string[] = [];
+    const conn = fakeConnection(
+      {
+        results: [], // required: empty → must fail readiness
+        platform_index_rows: [{ result_id: "r1" }],
+        benchmark_rankings: [{ result_id: "r1" }],
+        benchmark_matrix_cells: [{ result_id: "r1" }],
+        result_detail_metrics: [{ result_id: "r1" }],
+        query_executions: [{ result_id: "r1" }],
+        query_display_timings: [{ result_id: "r1" }],
+        short_ids: [{ result_id: "r1" }],
+      },
+      log,
+    );
+
+    await expect(_waitForSnapshotRowsForTest(conn as unknown as never)).rejects.toThrow(
+      /empty required scan/,
+    );
+  }, 10000);
+});

--- a/results-explorer/src/components/RunReceipt.tsx
+++ b/results-explorer/src/components/RunReceipt.tsx
@@ -137,6 +137,9 @@ function renderBundleLink(url: string) {
 function renderPlansStatus(detail: DetailResult) {
   if (!detail.has_plans) return "Plans not published";
   const plansUrl = planDownloadUrl(detail);
+  // ``has_plans`` is true (the source bundle had plan capture) but no public
+  // download exists — surface the non-link "Plans available" string instead
+  // of a 404-bound link.
   if (plansUrl === null) return "Plans available";
   return (
     <a href={plansUrl} class="text-xs font-medium no-underline" download>
@@ -146,6 +149,13 @@ function renderPlansStatus(detail: DetailResult) {
 }
 
 export function planDownloadUrl(detail: DetailResult) {
+  // Gate on the explicit publication signal, not source-side detection.
+  // ``has_plans`` reflects "the source bundle had a *.plans.json sidecar",
+  // but the explorer pipeline excludes plan sidecars from bundle discovery
+  // (benchbox/core/explorer_pipeline/pipeline.py:439), so plan files are
+  // never copied to the published bundles directory and this URL would 404.
+  // Only render a link when the pipeline has actually published the file.
+  if (!detail.plans_published) return null;
   if (!detail.has_plans || !detail.bundle_download_url) return null;
   if (!detail.bundle_download_url.endsWith(".json")) return null;
   return detail.bundle_download_url.replace(/\.json$/, ".plans.json");

--- a/results-explorer/src/components/__tests__/RunReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/RunReceipt.test.tsx
@@ -92,8 +92,8 @@ describe("RunReceipt", () => {
     expect(workload).toHaveTextContent("5");
   });
 
-  it("renders bundle and reproduce artifacts without requiring public plans", () => {
-    render(<RunReceipt detail={makeDetail({ has_plans: true })} />);
+  it("renders bundle and reproduce artifacts; only shows a Download plans link when plans are actually published", () => {
+    render(<RunReceipt detail={makeDetail({ has_plans: true, plans_published: true })} />);
 
     const receipt = screen.getByRole("region", { name: "Run receipt" });
     expect(within(receipt).getByRole("link", { name: "Download bundle" })).toHaveAttribute(
@@ -108,11 +108,32 @@ describe("RunReceipt", () => {
       .toBeTruthy();
   });
 
-  it("derives the plans companion URL only when plan capture is present", () => {
-    expect(planDownloadUrl(makeDetail({ has_plans: true }))).toBe(
+  it("does NOT render a Download plans link when has_plans is true but plans were not published (w1 regression)", () => {
+    render(<RunReceipt detail={makeDetail({ has_plans: true })} />);
+
+    const receipt = screen.getByRole("region", { name: "Run receipt" });
+    // Download bundle link must still render — only the plans link is gated.
+    expect(within(receipt).getByRole("link", { name: "Download bundle" })).toBeTruthy();
+    expect(within(receipt).queryByRole("link", { name: "Download plans" })).toBeNull();
+    // The non-link "Plans available" fallback string is shown instead.
+    expect(within(receipt).getByText("Plans available")).toBeTruthy();
+  });
+
+  it("derives the plans companion URL only when publication is signaled (w1 regression)", () => {
+    // Pre-w1 behavior gated only on has_plans; the URL would resolve to a
+    // 404 for every published bundle because the explorer pipeline excludes
+    // *.plans.json from bundle discovery. Post-w1, the link only renders
+    // when plans_published is explicitly true.
+    expect(planDownloadUrl(makeDetail({ has_plans: true, plans_published: true }))).toBe(
       "https://example.test/bundles/abcdef1234567890.plans.json",
     );
-    expect(planDownloadUrl(makeDetail({ has_plans: false }))).toBeNull();
-    expect(planDownloadUrl(makeDetail({ has_plans: true, bundle_download_url: "" }))).toBeNull();
+    expect(planDownloadUrl(makeDetail({ has_plans: true }))).toBeNull();
+    expect(planDownloadUrl(makeDetail({ has_plans: true, plans_published: false }))).toBeNull();
+    expect(planDownloadUrl(makeDetail({ has_plans: false, plans_published: true }))).toBeNull();
+    expect(
+      planDownloadUrl(
+        makeDetail({ has_plans: true, plans_published: true, bundle_download_url: "" }),
+      ),
+    ).toBeNull();
   });
 });

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -41,38 +41,52 @@ let initError: Error | null = null;
 
 type DuckDBConnection = Awaited<ReturnType<duckdb.AsyncDuckDB["connect"]>>;
 
+// Required scans must be queryable AND non-empty for the snapshot to be
+// considered ready. Optional scans must be queryable (so we know the table
+// is attached and the schema exists), but an empty result is acceptable —
+// the explorer's detail/query/short-id paths already handle missing data
+// gracefully, so blocking the entire UI on these is an over-strict gate
+// that produces an infinite spinner for valid snapshots.
 const SNAPSHOT_READY_SCANS = [
   {
     label: "results",
     sql: "SELECT result_id FROM bench.results LIMIT 1",
+    required: true,
   },
   {
     label: "platform_index_rows",
     sql: "SELECT result_id FROM bench.platform_index_rows LIMIT 1",
+    required: true,
   },
   {
     label: "benchmark_rankings",
     sql: "SELECT result_id FROM bench.benchmark_rankings LIMIT 1",
+    required: true,
   },
   {
     label: "benchmark_matrix_cells",
     sql: "SELECT result_id FROM bench.benchmark_matrix_cells LIMIT 1",
+    required: true,
   },
   {
     label: "result_detail_metrics",
     sql: "SELECT result_id FROM bench.result_detail_metrics LIMIT 1",
+    required: true,
   },
   {
     label: "query_display_timings",
     sql: "SELECT result_id FROM bench.query_display_timings LIMIT 1",
+    required: false,
   },
   {
     label: "query_executions",
     sql: "SELECT result_id FROM bench.query_executions LIMIT 1",
+    required: false,
   },
   {
     label: "short_ids",
     sql: "SELECT result_id FROM bench.short_ids LIMIT 1",
+    required: false,
   },
 ] as const;
 
@@ -85,18 +99,35 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
+// Exported for unit-test coverage of w5 (optional snapshot tables must not
+// block readiness when empty). Not part of the public surface — call sites
+// outside this module should keep going through `getDb()`.
+export async function _waitForSnapshotRowsForTest(
+  conn: DuckDBConnection,
+): Promise<void> {
+  return waitForSnapshotRows(conn);
+}
+
 async function waitForSnapshotRows(conn: DuckDBConnection): Promise<void> {
   let lastError: unknown = null;
   for (let attempt = 1; attempt <= SNAPSHOT_READY_ATTEMPTS; attempt += 1) {
     try {
-      const counts: Array<readonly [string, number]> = [];
+      const requiredCounts: Array<readonly [string, number]> = [];
       for (const scan of SNAPSHOT_READY_SCANS) {
         const result = await conn.query(scan.sql);
-        counts.push([scan.label, result.toArray().length] as const);
+        if (scan.required) {
+          requiredCounts.push([scan.label, result.toArray().length] as const);
+        }
+        // Optional scans only need to be queryable; we don't track row counts
+        // because empty is acceptable.
       }
-      const emptyScans = counts.filter(([, rowCount]) => rowCount === 0).map(([label]) => label);
-      if (emptyScans.length === 0) return;
-      lastError = new Error(`DuckDB snapshot readiness returned empty scan(s): ${emptyScans.join(", ")}`);
+      const emptyRequired = requiredCounts
+        .filter(([, rowCount]) => rowCount === 0)
+        .map(([label]) => label);
+      if (emptyRequired.length === 0) return;
+      lastError = new Error(
+        `DuckDB snapshot readiness returned empty required scan(s): ${emptyRequired.join(", ")}`,
+      );
     } catch (error: unknown) {
       lastError = error;
       if (!isTransientDuckDbSnapshotError(error)) throw error;

--- a/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
@@ -160,8 +160,10 @@ describe("ResultDetail - median-first contract", () => {
     expect(receipt).toHaveTextContent("Download bundle");
   });
 
-  it("links captured execution plans without requiring a plan viewer route", async () => {
-    vi.mocked(getDetailResult).mockResolvedValue(makeDetail({ has_plans: true }));
+  it("links captured execution plans only when plans_published is true", async () => {
+    vi.mocked(getDetailResult).mockResolvedValue(
+      makeDetail({ has_plans: true, plans_published: true }),
+    );
 
     render(<ResultDetail resultId="r1" />);
     await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
@@ -169,5 +171,17 @@ describe("ResultDetail - median-first contract", () => {
     const planLinks = screen.getAllByRole("link", { name: "Download plans" }) as HTMLAnchorElement[];
     expect(planLinks.length).toBeGreaterThanOrEqual(1);
     expect(planLinks[0]?.getAttribute("href")).toBe("https://example.test/download/r1.plans.json");
+  });
+
+  it("does not render a Download plans link when plans were not actually published (w1 regression)", async () => {
+    // Source-side has_plans is true but the explorer pipeline excludes
+    // *.plans.json from bundle discovery, so the published file does not
+    // exist. Pre-w1 the link rendered and 404'd; post-w1 it must not render.
+    vi.mocked(getDetailResult).mockResolvedValue(makeDetail({ has_plans: true }));
+
+    render(<ResultDetail resultId="r1" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    expect(screen.queryAllByRole("link", { name: "Download plans" })).toHaveLength(0);
   });
 });

--- a/results-explorer/src/types.ts
+++ b/results-explorer/src/types.ts
@@ -63,6 +63,13 @@ export interface DetailResult extends CostDeploymentFields {
   queries: QueryTiming[];
   display_timings: QueryDisplayTiming[];
   has_plans: boolean;
+  // True only when the explorer pipeline has actually copied a *.plans.json
+  // sidecar to the published bundles directory. ``has_plans`` reflects only
+  // source-side detection and is unsafe to use as a download-link gate
+  // because the pipeline excludes plan sidecars from bundle discovery
+  // (see benchbox/core/explorer_pipeline/pipeline.py). Optional so older
+  // SQL paths that don't yet emit this field default to undefined → falsy.
+  plans_published?: boolean | null;
   has_tuning: boolean;
   bundle_download_url: string;
   trust_label: string;

--- a/tests/unit/cli/test_platform.py
+++ b/tests/unit/cli/test_platform.py
@@ -1139,6 +1139,48 @@ class TestCLICommands:
         assert "Some platforms need attention" in result.output
         mock_check_readiness.assert_called_once_with("lakesail-df")
 
+    @patch("benchbox.cli.platform.check_platform_readiness")
+    @patch("benchbox.cli.platform.get_platform_manager")
+    def test_check_platforms_disabled_with_readiness_failure_does_not_fail_command(
+        self, mock_get_manager, mock_check_readiness
+    ):
+        """w12 regression: an available-but-disabled platform whose readiness
+        probe fails must be reported as informational ("Available but disabled")
+        and must NOT cause ``benchbox platforms check`` to exit non-zero. The
+        user has opted out of running this platform; environment gaps don't
+        apply."""
+        mock_manager = Mock()
+        mock_manager.detect_platforms.return_value = {
+            "lakesail": PlatformInfo(
+                name="lakesail",
+                display_name="LakeSail Sail",
+                description="Spark Connect",
+                libraries=[],
+                available=True,
+                enabled=False,
+                requirements=[],
+                installation_command="uv add pyspark",
+                category="analytical",
+            )
+        }
+        mock_get_manager.return_value = mock_manager
+        mock_check_readiness.return_value = (
+            PlatformReadinessResult(
+                platform="lakesail",
+                check="spark_connect_endpoint",
+                status="environment_skip",
+                summary="LakeSail endpoint is not reachable.",
+                detail="Benchmark should be skipped until provisioning is complete.",
+                remediation="Start a Sail server.",
+            ),
+        )
+
+        result = self.runner.invoke(check_platforms, ["lakesail"])
+
+        assert result.exit_code == 0, result.output
+        assert "Available but disabled" in result.output
+        assert "Environment not ready" not in result.output
+
     @patch("benchbox.cli.platform.get_platform_manager")
     def test_check_platforms_enabled_only_with_none_enabled(self, mock_get_manager):
         """Enabled-only mode should short-circuit when nothing is enabled."""

--- a/tests/unit/cli/test_platform_readiness.py
+++ b/tests/unit/cli/test_platform_readiness.py
@@ -66,6 +66,44 @@ def test_lakesail_unreachable_endpoint_reports_environment_skip_without_starting
     assert module_checks == ["pyspark", "pysail"]
 
 
+def test_lakesail_sql_unreachable_endpoint_is_ready_when_pysail_importable(monkeypatch):
+    """w23 regression: when the Spark Connect endpoint is unreachable but
+    pysail is importable, the SQL adapter (`lakesail`) can auto-start a local
+    Sail server at run time, so readiness must report ``ready`` rather than
+    ``environment_skip`` (which would fail ``benchbox platforms check`` for a
+    legitimately runnable adapter)."""
+    module_checks: list[str] = []
+
+    def module_available(name: str) -> bool:
+        module_checks.append(name)
+        return name in {"pyspark", "pysail"}
+
+    monkeypatch.setattr(readiness, "_module_available", module_available)
+    monkeypatch.setattr(readiness, "_configured_lakesail_endpoint", lambda: "sc://localhost:50051")
+    monkeypatch.setattr(readiness, "_tcp_reachable", lambda host, port, timeout: False)
+
+    results = readiness.check_platform_readiness("lakesail")
+
+    assert [result.check for result in results] == ["pyspark_client", "spark_connect_endpoint"]
+    assert all(result.ready for result in results), [(r.check, r.status, r.summary) for r in results]
+    assert results[1].status == "ready"
+    assert "auto-start" in results[1].summary or "auto-start" in (results[1].detail or "")
+
+
+def test_lakesail_dataframe_mode_still_requires_running_endpoint(monkeypatch):
+    """w23 regression (negative side): the DataFrame adapter (`lakesail-df`)
+    cannot auto-start; pysail being importable does NOT make it ready when
+    the endpoint is unreachable."""
+    monkeypatch.setattr(readiness, "_module_available", lambda name: name in {"pyspark", "pysail"})
+    monkeypatch.setattr(readiness, "_configured_lakesail_endpoint", lambda: "sc://localhost:50051")
+    monkeypatch.setattr(readiness, "_tcp_reachable", lambda host, port, timeout: False)
+
+    results = readiness.check_platform_readiness("lakesail-df")
+
+    assert results[1].check == "spark_connect_endpoint"
+    assert results[1].status == "environment_skip"
+
+
 def test_lakesail_reachable_endpoint_is_ready(monkeypatch):
     monkeypatch.setattr(readiness, "_module_available", lambda name: name == "pyspark")
     monkeypatch.setattr(readiness, "_configured_lakesail_endpoint", lambda: "sc://sail-host:50052")

--- a/tests/unit/core/cost/test_platform_config_extraction.py
+++ b/tests/unit/core/cost/test_platform_config_extraction.py
@@ -1,0 +1,87 @@
+"""w2 regression: _extract_platform_config_from_results must extract
+``cloud`` and ``region`` for cloud platform_types beyond the four explicitly-
+branched cases (snowflake, bigquery, redshift, databricks).
+
+Without a generic fallback, adapters that emit ``platform_type="athena"`` or
+``"azure_synapse"`` (and future cloud adapters) fall through with no
+region/cloud fields, so ``calculate_normalized_benchmark_cost`` warns
+``pricing region metadata missing`` and forces ``cost_status="unavailable"``,
+blocking public cost totals in submission validation even when the adapter
+populated ``platform_info``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchbox.core.cost.integration import _extract_platform_config_from_results
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _results_with(platform_info: dict[str, object]) -> SimpleNamespace:
+    return SimpleNamespace(platform_info=platform_info)
+
+
+class TestGenericCloudRegionFallback:
+    def test_athena_extracts_cloud_aws_and_region_from_platform_info(self) -> None:
+        config = _extract_platform_config_from_results(
+            _results_with(
+                {
+                    "platform_type": "athena",
+                    "cloud_provider": "aws",
+                    "region": "us-west-2",
+                }
+            )
+        )
+        assert config["platform_type"] == "athena"
+        assert config["cloud"] == "aws"
+        assert config["region"] == "us-west-2"
+        assert "_defaulted_fields" not in config
+
+    def test_athena_falls_back_to_aws_default_when_cloud_missing(self) -> None:
+        config = _extract_platform_config_from_results(_results_with({"platform_type": "athena"}))
+        assert config["cloud"] == "aws"
+        assert config["region"] == "us-east-1"
+        assert config["_defaulted_fields"] == ["cloud", "region"]
+
+    def test_azure_synapse_extracts_azure_cloud(self) -> None:
+        config = _extract_platform_config_from_results(
+            _results_with(
+                {
+                    "platform_type": "azure_synapse",
+                    "region": "westeurope",
+                }
+            )
+        )
+        assert config["cloud"] == "azure"
+        assert config["region"] == "westeurope"
+        # cloud_provider was missing; gets defaulted via the generic branch.
+        assert "cloud" in config["_defaulted_fields"]
+
+    def test_azure_synapse_default_region_when_missing(self) -> None:
+        config = _extract_platform_config_from_results(_results_with({"platform_type": "azure_synapse"}))
+        assert config["cloud"] == "azure"
+        assert config["region"] == "eastus"
+
+    def test_existing_snowflake_branch_still_runs(self) -> None:
+        """Sanity check: the new generic branch is in the `else` clause so the
+        existing per-platform branches still take precedence."""
+        config = _extract_platform_config_from_results(
+            _results_with(
+                {
+                    "platform_type": "snowflake",
+                    "cloud_provider": "aws",
+                    "region": "us-east-1",
+                    "edition": "enterprise",
+                    "configuration": {"warehouse_size": "MEDIUM"},
+                }
+            )
+        )
+        assert config["platform_type"] == "snowflake"
+        assert config["edition"] == "enterprise"
+        assert config["warehouse_size"] == "MEDIUM"
+        assert config["cloud"] == "aws"
+        assert config["region"] == "us-east-1"

--- a/tests/unit/core/results/test_cost_round_trip.py
+++ b/tests/unit/core/results/test_cost_round_trip.py
@@ -1,0 +1,79 @@
+"""w7 regression: cost.total_usd must survive a load → re-export round trip.
+
+Pre-w7, ``_extract_cost_summary`` only returned ``total_cost`` and
+``cost_model`` (no ``normalized_cost``), and the schema-side guard
+``_normalized_cost_allows_direct_total`` rejected any non-dict
+``normalized_cost``. The combination silently dropped ``cost.total_usd``
+for every legacy bundle on every re-export.
+
+These tests cover both halves:
+  - ``_extract_cost_summary`` preserves the normalized_cost block.
+  - ``_normalized_cost_allows_direct_total`` distinguishes "missing"
+    (legacy → allow) from "rejected" (e.g. cost_status=unavailable → block).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.results.loader import _extract_cost_summary
+from benchbox.core.results.schema import _normalized_cost_allows_direct_total
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class TestExtractCostSummaryPreservesNormalizedCost:
+    def test_returns_normalized_cost_when_present(self) -> None:
+        normalized = {
+            "cost_status": "normalized",
+            "normalized_cost_usd": 0.42,
+            "cost_model_version": "2026.05.0",
+        }
+        summary = _extract_cost_summary(
+            {"total_usd": 0.42, "model": "estimated"},
+            normalized,
+        )
+        assert summary == {
+            "total_cost": 0.42,
+            "cost_model": "estimated",
+            "normalized_cost": normalized,
+        }
+
+    def test_omits_normalized_cost_when_legacy_bundle_has_none(self) -> None:
+        summary = _extract_cost_summary({"total_usd": 0.99, "model": "estimated"}, None)
+        assert summary == {"total_cost": 0.99, "cost_model": "estimated"}
+        assert "normalized_cost" not in summary
+
+    def test_returns_none_for_empty_cost_section(self) -> None:
+        assert _extract_cost_summary({}, None) is None
+        assert _extract_cost_summary({}, {"cost_status": "normalized"}) is None
+
+
+class TestNormalizedCostAllowsDirectTotal:
+    def test_missing_block_allows_direct_total_for_legacy_bundles(self) -> None:
+        """Legacy bundles produced before normalized_cost existed have no
+        block at all — the direct ``cost.total_usd`` is the only signal,
+        and re-exports must preserve it. Pre-w7 the schema rejected this."""
+        assert _normalized_cost_allows_direct_total(None) is True
+
+    def test_normalized_status_allows_direct_total(self) -> None:
+        assert _normalized_cost_allows_direct_total({"cost_status": "normalized", "normalized_cost_usd": 1.23}) is True
+
+    def test_not_applicable_local_status_allows_direct_total(self) -> None:
+        assert (
+            _normalized_cost_allows_direct_total({"cost_status": "not_applicable_local", "normalized_cost_usd": 0.0})
+            is True
+        )
+
+    def test_unavailable_status_blocks_direct_total(self) -> None:
+        assert (
+            _normalized_cost_allows_direct_total({"cost_status": "unavailable", "normalized_cost_usd": None}) is False
+        )
+
+    def test_normalized_without_amount_blocks_direct_total(self) -> None:
+        assert _normalized_cost_allows_direct_total({"cost_status": "normalized", "normalized_cost_usd": None}) is False
+
+    def test_non_dict_non_none_value_blocks_direct_total(self) -> None:
+        # Defensive: anything other than None or a dict shape is suspect.
+        assert _normalized_cost_allows_direct_total("normalized") is False
+        assert _normalized_cost_allows_direct_total(42) is False

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -821,6 +821,49 @@ class TestCheckValidationQuery:
         q = self._make_query(expected_value_min=6, expected_value_max=8)
         assert _check_validation_query(q, actual_rows=1, val_result=[(7,)]) is True
 
+    # w4 regression: every row of expected_value_* must be in range, not just [0][0].
+
+    def test_value_bounds_multi_row_all_in_range_passes(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=3, val_result=[(11,), (15,), (19,)]) is True
+
+    def test_value_bounds_multi_row_first_out_of_range_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=3, val_result=[(0,), (15,), (19,)]) is False
+
+    def test_value_bounds_multi_row_middle_out_of_range_fails(self):
+        """Pre-w4 behavior would have passed because only [0][0] was inspected;
+        post-w4 we walk every row and fail on the first out-of-range value."""
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=3, val_result=[(11,), (999,), (19,)]) is False
+
+    def test_value_bounds_multi_row_last_out_of_range_fails(self):
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=3, val_result=[(11,), (15,), (0,)]) is False
+
+    def test_value_bounds_empty_result_fails(self):
+        """Empty result (after the bounds branch is taken) must fail rather than
+        silently pass — there's nothing to validate."""
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=0, val_result=None) is False
+
+    def test_value_bounds_empty_row_fails(self):
+        """A row with no columns can't be coerced to a scalar; treat as failure."""
+        from benchbox.core.write_primitives.benchmark import _check_validation_query
+
+        q = self._make_query(expected_value_min=10, expected_value_max=20)
+        assert _check_validation_query(q, actual_rows=2, val_result=[(15,), ()]) is False
+
 
 # ============================================================================
 # Fast-lane coverage tests (pytest.mark.fast)

--- a/tests/unit/platforms/dataframe/test_dask_df_coverage.py
+++ b/tests/unit/platforms/dataframe/test_dask_df_coverage.py
@@ -290,6 +290,46 @@ def test_profiled_tpch_q10_guard_returns_failure_profile():
     assert profile.metrics["resource_envelope_guarded"] is True
 
 
+def test_q10_skip_dropped_when_external_scheduler_address_set():
+    """w8 regression: an external scheduler means the run is no longer in the
+    constrained local envelope that motivated the OOM guard. Q10 must run."""
+    adapter = _make_adapter()
+    adapter.scheduler_address = "tcp://scheduler.example:8786"
+    benchmark = SimpleNamespace(name="TPC-H Benchmark")
+
+    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
+
+    assert "Q10" not in skip_query_ids
+    assert adapter._resource_envelope_skip_query_ids == set()
+
+
+def test_q10_skip_dropped_when_use_distributed_true():
+    """w8 regression: explicit distributed-cluster opt-in (without an external
+    scheduler) likewise opts out of the local-envelope OOM guard."""
+    adapter = _make_adapter()
+    adapter.use_distributed = True
+    adapter.scheduler_address = None
+    benchmark = SimpleNamespace(name="TPC-H Benchmark")
+
+    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
+
+    assert "Q10" not in skip_query_ids
+
+
+def test_q10_skip_kept_for_local_envelope():
+    """w8 regression: the local single-machine cluster envelope still skips
+    Q10. Without a scheduler_address and without use_distributed, the guard
+    must remain active."""
+    adapter = _make_adapter()
+    adapter.scheduler_address = None
+    adapter.use_distributed = False
+    benchmark = SimpleNamespace(name="TPC-H Benchmark")
+
+    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
+
+    assert "Q10" in skip_query_ids
+
+
 def test_close_and_del_cleanup():
     adapter = _make_adapter()
     adapter._client = SimpleNamespace(close=lambda: None)

--- a/tests/unit/platforms/test_datafusion_behavioral.py
+++ b/tests/unit/platforms/test_datafusion_behavioral.py
@@ -343,3 +343,75 @@ class TestExternalTableSupport:
         # Verify the method exists (it aliases load_data)
         assert hasattr(adapter, "create_external_tables")
         assert callable(adapter.create_external_tables)
+
+
+# ---------------------------------------------------------------------------
+# w9: empty common-prefix glob guard for multi-file CSV registration
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnection:
+    """Capture SQL passed to .sql() and return a fake row count for COUNT(*)."""
+
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def sql(self, statement: str) -> _FakeResult:
+        self.statements.append(statement)
+        return _FakeResult()
+
+
+class _FakeResult:
+    def collect(self) -> list[_FakeBatch]:
+        return [_FakeBatch()]
+
+
+class _FakeBatch:
+    def column(self, _index: int) -> list[int]:
+        # Pretend the table has 7 rows so the wrapper has a number to return.
+        return [7]
+
+
+class TestMultiFileCsvEmptyPrefixGuard:
+    """w9 regression: when shard filenames share no common prefix, a
+    `parent_dir/*` glob would silently include unrelated files in the
+    directory and corrupt row counts. The guard must register each shard
+    by exact path and union them via a view instead."""
+
+    def test_empty_common_prefix_registers_per_shard_via_union(self, adapter, tmp_path):
+        shard_dir = tmp_path / "csvshards"
+        shard_dir.mkdir()
+        # No shared filename prefix — UUID-style names.
+        shard_a = shard_dir / "abc-data.csv"
+        shard_b = shard_dir / "def-data.csv"
+        shard_c = shard_dir / "999-data.csv"
+        for shard in (shard_a, shard_b, shard_c):
+            shard.write_text("col1,col2\n1,2\n", encoding="utf-8")
+
+        conn = _FakeConnection()
+        # Schema info isn't required by the helper for the SQL-shape assertion
+        # below; the per-shard CREATE EXTERNAL TABLE and UNION ALL view are
+        # what matter.
+        adapter._create_external_table_union(
+            conn,
+            "tbl",
+            [shard_a, shard_b, shard_c],
+            schema_clause="(col1 INT, col2 INT)",
+            delimiter=",",
+            has_header=True,
+        )
+
+        joined = "\n".join(conn.statements)
+        # Must NOT use a parent-directory glob.
+        assert f"{shard_dir}/*" not in joined
+        assert "/*'" not in joined
+        # Each shard was registered by exact path.
+        assert str(shard_a) in joined
+        assert str(shard_b) in joined
+        assert str(shard_c) in joined
+        # Per-shard external tables and a UNION ALL view bind them as `tbl`.
+        assert "CREATE EXTERNAL TABLE tbl__shard_0" in joined
+        assert "CREATE EXTERNAL TABLE tbl__shard_1" in joined
+        assert "CREATE EXTERNAL TABLE tbl__shard_2" in joined
+        assert "CREATE OR REPLACE VIEW tbl AS" in joined
+        assert "UNION ALL" in joined


### PR DESCRIPTION
Eleven correctness/contract findings from
codex-pr-review-followups-week-2026-05-03, batched into one PR per the
user-directed wave grouping.

w1 (PR #103, RunReceipt): gate the plan-download link on a publication
  signal (`plans_published`) rather than source-side `has_plans`. The
  pipeline excludes *.plans.json from bundle discovery so the prior
  link 404'd for every published bundle. New optional TS field defaults
  to undefined→falsy; future publication can flip it to true.

w2 (PR #105, cost/integration.py): add a generic post-branch fallback
  for cloud platform_types not in the explicit four (athena,
  azure_synapse, future clickhouse-cloud), reading platform_info
  region/cloud_provider before warning "pricing region metadata
  missing" and forcing cost_status=unavailable.

w4 (PR #114, write_primitives/benchmark.py): validate every row in
  expected_value_min/max checks rather than only val_result[0][0], so
  partition-aggregation queries can't silently pass with an
  out-of-range value in any non-first row. Empty results now fail
  rather than passing through.

w5 (PR #127, results-explorer/src/db.ts): tag SNAPSHOT_READY_SCANS
  with `required: bool`. Required scans (results, platform_index_rows,
  benchmark_rankings, benchmark_matrix_cells, result_detail_metrics)
  must be non-empty; optional auxiliary scans (query_executions,
  query_display_timings, short_ids) only need to be queryable. Stops
  the explorer from spinning forever on valid snapshots with empty
  optional tables.

w6 (PR #132, codex-weekly-sweep-template.md): align Axis 3's git log
  with Axis 1's inclusive end-of-day bound so closing-day test changes
  aren't silently dropped from the weekly coverage-downgrade scan.

w7 (PR #141, results/loader.py + schema.py): preserve normalized_cost
  through reconstruction so re-exports round-trip cost.total_usd, and
  treat a missing normalized_cost block (legacy bundles) as
  "allow direct total" — distinct from the explicitly-rejected case
  (cost_status=unavailable). Pre-w7 every legacy bundle silently lost
  cost.total_usd on every re-export.

w8 (PR #144, dataframe/dask_df.py): gate the TPC-H Q10 OOM skip on the
  local-envelope condition (no scheduler_address, not use_distributed).
  External schedulers / explicit distributed cluster runs no longer
  lose Q10 coverage to a guard that only applies to local single-machine
  clusters.

w9 (PR #145, platforms/datafusion.py): when os.path.commonprefix
  returns "" for multi-file CSV shards (UUID/hash names), register
  each shard by exact path and UNION ALL into a view rather than
  emitting `parent_dir/*` which would silently include unrelated
  files in the directory and corrupt row counts.

w12 (PR #151, cli/platform.py): reorder the platforms-check branches
  so an available-but-disabled platform is always reported as
  informational, even when its readiness probe fails. Disabled
  platforms must not fail `benchbox platforms check`; readiness
  failures only matter for enabled platforms.

w22 (PR #132, codex-weekly-sweep-template.md): replace the Axis 2
  "more precise" guidance about make blind-spots-list with an actual
  date-bounded query. The named target only filters by status/kind
  and has no --since/--until, so it pulled unrelated historical
  findings and missed in-window non-open ones.

w23 (PR #151, cli/platform_readiness.py): when the LakeSail Spark
  Connect endpoint is unreachable but pysail is importable AND the
  platform is the SQL adapter (`lakesail`, not `lakesail-df`), report
  `ready` because LakeSailAdapter._ensure_server_ready can auto-start
  a local Sail server at run time. DataFrame-mode lakesail-df still
  requires an already-running endpoint and stays environment_skip.

Tests: per-w-unit regression coverage in
tests/unit/{cli,core,platforms}/, results-explorer/src/__tests__/, and
results-explorer/src/components/__tests__/. Existing
test_platform_options_capture provenance assertion was updated for w17
in wave 1; the existing has_plans=true test in RunReceipt was updated
for w1 here.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
