### PR TITLE
feat(explorer): in-page Compare builder, reactive subnav, semantic Query sort headers

### DIFF
--- a/_project/verification-logs/results-explorer-bundle-1/w0.log
+++ b/_project/verification-logs/results-explorer-bundle-1/w0.log
@@ -1,0 +1,127 @@
+# PR 1 bundle (items 1+2+3) — w0 audit log
+
+Date: 2026-05-08
+Worktree base: feat/explorer-compare-nav-table on develop tip 24b8aaef2
+(post-#277, post-#281, post-#282).
+Bundling chosen by user; original spec is one TODO per PR.
+
+## Item 1 — `results-explorer-compare-flow-entrypoints` (Critical)
+
+w1 (Inventory):
+  - Compare.tsx ll.56–62 — empty-IDs state surfaces the literal copy
+    "No result IDs provided. Add ?ids=id1,id2 to the URL." Confirmed.
+  - Compare.tsx ll.64–89 — single ID redirects back to `/results/r/<id>`,
+    which makes the ResultDetail "Compare this result" button (l.231)
+    a no-op round-trip. Confirmed.
+  - Query.tsx — no compare selection column / tray. Confirmed.
+  - Home.tsx — leaderboard rows have no compare affordance. Confirmed.
+  - BenchmarkIndex / PlatformIndex — checkbox column already exists in
+    QueryHeatmap (l.387 `hasSelection`), but no compatibility constraint
+    on selection. Confirmed.
+  - Hidden result_id column: rows already carry `result_id` per
+    DetailResult typing; visible-columns toggle hides display only.
+
+w2 (replace empty error with builder):       Confirmed
+w3 (single-result compare from ResultDetail): Confirmed
+w4 (Query compare selection):                 Confirmed
+w5 (Home compare entrypoints):                Confirmed
+w6 (cohort selection on detail pages):        Confirmed
+w7 (tests):                                   Confirmed
+
+## Item 2 — `results-explorer-navigation-and-pivot-controls` (High)
+
+w1 (reactive Layout nav active state):
+  - Layout.tsx l.18 reads `window.location.pathname` ONCE at render time.
+    `Layout` sits OUTSIDE `<Router>` (App.tsx: Layout wraps Router), so
+    `route()` calls re-render the Router children but NOT Layout.
+    The active-tab pills become stale after every client-side nav.
+    Confirmed.
+  - Fix path: `useRouter()` from preact-router subscribes to URL
+    changes even when called outside the Router tree (preact-router
+    source: `if (n === g) { ... y.push(setter) ... }` in `useRouter`).
+
+w2 (benchmark switcher in BenchmarkIndex):    Confirmed (no switcher exists)
+w3 (platform switcher in PlatformIndex):      Confirmed (no switcher exists)
+w4 (Home leaderboard filters above matrix):   Confirmed (need to verify
+                                              current ordering)
+w5 (tests):                                   Confirmed
+
+## Item 3 — `results-explorer-table-sticky-density-and-semantics` (High)
+
+w1 (audit):
+  - QueryHeatmap.tsx ll.387–408: when `hasSelection` is true, a 12-unit
+    checkbox `<th>` precedes the sticky Platform `<th>` whose `left-0`
+    class assumes the checkbox column doesn't exist. The Platform col
+    overlays the checkbox, miscalibrated by the unscrolled width.
+    Same issue on the body row's sticky cell at l.484.
+  - Header `<thead>` is NOT `sticky top-0` — vertical scroll loses the
+    query-id column headers. Confirmed.
+  - Provenance cells (Platform body cell ll.482–503) stack platform name +
+    optional version + Receipt link in one cell; Trust col adds two
+    badges. Confirmed (compaction work).
+
+w2 (heatmap sticky-left offsets):             Confirmed
+w3 (heatmap header vertically sticky):        Confirmed
+w4 (compact provenance/trust cells):          Confirmed
+w5 (Platform detail filters):                 Confirmed (no filters)
+w6 (Query Workbench semantic sort headers):
+  - Query.tsx ll.578–586 use clickable `<th>` with `class="cursor-pointer"`
+    onClick handlers. No `aria-sort`, no `<button>`, not keyboard-focusable
+    by default. Confirmed.
+w7 (tests):                                   Confirmed
+
+## Actually delivered in this PR
+
+  Item 2 w1: Layout reactive active-tab via `useRouter()` + `getCurrentUrl()`.
+    - `Header()` now subscribes via `useRouter()`, reads URL via
+      `getCurrentUrl()` each render. New regression test
+      `Layout.test.tsx > "updates the active explorer subnav after a
+      client-side route() call"` exercises an actual `route("/results/query")`
+      transition under a wrapping `<Router>`.
+
+  Item 3 w6: Query Workbench semantic sort headers.
+    - `Query.tsx` table headers now render `<th aria-sort=...><button>` per
+      column with focus-visible outline. The arrow indicator stays visible
+      inside the button text so existing
+      `getAllByText(/^Benchmark(?:\s[↑↓])?$/)` assertions still match.
+      No new test added; existing Query.test.tsx sort assertions cover
+      the contract.
+
+  Item 1 w2: Compare empty-state → in-page builder.
+    - New `CompareBuilder` component embedded in `Compare.tsx`. Pulls
+      candidate runs via `listResults()`, exposes benchmark/scale/phase
+      filters, enforces same-cohort selection (first selection locks
+      cohort), and disables `Compare N runs` button until ≥2 compatible
+      runs are selected. Uses `toShortIds` + `buildCompareUrl` to launch.
+      `compare-builder` testid lets coverage assert presence.
+
+  Item 1 w3: ResultDetail single-result `Compare this result` opens
+    builder with that run pinned, instead of redirecting back to
+    `/results/r/<id>`. Test rewritten:
+    `"opens the compare builder with a single ID pinned (instead of
+    redirecting back to the detail page)"`.
+
+  Tests:
+    - `Layout.test.tsx`: 4 passing (was 3)
+    - `Compare.test.tsx`: 22 passing (was 21; one rewritten + one new
+      cohort-lock + launch test)
+    - Full vitest run: 518/518 passing.
+    - Build: clean. JS bundle 275.97 kB (+7.65 kB / +2.86% vs pre-PR
+      268.32 kB). Under the 5% PR-flag threshold; not flagged.
+
+## Deferred to follow-up TODOs (call out in PR body)
+
+  - Item 1 w4 (Query compare selection)
+  - Item 1 w5 (Home compare entrypoints)
+  - Item 1 w6 (cohort selection on detail pages — Benchmark + Platform
+    detail)
+  - Item 2 w2 (benchmark switcher)
+  - Item 2 w3 (platform switcher)
+  - Item 2 w4 (Home filter relocation)
+  - Item 3 w2 (heatmap sticky-left offsets)
+  - Item 3 w3 (heatmap header vertical sticky)
+  - Item 3 w4 (compact provenance cells)
+  - Item 3 w5 (Platform detail filters)
+
+The deferred items will keep their original TODO IDs and become
+follow-up planning TODOs scoped to the specific work units.

--- a/results-explorer/src/components/Layout.tsx
+++ b/results-explorer/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import type { ComponentChildren } from "preact";
+import { getCurrentUrl, useRouter } from "preact-router";
 
 interface LayoutProps {
   children: ComponentChildren;
@@ -15,7 +16,13 @@ export function Layout({ children }: LayoutProps) {
 }
 
 function Header() {
-  const currentPath = typeof window === "undefined" ? "/results/" : window.location.pathname;
+  // Subscribe to preact-router URL changes so client-side `route()` calls
+  // re-render this component. `useRouter()` works from outside the Router
+  // tree by registering a forced-update setter when the consumed context
+  // is the default value.
+  useRouter();
+  const rawUrl = typeof window === "undefined" ? "/results/" : getCurrentUrl();
+  const currentPath = rawUrl.split("?")[0]!.split("#")[0]!;
   const inResults = currentPath === "/" || currentPath === "/results" || currentPath.startsWith("/results/");
 
   return (

--- a/results-explorer/src/components/__tests__/Layout.test.tsx
+++ b/results-explorer/src/components/__tests__/Layout.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, within } from "@testing-library/preact";
+import { render, screen, waitFor, within } from "@testing-library/preact";
 import { describe, expect, it } from "vitest";
+import Router, { route } from "preact-router";
 import { Layout } from "@/components/Layout";
 
 function renderAt(path: string) {
@@ -7,6 +8,20 @@ function renderAt(path: string) {
   return render(
     <Layout>
       <div>Page content</div>
+    </Layout>,
+  );
+}
+
+function renderWithRouter(initialPath: string) {
+  window.history.replaceState(null, "", initialPath);
+  return render(
+    <Layout>
+      <Router>
+        <div path="/results/" />
+        <div path="/results/query" />
+        <div path="/results/compare" />
+        <div default />
+      </Router>
     </Layout>,
   );
 }
@@ -50,6 +65,23 @@ describe("Layout", () => {
       expect(within(explorerNav).getByRole("link", { name: label })).toBeTruthy();
     }
     expect(within(explorerNav).getByRole("link", { name: "Query" })).toHaveAttribute("aria-current", "page");
+    expect(within(explorerNav).getByRole("link", { name: "Leaderboards" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("updates the active explorer subnav after a client-side route() call", async () => {
+    // Regression: prior to this fix, Layout read `window.location.pathname`
+    // once at module render time, so navigating from Leaderboards to Query
+    // via preact-router left "Leaderboards" highlighted indefinitely.
+    renderWithRouter("/results/");
+
+    const explorerNav = screen.getByRole("navigation", { name: "Results Explorer" });
+    expect(within(explorerNav).getByRole("link", { name: "Leaderboards" })).toHaveAttribute("aria-current", "page");
+
+    route("/results/query");
+
+    await waitFor(() => {
+      expect(within(explorerNav).getByRole("link", { name: "Query" })).toHaveAttribute("aria-current", "page");
+    });
     expect(within(explorerNav).getByRole("link", { name: "Leaderboards" })).not.toHaveAttribute("aria-current");
   });
 });

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { route } from "preact-router";
 import type { RoutableProps } from "preact-router";
 import type { DetailResult } from "@/types";
-import { getDetailResult, getPrimaryMetricForBenchmark, resolveShortId, toShortIds } from "@/lib/duckdbQueries";
+import {
+  getDetailResult,
+  getPrimaryMetricForBenchmark,
+  listResults,
+  resolveShortId,
+  toShortIds,
+  type ResultRow,
+} from "@/lib/duckdbQueries";
 import { humanizeBenchmark, errMsg, fmtGeomean } from "@/utils";
+import { buildCompareUrl } from "@/lib/resultLinks";
 import { CompareSummarySkeleton } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { Breadcrumb } from "@/components/Breadcrumb";
@@ -35,6 +43,13 @@ export function Compare(_: RoutableProps) {
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState(false);
   const [baselineIndex, setBaselineIndex] = useState(0);
+  // Builder mode: rendered when 0 ids are supplied, or when 1 id is supplied
+  // (single-result entry from ResultDetail "Compare this result" button).
+  // Was previously an error string ("No result IDs provided. Add ?ids=...")
+  // or a silent redirect back to ResultDetail; both forced URL editing or
+  // dead-ended the user on the page they came from.
+  const [builderPinnedId, setBuilderPinnedId] = useState<string | null>(null);
+  const [showBuilder, setShowBuilder] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const results = compareState?.results ?? EMPTY_RESULTS;
   const primaryMetric = compareState?.primaryMetric ?? "display_geomean_ms";
@@ -54,7 +69,8 @@ export function Compare(_: RoutableProps) {
       .slice(0, 4);
 
     if (ids.length === 0) {
-      setError("No result IDs provided. Add ?ids=id1,id2 to the URL.");
+      setShowBuilder(true);
+      setBuilderPinnedId(null);
       setLoading(false);
       return () => {
         cancelled = true;
@@ -75,7 +91,13 @@ export function Compare(_: RoutableProps) {
             setLoading(false);
             return;
           }
-          route(`/results/r/${encodeURIComponent(resolvedId)}`, true);
+          // Pin this run in the builder rather than redirecting back to
+          // ResultDetail. The user clicked "Compare this result"; the
+          // expected outcome is a comparison surface, not the page they
+          // came from.
+          setBuilderPinnedId(resolvedId);
+          setShowBuilder(true);
+          setLoading(false);
         })
         .catch((err: unknown) => {
           if (!cancelled) {
@@ -153,6 +175,10 @@ export function Compare(_: RoutableProps) {
         </a>
       </div>
     );
+
+  if (showBuilder) {
+    return <CompareBuilder pinnedId={builderPinnedId} />;
+  }
 
   if (results.length === 0) return null;
 
@@ -425,4 +451,302 @@ function severeCohortMismatchReason(results: DetailResult[]) {
     reasons.push("scale factors differ");
   }
   return reasons.length > 0 ? reasons.join(" and ") : null;
+}
+
+const MAX_COMPARE_SELECTIONS = 4;
+
+function CompareBuilder({ pinnedId }: { pinnedId: string | null }) {
+  const [candidates, setCandidates] = useState<ResultRow[] | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(pinnedId ? [pinnedId] : []),
+  );
+  const [benchmarkFilter, setBenchmarkFilter] = useState<string>("");
+  const [scaleFilter, setScaleFilter] = useState<string>("");
+  const [phaseFilter, setPhaseFilter] = useState<string>("");
+
+  useDocumentTitle("Compare · BenchBox Results");
+
+  useEffect(() => {
+    let cancelled = false;
+    listResults()
+      .then((rows) => {
+        if (cancelled) return;
+        setCandidates(rows);
+        // If a run is pinned and filters are still empty, lock the cohort to
+        // its benchmark/scale/phase so the candidate list is immediately
+        // useful.
+        if (pinnedId) {
+          const pinned = rows.find((row) => row.result_id === pinnedId);
+          if (pinned) {
+            setBenchmarkFilter(pinned.benchmark);
+            setScaleFilter(String(pinned.scale_factor));
+            setPhaseFilter(pinned.test_type ?? "");
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setLoadError(errMsg(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [pinnedId]);
+
+  // First selected run sets the comparable cohort: benchmark + scale + phase
+  // must match. This is what `severeCohortMismatchReason` enforces post-hoc;
+  // here we enforce it pre-hoc so users can't choose mixed-cohort sets.
+  const cohortLock = useMemo(() => {
+    if (candidates === null) return null;
+    const firstId = Array.from(selectedIds)[0];
+    if (!firstId) return null;
+    const first = candidates.find((row) => row.result_id === firstId);
+    if (!first) return null;
+    return {
+      benchmark: first.benchmark,
+      scale_factor: first.scale_factor,
+      test_type: first.test_type ?? "",
+    };
+  }, [candidates, selectedIds]);
+
+  const benchmarkOptions = useMemo(() => {
+    if (candidates === null) return [];
+    return Array.from(new Set(candidates.map((row) => row.benchmark))).sort();
+  }, [candidates]);
+  const scaleOptions = useMemo(() => {
+    if (candidates === null) return [];
+    const filtered = benchmarkFilter
+      ? candidates.filter((row) => row.benchmark === benchmarkFilter)
+      : candidates;
+    return Array.from(new Set(filtered.map((row) => String(row.scale_factor)))).sort();
+  }, [candidates, benchmarkFilter]);
+  const phaseOptions = useMemo(() => {
+    if (candidates === null) return [];
+    const filtered = candidates.filter(
+      (row) =>
+        (!benchmarkFilter || row.benchmark === benchmarkFilter) &&
+        (!scaleFilter || String(row.scale_factor) === scaleFilter),
+    );
+    return Array.from(new Set(filtered.map((row) => row.test_type ?? ""))).filter(Boolean).sort();
+  }, [candidates, benchmarkFilter, scaleFilter]);
+
+  const filteredRows = useMemo(() => {
+    if (candidates === null) return [];
+    return candidates.filter((row) => {
+      if (benchmarkFilter && row.benchmark !== benchmarkFilter) return false;
+      if (scaleFilter && String(row.scale_factor) !== scaleFilter) return false;
+      if (phaseFilter && (row.test_type ?? "") !== phaseFilter) return false;
+      return true;
+    });
+  }, [candidates, benchmarkFilter, scaleFilter, phaseFilter]);
+
+  function isCompatible(row: ResultRow): boolean {
+    if (!cohortLock) return true;
+    return (
+      row.benchmark === cohortLock.benchmark &&
+      row.scale_factor === cohortLock.scale_factor &&
+      (row.test_type ?? "") === cohortLock.test_type
+    );
+  }
+
+  function toggleSelection(row: ResultRow) {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(row.result_id)) {
+        next.delete(row.result_id);
+      } else if (next.size < MAX_COMPARE_SELECTIONS && isCompatible(row)) {
+        next.add(row.result_id);
+      }
+      return next;
+    });
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+
+  const selectedCount = selectedIds.size;
+  const canLaunch = selectedCount >= 2 && selectedCount <= MAX_COMPARE_SELECTIONS;
+
+  function launch() {
+    if (!canLaunch) return;
+    toShortIds(Array.from(selectedIds))
+      .then((shortIds) => {
+        route(buildCompareUrl(shortIds));
+      })
+      .catch(() => {
+        // Fallback: use long ids directly. The existing canonicalize-to-short
+        // effect on Compare load will replace them.
+        route(buildCompareUrl(Array.from(selectedIds)));
+      });
+  }
+
+  return (
+    <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8" data-testid="compare-builder">
+      <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: "Compare" }]} />
+
+      <section class="mt-6 mb-6 panel-elevated p-5" aria-label="Compare builder intro">
+        <p class="text-xs font-semibold uppercase tracking-wide text-[var(--bb-data-fg-subtle)]">Compare</p>
+        <h1 class="mt-1 text-2xl font-bold text-[var(--bb-data-fg-primary)]">Pick runs to compare</h1>
+        <p class="mt-2 text-sm text-[var(--bb-data-fg-muted)]">
+          Select two to four runs from the same benchmark, scale, and phase. The first selection locks the cohort; runs from
+          other cohorts will be disabled with a reason. You never need to edit the URL.
+        </p>
+      </section>
+
+      {loadError && <ErrorMessage title="Could not load candidate runs" message={loadError} />}
+
+      <section class="mb-4 panel p-4" aria-label="Filters">
+        <div class="flex flex-wrap gap-3">
+          <label class="flex flex-col text-sm">
+            <span class="text-xs font-medium text-[var(--bb-data-fg-muted)]">Benchmark</span>
+            <select
+              class="mt-1 rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm"
+              value={benchmarkFilter}
+              onChange={(e) => setBenchmarkFilter((e.target as HTMLSelectElement).value)}
+            >
+              <option value="">Any benchmark</option>
+              {benchmarkOptions.map((bm) => (
+                <option key={bm} value={bm}>{humanizeBenchmark(bm)}</option>
+              ))}
+            </select>
+          </label>
+          <label class="flex flex-col text-sm">
+            <span class="text-xs font-medium text-[var(--bb-data-fg-muted)]">Scale</span>
+            <select
+              class="mt-1 rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm"
+              value={scaleFilter}
+              onChange={(e) => setScaleFilter((e.target as HTMLSelectElement).value)}
+            >
+              <option value="">Any scale</option>
+              {scaleOptions.map((sf) => (
+                <option key={sf} value={sf}>SF {sf}</option>
+              ))}
+            </select>
+          </label>
+          <label class="flex flex-col text-sm">
+            <span class="text-xs font-medium text-[var(--bb-data-fg-muted)]">Phase</span>
+            <select
+              class="mt-1 rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm"
+              value={phaseFilter}
+              onChange={(e) => setPhaseFilter((e.target as HTMLSelectElement).value)}
+            >
+              <option value="">Any phase</option>
+              {phaseOptions.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <div class="mb-3 flex flex-wrap items-center justify-between gap-2 text-sm">
+        <p class="text-[var(--bb-data-fg-muted)]" data-testid="compare-builder-status">
+          {selectedCount === 0
+            ? `${filteredRows.length} candidate${filteredRows.length === 1 ? "" : "s"}. Select at least 2 to launch a comparison.`
+            : selectedCount < 2
+            ? `1 selected. Select 1 more compatible run to launch.`
+            : `${selectedCount} selected. ${cohortLock ? `Cohort: ${humanizeBenchmark(cohortLock.benchmark)} · SF ${cohortLock.scale_factor}${cohortLock.test_type ? ` · ${cohortLock.test_type}` : ""}` : ""}`}
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            onClick={clearSelection}
+            disabled={selectedCount === 0}
+          >
+            Clear selection
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            onClick={launch}
+            disabled={!canLaunch}
+            data-testid="compare-builder-launch"
+          >
+            Compare {selectedCount} run{selectedCount === 1 ? "" : "s"}
+          </button>
+        </div>
+      </div>
+
+      <div class="overflow-x-auto rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+        <table class="min-w-full divide-y divide-[var(--bb-data-border)] text-sm">
+          <thead class="bg-[var(--bb-surface-data-muted)]">
+            <tr>
+              <th scope="col" class="table-th w-12 px-3" aria-label="Select for comparison" />
+              <th scope="col" class="table-th text-left">Platform</th>
+              <th scope="col" class="table-th text-left">Benchmark</th>
+              <th scope="col" class="table-th text-left">Scale</th>
+              <th scope="col" class="table-th text-left">Phase</th>
+              <th scope="col" class="table-th text-left">Run date</th>
+              <th scope="col" class="table-th text-left">Trust</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-[var(--bb-data-border)]">
+            {candidates === null && (
+              <tr>
+                <td colSpan={7} class="px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
+                  Loading candidate runs...
+                </td>
+              </tr>
+            )}
+            {candidates !== null && filteredRows.length === 0 && (
+              <tr>
+                <td colSpan={7} class="px-4 py-3 text-sm text-[var(--bb-data-fg-muted)]">
+                  No candidates match the current filters.
+                </td>
+              </tr>
+            )}
+            {filteredRows.map((row) => {
+              const isSelected = selectedIds.has(row.result_id);
+              const compatible = isCompatible(row);
+              const disabledReason = !compatible
+                ? `Different cohort from selection (${cohortLock?.benchmark}/SF${cohortLock?.scale_factor}${cohortLock?.test_type ? `/${cohortLock.test_type}` : ""})`
+                : selectedCount >= MAX_COMPARE_SELECTIONS && !isSelected
+                ? `Up to ${MAX_COMPARE_SELECTIONS} runs can be compared`
+                : "";
+              const isPinned = row.result_id === pinnedId;
+              return (
+                <tr
+                  key={row.result_id}
+                  class={`${isSelected ? "bg-[var(--bb-tone-info-bg)]" : ""} ${
+                    !compatible ? "opacity-60" : ""
+                  }`}
+                  data-testid={`compare-builder-row-${row.result_id}`}
+                >
+                  <td class="px-3 py-2 align-middle">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      disabled={!isSelected && !!disabledReason}
+                      aria-label={`Select ${row.platform} for comparison`}
+                      title={disabledReason || undefined}
+                      onChange={() => toggleSelection(row)}
+                      class="h-4 w-4 rounded border-[var(--bb-data-border-strong)]"
+                    />
+                  </td>
+                  <td class="table-td">
+                    <div class="font-medium text-[var(--bb-data-fg-primary)]">
+                      {row.platform}
+                      {isPinned && (
+                        <span class="ml-2 text-xs text-[var(--bb-data-fg-subtle)]">(from result detail)</span>
+                      )}
+                    </div>
+                    {row.platform_version && (
+                      <div class="text-xs text-[var(--bb-data-fg-subtle)]">{row.platform_version}</div>
+                    )}
+                  </td>
+                  <td class="table-td">{humanizeBenchmark(row.benchmark)}</td>
+                  <td class="table-td font-mono">SF {row.scale_factor}</td>
+                  <td class="table-td">{row.test_type ?? "-"}</td>
+                  <td class="table-td">{row.run_date.slice(0, 10)}</td>
+                  <td class="table-td"><TrustBadge trustLabel={row.trust_label} compact /></td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -578,16 +578,31 @@ export function Query(_: RoutableProps) {
                   <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
                     <thead class="bg-[var(--bb-surface-data-muted)]">
                       <tr>
-                        {visibleColumns.map((column) => (
-                          <th
-                            key={column}
-                            class="table-th cursor-pointer select-none"
-                            onClick={() => toggleSort(column)}
-                          >
-                            {formatQueryColumnLabel(column)}
-                            {sort.column === column ? (sort.direction === "asc" ? " ↑" : " ↓") : ""}
-                          </th>
-                        ))}
+                        {visibleColumns.map((column) => {
+                          const isActive = sort.column === column;
+                          const arrow = isActive ? (sort.direction === "asc" ? " ↑" : " ↓") : "";
+                          const ariaSort = isActive
+                            ? sort.direction === "asc"
+                              ? "ascending"
+                              : "descending"
+                            : "none";
+                          return (
+                            <th
+                              key={column}
+                              scope="col"
+                              aria-sort={ariaSort}
+                              class="p-0"
+                            >
+                              <button
+                                type="button"
+                                class="table-th block w-full cursor-pointer select-none border-0 bg-transparent text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--bb-accent)]"
+                                onClick={() => toggleSort(column)}
+                              >
+                                {formatQueryColumnLabel(column)}{arrow}
+                              </button>
+                            </th>
+                          );
+                        })}
                         <th class="table-th sticky right-0 z-10 bg-[var(--bb-surface-data-muted)]" />
                       </tr>
                     </thead>

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -10,7 +10,7 @@
  *   (d) Baseline selector changes which result is treated as baseline in chart section
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/preact";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { route } from "preact-router";
 import type { DetailResult } from "@/types";
@@ -31,10 +31,11 @@ vi.mock("@/lib/duckdbQueries", async () => {
     resolveShortId: vi.fn((id: string) => Promise.resolve(id)),
     toShortIds: vi.fn((ids: string[]) => Promise.resolve(ids)),
     getPrimaryMetricForBenchmark: vi.fn().mockResolvedValue("power_score"),
+    listResults: vi.fn().mockResolvedValue([]),
   };
 });
 
-import { getDetailResult, getPrimaryMetricForBenchmark, resolveShortId, toShortIds } from "@/lib/duckdbQueries";
+import { getDetailResult, getPrimaryMetricForBenchmark, listResults, resolveShortId, toShortIds } from "@/lib/duckdbQueries";
 import { Compare } from "@/pages/Compare";
 
 // ---------------------------------------------------------------------------
@@ -128,19 +129,19 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("Compare", () => {
-  it("redirects a single compare ID to its result detail page", async () => {
+  it("opens the compare builder with a single ID pinned (instead of redirecting back to the detail page)", async () => {
     setupUrl(["a556e716"]);
     vi.mocked(resolveShortId).mockResolvedValue("tpch-duckdb-sf0.01-20260403-7fe93365");
+    vi.mocked(getDetailResult).mockResolvedValue(DUCKDB);
 
     render(<Compare />);
 
-    await waitFor(() =>
-      expect(route).toHaveBeenCalledWith(
-        "/results/r/tpch-duckdb-sf0.01-20260403-7fe93365",
-        true,
-      ),
-    );
+    await waitFor(() => expect(screen.getByTestId("compare-builder")).toBeTruthy());
     expect(getDetailResult).toHaveBeenCalledWith("tpch-duckdb-sf0.01-20260403-7fe93365");
+    // The old behavior was a redirect to /results/r/<id>; that round-trip is
+    // gone. The user must end up on a comparison surface, not the detail page
+    // they came from.
+    expect(route).not.toHaveBeenCalledWith(expect.stringMatching(/^\/results\/r\//), true);
   });
 
   it("keeps a single unknown compare ID on the Compare error path", async () => {
@@ -155,15 +156,170 @@ describe("Compare", () => {
     expect(route).not.toHaveBeenCalled();
   });
 
-  it("keeps the empty ids error on the Compare page", async () => {
+  it("renders the in-page compare builder when no ids are provided (no URL editing required)", async () => {
     setupUrl([]);
 
     render(<Compare />);
 
-    await waitFor(() =>
-      expect(screen.getByText(/No result IDs provided/)).toBeTruthy(),
-    );
+    await waitFor(() => expect(screen.getByTestId("compare-builder")).toBeTruthy());
+    expect(screen.getByText(/Pick runs to compare/)).toBeTruthy();
+    expect(screen.queryByText(/Add \?ids=/)).toBeNull();
     expect(route).not.toHaveBeenCalled();
+  });
+
+  it("compare builder enforces same-cohort selection and launches with two compatible runs", async () => {
+    setupUrl([]);
+    // Two compatible (same benchmark/scale/phase) and one incompatible (different benchmark)
+    vi.mocked(listResults).mockResolvedValue([
+      {
+        result_id: "r1",
+        benchmark: "tpch",
+        scale_factor: 0.1,
+        platform: "DuckDB",
+        platform_id: "duckdb",
+        driver_version: null,
+        run_date: "2026-04-17",
+        power_score: 3000,
+        total_duration_s: 60,
+        geomean_ms: 10,
+        display_geomean_ms: 10,
+        query_count: 22,
+        trust_label: "maintainer-run",
+        visibility: "public-curated",
+        platform_version: null,
+        execution_mode: null,
+        tuning_mode: null,
+        tuning_hash: null,
+        test_type: "measurement",
+        validation_status: null,
+        cost_usd: null,
+        compliance_class: null,
+        is_ranking_eligible: true,
+        has_plans: false,
+        plans_published: false,
+        has_tuning: false,
+        bundle_download_url: "",
+        normalized_cost_usd: null,
+        cost_model_version: null,
+        cost_status: null,
+        cost_scope: null,
+        deployment_class: null,
+        cloud_provider: null,
+        cloud_region: null,
+        instance_or_warehouse: null,
+        storage_format: null,
+      } as never,
+      {
+        result_id: "r2",
+        benchmark: "tpch",
+        scale_factor: 0.1,
+        platform: "SQLite",
+        platform_id: "sqlite",
+        driver_version: null,
+        run_date: "2026-04-17",
+        power_score: 300,
+        total_duration_s: 600,
+        geomean_ms: 100,
+        display_geomean_ms: 100,
+        query_count: 22,
+        trust_label: "maintainer-run",
+        visibility: "public-curated",
+        platform_version: null,
+        execution_mode: null,
+        tuning_mode: null,
+        tuning_hash: null,
+        test_type: "measurement",
+        validation_status: null,
+        cost_usd: null,
+        compliance_class: null,
+        is_ranking_eligible: true,
+        has_plans: false,
+        plans_published: false,
+        has_tuning: false,
+        bundle_download_url: "",
+        normalized_cost_usd: null,
+        cost_model_version: null,
+        cost_status: null,
+        cost_scope: null,
+        deployment_class: null,
+        cloud_provider: null,
+        cloud_region: null,
+        instance_or_warehouse: null,
+        storage_format: null,
+      } as never,
+      {
+        result_id: "r3",
+        benchmark: "clickbench",
+        scale_factor: 0.1,
+        platform: "DuckDB",
+        platform_id: "duckdb",
+        driver_version: null,
+        run_date: "2026-04-17",
+        power_score: null,
+        total_duration_s: 60,
+        geomean_ms: 10,
+        display_geomean_ms: 10,
+        query_count: 43,
+        trust_label: "maintainer-run",
+        visibility: "public-curated",
+        platform_version: null,
+        execution_mode: null,
+        tuning_mode: null,
+        tuning_hash: null,
+        test_type: "measurement",
+        validation_status: null,
+        cost_usd: null,
+        compliance_class: null,
+        is_ranking_eligible: true,
+        has_plans: false,
+        plans_published: false,
+        has_tuning: false,
+        bundle_download_url: "",
+        normalized_cost_usd: null,
+        cost_model_version: null,
+        cost_status: null,
+        cost_scope: null,
+        deployment_class: null,
+        cloud_provider: null,
+        cloud_region: null,
+        instance_or_warehouse: null,
+        storage_format: null,
+      } as never,
+    ]);
+
+    const { getByTestId } = render(<Compare />);
+
+    await waitFor(() => expect(getByTestId("compare-builder")).toBeTruthy());
+    await waitFor(() => expect(getByTestId("compare-builder-row-r1")).toBeTruthy());
+
+    // Launch is disabled before any selection
+    const launch = getByTestId("compare-builder-launch") as HTMLButtonElement;
+    expect(launch.disabled).toBe(true);
+
+    // Select first compatible run
+    const r1Checkbox = within(getByTestId("compare-builder-row-r1")).getByRole("checkbox") as HTMLInputElement;
+    r1Checkbox.click();
+
+    // r3 (different benchmark) should now be disabled
+    await waitFor(() => {
+      const r3Checkbox = within(getByTestId("compare-builder-row-r3")).getByRole("checkbox") as HTMLInputElement;
+      expect(r3Checkbox.disabled).toBe(true);
+    });
+
+    // Add second compatible run; launch enables
+    const r2Checkbox = within(getByTestId("compare-builder-row-r2")).getByRole("checkbox") as HTMLInputElement;
+    r2Checkbox.click();
+    await waitFor(() => expect((getByTestId("compare-builder-launch") as HTMLButtonElement).disabled).toBe(false));
+
+    // Click Launch — must navigate to /results/compare?ids=r1,r2 (or r2,r1)
+    (getByTestId("compare-builder-launch") as HTMLButtonElement).click();
+    await waitFor(() => {
+      const calls = vi.mocked(route).mock.calls.map((c) => String(c[0]));
+      const compareCall = calls.find((url) => url.startsWith("/results/compare?ids="));
+      expect(compareCall).toBeTruthy();
+      expect(compareCall).toContain("r1");
+      expect(compareCall).toContain("r2");
+    });
   });
 
   it("shows 'vs worst' speedup of 10.00x in the DuckDB summary card (power_score primary)", async () => {


### PR DESCRIPTION
Bundles a coherent subset of three Results Explorer follow-up TODOs into
one PR (per user direction; bundling violates the default one-TODO-per-PR
rule). Lands the highest-impact, lowest-risk work units from each item
and documents the rest as explicit deferred follow-ups.

Item 1 — `results-explorer-compare-flow-entrypoints` (Critical), partial:
  - w2 Compare empty-state → in-page CompareBuilder. Filters by benchmark,
    scale, and phase; enforces same-cohort selection (first pick locks
    cohort and disables incompatible candidates with reason); launches
    via `toShortIds` + `buildCompareUrl`; URL editing is no longer
    surfaced anywhere.
  - w3 ResultDetail "Compare this result" opens the builder with that
    run pinned, instead of the previous redirect-to-detail round-trip.
  - Deferred (separate PRs): w4 Query compare selection, w5 Home compare
    entrypoints, w6 cohort selection on Benchmark/Platform detail pages,
    full w7 coverage.

Item 2 — `results-explorer-navigation-and-pivot-controls` (High), partial:
  - w1 Layout active subnav now reacts to client-side `route()` calls by
    subscribing via `preact-router`'s `useRouter()` (works from outside
    the Router tree) and reading `getCurrentUrl()` per render. New
    regression test exercises a real `route()` transition.
  - Deferred: w2 benchmark switcher, w3 platform switcher, w4 Home
    leaderboard filter relocation.

Item 3 — `results-explorer-table-sticky-density-and-semantics` (High),
partial:
  - w6 Query Workbench column headers are now keyboard-accessible
    `<th><button></button></th>` with `aria-sort` state and focus-visible
    outline. The arrow indicator stays in the button label so existing
    `getAllByText(/^Benchmark[↑↓]?$/)` matchers continue to pass.
  - Deferred: w2 heatmap sticky-left offsets, w3 heatmap header vertical
    sticky, w4 compact provenance cells, w5 Platform detail filters.

Verification:
  - 518/518 vitest pass (was 515/516 on develop tip, fully green now —
    PR #277 closed the 4th maintainer-run gap).
  - Targeted: Layout.test.tsx 4/4, Compare.test.tsx 22/22, Query.test.tsx
    18/18.
  - typecheck: clean.
  - build: clean. JS bundle index-*.js grew +7.65 kB (+2.86%); under the
    5% threshold, not flagged.

Out-of-scope sweeping changes are intentionally avoided. The deferred
work units stay in their original TODO files (items 1, 2, 3 remain
"Not Started" since their full work is incomplete; per-work-unit
progress is tracked separately).

w0 audit: `_project/verification-logs/results-explorer-bundle-1/w0.log`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
