### PR TITLE
refactor(review-protocol): consolidate blind-spot rules in SHARED protocol

### DIFF
--- a/.claude/commands/blind-spot.md
+++ b/.claude/commands/blind-spot.md
@@ -11,77 +11,36 @@ description: Record a blind-spot audit finding to _project/blind-spots/ (file-fi
 
 ## Your task
 
-The user wants to record a blind-spot audit finding. Follow the protocol in
-`_project/blind-spots/README.md` exactly. Do **not** invent a different shape.
+Follow `~/.claude/skills/SHARED/review-protocol.md` exactly. Apply §2
+(defect gate) **before** anything else. If the gate triggers, refuse
+to file and offer the user the TODO / inline-fix / escalation menu
+described in SHARED §2. If the gate passes:
 
-1. **Pick the slug.** From the user's description (the part after `/blind-spot`),
-   derive a 3–6 word kebab-case slug capturing the *class*, not the *instance*.
-   Example: "react keys collide on platform name" → `react-key-collision-class`.
-   If the user gave nothing, ask one short clarifying question and stop.
+1. **Pick the slug.** Derive a 3–6 word kebab-case slug capturing the
+   *class*, not the *instance*. Example: "react keys collide on
+   platform name" → `react-key-collision-class`. If the user gave
+   nothing, ask one short clarifying question and stop.
 
-2. **Compose the filename.** Use the timestamp from the Context block above:
-   `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`. Filename stem must equal
-   the `id` field in the frontmatter. If that exact path already exists, append
-   a short numeric suffix before `.md` (`...-<slug>-2.md`, then `-3`, etc.).
+2. **Compose the filename** `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`
+   using the timestamp from the Context block above. Filename stem must
+   equal the `id` field in the frontmatter. If the path collides, append
+   `-2`, `-3`, … before `.md`.
 
-3. **Write the file** using this exact frontmatter schema. Required fields are
-   `id`, `date`, `status` (always `open` at write time), `finding_kind`, and
-   `review_context`. Optional: `related_paths`, `suggested_sweep`, `todo_id`.
+3. **Write the file** using the schema and body shape in
+   `_project/blind-spots/README.md` (storage spec).
 
-   ```yaml
-   ---
-   id: <filename stem>
-   date: <YYYY-MM-DD>
-   status: open
-   finding_kind: <framework-gap | bug-class | missed-axis | scope-creep | assumption | other>
-   review_context: "<one line: which review / branch / agent surfaced this>"
-   related_paths:
-     - <repo-relative path>
-   suggested_sweep: "<one-line hint for the sweep step>"
-   todo_id: null
-   ---
-   ```
-
-   Body shape:
-
-   ```markdown
-   # <Title — one line, no jargon>
-
-   ## Finding
-   <verbatim audit text from the review — copy/paste, don't paraphrase>
-
-   ## Why this matters
-   <one short paragraph on the lesson, not the instance>
-
-   ## Suggested next steps
-   - [ ] <concrete action 1>
-   - [ ] <concrete action 2>
-   ```
-
-4. **Validate** the new file:
-
+4. **Validate**:
    ```
    uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py _project/blind-spots/<filename>
    ```
+   If validation fails, fix the frontmatter and re-run.
 
-   If validation fails, fix the frontmatter and re-run. Do not commit a
-   malformed finding.
-
-5. **Report** to the user with one line and a quote of the body:
-
-   ```
-   Recorded: _project/blind-spots/<filename>.md
-
-   <body content>
-   ```
-
-   Do not commit unless the user asks. The file lives on the current branch;
-   it'll ride along with whatever PR is in flight.
+5. **Report** with `Recorded: _project/blind-spots/<filename>.md` and
+   a quote of the body. **Stop there** — do not commit, do not push,
+   do not run `make pr-open`. Per SHARED §4, the disk-write is local-only.
 
 ## Notes
 
-- Findings are **observations**, not actionable TODOs. Promotion-to-TODO is a
-  sweep-step decision (`make blind-spots-sweep`), not a write-step decision.
-- Keep the body short. Long context belongs in a TODO or audit doc.
-- Never hand-edit `_project/blind-spots/_indexes/` — there is no checked-in
-  index by design (avoids merge collisions). Reports are regenerated on demand.
+Behavior is governed by `~/.claude/skills/SHARED/review-protocol.md`.
+Storage is governed by `_project/blind-spots/README.md`. Don't restate
+either here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 → **See AGENTS.md for full guidance.** Claude Code-specific shortcuts only.
 
-**Critical rules**: Always `uv run` (never bare `python`/`pytest`/`ruff`/`ty`). Never `git add -A`. Dev PRs target `develop`, never `main` (`main` is release-only and `develop` is PR-gated — no direct push to either). **All agent edits and commits happen in a worktree off `develop`. If a session begins in the main clone (`/Users/joe/Developer/BenchBox`), creating a worktree is the FIRST action (see "Session start" below). Never `git checkout`/`switch`/`branch -m` in the main clone without explicit user approval — that clone stays on `develop`.** TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox (stock dsdgen crashes at SF<1; see `patch-and-redistribute-tpcds-dsdgen-subscale-support`). No `-o "addopts="` with pytest.
+**Critical rules**: Always `uv run` (never bare `python`/`pytest`/`ruff`/`ty`). Never `git add -A`. Dev PRs target `develop`, never `main` (`main` is release-only and `develop` is PR-gated — no direct push to either). **All agent edits and commits happen in a worktree off `develop`. If a session begins in the main clone (`/Users/joe/Developer/BenchBox`), creating a worktree is the FIRST action (see "Session start" below). Never `git checkout`/`switch`/`branch -m` in the main clone without explicit user approval — that clone stays on `develop`.** **Never open a PR or enable auto-merge as a side-effect of a review, audit, or research action — see `~/.claude/skills/SHARED/review-protocol.md` §1. Landing changes requires explicit user authorization in a separate turn; this fires before any "auto-commit" or "file-first capture" mandate elsewhere.** TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox (stock dsdgen crashes at SF<1; see `patch-and-redistribute-tpcds-dsdgen-subscale-support`). No `-o "addopts="` with pytest.
 
 ## Session start
 
@@ -191,30 +191,25 @@ during the single-repo migration).
   (`_project/`, `_blog/`, agent configs, etc.) live only on develop by
   design. Full runbook: `docs/operations/release-guide.md`.
 
