### PR TITLE
fix(codex-followups): wave 3 — P2 polish batch (w13-w16, w18-w21, w24)

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -40,10 +40,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout develop
+      - name: Checkout the triggering commit
+        # Pin to ${{ github.sha }} (not `ref: develop`) so each run mirrors
+        # the exact commit that triggered it. With concurrency.cancel-in-progress
+        # set to false, an older queued run that picked up `develop`'s
+        # current tip would mirror newer corpus content while still naming
+        # the branch / PR with the older GITHUB_SHA, producing misattributed
+        # or duplicate mirror PRs.
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: ${{ github.sha }}
           fetch-depth: 0  # full history so we can switch branches and diff
 
       - name: Configure git identity

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ DEV_LOOP_METRICS_LIMIT ?= 100
 # 5 GB. Override to 0 to bypass the check (e.g. during low-space CI).
 POOL_MIN_FREE_KB ?= 5000000
 
+# Age threshold (in seconds) before a `.benchbox/claim_in_progress` marker
+# is treated as evidence of an aborted claim by `worktree-pool-check`.
+# Fresh markers indicate an in-flight `worktree-claim` and must not be
+# reported as aborted: `worktree-pool-check` is documented as safe for
+# periodic / cron use, and `worktree-claim` writes the marker at the
+# start of a normal claim and only removes it at the end. Default 600s
+# (10 min); concurrent claim runs typically finish in seconds.
+POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
+
 # Shell command snippet that resolves the main clone's directory name
 # (e.g. "BenchBox"). Pool worktree paths derive from it as
 # $(WORKTREE_POOL_PARENT)/$(POOL_REPO_CMD).pool-NN. Inlined as a Make
@@ -1247,6 +1256,7 @@ worktree-pool-check:
 	missing_count=0; \
 	aborted_count=0; \
 	i=1; \
+	now_epoch=$$(date +%s); \
 	while [ "$$i" -le "$(POOL_SIZE)" ]; do \
 		pool=$$(printf 'pool-%02d' "$$i"); \
 		wt="$(WORKTREE_POOL_PARENT)/$$POOL_REPO.$$pool"; \
@@ -1254,9 +1264,13 @@ worktree-pool-check:
 			violations="$$violations  - $$pool: missing ($$wt is not a git worktree)\n"; \
 			missing_count=$$((missing_count + 1)); \
 		elif [ -f "$$wt/.benchbox/claim_in_progress" ]; then \
+			marker_mtime_epoch=$$(stat -f %m "$$wt/.benchbox/claim_in_progress" 2>/dev/null || stat -c %Y "$$wt/.benchbox/claim_in_progress" 2>/dev/null || echo 0); \
+			marker_age_seconds=$$((now_epoch - marker_mtime_epoch)); \
 			marker_age=$$(date -u -r "$$wt/.benchbox/claim_in_progress" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?"); \
-			violations="$$violations  - $$pool: aborted (claim_in_progress marker present, mtime $$marker_age)\n"; \
-			aborted_count=$$((aborted_count + 1)); \
+			if [ "$$marker_age_seconds" -ge "$(POOL_CLAIM_MARKER_STALE_SECONDS)" ]; then \
+				violations="$$violations  - $$pool: aborted (claim_in_progress marker present, mtime $$marker_age, age $${marker_age_seconds}s >= $(POOL_CLAIM_MARKER_STALE_SECONDS)s)\n"; \
+				aborted_count=$$((aborted_count + 1)); \
+			fi; \
 		fi; \
 		i=$$((i + 1)); \
 	done; \

--- a/Makefile
+++ b/Makefile
@@ -1264,7 +1264,8 @@ worktree-pool-check:
 			violations="$$violations  - $$pool: missing ($$wt is not a git worktree)\n"; \
 			missing_count=$$((missing_count + 1)); \
 		elif [ -f "$$wt/.benchbox/claim_in_progress" ]; then \
-			marker_mtime_epoch=$$(stat -f %m "$$wt/.benchbox/claim_in_progress" 2>/dev/null || stat -c %Y "$$wt/.benchbox/claim_in_progress" 2>/dev/null || echo 0); \
+			marker_mtime_epoch=$$(stat -c %Y "$$wt/.benchbox/claim_in_progress" 2>/dev/null || stat -f %m "$$wt/.benchbox/claim_in_progress" 2>/dev/null || echo 0); \
+			case "$$marker_mtime_epoch" in ''|*[!0-9]*) marker_mtime_epoch=0 ;; esac; \
 			marker_age_seconds=$$((now_epoch - marker_mtime_epoch)); \
 			marker_age=$$(date -u -r "$$wt/.benchbox/claim_in_progress" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?"); \
 			if [ "$$marker_age_seconds" -ge "$(POOL_CLAIM_MARKER_STALE_SECONDS)" ]; then \

--- a/benchbox/core/cost/calculator.py
+++ b/benchbox/core/cost/calculator.py
@@ -230,12 +230,16 @@ class CostCalculator:
             "pyspark",
             # DataFrame platforms
             "datafusion",
+            "datafusion-df",
             "polars",
             "polars-df",
             "pandas-df",
             "cudf-df",
             "modin-df",
             "dask-df",
+            "pyspark-df",
+            "lakesail",
+            "lakesail-df",
         }
 
     def is_local_platform(self, platform: str) -> bool:

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -661,6 +661,14 @@ try:
     # These platforms use lazy config builders to avoid importing heavy SDKs
     # at module load time. Option specs are registered unconditionally.
 
