### PR TITLE
fix(write-primitives): action items from sketch-cluster /code review

### DIFF
--- a/_project/TODO/main/planning/write-primitives-sketch-clickhouse-local-smoke.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-clickhouse-local-smoke.yaml
@@ -1,0 +1,118 @@
+id: write-primitives-sketch-clickhouse-local-smoke
+title: "Write Primitives sketch: real benchbox-run smoke test for ClickHouse-native sketch overrides"
+worktree: main
+priority: Low
+status: "Not Started"
+category: "Verification"
+
+description: |
+  ## Background
+
+  PR #180 (`write-primitives-sketch-clickhouse-and-storage-metrics`)
+  shipped 8 ClickHouse-native sketch overrides plus per-engine
+  storage-size validations. SQL syntax was verified end-to-end via
+  chDB 26.1.0 inside the implementation session
+  (`uniqMerge`/`quantileTDigestMerge(0.5)`/`topKMerge(8)` plus
+  state-byte sizes), but **no real
+  `benchbox run --platform clickhouse-local`** was executed.
+
+  The follow-up PR
+  (`fix/write-primitives-review-followups`) split the storage-size
+  validations into per-engine variants, which adds new validation
+  bodies to dispatch through the ClickHouse adapter. Both changes
+  benefit from a live benchbox-driven smoke test before users
+  encounter adapter-level bugs in the wild.
+
+  ## What this delivers
+
+  1. A real `benchbox run --platform clickhouse-local --benchmark
+     write_primitives --scale 0.01 --queries
+     sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine`
+     against a clickhouse-local install.
+
+  2. Confirmation that:
+     - Multi-statement SQL bodies (DROP/CREATE/INSERT/SELECT inside
+       one `write_sql` override) dispatch through the BenchBox
+       ClickHouse adapter without statement splitting issues.
+     - The new per-engine `*_storage_size_clickhouse` validations
+       fall through correctly: ClickHouse picks them up (default
+       `null` skip on duckdb / databricks / snowflake / bigquery /
+       redshift / datafusion / sqlite / starrocks), and DuckDB picks
+       up the `*_storage_size_duckdb` siblings.
+     - The `length(toString(<agg>MergeState(...)))` idiom returns a
+       value within the per-engine bounds.
+
+  3. Per-engine bound retuning if the live observation drifts
+     materially from the chDB-spike numbers (theta ~60KB, KLL ~3.8KB,
+     topK ~294B) recorded in the documentation.
+
+  ## Verification
+
+  ```bash
+  uv run -- benchbox run --platform clickhouse-local --benchmark write_primitives \
+    --scale 0.01 \
+    --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table
+  ```
+
+  Expected: 8/8 ops pass; both scalar-bounds and storage-size
+  validations report passed (storage-size on ClickHouse, not DuckDB).
+
+context_sections:
+  "Why this is low priority": |
+    chDB syntax verification covers the SQL semantics. The remaining
+    risk is BenchBox-adapter-level: connection pooling, multi-statement
+    handling, error propagation. The blast radius is "first user gets
+    a confusing failure"; not data loss. Worth doing, doesn't block
+    anything.
+
+  "What it does NOT cover": |
+    Cloud ClickHouse Cloud verification — that's tracked in
+    `write-primitives-sketch-cloud-verification` (the cloud-cred
+    TODO). This smoke test stays on local clickhouse-local /
+    clickhouse-cli only.
+
+work:
+  - id: w1
+    summary: "Run the verification command against a clickhouse-local install"
+    status: pending
+    notes: |
+      Install clickhouse-local locally (homebrew or container).
+      Run the full 8-op verification set at SF=0.01. If anything
+      fails, capture the error, identify whether it's syntax,
+      adapter, or bound, and decide: fix-here vs file-fix-class TODO.
+
+  - id: w2
+    summary: "Update inline tolerance comments with live observed values"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace "verified chDB" comments in the storage-size validation
+      blocks with "verified clickhouse-local SF=0.01" plus the actual
+      observation. If the observation falls outside the current
+      bounds, retune the per-engine bounds to bracket the live value
+      ±20%.
+
+  - id: w3
+    summary: "Add a ClickHouse-only fast-test invocation to the docs"
+    needs: [w2]
+    status: pending
+    notes: |
+      `docs/benchmarks/write-primitives-sketch-functions.md` should
+      gain a "Try it locally" snippet for clickhouse-local so users
+      can reproduce the headline numbers without cloud creds.
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/write_primitives/dataframe_operations.py
+  rationale: |
+    Surface a smoke test, not a refactor. Bound retuning happens
+    in operations.yaml; structural changes belong in a different
+    TODO.
+
+deps:
+  needs: []

