### PR TITLE
chore(todo): rebind evidence and fix paths in explorer follow-up planning items

### DIFF
--- a/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
+++ b/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
@@ -1,0 +1,175 @@
+id: results-explorer-chart-panel-scope-and-labeling
+title: "Trim chart panel dead space and correct chart metric labeling"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Frontend UX
+
+description: |
+  Remove chart-panel dead space, hide or clarify empty/duplicate chart views, and
+  fix metric/contrast copy that contradicts rendered data. Defects this item
+  addresses were flagged in the 2026-05-08 Results Explorer follow-up review
+  (chat-only artifact, not committed to _project/audits/). w0 rebinds the
+  review evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #21/#22/#23/#37/#38/#39" citations as the durable reference.
+
+deps:
+  needs:
+    - results-explorer-compare-flow-entrypoints
+    - results-explorer-run-identity-disambiguation
+
+work:
+  - id: w0
+    summary: "Rebind chart-panel review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk Charts > Overview, Per-query (Heatmap, Histogram), Cost, Trend,
+      Rank, and Compare > Normalized Speedup against the current develop tip
+      using a benchmark detail with cost data and one without. Capture
+      observed defects (chart-panel header height, empty/duplicate Per-query
+      heatmap, Cost-tab behavior with no normalized cost, heatmap legend copy
+      vs rendered cells, contrast/reduced-color visual delta, Compare
+      normalized-speedup row count and dash density) to
+      _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log.
+      Output is the rebind reference for w1-w7 acceptance.
+
+  - id: w1
+    summary: "Compact the chart panel header and tab band"
+    needs: [w0]
+    status: pending
+    notes: |
+      Reduce the large empty band above chart subtabs by moving chart title,
+      primary tabs, secondary tabs, and active filters into a compact header
+      region. Preserve usable click targets while removing unused vertical
+      whitespace.
+
+  - id: w2
+    summary: "Remove or rescope the duplicate Per-query heatmap"
+    needs: [w0]
+    status: pending
+    notes: |
+      On Benchmark detail pages where the matrix is already rendered above the
+      Charts panel, hide Charts > Per-query > Heatmap or replace it with a
+      scoped view that adds information not present in the main matrix. Keep a
+      clear path to Histogram if that subview remains useful.
+
+  - id: w3
+    summary: "Hide or disable Cost tabs when no cost data exists"
+    needs: [w0]
+    status: pending
+    notes: |
+      When no normalized cost data exists for the current cohort, disable or
+      hide the Cost chart tab and show a short unavailable-cost note in a
+      predictable place. Do not let users open a selectable blank panel.
+
+  - id: w4
+    summary: "Correct heatmap metric copy for latency cells"
+    needs: [w0]
+    status: pending
+    notes: |
+      Change the Benchmark heatmap legend heading from "Power Score: higher is
+      better" when cells are per-query latency values. The visible heading
+      must name the metric actually rendered, for example "Per-query latency
+      (ms): lower is better", while the power-score column keeps its own
+      explanation.
+
+  - id: w5
+    summary: "Repair or rename high-contrast heatmap mode"
+    needs: [w0]
+    status: pending
+    notes: |
+      Either implement a true high-contrast heatmap palette with stronger
+      luminance separation and accessible text contrast, or rename the control
+      to "Reduced color" if the intended behavior is greyscale. The selected
+      mode must visibly improve contrast or accurately describe the rendered
+      heatmap.
+
+  - id: w6
+    summary: "Constrain long Compare normalized-speedup charts"
+    needs: [w0]
+    status: pending
+    notes: |
+      Fix Compare normalized speedup/read-primitives charts that render about
+      149 query rows with many dash values. Add a query filter, "show
+      comparable only" default, or per-benchmark grouping so the chart is
+      readable without scrolling through mostly missing rows. Coordinate with
+      the upstream Compare rebuild (results-explorer-compare-flow-entrypoints)
+      and identity labels (results-explorer-run-identity-disambiguation) to
+      avoid stomping their changes.
+
+  - id: w7
+    summary: "Cover chart panel scope, labels, and contrast behavior"
+    needs: [w1, w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Add tests and browser screenshots for chart header height, Per-query tab
+      behavior, absent Cost data, heatmap legend copy, contrast/reduced-color
+      mode, and long Compare chart filtering.
+
+must_preserve:
+  - "Existing chart tabs that contain data must remain reachable."
+  - "Benchmark matrix data and chart data must continue to derive from the same cohort."
+  - "Color palettes must keep readable text contrast."
+
+approach: |
+  Prefer hiding or disabled states for tabs with no data over rendering blank
+  panels. Make copy depend on the displayed metric instead of the page-level
+  benchmark score. Use small localized layout changes inside the current chart
+  panel information architecture. Run after compare-flow-entrypoints and
+  run-identity-disambiguation so Compare.tsx and NormalizedSpeedupChart.tsx
+  are not edited by three concurrent worktrees.
+
+anti_patterns:
+  - "DO NOT create new pages or a redesigned chart explorer."
+  - "DO NOT keep duplicate matrix views unless the duplicate has a distinct scope."
+  - "DO NOT call greyscale high contrast unless measured contrast actually improves."
+
+verification:
+  - description: "Chart panel and heatmap tests pass"
+    command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/QueryHeatmap.test.tsx src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual chart browser check is complete"
+    command: "echo 'Manual: browser-check /results/tpch/ chart Overview, Per-query, Distribution, Cost, Trend, Rank, and Compare normalized speedup'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/components/CostScatter.tsx"
+    - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/src/index.css"
+  do_not_modify:
+    - "benchbox/"
+    - "Generated result data unless cost availability flags are missing from presentation data."
+
+metadata:
+  tags:
+    - results-explorer
+    - charts
+    - labels
+    - usability-review
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Makes chart panels denser and more truthful without changing the overall
+    Results Explorer route structure.
+  user_impact: |
+    Users see fewer blank/duplicate panels and metric labels that match the data
+    they are interpreting.
+  technical_debt: |
+    Encodes chart availability and displayed-metric labeling as tested behavior.

--- a/_project/TODO/main/planning/results-explorer-compare-flow-entrypoints.yaml
+++ b/_project/TODO/main/planning/results-explorer-compare-flow-entrypoints.yaml
@@ -1,0 +1,174 @@
+id: results-explorer-compare-flow-entrypoints
+title: "Repair Results Explorer compare flow entrypoints"
+worktree: main
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  Build a complete in-page compare flow for Results Explorer so users can
+  discover, select, and compare compatible runs without editing URLs. Defects
+  this item addresses were flagged in the 2026-05-08 Results Explorer
+  follow-up review (chat-only artifact, not committed to _project/audits/).
+  w0 rebinds the review evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-compare-flow-entrypoints/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #1/#2/#4/#5/#34/#35/#36" citations as the durable reference.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Rebind compare-flow review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk /results/compare (empty), /results/r/<id> (single-result compare
+      CTA), /results/query (no compare selection), /results/ (Home leaderboard
+      and Recent Results compare affordances), /results/tpch/ (Benchmark
+      detail row selection), and /results/p/<platform>/ (Platform detail row
+      selection) against the current develop tip. Capture observed defects
+      (URL-editing prompts, dead-end CTAs, missing checkboxes, mixed-cohort
+      acceptance, hidden result_id availability) to
+      _project/verification-logs/results-explorer-compare-flow-entrypoints/w0.log.
+      Output is the rebind reference for w1-w7 acceptance.
+
+  - id: w1
+    summary: "Inventory current compare route contracts and id availability"
+    needs: [w0]
+    status: pending
+    notes: |
+      Inventory Compare, ResultDetail, Query, Home, BenchmarkIndex, and
+      PlatformIndex. Record current compare route contracts, link helpers,
+      selection state, and which transformed row datasets already carry a
+      usable hidden result id. Write the inventory to
+      _project/audits/compare-entrypoint-inventory-2026-05-08.md so w2-w6 can
+      cite it instead of re-deriving.
+
+  - id: w2
+    summary: "Replace the empty Compare URL-editing error with an in-page builder"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace the empty `/results/compare` state that tells users to add
+      `?ids=id1,id2` with a compare builder. The builder exposes benchmark,
+      platform, scale, phase, and metric-contract filters; renders selectable
+      candidate runs; and disables launch until two compatible ids are
+      selected.
+
+  - id: w3
+    summary: "Support single-result compare starts from Result Detail"
+    needs: [w1]
+    status: pending
+    notes: |
+      Fix ResultDetail "Compare this result" so one selected result opens the
+      compare builder with that run pinned and compatible candidates listed.
+      The page must not redirect to a broken compare state or silently no-op
+      with only one id.
+
+  - id: w4
+    summary: "Add Query Workbench compare selection"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a checkbox selection column and compare tray to Query Workbench
+      result rows. Preserve hidden result_id values even when the Result ID
+      column is not visible, show selected-run count plus compatibility
+      messages, and launch Compare from the current filtered result set.
+
+  - id: w5
+    summary: "Add Home leaderboard and recent-result compare entrypoints"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add compare affordances to Home leaderboard and Recent Results surfaces.
+      Either provide row checkboxes where ids are present or route to the
+      compare builder with benchmark/platform/scale context prefilled. Remove
+      any link that lands on an empty Compare error.
+
+  - id: w6
+    summary: "Constrain compatible cohort selection on detail pages"
+    needs: [w1]
+    status: pending
+    notes: |
+      On Benchmark and Platform detail pages, enforce same-cohort selection as
+      users select rows. After the first selection, disable incompatible rows
+      with a short reason, keep compatible rows selectable, and replace dead
+      disabled CTA copy with instructions tied to visible checkboxes.
+
+  - id: w7
+    summary: "Cover compare entrypoints with automated and browser checks"
+    needs: [w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Add unit and browser coverage for the empty Compare builder,
+      single-result start, Query Workbench selection, Home selection/routing,
+      Benchmark detail selection, and Platform detail selection. Tests must
+      assert that users are never told to edit the URL to start comparison.
+
+must_preserve:
+  - "Existing `/results/compare?ids=...` deep links must keep working."
+  - "Static export compatibility; no server endpoint or runtime database dependency."
+  - "Comparable cohort rules: benchmark, scale, phase, metric, and unit stay fixed."
+
+approach: |
+  Prefer one shared compare-selection helper or tray over page-specific logic
+  where the data shape already matches. Keep result ids hidden from ordinary
+  table layout unless the user explicitly enables the Result ID column. Treat
+  the empty Compare page as a task-start page, not an error page.
+
+anti_patterns:
+  - "DO NOT require manual URL editing."
+  - "DO NOT allow mixed-cohort compares and then fail after navigation."
+  - "DO NOT duplicate incompatible compare-selection implementations across each page."
+
+verification:
+  - description: "Targeted compare entrypoint tests pass"
+    command: "cd results-explorer && npm test -- --run src/pages/__tests__/Compare.test.tsx src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual compare flow browser check is complete"
+    command: "echo 'Manual: browser-check /results/compare, /results/query, /results/, /results/tpch/, /results/p/polars/, and /results/r/<id> for end-to-end selection and launch'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/lib/resultLinks.ts"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/e2e/"
+    - "_project/audits/compare-entrypoint-inventory-2026-05-08.md"
+  do_not_modify:
+    - "benchmark_runs/"
+    - "benchbox/"
+    - "Generated result snapshot content unless a missing result_id field is proven to be the blocker."
+
+metadata:
+  tags:
+    - results-explorer
+    - compare
+    - p0
+    - usability-review
+  estimated_effort: "Large (2-4 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Converts Compare from a dead-end route into the central cross-run
+    investigation workflow promised by the Results Explorer UI.
+  user_impact: |
+    Database engineers can select runs from the pages where they discover them
+    and complete comparison without reading or editing the URL bar.
+  technical_debt: |
+    Consolidates compare selection rules that are currently implied in several
+    pages but not implemented consistently.

--- a/_project/TODO/main/planning/results-explorer-followup-usability-release-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-followup-usability-release-gate.yaml
@@ -1,0 +1,145 @@
+id: results-explorer-followup-usability-release-gate
+title: "Verify Results Explorer follow-up usability fixes before release"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Run the evidence gate for the Results Explorer follow-up review after the
+  implementation TODOs land. The follow-up review was a 2026-05-08 chat-only
+  artifact (not committed to _project/audits/); each implementation TODO
+  rebinds its own slice of the review via its w0 work unit and writes a log
+  under _project/verification-logs/<id>/w0.log. This gate's matrix synthesizes
+  those logs into a single closure record so each defect has either a fix, a
+  documented intentional behavior, or a follow-up blocker tracked.
+
+deps:
+  needs:
+    - results-explorer-compare-flow-entrypoints
+    - results-explorer-navigation-and-pivot-controls
+    - results-explorer-table-sticky-density-and-semantics
+    - results-explorer-run-identity-disambiguation
+    - results-explorer-query-workbench-controls-and-facets
+    - results-explorer-chart-panel-scope-and-labeling
+    - results-explorer-result-detail-metadata-density
+
+work:
+  - id: w1
+    summary: "Build the per-defect evidence matrix from per-item w0 logs"
+    status: pending
+    notes: |
+      Aggregate the seven dependency items' w0 evidence logs from
+      _project/verification-logs/<id>/w0.log into a single closure matrix at
+      _project/audits/results-explorer-followup-usability-release-2026-05-08.md.
+      Map each rebound defect to the PR, file, test, and browser route that
+      fixed it. Include unresolved defects only if they have a new TODO id,
+      priority, and owner-ready description. Do not rely on the original
+      uncommitted row numbering.
+
+  - id: w2
+    summary: "Run automated Results Explorer verification gates"
+    needs: [w1]
+    status: pending
+    notes: |
+      Run targeted Results Explorer tests plus typecheck and build. Capture
+      failures with exact test names and keep logs outside the worktree if
+      output is long.
+
+  - id: w3
+    summary: "Browser-drive all primary Results Explorer routes"
+    needs: [w2]
+    status: pending
+    notes: |
+      Browser-drive `/results/`, `/results/query`, `/results/compare`, a
+      benchmark detail, a platform detail, a result detail, and every chart
+      tab/subtab. Click each visible button/toggle once, verify active nav and
+      breadcrumbs, test compare selection end to end, and test horizontal and
+      vertical scrolling in dense tables.
+
+  - id: w4
+    summary: "Capture before-release screenshots for repaired states"
+    needs: [w3]
+    status: pending
+    notes: |
+      Capture desktop screenshots for Compare builder, Query controls,
+      Benchmark heatmap scrolled horizontally and vertically, Platform
+      filters, duplicate-run chart labels, chart panel tabs, and sparse
+      Result Detail metadata.
+
+  - id: w5
+    summary: "Validate TODO graph, reindex, and close ready items"
+    needs: [w4]
+    status: pending
+    notes: |
+      Run TODO validation and reindexing after implementation TODO statuses
+      are updated. Move completed implementation items only after their
+      verification evidence is attached or referenced in work notes.
+
+must_preserve:
+  - "No release approval unless Critical (P0) or High (P1) defects from the matrix are fixed or explicitly blocked."
+  - "No broad generated-data churn as part of the evidence gate."
+  - "No claim of browser verification without route names and observed outcomes."
+
+approach: |
+  Use the per-item w0 logs as the release checklist instead of the original
+  uncommitted row numbers. Prefer targeted automated checks first, then
+  browser verification of actual user workflows. Capture evidence in
+  _project/audits/ artifacts rather than relying on chat history. Map this
+  TODO system's priority labels to the matrix as Critical→P0, High→P1,
+  Medium-High→P2, Medium→P3, Low→P4 so legacy P-tier callers stay
+  interpretable.
+
+anti_patterns:
+  - "DO NOT close defects because they were hard to reproduce without documenting the reproduction attempt."
+  - "DO NOT ship with pending Critical or High defects hidden as Medium polish."
+  - "DO NOT rerun broad suites repeatedly without inspecting targeted failures first."
+
+verification:
+  - description: "Frontend unit test suite passes"
+    command: "cd results-explorer && npm test -- --run"
+    expected_output: "all tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "TODO validation passes"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate"
+    expected_output: "all TODO files valid"
+  - description: "TODO indexes regenerate"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex"
+    expected_output: "indexes updated successfully"
+
+scope_limit:
+  only_modify:
+    - "_project/TODO/"
+    - "_project/DONE/"
+    - "_project/audits/"
+    - "_project/verification-logs/"
+    - "results-explorer/e2e/"
+  do_not_modify:
+    - "benchbox/"
+    - "benchmark_runs/"
+    - "Production source code except to make a narrowly scoped verification-only test fixture adjustment."
+
+metadata:
+  tags:
+    - results-explorer
+    - release-gate
+    - usability-review
+    - qa
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Prevents the follow-up review from becoming a loose issue list by tying each
+    defect to implementation evidence before release.
+  user_impact: |
+    Ensures the highest-impact compare, navigation, table, chart, and label
+    repairs are verified in the browser workflows users actually take.
+  technical_debt: |
+    Creates a durable closeout matrix that future Results Explorer audits can
+    reuse instead of reconstructing context from screenshots and chat.

--- a/_project/TODO/main/planning/results-explorer-navigation-and-pivot-controls.yaml
+++ b/_project/TODO/main/planning/results-explorer-navigation-and-pivot-controls.yaml
@@ -1,0 +1,144 @@
+id: results-explorer-navigation-and-pivot-controls
+title: "Fix Results Explorer navigation state and sibling pivots"
+worktree: main
+priority: High
+status: Not Started
+category: Frontend UX
+
+description: |
+  Correct stale navigation indicators and add sibling-pivot controls on detail
+  pages so users can switch benchmark/platform context without backing out to
+  an index. Defects this item addresses were flagged in the 2026-05-08
+  Results Explorer follow-up review (chat-only artifact, not committed to
+  _project/audits/). w0 rebinds the review evidence against develop tip and
+  captures it to
+  _project/verification-logs/results-explorer-navigation-and-pivot-controls/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #3/#6/#7/#32" citations as the durable reference.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Rebind navigation and pivot review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk Layout subnav transitions (Leaderboards → Query → Platforms →
+      Compare → benchmark detail → platform detail → result detail), Home
+      leaderboard filter placement, and the absence of benchmark/platform
+      switchers on detail pages against the current develop tip. Capture
+      stale active-tab cases, missing pivots, and filter placement defects to
+      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w0.log.
+      Output is the rebind reference for w1-w5 acceptance.
+
+  - id: w1
+    summary: "Make the Results subnav active state reactive to route changes"
+    needs: [w0]
+    status: pending
+    notes: |
+      Refactor active-tab calculation so it updates after client-side route
+      changes. Verify navigation from Leaderboards to Query, Platforms,
+      Compare, benchmark detail, platform detail, and result detail
+      highlights the route the user is actually on.
+
+  - id: w2
+    summary: "Add a benchmark switcher to Benchmark detail pages"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add a benchmark switcher to the Benchmark detail header near the
+      breadcrumb or title. It must list all available benchmarks, navigate
+      directly to the chosen benchmark detail route, preserve valid
+      scale/view state when possible, and clear invalid query params rather
+      than producing an empty page.
+
+  - id: w3
+    summary: "Add a platform switcher to Platform detail pages"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add a platform switcher to the Platform detail header near the
+      breadcrumb or title. It must list all available platforms, navigate
+      directly to the chosen platform route, and preserve applicable filters
+      once platform-page filtering exists.
+
+  - id: w4
+    summary: "Move Home leaderboard filters above the affected matrix"
+    needs: [w0]
+    status: pending
+    notes: |
+      Move the Home leaderboard cohort controls above or into the same panel
+      as the matrix they affect. Active filter state must be visible before
+      the table so the user does not have to scroll past the matrix to
+      understand how to change benchmark, scale, or platform context.
+
+  - id: w5
+    summary: "Cover nav and sibling pivots with regression tests"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Add regression tests for SPA subnav updates, benchmark switcher
+      routing, platform switcher routing, and Home filter placement/state.
+      Include a browser smoke check that active nav does not remain on
+      Leaderboards after opening Query.
+
+must_preserve:
+  - "Existing result URLs and static-export routes."
+  - "Breadcrumb links back to `/results/`."
+  - "Keyboard access to nav and switcher controls."
+
+approach: |
+  Use the router/location source already used by the app instead of reading
+  `window.location` once at module render time. Keep the pivot controls
+  compact and local to the current detail page; do not create new index or
+  landing pages.
+
+anti_patterns:
+  - "DO NOT solve stale nav with full-page reloads."
+  - "DO NOT add sibling links that drop the user into a 404 or empty dataset for valid choices."
+
+verification:
+  - description: "Targeted navigation and pivot tests pass"
+    command: "cd results-explorer && npm test -- --run src/components/__tests__/Layout.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Home.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual nav browser check is complete"
+    command: "echo 'Manual: browser-check /results/query, /results/tpch/, and /results/p/polars/ for active nav and sibling switching'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/Layout.tsx"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/pages/__tests__/"
+  do_not_modify:
+    - "benchbox/"
+    - "Result snapshot generation unless switcher data is missing from exported metadata."
+
+metadata:
+  tags:
+    - results-explorer
+    - navigation
+    - usability-review
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Removes false location signals and makes benchmark/platform exploration
+    possible without backtracking.
+  user_impact: |
+    Users can pivot between sibling result views from the page where they notice
+    the need to compare another benchmark or platform.
+  technical_debt: |
+    Replaces one-time location reads with route-aware state and adds regression
+    coverage for SPA navigation.

