### PR TITLE
chore(todo): file six 2026-05-05 UAT sweep follow-ups

### DIFF
--- a/_project/TODO/main/planning/results-explorer-uat-defect-disk-budget-resume-plan.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-disk-budget-resume-plan.yaml
@@ -1,0 +1,160 @@
+id: results-explorer-uat-defect-disk-budget-resume-plan
+title: "UAT disk-budget preflight estimator + resumable execution"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The 2026-05-05 tuned UAT follow-up sweep stopped at 141 of 1,503 candidate
+  cells when free disk crossed the 5 GiB safety boundary. 435 cells were
+  marked "resource-budget blocked" and never attempted; the remaining native
+  slow platforms (sqlite, spark, clickhouse-local tail) and every DataFrame
+  platform (polars-df, pandas-df, modin-df, pyspark-df, dask-df,
+  datafusion-df) were untouched.
+
+  The framework today has a `preflight.min_free_gib` floor and aborts the
+  sweep when it is crossed, but it does not estimate the disk budget for a
+  given config up front, and it cannot resume a partially complete sweep —
+  reaching the floor truncates the run and discards the remaining cells.
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`.
+  Follow-up to PR #235 (chore/results-explorer-tuned-followup-resume-20260505).
+
+  This TODO adds two capabilities so a multi-day sweep on a constrained host
+  can complete:
+
+    1. Preflight disk-budget estimator that, given a config, predicts peak
+       disk (datagen + transient growth + result/log artifacts) before the
+       sweep begins, and either gates execution or partitions the cells into
+       resumable batches.
+    2. Resumable execution: a sweep that hits the disk floor records a
+       resume manifest (cells attempted, cells remaining) so a subsequent
+       invocation picks up where it stopped after operator cleanup.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Re-validate cited 2026-05-05 sweep evidence and capture to verification log"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      Before w1, confirm the handoff figures still reproduce by inspecting
+      the captured sweep artifacts:
+
+        wc -l ~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun/coverage_cells.tsv
+        awk -F'\t' 'NR>1 {print $NF}' \
+          ~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun/coverage_cells.tsv \
+          | sort | uniq -c
+        du -sh /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/datagen \
+                /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/databases
+
+      Expected (handoff anchor): 1,503 candidate cells; 141 attempted
+      (114 passed, 25 failed, 2 timed out); 435 resource-budget blocked;
+      855 skipped unreachable; 8.6 GiB datagen + 21 GiB databases on
+      pool-02. Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-disk-budget-resume-plan/w0.log`
+      and commit. If the figures have already drifted (e.g., pool-02
+      cleanup ran first), update the description and gate w1 on what
+      survives.
+
+  - id: w1
+    summary: "Inventory current disk consumption per platform/benchmark/scale from the 2026-05-02 + 2026-05-05 sweep telemetry"
+    needs: [w0]
+    status: pending
+    notes: |
+      Goal: a per-(platform, benchmark, scale) datagen + transient growth
+      table that the estimator can consume. Sources:
+        - `~/Developer/benchmark_runs/datagen` and `databases` directories
+          from the 2026-05-05 sweep (8.6 GiB datagen, 21 GiB databases on
+          pool-02 alone — see `pool02-artifact-cleanup` TODO).
+        - Per-cell logs under
+          `~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun/`.
+      Output: `tests/uat/data/disk_budget_table.tsv` keyed by
+      `(platform, benchmark, scale_factor)` with `peak_datagen_gib`,
+      `peak_database_gib`, `transient_growth_gib`. Land as a checked-in
+      artifact; updaters write a follow-up.
+
+  - id: w2
+    summary: "Add `tests/uat/preflight_budget.py` that consumes the table and reports estimated peak free-disk demand for a config"
+    needs: [w1]
+    status: pending
+    notes: |
+      New module exposes `estimate_peak_disk(config) -> DiskBudget` with
+      fields: `cells`, `est_peak_gib`, `est_steady_gib`, `unknown_cells`.
+      Wire into `tests/uat/phases/preflight.py` so `make uat-preflight`
+      and `make uat-sweep` print the estimate before any cell runs.
+      Fast-marked unit test using a fixture config.
+
+  - id: w3
+    summary: "Add resume manifest: orchestrator writes `<log-dir>/resume.json` on disk-floor abort; `--resume <manifest>` skips already-attempted cells"
+    needs: [w2]
+    status: pending
+    notes: |
+      `tests/uat/orchestrator.py` writes a JSON manifest with attempted
+      cells (cell_key + terminal_state + result_path) when execution
+      aborts on `min_free_gib`. `tests/uat/_cli.py::execute_main` and
+      `sweep_main` accept `--resume <path>` and skip cells already in
+      `attempted`. Fast-marked test: simulated abort writes manifest;
+      second invocation with `--resume` enumerates the complement.
+
+  - id: w4
+    summary: "Document the new flow in `docs/operations/uat-framework.md` and `_project/specs/uat-framework.md`"
+    needs: [w3]
+    status: pending
+    notes: |
+      Operator-facing: how to read the preflight estimate, when to partition
+      into batches, how `--resume` interacts with `preserve_datagen` and
+      datagen reuse. Spec-side: contract for the resume manifest and
+      backwards-compat posture (none — new file format).
+
+must_preserve:
+  - "Existing `preflight.min_free_gib` abort semantics: framework still aborts when the floor is crossed."
+  - "datagen reuse across cells (e.g., tpcds_obt → tpcds, write_primitives → tpch) — resume must not invalidate cached datagen."
+  - "Validator-clean-rate floor enforcement; nothing about resumability bypasses validation."
+
+anti_patterns:
+  - "DO NOT make the preflight estimator a hard gate — it must be advisory, because per-platform disk envelopes drift faster than the table can be re-inventoried, and a bad estimate must not block a deliberate operator."
+  - "DO NOT reuse `tests/uat/configs/.frozen-hashes.json`-style ceremony for the disk budget table — refresh is operator-driven and the table is allowed to drift; a stale-table warning is sufficient."
+
+verification:
+  - description: "Preflight estimator runs and prints a non-empty disk budget"
+    command: "uv run -- python -m tests.uat._cli preflight --config tests/uat/configs/stress-default.yaml"
+    expected_output: "Disk budget estimate: ... GiB"
+  - description: "Resume manifest round-trips a partial sweep"
+    command: "uv run -- python -m pytest tests/uat/test_orchestrator.py -m fast -k resume -q"
+    expected_output: "1 passed"
+  - description: "Disk budget table is checked in"
+    command: "test -f tests/uat/data/disk_budget_table.tsv && echo OK"
+    expected_output: "OK"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/preflight_budget.py"
+    - "tests/uat/phases/preflight.py"
+    - "tests/uat/orchestrator.py"
+    - "tests/uat/_cli.py"
+    - "tests/uat/data/disk_budget_table.tsv"
+    - "tests/uat/test_orchestrator.py"
+    - "tests/uat/test_preflight_budget.py"
+    - "docs/operations/uat-framework.md"
+    - "_project/specs/uat-framework.md"
+  do_not_modify:
+    - "benchbox/cli/"
+    - "benchbox/core/"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - disk-budget
+    - resumable
+    - operations
+  estimated_effort: "Medium (~3-5 days, 4 work units)"
+  created_date: "2026-05-06"
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #1. Sweep stopped at 141/1503 cells on the 5 GiB
+    floor; 435 cells were never attempted.

