### PR TITLE
chore(todo): refine retire-sqlglot-duckdb-all-workaround review action items

### DIFF
--- a/_project/TODO/main/planning/retire-sqlglot-duckdb-all-workaround.yaml
+++ b/_project/TODO/main/planning/retire-sqlglot-duckdb-all-workaround.yaml
@@ -64,31 +64,42 @@ context_sections:
     so the documentation correction is not a public-facing emergency.
 
 work:
-  - id: w1
-    summary: "Identify the first sqlglot release containing PR #3756"
+  - id: w0
+    summary: "Re-validate the repro harness against the resolved sqlglot version before any code change"
     status: pending
     notes: |
-      Read the sqlglot CHANGELOG / release notes / git tags around the
-      merge date of https://github.com/tobymao/sqlglot/pull/3756. Record
-      the first tagged release containing the fix in this TODO's
-      "Research findings" section, e.g. "first fix release: sqlglot
-      vX.Y.Z (YYYY-MM-DD)". This number drives w2.
+      The TODO's PASS evidence was recorded against `sqlglot==30.6.0` on
+      2026-05-04. Before touching pyproject or code:
+        - Run `uv run --with sqlglot python _project/sqlglot-upstream/repros/repro_all.py`
+          (no version pin) so it resolves whatever the current cap allows.
+        - Confirm item #1 still PASSes; items #2/#3/#5/#6 still FAIL as
+          recorded.
+      If item #1 no longer PASSes (e.g., upstream regressed it after our
+      observation), STOP and re-investigate before proceeding. If a new
+      sqlglot major (>=31.0.0) has shipped that the cap excludes, surface
+      that in the PR — it may need to be widened in the same change.
 
-  - id: w2
-    summary: "Bump sqlglot floor in pyproject.toml and refresh uv.lock"
+  - id: w1
+    summary: "Identify min sqlglot release containing PR #3756, bump floor, relock"
     status: pending
-    needs: [w1]
+    needs: [w0]
     notes: |
-      Update the `sqlglot` requirement in `pyproject.toml` from the
-      current `>=20.0.0,<31.0.0` to `>=<min-with-3756>,<31.0.0`. Run
-      `uv lock` to refresh `uv.lock`. Confirm the resolved version is
-      still `30.6.0` (no unintended downgrade or upgrade). Note in the
-      PR body that the floor bump is the safety predicate for w3.
+      Lookup: read sqlglot's CHANGELOG/release notes/git tags around the
+      merge of https://github.com/tobymao/sqlglot/pull/3756; record the
+      first tagged release containing the fix in this TODO's "Research
+      findings" section, e.g. "first fix release: sqlglot vX.Y.Z
+      (YYYY-MM-DD)".
+
+      Bump: update the `sqlglot` requirement in `pyproject.toml` from
+      `>=20.0.0,<31.0.0` to `>=<min-with-3756>,<31.0.0`. Run `uv lock`
+      to refresh `uv.lock`. Confirm the resolved version matches w0
+      (no unintended downgrade or upgrade). Note in the PR body that
+      the floor bump is the safety predicate for w3.
 
   - id: w3
     summary: "Remove _restore_group_order_by_all_keyword and _query_has_group_or_order_by_all"
     status: pending
-    needs: [w2]
+    needs: [w1]
     notes: |
       In `benchbox/utils/dialect_utils.py`:
         - Delete the two helper functions.
@@ -101,21 +112,28 @@ work:
       Leave the surrounding `translate_sql_query` flow control unchanged.
 
   - id: w4
-    summary: "Prune dialect_utils unit tests; add regression test for GROUP/ORDER BY ALL"
+    summary: "Prune direct private-helper test references; keep existing public-path regression tests"
     status: pending
     needs: [w3]
     notes: |