--- a/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
@@ -1,0 +1,166 @@
+id: results-explorer-query-workbench-controls-and-facets
+title: "Tighten Query Workbench controls, facets, and labels"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Frontend UX
+
+description: |
+  Make Query Workbench controls earn their space, keep long facets navigable,
+  and replace raw internal labels with user-facing labels. Defects this item
+  addresses were flagged in the 2026-05-08 Results Explorer follow-up review
+  (chat-only artifact, not committed to _project/audits/). w0 rebinds the
+  review evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #25/#26/#27/#28/#29/#30" citations as the durable reference.
+
+deps:
+  needs:
+    - query-test-configure-visible-columns-failures
+
+work:
+  - id: w0
+    summary: "Rebind Query Workbench review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk /results/query (desktop and mobile), /results/ Browse-by-Benchmark,
+      and Query CSV/JSON export against the current develop tip. Capture the
+      Visible Columns control's vertical footprint, facet collapse state for
+      long Benchmark groups, duplicate SSB labels, and raw enum strings
+      visible in rows/filters/exports/receipts to
+      _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log.
+      Output is the rebind reference for w1-w7 acceptance.
+
+  - id: w1
+    summary: "Confirm Query Workbench visible-column contract before layout changes"
+    needs: [w0]
+    status: pending
+    notes: |
+      Confirm `query-test-configure-visible-columns-failures` is closed and
+      re-run `cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx`
+      against develop tip to verify visible-column tests are green. Capture
+      the PASS line to
+      _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w1.log.
+      Subsequent work units must not weaken assertions around column
+      visibility, sorting, or export behavior.
+
+  - id: w2
+    summary: "Move Visible Columns into a compact Configure columns disclosure"
+    needs: [w1]
+    status: pending
+    notes: |
+      Move Visible Columns out of the dominant top content block and into a
+      compact "Configure columns" disclosure near the results toolbar. The
+      table and result count should be visible sooner on desktop without
+      losing column customization.
+
+  - id: w3
+    summary: "Add reset and bulk actions to visible-column controls"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add Reset to default, Select all, and Clear optional columns actions.
+      Prevent users from hiding every useful data column by keeping required
+      row actions and at least one identifying/result column visible.
+
+  - id: w4
+    summary: "Make left-rail facet groups collapsible and searchable"
+    needs: [w0]
+    status: pending
+    notes: |
+      Make desktop and mobile facet groups collapsible. Long groups such as
+      Benchmark must show a compact top segment with "Show all" or internal
+      search, avoid pushing Platform and Scale below the fold, and keep
+      active facets visible even when collapsed.
+
+  - id: w5
+    summary: "Disambiguate duplicate SSB benchmark labels"
+    needs: [w0]
+    status: pending
+    notes: |
+      Fix duplicate SSB labels in Query Workbench facets and Home Browse by
+      Benchmark. Use canonical display names or add a short qualifier so the
+      two choices are distinguishable before navigation or filtering.
+
+  - id: w6
+    summary: "Centralize public formatting for raw enum labels"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add a shared display formatter for internal enum values shown to users:
+      community-submission, public-curated, not_applicable, validation
+      status, visibility, cost status, and similar raw fields. Apply it to
+      Query rows, filters, exports where appropriate, result receipts, and
+      tooltips.
+
+  - id: w7
+    summary: "Cover Query controls, facets, and label formatting"
+    needs: [w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Add tests for column disclosure open/close, bulk actions, export
+      visible column behavior, facet collapse/show all, duplicate benchmark
+      labels, and formatted enum labels. Include one browser check on
+      `/results/query` with a long benchmark facet list.
+
+must_preserve:
+  - "CSV/JSON exports must continue to honor the currently visible columns."
+  - "Facet counts and active filter chips must remain accurate."
+  - "Shareable query state must keep working after controls move."
+
+approach: |
+  Repair the existing visible-column test TODO before layout churn. Use
+  shared label formatting so Query, receipts, and filters do not diverge.
+  Collapse controls by default only when the active state remains
+  discoverable.
+
+anti_patterns:
+  - "DO NOT hide selected filters inside a closed panel with no visible summary."
+  - "DO NOT expose raw database enum strings as primary user-facing copy."
+  - "DO NOT remove visible-column customization to reclaim space."
+
+verification:
+  - description: "Query controls and label tests pass"
+    command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx src/lib/__tests__/displayLabels.test.ts"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual Query Workbench browser check is complete"
+    command: "echo 'Manual: browser-check /results/query and /results/ for column disclosure, facet collapse, and duplicate SSB labels'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/lib/displayLabels.ts"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/src/lib/__tests__/"
+  do_not_modify:
+    - "benchbox/"
+    - "DuckDB snapshot generation unless duplicate benchmark labels cannot be resolved in presentation data."
+
+metadata:
+  tags:
+    - results-explorer
+    - query-workbench
+    - facets
+    - usability-review
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Turns Query Workbench into a scannable analysis surface instead of a control
+    wall that delays access to results.
+  user_impact: |
+    Users can reach the result table sooner, collapse long filters, recover
+    column defaults, and read public labels instead of raw enum strings.
+  technical_debt: |
+    Introduces shared display formatting and aligns the visible-column behavior
+    with existing test contracts.

--- a/_project/TODO/main/planning/results-explorer-result-detail-metadata-density.yaml
+++ b/_project/TODO/main/planning/results-explorer-result-detail-metadata-density.yaml
@@ -1,0 +1,143 @@
+id: results-explorer-result-detail-metadata-density
+title: "Reduce Result Detail missing-metadata noise"
+worktree: main
+priority: Medium
+status: Not Started
+category: Frontend UX
+
+description: |
+  Make Result Detail metadata and receipt sections useful when many fields are
+  not recorded, while preserving provenance access. Defects this item
+  addresses were flagged in the 2026-05-08 Results Explorer follow-up review
+  (chat-only artifact, not committed to _project/audits/). w0 rebinds the
+  review evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-result-detail-metadata-density/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #41" citation (and the shared row #30 enum-label cleanup) as the durable
+  reference.
+
+deps:
+  needs:
+    - results-explorer-query-workbench-controls-and-facets
+
+work:
+  - id: w0
+    summary: "Rebind Result Detail review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk /results/r/<sparse-id> and /results/r/<complete-id> against the
+      current develop tip and capture (a) the count and grouping of "Not
+      recorded" rows in the first viewport, (b) raw enum strings still shown
+      to users, and (c) which provenance fields are recorded vs missing per
+      example. Write findings to
+      _project/verification-logs/results-explorer-result-detail-metadata-density/w0.log.
+      Output is the rebind reference for w1-w5 acceptance.
+
+  - id: w1
+    summary: "Audit Result Detail metadata and receipt fields"
+    needs: [w0]
+    status: pending
+    notes: |
+      Audit environment, source, validation, cost, and receipt sections for
+      fields that frequently render as "Not recorded" or raw internal enum
+      values. Identify essential summary metadata versus expandable
+      provenance detail.
+
+  - id: w2
+    summary: "Collapse empty or nearly empty environment summaries"
+    needs: [w1]
+    status: pending
+    notes: |
+      Suppress the top Environment summary when all or nearly all fields are
+      missing, or replace it with one compact "Environment metadata not
+      recorded" row. Do not render multiple adjacent cards that repeat
+      missing values.
+
+  - id: w3
+    summary: "Group missing receipt fields behind disclosure"
+    needs: [w1]
+    status: pending
+    notes: |
+      In the receipt/provenance section, show recorded fields first and
+      group missing fields behind a "Show missing metadata" disclosure. The
+      default view must prioritize run date, platform, benchmark,
+      trust/validation, source, and receipt link when present.
+
+  - id: w4
+    summary: "Apply shared display labels to Result Detail enums"
+    needs: [w1]
+    status: pending
+    notes: |
+      Reuse the shared display-label formatter from Query Workbench
+      (results-explorer-query-workbench-controls-and-facets w6) for raw
+      enums in Result Detail and receipts. Values such as not_applicable and
+      community-submission must render as concise user-facing labels.
+
+  - id: w5
+    summary: "Cover complete and sparse Result Detail metadata cases"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Add tests for a result with complete metadata and a result with sparse
+      metadata. Assert the sparse case does not repeat "Not recorded" across
+      the first viewport and that recorded provenance remains visible.
+
+must_preserve:
+  - "Receipt/provenance remains available for audit."
+  - "Complete metadata results still show their full useful details."
+  - "Deep links to result detail pages remain unchanged."
+
+approach: |
+  Use progressive disclosure for missing data, not deletion of provenance.
+  Reuse display-label formatting from Query Workbench instead of local string
+  replacements. w4 must run only after the parent TODO's formatter (w6 of
+  results-explorer-query-workbench-controls-and-facets) is in place; the
+  inter-item dep above enforces ordering.
+
+anti_patterns:
+  - "DO NOT hide recorded metadata to make sparse pages look cleaner."
+  - "DO NOT render raw enum strings in user-facing detail sections."
+
+verification:
+  - description: "Result Detail metadata tests pass"
+    command: "cd results-explorer && npm test -- --run src/pages/__tests__/ResultDetail.test.tsx src/lib/__tests__/displayLabels.test.ts"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual Result Detail browser check is complete"
+    command: "echo 'Manual: browser-check /results/r/<sparse-id> and /results/r/<complete-id> for first-viewport metadata density'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/lib/displayLabels.ts"
+    - "results-explorer/src/pages/__tests__/ResultDetail.test.tsx"
+    - "results-explorer/src/lib/__tests__/displayLabels.test.ts"
+  do_not_modify:
+    - "benchbox/"
+    - "Generated result snapshots unless a required recorded field is missing from the export."
+
+metadata:
+  tags:
+    - results-explorer
+    - result-detail
+    - metadata
+    - usability-review
+  estimated_effort: "Small-Medium (1 day)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Keeps result provenance credible without burying useful content under
+    repeated missing-field rows.
+  user_impact: |
+    Users can quickly understand what is known about a run and expand only when
+    they need full sparse metadata details.
+  technical_debt: |
+    Reuses shared display labels and defines a sparse-metadata rendering
+    contract for Result Detail.

