### PR TITLE
fix(codex-followup): address /code review of routine added in #194

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -901,13 +901,21 @@ codex-pr-review-followups-list:
 		$(if $(CODEX_REVIEW_UNTIL),--until "$(CODEX_REVIEW_UNTIL)")
 
 # One-comment-at-a-time Codex follow-up loop for merged PR review findings.
-# Replies to each actioned source comment with a marker, then submits one PR
-# through the normal pr-preflight + pr-open workflow. Useful overrides:
+# Each actioned comment lands as its own commit *before* the GitHub marker
+# reply is posted, so a mid-sweep crash never leaves a phantom-actioned
+# thread on GitHub. After the loop, the routine runs pr-preflight and
+# opens one PR through the normal pr-open workflow.
+#
+# Useful overrides:
 #   CODEX_REVIEW_MAX_COMMENTS=N   cap an iteration batch
 #   CODEX_REVIEW_SINCE=YYYY-MM-DD scope by merged-at date
 #   CODEX_REVIEW_MODEL=<model>    choose the nested codex exec model
-#   CODEX_REVIEW_REPLY=0          skip GitHub replies
-#   CODEX_REVIEW_SUBMIT=0         skip final pr-open
+#   CODEX_REVIEW_REPLY=0          skip GitHub replies. Only the literals
+#                                 0|false|no disable; anything else
+#                                 (including "1" or "true") is treated as
+#                                 the default, so the reply is posted.
+#   CODEX_REVIEW_SUBMIT=0         skip final pr-open. Same accepted values
+#                                 as CODEX_REVIEW_REPLY above.
 codex-pr-review-followups:
 	@uv run --project _project/scripts -- python _project/scripts/codex_pr_review_followups.py run \
 		--base "$(CODEX_REVIEW_BASE)" \

--- a/_project/audits/codex-weekly-sweep-template.md
+++ b/_project/audits/codex-weekly-sweep-template.md
@@ -38,6 +38,38 @@ historical DONE verification commands when they are still executable
 documentation, and skips future reprocessing only after it has posted a reply
 containing the `benchbox-codex-review-followup-actioned` marker.
 
+## Trust model — review the resulting PR before merge
+
+The routine runs `codex exec --sandbox workspace-write -c approval_policy=never`
+against the contents of comments authored by `chatgpt-codex-connector[bot]`.
+That gives codex unattended write access to the repo for the duration of the
+sweep. The trust boundary is the **author filter** (`--author` /
+`CODEX_REVIEW_AUTHOR`). Anyone with repo write can change that flag to action
+comments from any author. Treat the routine accordingly:
+
+- The codex sandbox (`workspace-write`) permits codex to read the whole repo
+  and write any file under the worktree. It does not get network access by
+  default, but it can run any local command (including `git`, `uv`, `make`).
+- `approval_policy=never` means codex never prompts before running a local
+  command — including ones that mutate state. The routine is intentionally
+  unattended, so this is required.
+- Per-comment commits land **before** the GitHub marker reply is posted, and
+  each commit message includes the source PR# + comment id (see
+  `commit_message_for_result`). This means a crash mid-sweep leaves a
+  reviewable diff on the branch and no phantom-actioned thread on GitHub.
+- The reviewer of the resulting PR should: (a) skim each per-comment commit
+  to confirm the change matches the source comment's intent, (b) reject any
+  commit that pulled in unrelated edits, (c) verify that a "fixed"
+  disposition actually corresponds to a change on disk (a stale Codex run
+  could in principle fabricate an evidence block while leaving the tree
+  unchanged — the per-commit diff is the ground truth).
+- Prompt-injection content inside a Codex comment body is treated as input,
+  not instruction; the prompt template
+  (`_project/scripts/prompts/codex_pr_review_followup.md`) tells codex to
+  verify against the current tree and to make the smallest coherent fix.
+  Reviewers should still be alert to PRs that touch suspiciously broad
+  surface area for a single Codex finding.
+
 ## Required scope axes
 
 The frame "unresolved Codex review threads from PRs #N–#M" is good at

--- a/_project/blind-spots/2026-05-04-180735-codex-followups-reply-before-commit-phantom-actioned.md
+++ b/_project/blind-spots/2026-05-04-180735-codex-followups-reply-before-commit-phantom-actioned.md
@@ -1,0 +1,32 @@
+---
+id: 2026-05-04-180735-codex-followups-reply-before-commit-phantom-actioned
+date: 2026-05-04
+status: open
+finding_kind: bug-class
+review_context: "/code review of PR #194 (codex-pr-review-followups routine) on chore/codex-pr-review-followups"
+related_paths:
+  - _project/scripts/codex_pr_review_followups.py
+suggested_sweep: "audit other long-running orchestrators that post external state mutations before local commits land"
+todo_id: null
+---
+
+# Reply-before-commit creates phantom-actioned comments if the routine dies mid-loop
+
+## Finding
+
+`run_action_loop` posts the GitHub reply marker (`benchbox-codex-review-followup-actioned`) to a Codex comment **inside the per-comment loop** (`reply_to_comment` at line 596), but the actual `git commit` of the codex-produced changes only happens later in `submit_changes` (line 546) after **all** comments are processed. If the routine crashes, is `Ctrl-C`'d, or `make pr-preflight` fails between the reply and the commit, the reply marker persists on GitHub while the diff is gone (working tree blown away by the next `worktree-claim`, or simply discarded). The next sweep skips the comment as "already actioned" and the fix never lands. There is no resumable checkpoint and no rollback of the marker reply.
+
+The five-axis review (correctness/readability/architecture/security/performance) did not surface this because partial-failure recovery is an *operability* dimension — neither correctness nor architecture in isolation flag it.
+
+## Why this matters
+
+This is a class: **scripts that mutate external state (GitHub comments, Slack, Jira) ahead of the local commit that justifies the mutation**. The external system becomes the source of truth for "this work was done" while the actual artifact is ephemeral. Once the marker is on GitHub, no local recovery path exists — the operator has to manually delete the marker reply or hand-edit `has_action_marker` matching to ignore it.
+
+Other orchestrators in the repo that post-then-mutate (or vice versa) should be audited for the same pattern: the bug is not in any one line of code, it's in the order of side effects.
+
+## Suggested next steps
+
+- [ ] Reorder `run_action_loop`: stage + commit per-comment locally *before* posting the GitHub reply, so the reply is the last write. A failure between commit and reply leaves a benign uncommented commit; a failure before the commit leaves nothing on GitHub.
+- [ ] If a single batched commit is preferred for PR ergonomics, persist a local sidecar (`_project/iterate/codex-followups/<run-id>/state.json`) that records reply-posted-but-uncommitted comments, so a resume run can detect them and either retry the commit or post a corrective reply.
+- [ ] Add a smoke test that simulates an exception thrown between `reply_to_comment` and `submit_changes` and asserts the system can be re-driven to a consistent state.
+- [ ] Sweep other repo orchestrators (`make pr-fanout`, dev-loop post-merge revert workflow, etc.) for the same "external write before local commit" pattern.