-## Review workflow — blind-spot capture (mandatory)
+## Review workflow — blind-spot capture
 
-When you produce a **Blind-Spot Audit (L2)** during any review (ultrareview,
-`/review`, ad-hoc code review, research, planning), you MUST:
+Behavior is governed by `~/.claude/skills/SHARED/review-protocol.md`. When
+that protocol authorizes a blind-spot capture, BenchBox bindings are:
 
-1. **Write the finding to disk first** at
-   `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`, using the frontmatter
-   schema and body shape in `_project/blind-spots/README.md`.
-2. **Then** quote the finding in your chat reply, prefixed with one line:
-   `Recorded: _project/blind-spots/<file>.md`.
+- Path: `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`
+- Schema: see `_project/blind-spots/README.md` (storage spec)
+- Validate: `uv run --project _project/scripts -- python _project/scripts/validate_blind_spot.py _project/blind-spots/<file>.md`
+- Sweep: `make blind-spots-{list,report,sweep}` — promotion to TODO is a sweep-step decision
+- Chat marker: prefix the body quote with `Recorded: _project/blind-spots/<file>.md`
 
-Do not skip the file write because the finding "feels minor" — sweep-time
-triage is where dismissals belong, not write-time. Findings printed only in
-chat get lost; file-first capture is what makes the L2 audit habit pay off.
-If a review response contains an L2 audit without a `Recorded:` pointer for
-each finding, treat the response as protocol drift and record the missing
-finding before continuing.
+Per SHARED §4, the capture is local-only: do not commit beyond the
+capture file, do not push, do not run `make pr-open`. The user
+authorizes any PR in a separate turn. Apply the SHARED §2 defect gate
+before recording — defects belong in the severity table and TODOs, not
+in the blind-spots directory.
 
-Sweep / triage findings with `make blind-spots-{list,report,sweep}`. Promotion
-to a TODO is a sweep-step decision, not a write-step decision. See
-`_project/blind-spots/README.md` for the full protocol.
-
-The `/blind-spot` slash command (`.claude/commands/blind-spot.md`) wraps the
-file-first capture flow when you want to record one explicitly outside a review.
+The `/blind-spot` slash command (`.claude/commands/blind-spot.md`) is the
+explicit-recording entrypoint and follows the same protocol.
 
 ## Commands
 

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -1,36 +1,18 @@
 # Blind-Spot Findings
 
-Centralized capture for **blind-spot audit (L2)** findings produced during
-reviews — observations that *may* warrant action but haven't been triaged yet.
+Storage for **blind-spot audit (L2)** findings: framework gaps, post-fix
+pattern notes, and dormant assumptions. One file per finding, sweepable
+later without PR merge collisions.
 
