### PR TITLE
chore(blind-spots): sweep open queue and promote three TODOs

### DIFF
--- a/_project/TODO/main/planning/audit-develop-sha-stamping-and-ci-gate.yaml
+++ b/_project/TODO/main/planning/audit-develop-sha-stamping-and-ci-gate.yaml
@@ -1,0 +1,251 @@
+id: audit-develop-sha-stamping-and-ci-gate
+title: "Stamp develop SHA into release-readiness audits and gate stale audits in CI"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Quality
+
+description: |
+  Release-readiness reports under `_project/audits/` describe a tree. If
+  the tree the report describes is not the tree that ships, the verdict
+  is structurally unreliable — even when every individual check passes.
+  PR #269 demonstrated this: a release-readiness report and capture
+  generated against the PR branch were squash-merged onto a develop tip
+  that included PR #268's literal-styled `Result summary` panel and
+  `Compare guardrails` section, and the report still claimed READY.
+  PR #271 (commit `274a4a11e`) closed the immediate token regression
+  manually, but the framework gap remains.
+
+  This TODO adds a durable, audit-agnostic gate so the same class of
+  regression is caught at PR time across every structured audit, not
+  only retheme work:
+
+  1. Every `_project/audits/*.md` audit landing after the cutoff date
+     must include a `develop_sha:` frontmatter field naming the develop
+     SHA the report describes.
+  2. The capture flow that authors release-final reports
+     (`results-explorer/e2e/captures/release-final.spec.ts` and any
+     sibling `*-final.spec.ts` drivers) records the develop SHA at
+     run-start so the human author copies it into the audit
+     frontmatter.
+  3. A small validator (`_project/scripts/audit_sha_check.py`) and a
+     `make audit-sha-check FILE=…` target verify the field is present,
+     resolves to a SHA reachable from `origin/develop`, and is not too
+     far behind the merge target's tip.
+  4. A path-aware CI hook on `_project/audits/**` and
+     `results-explorer/e2e/captures/**` runs the validator on every PR
+     and refuses to merge a release-readiness audit whose recorded SHA
+     is missing or stale relative to the merge target.
+
+  Complements (does not replace)
+  `results-explorer-token-scan-ci-gate.yaml`: that gate prevents the
+  literal-color regression class from shipping; this gate makes every
+  release-readiness audit's tree-claim auditable so future cross-PR
+  races on any surface (security, performance, docs migration) are
+  caught at the audit-author step rather than after merge.
+
+deps:
+  needs:
+    - results-explorer-token-scan-ci-gate
+
+context_sections:
+  "Source blind-spot": |
+    Recorded: _project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
+    Status: actionable. Re-verified 2026-05-08 (PR #271 landed; framework
+    gap unresolved).
+  "Why this is generalised, not retheme-only": |
+    The blind-spot author called this out explicitly: "any audit-style PR
+    with a structured report (security review, performance baseline, docs
+    migration) has the same exposure." Making the validator and CI hook
+    operate on `_project/audits/**` (rather than only
+    `results-explorer-retheme-final-*`) closes the class, not the
+    instance.
+
+work:
+  - id: w1
+    summary: "Define the develop_sha frontmatter contract"
+    status: pending
+    notes: |
+      Specify in `docs/operations/results-explorer-qa.md` (smallest
+      doc-change footprint; broaden later when other audit owners
+      adopt):
+        - Required field name: `develop_sha:` (full 40-char SHA).
+        - Required on every audit under `_project/audits/*.md` —
+          historical audits are backfilled in w3 so the validator can
+          enforce the requirement uniformly without grandfathering.
+        - Allowed staleness: configurable via CLI flag, default 0 (any
+          ancestor of `origin/develop` is acceptable; reviewers may
+          require `--require-current` for top-of-tree audits).
+        - Backfill rule (consumed by w3): for each existing audit,
+          derive the SHA from the introducing commit via `git log
+          --diff-filter=A --reverse --format=%H -- <audit-file> | head
+          -1`, then use that commit's parent on develop. Document this
+          rule so future agents can re-derive it deterministically.
+
+  - id: w2
+    summary: "Implement audit_sha_check.py validator + Makefile target"
+    needs: [w1]
+    status: pending
+    notes: |
+      New file: `_project/scripts/audit_sha_check.py`.
+      Behavior:
+        - Parse the audit's YAML frontmatter; require `develop_sha:`
+          unconditionally (no date cutoff after backfill in w3 lands).
+        - Run `git merge-base --is-ancestor <develop_sha> origin/develop`
+          and exit non-zero if the SHA is not reachable.
+        - With `--require-current N`, also require that the SHA is
+          within N commits of `origin/develop` tip.
+      Add `make audit-sha-check FILE=<path>` that wraps the script
+      under the existing `audit-*` target convention, and add the
+      target to the pre-approved-commands allowlist in CLAUDE.md so
+      agents can invoke it without prompts.
+
+  - id: w3
+    summary: "Backfill develop_sha into every existing _project/audits/*.md"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each `_project/audits/*.md`:
+        sha=$(git log --diff-filter=A --reverse --format=%H -- "$f" | head -1)
+        # Verify the introducing commit is reachable from origin/develop;
+        # if not (e.g., authored on a feature branch and squashed), fall
+        # back to the squash-merge commit that landed it on develop.
+        # If still unreachable, fall back to `git rev-parse $sha^` (the
+        # parent before the audit was added) and document the deviation
+        # inline as a frontmatter comment.
+      Add a bulk-backfill helper script (`_project/scripts/audit_sha_backfill.py`)
+      so the operation is repeatable and reviewers can audit the
+      derivation per file. The script must:
+        - Not modify audits whose `develop_sha:` is already present.
+        - Print the derivation source per file ("introducing commit",
+          "merge commit", "parent fallback") to stdout so reviewers
+          can spot edge cases.
+        - Be idempotent: running it twice changes nothing.
+      Run the backfill, eyeball the per-file derivation log, and land
+      the backfilled audits in the same PR as the validator so CI
+      starts green on the existing tree.
+
+  - id: w4
+    summary: "Wire the develop SHA into the release-final capture flow"
+    needs: [w2]
+    status: pending
+    notes: |
+      Modify `results-explorer/e2e/captures/release-final.spec.ts` (and
+      any sibling `*-final.spec.ts` drivers) to:
+        - Run `git fetch --no-tags origin develop` and `git rev-parse
+          origin/develop` at spec setup.
+        - Inject the resulting SHA into the screenshot manifest under a
+          new `develop_sha:` key.
+        - Print a copy-paste-ready frontmatter snippet to stdout at
+          spec teardown so the audit author drops it into the report.
+      Out of scope: rewriting the capture spec's screenshot logic.
+
+  - id: w5
+    summary: "Add path-aware CI hook on _project/audits/** and capture specs"
+    needs: [w3, w4]
+    status: pending
+    notes: |
+      Reuse the explorer test job's path filter pattern. New CI step:
+        - Triggers on PRs touching `_project/audits/**` or
+          `results-explorer/e2e/captures/**`.
+        - Runs `make audit-sha-check FILE=<changed-audit>` for every
+          modified audit file (loop over `git diff --name-only`).
+        - Refuses the PR if any audit fails the validator.
+      Job must remain a no-op for PRs that don't touch the path filter.
+      Pre-merge sanity check: with the backfill from w3 landed, run the
+      validator across the entire `_project/audits/` tree from a fresh
+      clone and confirm exit 0 before declaring CI green.
+
+  - id: w6
+    summary: "Document the contract and link from the source blind-spot"
+    needs: [w5]
+    status: pending
+    notes: |
+      Update `docs/operations/results-explorer-qa.md` with:
+        - The `develop_sha:` field requirement (uniform — no cutoff).
+        - The `make audit-sha-check` invocation.
+        - The backfill derivation rule from w1 so future sweeps can
+          repeat it on any newly-orphaned audits.
+        - A note that the contract applies to every report under
+          `_project/audits/`, not only retheme audits.
+      Append a `commits:` reference back to this TODO from the source
+      blind-spot file via a new triage-log entry once the gate ships.
+
+must_preserve:
+  - "Existing pre-commit hooks and the `make lint` umbrella target."
+  - "CI required-result aggregator path-filter behavior."
+  - "Existing _project/audits/*.md content — backfill only adds the `develop_sha:` frontmatter field; body text and other frontmatter fields stay byte-identical."
+  - "Backfill must be idempotent — re-running the helper on already-stamped audits is a no-op."
+
+approach: |
+  Build the validator before touching anything else: w2 makes the
+  contract executable. Then w3 backfills the entire existing tree so
+  CI starts green and the validator can enforce uniformly without a
+  date cutoff. w4 wires the capture flow for new audits, w5 enforces
+  via CI, w6 documents. Keep the validator narrow (no markdown
+  linting, no audit-content checks) so it stays trustworthy as a CI
+  gate. Reuse the existing explorer-job path filter pattern in w5
+  rather than authoring a new workflow from scratch — that pattern
+  is already proven and keeps CI cost flat for non-audit PRs.
+
+anti_patterns:
+  - "DO NOT extend the validator to lint audit content (markdown, headings, sections) — because the validator must stay narrow to remain trustworthy as a CI gate — content-quality checks belong in a separate audit-review TODO."
+  - "DO NOT make the gate run on every CI build — because most PRs do not touch audits — use a path filter on `_project/audits/**` and `results-explorer/e2e/captures/**` so non-audit PRs see no overhead."
+  - "DO NOT backfill develop_sha by hand — because per-file judgment calls about which commit to use will drift over time — drive the backfill from `_project/scripts/audit_sha_backfill.py` so the derivation is auditable and idempotent."
+  - "DO NOT land the validator before the backfill — because CI would fail on the existing tree from day one — sequence is w2 (validator) → w3 (backfill) → w5 (CI gate) in the same PR series, with w3's output landing before w5 enables enforcement."
+
+verification:
+  - description: "Validator fails on an audit missing develop_sha"
+    command: "bash -lc 'set -e; tmp=$(mktemp _project/audits/_gate_test_XXXXX.md); printf -- \"---\\nid: gate-test\\ndate: 2026-05-08\\n---\\n# Stub\\n\" > \"$tmp\"; trap \"rm -f $tmp\" EXIT; ! make audit-sha-check FILE=\"$tmp\"'"
+    expected_output: "non-zero exit (validator caught the missing field)"
+  - description: "Validator passes on an audit with a real develop_sha"
+    command: "bash -lc 'set -e; sha=$(git rev-parse origin/develop); tmp=$(mktemp _project/audits/_gate_test_XXXXX.md); printf -- \"---\\nid: gate-test\\ndate: 2026-05-08\\ndevelop_sha: $sha\\n---\\n# Stub\\n\" > \"$tmp\"; trap \"rm -f $tmp\" EXIT; make audit-sha-check FILE=\"$tmp\"'"
+    expected_output: "exit 0"
+  - description: "CI gate runs only on PRs touching _project/audits/** or captures"
+    command: "echo 'Manual: open a no-op docs PR and confirm audit-sha-check job is skipped via path filter'"
+    expected_output: "Job is reported as skipped on the PR checks tab"
+
+scope_limit:
+  only_modify:
+    - "_project/scripts/"
+    - "Makefile"
+    - ".github/workflows/"
+    - "results-explorer/e2e/captures/"
+    - "docs/operations/"
+    - "CLAUDE.md"
+    - "_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md"
+    - "_project/audits/"  # backfill-only: w3 adds `develop_sha:` frontmatter to existing audits; body unchanged
+  do_not_modify:
+    - "results-explorer/src/"
+    - "benchbox/"
+    - "results-data/"
+
+success_metrics:
+  - "Every _project/audits/*.md file (including backfilled historical audits) carries a `develop_sha:` field that `audit_sha_check.py` accepts."
+  - "Running `audit_sha_backfill.py` twice produces no changes (idempotent)."
+  - "CI fails on a release-readiness audit whose recorded develop_sha is unreachable from origin/develop or missing entirely."
+  - "release-final.spec.ts emits a copy-paste-ready frontmatter snippet at teardown."
+  - "Source blind-spot `2026-05-07-211858-release-readiness-against-pre-merge-tree` updated with a `commits:` reference once the gate ships."
+
+metadata:
+  tags:
+    - quality
+    - ci
+    - audits
+    - tokenization
+    - retheme
+  estimated_effort: "Medium (~1-2 days)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Closes a class of merge-race regression — audit reports describing a
+    tree that did not ship — that affects every structured release
+    review, not only retheme work.
+  user_impact: |
+    Indirect: protects users from shipping surfaces that contradict
+    their release-readiness verdict (e.g., literal colors after a
+    tokenization claim, perf regressions after a baseline claim).
+  technical_debt: |
+    Replaces a manual reviewer habit ("check the SHA was current") with
+    an enforced PR-time gate so the audit contract is durable.

