### PR TITLE
[codex] Plan Results Explorer retheme remediation

### DIFF
--- a/_project/TODO/main/planning/results-explorer-retheme-browse-pages.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-browse-pages.yaml
@@ -1,0 +1,175 @@
+id: results-explorer-retheme-browse-pages
+title: "Retheme benchmark and platform browse pages after route correctness is restored"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Benchmark and platform pages are central browse flows, but the audit could
+  not fully evaluate them because they currently render cost-schema binder
+  errors. Once route correctness is restored, these pages need a focused
+  retheme and usability pass. Current code shows legacy native selects, mixed
+  segmented controls, static-looking filter clusters, white tables/cards, a
+  bottom compare selection bar, and page-specific table/chart treatments that
+  are not aligned with the intended BenchBox product identity.
+
+  This item covers `/results/:benchmark/` and `/results/p/:platform/`.
+  It should make benchmark matrices, rank/list modes, platform timelines,
+  filters, row selection, compare entry, empty states, and responsive behavior
+  feel like one coherent data-browse system.
+
+deps:
+  needs:
+    - results-explorer-retheme-schema-cost-regression
+    - results-explorer-retheme-theme-system-foundation
+
+work:
+  - id: w1
+    summary: "Re-audit rendered benchmark and platform pages after the schema blocker is fixed"
+    status: pending
+    notes: |
+      Capture 390px, 768px, 1280px, and 1600px screenshots for:
+        - `/results/tpch/?sf=0.01&phase=standard`
+        - `/results/star_schema/?sf=0.1&phase=power`
+        - `/results/p/duckdb/`
+        - `/results/p/polars/`
+
+      Record all controls, tables, charts, empty states, compare-selection
+      flows, and mobile behavior before editing.
+
+  - id: w2
+    summary: "Normalize page headers, breadcrumbs, and primary controls"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply shared theme primitives to:
+        - breadcrumb treatment;
+        - page title and metadata;
+        - scale/phase/tuning filters;
+        - trust filters;
+        - matrix/ranks/list view toggle;
+        - high-contrast toggle;
+        - compare action.
+
+      The primary page question should be obvious: benchmark page compares
+      platforms within a benchmark cohort; platform page audits one platform
+      across cohorts.
+
+  - id: w3
+    summary: "Retheme BenchmarkIndex matrix, rank, and list views"
+    needs: [w2]
+    status: pending
+    notes: |
+      Use shared table and heatmap primitives. Confirm:
+        - sortable columns have consistent affordances and `aria-sort`;
+        - heatmap cells use the same legend/color semantics as Home;
+        - missing timings and failed queries are visually distinct;
+        - trust/validation badges do not dominate per-query values;
+        - the matrix is scan-friendly at desktop widths.
+
+  - id: w4
+    summary: "Retheme PlatformIndex table, trend sections, and cohort grouping"
+    needs: [w2]
+    status: pending
+    notes: |
+      Ensure the Platform page does not imply mixed benchmark/scale cohorts are
+      one comparable time series. Trend sections should label cohort, scale,
+      phase, and primary metric. The main table should expose benchmark, scale,
+      date, power/geomean, trust, validation, and source/action consistently.
+
+  - id: w5
+    summary: "Design mobile browse behavior for dense matrices and platform tables"
+    needs: [w3, w4]
+    status: pending
+    notes: |
+      At 390px and 768px, decide per surface:
+        - keep horizontal table scroll with visible affordance and sticky first
+          columns; or
+        - switch to compact cards with the same comparison semantics.
+
+      Do not let primary action links or the Compare selection bar fall off
+      screen without an affordance.
+
+  - id: w6
+    summary: "Unify compare-selection behavior and the selected-result bar"
+    needs: [w5]
+    status: pending
+    notes: |
+      Benchmark and platform pages should use the same selection model,
+      selected-count language, compare button state, and incompatibility
+      feedback. Single selection should clearly explain that two or more
+      comparable results are required.
+
+  - id: w7
+    summary: "Polish empty, filtered-empty, and not-found states"
+    needs: [w6]
+    status: pending
+    notes: |
+      Replace blank or generic copy with branded, actionable states:
+        - no results for platform;
+        - no benchmark data for selected scale/phase;
+        - filters exclude all rows;
+        - result set not comparable.
+
+      Raw internal SQL errors should never appear in these states by default.
+
+must_preserve:
+  - "Benchmark page route contract `/results/{benchmark}/?sf=...&phase=...`."
+  - "Platform page route contract `/results/p/{platform_id}/`."
+  - "Existing row-selection to Compare flow with compact IDs when available."
+  - "High-contrast heatmap toggle behavior."
+  - "Sortable table behavior added by pass-2 follow-ups."
+
+anti_patterns:
+  - "DO NOT retheme benchmark and platform pages independently with divergent controls."
+  - "DO NOT chart mixed benchmark/scale cohorts as a single comparable trend."
+  - "DO NOT hide compare selection state behind table scroll."
+  - "DO NOT make mobile users inspect large matrices without a scroll cue or card fallback."
+
+verification:
+  - description: "Benchmark and platform unit tests pass"
+    command: "cd results-explorer && npm test -- src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/components/__tests__/QueryHeatmap.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Browser smoke covers benchmark and platform pages"
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npx playwright test --project=chromium --grep \"benchmark|platform\""
+    expected_output: "browser smoke passes"
+  - description: "Manual responsive captures are clean"
+    command: "echo 'Manual: capture benchmark and platform routes at 390, 768, 1280, 1600 and verify controls, tables, charts, compare bar, empty states, and no raw errors'"
+    expected_output: "manual evidence captured in _project/audits/"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/components/RankTable.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/components/SparklineTable.tsx"
+    - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+    - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
+    - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+    - "results-explorer/e2e/"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - benchmark-page
+    - platform-page
+    - responsive
+  estimated_effort: "Medium (~2-3 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Turns the core browse routes into credible public product surfaces.
+  user_impact: |
+    Users can move from benchmark/platform browsing into comparison without
+    fighting inconsistent controls or dense unresponsive tables.
+  technical_debt: |
+    Consolidates browse-page controls and data-table patterns around shared
+    primitives.

