### PR TITLE
fix(explorer): widen scroll-affordance breakpoint, standardize hint placement

### DIFF
--- a/_project/TODO/main/planning/results-explorer-explorer-nav-focus-visible.yaml
+++ b/_project/TODO/main/planning/results-explorer-explorer-nav-focus-visible.yaml
@@ -1,0 +1,98 @@
+id: results-explorer-explorer-nav-focus-visible
+title: "Add focus-visible styling to ExplorerNavLink and other interactive surfaces"
+worktree: main
+priority: Low
+status: Not Started
+category: Frontend / Accessibility
+
+description: |
+  PR #246 audit finding VH-1 ("Home leaderboard shows an active-looking focus
+  ring before user intent") flagged that focus, selection, and analytical
+  highlight states are visually conflated in the Results Explorer. PRs #259/#270
+  remediated the leaderboard ring and the responsive nav respectively, but
+  `ExplorerNavLink` (`results-explorer/src/components/Layout.tsx:97-119`) still
+  has no `focus-visible:` style and relies on the user-agent default outline.
+  The same pattern likely repeats on other Tailwind link/button helpers and
+  on grid cells that emit selection rings.
+
+  This TODO is the follow-on to the PR #246 nav remediation: define a single
+  `focus-visible` token and apply it to the Explorer secondary nav, global nav,
+  table action links (View →), filter pill triggers, and any other surfaces
+  that currently style only `:focus`. Selection state should remain visually
+  distinct from focus.
+
+deps:
+  needs:
+    - results-explorer-pr246-responsive-navigation-overflow-remediation
+
+context_sections:
+  evidence_source: |
+    PR #246 audit:
+    `_project/audits/results-explorer-hierarchy-usability-data-audit-20260507.md`
+    (finding VH-1 and the broader focus/selection conflation discussion).
+    Post-merge review of PR #270 also called this out as out-of-scope-but-
+    deferred.
+  scope_anchor: |
+    `results-explorer/src/components/Layout.tsx:97-119` is the canonical
+    starting point. Audit `Home`, `BenchmarkIndex`, `PlatformIndex`,
+    `Compare`, `Query`, `ResultDetail`, and the shared `DataTable` /
+    `MetaLeaderboard` cells while you are in there.
+
+work:
+  - id: w1
+    summary: "Audit current focus/selection styles across Explorer surfaces"
+    status: pending
+    notes: |
+      Grep for `:focus`, `focus-visible`, and `outline` in
+      `results-explorer/src/`. Note where focus is intentional
+      (modal close buttons, primary CTA), where focus is suppressed
+      (e.g. roving-grid focus on `Home.tsx`), and where the
+      browser default outline is the only feedback.
+
+  - id: w2
+    summary: "Define a focus-visible token + utility class"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a `--bb-focus-ring` style or `.focus-ring` utility in
+      `results-explorer/src/index.css` that paints a 2px ring with
+      sufficient contrast on both light data surfaces and the dark
+      hero. Selection state must NOT reuse this style.
+
+  - id: w3
+    summary: "Apply focus-visible token to ExplorerNavLink and peers"
+    needs: [w2]
+    status: pending
+    notes: |
+      Update `Layout.tsx` ExplorerNavLink + GlobalNavLink, table
+      action links (`Home.tsx`, `Query.tsx`, `MetaLeaderboard.tsx`),
+      and filter pill triggers. Confirm the leaderboard ring change
+      from PR #259 still uses a *different* visual language (selected
+      vs focused).
+
+  - id: w4
+    summary: "Add a Playwright a11y assertion that nav links expose a focus ring"
+    needs: [w3]
+    status: pending
+    notes: |
+      Tab through the secondary nav at 390/768/1280 and assert each
+      link gets `outline` or computed `box-shadow` matching the new
+      ring on `:focus-visible`. Pair with a test that pointer-only
+      activation does NOT show the ring.
+
+verification:
+  - description: "Every ExplorerNavLink has a non-default focus-visible style"
+    command: "grep -nE 'focus-visible' results-explorer/src/components/Layout.tsx"
+    expected_output: ">= 1 match"
+  - description: "Playwright a11y suite passes"
+    command: "cd results-explorer && npx playwright test --project=chromium --grep '@a11y|focus-visible'"
+    expected_output: "exit 0"
+
+must_preserve:
+  - "PR #259 leaderboard ring fix (VH-1) — focus and selected must stay visually distinct"
+  - "Existing keyboard reachability of every nav link at every viewport"
+  - "Pointer-click activation does not produce a stuck focus ring"
+
+anti_patterns:
+  - "DO NOT replace the user-agent outline with `outline: none` without a same-pass replacement"
+  - "DO NOT reuse the leaderboard selection ring color/style for focus — that is the bug VH-1 already fixed"