+      Existing `translate_sql_query`-level regression coverage already
+      lives at `tests/unit/utils/test_dialect_utils.py` lines 178 and 191
+      (`Test DuckDB translation keeps ORDER BY ALL as a keyword`,
+      `Test DuckDB translation keeps GROUP BY ALL as a keyword`). KEEP
+      these — they are the regression contract. Do NOT add duplicates.
+
       In `tests/unit/utils/test_dialect_utils.py`:
-        - Remove tests that exercise `_query_has_group_or_order_by_all`
-          and `_restore_group_order_by_all_keyword` directly.
-        - Add a regression test that calls the public
-          `translate_sql_query` with `target_dialect="duckdb"`,
-          `identify=True`, and an input containing `GROUP BY ALL`.
-          Assert the output preserves the bare keyword and does NOT
-          contain `"ALL"`.
+        - Remove the import of `_query_has_group_or_order_by_all` from
+          line 10 (it is the only private helper imported there;
+          `_restore_group_order_by_all_keyword` is not imported).
+        - Remove the direct call at line 206
+          (`assert _query_has_group_or_order_by_all(query) is False`)
+          and the test method that wraps it.
       In `tests/unit/sql_compat/test_translate_sql_delegation.py`:
         - Update the docstring/comment block on/near line 149 that
-          references the old workaround.
+          references the old workaround (`AFTER: _restore_group_order_by_all_keyword()
+          strips the quotes.`) to reflect that the upstream fix now
+          handles this directly.
 
   - id: w5
     summary: "Live regression: TPC-H/TPC-DS/SSB on DuckDB SF 0.01"
@@ -170,7 +188,7 @@ metadata:
     - duckdb
     - tech-debt
     - documentation
-  estimated_effort: "Small (half-day)"
+  estimated_effort: "Small (half-day) — note that w5 (live regression on TPC-H + TPC-DS + SSB at SF 0.01 with --validation full) is the dominant wall-time cost (~5-15 min on a cold machine); the rest is minutes of editing."
   created_date: "2026-05-04"
 
 impact:
@@ -214,14 +232,19 @@ approach: |
   upstream README) stay in sync with the code.
 
 anti_patterns:
+  - "DO NOT skip w0 (re-validate the harness against the resolved sqlglot version) - because the original PASS observation was recorded on 2026-05-04 against 30.6.0; if this TODO sits in planning/ for weeks, `uv lock` may resolve a different version and the safety predicate quietly drifts."
   - "DO NOT delete the workaround without bumping the sqlglot floor first - because users on the current floor (>=20.0.0) may be on a sqlglot version pre-#3756 and would silently produce broken DuckDB SQL."
   - "DO NOT skip the live DuckDB regression in w5 - because unit tests on translate_sql_query do not exercise the full per-platform call path through dialect_translation.py."
   - "DO NOT touch the SQLite or Postgres post-fix branches - because those are independently load-bearing per the repro harness FAIL results for items #2, #3 in the upstream prep."
+  - "DO NOT add a new public-path regression test in w4 - the existing tests at test_dialect_utils.py:178,191 already cover GROUP/ORDER BY ALL through translate_sql_query; adding more would duplicate coverage."
 
 verification:
-  - description: "Repro harness still PASSes the DuckDB ALL case and continues to FAIL the other items"
+  - description: "Repro harness still PASSes the DuckDB ALL case at the version pinned to the original PASS evidence (deterministic harness contract)"
     command: "uv run --with sqlglot==30.6.0 python _project/sqlglot-upstream/repros/repro_all.py"
     expected_output: "Item #1 reports [PASS]; items #2, #3, #5, #6 report [FAIL] (unchanged)"
+  - description: "Repro harness PASSes item #1 at the sqlglot version uv resolves under the (post-w1) cap (w0 freshness check)"
+    command: "uv run --with sqlglot python _project/sqlglot-upstream/repros/repro_all.py"
+    expected_output: "Item #1 reports [PASS] at the resolved version. If [FAIL], STOP and re-investigate before w1."
   - description: "dialect_utils unit tests pass after pruning"
     command: "uv run -- python -m pytest tests/unit/utils/test_dialect_utils.py -v"
     expected_output: "all tests pass; no references to removed helpers"
