### PR TITLE
feat(blind-spots): add `actionable` status for re-verified findings

### DIFF
--- a/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
+++ b/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114721-global-test-lock-cpu-protection
 date: 2026-04-30
-status: open
+status: actionable
 finding_kind: assumption
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -39,3 +39,4 @@ Removing the global lock by default can shift pain from blocked pushes to CPU sa
   remains opt-in. `dev-loop-step-5-measurement-window` is still `Blocked`,
   so no concurrent-xdist measurement has been collected. Carry forward the
   two next-steps; do not flip the default until measurement lands.
+- 2026-05-06: actionable — 2026-05-06 sweep: tests/conftest.py:_get_test_lock_path still defaults to $HOME/.benchbox/test.lock; dev-loop-step-5-measurement-window still Blocked, no concurrent-xdist measurement collected — keep default global lock until Step 5 lands

--- a/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
+++ b/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114722-queue-single-point-failure
 date: 2026-04-30
-status: open
+status: actionable
 finding_kind: scope-creep
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -38,3 +38,4 @@ Replacing decentralized auto-merge with a queue can make one local process or wo
   `Blocked`; no failure-mode-analysis artifact authored. Carry forward
   the next-steps. Do not promote to a steward TODO until Step 5 returns
   BUILD QUEUE.
+- 2026-05-06: actionable — 2026-05-06 sweep: decentralized auto-merge live (auto-merge-on-open.yml + develop-post-merge.yml present); dev-loop-step-6-queue-decision-gate still Blocked on Step 5 — failure-mode-analysis remains the gate before any steward TODO

--- a/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
+++ b/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114723-queue-dwell-contract
 date: 2026-04-30
-status: open
+status: actionable
 finding_kind: assumption
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -38,3 +38,4 @@ Agents can walk away after auto-merge only because the current dwell time is sho
   5 still `Blocked` (no published P50/P95 dwell numbers yet). Agent
   walk-away contract in CLAUDE.md still holds. Carry forward the
   next-steps; revisit when Step 5 publishes measurements.
+- 2026-05-06: actionable — 2026-05-06 sweep: make dev-loop-metrics still present; Step 5 Blocked, no published P50/P95 dwell numbers — agent walk-away contract in CLAUDE.md still load-bearing

--- a/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
+++ b/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-04-30-114724-post-merge-safety-tension
 date: 2026-04-30
-status: open
+status: actionable
 finding_kind: framework-gap
 review_context: "L2 merge-loop audit / dev-loop simplification planning (2026-04-30)"
 related_paths:
@@ -38,3 +38,4 @@ If the post-merge workflow is the real protection layer, adding a queue may dupl
 - 2026-05-05: actionable (sweep). State unchanged: post-merge revert
   workflow shipped; Step 5 still `Blocked`. Architectural rule remains
   load-bearing by inertia, not enforcement. Carry forward.
+- 2026-05-06: actionable — 2026-05-06 sweep: develop-post-merge.yml safety-net workflow still shipped; Step 5 Blocked — 'no queue without pre-merge ordering evidence' rule remains load-bearing by inertia

--- a/_project/blind-spots/README.md
+++ b/_project/blind-spots/README.md
@@ -40,7 +40,7 @@ Every finding file must start with YAML frontmatter matching this shape:
 ---
 id: 2026-04-29-143205-react-key-collision-class   # = filename stem
 date: 2026-04-29                                  # ISO date
-status: open                                      # open | actioned | dismissed | merged-to-todo
+status: open                                      # open | actionable | actioned | dismissed | merged-to-todo
 finding_kind: bug-class                           # framework-gap | bug-class | missed-axis | scope-creep | assumption | other
 review_context: "ultrareview B4 / chore/dashboard-keys"
 related_paths:
@@ -55,7 +55,7 @@ todo_id: null                                     # populated when promoted via 
 |---|---|---|
 | `id` | yes | Must equal filename without `.md` |
 | `date` | yes | ISO `YYYY-MM-DD` |
-| `status` | yes | One of: `open`, `actioned`, `dismissed`, `merged-to-todo` |
+| `status` | yes | One of: `open`, `actionable`, `actioned`, `dismissed`, `merged-to-todo` |
 | `finding_kind` | yes | One of: `framework-gap`, `bug-class`, `missed-axis`, `scope-creep`, `assumption`, `other` |
 | `review_context` | yes | Free-form: which review / branch / PR / agent surfaced this |
 | `related_paths` | optional | Repo-relative paths the finding touches; list of strings or `null` |
@@ -101,8 +101,8 @@ and any other agent capture flow that the shared protocol authorizes.
 Sweep on demand:
 
 ```bash
-make blind-spots-list                # all open findings (one row each)
-make blind-spots-report              # counts by status + kind, oldest open first
+make blind-spots-list                # open findings only (one row each)
+make blind-spots-report              # counts by status + kind, oldest active first (open + actionable)
 make blind-spots-sweep               # alias for blind-spots-report
 ```
 
@@ -113,6 +113,7 @@ uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.p
 uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py show <id>
 uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action dismiss  --reason "..."
 uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action actioned [--reason "..."]
+uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action actionable --reason "..."
 uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action promote  --todo-id <todo-slug>
 ```
 
@@ -123,6 +124,15 @@ appends a one-line entry under `## Triage log` in the body):
   warrant action.
 - **`actioned`** — sets `status: actioned`. Use when a fix landed without
   needing a separate TODO (e.g., handled inline during the same review).
+- **`actionable`** — sets `status: actionable`. Use when a sweep
+  re-verifies the finding against current code, confirms it is still
+  load-bearing, but the work is not yet ready for TODO promotion (e.g.,
+  blocked on prerequisite measurement). Requires `--reason "..."`; the
+  reason becomes the triage-log entry that names the verifying review,
+  so a future sweep can tell `actionable` ("re-checked today, still
+  real") apart from `open` ("recorded once, never re-checked"). Default
+  `list` filter remains `open`-only — `actionable` items surface via
+  `--status actionable`.
 - **`promote`** — sets `status: merged-to-todo` and fills `todo_id`.
   Authoring the TODO file itself is **your** job — use
   `_project/TODO_ENTRY_TEMPLATE.yaml` and place it under

--- a/_project/scripts/sweep_blind_spots.py
+++ b/_project/scripts/sweep_blind_spots.py
@@ -7,8 +7,9 @@ Subcommands::
     show <id>                               Print one finding (frontmatter + body).
     report                                  Counts by status + kind, oldest open first.
     triage <id> --action ACTION [...]       Stamp frontmatter to record triage outcome.
-        --action dismiss --reason "..."
+        --action dismiss [--reason "..."]
         --action actioned [--reason "..."]
+        --action actionable --reason "..."
         --action promote --todo-id <slug>
 
 Triage edits only the frontmatter and appends one line under a
@@ -27,12 +28,14 @@ from pathlib import Path
 
 import yaml
 
-ALLOWED_STATUS = {"open", "actioned", "dismissed", "merged-to-todo"}
+ALLOWED_STATUS = {"open", "actionable", "actioned", "dismissed", "merged-to-todo"}
 ACTION_TO_STATUS = {
     "dismiss": "dismissed",
     "actioned": "actioned",
+    "actionable": "actionable",
     "promote": "merged-to-todo",
 }
+REQUIRES_REASON = {"actionable"}
 FINDING_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{6}-[a-z0-9]+(?:-[a-z0-9]+)*$")
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|\Z)", re.DOTALL)
 TRIAGE_LOG_HEADING_RE = re.compile(r"(?m)^## Triage log\s*$")
@@ -179,14 +182,14 @@ def cmd_report(bs_dir: Path, args: argparse.Namespace) -> int:
 
     by_status: dict[str, int] = {}
     by_kind: dict[str, int] = {}
-    open_findings: list[tuple[str, dict, str]] = []
+    active_findings: list[tuple[str, dict, str]] = []
     for path, data, body in findings:
         st = str(data.get("status", "?"))
         kn = str(data.get("finding_kind", "?"))
         by_status[st] = by_status.get(st, 0) + 1
         by_kind[kn] = by_kind.get(kn, 0) + 1
-        if st == "open":
-            open_findings.append((fmt_date(data.get("date", "")), data, body))
+        if st in {"open", "actionable"}:
+            active_findings.append((fmt_date(data.get("date", "")), data, body))
 
     print(f"Total findings: {len(findings)}\n")
 
@@ -200,15 +203,16 @@ def cmd_report(bs_dir: Path, args: argparse.Namespace) -> int:
         print(f"  {kn:<16} {by_kind[kn]:>4}")
     print()
 
-    if open_findings:
-        open_findings.sort(key=lambda t: t[0])
-        print(f"Oldest open ({min(args.top, len(open_findings))} of {len(open_findings)}):")
-        for d, data, body in open_findings[: args.top]:
-            print(f"  {d}  {data.get('id', '?')}  — {extract_title(body)}")
+    if active_findings:
+        active_findings.sort(key=lambda t: t[0])
+        print(f"Oldest active ({min(args.top, len(active_findings))} of {len(active_findings)}):")
+        for d, data, body in active_findings[: args.top]:
+            st = str(data.get("status", "?"))
+            print(f"  {d}  [{st}]  {data.get('id', '?')}  — {extract_title(body)}")
     else:
-        print("No open findings.")
+        print("No active findings.")
 
-    print("\nTriage with: sweep_blind_spots.py triage <id> --action {dismiss|actioned|promote} [...]")
+    print("\nTriage with: sweep_blind_spots.py triage <id> --action {dismiss|actioned|actionable|promote} [...]")
     return 0
 
 
@@ -279,6 +283,9 @@ def cmd_triage(bs_dir: Path, args: argparse.Namespace) -> int:
     else:
         if args.todo_id:
             print("error: --todo-id is only valid with --action promote", file=sys.stderr)
+            return 2
+        if args.action in REQUIRES_REASON and not (args.reason and args.reason.strip()):
+            print(f"error: --reason is required for --action {args.action}", file=sys.stderr)
             return 2
         todo_id = None
         reason = args.reason or ""