--- a/_project/TODO/main/planning/results-explorer-uat-defect-explorer-smoke-current-cli.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-explorer-smoke-current-cli.yaml
@@ -1,0 +1,155 @@
+id: results-explorer-uat-defect-explorer-smoke-current-cli
+title: "Fix UAT explorer-smoke phase to use the current Playwright contract"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The UAT `explorer_smoke` phase did not complete the browser smoke check
+  in the 2026-05-05 sweep — not because of an Explorer UI regression, but
+  because `tests/uat/phases/explorer_smoke.py` calls a stale CLI contract
+  for both the build step and the browser step.
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`
+  (sections "Explorer Smoke" + "Defect Classification → UAT-infrastructure").
+  Follow-up to PR #235.
+
+  Observed drift:
+
+    - **Build side** — `benchbox explorer build` now expects `--data-dir`,
+      not `--bundles-dir`. The handoff says the build-side wiring was
+      partially fixed in the worktree that became PR #235; this TODO
+      covers anything still drifting and the regression guard.
+    - **Browser side** — `results-explorer/scripts/serve-browser-tests.mjs`
+      does not accept `--data-dir` or `--browsers`. It expects `--dist-dir`
+      and `--fixture-dir`, and is a server helper, not a one-shot
+      Playwright runner. The phase needs to launch Playwright directly
+      against a built Explorer app.
+
+  Until this is fixed, `make uat-explorer-smoke` will continue to fail
+  before it asserts anything browser-side, and any UI regression in
+  Explorer is invisible to UAT.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Capture the current `benchbox explorer build` and `serve-browser-tests.mjs` CLI shape"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      The fix in w2/w3 targets a specific contract; pin it before
+      rewriting so a reviewer can replay:
+
+        uv run -- benchbox explorer build --help
+        node results-explorer/scripts/serve-browser-tests.mjs --help 2>&1 || true
+        grep -n -- '--bundles-dir\|--data-dir\|--browsers\|--dist-dir\|--fixture-dir' \
+          tests/uat/phases/explorer_smoke.py \
+          results-explorer/scripts/serve-browser-tests.mjs
+
+      Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-explorer-smoke-current-cli/w0.log`
+      and commit. If `--bundles-dir` no longer appears anywhere (handoff
+      drift was already closed), this TODO collapses to w4 only.
+
+  - id: w1
+    summary: "Audit current `tests/uat/phases/explorer_smoke.py` against the Explorer's actual CLI surface"
+    needs: [w0]
+    status: pending
+    notes: |
+      Read `benchbox/cli/commands/explorer.py` and
+      `results-explorer/scripts/serve-browser-tests.mjs` end-to-end. List
+      every flag/arg the phase passes today vs. what each consumer actually
+      accepts. Output: a short audit note in this TODO (or a captured
+      verification log) so the fix in w2 has a clear surface contract.
+
+  - id: w2
+    summary: "Rewrite the browser-side step to invoke Playwright directly against a built Explorer app"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace the misuse of `serve-browser-tests.mjs` with the real
+      Playwright smoke flow used by the `results-explorer-browser.yml`
+      workflow:
+        cd results-explorer
+        npm ci
+        npm run build  # or equivalent to populate dist/
+        BENCHBOX_DATA_DIR=<built data dir> npx playwright test --grep @smoke
+      Wrap that in `_run_browser_smoke(config, build_output_dir)` inside
+      the phase. Honor `config.explorer_smoke.browsers` (Chromium-only by
+      default; Firefox/WebKit are advisory until the
+      `graduate-browser-smoke-to-blocking-gates` TODO lands).
+
+  - id: w3
+    summary: "Confirm build-side wiring uses `--data-dir`; remove any residual `--bundles-dir` references"
+    needs: [w1]
+    status: pending
+    notes: |
+      Grep `tests/uat/` and `Makefile` for `--bundles-dir`. Replace each
+      with `--data-dir` matching the current CLI. The handoff says this
+      was partially done; close the loop and add a regression test:
+        def test_explorer_smoke_uses_data_dir_flag(...): ...
+      that asserts the phase's argv builder emits `--data-dir`, not
+      `--bundles-dir`.
+
+  - id: w4
+    summary: "Add a fast-marked smoke that runs the phase against a fixture corpus end-to-end"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Test takes 5-10 staged bundles from `results-data/bundles/`, runs the
+      phase against them, asserts: (a) `benchbox explorer build` exits 0,
+      (b) Playwright smoke exits 0 (Chromium-only). Mark `slow` if it
+      exceeds the fast-test budget; otherwise fast.
+
+must_preserve:
+  - "The Chromium blocking-gate behaviour from `.github/workflows/results-explorer-browser.yml` — the UAT phase mirrors it, does not redefine it."
+  - "Existing `explorer_smoke.browsers` config field (the default and the validator stay)."
+  - "All eight `make uat-*` targets continue to work unchanged."
+
+anti_patterns:
+  - "DO NOT introduce a fourth way to run Explorer browser tests — the workflow uses `npx playwright test`, this phase must use the same entrypoint, because divergent invocations are how the original drift happened."
+  - "DO NOT depend on `serve-browser-tests.mjs` from the UAT phase — that script is a developer-loop server helper; coupling UAT to it re-creates the contract drift."
+  - "DO NOT silently fall back to a smaller browser set — if a requested browser is unavailable, fail loudly so operators see it."
+
+verification:
+  - description: "Phase invokes the current CLI surface"
+    command: "uv run -- python -c 'from tests.uat.phases.explorer_smoke import build_argv; print(build_argv())' | grep -- --data-dir"
+    expected_output: "non-empty (contains --data-dir)"
+  - description: "Phase no longer references --bundles-dir"
+    command: "! grep -rn 'bundles-dir' tests/uat/ --include='*.py'"
+    expected_output: "no matches (exit 0)"
+  - description: "Phase no longer launches `serve-browser-tests.mjs`"
+    command: "! grep -rn 'serve-browser-tests' tests/uat/ --include='*.py'"
+    expected_output: "no matches (exit 0)"
+  - description: "End-to-end smoke against fixture corpus passes"
+    command: "uv run -- python -m pytest tests/uat/test_explorer_smoke.py -m fast -q"
+    expected_output: "all green"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/phases/explorer_smoke.py"
+    - "tests/uat/test_explorer_smoke.py"
+    - "tests/uat/_cli.py"
+    - "Makefile"
+  do_not_modify:
+    - "results-explorer/src/"
+    - "results-explorer/scripts/serve-browser-tests.mjs"
+    - "benchbox/cli/commands/explorer.py"
+    - ".github/workflows/results-explorer-browser.yml"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - playwright
+    - browser-smoke
+    - cli-drift
+  estimated_effort: "Small (~1-2 days, 4 work units)"
+  created_date: "2026-05-06"
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #3. Browser smoke did not complete in the
+    2026-05-05 sweep due to phase CLI drift, not Explorer UI regression.

