### PR TITLE
docs(blog): revise sketch outline #12 for currency drift + framing

### DIFF
--- a/_blog/building-benchbox/outlines/12-sketch-functions-databricks-response.md
+++ b/_blog/building-benchbox/outlines/12-sketch-functions-databricks-response.md
@@ -6,15 +6,15 @@ author: Joe Harris
 series: building-benchbox
 post_number: 12
 type: architecture-design
-tags: benchbox, approximate-functions, sketches, datasketches, hyperloglog, kll, theta, top-k, databricks, snowflake, bigquery, redshift, clickhouse, duckdb, methodology, design-decision
+tags: benchbox, sketches, datasketches, databricks, clickhouse, duckdb, methodology, design-decision
 meta_description: "Why responding to Databricks' new sketch functions took two BenchBox benchmarks instead of one — and what cross-engine sketch coverage actually looks like."
 ---
 
 # Two benchmarks for one announcement: covering Databricks' new sketch functions in BenchBox
 
-> Databricks shipped sketch functions for distinct counts, quantiles, and top-K. The headline claim wasn't the function names — it was that sketches are *storable, mergeable, requeryable artifacts*. Function-parity tables miss that distinction entirely.
+> Databricks shipped sketch functions for distinct counts, quantiles, and top-K. The headline isn't the function names — it's that sketches are *storable, mergeable, requeryable artifacts*. That's not a single-query story.
 
