### PR TITLE
fix(explorer): tighten Query workbench desktop intro to keep results panel above the fold

### DIFF
--- a/_project/DONE/main/results-explorer-responsive-desktop-query-panel-regression.yaml
+++ b/_project/DONE/main/results-explorer-responsive-desktop-query-panel-regression.yaml
@@ -2,7 +2,8 @@ id: results-explorer-responsive-desktop-query-panel-regression
 title: "Fix or relax responsive.spec.ts query workbench desktop assertion (regression on develop)"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
+completed: 2026-05-08
 category: Frontend / Test Infrastructure
 
 description: |
@@ -61,34 +62,53 @@ context_sections:
 work:
   - id: w1
     summary: "Bisect the 9px regression to a specific PR #270 hunk"
-    status: pending
+    status: done
     notes: |
-      Locally check out commits between b26f6aff3 (the merge-base) and
-      27fbd73d7 (PR #270 merge) on `results-explorer/src/pages/Query.tsx`.
-      Run the failing assertion at each step and pinpoint the hunk that
-      pushes the panel from ≤900 to 909.
+      Reframed: not a regression in PR #270 source. With pre-PR-#270 source
+      checked out (Query.tsx, Layout.tsx, index.css at b26f6aff3), the live
+      DOM probe of `/results/query` at desktop (1280/1440/1600) reports
+      `query-results-panel.top = 909` — identical to develop tip. The
+      `lg:order-1` placement of `query-visible-columns` at the top of the
+      right column at lg+ has been the design since PR #120, and its chip
+      list has consistently produced ≈494px above the result summary.
+      PR #270's only Query.tsx changes were sticky right-column cells,
+      `min-w-full w-max` on the table, and scroll-hint `data-testid`s — none
+      of which alter the panel's vertical position. PR #270's actual
+      contribution to this failure was the test side: it relaxed desktop
+      `maxY` from 800 to 900 while narrowing the desktop viewport from 1440
+      to 1280, but the panel was already at 909, so the test was still 9px
+      short. This explains why no per-commit bisect could be performed —
+      PR #270 was squash-merged, and the layout shift the TODO assumed had
+      never existed.
 
   - id: w2
     summary: "Decide between layout fix or threshold relaxation"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      If the 9px shift is incidental (an unintended border/padding from
-      a token swap), tighten the layout. If it is the new mobile drawer
-      trigger that legitimately occupies 9px on desktop, relax desktop
-      maxY to ~960 with a comment explaining the budget. Document the
-      rationale either way.
+      Chose option (1) — tighten layout above the panel — to honour the
+      TODO's preference and to keep the rows panel above the fold at
+      desktop. Single-line, lg-only change in `results-explorer/src/pages/Query.tsx:494`:
+      the page intro container's `mb-6` becomes `mb-6 lg:mb-3`. This drops
+      12px of vertical space between the description block and the grid at
+      lg+ widths only; mobile/tablet spacing is unchanged, so the
+      drawer/results ordering and `maxY=1200` budgets at 390/768 are
+      preserved. After fix, the live probe reports
+      `query-results-panel.top = 897` at 1280/1440/1600 — within the
+      `maxY=900` budget with 3px of margin.
 
   - id: w3
     summary: "Re-run responsive grep end-to-end and confirm tablet affordance + overflow tests run after the fix"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
-      The PR #272 verification log only validates the affordance + overflow
-      tests in isolation because the desktop failure stops the serial run
-      early. After fixing this regression, run
-      `npx playwright test --project=chromium --grep "responsive|layout|a11y|mobile"`
-      and capture full output to a verification log.
+      Captured to
+      `_project/verification-logs/results-explorer-responsive-desktop-query-panel-regression/responsive-grep.log`.
+      `cd results-explorer && npx playwright test --project=chromium --grep 'responsive|layout|a11y|mobile' --workers=1`
+      → 24 passed, 2 skipped (tag-gated `@pr246-capture` / `@retheme-capture`
+      capture specs that don't run under this grep), 0 failed, exit 0. The
+      previously-masked tablet affordance + document-overflow tests now run
+      end-to-end alongside the desktop assertion.
 
 verification:
   - description: "responsive grep suite passes end-to-end on develop after fix"

--- a/_project/verification-logs/results-explorer-responsive-desktop-query-panel-regression/responsive-grep.log
+++ b/_project/verification-logs/results-explorer-responsive-desktop-query-panel-regression/responsive-grep.log
@@ -1,0 +1,35 @@
+[2m[WebServer] [22m[serve-browser-tests] dist=/Users/joe/Developer/BenchBox.pool-04/results-explorer/dist
+[2m[WebServer] [22m[serve-browser-tests] fixtures=/Users/joe/Developer/BenchBox.pool-04/results-explorer/test-fixtures/.generated/data
+[2m[WebServer] [22m[serve-browser-tests] listening on http://127.0.0.1:4319/results/
+
+Running 26 tests using 1 worker
+
+  -   1 [chromium] › e2e/captures/pr246-responsive-remediation.spec.ts:107:3 › @pr246-capture responsive remediation › captures mobile and tablet responsive evidence
+  -   2 [chromium] › e2e/captures/responsive-a11y-pass.spec.ts:40:3 › @retheme-capture responsive-a11y pass › captures every primary route at 4 widths
+  ✓   3 [chromium] › e2e/responsive.spec.ts:28:5 › responsive explorer assertions › secondary nav exposes every Explorer route at mobile (509ms)
+  ✓   4 [chromium] › e2e/responsive.spec.ts:40:5 › responsive explorer assertions › home keeps headline, cohort summary, and leaderboard rows high in the viewport at mobile (1.0s)
+  ✓   5 [chromium] › e2e/responsive.spec.ts:73:5 › responsive explorer assertions › benchmark heatmap exposes overflow affordance when needed at mobile (1.0s)
+  ✓   6 [chromium] › e2e/responsive.spec.ts:89:5 › responsive explorer assertions › query workbench renders summary, active filters, and rows before deep controls at mobile (1.1s)
+  ✓   7 [chromium] › e2e/responsive.spec.ts:114:5 › responsive explorer assertions › compare route keeps decision summary and query evidence reachable at mobile (1.0s)
+  ✓   8 [chromium] › e2e/responsive.spec.ts:28:5 › responsive explorer assertions › secondary nav exposes every Explorer route at tablet (176ms)
+  ✓   9 [chromium] › e2e/responsive.spec.ts:40:5 › responsive explorer assertions › home keeps headline, cohort summary, and leaderboard rows high in the viewport at tablet (1.0s)
+  ✓  10 [chromium] › e2e/responsive.spec.ts:73:5 › responsive explorer assertions › benchmark heatmap exposes overflow affordance when needed at tablet (1.0s)
+  ✓  11 [chromium] › e2e/responsive.spec.ts:89:5 › responsive explorer assertions › query workbench renders summary, active filters, and rows before deep controls at tablet (1.1s)
+  ✓  12 [chromium] › e2e/responsive.spec.ts:114:5 › responsive explorer assertions › compare route keeps decision summary and query evidence reachable at tablet (1.0s)
+  ✓  13 [chromium] › e2e/responsive.spec.ts:28:5 › responsive explorer assertions › secondary nav exposes every Explorer route at desktop (194ms)
+  ✓  14 [chromium] › e2e/responsive.spec.ts:40:5 › responsive explorer assertions › home keeps headline, cohort summary, and leaderboard rows high in the viewport at desktop (1.0s)
+  ✓  15 [chromium] › e2e/responsive.spec.ts:73:5 › responsive explorer assertions › benchmark heatmap exposes overflow affordance when needed at desktop (1.0s)
+  ✓  16 [chromium] › e2e/responsive.spec.ts:89:5 › responsive explorer assertions › query workbench renders summary, active filters, and rows before deep controls at desktop (1.1s)
+  ✓  17 [chromium] › e2e/responsive.spec.ts:114:5 › responsive explorer assertions › compare route keeps decision summary and query evidence reachable at desktop (1.1s)
+  ✓  18 [chromium] › e2e/responsive.spec.ts:28:5 › responsive explorer assertions › secondary nav exposes every Explorer route at wide (183ms)
+  ✓  19 [chromium] › e2e/responsive.spec.ts:40:5 › responsive explorer assertions › home keeps headline, cohort summary, and leaderboard rows high in the viewport at wide (1.1s)
+  ✓  20 [chromium] › e2e/responsive.spec.ts:73:5 › responsive explorer assertions › benchmark heatmap exposes overflow affordance when needed at wide (1.0s)
+  ✓  21 [chromium] › e2e/responsive.spec.ts:89:5 › responsive explorer assertions › query workbench renders summary, active filters, and rows before deep controls at wide (1.1s)
+  ✓  22 [chromium] › e2e/responsive.spec.ts:114:5 › responsive explorer assertions › compare route keeps decision summary and query evidence reachable at wide (1.1s)
+  ✓  23 [chromium] › e2e/responsive.spec.ts:129:5 › responsive explorer assertions › audited routes avoid document overflow at mobile (5.5s)
+  ✓  24 [chromium] › e2e/responsive.spec.ts:138:5 › responsive explorer assertions › mobile table affordances remain visible at mobile (3.8s)
+  ✓  25 [chromium] › e2e/responsive.spec.ts:129:5 › responsive explorer assertions › audited routes avoid document overflow at tablet (5.5s)
+  ✓  26 [chromium] › e2e/responsive.spec.ts:138:5 › responsive explorer assertions › mobile table affordances remain visible at tablet (3.8s)
+
+  2 skipped
+  24 passed (37.4s)

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -491,7 +491,7 @@ export function Query(_: RoutableProps) {
 
   return (
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <div class="mb-6">
+      <div class="mb-6 lg:mb-3">
         <h1 class="text-3xl font-bold text-[var(--bb-data-fg-primary)]">Results Query Workbench</h1>
         <p class="mt-2 max-w-3xl text-sm text-[var(--bb-data-fg-muted)]">
           Query the <code class="rounded bg-[var(--bb-surface-app)] px-1 font-mono text-xs">results.duckdb</code> snapshot in-browser


### PR DESCRIPTION
Reduce the page-intro container's bottom margin to `mb-3` at lg+ widths
(unchanged at mobile/tablet) so `query-results-panel.top` lands at 897px
on desktop — within the responsive.spec.ts `maxY=900` budget rather than
the 909px the live DOM produced beforehand.

The TODO framed this as a PR #270 layout regression, but probing the
pre-#270 source (Query.tsx, Layout.tsx, index.css at b26f6aff3) reproduced
the same 909px panel top: PR #270 only touched right-column sticky cells
and scroll-hint testids, and `lg:order-1` on `query-visible-columns` has
held since PR #120. PR #270's actual contribution to the failure was on
the test side — relaxing desktop maxY 800→900 while narrowing the
viewport 1440→1280, still 9px short of the existing layout. So this is a
chronic-budget tighten, not a regression undo.

Verified with the full responsive grep:
`_project/verification-logs/results-explorer-responsive-desktop-query-panel-regression/responsive-grep.log`
24 passed / 0 failed / 2 tag-gated capture specs skipped, exit 0. The
previously-masked tablet affordance and document-overflow assertions now
run end-to-end alongside the desktop assertion.

Closes results-explorer-responsive-desktop-query-panel-regression.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
