### PR TITLE
chore(todo): structure stale-Blocked rationale + tighten migration deps

### DIFF
--- a/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
+++ b/_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml
@@ -28,6 +28,12 @@ deps:
     - dev-loop-step-3a-path-based-ci-skip
     - dev-loop-step-4-post-merge-safety-net
 
+blockers:
+  - date: "2026-04-30"
+    work: [w2, w3, w4, w5]
+    reason: "Calendar-gated: the 30-day measurement window started at 2026-04-30T21:33:45Z (Step 4 PR #81 merge timestamp, the later of the two prerequisite merges). Aggregation, threshold evaluation, and decision-record work cannot begin until the window closes — early aggregation would bias the result with a contaminated baseline."
+    unblock: "Window closes 2026-05-30. Run `make dev-loop-metrics DEV_LOOP_METRICS_DAYS=30 DEV_LOOP_METRICS_LIMIT=500` on or after that date to start w2."
+
 work:
   - id: w1
     summary: "Wait for 30 calendar days after Step 3a and Step 4 have both merged before starting w2"

--- a/_project/TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
+++ b/_project/TODO/main/planning/enable-duckdb-wasm-http-range-reads-for-registered-urls.yaml
@@ -52,6 +52,12 @@ deps:
   needs:
     - implement-results-explorer-browser-functional-tests
 
+blockers:
+  - date: "2026-05-01"
+    work: [w2, w3]
+    reason: "Upstream duckdb-wasm has not shipped a stable 1.33.x release with the per-URL range-read fix. As of 2026-05-01 npm publishes only 1.32.0 stable plus dev pre-releases (1.33.1-dev45 / dev53), and upstream issue duckdb/duckdb-wasm#1984 remains open. Pinning to a dev pre-release violates the TODO's `approach` constraint, and no public-config workaround exists on 1.32.0."
+    unblock: "Upstream ships a stable @duckdb/duckdb-wasm 1.33.x (or later) build that issues 206 Partial Content responses against URLs registered with `HTTP, directIO=true`."
+
 work:
   - id: w1
     summary: "Re-audit duckdb-wasm runtime flags and the HTTP file-reader code path for the current version"

--- a/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
+++ b/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
@@ -7,6 +7,7 @@ category: Release Tooling
 
 deps:
   needs:
+  - single-repo-migration-phase-4-test-release-with-new-flow
   - single-repo-migration-phase-6-delete-obsolete-tooling
   - single-repo-migration-phase-7-docs-cleanup
 

--- a/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
+++ b/_project/TODO/main/planning/write-primitives-sketch-cloud-verification.yaml
@@ -264,6 +264,12 @@ deps:
   needs:
     - write-primitives-architecture-fixes
 
+blockers:
+  - date: "2026-05-02"
+    work: [w1, w2, w3, w4]
+    reason: "No live cloud credentials available locally for Snowflake / BigQuery / Databricks / Redshift. Each work unit requires running the supported sketch-op set against a real cloud engine (small warehouse / job / cluster) to verify function-signature drift and re-tune expected_value tolerance bounds per engine. The architectural prerequisite (`write-primitives-architecture-fixes`) has landed, so this is purely a credential gate."
+    unblock: "Provision creds for at least one of Snowflake / BigQuery / Databricks / Redshift. Each engine's verification is its own work unit / PR — partial unblock per engine is supported and preferred."
+
 metadata:
   owners:
     - joeharris76


### PR DESCRIPTION
Three open TODOs marked status=Blocked declared `deps.needs` that were
already satisfied (target items in DONE/), making the dependency graph
look like the items were graph-blocked when the actual blocker was
external (upstream library version, calendar window, missing live
cloud creds). Surface the real reason via structured `blockers:` field
matching the existing `motherduck-cloud-features` pattern, so future
graph queries can distinguish graph-blocked from externally-blocked.

- enable-duckdb-wasm-http-range-reads: blocked on upstream
  duckdb-wasm 1.33.x stable release with the per-URL range-read fix
  (not on the already-DONE explorer browser-functional-tests dep)
- dev-loop-step-5-measurement-window: blocked on the calendar window
  that closes 2026-05-30 (not on Step 1-4 deps, all DONE)
- write-primitives-sketch-cloud-verification: blocked on live cloud
  creds for SF/BQ/Databricks/Redshift (architecture-fixes dep
  has landed)

Also adds the missing `single-repo-migration-phase-4` -> phase-8
deps edge so the migration sequence is enforced by the graph rather
than only by narrative.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