--- a/_project/TODO/main/planning/write-primitives-sketch-pyspark-cli-integration.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-pyspark-cli-integration.yaml
@@ -1,0 +1,161 @@
+id: write-primitives-sketch-pyspark-cli-integration
+title: "Write Primitives sketch: wire PySpark sketch factories into the benchbox CLI"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Core Functionality"
+
+description: |
+  ## Background
+
+  PR #181 (`write-primitives-sketch-pyspark-dataframe-surface`) shipped
+  factory helpers in
+  `benchbox/core/write_primitives/dataframe_operations.py`
+  (`make_pyspark_hll_persist_builder`,
+  `make_pyspark_hll_merge_extract`,
+  `make_pyspark_topk_persist_builder`,
+  `make_pyspark_topk_merge_extract`,
+  `pyspark_supports_approx_top_k`) plus tests using mocked PySpark.
+
+  The TODO it implemented (`write-primitives-sketch-pyspark-dataframe-
+  surface`) had a scope/verification contradiction recorded as a
+  blind-spot
+  (`_project/blind-spots/2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch.md`):
+  the `scope_limit.only_modify` block forbade editing
+  `operations.yaml` and `benchmark.py`, but the verification command
+  was `benchbox run --queries sketch_df_hll_persist_merge` — which
+  cannot pass without entries in `operations.yaml` and an
+  engine-aware dispatch fork in `benchmark.py`.
+
+  PR #181 honored the scope and left the CLI integration as a tracked
+  follow-up. This TODO closes that gap.
+
+  ## What this delivers
+
+  1. Catalog entries for the persist+merge cycle, expressed as the new
+     `AGGREGATE_PERSIST` / `AGGREGATE_MERGE` op shapes:
+       - `sketch_df_hll_persist_merge`
+       - `sketch_df_topk_persist_merge` (Spark 4.1+ guarded)
+
+  2. Engine-aware dispatch fork in
+     `_execute_dataframe_sql_parity_workload` (or its successor) that
+     routes `AGGREGATE_PERSIST` / `AGGREGATE_MERGE` ops to
+     `manager.execute_aggregate_persist` /
+     `manager.execute_aggregate_merge` rather than embedding the SQL
+     into the DuckDB parity path.
+
+  3. Integration test that runs the full persist+merge cycle against
+     a real Spark 3.5+ session at least once. The factory tests today
+     are MagicMock-based and do NOT exercise the actual Spark APIs;
+     this is the first place that does.
+
+  4. Documentation update in
+     `docs/benchmarks/write-primitives-sketch-functions.md` removing
+     the "CLI integration gap" notice and replacing it with the
+     working invocation example.
+
+  5. Mark blind-spot file
+     `_project/blind-spots/2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch.md`
+     as resolved.
+
+  ## Verification
+
+  ```bash
+  uv run -- benchbox run --platform pyspark --benchmark write_primitives \
+    --scale 0.01 --queries sketch_df_hll_persist_merge
+  ```
+
+  Expected: persist phase reports rows_affected = number of (date,
+  region) groups; merge phase reports `aggregate_value` ≈ 15000
+  (true distinct l_orderkeys at SF=0.01) within ±5%.
+
+context_sections:
+  "Why this is medium priority": |
+    The factory helpers exist and are unit-tested, but they're not
+    callable via `benchbox run`. Until this lands, PySpark sketch
+    persist+merge cycles cannot be measured by any benchbox user
+    without writing custom Python. The blind-spot makes the gap
+    visible; this TODO closes it.
+
+  "Why this might surface bugs the mocks missed": |
+    The MagicMock fixture in
+    `tests/unit/core/write_primitives/test_pyspark_sketch_factories.py`
+    auto-chains attribute access. So the test passes whether or not
+    `F.hll_sketch_estimate(F.hll_union_agg(col))` is actually a
+    valid Spark Column expression — the mock will accept any nested
+    call. A real Spark 3.5+ session will surface type-shape bugs
+    (e.g. "approx_top_k_combine returns Column, but
+    approx_top_k_estimate expects ARRAY<STRUCT>"). Plan to debug
+    type errors during w3.
+
+work:
+  - id: w1
+    summary: "Add sketch_df_hll_persist_merge and sketch_df_topk_persist_merge ops to operations.yaml"
+    status: pending
+    notes: |
+      Two new entries with the AGGREGATE_PERSIST/MERGE op shape. The
+      DataFrame ops live in operations.yaml alongside SQL ops; a
+      `dispatch: aggregate_state` (or similar) marker distinguishes
+      them. Bonds, source paths, and group_cols are catalog inputs
+      that the dispatch passes to the factory helpers.
+
+  - id: w2
+    summary: "Add aggregate-state dispatch fork in DataFrame workload runner"
+    needs: [w1]
+    status: pending
+    notes: |
+      `benchbox/core/write_primitives/benchmark.py` has the
+      DataFrame workload runner; today every op routes through
+      embedded DuckDB SQL (`_execute_dataframe_sql_parity_workload`).
+      Add an early branch: if the catalog entry is shaped as
+      AGGREGATE_PERSIST/MERGE, instantiate the appropriate factory
+      (HLL or top-K), call
+      `manager.execute_aggregate_persist(...)` then
+      `manager.execute_aggregate_merge(...)`, and roll the two
+      DataFrameWriteResults into the operation envelope.
+
+  - id: w3
+    summary: "Run the verification command against a real Spark 3.5+ session"
+    needs: [w2]
+    status: pending
+    notes: |
+      First real-Spark integration of these helpers. Expect at least
+      one type-shape bug to surface — debug, fix, document. If the
+      top-K nested expression
+      `F.size(F.approx_top_k_estimate(F.approx_top_k_combine(col)))`
+      doesn't resolve cleanly inside `state.agg(...)`, restructure
+      the merge_extract to do agg-then-select rather than nesting
+      everything.
+
+  - id: w4
+    summary: "Update docs and mark blind-spot resolved"
+    needs: [w3]
+    status: pending
+    notes: |
+      Remove "CLI integration gap" subsection from
+      docs/benchmarks/write-primitives-sketch-functions.md; add the
+      verified invocation example. Set blind-spot file's frontmatter
+      `status:` to `resolved` and link this TODO from
+      `todo_id:`.
+
+  - id: w5
+    summary: "Add changelog entry"
+    needs: [w4]
+    status: pending
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - benchbox/core/write_primitives/benchmark.py
+    - tests/integration/core/write_primitives/
+    - docs/benchmarks/write-primitives-sketch-functions.md
+    - _project/blind-spots/2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch.md
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/dataframe_operations.py
+  rationale: |
+    Factory helpers are stable and tested; this TODO wires them
+    in, doesn't redesign them.
+
+deps:
+  needs: []

--- a/_project/TODO/main/planning/write-primitives-sketch-storage-bounds-touchups.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-storage-bounds-touchups.yaml
@@ -1,0 +1,96 @@
+id: write-primitives-sketch-storage-bounds-touchups
+title: "Write Primitives sketch: tighten/widen sweep variant storage bounds after PR #184 lands"
+worktree: main
+priority: Low
+status: "Not Started"
+category: "Verification"
+
+description: |
+  ## Background
+
+  Captured during the multi-PR review of the write-primitives sketch
+  cluster. PR #184 (parameter-sweep variants) was OPEN at review time
+  and the lgmm10 storage-size lower bound `[500, 5000]` was flagged
+  as potentially too tight: at `lg_max_map_size=10` (1024 buckets)
+  over only 7 distinct shipmodes in TPC-H lineitem, the merged
+  frequent-items sketch may stay near its empty-state baseline
+  (~600B-ish) and false-fail.
+
+  The fix could not land in the current followup PR
+  (`fix/write-primitives-review-followups`) because the lgmm10 op
+  doesn't exist on `develop` until PR #184 merges. This TODO
+  captures the deferred bound-retouchup work.
+
+  ## What this delivers
+
+  1. Re-run `sketch_query_topk_combine_lgmm10` (and its lgmm8
+     counterpart for symmetry) at SF=0.01 against the installed
+     datasketches extension. Capture observed storage-size bytes.
+
+  2. Adjust bounds in
+     `benchbox/core/write_primitives/catalog/operations.yaml` to
+     bracket the observation ±50% (or wider if the variance is high).
+
+  3. While there: spot-check the Theta `_lgk10` and `_lgk14` storage
+     bounds against the current build if/when the
+     `datasketch_theta` extension drift is resolved
+     (`_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`).
+     Inherit-broken-from-parent bounds were spec-derived, not
+     measured.
+
+  ## Verification
+
+  ```bash
+  uv run -- benchbox run --platform duckdb --benchmark write_primitives \
+    --scale 0.01 \
+    --queries sketch_query_topk_combine_lgmm10,sketch_query_topk_combine_lgmm8
+  ```
+
+  Expected: both ops pass with the re-tuned bounds; observed storage
+  size is captured in inline comments next to the bound.
+
+context_sections:
+  "Why this is deferred": |
+    The lgmm10 op doesn't exist on develop until PR #184 lands. The
+    review-followups PR cannot reference a sketch_query_topk_combine_lgmm10
+    op that develop doesn't see yet without creating a merge conflict.
+    Right answer: land bound retuning as a separate small PR after
+    PR #184 merges.
+
+  "Why low priority": |
+    Sweep variants are exploratory benchmarks; a too-tight bound
+    causes a false-fail on a low-priority op, not silent data loss.
+    Address opportunistically.
+
+work:
+  - id: w1
+    summary: "Run lgmm10 / lgmm8 / lgk10 / lgk14 ops at SF=0.01 on the installed extension and capture observed bytes"
+    status: pending
+    notes: |
+      Theta lgk10/lgk14 only if the datasketch_theta extension drift
+      is resolved; otherwise skip those and re-flag via the existing
+      blind-spot.
+
+  - id: w2
+    summary: "Retune each variant's storage_size bounds to bracket the observation"
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: "Update inline yaml comments with the observed value"
+    needs: [w2]
+    status: pending
+
+scope_limit:
+  only_modify:
+    - benchbox/core/write_primitives/catalog/operations.yaml
+    - CHANGELOG.md
+  do_not_modify:
+    - benchbox/core/write_primitives/benchmark.py
+    - benchbox/core/write_primitives/dataframe_operations.py
+  rationale: |
+    Bound-retune is a yaml-only change.
+
+deps:
+  needs:
+    - write-primitives-sketch-parameter-sweeps

--- a/_project/blind-spots/2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch.md
+++ b/_project/blind-spots/2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch.md
@@ -1,17 +1,25 @@
 ---
 id: 2026-05-04-011321-pyspark-sketch-todo-scope-vs-verification-mismatch
 date: 2026-05-04
-status: open
+status: merged-to-todo
 finding_kind: scope-creep
 review_context: "/code review w2 prep / write-primitives-sketch-pyspark-dataframe-surface"
 related_paths:
   - _project/TODO/main/planning/write-primitives-sketch-pyspark-dataframe-surface.yaml
+  - _project/TODO/main/planning/write-primitives-sketch-pyspark-cli-integration.yaml
   - benchbox/core/write_primitives/benchmark.py
   - benchbox/core/write_primitives/catalog/operations.yaml
   - benchbox/core/write_primitives/dataframe_operations.py
 suggested_sweep: "decide whether the pyspark-dataframe-surface TODO is a 'primitives layer only' deliverable (current scope_limit) or includes the benchbox CLI wire-up (current verification commands); update one or the other so they agree"
-todo_id: write-primitives-sketch-pyspark-dataframe-surface
+todo_id: write-primitives-sketch-pyspark-cli-integration
 ---
+
+> **Update 2026-05-04**: the concrete CLI-wireup gap is now tracked in
+> `_project/TODO/main/planning/write-primitives-sketch-pyspark-cli-integration.yaml`.
+> The process learning ("watch for scope vs verification contradictions
+> when authoring TODOs") stays as a blind-spot for future-author hint;
+> the actionable closure is the new TODO.
+
 
 # pyspark-dataframe-surface TODO: scope_limit vs verification command contradict
 

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -152,10 +152,7 @@ def _resolve_validation_sql(val_query: Any, platform_key: str | None) -> tuple[s
     not "failed"). Mirrors `_get_effective_write_sql` for the operation-level
     overrides.
     """
-    # `getattr` with a default is intentional defensive coding — test fixtures
-    # mock val_query as MagicMock without the new field, and production callers
-    # always have the dataclass-default empty dict.
-    overrides = getattr(val_query, "platform_overrides", None) or {}
+    overrides = val_query.platform_overrides or {}
     if not platform_key or platform_key not in overrides:
         return val_query.sql, None
     override = overrides[platform_key]

--- a/benchbox/core/write_primitives/catalog/operations.yaml
+++ b/benchbox/core/write_primitives/catalog/operations.yaml
@@ -3114,29 +3114,47 @@ operations:
             FROM sketch_ops_daily_users
       # Storage-size validation: octet_length() of the merged sketch state
       # certifies the persisted bytes haven't regressed to zero or grown
-      # unbounded. Bounds tuned per engine because uniq's HLL++ encoding
-      # produces meaningfully different sizes than DataSketches Theta.
-      # Skipped on platforms whose merged-sketch byte length isn't
-      # interesting / accessible via the same shape.
-      - id: theta_storage_size
+      # unbounded. Split into two engine-specific validations so each engine
+      # gets bounds tight enough to flag material regressions (a wide
+      # cross-engine envelope would let DuckDB grow 5x silently before
+      # alarming). Each variant skips all non-target engines via explicit
+      # null overrides.
+      - id: theta_storage_size_duckdb
         sql: |
           SELECT octet_length(datasketch_theta(user_sketch)) AS sketch_bytes
           FROM sketch_ops_daily_users
-        # Bounds span both engines' observed merged-state sizes:
-        #   DuckDB DataSketches Theta lg_k=12 → ~16KB
-        #   ClickHouse uniq HLL++ default precision → ~60KB (verified chDB)
-        # Wide enough to absorb encoding drift on either family, tight
-        # enough to flag a sketch becoming a no-op (size 0) or growing
-        # unboundedly. Per-engine tightening can land in a follow-up.
+        # DuckDB DataSketches Theta lg_k=12 → ~16KB merged at SF=0.01.
+        # Bounds tight enough to flag a 2x growth (e.g. accidental lg_k=14
+        # bump) while tolerating modest encoding-format drift.
         expected_value_min: 4000
+        expected_value_max: 32000
+        platform_overrides:
+          clickhouse: null
+          databricks: null
+          snowflake: null
+          bigquery: null
+          redshift: null
+          datafusion: null
+          sqlite: null
+          starrocks: null
+      - id: theta_storage_size_clickhouse
+        # Default sql is ClickHouse-only; every non-clickhouse engine is
+        # explicitly skipped below so the default body is never executed
+        # off-target. ClickHouse AggregateFunction columns aren't a
+        # length() input directly; toString() serializes the merged state
+        # to its bytes-of-string representation, which is correlated with
+        # but not identical to the on-disk binary state size — stable
+        # enough for regression detection across runs.
+        sql: |
+          SELECT length(toString(uniqMergeState(user_sketch))) AS sketch_bytes
+          FROM sketch_ops_daily_users
+        # ClickHouse uniq HLL++ default precision → ~60KB (verified chDB).
+        # Bounds tight enough that a regression to <16KB or growth past
+        # 100KB alarms; wide enough to absorb encoding drift.
+        expected_value_min: 16000
         expected_value_max: 100000
         platform_overrides:
-          # ClickHouse AggregateFunction columns aren't a length() input;
-          # toString() serializes the merged state to its bytes-of-string
-          # representation which is what we want to measure.
-          clickhouse: |
-            SELECT length(toString(uniqMergeState(user_sketch))) AS sketch_bytes
-            FROM sketch_ops_daily_users
+          duckdb: null
           databricks: null
           snowflake: null
           bigquery: null
@@ -3265,23 +3283,36 @@ operations:
           clickhouse: |
             SELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price
             FROM sketch_ops_kll_partitions
-      - id: kll_storage_size
+      # See theta_storage_size_duckdb above for why the storage-size check
+      # is split into per-engine variants — same rationale here.
+      - id: kll_storage_size_duckdb
         sql: |
           SELECT octet_length(datasketch_kll(200, price_sketch::sketch_kll_double)) AS sketch_bytes
           FROM sketch_ops_kll_partitions
-        # DuckDB DataSketches KLL k=200 merged state observed ~3KB at
-        # SF=0.01. Bounds intentionally wide enough to absorb encoding
-        # drift but tight enough to catch a no-op regression.
+        # DuckDB DataSketches KLL k=200 → ~3KB merged at SF=0.01.
+        # Tight bounds to flag any 2x growth without false-failing on
+        # within-family encoding drift.
         expected_value_min: 1000
+        expected_value_max: 6000
+        platform_overrides:
+          clickhouse: null
+          databricks: null
+          snowflake: null
+          bigquery: null
+          redshift: null
+          datafusion: null
+          sqlite: null
+          starrocks: null
+      - id: kll_storage_size_clickhouse
+        sql: |
+          SELECT length(toString(quantileTDigestMergeState(0.5)(price_sketch))) AS sketch_bytes
+          FROM sketch_ops_kll_partitions
+        # ClickHouse quantileTDigest at compression=100 → ~3.8KB merged
+        # (verified chDB, SF=0.01). Bounds tight to its observed range.
+        expected_value_min: 1500
         expected_value_max: 8000
         platform_overrides:
-          # ClickHouse quantileTDigest merged state observed ~3.8KB in
-          # spike (chDB, SF=0.01); compression=100 produces similar bytes
-          # to KLL k=200, fitting inside the DuckDB bounds. Use toString()
-          # because length() doesn't accept an AggregateFunction directly.
-          clickhouse: |
-            SELECT length(toString(quantileTDigestMergeState(0.5)(price_sketch))) AS sketch_bytes
-            FROM sketch_ops_kll_partitions
+          duckdb: null
           databricks: null
           snowflake: null
           bigquery: null
@@ -3383,22 +3414,36 @@ operations:
           clickhouse: |
             SELECT length(topKMerge(8)(topk_sketch)) AS frequent_count
             FROM sketch_ops_topk
-      - id: topk_storage_size
+      # See theta_storage_size_duckdb above for why the storage-size check
+      # is split into per-engine variants.
+      - id: topk_storage_size_duckdb
         sql: |
           SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes
           FROM sketch_ops_topk
         # DuckDB DataSketches frequent-items lg_max_map_size=8 (256 buckets)
-        # merged state observed ~600 bytes at SF=0.01.
-        expected_value_min: 200
-        expected_value_max: 2000
+        # → ~600B merged at SF=0.01.
+        expected_value_min: 300
+        expected_value_max: 1200
         platform_overrides:
-          # ClickHouse topK(8) merged state observed ~294 bytes in spike
-          # (chDB, SF=0.01); much smaller than DataSketches frequent-items
-          # but fits inside the DuckDB bounds. Use toString() because
-          # length() doesn't accept an AggregateFunction directly.
-          clickhouse: |
-            SELECT length(toString(topKMergeState(8)(topk_sketch))) AS sketch_bytes
-            FROM sketch_ops_topk
+          clickhouse: null
+          databricks: null
+          snowflake: null
+          bigquery: null
+          redshift: null
+          datafusion: null
+          sqlite: null
+          starrocks: null
+      - id: topk_storage_size_clickhouse
+        sql: |
+          SELECT length(toString(topKMergeState(8)(topk_sketch))) AS sketch_bytes
+          FROM sketch_ops_topk
+        # ClickHouse topK(8) merged state → ~294B at SF=0.01 (verified chDB).
+        # Tighter than the DataSketches frequent-items size; still loose
+        # enough to absorb encoding drift.
+        expected_value_min: 150
+        expected_value_max: 800
+        platform_overrides:
+          duckdb: null
           databricks: null
           snowflake: null
           bigquery: null

--- a/benchbox/core/write_primitives/dataframe_operations.py
+++ b/benchbox/core/write_primitives/dataframe_operations.py
@@ -945,6 +945,9 @@ class DataFrameWriteOperationsManager:
 
         start_time = time.time()
         target_path = Path(target_path)
+        # Track whether we created the directory ourselves so a failed persist
+        # doesn't leak an empty directory onto disk for the caller to clean up.
+        target_existed_before = target_path.exists()
         try:
             state_df = state_builder()
             target_path.mkdir(parents=True, exist_ok=True)
@@ -963,6 +966,12 @@ class DataFrameWriteOperationsManager:
             )
         except Exception as e:
             self.logger.error(f"AGGREGATE_PERSIST failed: {e}")
+            if not target_existed_before and target_path.exists():
+                try:
+                    if not any(target_path.iterdir()):
+                        target_path.rmdir()
+                except OSError:
+                    pass
             return DataFrameWriteResult.failure(
                 WriteOperationType.AGGREGATE_PERSIST,
                 str(e),
@@ -1105,6 +1114,12 @@ def pyspark_supports_approx_top_k(spark_session: Any) -> bool:
     BenchBox's PySpark adapter targets Spark 3.5+, so callers must guard
     top-K aggregate-state ops on the runtime version. Returns False on
     older Spark versions or when the function symbol is not available.
+
+    Note: this is a conservative version-then-attribute check. If a
+    distribution backports `approx_top_k_accumulate` to a 3.5.x build,
+    the `< (4, 1)` gate rejects it spuriously — callers in that
+    environment should bypass this guard or file a TODO to add the
+    backport-detection branch.
 
     Args:
         spark_session: A SparkSession.

--- a/docs/benchmarks/write-primitives-sketch-functions.md
+++ b/docs/benchmarks/write-primitives-sketch-functions.md
@@ -168,6 +168,21 @@ accuracy relative to the quantile value rather than its rank position.
 | DuckDB ext | `datasketch_req(k, x)`                   | `datasketch_req(k, sketch::sketch_req_float)` (fold-merge)   | `datasketch_req_quantile(sketch, 0.5::DOUBLE, true)`                    |
 | All others | — (no native REQ surface today)          | —                                                            | —                                                                        |
 
+#### Per-family persistence tables for CPC and REQ
+
+CPC and REQ each persist into their own table (`sketch_cpc_partitions`,
+`sketch_req_partitions`) rather than sharing a mega-sketch table with
+the Theta/KLL/Top-K families. The reasoning: each family carries a
+different storage column type and parameter knob (CPC's `lg_k` vs
+Theta's `lg_k` vs KLL's `k` vs frequent-items' `lg_max_map_size`), and
+the cast pattern at merge time differs (`sketch::sketch_cpc` vs
+`sketch::sketch_kll_double` vs `sketch::sketch_req_float`). A combined
+table would either need to widen to all column types (carrying nulls
+across rows) or normalize via a tagged-union column (forcing additional
+casts per query). Per-family tables keep each op self-contained and
+make the storage-size validation queries trivial — `octet_length` is
+applied to the column whose type already matches the family.
+
 ClickHouse's `-State` / `-Merge` aggregate combinators are *algorithmically*
 comparable to DataSketches Theta / KLL / frequent-items but are **not
 binary-portable** with the Apache DataSketches binary format — different
@@ -197,19 +212,31 @@ lands.
 
 ## Storage-size methodology
 
-Each ★ headline op carries a second `validation_query` (`*_storage_size`)
-that measures the byte length of the merged sketch state. This certifies
-the persisted sketch hasn't regressed to zero or grown unboundedly — the
-cost-per-byte side of the persistence-vs-recompute tradeoff that latency
-alone doesn't surface.
+Each ★ headline op carries a pair of `*_storage_size_<engine>`
+`validation_query` entries that measure the byte length of the merged
+sketch state. This certifies the persisted sketch hasn't regressed to
+zero or grown unboundedly — the cost-per-byte side of the
+persistence-vs-recompute tradeoff that latency alone doesn't surface.
 
-| Op                                | DuckDB observed    | ClickHouse observed   | Bounds          |
-|-----------------------------------|--------------------|------------------------|-----------------|
-| `sketch_query_theta_union_merge`  | ~16KB (Theta lg_k=12) | ~60KB (uniq HLL++ default) | [4000, 100000] |
-| `sketch_query_kll_quantiles_merge`| ~3KB (KLL k=200)   | ~3.8KB (T-Digest comp=100) | [1000, 8000]   |
-| `sketch_query_topk_combine`       | ~600B (lg_max_map_size=8) | ~294B (topK K=8)    | [200, 2000]    |
-| `sketch_cpc_query_union_merge`    | ~1.2KB (CPC lg_k=11)  | — (DuckDB-only)            | [400, 4000]    |
-| `sketch_req_query_quantile_merge` | ~2.5KB (REQ k=12)     | — (DuckDB-only)            | [1000, 8000]   |
+The split into per-engine variants (rather than a single cross-engine
+validation with a wide envelope) is deliberate: a wide envelope spanning
+DuckDB's ~16KB and ClickHouse's ~60KB would let DuckDB silently grow 5x
+before alarming. Each variant runs only on its target engine via explicit
+`null` overrides for every other engine.
+
+| Op                                | DuckDB variant + bounds                        | ClickHouse variant + bounds                       |
+|-----------------------------------|-------------------------------------------------|---------------------------------------------------|
+| `sketch_query_theta_union_merge`  | `theta_storage_size_duckdb` [4000, 32000]       | `theta_storage_size_clickhouse` [16000, 100000]   |
+| `sketch_query_kll_quantiles_merge`| `kll_storage_size_duckdb` [1000, 6000]          | `kll_storage_size_clickhouse` [1500, 8000]        |
+| `sketch_query_topk_combine`       | `topk_storage_size_duckdb` [300, 1200]          | `topk_storage_size_clickhouse` [150, 800]         |
+| `sketch_cpc_query_union_merge`    | `cpc_storage_size` [400, 4000] (DuckDB-only)    | —                                                  |
+| `sketch_req_query_quantile_merge` | `req_storage_size` [1000, 8000] (DuckDB-only)   | —                                                  |
+
+Observed sizes at SF=0.01 (the source of the bounds): Theta lg_k=12 ~16KB
+on DuckDB and ~60KB on ClickHouse (uniq HLL++ default precision); KLL
+k=200 ~3KB on DuckDB and ~3.8KB on ClickHouse (T-Digest compression=100);
+frequent-items lg_max_map_size=8 ~600B on DuckDB and ~294B on ClickHouse
+(topK K=8); CPC lg_k=11 ~1.2KB merged; REQ k=12 ~2.5KB merged.
 
 CPC vs Theta storage: CPC at ~1.2KB is roughly **13× smaller** than Theta
 at ~16KB on the same 15K distinct keys at SF=0.01. The tradeoff is
@@ -224,19 +251,19 @@ error, REQ gives relative-error. Cross-reference
 
 Per-engine SQL is wired through `validation_query.platform_overrides`:
 
-- DuckDB: `octet_length(<merged_sketch>)` against the `BLOB` column
+- DuckDB: `octet_length(<merged_sketch>)` against the `BLOB` column.
 - ClickHouse: `length(toString(<agg>MergeState(...)))` against the
   `AggregateFunction(...)` column. `length()` doesn't accept
   AggregateFunction directly, so `toString()` serializes the merged state
-  to its bytes-of-string representation.
-- Other engines: skipped via explicit `null` overrides (per-engine
-  byte-length probes for sketch state aren't yet wired). Add them in
+  to its bytes-of-string representation. Caveat: this is the textual
+  representation length, not the on-disk binary state length — these are
+  correlated and stable enough across runs for regression detection, but
+  do not interpret the absolute number as the storage cost a ClickHouse
+  user actually pays.
+- Other engines (Databricks, Snowflake, BigQuery, Redshift, DataFusion,
+  SQLite, StarRocks): skipped via explicit `null` overrides because their
+  byte-length probes for sketch state aren't yet wired. Add them in
   follow-up TODOs as cloud verification lands.
-
-Bounds span both engines so a single validation passes on whichever
-engine the op runs on. Per-engine tightening (separate
-`*_storage_size_<engine>` validations with engine-specific bounds) is a
-future option if drift detection needs to be tighter.
 
 ## Single-query scope: what this benchmark is **not**
 
@@ -357,6 +384,17 @@ the spark-read / groupBy / agg chain by hand:
 Top-K requires `F.approx_top_k_accumulate`, which ships with Spark 4.1+.
 Guard with `pyspark_supports_approx_top_k(spark)` before calling the
 top-K factory; older runtimes should skip cleanly with a logged reason.
+The guard is conservative: it requires both the version gate (≥4.1) and
+the function symbol — distributions that backport the function to a
+3.5.x build will be rejected by the version check. If you hit that case,
+bypass the guard or open a TODO to add a backport-detection branch.
+
+The current factory tests are MagicMock-based and verify call patterns
+without booting a real Spark session. Until the CLI integration follow-up
+runs the persist+merge cycle against Spark 3.5+ at least once, treat
+type-shape concerns (e.g. whether `F.hll_sketch_estimate` accepts the
+`Column` produced by `F.hll_union_agg` directly inside an `agg(...)`)
+as unverified.
 
 KLL is intentionally **not** implemented at the DataFrame layer because
 Spark's KLL surface is SQL-UDAF-only today; using `percentile_approx`

--- a/tests/unit/core/write_primitives/test_benchmark_operations.py
+++ b/tests/unit/core/write_primitives/test_benchmark_operations.py
@@ -68,6 +68,7 @@ class TestRunOperationValidation:
             expected_rows_max=None,
             expected_values=None,
             check_expression=None,
+            platform_overrides={},
         )
         operation = SimpleNamespace(validation_queries=[val_query])
         conn = MagicMock()
@@ -86,6 +87,7 @@ class TestRunOperationValidation:
             expected_rows_max=None,
             expected_values=None,
             check_expression=None,
+            platform_overrides={},
         )
         operation = SimpleNamespace(validation_queries=[val_query])
         conn = MagicMock()

--- a/tests/unit/core/write_primitives/test_dataframe_aggregate_state_ops.py
+++ b/tests/unit/core/write_primitives/test_dataframe_aggregate_state_ops.py
@@ -174,6 +174,41 @@ class TestExecuteAggregatePersist:
         assert "builder blew up" in result.error_message
         assert result.operation_type == WriteOperationType.AGGREGATE_PERSIST
 
+    def test_persist_failure_cleans_up_empty_target_dir(self, tmp_path: Path, monkeypatch):
+        caps = DataFrameWriteCapabilities(platform_name="test", supports_aggregate_persist=True)
+        manager = _make_manager_with_caps(caps)
+        builder = MagicMock(return_value=MagicMock(name="state_df"))
+
+        def boom_persist(df, path, compression):
+            raise RuntimeError("write blew up")
+
+        monkeypatch.setattr(manager, "_persist_dataframe_to_parquet", boom_persist)
+
+        target = tmp_path / "state"
+        result = manager.execute_aggregate_persist(target, builder)
+        assert result.success is False
+        # Failed persist should not leak an empty directory.
+        assert not target.exists()
+
+    def test_persist_failure_preserves_pre_existing_target_dir(self, tmp_path: Path, monkeypatch):
+        caps = DataFrameWriteCapabilities(platform_name="test", supports_aggregate_persist=True)
+        manager = _make_manager_with_caps(caps)
+        builder = MagicMock(return_value=MagicMock(name="state_df"))
+        monkeypatch.setattr(
+            manager,
+            "_persist_dataframe_to_parquet",
+            lambda df, path, compression: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        target = tmp_path / "state"
+        target.mkdir()
+        sentinel = target / "marker.txt"
+        sentinel.write_text("preexisting")
+        result = manager.execute_aggregate_persist(target, builder)
+        assert result.success is False
+        # Caller-owned directories must not be removed even if persist fails.
+        assert target.exists()
+        assert sentinel.read_text() == "preexisting"
+
 
 class TestExecuteAggregateMerge:
     def test_returns_failure_when_unsupported(self, tmp_path: Path):

--- a/tests/unit/core/write_primitives/test_validation_query_overrides.py
+++ b/tests/unit/core/write_primitives/test_validation_query_overrides.py
@@ -138,13 +138,6 @@ class TestResolveValidationSql:
         assert "redshift" in skip
         assert "v1" in skip
 
-    def test_handles_mock_validationquery_without_field(self):
-        """Defensive guard: test fixtures sometimes mock val_query without the new field."""
-        vq = SimpleNamespace(id="v1", sql="DEFAULT")  # no platform_overrides attr
-        sql, skip = _resolve_validation_sql(vq, "clickhouse")
-        assert sql == "DEFAULT"
-        assert skip is None
-
 
 # ---------------------------------------------------------------------------
 # Integration: _run_operation_validation

--- a/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
+++ b/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
@@ -40,6 +40,7 @@ def _make_val_query(
         expected_rows=expected_rows,
         expected_rows_min=expected_rows_min,
         expected_rows_max=expected_rows_max,
+        platform_overrides={},
     )
 
 


### PR DESCRIPTION
Address every actionable nit/consideration/required item from the
multi-PR review of the write-primitives sketch cluster (#176/#180/#181/
#182/#184).

Code:
- Remove defensive getattr fallback for ValidationQuery.platform_overrides
  in _resolve_validation_sql; update test mocks to set the field
  explicitly. The defensive coding was hiding bad mock hygiene.
- execute_aggregate_persist now cleans up an empty target directory it
  created itself when the persist phase fails, while preserving caller-
  owned directories untouched.

Catalog:
- Split theta/kll/topk storage_size validations into per-engine variants
  (*_storage_size_duckdb / *_storage_size_clickhouse) with engine-tight
  bounds. The previous cross-engine envelope let DuckDB grow ~5x silently
  before alarming. Each variant skips all non-target engines via explicit
  null platform_overrides.

Docs:
- Document the per-engine storage-size split rationale and the
  toString()-vs-on-disk-bytes caveat for ClickHouse.
- Document why CPC and REQ persist into per-family tables.
- Document the conservative version-then-attribute behaviour of
  pyspark_supports_approx_top_k (and its backport-rejection caveat).
- Note that PySpark factory tests are MagicMock-based and have not been
  exercised against a real Spark session.

Follow-up TODOs filed:
- write-primitives-sketch-pyspark-cli-integration: add sketch_df_* ops to
  operations.yaml + dispatch fork in benchmark.py + run verification
  against real Spark 3.5+ at least once. Closes the concrete gap captured
  by the pyspark scope-vs-verification blind-spot; that blind-spot now
  links to this TODO and is marked merged-to-todo.
- write-primitives-sketch-clickhouse-local-smoke: real benchbox-run smoke
  test for the ClickHouse sketch overrides (chDB syntax verification only
  today).
- write-primitives-sketch-storage-bounds-touchups: deferred lgmm10 lower
  bound widening + Theta sweep bound re-tuning, dependent on PR #184
  landing first.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
