### PR TITLE
chore(tuning): rename static_regressions to static_matrix_drift

### DIFF
--- a/benchbox/core/tuning/coverage.py
+++ b/benchbox/core/tuning/coverage.py
@@ -162,25 +162,31 @@ def read_tuning_coverage_tsv(path: Path) -> list[TuningCoverageRow]:
     return rows
 
 
-def static_regressions(
+def static_matrix_drift(
     recorded_rows: Iterable[TuningCoverageRow],
     current_rows: Iterable[TuningCoverageRow],
 ) -> list[str]:
-    """Return checked-in matrix drift that would hide coverage regressions."""
+    """Return checked-in matrix drift that would hide coverage regressions.
+
+    Flags three kinds of drift between the checked-in TSV and the
+    currently-derived inventory: (1) recorded keys missing from current,
+    (2) status downgrades vs. the recorded baseline, and (3) newly-derived
+    keys that have not yet been added to the matrix.
+    """
     recorded_by_key = {row.key: row for row in recorded_rows}
     current_by_key = {row.key: row for row in current_rows}
-    regressions: list[str] = []
+    drift: list[str] = []
     for recorded in recorded_by_key.values():
         current = current_by_key.get(recorded.key)
         if current is None:
-            regressions.append(f"missing current row for {recorded.platform}/{recorded.benchmark}")
+            drift.append(f"missing current row for {recorded.platform}/{recorded.benchmark}")
             continue
         if STATUS_RANK[current.status] < STATUS_RANK[recorded.status]:
-            regressions.append(f"{recorded.platform}/{recorded.benchmark}: {recorded.status} -> {current.status}")
+            drift.append(f"{recorded.platform}/{recorded.benchmark}: {recorded.status} -> {current.status}")
     for current in current_by_key.values():
         if current.key not in recorded_by_key:
-            regressions.append(f"new current row missing from matrix for {current.platform}/{current.benchmark}")
-    return regressions
+            drift.append(f"new current row missing from matrix for {current.platform}/{current.benchmark}")
+    return drift
 
 
 def parse_runtime_tuning_logs(

--- a/tests/uat/test_explorer_smoke.py
+++ b/tests/uat/test_explorer_smoke.py
@@ -85,6 +85,18 @@ def test_short_circuits_on_build_failure(tmp_path: Path):
     assert len(invocations) == 1
 
 
+def test_default_playwright_fixture_dir_matches_serve_browser_tests_mount():
+    default = explorer_smoke._default_playwright_fixture_dir()
+    assert default == explorer_smoke.EXPLORER_DIR / "test-fixtures" / ".generated" / "data"
+
+    serve_script = explorer_smoke.EXPLORER_DIR / "scripts" / "serve-browser-tests.mjs"
+    serve_text = serve_script.read_text(encoding="utf-8")
+    assert '"test-fixtures", ".generated", "data"' in serve_text, (
+        "serve-browser-tests.mjs default fixture mount diverged from "
+        "_default_playwright_fixture_dir(); update both ends together"
+    )
+
+
 def test_requested_browser_projects_are_not_silently_dropped(tmp_path: Path):
     invocations: list[list[str]] = []
 

--- a/tests/uat/test_tuning_coverage.py
+++ b/tests/uat/test_tuning_coverage.py
@@ -18,7 +18,7 @@ from benchbox.core.tuning.coverage import (
     parse_runtime_tuning_logs,
     read_tuning_coverage_tsv,
     runtime_mismatches,
-    static_regressions,
+    static_matrix_drift,
 )
 from tests.uat.matrix import PLATFORM_GROUPS, load_benchmarks, resolve_benchmarks
 
@@ -36,13 +36,13 @@ def test_tuning_coverage_matrix_is_checked_in_and_has_decisions():
     assert any(row.status == BASIC_CONSTRAINTS and row.decision == DECISION_AUTHOR for row in rows)
 
 
-def test_checked_in_tuning_coverage_has_no_static_regressions():
+def test_checked_in_tuning_coverage_has_no_static_drift():
     recorded = read_tuning_coverage_tsv(MATRIX_PATH)
     current = build_tuning_coverage_rows(_uat_platforms(), _uat_benchmarks())
-    assert static_regressions(recorded, current) == []
+    assert static_matrix_drift(recorded, current) == []
 
 
-def test_static_regressions_flags_new_current_rows_missing_from_matrix():
+def test_static_matrix_drift_flags_new_current_rows_missing_from_matrix():
     recorded = [
         TuningCoverageRow(
             platform="duckdb",
@@ -63,7 +63,7 @@ def test_static_regressions_flags_new_current_rows_missing_from_matrix():
         ),
     ]
 
-    assert static_regressions(recorded, current) == ["new current row missing from matrix for duckdb/newbench"]
+    assert static_matrix_drift(recorded, current) == ["new current row missing from matrix for duckdb/newbench"]
 
 
 def test_runtime_log_parser_matches_matrix_rows(tmp_path: Path):


### PR DESCRIPTION
## Summary

Follow-up nits surfaced while reviewing PR #255 (Results Explorer UAT review-followups, already merged).

- **Rename `static_regressions` → `static_matrix_drift`** (`benchbox/core/tuning/coverage.py`). #255 broadened the function to flag (1) recorded keys missing from current, (2) status downgrades, and (3) new keys missing from the checked-in matrix. The previous name only described case (2). Docstring now enumerates all three drift kinds.
- **Lock the Playwright fixture-dir contract** (`tests/uat/test_explorer_smoke.py`). New unit test asserts that `_default_playwright_fixture_dir()` and `results-explorer/scripts/serve-browser-tests.mjs` agree on the `test-fixtures/.generated/data` mount path. If either end is changed in isolation the UAT browser smoke would silently fall back to the curated corpus instead of UAT-built data; this test fails loudly so the contract has to be updated together.

## Verification

- `uv run -- python -m pytest tests/uat/test_tuning_coverage.py tests/uat/test_explorer_smoke.py -m fast -q` → 11 passed.
- `uv run -- ruff check` on changed files → clean.
- `make pr-open` ran `pr-preflight` (fast lane, mirrors CI) → passed.

## Merge-order note

`make pr-open` flagged textual conflicts with two still-open PRs:

- **PR #245** (`fix/results-explorer-disk-budget-resume-plan`) — already needs rebase post-#255 across `tests/uat/_cli.py`, `orchestrator.py`, `phases/preflight.py`. This PR adds an additional touchpoint on `tests/uat/test_explorer_smoke.py` and `benchbox/core/tuning/coverage.py` if #245 sweeps those.
- **PR #261** (`chore/pr-review-followups-2026-05-07`) — overlaps on `benchbox/core/tuning/coverage.py`, `tests/uat/test_tuning_coverage.py`, `tests/uat/test_explorer_smoke.py`. The rename here will require #261 to update any references to `static_regressions` introduced in that branch.

Recommend landing this PR first (small, mechanical) so that #245 / #261 absorb the rename in one rebase pass rather than racing it.

## Test plan

- [x] Fast tests pass on the touched modules
- [x] Ruff clean on changed files
- [x] `pr-preflight` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)