### PR TITLE
chore(blind-spots): record L2 audit findings from /code review of PR #205

### DIFF
--- a/_project/blind-spots/2026-05-05-080138-uat-bash-parity-structural-only.md
+++ b/_project/blind-spots/2026-05-05-080138-uat-bash-parity-structural-only.md
@@ -1,0 +1,56 @@
+---
+id: 2026-05-05-080138-uat-bash-parity-structural-only
+date: 2026-05-05
+status: open
+finding_kind: assumption
+review_context: "/code review of PR #205 (UAT framework W2-W11)"
+related_paths:
+  - tests/uat/test_matrix.py
+  - tests/uat/timeouts.py
+  - tests/uat/matrix.py
+  - scripts/local_stress_test.sh
+suggested_sweep: "in any future bash→Python port, treat structural parity (same dict keys/values) and behavioral parity (same outcome under boundary inputs) as separate test contracts."
+todo_id: null
+---
+
+# "Bash parity" tested at dictionary level, not behavioral level
+
+## Finding
+The bash-parity tests assert that PLATFORM_PORTS, PLATFORM_EXTRA_OPTS,
+PLATFORM_CLI_FLAGS, and PLATFORM_UV_EXTRA in `matrix.py` have the same
+keys and values as the corresponding bash case statements. This catches
+key-set drift but does NOT assert behavioral parity. Examples where the
+two could diverge silently:
+
+- `tcp_probe` in bash uses `nc -z` (or /dev/tcp fallback) and returns
+  exit 1 on TIMEOUT, REFUSED, or NXDOMAIN uniformly; the Python port
+  catches `(OSError, ValueError)` and returns False. NXDOMAIN raises
+  socket.gaierror (an OSError subclass) — caught. But timing
+  characteristics differ: bash nc has its own timeout heuristic; Python's
+  `create_connection(timeout=2.0)` is rigorously 2s. On a cold sweep
+  hitting unreachable platforms, divergent timeout behavior could
+  produce different "skip vs hang" outcomes between the two paths.
+- `run_with_timeout` reaps SIGKILL after 200ms; the perl wrapper does
+  the same in principle, but the perl wrapper waited on `setpgrp`
+  semantics that are not bit-identical to `os.setsid + os.killpg`
+  on macOS vs Linux.
+
+## Why this matters
+Bash-to-Python ports of operationally-load-bearing scripts almost
+always introduce subtle Unix-y semantics gaps. Asserting "the dict has
+the same entries" is necessary but not sufficient. The user-facing
+question is: under the same boundary inputs (timeout firing,
+unreachable platform, SIGKILL'd child), do the two paths produce the
+same observable outcome (exit code, log content, timing)?
+
+## Suggested next steps
+- [ ] Add a behavioral-parity smoke test that runs `tcp_probe` against
+      a known-closed port from both the bash function (via `bash -c`)
+      and the Python function, asserting same return value and similar
+      timing.
+- [ ] For `run_with_timeout`, add a slow test that runs the perl
+      wrapper and the Python wrapper against a `sleep 30` child with a
+      1s cap and asserts both return exit code 124 within 1.5s.
+- [ ] When porting future bash scripts, write structural and behavioral
+      parity tests as separate suites; do not let the structural one
+      satisfy the audit.

--- a/_project/blind-spots/2026-05-05-080138-uat-claudemd-auto-allow-blast-radius.md
+++ b/_project/blind-spots/2026-05-05-080138-uat-claudemd-auto-allow-blast-radius.md
@@ -1,0 +1,55 @@
+---
+id: 2026-05-05-080138-uat-claudemd-auto-allow-blast-radius
+date: 2026-05-05
+status: open
+finding_kind: scope-creep
+review_context: "/code review of PR #205 (UAT framework W2-W11)"
+related_paths:
+  - CLAUDE.md
+  - tests/uat/_cli.py
+suggested_sweep: "audit the entire CLAUDE.md Pre-approved Commands section: which entries are local-only/idempotent vs. potentially-remote/billable? Tag accordingly."
+todo_id: null
+---
+
+# CLAUDE.md auto-allow grants UAT targets without local-vs-cloud differentiation
+
+## Finding
+PR #205 adds a single line to CLAUDE.md's Pre-approved Commands:
+
+```
+- **UAT framework** (operator targets; see `docs/operations/uat-framework.md`):
+  `make uat-cell PLATFORM=* BENCHMARK=* SCALE=*`, `make uat-stress`,
+  `make uat-stress PLATFORM=* BENCHMARK=* SCALE=*`, `make uat-sweep CONFIG=*`,
+  `make uat-execute CONFIG=*`, `make uat-validate RESULTS_DIR=* OUTPUT_TSV=*`,
+  `make uat-package CONFIG=* SUBMISSIONS_DIR=* RESULTS=*`,
+  `make uat-explorer-smoke BUNDLES_DIR=* OUTPUT_DIR=* LOG_DIR=*`,
+  `make uat-report CELLS_JSONL=* OUTPUT_TSV=*`
+```
+
+These targets call into `tests/uat/_cli.py`, which calls `benchbox run`.
+`benchbox run` accepts `--platform snowflake|databricks|motherduck|...` —
+all of which are billable cloud platforms. A subagent invoking
+`make uat-cell PLATFORM=snowflake BENCHMARK=tpcds SCALE=1.0` without a
+prompt could rack up substantial cost. The five-axis review caught
+"this is correct code" but missed the operational blast radius the
+CLAUDE.md change unlocks.
+
+## Why this matters
+The CLAUDE.md Pre-approved Commands section has been growing
+file-by-file without an explicit local-vs-cloud policy. Many existing
+entries (`make test-*`, `git status`, `gh pr view`) are idempotent and
+free. UAT targets straddle the line: `make uat-validate` is local and
+idempotent; `make uat-cell PLATFORM=snowflake` is potentially-billable.
+Granting both under the same banner is a category error.
+
+## Suggested next steps
+- [ ] Audit the existing Pre-approved Commands section and tag each
+      entry as `local-only`, `local-stateful` (writes/deletes files),
+      or `potentially-remote-billable`.
+- [ ] For UAT specifically, narrow the auto-allow: leave
+      `uat-validate`, `uat-report`, `uat-explorer-smoke` (local only)
+      auto-allowed; require prompt for `uat-cell`, `uat-stress`,
+      `uat-sweep`, `uat-execute` (any of which can hit cloud platforms
+      via `--platform`).
+- [ ] Add a doc note in `docs/operations/uat-framework.md` flagging
+      which targets can hit billable cloud platforms.

--- a/_project/blind-spots/2026-05-05-080138-uat-cleanup-graph-revisit.md
+++ b/_project/blind-spots/2026-05-05-080138-uat-cleanup-graph-revisit.md
@@ -1,0 +1,49 @@
+---
+id: 2026-05-05-080138-uat-cleanup-graph-revisit
+date: 2026-05-05
+status: open
+finding_kind: bug-class
+review_context: "/code review of PR #205 (UAT framework W2-W11)"
+related_paths:
+  - tests/uat/phases/execute.py
+  - tests/uat/cleanup.py
+suggested_sweep: "search for prune-once-only patterns in cleanup graphs across the repo (e.g. results-explorer datagen retention, snapshot-bundle cleanup) — reuse-aware DAGs that don't re-check after consumer completion are likely a recurring class."
+todo_id: null
+---
+
+# Reuse-aware cleanup that never re-checks the source
+
+## Finding
+The cleanup loop in `run_execute` runs once per `(platform, benchmark)` pair
+and only attempts to prune the directory matching the benchmark that JUST
+completed. When `(p1, tpch)` finishes, `can_prune("tpch", ...)` correctly
+blocks because read_primitives (a tpch consumer) is still pending. Later,
+when `(p1, read_primitives)` completes, the code prunes
+`databases/p1/read_primitives/<scale>` — NOT `databases/p1/tpch/<scale>`.
+The tpch loaded DB is therefore never pruned during the sweep, even
+though the safe-to-prune condition becomes true the moment the last
+consumer completes. The five-axis frame caught this because I was
+already tracing the cleanup ordering — but the underlying pattern (a
+reuse-graph traversal that defers a prune attempt and never re-tries)
+is general.
+
+## Why this matters
+Reuse-aware cleanup is a recurring shape in benchmarking infrastructure:
+preserve a costly artefact while it still has consumers, prune at safe
+boundaries. The "safe boundary" is "all consumers done", which is a
+property that becomes true *over time* — but a cleanup loop indexed on
+"the thing I just ran" only checks pruneability at the wrong moment.
+The bug class is "single-pass cleanup over a DAG, indexed on the just-
+completed node, with no retry when downstream nodes finish".
+
+## Suggested next steps
+- [ ] Restructure the cleanup loop in execute.py to either (a) prune
+      sources at end-of-platform after all benchmarks for the platform
+      finish, or (b) on each consumer completion, re-check pruneability
+      of every upstream source for that (platform, scale).
+- [ ] Add an integration-style fast test that walks a small fake matrix
+      with `tpch → read_primitives` and asserts the tpch DB directory is
+      gone by sweep end.
+- [ ] Sweep the codebase for similar shapes: results-explorer datagen
+      retention, snapshot bundle cleanup, anything with a SOURCE_REUSE_GRAPH
+      analogue.

--- a/_project/blind-spots/2026-05-05-080138-uat-end-to-end-semantic-test-gap.md
+++ b/_project/blind-spots/2026-05-05-080138-uat-end-to-end-semantic-test-gap.md
@@ -1,0 +1,47 @@
+---
+id: 2026-05-05-080138-uat-end-to-end-semantic-test-gap
+date: 2026-05-05
+status: open
+finding_kind: missed-axis
+review_context: "/code review of PR #205 (UAT framework W2-W11)"
+related_paths:
+  - tests/uat/test_replay_2026_05_02.py
+  - tests/uat/orchestrator.py
+  - tests/uat/phases/execute.py
+suggested_sweep: "audit other multi-phase orchestrators in the repo (release pipeline, CI metrics rollup) for the same gap: unit tests of math + dry-run E2E, but no E2E with non-trivial fake state."
+todo_id: null
+---
+
+# Unit tests + dry-run E2E ≠ semantic E2E
+
+## Finding
+The five-axis review framework checks each module's correctness in
+isolation but does not catch missing integration-style coverage. PR #205
+has 96 fast tests covering ladder math, parse_rollup math, regex
+extraction, frozen-config hashing, etc. — and a slow-marked replay test
+that runs the full sweep, but only with `dry_run=True` (which short-
+circuits every phase to exit 0). There is no test that walks a non-
+trivial fake matrix end-to-end — multiple platforms and benchmarks,
+ladder pruning, cleanup graph traversal, JSONL emission, report
+round-trip — and asserts the cleanup pruned the right directories at
+the right times.
+
+## Why this matters
+Multi-phase orchestrators have emergent behavior: each phase passes
+state to the next via files (cells.jsonl → report TSV) and shared
+filesystem state (databases/, logs/). A test that only exercises one
+phase at a time misses contract drift between phases. The replay-as-
+dry-run pattern looks like coverage but is actually closer to a
+"does it import?" check, because `dry_run` is a kill switch that
+bypasses the very logic the test is named after.
+
+## Suggested next steps
+- [ ] Add a `run_execute → orchestrator → report` integration test
+      using a stubbed runner that drives ladder pruning and validator
+      results, with assertions on cells.jsonl content, TSV column
+      shape AND row contents, and prune calls observed via a fake
+      filesystem.
+- [ ] Audit other multi-phase orchestrators (release pipeline, CI
+      metrics rollup, ralph-loop) for the same shape: unit tests of
+      individual stages plus a dry-run E2E that doesn't actually
+      exercise the wiring.

--- a/_project/blind-spots/2026-05-05-080138-uat-frozen-config-replay-not-runnable.md
+++ b/_project/blind-spots/2026-05-05-080138-uat-frozen-config-replay-not-runnable.md
@@ -1,0 +1,53 @@
+---
+id: 2026-05-05-080138-uat-frozen-config-replay-not-runnable
+date: 2026-05-05
+status: open
+finding_kind: assumption
+review_context: "/code review of PR #205 (UAT framework W2-W11)"
+related_paths:
+  - tests/uat/configs/uat-2026-05-02.yaml
+  - tests/uat/test_replay_2026_05_02.py
+  - tests/uat/test_frozen_configs.py
+suggested_sweep: "any 'frozen historical record' pattern in the repo — audit whether the freeze guarantees runnability at thaw time, or only readability."
+todo_id: null
+---
+
+# Frozen-config policy proves the file hasn't changed; not that it can still drive a sweep
+
+## Finding
+The frozen-config mechanism (`tests/uat/configs/uat-2026-05-02.yaml`
++ `.frozen-hashes.json` + `test_frozen_configs.py`) catches edits to
+the file. The slow-marked replay test runs the orchestrator with
+`dry_run=True`, which short-circuits every phase. Together these
+guarantee the YAML bytes haven't changed and that the file parses.
+They do NOT guarantee the file would actually drive a real sweep
+months from now, because:
+
+- The platform list (e.g. `cedardb`, `velox`) could be retired from
+  `PLATFORM_GROUPS` in `matrix.py`.
+- The benchmark group `dataframe` could change shape if the registry
+  retires/adds platforms.
+- The `submit_terminal_state` vocabulary could narrow.
+
+The dry-run replay test silently passes through all of these; a real
+re-run with `dry_run=False` would fail at execute or package time.
+The first user to actually replay this file in 2027 eats the failure
+without warning.
+
+## Why this matters
+"Frozen historical record" is a recurring pattern (release manifests,
+golden snapshot tests, frozen test fixtures). The freeze typically
+guards content but not runnability. Two different invariants —
+"this file hasn't been edited" vs. "this file still works against
+the current code" — get conflated under the same "frozen" label.
+
+## Suggested next steps
+- [ ] Add a fast test that loads each FROZEN config via
+      `load_config()` AND runs `enumerate_cells(config.raw)` against
+      the current registry, asserting the cell list is non-empty and
+      every (platform, benchmark) is still resolvable. This catches
+      registry retirement at PR time, not at replay time.
+- [ ] Document the policy explicitly: the freeze is content-stable,
+      not behavior-stable. If a registry change retires a platform
+      cited in a frozen config, file an issue rather than silently
+      regenerating the hash.


### PR DESCRIPTION
Five findings surfaced during the five-axis review of the UAT framework
(W2-W11 implementation):

- uat-cleanup-graph-revisit: reuse-aware cleanup loop never re-checks
  source DBs after consumers complete (tpch DBs persist for the sweep
  even when safe to prune).
- uat-end-to-end-semantic-test-gap: 96 unit tests + dry-run replay
  cover math but not phase-to-phase contract drift.
- uat-bash-parity-structural-only: dictionary-level parity asserted;
  behavioral parity (timeout/refused/NXDOMAIN outcomes) is not.
- uat-frozen-config-replay-not-runnable: hash check guards content
  but the replay runs only with dry_run=True, so registry retirement
  goes undetected.
- uat-claudemd-auto-allow-blast-radius: new pre-approved commands mix
  local-only and cloud-billable targets without distinction.

Status: open. Sweep via `make blind-spots-sweep`.