--- a/_project/TODO/main/planning/results-explorer-responsive-desktop-query-panel-regression.yaml
+++ b/_project/TODO/main/planning/results-explorer-responsive-desktop-query-panel-regression.yaml
@@ -1,0 +1,109 @@
+id: results-explorer-responsive-desktop-query-panel-regression
+title: "Fix or relax responsive.spec.ts query workbench desktop assertion (regression on develop)"
+worktree: main
+priority: Medium
+status: Not Started
+category: Frontend / Test Infrastructure
+
+description: |
+  After PR #270 (responsive/navigation overflow remediation) merged into
+  develop, the Playwright assertion at
+  `results-explorer/e2e/responsive.spec.ts:89` ("query workbench renders
+  summary, active filters, and rows before deep controls at desktop")
+  fails on develop with:
+
+      query results panel top should be within 900px
+      Expected: <= 900
+      Received:    909
+
+  The test expects `query-results-panel` top within `viewport.maxY = 900` at
+  the desktop viewport (1280×900). The 9px regression came in with PR #270's
+  Query workbench restructuring (mobile drawer + filter bar reorganization),
+  not with the post-merge follow-up PR #272. PR #272 was only able to
+  validate its own affordance + document-overflow changes by running them in
+  isolation because `responsive.spec.ts` runs serially and this test fails
+  before the affordance loop runs.
+
+  Two reasonable resolutions:
+    1) Trim 9px of vertical space above the results panel on the Query
+       workbench at lg+ widths (e.g. tighten `mt-*` / `gap-*` between the
+       result summary and the panel).
+    2) Relax `viewport.maxY` for desktop from 900 to ~960. The original 900
+       choice equals the viewport height itself, leaving zero margin for
+       layout drift. Tablet uses 1200/900=1.33, mobile uses 1200/900=1.33;
+       desktop's 900/900=1.0 is the only "no margin" pick in the matrix.
+
+  Resolution (1) is preferable because it forces every future PR to keep the
+  result panel above the fold; (2) is acceptable if the post-PR-270 layout
+  is intentional and we only want a guardrail against gross regressions.
+
+deps:
+  needs: []
+
+context_sections:
+  evidence_source: |
+    Verification log committed by PR #272:
+    `_project/verification-logs/results-explorer-pr270-followups/responsive-isolated.log`
+    Failing case: `[chromium] e2e/responsive.spec.ts:89:5 ... at desktop`
+    Reproducible on develop (post-PR-270) with no working-tree changes.
+  test_pattern: |
+    The test runs at viewports {mobile: 390x900, tablet: 768x900, desktop:
+    1280x900, wide: 1600x900} with `maxY` of {1200, 1200, 900, 900}. Tests
+    are serial — when this test fails the rest of the responsive grep does
+    not run, masking other potential regressions.
+  related_pr_history: |
+    PR #270 added the second-row mobile drawer + restructured Query
+    controls. That change is the suspected source of the 9px shift.
+    PR #272 (this branch's parent context) only modifies the affordance
+    breakpoint and hint placement and does not change Query workbench
+    vertical layout.
+
+work:
+  - id: w1
+    summary: "Bisect the 9px regression to a specific PR #270 hunk"
+    status: pending
+    notes: |
+      Locally check out commits between b26f6aff3 (the merge-base) and
+      27fbd73d7 (PR #270 merge) on `results-explorer/src/pages/Query.tsx`.
+      Run the failing assertion at each step and pinpoint the hunk that
+      pushes the panel from ≤900 to 909.
+
+  - id: w2
+    summary: "Decide between layout fix or threshold relaxation"
+    needs: [w1]
+    status: pending
+    notes: |
+      If the 9px shift is incidental (an unintended border/padding from
+      a token swap), tighten the layout. If it is the new mobile drawer
+      trigger that legitimately occupies 9px on desktop, relax desktop
+      maxY to ~960 with a comment explaining the budget. Document the
+      rationale either way.
+
+  - id: w3
+    summary: "Re-run responsive grep end-to-end and confirm tablet affordance + overflow tests run after the fix"
+    needs: [w2]
+    status: pending
+    notes: |
+      The PR #272 verification log only validates the affordance + overflow
+      tests in isolation because the desktop failure stops the serial run
+      early. After fixing this regression, run
+      `npx playwright test --project=chromium --grep "responsive|layout|a11y|mobile"`
+      and capture full output to a verification log.
+
+verification:
+  - description: "responsive grep suite passes end-to-end on develop after fix"
+    command: "cd results-explorer && npx playwright test --project=chromium --grep 'responsive|layout|a11y|mobile'"
+    expected_output: "exit 0; 24+ passed, 0 failed"
+  - description: "Query results panel top stays within desktop viewport"
+    command: "cd results-explorer && npx playwright test --project=chromium e2e/responsive.spec.ts:89 --grep desktop"
+    expected_output: "exit 0"
+
+must_preserve:
+  - "PR #270's contract that mobile drawer + Query controls remain reachable above the fold at every viewport"
+  - "Serial mode for `responsive.spec.ts` if its current invariants depend on it"
+  - "PR #272's affordance + overflow tests continue to pass at 390/768"
+
+anti_patterns:
+  - "DO NOT relax tablet/mobile maxY values — only desktop is at issue"
+  - "DO NOT silently `test.skip` the failing test — that hides the regression and allows further drift"
+  - "DO NOT change the test's selectors or panel data-testid — downstream regression tests rely on them"

--- a/_project/TODO/main/planning/results-explorer-table-scroll-hint-helper.yaml
+++ b/_project/TODO/main/planning/results-explorer-table-scroll-hint-helper.yaml
@@ -1,0 +1,89 @@
+id: results-explorer-table-scroll-hint-helper
+title: "Extract a shared TableScrollHint helper to converge bb-scroll-affordance copies"
+worktree: main
+priority: Low
+status: Not Started
+category: Frontend / Refactor
+
+description: |
+  PR #270 added the `bb-scroll-affordance` cue across six dense tables
+  (Home recent results, MetaLeaderboard, DataTable, Query results, Query SQL,
+  ResultDetail timings, ResultDetail samples, QueryDiff). PR #270's follow-up
+  (this branch) standardized placement so the hint always sits OUTSIDE the
+  `.overflow-x-auto` container — but the copies still duplicate the same
+  `<div class="mb-2 flex justify-end"><span class="bb-scroll-affordance">…</span></div>`
+  scaffolding in 6+ places.
+
+  Extract a `<TableScrollHint testId="…" label="…" />` helper that owns the
+  layout + class wiring, and refactor every existing call site to use it.
+  Optional: also accept an `onlyWhenOverflowing` prop that gates visibility
+  on `scrollWidth > clientWidth` for parity with the QueryHeatmap pattern at
+  `results-explorer/src/components/QueryHeatmap.tsx`.
+
+deps:
+  needs: []
+
+context_sections:
+  evidence_source: |
+    Post-merge review of PR #270 (fix/pr246-responsive-navigation-overflow)
+    flagged the duplicated scaffolding. The follow-up PR
+    `fix/pr270-followups-affordance-breakpoint` standardized placement but
+    deliberately did NOT introduce a helper — that is what this TODO owns.
+  current_call_sites: |
+    `results-explorer/src/pages/Home.tsx` (recent-results hint)
+    `results-explorer/src/pages/Query.tsx` (results + SQL hints, inside meta bar)
+    `results-explorer/src/pages/ResultDetail.tsx` (timings + samples hints)
+    `results-explorer/src/components/MetaLeaderboard.tsx`
+    `results-explorer/src/components/QueryDiffTable.tsx`
+    `results-explorer/src/components/DataTable.tsx`
+
+work:
+  - id: w1
+    summary: "Add TableScrollHint component with the standardized markup"
+    status: pending
+    notes: |
+      New file `results-explorer/src/components/TableScrollHint.tsx` exporting
+      `<TableScrollHint testId={string} label={string} className?={string} />`.
+      Default label is "← scroll →"; Home/MetaLeaderboard pass the longer
+      "Scroll table for more columns →" / "Scroll table for more cohorts →"
+      copy.
+
+  - id: w2
+    summary: "Refactor existing call sites to use TableScrollHint"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace inline `<span class="bb-scroll-affordance">` in each call site
+      with `<TableScrollHint />`. Preserve every existing data-testid so
+      Playwright assertions in `responsive.spec.ts` keep working unchanged.
+
+  - id: w3
+    summary: "Optional: gate hint on actual overflow"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add `onlyWhenOverflowing` boolean prop. When true, the helper measures
+      the nearest `[data-scroll-container]` ancestor and only renders when
+      `scrollWidth > clientWidth`. Mirrors QueryHeatmap behavior. Adopt on
+      DataTable first (its callers may have few-column tables that don't
+      actually overflow) before the dense tables.
+
+verification:
+  - description: "Helper exists and is exported"
+    command: "test -f results-explorer/src/components/TableScrollHint.tsx"
+    expected_output: "exit 0"
+  - description: "No remaining inline `bb-scroll-affordance` spans outside the helper"
+    command: "grep -rE 'bb-scroll-affordance' results-explorer/src/ --exclude-dir=__tests__ | grep -v 'TableScrollHint.tsx' | grep -v 'index.css'"
+    expected_output: "no matches"
+  - description: "responsive Playwright grep still passes"
+    command: "cd results-explorer && npx playwright test --project=chromium --grep responsive"
+    expected_output: "exit 0"
+
+must_preserve:
+  - "All existing `data-testid` values for scroll hints — Playwright responsive.spec.ts and capture spec depend on them"
+  - "Hint placement OUTSIDE `.overflow-x-auto` (so the hint stays put when the user scrolls)"
+  - "CSS visibility threshold (`max-width: 48rem`) — the helper renders the same `bb-scroll-affordance` class, no inline display override"
+
+anti_patterns:
+  - "DO NOT inline new `bb-scroll-affordance` spans after the helper exists — every cue should route through the helper"
+  - "DO NOT silently change copy on the longer Home/MetaLeaderboard hints; they intentionally describe what scrolls"

--- a/_project/verification-logs/results-explorer-pr270-followups/responsive-isolated.log
+++ b/_project/verification-logs/results-explorer-pr270-followups/responsive-isolated.log
@@ -1,0 +1,20 @@
+[2m[WebServer] [22m[serve-browser-tests] dist=/Users/joe/Developer/BenchBox.pool-03/results-explorer/dist
+[2m[WebServer] [22m[serve-browser-tests] fixtures=/Users/joe/Developer/BenchBox.pool-03/results-explorer/test-fixtures/.generated/data
+[2m[WebServer] [22m[serve-browser-tests] listening on http://127.0.0.1:4319/results/
+
+Running 2 tests using 1 worker
+
+  ✓  1 [chromium] › e2e/responsive.spec.ts:138:5 › responsive explorer assertions › mobile table affordances remain visible at mobile (5.0s)
+  ✓  2 [chromium] › e2e/responsive.spec.ts:138:5 › responsive explorer assertions › mobile table affordances remain visible at tablet (5.9s)
+
+  2 passed (11.7s)
+[2m[WebServer] [22m[serve-browser-tests] dist=/Users/joe/Developer/BenchBox.pool-03/results-explorer/dist
+[2m[WebServer] [22m[serve-browser-tests] fixtures=/Users/joe/Developer/BenchBox.pool-03/results-explorer/test-fixtures/.generated/data
+[2m[WebServer] [22m[serve-browser-tests] listening on http://127.0.0.1:4319/results/
+
+Running 2 tests using 1 worker
+
+  ✓  1 [chromium] › e2e/responsive.spec.ts:129:5 › responsive explorer assertions › audited routes avoid document overflow at mobile (5.5s)
+  ✓  2 [chromium] › e2e/responsive.spec.ts:129:5 › responsive explorer assertions › audited routes avoid document overflow at tablet (5.5s)
+
+  2 passed (11.9s)

--- a/results-explorer/src/components/QueryDiffTable.tsx
+++ b/results-explorer/src/components/QueryDiffTable.tsx
@@ -48,10 +48,10 @@ export function QueryDiffTable({ results, baselineIndex = 0, suppressionReason =
         </div>
       )}
 
+      <div class="mb-2 flex justify-end">
+        <span class="bb-scroll-affordance" data-testid="query-diff-scroll-hint">← scroll →</span>
+      </div>
       <div class="overflow-x-auto" data-testid="query-diff-scroll-container">
-        <div class="mb-2 flex justify-end">
-          <span class="bb-scroll-affordance" data-testid="query-diff-scroll-hint">← scroll →</span>
-        </div>
         <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)] text-sm">
           <thead class="bg-[var(--bb-surface-data-muted)]">
             <tr>

--- a/results-explorer/src/index.css
+++ b/results-explorer/src/index.css
@@ -323,16 +323,15 @@
     /* Compact "←/→ scroll" cue for dense tables that overflow at narrow
        widths. Pair with `overflow-x-auto` on the parent so the table
        still scrolls; this label only signals scrollability so users
-       don't think they are seeing a clipped view. */
+       don't think they are seeing a clipped view. Threshold matches
+       --bb-bp-mobile inclusively so 768px tablets (where dense
+       cohort/query tables still overflow horizontally) keep the cue. */
     .bb-scroll-affordance {
         display: none;
         font-size: var(--bb-text-xs);
         color: var(--bb-data-fg-subtle);
     }
-    /* 47.999rem = --bb-bp-mobile (48rem) - 0.001rem.
-       var() and calc() are not supported in @media queries,
-       so this literal must stay in sync with --bb-bp-mobile above. */
-    @media (max-width: 47.999rem) {
+    @media (max-width: 48rem) {
         .bb-scroll-affordance {
             display: inline-flex;
             align-items: center;

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -566,7 +566,7 @@ export function Query(_: RoutableProps) {
                 columns={visibleColumns.length || DEFAULT_COLUMNS.length}
               />
             ) : (
-              <div class="overflow-x-auto rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] shadow-sm">
+              <div class="overflow-hidden rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] shadow-sm">
                 <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
                   <span>
                     Showing {visibleRows.length.toLocaleString()} of {rows.length.toLocaleString()} returned rows
@@ -574,39 +574,41 @@ export function Query(_: RoutableProps) {
                   <span>Query limit: {rowLimitMode === "all" ? "all" : DEFAULT_ROW_LIMIT.toLocaleString()}</span>
                   <span class="bb-scroll-affordance" data-testid="query-results-scroll-hint">← scroll →</span>
                 </div>
-                <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
-                  <thead class="bg-[var(--bb-surface-data-muted)]">
-                    <tr>
-                      {visibleColumns.map((column) => (
-                        <th
-                          key={column}
-                          class="table-th cursor-pointer select-none"
-                          onClick={() => toggleSort(column)}
-                        >
-                          {formatQueryColumnLabel(column)}
-                          {sort.column === column ? (sort.direction === "asc" ? " ↑" : " ↓") : ""}
-                        </th>
-                      ))}
-                      <th class="table-th sticky right-0 z-10 bg-[var(--bb-surface-data-muted)]" />
-                    </tr>
-                  </thead>
-                  <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-                    {visibleRows.map((row) => (
-                      <tr key={String(row.result_id)} class="hover:bg-[var(--bb-surface-data-muted)]">
+                <div class="overflow-x-auto">
+                  <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
+                    <thead class="bg-[var(--bb-surface-data-muted)]">
+                      <tr>
                         {visibleColumns.map((column) => (
-                          <td key={column} class="table-td">
-                            {formatQueryCell(column, row[column])}
-                          </td>
+                          <th
+                            key={column}
+                            class="table-th cursor-pointer select-none"
+                            onClick={() => toggleSort(column)}
+                          >
+                            {formatQueryColumnLabel(column)}
+                            {sort.column === column ? (sort.direction === "asc" ? " ↑" : " ↓") : ""}
+                          </th>
                         ))}
-                        <td class="table-td sticky right-0 z-10 bg-[var(--bb-surface-data)] text-right">
-                          <a href={`/results/r/${row.result_id}`} class="text-xs font-medium no-underline">
-                            View →
-                          </a>
-                        </td>
+                        <th class="table-th sticky right-0 z-10 bg-[var(--bb-surface-data-muted)]" />
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
+                    </thead>
+                    <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+                      {visibleRows.map((row) => (
+                        <tr key={String(row.result_id)} class="hover:bg-[var(--bb-surface-data-muted)]">
+                          {visibleColumns.map((column) => (
+                            <td key={column} class="table-td">
+                              {formatQueryCell(column, row[column])}
+                            </td>
+                          ))}
+                          <td class="table-td sticky right-0 z-10 bg-[var(--bb-surface-data)] text-right">
+                            <a href={`/results/r/${row.result_id}`} class="text-xs font-medium no-underline">
+                              View →
+                            </a>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
                 {visibleRows.length < rows.length && (
                   <div class="border-t border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-center">
                     <button
@@ -645,33 +647,35 @@ export function Query(_: RoutableProps) {
                 )}
               </div>
               {sqlRows.length > 0 && (
-                <div class="overflow-x-auto rounded-lg border border-[var(--bb-data-border)]">
+                <div class="overflow-hidden rounded-lg border border-[var(--bb-data-border)]">
                   <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
                     <span>Showing {visibleSqlRows.length.toLocaleString()} of {sqlRows.length.toLocaleString()} SQL rows</span>
                     <span class="bb-scroll-affordance" data-testid="query-sql-scroll-hint">← scroll →</span>
                   </div>
-                  <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
-                    <thead class="bg-[var(--bb-surface-data-muted)]">
-                      <tr>
-                        {sqlColumns.map((column) => (
-                          <th key={column} class="table-th">
-                            {column}
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-                      {visibleSqlRows.map((row, index) => (
-                        <tr key={index}>
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
+                      <thead class="bg-[var(--bb-surface-data-muted)]">
+                        <tr>
                           {sqlColumns.map((column) => (
-                            <td key={column} class="table-td">
-                              {formatCell(row[column])}
-                            </td>
+                            <th key={column} class="table-th">
+                              {column}
+                            </th>
                           ))}
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+                        {visibleSqlRows.map((row, index) => (
+                          <tr key={index}>
+                            {sqlColumns.map((column) => (
+                              <td key={column} class="table-td">
+                                {formatCell(row[column])}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                   {visibleSqlRows.length < sqlRows.length && (
                     <div class="border-t border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-center">
                       <button

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -339,10 +339,10 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
             <h2 class="mb-4 text-base font-semibold text-[var(--bb-data-fg-primary)]">
               Query Timings ({detail.display_timings.length})
             </h2>
+            <div class="mb-2 flex justify-end">
+              <span class="bb-scroll-affordance" data-testid="detail-timings-scroll-hint">← scroll →</span>
+            </div>
             <div class="overflow-x-auto" data-testid="detail-timings-scroll-container">
-              <div class="mb-2 flex justify-end">
-                <span class="bb-scroll-affordance" data-testid="detail-timings-scroll-hint">← scroll →</span>
-              </div>
               <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
                 <thead class="bg-[var(--bb-surface-data-muted)]">
                   <tr>
@@ -387,10 +387,10 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                 <summary class="cursor-pointer select-none text-sm text-[var(--bb-data-fg-muted)] hover:text-[var(--bb-data-fg-primary)]">
                   Individual samples ({detail.queries.length})
                 </summary>
-                <div class="mt-3 overflow-x-auto" data-testid="detail-samples-scroll-container">
-                  <div class="mb-2 flex justify-end">
-                    <span class="bb-scroll-affordance" data-testid="detail-samples-scroll-hint">← scroll →</span>
-                  </div>
+                <div class="mt-3 mb-2 flex justify-end">
+                  <span class="bb-scroll-affordance" data-testid="detail-samples-scroll-hint">← scroll →</span>
+                </div>
+                <div class="overflow-x-auto" data-testid="detail-samples-scroll-container">
                   <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
                     <thead class="bg-[var(--bb-surface-data-muted)]">
                       <tr>


### PR DESCRIPTION
Follow-up to PR #270 (#270 review).

The bb-scroll-affordance media query used max-width: 47.999rem (~767.98px),
which excluded the 768px tablet viewport. Playwright assertions like
"mobile table affordances remain visible at tablet" expected the hint
visible at viewport.width=768; without this fix the assertion only passed
because the upstream serial test failed first and prevented it from running.
Widen to max-width: 48rem inclusive — dense cohort/query tables still
overflow horizontally at 768.

Also standardize hint placement: the Query results table, Query SQL output,
ResultDetail timing/sample tables, and QueryDiff now place the hint OUTSIDE
the .overflow-x-auto container so the cue stays visible when the user
scrolls. Home/MetaLeaderboard/DataTable already followed this pattern.

Capture verification log at _project/verification-logs/results-explorer-pr270-followups/
covering the affordance + document-overflow tests in isolation (the
serial-mode failure on the unrelated 'query workbench... at desktop' test
is pre-existing on develop and out of scope here).

Adds two follow-up TODOs: focus-visible styling for ExplorerNavLink (audit
VH-1 follow-on) and a TableScrollHint helper to converge the 6+ duplicated
affordance copies.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
