### PR TITLE
chore(pr-review-followups): rename codex-named surface, decouple from cadence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 # This makefile provides commands for building, testing and development
 
 PR_FANOUT_JOBS ?= 4
-CODEX_REVIEW_BASE ?= develop
-CODEX_REVIEW_PR_LIMIT ?= 1000
-CODEX_REVIEW_MAX_COMMENTS ?= 0
-CODEX_REVIEW_CODEX_SANDBOX ?= workspace-write
-CODEX_REVIEW_CODEX_APPROVAL ?= never
+PR_REVIEW_BASE ?= develop
+PR_REVIEW_PR_LIMIT ?= 1000
+PR_REVIEW_MAX_COMMENTS ?= 0
+PR_REVIEW_EXECUTOR_SANDBOX ?= workspace-write
+PR_REVIEW_EXECUTOR_APPROVAL ?= never
 POOL_SIZE ?= 10
 WORKTREE_POOL_PARENT ?= ..
 DEV_LOOP_METRICS_DAYS ?= 30
@@ -32,7 +32,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status codex-pr-review-followups codex-pr-review-followups-list dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -762,7 +762,7 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status codex-pr-review-followups codex-pr-review-followups-list dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
+.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-add worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
 
 # Mirror the CI gate locally before pushing. Catches ~all CI failures
 # without the network roundtrip. Delegates to ci-lint so the local
@@ -899,52 +899,56 @@ pr-status:
 	@gh pr list --base develop --state open --limit 20 --json number,title,headRefName,statusCheckRollup,autoMergeRequest \
 		--template '{{range .}}#{{.number}} {{.title}} ({{.headRefName}}){{"\n"}}  auto-merge: {{if .autoMergeRequest}}ON{{else}}OFF{{end}}{{"\n"}}  checks: {{range .statusCheckRollup}}{{.name}}={{.conclusion}} {{end}}{{"\n\n"}}{{end}}'
 
-# Discover candidate Codex web-agent comments on merged PRs without making changes.
-codex-pr-review-followups-list:
-	@uv run --project _project/scripts -- python _project/scripts/codex_pr_review_followups.py list \
-		--base "$(CODEX_REVIEW_BASE)" \
-		--limit-prs "$(CODEX_REVIEW_PR_LIMIT)" \
-		--max-comments "$(CODEX_REVIEW_MAX_COMMENTS)" \
-		$(if $(CODEX_REVIEW_REPO),--repo "$(CODEX_REVIEW_REPO)") \
-		$(if $(CODEX_REVIEW_SINCE),--since "$(CODEX_REVIEW_SINCE)") \
-		$(if $(CODEX_REVIEW_UNTIL),--until "$(CODEX_REVIEW_UNTIL)")
+# Discover candidate bot/agent review comments on merged PRs without making changes.
+# Default --author filter is the chatgpt-codex-connector bot; override with --author
+# (or by editing DEFAULT_REVIEW_AUTHORS in the script) to add other reviewers.
+pr-review-followups-list:
+	@uv run --project _project/scripts -- python _project/scripts/pr_review_followups.py list \
+		--base "$(PR_REVIEW_BASE)" \
+		--limit-prs "$(PR_REVIEW_PR_LIMIT)" \
+		--max-comments "$(PR_REVIEW_MAX_COMMENTS)" \
+		$(if $(PR_REVIEW_REPO),--repo "$(PR_REVIEW_REPO)") \
+		$(if $(PR_REVIEW_SINCE),--since "$(PR_REVIEW_SINCE)") \
+		$(if $(PR_REVIEW_UNTIL),--until "$(PR_REVIEW_UNTIL)")
 
-# One-comment-at-a-time Codex follow-up loop for merged PR review findings.
-# Each actioned comment lands as its own commit *before* the GitHub marker
-# reply is posted, so a mid-sweep crash never leaves a phantom-actioned
-# thread on GitHub. After the loop, the routine runs pr-preflight and
-# opens one PR through the normal pr-open workflow.
+# One-comment-at-a-time follow-up loop for merged PR review findings from any
+# configured reviewer (default: chatgpt-codex-connector). The local executor is
+# the codex CLI but is isolated behind --executor-* flags. Each actioned
+# comment lands as its own commit *before* the GitHub marker reply is posted,
+# so a mid-sweep crash never leaves a phantom-actioned thread on GitHub. After
+# the loop, the routine runs pr-preflight and opens one PR through the normal
+# pr-open workflow.
 #
 # Useful overrides:
-#   CODEX_REVIEW_MAX_COMMENTS=N   cap an iteration batch
-#   CODEX_REVIEW_SINCE=YYYY-MM-DD scope by merged-at date
-#   CODEX_REVIEW_MODEL=<model>    choose the nested codex exec model
-#   CODEX_REVIEW_REPLY=0          skip GitHub replies. Only the literals
-#                                 0|false|no disable; anything else
-#                                 (including "1" or "true") is treated as
-#                                 the default, so the reply is posted.
-#   CODEX_REVIEW_SUBMIT=0         skip final pr-open. Same accepted values
-#                                 as CODEX_REVIEW_REPLY above.
-#   CODEX_REVIEW_RESUME=1         re-drive the routine on a branch that
-#                                 already carries per-comment commits from a
-#                                 prior crashed sweep. Implies --allow-dirty
-#                                 and skips comments already committed
-#                                 locally. Only the literals 1|true|yes
-#                                 enable it.
-codex-pr-review-followups:
-	@uv run --project _project/scripts -- python _project/scripts/codex_pr_review_followups.py run \
-		--base "$(CODEX_REVIEW_BASE)" \
-		--limit-prs "$(CODEX_REVIEW_PR_LIMIT)" \
-		--max-comments "$(CODEX_REVIEW_MAX_COMMENTS)" \
-		--codex-sandbox "$(CODEX_REVIEW_CODEX_SANDBOX)" \
-		--codex-approval "$(CODEX_REVIEW_CODEX_APPROVAL)" \
-		$(if $(CODEX_REVIEW_REPO),--repo "$(CODEX_REVIEW_REPO)") \
-		$(if $(CODEX_REVIEW_SINCE),--since "$(CODEX_REVIEW_SINCE)") \
-		$(if $(CODEX_REVIEW_UNTIL),--until "$(CODEX_REVIEW_UNTIL)") \
-		$(if $(CODEX_REVIEW_MODEL),--codex-model "$(CODEX_REVIEW_MODEL)") \
-		$(if $(filter 0 false no,$(CODEX_REVIEW_REPLY)),--no-reply) \
-		$(if $(filter 0 false no,$(CODEX_REVIEW_SUBMIT)),--no-submit) \
-		$(if $(filter 1 true yes,$(CODEX_REVIEW_RESUME)),--resume)
+#   PR_REVIEW_MAX_COMMENTS=N         cap an iteration batch
+#   PR_REVIEW_SINCE=YYYY-MM-DD       scope by merged-at date
+#   PR_REVIEW_EXECUTOR_MODEL=<name>  choose the executor model
+#   PR_REVIEW_REPLY=0                skip GitHub replies. Only the literals
+#                                    0|false|no disable; anything else
+#                                    (including "1" or "true") is treated as
+#                                    the default, so the reply is posted.
+#   PR_REVIEW_SUBMIT=0               skip final pr-open. Same accepted values
+#                                    as PR_REVIEW_REPLY above.
+#   PR_REVIEW_RESUME=1               re-drive the routine on a branch that
+#                                    already carries per-comment commits from
+#                                    a prior crashed sweep. Implies
+#                                    --allow-dirty and skips comments already
+#                                    committed locally. Only the literals
+#                                    1|true|yes enable it.
+pr-review-followups:
+	@uv run --project _project/scripts -- python _project/scripts/pr_review_followups.py run \
+		--base "$(PR_REVIEW_BASE)" \
+		--limit-prs "$(PR_REVIEW_PR_LIMIT)" \
+		--max-comments "$(PR_REVIEW_MAX_COMMENTS)" \
+		--executor-sandbox "$(PR_REVIEW_EXECUTOR_SANDBOX)" \
+		--executor-approval "$(PR_REVIEW_EXECUTOR_APPROVAL)" \
+		$(if $(PR_REVIEW_REPO),--repo "$(PR_REVIEW_REPO)") \
+		$(if $(PR_REVIEW_SINCE),--since "$(PR_REVIEW_SINCE)") \
+		$(if $(PR_REVIEW_UNTIL),--until "$(PR_REVIEW_UNTIL)") \
+		$(if $(PR_REVIEW_EXECUTOR_MODEL),--executor-model "$(PR_REVIEW_EXECUTOR_MODEL)") \
+		$(if $(filter 0 false no,$(PR_REVIEW_REPLY)),--no-reply) \
+		$(if $(filter 0 false no,$(PR_REVIEW_SUBMIT)),--no-submit) \
+		$(if $(filter 1 true yes,$(PR_REVIEW_RESUME)),--resume)
 
 dev-loop-metrics:
 	@set -e; \
@@ -1691,8 +1695,8 @@ help:
 	@echo "  make pr-fanout       Run pr-open across worktrees with bounded parallelism (PR_FANOUT_JOBS=$(PR_FANOUT_JOBS))"
 	@echo "  make pr-refresh      Merge origin/develop into current branch, push, and re-enable auto-merge"
 	@echo "  make pr-status       List your open PRs vs develop with CI + auto-merge state"
