### PR TITLE
fix(uat): resolve review-followup remediations

### DIFF
--- a/_project/specs/uat-framework.md
+++ b/_project/specs/uat-framework.md
@@ -488,8 +488,15 @@ reports 1,530 candidate cells, 527 real attempted terminal cells,
 exactly:
 
 ```
-platform | benchmark | scale | status | elapsed_s | log_path | result_path | validator_status
+platform | benchmark | scale | status | elapsed_s | log_path | result_path | submit_terminal_state | validator_status
 ```
+
+The `submit_terminal_state` column was inserted in PR #247 between
+`result_path` and `validator_status`; the historical fixture
+(`tests/uat/fixtures/uat-2026-05-02-matrix-summary-header.tsv`)
+was bumped at the same time. External consumers parsing the TSV by
+positional index (`awk '{print $8}'`) must move `validator_status`
+from column 8 to column 9 to stay correct.
 
 Wall-clock match is impossible (dry-run prints intent without
 invoking benchbox); structural parity is the bar.

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -96,6 +96,26 @@ Inspect a UAT-owned stack with:
 docker compose -p <benchbox-uat-project> ps
 ```
 
+## Explorer smoke (browser)
+
+`make uat-explorer-smoke` invokes Playwright directly against a freshly
+built Explorer app, mirroring the `results-explorer-browser.yml` workflow
+entrypoint. Each invocation runs three steps inside `results-explorer/`
+in order:
+
+1. `npm ci` — clean install of Explorer JS dependencies.
+2. `npm run build` — full Explorer production build.
+3. `npx playwright test --grep @smoke --project <browser>` — the actual
+   smoke run, against the staged data dir.
+
+Steps 1 and 2 are not cached locally, so a single `make uat-explorer-smoke`
+invocation pays the full npm cost every time. The CI workflow caches
+`node_modules/` and the build output; a developer-loop sweep does not. If
+you are iterating on a UAT change unrelated to the Explorer browser smoke,
+prefer running the targeted test (`uv run -- python -m pytest
+tests/uat/test_explorer_smoke.py -m fast`) and reserve
+`make uat-explorer-smoke` for end-to-end validation.
+
 ## Submission terminal states
 
 The package phase reads `package.submit_terminal_state` from YAML;

--- a/tests/uat/phases/preflight.py
+++ b/tests/uat/phases/preflight.py
@@ -14,23 +14,30 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
+from tests.uat import docker_assets
 from tests.uat.matrix import platform_is_reachable, reset_reachability_cache, resolve_platforms
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-AUTOMATED_LOCAL_PLATFORMS: tuple[str, ...] = (
-    "cedardb",
-    "clickhouse-server",
-    "databend",
-    "doris",
-    "influxdb",
-    "postgresql",
-    "presto",
-    "questdb",
-    "singlestore",
-    "starrocks",
-    "trino",
-    "velox",
-)
+
+
+def automated_local_platforms() -> tuple[str, ...]:
+    """Derive the UAT-managed local platform set from `docker_assets`.
+
+    Single source of truth: a platform is UAT-managed iff its
+    `DockerPlatformSpec.managed_start_allowed` is true and it has no
+    `fixed_container_names`. Mirrors the rule used by
+    `scripts/uat-bring-up/uat_bring_up.py:automated_platforms`.
+    """
+    return tuple(
+        sorted(
+            platform
+            for platform, spec in docker_assets.docker_platform_specs().items()
+            if spec.managed_start_allowed and not spec.fixed_container_names
+        )
+    )
+
+
+AUTOMATED_LOCAL_PLATFORMS: tuple[str, ...] = automated_local_platforms()
 
 BringUpRunner = Callable[[str], int]
 ReachabilityChecker = Callable[[str], bool]
@@ -169,10 +176,11 @@ def _check_local_platforms(
     checked = tuple(dict.fromkeys(requested_platforms))
     attempted: list[str] = []
     warnings: list[str] = []
+    automated = set(automated_local_platforms())
     for platform in checked:
         if reachability_checker(platform):
             continue
-        if platform not in AUTOMATED_LOCAL_PLATFORMS:
+        if platform not in automated:
             return (
                 checked,
                 tuple(attempted),

--- a/tests/uat/test_preflight.py
+++ b/tests/uat/test_preflight.py
@@ -113,6 +113,14 @@ def test_uat_bring_up_velox_passes_benchmark_runs_dir_env(tmp_path: Path, monkey
     assert "UAT bring-up OK" in capsys.readouterr().out
 
 
+def test_preflight_automated_set_matches_script_automated_set():
+    """Preflight and the bring-up script must agree on which platforms are automated."""
+    bring_up = _load_bring_up_module()
+
+    assert bring_up.automated_platforms() == preflight.automated_local_platforms()
+    assert bring_up.automated_platforms() == preflight.AUTOMATED_LOCAL_PLATFORMS
+
+
 def _load_bring_up_module():
     path = Path("scripts/uat-bring-up/uat_bring_up.py").resolve()
     spec = importlib.util.spec_from_file_location("uat_bring_up", path)


### PR DESCRIPTION
Address remaining items from the post-#255 review:

- preflight: derive AUTOMATED_LOCAL_PLATFORMS from docker_assets so
  the bring-up script and the preflight allowlist share a single
  source of truth. Adds a regression test that pins both sides to
  the same set.
- spec: document the matrix-summary TSV column-order bump that
  PR #247 introduced (`submit_terminal_state` between `result_path`
  and `validator_status`).
- ops doc: warn that `make uat-explorer-smoke` runs a full `npm ci`
  + `npm run build` per invocation and is not locally cached.

The disk_budget_table.tsv `peak_database_gib=0.0` clarification is
deferred until PR #245 lands; nothing to annotate on develop yet.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
