### PR TITLE
chore(todo): prioritize open backlog (2026-05-04)

### DIFF
--- a/_project/TODO/main/planning/add-hypothesis-property-tests.yaml
+++ b/_project/TODO/main/planning/add-hypothesis-property-tests.yaml
@@ -1,7 +1,7 @@
 id: add-hypothesis-property-tests
 title: "Add Hypothesis property-based tests for pure-function invariants"
 worktree: main
-priority: Medium-High
+priority: Medium
 status: Not Started
 description: |
   Analysis of the full test suite (~16,800 test functions) identified ~20 tests

--- a/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml
@@ -1,7 +1,7 @@
 id: dev-loop-step-6-queue-decision-gate
 title: "Dev-loop simplification — Step 6: queue implementation gate — DEFERRED until Step 5 justifies"
 worktree: main
-priority: Medium-High
+priority: Medium
 status: Blocked
 category: Core Functionality
 

--- a/_project/TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
+++ b/_project/TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
@@ -1,7 +1,7 @@
 id: enable-duckdb-wasm-http-range-reads-for-registered-urls
 title: "Enable DuckDB-WASM HTTP range-reads for URLs registered via registerFileURL"
 worktree: main
-priority: Medium
+priority: Low
 status: Blocked
 category: Performance
 

--- a/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
+++ b/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
@@ -1,7 +1,7 @@
 id: external-contributor-submission-dry-run
 title: "Run a Phase 2 dry-run with one external trusted contributor"
 worktree: main
-priority: High
+priority: Medium-High
 status: Not Started
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
+++ b/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
@@ -1,7 +1,7 @@
 id: single-repo-migration-phase-8-first-post-migration-release
 title: "Single-repo migration phase 8: cut the first release after deletion and docs cleanup"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Release Tooling
 

--- a/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
@@ -1,7 +1,7 @@
 id: write-primitives-sketch-cloud-verification
 title: "Write Primitives sketch: cloud verification of Snowflake / BigQuery / Databricks / Redshift platform_overrides"
 worktree: main
-priority: Medium
+priority: Low
 status: "Blocked"
 category: "Verification"
 

--- a/_project/TODO/platform-expansion/active/motherduck-cloud-features.yaml
+++ b/_project/TODO/platform-expansion/active/motherduck-cloud-features.yaml
@@ -1,7 +1,7 @@
 id: motherduck-cloud-features
 title: "MotherDuck Cloud Feature Completion - Credential Wizard, Cloud Upload, Cache Control"
 worktree: platform-expansion
-priority: High
+priority: Medium
 status: Blocked
 category: Platform Expansion
 description: |

--- a/_project/TODO/platform-expansion/planning/ballista-distributed-adapter.yaml
+++ b/_project/TODO/platform-expansion/planning/ballista-distributed-adapter.yaml
@@ -1,7 +1,7 @@
 id: ballista-distributed-adapter
 title: "Add Apache DataFusion Ballista Distributed Query Platform Adapter"
 worktree: platform-expansion
-priority: Medium
+priority: Low
 status: Not Started
 category: Platform Expansion
 description: |


### PR DESCRIPTION
Rebalance 8 items based on actionability and calendar pressure:

Demote (blocker / no-pull):
- motherduck-cloud-features:        High        -> Medium
- external-contributor-submission:  High        -> Medium-High
- add-hypothesis-property-tests:    Medium-High -> Medium
- dev-loop-step-6-queue-gate:       Medium-High -> Medium
- enable-duckdb-wasm-http-range:    Medium      -> Low
- write-primitives-sketch-cloud:    Medium      -> Low
- ballista-distributed-adapter:     Medium      -> Low

Promote (about to gate the migration):
- single-repo-migration-phase-8:    Medium      -> Medium-High

Distribution: High 2 / Medium-High 5 / Medium 11 / Low 20.
