### PR TITLE
chore(skills): propagate review protocol to Codex

### DIFF
--- a/.claude/commands/blind-spot.md
+++ b/.claude/commands/blind-spot.md
@@ -11,7 +11,7 @@ description: Record a blind-spot audit finding to _project/blind-spots/ (file-fi
 
 ## Your task
 
-Follow `~/.claude/skills/SHARED/review-protocol.md` exactly. Apply §2
+Follow the synced `SHARED/review-protocol` skill exactly. Apply §2
 (defect gate) **before** anything else. If the gate triggers, refuse
 to file and offer the user the TODO / inline-fix / escalation menu
 described in SHARED §2. If the gate passes:
@@ -41,6 +41,6 @@ described in SHARED §2. If the gate passes:
 
 ## Notes
 
-Behavior is governed by `~/.claude/skills/SHARED/review-protocol.md`.
+Behavior is governed by `SHARED/review-protocol`.
 Storage is governed by `_project/blind-spots/README.md`. Don't restate
 either here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ Consistent tooling, safe defaults, minimal surprises.
 - Research before coding: read files, run tests, understand first
 - Run test suite after multi-file edits; review every find-replace in context
 - Stop on user interrupt/redirect
+- Review-shaped actions (review, audit, research, compare, to-spec, security
+  review, L2 blind-spot audit) are read-only plus local capture per the synced
+  `SHARED/review-protocol` skill. Captures may write designated local files and
+  must be surfaced with `Recorded: <path>`, but they do not authorize commit,
+  push, PR creation, or auto-merge.
 
 ## Tooling
 Use `rg`; read files in ≤250-line chunks. Always `uv run --` for Python tools. `make` wrappers OK. Run `benchbox --help` after dev install.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 → **See AGENTS.md for full guidance.** Claude Code-specific shortcuts only.
 
-**Critical rules**: Always `uv run` (never bare `python`/`pytest`/`ruff`/`ty`). Never `git add -A`. Dev PRs target `develop`, never `main` (`main` is release-only and `develop` is PR-gated — no direct push to either). **All agent edits and commits happen in a worktree off `develop`. If a session begins in the main clone (`/Users/joe/Developer/BenchBox`), creating a worktree is the FIRST action (see "Session start" below). Never `git checkout`/`switch`/`branch -m` in the main clone without explicit user approval — that clone stays on `develop`.** **Never open a PR or enable auto-merge as a side-effect of a review, audit, or research action — see `~/.claude/skills/SHARED/review-protocol.md` §1. Landing changes requires explicit user authorization in a separate turn; this fires before any "auto-commit" or "file-first capture" mandate elsewhere.** TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox (stock dsdgen crashes at SF<1; see `patch-and-redistribute-tpcds-dsdgen-subscale-support`). No `-o "addopts="` with pytest.
+**Critical rules**: Always `uv run` (never bare `python`/`pytest`/`ruff`/`ty`). Never `git add -A`. Dev PRs target `develop`, never `main` (`main` is release-only and `develop` is PR-gated — no direct push to either). **All agent edits and commits happen in a worktree off `develop`. If a session begins in the main clone (`/Users/joe/Developer/BenchBox`), creating a worktree is the FIRST action (see "Session start" below). Never `git checkout`/`switch`/`branch -m` in the main clone without explicit user approval — that clone stays on `develop`.** **Never open a PR or enable auto-merge as a side-effect of a review, audit, or research action — see the synced `SHARED/review-protocol` skill §1. Landing changes requires explicit user authorization in a separate turn; this fires before any "auto-commit" or "file-first capture" mandate elsewhere.** TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox (stock dsdgen crashes at SF<1; see `patch-and-redistribute-tpcds-dsdgen-subscale-support`). No `-o "addopts="` with pytest.
 
 ## Session start
 
@@ -193,8 +193,8 @@ during the single-repo migration).
 
 ## Review workflow — blind-spot capture
 