-	@echo "  make codex-pr-review-followups-list  List un-actioned Codex comments on merged PRs"
-	@echo "  make codex-pr-review-followups       Action each comment, reply with marker, submit PR"
+	@echo "  make pr-review-followups-list        List un-actioned bot/agent review comments on merged PRs"
+	@echo "  make pr-review-followups             Action each comment, reply with marker, submit PR"
 	@echo "  make dev-loop-metrics  Summarize recent develop post-merge metrics (DEV_LOOP_METRICS_DAYS=$(DEV_LOOP_METRICS_DAYS))"
 	@echo "Worktree-pool lifecycle (preferred for new write sessions):"
 	@echo "  make worktree-pool-init           Bootstrap retained pool worktrees (POOL_SIZE=$(POOL_SIZE))"

--- a/_project/audits/pr-review-sweep-template.md
+++ b/_project/audits/pr-review-sweep-template.md
@@ -1,20 +1,30 @@
-# Weekly Codex PR-Review Sweep — Template
+# PR-Review Sweep — Template
 
-A reusable checklist for the recurring "Codex PR-review follow-ups for week
-ending YYYY-MM-DD" TODOs. Built from the
-`codex-pr-review-followups-week-2026-05-01` execution and extended with the
-two axes the original sweep template missed (captured in blind-spot
+A reusable checklist for "PR-review follow-ups" TODOs. Built from the
+`codex-pr-review-followups-week-2026-05-01` execution (historical TODO id;
+the routine is now the reviewer-agnostic `pr-review-followups`) and extended
+with the two axes the original sweep template missed (captured in blind-spot
 `_project/blind-spots/2026-05-01-130000-codex-followups-todo-misses-coverage-downgrades.md`).
+
+The default `--author` filter targets `chatgpt-codex-connector[bot]`, but the
+routine accepts any reviewer login (other bots, human reviewers, etc.) via
+`--author` or `DEFAULT_REVIEW_AUTHORS`. The local executor is currently the
+codex CLI, isolated behind `--executor-*` flags.
 
 ## When to use this template
 
-Run a sweep weekly (or whenever a backlog of `chatgpt-codex-connector[bot]`
-inline review threads has accumulated on merged PRs). Each sweep produces:
+Run a sweep whenever a backlog of bot/agent inline review threads has
+accumulated on merged PRs. Cadence is operator-driven (no fixed schedule);
+pick a sweep window appropriate to the volume of merged PRs and the size of
+the unactioned queue (`make pr-review-followups-list` previews it). Each
+sweep produces:
 
 1. A new TODO at
-   `_project/TODO/main/planning/codex-pr-review-followups-week-YYYY-MM-DD.yaml`
+   `_project/TODO/main/planning/pr-review-followups-<window-tag>.yaml`
+   (the window tag identifies the chosen sweep range, e.g. `2026-05-01-to-05-07`
+   or `since-2026-05-01`; legacy entries used `week-YYYY-MM-DD`)
 2. A rescan audit at
-   `_project/audits/codex-thread-rescan-week-YYYY-MM-DD.md` listing
+   `_project/audits/pr-review-thread-rescan-<window-tag>.md` listing
    resolved-by-this-TODO, already-fixed-by-earlier-merges, and
    still-actionable threads
 3. Optional cross-links from in-window blind-spots filed under
@@ -25,25 +35,25 @@ creating another manual inventory:
 
 ```bash
 # Preview the candidate queue.
-make codex-pr-review-followups-list CODEX_REVIEW_SINCE=YYYY-MM-DD CODEX_REVIEW_UNTIL=YYYY-MM-DD
+make pr-review-followups-list PR_REVIEW_SINCE=YYYY-MM-DD PR_REVIEW_UNTIL=YYYY-MM-DD
 
 # In a feature worktree, action each queued comment, reply with the
 # BenchBox action marker, run preflight, and open the batched PR.
-make codex-pr-review-followups CODEX_REVIEW_SINCE=YYYY-MM-DD CODEX_REVIEW_UNTIL=YYYY-MM-DD
+make pr-review-followups PR_REVIEW_SINCE=YYYY-MM-DD PR_REVIEW_UNTIL=YYYY-MM-DD
 ```
 
 The routine uses the same judgment rules below: it verifies current behavior
 before editing, treats stale-but-fixed threads as no-current-action, preserves
 historical DONE verification commands when they are still executable
 documentation, and skips future reprocessing only after it has posted a reply
-containing the `benchbox-codex-review-followup-actioned` marker.
+containing the `benchbox-pr-review-followup-actioned` marker.
 
 If the routine crashes mid-sweep (transient `gh api` failures and pre-commit
 hook auto-fixes will normally retry; anything else exits with a non-zero
-status), re-drive it on the same worktree with `CODEX_REVIEW_RESUME=1`:
+status), re-drive it on the same worktree with `PR_REVIEW_RESUME=1`:
 
 ```bash
-make codex-pr-review-followups CODEX_REVIEW_RESUME=1 CODEX_REVIEW_SINCE=YYYY-MM-DD
+make pr-review-followups PR_REVIEW_RESUME=1 PR_REVIEW_SINCE=YYYY-MM-DD
 ```
 
 `--resume` (or its env-var form) implies `--allow-dirty` so the prior
@@ -51,24 +61,26 @@ per-comment commits on the branch are accepted, and parses
 `git log origin/<base>..HEAD` for the per-comment commit subject to skip
 comments whose fix already landed locally. The GitHub-marker check still
 catches threads where both the commit and the reply already succeeded, so
-`--resume` only needs to short-circuit the codex re-run for half-completed
+`--resume` only needs to short-circuit the executor re-run for half-completed
 work. Use it after any unplanned exit; do not use it on a fresh branch.
 
 ## Trust model — review the resulting PR before merge
 
-The routine runs `codex exec --sandbox workspace-write -c approval_policy=never`
-against the contents of comments authored by `chatgpt-codex-connector[bot]`.
-That gives codex unattended write access to the repo for the duration of the
-sweep. The trust boundary is the **author filter** (`--author` /
-`CODEX_REVIEW_AUTHOR`). Anyone with repo write can change that flag to action
-comments from any author. Treat the routine accordingly:
+The routine runs the executor (currently `codex exec --sandbox workspace-write
+-c approval_policy=never`) against the contents of comments authored by the
+configured reviewer set (default: `chatgpt-codex-connector[bot]`). That gives
+the executor unattended write access to the repo for the duration of the
+sweep. The trust boundary is the **author filter** (`--author`). Anyone with
+repo write can change that flag to action comments from any author. Treat the
+routine accordingly:
 
-- The codex sandbox (`workspace-write`) permits codex to read the whole repo
-  and write any file under the worktree. It does not get network access by
-  default, but it can run any local command (including `git`, `uv`, `make`).
-- `approval_policy=never` means codex never prompts before running a local
-  command — including ones that mutate state. The routine is intentionally
-  unattended, so this is required.
+- The executor sandbox (`workspace-write`) permits the executor to read the
+  whole repo and write any file under the worktree. It does not get network
+  access by default, but it can run any local command (including `git`,
+  `uv`, `make`).
+- `approval_policy=never` means the executor never prompts before running a
+  local command — including ones that mutate state. The routine is
+  intentionally unattended, so this is required.
 - Per-comment commits land **before** the GitHub marker reply is posted, and
   each commit message includes the source PR# + comment id (see
   `commit_message_for_result`). This means a crash mid-sweep leaves a
@@ -76,24 +88,25 @@ comments from any author. Treat the routine accordingly:
 - The reviewer of the resulting PR should: (a) skim each per-comment commit
   to confirm the change matches the source comment's intent, (b) reject any
   commit that pulled in unrelated edits, (c) verify that a "fixed"