--- a/_project/TODO/main/planning/results-explorer-retheme-leaderboard-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-leaderboard-semantics.yaml
@@ -1,0 +1,168 @@
+id: results-explorer-retheme-leaderboard-semantics
+title: "Retheme the home leaderboard around metric clarity and comparison semantics"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The Home page is the strongest expression of the intended BenchBox brand, but
+  the cross-benchmark leaderboard still has data-presentation and accessibility
+  issues. The audit observed an active-looking blue ring on a `No run` cell at
+  first render, mixed units in the same mode (`1 ms` for SSB next to TPC-H power
+  score values such as `11,636.653`), visually competing heatmap colors, blue
+  links, green trust badges, green validation badges, and weak explanations of
+  missing runs, coverage, ranking, and speedup semantics.
+
+  This item should make the leaderboard feel like a rigorous benchmark product:
+  every cohort must clearly state metric, unit, and direction; missing data must
+  be distinct from slow data; trust and validation must be visible without
+  overpowering quantitative comparison; and keyboard focus must be intentional.
+
+deps:
+  needs:
+    - results-explorer-retheme-theme-system-foundation
+
+work:
+  - id: w1
+    summary: "Remove the misleading initial focus/selection ring from leaderboard cells"
+    status: pending
+    notes: |
+      In `MetaLeaderboard.tsx`, distinguish roving-grid internal focus position
+      from visible keyboard focus. The first cell should not show a blue ring
+      until the user actually keyboard-focuses the grid or selects a cell.
+      Prefer `focus-visible` styling over always applying `ring-2` from
+      `focusPos`.
+
+  - id: w2
+    summary: "Add metric, unit, and direction labels to each cohort header"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update cohort headers so visible text or compact sublabels communicate:
+        - benchmark label;
+        - scale factor;
+        - phase;
+        - metric family (`Geomean latency`, `Power score`, etc.);
+        - unit (`ms`, score, ratio);
+        - direction (`lower is faster` or `higher is better`).
+
+      Do not rely on title tooltips. Tooltips are additive only.
+
+  - id: w3
+    summary: "Redesign mode and sort controls so they read as analytical controls, not generic tabs"
+    needs: [w2]
+    status: pending
+    notes: |
+      Replace the two adjacent segmented groups with shared primitives from the
+      theme-system TODO. Labels should explain the mode:
+        - `Times` -> native metric values;
+        - `Ranks` -> rank within each cohort;
+        - `Speedup` -> relative to cohort best.
+
+      Consider grouping sort and mode under a compact toolbar with labels so
+      `Avg rank over covered cohorts` does not dominate mobile.
+
+  - id: w4
+    summary: "Separate quantitative heat from trust and validation metadata"
+    needs: [w3]
+    status: pending
+    notes: |
+      Define a cell layout where the value remains the primary read, heatmap
+      shade is secondary, and trust/validation metadata is either compact,
+      de-emphasized, or exposed in a consistent metadata row. The trust badge
+      and validation badge should not both look like the same green success
+      chip.
+
+  - id: w5
+    summary: "Define accessible color and legend behavior for heatmap and speedup modes"
+    needs: [w4]
+    status: pending
+    notes: |
+      Add a compact legend that names:
+        - best/slowest or stronger/weaker shade semantics;
+        - missing run treatment;
+        - validation/trust glyph or badge meaning;
+        - whether speedup values below `1.00x` are worse.
+
+      Reuse the existing reduced-color/high-contrast logic and verify it still
+      works after the visual changes.
+
+  - id: w6
+    summary: "Clarify ranking and coverage labels"
+    needs: [w5]
+    status: pending
+    notes: |
+      The `Avg rank over covered cohorts` column should make clear that missing
+      cohorts are not scored. The `1/4 cohorts` coverage chip should remain
+      visible but not compete with the platform name. Add copy or a legend
+      explaining `No run` vs not eligible vs filtered out.
+
+  - id: w7
+    summary: "Verify desktop and mobile leaderboard behavior"
+    needs: [w6]
+    status: pending
+    notes: |
+      Check 390px, 768px, 1280px, and 1600px. At mobile widths, either add a
+      clear horizontal-scroll affordance or introduce compact platform cards
+      that preserve cohort comparison. Keyboard traversal must remain possible
+      without invisible focus or focus/selection ambiguity.
+
+must_preserve:
+  - "Existing leaderboard URL mode contract (`?mode=ranks`, `?mode=speedup`) unless explicitly migrated."
+  - "Clickable cohort headers and result receipt links."
+  - "Coverage policy: missing cohorts are not scored; coverage is shown separately."
+  - "High-contrast/reduced-color path for heatmap cells."
+
+anti_patterns:
+  - "DO NOT hide metric direction in title attributes only."
+  - "DO NOT use the same green pill style for trust, validation, computed, and ranking states."
+  - "DO NOT make missing runs look like slow runs or zero values."
+  - "DO NOT remove keyboard grid navigation while fixing focus styling."
+
+verification:
+  - description: "MetaLeaderboard unit and accessibility tests pass"
+    command: "cd results-explorer && npm test -- src/components/__tests__/MetaLeaderboard.test.tsx src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+    expected_output: "all MetaLeaderboard tests pass"
+  - description: "Home page browser smoke covers all three modes"
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npx playwright test --project=chromium --grep home"
+    expected_output: "home smoke passes for times, ranks, and speedup"
+  - description: "Manual visual QA across requested viewports"
+    command: "echo 'Manual: capture /results/ at 390, 768, 1280, 1600 in times/ranks/speedup and verify focus, units, heatmap, missing runs, badges, and coverage labels'"
+    expected_output: "manual evidence captured in _project/audits/"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/components/TrustBadge.tsx"
+    - "results-explorer/src/components/TuningBadge.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/lib/chartMath.ts"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+    - "results-explorer/src/pages/__tests__/Home.test.tsx"
+    - "results-explorer/e2e/routes/home.spec.ts"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - leaderboard
+    - heatmap
+    - accessibility
+  estimated_effort: "Medium (~2 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Makes the landing leaderboard credible as the public face of BenchBox
+    results.
+  user_impact: |
+    Users can understand what each value means, what is missing, and whether a
+    platform is actually better.
+  technical_debt: |
+    Clarifies the semantic contract between ranking data, visual encoding, and
+    accessibility behavior.