--- a/_project/TODO/main/planning/dev-loop-queue-acceptance-criteria-from-blind-spots.yaml
+++ b/_project/TODO/main/planning/dev-loop-queue-acceptance-criteria-from-blind-spots.yaml
@@ -1,0 +1,187 @@
+id: dev-loop-queue-acceptance-criteria-from-blind-spots
+title: "Pre-register four 2026-04-30 blind-spots as Step 6 queue acceptance criteria"
+worktree: main
+priority: Medium
+status: Blocked
+category: Process and Workflow
+
+description: |
+  The 2026-04-30 L2 merge-loop audit produced four still-actionable
+  blind-spot findings that all gate any future steward-queue
+  implementation:
+
+    - 2026-04-30-114721-global-test-lock-cpu-protection — keep the
+      global lock default until measurement shows concurrent xdist
+      runs are CPU-safe.
+    - 2026-04-30-114722-queue-single-point-failure — require explicit
+      failure-mode analysis before adding a steward queue; prefer
+      native GitHub features if they appear.
+    - 2026-04-30-114723-queue-dwell-contract — treat dwell-time
+      targets as part of any queue acceptance criteria; update agent
+      handoff docs if dwell becomes materially longer than CI.
+    - 2026-04-30-114724-post-merge-safety-tension — define the exact
+      failure that develop-post-merge.yml handles; do not add a queue
+      unless Step 5 metrics show a pre-merge ordering problem.
+
+  All four are blocked on the same gate:
+  `dev-loop-step-5-measurement-window` — a 30-day measurement window
+  that started 2026-04-30 and closes ~2026-05-30. Until Step 5
+  publishes its decision record, none of these findings are
+  individually actionable.
+
+  This TODO does NOT pre-build the queue (that anti-pattern is
+  explicit in Step 5's `do_not_modify` list). It exists to ensure
+  that, IF Step 5 returns BUILD QUEUE, Step 6 inherits these four
+  findings as named acceptance criteria — not as four ad-hoc reviewer
+  comments that get lost in the queue spec.
+
+  If Step 5 returns DO NOT BUILD or REASSESS, this TODO closes as
+  superseded with a one-line note pointing to the Step 5 decision
+  record; the four blind-spots themselves move to `actioned` in the
+  same close-out.
+
+deps:
+  needs:
+    - dev-loop-step-5-measurement-window
+
+context_sections:
+  "Source blind-spots": |
+    Recorded:
+      - _project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
+      - _project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
+      - _project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
+      - _project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
+    All four sweep-verified 2026-05-08; all four still load-bearing
+    by inertia (Step 5 calendar-blocked, dev-loop architecture intact).
+  "Why a single TODO, not four": |
+    These findings share one trigger (Step 5 outcome) and one
+    consumer (Step 6 queue spec). Splitting them into four TODOs
+    would multiply Step 5's blocked-on count without adding
+    independent action paths. A single Step-6-handoff TODO keeps the
+    DAG clean and groups the four guardrails in one place when (or
+    if) they need to fold into the queue spec.
+
+work:
+  - id: w1
+    summary: "Watch Step 5 decision record; branch on outcome"
+    status: pending
+    notes: |
+      Trigger: `dev-loop-step-5-measurement-window` publishes
+      `_project/decisions/dev-loop-measurement-<window-end>.md` with a
+      BUILD QUEUE / DO NOT BUILD / REASSESS verdict.
+        - BUILD QUEUE -> proceed to w2.
+        - DO NOT BUILD -> mark all four blind-spots `actioned` with a
+          triage-log line citing the Step 5 decision SHA, then close
+          this TODO as completed-via-supersede.
+        - REASSESS -> stay Blocked; let Step 5's REASSESS path drive
+          the next iteration.
+
+  - id: w2
+    summary: "Fold the four guardrails into Step 6's acceptance criteria"
+    needs: [w1]
+    status: pending
+    notes: |
+      Edit `_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml`
+      (only after Step 5 unblocks it) so its `success_metrics` /
+      `must_preserve` explicitly include:
+        - "CPU-protection default preserved: queue must not silently
+          flip the global test-lock default before concurrent-xdist
+          measurement clears it as safe."
+          Cites: 2026-04-30-114721-global-test-lock-cpu-protection.
+        - "Failure-mode analysis is a prerequisite: a written analysis
+          of steward-queue failure modes (single-point-of-failure,
+          recovery, fallback commands) lands before the steward
+          implementation TODO is authored."
+          Cites: 2026-04-30-114722-queue-single-point-failure.
+        - "Dwell-time SLO is a queue acceptance criterion: queue spec
+          names a target P50/P95 dwell-time and a triggering
+          measurement source; agent handoff docs update if dwell
+          becomes materially longer than current CI."
+          Cites: 2026-04-30-114723-queue-dwell-contract.
+        - "Post-merge safety tension is resolved before queue lands:
+          queue spec states explicitly which failures
+          develop-post-merge.yml handles vs which the queue handles,
+          and does not duplicate safety machinery without measurable
+          recovery improvement."
+          Cites: 2026-04-30-114724-post-merge-safety-tension.
+
+  - id: w3
+    summary: "Promote the four blind-spots to merged-to-todo with the right TODO IDs"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each of the four 2026-04-30 blind-spots run:
+        `uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py triage <id> --action promote --todo-id dev-loop-step-6-queue-decision-gate`
+      The promote action sets `status: merged-to-todo` and fills
+      `todo_id`. The triage-log entry should cite Step 5's decision
+      SHA and this TODO's id as the merge path.
+
+must_preserve:
+  - "dev-loop-step-5-measurement-window's calendar-gated Blocked status — this TODO must not push Step 5 to publish early."
+  - "The 'do not pre-build the queue during measurement' anti-pattern in Step 5."
+  - "All four blind-spots' historical record — promotion to merged-to-todo is the only mutation; triage log entries are append-only."
+
+approach: |
+  This is a watcher-and-handoff TODO, not an implementation TODO. The
+  only state changes happen at two well-defined trigger points:
+    1. Step 5 publishes its decision record (w1 branches).
+    2. If BUILD QUEUE: edit Step 6 (w2) and promote the blind-spots
+       (w3) in a single PR.
+  Keep the PR scoped to the four files: Step 6 YAML and the four
+  blind-spot files. Do not touch Step 5, the dev-loop infrastructure,
+  or any other architecture in the same change.
+
+anti_patterns:
+  - "DO NOT pre-author a steward-queue implementation TODO 'just in case' — because that primes the Step 5 decision and violates the Step 5 anti-pattern list — wait for the verdict."
+  - "DO NOT collapse the four guardrails into a single bullet on Step 6 — because each one cites a specific blind-spot and a specific failure mode — keep them as four named acceptance criteria so reviewers can trace each one back to its source."
+  - "DO NOT promote the blind-spots to merged-to-todo before Step 6 is unblocked — because the todo_id field would point at a still-Blocked TODO, leaving the link load-bearing on something that may itself never ship."
+
+verification:
+  - description: "Step 5 decision record exists before this TODO begins w2"
+    command: "ls _project/decisions/dev-loop-measurement-*.md"
+    expected_output: "at least one file"
+  - description: "If BUILD QUEUE: Step 6 YAML lists the four guardrails by blind-spot ID"
+    command: "grep -E '2026-04-30-114(721|722|723|724)-' _project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml"
+    expected_output: "four matching lines, one per blind-spot id"
+  - description: "Four blind-spots show status: merged-to-todo with todo_id populated"
+    command: "for id in 2026-04-30-114721-global-test-lock-cpu-protection 2026-04-30-114722-queue-single-point-failure 2026-04-30-114723-queue-dwell-contract 2026-04-30-114724-post-merge-safety-tension; do uv run --project _project/scripts -- python _project/scripts/sweep_blind_spots.py show $id | grep -E 'status:|todo_id:'; done"
+    expected_output: "all four show status: merged-to-todo and a non-null todo_id"
+
+scope_limit:
+  only_modify:
+    - "_project/TODO/main/planning/dev-loop-step-6-queue-decision-gate.yaml"
+    - "_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md"
+    - "_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md"
+    - "_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md"
+    - "_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md"
+  do_not_modify:
+    - "_project/TODO/main/planning/dev-loop-step-5-measurement-window.yaml"
+    - ".github/workflows/"
+    - "tests/conftest.py"
+    - "Makefile"
+
+success_metrics:
+  - "All four 2026-04-30 blind-spots transition to either `actioned` (DO NOT BUILD path) or `merged-to-todo` (BUILD QUEUE path) within one week of Step 5 publishing its decision record."
+  - "If BUILD QUEUE: dev-loop-step-6-queue-decision-gate.yaml names each of the four guardrails in its acceptance criteria, with the blind-spot id as the citation."
+  - "No queue implementation TODO is authored before this TODO's w2 lands."
+
+metadata:
+  tags:
+    - dev-loop
+    - blind-spot-handoff
+    - queue
+    - watcher
+  estimated_effort: "Small (~0.5 day, gated on Step 5)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Ensures the four named guardrails surfaced by the 2026-04-30 audit
+    (CPU protection, failure-mode analysis, dwell SLO, post-merge
+    tension) actually shape the queue spec — instead of getting lost
+    between blind-spot capture and queue implementation.
+  technical_debt: |
+    Closes the open loop where four blind-spots have been re-verified
+    as actionable for >7 days but cannot promote independently because
+    they all share one upstream gate. Centralizes the handoff in one
+    place.

--- a/_project/TODO/main/planning/results-explorer-retheme-recapture-against-post-271-develop.yaml
+++ b/_project/TODO/main/planning/results-explorer-retheme-recapture-against-post-271-develop.yaml
@@ -1,0 +1,160 @@
+id: results-explorer-retheme-recapture-against-post-271-develop
+title: "Re-run release-final retheme capture against post-#271 develop tip"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The release-readiness artifact set under
+  `_project/audits/results-explorer-retheme-final-2026-05-07.md` and
+  its screenshots under
+  `_project/audits/screenshots/results-explorer-retheme-final-2026-05-07/`
+  were generated against PR #269's branch tree. PR #268 had already
+  introduced literal-styled `Result summary` and `Compare guardrails`
+  sections that survived PR #269's squash merge, contradicting the
+  README's READY verdict. PR #271 (`274a4a11e`,
+  `fix(explorer): retokenize result/compare panels reintroduced by
+  PR #268/#269 squash race`) closed the regression on develop.
+
+  The artifact set on disk still describes the pre-#271 tree. Re-run
+  the release-final capture against the current develop tip,
+  regenerate the screenshots, and replace (or supersede) the 2026-05-07
+  audit so the on-disk artifacts reflect the shipped state. Once
+  `audit-develop-sha-stamping-and-ci-gate` lands its `develop_sha:`
+  field requirement, this re-capture exercises and validates that
+  contract end-to-end.
+
+  This is a one-shot evidence task. It does not modify production
+  code, only audit artifacts and the capture spec's recorded
+  metadata.
+
+deps:
+  needs:
+    - audit-develop-sha-stamping-and-ci-gate
+
+context_sections:
+  "Source blind-spot": |
+    Recorded: _project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
+    Step #4 of the suggested next steps.
+  "What 'against post-#271 develop tip' means": |
+    `git log --oneline -5 -- results-explorer/src/pages/ResultDetail.tsx
+    results-explorer/src/pages/Compare.tsx` should include 274a4a11e
+    among the captured tree's ancestry. The new capture must be
+    generated from a workspace whose `git rev-parse origin/develop`
+    resolves to a commit at or after 274a4a11e.
+
+work:
+  - id: w1
+    summary: "Confirm post-#271 develop tip and regenerate screenshots"
+    status: pending
+    notes: |
+      From a fresh worktree off `develop`:
+        - `git rev-parse origin/develop` -> capture SHA (must be
+          274a4a11e or a descendant).
+        - Run the release-final capture spec under
+          `results-explorer/e2e/captures/release-final.spec.ts` and
+          collect the resulting screenshot set.
+      Confirm the captured Result Detail and Compare panels render
+      tokenized colors (no literal `text-gray-*` / `bg-slate-*`
+      classes in the rendered DOM).
+
+  - id: w2
+    summary: "Replace the 2026-05-07 audit in place with the post-#271 capture"
+    needs: [w1]
+    status: pending
+    notes: |
+      Overwrite `_project/audits/results-explorer-retheme-final-2026-05-07.md`
+      with the new audit body generated against the post-#271 develop
+      tip. Required edits:
+        - Update the `date:` frontmatter to the recapture date.
+        - Add the `develop_sha:` frontmatter field per the contract
+          from `audit-develop-sha-stamping-and-ci-gate`.
+        - Rename the file to `results-explorer-retheme-final-<YYYY-MM-DD>.md`
+          where `<YYYY-MM-DD>` is the recapture date (use `git mv` so
+          history follows). Update any cross-references (TODO yamls,
+          docs) that link to the old filename.
+        - Replace the screenshot directory under
+          `_project/audits/screenshots/results-explorer-retheme-final-2026-05-07/`
+          with the new capture set (also `git mv` to the new dated
+          path).
+      Git history preserves the pre-#271 version of the file —
+      reviewers can `git log -p` the old path if the historical
+      verdict is needed for a post-mortem.
+
+  - id: w3
+    summary: "Run audit-sha-check on the new audit and confirm CI gate passes"
+    needs: [w2]
+    status: pending
+    notes: |
+      `make audit-sha-check FILE=_project/audits/results-explorer-retheme-final-<YYYY-MM-DD>.md`
+      should exit 0. Push the audit on a small PR and confirm the
+      path-aware audit-sha-check CI job runs and passes. This is the
+      end-to-end validation of the framework introduced by
+      `audit-develop-sha-stamping-and-ci-gate`.
+
+must_preserve:
+  - "Git history of the pre-#271 audit and screenshots — replacement uses `git mv` so the file's `git log` chain still resolves."
+  - "Cross-references from other repo files (TODO yamls, docs) — w2 must update every link to the renamed audit/screenshot paths in the same commit."
+
+approach: |
+  Treat this as an evidence-only task. Do not edit
+  `results-explorer/src/` to make the capture pass — if the new
+  capture surfaces a regression, that's a separate bug TODO with the
+  new screenshot as evidence. The point of the re-run is to make the
+  on-disk artifact match the shipping tree, not to fix new bugs as a
+  side-effect. Use `git mv` (not delete + add) so reviewers can
+  `git log --follow` to recover the pre-#271 verdict if a future
+  post-mortem needs it.
+
+anti_patterns:
+  - "DO NOT use `rm` + `add` to replace the 2026-05-07 audit — because that breaks `git log --follow` and makes the pre-#271 verdict harder to recover for post-mortems — use `git mv` so the rename is recorded as a rename."
+  - "DO NOT bundle source-code edits with this re-capture — because a re-capture's only job is to match the shipping tree — file any newly-surfaced regressions as separate TODOs with the new screenshots as evidence."
+  - "DO NOT run the capture from a stale worktree — because that defeats the entire point — verify `git rev-parse origin/develop` resolves at or after 274a4a11e before recording any screenshot."
+  - "DO NOT leave dangling links — because cross-references from other TODOs/docs to the 2026-05-07 path will break when the file is renamed — grep the repo for the old filename and update every hit in the same commit as the rename."
+
+verification:
+  - description: "Captured tree is at or after PR #271"
+    command: "bash -lc 'git fetch --no-tags origin develop >/dev/null && git merge-base --is-ancestor 274a4a11e $(git rev-parse origin/develop)'"
+    expected_output: "exit 0"
+  - description: "New audit passes audit-sha-check"
+    command: "make audit-sha-check FILE=_project/audits/results-explorer-retheme-final-<YYYY-MM-DD>.md"
+    expected_output: "exit 0"
+  - description: "Result Detail and Compare panels render no literal Tailwind palette classes in the captured DOM"
+    command: "bash -lc 'set -e; cd results-explorer && grep -RnE \"text-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900|950)\" e2e/captures/release-final-output/dom-snapshots/ResultDetail* e2e/captures/release-final-output/dom-snapshots/Compare* || true'"
+    expected_output: "no matches (or only allow-listed inline-SVG attributes)"
+
+scope_limit:
+  only_modify:
+    - "_project/audits/"
+    - "_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md"
+    - "results-explorer/e2e/captures/"  # only metadata/manifest fields, not test logic
+  do_not_modify:
+    - "results-explorer/src/"
+    - "results-data/"
+    - "benchbox/"
+
+success_metrics:
+  - "Renamed retheme release-final audit (`results-explorer-retheme-final-<recapture-date>.md`) exists with a develop_sha matching post-#271 develop tip."
+  - "audit-sha-check passes on the renamed audit, both locally and via the CI gate from `audit-develop-sha-stamping-and-ci-gate`."
+  - "`git log --follow` on the renamed audit traces back to the 2026-05-07 file (rename detected, history intact)."
+  - "No file in the repo (TODOs, docs, other audits) still references the literal path `_project/audits/results-explorer-retheme-final-2026-05-07.md` after the rename."
+
+metadata:
+  tags:
+    - results-explorer
+    - retheme
+    - audit-evidence
+    - one-shot
+  estimated_effort: "Small (~0.5 day)"
+  created_date: "2026-05-08"
+
+impact:
+  business_value: |
+    Replaces the misaligned 2026-05-07 release-readiness artifact with
+    one that actually describes the shipped tree, restoring trust in
+    the audit folder as a release record.
+  user_impact: |
+    Indirect: closes the loop on a user-visible regression (literal
+    grays on Result Detail and Compare guardrails) by recording its
+    fix in the same artifact set that originally claimed READY.