--- a/_project/TODO/main/planning/results-explorer-uat-defect-local-platform-bring-up-automation.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-local-platform-bring-up-automation.yaml
@@ -1,0 +1,177 @@
+id: results-explorer-uat-defect-local-platform-bring-up-automation
+title: "Author runbook + bring-up automation for Lakesail and the 15 TCP-backed local platforms"
+worktree: main
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  The 2026-05-05 tuned UAT sweep marked 855 cells "skipped unreachable"
+  because their target platforms were not provisioned on the local host.
+  This was not a defect in those platforms — they simply require a
+  process or container the UAT host had not started.
+
+  Affected platforms:
+
+    - Lakesail (local Sail / pysail server not provisioned)
+    - 15 TCP-backed SQL platforms: cedardb, clickhouse-server, databend,
+      doris, influxdb, pg-duckdb, pg-mooncake, postgresql, presto,
+      questdb, singlestore, starrocks, timescaledb, trino, velox
+
+  Reachable platforms in the same sweep were `duckdb`, `datafusion`,
+  `lakesail` (incomplete), and `clickhouse-local`.
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`
+  ("Coverage" + "Defect Classification → Environment/provisioning").
+  Follow-up to PR #235. Builds on the inventory landed by
+  `_project/DONE/main/active/results-explorer-uat-defect-local-platform-provisioning.yaml`
+  (closed 2026-05-03) — that TODO catalogued what needs to be running;
+  this one converts the catalogue into a runbook and per-platform
+  bring-up target.
+
+  Today an operator running a multi-platform sweep has to know which
+  platforms need a TCP server up, on which port, and how to start it.
+  That tribal knowledge means most sweeps cover only the embedded
+  subset; cross-platform comparison drifts toward the easy-to-provision
+  edge of the matrix.
+
+  This TODO either documents the provisioning steps in a
+  reproducible runbook, or — where realistic — automates them via the
+  existing Docker / pool tooling so `make uat-sweep` brings up the
+  required platforms before enumeration.
+
+deps:
+  needs:
+    - results-explorer-uat-defect-local-platform-provisioning
+
+work:
+  - id: w0
+    summary: "Capture the current unreachable-platform set from the 2026-05-05 sweep coverage TSV"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      The "855 cells skipped unreachable" + 16-platform list is anchored
+      to one sweep; pin the live numbers so the runbook in w5 cites a
+      reproducible source:
+
+        LOGS=~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun
+        awk -F'\t' 'NR==1 || $NF=="skipped_unreachable" {print}' \
+          "$LOGS/coverage_cells.tsv" | wc -l
+        cat "$LOGS/coverage_platform_summary.tsv"
+
+      Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-local-platform-provisioning/w0.log`
+      and commit. If a platform listed in the description is now reachable
+      (because it was provisioned independently), drop it from the w1
+      inventory before authoring the runbook.
+
+  - id: w1
+    summary: "Inventory each platform's current readiness contract: what process/container, what port, what env"
+    needs: [w0]
+    status: pending
+    notes: |
+      For each of the 16 platforms, capture:
+        - default port the BenchBox connector expects
+        - launch command (docker compose service name, native binary, etc.)
+        - whether `docker-compose.yml` already defines the service
+        - whether a healthcheck exists
+      Output: `docs/operations/local-platform-provisioning.tsv` keyed
+      by platform with the columns above. Land as a checked-in artifact.
+
+  - id: w2
+    summary: "Distinguish 'document only' from 'automate' per platform"
+    needs: [w1]
+    status: pending
+    notes: |
+      Some platforms are heavy enough or licensed enough that automated
+      bring-up isn't warranted (e.g., Singlestore, large vendor images).
+      Decision per platform: `document` (runbook step only) vs.
+      `automate` (a target that brings it up). Output: `decision`
+      column on the TSV from w1.
+
+  - id: w3
+    summary: "For 'automate' platforms, add a `make uat-bring-up PLATFORM=<name>` target that starts and healthchecks"
+    needs: [w2]
+    status: pending
+    notes: |
+      Generic Make target that dispatches per-platform:
+        make uat-bring-up PLATFORM=postgresql  # docker compose up + wait
+        make uat-bring-up PLATFORM=trino       # docker compose up + wait
+      Wraps the service launch + a TCP/health probe with a timeout.
+      Idempotent: re-running on an already-up service is a no-op + OK.
+      Add a fast-marked unit test that asserts the dispatcher returns
+      a sensible error on an unknown platform.
+
+  - id: w4
+    summary: "Optional `preflight.local_platforms_check: true` config field that runs reachability per requested platform"
+    needs: [w3]
+    status: pending
+    notes: |
+      When set, the preflight phase pings each platform in
+      `platforms.include` and aborts the sweep with a clear error if any
+      requested platform is unreachable AND not in the `automate` set.
+      `automate`-set platforms get a one-shot `make uat-bring-up`
+      attempt before the abort. Default: `false` (preserves current
+      "skip unreachable" behaviour).
+
+  - id: w5
+    summary: "Write the operator runbook in `docs/operations/uat-local-provisioning.md`"
+    needs: [w2]
+    status: pending
+    notes: |
+      Per-platform sections (16 entries) covering the document-only
+      bring-up steps, ports, and any quirks (e.g., Doris JDK requirement,
+      Trino catalog config, Lakesail `pysail` install). Cross-link to
+      the new `make uat-bring-up` for automate-set platforms. This is
+      the canonical reference; the platform-readiness TSV from w1 is
+      the index.
+
+must_preserve:
+  - "Current `skipped_unreachable` terminal state — the sweep does not become more aggressive about failing when a platform is missing unless `local_platforms_check` is opted in."
+  - "BenchBox connector defaults — port and connection logic stays in the connectors, not the UAT framework."
+  - "Each platform's existing test suite (tests/integration/test_local_platform_benchmark_matrix.py)."
+
+anti_patterns:
+  - "DO NOT start automating a platform without a healthcheck — a `docker compose up` that returns before the server is accepting connections produces flaky sweeps and is worse than 'document only'."
+  - "DO NOT couple `make uat-sweep` to bringing up every platform implicitly — bring-up is opt-in via `preflight.local_platforms_check` or explicit `make uat-bring-up`. Implicit bring-up makes 'why is my disk full' a UAT-framework debugging session."
+  - "DO NOT consolidate runbook steps into a script that hides the per-platform commands — operators benefit from seeing the literal commands; the script is the convenience, not the truth."
+
+verification:
+  - description: "Provisioning TSV is checked in and covers all 16 platforms"
+    command: "wc -l docs/operations/local-platform-provisioning.tsv"
+    expected_output: ">= 17 (header + 16 platforms)"
+  - description: "Operator runbook exists and references each platform"
+    command: "for p in lakesail cedardb clickhouse-server databend doris influxdb pg-duckdb pg-mooncake postgresql presto questdb singlestore starrocks timescaledb trino velox; do grep -q \"$p\" docs/operations/uat-local-provisioning.md || echo MISSING $p; done"
+    expected_output: "(no MISSING lines)"
+  - description: "`make uat-bring-up PLATFORM=<unknown>` fails with a clear error"
+    command: "make uat-bring-up PLATFORM=does-not-exist 2>&1 | tail -1"
+    expected_output: "non-zero exit; error mentions 'unknown platform'"
+  - description: "Optional preflight reachability check works against a known-down port"
+    command: "uv run -- python -m pytest tests/uat/test_preflight.py -m fast -k local_platforms_check -q"
+    expected_output: "all green"
+
+scope_limit:
+  only_modify:
+    - "Makefile"
+    - "tests/uat/phases/preflight.py"
+    - "tests/uat/test_preflight.py"
+    - "docs/operations/uat-local-provisioning.md"
+    - "docs/operations/local-platform-provisioning.tsv"
+    - "scripts/uat-bring-up/"
+  do_not_modify:
+    - "benchbox/core/platform_registry.py"
+    - "benchbox/core/connectors/"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - platform-provisioning
+    - operations
+    - docker
+  estimated_effort: "Medium (~1-2 weeks, 5 work units)"
+  created_date: "2026-05-06"
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #6. 855 cells were "skipped unreachable" in
+    the 2026-05-05 sweep purely due to local provisioning gaps.

