### PR TITLE
fix(explorer): retokenize result/compare panels reintroduced by PR #268/#269 squash race

### DIFF
--- a/_project/DONE/main/planning/results-explorer-retheme-result-and-compare-postmerge.yaml
+++ b/_project/DONE/main/planning/results-explorer-retheme-result-and-compare-postmerge.yaml
@@ -1,0 +1,136 @@
+id: results-explorer-retheme-result-and-compare-postmerge
+title: "Retokenize Result Detail and Compare panels reintroduced as literal classes during the PR #268/#269 squash race"
+worktree: main
+priority: High
+status: Completed
+completed_date: "2026-05-07"
+category: Core Functionality
+
+description: |
+  PR #269 (`fix(explorer): address retheme release audit gaps`) was authored
+  on a base where Result Detail and Compare were already tokenized. PR #268
+  (`fix/pr246 result compare evidence`) merged onto develop ~1 hour earlier
+  and introduced a new literal-styled Result summary panel, ResultMetricCard
+  helper, and Compare guardrails section. The PR #269 squash kept #268's
+  literal-styled sections, so the merged tree on develop carried a tokenization
+  gap that the PR #269 release-readiness report did not flag (it was generated
+  against the PR branch, not the post-merge tree).
+
+  This follow-up retokenizes the regressed surfaces against the develop tip
+  and extends the cleanup to the remaining literal-color sites surfaced by a
+  full Tailwind palette scan over `results-explorer/src`.
+
+deps:
+  needs:
+  - results-explorer-retheme-result-and-compare
+
+work:
+- id: w1
+  summary: "Retokenize Result Detail Result-summary panel and ResultMetricCard helper"
+  status: done
+  notes: |
+    Outcome: `<section aria-label="Result summary">` switched from
+    `rounded-xl border border-gray-200 bg-white p-5 shadow-sm` to
+    `panel-elevated p-5`, the curated visibility chip uses `<StatusBadge
+    role="visibility" tone="success">`, and headings/body copy use the
+    `--bb-data-fg-primary`/`--bb-data-fg-muted` tokens. `ResultMetricCard`
+    moved from `border-gray-100 bg-gray-50 text-gray-500/900` to
+    `panel-muted` with `--bb-data-fg-subtle`/`primary`/`muted` tokens.
+
+- id: w2
+  summary: "Retokenize Compare guardrails section"
+  status: done
+  notes: |
+    Outcome: `<CompareGuardrailSummary>` switched from
+    `rounded-lg border border-gray-200 bg-white p-4 shadow-sm` plus
+    `badge badge-yellow|badge-green` to `panel-elevated p-4` with a
+    `<StatusBadge role="comparison" tone="warning|success">`.
+
+- id: w3
+  summary: "Retokenize remaining literal-color callouts and chart text"
+  status: done
+  notes: |
+    Outcome: QueryDiffTable suppression callout and BenchmarkIndex matrix/rank
+    error callouts switched to `tone-warning` + `--bb-data-border`.
+    NormalizedSpeedupChart empty-state panel now uses `panel-muted` and
+    foreground tokens. PercentileLadder SVG `<text>` fills moved to
+    `fill-[var(--bb-data-fg-{subtle,muted,primary})]`. MetaLeaderboard
+    rank=1 highlight switched from `text-green-700` to
+    `text-[var(--bb-tone-success-fg)]`. FacetRail mobile drawer apply/reset
+    buttons moved to shared `btn btn-primary`/`btn btn-secondary` and the
+    divider border now uses `--bb-data-border`.
+
+- id: w4
+  summary: "Comment the @media breakpoint literal so it stays in sync with --bb-bp-mobile"
+  status: done
+  notes: |
+    Outcome: index.css `@media (max-width: 47.999rem)` now carries an
+    inline comment explaining that var() and calc() are not valid in @media
+    queries, so this literal must stay aligned with `--bb-bp-mobile: 48rem`.
+
+- id: w5
+  summary: "Verify token scan is empty across results-explorer/src"
+  status: done
+  notes: |
+    Outcome: `grep -rE '\\b(text|bg|border|ring|divide|placeholder|fill|stroke|outline|shadow)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)\\b' results-explorer/src` returns zero matches at this branch tip. Codified into
+    a follow-up CI gate TODO (`results-explorer-token-scan-ci-gate`).
+
+must_preserve:
+- "Result detail route `/results/r/{result_id}` and visible heading."
+- "Compare route share URL contract and severe-mismatch suppression text."
+- "TrustBadge / ValidationBadge / TuningBadge / curated visibility surfaces."
+- "QueryDiffTable suppression copy and BenchmarkIndex matrix/rank error copy."
+
+anti_patterns:
+- "DO NOT mark the retheme ready against a tree the report was not generated from."
+- "DO NOT skip the develop-tip token scan on retheme follow-ups."
+- "DO NOT replace tokenized surfaces with raw Tailwind palette literals during merge resolution."
+
+verification:
+- description: "Token scan returns zero raw Tailwind palette literals"
+  command: "grep -rE '\\b(text|bg|border|ring|divide|placeholder|fill|stroke|outline|shadow)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)\\b' results-explorer/src || echo CLEAN"
+  expected_output: "CLEAN"
+- description: "Targeted unit tests for retokenized components pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/ResultDetail.test.tsx src/pages/__tests__/Compare.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx src/components/__tests__/QueryDiffTable.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Typecheck and build are clean"
+  command: "cd results-explorer && npm run typecheck && npm run build"
+  expected_output: "no errors"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/ResultDetail.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/PercentileLadder.tsx"
+  - "results-explorer/src/components/MetaLeaderboard.tsx"
+  - "results-explorer/src/components/FacetRail.tsx"
+  - "results-explorer/src/index.css"
+  - "_project/DONE/main/planning/results-explorer-retheme-result-and-compare-postmerge.yaml"
+  - "_project/TODO/main/planning/results-explorer-token-scan-ci-gate.yaml"
+  do_not_modify:
+  - "results-data/"
+  - "benchbox/"
+
+metadata:
+  tags:
+  - results-explorer
+  - retheme
+  - tokenization
+  - postmerge
+  estimated_effort: "Small (few hours)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Restores the tokenized surface model on the most prominent Result Detail
+    and Compare panels so the v0.2.x retheme delivery on develop matches the
+    release-readiness report claim.
+  user_impact: |
+    Users see consistent surfaces, semantic status badges, and accessible
+    contrast on the result/compare pages instead of mismatched legacy panels.
+  technical_debt: |
+    Surfaces a class of merge-race regressions that the per-PR token scan
+    cannot catch; codified as a follow-up CI gate.

