### PR TITLE
chore(explorer): PR #276 review follow-ups (budget comment, YAML field, lg:order TODO)

### DIFF
--- a/_project/DONE/main/results-explorer-responsive-desktop-query-panel-regression.yaml
+++ b/_project/DONE/main/results-explorer-responsive-desktop-query-panel-regression.yaml
@@ -3,7 +3,7 @@ title: "Fix or relax responsive.spec.ts query workbench desktop assertion (regre
 worktree: main
 priority: Medium
 status: Completed
-completed: 2026-05-08
+completed_date: "2026-05-08"
 category: Frontend / Test Infrastructure
 
 description: |

--- a/_project/TODO/main/planning/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
@@ -1,0 +1,141 @@
+id: results-explorer-query-visible-columns-desktop-order-vs-test-name
+title: "Resolve Query workbench desktop ordering vs `responsive.spec.ts` test-name semantic"
+worktree: main
+priority: Low
+status: Not Started
+category: Frontend / Test Infrastructure
+
+description: |
+  PR #276 (`fix(explorer): tighten Query workbench desktop intro to keep
+  results panel above the fold`) closed the failing `responsive.spec.ts`
+  desktop assertion by trimming 12px of vertical space above the grid at
+  lg+ widths only. That fix passes the numeric `expectTopWithin(...,
+  maxY=900)` check (panel.top is now 897), but it leaves two related soft
+  issues that the PR #276 review surfaced and explicitly deferred:
+
+  1) **Layout/test-name semantic mismatch.** The test is titled
+     "query workbench renders summary, active filters, and rows
+     **before deep controls** at desktop", but `query-visible-columns`
+     keeps `lg:order-1` (in
+     `results-explorer/src/pages/Query.tsx:697`), so at desktop the
+     column-toggle UI still renders **above** the summary and rows. The
+     numeric assertion passes but the test name promises ordering the
+     layout does not deliver.
+
+  2) **Brittle 3px desktop budget.** After PR #276, panel.top = 897
+     against `maxY = 900` at desktop. Any future change that adds a
+     border, a font-metrics tick, or a half-line wrap on the intro
+     paragraph at the desktop viewport (1280×900) will retrip the same
+     assertion. Comment landed in PR #277 alongside this TODO; this
+     TODO is the durable answer.
+
+  Resolving (1) structurally also resolves (2): if `query-visible-columns`
+  drops `lg:order-1` (or moves to `lg:order-5` so the right-column flex
+  order at desktop becomes summary → panel → details → visible-columns),
+  panel.top drops from 897 to ≈399, leaving ≈500px of headroom against
+  `maxY=900`.
+
+  Two reasonable resolutions:
+    a) **Restructure the layout to match the test name.** Drop
+       `lg:order-1` from `query-visible-columns` so the section's flex
+       order at desktop is summary → panel → details → visible-columns,
+       matching the test's "rows before deep controls" promise. UX
+       change: the column-toggle UI moves from the top of the right
+       column to the bottom at desktop. Mobile/tablet ordering is
+       already this way (visible-columns at the bottom via `order-5`).
+    b) **Rename the test and document the lg-order intent.** Keep the
+       `lg:order-1` placement (PR #120's design intent of putting
+       column configuration above the table at desktop) and rename the
+       test to something like "renders summary, results panel, and
+       deep controls within the desktop viewport budget" so the title
+       matches what the assertions actually check.
+
+  Resolution (a) is preferable because it removes a documented
+  inconsistency and gives the desktop budget durable headroom; (b) is
+  acceptable if PR #120's design intent is still load-bearing.
+
+deps:
+  needs: []
+
+context_sections:
+  evidence_source: |
+    PR #276 review (in-session with Claude on 2026-05-08) flagged the
+    semantic mismatch and brittleness. The DOM probe captured during
+    that session showed `query-results-panel.top = 909` at all
+    desktop+ widths under `lg:order-1`; with `lg:order-1` removed the
+    panel would land at ≈399 (computed: section start 251 + summary
+    132 + 16 gap = 399).
+  related_pr_history: |
+    PR #120 (a42c65690) introduced `lg:order-1` on
+    `query-visible-columns`, putting the column-toggle UI above the
+    table at desktop only. PR #266/#270/#272 did not touch the lg
+    order. PR #276 (this TODO's parent) tightened intro spacing 12px
+    at lg+ to fit the existing panel into the existing budget.
+  affected_files: |
+    - results-explorer/src/pages/Query.tsx (line 697 — the
+      `lg:order-1` class on `query-visible-columns`)
+    - results-explorer/e2e/responsive.spec.ts:89 (the test name and
+      assertions in question)
+
+work:
+  - id: w1
+    summary: "Decide between layout restructure (a) or test rename (b)"
+    status: pending
+    notes: |
+      Read PR #120's PR description and the visible-columns design
+      rationale. If PR #120's intent (configure-columns-first at
+      desktop) is still load-bearing, choose (b); otherwise (a).
+      Document the chosen rationale in the work-unit notes so the
+      next reviewer sees the decision trail.
+
+  - id: w2
+    summary: "Apply the chosen change"
+    needs: [w1]
+    status: pending
+    notes: |
+      For (a): single-line edit removing `lg:order-1` from
+      `results-explorer/src/pages/Query.tsx:697` (or replacing with
+      `lg:order-5`); also drop the now-vestigial `mb-6 lg:mb-3` from
+      Query.tsx:494 added by PR #276 since the budget no longer
+      requires the lg-only tighten.
+      For (b): rename the test at
+      `results-explorer/e2e/responsive.spec.ts:89` and add a one-line
+      comment near `query-visible-columns` documenting the lg-order
+      intent.
+
+  - id: w3
+    summary: "Re-run responsive grep end-to-end and capture verification"
+    needs: [w2]
+    status: pending
+    notes: |
+      `cd results-explorer && npx playwright test --project=chromium --grep 'responsive|layout|a11y|mobile' --workers=1`.
+      Capture to
+      `_project/verification-logs/results-explorer-query-visible-columns-desktop-order-vs-test-name/responsive-grep.log`.
+      For resolution (a), also include a DOM probe confirming
+      panel.top dropped meaningfully (target: ≤500 at 1280/1440/1600).
+
+verification:
+  - description: "Responsive grep stays green end-to-end"
+    command: "cd results-explorer && npx playwright test --project=chromium --grep 'responsive|layout|a11y|mobile' --workers=1"
+    expected_output: "exit 0; 24+ passed, 0 failed"
+  - description: "If resolution (a): panel.top has ≥100px headroom at desktop"
+    command: "cd results-explorer && npx playwright test --project=chromium e2e/responsive.spec.ts:89 --grep desktop"
+    expected_output: "exit 0 with measurable margin (manual probe ≤800)"
+
+must_preserve:
+  - "Mobile/tablet ordering: results panel above visible-columns (the existing `order-3` < `order-5` invariant)."
+  - "All `data-testid`s on `query-visible-columns`, `query-results-panel`, `query-result-summary`, and `query-mobile-filter-drawer` — downstream tests rely on them."
+  - "`maxY=1200` budgets at mobile/tablet."
+
+anti_patterns:
+  - "DO NOT silently `test.skip` the failing assertion if a future regression retripps the desktop budget."
+  - "DO NOT relax `maxY` at mobile/tablet — only desktop is at issue."
+  - "DO NOT delete the desktop-budget comment in `responsive.spec.ts` added by PR #277 without first resolving this TODO."
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Query.tsx (one to two lines around the `query-visible-columns` and intro container if resolving (a); else untouched)"
+    - "results-explorer/e2e/responsive.spec.ts (test title + comment if resolving (b); else untouched)"
+  do_not_touch:
+    - "Other pages or layouts in results-explorer/src/pages/."
+    - "The desktop-budget comment block on `VIEWPORTS` in `responsive.spec.ts` (it documents the budget regardless of which resolution is chosen)."

--- a/_project/TODO/main/planning/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
@@ -15,25 +15,37 @@ description: |
 
   1) **Layout/test-name semantic mismatch.** The test is titled
      "query workbench renders summary, active filters, and rows
-     **before deep controls** at desktop", but `query-visible-columns`
-     keeps `lg:order-1` (in
-     `results-explorer/src/pages/Query.tsx:697`), so at desktop the
-     column-toggle UI still renders **above** the summary and rows. The
-     numeric assertion passes but the test name promises ordering the
-     layout does not deliver.
+     **before deep controls** at desktop", but the `query-visible-columns`
+     element (locate by `data-testid="query-visible-columns"` in
+     `results-explorer/src/pages/Query.tsx`) keeps the `lg:order-1`
+     class, so at desktop the column-toggle UI still renders **above**
+     the summary and rows. The numeric assertion passes but the test
+     name promises ordering the layout does not deliver. This is the
+     durable concern and survives any future visible-columns
+     restructure.
 
-  2) **Brittle 3px desktop budget.** After PR #276, panel.top = 897
-     against `maxY = 900` at desktop. Any future change that adds a
-     border, a font-metrics tick, or a half-line wrap on the intro
-     paragraph at the desktop viewport (1280×900) will retrip the same
-     assertion. Comment landed in PR #277 alongside this TODO; this
-     TODO is the durable answer.
+  2) **Brittle 3px desktop budget (state-dependent).** Immediately
+     after PR #276 landed, panel.top = 897 against `maxY = 900` at
+     desktop — any future change adding a border, a font-metrics tick,
+     or a half-line wrap on the intro paragraph would retrip the
+     assertion. The block comment above `VIEWPORTS` in
+     `results-explorer/e2e/responsive.spec.ts` (added by PR #278
+     alongside this TODO) documents the brittleness. **Important
+     state-dependence:** PR #277 (concurrent, may land before this
+     TODO is actioned) restructures `query-visible-columns` from a
+     div into a default-collapsed `<details>`/`<summary>` affordance,
+     which collapses the visible-columns block from ≈494px to ≈30px
+     by default at lg:order-1. Once PR #277 is in develop, the live
+     panel.top drops to ≈445 and the brittleness rationale evaporates;
+     only the semantic mismatch (1) remains. Re-measure with the live
+     DOM probe before deciding which resolution to pick.
 
-  Resolving (1) structurally also resolves (2): if `query-visible-columns`
-  drops `lg:order-1` (or moves to `lg:order-5` so the right-column flex
-  order at desktop becomes summary → panel → details → visible-columns),
-  panel.top drops from 897 to ≈399, leaving ≈500px of headroom against
-  `maxY=900`.
+  Resolving (1) structurally also resolves (2) regardless of PR #277's
+  merge state: if `query-visible-columns` drops `lg:order-1` (or moves
+  to `lg:order-5` so the right-column flex order at desktop becomes
+  summary → panel → details → visible-columns), panel.top falls into
+  the low hundreds and the desktop budget stops being a recurring
+  concern.
 
   Two reasonable resolutions:
     a) **Restructure the layout to match the test name.** Drop
@@ -72,10 +84,17 @@ context_sections:
     order. PR #276 (this TODO's parent) tightened intro spacing 12px
     at lg+ to fit the existing panel into the existing budget.
   affected_files: |
-    - results-explorer/src/pages/Query.tsx (line 697 — the
-      `lg:order-1` class on `query-visible-columns`)
-    - results-explorer/e2e/responsive.spec.ts:89 (the test name and
-      assertions in question)
+    - results-explorer/src/pages/Query.tsx — locate by
+      `data-testid="query-visible-columns"`; the line carrying the
+      `lg:order-1` class on that element is the structural lever.
+      `data-testid="query-result-summary"` and `data-testid="query-results-panel"`
+      are the sibling testids the test asserts against. Line numbers
+      are intentionally omitted because PR #277's `<details>`/`<summary>`
+      restructure shifts surrounding content.
+    - results-explorer/e2e/responsive.spec.ts — the test
+      "query workbench renders summary, active filters, and rows before
+      deep controls at ${viewport.name}" (currently anchored at line 89
+      on develop tip; locate by the title pattern, not the line).
 
 work:
   - id: w1
@@ -93,15 +112,19 @@ work:
     needs: [w1]
     status: pending
     notes: |
-      For (a): single-line edit removing `lg:order-1` from
-      `results-explorer/src/pages/Query.tsx:697` (or replacing with
-      `lg:order-5`); also drop the now-vestigial `mb-6 lg:mb-3` from
-      Query.tsx:494 added by PR #276 since the budget no longer
-      requires the lg-only tighten.
-      For (b): rename the test at
-      `results-explorer/e2e/responsive.spec.ts:89` and add a one-line
-      comment near `query-visible-columns` documenting the lg-order
-      intent.
+      For (a): single-line edit removing `lg:order-1` from the element
+      with `data-testid="query-visible-columns"` in `Query.tsx` (or
+      replacing with `lg:order-5`); also drop the now-vestigial
+      `mb-6 lg:mb-3` (PR #276) on the page-intro container in the
+      same file since the budget no longer requires the lg-only
+      tighten; and update or remove the `VIEWPORTS` block comment in
+      `responsive.spec.ts` so it reflects the post-fix headroom rather
+      than the historical 3px brittleness.
+      For (b): rename the test "query workbench renders summary,
+      active filters, and rows before deep controls at ..." in
+      `responsive.spec.ts` to match the actual lg-order, and add a
+      one-line comment near `query-visible-columns` in `Query.tsx`
+      documenting the lg-order intent.
 
   - id: w3
     summary: "Re-run responsive grep end-to-end and capture verification"
@@ -130,12 +153,11 @@ must_preserve:
 anti_patterns:
   - "DO NOT silently `test.skip` the failing assertion if a future regression retripps the desktop budget."
   - "DO NOT relax `maxY` at mobile/tablet — only desktop is at issue."
-  - "DO NOT delete the desktop-budget comment in `responsive.spec.ts` added by PR #277 without first resolving this TODO."
+  - "DO NOT delete the desktop-budget comment block on `VIEWPORTS` in `responsive.spec.ts` (added by PR #278) without resolving this TODO; under resolution (a) the comment must be UPDATED to reflect the new headroom, not silently dropped."
 
 scope_limit:
   only_modify:
     - "results-explorer/src/pages/Query.tsx (one to two lines around the `query-visible-columns` and intro container if resolving (a); else untouched)"
-    - "results-explorer/e2e/responsive.spec.ts (test title + comment if resolving (b); else untouched)"
+    - "results-explorer/e2e/responsive.spec.ts (test title + comment if resolving (b); update the `VIEWPORTS` budget comment under (a) to reflect the new headroom)"
   do_not_touch:
     - "Other pages or layouts in results-explorer/src/pages/."
-    - "The desktop-budget comment block on `VIEWPORTS` in `responsive.spec.ts` (it documents the budget regardless of which resolution is chosen)."

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -5,6 +5,14 @@ const SHORT_DUCKDB = "ba6a8c83";
 const SHORT_DATAFUSION = "5e6c5eba";
 const DETAIL_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
 
+// Desktop/wide use maxY = viewport.height (900); mobile/tablet use 1200 (1.33x).
+// PR #276 brought the live `query-results-panel.top` from 909 to 897 against
+// the 900 budget — only 3px of headroom. If you add height above the grid on
+// the Query workbench (intro paragraph, breadcrumb, banner) or change
+// `lg:order-1` placement of `query-visible-columns`, run the responsive grep
+// before merging or relax this budget. See DONE TODO
+// `results-explorer-responsive-desktop-query-panel-regression` for the
+// full layout accounting and rationale.
 const VIEWPORTS = [
   { name: "mobile", width: 390, height: 900, maxY: 1200 },
   { name: "tablet", width: 768, height: 900, maxY: 1200 },


### PR DESCRIPTION
Three follow-ups identified during the PR #276 self-review:

1. **Desktop-budget comment in `responsive.spec.ts`.** PR #276 left the
   live `query-results-panel.top` at 897 against `maxY=900` — only 3px
   of headroom. Added a block comment above `VIEWPORTS` documenting the
   budget, the failure mode, the closed TODO, and the next-action
   pointer (`lg:order-1` placement) so the next person editing intro
   spacing or the desktop layout knows why this is tight before they
   ship. Pure comment; no runtime impact.

2. **YAML field-name normalization.** PR #276's closed TODO used
   `completed: 2026-05-08`, but the rest of `_project/DONE/main/`
   (300 other items, including those landed in PR #277) uses
   `completed_date: "2026-05-08"`. Renamed the field on PR #276's
   TODO to match. Sweep across `_project/DONE/main/` confirmed the
   drift was isolated to that one file.

3. **Follow-up TODO for the lg:order-1 vs test-name semantic.** Created
   `results-explorer-query-visible-columns-desktop-order-vs-test-name`
   (Low priority) capturing the deferred decision: restructure the
   right-column flex order at desktop so `query-visible-columns`
   stops rendering above summary/rows (matching the test name), or
   rename the responsive test to match the existing `lg:order-1`
   layout intent from PR #120. Resolving option (a) also retires the
   3px desktop-budget brittleness, which is documented in the TODO.

Pre-flight: `make pr-preflight` clean (21926 passed). `npm run
typecheck` clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