@@ -231,12 +254,12 @@ verification:
   - description: "Live DuckDB regression on TPC-H, TPC-DS, SSB at SF 0.01 with --validation full"
     command: "benchbox run --platform duckdb --benchmark tpch --scale 0.01 --validation full && benchbox run --platform duckdb --benchmark tpcds --scale 0.01 --validation full && benchbox run --platform duckdb --benchmark ssb --scale 0.01 --validation full"
     expected_output: "validation passes for every benchmark, results match pre-change baseline"
-  - description: "Blog post 11 reflects retirement"
-    command: "grep -c '_restore_group_order_by_all_keyword' _blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md"
-    expected_output: "0"
-  - description: "SQLGlot upstream README verdict reflects retirement"
-    command: "grep -A1 'Retire workaround in BenchBox' _project/sqlglot-upstream/README.md || true"
-    expected_output: "no remaining 'Retire workaround in BenchBox' status (replaced by 'Retired in PR ...')"
+  - description: "Blog post 11 'Post-generation fixups' table no longer lists the DuckDB ALL row"
+    command: "awk '/^## /{s=$0} s ~ /Post-generation fixups/' _blog/building-benchbox/drafts/11-what-we-built-on-top-of-sqlglot.md | grep -c '_restore_group_order_by_all_keyword'"
+    expected_output: "0 (a retrospective past-tense mention elsewhere in the post is fine; the assertion is scoped to the active fixups section)"
+  - description: "SQLGlot upstream README verdict no longer marks the workaround as un-retired"
+    command: "! grep -q 'Retire workaround in BenchBox' _project/sqlglot-upstream/README.md"
+    expected_output: "command exits 0 (the 'Retire workaround in BenchBox' status has been replaced by 'Retired in PR ...')"
 
 scope_limit:
   only_modify:
@@ -264,4 +287,4 @@ success_metrics:
 
 open_questions:
   - "What is the first sqlglot release containing PR #3756? (Answered in w1.)"
-  - "Does any external benchbox extension package import _restore_group_order_by_all_keyword by name? (If yes, may need a deprecation shim instead of straight delete.)"
+  - "Does any external benchbox extension package import _restore_group_order_by_all_keyword by name? (Answered: no shim needed. Both helpers are leading-underscore by name, which is the project's standard signal for private/internal API. Anything importing them was on notice. If a downstream user surfaces breakage post-release, address as a one-off.)"