--- a/_project/TODO/main/planning/results-explorer-retheme-query-workbench.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-query-workbench.yaml
@@ -1,0 +1,167 @@
+id: results-explorer-retheme-query-workbench
+title: "Polish Query Workbench into a coherent public explorer surface"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The Query Workbench is functional, but the retheme audit found that it still
+  looks and behaves like an internal debugging tool. Desktop prioritizes
+  `Visible Columns` above the result table, filters use plain white cards and
+  native checkboxes, the mobile drawer is a default full-screen list, and the
+  advanced SQL surface competes with the primary browse workflow. The page also
+  inherits inconsistent button, table, card, chip, and form styling.
+
+  This item should preserve the power-user capability while making the default
+  experience understandable for public users who want to filter, inspect, and
+  export result bundles.
+
+deps:
+  needs:
+    - results-explorer-retheme-theme-system-foundation
+
+work:
+  - id: w1
+    summary: "Define the public Query Workbench workflow and advanced-only controls"
+    status: pending
+    notes: |
+      Decide which controls belong in the primary path:
+        - result count;
+        - filters;
+        - result rows;
+        - row limit;
+        - export.
+
+      Move developer/power-user controls behind advanced affordances:
+        - visible column introspection;
+        - SQL scratchpad;
+        - build SQL from filters.
+
+      Document the decision in the TODO notes or a short analysis file.
+
+  - id: w2
+    summary: "Retheme the query header, summary toolbar, row-limit control, and exports"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply shared primitives. The toolbar should read as a single control
+      surface rather than separate default buttons. Export buttons should have
+      predictable states and not crowd mobile widths.
+
+  - id: w3
+    summary: "Redesign desktop and mobile filters"
+    needs: [w2]
+    status: pending
+    notes: |
+      Convert `FacetRail`/`FacetDrawer` to the shared filter system:
+        - clearer active filter chips;
+        - consistent checkbox styling and target size;
+        - reset affordance;
+        - count labels;
+        - mobile drawer header/footer actions;
+        - focus trap and escape behavior preserved.
+
+      The mobile drawer should feel like an app-level filter panel, not a
+      browser-default form list.
+
+  - id: w4
+    summary: "Move and retheme Visible Columns"
+    needs: [w2]
+    status: pending
+    notes: |
+      Visible Columns should not occupy the first desktop data slot by default.
+      Move it below the table, into a disclosure, or into a compact configuration
+      popover. Keep schema-driven columns and URL/export behavior intact.
+
+  - id: w5
+    summary: "Retheme result and SQL tables with consistent formatting"
+    needs: [w3, w4]
+    status: pending
+    notes: |
+      Use the shared data-table primitive. Confirm:
+        - units and numeric columns are aligned consistently;
+        - dates do not wrap awkwardly unless intentionally compacted;
+        - row action remains discoverable;
+        - selected/sorted states are visible;
+        - horizontal scroll has an affordance at 390px and 768px.
+
+  - id: w6
+    summary: "Retheme Advanced SQL and starter queries"
+    needs: [w5]
+    status: pending
+    notes: |
+      Keep SQL available, but position it as advanced. The text area, starter
+      query chips, run button, errors, and SQL result table should use the same
+      component language as the rest of the page.
+
+  - id: w7
+    summary: "Verify URL state, export behavior, mobile drawer, and keyboard paths"
+    needs: [w6]
+    status: pending
+    notes: |
+      Regression checks should cover:
+        - facet URL round trip;
+        - row-limit mode;
+        - visible columns do not leak hidden `result_id` into exports;
+        - CSV/JSON export still works;
+        - mobile drawer focus trap;
+        - keyboard tab order through filters, toolbar, table, and advanced SQL.
+
+must_preserve:
+  - "Query Workbench route `/results/query`."
+  - "Shareable facet URL state."
+  - "Schema-driven visible column list."
+  - "CSV and JSON export output exactly the user-visible selected columns."
+  - "Hidden `result_id` remains available for row View links."
+  - "SQL scratchpad remains read-only against the browser snapshot."
+
+anti_patterns:
+  - "DO NOT turn Query Workbench into a marketing explainer page; it is a tool surface."
+  - "DO NOT make every column visible by default to avoid designing the column controls."
+  - "DO NOT remove SQL/export power features; make them subordinate to the primary workflow."
+  - "DO NOT break mobile drawer focus trapping while retheming the filters."
+
+verification:
+  - description: "Query page unit tests pass"
+    command: "cd results-explorer && npm test -- src/pages/__tests__/Query.test.tsx src/components/__tests__/FacetRail.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Query browser smoke passes"
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npx playwright test --project=chromium --grep query"
+    expected_output: "query route smoke passes"
+  - description: "Manual Query responsive QA"
+    command: "echo 'Manual: capture /results/query at 390, 768, 1280, 1600; test filters drawer, exports, visible columns, SQL, row action, and table overflow'"
+    expected_output: "manual evidence captured in _project/audits/"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/components/FacetRail.tsx"
+    - "results-explorer/src/lib/queryFilters.ts"
+    - "results-explorer/src/lib/facetModel.ts"
+    - "results-explorer/src/lib/facetDisplay.ts"
+    - "results-explorer/src/pages/__tests__/Query.test.tsx"
+    - "results-explorer/src/components/__tests__/FacetRail.test.tsx"
+    - "results-explorer/e2e/"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - query-workbench
+    - filters
+    - usability
+  estimated_effort: "Medium (~2 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Turns a powerful but internal-feeling workbench into a credible public tool.
+  user_impact: |
+    Users can filter, inspect, and export results without needing to understand
+    the underlying DuckDB schema first.
+  technical_debt: |
+    Consolidates facet and table behavior around reusable components.

--- a/_project/TODO/main/planning/results-explorer-retheme-release-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-release-gate.yaml
@@ -1,0 +1,176 @@
+id: results-explorer-retheme-release-gate
+title: "Gate the Results Explorer retheme with route, viewport, and evidence-based QA"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The retheme should not be considered complete after isolated component or page
+  changes. The final release gate must rerun the maintained Results Explorer QA
+  plan plus the specific 2026-05-07 design audit checks: brand coherence,
+  visual hierarchy, retheme completeness, usability, accessibility,
+  responsiveness, and data-presentation quality.
+
+  This item closes the remediation sequence. It should produce durable evidence
+  that every public route renders without internal errors, looks coherent at the
+  requested breakpoints, and communicates benchmark rigor without visual or
+  semantic ambiguity.
+
+deps:
+  needs:
+    - results-explorer-retheme-schema-cost-regression
+    - results-explorer-retheme-theme-system-foundation
+    - results-explorer-retheme-leaderboard-semantics
+    - results-explorer-retheme-browse-pages
+    - results-explorer-retheme-result-and-compare
+    - results-explorer-retheme-query-workbench
+    - results-explorer-retheme-responsive-accessibility
+
+work:
+  - id: w1
+    summary: "Prepare the final QA run plan and route matrix"
+    status: pending
+    notes: |
+      Base the matrix on `docs/operations/results-explorer-qa.md` and add the
+      design audit requirements:
+        - `/results/`;
+        - `/results/tpch/`;
+        - `/results/star_schema/`;
+        - `/results/p/duckdb/`;
+        - `/results/p/datafusion/`;
+        - `/results/p/polars/`;
+        - representative result detail routes;
+        - same-cohort Compare;
+        - mismatch Compare;
+        - `/results/query`;
+        - bad result/not-found states.
+
+      Viewports: 390px, 768px, 1280px, 1600px.
+
+  - id: w2
+    summary: "Run cold-load route checks with console and network capture"
+    needs: [w1]
+    status: pending
+    notes: |
+      For each route, cold-load with cache disabled where practical. Record:
+        - full URL;
+        - page title;
+        - visible heading;
+        - console warnings/errors;
+        - non-2xx network responses;
+        - whether raw SQL/internal errors are visible.
+
+      Any route showing `Binder Error`, stack traces, undefined IDs, or blank
+      loaded states is a release blocker.
+
+  - id: w3
+    summary: "Capture final screenshots across the viewport matrix"
+    needs: [w2]
+    status: pending
+    notes: |
+      Store screenshots under
+      `_project/audits/screenshots/results-explorer-retheme-final-<date>/`.
+      For long pages, capture first viewport and the primary data/chart/table
+      viewport. Include at least Home times/ranks/speedup, Result Detail chart
+      section, Compare chart section, Query filters, Benchmark matrix/list, and
+      Platform table/trend.
+
+  - id: w4
+    summary: "Run interaction QA for filters, modes, compare, query, and disclosures"
+    needs: [w3]
+    status: pending
+    notes: |
+      Exercise:
+        - Home mode and sort controls;
+        - benchmark scale/phase/view/high-contrast controls;
+        - benchmark/platform selection to Compare;
+        - Compare baseline selector and share URL;
+        - Query filters, row-limit, visible columns, CSV/JSON export, SQL;
+        - Result Detail methodology and sample disclosures;
+        - navigation and breadcrumbs.
+
+      Verify URL state round trips where documented.
+
+  - id: w5
+    summary: "Run automated checks and browser smoke"
+    needs: [w4]
+    status: pending
+    notes: |
+      Run the broadest practical local suite before release:
+        - `cd results-explorer && npm run typecheck`
+        - `cd results-explorer && npm test`
+        - `cd results-explorer && npm run build`
+        - targeted Playwright smoke, at least Chromium.
+
+      If full browser suites are too slow or require unavailable browsers,
+      document the skipped browser and reason.
+
+  - id: w6
+    summary: "Write the release-readiness report and file residual defects"
+    needs: [w5]
+    status: pending
+    notes: |
+      Produce `_project/audits/results-explorer-retheme-final-<date>.md`
+      with:
+        - verdict: ready, partially ready, or not ready;
+        - route matrix;
+        - screenshot index;
+        - console/network summary;
+        - accessibility/responsive summary;
+        - residual issues with severity and owner TODO.
+
+      Do not mark this TODO done if any Blocker or unowned Major finding
+      remains.
+
+must_preserve:
+  - "Maintained QA plan in `docs/operations/results-explorer-qa.md` remains the baseline."
+  - "Final evidence is stored under `_project/audits/` and can be replayed by future reviewers."
+  - "No launch-ready verdict without benchmark and platform pages rendering data."
+
+anti_patterns:
+  - "DO NOT substitute unit tests for visual and interaction QA on this retheme."
+  - "DO NOT ignore console or network errors because the page looks acceptable."
+  - "DO NOT mark the retheme ready while any raw internal error is visible."
+  - "DO NOT bury residual defects in prose; every release-blocking issue needs a concrete TODO or fix."
+
+verification:
+  - description: "Frontend verification suite passes"
+    command: "cd results-explorer && npm run typecheck && npm test && npm run build"
+    expected_output: "all commands pass"
+  - description: "Chromium browser smoke passes"
+    command: "cd results-explorer && npm run test:e2e:chromium"
+    expected_output: "all Chromium e2e checks pass"
+  - description: "Final readiness report exists"
+    command: "test -n \"$(find _project/audits -maxdepth 1 -name 'results-explorer-retheme-final-*.md' -print -quit)\""
+    expected_output: "at least one final readiness report exists"
+
+scope_limit:
+  only_modify:
+    - "_project/audits/"
+    - "docs/operations/results-explorer-qa.md"
+    - "results-explorer/e2e/"
+    - "results-explorer/src/"
+  do_not_modify:
+    - "results-data/bundles/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - release-gate
+    - qa
+    - visual-regression
+  estimated_effort: "Small to Medium (~1 day after retheme work lands)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Provides a defensible release gate for a public-facing BenchBox product
+    surface.
+  user_impact: |
+    Users receive a coherent, tested, accessible explorer rather than a partial
+    retheme with hidden broken routes.
+  technical_debt: |
+    Converts the ad hoc design audit into a repeatable release-readiness check.

