### PR TITLE
fix(codex-followup): operability patches for 100-comment sweep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -925,6 +925,12 @@ codex-pr-review-followups-list:
 #                                 the default, so the reply is posted.
 #   CODEX_REVIEW_SUBMIT=0         skip final pr-open. Same accepted values
 #                                 as CODEX_REVIEW_REPLY above.
+#   CODEX_REVIEW_RESUME=1         re-drive the routine on a branch that
+#                                 already carries per-comment commits from a
+#                                 prior crashed sweep. Implies --allow-dirty
+#                                 and skips comments already committed
+#                                 locally. Only the literals 1|true|yes
+#                                 enable it.
 codex-pr-review-followups:
 	@uv run --project _project/scripts -- python _project/scripts/codex_pr_review_followups.py run \
 		--base "$(CODEX_REVIEW_BASE)" \
@@ -937,7 +943,8 @@ codex-pr-review-followups:
 		$(if $(CODEX_REVIEW_UNTIL),--until "$(CODEX_REVIEW_UNTIL)") \
 		$(if $(CODEX_REVIEW_MODEL),--codex-model "$(CODEX_REVIEW_MODEL)") \
 		$(if $(filter 0 false no,$(CODEX_REVIEW_REPLY)),--no-reply) \
-		$(if $(filter 0 false no,$(CODEX_REVIEW_SUBMIT)),--no-submit)
+		$(if $(filter 0 false no,$(CODEX_REVIEW_SUBMIT)),--no-submit) \
+		$(if $(filter 1 true yes,$(CODEX_REVIEW_RESUME)),--resume)
 
 dev-loop-metrics:
 	@set -e; \

--- a/_project/audits/codex-weekly-sweep-template.md
+++ b/_project/audits/codex-weekly-sweep-template.md
@@ -38,6 +38,22 @@ historical DONE verification commands when they are still executable
 documentation, and skips future reprocessing only after it has posted a reply
 containing the `benchbox-codex-review-followup-actioned` marker.
 
+If the routine crashes mid-sweep (transient `gh api` failures and pre-commit
+hook auto-fixes will normally retry; anything else exits with a non-zero
+status), re-drive it on the same worktree with `CODEX_REVIEW_RESUME=1`:
+
+```bash
+make codex-pr-review-followups CODEX_REVIEW_RESUME=1 CODEX_REVIEW_SINCE=YYYY-MM-DD
+```
+
+`--resume` (or its env-var form) implies `--allow-dirty` so the prior
+per-comment commits on the branch are accepted, and parses
+`git log origin/<base>..HEAD` for the per-comment commit subject to skip
+comments whose fix already landed locally. The GitHub-marker check still
+catches threads where both the commit and the reply already succeeded, so
+`--resume` only needs to short-circuit the codex re-run for half-completed
+work. Use it after any unplanned exit; do not use it on a fresh branch.
+
 ## Trust model — review the resulting PR before merge
 
 The routine runs `codex exec --sandbox workspace-write -c approval_policy=never`

--- a/_project/scripts/codex_pr_review_followups.py
+++ b/_project/scripts/codex_pr_review_followups.py
@@ -18,9 +18,10 @@ import re
 import subprocess
 import sys
 import textwrap
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 DEFAULT_CODEX_AUTHORS = ("chatgpt-codex-connector[bot]", "chatgpt-codex-connector")
 ACTION_MARKER = "benchbox-codex-review-followup-actioned"
@@ -30,6 +31,16 @@ PER_COMMENT_COMMIT_PREFIX = "fix(codex-followup)"
 MAX_REPLY_SUMMARY_CHARS = 8000
 PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "prompts" / "codex_pr_review_followup.md"
 MIN_CODEX_VERSION = (0, 20, 0)