-Behavior is governed by `~/.claude/skills/SHARED/review-protocol.md`. When
-that protocol authorizes a blind-spot capture, BenchBox bindings are:
+Behavior is governed by the synced `SHARED/review-protocol` skill. When that
+protocol authorizes a blind-spot capture, BenchBox bindings are:
 
 - Path: `_project/blind-spots/YYYY-MM-DD-HHMMSS-<slug>.md`
 - Schema: see `_project/blind-spots/README.md` (storage spec)
@@ -202,8 +202,8 @@ that protocol authorizes a blind-spot capture, BenchBox bindings are:
 - Sweep: `make blind-spots-{list,report,sweep}` — promotion to TODO is a sweep-step decision
 - Chat marker: prefix the body quote with `Recorded: _project/blind-spots/<file>.md`
 
-Per SHARED §4, the capture is local-only: do not commit beyond the
-capture file, do not push, do not run `make pr-open`. The user
+Per SHARED §4, the capture is local-only: do not commit any file,
+including the capture file, do not push, do not run `make pr-open`. The user
 authorizes any PR in a separate turn. Apply the SHARED §2 defect gate
 before recording — defects belong in the severity table and TODOs, not
 in the blind-spots directory.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,6 +6,10 @@ This file provides guidance to Gemini when working with BenchBox.
 - **Single repo, single remote**: `origin` → `joeharris76/BenchBox`. Canonical clone: `/Users/joe/Developer/BenchBox`. There is no `private` / `public` remote; the pre-migration two-remote setup is retired (see `_project/decisions/single-repo-migration.md` for history).
 - **Branches**: `develop` is the long-lived dev branch; `main` is release-only. Dev PRs target `develop`, squash-merge.
 - **One-shot PR flow**: from a feature branch, `make pr-preflight && make pr-open`. Opens the PR vs `develop` with `gh pr create --fill` and enables auto-merge once CI is green. Walk away — don't poll.
+- **Review protocol**: review, audit, research, compare, to-spec, security
+  review, and L2 blind-spot audit actions are read-only plus local capture per
+  the synced `SHARED/review-protocol` skill. Local capture does not authorize
+  commit, push, PR creation, or auto-merge.
 - **Worktrees**: `~/Developer/BenchBox/` stays on `develop`, always. `make worktree-add BRANCH=fix/foo` creates `../BenchBox.fix-foo/` off `origin/develop`. `cd` in, `uv sync --group dev`, work, `make pr-open` from inside. **Agents must not `git checkout`/`switch`/`branch -m` in the main clone without explicit user approval; create a worktree first.**
 - **Releases**: 2-command flow on `develop` — `make release-cut VERSION=X.Y.Z` then `make release-finalize VERSION=X.Y.Z`. See `docs/operations/release-guide.md`.
 

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -8,11 +8,9 @@ later without PR merge collisions.
 
 The rules for **when** to write a finding here, **what** counts as a
 blind spot vs a defect, and **what** capture authorizes (and does not
-authorize) live in `~/.claude/skills/SHARED/review-protocol.md`. This
+authorize) live in the synced `SHARED/review-protocol` skill. This
 README documents only **storage**: frontmatter schema, file naming,
-validation, and sweep workflow. Defects (anything that materially
-affects correctness, performance, or security) go to TODOs, not here —
-see SHARED §2.
+validation, and sweep workflow.
 
 ---
 
@@ -90,14 +88,11 @@ the top-level title plus the three required `##` sections below.
 
 ---
 
-## How findings get written
+## Recording bindings
 
-Behavior governed by `~/.claude/skills/SHARED/review-protocol.md` §4.
-When that protocol authorizes a capture, the file is written here on
-the local branch and surfaced in chat with a `Recorded: <path>` line.
-The capture is local-only — it does not authorize a commit beyond the
-file, a push, or a PR. Use the `/blind-spot` slash command for explicit
-recording.
+Behavior is governed by `SHARED/review-protocol`. This directory stores
+the file shape used by the `/blind-spot` slash command and any other
+agent capture flow that the shared protocol authorizes.
 
 ---
 