--- a/_project/TODO/main/planning/results-explorer-uat-defect-pool02-artifact-cleanup.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-pool02-artifact-cleanup.yaml
@@ -1,0 +1,143 @@
+id: results-explorer-uat-defect-pool02-artifact-cleanup
+title: "Reclaim 29.6 GiB of pool-02 datagen + databases left by the 2026-05-05 sweep"
+worktree: main
+priority: Medium
+status: Blocked
+category: Operations
+
+description: |
+  The 2026-05-05 tuned UAT sweep wrote runtime artifacts under the
+  worktree-local `benchmark_runs/` because `BENCHBOX_OUTPUT_DIR` was not
+  propagated to `benchbox run` subprocesses. Results have been mirrored
+  into the shared `~/Developer/benchmark_runs/` (handoff confirms 0
+  missing JSONs post-copy), so the pool-02 tree is now redundant.
+
+  Pool-local artifacts to reclaim:
+
+    - `/Users/joe/Developer/BenchBox.pool-02/benchmark_runs/datagen` — 8.6 GiB
+    - `/Users/joe/Developer/BenchBox.pool-02/benchmark_runs/databases` — 21 GiB
+    - Total — 29.6 GiB
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`
+  ("Runtime Path Audit" + "Consolidation performed"). Follow-up to PR #235.
+
+  **Status: Blocked on explicit user approval.** This is a destructive
+  filesystem operation. The handoff explicitly notes the deletion was not
+  done because it requires authorization.
+
+  The propagation defect itself was fixed in PR #235 (UAT execute now
+  passes a non-worktree root as `BENCHBOX_OUTPUT_DIR`), so future sweeps
+  will not recreate this situation. This TODO is purely about the
+  one-time cleanup.
+
+deps:
+  needs:
+    - results-explorer-uat-defect-disk-budget-resume-plan
+
+work:
+  - id: w0
+    summary: "Re-validate cited disk footprint before any cleanup"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      The handoff anchors this TODO to a specific 29.6 GiB footprint;
+      capture the current footprint so the reviewer-days-later (or the
+      operator approving the destructive op) sees the live size, not a
+      stale citation:
+
+        du -sh /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/datagen \
+                /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/databases \
+                /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/results
+        df -h /Users/joe/Developer/BenchBox.pool-02
+
+      Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-pool02-artifact-cleanup/w0.log`
+      and commit. Also confirms the trees still exist — if the
+      `disk-budget-resume-plan/w1` inventory already harvested everything
+      it needs, this w0 confirms it BEFORE deletion is requested.
+
+  - id: w1
+    summary: "Verify pool-02 result JSONs are still mirrored to the shared root before removal"
+    needs: [w0]
+    status: pending
+    notes: |
+      Repeat the post-copy diff from the handoff:
+        diff <(ls /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/results) \
+             <(ls ~/Developer/benchmark_runs/results)
+      Expected: every pool-02 result JSON has a same-name counterpart in
+      the shared root. If anything is missing, copy it BEFORE w2.
+
+  - id: w2
+    summary: "After explicit user approval, remove the pool-02 datagen and databases trees"
+    needs: [w1]
+    status: pending
+    notes: |
+      Hard prerequisite: `results-explorer-uat-defect-disk-budget-resume-plan/w1`
+      (per-platform/benchmark/scale disk inventory) must have completed.
+      That work unit harvests data from these exact trees; deleting them
+      first destroys its source. The `deps.needs` edge above gates the
+      whole cleanup TODO on that ancestor TODO, but call it out here too
+      so a single-work-unit operator sees the constraint inline.
+    notes: |
+      Operator command (run only after the user authorizes AND
+      disk-budget-resume-plan/w1 is done):
+        rm -rf /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/datagen
+        rm -rf /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/databases
+      Capture before/after `du -sh` to a verification log.
+      Do NOT rm `benchmark_runs/results` — those JSONs are the run record
+      and stay until the corpus integration is closed out.
+
+  - id: w3
+    summary: "Confirm pool-02 free disk recovered and the worktree is reusable"
+    needs: [w2]
+    status: pending
+    notes: |
+      `df -h /Users/joe/Developer/BenchBox.pool-02` and
+      `make worktree-pool-status` should show pool-02 healthy.
+      Update the handoff with the final reclaimed-bytes figure.
+
+must_preserve:
+  - "Pool-02 result JSONs under `benchmark_runs/results/` until corpus integration is closed."
+  - "Pool-02 worktree itself (release via `make worktree-release` is a separate operation)."
+  - "Cross-pool symmetry — do not delete other pools' artifacts as a side effect."
+
+anti_patterns:
+  - "DO NOT run `rm -rf` without the verification step (w1) confirming results are mirrored, because a single missed result JSON is unrecoverable and breaks the corpus inventory."
+  - "DO NOT generalize this TODO into a recurring sweep job — the propagation bug is fixed, future sweeps will not write to pool-local paths, so a recurring cleanup masks rather than surfaces any regression."
+  - "DO NOT chain deletion to the worktree-pool-sweep-stale workflow — that operates on stale claims; this is a one-time artifact cleanup."
+
+verification:
+  - description: "Pool-02 datagen tree is gone"
+    command: "test ! -d /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/datagen && echo OK"
+    expected_output: "OK"
+  - description: "Pool-02 databases tree is gone"
+    command: "test ! -d /Users/joe/Developer/BenchBox.pool-02/benchmark_runs/databases && echo OK"
+    expected_output: "OK"
+  - description: "Result JSONs still present in shared root"
+    command: "ls ~/Developer/benchmark_runs/results | wc -l"
+    expected_output: ">= 183 (the count from the handoff)"
+  - description: "Pool-02 free disk recovered (target: ~30 GiB more free than pre-cleanup)"
+    command: "df -h /Users/joe/Developer/BenchBox.pool-02 | tail -1"
+    expected_output: "non-empty; capture in verification log"
+
+scope_limit:
+  only_modify: []
+  do_not_modify:
+    - "benchmark_runs/results/ in any worktree"
+    - "results-data/"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - operations
+    - cleanup
+    - destructive
+  estimated_effort: "Trivial (~30 min after approval)"
+  created_date: "2026-05-06"
+  blocking_reason: "Awaiting explicit user approval for destructive filesystem operation."
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #2. 29.6 GiB pool-local artifacts left by the
+    2026-05-05 sweep due to missing `BENCHBOX_OUTPUT_DIR` propagation
+    (now fixed in PR #235).

--- a/_project/TODO/main/planning/results-explorer-uat-defect-submit-partial-success-refusals.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-submit-partial-success-refusals.yaml
@@ -1,0 +1,185 @@
+id: results-explorer-uat-defect-submit-partial-success-refusals
+title: "Surface query-level failures as failed UAT cells before the package phase"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  In the 2026-05-05 tuned UAT sweep, 27 of 114 result JSONs from
+  "passed" cells were refused by `benchbox submit --output` during the
+  package phase. Most refusals were for query-level failures hidden
+  inside otherwise-successful runs, with a smaller share for
+  unofficial TPC-DS compliance classes (`unofficial_subscale`,
+  `unofficial_nonstandard`).
+
+  Affected benchmarks/platforms in the dominant refusals:
+    - DataVault
+    - FlightData / DataFusion
+    - JoinOrder / DataFusion
+    - metadata, read, write, transaction primitives
+    - TPC-DI
+    - TPC-DS OBT
+    - TPCHavoc
+    - TSBS / DataFusion
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`
+  ("Submission And Validation" + "Defect Classification →
+  Submission-contract"). Follow-up to PR #235.
+
+  Today the UAT cell-level outcome is "passed" if the run produced a
+  result JSON, even when individual queries inside the run failed. The
+  package phase is the first place these are caught — too late for the
+  validator-clean rate to mean what it claims, and too late for an
+  operator to triage during the sweep.
+
+  This TODO makes the UAT execute phase classify a cell as failed
+  whenever its result JSON contains query-level errors (or any other
+  condition `benchbox submit` would refuse), so the sweep terminal
+  state matches the submittable-bundle reality.
+
+  Out of scope: TPC-DS compliance-class refusals are deliberate and
+  correct — those cells should not be force-promoted; they remain as
+  "passed but unofficial" in the matrix and are excluded from
+  submission packaging by design.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Replay current `benchbox submit --output` against the 2026-05-05 corpus and capture the refusal split"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      The whole TODO turns on the "27 of 114 refused" figure; pin it now
+      so the implementer (and the w5 sanity check) can compare against a
+      captured baseline:
+
+        CORPUS=~/Developer/benchmark_runs/submissions/uat-tuned-followup-20260505
+        for r in "$CORPUS"/*.json; do
+          uv run -- benchbox submit --output "$r" --dry-run 2>&1 \
+            | tail -1
+        done | sort | uniq -c
+
+      Expected (handoff anchor): 87 staged; 27 refused (mostly
+      query-level failures); validator-clean rate 95.4% on the staged
+      subset. Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-submit-partial-success-refusals/w0.log`
+      and commit. If the refusal count has drifted (submit.py rules
+      changed since 2026-05-05), update the description's count and the
+      w5 expected split before proceeding.
+
+  - id: w1
+    summary: "Catalogue every condition `benchbox submit --output` refuses today"
+    needs: [w0]
+    status: pending
+    notes: |
+      Read `benchbox/cli/commands/submit.py` end-to-end. List the explicit
+      refusal predicates (compliance class, query-level failure markers,
+      missing manifest fields, etc.) and the result-JSON fields each
+      consults. Output: short table in this TODO (or a captured log)
+      keyed by predicate → result-JSON path. This is the contract the
+      execute phase must replicate to detect-early.
+
+  - id: w2
+    summary: "Add `submit_terminal_state` classifier in `tests/uat/runner.py` (or new module) that mirrors the submit refusals"
+    needs: [w1]
+    status: pending
+    notes: |
+      Function: `classify_for_submit(result_json) -> SubmitTerminalState`
+      where `SubmitTerminalState ∈ {submittable, unofficial,
+      query_failure, schema_violation, missing_manifest}`. Call after
+      every cell's runner exit. The classifier reuses the predicates
+      catalogued in w1; do NOT branch off `submit.py`'s implementation —
+      delegate where possible (import the public predicate functions),
+      mirror only what cannot be imported. Refusing to package an
+      unsubmittable cell is a feature, not a regression — operators see
+      it during execute, not at the package boundary.
+
+  - id: w3
+    summary: "Update execute phase: cells whose `submit_terminal_state` is `query_failure` or `schema_violation` are reported FAILED, not PASSED"
+    needs: [w2]
+    status: pending
+    notes: |
+      `tests/uat/phases/execute.py` per-cell terminal-state computation
+      consumes `classify_for_submit` and downgrades the cell. Cells with
+      `unofficial` stay PASSED but are tagged so the package phase still
+      excludes them with a clear reason. Update the per-platform/per-
+      benchmark coverage TSV columns accordingly. Update existing
+      package-phase refusal logging to reference the upstream classify
+      result rather than re-deriving.
+
+  - id: w4
+    summary: "Regression test: synthetic result JSON with a query failure → execute phase reports FAILED, package phase agrees"
+    needs: [w3]
+    status: pending
+    notes: |
+      Fast-marked. Two fixture JSONs: (a) clean → submittable + PASSED,
+      (b) clean shape but one query has `error: ...` → query_failure +
+      FAILED. Assert both runner output and package-phase refusal list
+      agree. Prevents regression of the "passed but refused" gap.
+
+  - id: w5
+    summary: "Replay 2026-05-05 corpus through the new classifier; expect 27 cells to flip from PASSED to FAILED"
+    needs: [w4]
+    status: pending
+    notes: |
+      Sanity check that the implementation matches the observed defect.
+      Run `classify_for_submit` over the 114 result JSONs from
+      `~/Developer/benchmark_runs/submissions/uat-tuned-followup-20260505/`
+      and assert: 87 submittable + N unofficial + 27 (query_failure ∪
+      schema_violation) = 114. Capture the exact split into the
+      verification log under `_project/verification-logs/<this-id>/`.
+
+must_preserve:
+  - "`benchbox submit --output` remains the source of truth for refusals — UAT mirrors it, does not override it."
+  - "Direction of dependency: `tests/uat/runner.py` may IMPORT public predicates from `benchbox.cli.commands.submit`, but never the reverse. The CLI must not depend on the UAT framework."
+  - "`unofficial` compliance-class cells continue to PASS at the cell level (they ran successfully; they are simply not submittable)."
+  - "validator-clean-rate floor enforcement; tightening the cell-level pass criterion does not weaken the validator gate."
+
+anti_patterns:
+  - "DO NOT branch off submit.py's refusal logic — duplicating predicates means the next refusal-rule change diverges UAT from submit. Import where possible; document each mirror as 'mirror of submit.py:<line>'."
+  - "DO NOT mark `unofficial` cells as FAILED — they ran, they just are not submittable. Conflating these obscures real query-level failures."
+  - "DO NOT add a config flag to opt out of the new classifier — opting out re-creates the gap; if a future contract change is needed, it lives in the classifier itself."
+
+verification:
+  - description: "Classifier is importable and has the expected vocabulary"
+    command: "uv run -- python -c 'from tests.uat.runner import classify_for_submit, SubmitTerminalState; print(SubmitTerminalState.__members__.keys())'"
+    expected_output: "submittable, unofficial, query_failure, schema_violation, missing_manifest"
+  - description: "Synthetic-failure fixture produces FAILED at the execute phase"
+    command: "uv run -- python -m pytest tests/uat/test_runner.py -m fast -k classify_for_submit -q"
+    expected_output: "all green"
+  - description: "Replay against 2026-05-05 corpus matches handoff numbers"
+    command: "uv run -- python -m tests.uat._cli replay-classify --corpus ~/Developer/benchmark_runs/submissions/uat-tuned-followup-20260505/"
+    expected_output: "27 query_failure or schema_violation; 87 submittable"
+  - description: "Cell-level coverage TSV exposes `submit_terminal_state` column"
+    command: "head -1 ~/Developer/benchmark_runs/logs/<latest-sweep>/coverage_cells.tsv"
+    expected_output: "header includes submit_terminal_state"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/runner.py"
+    - "tests/uat/phases/execute.py"
+    - "tests/uat/phases/package.py"
+    - "tests/uat/_cli.py"
+    - "tests/uat/test_runner.py"
+    - "tests/uat/test_phases.py"
+  do_not_modify:
+    - "benchbox/cli/commands/submit.py"
+    - "benchbox/core/results/schema.py"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - submission
+    - cell-classification
+    - validator
+  estimated_effort: "Medium (~3-5 days, 5 work units)"
+  created_date: "2026-05-06"
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #4. 27 of 114 result JSONs were refused by
+    `benchbox submit --output` in the 2026-05-05 sweep, mostly for
+    query-level failures hidden inside "passed" cells.

--- a/_project/TODO/main/planning/results-explorer-uat-defect-tuned-template-coverage.yaml
+++ b/_project/TODO/main/planning/results-explorer-uat-defect-tuned-template-coverage.yaml
@@ -1,0 +1,169 @@
+id: results-explorer-uat-defect-tuned-template-coverage
+title: "Inventory tuned-template coverage gaps; author or explicitly waive each"
+worktree: main
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  In the 2026-05-05 tuned UAT sweep every attempted command log started
+  with `--tuning tuned`, and every successful result JSON has
+  `execution.tuning_mode == "tuned"`. However several runs reported a
+  fallback in their tuning log:
+
+      Tuning: using basic constraints (no optimized template available)
+
+  Examples in the handoff: DuckDB NYC Taxi, DuckDB FlightData. These
+  are still tuned-mode runs, but they are not benchmark-specific
+  tuned-template runs — the tuning layer fell back to platform-level
+  basic constraints because no `(platform, benchmark)` template
+  exists.
+
+  Source: `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`
+  ("Tuning Verification"). Follow-up to PR #235.
+
+  This TODO produces a complete `(platform, benchmark)` coverage matrix
+  showing which cells have a tuned template, which fall back to basic
+  constraints, and which fall back further (no tuning at all). Each
+  gap is then either authored or explicitly waived with a recorded
+  reason — so the next UAT sweep can claim "tuned" with confidence
+  about what tuned actually means per cell.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Capture the current 'basic constraints' fallback set from the 2026-05-05 sweep logs"
+    status: pending
+    notes: |
+      Evidence-durability gate per `_project/verification-logs/README.md`.
+      The TODO calls out DuckDB NYC Taxi and FlightData as examples;
+      pin the actual fallback list now:
+
+        LOGS=~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun
+        grep -rn 'basic constraints (no optimized template available)' "$LOGS" \
+          | sed -E 's/.*\/([^/]+)\.log:.*/\1/' \
+          | sort -u
+
+      Capture stdout under
+      `_project/verification-logs/results-explorer-uat-defect-tuned-template-coverage/w0.log`
+      and commit. The captured set becomes the input to w3's triage — if
+      the static matrix in w1 omits a cell that observably fell back at
+      runtime, w2's mismatch check will fire.
+
+  - id: w1
+    summary: "Generate the tuned-template coverage matrix from the registry + tuning module"
+    needs: [w0]
+    status: pending
+    notes: |
+      Script (or `make` target) that walks
+      `(platform_registry × benchmark_registry)` and for each cell
+      reports one of:
+        - `tuned_template`           — a benchmark-specific template exists
+        - `basic_constraints`        — only platform-level constraints
+        - `untuned`                  — no tuning input at all
+      Output: `tests/uat/data/tuning_coverage.tsv` keyed by
+      `(platform, benchmark)`. Land as a checked-in artifact so reviewers
+      can diff coverage over time.
+
+  - id: w2
+    summary: "Cross-reference the matrix against actual 2026-05-05 sweep tuning logs"
+    needs: [w1]
+    status: pending
+    notes: |
+      Parse the per-cell tuning preamble from
+      `~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun/`
+      and assert each cell's classification matches w1's static derivation.
+      Any mismatch is itself a defect (the runtime tuning behaviour
+      diverges from the static template inventory) and gets its own
+      blind-spot capture.
+
+  - id: w3
+    summary: "Triage each `basic_constraints` and `untuned` cell into authored / waived"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each gap, decide:
+        - **author** — a tuned template should exist and there is a
+          natural one to write (e.g., ClickHouse-Local TPC-H bears
+          straightforward constraints)
+        - **waive** — tuned template is not meaningful for this cell
+          (e.g., a pure ingestion benchmark, or a platform that doesn't
+          accept user-provided constraints) — waiver records the reason
+      Output: `tests/uat/data/tuning_coverage.tsv` gains a `decision`
+      column with `author | waived | done`, and a `reason` column for
+      waivers. This is the working list for w4.
+
+  - id: w4
+    summary: "Author the high-priority tuned templates; record the rest as backlog"
+    needs: [w3]
+    status: pending
+    notes: |
+      Land tuned templates for cells where the value is highest (heavy
+      cells in the standard cohort, e.g., DuckDB NYC Taxi, DuckDB
+      FlightData per the handoff). The remainder stays in the matrix
+      as a tracked backlog; this TODO does NOT block on hitting 100%
+      authored coverage — it blocks on the matrix being complete and
+      every cell having a `decision`.
+
+  - id: w5
+    summary: "Add a regression test that flags new `basic_constraints` regressions"
+    needs: [w4]
+    status: pending
+    notes: |
+      Fast-marked test that re-derives the matrix and compares against
+      the checked-in TSV. Any cell that drops from `tuned_template` to
+      `basic_constraints` or `untuned` fails the test (the inverse
+      direction — improvements — is allowed). Prevents silent
+      regression when a new platform or benchmark lands without a
+      tuned template.
+
+must_preserve:
+  - "`execution.tuning_mode == \"tuned\"` semantics — a cell with `basic_constraints` is still legitimately tuned, just not benchmark-specific."
+  - "Existing tuning module surface (`benchbox.core.tuning` if present, or wherever templates are loaded today)."
+  - "TPC-H / TPC-DS official-mode templates — those are governed by compliance and not in scope for waiver decisions."
+
+anti_patterns:
+  - "DO NOT make `basic_constraints` itself an error condition — many cells have no tuned template by design, and treating fallback as failure makes operators less informed, not more."
+  - "DO NOT author tuned templates speculatively without evidence they help — a template that is identical to basic constraints just adds maintenance overhead without runtime benefit."
+  - "DO NOT introduce a new top-level config flag to gate tuned-template authoring — registration belongs in the tuning module, not in YAML config."
+
+verification:
+  - description: "Coverage matrix is checked in"
+    command: "test -f tests/uat/data/tuning_coverage.tsv && echo OK"
+    expected_output: "OK"
+  - description: "Every `(platform, benchmark)` row has a `decision`"
+    command: "uv run -- python -c 'import csv; rows=list(csv.DictReader(open(\"tests/uat/data/tuning_coverage.tsv\"), delimiter=\"\\t\")); assert all(r[\"decision\"] in (\"author\",\"waived\",\"done\") for r in rows), [r for r in rows if r[\"decision\"] not in (\"author\",\"waived\",\"done\")]; print(\"OK\")'"
+    expected_output: "OK"
+  - description: "Regression test flags drops in template coverage"
+    command: "uv run -- python -m pytest tests/uat/test_tuning_coverage.py -m fast -q"
+    expected_output: "all green"
+  - description: "Static matrix and 2026-05-05 sweep observations agree"
+    command: "uv run -- python -m tests.uat._cli verify-tuning-matrix --logs ~/Developer/benchmark_runs/logs/uat_tuned_followup_20260505_pool02_rerun/"
+    expected_output: "no mismatches"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/data/tuning_coverage.tsv"
+    - "tests/uat/test_tuning_coverage.py"
+    - "tests/uat/_cli.py"
+    - "benchbox/core/tuning/"
+  do_not_modify:
+    - "benchbox/core/tpch/"
+    - "benchbox/core/tpcds/"
+
+metadata:
+  tags:
+    - uat-framework
+    - results-explorer
+    - tuning
+    - coverage
+    - templates
+  estimated_effort: "Medium (~1 week, 5 work units)"
+  created_date: "2026-05-06"
+  source: |
+    Handoff `_project/handoffs/results-explorer-uat-tuned-followup-20260505.md`,
+    Follow-Up TODO Candidate #5. Several 2026-05-05 sweep cells reported
+    "Tuning: using basic constraints (no optimized template available)"
+    despite running in `--tuning tuned` mode.


### PR DESCRIPTION
Source: _project/handoffs/results-explorer-uat-tuned-followup-20260505.md.
Each item carries a w0 evidence-durability gate that captures the
handoff figures (141/1503 cells, 27/114 refused, 855 unreachable, etc.)
to _project/verification-logs/<id>/w0.log before the work proceeds.

- disk-budget-resume-plan: preflight estimator + resume manifest
- pool02-artifact-cleanup: reclaim 29.6 GiB after explicit approval
  (deps.needs disk-budget-resume-plan so its inventory runs first)
- explorer-smoke-current-cli: fix UAT phase to current Playwright contract
- submit-partial-success-refusals: surface query-level failures pre-package
- tuned-template-coverage: inventory + waive/author basic-constraints fallbacks
- local-platform-bring-up-automation: runbook + per-platform bring-up
  (deps.needs the 2026-05-03 inventory TODO already in DONE)
