### PR TITLE
chore(retheme): raise PR #269 review follow-up TODOs and L2 blind-spot

### DIFF
--- a/_project/TODO/main/bugs/query-test-configure-visible-columns-failures.yaml
+++ b/_project/TODO/main/bugs/query-test-configure-visible-columns-failures.yaml
@@ -1,0 +1,103 @@
+id: query-test-configure-visible-columns-failures
+title: "Restore Configure visible columns affordance (Query.test.tsx 3 failures on develop tip)"
+worktree: main
+priority: Medium
+status: Not Started
+category: Bug Fix
+
+description: |
+  `cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx`
+  fails three cases on the current develop tip (commit 27fbd73d7,
+  PR #270 merged). All three failures are
+  `screen.getByText("Configure visible columns")` returning no element:
+
+  - "uses public table labels and formatted values in the default result table"
+    (Query.test.tsx:245)
+  - "exposes visible-columns sidebar text on Query page"
+    (Query.test.tsx:269 textContent assertion)
+  - "orders mobile query controls so results appear before deep filters"
+    (Query.test.tsx:336)
+
+  `grep -rn "Configure visible columns" results-explorer/src/pages/Query.tsx`
+  returns no matches in the production source — the affordance label was
+  removed or renamed somewhere in the chain of PRs #266 / #268 / #269 / #270
+  but the tests were not updated to match. PR #269's release-readiness
+  report claimed `Tests 506 passed (506)` against the PR branch's tree,
+  which masked the regression that landed on develop afterward.
+
+  Either:
+    a) restore the affordance with the literal "Configure visible columns"
+       label so the existing accessibility/visibility contract holds, or
+    b) update the tests to match the new affordance label/behavior, with a
+       short note in the test file explaining the rename.
+
+  Bisect against PRs #266, #268, #269, #270 to confirm which change broke
+  the contract before deciding which side to repair.
+
+deps: {}
+
+work:
+- id: w1
+  summary: "Bisect develop tip back through PRs #266, #268, #269, #270 to find the breaking commit"
+  status: pending
+
+- id: w2
+  summary: "Decide whether to restore the affordance label or update the tests"
+  needs: [w1]
+  status: pending
+
+- id: w3
+  summary: "Apply the chosen fix and confirm Query.test.tsx is green"
+  needs: [w2]
+  status: pending
+
+- id: w4
+  summary: "Add a regression note in the test file referencing this TODO and the breaking PR"
+  needs: [w3]
+  status: pending
+
+must_preserve:
+- "URL state, row-limit, export, and SQL behavior on the Query page."
+- "Mobile drawer order: results panel before deep filters."
+
+anti_patterns:
+- "DO NOT silence the failing tests without restoring an equivalent visibility/columns affordance."
+- "DO NOT delete the test cases — they encode the existing public Query Workbench contract."
+
+verification:
+- description: "Query.test.tsx is fully green"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx"
+  expected_output: "all tests pass"
+- description: "Full vitest run is green"
+  command: "cd results-explorer && npm test -- --run"
+  expected_output: "all tests pass"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/__tests__/Query.test.tsx"
+  - "results-explorer/src/components/"
+  do_not_modify:
+  - "results-data/"
+  - "benchbox/"
+
+metadata:
+  tags:
+  - results-explorer
+  - bug
+  - tests
+  - query-workbench
+  estimated_effort: "Small (~half day)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Restores the Query Workbench test contract so subsequent PRs can rely
+    on a green baseline.
+  user_impact: |
+    Either restores a removed visibility/columns affordance users had, or
+    aligns the tests with the new affordance so future regressions will
+    actually be caught.
+  technical_debt: |
+    Closes a silent test-suite regression that landed under the noise of
+    a multi-PR remediation chain on develop.