--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "lockedAt": "2026-04-30T14:22:20.587Z",
+  "lockedAt": "2026-05-05T12:56:13.065Z",
   "skills": {
     "blog": {
       "source": {
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/blog",
-        "fetchedAt": "2026-04-30T14:22:20.515Z"
+        "fetchedAt": "2026-05-05T12:55:37.100Z"
       },
       "installMode": "mirror",
       "files": {
@@ -24,8 +24,8 @@
           "size": 3107
         },
         "SKILL.md": {
-          "sha256": "fb911edea875cd92bda7b4ba44541cf47a6e05bcd9ba603582c2f02fd1cd9b95",
-          "size": 9107
+          "sha256": "9f8175eb68c2ed536d65eaa5a61d35438e9e29dd2e389f2d3ad5a012c1431d47",
+          "size": 9323
         },
         "skill.yaml": {
           "sha256": "aa5ae37ee34c1ddfd90617ebd9a87bd5993b89d3a96d90445411d5123d1b2faf",
@@ -38,7 +38,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/code",
-        "fetchedAt": "2026-04-30T14:22:20.518Z"
+        "fetchedAt": "2026-05-05T12:55:37.103Z"
       },
       "installMode": "mirror",
       "files": {
@@ -51,8 +51,8 @@
           "size": 1729
         },
         "references/five-axis-review.md": {
-          "sha256": "4434ef143b98ad44e833082d2072e2f03433c43d0c72be0f4c8e2271f97c4832",
-          "size": 2002
+          "sha256": "dc76557029df6eaaf7eeb7a94405d6d4bd6467373edcc67b831a0f6dbda28de1",
+          "size": 2180
         },
         "references/handoff.md": {
           "sha256": "e514dbe39d97a87214b29ae6f3730ec2176d6d6ec718c5866068cfffc74803da",
@@ -75,12 +75,12 @@
           "size": 2387
         },
         "SKILL.md": {
-          "sha256": "1d8b419c79dcf67aa83c286f1a37f0cd11638e520045a8c16bffd3d53e9d6949",
-          "size": 6711
+          "sha256": "23021dcd7142b44bedef26e687b0baa2f532dd51abc25c3a0d1b15dfa3e90a53",
+          "size": 7037
         },
         "skill.yaml": {
-          "sha256": "cb7a8c724fd0229a119d7c6e68fb2845e50aa69fe0652f8805a595abd161c87c",
-          "size": 1017
+          "sha256": "d828f5f4c7075ad76083914ad5b3525bb3ab16d59ba0c293cb8d1f2759cf75bf",
+          "size": 1044
         }
       }
     },