--- a/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
+++ b/_project/blind-spots/2026-04-30-114721-global-test-lock-cpu-protection.md
@@ -40,3 +40,4 @@ Removing the global lock by default can shift pain from blocked pushes to CPU sa
   so no concurrent-xdist measurement has been collected. Carry forward the
   two next-steps; do not flip the default until measurement lands.
 - 2026-05-06: actionable — 2026-05-06 sweep: tests/conftest.py:_get_test_lock_path still defaults to $HOME/.benchbox/test.lock; dev-loop-step-5-measurement-window still Blocked, no concurrent-xdist measurement collected — keep default global lock until Step 5 lands
+- 2026-05-08: actionable — sweep: tests/conftest.py:_get_test_lock_path:56 still defaults global; BENCHBOX_TEST_LOCK_DIR still opt-in; dev-loop-step-5-measurement-window still Blocked (window started 2026-04-30, ends ~2026-05-30 — 22 days remaining) — carry forward, do not promote yet

--- a/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
+++ b/_project/blind-spots/2026-04-30-114722-queue-single-point-failure.md
@@ -39,3 +39,4 @@ Replacing decentralized auto-merge with a queue can make one local process or wo
   the next-steps. Do not promote to a steward TODO until Step 5 returns
   BUILD QUEUE.
 - 2026-05-06: actionable — 2026-05-06 sweep: decentralized auto-merge live (auto-merge-on-open.yml + develop-post-merge.yml present); dev-loop-step-6-queue-decision-gate still Blocked on Step 5 — failure-mode-analysis remains the gate before any steward TODO