-This directory exists because audit findings printed only in chat get lost.
-Persisting each finding as its own file makes the backlog sweepable later
-without creating PR merge collisions.
+## Behavior is governed elsewhere
 
----
-
-## What goes here
-
-A finding belongs in this directory when it surfaces:
-
-- A **gap in a review framework** that was used (axis missing, dimension
-  the rubric can't capture).
-- A **bug class** behind a reported instance (the symptom was fixed, but
-  the underlying pattern probably exists elsewhere).
-- A **scope-creep flag** — work that wasn't requested but might be load-bearing.
-- An **assumption worth testing later** — something that was true at audit
-  time but might decay.
-- Anything else that came out of a Blind-Spot Audit (L2) section in a review.
-
-### What does NOT go here
-
-- Concrete actionable bugs with a clear owner → make a TODO.
-- Architectural decisions → `_project/decisions/` (ADRs).
-- Full reviews / audits → `_project/audits/`.
-- Random ideas / brainstorming → `_project/notes/`.
-
-If unsure, write the finding here. The sweep step is where dismissals happen,
-not the write step.
+The rules for **when** to write a finding here, **what** counts as a
+blind spot vs a defect, and **what** capture authorizes (and does not
+authorize) live in `~/.claude/skills/SHARED/review-protocol.md`. This
+README documents only **storage**: frontmatter schema, file naming,
+validation, and sweep workflow. Defects (anything that materially
+affects correctness, performance, or security) go to TODOs, not here —
+see SHARED §2.
 
 ---
 
@@ -110,13 +92,12 @@ the top-level title plus the three required `##` sections below.
 
 ## How findings get written
 
-Project `CLAUDE.md` binds Claude Code's L2 audits to this directory:
-when an L2 audit is generated during any review, the audit is **written to
-disk first**, then quoted in the chat response. The chat output becomes a
-view of the persisted file, not a separate ephemeral artifact.
-
-Humans (and other agents) can also invoke the `/blind-spot` slash command
-to record one explicitly.
+Behavior governed by `~/.claude/skills/SHARED/review-protocol.md` §4.
+When that protocol authorizes a capture, the file is written here on
+the local branch and surfaced in chat with a `Recorded: <path>` line.
+The capture is local-only — it does not authorize a commit beyond the
+file, a push, or a PR. Use the `/blind-spot` slash command for explicit
+recording.
 
 ---
 


### PR DESCRIPTION
Behavior rules for review-shaped actions (defect gate, scope of L2,
capture-is-local-only, side-effect ban) move to a new user-global file
~/.claude/skills/SHARED/review-protocol.md. Project wrappers shrink to
thin pointers + BenchBox-specific bindings (paths, validator command,
sweep make targets).

Closes two failure modes:

- Classification drift: defects mis-filed as blind spots under
  bug-class / scope-creep / assumption finding_kinds. SHARED §2
  defines the gate ("materially affects correctness, performance,
  security?") and tightens the kind definitions so they can't be
  used as loopholes for unfixed defects.

- Side-effect cascade (PR #206 / #207 incident): a plain /code review
  chained file-first capture → auto-commit → make pr-open → auto-merge.
  SHARED §1 declares review-shaped actions read-only-plus-local-capture
  and forbids PR/push/auto-merge as side-effects, with explicit
  "fires before any auto-commit or file-first capture mandate"
  precedence. Project CLAUDE.md Critical rules now points at SHARED §1.

Files in this commit (tracked):
  - CLAUDE.md: trim "Review workflow" section to a binding; add
    Critical-rules entry pointing at SHARED §1.
  - _project/blind-spots/README.md: trim behavior content; keep only
    storage spec (frontmatter, file naming, validation, sweep).
  - .claude/commands/blind-spot.md: replace body with SHARED reference
    + 5-step list; defect gate runs before slug step.

Untracked-but-edited siblings (in main clone):
  - .claude/skills/code/SKILL.md (auto-commit rule + L2 trigger)
  - .claude/skills/SHARED/plan-deepening-framework/SKILL.md (Layer 2)
  - .claude/skills/code/references/five-axis-review.md (severity table)

User-global edits (not in this repo):
  - ~/.claude/skills/SHARED/review-protocol.md (new — source of truth)
  - ~/.claude/skills/code/SKILL.md (mirror of project skill changes)
  - ~/.claude/CLAUDE.md (L2 line + Anti-Patterns entry)
  - ~/.claude/skills/SHARED/plan-deepening-framework.md
  - ~/.claude/skills/references/five-axis-review.md

Plan: ~/.claude/plans/think-hard-about-how-floofy-rossum.md

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