@@ -116,7 +116,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/docs",
-        "fetchedAt": "2026-04-30T14:22:20.520Z"
+        "fetchedAt": "2026-05-05T12:55:37.107Z"
       },
       "installMode": "mirror",
       "files": {
@@ -133,8 +133,8 @@
           "size": 2455
         },
         "SKILL.md": {
-          "sha256": "53a31224a05f3f1a24e847613879593bbaf84674eebc86f2142ce509fc63b630",
-          "size": 4925
+          "sha256": "825906c22660998f69e7dfb77ae7951376596a40d5b89206e4bc7f9359051201",
+          "size": 5095
         },
         "skill.yaml": {
           "sha256": "b348d06c928d986a3714d5337723e59c40a45939e31405a8de2019171de32970",
@@ -147,7 +147,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/todo",
-        "fetchedAt": "2026-04-30T14:22:20.521Z"
+        "fetchedAt": "2026-05-05T12:55:37.108Z"
       },
       "installMode": "mirror",
       "files": {
@@ -164,8 +164,8 @@
           "size": 3697
         },
         "SKILL.md": {
-          "sha256": "5c0c6870c940342c4c3151f6e38f5af2633337ea1066cd44e54a28cfb9c717d4",
-          "size": 10274
+          "sha256": "d4a49f52f7562e5a6fde3a6a3359d77e7dc369fa243a1372285d9ec4bf295325",
+          "size": 10414
         },
         "skill.yaml": {
           "sha256": "02fb9215abb958fbb853438905ee2fab5eaf49c9cc820033edb23c992313fe20",
@@ -419,17 +419,36 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/SHARED/plan-deepening-framework",
-        "fetchedAt": "2026-04-30T14:22:20.527Z"
+        "fetchedAt": "2026-05-05T12:55:37.118Z"
       },
       "installMode": "mirror",
       "files": {
         "SKILL.md": {
-          "sha256": "0bd5bdee5530275cf3fe4e0f6e0e25951084b77f8cff50050527cd1594b7d324",
-          "size": 1021
+          "sha256": "4d9d208986af93e200d3d3b2821c1f2cd11b4bcf1179db77498584156db0eb3d",
+          "size": 1233
         },
         "skill.yaml": {
           "sha256": "39b007a53d9126d3fe4e8938a67d616a52be210a82ba211753afa92a073d06bd",
           "size": 78
+        }
+      }
+    },
+    "SHARED/review-protocol": {
+      "source": {
+        "type": "local",
+        "name": "personal",
+        "path": "/Users/joe/.skill-sync/skills/SHARED/review-protocol",
+        "fetchedAt": "2026-05-05T12:55:37.119Z"
+      },
+      "installMode": "mirror",
+      "files": {
+        "SKILL.md": {
+          "sha256": "8515d6bcd14e3583258ddbc2152a5f1df75c88e4fa0301c2fca55bb6e2db948a",
+          "size": 5731
+        },
+        "skill.yaml": {
+          "sha256": "efe5d79366ee8ff39450f8e68b47c2fcd021f547585d1546a35e3e3f66078545",
+          "size": 104
         }
       }
     }

--- a/skill-sync.yaml
+++ b/skill-sync.yaml
@@ -18,6 +18,7 @@ skills:
   - SHARED/context-guide
   - SHARED/debug-framework
   - SHARED/slicing-framework
+  - SHARED/review-protocol
   - skill-sync
   - tidy-perms
 targets:


### PR DESCRIPTION
## Summary
- Adds the synced `SHARED/review-protocol` skill to BenchBox skill-sync so Codex, Claude, and Gemini consume the same review-shaped action contract.
- Retargets project wrappers from Claude-global paths to the synced shared skill and adds Codex/Gemini top-level bindings.
- Tightens blind-spot storage docs so behavior stays in the shared protocol, and closes the capture-file commit ambiguity by pointing at the shared rule.

## Why
PR #209 consolidated the Claude blind-spot protocol, but Codex would still have relied on stale local/global skill mirrors and wrappers unless the shared protocol was installed through skill-sync and bound into AGENTS.md. This follow-up makes the protocol agent-neutral and keeps review-shaped captures from cascading into commit/push/PR behavior.

## Validation
- `make skill-sync`
- `make skill-sync-check`
- `git diff --check`
- `make pr-preflight` passed the lint/metadata lanes; the first fast-test attempt was blocked by an existing pool-03 test lock, and later full parallel fast-test runs reproduced three unrelated registry/mock pollution failures that pass when run directly.
- `uv run -- python -m pytest tests/unit/core/test_platform_registry_behavioral.py::TestAdapterRegistration::test_get_adapter_class_for_duckdb tests/unit/core/test_platform_registry_behavioral.py::TestAdapterRegistration::test_get_adapter_class_resolves_alias tests/unit/platforms/databricks/test_databricks_df_adapter.py::TestDatabricksDataFrameAdapterIntegration::test_adapter_creates_with_from_config_factory -q`
- Push hook: `pr-preflight (fast tests, mirrors CI)` passed.