+PER_COMMENT_COMMIT_SUBJECT_REGEX = re.compile(
+    rf"^{re.escape(PER_COMMENT_COMMIT_PREFIX)}: PR #(\d+) comment (\d+) "
+)
+GH_API_RETRY_ATTEMPTS = 3
+# Sleep schedule (seconds) consumed in order between retries. Three values are
+# defined so the schedule remains stable if the attempt cap is later raised; at
+# GH_API_RETRY_ATTEMPTS == 3 only the first two are used (1s before retry 2,
+# 4s before retry 3).
+GH_API_RETRY_BACKOFFS: tuple[int, ...] = (1, 4, 9)
+HOOK_AUTOFIX_STDERR_MARKER = "files were modified by this hook"
 
 
 @dataclass(frozen=True)
@@ -482,6 +493,25 @@ def local_commit_count(runner: CommandRunner, base_ref: str) -> int:
     return int(result.stdout.strip() or "0")
 
 
+def discover_locally_committed_pairs(
+    runner: CommandRunner, base_ref: str
+) -> set[tuple[int, int]]:
+    """Return (pr_number, comment_id) pairs for per-comment commits already on HEAD.
+
+    Used by `--resume` to skip pending comments whose fix already landed
+    locally during a prior crashed sweep. Only the per-comment subject format
+    produced by `commit_message_for_result` matches; the fallback batch commit
+    in `finalize_changes` does not.
+    """
+    result = checked(runner, ["git", "log", "--format=%s", f"{base_ref}..HEAD"])
+    pairs: set[tuple[int, int]] = set()
+    for line in result.stdout.splitlines():
+        match = PER_COMMENT_COMMIT_SUBJECT_REGEX.match(line)
+        if match:
+            pairs.add((int(match.group(1)), int(match.group(2))))
+    return pairs
+
+
 def current_branch(runner: CommandRunner) -> str:
     return checked(runner, ["git", "branch", "--show-current"]).stdout.strip()
 
@@ -624,6 +654,28 @@ def commit_message_for_result(result: ActionResult) -> str:
     return f"{subject}\n\n{body}"
 
 
+def _porcelain_paths_with_worktree_mods(porcelain: str) -> set[str]:
+    """Return paths from `git status --porcelain` whose work-tree column is non-space.
+
+    The work-tree column (Y in `XY <path>`) is non-space whenever the file has
+    uncommitted changes relative to the index. After a pre-commit auto-fix this
+    is exactly how a previously-staged path surfaces.
+    """
+    paths: set[str] = set()
+    for line in porcelain.splitlines():
+        if len(line) < 4 or line[2] != " ":
+            continue
+        worktree_status = line[1]
+        if worktree_status == " ":
+            continue
+        path = line[3:]
+        # Renames: `R  <old> -> <new>`. Take the destination path.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.add(path)
+    return paths
+
+
 def commit_changes_for_result(
     runner: CommandRunner, result: ActionResult
 ) -> bool:
@@ -633,6 +685,13 @@ def commit_changes_for_result(
     is posted so a crash between codex and reply leaves no phantom-actioned
     state on GitHub: either the commit landed (next run sees no change), or
     nothing happened (next run reprocesses the comment cleanly).
+
+    A pre-commit hook that auto-formats the staged paths (e.g. `ruff-format`)
+    aborts the first commit with the marker `files were modified by this hook`
+    and leaves the formatted change in the work tree. We re-stage the same
+    paths and retry once. We deliberately do NOT generalise this to all commit
+    failures: a hook that detects a real bug (a test runner, a banned-pattern
+    grep) must still surface as a hard failure.
     """
     if result.disposition != "fixed":
         return False
@@ -646,7 +705,22 @@ def commit_changes_for_result(
     staged_paths = checked(runner, ["git", "diff", "--cached", "--name-only"]).stdout.splitlines()
     if not staged_paths:
         return False
-    checked(runner, ["git", "commit", "-m", commit_message_for_result(result)])
+    commit_args = ["git", "commit", "-m", commit_message_for_result(result)]
+    commit_result = runner.run(commit_args)
+    if commit_result.returncode == 0:
+        return True
+    stderr = commit_result.stderr or ""
+    if HOOK_AUTOFIX_STDERR_MARKER not in stderr:
+        raise CommandError(commit_args, commit_result)
+    porcelain = checked(runner, ["git", "status", "--porcelain"]).stdout
+    auto_fixed = _porcelain_paths_with_worktree_mods(porcelain)
+    if not auto_fixed.intersection(staged_paths):
+        # The hook ran, but the working-tree mods (if any) don't overlap the
+        # paths we just staged — treat as a genuine pre-commit failure.
+        raise CommandError(commit_args, commit_result)
+    print("==> pre-commit hook auto-fixed staged paths; re-staging and retrying once")
+    stage_paths(runner, staged_paths)
+    checked(runner, commit_args)
     return True
 
 
@@ -670,11 +744,67 @@ def build_reply_body(result: ActionResult, *, branch: str) -> str:
     ).strip()
 
 
-def reply_to_comment(runner: CommandRunner, *, repo: str, result: ActionResult, branch: str) -> None:
+_TRANSIENT_GH_STDERR_REGEX = re.compile(
+    r"error connecting to|check your internet connection|\bHTTP 5\d\d\b|\bHTTP 429\b",
+    re.IGNORECASE,
+)
+
+
+def _is_transient_gh_failure(stderr: str) -> bool:
+    """True for connection failures, HTTP 5xx, or HTTP 429.
+
+    Permanent 4xx (e.g. 404 — comment deleted upstream) returns False so the
+    caller fails loud instead of looping on a request that will never succeed.
+    """
+    if not stderr:
+        return False
+    return bool(_TRANSIENT_GH_STDERR_REGEX.search(stderr))
+
+
+def _gh_api_with_retry(
+    runner: CommandRunner,
+    args: Sequence[str],
+    *,
+    attempts: int = GH_API_RETRY_ATTEMPTS,
+    backoffs: Sequence[int] = GH_API_RETRY_BACKOFFS,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> subprocess.CompletedProcess[str]:
+    """Run a `gh api` call, retrying only on transient failures.
+
+    Targeted at the reply-posting path: a flaky network or transient GitHub 5xx
+    aborted multiple sweeps in 2026-05-04. Permanent failures (e.g. 404) still
+    raise immediately — see `_is_transient_gh_failure`.
+    """
+    for attempt in range(1, attempts + 1):
+        result = runner.run(args)
+        if result.returncode == 0:
+            return result
+        stderr = result.stderr or ""
+        if not _is_transient_gh_failure(stderr) or attempt >= attempts:
+            raise CommandError(args, result)
+        backoff = backoffs[attempt - 1] if attempt - 1 < len(backoffs) else backoffs[-1]
+        print(
+            f"Transient gh api failure on attempt {attempt}/{attempts}; retrying in {backoff}s.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sleeper(backoff)
+    # Defensive: the loop always returns or raises above.
+    raise RuntimeError("_gh_api_with_retry exited without returning or raising")
+
+
+def reply_to_comment(
+    runner: CommandRunner,
+    *,
+    repo: str,
+    result: ActionResult,
+    branch: str,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
     pr_number = result.pending.pr.number
     comment_id = result.pending.comment.id
     body = build_reply_body(result, branch=branch)
-    checked(
+    _gh_api_with_retry(
         runner,
         [
             "gh",
@@ -685,6 +815,7 @@ def reply_to_comment(runner: CommandRunner, *, repo: str, result: ActionResult, 
             "-f",
             f"body={body}",
         ],
+        sleeper=sleeper,
     )
     print(f"Replied to PR #{pr_number} comment {comment_id}.")
 
@@ -763,12 +894,17 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
     until = parse_bound(args.until, end_of_day=True)
     authors = set(args.author)
     branch = ""
+    resume = bool(getattr(args, "resume", False))
     if args.command == "run":
         if not args.dry_run:
             branch = current_branch(runner)
             ensure_action_branch(branch, no_submit=args.no_submit)
             check_codex_version(runner)
-        ensure_clean_start(runner, allow_dirty=args.allow_dirty or args.dry_run, base_ref=f"origin/{args.base}")
+        ensure_clean_start(
+            runner,
+            allow_dirty=args.allow_dirty or args.dry_run or resume,
+            base_ref=f"origin/{args.base}",
+        )
     pending = discover_pending_comments(
         runner,
         repo=repo,
@@ -778,6 +914,18 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
         until=until,
         author_logins=authors,
     )
+    if resume and args.command == "run":
+        already = discover_locally_committed_pairs(runner, f"origin/{args.base}")
+        if already:
+            before = len(pending)
+            pending = [
+                item for item in pending
+                if (item.pr.number, item.comment.id) not in already
+            ]
+            print(
+                f"--resume: skipping {before - len(pending)} comment(s) already "
+                f"committed locally on this branch."
+            )
     if args.max_comments > 0:
         pending = pending[: args.max_comments]
 
@@ -833,6 +981,16 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--allow-dirty", action="store_true")
     run_parser.add_argument("--no-reply", action="store_true")
     run_parser.add_argument("--no-submit", action="store_true")
+    run_parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Skip pending comments whose per-comment fix already landed locally "
+            "(parses `git log origin/<base>..HEAD` for the per-comment commit "
+            "subject). Implies --allow-dirty so a branch with prior commits is "
+            "accepted. Use this after a crashed sweep to re-drive the routine."
+        ),
+    )
     run_parser.add_argument("--codex-model", default=os.environ.get("CODEX_REVIEW_MODEL"))
     run_parser.add_argument(
         "--codex-sandbox",

--- a/tests/unit/scripts/test_codex_pr_review_followups.py
+++ b/tests/unit/scripts/test_codex_pr_review_followups.py
@@ -37,10 +37,20 @@ codex_pr_review_followups = _load_script()
 
 
 class RecordingRunner:
-    def __init__(self, responses: dict[tuple[str, ...], subprocess.CompletedProcess[str]] | None = None) -> None:
+    def __init__(
+        self,
+        responses: dict[tuple[str, ...], subprocess.CompletedProcess[str]] | None = None,
+        *,
+        scripted: dict[tuple[str, ...], list[subprocess.CompletedProcess[str]]] | None = None,
+    ) -> None:
         self.commands: list[list[str]] = []
         self.inputs: list[str | None] = []
         self.responses = responses or {}
+        # Per-call queue keyed by argv tuple. Earlier entries are consumed first;
+        # once exhausted, the runner falls back to `responses` then to a 0-rc
+        # default. Patch 2 needs this so the same argv (`git commit -m ...`) can
+        # return rc=1 once and rc=0 the next time.
+        self.scripted = {key: list(values) for key, values in (scripted or {}).items()}
         self.cwd = Path.cwd()
 
     def run(self, args: Sequence[str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
@@ -48,6 +58,8 @@ class RecordingRunner:
         self.commands.append(argv)
         self.inputs.append(input_text)
         key = tuple(argv)
+        if key in self.scripted and self.scripted[key]:
+            return self.scripted[key].pop(0)
         if key in self.responses:
             return self.responses[key]
         return subprocess.CompletedProcess(argv, 0, "", "")
@@ -399,3 +411,360 @@ def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
         text=True,
     ).stdout
     assert "comment 999" in log_out
+
+
+# ---------------------------------------------------------------------------
+# Patch 1 — reply_to_comment retries transient gh api failures
+# ---------------------------------------------------------------------------
+
+
+def _reply_args(repo: str, pr_number: int, comment_id: int) -> tuple[str, ...]:
+    return (
+        "gh",
+        "api",
+        "-X",
+        "POST",
+        f"repos/{repo}/pulls/{pr_number}/comments/{comment_id}/replies",
+    )
+
+
+def test_reply_to_comment_retries_transient_gh_failure_then_succeeds() -> None:
+    """A flaky `gh api` (network drop, 5xx) must be retried, not crash the sweep."""
+    transient = subprocess.CompletedProcess(
+        [],
+        1,
+        "",
+        "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com\n",
+    )
+    success = subprocess.CompletedProcess([], 0, "", "")
+    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(33), replies=())
+    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+
+    sleeps: list[float] = []
+
+    class GhScriptedRunner(RecordingRunner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.gh_responses = [transient, success]
+
+        def run(self, args, input_text=None):  # type: ignore[override]
+            argv = list(args)
+            self.commands.append(argv)
+            self.inputs.append(input_text)
+            if (
+                argv[:4] == ["gh", "api", "-X", "POST"]
+                and "/replies" in (argv[4] if len(argv) > 4 else "")
+                and self.gh_responses
+            ):
+                return self.gh_responses.pop(0)
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+    runner = GhScriptedRunner()
+
+    codex_pr_review_followups.reply_to_comment(
+        runner,
+        repo="joeharris76/BenchBox",
+        result=result,
+        branch="fix/sample",
+        sleeper=sleeps.append,
+    )
+
+    reply_calls = [cmd for cmd in runner.commands if cmd[:4] == ["gh", "api", "-X", "POST"]]
+    assert len(reply_calls) == 2, "transient failure should be retried exactly once before success"
+    assert sleeps == [1], "first retry must use the 1s backoff slot"
+    assert not runner.gh_responses, "scripted responses should be exhausted"
+
+
+def test_reply_to_comment_does_not_retry_permanent_4xx() -> None:
+    """A 404 (comment deleted upstream) must fail loud on the first attempt."""
+    permanent = subprocess.CompletedProcess(
+        [],
+        1,
+        "",
+        "gh: HTTP 404: Not Found (https://api.github.com/repos/x/y/pulls/1/comments/1/replies)\n",
+    )
+    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(34), replies=())
+    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+
+    sleeps: list[float] = []
+
+    class GhPermFailRunner(RecordingRunner):
+        def run(self, args, input_text=None):  # type: ignore[override]
+            argv = list(args)
+            self.commands.append(argv)
+            self.inputs.append(input_text)
+            if argv[:4] == ["gh", "api", "-X", "POST"]:
+                return permanent
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+    runner = GhPermFailRunner()
+
+    with pytest.raises(codex_pr_review_followups.CommandError, match="HTTP 404"):
+        codex_pr_review_followups.reply_to_comment(
+            runner,
+            repo="joeharris76/BenchBox",
+            result=result,
+            branch="fix/sample",
+            sleeper=sleeps.append,
+        )
+
+    reply_calls = [cmd for cmd in runner.commands if cmd[:4] == ["gh", "api", "-X", "POST"]]
+    assert len(reply_calls) == 1, "permanent 4xx must not retry"
+    assert sleeps == [], "no backoff sleep should have happened"
+
+
+def test_is_transient_gh_failure_classification() -> None:
+    """Sanity-check the discriminator covers the flagged classes and nothing else."""
+    assert codex_pr_review_followups._is_transient_gh_failure("error connecting to api.github.com")
+    assert codex_pr_review_followups._is_transient_gh_failure(
+        "check your internet connection or https://githubstatus.com"
+    )
+    assert codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 503: Service Unavailable")
+    assert codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 429: Too Many Requests")
+    assert not codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 404: Not Found")
+    assert not codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 422: Validation failed")
+    assert not codex_pr_review_followups._is_transient_gh_failure("")
+
+
+# ---------------------------------------------------------------------------
+# Patch 2 — commit_changes_for_result retries when a hook auto-fixes paths
+# ---------------------------------------------------------------------------
+
+
+def test_commit_changes_for_result_retries_after_hook_autofix() -> None:
+    """ruff-format reformats a staged file, commit aborts, second commit succeeds."""
+    pending = codex_pr_review_followups.PendingComment(
+        pr=_pr(), comment=_comment(55, body="[P1] Add the missing test"), replies=()
+    )
+    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    expected_message = codex_pr_review_followups.commit_message_for_result(result)
+    commit_argv = ("git", "commit", "-m", expected_message)
+
+    target_path = "tests/unit/example.py"
+    diff_name = subprocess.CompletedProcess([], 0, f"{target_path}\n", "")
+    diff_cached_name_empty = subprocess.CompletedProcess([], 0, "", "")
+    ls_files = subprocess.CompletedProcess([], 0, f"{target_path}\n", "")
+    diff_cached_after_stage = subprocess.CompletedProcess([], 0, f"{target_path}\n", "")
+    commit_hook_failure = subprocess.CompletedProcess(
+        [],
+        1,
+        "",
+        "ruff-format..............................................................Failed\n"
+        "- hook id: ruff-format\n"
+        f"- files were modified by this hook\n\nReformatted: {target_path}\n",
+    )
+    porcelain_after_hook = subprocess.CompletedProcess([], 0, f"AM {target_path}\n", "")
+    commit_success = subprocess.CompletedProcess([], 0, "ok\n", "")
+
+    runner = RecordingRunner(
+        scripted={
+            ("git", "diff", "--name-only"): [diff_name],
+            ("git", "diff", "--cached", "--name-only"): [
+                # First call: from git_changed_paths — nothing pre-staged.
+                diff_cached_name_empty,
+                # Second call: post-stage_paths to verify staged content.
+                diff_cached_after_stage,
+            ],
+            ("git", "ls-files", "--others", "--exclude-standard"): [ls_files],
+            commit_argv: [commit_hook_failure, commit_success],
+            ("git", "status", "--porcelain"): [porcelain_after_hook],
+        }
+    )
+
+    landed = codex_pr_review_followups.commit_changes_for_result(runner, result)
+
+    assert landed is True
+    commit_calls = [tuple(cmd) for cmd in runner.commands if tuple(cmd) == commit_argv]
+    assert len(commit_calls) == 2, "hook auto-fix must trigger exactly one retry commit"
+    add_calls = [cmd for cmd in runner.commands if cmd[:3] == ["git", "add", "--"]]
+    assert len(add_calls) == 2, "second `git add` must re-stage the hook-modified path"
+    assert add_calls[1] == ["git", "add", "--", target_path]
+
+
+def test_commit_changes_for_result_does_not_retry_genuine_hook_failure() -> None:
+    """If the hook fails without auto-fixing the staged paths, fail loud."""
+    pending = codex_pr_review_followups.PendingComment(
+        pr=_pr(), comment=_comment(56, body="[P1] do something"), replies=()
+    )
+    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    expected_message = codex_pr_review_followups.commit_message_for_result(result)
+    commit_argv = ("git", "commit", "-m", expected_message)
+
+    target_path = "tests/unit/example.py"
+    diff_name = subprocess.CompletedProcess([], 0, f"{target_path}\n", "")
+    diff_cached_empty = subprocess.CompletedProcess([], 0, "", "")
+    ls_files = subprocess.CompletedProcess([], 0, "", "")
+    diff_cached_after_stage = subprocess.CompletedProcess([], 0, f"{target_path}\n", "")
+    # Genuine pre-commit failure (e.g. a test runner detected a real bug):
+    # commit fails, but porcelain shows no fresh work-tree mods.
+    commit_failure = subprocess.CompletedProcess(
+        [], 1, "", "test-runner..............................................................Failed\n"
+    )
+    porcelain_clean = subprocess.CompletedProcess([], 0, "", "")
+
+    runner = RecordingRunner(
+        scripted={
+            ("git", "diff", "--name-only"): [diff_name],
+            ("git", "diff", "--cached", "--name-only"): [
+                diff_cached_empty,
+                diff_cached_after_stage,
+            ],
+            ("git", "ls-files", "--others", "--exclude-standard"): [ls_files],
+            commit_argv: [commit_failure],
+            ("git", "status", "--porcelain"): [porcelain_clean],
+        }
+    )
+
+    with pytest.raises(codex_pr_review_followups.CommandError):
+        codex_pr_review_followups.commit_changes_for_result(runner, result)
+
+    commit_calls = [tuple(cmd) for cmd in runner.commands if tuple(cmd) == commit_argv]
+    assert len(commit_calls) == 1, "genuine hook failure must not retry"
+
+
+def test_porcelain_paths_with_worktree_mods_parses_added_modified_and_renamed() -> None:
+    porcelain = (
+        "AM tests/unit/example.py\nM  src/module.py\n M docs/notes.md\n?? new_file.txt\nR  old_name.py -> new_name.py\n"
+    )
+
+    paths = codex_pr_review_followups._porcelain_paths_with_worktree_mods(porcelain)
+
+    # AM, " M", "??" all have non-space work-tree column -> included.
+    # "M  " has a space work-tree column -> excluded (purely staged).
+    # "R  " rename has space work-tree column -> excluded.
+    assert paths == {"tests/unit/example.py", "docs/notes.md", "new_file.txt"}
+
+
+# ---------------------------------------------------------------------------
+# Patch 3 — --resume skips comments already committed locally
+# ---------------------------------------------------------------------------
+
+
+def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.name", "Test"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "commit.gpgsign", "false"], check=True)
+    (repo_root / "README").write_text("ok\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", "README"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "branch", "-M", "develop"], check=True)
+    head = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(repo_root), "update-ref", "refs/remotes/origin/develop", head], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-q", "-b", "fix/codex-resume"], check=True)
+    # A per-comment commit from a prior crashed sweep: PR #999, comment 12345.
+    (repo_root / "fix.txt").write_text("prior fix\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", "fix.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "commit",
+            "-q",
+            "-m",
+            "fix(codex-followup): PR #999 comment 12345 — recovered fix",
+        ],
+        check=True,
+    )
+
+    already_pr = codex_pr_review_followups.PullRequest(
+        number=999, title="prior", merged_at="2026-05-01T00:00:00Z", url="https://example/999"
+    )
+    already_comment = codex_pr_review_followups.ReviewComment(
+        id=12345,
+        body="[P1] already done",
+        path="fix.txt",
+        html_url="https://example/999#12345",
+        user_login="chatgpt-codex-connector[bot]",
+        created_at="2026-04-30T00:00:00Z",
+    )
+    fresh_pr = codex_pr_review_followups.PullRequest(
+        number=777, title="new", merged_at="2026-05-04T00:00:00Z", url="https://example/777"
+    )
+    fresh_comment = codex_pr_review_followups.ReviewComment(
+        id=88888,
+        body="[P1] still to do",
+        path="other.txt",
+        html_url="https://example/777#88888",
+        user_login="chatgpt-codex-connector[bot]",
+        created_at="2026-05-03T00:00:00Z",
+    )
+    pending_already = codex_pr_review_followups.PendingComment(pr=already_pr, comment=already_comment, replies=())
+    pending_fresh = codex_pr_review_followups.PendingComment(pr=fresh_pr, comment=fresh_comment, replies=())
+
+    seen_codex_calls: list[int] = []
+
+    monkeypatch.setattr(codex_pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
+    monkeypatch.setattr(
+        codex_pr_review_followups,
+        "discover_pending_comments",
+        lambda runner, **_: [pending_already, pending_fresh],
+    )
+    monkeypatch.setattr(codex_pr_review_followups, "check_codex_version", lambda runner: (0, 128, 0))
+    monkeypatch.setattr(
+        codex_pr_review_followups,
+        "run_codex_for_comment",
+        lambda runner, item, **_: (
+            seen_codex_calls.append(item.comment.id)
+            or codex_pr_review_followups.ActionResult(pending=item, disposition="no-current-action", summary="skip")
+        ),
+    )
+    monkeypatch.setattr(codex_pr_review_followups, "commit_changes_for_result", lambda runner, result: False)
+    monkeypatch.setattr(codex_pr_review_followups, "reply_to_comment", lambda runner, **_: None)
+    monkeypatch.setattr(codex_pr_review_followups, "finalize_changes", lambda runner, **_: None)
+
+    runner = codex_pr_review_followups.CommandRunner(repo_root)
+    args = codex_pr_review_followups.build_parser().parse_args(
+        [
+            "run",
+            "--repo",
+            "joeharris76/BenchBox",
+            "--base",
+            "develop",
+            "--no-submit",
+            "--resume",
+        ]
+    )
+
+    rc = codex_pr_review_followups.run_action_loop(args, runner)
+
+    assert rc == 0
+    assert seen_codex_calls == [88888], (
+        "comment 12345 was already committed locally and must be skipped; "
+        "only the unrelated comment 88888 should reach run_codex_for_comment"
+    )
+
+
+def test_discover_locally_committed_pairs_matches_per_comment_subjects(tmp_path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.email", "t@e.com"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "user.name", "T"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "config", "commit.gpgsign", "false"], check=True)
+    (repo_root / "f").write_text("a\n")
+    subprocess.run(["git", "-C", str(repo_root), "add", "f"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "commit", "-q", "-m", "init"], check=True)
+    head = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+    subprocess.run(["git", "-C", str(repo_root), "update-ref", "refs/remotes/origin/develop", head], check=True)
+    for subject in (
+        "fix(codex-followup): PR #1 comment 100 — first",
+        "chore: unrelated commit",
+        "fix(codex-followup): PR #2 comment 200 — second",
+    ):
+        path = repo_root / f"x_{subject[-5:].strip()}.txt"
+        path.write_text(subject)
+        subprocess.run(["git", "-C", str(repo_root), "add", path.name], check=True)
+        subprocess.run(["git", "-C", str(repo_root), "commit", "-q", "-m", subject], check=True)
+
+    runner = codex_pr_review_followups.CommandRunner(repo_root)
+    pairs = codex_pr_review_followups.discover_locally_committed_pairs(runner, "origin/develop")
+
+    assert pairs == {(1, 100), (2, 200)}


### PR DESCRIPTION
Three operability patches the original /code review's blind-spot file
flagged as gaps and that came up for real during the 2026-05-04 sweep
(routine crashed three times across four runs). Builds on PR #195.

- reply_to_comment now retries transient gh api failures (connection
  errors, HTTP 5xx, 429) with backoff. Permanent 4xx (e.g. 404 — comment
  deleted upstream) still fails loud on the first attempt.
- commit_changes_for_result detects a pre-commit hook auto-fix
  ("files were modified by this hook" + porcelain shows fresh work-tree
  mods on the staged paths) and re-stages + retries once. Genuine hook
  failures (test runner detects a real bug) still surface as hard
  failures; --no-verify is not used.
- New --resume flag (also CODEX_REVIEW_RESUME=1) makes
  make codex-pr-review-followups re-runnable after a crash. Implies
  --allow-dirty and skips pending comments whose per-comment commit
  subject already exists in origin/<base>..HEAD.

Reference:
- Prior hardening: PR #195
- Blind-spot:
  _project/blind-spots/2026-05-04-180735-codex-followups-reply-before-commit-phantom-actioned.md

Tests: 21 passed (was 13). Local pr-preflight green (21,709 tests).