+    # MotherDuck — the credential wizard saves a `database` field, but the
+    # default builder did not call CredentialManager, so the configured
+    # database was silently dropped at run time. Routing through a lazy
+    # config builder pulls the wizard-saved database into runtime config.
+    PlatformHookRegistry.register_config_builder(
+        "motherduck", _make_lazy_config_builder(".motherduck", "_build_motherduck_config")
+    )
+
     # Databricks
     PlatformHookRegistry.register_config_builder(
         "databricks", _make_lazy_config_builder(".databricks", "_build_databricks_config")

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -55,6 +55,40 @@ def _redact_motherduck_token(message: str, token: str | None = None) -> str:
     return _MOTHERDUCK_TOKEN_RE.sub(r"\1****", redacted)
 
 
+def _build_motherduck_config(
+    platform: str,
+    options: dict[str, Any],
+    overrides: dict[str, Any],
+    info: Any,
+) -> Any:
+    """Build the MotherDuck DatabaseConfig.
+
+    The credential setup wizard (`benchbox/platforms/credentials/motherduck.py`)
+    saves a ``database`` field, but the default config builder did not call
+    CredentialManager, so runtime runs always fell back to the adapter's
+    internal default (``benchbox``) regardless of what the wizard captured.
+    Routing MotherDuck through the shared ``build_platform_config`` helper
+    pulls the saved database into ``options["database"]`` so the adapter's
+    ``config.get("database", "benchbox")`` resolves to the wizard value.
+    """
+    from benchbox.platforms.base.config_utils import build_platform_config
+
+    return build_platform_config(
+        platform_type="motherduck",
+        credential_key="motherduck",
+        default_display_name="MotherDuck",
+        default_driver_package="duckdb",
+        platform_fields=[
+            "database",
+            "memory_limit",
+            "token_env_var",
+        ],
+        options=options,
+        overrides=overrides,
+        info=info,
+    )
+
+
 class MotherDuckAdapter(PlatformAdapter):
     """MotherDuck platform adapter - serverless DuckDB in the cloud.
 

--- a/results-explorer/src/__tests__/chartMath.scale.test.ts
+++ b/results-explorer/src/__tests__/chartMath.scale.test.ts
@@ -21,7 +21,15 @@ describe("latency bar scale", () => {
 
     expect(scale?.mode).toBe("log");
     expect(scale?.spanRatio).toBe(100);
-    expect(latencyScaleTicks(scale!)).toStrictEqual([10, 100, 1000]);
+    // w15: ticks now always include the domain endpoints so the right edge
+    // of the bar chart has a labelled terminal value. The interior canonical
+    // powers of ten remain in the middle.
+    const ticks = latencyScaleTicks(scale!);
+    expect(ticks[0]).toBe(scale!.domainMin);
+    expect(ticks[ticks.length - 1]).toBe(scale!.domainMax);
+    for (const tick of [10, 100, 1000]) {
+      expect(ticks).toContain(tick);
+    }
 
     const fast = latencyScaleFraction(10, scale!);
     const middle = latencyScaleFraction(100, scale!);
@@ -39,6 +47,44 @@ describe("latency bar scale", () => {
     expect(scale?.mode).toBe("log");
     expect(latencyScaleFraction(0.01, scale!)).toBeGreaterThan(0);
     expect(latencyScaleFraction(1, scale!)).toBe(1);
+  });
+
+  it("includes both endpoints in log-mode ticks for narrow ranges (w15)", () => {
+    // 0.2-2 ms: pre-w15 the ticks omitted both endpoints because no
+    // canonical power-of-ten falls in the open interval. The right edge
+    // of the bar would render against an unlabelled endpoint.
+    const scale = buildLatencyBarScale([0.2, 2]);
+    expect(scale?.mode).toBe("log");
+    const ticks = latencyScaleTicks(scale!);
+    expect(ticks[0]).toBe(scale!.domainMin);
+    expect(ticks[ticks.length - 1]).toBe(scale!.domainMax);
+    // Interior power-of-ten (1 ms) is included between endpoints.
+    expect(ticks).toContain(1);
+  });
+
+  it("includes both endpoints in log-mode ticks for very wide ranges (w15)", () => {
+    // 100k-50M ms: pre-w15 omitted the upper endpoint because no
+    // power-of-ten was within ±1% of it.
+    const scale = buildLatencyBarScale([100_000, 50_000_000]);
+    expect(scale?.mode).toBe("log");
+    const ticks = latencyScaleTicks(scale!);
+    expect(ticks[0]).toBe(scale!.domainMin);
+    expect(ticks[ticks.length - 1]).toBe(scale!.domainMax);
+    // At least one interior power of ten is present.
+    expect(ticks.some((tick) => tick === 100_000 || tick === 1_000_000 || tick === 10_000_000)).toBe(
+      true,
+    );
+  });
+
+  it("dedupes endpoints against canonical powers-of-ten (w15)", () => {
+    // 1-1000 ms: domainMin and domainMax may already equal canonical ticks
+    // depending on padding; the dedupe must not produce duplicates.
+    const scale = buildLatencyBarScale([1, 1000]);
+    expect(scale?.mode).toBe("log");
+    const ticks = latencyScaleTicks(scale!);
+    expect(ticks[0]).toBe(scale!.domainMin);
+    expect(ticks[ticks.length - 1]).toBe(scale!.domainMax);
+    expect(new Set(ticks).size).toBe(ticks.length);
   });
 
   it("ignores null, zero, and non-finite inputs when choosing a scale", () => {

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -35,6 +35,12 @@ interface ChartPanelProps {
   context: ChartContext;
   baselineIndex?: number;
   onBaselineIndexChange?: (baselineIndex: number) => void;
+  // w18: thread the Compare-page guardrail (cohort mismatch → suppress
+  // winner language) into chart-level summaries. Without this, ChartPanel
+  // could still surface "Best power" / "Best geomean" claims even when the
+  // page-level decision summary correctly avoided them.
+  suppressWinnerClaims?: boolean;
+  suppressionReason?: string;
 }
 
 interface CompareQueryRow {
@@ -68,7 +74,13 @@ const CHART_BUTTON_LABELS: Record<string, string> = {
   rank_table: "Ranks",
 };
 
-export function ChartPanel({ context, baselineIndex, onBaselineIndexChange }: ChartPanelProps) {
+export function ChartPanel({
+  context,
+  baselineIndex,
+  onBaselineIndexChange,
+  suppressWinnerClaims = false,
+  suppressionReason,
+}: ChartPanelProps) {
   const charts = useMemo(() => applicableCharts(context), [context]);
   const chartGroups = useMemo(() => groupChartsByQuestion(charts), [charts]);
   const summary = useMemo(() => buildRenderableSummary(context), [context]);
@@ -235,6 +247,8 @@ export function ChartPanel({ context, baselineIndex, onBaselineIndexChange }: Ch
           compareRows,
           compareGroups,
           baselineIdx,
+          suppressWinnerClaims,
+          suppressionReason,
         })}
       </div>
     </section>
@@ -287,6 +301,8 @@ function renderChart(
     compareRows,
     compareGroups,
     baselineIdx,
+    suppressWinnerClaims = false,
+    suppressionReason,
   }: {
     context: ChartContext;
     summary: BenchmarkSummary | null;
@@ -294,6 +310,8 @@ function renderChart(
     compareRows: CompareQueryRow[];
     compareGroups: { queryId: string; values: { label: string; value: number | null; color: string }[] }[];
     baselineIdx: number;
+    suppressWinnerClaims?: boolean;
+    suppressionReason?: string;
   },
 ) {
   switch (chart.id) {
@@ -350,7 +368,15 @@ function renderChart(
         />
       ) : null;
     case "summary_box":
-      return <SummaryBoxPanel context={context} summary={summary} historical={historical} />;
+      return (
+        <SummaryBoxPanel
+          context={context}
+          summary={summary}
+          historical={historical}
+          suppressWinnerClaims={suppressWinnerClaims}
+          suppressionReason={suppressionReason}
+        />
+      );
     case "percentile_ladder":
       return summary ? (
         <PercentileLadder
@@ -589,10 +615,14 @@ function SummaryBoxPanel({
   context,
   summary,
   historical,
+  suppressWinnerClaims = false,
+  suppressionReason,
 }: {
   context: ChartContext;
   summary: BenchmarkSummary | null;
   historical: ChartHistoricalEntry[];
+  suppressWinnerClaims?: boolean;
+  suppressionReason?: string;
 }) {
   if (context.kind === "summary" && context.summary === null) {
     const benchmarks = new Set(historical.map((entry) => entry.benchmark));
@@ -636,14 +666,23 @@ function SummaryBoxPanel({
       <SummaryStat label="Platforms" value={String(summary.platforms.length)} />
       <SummaryStat label="Queries" value={String(summary.query_ids.length)} />
       <SummaryStat
-        label={primaryMetric === "power_score" ? "Best power" : "Best geomean"}
+        label={
+          suppressWinnerClaims
+            ? primaryMetric === "power_score"
+              ? "Highest power score in cohort"
+              : "Lowest geomean in cohort"
+            : primaryMetric === "power_score"
+              ? "Best power"
+              : "Best geomean"
+        }
         value={
           best
             ? `${best.platform} · ${
                 primaryMetric === "power_score" ? fmtScore(best.power_score) : fmtGeomean(best.display_geomean_ms)
-              }`
+              }${suppressWinnerClaims ? " (cohort mismatch — not comparable)" : ""}`
             : "-"
         }
+        title={suppressWinnerClaims ? suppressionReason : undefined}
       />
       <SummaryStat
         label={sampleCount !== null ? "Median samples" : "Phase"}
@@ -653,9 +692,9 @@ function SummaryBoxPanel({
   );
 }
 
-function SummaryStat({ label, value }: { label: string; value: string }) {
+function SummaryStat({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
-    <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3" title={title}>
       <div class="text-xs font-medium uppercase tracking-wide text-gray-500">{label}</div>
       <div class="mt-1 text-sm font-semibold text-gray-900">{value}</div>
     </div>

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -420,4 +420,36 @@ describe("ChartPanel", () => {
     expect(screen.queryByRole("button", { name: "Normalized Speedup" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Performance Trend" })).toBeNull();
   });
+
+  it("uses winner language by default in the summary box", () => {
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary: makeSummary(),
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Summary Box" }));
+    expect(screen.getByText("Best geomean")).toBeTruthy();
+    expect(screen.queryByText(/Lowest geomean in cohort/)).toBeNull();
+    expect(screen.queryByText(/cohort mismatch/)).toBeNull();
+  });
+
+  it("suppresses winner language in the summary box when suppressWinnerClaims is on (w18)", () => {
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary: makeSummary(),
+        }}
+        suppressWinnerClaims
+        suppressionReason="benchmarks differ across results"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Summary Box" }));
+    expect(screen.queryByText("Best geomean")).toBeNull();
+    expect(screen.getByText("Lowest geomean in cohort")).toBeTruthy();
+    expect(screen.getByText(/cohort mismatch — not comparable/)).toBeTruthy();
+  });
 });

--- a/results-explorer/src/lib/__tests__/facetModel.test.ts
+++ b/results-explorer/src/lib/__tests__/facetModel.test.ts
@@ -93,7 +93,37 @@ describe("facet URL contract", () => {
     expect(readFacetParam(params, "benchmark")).toEqual(["tpch", "ssb"]);
     expect(readFacetParam(params, "date_window")).toBe("30d");
     expect(readFacetParam(params, "deployment_class")).toEqual(["cloud"]);
-    expect(readFacetParam(params, "instance_or_warehouse")).toEqual(["m6i.large"]);
+    // w16: when both ?instance_type= and ?warehouse_size= are present, the
+    // shared `instance_or_warehouse` facet must merge them rather than
+    // dropping one. Pre-w16 this returned only ["m6i.large"], silently
+    // discarding the warehouse_size value on the next mount.
+    expect(readFacetParam(params, "instance_or_warehouse")).toEqual(["m6i.large", "MEDIUM"]);
+  });
+
+  it("merges multiple legacy aliases for instance_or_warehouse (w16)", () => {
+    // Multi-value aliases on each side: both halves of the union should
+    // survive after dedupe.
+    const params = new URLSearchParams("instance_type=m6i.large,c5.xlarge&warehouse_size=MEDIUM,LARGE");
+    expect(readFacetParam(params, "instance_or_warehouse")).toEqual([
+      "m6i.large",
+      "c5.xlarge",
+      "MEDIUM",
+      "LARGE",
+    ]);
+  });
+
+  it("dedupes overlapping alias values when merging (w16)", () => {
+    const params = new URLSearchParams("instance_type=foo,bar&warehouse_size=bar,baz");
+    expect(readFacetParam(params, "instance_or_warehouse")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("canonical key takes precedence over aliases when both are present (w16)", () => {
+    // The canonical URL key for instance_or_warehouse is `shape` (see
+    // FACET_URL_KEYS); aliases include `instance_type` and `warehouse_size`.
+    const params = new URLSearchParams(
+      "shape=canonical&instance_type=foo&warehouse_size=bar",
+    );
+    expect(readFacetParam(params, "instance_or_warehouse")).toEqual(["canonical"]);
   });
 
   it("treats legacy all sentinel values as default selections", () => {

--- a/results-explorer/src/lib/chartMath.ts
+++ b/results-explorer/src/lib/chartMath.ts
@@ -94,10 +94,24 @@ export function latencyScaleTicks(scale: LatencyBarScale): number[] {
     return [0, 0.25, 0.5, 0.75, 1].map((fraction) => fraction * scale.domainMax);
   }
 
-  const ticks = LATENCY_LOG_TICKS_MS.filter(
+  // Always include both endpoint ticks so the right edge of the bar chart
+  // has a labelled terminal value. Without this, ranges like 0.2-2 ms or
+  // 100k-50M ms would be plotted against an unlabelled endpoint and the
+  // axis could be misread. Canonical powers of ten remain for interior
+  // labelling; dedupe collapses any duplicates at the endpoints.
+  const interior = LATENCY_LOG_TICKS_MS.filter(
     (ms) => ms >= scale.domainMin * 0.99 && ms <= scale.domainMax * 1.01,
   );
-  return ticks.length >= 2 ? ticks : [scale.min, scale.max];
+  const combined = [scale.domainMin, ...interior, scale.domainMax];
+  const seen = new Set<number>();
+  const ticks: number[] = [];
+  for (const value of combined) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      ticks.push(value);
+    }
+  }
+  return ticks;
 }
 
 // ---------------------------------------------------------------------------

--- a/results-explorer/src/lib/facetModel.ts
+++ b/results-explorer/src/lib/facetModel.ts
@@ -182,10 +182,49 @@ export function readFacetParam<K extends FacetKey>(
   params: URLSearchParams,
   key: K,
 ): FacetState[K] {
-  const raw = findFirstParam(params, [FACET_URL_KEYS[key], ...(FACET_URL_ALIASES[key] ?? [])]);
   const fallback = defaultFacetValue(key);
-  if (raw === null) return fallback;
   const serde = FACET_URL_SERDES[key] as unknown as UrlSerde<FacetState[K]>;
+  const canonicalKey = FACET_URL_KEYS[key];
+  const aliases = FACET_URL_ALIASES[key] ?? [];
+
+  // w16: when the canonical URL key is absent and multiple legacy aliases
+  // are present, merge their values into the canonical list rather than
+  // keeping only the first hit. Example: `?instance_type=foo&warehouse_size=bar`
+  // for `instance_or_warehouse` previously kept just one and silently dropped
+  // the other on the next mount; now both flow through.
+  if (params.get(canonicalKey) === null && aliases.length > 0) {
+    const aliasRaws = aliases
+      .map((alias) => params.get(alias))
+      .filter((value): value is string => value !== null);
+    if (aliasRaws.length > 0) {
+      const decodedValues = aliasRaws
+        .map((raw) => serde.decode(raw))
+        .filter((value): value is FacetState[K] => value !== null);
+      if (decodedValues.length === 0) return fallback;
+      // For array-valued facets, concatenate then dedupe; for scalar facets
+      // (e.g. date_window) the first decoded value wins, matching the
+      // pre-w16 single-source behavior since they don't have multi-alias
+      // arrays in practice.
+      const first = decodedValues[0]!;
+      if (Array.isArray(first)) {
+        const merged: string[] = [];
+        const seen = new Set<string>();
+        for (const decoded of decodedValues as unknown as readonly string[][]) {
+          for (const item of decoded) {
+            if (!seen.has(item)) {
+              seen.add(item);
+              merged.push(item);
+            }
+          }
+        }
+        return normalizeFacetValue(key, merged as FacetState[K]);
+      }
+      return normalizeFacetValue(key, first);
+    }
+  }
+
+  const raw = findFirstParam(params, [canonicalKey, ...aliases]);
+  if (raw === null) return fallback;
   const decoded = serde.decode(raw);
   return decoded === null ? fallback : normalizeFacetValue(key, decoded);
 }

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -367,6 +367,8 @@ export function Compare(_: RoutableProps) {
             context={{ kind: "compare", results, primaryMetric }}
             baselineIndex={normalizedBaselineIndex}
             onBaselineIndexChange={setBaselineIndex}
+            suppressWinnerClaims={severeMismatchReason !== null}
+            suppressionReason={severeMismatchReason ?? undefined}
           />
         </div>
       )}

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -328,7 +328,12 @@ export function Home(_: RoutableProps) {
                 allLabel="All benchmarks"
                 options={benchmarkOptions}
                 current={benchmarkFilters}
-                onSelect={(value) => setFacet("benchmark", value === "all" ? [] : [value])}
+                onSelect={(value) =>
+                  setFacet(
+                    "benchmark",
+                    value === "all" ? [] : toggleFacetValue(benchmarkFilters, value),
+                  )
+                }
                 format={(value) => humanizeBenchmark(value)}
               />
               <MultiSelectFilter
@@ -336,7 +341,12 @@ export function Home(_: RoutableProps) {
                 allLabel="All scales"
                 options={scaleOptions}
                 current={scaleFilters}
-                onSelect={(value) => setFacet("scale_factor", value === "all" ? [] : [value])}
+                onSelect={(value) =>
+                  setFacet(
+                    "scale_factor",
+                    value === "all" ? [] : toggleFacetValue(scaleFilters, value),
+                  )
+                }
                 format={(value) => `SF ${value}`}
               />
               <SelectFilter
@@ -715,6 +725,18 @@ function appendFacetParams(params: URLSearchParams, facets: FacetState, omit: Re
 
 function singleFacetValue(values: string[]): string {
   return values.length === 1 ? (values[0] ?? "all") : "all";
+}
+
+// w13: preserve multi-select semantics when the user clicks an option in the
+// dropdown. URL state already models bm/sf as arrays (e.g. ?bm=tpch,clickbench),
+// but the prior `[value]` replacement collapsed any subsequent click to a
+// single-element array, breaking cross-benchmark / cross-scale comparison
+// flows. Toggling keeps the rest of the selection intact.
+export function toggleFacetValue(current: string[], value: string): string[] {
+  const next = current.includes(value)
+    ? current.filter((entry) => entry !== value)
+    : [...current, value];
+  return next;
 }
 
 function toDateWindowFacet(value: string): DateWindowFacet {

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -12,7 +12,7 @@ import {
   EXPLORER_PERFORMANCE_MEASURES,
   clearExplorerPerformanceEntriesForTests,
 } from "@/lib/performanceMarks";
-import { Home } from "@/pages/Home";
+import { Home, toggleFacetValue } from "@/pages/Home";
 
 /**
  * ResultRow fixtures - shape mirrors `bench.results` (SELECT * FROM bench.results).
@@ -585,5 +585,28 @@ describe("Home", () => {
     expect(cohortLink.getAttribute("href")).toContain("sf=0.1");
     expect(cohortLink.getAttribute("href")).toContain("phase=power");
     expect(cohortLink.getAttribute("href")).toContain("tuning=auto");
+  });
+});
+
+describe("toggleFacetValue (w13)", () => {
+  it("removes a value when it is already selected, leaving siblings intact", () => {
+    // Pre-w13 the dropdown handler did `[value]` (single-element replacement),
+    // collapsing ?bm=tpch,clickbench to just one entry on any subsequent click.
+    expect(toggleFacetValue(["tpch", "clickbench"], "tpch")).toEqual(["clickbench"]);
+    expect(toggleFacetValue(["tpch", "clickbench"], "clickbench")).toEqual(["tpch"]);
+  });
+
+  it("adds a value when it is not already selected", () => {
+    expect(toggleFacetValue(["tpch"], "clickbench")).toEqual(["tpch", "clickbench"]);
+  });
+
+  it("returns an empty list when toggling the only selected value", () => {
+    expect(toggleFacetValue(["tpch"], "tpch")).toEqual([]);
+  });
+
+  it("does not mutate the input list", () => {
+    const input = ["tpch", "clickbench"];
+    toggleFacetValue(input, "tpch");
+    expect(input).toEqual(["tpch", "clickbench"]);
   });
 });

--- a/tests/integration/test_hosted_submit_validator_contract.py
+++ b/tests/integration/test_hosted_submit_validator_contract.py
@@ -220,3 +220,77 @@ def test_hosted_manifest_schema_matches_pr_flow_for_required_keys(tmp_path: Path
     # for the same source file — the manifests differ only in metadata.
     for key in ("bundle_file", "bundle_hash", "benchmark", "platform", "scale_factor"):
         assert pr_manifest[key] == hosted_manifest[key], f"{key} drift"
+
+
+def test_hosted_and_pr_manifest_built_via_dispatch_call_sites(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """w21 regression: drive each manifest through its dispatching call site
+    (the hosted-service path and the PR-package path) rather than calling
+    ``_build_submission_manifest`` directly with hard-coded arguments. If a
+    future iteration of either dispatch mutates the manifest after
+    construction or starts passing different arguments, the parity check
+    below catches it; the previous direct-construction test could not."""
+    from click.testing import CliRunner
+
+    sub = importlib.import_module("benchbox.cli.commands.submit")
+
+    src = tmp_path / "tpch_duckdb.json"
+    src.write_text(json.dumps(_minimal_schema_v2_bundle()), encoding="utf-8")
+
+    monkeypatch.setattr(sub, "load_result_file", lambda *_a, **_k: (_fake_result(), {}))
+
+    # ----- Drive the PR-package path through the CLI to capture its manifest -----
+    out_dir = tmp_path / "submission"
+    pr_result = CliRunner().invoke(sub.submit, [str(src), "--output", str(out_dir)])
+    assert pr_result.exit_code == 0, pr_result.output
+    pr_manifest_path = out_dir / "tpch_duckdb.manifest.json"
+    assert pr_manifest_path.exists(), pr_result.output
+    pr_manifest = json.loads(pr_manifest_path.read_text(encoding="utf-8"))
+
+    # ----- Drive the hosted dispatch path with stubbed network calls --------
+    captured_manifest: dict[str, dict] = {}
+
+    def fake_submit_hosted_bundle(*, manifest: dict, bundle_hash: str, **_kwargs):
+        captured_manifest["payload"] = manifest
+        from benchbox.cli.submit_service import HostedSubmitResult, make_idempotency_key
+
+        return HostedSubmitResult(
+            status="accepted",
+            idempotency_key=make_idempotency_key("https://hosted.invalid", bundle_hash),
+            submission_id="fake-id",
+        )
+
+    monkeypatch.setattr(sub, "submit_hosted_bundle", fake_submit_hosted_bundle)
+    monkeypatch.setattr(
+        sub,
+        "resolve_submission_token",
+        lambda _service_url: SimpleNamespace(token="fake-token"),
+    )
+    monkeypatch.setattr(
+        sub,
+        "record_hosted_submission",
+        lambda **_kwargs: tmp_path / "fake_history.json",
+    )
+
+    hosted_result = CliRunner().invoke(
+        sub.submit,
+        [
+            str(src),
+            "--service",
+            "https://hosted.invalid",
+            "--no-wait",
+            "--visibility",
+            "public",
+        ],
+    )
+    assert hosted_result.exit_code == 0, hosted_result.output
+    assert "payload" in captured_manifest, "hosted dispatch never called submit_hosted_bundle"
+    hosted_manifest = captured_manifest["payload"]
+
+    # Same key set; hosted vs PR diverges only in submission_path metadata.
+    assert set(pr_manifest.keys()) == set(hosted_manifest.keys()), (
+        f"hosted vs PR manifest key drift via dispatch call sites. PR={set(pr_manifest)}, hosted={set(hosted_manifest)}"
+    )
+    assert pr_manifest["submission_path"] == "PR-based"
+    assert hosted_manifest["submission_path"] == "hosted-service"
+    for key in ("bundle_file", "bundle_hash", "benchmark", "platform", "scale_factor"):
+        assert pr_manifest[key] == hosted_manifest[key], f"{key} drift via dispatch call sites"

--- a/tests/integration/worktree/test_worktree_pool_check.py
+++ b/tests/integration/worktree/test_worktree_pool_check.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -103,10 +104,36 @@ def test_pool_check_fails_when_claim_in_progress_marker_present(tmp_path: Path) 
     marker = pool_parent / "BenchBox.pool-01" / ".benchbox" / "claim_in_progress"
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("pid=99999 started=2026-05-02T00:00:00Z branch=feature/dead\n", encoding="utf-8")
+    # w20: pool-check ignores fresh `claim_in_progress` markers (an in-flight
+    # `worktree-claim` writes one at the start of a normal claim and removes
+    # it at the end), so for the aborted-detection test we need to either
+    # backdate the marker beyond the stale threshold, or override the
+    # threshold to 0 for the test invocation. Backdate the mtime to one
+    # hour ago so the test exercises a genuinely stale marker.
+    one_hour_ago = time.time() - 3600
+    os.utime(marker, (one_hour_ago, one_hour_ago))
     result = invoke_check(main, pool_parent, pool_size=2)
     assert result.returncode != 0
     assert "aborted" in result.stderr
     assert "pool-01" in result.stderr
+
+
+def test_pool_check_ignores_fresh_claim_in_progress_marker(tmp_path: Path) -> None:
+    """w20 regression: a fresh ``.benchbox/claim_in_progress`` marker
+    indicates an active concurrent claim, not an aborted slot. The check
+    is documented as periodic / cron-safe; flagging in-flight claims as
+    aborted produces false positives that mask real pool problems."""
+    main, pool_parent = setup_pool(tmp_path, num_slots=2)
+    marker = pool_parent / "BenchBox.pool-01" / ".benchbox" / "claim_in_progress"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("pid=99999 started=2026-05-02T00:00:00Z branch=feature/active\n", encoding="utf-8")
+    # Fresh mtime (newly written above) — must NOT be flagged as aborted.
+    result = invoke_check(main, pool_parent, pool_size=2)
+    assert result.returncode == 0, (
+        f"pool-check flagged a fresh claim_in_progress marker as aborted "
+        f"(stdout={result.stdout!r}, stderr={result.stderr!r})"
+    )
+    assert "aborted" not in result.stderr.lower()
 
 
 def test_pool_check_fails_when_extra_slot_beyond_pool_size(tmp_path: Path) -> None:

--- a/tests/unit/core/cost/test_calculator.py
+++ b/tests/unit/core/cost/test_calculator.py
@@ -201,6 +201,43 @@ class TestCostCalculator:
         assert normalized_cost.normalized_cost_usd == 0
         assert normalized_cost.cost_usd is None
 
+    def test_dataframe_variant_platforms_are_local(self):
+        """w14 regression: every registered DataFrame variant whose primary
+        execution is on the developer's machine must be classified as local
+        so cost normalization yields ``not_applicable_local`` rather than
+        ``unavailable``. Prior to w14, ``datafusion-df`` and ``pyspark-df``
+        were missing from the allowlist, polluting cost facets and the
+        empty-state logic that depends on ``cost_status``."""
+        calculator = CostCalculator()
+        for platform_id in [
+            "datafusion",
+            "datafusion-df",
+            "polars",
+            "polars-df",
+            "pandas-df",
+            "cudf-df",
+            "modin-df",
+            "dask-df",
+            "pyspark",
+            "pyspark-df",
+            "lakesail",
+            "lakesail-df",
+            "duckdb",
+            "sqlite",
+        ]:
+            assert calculator.is_local_platform(platform_id), (
+                f"{platform_id!r} should be classified as a local platform"
+            )
+
+    def test_cloud_platforms_are_not_local(self):
+        """w14 sanity check: known cloud platforms remain non-local so cost
+        normalization keeps trying to resolve their region/cloud pricing."""
+        calculator = CostCalculator()
+        for platform_id in ["snowflake", "bigquery", "redshift", "databricks", "athena"]:
+            assert not calculator.is_local_platform(platform_id), (
+                f"{platform_id!r} should NOT be classified as a local platform"
+            )
+
     def test_normalized_benchmark_cost_unavailable_when_metadata_defaulted(self):
         """Cloud rows with defaulted pricing metadata do not become comparable normalized costs."""
         calculator = CostCalculator()

--- a/tests/unit/platforms/test_motherduck.py
+++ b/tests/unit/platforms/test_motherduck.py
@@ -230,6 +230,60 @@ class TestMotherDuckFromConfig:
         assert adapter.memory_limit == "8GB"
 
 
+class TestMotherDuckConfigBuilder:
+    """w19 regression: the credential wizard saves a `database` field, but the
+    default registry builder did not call CredentialManager, so runtime always
+    fell back to the adapter's internal default (``benchbox``). Routing
+    MotherDuck through ``_build_motherduck_config`` (registered in
+    benchbox/platforms/__init__.py) pulls the wizard-saved database into
+    runtime config so adapters land on the configured database."""
+
+    def test_config_builder_pulls_database_from_credential_manager(self, monkeypatch):
+        from benchbox.platforms.motherduck import _build_motherduck_config
+
+        # Patch CredentialManager to return a wizard-saved database value.
+        class _FakeCredentialManager:
+            def get_platform_credentials(self, key: str):
+                assert key == "motherduck"
+                return {"database": "wizard_saved_db", "token_env_var": "MOTHERDUCK_TOKEN"}
+
+        monkeypatch.setattr(
+            "benchbox.security.credentials.CredentialManager",
+            lambda: _FakeCredentialManager(),
+        )
+
+        config = _build_motherduck_config(
+            "motherduck",
+            options={},
+            overrides={},
+            info=None,
+        )
+
+        assert config.options["database"] == "wizard_saved_db"
+        assert config.options["token_env_var"] == "MOTHERDUCK_TOKEN"
+
+    def test_explicit_cli_database_overrides_credential_value(self, monkeypatch):
+        from benchbox.platforms.motherduck import _build_motherduck_config
+
+        class _FakeCredentialManager:
+            def get_platform_credentials(self, key: str):
+                return {"database": "saved_db"}
+
+        monkeypatch.setattr(
+            "benchbox.security.credentials.CredentialManager",
+            lambda: _FakeCredentialManager(),
+        )
+
+        config = _build_motherduck_config(
+            "motherduck",
+            options={},
+            overrides={"_explicit_platform_options": {"database": "cli_db"}},
+            info=None,
+        )
+
+        assert config.options["database"] == "cli_db"
+
+
 class TestMotherDuckCreateConnection:
     """Test create_connection with a mocked duckdb.connect."""
 


### PR DESCRIPTION
Nine UX/robustness/tooling-polish findings from
codex-pr-review-followups-week-2026-05-03, batched into one PR per the
user-directed wave grouping.

w13 (PR #102, Home.tsx): preserve multi-select semantics for the
  benchmark/scale_factor leaderboard filters. URL state already models
  these as arrays; the prior `[value]` replacement collapsed any
  subsequent click to a single-element array. Now the dropdown handler
  toggles via toggleFacetValue, keeping cross-benchmark / cross-scale
  comparisons reachable from the page controls.

w14 (PR #105, cost/calculator.py): add datafusion-df, pyspark-df,
  lakesail, lakesail-df to the local-platform allowlist so their cost
  status normalizes to not_applicable_local rather than unavailable,
  matching the registered platform-manager IDs.

w15 (PR #107, chartMath.ts): always include scale.domainMin and
  scale.domainMax as endpoint ticks in the log-mode latency axis so the
  right edge of the bar chart has a labelled terminal value. Prior
  ranges like 0.2–2 ms or 100k–50M ms plotted bars against an
  unlabelled endpoint and could be misread.

w16 (PR #111, facetModel.ts): when the canonical URL key is absent and
  multiple legacy aliases are present (e.g. ?instance_type=foo&warehouse_size=bar
  for instance_or_warehouse), merge values across aliases instead of
  keeping only the first hit. Prevents Query-page filter loss after the
  shared facet state mounts.

w18 (PR #115, Compare.tsx + ChartPanel.tsx): thread suppressWinnerClaims
  / suppressionReason from the Compare page into ChartPanel and
  SummaryBoxPanel so the cohort-mismatch guardrail also strips
  "Best power" / "Best geomean" wording from the chart-level summary.
  Replaces winner language with neutral "Highest power score in cohort
  (cohort mismatch — not comparable)".

w19 (PR #119, motherduck.py + platforms/__init__.py): register a
  _build_motherduck_config builder and wire it through the lazy config
  registry. The credential setup wizard saves a `database` field, but
  the default builder did not call CredentialManager, so runtime always
  fell back to the adapter's internal default. Wizard-saved database
  values now actually reach the run.

w20 (PR #129, Makefile): treat `.benchbox/claim_in_progress` markers as
  aborted only when older than POOL_CLAIM_MARKER_STALE_SECONDS (default
  600s). Fresh markers indicate an in-flight `worktree-claim` and must
  not produce false positives in the documented periodic / cron use of
  `worktree-pool-check`.

w21 (PR #131, test_hosted_submit_validator_contract.py): drive the
  hosted-vs-PR manifest parity check through each dispatch call site
  (CLI hosted-service path with stubbed network, CLI PR-package path
  via --output) rather than calling _build_submission_manifest directly
  with hard-coded arguments. Catches drift in either dispatch's call
  shape, not just the helper signature.

w24 (PR #167, sync-results-data-to-published.yml): pin the workflow
  checkout to ${{ github.sha }} instead of `ref: develop`. With
  concurrency.cancel-in-progress set to false, queued older runs would
  otherwise mirror newer corpus content while naming the branch / PR
  with the older GITHUB_SHA, producing misattributed mirror PRs.

Tests: regression coverage in tests/{unit,integration} and
results-explorer/src/{__tests__,lib/__tests__,pages/__tests__,
components/__tests__}/. The existing
test_pool_check_fails_when_claim_in_progress_marker_present was
backdated to exercise a genuinely stale marker; a paired
test_pool_check_ignores_fresh_claim_in_progress_marker locks in the
new fresh-marker behavior.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
