### PR TITLE
chore: address nits from PR #261 review

### DIFF
--- a/results-explorer/src/components/Tabs.tsx
+++ b/results-explorer/src/components/Tabs.tsx
@@ -27,6 +27,7 @@ export function Tabs<T extends string>({
   class: extraClass = "",
 }: TabsProps<T>) {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  tabRefs.current.length = items.length;
 
   const selectAndFocus = (index: number) => {
     const item = items[index];

--- a/tests/uat/matrix.py
+++ b/tests/uat/matrix.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 # Platform → "host:port" for TCP reachability probes. Mirrors
-# `get_platform_port` in scripts/local_stress_test.sh:142-161.
+# `get_platform_port` in scripts/local_stress_test.sh.
 PLATFORM_PORTS: dict[str, str] = {
     "lakesail": "localhost:50051",
     "singlestore": "localhost:13306",

--- a/tests/uat/test_tuning_coverage.py
+++ b/tests/uat/test_tuning_coverage.py
@@ -67,6 +67,18 @@ def test_static_matrix_drift_flags_new_current_rows_missing_from_matrix():
     assert static_matrix_drift(recorded, current) == ["new current row missing from matrix for duckdb/newbench"]
 
 
+def test_static_regressions_reports_current_rows_missing_from_checked_in_matrix():
+    recorded = [
+        TuningCoverageRow("duckdb", "tpch", TUNED_TEMPLATE, DECISION_DONE, "benchmark-specific tuned template exists")
+    ]
+    current = [
+        *recorded,
+        TuningCoverageRow("duckdb", "newbench", BASIC_CONSTRAINTS, DECISION_WAIVED, "needs checked-in triage"),
+    ]
+
+    assert static_regressions(recorded, current) == ["missing checked-in matrix row for duckdb/newbench"]
+
+
 def test_runtime_log_parser_matches_matrix_rows(tmp_path: Path):
     log_path = tmp_path / "duckdb_tpch_0.01_20260505_010203.log"
     log_path.write_text("Tuning: auto-discovered template at examples/tunings/duckdb/tpch_tuned.yaml\n")

--- a/tests/uat/test_tuning_coverage.py
+++ b/tests/uat/test_tuning_coverage.py
@@ -67,18 +67,6 @@ def test_static_matrix_drift_flags_new_current_rows_missing_from_matrix():
     assert static_matrix_drift(recorded, current) == ["new current row missing from matrix for duckdb/newbench"]
 
 
-def test_static_regressions_reports_current_rows_missing_from_checked_in_matrix():
-    recorded = [
-        TuningCoverageRow("duckdb", "tpch", TUNED_TEMPLATE, DECISION_DONE, "benchmark-specific tuned template exists")
-    ]
-    current = [
-        *recorded,
-        TuningCoverageRow("duckdb", "newbench", BASIC_CONSTRAINTS, DECISION_WAIVED, "needs checked-in triage"),
-    ]
-
-    assert static_regressions(recorded, current) == ["missing checked-in matrix row for duckdb/newbench"]
-
-
 def test_runtime_log_parser_matches_matrix_rows(tmp_path: Path):
     log_path = tmp_path / "duckdb_tpch_0.01_20260505_010203.log"
     log_path.write_text("Tuning: auto-discovered template at examples/tunings/duckdb/tpch_tuned.yaml\n")


### PR DESCRIPTION
## Summary

Two nit fixes surfaced while reviewing #261; both touch code added by that PR, so this branch stacks on `chore/pr-review-followups-2026-05-07`.

- **`tests/uat/matrix.py`** — drop the `:142-161` line-range from the `get_platform_port` comment citation. Line numbers drift as `local_stress_test.sh` evolves; the function name alone is a stable reference.
- **`results-explorer/src/components/Tabs.tsx`** — set `tabRefs.current.length = items.length` so stale entries from prior renders don't linger when the items array shrinks. Read-only impact today (refs are accessed by index), but keeps invariants tight.

## Stacking note

Until #261 merges, this PR will show all of #261's commits plus one cleanup commit on top. Once #261 lands on `develop`, GitHub auto-rebases this PR to the single cleanup commit. Suggested merge order: #261 → this PR.

## Test plan

- [x] `npm test -- --run primitives.test` — 21/21 pass (Tabs.tsx ref-length-trim is safe)
- [x] `uv run -- python -m pytest tests/uat/test_preflight.py -n 0 -q` — 6/6 pass
- [x] `uv run -- ruff check tests/uat/matrix.py` — clean
- [x] `npx tsc --noEmit` (results-explorer/) — clean
- [x] Pre-push hooks: timing policy + pr-preflight fast tests passed