-  disposition actually corresponds to a change on disk (a stale Codex run
+  disposition actually corresponds to a change on disk (a stale executor run
   could in principle fabricate an evidence block while leaving the tree
   unchanged — the per-commit diff is the ground truth).
-- Prompt-injection content inside a Codex comment body is treated as input,
-  not instruction; the prompt template
-  (`_project/scripts/prompts/codex_pr_review_followup.md`) tells codex to
+- Prompt-injection content inside a reviewer's comment body is treated as
+  input, not instruction; the prompt template
+  (`_project/scripts/prompts/pr_review_followup.md`) tells the executor to
   verify against the current tree and to make the smallest coherent fix.
   Reviewers should still be alert to PRs that touch suspiciously broad
-  surface area for a single Codex finding.
+  surface area for a single source comment.
 
 ## Required scope axes
 
-The frame "unresolved Codex review threads from PRs #N–#M" is good at
-catching what Codex flagged-and-was-never-resolved, but blind to several
-adjacent failure modes. **All five axes below are mandatory** — skip any
-one of them only with an explicit `out-of-scope:` line citing why.
+The frame "unresolved bot/agent review threads from PRs #N–#M" is good at
+catching what the configured reviewers flagged-and-was-never-resolved, but
+blind to several adjacent failure modes. **All five axes below are
+mandatory** — skip any one of them only with an explicit `out-of-scope:`
+line citing why.
 
-### Axis 1 — Codex inline threads (the canonical scan)
+### Axis 1 — Reviewer inline threads (the canonical scan)
 
 ```bash
 # Discover merged PRs in the review window.
@@ -115,14 +128,14 @@ in the TODO)**.
 ### Axis 2 — In-window blind-spot findings
 
 `_project/blind-spots/YYYY-MM-DD-*.md` may have been filed during the same
-review window by `/code review`, `/blind-spot`, or other paths. Codex
+review window by `/code review`, `/blind-spot`, or other paths. PR-review
 threads will not surface these — they came from local agents.
 
 ```bash
 # Findings filed during the review window. Use explicit start/end dates so
 # the listing is bounded to the actual sweep range; ${START_DATE:0:7} only
 # scopes to a calendar month, which can pull pre-window findings or omit
-# late-week ones.
+# late-window ones.
 ls _project/blind-spots/ \
   | awk -v s="$START_DATE" -v e="$END_DATE" '
       /^[0-9]{4}-[0-9]{2}-[0-9]{2}-/ {
@@ -142,8 +155,8 @@ ls _project/blind-spots/ \
 For each in-window finding:
 
 - Cross-link it from the TODO's `description:` or relevant `w-unit notes:`.
-- If the finding maps to a w-unit (e.g. a test was loosened in a PR Codex
-  also commented on), add a `must_not_do:` line connecting them so a
+- If the finding maps to a w-unit (e.g. a test was loosened in a PR a
+  reviewer also commented on), add a `must_not_do:` line connecting them so a
   future agent picking up the w-unit cannot land the fix without
   addressing the blind-spot.
 - If the finding is out-of-window or unrelated, mention it explicitly
@@ -153,11 +166,11 @@ For each in-window finding:
 The 2026-05-01 sweep added the `do not fix Home.tsx without restoring
 strict cold-load row counts` rule to its `must_not_do` list precisely
 because cross-linking the blind-spot caught the regression-coverage
-downgrade Codex itself never flagged.
+downgrade the reviewer itself never flagged.
 
 ### Axis 3 — Tests weakened in the window
 
-Codex flags individual lines, not coverage downgrades. A PR can land a fix
+Reviewers flag individual lines, not coverage downgrades. A PR can land a fix
 that simultaneously loosens an assertion that was guarding the same
 failure mode. The bug class is "assertion-loosening alongside fix lands
 without a guard"; the original scan template had no axis for it.
@@ -184,14 +197,14 @@ Patterns to flag (non-exhaustive — extend as new patterns surface):
 - Loosening `expect(..., {timeout: T1})` to `expect(..., {timeout: T2 > T1})`
   by an order of magnitude (often masks intermittent regressions).
 
-For each match: if Codex did not flag it, file a w-unit OR a blind-spot
+For each match: if no reviewer flagged it, file a w-unit OR a blind-spot
 finding pointing at the diff. Do not silently accept "the team
 simplified" without confirming the regression mode the original test
 guarded is still covered.
 
-### Axis 4 — Codex threads that were "marked resolved" without a fix
+### Axis 4 — Reviewer threads that were "marked resolved" without a fix
 
-Codex's resolved-state in GitHub is unreliable: a contributor can resolve
+A reviewer's resolved-state in GitHub is unreliable: a contributor can resolve
 a thread by replying or by clicking the resolve button, even if the code
 was never changed. A thread that GitHub reports as resolved but for which
 no commit in the window matches the fix description is a candidate for a
@@ -216,7 +229,7 @@ silently no-op or fail. The 2026-05-01 policy decision below is
 inherited:
 
 > Historical DONE-item verification commands are kept executable. If a
-> Codex finding identifies a portability or correctness defect in a
+> reviewer finding identifies a portability or correctness defect in a
 > DONE-item verification block, fix it in place. Rationale: those
 > commands serve as runnable documentation of how the policy was
 > confirmed, so anyone re-verifying the historical decision (forks,
@@ -225,18 +238,21 @@ inherited:
 ## TODO file shape
 
 Use `_project/TODO_ENTRY_TEMPLATE.yaml` as the base. The conventional
-fields for a Codex sweep TODO:
+fields for a sweep TODO:
 
-- `id: codex-pr-review-followups-week-YYYY-MM-DD`
-- `title: "Address unresolved Codex PR review follow-ups from the week ending YYYY-MM-DD"`
+- `id: pr-review-followups-<window-tag>` (e.g. `pr-review-followups-2026-05-01-to-05-07`
+  or `pr-review-followups-since-2026-05-01`; the window tag should be readable
+  enough to identify the sweep range without opening the file)
+- `title: "Address unresolved PR review follow-ups for <window>"`
 - `worktree: main`
 - `priority: High`
 - `category: Testing and Quality Assurance`
-- `description:` — number of merged PRs scanned, number of Codex comments
-  found, the policy decision quoted from Axis 5, AND a paragraph noting
-  which in-window blind-spots were folded in vs out-of-scope (Axis 2).
+- `description:` — sweep window (start/end or "since"), number of merged PRs
+  scanned, number of reviewer comments found, the policy decision quoted from
+  Axis 5, AND a paragraph noting which in-window blind-spots were folded in
+  vs out-of-scope (Axis 2).
 - `work:` — one w-unit per still-actionable thread; one
-  `summary: "Re-run the Codex thread scan and produce the rescan audit"`
+  `summary: "Re-run the PR-review thread scan and produce the rescan audit"`
   unit at the end whose `notes:` block lists the required audit sections.
 - `must_not_do:` — must include cross-links from any folded-in
   blind-spots so the rule travels with the work.
@@ -245,8 +261,9 @@ fields for a Codex sweep TODO:
 
 ## Rescan audit shape
 
-`_project/audits/codex-thread-rescan-week-YYYY-MM-DD.md` is the
-per-sweep public record. Required sections:
+`_project/audits/pr-review-thread-rescan-<window-tag>.md` is the per-sweep
+public record (legacy entries used `codex-thread-rescan-week-YYYY-MM-DD.md`).
+Required sections:
 
 1. `## Resolved By w1-wN` — one row per fixed thread, link to the
    commit that fixed it.

--- a/_project/scripts/oneoff_rewrite_review_followup_marker.py
+++ b/_project/scripts/oneoff_rewrite_review_followup_marker.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""One-off migration: rewrite the OLD action marker in existing GitHub replies.
+
+Run AFTER the rename PR lands. The PR-review-followup routine previously posted
+replies carrying the marker
+
+    benchbox-codex-review-followup-actioned
+
+The rename moved the marker to
+
+    benchbox-pr-review-followup-actioned
+
+Existing replies on GitHub still carry the OLD marker, so the new routine
+would re-action threads that were already actioned. This script walks merged
+PRs, finds review-comment replies whose body contains the OLD marker, and
+PATCHes each one in place to use the NEW marker. Body content otherwise
+unchanged.
+
+Dry-run by default (lists matches, no writes). Pass --apply to mutate.
+
+After this lands successfully, delete this script in a follow-up PR — it is
+intentionally one-off and not part of the routine surface.
+
+Usage:
+  uv run -- python _project/scripts/oneoff_rewrite_review_followup_marker.py
+  uv run -- python _project/scripts/oneoff_rewrite_review_followup_marker.py --apply
+  uv run -- python _project/scripts/oneoff_rewrite_review_followup_marker.py \
+      --repo joeharris76/BenchBox --since 2026-01-01 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+OLD_MARKER = "benchbox-codex-review-followup-actioned"
+NEW_MARKER = "benchbox-pr-review-followup-actioned"
+
+
+@dataclass(frozen=True)
+class CommentHit:
+    pr_number: int
+    comment_id: int
+    html_url: str
+    body: str
+
+
+def gh_json(args: list[str]) -> Any:
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"gh failed ({result.returncode}): {' '.join(args)}\n{result.stderr.strip()}")
+    text = result.stdout.strip()
+    return json.loads(text) if text else None
+
+
+def list_merged_prs(repo: str, since: str | None, limit: int) -> list[int]:
+    args = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--base",
+        "develop",
+        "--limit",
+        str(limit),
+        "--json",
+        "number,mergedAt",
+    ]
+    raw = gh_json(args) or []
+    numbers: list[int] = []
+    for item in raw:
+        merged_at = str(item.get("mergedAt") or "")
+        if since and merged_at and merged_at < since:
+            continue
+        numbers.append(int(item["number"]))
+    # Also check open PRs — markers can land on those too.
+    open_args = [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--base",
+        "develop",
+        "--limit",
+        str(limit),
+        "--json",
+        "number",
+    ]
+    for item in gh_json(open_args) or []:
+        numbers.append(int(item["number"]))
+    return sorted(set(numbers))
+
+
+def fetch_review_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    args = [
+        "gh",
+        "api",
+        "--paginate",
+        f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+        "--jq",
+        ".[] | @json",
+    ]
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"gh failed for PR #{pr_number}: {result.stderr.strip()}")
+    rows: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def collect_hits(repo: str, since: str | None, limit: int) -> list[CommentHit]:
+    hits: list[CommentHit] = []
+    for pr_number in list_merged_prs(repo, since, limit):
+        for comment in fetch_review_comments(repo, pr_number):
+            body = str(comment.get("body") or "")
+            if OLD_MARKER not in body:
+                continue
+            hits.append(
+                CommentHit(
+                    pr_number=pr_number,
+                    comment_id=int(comment["id"]),
+                    html_url=str(comment.get("html_url") or ""),
+                    body=body,
+                )
+            )
+    return hits
+
+
+def patch_comment(repo: str, comment_id: int, new_body: str) -> None:
+    args = [
+        "gh",
+        "api",
+        "-X",
+        "PATCH",
+        f"repos/{repo}/pulls/comments/{comment_id}",
+        "-f",
+        f"body={new_body}",
+    ]
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"PATCH failed for comment {comment_id}: {result.stderr.strip()}")
+
+
+def resolve_repo(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    args = ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+    result = subprocess.run(args, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError("Could not resolve repo via `gh repo view`. Pass --repo.")
+    name = result.stdout.strip()
+    if not name:
+        raise RuntimeError("Empty repo name from `gh repo view`. Pass --repo.")
+    return name
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("PR_REVIEW_REPO"))
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Only scan PRs merged on or after this ISO date (YYYY-MM-DD). Default: all.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=1000,
+        help="Max PRs to fetch per state (open/merged). Default: 1000.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually PATCH the comments. Without this flag, only print matches.",
+    )
+    args = parser.parse_args(argv)
+
+    repo = resolve_repo(args.repo)
+    print(f"Scanning {repo} for replies containing OLD marker `{OLD_MARKER}` ...")
+    hits = collect_hits(repo, args.since, args.limit)
+
+    if not hits:
+        print("No replies with the OLD marker found. Nothing to do.")
+        return 0
+
+    print(f"\nFound {len(hits)} reply comment(s) carrying the OLD marker:\n")
+    for hit in hits:
+        print(f"  PR #{hit.pr_number} comment {hit.comment_id}: {hit.html_url}")
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply to PATCH each comment.")
+        return 0
+
+    print(f"\nApplying rewrite ({OLD_MARKER} -> {NEW_MARKER}) ...")
+    failures: list[CommentHit] = []
+    for hit in hits:
+        new_body = hit.body.replace(OLD_MARKER, NEW_MARKER)
+        try:
+            patch_comment(repo, hit.comment_id, new_body)
+            print(f"  patched PR #{hit.pr_number} comment {hit.comment_id}")
+        except RuntimeError as exc:
+            print(f"  FAILED  PR #{hit.pr_number} comment {hit.comment_id}: {exc}", file=sys.stderr)
+            failures.append(hit)
+
+    if failures:
+        print(f"\n{len(failures)} comment(s) failed to update. Re-run --apply to retry.")
+        return 1
+    print(f"\nDone. {len(hits)} comment(s) rewritten to the new marker.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/_project/scripts/pr_review_followups.py
+++ b/_project/scripts/pr_review_followups.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
-"""Action stale Codex web-agent review comments left on merged PRs.
+"""Action stale bot/agent review comments left on merged PRs.
 
 The script is intentionally an orchestrator, not a static fixer. It gathers
-candidate inline review comments, skips comments that already carry the
-BenchBox action marker reply, asks local `codex exec` to assess and fix each
-remaining finding against the current tree, replies to the source comment, and
-then optionally submits one batched PR through the existing Make workflow.
+candidate inline review comments from configured authors, skips comments that
+already carry the BenchBox action marker reply, asks the local executor (the
+`codex` CLI) to assess and fix each remaining finding against the current
+tree, replies to the source comment, and then optionally submits one batched
+PR through the existing Make workflow. The reviewer set is configurable via
+`--author`; the executor is currently codex but is isolated behind the
+`--executor-*` flags so it can be swapped without touching the orchestration.
 """
 
 from __future__ import annotations
@@ -23,14 +26,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
-DEFAULT_CODEX_AUTHORS = ("chatgpt-codex-connector[bot]", "chatgpt-codex-connector")
-ACTION_MARKER = "benchbox-codex-review-followup-actioned"
+DEFAULT_REVIEW_AUTHORS = ("chatgpt-codex-connector[bot]", "chatgpt-codex-connector")
+ACTION_MARKER = "benchbox-pr-review-followup-actioned"
 ACTION_MARKER_REGEX = re.compile(rf"(?m)^<!--\s*{re.escape(ACTION_MARKER)}\b")
-DEFAULT_COMMIT_MESSAGE = "fix: address stale Codex PR review follow-ups"
-PER_COMMENT_COMMIT_PREFIX = "fix(codex-followup)"
+DEFAULT_COMMIT_MESSAGE = "fix: address stale PR review follow-ups"
+PER_COMMENT_COMMIT_PREFIX = "fix(pr-followup)"
 MAX_REPLY_SUMMARY_CHARS = 8000
-PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "prompts" / "codex_pr_review_followup.md"
-MIN_CODEX_VERSION = (0, 20, 0)
+PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent / "prompts" / "pr_review_followup.md"
+MIN_EXECUTOR_VERSION = (0, 20, 0)
 PER_COMMENT_COMMIT_SUBJECT_REGEX = re.compile(
     rf"^{re.escape(PER_COMMENT_COMMIT_PREFIX)}: PR #(\d+) comment (\d+) "
 )
@@ -457,7 +460,7 @@ def first_body_line(body: str) -> str:
 
 def print_pending_table(pending: Sequence[PendingComment]) -> None:
     if not pending:
-        print("No pending Codex PR review comments found.")
+        print("No pending PR review comments found.")
         return
     print(f"{'PR':>6}  {'Comment':>12}  {'Path':<52}  Finding")
     print(f"{'-' * 6}  {'-' * 12}  {'-' * 52}  {'-' * 40}")
@@ -469,8 +472,8 @@ def print_pending_table(pending: Sequence[PendingComment]) -> None:
 def git_status_snapshot(runner: CommandRunner) -> str:
     """Snapshot of working-tree state used as a disposition baseline.
 
-    `git diff` only sees unstaged tracked-file changes. Codex may stage edits
-    (`git add`) or create new untracked files; both must count as "fixed".
+    `git diff` only sees unstaged tracked-file changes. The executor may stage
+    edits (`git add`) or create new untracked files; both must count as "fixed".
     `git status --porcelain` covers all three: modified, staged, and untracked.
     """
     return checked(runner, ["git", "status", "--porcelain"]).stdout
@@ -527,7 +530,7 @@ def load_prompt_template(path: Path = PROMPT_TEMPLATE_PATH) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def build_codex_prompt(
+def build_executor_prompt(
     item: PendingComment,
     *,
     repo: str,
@@ -556,20 +559,21 @@ def build_codex_prompt(
     return rendered.strip()
 
 
-def check_codex_version(
-    runner: CommandRunner, *, minimum: tuple[int, int, int] = MIN_CODEX_VERSION
+def check_executor_version(
+    runner: CommandRunner, *, minimum: tuple[int, int, int] = MIN_EXECUTOR_VERSION
 ) -> tuple[int, int, int]:
-    """Probe `codex --version` and assert it parses to >= minimum.
+    """Probe the executor's `--version` and assert it parses to >= minimum.
 
-    Surfaces a clear remediation when the binary is missing or too old, so the
-    routine fails fast instead of mid-loop with an opaque flag-not-recognized
-    error from a stale codex CLI.
+    The executor is currently the codex CLI; the function name stays generic so
+    a future executor swap doesn't require a rename. Surfaces a clear
+    remediation when the binary is missing or too old, so the routine fails
+    fast instead of mid-loop with an opaque flag-not-recognized error.
     """
     try:
         result = runner.run(["codex", "--version"])
     except FileNotFoundError as exc:
         raise RuntimeError(
-            "codex CLI not found on PATH. Install codex-cli "
+            "Executor binary `codex` not found on PATH. Install codex-cli "
             f">= {'.'.join(str(p) for p in minimum)} (https://github.com/openai/codex)."
         ) from exc
     if result.returncode != 0:
@@ -577,28 +581,28 @@ def check_codex_version(
     text = (result.stdout or result.stderr or "").strip()
     match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
     if not match:
-        raise RuntimeError(f"Could not parse codex CLI version from output: {text!r}")
+        raise RuntimeError(f"Could not parse executor version from output: {text!r}")
     parsed = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
     if parsed < minimum:
         raise RuntimeError(
-            f"codex CLI {'.'.join(str(p) for p in parsed)} is below the required "
-            f">= {'.'.join(str(p) for p in minimum)}. Upgrade codex-cli."
+            f"Executor codex-cli {'.'.join(str(p) for p in parsed)} is below the required "
+            f">= {'.'.join(str(p) for p in minimum)}. Upgrade the executor."
         )
     return parsed
 
 
-def run_codex_for_comment(
+def run_executor_for_comment(
     runner: CommandRunner,
     item: PendingComment,
     *,
     repo: str,
     base: str,
-    codex_model: str | None,
-    codex_sandbox: str,
-    codex_approval: str,
+    executor_model: str | None,
+    executor_sandbox: str,
+    executor_approval: str,
 ) -> ActionResult:
     before = git_status_snapshot(runner)
-    prompt = build_codex_prompt(item, repo=repo, base=base)
+    prompt = build_executor_prompt(item, repo=repo, base=base)
     # codex-cli >= 0.20 dropped `--ask-for-approval`. The config-override
     # syntax (`-c approval_policy=<mode>`) works across the supported version
     # range and is forward-stable.
@@ -608,12 +612,12 @@ def run_codex_for_comment(
         "--cd",
         str(runner.cwd),
         "--sandbox",
-        codex_sandbox,
+        executor_sandbox,
         "-c",
-        f"approval_policy={codex_approval}",
+        f"approval_policy={executor_approval}",
     ]
-    if codex_model:
-        cmd.extend(["--model", codex_model])
+    if executor_model:
+        cmd.extend(["--model", executor_model])
     cmd.append("-")
 
     print(f"\n==> PR #{item.pr.number} comment {item.comment.id}: {item.comment.html_url}", flush=True)
@@ -638,7 +642,7 @@ def commit_message_for_result(result: ActionResult) -> str:
     headline = first_body_line(comment.body)
     subject = f"{PER_COMMENT_COMMIT_PREFIX}: PR #{pr.number} comment {comment.id} — {headline}"
     # Keep commit subjects under the conventional ~100-char soft cap; truncate
-    # the codex headline before composing rather than after, so the trailer
+    # the comment headline before composing rather than after, so the trailer
     # stays intact.
     if len(subject) > 100:
         keep = 100 - (len(subject) - len(headline)) - 1
@@ -679,12 +683,12 @@ def _porcelain_paths_with_worktree_mods(porcelain: str) -> set[str]:
 def commit_changes_for_result(
     runner: CommandRunner, result: ActionResult
 ) -> bool:
-    """Stage + commit codex-produced changes for one comment.
+    """Stage + commit executor-produced changes for one comment.
 
     Returns True when a commit was created. Called *before* the GitHub reply
-    is posted so a crash between codex and reply leaves no phantom-actioned
-    state on GitHub: either the commit landed (next run sees no change), or
-    nothing happened (next run reprocesses the comment cleanly).
+    is posted so a crash between the executor run and the reply leaves no
+    phantom-actioned state on GitHub: either the commit landed (next run sees
+    no change), or nothing happened (next run reprocesses the comment cleanly).
 
     A pre-commit hook that auto-formats the staged paths (e.g. `ruff-format`)
     aborts the first commit with the marker `files were modified by this hook`
@@ -731,7 +735,7 @@ def build_reply_body(result: ActionResult, *, branch: str) -> str:
     return textwrap.dedent(
         f"""
         <!-- {ACTION_MARKER}: pr={pr.number} comment_id={comment.id} branch={branch} -->
-        Follow-up sweep actioned this Codex review comment.
+        Follow-up sweep actioned this PR review comment.
 
         Disposition: {result.disposition}
         Branch: `{branch}`
@@ -858,7 +862,7 @@ def finalize_changes(
 
     Per-comment commits are produced inside `run_action_loop` *before* the
     GitHub reply is posted. This finalizer's job is just to (a) sweep up any
-    leftover unstaged paths into a fallback batch commit (codex output that
+    leftover unstaged paths into a fallback batch commit (executor output that
     was somehow missed by `commit_changes_for_result`), (b) run preflight,
     (c) open the PR.
     """
@@ -899,7 +903,7 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
         if not args.dry_run:
             branch = current_branch(runner)
             ensure_action_branch(branch, no_submit=args.no_submit)
-            check_codex_version(runner)
+            check_executor_version(runner)
         ensure_clean_start(
             runner,
             allow_dirty=args.allow_dirty or args.dry_run or resume,
@@ -935,17 +939,17 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
 
     results: list[ActionResult] = []
     for item in pending:
-        result = run_codex_for_comment(
+        result = run_executor_for_comment(
             runner,
             item,
             repo=repo,
             base=args.base,
-            codex_model=args.codex_model,
-            codex_sandbox=args.codex_sandbox,
-            codex_approval=args.codex_approval,
+            executor_model=args.executor_model,
+            executor_sandbox=args.executor_sandbox,
+            executor_approval=args.executor_approval,
         )
-        # Order matters: commit BEFORE replying. A crash between codex and
-        # the reply leaves nothing on GitHub; a crash between commit and
+        # Order matters: commit BEFORE replying. A crash between the executor
+        # and the reply leaves nothing on GitHub; a crash between commit and
         # reply leaves a benign uncommented commit. Reply-before-commit
         # would create phantom-actioned threads that future sweeps would
         # silently skip even though no fix landed.
@@ -954,7 +958,7 @@ def run_action_loop(args: argparse.Namespace, runner: CommandRunner) -> int:
         if not args.no_reply:
             reply_to_comment(runner, repo=repo, result=result, branch=branch)
 
-    print(f"\nActioned {len(results)} Codex review comment(s).")
+    print(f"\nActioned {len(results)} PR review comment(s).")
     finalize_changes(
         runner,
         base_ref=f"origin/{args.base}",
@@ -969,13 +973,13 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     for command in ("list", "run"):
         sub = subparsers.add_parser(command)
-        sub.add_argument("--repo", default=os.environ.get("CODEX_REVIEW_REPO"))
-        sub.add_argument("--base", default=os.environ.get("CODEX_REVIEW_BASE", "develop"))
-        sub.add_argument("--limit-prs", type=int, default=int(os.environ.get("CODEX_REVIEW_PR_LIMIT", "1000")))
-        sub.add_argument("--max-comments", type=int, default=int(os.environ.get("CODEX_REVIEW_MAX_COMMENTS", "0")))
-        sub.add_argument("--since", default=os.environ.get("CODEX_REVIEW_SINCE"))
-        sub.add_argument("--until", default=os.environ.get("CODEX_REVIEW_UNTIL"))
-        sub.add_argument("--author", action="append", default=list(DEFAULT_CODEX_AUTHORS))
+        sub.add_argument("--repo", default=os.environ.get("PR_REVIEW_REPO"))
+        sub.add_argument("--base", default=os.environ.get("PR_REVIEW_BASE", "develop"))
+        sub.add_argument("--limit-prs", type=int, default=int(os.environ.get("PR_REVIEW_PR_LIMIT", "1000")))
+        sub.add_argument("--max-comments", type=int, default=int(os.environ.get("PR_REVIEW_MAX_COMMENTS", "0")))
+        sub.add_argument("--since", default=os.environ.get("PR_REVIEW_SINCE"))
+        sub.add_argument("--until", default=os.environ.get("PR_REVIEW_UNTIL"))
+        sub.add_argument("--author", action="append", default=list(DEFAULT_REVIEW_AUTHORS))
     run_parser = subparsers.choices["run"]
     run_parser.add_argument("--dry-run", action="store_true")
     run_parser.add_argument("--allow-dirty", action="store_true")
@@ -991,12 +995,21 @@ def build_parser() -> argparse.ArgumentParser:
             "accepted. Use this after a crashed sweep to re-drive the routine."
         ),
     )
-    run_parser.add_argument("--codex-model", default=os.environ.get("CODEX_REVIEW_MODEL"))
     run_parser.add_argument(
-        "--codex-sandbox",
-        default=os.environ.get("CODEX_REVIEW_CODEX_SANDBOX", "workspace-write"),
+        "--executor-model",
+        default=os.environ.get("PR_REVIEW_EXECUTOR_MODEL"),
+        help="Optional model name passed through to the executor (`codex --model`).",
     )
-    run_parser.add_argument("--codex-approval", default=os.environ.get("CODEX_REVIEW_CODEX_APPROVAL", "never"))
+    run_parser.add_argument(
+        "--executor-sandbox",
+        default=os.environ.get("PR_REVIEW_EXECUTOR_SANDBOX", "workspace-write"),
+        help="Sandbox profile passed through to the executor (`codex --sandbox`).",
+    )
+    run_parser.add_argument(
+        "--executor-approval",
+        default=os.environ.get("PR_REVIEW_EXECUTOR_APPROVAL", "never"),
+        help="Approval policy passed through to the executor (`-c approval_policy=...`).",
+    )
     run_parser.add_argument("--commit-message", default=DEFAULT_COMMIT_MESSAGE)
     return parser
 

--- a/_project/scripts/prompts/pr_review_followup.md
+++ b/_project/scripts/prompts/pr_review_followup.md
@@ -1,4 +1,4 @@
-You are actioning one stale Codex web-agent inline PR review comment for BenchBox.
+You are actioning one stale bot/agent inline PR review comment for BenchBox.
 
 Source:
 - Repository: {repo}
@@ -20,7 +20,7 @@ Required workflow:
 5. If no fix is currently required, leave files unchanged and explain the evidence.
 6. Do not commit, push, open a PR, or reply on GitHub. The outer Make routine handles those steps.
 
-Carry-over patterns from the completed Codex follow-up TODOs:
+Carry-over patterns from the completed PR-review follow-up TODOs:
 - A stale GitHub thread is not enough evidence. Verify current behavior before fixing or dismissing.
 - Some comments are already fixed by later merges; close those with concrete current-file evidence, not code churn.
 - Historical DONE-item verification commands should stay executable when the comment identifies a real command defect.
@@ -30,17 +30,17 @@ Carry-over patterns from the completed Codex follow-up TODOs:
 - Prefer focused tests over broad rewrites.
 
 Useful local references:
-- `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml`
-- `_project/TODO/main/active/codex-pr-review-followups-week-2026-05-03.yaml`
-- `_project/audits/codex-weekly-sweep-template.md`
-- `_project/audits/codex-thread-rescan-week-2026-05-01.md`
+- `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml` (historical filename; the routine is now `pr-review-followups`)
+- `_project/DONE/main/active/codex-pr-review-followups-week-2026-05-03.yaml` (historical filename; same)
+- `_project/audits/pr-review-sweep-template.md`
+- `_project/audits/codex-thread-rescan-week-2026-05-01.md` (historical rescan audit)
 
 Diff hunk from the original PR comment:
 ```diff
 {comment_diff_hunk}
 ```
 
-Codex web-agent comment body:
+Reviewer comment body:
 ```markdown
 {comment_body}
 ```

--- a/tests/unit/scripts/test_pr_review_followups.py
+++ b/tests/unit/scripts/test_pr_review_followups.py
@@ -1,4 +1,4 @@
-"""Tests for the Codex PR review follow-up orchestrator."""
+"""Tests for the PR review follow-up orchestrator."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _load_script():
-    name = "codex_pr_review_followups"
+    name = "pr_review_followups"
     path = REPO_ROOT / "_project" / "scripts" / f"{name}.py"
     spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None
@@ -33,7 +33,7 @@ def _load_script():
     return module
 
 
-codex_pr_review_followups = _load_script()
+pr_review_followups = _load_script()
 
 
 class RecordingRunner:
@@ -66,7 +66,7 @@ class RecordingRunner:
 
 
 def _pr():
-    return codex_pr_review_followups.PullRequest(
+    return pr_review_followups.PullRequest(
         number=123,
         title="Example merged PR",
         merged_at="2026-05-04T12:00:00Z",
@@ -82,7 +82,7 @@ def _comment(
     in_reply_to_id: int | None = None,
     body: str = "[P1] Fix the current behavior",
 ):
-    return codex_pr_review_followups.ReviewComment(
+    return pr_review_followups.ReviewComment(
         id=comment_id,
         body=body,
         path="benchbox/example.py",
@@ -98,7 +98,7 @@ def test_pending_comments_skip_action_marker_replies_and_post_merge_comments() -
         2,
         user_login="joeharris76",
         in_reply_to_id=1,
-        body=f"<!-- {codex_pr_review_followups.ACTION_MARKER}: comment_id=1 --> done",
+        body=f"<!-- {pr_review_followups.ACTION_MARKER}: comment_id=1 --> done",
     )
     comments = [
         _comment(1),
@@ -108,7 +108,7 @@ def test_pending_comments_skip_action_marker_replies_and_post_merge_comments() -
         _comment(5, user_login="other-reviewer"),
     ]
 
-    pending = codex_pr_review_followups.pending_comments_for_pr(
+    pending = pr_review_followups.pending_comments_for_pr(
         _pr(),
         comments,
         author_logins={"chatgpt-codex-connector[bot]"},
@@ -129,7 +129,7 @@ def test_action_marker_match_requires_html_comment_at_start_of_line() -> None:
         in_reply_to_id=1,
         body=(
             "Discussion: I noticed the script uses the marker "
-            f"`{codex_pr_review_followups.ACTION_MARKER}` to dedupe. "
+            f"`{pr_review_followups.ACTION_MARKER}` to dedupe. "
             "We should document this somewhere."
         ),
     )
@@ -138,13 +138,13 @@ def test_action_marker_match_requires_html_comment_at_start_of_line() -> None:
         user_login="joeharris76",
         in_reply_to_id=3,
         body=(
-            f"<!-- {codex_pr_review_followups.ACTION_MARKER}: pr=123 comment_id=3 -->\n"
+            f"<!-- {pr_review_followups.ACTION_MARKER}: pr=123 comment_id=3 -->\n"
             "Follow-up sweep actioned this Codex review comment."
         ),
     )
     comments = [_comment(1), quoted_marker_reply, _comment(3), real_marker_reply]
 
-    pending = codex_pr_review_followups.pending_comments_for_pr(
+    pending = pr_review_followups.pending_comments_for_pr(
         _pr(),
         comments,
         author_logins={"chatgpt-codex-connector[bot]"},
@@ -156,22 +156,22 @@ def test_action_marker_match_requires_html_comment_at_start_of_line() -> None:
 
 
 def test_prompt_carries_completed_sweep_patterns() -> None:
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(10), replies=())
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(10), replies=())
 
-    prompt = codex_pr_review_followups.build_codex_prompt(pending, repo="joeharris76/BenchBox", base="develop")
+    prompt = pr_review_followups.build_executor_prompt(pending, repo="joeharris76/BenchBox", base="develop")
 
     assert "Do not commit, push, open a PR, or reply on GitHub" in prompt
     assert "Historical DONE-item verification commands should stay executable" in prompt
     assert "_project/DONE/main/active/codex-pr-review-followups-week-2026-05-01.yaml" in prompt
-    assert "_project/audits/codex-weekly-sweep-template.md" in prompt
+    assert "_project/audits/pr-review-sweep-template.md" in prompt
 
 
 def test_prompt_template_file_exists_and_renders_comment_metadata() -> None:
-    template_path = codex_pr_review_followups.PROMPT_TEMPLATE_PATH
+    template_path = pr_review_followups.PROMPT_TEMPLATE_PATH
     assert template_path.exists(), f"prompt template file missing at {template_path}"
 
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(77), replies=())
-    prompt = codex_pr_review_followups.build_codex_prompt(pending, repo="joeharris76/BenchBox", base="develop")
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(77), replies=())
+    prompt = pr_review_followups.build_executor_prompt(pending, repo="joeharris76/BenchBox", base="develop")
 
     assert "Comment id: 77" in prompt
     assert "Path: benchbox/example.py" in prompt
@@ -179,54 +179,54 @@ def test_prompt_template_file_exists_and_renders_comment_metadata() -> None:
 
 
 def test_reply_body_contains_skip_marker_and_disposition() -> None:
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(11), replies=())
-    result = codex_pr_review_followups.ActionResult(
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(11), replies=())
+    result = pr_review_followups.ActionResult(
         pending=pending,
         disposition="fixed",
         summary="Disposition: fixed\nEvidence: updated the current code and ran tests.",
     )
 
-    body = codex_pr_review_followups.build_reply_body(result, branch="feat/codex-followups")
+    body = pr_review_followups.build_reply_body(result, branch="feat/codex-followups")
 
-    assert codex_pr_review_followups.ACTION_MARKER in body
+    assert pr_review_followups.ACTION_MARKER in body
     assert "comment_id=11" in body
     assert "Disposition: fixed" in body
     assert "Future sweeps skip comments" in body
     # The reply body itself must match the strict marker matcher so the
     # *next* sweep recognizes its own previous reply.
-    assert codex_pr_review_followups.ACTION_MARKER_REGEX.search(body)
+    assert pr_review_followups.ACTION_MARKER_REGEX.search(body)
 
 
 def test_submit_branch_guard_refuses_protected_branches() -> None:
     with pytest.raises(RuntimeError, match="Claim a feature worktree"):
-        codex_pr_review_followups.ensure_action_branch("develop", no_submit=False)
+        pr_review_followups.ensure_action_branch("develop", no_submit=False)
 
-    codex_pr_review_followups.ensure_action_branch("develop", no_submit=True)
+    pr_review_followups.ensure_action_branch("develop", no_submit=True)
 
 
 def test_stage_paths_uses_explicit_paths_not_git_add_all() -> None:
     runner = RecordingRunner()
 
-    codex_pr_review_followups.stage_paths(runner, ["Makefile", "_project/scripts/codex_pr_review_followups.py"])
+    pr_review_followups.stage_paths(runner, ["Makefile", "_project/scripts/pr_review_followups.py"])
 
     assert runner.commands == [
-        ["git", "add", "--", "Makefile", "_project/scripts/codex_pr_review_followups.py"],
+        ["git", "add", "--", "Makefile", "_project/scripts/pr_review_followups.py"],
     ]
 
 
-def test_check_codex_version_accepts_supported_release() -> None:
+def test_check_executor_version_accepts_supported_release() -> None:
     runner = RecordingRunner(
         responses={
             ("codex", "--version"): subprocess.CompletedProcess(["codex", "--version"], 0, "codex-cli 0.128.0\n", "")
         }
     )
 
-    parsed = codex_pr_review_followups.check_codex_version(runner)
+    parsed = pr_review_followups.check_executor_version(runner)
 
     assert parsed == (0, 128, 0)
 
 
-def test_check_codex_version_rejects_too_old_release() -> None:
+def test_check_executor_version_rejects_too_old_release() -> None:
     runner = RecordingRunner(
         responses={
             ("codex", "--version"): subprocess.CompletedProcess(["codex", "--version"], 0, "codex-cli 0.10.0\n", "")
@@ -234,10 +234,10 @@ def test_check_codex_version_rejects_too_old_release() -> None:
     )
 
     with pytest.raises(RuntimeError, match="below the required"):
-        codex_pr_review_followups.check_codex_version(runner)
+        pr_review_followups.check_executor_version(runner)
 
 
-def test_check_codex_version_surfaces_missing_binary() -> None:
+def test_check_executor_version_surfaces_missing_binary() -> None:
     class MissingBinaryRunner(RecordingRunner):
         def run(self, args, input_text=None):  # type: ignore[override]
             self.commands.append(list(args))
@@ -245,55 +245,55 @@ def test_check_codex_version_surfaces_missing_binary() -> None:
 
     runner = MissingBinaryRunner()
 
-    with pytest.raises(RuntimeError, match="codex CLI not found"):
-        codex_pr_review_followups.check_codex_version(runner)
+    with pytest.raises(RuntimeError, match="Executor binary `codex` not found"):
+        pr_review_followups.check_executor_version(runner)
 
 
-def test_run_codex_for_comment_uses_config_override_for_approval_policy() -> None:
+def test_run_executor_for_comment_uses_config_override_for_approval_policy() -> None:
     """The legacy `--ask-for-approval` flag was dropped in codex-cli >= 0.20.
 
     The orchestrator must use `-c approval_policy=<mode>` so it works against
     current and future codex releases.
     """
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(50), replies=())
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(50), replies=())
     runner = RecordingRunner()
 
-    result = codex_pr_review_followups.run_codex_for_comment(
+    result = pr_review_followups.run_executor_for_comment(
         runner,
         pending,
         repo="joeharris76/BenchBox",
         base="develop",
-        codex_model=None,
-        codex_sandbox="workspace-write",
-        codex_approval="never",
+        executor_model=None,
+        executor_sandbox="workspace-write",
+        executor_approval="never",
     )
 
-    codex_calls = [cmd for cmd in runner.commands if cmd and cmd[0] == "codex"]
-    assert codex_calls, "expected at least one codex invocation"
-    codex_argv = codex_calls[0]
-    assert "--ask-for-approval" not in codex_argv
-    assert "-c" in codex_argv
-    assert "approval_policy=never" in codex_argv
+    executor_calls = [cmd for cmd in runner.commands if cmd and cmd[0] == "codex"]
+    assert executor_calls, "expected at least one executor invocation"
+    executor_argv = executor_calls[0]
+    assert "--ask-for-approval" not in executor_argv
+    assert "-c" in executor_argv
+    assert "approval_policy=never" in executor_argv
     assert result.disposition == "no-current-action"  # RecordingRunner produces no diff
 
 
 def test_commit_message_for_result_includes_pr_and_comment_id() -> None:
-    pending = codex_pr_review_followups.PendingComment(
+    pending = pr_review_followups.PendingComment(
         pr=_pr(), comment=_comment(101, body="[P1] Tighten the merge guard"), replies=()
     )
-    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    result = pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
 
-    message = codex_pr_review_followups.commit_message_for_result(result)
+    message = pr_review_followups.commit_message_for_result(result)
 
-    assert message.startswith("fix(codex-followup):")
+    assert message.startswith("fix(pr-followup):")
     assert "PR #123" in message
     assert "comment 101" in message
     assert "Source: " in message
 
 
 def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
-    """A crash between the codex run and the reply must not leave a phantom
-    actioned thread on GitHub. The order is: codex → commit → reply.
+    """A crash between the executor run and the reply must not leave a phantom
+    actioned thread on GitHub. The order is: executor → commit → reply.
     """
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -348,10 +348,10 @@ def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
     codex_shim.chmod(codex_shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
 
-    pending_pr = codex_pr_review_followups.PullRequest(
+    pending_pr = pr_review_followups.PullRequest(
         number=42, title="t", merged_at="2026-05-04T12:00:00Z", url="https://example/42"
     )
-    pending_comment = codex_pr_review_followups.ReviewComment(
+    pending_comment = pr_review_followups.ReviewComment(
         id=999,
         body="[P1] do the thing",
         path="codex-fix.txt",
@@ -359,18 +359,18 @@ def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
         user_login="chatgpt-codex-connector[bot]",
         created_at="2026-05-04T10:00:00Z",
     )
-    pending_item = codex_pr_review_followups.PendingComment(pr=pending_pr, comment=pending_comment, replies=())
+    pending_item = pr_review_followups.PendingComment(pr=pending_pr, comment=pending_comment, replies=())
 
     side_effect_log: list[str] = []
 
-    monkeypatch.setattr(codex_pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
+    monkeypatch.setattr(pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
     monkeypatch.setattr(
-        codex_pr_review_followups,
+        pr_review_followups,
         "discover_pending_comments",
         lambda runner, **_: [pending_item],
     )
 
-    real_commit = codex_pr_review_followups.commit_changes_for_result
+    real_commit = pr_review_followups.commit_changes_for_result
 
     def trace_commit(runner, result):
         side_effect_log.append("commit")
@@ -383,12 +383,12 @@ def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
     def trace_finalize(runner, **kwargs):
         side_effect_log.append("finalize")
 
-    monkeypatch.setattr(codex_pr_review_followups, "commit_changes_for_result", trace_commit)
-    monkeypatch.setattr(codex_pr_review_followups, "reply_to_comment", trace_reply)
-    monkeypatch.setattr(codex_pr_review_followups, "finalize_changes", trace_finalize)
+    monkeypatch.setattr(pr_review_followups, "commit_changes_for_result", trace_commit)
+    monkeypatch.setattr(pr_review_followups, "reply_to_comment", trace_reply)
+    monkeypatch.setattr(pr_review_followups, "finalize_changes", trace_finalize)
 
-    runner = codex_pr_review_followups.CommandRunner(repo_root)
-    args = codex_pr_review_followups.build_parser().parse_args(
+    runner = pr_review_followups.CommandRunner(repo_root)
+    args = pr_review_followups.build_parser().parse_args(
         [
             "run",
             "--repo",
@@ -398,7 +398,7 @@ def test_run_action_loop_commits_before_replying(monkeypatch, tmp_path) -> None:
             "--no-submit",
         ]
     )
-    rc = codex_pr_review_followups.run_action_loop(args, runner)
+    rc = pr_review_followups.run_action_loop(args, runner)
 
     assert rc == 0
     assert side_effect_log == ["commit", "reply", "finalize"]
@@ -437,8 +437,8 @@ def test_reply_to_comment_retries_transient_gh_failure_then_succeeds() -> None:
         "error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com\n",
     )
     success = subprocess.CompletedProcess([], 0, "", "")
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(33), replies=())
-    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(33), replies=())
+    result = pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
 
     sleeps: list[float] = []
 
@@ -461,7 +461,7 @@ def test_reply_to_comment_retries_transient_gh_failure_then_succeeds() -> None:
 
     runner = GhScriptedRunner()
 
-    codex_pr_review_followups.reply_to_comment(
+    pr_review_followups.reply_to_comment(
         runner,
         repo="joeharris76/BenchBox",
         result=result,
@@ -483,8 +483,8 @@ def test_reply_to_comment_does_not_retry_permanent_4xx() -> None:
         "",
         "gh: HTTP 404: Not Found (https://api.github.com/repos/x/y/pulls/1/comments/1/replies)\n",
     )
-    pending = codex_pr_review_followups.PendingComment(pr=_pr(), comment=_comment(34), replies=())
-    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(34), replies=())
+    result = pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
 
     sleeps: list[float] = []
 
@@ -499,8 +499,8 @@ def test_reply_to_comment_does_not_retry_permanent_4xx() -> None:
 
     runner = GhPermFailRunner()
 
-    with pytest.raises(codex_pr_review_followups.CommandError, match="HTTP 404"):
-        codex_pr_review_followups.reply_to_comment(
+    with pytest.raises(pr_review_followups.CommandError, match="HTTP 404"):
+        pr_review_followups.reply_to_comment(
             runner,
             repo="joeharris76/BenchBox",
             result=result,
@@ -515,15 +515,13 @@ def test_reply_to_comment_does_not_retry_permanent_4xx() -> None:
 
 def test_is_transient_gh_failure_classification() -> None:
     """Sanity-check the discriminator covers the flagged classes and nothing else."""
-    assert codex_pr_review_followups._is_transient_gh_failure("error connecting to api.github.com")
-    assert codex_pr_review_followups._is_transient_gh_failure(
-        "check your internet connection or https://githubstatus.com"
-    )
-    assert codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 503: Service Unavailable")
-    assert codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 429: Too Many Requests")
-    assert not codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 404: Not Found")
-    assert not codex_pr_review_followups._is_transient_gh_failure("gh: HTTP 422: Validation failed")
-    assert not codex_pr_review_followups._is_transient_gh_failure("")
+    assert pr_review_followups._is_transient_gh_failure("error connecting to api.github.com")
+    assert pr_review_followups._is_transient_gh_failure("check your internet connection or https://githubstatus.com")
+    assert pr_review_followups._is_transient_gh_failure("gh: HTTP 503: Service Unavailable")
+    assert pr_review_followups._is_transient_gh_failure("gh: HTTP 429: Too Many Requests")
+    assert not pr_review_followups._is_transient_gh_failure("gh: HTTP 404: Not Found")
+    assert not pr_review_followups._is_transient_gh_failure("gh: HTTP 422: Validation failed")
+    assert not pr_review_followups._is_transient_gh_failure("")
 
 
 # ---------------------------------------------------------------------------
@@ -533,11 +531,11 @@ def test_is_transient_gh_failure_classification() -> None:
 
 def test_commit_changes_for_result_retries_after_hook_autofix() -> None:
     """ruff-format reformats a staged file, commit aborts, second commit succeeds."""
-    pending = codex_pr_review_followups.PendingComment(
+    pending = pr_review_followups.PendingComment(
         pr=_pr(), comment=_comment(55, body="[P1] Add the missing test"), replies=()
     )
-    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
-    expected_message = codex_pr_review_followups.commit_message_for_result(result)
+    result = pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    expected_message = pr_review_followups.commit_message_for_result(result)
     commit_argv = ("git", "commit", "-m", expected_message)
 
     target_path = "tests/unit/example.py"
@@ -571,7 +569,7 @@ def test_commit_changes_for_result_retries_after_hook_autofix() -> None:
         }
     )
 
-    landed = codex_pr_review_followups.commit_changes_for_result(runner, result)
+    landed = pr_review_followups.commit_changes_for_result(runner, result)
 
     assert landed is True
     commit_calls = [tuple(cmd) for cmd in runner.commands if tuple(cmd) == commit_argv]
@@ -583,11 +581,9 @@ def test_commit_changes_for_result_retries_after_hook_autofix() -> None:
 
 def test_commit_changes_for_result_does_not_retry_genuine_hook_failure() -> None:
     """If the hook fails without auto-fixing the staged paths, fail loud."""
-    pending = codex_pr_review_followups.PendingComment(
-        pr=_pr(), comment=_comment(56, body="[P1] do something"), replies=()
-    )
-    result = codex_pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
-    expected_message = codex_pr_review_followups.commit_message_for_result(result)
+    pending = pr_review_followups.PendingComment(pr=_pr(), comment=_comment(56, body="[P1] do something"), replies=())
+    result = pr_review_followups.ActionResult(pending=pending, disposition="fixed", summary="ok")
+    expected_message = pr_review_followups.commit_message_for_result(result)
     commit_argv = ("git", "commit", "-m", expected_message)
 
     target_path = "tests/unit/example.py"
@@ -615,8 +611,8 @@ def test_commit_changes_for_result_does_not_retry_genuine_hook_failure() -> None
         }
     )
 
-    with pytest.raises(codex_pr_review_followups.CommandError):
-        codex_pr_review_followups.commit_changes_for_result(runner, result)
+    with pytest.raises(pr_review_followups.CommandError):
+        pr_review_followups.commit_changes_for_result(runner, result)
 
     commit_calls = [tuple(cmd) for cmd in runner.commands if tuple(cmd) == commit_argv]
     assert len(commit_calls) == 1, "genuine hook failure must not retry"
@@ -627,7 +623,7 @@ def test_porcelain_paths_with_worktree_mods_parses_added_modified_and_renamed() 
         "AM tests/unit/example.py\nM  src/module.py\n M docs/notes.md\n?? new_file.txt\nR  old_name.py -> new_name.py\n"
     )
 
-    paths = codex_pr_review_followups._porcelain_paths_with_worktree_mods(porcelain)
+    paths = pr_review_followups._porcelain_paths_with_worktree_mods(porcelain)
 
     # AM, " M", "??" all have non-space work-tree column -> included.
     # "M  " has a space work-tree column -> excluded (purely staged).
@@ -655,7 +651,7 @@ def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) 
         ["git", "-C", str(repo_root), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
     ).stdout.strip()
     subprocess.run(["git", "-C", str(repo_root), "update-ref", "refs/remotes/origin/develop", head], check=True)
-    subprocess.run(["git", "-C", str(repo_root), "checkout", "-q", "-b", "fix/codex-resume"], check=True)
+    subprocess.run(["git", "-C", str(repo_root), "checkout", "-q", "-b", "fix/pr-review-resume"], check=True)
     # A per-comment commit from a prior crashed sweep: PR #999, comment 12345.
     (repo_root / "fix.txt").write_text("prior fix\n")
     subprocess.run(["git", "-C", str(repo_root), "add", "fix.txt"], check=True)
@@ -667,15 +663,15 @@ def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) 
             "commit",
             "-q",
             "-m",
-            "fix(codex-followup): PR #999 comment 12345 — recovered fix",
+            "fix(pr-followup): PR #999 comment 12345 — recovered fix",
         ],
         check=True,
     )
 
-    already_pr = codex_pr_review_followups.PullRequest(
+    already_pr = pr_review_followups.PullRequest(
         number=999, title="prior", merged_at="2026-05-01T00:00:00Z", url="https://example/999"
     )
-    already_comment = codex_pr_review_followups.ReviewComment(
+    already_comment = pr_review_followups.ReviewComment(
         id=12345,
         body="[P1] already done",
         path="fix.txt",
@@ -683,10 +679,10 @@ def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) 
         user_login="chatgpt-codex-connector[bot]",
         created_at="2026-04-30T00:00:00Z",
     )
-    fresh_pr = codex_pr_review_followups.PullRequest(
+    fresh_pr = pr_review_followups.PullRequest(
         number=777, title="new", merged_at="2026-05-04T00:00:00Z", url="https://example/777"
     )
-    fresh_comment = codex_pr_review_followups.ReviewComment(
+    fresh_comment = pr_review_followups.ReviewComment(
         id=88888,
         body="[P1] still to do",
         path="other.txt",
@@ -694,32 +690,32 @@ def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) 
         user_login="chatgpt-codex-connector[bot]",
         created_at="2026-05-03T00:00:00Z",
     )
-    pending_already = codex_pr_review_followups.PendingComment(pr=already_pr, comment=already_comment, replies=())
-    pending_fresh = codex_pr_review_followups.PendingComment(pr=fresh_pr, comment=fresh_comment, replies=())
+    pending_already = pr_review_followups.PendingComment(pr=already_pr, comment=already_comment, replies=())
+    pending_fresh = pr_review_followups.PendingComment(pr=fresh_pr, comment=fresh_comment, replies=())
 
-    seen_codex_calls: list[int] = []
+    seen_executor_calls: list[int] = []
 
-    monkeypatch.setattr(codex_pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
+    monkeypatch.setattr(pr_review_followups, "resolve_repo", lambda runner, repo: "joeharris76/BenchBox")
     monkeypatch.setattr(
-        codex_pr_review_followups,
+        pr_review_followups,
         "discover_pending_comments",
         lambda runner, **_: [pending_already, pending_fresh],
     )
-    monkeypatch.setattr(codex_pr_review_followups, "check_codex_version", lambda runner: (0, 128, 0))
+    monkeypatch.setattr(pr_review_followups, "check_executor_version", lambda runner: (0, 128, 0))
     monkeypatch.setattr(
-        codex_pr_review_followups,
-        "run_codex_for_comment",
+        pr_review_followups,
+        "run_executor_for_comment",
         lambda runner, item, **_: (
-            seen_codex_calls.append(item.comment.id)
-            or codex_pr_review_followups.ActionResult(pending=item, disposition="no-current-action", summary="skip")
+            seen_executor_calls.append(item.comment.id)
+            or pr_review_followups.ActionResult(pending=item, disposition="no-current-action", summary="skip")
         ),
     )
-    monkeypatch.setattr(codex_pr_review_followups, "commit_changes_for_result", lambda runner, result: False)
-    monkeypatch.setattr(codex_pr_review_followups, "reply_to_comment", lambda runner, **_: None)
-    monkeypatch.setattr(codex_pr_review_followups, "finalize_changes", lambda runner, **_: None)
+    monkeypatch.setattr(pr_review_followups, "commit_changes_for_result", lambda runner, result: False)
+    monkeypatch.setattr(pr_review_followups, "reply_to_comment", lambda runner, **_: None)
+    monkeypatch.setattr(pr_review_followups, "finalize_changes", lambda runner, **_: None)
 
-    runner = codex_pr_review_followups.CommandRunner(repo_root)
-    args = codex_pr_review_followups.build_parser().parse_args(
+    runner = pr_review_followups.CommandRunner(repo_root)
+    args = pr_review_followups.build_parser().parse_args(
         [
             "run",
             "--repo",
@@ -731,12 +727,12 @@ def test_resume_skips_comments_already_committed_locally(monkeypatch, tmp_path) 
         ]
     )
 
-    rc = codex_pr_review_followups.run_action_loop(args, runner)
+    rc = pr_review_followups.run_action_loop(args, runner)
 
     assert rc == 0
-    assert seen_codex_calls == [88888], (
+    assert seen_executor_calls == [88888], (
         "comment 12345 was already committed locally and must be skipped; "
-        "only the unrelated comment 88888 should reach run_codex_for_comment"
+        "only the unrelated comment 88888 should reach run_executor_for_comment"
     )
 
 
@@ -755,16 +751,16 @@ def test_discover_locally_committed_pairs_matches_per_comment_subjects(tmp_path)
     ).stdout.strip()
     subprocess.run(["git", "-C", str(repo_root), "update-ref", "refs/remotes/origin/develop", head], check=True)
     for subject in (
-        "fix(codex-followup): PR #1 comment 100 — first",
+        "fix(pr-followup): PR #1 comment 100 — first",
         "chore: unrelated commit",
-        "fix(codex-followup): PR #2 comment 200 — second",
+        "fix(pr-followup): PR #2 comment 200 — second",
     ):
         path = repo_root / f"x_{subject[-5:].strip()}.txt"
         path.write_text(subject)
         subprocess.run(["git", "-C", str(repo_root), "add", path.name], check=True)
         subprocess.run(["git", "-C", str(repo_root), "commit", "-q", "-m", subject], check=True)
 
-    runner = codex_pr_review_followups.CommandRunner(repo_root)
-    pairs = codex_pr_review_followups.discover_locally_committed_pairs(runner, "origin/develop")
+    runner = pr_review_followups.CommandRunner(repo_root)
+    pairs = pr_review_followups.discover_locally_committed_pairs(runner, "origin/develop")
 
     assert pairs == {(1, 100), (2, 200)}


### PR DESCRIPTION
Disregarding backwards compat per maintainer ask: rename the routine surface
to be reviewer-agnostic so it doesn't imply a single source. The local
executor is still codex but is now isolated behind --executor-* flags.
Cadence framing ("weekly") is dropped from the sweep template — sweep
frequency is operator-driven and depends on PR volume.

Reviewer surface (renamed):
- Make targets: codex-pr-review-followups[-list] -> pr-review-followups[-list]
- Env vars: CODEX_REVIEW_* -> PR_REVIEW_*
- Action marker: benchbox-codex-review-followup-actioned
                 -> benchbox-pr-review-followup-actioned
- Commit prefix: fix(codex-followup): -> fix(pr-followup):
- Script: _project/scripts/codex_pr_review_followups.py
          -> _project/scripts/pr_review_followups.py
- Prompt template: prompts/codex_pr_review_followup.md
                   -> prompts/pr_review_followup.md
- Audit template: codex-weekly-sweep-template.md
                  -> pr-review-sweep-template.md (also drops "weekly")
- Tests: test_codex_pr_review_followups.py -> test_pr_review_followups.py
- Identifiers: DEFAULT_CODEX_AUTHORS -> DEFAULT_REVIEW_AUTHORS,
               build_codex_prompt -> build_executor_prompt,
               run_codex_for_comment -> run_executor_for_comment

Executor surface (still codex CLI underneath):
- CLI flags: --codex-{model,sandbox,approval} -> --executor-{model,sandbox,approval}
- Env vars: PR_REVIEW_EXECUTOR_{MODEL,SANDBOX,APPROVAL}
- Identifiers: check_codex_version -> check_executor_version,
               MIN_CODEX_VERSION -> MIN_EXECUTOR_VERSION
- The literal `codex` binary name in subprocess calls stays (it IS the
  on-disk binary) and the version-check error references codex-cli for
  remediation clarity.

One-off migration script:
- _project/scripts/oneoff_rewrite_review_followup_marker.py
  Walks merged + open PRs, finds review-comment replies carrying the OLD
  marker, and PATCHes each one to the NEW marker. Dry-run by default;
  --apply to mutate. Operator runs it AFTER this PR lands. 41 affected
  comments per repo search.

Sweep template:
- "Weekly PR-Review Sweep" -> "PR-Review Sweep"; cadence is now operator-
  driven. Window-tag conventions (e.g. since-YYYY-MM-DD or YYYY-MM-DD-to-
  YYYY-MM-DD) replace "week-YYYY-MM-DD" in TODO ids and rescan-audit
  filenames. Historical filenames containing "week-YYYY-MM-DD" are kept
  intact (DONE files, prior rescans).

Default --author still resolves to chatgpt-codex-connector[bot] (it is
the only configured reviewer in production today); other reviewers can be
added via --author or by editing DEFAULT_REVIEW_AUTHORS.

Tests: 21 passed (full file). Unrelated parallel-execution flakes in
test_platform_registry_behavioral.py and test_databricks_df_adapter.py
are confirmed environmental — pass under serial execution and not touched
by this PR.

Reference: previous routine PR #194 / hardening PR #195 / operability
patches PR #204.