--- a/_project/blind-spots/2026-05-04-180736-codex-followups-no-external-cli-version-contract.md
+++ b/_project/blind-spots/2026-05-04-180736-codex-followups-no-external-cli-version-contract.md
@@ -1,0 +1,39 @@
+---
+id: 2026-05-04-180736-codex-followups-no-external-cli-version-contract
+date: 2026-05-04
+status: open
+finding_kind: framework-gap
+review_context: "/code review of PR #194 (codex-pr-review-followups routine) on chore/codex-pr-review-followups"
+related_paths:
+  - _project/scripts/codex_pr_review_followups.py
+  - Makefile
+suggested_sweep: "find other scripts that shell out to third-party CLIs without a version probe or pin"
+todo_id: null
+---
+
+# Routine ships hard-coded codex-cli flags with no version contract
+
+## Finding
+
+`run_codex_for_comment` hard-codes `--ask-for-approval` (line 434) and `--sandbox` (line 432) as positional flag/value pairs in the codex-cli argv. The installed codex-cli (`0.128.0`) does not have `--ask-for-approval`; the equivalent is now `-c approval_policy=...` or `--dangerously-bypass-approvals-and-sandbox`. The routine fails at the first comment with `error: unexpected argument '--ask-for-approval' found` and never advances. There is:
+
+- no `codex --version` probe at startup,
+- no minimum-version assertion or compat note in `pyproject.toml` / docs,
+- no fallback flag style,
+- no integration test that actually invokes `codex exec` against a real binary.
+
+The five-axis review framework (correctness/readability/architecture/security/performance) does not include a "third-party CLI compatibility" axis, so reviews of scripts that wrap external tools systematically miss this class of failure until the script runs in anger.
+
+## Why this matters
+
+This is a **framework gap, not a single-script bug**. BenchBox has many scripts that shell out to `gh`, `git`, `make`, `uv`, `codex`, and platform CLIs (`duckdb`, `clickhouse-cloud`, etc.). Each one inherits the host machine's installed version. When upstream renames a flag, the failure surface is "the routine simply stops working" with no early warning. The five-axis frame treats external CLIs as black-box subprocess invocations whose return code is the only contract; it doesn't ask "what version contract does this script depend on, and how is it enforced?"
+
+The PR also shipped without an end-to-end integration test — the test file exercises pure functions and one branch guard, but `codex exec` is never invoked against the real binary even in CI smoke. A `--codex-binary echo` or `--dry-codex` mode would have caught this.
+
+## Suggested next steps
+
+- [ ] Add a `_check_codex_version()` probe at the top of `run_action_loop` that runs `codex --version`, parses semver, and rejects unsupported versions with a clear remediation (upgrade/downgrade command).
+- [ ] Replace `--ask-for-approval <mode>` with `-c approval_policy=<mode>` (config override syntax exists in 0.128.0 and likely in earlier versions) — this is more durable across codex-cli releases.
+- [ ] Add an integration smoke test that invokes the routine with a fake `codex` shim on `PATH` (a 5-line bash script that echoes a fixed disposition) so the end-to-end argv assembly is exercised in CI.
+- [ ] Adopt a repo-wide convention: any script that shells out to a non-bundled CLI declares its supported version range in a module-level constant + a probe function, and the test suite asserts the probe runs.
+- [ ] Sweep `_project/scripts/` and `scripts/` for similar shell-outs (`subprocess.run([...])` with a non-stdlib binary) and audit each for a version contract.

--- a/_project/scripts/codex_pr_review_followups.py
+++ b/_project/scripts/codex_pr_review_followups.py
@@ -14,6 +14,7 @@ import argparse
 import datetime as dt
 import json
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -23,8 +24,12 @@ from typing import Any, Sequence
 
 DEFAULT_CODEX_AUTHORS = ("chatgpt-codex-connector[bot]", "chatgpt-codex-connector")
 ACTION_MARKER = "benchbox-codex-review-followup-actioned"
+ACTION_MARKER_REGEX = re.compile(rf"(?m)^<!--\s*{re.escape(ACTION_MARKER)}\b")
 DEFAULT_COMMIT_MESSAGE = "fix: address stale Codex PR review follow-ups"