--- a/_project/TODO/main/planning/results-explorer-retheme-responsive-accessibility.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-responsive-accessibility.yaml
@@ -1,0 +1,170 @@
+id: results-explorer-retheme-responsive-accessibility
+title: "Run integrated responsive and accessibility hardening for the rethemed Explorer"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The retheme audit found cross-route responsive and accessibility risks:
+  the mobile secondary nav can hide the Query item off-canvas, dense tables rely
+  on horizontal overflow without obvious affordances, Compare charts overflow
+  their SVG/container at several widths, Result Detail charts can exceed mobile
+  viewport width, and focus styling can be confused with analytical selection.
+  These issues cut across pages and should be hardened after the shared theme
+  and page-specific rethemes land.
+
+  This item is the integrated pass for WCAG AA visible risks, keyboard paths,
+  target sizes, table overflow, chart overflow, nav behavior, focus-visible
+  semantics, and responsive layouts at 390px, 768px, 1280px, and 1600px.
+
+deps:
+  needs:
+    - results-explorer-retheme-theme-system-foundation
+    - results-explorer-retheme-leaderboard-semantics
+    - results-explorer-retheme-browse-pages
+    - results-explorer-retheme-result-and-compare
+    - results-explorer-retheme-query-workbench
+
+work:
+  - id: w1
+    summary: "Define the responsive contracts per route and data surface"
+    status: pending
+    notes: |
+      For each route, specify whether the main data surface uses:
+        - horizontal table scroll with sticky first/action columns;
+        - card summaries;
+        - responsive chart resizing;
+        - stacked control groups;
+        - drawer/filter panel.
+
+      Cover `/results/`, benchmark, platform, result detail, compare, query,
+      and error/not-found states.
+
+  - id: w2
+    summary: "Fix mobile and tablet navigation discoverability"
+    needs: [w1]
+    status: pending
+    notes: |
+      The audit observed the Query nav item off-canvas at 390px. Add a mobile
+      navigation pattern or visible scroll affordance so all Explorer nav items
+      are discoverable. Ensure active route state remains clear and target
+      sizes are at least 44px where practical.
+
+  - id: w3
+    summary: "Harden table overflow and sticky action behavior"
+    needs: [w1]
+    status: pending
+    notes: |
+      Audit every table/grid:
+        - Home MetaLeaderboard;
+        - Benchmark QueryHeatmap matrix;
+        - PlatformIndex table;
+        - Query Workbench result and SQL tables;
+        - Result Detail timing/sample tables;
+        - Compare query diff table.
+
+      Add scroll shadows, labels, sticky first/action columns, or card fallbacks
+      so users understand more content is available.
+
+  - id: w4
+    summary: "Harden chart sizing and SVG overflow"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add tests or Playwright checks where feasible to catch:
+        - SVGs wider than their container;
+        - labels clipped outside chart bounds;
+        - huge blank plot regions;
+        - legends overlapping chart content;
+        - charts collapsing before ResizeObserver fires.
+
+      Cover Result Detail and Compare first because the audit found concrete
+      overflow there.
+
+  - id: w5
+    summary: "Normalize focus-visible, selected, active, hover, and disabled states"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Focus must indicate keyboard location only. Active tab, selected row,
+      analytical highlight, validation status, and hover must each have distinct
+      visual language. Check segmented controls, filters, tables, chart tabs,
+      compare selection, links, and disclosures.
+
+  - id: w6
+    summary: "Run WCAG AA contrast and target-size checks on rethemed routes"
+    needs: [w5]
+    status: pending
+    notes: |
+      Use axe where already wired plus manual checks for:
+        - dark header contrast;
+        - muted text on light panels;
+        - pale green/yellow badge contrast;
+        - heatmap and reduced-color mode;
+        - disabled/missing data states;
+        - focus ring contrast;
+        - tap target sizes in mobile nav/filter/table actions.
+
+  - id: w7
+    summary: "Record final responsive/a11y evidence and defects"
+    needs: [w6]
+    status: pending
+    notes: |
+      Capture screenshots and findings under `_project/audits/` for 390px,
+      768px, 1280px, and 1600px. Any remaining issue that would block public
+      release must become a concrete TODO or be fixed before the release-gate
+      item is marked done.
+
+must_preserve:
+  - "All existing public routes and share URLs."
+  - "Keyboard access to leaderboard cells, filters, table sort controls, chart tabs, disclosures, and row actions."
+  - "High-contrast/reduced-color behavior for heatmaps."
+  - "Dense data scanability at desktop widths."
+
+anti_patterns:
+  - "DO NOT treat horizontal scrolling as acceptable without a visible affordance."
+  - "DO NOT use focus rings to represent active tabs, selected rows, or data highlights."
+  - "DO NOT hide navigation items on mobile without an obvious menu or scroll cue."
+  - "DO NOT rely on color alone for trust, validation, speedup, warning, or missing-data meaning."
+
+verification:
+  - description: "Axe-backed component/page tests pass"
+    command: "cd results-explorer && npm test -- src/components/__tests__ src/pages/__tests__"
+    expected_output: "all relevant accessibility/unit tests pass"
+  - description: "Browser responsive smoke passes"
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npx playwright test --project=chromium --grep \"responsive|layout|a11y\""
+    expected_output: "responsive/a11y smoke tests pass"
+  - description: "Manual viewport matrix complete"
+    command: "echo 'Manual: capture every route at 390, 768, 1280, 1600 and inspect nav, focus, overflow, charts, target sizes, and contrast'"
+    expected_output: "manual evidence and findings stored under _project/audits/"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/"
+    - "results-explorer/e2e/"
+    - "results-explorer/playwright.config.ts"
+    - "_project/audits/"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - accessibility
+    - responsive
+    - wcag
+  estimated_effort: "Medium (~2 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Reduces launch risk by checking the complete rethemed experience under real
+    viewport and accessibility constraints.
+  user_impact: |
+    Users on mobile, tablet, keyboard, and high-contrast settings can navigate
+    and compare results reliably.
+  technical_debt: |
+    Adds cross-route responsive contracts that future Explorer work can preserve.