--- a/_project/TODO/main/planning/results-explorer-retheme-link-hover-direction.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-link-hover-direction.yaml
@@ -1,0 +1,94 @@
+id: results-explorer-retheme-link-hover-direction
+title: "Confirm intended link hover direction (lighter vs darker on light surfaces)"
+worktree: main
+priority: Low
+status: Not Started
+category: Polish
+
+description: |
+  PR #269 changed the `<a>` rule in `results-explorer/src/index.css` to:
+
+  ```css
+  a       { color: var(--bb-accent-hover); }   /* #1f6feb */
+  a:hover { color: var(--bb-accent); }         /* #58a6ff */
+  ```
+
+  On light data surfaces this produces a *lighter* blue on hover, inverting
+  the conventional darker-on-hover affordance most users expect. The token
+  semantics are partly to blame: `--bb-accent` and `--bb-accent-hover` were
+  named for the dark global chrome where `--bb-accent-hover` is the deeper
+  pressed-state and `--bb-accent` is the lighter resting state.
+
+  Two clean fixes, pick one:
+
+    a) Swap the `a` and `a:hover` colors so resting state is `--bb-accent`
+       (or a new `--bb-link-fg` token) and hover is `--bb-accent-hover`,
+       making hover darker on light surfaces. This matches the conventional
+       affordance.
+
+    b) Introduce dedicated `--bb-link-fg` / `--bb-link-fg-hover` tokens so
+       `<a>` styling is independent of the dark-chrome accent semantics.
+
+  The decision is design-owned. Until the design call lands, the current
+  rule is shipped on develop and observable on every link in the explorer,
+  including breadcrumbs, methodology disclosures, tuning expand toggles,
+  and data tables.
+
+deps: {}
+
+work:
+- id: w1
+  summary: "Decide between option (a) swap accent tokens or (b) introduce dedicated link tokens"
+  status: pending
+
+- id: w2
+  summary: "Apply the chosen fix and update any docs that reference --bb-accent in link contexts"
+  needs: [w1]
+  status: pending
+
+- id: w3
+  summary: "Spot-check breadcrumbs, methodology disclosures, tuning toggles, and data tables in a real browser at 390/768/1280 widths"
+  needs: [w2]
+  status: pending
+
+must_preserve:
+- "Existing focus-visible ring behavior on links."
+- "WCAG AA contrast on resting and hover states for both light data surfaces and dark chrome surfaces."
+
+anti_patterns:
+- "DO NOT reintroduce raw Tailwind `text-blue-*`/`text-brand-*` classes on `<a>` — the rule must stay token-driven."
+- "DO NOT change the rule without testing both light and dark chrome surfaces — the dark chrome relies on the accent token producing legible text."
+
+verification:
+- description: "Targeted unit + e2e suites stay green"
+  command: "cd results-explorer && npm run typecheck && npm test -- --run && npx playwright test --project=chromium --workers=1 --grep-invert @performance"
+  expected_output: "no regressions"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/index.css"
+  - "_project/analysis/"
+  - "_project/audits/"
+  do_not_modify:
+  - "results-data/"
+  - "benchbox/"
+
+metadata:
+  tags:
+  - results-explorer
+  - retheme
+  - polish
+  estimated_effort: "Small (~hour)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Aligns hover semantics with conventional UI affordances so links don't
+    read as resting-state on hover.
+  user_impact: |
+    Subtle: hover state will indicate interactive intent more clearly on
+    light data surfaces.
+  technical_debt: |
+    Decouples link semantics from the dark-chrome accent token if option
+    (b) is chosen, removing one source of cross-context coupling in the
+    token system.