--- a/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
@@ -1,0 +1,183 @@
+id: results-explorer-run-identity-disambiguation
+title: "Disambiguate duplicate run labels across Results Explorer"
+worktree: main
+priority: High
+status: Not Started
+category: Frontend UX
+
+description: |
+  Introduce and apply a consistent run identity display so charts, tables, and
+  compare controls do not show indistinguishable duplicate labels such as
+  DataFusion, Polars, PySpark, or Spark. Defects this item addresses were
+  flagged in the 2026-05-08 Results Explorer follow-up review (chat-only
+  artifact, not committed to _project/audits/). w0 rebinds the review
+  evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-run-identity-disambiguation/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #12 through #19 plus #40" citations as the durable reference.
+
+deps:
+  needs:
+    - results-explorer-compare-flow-entrypoints
+
+work:
+  - id: w0
+    summary: "Rebind run-identity review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk Charts > Rank, Distribution (Box Plot, Percentiles, CDF), Overview
+      (Performance, Power, Summary, Phases, Sparklines), Trend, and Compare
+      (baseline select, result cards, Decision Summary, Query-Level Diff)
+      against the current develop tip using a fixture cohort containing
+      duplicate platforms (e.g., two DataFusion runs differing only by
+      version or hardware). Capture which surfaces show indistinguishable
+      labels to
+      _project/verification-logs/results-explorer-run-identity-disambiguation/w0.log.
+      Output is the rebind reference for w1-w7 acceptance.
+
+  - id: w1
+    summary: "Define a shared RunIdentity formatter and component"
+    needs: [w0]
+    status: pending
+    notes: |
+      Define compact, table, chart, select-option, and tooltip variants. The
+      identity must include platform name plus enough available qualifiers
+      to distinguish duplicates: driver/platform version, run date, scale,
+      hardware or deployment fingerprint, source tier, and short result id
+      when other qualifiers remain identical.
+
+  - id: w2
+    summary: "Apply RunIdentity labels to Rank chart headers"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply RunIdentity labels to Charts Rank column headers. Keep column
+      widths compact, provide full identity in a tooltip, and ensure
+      duplicate platform headers no longer render as identical
+      human-readable names.
+
+  - id: w3
+    summary: "Apply RunIdentity labels to distribution chart rows"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply RunIdentity labels to Distribution Box Plot, Percentiles, and
+      CDF rows. Increase or measure the left label gutter so labels do not
+      overlap the plot area, and truncate only with a tooltip that
+      preserves the full identity.
+
+  - id: w4
+    summary: "Apply RunIdentity labels to overview and sparkline charts"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply RunIdentity labels to Overview Performance, Power, Summary,
+      Phases, and Sparklines. Repeated platform names must either be
+      aggregated intentionally with clear copy or shown as distinct runs
+      with qualifiers.
+
+  - id: w5
+    summary: "Apply RunIdentity labels and run-aware copy to Compare"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply RunIdentity to Compare baseline select options, result cards,
+      Decision Summary winner statements, and Query-Level Diff candidate
+      columns. Change copy from "2 platforms" to "2 runs" when selected
+      results have the same platform name. Run after the upstream Compare
+      rebuild (results-explorer-compare-flow-entrypoints) so labels apply
+      to the new builder structure.
+
+  - id: w6
+    summary: "Disambiguate or aggregate repeated Trend chart series"
+    needs: [w1]
+    status: pending
+    notes: |
+      Fix Trend chart legends that repeat platform names. Either aggregate
+      repeated runs into one platform series with explicit aggregation copy
+      or display each run with its RunIdentity qualifier.
+
+  - id: w7
+    summary: "Cover duplicate label cases across charts and Compare"
+    needs: [w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Add tests with duplicate platform fixtures for every affected
+      component. Assertions must fail if duplicate visible labels remain in
+      chart headers, chart row labels, compare select options, or decision
+      summary copy.
+
+must_preserve:
+  - "Existing color assignment should remain stable for the same run where possible."
+  - "Small chart labels must stay scannable at standard desktop width."
+  - "Full identity must be available by tooltip, accessible label, or details text."
+
+approach: |
+  Centralize identity generation before changing individual charts. Use the
+  shortest unique qualifier set needed per cohort; do not force every chart
+  to show every metadata field. Fallback to short result id only when
+  version, date, and hardware fields do not disambiguate. Run after
+  compare-flow-entrypoints so Compare.tsx is not edited by two concurrent
+  worktrees.
+
+anti_patterns:
+  - "DO NOT append raw UUID-length ids to every label."
+  - "DO NOT leave duplicate labels and rely on color alone."
+  - "DO NOT invent metadata that is not present in the result snapshot."
+
+verification:
+  - description: "Run identity and duplicate-label tests pass"
+    command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/GroupedQueryChart.test.tsx src/components/__tests__/QueryDiffTable.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual duplicate-run browser check is complete"
+    command: "echo 'Manual: browser-check chart Rank, Distribution, Overview/Sparklines, Trend, and Compare with duplicate DataFusion/Polars fixtures'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/lib/runIdentity.ts"
+    - "results-explorer/src/lib/__tests__/"
+    - "results-explorer/src/components/RankTable.tsx"
+    - "results-explorer/src/components/DistributionBox.tsx"
+    - "results-explorer/src/components/PercentileLadder.tsx"
+    - "results-explorer/src/components/CDFChart.tsx"
+    - "results-explorer/src/components/PowerBar.tsx"
+    - "results-explorer/src/components/SparklineTable.tsx"
+    - "results-explorer/src/components/StackedPhase.tsx"
+    - "results-explorer/src/components/QueryTimingChart.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+    - "results-explorer/src/components/CompareSummary.tsx"
+    - "results-explorer/src/components/QueryDiffTable.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/__tests__/"
+  do_not_modify:
+    - "benchbox/"
+    - "Generated result data unless required identity fields are missing from the export."
+
+metadata:
+  tags:
+    - results-explorer
+    - run-identity
+    - charts
+    - usability-review
+  estimated_effort: "Large (2-4 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Makes repeated benchmark runs interpretable and prevents comparison claims
+    from referring to ambiguous platform labels.
+  user_impact: |
+    Users can distinguish same-platform runs by version, date, hardware, source,
+    or short id wherever duplicates appear.
+  technical_debt: |
+    Creates one identity contract instead of ad hoc platform-name rendering in
+    each chart and compare control.

--- a/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
@@ -1,0 +1,170 @@
+id: results-explorer-table-sticky-density-and-semantics
+title: "Repair Results Explorer table stickiness, density, and semantics"
+worktree: main
+priority: High
+status: Not Started
+category: Frontend UX
+
+description: |
+  Fix broken sticky/frozen table behavior, add missing filters to large
+  tables, and reduce row-height inflation from overloaded cells. Defects
+  this item addresses were flagged in the 2026-05-08 Results Explorer
+  follow-up review (chat-only artifact, not committed to _project/audits/).
+  w0 rebinds the review evidence against develop tip and captures it to
+  _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w0.log
+  before any other work unit runs; that log replaces the previous "review row
+  #8/#10/#11/#24/#31/#33" citations as the durable reference.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Rebind dense-table review evidence against develop tip"
+    status: pending
+    notes: |
+      Walk QueryHeatmap (Benchmark detail, horizontal and vertical scroll),
+      MetaLeaderboard (Home), PlatformIndex (>= 25 rows), and Query results
+      against the current develop tip with the compare checkbox column both
+      visible and hidden. Capture frozen-column offset drift, header
+      transparency over scrolled cells, overloaded provenance cells, missing
+      Platform-page filters, and Query header semantics/keyboard
+      accessibility to
+      _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w0.log.
+      Output is the rebind reference for w1-w7 acceptance.
+
+  - id: w1
+    summary: "Audit dense scrollable tables and overloaded cells"
+    needs: [w0]
+    status: pending
+    notes: |
+      Audit QueryHeatmap, MetaLeaderboard, PlatformIndex, Query results, and
+      any table with horizontal scroll or frozen columns. Document frozen
+      columns, sticky offsets, header behavior, row heights, and cells that
+      stack platform, version, trust badges, validation badges, and receipt
+      links.
+
+  - id: w2
+    summary: "Fix Benchmark heatmap sticky-left offsets"
+    needs: [w1]
+    status: pending
+    notes: |
+      Fix Benchmark heatmap sticky-left offsets so the optional compare
+      checkbox, platform column, trust/status column, score column, and
+      geomean column stay aligned with horizontally scrolled query cells.
+      Offsets must come from the actual rendered frozen columns rather than
+      hard-coded assumptions.
+
+  - id: w3
+    summary: "Make Benchmark heatmap headers vertically sticky"
+    needs: [w1]
+    status: pending
+    notes: |
+      Make the Benchmark heatmap header row vertically sticky within the
+      scroll container so query numbers stay visible while scrolling down.
+      Set z-index and background layers so frozen column headers and query
+      headers do not overlap or become transparent over cells.
+
+  - id: w4
+    summary: "Compact provenance and trust/status table cells"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace overloaded primary cells that stack platform name, official
+      status, version, receipt link, trust badge, and validation badge.
+      Keep the frozen region to platform identity plus essential metric, and
+      move receipt and secondary provenance into a compact action, tooltip,
+      or detail cell.
+
+  - id: w5
+    summary: "Add filters to large Platform detail tables"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add visible filters to Platform detail tables with >= 25 rows:
+      benchmark, scale, phase, date range, trust tier, validation status,
+      and metric contract. The count label must update from "Showing 70 of
+      70 results" to the filtered count and provide one-click reset.
+
+  - id: w6
+    summary: "Make Query Workbench sort headers semantic and keyboard accessible"
+    needs: [w0]
+    status: pending
+    notes: |
+      Replace clickable Query table `<th>` headers with keyboard-accessible
+      sort buttons. Add `aria-sort` state, visible focus treatment, and
+      tests asserting ascending/descending sort state changes are announced
+      and reflected in row order.
+
+  - id: w7
+    summary: "Cover sticky, density, filter, and sort behavior"
+    needs: [w2, w3, w4, w5, w6]
+    status: pending
+    notes: |
+      Add tests and browser screenshot checks for horizontal heatmap
+      scroll, vertical header stickiness, compact cell height, platform
+      filtering, and Query sort accessibility. Use at least one fixture
+      with the compare checkbox column visible and one without it.
+
+must_preserve:
+  - "Existing sort behavior and default ordering."
+  - "Receipt/provenance access for every row."
+  - "Readable frozen columns at desktop width."
+
+approach: |
+  Prefer shared table helpers only where existing table structures are
+  already compatible. Use CSS sticky with explicit measured widths or stable
+  CSS variables, and keep layout stable during horizontal scroll. Treat
+  filters as table controls, not separate navigation.
+
+anti_patterns:
+  - "DO NOT hide provenance entirely to gain density."
+  - "DO NOT introduce nested cards or large explanatory text blocks around table controls."
+  - "DO NOT add filters that reset the user to another route."
+
+verification:
+  - description: "Targeted dense table tests pass"
+    command: "cd results-explorer && npm test -- --run src/components/__tests__/QueryHeatmap.test.tsx src/components/__tests__/MetaLeaderboard.test.tsx src/components/__tests__/MetaLeaderboard.a11y.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual dense table browser check is complete"
+    command: "echo 'Manual: browser-check /results/tpch/, /results/p/polars/, /results/query, and /results/ with horizontal and vertical scrolling'"
+    expected_output: "manual evidence captured in PR notes or audit artifact"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/QueryHeatmap.tsx"
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/index.css"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/pages/__tests__/"
+  do_not_modify:
+    - "benchbox/"
+    - "Generated benchmark data files unless a missing filter field is proven to be absent from the export."
+
+metadata:
+  tags:
+    - results-explorer
+    - tables
+    - density
+    - usability-review
+  estimated_effort: "Large (2-4 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Makes dense benchmark and platform tables trustworthy and usable for real
+    result comparison instead of visually drifting during scroll.
+  user_impact: |
+    Users can filter large tables, keep headers aligned, and scan rows without
+    provenance badges inflating every row.
+  technical_debt: |
+    Forces sticky-column and sort-header behavior into tested contracts instead
+    of implicit CSS assumptions.


### PR DESCRIPTION
## Summary

Apply the review fixes from the prior /todo review of the eight
results-explorer-* planning TODOs. Authored at the worktree branched off
develop tip; the items did not yet exist on develop, so each is added with
the fixes already integrated.

### Required findings addressed

- **R1 — unbound "review row #N" citations:** Each implementation TODO now
  has a `w0:` work unit that walks the relevant routes against develop tip
  and writes the rebind evidence to
  `_project/verification-logs/<id>/w0.log`. Subsequent work units gate on
  `w0`, so no code change can run without re-establishing the review claim
  against current state. Descriptions cite the chat-only source honestly
  rather than referencing row numbers no committed audit contains. The
  release-gate TODO synthesizes the per-item w0 logs into a closure matrix
  at `_project/audits/results-explorer-followup-usability-release-2026-05-08.md`.
- **R2 — `src/components/charts/` does not exist:** chart-panel and
  run-identity now scope `only_modify` and verification to the actual flat
  `src/components/` files (RankTable, DistributionBox, CDFChart,
  PercentileLadder, NormalizedSpeedupChart, CompareSummary, QueryDiffTable,
  PowerBar, SparklineTable, StackedPhase, QueryTimingChart, TimeSeries,
  ChartPanel, QueryHeatmap, CostScatter) and to the test files that exist
  under `src/components/__tests__/`.
- **R3 — `src/styles/` does not exist:** the table-density TODO now scopes
  `results-explorer/src/index.css` (where `--bb-surface-sticky` and other
  shared tokens live). Sticky offsets are inline Tailwind on
  `QueryHeatmap.tsx`, already in scope.

### Recommended findings addressed

- **compare-flow-entrypoints w1:** binds inventory output to
  `_project/audits/compare-entrypoint-inventory-2026-05-08.md`.
- **query-workbench-controls-and-facets w1:** replaces the placeholder
  "coordinate" step with a concrete contract-confirmation step that
  captures Query.test.tsx PASS to `w1.log`.
- **result-detail-metadata-density approach:** notes that w4 must run after
  the parent's formatter (query-workbench w6); the inter-item dep already
  enforces ordering.
- **chart-panel + run-identity inter-item deps:** chart-panel waits on
  compare-flow plus run-identity; run-identity waits on compare-flow. This
  serializes the three TODOs that touch `Compare.tsx` and
  `NormalizedSpeedupChart.tsx`.
- **table-sticky w5:** `>= 25 rows` instead of "more than about 25 rows".
- **followup-usability-release-gate `must_preserve`:** spells out
  Critical→P0, High→P1, Medium-High→P2, Medium→P3, Low→P4 mapping so
  legacy P-tier callers stay interpretable.

### Recommendations dropped after deeper checks

- The earlier review flagged the gate's `validate`/`reindex` subcommands as
  possibly wrong. They are correct — both are valid `_project/scripts/todo_cli.py`
  subcommands.
- The earlier review suggested adding `src/lib/queryLabels.ts` to
  run-identity's `only_modify`. queryLabels concerns query-id ordering, not
  run identity — orthogonal; leaving it out keeps the scope honest.

### Validation

- `todo_cli.py validate` — 935 files, 935 valid
- `todo_cli.py check-graph` — no cycles, no dangling references, 52 items
- `make pr-preflight-fast-tests` — passed (no code changes; planning-only)
- `todo_cli.py next` spot-check on chart-panel and compare-flow shows the
  w0 gate resolves as intended

## Test plan

- [x] `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
- [x] `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- [x] `make pr-preflight-fast-tests`
- [ ] CI develop checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)