+- 2026-05-08: actionable — sweep: auto-merge-on-open.yml + develop-post-merge.yml still shipped; dev-loop-step-6-queue-decision-gate still Blocked (waiting on Step 5 measurement window through ~2026-05-30) — failure-mode-analysis pre-condition stands

--- a/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
+++ b/_project/blind-spots/2026-04-30-114723-queue-dwell-contract.md
@@ -39,3 +39,4 @@ Agents can walk away after auto-merge only because the current dwell time is sho
   walk-away contract in CLAUDE.md still holds. Carry forward the
   next-steps; revisit when Step 5 publishes measurements.
 - 2026-05-06: actionable — 2026-05-06 sweep: make dev-loop-metrics still present; Step 5 Blocked, no published P50/P95 dwell numbers — agent walk-away contract in CLAUDE.md still load-bearing
+- 2026-05-08: actionable — sweep: `make dev-loop-metrics` still defined (Makefile:959); Step 5 still calendar-blocked through ~2026-05-30; CLAUDE.md walk-away contract (commit→push→PR auth, no polling) intact — carry forward dwell-target acceptance criteria

--- a/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
+++ b/_project/blind-spots/2026-04-30-114724-post-merge-safety-tension.md
@@ -39,3 +39,4 @@ If the post-merge workflow is the real protection layer, adding a queue may dupl
   workflow shipped; Step 5 still `Blocked`. Architectural rule remains
   load-bearing by inertia, not enforcement. Carry forward.
 - 2026-05-06: actionable — 2026-05-06 sweep: develop-post-merge.yml safety-net workflow still shipped; Step 5 Blocked — 'no queue without pre-merge ordering evidence' rule remains load-bearing by inertia