--- a/_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
+++ b/_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
@@ -1,0 +1,70 @@
+---
+id: 2026-05-07-211858-release-readiness-against-pre-merge-tree
+date: 2026-05-07
+status: open
+finding_kind: framework-gap
+review_context: "PR #269 review (results-explorer-retheme-audit-followups) → PR #271 (results-explorer-retheme-postmerge-tokenize)"
+related_paths:
+  - _project/audits/results-explorer-retheme-final-2026-05-07.md
+  - results-explorer/e2e/captures/release-final.spec.ts
+  - results-explorer/src/pages/ResultDetail.tsx
+  - results-explorer/src/pages/Compare.tsx
+suggested_sweep: "before any retheme/release-readiness PR is marked READY, re-run the token scan and the release-final capture against the squash-merged develop tip, not just the PR branch"
+todo_id: null
+---
+
+# Release-readiness reports generated against pre-merge tree silently miss concurrent-PR regressions
+
+## Finding
+
+PR #269 (`fix(explorer): address retheme release audit gaps`) authored a
+release-readiness report and a `release-final.spec.ts` capture against its
+own branch tree. PR #268 (`fix/pr246 result compare evidence`) merged onto
+develop ~1h before #269 and introduced a new literal-styled `Result summary`
+panel, `ResultMetricCard` helper, and `Compare guardrails` section in the
+exact files PR #269 was tokenizing. PR #269 squash-merged onto the
+now-#268-included develop, the merge resolution kept #268's literal-styled
+sections, and PR #269's report still claimed READY because:
+
+- the per-PR token scan ran against the PR branch, not the merged tree;
+- the `release-final.spec.ts` capture and screenshots were generated against
+  the PR branch, not the merged tree;
+- CI green covered typecheck/tests/build but no token-scan gate.
+
+The merged result on develop carried untokenized literal grays on the most
+prominent panel of `/results/r/...` and on the Compare guardrails section,
+contradicting the report. PR #271 closed the gap manually. The framework
+has no automated gate against this class.
+
+## Why this matters
+
+Release-readiness reports describe a tree. If the tree the report
+describes is not the tree that ships, the verdict is structurally
+unreliable — even when every individual check passes. Concurrent PRs that
+edit the same files are the obvious failure mode, but any post-authoring
+change to develop (auto-rebases, CODEOWNER edits, hotfixes that land
+between report generation and merge) produces the same gap. The report's
+authority comes from coverage, and "coverage at PR HEAD" is a different
+claim than "coverage on develop after merge."
+
+This is not unique to retheme work. Any audit-style PR with a structured
+report (security review, performance baseline, docs migration) has the
+same exposure if the report and the merge are not regenerated together.
+
+## Suggested next steps
+
+- [ ] Add a token-scan gate (see TODO `results-explorer-token-scan-ci-gate`)
+      that runs on every PR touching `results-explorer/src` and on develop
+      after merge, so concurrent-PR regressions break CI rather than ship
+      silently.
+- [ ] Update the release-final capture flow to record the develop SHA the
+      capture was generated from in the audit report, and add a CI job that
+      refuses a "READY" verdict until the SHA matches the merge target's
+      tip.
+- [ ] Generalize: any structured report under `_project/audits/` should
+      include the develop SHA it describes, and reviewers should refuse to
+      merge a release-readiness PR whose report SHA is older than the merge
+      target.
+- [ ] Sweep: re-run `results-explorer-retheme-final-2026-05-07.md` with a
+      capture against develop tip after PR #271 lands, so the artifact set
+      reflects the shipped state.


### PR DESCRIPTION
## Summary
- Two follow-up TODOs and one L2 blind-spot surfaced by the PR #269 review and the PR #271 post-merge remediation.
- No source code changes; planning/governance artifacts only.

## Artifacts
- **TODO `query-test-configure-visible-columns-failures`** (Bug, Medium) — `_project/TODO/main/bugs/`. `Query.test.tsx` fails 3 cases on develop tip looking for `Configure visible columns` text that no longer appears in `Query.tsx`. Bisect across PRs #266/#268/#269/#270 to find the breaking change and either restore the affordance or align the tests.
- **TODO `results-explorer-retheme-link-hover-direction`** (Polish, Low) — `_project/TODO/main/planning/`. `index.css` `a` / `a:hover` now produces lighter-on-hover on light data surfaces, inverting the conventional darker-on-hover affordance. Two clean fixes documented (swap accent tokens vs introduce dedicated `--bb-link-fg` tokens). Design-owned.
- **Blind-spot `release-readiness-against-pre-merge-tree`** (framework-gap) — `_project/blind-spots/2026-05-07-211858-...`. Release-readiness reports/captures generated against a PR branch can miss literal-color regressions introduced by concurrent PRs to the same files (the PR #268 ↔ PR #269 race). Sweep hint references `results-explorer-token-scan-ci-gate` (already raised as a TODO in PR #271).

## Test plan
- [x] `validate_todo.py` — both new TODO YAMLs valid.
- [x] `validate_blind_spot.py` — blind-spot file valid.
- [x] `todo_cli.py check-graph` — 41 items, no cycles or dangling references.
- [x] `make blind-spots-list` — new finding listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)