--- a/_project/scripts/validate_blind_spot.py
+++ b/_project/scripts/validate_blind_spot.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import yaml
 
-ALLOWED_STATUS = {"open", "actioned", "dismissed", "merged-to-todo"}
+ALLOWED_STATUS = {"open", "actionable", "actioned", "dismissed", "merged-to-todo"}
 ALLOWED_KIND = {
     "framework-gap",
     "bug-class",

--- a/tests/unit/scripts/test_blind_spot_tools.py
+++ b/tests/unit/scripts/test_blind_spot_tools.py
@@ -251,3 +251,104 @@ def test_triage_rejects_promote_reason_combo(tmp_path: Path) -> None:
 
     assert result == 2
     assert "status: open" in path.read_text(encoding="utf-8")
+
+
+def test_validator_accepts_actionable_status(tmp_path: Path) -> None:
+    stem = "2026-04-29-120010-actionable-status"
+    path = tmp_path / f"{stem}.md"
+    path.write_text(_finding_text(stem, status="actionable"), encoding="utf-8")
+
+    assert validate_blind_spot.validate_file(path) == []
+
+
+def test_triage_actionable_requires_reason(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    stem = "2026-04-29-120011-actionable-needs-reason"
+    path = _write_finding(bs_dir, stem)
+    args = SimpleNamespace(id=stem, action="actionable", reason=None, todo_id=None)
+
+    result = sweep_blind_spots.cmd_triage(bs_dir, args)
+
+    assert result == 2
+    assert "--reason is required" in capsys.readouterr().err
+    assert "status: open" in path.read_text(encoding="utf-8")
+
+
+def test_triage_actionable_rejects_blank_reason(tmp_path: Path) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    stem = "2026-04-29-120012-actionable-blank-reason"
+    path = _write_finding(bs_dir, stem)
+    args = SimpleNamespace(id=stem, action="actionable", reason="   ", todo_id=None)
+
+    result = sweep_blind_spots.cmd_triage(bs_dir, args)
+
+    assert result == 2
+    assert "status: open" in path.read_text(encoding="utf-8")
+
+
+def test_triage_actionable_stamps_status_and_logs_reason(tmp_path: Path) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    stem = "2026-04-29-120013-actionable-happy-path"
+    path = _write_finding(bs_dir, stem)
+    args = SimpleNamespace(
+        id=stem,
+        action="actionable",
+        reason="2026-05-06 sweep: still load-bearing; blocked on prerequisite",
+        todo_id=None,
+    )
+
+    result = sweep_blind_spots.cmd_triage(bs_dir, args)
+
+    assert result == 0
+    text = path.read_text(encoding="utf-8")
+    assert "status: actionable" in text
+    assert "## Triage log" in text
+    assert "actionable — 2026-05-06 sweep" in text
+
+
+def test_default_list_filter_excludes_actionable(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    _write_finding(bs_dir, "2026-04-29-120014-still-open")
+    _write_finding(bs_dir, "2026-04-29-120015-now-actionable", status="actionable")
+
+    result = sweep_blind_spots.cmd_list(bs_dir, SimpleNamespace(status="open", kind=None))
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "2026-04-29-120014-still-open" in out
+    assert "2026-04-29-120015-now-actionable" not in out
+    assert "1 finding(s)." in out
+
+
+def test_actionable_status_filter_surfaces_only_actionable(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    _write_finding(bs_dir, "2026-04-29-120016-still-open")
+    _write_finding(bs_dir, "2026-04-29-120017-now-actionable", status="actionable")
+
+    result = sweep_blind_spots.cmd_list(bs_dir, SimpleNamespace(status="actionable", kind=None))
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "2026-04-29-120017-now-actionable" in out
+    assert "2026-04-29-120016-still-open" not in out
+    assert "1 finding(s)." in out
+
+
+def test_report_oldest_section_surfaces_actionable_alongside_open(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bs_dir = tmp_path / "_project" / "blind-spots"
+    _write_finding(bs_dir, "2026-04-29-120020-stale-open")
+    _write_finding(bs_dir, "2026-04-30-120021-confirmed-actionable", date="2026-04-30", status="actionable")
+    _write_finding(bs_dir, "2026-04-29-120022-already-dismissed", status="dismissed")
+
+    result = sweep_blind_spots.cmd_report(bs_dir, SimpleNamespace(top=10))
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Oldest active (2 of 2)" in out
+    assert "[open]" in out
+    assert "[actionable]" in out
+    assert "2026-04-29-120020-stale-open" in out
+    assert "2026-04-30-120021-confirmed-actionable" in out
+    assert "2026-04-29-120022-already-dismissed" not in out


### PR DESCRIPTION
Findings re-checked against current code that are still load-bearing
but blocked on prerequisite work (e.g., the four 2026-04-30 dev-loop
findings waiting on Step 5 measurement) had no way to express "I
verified this today, it's still real" — they collapsed into `open`,
indistinguishable from never-re-checked entries. New status fills
that gap; required `--reason` carries the verifying-review note into
the triage log. `cmd_list` default filter remains `open` only;
`cmd_report` "Oldest active" section surfaces both. Backfilled the
four dev-loop findings.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