-MAX_REPLY_SUMMARY_CHARS = 1800
+PER_COMMENT_COMMIT_PREFIX = "fix(codex-followup)"
+MAX_REPLY_SUMMARY_CHARS = 8000
+PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "prompts" / "codex_pr_review_followup.md"
+MIN_CODEX_VERSION = (0, 20, 0)
 
 
 @dataclass(frozen=True)
@@ -224,6 +229,12 @@ def review_comment_from_api(item: dict[str, Any]) -> ReviewComment:
 
 
 def fetch_pr_review_comments(runner: CommandRunner, *, repo: str, pr_number: int) -> list[ReviewComment]:
+    """REST fallback: fetch review comments for a single PR.
+
+    Used when the GraphQL batch path is not viable (e.g. tests injecting a
+    minimal recording runner). Production runs go through
+    `fetch_review_comments_batched`.
+    """
     rows = gh_json_lines(
         runner,
         [
@@ -238,14 +249,138 @@ def fetch_pr_review_comments(runner: CommandRunner, *, repo: str, pr_number: int
     return [review_comment_from_api(row) for row in rows]
 
 
+REVIEW_COMMENTS_GRAPHQL_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 50, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          comments(first: 100) {
+            nodes {
+              databaseId
+              body
+              path
+              url
+              createdAt
+              diffHunk
+              line
+              originalLine
+              originalCommit { oid }
+              commit { oid }
+              replyTo { databaseId }
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+
+def _graphql_comment_to_api_shape(node: dict[str, Any]) -> dict[str, Any]:
+    author = node.get("author") or {}
+    reply_to = node.get("replyTo") or {}
+    original_commit = node.get("originalCommit") or {}
+    commit = node.get("commit") or {}
+    return {
+        "id": node.get("databaseId"),
+        "body": node.get("body") or "",
+        "path": node.get("path") or "",
+        "html_url": node.get("url") or "",
+        "user": {"login": author.get("login") or ""},
+        "created_at": node.get("createdAt") or "",
+        "diff_hunk": node.get("diffHunk") or "",
+        "in_reply_to_id": reply_to.get("databaseId"),
+        "original_commit_id": original_commit.get("oid"),
+        "commit_id": commit.get("oid"),
+        "line": node.get("line"),
+        "original_line": node.get("originalLine"),
+    }
+
+
+def fetch_review_comments_via_graphql(
+    runner: CommandRunner, *, repo: str, pr_number: int
+) -> list[ReviewComment] | None:
+    """Fetch one PR's review comments via a single GraphQL request (paginated).
+
+    Returns None if the GraphQL endpoint is unavailable in this environment
+    (the caller falls back to the REST path). Each merged PR still costs one
+    GraphQL roundtrip, but each roundtrip pulls every thread + comment for
+    that PR — replacing the prior per-page REST chain.
+    """
+    owner, _, name = repo.partition("/")
+    if not owner or not name:
+        return None
+
+    cursor: str | None = None
+    rows: list[dict[str, Any]] = []
+    while True:
+        args = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={REVIEW_COMMENTS_GRAPHQL_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+        ]
+        if cursor is not None:
+            args.extend(["-F", f"cursor={cursor}"])
+        result = runner.run(args)
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout) if result.stdout.strip() else {}
+        except json.JSONDecodeError:
+            return None
+        pr = (((payload.get("data") or {}).get("repository") or {}).get("pullRequest") or {})
+        threads = (pr.get("reviewThreads") or {})
+        for thread in threads.get("nodes") or []:
+            for node in (thread.get("comments") or {}).get("nodes") or []:
+                if node.get("databaseId") is None:
+                    continue
+                rows.append(_graphql_comment_to_api_shape(node))
+        page_info = threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+    return [review_comment_from_api(row) for row in rows]
+
+
+def load_pr_review_comments(
+    runner: CommandRunner, *, repo: str, pr_number: int
+) -> list[ReviewComment]:
+    """Prefer GraphQL; fall back to REST on any failure for resilience."""
+    via_graphql = fetch_review_comments_via_graphql(runner, repo=repo, pr_number=pr_number)
+    if via_graphql is not None:
+        return via_graphql
+    return fetch_pr_review_comments(runner, repo=repo, pr_number=pr_number)
+
+
 def has_action_marker(replies: Sequence[ReviewComment]) -> bool:
-    return any(ACTION_MARKER in reply.body for reply in replies)
+    """Match the marker only inside an HTML comment at start-of-line.
+
+    Substring matching let any reply that quoted the marker string (e.g. in a
+    meta-discussion) silently kill future sweeps for the thread.
+    """
+    return any(ACTION_MARKER_REGEX.search(reply.body) for reply in replies)
 
 
 def comment_precedes_merge(comment: ReviewComment, pr: PullRequest) -> bool:
     comment_time = parse_github_time(comment.created_at)
     merged_time = parse_github_time(pr.merged_at)
-    if comment_time is None or merged_time is None:
+    if merged_time is None:
+        raise ValueError(f"PR #{pr.number} is missing mergedAt; should be filtered upstream")
+    if comment_time is None:
         return False
     return comment_time < merged_time
 
@@ -296,7 +431,7 @@ def discover_pending_comments(
         until=until,
     )
     for pr in pull_requests:
-        comments = fetch_pr_review_comments(runner, repo=repo, pr_number=pr.number)
+        comments = load_pr_review_comments(runner, repo=repo, pr_number=pr.number)
         pending.extend(pending_comments_for_pr(pr, comments, author_logins=author_logins))
     return pending
 
@@ -320,8 +455,14 @@ def print_pending_table(pending: Sequence[PendingComment]) -> None:
         print(f"#{item.pr.number:<5}  {item.comment.id:>12}  {path:<52}  {first_body_line(item.comment.body)}")
 
 
-def git_diff(runner: CommandRunner) -> str:
-    return checked(runner, ["git", "diff", "--binary"]).stdout
+def git_status_snapshot(runner: CommandRunner) -> str:
+    """Snapshot of working-tree state used as a disposition baseline.
+
+    `git diff` only sees unstaged tracked-file changes. Codex may stage edits
+    (`git add`) or create new untracked files; both must count as "fixed".
+    `git status --porcelain` covers all three: modified, staged, and untracked.
+    """
+    return checked(runner, ["git", "status", "--porcelain"]).stdout
 
 
 def git_changed_paths(runner: CommandRunner) -> list[str]:
@@ -352,64 +493,68 @@ def truncate_summary(text: str, limit: int = MAX_REPLY_SUMMARY_CHARS) -> str:
     return normalized[: limit - 15].rstrip() + "\n[truncated]"
 
 
-def build_codex_prompt(item: PendingComment, *, repo: str, base: str) -> str:
+def load_prompt_template(path: Path = PROMPT_TEMPLATE_PATH) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def build_codex_prompt(
+    item: PendingComment,
+    *,
+    repo: str,
+    base: str,
+    template: str | None = None,
+) -> str:
     comment = item.comment
     pr = item.pr
-    return textwrap.dedent(
-        f"""
-        You are actioning one stale Codex web-agent inline PR review comment for BenchBox.
+    rendered = (template or load_prompt_template()).format(
+        repo=repo,
+        base=base,
+        pr_number=pr.number,
+        pr_title=pr.title,
+        pr_url=pr.url,
+        pr_merged_at=pr.merged_at,
+        comment_html_url=comment.html_url,
+        comment_id=comment.id,
+        comment_path=comment.path,
+        comment_line=comment.line,
+        comment_original_line=comment.original_line,
+        comment_commit_id=comment.commit_id,
+        comment_original_commit_id=comment.original_commit_id,
+        comment_diff_hunk=comment.diff_hunk,
+        comment_body=comment.body,
+    )
+    return rendered.strip()
 
-        Source:
-        - Repository: {repo}
-        - Base branch: {base}
-        - Merged PR: #{pr.number} {pr.title}
-        - PR URL: {pr.url}
-        - PR merged at: {pr.merged_at}
-        - Review comment: {comment.html_url}
-        - Comment id: {comment.id}
-        - Path: {comment.path}
-        - Line: current={comment.line}, original={comment.original_line}
-        - Commit: current={comment.commit_id}, original={comment.original_commit_id}
 
-        Required workflow:
-        1. Inspect the current repository state before editing. Do not assume the old PR diff still reflects the tree.
-        2. Decide whether the finding still requires action on the current branch.
-        3. If a fix is still required, make the smallest coherent fix and add/update focused regression coverage.
-        4. Run the narrowest relevant verification command. Use `uv run --` for Python tooling.
-        5. If no fix is currently required, leave files unchanged and explain the evidence.
-        6. Do not commit, push, open a PR, or reply on GitHub. The outer Make routine handles those steps.
+def check_codex_version(
+    runner: CommandRunner, *, minimum: tuple[int, int, int] = MIN_CODEX_VERSION
+) -> tuple[int, int, int]:
+    """Probe `codex --version` and assert it parses to >= minimum.
 
-        Carry-over patterns from the completed Codex follow-up TODOs:
-        - A stale GitHub thread is not enough evidence. Verify current behavior before fixing or dismissing.
-        - Some comments are already fixed by later merges; close those with concrete current-file evidence, not code churn.
-        - Historical DONE-item verification commands should stay executable when the comment identifies a real command defect.
-        - Comments on obsolete DONE verification commands can be closed as no-current-action only when the command is not reused
-          and the current sweep/template captures the protocol hygiene lesson.
-        - Cross-check related blind-spots and weakened tests when the finding is about regression coverage.
-        - Prefer focused tests over broad rewrites.
-
-        Useful local references:
-        - `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml`
-        - `_project/TODO/main/active/codex-pr-review-followups-week-2026-05-03.yaml`
-        - `_project/audits/codex-weekly-sweep-template.md`
-        - `_project/audits/codex-thread-rescan-week-2026-05-01.md`
-
-        Diff hunk from the original PR comment:
-        ```diff
-        {comment.diff_hunk}
-        ```
-
-        Codex web-agent comment body:
-        ```markdown
-        {comment.body}
-        ```
-
-        Final response format:
-        - `Disposition: fixed` or `Disposition: no-current-action`
-        - `Evidence:` one short paragraph with files/tests checked
-        - `Verification:` command(s) run, or why verification was not applicable
-        """
-    ).strip()
+    Surfaces a clear remediation when the binary is missing or too old, so the
+    routine fails fast instead of mid-loop with an opaque flag-not-recognized
+    error from a stale codex CLI.
+    """
+    try:
+        result = runner.run(["codex", "--version"])
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "codex CLI not found on PATH. Install codex-cli "
+            f">= {'.'.join(str(p) for p in minimum)} (https://github.com/openai/codex)."
+        ) from exc
+    if result.returncode != 0:
+        raise CommandError(["codex", "--version"], result)
+    text = (result.stdout or result.stderr or "").strip()
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
+    if not match:
+        raise RuntimeError(f"Could not parse codex CLI version from output: {text!r}")
+    parsed = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    if parsed < minimum:
+        raise RuntimeError(
+            f"codex CLI {'.'.join(str(p) for p in parsed)} is below the required "
+            f">= {'.'.join(str(p) for p in minimum)}. Upgrade codex-cli."
+        )
+    return parsed
 
 
 def run_codex_for_comment(
@@ -422,8 +567,11 @@ def run_codex_for_comment(
     codex_sandbox: str,
     codex_approval: str,
 ) -> ActionResult:
-    before = git_diff(runner)
+    before = git_status_snapshot(runner)
     prompt = build_codex_prompt(item, repo=repo, base=base)
+    # codex-cli >= 0.20 dropped `--ask-for-approval`. The config-override
+    # syntax (`-c approval_policy=<mode>`) works across the supported version
+    # range and is forward-stable.
     cmd = [
         "codex",
         "exec",
@@ -431,8 +579,8 @@ def run_codex_for_comment(
         str(runner.cwd),
         "--sandbox",
         codex_sandbox,
-        "--ask-for-approval",
-        codex_approval,
+        "-c",
+        f"approval_policy={codex_approval}",
     ]
     if codex_model:
         cmd.extend(["--model", codex_model])
@@ -447,10 +595,59 @@ def run_codex_for_comment(
     if result.returncode != 0:
         raise CommandError(cmd, result)
 
-    after = git_diff(runner)
+    after = git_status_snapshot(runner)
     disposition = "fixed" if after != before else "no-current-action"
     summary = result.stdout.strip() or result.stderr.strip() or f"Disposition: {disposition}"
     return ActionResult(pending=item, disposition=disposition, summary=summary)
+
+
+def commit_message_for_result(result: ActionResult) -> str:
+    """One commit per actioned comment, with PR# + comment id for traceability."""
+    pr = result.pending.pr
+    comment = result.pending.comment
+    headline = first_body_line(comment.body)
+    subject = f"{PER_COMMENT_COMMIT_PREFIX}: PR #{pr.number} comment {comment.id} — {headline}"
+    # Keep commit subjects under the conventional ~100-char soft cap; truncate
+    # the codex headline before composing rather than after, so the trailer
+    # stays intact.
+    if len(subject) > 100:
+        keep = 100 - (len(subject) - len(headline)) - 1
+        subject = (
+            f"{PER_COMMENT_COMMIT_PREFIX}: PR #{pr.number} comment {comment.id} — "
+            f"{headline[: max(keep, 1)]}…"
+        )
+    body = (
+        f"Disposition: {result.disposition}\n"
+        f"Source: {comment.html_url}\n"
+        f"Path: {comment.path}\n"
+    )
+    return f"{subject}\n\n{body}"
+
+
+def commit_changes_for_result(
+    runner: CommandRunner, result: ActionResult
+) -> bool:
+    """Stage + commit codex-produced changes for one comment.
+
+    Returns True when a commit was created. Called *before* the GitHub reply
+    is posted so a crash between codex and reply leaves no phantom-actioned
+    state on GitHub: either the commit landed (next run sees no change), or
+    nothing happened (next run reprocesses the comment cleanly).
+    """
+    if result.disposition != "fixed":
+        return False
+    paths = git_changed_paths(runner)
+    if not paths:
+        return False
+    print("==> Staging changed paths for this comment")
+    for path in paths:
+        print(f"  {path}")
+    stage_paths(runner, paths)
+    staged_paths = checked(runner, ["git", "diff", "--cached", "--name-only"]).stdout.splitlines()
+    if not staged_paths:
+        return False
+    checked(runner, ["git", "commit", "-m", commit_message_for_result(result)])
+    return True
 
 
 def build_reply_body(result: ActionResult, *, branch: str) -> str:
@@ -519,31 +716,38 @@ def stage_paths(runner: CommandRunner, paths: Sequence[str]) -> None:
     checked(runner, ["git", "add", "--", *paths])
 
 
-def submit_changes(
+def finalize_changes(
     runner: CommandRunner,
     *,
     base_ref: str,
     commit_message: str,
     no_submit: bool,
 ) -> None:
+    """Run preflight + open the PR over the per-comment commits already on HEAD.
+
+    Per-comment commits are produced inside `run_action_loop` *before* the
+    GitHub reply is posted. This finalizer's job is just to (a) sweep up any
+    leftover unstaged paths into a fallback batch commit (codex output that
+    was somehow missed by `commit_changes_for_result`), (b) run preflight,
+    (c) open the PR.
+    """
     paths = git_changed_paths(runner)
-    commits_before = local_commit_count(runner, base_ref)
-    if not paths and commits_before == 0:
+    commits = local_commit_count(runner, base_ref)
+    if not paths and commits == 0:
         print("No file changes or local commits were produced; skipping PR submission.")
         return
 
     if paths:
-        print("\n==> Staging changed paths")
+        print("\n==> Sweeping leftover changed paths into fallback commit")
         for path in paths:
             print(f"  {path}")
         stage_paths(runner, paths)
+        staged = checked(runner, ["git", "diff", "--cached", "--name-only"]).stdout.splitlines()
+        if staged:
+            checked(runner, ["git", "commit", "-m", commit_message])
 
     print("\n==> Running pr-preflight")
     checked(runner, ["make", "pr-preflight"])
-
-    staged_paths = checked(runner, ["git", "diff", "--cached", "--name-only"]).stdout.splitlines()
-    if staged_paths:
-        checked(runner, ["git", "commit", "-m", commit_message])
 
     if no_submit:
         print("Skipping PR submission because --no-submit was set.")
@@ -563,6 +767,7 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
         if not args.dry_run:
             branch = current_branch(runner)
             ensure_action_branch(branch, no_submit=args.no_submit)
+            check_codex_version(runner)
         ensure_clean_start(runner, allow_dirty=args.allow_dirty or args.dry_run, base_ref=f"origin/{args.base}")
     pending = discover_pending_comments(
         runner,
@@ -591,12 +796,18 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
             codex_sandbox=args.codex_sandbox,
             codex_approval=args.codex_approval,
         )
+        # Order matters: commit BEFORE replying. A crash between codex and
+        # the reply leaves nothing on GitHub; a crash between commit and
+        # reply leaves a benign uncommented commit. Reply-before-commit
+        # would create phantom-actioned threads that future sweeps would
+        # silently skip even though no fix landed.
+        commit_changes_for_result(runner, result)
         results.append(result)
         if not args.no_reply:
             reply_to_comment(runner, repo=repo, result=result, branch=branch)
 
     print(f"\nActioned {len(results)} Codex review comment(s).")
-    submit_changes(
+    finalize_changes(
         runner,
         base_ref=f"origin/{args.base}",
         commit_message=args.commit_message,

--- a/_project/scripts/prompts/codex_pr_review_followup.md
+++ b/_project/scripts/prompts/codex_pr_review_followup.md
@@ -1,0 +1,51 @@
+You are actioning one stale Codex web-agent inline PR review comment for BenchBox.
+
+Source:
+- Repository: {repo}
+- Base branch: {base}
+- Merged PR: #{pr_number} {pr_title}
+- PR URL: {pr_url}
+- PR merged at: {pr_merged_at}
+- Review comment: {comment_html_url}
+- Comment id: {comment_id}
+- Path: {comment_path}
+- Line: current={comment_line}, original={comment_original_line}
+- Commit: current={comment_commit_id}, original={comment_original_commit_id}
+
+Required workflow:
+1. Inspect the current repository state before editing. Do not assume the old PR diff still reflects the tree.
+2. Decide whether the finding still requires action on the current branch.
+3. If a fix is still required, make the smallest coherent fix and add/update focused regression coverage.
+4. Run the narrowest relevant verification command. Use `uv run --` for Python tooling.
+5. If no fix is currently required, leave files unchanged and explain the evidence.
+6. Do not commit, push, open a PR, or reply on GitHub. The outer Make routine handles those steps.
+
+Carry-over patterns from the completed Codex follow-up TODOs:
+- A stale GitHub thread is not enough evidence. Verify current behavior before fixing or dismissing.
+- Some comments are already fixed by later merges; close those with concrete current-file evidence, not code churn.
+- Historical DONE-item verification commands should stay executable when the comment identifies a real command defect.
+- Comments on obsolete DONE verification commands can be closed as no-current-action only when the command is not reused
+  and the current sweep/template captures the protocol hygiene lesson.
+- Cross-check related blind-spots and weakened tests when the finding is about regression coverage.
+- Prefer focused tests over broad rewrites.
+
+Useful local references:
+- `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml`
+- `_project/TODO/main/active/codex-pr-review-followups-week-2026-05-03.yaml`
+- `_project/audits/codex-weekly-sweep-template.md`
+- `_project/audits/codex-thread-rescan-week-2026-05-01.md`
+
+Diff hunk from the original PR comment:
+```diff
+{comment_diff_hunk}
+```
+
+Codex web-agent comment body:
+```markdown
+{comment_body}
+```
+
+Final response format:
+- `Disposition: fixed` or `Disposition: no-current-action`
+- `Evidence:` one short paragraph with files/tests checked
+- `Verification:` command(s) run, or why verification was not applicable

--- a/tests/unit/scripts/test_codex_pr_review_followups.py
+++ b/tests/unit/scripts/test_codex_pr_review_followups.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import stat
 import subprocess
 import sys
+import textwrap
 from pathlib import Path
 from typing import Sequence
 
@@ -34,13 +37,20 @@ codex_pr_review_followups = _load_script()
 
 
 class RecordingRunner:
-    def __init__(self) -> None:
+    def __init__(self, responses: dict[tuple[str, ...], subprocess.CompletedProcess[str]] | None = None) -> None:
         self.commands: list[list[str]] = []
+        self.inputs: list[str | None] = []
+        self.responses = responses or {}
+        self.cwd = Path.cwd()
 
     def run(self, args: Sequence[str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
-        del input_text
-        self.commands.append(list(args))
-        return subprocess.CompletedProcess(list(args), 0, "", "")
+        argv = list(args)
+        self.commands.append(argv)
+        self.inputs.append(input_text)
+        key = tuple(argv)
+        if key in self.responses:
+            return self.responses[key]
+        return subprocess.CompletedProcess(argv, 0, "", "")
 
 
 def _pr():
@@ -95,6 +105,44 @@ def test_pending_comments_skip_action_marker_replies_and_post_merge_comments() -
     assert [item.comment.id for item in pending] == [3]
 
 
+def test_action_marker_match_requires_html_comment_at_start_of_line() -> None:
+    """Substring matching let unrelated quotes silently kill future sweeps.
+
+    The strict matcher only accepts the marker inside an HTML comment that
+    starts at the beginning of a line — the shape `build_reply_body` posts.
+    """
+    quoted_marker_reply = _comment(
+        2,
+        user_login="joeharris76",
+        in_reply_to_id=1,
+        body=(
+            "Discussion: I noticed the script uses the marker "
+            f"`{codex_pr_review_followups.ACTION_MARKER}` to dedupe. "
+            "We should document this somewhere."
+        ),
+    )
+    real_marker_reply = _comment(
+        4,
+        user_login="joeharris76",
+        in_reply_to_id=3,
+        body=(
+            f"<!-- {codex_pr_review_followups.ACTION_MARKER}: pr=123 comment_id=3 -->\n"
+            "Follow-up sweep actioned this Codex review comment."
+        ),
+    )
+    comments = [_comment(1), quoted_marker_reply, _comment(3), real_marker_reply]
+
+    pending = codex_pr_review_followups.pending_comments_for_pr(
+        _pr(),
+        comments,
+        author_logins={"chatgpt-codex-connector[bot]"},
+    )
+
+    # comment 1 is still pending because the quoted-marker reply doesn't
+    # match; comment 3 is skipped because the real marker reply does.
+    assert [item.comment.id for item in pending] == [1]
+
+
 def test_prompt_carries_completed_sweep_patterns() -> None:
     pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(10), replies=())
 
@@ -104,6 +152,18 @@ def test_prompt_carries_completed_sweep_patterns() -> None:
     assert "Historical DONE-item verification commands should stay executable" in prompt
     assert "_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml" in prompt
     assert "_project/audits/codex-weekly-sweep-template.md" in prompt
+
+
+def test_prompt_template_file_exists_and_renders_comment_metadata() -> None:
+    template_path = codex_pr_review_followups.PROMPT_TEMPLATE_PATH
+    assert template_path.exists(), f"prompt template file missing at {template_path}"
+
+    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(77), replies=())
+    prompt = codex_pr_review_followups.build_codex_prompt(pending, repo="joeharris76/BenchBox", base="develop")
+
+    assert "Comment id: 77" in prompt
+    assert "Path: benchbox/example.py" in prompt
+    assert "joeharris76/BenchBox" in prompt
 
 
 def test_reply_body_contains_skip_marker_and_disposition() -> None:
@@ -120,6 +180,9 @@ def test_reply_body_contains_skip_marker_and_disposition() -> None:
     assert "comment_id=11" in body
     assert "Disposition: fixed" in body
     assert "Future sweeps skip comments" in body
+    # The reply body itself must match the strict marker matcher so the
+    # *next* sweep recognizes its own previous reply.
+    assert codex_pr_review_followups.ACTION_MARKER_REGEX.search(body)
 
 
 def test_submit_branch_guard_refuses_protected_branches() -> None:
@@ -137,3 +200,202 @@ def test_stage_paths_uses_explicit_paths_not_git_add_all() -> None:
     assert runner.commands == [
         ["git", "add", "--", "Makefile", "_project/scripts/codex_pr_review_followups.py"],
     ]
+
+
+def test_check_codex_version_accepts_supported_release() -> None:
+    runner = RecordingRunner(
+        responses={
+            ("codex", "--version"): subprocess.CompletedProcess(["codex", "--version"], 0, "codex-cli 0.128.0\n", "")
+        }
+    )
+
+    parsed = codex_pr_review_followups.check_codex_version(runner)
+
+    assert parsed == (0, 128, 0)
+
+
+def test_check_codex_version_rejects_too_old_release() -> None:
+    runner = RecordingRunner(
+        responses={
+            ("codex", "--version"): subprocess.CompletedProcess(["codex", "--version"], 0, "codex-cli 0.10.0\n", "")
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="below the required"):
+        codex_pr_review_followups.check_codex_version(runner)
+
+
+def test_check_codex_version_surfaces_missing_binary() -> None:
+    class MissingBinaryRunner(RecordingRunner):
+        def run(self, args, input_text=None):  # type: ignore[override]
+            self.commands.append(list(args))
+            raise FileNotFoundError("codex")
+
+    runner = MissingBinaryRunner()
+
+    with pytest.raises(RuntimeError, match="codex CLI not found"):
+        codex_pr_review_followups.check_codex_version(runner)
+
+
+def test_run_codex_for_comment_uses_config_override_for_approval_policy() -> None:
+    """The legacy `--ask-for-approval` flag was dropped in codex-cli >= 0.20.
+
+    The orchestrator must use `-c approval_policy=<mode>` so it works against
+    current and future codex releases.
+    """
+    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(50), replies=())
+    runner = RecordingRunner()
+
+    result = codex_pr_review_followups.run_codex_for_comment(
+        runner,
+        pending,
+        repo="joeharris76/BenchBox",
+        base="develop",
+        codex_model=None,
+        codex_sandbox="workspace-write",
+        codex_approval="never",
+    )
+
+    codex_calls = [cmd for cmd in runner.commands if cmd and cmd[0] == "codex"]
+    assert codex_calls, "expected at least one codex invocation"
+    codex_argv = codex_calls[0]
+    assert "--ask-for-approval" not in codex_argv
+    assert "-c" in codex_argv
+    assert "approval_policy=never" in codex_argv
+    assert result.disposition == "no-current-action"  # RecordingRunner produces no diff
+
+
+def test_commit_message_for_result_includes_pr_and_comment_id() -> None:
+    pending = codex_pr_review_followups.PendingComment(
+        pr=_pr(), comment=_comment(101, body="[P1] Tighten the merge guard"), replies=()
+    )
+    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+
+    message = codex_pr_review_followups.commit_message_for_result(result)
+
+    assert message.startswith("fix(codex-followup):")
+    assert "PR #123" in message
+    assert "comment 101" in message
+    assert "Source: " in message
+
+
+def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
+    """A crash between the codex run and the reply must not leave a phantom
+    actioned thread on GitHub. The order is: codex → commit → reply.
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "commit.gpgsign", "false"], check=True)
+    (repo_root / "README").write_text("ok\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "develop"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-q", "-b", "chore/test"], check=True)
+    # Pretend origin/develop is the same SHA as the seed commit so
+    # local_commit_count returns 0 at start.
+    head = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(repo_root), "update-ref", "refs/remotes/origin/develop", head], check=True)
+
+    # Fake codex shim that writes a deterministic file to simulate a fix.
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    codex_shim = fake_bin / "codex"
+    codex_shim.write_text(
+        textwrap.dedent(
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [[ "${1:-}" == "--version" ]]; then
+              echo "codex-cli 0.128.0"
+              exit 0
+            fi
+            # exec subcommand: write a fix file inside the cwd given via --cd.
+            cd_dir="."
+            for ((i=1; i<=$#; i++)); do
+              if [[ "${!i}" == "--cd" ]]; then
+                next=$((i+1))
+                cd_dir="${!next}"
+              fi
+            done
+            mkdir -p "$cd_dir"
+            echo "codex-fix" > "$cd_dir/codex-fix.txt"
+            cat <<'OUT'
+            Disposition: fixed
+            Evidence: created codex-fix.txt
+            Verification: cat codex-fix.txt
+            OUT
+            """
+        ).strip()
+        + "\n"
+    )
+    codex_shim.chmod(codex_shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+
+    pending_pr = codex_pr_review_followups.PullRequest(
+        number=42, title="t", merged_at="2026-05-04T12:00:00Z", url="https://example/42"
+    )
+    pending_comment = codex_pr_review_followups.ReviewComment(
+        id=999,
+        body="[P1] do the thing",
+        path="codex-fix.txt",
+        html_url="https://example/42#999",
+        user_login="chatgpt-codex-connector[bot]",
+        created_at="2026-05-04T10:00:00Z",
+    )
+    pending_item = codex_pr_review_followups.PendingComment(pr=pending_pr, comment=pending_comment, replies=())
+
+    side_effect_log: list[str] = []
+
+    monkeypatch.setattr(codex_pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
+    monkeypatch.setattr(
+        codex_pr_review_followups,
+        "discover_pending_comments",
+        lambda runner, **_: [pending_item],
+    )
+
+    real_commit = codex_pr_review_followups.commit_changes_for_result
+
+    def trace_commit(runner, result):
+        side_effect_log.append("commit")
+        return real_commit(runner, result)
+
+    def trace_reply(runner, *, repo, result, branch):
+        side_effect_log.append("reply")
+        # Don't actually call gh; just record.
+
+    def trace_finalize(runner, **kwargs):
+        side_effect_log.append("finalize")
+
+    monkeypatch.setattr(codex_pr_review_followups, "commit_changes_for_result", trace_commit)
+    monkeypatch.setattr(codex_pr_review_followups, "reply_to_comment", trace_reply)
+    monkeypatch.setattr(codex_pr_review_followups, "finalize_changes", trace_finalize)
+
+    runner = codex_pr_review_followups.CommandRunner(repo_root)
+    args = codex_pr_review_followups.build_parser().parse_args(
+        [
+            "run",
+            "--repo",
+            "joeharris76/BenchBox",
+            "--base",
+            "develop",
+            "--no-submit",
+        ]
+    )
+    rc = codex_pr_review_followups.run_action_loop(args, runner)
+
+    assert rc == 0
+    assert side_effect_log == ["commit", "reply", "finalize"]
+
+    # Per-comment commit landed before reply ran.
+    log_out = subprocess.run(
+        ["git", "-C", str(repo_root), "log", "--oneline"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "comment 999" in log_out


### PR DESCRIPTION
Critical
- Replace `--ask-for-approval` (removed in codex-cli >= 0.20) with
  `-c approval_policy=...` config override; add `check_codex_version`
  probe so missing/old codex fails fast with a clear remediation.

Required
- Reorder per-comment loop to commit BEFORE replying. A crash between
  codex and the reply now leaves nothing on GitHub instead of a
  phantom-actioned thread that future sweeps would silently skip.
- Each actioned comment lands as its own commit, message tagged with
  `PR #N comment <id>` for review traceability; `submit_changes` becomes
  a thin `pr-preflight` + `pr-open` finalizer with a fallback batch
  commit for any leftover paths.
- Disposition baseline switches from `git diff --binary` (working-tree
  only) to `git status --porcelain` so codex's `git add` and new
  untracked files are detected.
- Document the trust model in `_project/audits/codex-weekly-sweep-template.md`
  (author filter is the only auth boundary; reviewer responsibilities
  for the resulting PR).
- Add integration smoke test with a fake `codex` shim that drives
  `run_action_loop` end-to-end and asserts commit-before-reply ordering.

Nits + considerations
- Tighten action-marker match to require an HTML comment at start-of-line
  (substring match let unrelated quotes silently kill future sweeps).
- Drop dead `merged_time is None` branch in `comment_precedes_merge`.
- Bump `MAX_REPLY_SUMMARY_CHARS` 1800 → 8000 (well under GitHub's ~65k).
- Batch per-PR review-comment fetch via `gh api graphql` with REST fallback.
- Lift the 50-line embedded prompt to
  `_project/scripts/prompts/codex_pr_review_followup.md`.
- Document accepted CODEX_REVIEW_REPLY/SUBMIT values in the Makefile.

Blind-spots filed during review (file-first per CLAUDE.md):
- 2026-05-04-180735 reply-before-commit phantom-actioned state (bug-class)
- 2026-05-04-180736 no external-CLI version contract (framework-gap)

Tests: 13 passed (was 5). Local preflight green (21,681 tests).