+- 2026-05-08: actionable — sweep: .github/workflows/develop-post-merge.yml still present; Step 5 calendar-blocked through ~2026-05-30; revert-PR/incident:develop-red flow intact — `no queue without Step 5 pre-merge ordering evidence` rule still load-bearing by inertia

--- a/_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
+++ b/_project/blind-spots/2026-05-07-211858-release-readiness-against-pre-merge-tree.md
@@ -1,7 +1,7 @@
 ---
 id: 2026-05-07-211858-release-readiness-against-pre-merge-tree
 date: 2026-05-07
-status: open
+status: actionable
 finding_kind: framework-gap
 review_context: "PR #269 review (results-explorer-retheme-audit-followups) → PR #271 (results-explorer-retheme-postmerge-tokenize)"
 related_paths:
@@ -68,3 +68,58 @@ same exposure if the report and the merge are not regenerated together.
 - [ ] Sweep: re-run `results-explorer-retheme-final-2026-05-07.md` with a
       capture against develop tip after PR #271 lands, so the artifact set
       reflects the shipped state.
+
+## Recommended actions
+
+Step #1 is already tracked by TODO
+`_project/TODO/main/planning/results-explorer-token-scan-ci-gate.yaml`
+(adds a CI gate against raw Tailwind palette literals under
+`results-explorer/src`). The remaining gaps need their own work:
+
+1. **Stamp `develop` SHA into release-readiness audits.**
+   Modify the capture flow that emits
+   `_project/audits/results-explorer-retheme-final-<date>.md` (and the
+   sibling `release-final.spec.ts` capture under
+   `results-explorer/e2e/captures/`) to record the `develop` SHA the
+   capture was generated against. Concretely:
+   - Extend the capture spec / its driver to call
+     `git rev-parse origin/develop` at run-start and inject it into the
+     screenshot manifest and audit frontmatter (e.g. a new
+     `develop_sha:` field).
+   - Add a CI job that compares that recorded SHA against the merge
+     target's tip and refuses a "READY" verdict if they diverge.
+   - Wire the gate into the existing `results-explorer/src` path filter
+     so it only runs when the explorer surface changes.
+
+2. **Generalize the SHA stamp to every structured `_project/audits/`
+   report.** The retheme audit is one instance of a class — security
+   reviews, performance baselines, docs migrations, etc. all have the
+   same exposure.
+   - Add a tiny helper script under `_project/scripts/` (e.g.
+     `audit_sha_check.py`) that parses an audit's frontmatter for a
+     `develop_sha:` field and exits non-zero if missing or stale
+     relative to a passed-in target SHA.
+   - Add a `make audit-sha-check FILE=…` target that wraps the script.
+   - Backfill `develop_sha:` into every existing `_project/audits/*.md`
+     via `_project/scripts/audit_sha_backfill.py` (idempotent, derives
+     the SHA from the introducing commit) so the validator can enforce
+     uniformly without grandfathering.
+   - Document the requirement in the closest audit-authoring doc (likely
+     `docs/operations/results-explorer-qa.md` for now, with a note that
+     the contract applies to all `_project/audits/` reports).
+   - Add a CI hook on `_project/audits/**` so any new audit landing
+     without a `develop_sha:` is blocked at PR time.
+
+3. **Re-run the release-final capture against post-#271 develop tip.**
+   PR #271 (`274a4a11e`) closed the literal regression, but the
+   2026-05-07 audit and screenshot set under
+   `_project/audits/screenshots/results-explorer-retheme-final-2026-05-07/`
+   still describe the pre-#271 tree. Regenerate the audit and capture
+   on top of the current `develop` and replace the 2026-05-07 artifact
+   in place via `git mv` (rename to a fresh dated path so `git log
+   --follow` recovers the pre-#271 verdict for post-mortems), stamping
+   the new artifact with `develop_sha:` per #1.
+
+## Triage log
+
+- 2026-05-08: actionable — Re-verified 2026-05-08: PR #271 (274a4a11e) closed the immediate token regression but next steps #2 (capture/develop-SHA gate), #3 (generalize SHA stamp to all _project/audits/ reports), and #4 (re-run release-final capture against post-#271 develop tip) remain. Next step #1 already tracked by TODO results-explorer-token-scan-ci-gate.


### PR DESCRIPTION
Triage of `_project/blind-spots/`:

- 2026-05-07-211858-release-readiness-against-pre-merge-tree:
  open -> actionable. PR #271 (274a4a11e) closed the immediate token
  regression but the framework gap remains. Added a Recommended
  actions section.
- Four 2026-04-30-1147* dev-loop findings: refreshed sweep log;
  status unchanged. All four still calendar-blocked on
  dev-loop-step-5-measurement-window (window closes ~2026-05-30).

New planning TODOs:

- audit-develop-sha-stamping-and-ci-gate: validator + Makefile target +
  CI gate that requires `develop_sha:` on every `_project/audits/*.md`.
  Includes a one-shot backfill helper so the existing tree starts green
  without grandfathering.
- results-explorer-retheme-recapture-against-post-271-develop:
  one-shot evidence task. Replaces the 2026-05-07 retheme audit in
  place via `git mv` so `git log --follow` still recovers the
  pre-#271 verdict.
- dev-loop-queue-acceptance-criteria-from-blind-spots: watcher TODO
  blocked on Step 5. Folds the four 2026-04-30 guardrails into Step 6's
  acceptance criteria if Step 5 returns BUILD QUEUE; closes them as
  superseded otherwise.

All TODOs validate, graph check passes (47 items, no cycles, no
dangling refs).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
