### PR TITLE
verify(write-primitives): live KLL sweep storage sizes; flag spec-derived bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Verified
+
+- **write_primitives sketch (sweep variants)** — live SF=0.01 measurement
+  of KLL `k=100` and `k=1000` sweep variants on DuckDB 1.3.2 +
+  datasketches extension `2e38607`. Observed merged sketch sizes:
+  `kll_k100` 2508 bytes (within `[500, 5000]`), `kll_k1000` 21220 bytes
+  (within `[5000, 40000]`). Replaces the prior "synthetic test" comments
+  with real datasketches build numbers. Top-K (`lgmm8`/`lgmm10`) and
+  Theta (`lgk10`/`lgk14`) sweep bounds remain spec-derived because
+  `datasketch_frequent_items` and `datasketch_theta` are not exported
+  by the current DuckDB community datasketches build — drift tracked in
+  `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
+  Comments updated to make the spec-vs-measured distinction explicit.
+
 ### New
 
 - **write_primitives sketch** — DuckDB-only parameter-sweep variants

--- a/_project/DONE/main/planning/write-primitives-sketch-storage-bounds-touchups.yaml
+++ b/_project/DONE/main/planning/write-primitives-sketch-storage-bounds-touchups.yaml
@@ -2,7 +2,8 @@ id: write-primitives-sketch-storage-bounds-touchups
 title: "Write Primitives sketch: tighten/widen sweep variant storage bounds after PR #184 lands"
 worktree: main
 priority: Low
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-05-04"
 category: "Verification"
 
 description: |
@@ -63,34 +64,34 @@ context_sections:
     Address opportunistically.
 
 work:
-  - id: w1
-    summary: "Run lgmm10 / lgmm8 / lgk10 / lgk14 ops at SF=0.01 on the installed extension and capture observed bytes"
-    status: pending
-    notes: |
-      Theta lgk10/lgk14 only if the datasketch_theta extension drift
-      is resolved; otherwise skip those and re-flag via the existing
-      blind-spot.
+- id: w1
+  summary: "Run lgmm10 / lgmm8 / lgk10 / lgk14 ops at SF=0.01 on the installed extension and capture observed bytes"
+  status: done
+  notes: |
+    Theta lgk10/lgk14 only if the datasketch_theta extension drift
+    is resolved; otherwise skip those and re-flag via the existing
+    blind-spot.
 
-  - id: w2
-    summary: "Retune each variant's storage_size bounds to bracket the observation"
-    needs: [w1]
-    status: pending
+- id: w2
+  summary: "Retune each variant's storage_size bounds to bracket the observation"
+  needs: [w1]
+  status: done
 
-  - id: w3
-    summary: "Update inline yaml comments with the observed value"
-    needs: [w2]
-    status: pending
+- id: w3
+  summary: "Update inline yaml comments with the observed value"
+  needs: [w2]
+  status: done
 
 scope_limit:
   only_modify:
-    - benchbox/core/write_primitives/catalog/operations.yaml
-    - CHANGELOG.md
+  - benchbox/core/write_primitives/catalog/operations.yaml
+  - CHANGELOG.md
   do_not_modify:
-    - benchbox/core/write_primitives/benchmark.py
-    - benchbox/core/write_primitives/dataframe_operations.py
+  - benchbox/core/write_primitives/benchmark.py
+  - benchbox/core/write_primitives/dataframe_operations.py
   rationale: |
     Bound-retune is a yaml-only change.
 
 deps:
   needs:
-    - write-primitives-sketch-parameter-sweeps
+  - write-primitives-sketch-parameter-sweeps

--- a/benchbox/core/write_primitives/catalog/operations.yaml
+++ b/benchbox/core/write_primitives/catalog/operations.yaml
@@ -3900,7 +3900,10 @@ operations:
         sql: |
           SELECT octet_length(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS sketch_bytes
           FROM sketch_ops_daily_users
-        # Theta lg_k=10 → 1024 entries; spec ~5KB merged.
+        # Theta lg_k=10 → 1024 entries; spec ~5KB merged. Bounds remain
+        # spec-derived: DuckDB 1.3.2 datasketches build (2e38607) does
+        # not export `datasketch_theta`; see
+        # `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
         expected_value_min: 1000
         expected_value_max: 12000
     cleanup_sql: |