--- a/_project/TODO/main/planning/results-explorer-token-scan-ci-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-token-scan-ci-gate.yaml
@@ -1,0 +1,132 @@
+id: results-explorer-token-scan-ci-gate
+title: "Add a CI gate that fails on raw Tailwind palette literals in results-explorer/src"
+worktree: main
+priority: Medium
+status: Not Started
+category: Quality
+
+description: |
+  The Results Explorer retheme moved every public surface to CSS-variable
+  tokens defined in `results-explorer/src/index.css`. PR #268 introduced new
+  literal-color sections in Result Detail and Compare during the same window
+  PR #269 was finalizing its release-readiness report; the squash merge of
+  #269 silently kept the literals because both the per-PR token scan and the
+  release-final capture were generated against the PR branch, not the
+  post-merge develop tree.
+
+  The post-merge tokenization gap was closed by
+  `results-explorer-retheme-result-and-compare-postmerge`. This TODO adds a
+  durable gate so the same class of regression is caught at PR time:
+
+  1. A repository check that fails when raw Tailwind palette literals
+     (text-/bg-/border-/divide-/ring-/placeholder-/fill-/stroke-/outline-/shadow-)
+     for slate/gray/zinc/neutral/stone/red/orange/amber/yellow/lime/green/
+     emerald/teal/cyan/sky/blue/indigo/violet/purple/fuchsia/pink/rose at
+     stops 50-950 appear inside `results-explorer/src` outside an explicit
+     allowlist.
+  2. An allowlist mechanism (e.g. a JSON file or inline `// allow: <reason>`
+     marker) so intentional uses (legacy badge aliases in `index.css`,
+     pre-existing inline-SVG `stroke="#xxxxxx"` attributes flagged for the
+     next chart-token follow-up) do not block the gate.
+  3. A CI hook that runs on every PR touching `results-explorer/src`.
+
+deps:
+  needs:
+  - results-explorer-retheme-result-and-compare-postmerge
+
+work:
+- id: w1
+  summary: "Pick the gate implementation: bash grep, ESLint rule, or stylelint plugin"
+  status: pending
+  notes: |
+    Bash grep is fastest to ship and matches what the audit already runs
+    manually. ESLint via `no-restricted-syntax` keeps the rule next to other
+    JSX checks but needs custom AST handling for `class={...}` template
+    literals. Stylelint targets CSS only and would miss JSX classnames.
+    Recommend bash grep for v1, with a TODO to graduate to ESLint once the
+    Results Explorer adopts a shared lint config that other projects can
+    reuse.
+
+- id: w2
+  summary: "Implement the scan and define the allowlist contract"
+  needs: [w1]
+  status: pending
+  notes: |
+    Initial allowlist:
+      - `results-explorer/src/index.css` legacy `.badge-{blue,green,yellow,red,gray}`
+        token aliases (each defined once, deliberately).
+      - PercentileLadder inline `stroke="#..."` SVG attributes are inline
+        SVG presentation attributes, not Tailwind classes; the scan should
+        only target class-attribute substrings, so these are out of scope.
+    Out of scope for v1: literal hex strings inside chartTheme.ts and
+    palette.ts (those will be migrated when ASCII chart parity is reopened).
+
+- id: w3
+  summary: "Wire the scan into pre-commit and CI"
+  needs: [w2]
+  status: pending
+  notes: |
+    Pre-commit: `make lint-explorer-tokens` (or equivalent) invoked from the
+    `make lint` umbrella target so local `make pr-preflight` catches
+    violations before push. CI: a path-aware job mirroring `ci-paths` so
+    only PRs touching `results-explorer/src` run the gate.
+
+- id: w4
+  summary: "Document the gate and the allowlist mechanism"
+  needs: [w3]
+  status: pending
+  notes: |
+    Update `docs/operations/results-explorer-qa.md` (or the closest
+    contributor-facing doc) with the gate command, the allowlist contract,
+    and a short rationale referencing the PR #268/#269 squash race that
+    motivated this work.
+
+must_preserve:
+- "Existing pre-commit hooks and `make lint` umbrella target."
+- "CI required-result aggregator path-filter behavior."
+
+anti_patterns:
+- "DO NOT add the gate without an allowlist mechanism — legitimate inline-SVG and legacy badge aliases will need explicit exemption."
+- "DO NOT silently extend the gate to other projects until at least one other consumer of the token system asks for it."
+
+verification:
+- description: "Gate fails on a planted literal under results-explorer/src"
+  command: "bash -lc 'set -e; tmp=$(mktemp results-explorer/src/_gate_test_XXXXX.tsx); echo \"<div class=\\\"text-gray-700\\\" />\" > \"$tmp\"; trap \"rm -f $tmp\" EXIT; ! make lint-explorer-tokens'"
+  expected_output: "non-zero exit (gate caught the literal)"
+- description: "Gate passes on the current results-explorer/src tree"
+  command: "make lint-explorer-tokens"
+  expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+  - "Makefile"
+  - "_project/scripts/"
+  - ".github/workflows/"
+  - "docs/operations/"
+  - "results-explorer/.eslintrc.*"
+  do_not_modify:
+  - "results-explorer/src/"
+  - "results-data/"
+  - "benchbox/"
+
+metadata:
+  tags:
+  - quality
+  - ci
+  - results-explorer
+  - retheme
+  - tokenization
+  estimated_effort: "Small (~1 day)"
+  created_date: "2026-05-07"
+
+impact:
+  business_value: |
+    Prevents future merge races from silently reintroducing raw Tailwind
+    color literals into the retheme surface model.
+  user_impact: |
+    Indirect: protects the visual consistency users see on Result Detail,
+    Compare, and other token-driven surfaces.
+  technical_debt: |
+    Replaces the manual audit-time scan with an automated PR-time gate so
+    the retheme contract is durable rather than relying on per-release
+    audits.