-**TL;DR**: BenchBox v0.2.x adds approximate-aggregate coverage to `read_primitives` (5 new queries: HLL distinct, KLL/T-Digest single quantile, vector quantiles, top-K) and a new `sketch` category to `write_primitives` (8 ops covering DataSketches Theta/KLL/Top-K persist + merge + requery). Splitting coverage across two benchmarks was a deliberate choice: the single-query catalog can measure aggregate latency, but it cannot exercise the persist/merge/requery loop that vendors actually compete on. Cross-engine coverage now spans 7 engines, with documented HLL-only ceilings on Redshift, native-but-distinct sketch state on ClickHouse, and explicit skips on DataFusion. The companion docs ship the per-engine function-name reference: [`read_primitives`](https://github.com/joeharris76/BenchBox/blob/develop/docs/benchmarks/read-primitives-approximate-functions.md), [`write_primitives` sketch](https://github.com/joeharris76/BenchBox/blob/develop/docs/benchmarks/write-primitives-sketch-functions.md).
+**TL;DR**: BenchBox develop (shipping in v0.3.0) covers the full Databricks sketch announcement: 5 approximate-aggregate queries in `read_primitives` and 16 persist+merge+requery ops in a new `write_primitives` sketch category (Theta, KLL, Top-K, plus DuckDB-only CPC and REQ families). Cross-engine sketch coverage spans 7 engines, including ClickHouse 8/8 via `-State`/`-Merge` combinators and Redshift via HLL substitution; DataFusion is the no-support skip. Storage-size validation now rides alongside scalar-bounds validation on the ★ headline ops.
 
 ---
 
@@ -22,18 +22,18 @@ meta_description: "Why responding to Databricks' new sketch functions took two B
 
 **Primary audience**: Data engineers and analytics engineers who read the Databricks announcement and want to know what cross-engine support actually looks like, plus BenchBox users who want to evaluate sketch performance on their own platform mix.
 
-**Secondary audience**: Benchmark designers and OSS maintainers who care about evaluation methodology — specifically about how to keep parity-table evaluations from missing the actually-novel half of a vendor announcement.
+**Secondary audience**: Benchmark designers and OSS maintainers who care about evaluation methodology — specifically about how to keep parity-table evaluations from missing the persistence half of a vendor announcement.
 
 **Out of scope** (call out, don't cover):
 - Approximation-quality tradeoffs (relative-error vs. exact). BenchBox measures latency under approximate semantics, not error magnitude. Deferred to a future benchmark.
 - Cross-engine sketch *portability* tests (write a sketch on engine A, query it on engine B). Needs two-engine orchestration BenchBox does not have today.
-- Parameter sweeps over `lg_k` / `k` / `lg_max_map_size`. Tracked in `write-primitives-sketch-parameter-sweeps`, blocked on architecture fixes.
+- Parameter sweeps over `lg_k` / `k` / `lg_max_map_size`. Tracked in `write-primitives-sketch-parameter-sweeps`.
 
 ---
 
 ## Thesis and key insight
 
-**Thesis**: Function-parity tables were the obvious response to the Databricks sketch announcement, but they capture only the boring half of what the post claims. The differentiated capability — millisecond merge across persisted sketch artifacts — needs an execution model with persistence and multi-query state. BenchBox's `read_primitives` cannot express that loop; `write_primitives` can. So the right response is two benchmarks, not one, with explicit honest-accounting on which engines clear which bar.
+**Thesis**: Function-parity tables were the obvious response to the Databricks sketch announcement, but they capture only the aggregate-latency path. The persist+merge+requery path needs an execution model with persistence and multi-query state. BenchBox's `read_primitives` cannot express that loop; `write_primitives` can. So the right response is two benchmarks, not one, with explicit accounting of which engines clear which bar.
 
 **The framework-gap insight** (recorded as a blind-spot finding, `2026-05-02-084332`):
 > The standard parity-table evaluation framework under-weights "stored,
@@ -42,7 +42,7 @@ meta_description: "Why responding to Databricks' new sketch functions took two B
 > for "does this benchmark's execution model fit the capability under
 > test."
 
-This is reusable: it applies to any vendor announcement framed as "stored, mergeable, requeryable" — sketches today, search indexes tomorrow, vector indexes the day after, incremental MVs after that, ML feature stores after that. Every time, the parity table will say "add the queries"; every time, the single-query benchmark will fail to exercise what's actually announced.
+The pattern is reusable. Any vendor announcement framed as "stored, mergeable, requeryable" — sketches today, vector indexes tomorrow, incremental MVs after that — surfaces the same execution-model question. Single-query catalogs can run the queries and produce numbers; they can't exercise the differentiated capability.
 
 ---
 
@@ -51,12 +51,12 @@ This is reusable: it applies to any vendor announcement framed as "stored, merge
 ### 1. The Problem (~300 words) — What Databricks announced and why parity tables miss the point
 
 - The April 2026 Databricks post: new sketch functions across three families (Theta-style distinct, KLL quantile, Top-K accumulator) with `*_accumulate` / `*_combine` / `*_estimate` trios.
-- Surface-level read: parity-table evaluation. Map each new function to its peer on Snowflake / BigQuery / DuckDB / ClickHouse / Redshift. Mark the gaps.
-- Hidden claim: **sketches are storable, mergeable, requeryable artifacts**. Aggregate latency has been "approximate-is-faster-than-exact" on every engine for a decade. The novel claim is "store sketches as columns, merge across time/partition, requery in milliseconds."
-- Why parity tables fail: the rubric has no axis for "does the benchmark's execution model fit the capability under test." A read-only single-query catalog can score aggregate latency, but it cannot exercise persist + merge + requery.
-- The L2 audit insight (cite the blind-spot file): single-query benchmarks can technically run sketch queries and produce numbers, but those numbers measure the trivial half of the announcement. The post will look correct on paper while missing the differentiated capability.
+- Surface-level read: parity-table evaluation. Map each new function to its peer on Snowflake / BigQuery / DuckDB / ClickHouse / Redshift. Mark the gaps. Ship a coverage table.
+- The persist+merge+requery story: **sketches are storable, mergeable, requeryable artifacts** — store sketches as columns, merge across time/partition, requery at near-constant cost. The aggregate-latency path has been "approximate-is-faster-than-exact" on every engine for a decade; the persist+merge+requery path is where vendors compete now.
+- Why parity tables come up short: the rubric has no axis for "does the benchmark's execution model fit the capability under test." A read-only single-query catalog can score aggregate latency, but it cannot exercise persist + merge + requery.
+- The L2 audit insight (cite the blind-spot file): single-query benchmarks can technically run sketch queries and produce numbers, but those numbers measure the aggregate-latency path. The post will look correct on paper while not exercising the persist+merge+requery story the announcement is centered on.
 
-**Key quotes/data points to include**:
+**Key data points to include**:
 - The exact `*_accumulate` / `*_combine` / `*_estimate` function trio from the Databricks post.
 - One paragraph paraphrasing what "millisecond-merge across partitioned sketch columns" actually means operationally.
 
@@ -65,17 +65,17 @@ This is reusable: it applies to any vendor announcement framed as "stored, merge
 - First-pass evaluation: function-by-function competitor parity research (see `_project/DONE/main/read-primitives-approximate-aggregate-queries.yaml`). The output was a clean table mapping each new Databricks function to its peer across 6 engines.
 - The L2 blind-spot audit caught the gap before queries shipped: `read_primitives` is structurally a single-query benchmark. Each query in `catalog/queries.yaml` runs in isolation against TPC-H tables, with no facility to write a sketch column, read it back later, or merge across partitions in a multi-query workflow.
 - Two options considered:
-  - **Option A**: Add sketch-aggregate queries to `read_primitives`. Honest: cheap, single-PR, measures latency. Dishonest: claims to cover the announcement while only exercising the un-novel half.
-  - **Option B**: Add a new `sketch` category to `write_primitives`. Honest: actually exercises persist + merge + requery. Cost: requires platform_overrides for cross-dialect DDL, BINARY column type translation, tolerance-based validation for non-deterministic sketch outputs, and explicit Redshift HLL-substitution.
+  - **Option A**: Add sketch-aggregate queries to `read_primitives`. Cheap, single-PR, measures aggregate latency. But it would only exercise the aggregate-latency path, not the persist+merge+requery loop the announcement centers on.
+  - **Option B**: Add a new `sketch` category to `write_primitives`. Actually exercises persist + merge + requery. Cost: requires `platform_overrides` for cross-dialect DDL, BINARY column-type translation, tolerance-based validation for non-deterministic sketch outputs, and explicit Redshift HLL-substitution.
 - The decision: do both, with explicit cross-references in both docs explaining which capability each benchmark covers.
-- A second-order finding from implementation: the architecture itself wasn't ready. Two write_primitives architectural gaps surfaced when the ClickHouse + cloud verification work started:
+- A second-order finding from implementation: the `write_primitives` architecture itself wasn't ready. Two gaps surfaced when ClickHouse + cloud verification work started:
   - `validation_query` had no per-platform override mechanism (`2026-05-02-155448`)
   - `WriteOperationType` enum had no aggregate-state shape for DataFrame engines (`2026-05-02-163132`)
-- Both fixes landed in the architecture-fixes work-item; the cloud verification, ClickHouse-native variants, DuckDB CPC/REQ families, PySpark DataFrame surface, and parameter sweeps are queued behind it. Honest accounting: cloud verification is deferred until credentials are available; cross-cloud measurements are not in this announcement.
+- Both fixes shipped in `feat/write-primitives-architecture-fixes` (PR #176): `validation_query.platform_overrides` mirrors the existing `write_sql.platform_overrides`, and `AGGREGATE_PERSIST` / `AGGREGATE_MERGE` op types extend the DataFrame execution model. The ClickHouse-native variants (PR #180) and DuckDB CPC/REQ families (PR #182) followed immediately, so the catalog surface today is broader than the original first-pass plan: 16 sketch ops covering five families. Cloud verification is the remaining deferral, blocked only on Snowflake / BigQuery / Databricks / Redshift credentials.
 
 **Key data points**:
-- Catalog of architectural gaps surfaced (table linking blind-spot file → resolution TODO).
-- Why "skip the persistence half" was rejected (it's the differentiated claim).
+- Catalog of architectural gaps surfaced (table linking blind-spot file → resolution PR).
+- Why "skip the persistence half" was rejected (it's the central claim of the announcement).
 
 ### 3. What We Built (~600 words) — The two-benchmark coverage with cross-engine matrices
 
@@ -91,19 +91,15 @@ This is reusable: it applies to any vendor announcement framed as "stored, merge
 | `approx_quantiles_array` | Vector quantiles per group | redshift, datafusion, sqlite |
 | `approx_top_k_lineitem` | Approximate top-K | redshift, datafusion, sqlite |
 
-Cross-engine function reference table (compressed; full version in docs):
+Cross-engine function-name reference (DuckDB / Snowflake / BigQuery / Databricks / ClickHouse / Redshift / DataFusion) lives in [`docs/benchmarks/read-primitives-approximate-functions.md`](https://github.com/joeharris76/BenchBox/blob/develop/docs/benchmarks/read-primitives-approximate-functions.md). Sample row to anchor the post:
 
 | Engine | Distinct | Quantile | Top-K |
 |--------|----------|----------|-------|
-| DuckDB | `APPROX_COUNT_DISTINCT` | `APPROX_QUANTILE(x, 0.5)` | `APPROX_TOP_K(x, 5)` |
-| Snowflake | `APPROX_COUNT_DISTINCT` | `APPROX_PERCENTILE(x, 0.5)` | `APPROX_TOP_K(x, 5)` |
-| BigQuery | `APPROX_COUNT_DISTINCT` | `APPROX_QUANTILES(x, 100)[OFFSET(50)]` | `APPROX_TOP_COUNT(x, 5)` |
-| Databricks | `approx_count_distinct` | `PERCENTILE_APPROX(x, 0.5)` | `approx_top_k(x, 5)` |
-| ClickHouse | `uniq` | `quantileTDigest(0.5)(x)` | `topK(5)(x)` |
+| DuckDB | `APPROX_COUNT_DISTINCT(x)` | `APPROX_QUANTILE(x, 0.5)` | `APPROX_TOP_K(x, 5)` |
+| ClickHouse | `uniq(x)` | `quantileTDigest(0.5)(x)` | `topK(5)(x)` |
 | Redshift | `APPROXIMATE COUNT(DISTINCT x)` | `APPROXIMATE PERCENTILE_DISC(0.5)…` | — (no top-K) |
-| DataFusion | `approx_distinct` | `approx_percentile_cont(x, 0.5)` | — |
 
-DataFrame surface (separate matrix; sketch-backed vs exact-fallback distinction):
+DataFrame surface — sketch-backed vs exact-fallback distinction:
 
 | Query | Polars | PySpark | DataFusion | pandas / Modin / cuDF | Dask |
 |-------|--------|---------|-----------|-----------------------|------|
@@ -111,41 +107,45 @@ DataFrame surface (separate matrix; sketch-backed vs exact-fallback distinction)
 | `approx_quantile_groupby` | exact | `percentile_approx` (KLL) | `approx_percentile_cont` (T-Digest) | exact | exact |
 | `approx_quantiles_array`, `approx_top_k_lineitem` | (skip) | (skip) | (skip) | (skip) | (skip) |
 
-Honest accounting: pandas / Modin / cuDF have no native sketch surface, so their "approximate" rows fall back to exact aggregates and are not directly comparable to sketch-backed engines on the same row.
+Pandas / Modin / cuDF have no native sketch surface, so their "approximate" rows fall back to exact aggregates — the benchmark still runs and reports a number, but it's the exact aggregate's latency, not directly comparable to sketch-backed engines on the same row.
 
 #### `write_primitives` sketch category (persist + merge + requery)
 
-8 ops covering the full DataSketches lifecycle:
+The Theta / KLL / Top-K trio is the original 8 ops. Two more families landed in PR #182 (DuckDB-only): CPC for HLL-family distinct-count with much smaller serialized state (~1.2 KB merged at SF=0.01 vs Theta's ~16 KB), and REQ for relative-error quantiles (vs KLL's normalized-rank error). 16 ops total today.
 
-| Op | Stage | Notes |
-|----|-------|-------|
-| `sketch_ddl_create_persistent_table` | DDL | CREATE/DROP overhead with BINARY columns |
-| `sketch_insert_theta_per_partition` | INSERT | Build Theta sketches per (date, region) |
-| `sketch_insert_kll_per_partition` | INSERT | Build KLL price sketches per (date, region) |
-| `sketch_insert_topk_per_shard` | INSERT | Build frequent-items sketches per shard |
-| ★ `sketch_query_theta_union_merge` | MERGE | HEADLINE — distinct from merged thetas |
-| ★ `sketch_query_kll_quantiles_merge` | MERGE | HEADLINE — median from merged KLLs |
-| ★ `sketch_query_topk_combine` | MERGE | HEADLINE — frequent items count from merge |
-| `sketch_drop_persistent_table` | DDL | DROP overhead |
+| Family | Ops | Stage | Notes |
+|--------|-----|-------|-------|
+| Theta (distinct) | DDL → insert → ★ merge → DROP | full | DataSketches binary-portable across DuckDB / Databricks / Snowflake; HLL substitution on BigQuery / Redshift; ClickHouse via `uniqState`/`uniqMerge` |
+| KLL (quantile) | DDL → insert → ★ merge → DROP | full | DataSketches across DuckDB / Databricks / Snowflake / BigQuery; `quantileTDigestState` on ClickHouse; skipped on Redshift |
+| Top-K (frequent items) | DDL → insert → ★ merge → DROP | full | DataSketches across DuckDB / Databricks / Snowflake; `topKState(8)` on ClickHouse; skipped on BigQuery / Redshift |
+| CPC (distinct, compact) | DDL → insert → merge → DROP | DuckDB-only | Compressed Probabilistic Counting; ~1.2 KB merged vs Theta's ~16 KB at SF=0.01; tradeoff is slower update/merge throughput |
+| REQ (quantile, rel-err) | DDL → insert → merge → DROP | DuckDB-only | Relative-error quantiles; ~2.5 KB merged at SF=0.01 |
 
-Sketch-family × engine support (compressed):
+Sketch-family × engine support, post-PR #180:
 
-| Family | DataSketches binary-portable | Native-but-distinct | No support |
-|--------|------------------------------|----------------------|------------|
-| Theta (distinct) | Databricks, Snowflake, BigQuery (HLL substitution), DuckDB ext | ClickHouse (`-State`/`-Merge`), Redshift (HLL substitution) | DataFusion |
-| KLL (quantile) | Databricks, Snowflake, BigQuery, DuckDB ext | ClickHouse (`quantileTDigestState`) | Redshift, DataFusion |
-| Top-K | Databricks, Snowflake, DuckDB ext | ClickHouse (`topKState`) | Redshift, BigQuery, DataFusion |
+| Family | DataSketches binary-portable | ClickHouse-native combinators | HLL substitution | No support |
+|--------|------------------------------|--------------------------------|------------------|-----------|
+| Theta (distinct) | Databricks, Snowflake, DuckDB ext | ClickHouse (`uniqState`/`uniqMerge`) | BigQuery, Redshift | DataFusion |
+| KLL (quantile) | Databricks, Snowflake, BigQuery, DuckDB ext | ClickHouse (`quantileTDigestState`) | — | Redshift, DataFusion |
+| Top-K | Databricks, Snowflake, DuckDB ext | ClickHouse (`topKState(8)`) | — | BigQuery, Redshift, DataFusion |
+| CPC | DuckDB ext only | — | — | all others |
+| REQ | DuckDB ext only | — | — | all others |
 
-Validation tolerance methodology — the ★ headline ops use `expected_value_min/max` because sketch outputs are non-deterministic across engines and runs. Bounds intentionally wide enough never to false-fail, tight enough to catch a regression to no-op or a wildly off estimate.
+ClickHouse coverage went from 0/8 (all skipped via `null` overrides) to 8/8 in PR #180 — full cross-engine sketch matrix for the Theta / KLL / Top-K trio. ClickHouse's combinator format isn't binary-portable with DataSketches, but the persist+merge+requery shape behaves identically.
 
-Redshift HLL-only ceiling — the catalog explicitly carries Redshift overrides that substitute `HLL_CREATE_SKETCH` / `HLL_COMBINE` / `HLL_CARDINALITY` for the Theta path, with KLL and Top-K skipped honestly. Redshift's `HLLSKETCH` columns carry non-trivial DDL restrictions (cannot be DISTKEY/SORTKEY, cannot appear in GROUP BY) that the Redshift-specific DDL emits inline.
+**Two validation axes per ★ headline op** (PR #180):
+- *Scalar bounds* — distinct count, median, frequent-item count must land inside `expected_value_min/max`.
+- *Storage size* — `octet_length(<sketch>)` on DuckDB, `length(toString(<agg>MergeState(...)))` on ClickHouse. Bounds tuned per engine because the encodings differ; the check certifies the merged state hasn't regressed to zero or grown unbounded.
+
+Redshift HLL-only ceiling — the catalog explicitly carries Redshift overrides that substitute `HLL_CREATE_SKETCH` / `HLL_COMBINE` / `HLL_CARDINALITY` for the Theta path, with KLL and Top-K skipped because Redshift has no equivalent. `HLLSKETCH` columns carry non-trivial DDL restrictions (cannot be DISTKEY/SORTKEY, cannot appear in GROUP BY) that the Redshift-specific DDL emits inline.
 
 ### 4. What We Learned (~400 words) — What this exposes about modern OLAP and benchmarking
 
-- **The two-tier reality of "approximate analytics"**. Every modern OLAP engine has the one-shot aggregate path. Only a subset have the persist-merge-requery path. Calling both "approximate functions" obscures the actual capability gap. Vendors compete on the second tier; benchmarks should distinguish them explicitly.
-- **DataSketches binary portability is real**. Databricks, Snowflake, BigQuery (for HLL), and the DuckDB community extension all share the underlying C++/Java/WASM core. ClickHouse runs its own format that is comparable algorithmically but not binary-compatible. This matters for any future cross-engine sketch portability story.
-- **The HLL-only ceiling on Redshift is structural**, not a roadmap gap. No KLL, no T-Digest, no Top-K, no Theta, no CMS. The April 2026 "Top-K optimization" announcement was an internal optimizer change for `ORDER BY … LIMIT N`, not a new function family. Honest accounting pushes us to skip with rationale rather than emulate via UDFs (which would measure UDF dispatch, not sketch performance).
-- **The framework-gap pattern repeats**. Whenever a vendor announces "stored, mergeable, requeryable" — sketches, materialized aggregates, search indexes, vector indexes, incremental MVs, ML features — a single-query benchmark catalog cannot test the differentiated claim. The evaluation rubric needs an explicit axis for "does this benchmark's execution model fit the capability under test?" We're going to apply this to vector indexes next.
+- **The two-tier reality of "approximate analytics"**. Every modern OLAP engine has the aggregate-latency path. A subset have the persist+merge+requery path. Calling both "approximate functions" obscures the actual capability gap. Vendors compete on the second tier; benchmarks should distinguish them explicitly.
+- **DataSketches binary portability is real, but not universal**. Databricks, Snowflake, BigQuery (for HLL), and the DuckDB community extension all share the underlying C++/Java/WASM core. ClickHouse runs its own `-State`/`-Merge` combinator format — comparable algorithmically, behaviorally identical for persist+merge+requery, not binary-compatible with DataSketches. Redshift is HLL-only by `HLLSKETCH` design. Anyone planning a cross-engine sketch-portability story has to map this terrain first.
+- **The HLL-only ceiling on Redshift is structural**, not a roadmap gap. No KLL, no T-Digest, no Top-K, no Theta, no CMS. The April 2026 "Top-K optimization" announcement was an internal optimizer change for `ORDER BY … LIMIT N`, not a new function family. The catalog skips the missing families with rationale comments rather than emulating via UDFs (which would measure UDF dispatch, not sketch performance).
+- **Sketch-size matters as much as sketch-latency**. PR #180's storage-size validation makes sketch byte-length a first-class measurement. CPC at ~1.2 KB merged vs. Theta at ~16 KB (PR #182) is a real tradeoff: 13× smaller persisted state, slower update/merge throughput. The benchmark surfaces both axes per op so users can pick the right family for their cost model.
+- **The framework-gap pattern repeats**. Whenever a vendor announces "stored, mergeable, requeryable" — sketches, materialized aggregates, search indexes, vector indexes, incremental MVs, ML features — a single-query benchmark catalog cannot test the differentiated claim. The same execution-model question applies the next time a "stored, mergeable, requeryable" announcement lands. The fix is to budget two benchmarks before parity-table planning starts.
 
 ### 5. Try It Yourself (~150 words) — Commands to run
 
@@ -155,9 +155,14 @@ benchbox run --platform duckdb --benchmark read_primitives \
   --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby,approx_quantiles_array,approx_top_k_lineitem \
   --scale 1
 
-# Write primitives sketch category — full persist + merge + requery loop
+# Write primitives sketch — Theta + KLL + Top-K full persist + merge + requery loop
 benchbox run --platform duckdb --benchmark write_primitives \
   --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table \
+  --scale 1
+
+# DuckDB-only CPC + REQ families — distinct (compact) and quantile (rel-err)
+benchbox run --platform duckdb --benchmark write_primitives \
+  --queries sketch_cpc_create_persistent_table,sketch_cpc_insert_per_partition,sketch_cpc_query_union_merge,sketch_cpc_drop_persistent_table,sketch_req_create_persistent_table,sketch_req_insert_per_partition,sketch_req_query_quantile_merge,sketch_req_drop_persistent_table \
   --scale 1
 
 # DataFrame surface — sketch-backed engines vs exact-fallback engines
@@ -165,7 +170,10 @@ benchbox run --platform polars-df,pyspark-df,datafusion-df,pandas-df --benchmark
   --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby \
   --scale 0.1
 
-# DuckDB datasketches extension is auto-installed; for ClickHouse, point at chDB
+# ClickHouse-native sketch ops via chDB
+benchbox run --platform chdb --benchmark write_primitives \
+  --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table \
+  --scale 0.1
 ```
 
 Pointer to docs:
@@ -180,19 +188,21 @@ The post's claims need supporting numbers from runs that are reproducible with w
 
 | # | Run | Platform(s) | Benchmark / queries | Scale | What it shows |
 |---|-----|-------------|---------------------|-------|---------------|
-| 1 | DuckDB approx vs exact latency | duckdb | `read_primitives` — all 5 approx queries + matched exact counterparts (`aggregation_distinct`, `statistical_percentiles`, …) | SF=1 | Approximate path is 2-10x faster than exact on the same data; concrete numbers anchor the "boring half" claim |
-| 2 | DuckDB sketch persist+merge cycle | duckdb | `write_primitives` sketch category — all 8 ops (DDL → 3 inserts → 3 ★ merges → DROP) | SF=1 | Persist+merge+requery is end-to-end working; ★ merge ops report sub-second latency on 14k-15k merged distincts |
-| 3 | Sketch merge holds across SF | duckdb | `write_primitives` ★ merge ops (`sketch_query_*_merge`) only | SF=0.1, 1, 10 | Merge latency stays roughly constant while exact aggregate latency grows with cardinality — the "millisecond merge" claim made concrete |
-| 4 | DataFrame sketch-backed vs exact-fallback | polars-df, pyspark-df, datafusion-df, pandas-df, dask-df | `read_primitives` — `approx_count_distinct_*` and `approx_quantile_groupby` | SF=0.1 | Sketch-backed engines (Polars HLL, PySpark KLL, DataFusion T-Digest) finish well ahead of exact-fallback engines (pandas, Dask groupby) on the same query — surfaces the capability gap that picking pandas hides |
-| 5 | ClickHouse-native variants | chDB (local) | `read_primitives` approx queries — `uniq`, `quantileTDigest`, `topK` via existing dialect variants | SF=0.1 | Demonstrates ClickHouse's native (non-DataSketches) approximate surface is competitive on the aggregate path |
-| 6 | (Deferred) Cloud verification | snowflake, bigquery, databricks, redshift | `read_primitives` approx queries + `write_primitives` sketch category | SF=0.1 | Validates the published cross-engine matrix end-to-end. Deferred to a follow-up post when credentials land; tracked in `write-primitives-sketch-cloud-verification`. |
+| 1 | DuckDB approx vs exact latency | duckdb | `read_primitives` — all 5 approx queries + matched exact counterparts (`aggregation_distinct`, `statistical_percentiles`, …) | SF=1 | Approximate path is materially faster than exact on the same data; concrete numbers anchor the aggregate-latency claim |
+| 2 | DuckDB sketch persist+merge cycle | duckdb | `write_primitives` Theta+KLL+Top-K — all 8 ops (DDL → 3 inserts → 3 ★ merges → DROP) | SF=1 | End-to-end persist+merge+requery is working. Note: the catalog's tolerance bounds (e.g. theta merge ∈ [14500, 15500]) are tuned to SF=0.01 (lineitem ~15k orderkeys); SF=1 cardinalities will be ~1.5M distinct and tolerance will need re-tuning before publication |
+| 3 | Sketch merge holds across SF | duckdb | `write_primitives` ★ merge ops (`sketch_query_*_merge`) only | SF=0.1, 1, 10 | Merge latency stays roughly constant while exact-aggregate latency grows with cardinality — the "millisecond merge" claim made concrete |
+| 4 | DataFrame sketch-backed vs exact-fallback | polars-df, pyspark-df, datafusion-df, pandas-df, dask-df | `read_primitives` — `approx_count_distinct_*` and `approx_quantile_groupby` | SF=0.1 | Sketch-backed engines (Polars HLL, PySpark KLL, DataFusion T-Digest) finish ahead of exact-fallback engines (pandas, Dask groupby) on the same query — surfaces the capability gap that picking pandas hides |
+| 5 | ClickHouse-native sketch matrix | chDB (local) | `write_primitives` sketch — all 8 Theta/KLL/Top-K ops via `-State`/`-Merge` overrides | SF=0.1 | ClickHouse 8/8 (post-PR #180) — confirms the persist+merge+requery shape behaves identically under combinator semantics. Companion read_primitives run uses native `uniq` / `quantileTDigest` / `topK` |
+| 6 | CPC vs Theta size/latency tradeoff | duckdb | `sketch_cpc_query_union_merge` vs `sketch_query_theta_union_merge` (paired) | SF=0.01, 0.1, 1 | Storage-size validation makes the ~1.2 KB CPC vs ~16 KB Theta delta visible directly; pair latencies show the throughput tradeoff |
+| 7 | (Deferred) Cloud verification | snowflake, bigquery, databricks, redshift | `read_primitives` approx queries + `write_primitives` sketch category | SF=0.1 | Validates the published cross-engine matrix end-to-end. Architecture fixes have shipped (PR #176); only blocker is creds. Tracked in `write-primitives-sketch-cloud-verification`. |
 
 Suggested chart types:
 - **Run 1**: side-by-side bar — exact-vs-approx latency, one panel per query.
 - **Run 2**: stacked bar — phase breakdown (DDL / insert / merge / DDL) per ★ op.
 - **Run 3**: line chart — merge latency vs SF on log-scale (showing flat sketch-merge curve next to a notional exact-aggregate growth curve).
 - **Run 4**: grouped bar — DataFrame engine × query, color-coded by sketch-backed (saturated) vs exact-fallback (hatched).
-- **Run 5**: companion bar to Run 1 — ClickHouse native variants side-by-side with DuckDB approx.
+- **Run 5**: bar — sketch-merge latency per family on chDB; companion read_primitives bar for `uniq` / `quantileTDigest` / `topK`.
+- **Run 6**: dual-axis bar — bytes (left) and ms (right) for CPC vs Theta merge per SF.
 
 All charts ASCII via `benchbox visualize` or the textcharts MCP.
 
@@ -201,8 +211,8 @@ All charts ASCII via `benchbox visualize` or the textcharts MCP.
 ## Voice and tone targets
 
 Per the building-benchbox series template:
-- Frame as "we built the framework gap" not "we caught a flaw" — the L2 audit is presented as the protocol working, not as embarrassment about a near-miss.
-- Neutral on platforms — Redshift's HLL-only ceiling and DataFusion's lack of support are stated as engineering facts, not as platform criticism. Databricks gets credit for the announcement that motivated the work.
+- Frame as "we noticed the gap and addressed it" not "we caught a flaw" — the L2 audit is presented as the protocol working, not as embarrassment about a near-miss. Equally, do not present it as proof of cleverness — the gap is structural, not a clever catch.
+- Neutral on platforms — Redshift's HLL-only ceiling and DataFusion's lack of support are stated as engineering facts, not as platform criticism. Databricks gets credit for the announcement that motivated the work. The Databricks team is a guaranteed reader; framings like "boring half" / "trivial half" / "actually-novel half" trade substance for editorial contrast and read dismissive — substitute "aggregate-latency path" / "persist+merge+requery path" throughout.
 - "We" for the project and community (per voice guide rule 1).
 - No "industry analyst" framing — share findings, don't pronounce judgments (per voice guide rule 5).
 - Acknowledge limitations explicitly (voice guide rule 3): cloud verification is deferred; approximation-quality vs latency isn't tested; cross-engine portability isn't tested.
@@ -211,7 +221,7 @@ Per the building-benchbox series template:
 
 - **Press-release TL;DR**: don't use "Databricks promised X but BenchBox delivered Y" framing. Databricks' announcement is credited as the motivating context, not contrasted against.
 - **Function-name list dump**: the cross-engine matrices already exist in the docs; the blog post should compress them, not duplicate them in full.
-- **"In our next post…"**: end with a CTA to the docs and the GitHub repo, not a series footer cliffhanger.
+- **"In our next post…"**: end with a CTA to the docs and the GitHub repo, not a series footer cliffhanger. Section 4's pattern-repeats closer should be an open observation, not a forecast of the next post.
 - **Defensive sections**: no "addressing skepticism about sketches" — let the data and the methodology footnotes do that work.
 - **Pre-defending absent critics**: don't write "you might think parity tables are fine, but…" — just present the framework-gap insight as the interesting finding.
 
@@ -228,10 +238,14 @@ Per the building-benchbox series template:
 - `_project/DONE/main/read-primitives-approximate-aggregates-dataframe-coverage.yaml` — DataFrame matrix research
 - `_project/DONE/main/redshift-maximum-approximate-coverage.yaml` — HLL-only ceiling
 - `_project/DONE/main/write-primitives-sketch-persistence-category.yaml` — persist+merge+requery design
+- `_project/DONE/main/planning/write-primitives-architecture-fixes.yaml` — `validation_query.platform_overrides` + `AGGREGATE_PERSIST/MERGE` op types
+- `_project/DONE/main/planning/write-primitives-sketch-clickhouse-and-storage-metrics.yaml` — ClickHouse 8/8 + storage-size validation
+- `_project/DONE/main/planning/write-primitives-sketch-duckdb-cpc-req-families.yaml` — DuckDB CPC + REQ
 - `_project/blind-spots/2026-05-02-084332-read-primitives-cant-test-sketch-persistence.md` — the framework-gap finding (this is the L2 audit insight to feature)
-- `_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md` — architectural gap surfaced
+- `_project/blind-spots/2026-05-02-155448-validation-query-no-per-platform-override.md` — architectural gap surfaced + resolved
 - `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md` — extension-drift caveat
-- `_project/blind-spots/2026-05-02-163132-write-primitives-dataframe-execution-model-no-sketch-shape.md` — DataFrame op-shape gap
+- `_project/blind-spots/2026-05-02-163132-write-primitives-dataframe-execution-model-no-sketch-shape.md` — DataFrame op-shape gap + resolved
+- `_project/blind-spots/2026-05-04-113747-blog-critique-currency-and-partisan-reader-axes.md` — rubric gap surfaced during this outline review
 - `docs/benchmarks/read-primitives-approximate-functions.md` — public per-engine reference
 - `docs/benchmarks/write-primitives-sketch-functions.md` — public per-engine reference
 
@@ -240,15 +254,13 @@ Per the building-benchbox series template:
 - PR #114 — runtime bound enforcement + Snowflake/BigQuery overrides
 - PR #134 — Redshift HLL-only coverage
 - PR #135 — DataFrame approx_count_distinct + sketch-backed quantile coverage
-- PR #138/139 — architecture fixes planning + sketch review followups
-- d4384c34c — `validation_query.platform_overrides`
-- fcc282e7d — `AGGREGATE_PERSIST` / `AGGREGATE_MERGE` DataFrame op types
+- PR #176 — `validation_query.platform_overrides` + `AGGREGATE_PERSIST` / `AGGREGATE_MERGE` DataFrame op types (architecture fixes)
+- PR #180 — ClickHouse 8/8 sketch coverage + storage-size validation
+- PR #182 — DuckDB CPC + REQ sketch families
 
-### Honest deferrals (called out in the post body, not hidden in a footnote)
-- `write-primitives-sketch-cloud-verification` — needs Snowflake/BigQuery/Databricks/Redshift creds
-- `write-primitives-sketch-clickhouse-and-storage-metrics` — ClickHouse-native variants + storage-size validation
-- `write-primitives-sketch-duckdb-cpc-req-families` — DuckDB CPC and REQ sketch families
-- `write-primitives-sketch-pyspark-dataframe-surface` — PySpark DataFrame sketch persist+merge
+### Remaining deferrals (foreground briefly; don't dwell)
+- `write-primitives-sketch-cloud-verification` — needs Snowflake / BigQuery / Databricks / Redshift creds (architecture-side blockers cleared in PR #176)
+- `write-primitives-sketch-pyspark-dataframe-surface` — PySpark DataFrame sketch persist+merge ops
 - `write-primitives-sketch-parameter-sweeps` — `lg_k` / `k` / `lg_max_map_size` parameter axis
 
 ---
@@ -257,5 +269,6 @@ Per the building-benchbox series template:
 
 - **Length target**: ~2,300-2,500 words (sits inside the 1,500-2,500 envelope; the cross-engine matrices push toward the upper end).
 - **Conflicts checked**: no overlap with any planned outline. Posts #1-11 are unrelated topics. The benchbox-in-action series is methodology-driven (no overlap with this engineering-decision framing).
-- **Next step**: gather the 5 in-scope benchmark runs (DuckDB approx-vs-exact, DuckDB sketch full cycle, multi-SF sketch merge, DataFrame matrix, chDB ClickHouse) and slot the actual numbers in before drafting. Cloud verification stays deferred and is called out as a follow-up.
+- **Next step**: gather the 6 in-scope benchmark runs (DuckDB approx-vs-exact, DuckDB sketch full cycle, multi-SF sketch merge, DataFrame matrix, chDB ClickHouse 8/8, CPC-vs-Theta size/latency) and slot the actual numbers in before drafting. Cloud verification stays deferred and is called out as a follow-up.
 - **Series-plan update**: row #12 added.
+- **Publication timing**: vendor-response posts have a 1-2 week shelf life; aim to draft and publish soon after the 6 runs land.

--- a/_project/blind-spots/2026-05-04-113747-blog-critique-currency-and-partisan-reader-axes.md
+++ b/_project/blind-spots/2026-05-04-113747-blog-critique-currency-and-partisan-reader-axes.md
@@ -1,0 +1,108 @@
+---
+id: 2026-05-04-113747-blog-critique-currency-and-partisan-reader-axes
+date: 2026-05-04
+status: open
+finding_kind: framework-gap
+review_context: "/blog critique of _blog/building-benchbox/outlines/12-sketch-functions-databricks-response.md"
+related_paths:
+  - _blog/STYLE_GUIDE.md
+  - _blog/VOICE_REFERENCE.md
+  - .claude/skills/blog/references/critique.md
+  - _blog/building-benchbox/outlines/12-sketch-functions-databricks-response.md
+suggested_sweep: "Audit the /blog critique rubric before the next vendor-response post (currently planned: vector indexes follow-up). Consider adding two checks to references/critique.md: (1) a Currency check — does the underlying technical claim still hold as of today, and is the publication window for time-sensitive vendor responses still open; (2) a Partisan-Reader check — would a reader from the source vendor's team find any framing dismissive (boring half / hidden claim / second-tier), and can the same substance survive without those framings."
+todo_id: null
+---
+
+# /blog critique rubric misses currency and partisan-reader axes for vendor-response posts
+
+## Finding
+
+The standard /blog critique rubric (Style / Technical / Engagement / Editorial)
+under-weights two dimensions that are load-bearing for **vendor-announcement
+response posts** specifically:
+
+1. **Currency drift between outline and present-day shipped state.**
+   Outline #12 was written 2026-05-03 and listed five "honest deferrals"
+   including ClickHouse-native sketch variants and DuckDB CPC/REQ families,
+   citing TODOs as blocked. Within ~24 hours, PR #176 (architecture
+   fixes), PR #180 (ClickHouse 8/8 + storage-size validation), and
+   PR #182 (DuckDB CPC + REQ families) all merged — three of the five
+   "deferrals" became shipped surface. The outline's technical claims
+   were already partially out of date when the user asked for a
+   re-review. The critique rubric's Technical lane has no explicit
+   "verify the outline's claims still match the codebase as of today"
+   check, so the drift would have surfaced only by chance.
+
+2. **Partisan-reader response to framing.**
+   The outline frames the Databricks announcement's aggregate-latency
+   half as "the boring half" and the persistence half as "the
+   actually-novel half" / "the differentiated capability." The substance
+   is correct (vendors compete on persist+merge+requery, not on
+   `APPROX_COUNT_DISTINCT` latency). But Databricks readers — and
+   Databricks employees who shipped the announcement — will read those
+   framings as dismissive of work they're proud of. The standard rubric
+   checks Voice and Neutral-on-Platforms but not "how would a reader
+   from the source material's team respond to the framing?" That's a
+   distinct check.
+
+## Why this matters
+
+Vendor-response posts are a recurring pattern for BenchBox content
+(prior: SQLGlot critique post, future: vector-index response per
+section 4). They share two structural properties that both blind-spot
+axes depend on:
+
+- **Time-sensitive shelf life.** Value of a response post peaks 1-2
+  weeks after the source announcement. An outline written week 1 and
+  drafted week 4 is worth half as much. The rubric needs to push toward
+  dating the outline against the source publication date and flagging
+  if the gap exceeds the shelf-life window.
+
+- **Adjacent partisans.** The source vendor's team is a guaranteed
+  reader, and a friendly framing of the same substance carries the
+  same weight without burning bridges or attracting "actually, here's
+  what we meant" rebuttals on social.
+
+Both dimensions repeat across vendor-response posts; both are missed by
+the current rubric. Adding them is cheap (a 2-bullet check in the
+Technical lane and a 1-bullet check in the Style lane) and pays back
+on every post in this category.
+
+## Suggested next steps
+
+Sweep promotes this to a TODO that adds two checklist items to
+`.claude/skills/blog/references/critique.md`:
+
+- **Technical / Currency**: "If the outline cites blocked TODOs,
+  honest deferrals, or 'not yet shipped' caveats, verify them against
+  `git log` and the current state of `_project/TODO/` and
+  `_project/DONE/`. Flag any item that's actually shipped since the
+  outline was written."
+- **Style / Partisan-Reader**: "For posts that respond to a vendor or
+  source-author publication, identify framings that contrast the
+  source against BenchBox's coverage (boring/novel, surface/hidden,
+  obvious/clever). Confirm each framing survives the test 'would a
+  reader from the source's team find this dismissive?' Substitute
+  technical specificity for editorial contrast where the answer is
+  yes."
+
+Sweep should also decide whether to add a third axis — **Shelf life**
+— that explicitly dates the outline against the source publication
+and flags when the response window is expired. Less important than
+the first two but cheap to add.
+
+## What the audit produced for this specific outline
+
+(Recorded here for traceability; the framework-gap itself is what
+warrants the file.)
+
+- The outline's "honest deferrals" list needed updating after PR #176,
+  PR #180, and PR #182 shipped between outline-write and outline-review.
+- The outline's "boring half" / "differentiated capability" framings
+  were substituted with technical specificity ("aggregate-latency
+  path" / "persist+merge+requery path") that doesn't carry editorial
+  contrast.
+
+These were addressed inline in the revised outline; this file captures
+the *framework* gap so the rubric improves before the next
+vendor-response post.


### PR DESCRIPTION
Addresses critique findings from re-review of outline #12:

P0 — technical currency. PR #176 (architecture fixes), PR #180
(ClickHouse 8/8 + storage-size), and PR #182 (DuckDB CPC + REQ)
shipped between outline-write and outline-review. Updates:

- Engine support matrix recasts ClickHouse from "Native-but-distinct"
  (read as partial) to "ClickHouse-native combinators (8/8 covered)";
  matrix gains CPC and REQ family rows (DuckDB-only).
- Sketch op count: 8 -> 16 ops total (Theta/KLL/TopK plus DuckDB-only
  CPC and REQ).
- New section on the two validation axes: scalar bounds + storage
  size (per-engine SQL: octet_length on DuckDB,
  length(toString(<agg>MergeState(...))) on ClickHouse).
- Honest-deferrals list pruned to three items (cloud verification,
  PySpark DataFrame surface, parameter sweeps).
- Run #5 expanded to cover write_primitives sketch ops on chDB;
  Run #6 added for CPC vs Theta size/latency tradeoff.
- Run #2 cardinality figure annotated: catalog tolerance bounds are
  SF=0.01-tuned; SF=1 cardinalities are ~1.5M and tolerance needs
  re-tuning before publication.
- Version framing corrected: "BenchBox develop (shipping in v0.3.0)",
  not "v0.2.x" (last released tag is v0.2.1; sketch work is on
  develop in [Unreleased]).

P1 — voice. Substituted "aggregate-latency path" / "persist+merge+
requery path" for "boring half" / "actually-novel half" / "trivial
half" throughout — same substance without the editorial contrast that
would read dismissive to Databricks readers. Section 4 closer rewritten
to drop the "we're going to apply this to vector indexes next"
cliffhanger; replaced with an open observation about the framework-gap
pattern.

P2 — editorial. TL;DR compressed from one ~150-word sentence to two
sentences. Tags trimmed from 15 to 8 (dropped redundant family-name
tags already covered by `sketches` / `datasketches`). Section 3
function-name table compressed to a 3-row sample with a link to the
full per-engine reference in docs/.

Also files L2 blind-spot finding
2026-05-04-113747-blog-critique-currency-and-partisan-reader-axes.md
capturing two rubric gaps that surfaced during this re-review:
(1) /blog critique has no currency check for outlines that drift
between write and review; (2) standard voice rules cover platform
neutrality but not partisan-reader response to source-vendor framings.
Both apply to every future vendor-response post.