--- a/_project/blind-spots/2026-05-04-074634-todo-implement-time-freshness-drift.md
+++ b/_project/blind-spots/2026-05-04-074634-todo-implement-time-freshness-drift.md
@@ -1,0 +1,65 @@
+---
+id: 2026-05-04-074634-todo-implement-time-freshness-drift
+date: 2026-05-04
+status: open
+finding_kind: framework-gap
+review_context: "/todo review retire-sqlglot-duckdb-all-workaround"
+related_paths:
+  - _project/TODO/main/planning/retire-sqlglot-duckdb-all-workaround.yaml
+  - _project/sqlglot-upstream/repros/repro_all.py
+  - .claude/skills/todo/SKILL.md
+suggested_sweep: "consider adding a 'verify research findings still hold' step at the start of any TODO whose safety hinges on an upstream third-party state — check across the planning/ backlog for similar shape (upstream-fix retirements, dependency-floor bumps, deprecated-warning sweeps)"
+todo_id: null
+---
+
+# TODO review rubric does not score implement-time freshness drift
+
+## Finding
+The /todo review rubric (clarity / completeness / actionability / freshness /
+guardrails / work-breakdown) scores write-time quality. It does not capture
+whether the *prerequisite evidence* a TODO depends on is still valid at
+implement time.
+
+`retire-sqlglot-duckdb-all-workaround` rests on a single PASS observation
+from `_project/sqlglot-upstream/repros/repro_all.py` against
+`sqlglot==30.6.0`. If the TODO sits in `planning/` for weeks or months, the
+evidence may decay in three ways the rubric does not surface:
+
+1. A new sqlglot major (>=31.0.0) lands; the upper-cap `<31.0.0` becomes the
+   harder constraint than the floor bump and may itself need re-validation
+   before the helper is removed.
+2. The repro script could be edited (paths, fixtures, expectations) and the
+   "PASS" the TODO description quotes may no longer reproduce verbatim.
+3. `uv lock` (in w2) pulls *current* sqlglot, not 30.6.0; if a regression is
+   introduced upstream between 30.6.0 and the version `uv lock` resolves, w5's
+   live regression is the only safety net.
+
+The TODO has thorough guardrails for *the deletion order* (floor first, then
+delete, then docs) but no instruction to re-run the repro harness against the
+*resolved* sqlglot version at the start of implementation, which is what
+links write-time evidence to implement-time reality.
+
+## Why this matters
+Any TODO whose safety predicate is "an external project's behavior at write
+time" carries this drift risk. The rubric scores the *quality of the artifact*;
+it has no axis for *the durability of its assumed inputs*. This is a
+framework gap, not a defect of this specific TODO. The same gap will recur on
+every "retire workaround once upstream lands fix" task, every "remove
+deprecation warning once Python X.Y is dropped" task, and every "narrow
+dependency cap once upstream stabilizes" task.
+
+A simple convention would close it: a `freshness_check` field (or a
+conventionally-named first work unit) that re-runs the original evidence
+against the *current* dependency snapshot before any code is touched.
+
+## Suggested next steps
+- [ ] Decide whether to add an optional `freshness_check` block to the TODO
+      schema (or a strong-convention "w0: re-validate research evidence" first
+      work unit) for upstream-dependent items.
+- [x] In-scope nudge for `retire-sqlglot-duckdb-all-workaround`: applied as
+      `w0` (re-run `repro_all.py` against the version `uv` resolves, gating
+      `w1`) plus a matching `anti_pattern` and a second `verification` entry
+      (unpinned harness check). Captured in the same PR as this finding.
+- [ ] Sweep planning/ for sibling TODOs that retire workarounds once an
+      upstream fix lands; if 2+ exist, the schema-level convention above pays
+      for itself.


### PR DESCRIPTION
Apply the seven refinement items from the /todo review of this TODO,
plus the in-scope nudge from a paired L2 blind-spot finding:

- Insert w0 (re-validate repro_all.py against the sqlglot version uv
  resolves) gating w1; this links write-time evidence to implement-time
  reality if the TODO sits in planning/ for weeks.
- Merge old w1+w2 (lookup + floor bump) into a single combined w1 to
  cut bookkeeping overhead on a 30-second changelog lookup.
- Reframe w4 from "add a regression test" to "keep existing public-path
  tests at test_dialect_utils.py:178,191; remove only the direct
  _query_has_group_or_order_by_all import (line 10) and call (line 206);
  fix the line-149 docstring in test_translate_sql_delegation.py."
- Tighten verification entry 6: replace `grep ... || true` (silent pass)
  with `! grep -q ...` so the check fails fast on regression.
- Loosen verification entry 5: scope the blog grep to the active
  "Post-generation fixups" section so a retrospective past-tense mention
  elsewhere in the post does not trip the assertion.
- Pre-answer open_question #2: leading-underscore signals private API;
  no deprecation shim required.
- Calibrate estimated_effort with a note that w5's live regression
  dominates wall time (~5-15 min on a cold machine).
- Add two new anti_patterns: skip-w0 freshness drift and
  duplicate-public-path test in w4.

Also files the L2 blind-spot finding that motivated w0
(2026-05-04-074634-todo-implement-time-freshness-drift). The framework
gap (rubric does not score implement-time freshness drift) stays open
for sweep; the in-scope nudge for this specific TODO is checked off.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