--- a/results-explorer/src/components/FacetRail.tsx
+++ b/results-explorer/src/components/FacetRail.tsx
@@ -164,17 +164,17 @@ export function FacetDrawer({
               onToggle={onToggle}
               onReset={onReset}
             />
-            <div class="mt-4 flex gap-2 border-t border-gray-200 pt-3 lg:hidden">
+            <div class="mt-4 flex gap-2 border-t border-[var(--bb-data-border)] pt-3 lg:hidden">
               <button
                 type="button"
-                class="flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700"
+                class="btn btn-secondary flex-1"
                 onClick={onReset}
               >
                 Reset filters
               </button>
               <button
                 type="button"
-                class="flex-1 rounded-md border border-brand-600 bg-brand-600 px-3 py-2 text-sm font-medium text-white"
+                class="btn btn-primary flex-1"
                 onClick={() => onOpenChange(false)}
               >
                 Apply filters

--- a/results-explorer/src/components/MetaLeaderboard.tsx
+++ b/results-explorer/src/components/MetaLeaderboard.tsx
@@ -452,7 +452,7 @@ function renderCellValue(
   const text = cellText(rank, cohort, mode);
   if (mode === "ranks") {
     return (
-      <span class={rank.rank === 1 ? "font-semibold text-green-700" : "text-[var(--bb-data-fg-primary)]"}>{text}</span>
+      <span class={rank.rank === 1 ? "font-semibold text-[var(--bb-tone-success-fg)]" : "text-[var(--bb-data-fg-primary)]"}>{text}</span>
     );
   }
   return text;

--- a/results-explorer/src/components/NormalizedSpeedupChart.tsx
+++ b/results-explorer/src/components/NormalizedSpeedupChart.tsx
@@ -217,12 +217,12 @@ function SpeedupParityState({
   speedupCount: number;
 }) {
   return (
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
-      <p class="font-semibold text-gray-900">No meaningful per-query speedup difference</p>
-      <p class="mt-1">
+    <div class="rounded-lg panel-muted p-4 text-sm">
+      <p class="font-semibold text-[var(--bb-data-fg-primary)]">No meaningful per-query speedup difference</p>
+      <p class="mt-1 text-[var(--bb-data-fg-muted)]">
         All {speedupCount.toLocaleString()} compared query speedups are 1.00× versus baseline {baseline}.
       </p>
-      <p class="mt-2 text-xs text-gray-500">
+      <p class="mt-2 text-xs text-[var(--bb-data-fg-muted)]">
         Baseline: <strong>{baseline}</strong>
         {candidates.length > 0 && <> · Compared with {candidates.join(", ")}</>}
       </p>

--- a/results-explorer/src/components/PercentileLadder.tsx
+++ b/results-explorer/src/components/PercentileLadder.tsx
@@ -77,7 +77,7 @@ export function PercentileLadder({ rows }: Props) {
             return (
               <g key={label} transform={`translate(${LABEL_W + li * 56}, 0)`}>
                 <rect width={14} height={10} y={3} fill={LEGEND_SWATCH_COLOR} opacity={opacity} rx={1} />
-                <text x={18} y={12} class="text-[10px] fill-gray-600 font-mono">
+                <text x={18} y={12} class="text-[10px] fill-[var(--bb-data-fg-muted)] font-mono">
                   {label}
                 </text>
               </g>
@@ -107,7 +107,7 @@ export function PercentileLadder({ rows }: Props) {
                 x={LABEL_W - 6}
                 y={midY + 4}
                 textAnchor="end"
-                class="text-xs fill-gray-700"
+                class="text-xs fill-[var(--bb-data-fg-primary)]"
                 style={{ fontSize: "11px" }}
               >
                 {row.platform.length > 18 ? row.platform.slice(0, 17) + "…" : row.platform}
@@ -136,7 +136,7 @@ export function PercentileLadder({ rows }: Props) {
               <text
                 x={xForMs(row.percentile_stats.p50) + 4}
                 y={midY + 4}
-                class="text-[10px] fill-gray-600 font-mono"
+                class="text-[10px] fill-[var(--bb-data-fg-muted)] font-mono"
                 style={{ fontSize: "10px" }}
               >
                 {row.percentile_stats.p50 >= 1000
@@ -164,7 +164,7 @@ export function PercentileLadder({ rows }: Props) {
                   x={x}
                   y={16}
                   textAnchor="middle"
-                  class="text-[10px] fill-gray-500 font-mono"
+                  class="text-[10px] fill-[var(--bb-data-fg-subtle)] font-mono"
                   style={{ fontSize: "10px" }}
                 >
                   {ms >= 1000 ? `${ms / 1000}s` : `${ms}ms`}

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -43,7 +43,7 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
       </div>
 
       {suppressionReason && (
-        <div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+        <div class="mb-4 rounded-md tone-warning border border-[var(--bb-data-border)] px-3 py-2 text-xs">
           Winner claims are suppressed because {suppressionReason}; use these query values as raw evidence only.
         </div>
       )}

--- a/results-explorer/src/index.css
+++ b/results-explorer/src/index.css
@@ -329,6 +329,9 @@
         font-size: var(--bb-text-xs);
         color: var(--bb-data-fg-subtle);
     }
+    /* 47.999rem = --bb-bp-mobile (48rem) - 0.001rem.
+       var() and calc() are not supported in @media queries,
+       so this literal must stay in sync with --bb-bp-mobile above. */
     @media (max-width: 47.999rem) {
         .bb-scroll-affordance {
             display: inline-flex;

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -543,7 +543,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
       {viewMode === "matrix" && (
         <>
           {summaryError ? (
-            <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <div class="rounded-lg tone-warning border border-[var(--bb-data-border)] px-4 py-3 text-sm">
               Could not load benchmark matrix: {summaryError}
             </div>
           ) : summaryLoading ? (
@@ -569,7 +569,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
       {viewMode === "ranks" && (
         <>
           {summaryError ? (
-            <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <div class="rounded-lg tone-warning border border-[var(--bb-data-border)] px-4 py-3 text-sm">
               Could not load rank data: {summaryError}
             </div>
           ) : summaryLoading ? (

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -395,19 +395,22 @@ function CompareGuardrailSummary({
 }) {
   const hasSevereMismatch = severeMismatchReason !== null;
   return (
-    <section aria-label="Compare guardrails" class="mb-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+    <section aria-label="Compare guardrails" class="mb-4 panel-elevated p-4">
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 class="text-base font-semibold text-gray-900">Comparability guardrails</h2>
-          <p class="mt-1 text-sm text-gray-600">
+          <h2 class="text-base font-semibold text-[var(--bb-data-fg-primary)]">Comparability guardrails</h2>
+          <p class="mt-1 text-sm text-[var(--bb-data-fg-muted)]">
             {hasSevereMismatch
               ? `Winner claims are suppressed because ${severeMismatchReason}.`
               : "Selected runs share the same benchmark and scale for winner claims."}
           </p>
         </div>
-        <span class={`badge ${hasSevereMismatch || warningCount > 0 ? "badge-yellow" : "badge-green"}`}>
+        <StatusBadge
+          role="comparison"
+          tone={hasSevereMismatch || warningCount > 0 ? "warning" : "success"}
+        >
           {hasSevereMismatch ? "Claims suppressed" : warningCount > 0 ? `${warningCount} warnings` : "Comparable"}
-        </span>
+        </StatusBadge>
       </div>
     </section>
   );

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -208,19 +208,21 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
         ]}
       />
 
-      <section aria-label="Result summary" class="mt-6 mb-8 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <section aria-label="Result summary" class="mt-6 mb-8 panel-elevated p-5">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div class="min-w-0">
             <div class="mb-3 flex flex-wrap items-center gap-3">
-              <h1 class="text-3xl font-bold text-gray-900">
+              <h1 class="text-3xl font-bold text-[var(--bb-data-fg-primary)]">
                 {benchmarkLabel} - {detail.platform}
               </h1>
               <TrustBadge trustLabel={detail.trust_label} />
               <ValidationBadge validationStatus={detail.validation_status} showMissing />
               {detail.tuning_mode && <TuningBadge tuningMode={detail.tuning_mode} />}
-              {detail.visibility === "public-curated" && <span class="badge badge-green">curated</span>}
+              {detail.visibility === "public-curated" && (
+                <StatusBadge role="visibility" tone="success">curated</StatusBadge>
+              )}
             </div>
-            <p class="text-sm text-gray-600">
+            <p class="text-sm text-[var(--bb-data-fg-muted)]">
               {benchmarkLabel} · SF {detail.scale_factor} · {detail.test_type ?? "standard"} · run{" "}
               {detail.run_date.slice(0, 10)}
             </p>
@@ -320,8 +322,8 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
 
           {detail.has_plans && !plansUrl && (
             <section class="card">
-              <h2 class="mb-2 text-base font-semibold text-gray-900">Execution plans</h2>
-              <p class="text-sm text-gray-500">Execution plans were recorded but are not published for download.</p>
+              <h2 class="mb-2 text-base font-semibold text-[var(--bb-data-fg-primary)]">Execution plans</h2>
+              <p class="text-sm text-[var(--bb-data-fg-muted)]">Execution plans were recorded but are not published for download.</p>
             </section>
           )}
         </div>
@@ -441,10 +443,10 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
 
 function ResultMetricCard({ label, value, helper }: { label: string; value: string; helper: string }) {
   return (
-    <div class="rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
-      <div class="text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</div>
-      <div class="mt-1 font-mono text-lg font-semibold text-gray-900">{value}</div>
-      <div class="mt-1 text-xs text-gray-500">{helper}</div>
+    <div class="rounded-lg panel-muted px-4 py-3">
+      <div class="text-xs font-semibold uppercase tracking-wide text-[var(--bb-data-fg-subtle)]">{label}</div>
+      <div class="mt-1 font-mono text-lg font-semibold text-[var(--bb-data-fg-primary)]">{value}</div>
+      <div class="mt-1 text-xs text-[var(--bb-data-fg-muted)]">{helper}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Retokenize Result Detail and Compare panels that landed as raw Tailwind palette literals in the squash merge of PR #269 (PR #268 merged ~1h before #269 and introduced literal-styled `Result summary`, `ResultMetricCard`, and `Compare guardrails` sections that #269's report did not flag because it was generated against the PR branch, not the post-merge tree).
- Extend the cleanup to all remaining literal-color sites in `results-explorer/src` so a full Tailwind palette scan returns zero hits (QueryDiffTable suppression callout, BenchmarkIndex matrix/rank error callouts, NormalizedSpeedupChart empty state, PercentileLadder SVG text, MetaLeaderboard rank=1 highlight, FacetRail mobile drawer apply/reset buttons).
- Comment the `@media (max-width: 47.999rem)` literal so it stays in sync with `--bb-bp-mobile: 48rem` (`var()`/`calc()` are not supported in `@media`).
- Add two follow-up TODO YAMLs: a Completed record of this post-merge work and a Not-Started CI gate to fail PRs that reintroduce raw Tailwind palette literals into `results-explorer/src`.

## Findings reference
This PR addresses the post-merge findings from the PR #269 review:
- **Required #1** — `ResultDetail.tsx` Result summary panel + `ResultMetricCard` literal grays.
- **Required #2** — `Compare.tsx` `CompareGuardrailSummary` literal grays + legacy `badge-yellow/badge-green`.
- **Major #3** — `QueryDiffTable.tsx:46`, `BenchmarkIndex.tsx:546,572` amber callouts.
- **Major #4** — `NormalizedSpeedupChart.tsx:220-225` empty-state literal grays.
- **Minor #5** — `PercentileLadder.tsx` SVG `fill-gray-*` text fills.
- **Minor #6** — `MetaLeaderboard.tsx:455` rank=1 `text-green-700`.
- **Info #8** — `index.css:332` `@media` literal documented.

Item #7 (link hover lighter-on-hover) is left untouched pending an explicit design decision; flagged separately in the review.

## Test plan
- [x] `grep -rE '\b(text|bg|border|ring|divide|placeholder|fill|stroke|outline|shadow)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)\b' results-explorer/src` returns zero hits.
- [x] `cd results-explorer && npm run typecheck` clean.
- [x] `cd results-explorer && npm run build` clean.
- [x] `cd results-explorer && npm test -- --run src/pages/__tests__/ResultDetail.test.tsx src/pages/__tests__/Compare.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx src/components/__tests__/QueryDiffTable.test.tsx` — 40 passed.
- [x] `make pr-preflight-fast-tests` — 21919 passed, 5 skipped, exit 0.
- [x] `validate_todo.py` and `todo_cli.py check-graph` clean for both new YAMLs.
- [ ] Maintainer eyeball pass on `/results/r/...` and `/results/compare?ids=...` to confirm the retokenized panels read consistently in the live explorer (the existing `release-final.spec.ts` capture should be re-run on develop tip after merge to refresh screenshots; tracked under the post-merge YAML).

Note: three pre-existing failures in `Query.test.tsx` (`screen.getByText("Configure visible columns")`) are present on develop tip prior to this branch and are unrelated to this work; left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)