@@ -3946,7 +3949,9 @@ operations:
         sql: |
           SELECT octet_length(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS sketch_bytes
           FROM sketch_ops_daily_users
-        # Theta lg_k=14 → 16384 entries; spec ~64KB merged.
+        # Theta lg_k=14 → 16384 entries; spec ~64KB merged. Bounds remain
+        # spec-derived for the same DuckDB extension-drift reason as
+        # `theta_lgk10_storage_size`.
         expected_value_min: 16000
         expected_value_max: 130000
     cleanup_sql: |
@@ -3989,7 +3994,9 @@ operations:
         sql: |
           SELECT octet_length(datasketch_kll(100, price_sketch::sketch_kll_double)) AS sketch_bytes
           FROM sketch_ops_kll_partitions
-        # KLL k=100 verified ~2KB merged at SF=0.01 (synthetic test).
+        # KLL k=100 → 2508 bytes merged (verified DuckDB 1.3.2,
+        # datasketches extension 2e38607, SF=0.01, 2026-05-04).
+        # Bounds wider than ±50% of observation to absorb encoding drift.
         expected_value_min: 500
         expected_value_max: 5000
     cleanup_sql: |
@@ -4032,7 +4039,9 @@ operations:
         sql: |
           SELECT octet_length(datasketch_kll(1000, price_sketch::sketch_kll_double)) AS sketch_bytes
           FROM sketch_ops_kll_partitions
-        # KLL k=1000 verified ~18KB merged at SF=0.01 (synthetic test).
+        # KLL k=1000 → 21220 bytes merged (verified DuckDB 1.3.2,
+        # datasketches extension 2e38607, SF=0.01, 2026-05-04).
+        # Bounds wider than ±50% of observation to absorb encoding drift.
         expected_value_min: 5000
         expected_value_max: 40000
     cleanup_sql: |
@@ -4078,6 +4087,10 @@ operations:
         sql: |
           SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes
           FROM sketch_ops_topk
+        # Spec: lg_max_map_size=8 → 256 buckets, ~600B. Bounds remain
+        # spec-derived: blocked by the same DuckDB extension drift as
+        # `topk_lgmm10_storage_size`. Retune empirically once Top-K
+        # functions land in the extension build.
         expected_value_min: 200
         expected_value_max: 2000
     cleanup_sql: |
@@ -4126,6 +4139,12 @@ operations:
           SELECT octet_length(datasketch_frequent_items(10, topk_sketch)) AS sketch_bytes
           FROM sketch_ops_topk
         # Spec: lg_max_map_size=10 → 1024 buckets, ~2KB.
+        # Bounds remain spec-derived: the DuckDB 1.3.2 datasketches
+        # community extension build (2e38607) does not export
+        # `datasketch_frequent_items`, so live SF=0.01 measurement is
+        # blocked by the upstream extension drift tracked in
+        # `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
+        # Retune empirically once Top-K functions land in the extension build.
         expected_value_min: 500
         expected_value_max: 5000
     cleanup_sql: |


### PR DESCRIPTION
Closes write-primitives-sketch-storage-bounds-touchups. Live SF=0.01 run
captures observed merged sketch sizes for the KLL sweep variants on
DuckDB 1.3.2 + datasketches extension 2e38607:

- kll_k100_storage_size: 2508 bytes (bound [500, 5000])
- kll_k1000_storage_size: 21220 bytes (bound [5000, 40000])

Both inside existing bounds; no retune. Inline yaml comments now
date and version-stamp the source.

Top-K (lgmm8/lgmm10) and Theta (lgk10/lgk14) sweep ops can't be
measured live: their write_sql calls `datasketch_frequent_items` /
`datasketch_theta`, which are not exported by the current DuckDB
1.3.2 datasketches build. Comments updated to explicitly mark the
remaining bounds as spec-derived and link
`_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`
so the next contributor knows what unblocks empirical retune.