--- a/_project/TODO/main/planning/results-explorer-retheme-result-and-compare.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-result-and-compare.yaml
@@ -1,0 +1,173 @@
+id: results-explorer-retheme-result-and-compare
+title: "Redesign Result Detail and Compare hierarchy, charts, and status semantics"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Result Detail and Compare are where users decide whether a result is credible
+  and whether one platform is meaningfully faster. The audit found that Result
+  Detail overweights the Run Receipt in the first viewport while primary
+  metrics are inline text, and Compare has chart overflow/blank-space issues in
+  the speedup chart. Both pages also inherit the broader badge, table, chart
+  control, and light-surface inconsistencies.
+
+  This item should redesign the information hierarchy for single-result and
+  multi-result analysis. It must preserve reproducibility and methodology
+  detail, but make the first read sharper: what was run, what metric matters,
+  what can be trusted, what differs between runs, and where to inspect query
+  details.
+
+deps:
+  needs:
+    - results-explorer-retheme-theme-system-foundation
+
+work:
+  - id: w1
+    summary: "Map the decision hierarchy for Result Detail and Compare"
+    status: pending
+    notes: |
+      Document the first-viewport priorities for each page:
+        - Result Detail: workload, platform, scale, phase, primary metric,
+          geomean, run date, trust, validation, reproducibility action.
+        - Compare: comparable dimensions, winner/suppression status,
+          baseline, headline delta, query wins, tail shape, warnings.
+
+      Decide what belongs in the first viewport, what belongs in receipt
+      details, and what belongs behind disclosure.
+
+  - id: w2
+    summary: "Redesign Result Detail top summary and receipt placement"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace inline metric text with a compact summary module or metric cards.
+      Keep the Run Receipt prominent enough for credibility, but do not let it
+      consume the whole first analytical read. Consider:
+        - a top metric strip;
+        - receipt summary with expandable sections;
+        - primary actions grouped consistently (`Compare this result`,
+          `Download bundle`, `Copy reproduce command`).
+
+  - id: w3
+    summary: "Retheme Result Detail environment, actions, charts, timing tables, and methodology sections"
+    needs: [w2]
+    status: pending
+    notes: |
+      Apply shared primitives to:
+        - Environment and Actions panels;
+        - ChartPanel controls;
+        - Query Timing table;
+        - Individual samples disclosure;
+        - How this was measured disclosure.
+
+      Query tables should format units consistently (`ms`, sample count,
+      status) and keep sorting indicators legible.
+
+  - id: w4
+    summary: "Redesign Compare top summary, comparability receipt, and baseline control"
+    needs: [w1]
+    status: pending
+    notes: |
+      Compare should lead with:
+        - clear comparability status;
+        - warning count and specific differences;
+        - decision summary only when comparisons are valid;
+        - baseline control placed near ratio/delta interpretation.
+
+      Receipt cards should not all look identical; match/differs/not-recorded
+      need distinct status treatments.
+
+  - id: w5
+    summary: "Fix Compare chart layout, overflow, labels, and default chart choice"
+    needs: [w4]
+    status: pending
+    notes: |
+      The audit saw the speedup chart waste large empty space and allow bars or
+      labels to overflow at 768px, 1280px, and 1600px. Rework chart domain,
+      margins, label placement, and responsive sizing. For two-result compares,
+      choose the clearest default chart rather than a generic high-dimensional
+      plot.
+
+  - id: w6
+    summary: "Retheme Query-Level Diff and result cards"
+    needs: [w5]
+    status: pending
+    notes: |
+      The query-level diff table should remain dense, but it needs consistent
+      units, badge semantics (`Faster`, `Slower`, `Same`), sticky/scroll behavior
+      on mobile, and a clearer relationship to the selected baseline.
+
+  - id: w7
+    summary: "Add focused regression coverage for charts and hierarchy"
+    needs: [w3, w6]
+    status: pending
+    notes: |
+      Add tests for:
+        - first-viewport summary labels;
+        - comparability status labels;
+        - baseline selector semantics;
+        - chart container width/height not collapsing;
+        - no SVG overflow in common chart cases if feasible in Playwright.
+
+must_preserve:
+  - "Result detail route `/results/r/{result_id}`."
+  - "Compare route `?ids=` share URL contract and compact ID canonicalization."
+  - "Run Receipt reproducibility details and download links."
+  - "Comparability receipt logic and mismatch suppression behavior."
+  - "Benchmark-derived primary metric semantics."
+
+anti_patterns:
+  - "DO NOT demote reproducibility so far that the result no longer feels auditable."
+  - "DO NOT claim a winner when severe benchmark/scale mismatches suppress winner claims."
+  - "DO NOT use chart labels that overflow the SVG viewport or require horizontal page scroll."
+  - "DO NOT introduce a user-selectable primary metric toggle unless the benchmark-derived contract is intentionally reopened."
+
+verification:
+  - description: "Result Detail and Compare tests pass"
+    command: "cd results-explorer && npm test -- src/pages/__tests__/ResultDetail.test.tsx src/pages/__tests__/Compare.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx src/components/__tests__/QueryDiffTable.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Chart smoke tests pass"
+    command: "cd results-explorer && npm test -- src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/ChartPanel.test.tsx"
+    expected_output: "chart tests pass"
+  - description: "Manual compare/detail responsive captures are clean"
+    command: "echo 'Manual: capture result detail and compare at 390, 768, 1280, 1600; inspect first viewport, charts, tables, disclosures, and overflow'"
+    expected_output: "manual evidence captured in _project/audits/"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/components/RunReceipt.tsx"
+    - "results-explorer/src/components/ComparabilityReceipt.tsx"
+    - "results-explorer/src/components/CompareSummary.tsx"
+    - "results-explorer/src/components/QueryDiffTable.tsx"
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/components/*Chart*.tsx"
+    - "results-explorer/src/pages/__tests__/ResultDetail.test.tsx"
+    - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/e2e/"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - result-detail
+    - compare
+    - charts
+  estimated_effort: "Medium (~2-3 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Improves the pages that prove reproducibility and comparison value.
+  user_impact: |
+    Users can quickly understand a result, compare it fairly, and inspect
+    query-level evidence.
+  technical_debt: |
+    Consolidates chart and status patterns that currently vary by page.

--- a/_project/TODO/main/planning/results-explorer-retheme-schema-cost-regression.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-schema-cost-regression.yaml
@@ -1,0 +1,169 @@
+id: results-explorer-retheme-schema-cost-regression
+title: "Fix Results Explorer cost-schema drift before retheme QA"
+worktree: main
+priority: Critical
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The 2026-05-07 retheme audit found that the benchmark and platform browse
+  routes cannot render their primary data surfaces. `/results/tpch/`,
+  `/results/star_schema/`, and `/results/p/duckdb/` display DuckDB binder
+  errors because frontend queries reference `r.normalized_cost_usd` and
+  related cost-model fields that are not present in the current
+  `bench.results` snapshot. The visible error exposes raw SQL and prevents
+  meaningful design, usability, accessibility, or data-presentation QA on
+  those pages.
+
+  This is the first remediation item because every page-level retheme depends
+  on a working data read model. The fix must reconcile the Explorer's query
+  contract with the generated DuckDB snapshot and add regression coverage so
+  future read-model drift fails in tests instead of in the public UI.
+
+deps:
+  needs: []
+
+work:
+  - id: w1
+    summary: "Reproduce and capture the current benchmark/platform route failures"
+    status: pending
+    notes: |
+      Run the dev server against the committed fixture corpus and cold-load:
+        - `/results/tpch/?sf=0.01&phase=standard`
+        - `/results/star_schema/?sf=0.1&phase=power`
+        - `/results/p/duckdb/`
+        - `/results/p/datafusion/`
+
+      Capture the exact visible error, browser console output, and the DuckDB
+      query source that emitted `normalized_cost_usd`. Save the reproduction
+      log under `_project/verification-logs/results-explorer-retheme-schema-cost-regression/w1.log`.
+
+  - id: w2
+    summary: "Audit the current snapshot schema against every Explorer query that reads cost fields"
+    needs: [w1]
+    status: pending
+    notes: |
+      Inspect:
+        - `results-explorer/src/lib/duckdbQueries.ts`
+        - `results-explorer/src/lib/duckdbSchema.ts`
+        - `results-explorer/src/lib/costDisplay.ts`
+        - fixture generation under `results-explorer/scripts/`
+        - the generated DuckDB snapshot in `results-explorer/public/data/`
+
+      Produce a field matrix for `cost_usd`, `normalized_cost_usd`,
+      `cost_model_version`, `cost_model_scope`, `cost_status`, and any display
+      alias used by Home, BenchmarkIndex, PlatformIndex, Query, ResultDetail,
+      and Compare. The matrix must name the source table/view, nullability, and
+      expected fallback behavior.
+
+  - id: w3
+    summary: "Choose and document the compatibility strategy"
+    needs: [w2]
+    status: pending
+    notes: |
+      Choose one path and record the decision in
+      `_project/analysis/results-explorer-cost-schema-compatibility-<date>.md`:
+        1. regenerate or migrate the snapshot to include normalized cost fields;
+        2. make frontend queries tolerate older snapshots by projecting nulls
+           when fields are absent;
+        3. change the canonical Explorer cost contract back to `cost_usd`
+           only, if normalized cost is no longer product-owned.
+
+      The decision must explain impact on published bundles, fixture
+      generation, Query Workbench visible columns, and the planned retheme
+      release gate.
+
+  - id: w4
+    summary: "Implement the query/read-model fix with a schema-readiness guard"
+    needs: [w3]
+    status: pending
+    notes: |
+      Apply the chosen compatibility strategy in the smallest owning layer.
+      If the frontend is made tolerant of missing fields, centralize that
+      behavior in `duckdbSchema`/`duckdbQueries` rather than sprinkling
+      `try/catch` across pages. If the snapshot is regenerated, add a guard
+      that verifies the expected columns before the app renders benchmark or
+      platform pages.
+
+  - id: w5
+    summary: "Add unit and browser regression coverage for benchmark and platform page readiness"
+    needs: [w4]
+    status: pending
+    notes: |
+      Add tests that fail when BenchmarkIndex or PlatformIndex query a missing
+      cost column. Include at least:
+        - one DuckDB query test for the projected schema;
+        - one BenchmarkIndex render test for TPC-H;
+        - one PlatformIndex render test for DuckDB;
+        - one browser smoke assertion that the routes do not show `Binder Error`.
+
+  - id: w6
+    summary: "Verify the fixed routes before any visual retheme work begins"
+    needs: [w5]
+    status: pending
+    notes: |
+      Cold-load the four routes from w1 at 390px and 1280px. Confirm:
+        - no raw SQL/internal error is visible;
+        - table/matrix content renders;
+        - empty states, if any, explain corpus absence rather than query failure;
+        - console has no route-level errors.
+
+must_preserve:
+  - "Existing published result IDs and route contracts under `/results/r/{result_id}`."
+  - "The Query Workbench column picker continues to reflect the actual snapshot schema."
+  - "Cost fields remain optional where the corpus does not provide cost data."
+  - "Benchmark and platform pages continue to render when normalized cost is unavailable."
+
+anti_patterns:
+  - "DO NOT hide the binder error with a broad catch while leaving the query contract broken."
+  - "DO NOT add per-page ad hoc SQL fallbacks; schema compatibility belongs in the data/query layer."
+  - "DO NOT require cost data for benchmark ranking eligibility unless the product decision explicitly changes ranking semantics."
+
+verification:
+  - description: "Frontend typecheck and targeted tests pass"
+    command: "cd results-explorer && npm run typecheck && npm test -- src/lib/__tests__/duckdbQueries.test.ts src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Production bundle builds"
+    command: "cd results-explorer && npm run build"
+    expected_output: "Vite build completes without errors"
+  - description: "Browser routes do not expose DuckDB binder errors"
+    command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npx playwright test --project=chromium --grep \"benchmark|platform\""
+    expected_output: "benchmark and platform smoke checks pass with no visible Binder Error"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/lib/duckdbQueries.ts"
+    - "results-explorer/src/lib/duckdbSchema.ts"
+    - "results-explorer/src/lib/costDisplay.ts"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+    - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
+    - "results-explorer/src/lib/__tests__/duckdbQueries.test.ts"
+    - "results-explorer/e2e/"
+    - "results-explorer/scripts/"
+    - "_project/analysis/results-explorer-cost-schema-compatibility-*.md"
+    - "_project/verification-logs/results-explorer-retheme-schema-cost-regression/"
+  do_not_modify:
+    - "benchbox/"
+    - "results-data/bundles/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - schema-drift
+    - duckdb-wasm
+    - blocker
+  estimated_effort: "Small to Medium (~1 day)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Restores the public browse routes required for a credible results product.
+  user_impact: |
+    Users see benchmark/platform data or clear empty states instead of raw SQL
+    diagnostics.
+  technical_debt: |
+    Converts a fragile implicit read-model assumption into tested schema
+    compatibility.

--- a/_project/TODO/main/planning/results-explorer-retheme-theme-system-foundation.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-theme-system-foundation.yaml
@@ -1,0 +1,174 @@
+id: results-explorer-retheme-theme-system-foundation
+title: "Establish Results Explorer theme tokens and shared UI primitives"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The retheme audit found a split visual system: Home and the global header use
+  dark BenchBox variables such as `--bb-bg-primary`, while most downstream
+  pages still use legacy Tailwind light surfaces (`bg-white`, `bg-gray-50`),
+  default rounded cards, native selects, plain checkboxes, inconsistent
+  segmented controls, and mixed badge treatments. This makes the Explorer feel
+  like several prototypes stitched together instead of one BenchBox product.
+
+  This item creates the design-system foundation required before page-specific
+  retheme work. It should define the intended surface model, tokens, and shared
+  components for cards, panels, buttons, tabs, forms, tables, badges, errors,
+  empty states, and chart controls. Page-level TODOs should consume these
+  primitives rather than inventing local class strings.
+
+deps:
+  needs: []
+
+work:
+  - id: w1
+    summary: "Inventory current style usage and mismatches across the Explorer"
+    status: pending
+    notes: |
+      Use `rg` over `results-explorer/src` to count and categorize direct
+      usage of:
+        - `bg-white`, `bg-gray-50`, `bg-gray-100`, `bg-gray-900`;
+        - `rounded-lg`, `rounded-md`, `shadow-sm`;
+        - `badge-*`;
+        - direct `brand-*` active states;
+        - native `select`, `input[type=checkbox]`, and table classes.
+
+      Output a concise inventory in this TODO or in
+      `_project/analysis/results-explorer-theme-inventory-<date>.md` naming
+      the highest-churn files and the primitives they should consume.
+
+  - id: w2
+    summary: "Decide the Explorer surface model and token contract"
+    needs: [w1]
+    status: pending
+    notes: |
+      Make an explicit product/design decision:
+        - dark BenchBox shell plus light analytical data panels; or
+        - fully dark analytical product; or
+        - fully light docs-adjacent product with dark global chrome.
+
+      Default recommendation from the audit: dark BenchBox global shell and
+      hero/filter summary surfaces, with restrained light data panels for dense
+      tables and charts. Document the decision, including acceptable uses of
+      dark surfaces, light panels, shadows, borders, and accent colors.
+
+  - id: w3
+    summary: "Create reusable tokens for surfaces, borders, text, focus, charts, badges, and states"
+    needs: [w2]
+    status: pending
+    notes: |
+      Extend `results-explorer/src/index.css` and Tailwind config only where
+      needed. Tokens must cover:
+        - app background;
+        - global chrome;
+        - hero/brand panel;
+        - data panel;
+        - elevated panel;
+        - table header/body/sticky cell;
+        - error/warning/empty/loading;
+        - focus-visible ring;
+        - chart categorical, sequential, diverging, success, warning, danger;
+        - trust, validation, visibility, computed, and comparison badge states.
+
+  - id: w4
+    summary: "Introduce shared UI primitives for the retheme"
+    needs: [w3]
+    status: pending
+    notes: |
+      Add or refactor components for:
+        - `Button` variants: primary, secondary, subtle, danger, icon/text;
+        - `SegmentedControl`;
+        - `Tabs`;
+        - `Panel`/`DataCard`;
+        - `DataTable`;
+        - `Select`;
+        - `Checkbox`;
+        - `FacetChip`;
+        - `StatusBadge`;
+        - `ErrorState`;
+        - `EmptyState`;
+        - chart control groups.
+
+      Prefer thin wrappers matching existing Preact style. Do not introduce a
+      heavy component framework.
+
+  - id: w5
+    summary: "Convert global Layout, footer, common badges, loading, error, and chart control shells"
+    needs: [w4]
+    status: pending
+    notes: |
+      Convert:
+        - `Layout.tsx` header, explorer nav, footer;
+        - `TrustBadge.tsx` and `TuningBadge.tsx`;
+        - `ErrorMessage.tsx`;
+        - `LoadingSpinner.tsx` skeleton surfaces;
+        - `ChartPanel.tsx` tab and chart-picker controls.
+
+      The visible result should remove the dark/light seam between the top
+      header, second-level nav, footer, and common cards.
+
+  - id: w6
+    summary: "Add design-system regression coverage and a visual fixture page if practical"
+    needs: [w5]
+    status: pending
+    notes: |
+      Add lightweight tests that verify shared primitives render accessible
+      names, focus states, disabled states, and selected states. If the app has
+      no component preview route, add a test-only render helper rather than a
+      public design-system page.
+
+must_preserve:
+  - "The Explorer remains a static Vite/Preact app under `/results/`."
+  - "Existing route paths and share URLs."
+  - "No new runtime design-system dependency unless justified by a separate decision."
+  - "Dense data tables remain efficient to scan; visual polish must not reduce information density without a product reason."
+
+anti_patterns:
+  - "DO NOT retheme by copying large Tailwind class strings into every page; shared primitives are the point of this item."
+  - "DO NOT let chart colors, badge colors, and link colors all share the same semantic role."
+  - "DO NOT use decorative gradients, large marketing cards, or ornamental backgrounds on data-workflow pages."
+
+verification:
+  - description: "No component-level accessibility regressions"
+    command: "cd results-explorer && npm test -- src/components/__tests__"
+    expected_output: "component tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "TypeScript passes"
+  - description: "Style inventory shows page-level direct theme classes reduced"
+    command: "cd results-explorer && (rg -n \"bg-white|bg-gray-50|shadow-sm|rounded-lg|badge-\" src/pages src/components || true)"
+    expected_output: "remaining matches are either in shared primitives or intentionally documented exceptions; review the command output, do not treat any match count as automatically passing"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/index.css"
+    - "results-explorer/tailwind.config.js"
+    - "results-explorer/src/components/"
+    - "results-explorer/src/components/__tests__/"
+    - "_project/analysis/results-explorer-theme-*.md"
+  do_not_modify:
+    - "results-data/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - design-system
+    - tokens
+    - components
+  estimated_effort: "Medium (~2-3 days)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Gives the public results surface a coherent BenchBox identity and reduces
+    the cost of future UI work.
+  user_impact: |
+    Users experience one product instead of a mix of brand shell and prototype
+    controls.
+  technical_debt: |
+    Removes repeated local Tailwind styling and creates reusable primitives for
+    later route work.

--- a/_project/analysis/results-explorer-retheme-audit-remediation-plan-2026-05-07.md
+++ b/_project/analysis/results-explorer-retheme-audit-remediation-plan-2026-05-07.md
@@ -1,0 +1,123 @@
+# Results Explorer Retheme Audit Remediation Plan
+
+Date: 2026-05-07
+Source audit target: `http://localhost:5173/results/`
+Scope: planning only. This document and the paired TODOs do not implement UI changes.
+
+## Executive Plan
+
+The Results Explorer is not release-ready. The remediation should proceed in
+four layers:
+
+1. Restore route correctness first.
+   Benchmark and platform routes currently expose DuckDB binder errors for
+   `normalized_cost_usd`. No retheme QA is meaningful until `/results/tpch/`,
+   `/results/star_schema/`, and `/results/p/duckdb/` render real data again.
+
+2. Establish the theme system before retheming pages.
+   The current UI mixes dark BenchBox tokens on the Home hero and global header
+   with legacy light Tailwind cards, forms, tables, tabs, badges, and chart
+   controls. The next implementation pass needs shared primitives and tokens,
+   not one-off page edits.
+
+3. Retheme the data experiences by product surface.
+   The highest-risk surfaces are the cross-benchmark leaderboard, benchmark and
+   platform browse pages, result detail and compare, and the query workbench.
+   Each needs a focused TODO because the UX contracts differ.
+
+4. Finish with cross-route responsive, accessibility, and release-gate QA.
+   Mobile navigation, table overflow, chart overflow, keyboard focus, contrast,
+   and badge semantics need a final integrated pass after page-level work lands.
+
+## Findings To TODO Map
+
+| Audit finding | Owning TODO |
+|---|---|
+| Benchmark and platform pages expose raw `normalized_cost_usd` binder errors | `results-explorer-retheme-schema-cost-regression` |
+| Dark BenchBox brand surfaces and light legacy surfaces are mixed | `results-explorer-retheme-theme-system-foundation` |
+| Buttons, selects, checkboxes, tabs, cards, badges, and tables are inconsistent | `results-explorer-retheme-theme-system-foundation` |
+| Leaderboard shows an active-looking blue ring on first load | `results-explorer-retheme-leaderboard-semantics` |
+| Leaderboard mixes units and unclear metric direction across cohorts | `results-explorer-retheme-leaderboard-semantics` |
+| Heatmap colors, blue links, trust badges, validation badges, and missing states compete | `results-explorer-retheme-leaderboard-semantics` |
+| Benchmark and platform browse pages cannot be assessed until they render | `results-explorer-retheme-browse-pages` |
+| Result Detail first viewport overweights the Run Receipt and underweights primary metrics | `results-explorer-retheme-result-and-compare` |
+| Compare charts overflow or waste large empty plot space | `results-explorer-retheme-result-and-compare` |
+| Query Workbench feels like an internal debug surface | `results-explorer-retheme-query-workbench` |
+| Mobile nav hides the Query item and dense tables lack clear scroll affordances | `results-explorer-retheme-responsive-accessibility` |
+| Contrast, focus, target size, table overflow, and chart overflow need integrated QA | `results-explorer-retheme-responsive-accessibility` |
+| Release readiness requires concrete route, viewport, console, network, and screenshot checks | `results-explorer-retheme-release-gate` |
+
+## Dependency Order
+
+```text
+results-explorer-retheme-schema-cost-regression
+        |
+        +--> results-explorer-retheme-browse-pages
+
+results-explorer-retheme-theme-system-foundation
+        |
+        +--> results-explorer-retheme-leaderboard-semantics
+        +--> results-explorer-retheme-browse-pages
+        +--> results-explorer-retheme-result-and-compare
+        +--> results-explorer-retheme-query-workbench
+
+page-level retheme TODOs
+        |
+        +--> results-explorer-retheme-responsive-accessibility
+        |
+        +--> results-explorer-retheme-release-gate
+```
+
+## Product Decisions Required
+
+- Theme model: keep the dark BenchBox shell plus light data panels, or move the
+  full explorer to a dark analytical surface. Default recommendation: dark
+  BenchBox shell, restrained light data panels, and dark-emphasis modules only
+  for hero/filter summary areas.
+- Leaderboard metric language: make every cohort header name the metric, unit,
+  and direction. Do not rely on tooltip-only explanation.
+- Badge taxonomy: separate trust, validation, visibility, computed status,
+  ranking status, and warning states by token, shape, or icon treatment.
+- Mobile data strategy: choose where tables remain horizontally scrollable and
+  where cards replace tables.
+- Query Workbench positioning: decide which controls are primary public workflow
+  and which belong behind an advanced/debug disclosure.
+
+## Acceptance Criteria
+
+The retheme remediation is complete only when:
+
+- `/results/`, benchmark pages, platform pages, result detail pages, compare,
+  and query all render without raw internal errors.
+- Viewports 390px, 768px, 1280px, and 1600px have no unintentional document
+  overflow, clipped controls, or hidden primary navigation.
+- The leaderboard displays units, metric direction, missing-run semantics,
+  trust, validation, and ranking/coverage information without color overload.
+- Compare and Result Detail charts fit inside their containers and have readable
+  labels at desktop, tablet, and mobile widths.
+- Keyboard focus is visible, intentional, and not confused with selected or
+  active analytical state.
+- The final QA pass captures screenshots and console/network evidence for every
+  route in the maintained Results Explorer QA plan.
+
+## TODO Review Pass
+
+The eight TODOs were reviewed against the `/todo review` criteria:
+clarity, completeness, actionability, freshness, guardrails, and work
+breakdown.
+
+| TODO | Review result |
+|---|---|
+| `results-explorer-retheme-schema-cost-regression` | Pass after tightening browser-smoke verification to call Playwright directly. |
+| `results-explorer-retheme-theme-system-foundation` | Pass after making the style-inventory verification explicitly review-based instead of match-count based. |
+| `results-explorer-retheme-leaderboard-semantics` | Pass after tightening Home browser-smoke verification. |
+| `results-explorer-retheme-browse-pages` | Pass after tightening benchmark/platform browser-smoke verification. |
+| `results-explorer-retheme-result-and-compare` | Pass with no review changes required. |
+| `results-explorer-retheme-query-workbench` | Pass after tightening Query browser-smoke verification. |
+| `results-explorer-retheme-responsive-accessibility` | Pass after tightening responsive/a11y browser-smoke verification. |
+| `results-explorer-retheme-release-gate` | Pass after replacing date-specific report verification with a final-report glob. |
+
+No remaining review findings are intentionally deferred. Any future reviewer
+should be able to pick up each TODO independently, see the audit evidence it
+addresses, understand its dependencies, run concrete verification, and avoid
+the explicitly named anti-patterns.


### PR DESCRIPTION
## Summary

Adds a detailed remediation plan for the 2026-05-07 BenchBox Results Explorer retheme audit and synthesizes it into eight planning TODOs:

- schema/cost read-model blocker
- shared theme system foundation
- home leaderboard semantics
- benchmark/platform browse page retheme
- result detail and compare redesign
- query workbench polish
- responsive/accessibility hardening
- final release-readiness gate

## Why

The audit found that the current Explorer is not release-ready: benchmark and platform routes expose DuckDB binder errors, while rendered pages mix the intended dark BenchBox brand direction with legacy light Tailwind controls and inconsistent data-presentation patterns. The new TODO series gives the implementation work dependency order, guardrails, verification commands, and page-specific acceptance criteria.

## Validation

- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex` (generated indexes are gitignored)
- pre-commit hooks on commit, including YAML, markdownlint, whitespace, large-file, merge-conflict, and secret checks
- push hooks, including timing policy fast-lane collect and PR preflight fast tests

## Notes

This is planning-only. It does not modify `results-explorer/src/` or implement UI changes.