### PR TITLE
feat(explorer): centralize display labels, add column bulk actions, disambiguate SSB

### DIFF
--- a/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
@@ -17,97 +17,97 @@ description: |
 
 deps:
   needs:
-    - query-test-configure-visible-columns-failures
+  - query-test-configure-visible-columns-failures
 
 work:
-  - id: w0
-    summary: "Rebind Query Workbench review evidence against develop tip"
-    status: pending
-    notes: |
-      Walk /results/query (desktop and mobile), /results/ Browse-by-Benchmark,
-      and Query CSV/JSON export against the current develop tip. Capture the
-      Visible Columns control's vertical footprint, facet collapse state for
-      long Benchmark groups, duplicate SSB labels, and raw enum strings
-      visible in rows/filters/exports/receipts to
-      _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log.
-      Output is the rebind reference for w1-w7 acceptance.
+- id: w0
+  summary: "Rebind Query Workbench review evidence against develop tip"
+  status: done
+  notes: |
+    Walk /results/query (desktop and mobile), /results/ Browse-by-Benchmark,
+    and Query CSV/JSON export against the current develop tip. Capture the
+    Visible Columns control's vertical footprint, facet collapse state for
+    long Benchmark groups, duplicate SSB labels, and raw enum strings
+    visible in rows/filters/exports/receipts to
+    _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log.
+    Output is the rebind reference for w1-w7 acceptance.
 
-  - id: w1
-    summary: "Confirm Query Workbench visible-column contract before layout changes"
-    needs: [w0]
-    status: pending
-    notes: |
-      Confirm `query-test-configure-visible-columns-failures` is closed and
-      re-run `cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx`
-      against develop tip to verify visible-column tests are green. Capture
-      the PASS line to
-      _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w1.log.
-      Subsequent work units must not weaken assertions around column
-      visibility, sorting, or export behavior.
+- id: w1
+  summary: "Confirm Query Workbench visible-column contract before layout changes"
+  needs: [w0]
+  status: done
+  notes: |
+    Confirm `query-test-configure-visible-columns-failures` is closed and
+    re-run `cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx`
+    against develop tip to verify visible-column tests are green. Capture
+    the PASS line to
+    _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w1.log.
+    Subsequent work units must not weaken assertions around column
+    visibility, sorting, or export behavior.
 
-  - id: w2
-    summary: "Move Visible Columns into a compact Configure columns disclosure"
-    needs: [w1]
-    status: pending
-    notes: |
-      Move Visible Columns out of the dominant top content block and into a
-      compact "Configure columns" disclosure near the results toolbar. The
-      table and result count should be visible sooner on desktop without
-      losing column customization.
+- id: w2
+  summary: "Move Visible Columns into a compact Configure columns disclosure"
+  needs: [w1]
+  status: done
+  notes: |
+    Move Visible Columns out of the dominant top content block and into a
+    compact "Configure columns" disclosure near the results toolbar. The
+    table and result count should be visible sooner on desktop without
+    losing column customization.
 
-  - id: w3
-    summary: "Add reset and bulk actions to visible-column controls"
-    needs: [w1]
-    status: pending
-    notes: |
-      Add Reset to default, Select all, and Clear optional columns actions.
-      Prevent users from hiding every useful data column by keeping required
-      row actions and at least one identifying/result column visible.
+- id: w3
+  summary: "Add reset and bulk actions to visible-column controls"
+  needs: [w1]
+  status: done
+  notes: |
+    Add Reset to default, Select all, and Clear optional columns actions.
+    Prevent users from hiding every useful data column by keeping required
+    row actions and at least one identifying/result column visible.
 
-  - id: w4
-    summary: "Make left-rail facet groups collapsible and searchable"
-    needs: [w0]
-    status: pending
-    notes: |
-      Make desktop and mobile facet groups collapsible. Long groups such as
-      Benchmark must show a compact top segment with "Show all" or internal
-      search, avoid pushing Platform and Scale below the fold, and keep
-      active facets visible even when collapsed.
+- id: w4
+  summary: "Make left-rail facet groups collapsible and searchable"
+  needs: [w0]
+  status: pending
+  notes: |
+    Make desktop and mobile facet groups collapsible. Long groups such as
+    Benchmark must show a compact top segment with "Show all" or internal
+    search, avoid pushing Platform and Scale below the fold, and keep
+    active facets visible even when collapsed.
 
-  - id: w5
-    summary: "Disambiguate duplicate SSB benchmark labels"
-    needs: [w0]
-    status: pending
-    notes: |
-      Fix duplicate SSB labels in Query Workbench facets and Home Browse by
-      Benchmark. Use canonical display names or add a short qualifier so the
-      two choices are distinguishable before navigation or filtering.
+- id: w5
+  summary: "Disambiguate duplicate SSB benchmark labels"
+  needs: [w0]
+  status: done
+  notes: |
+    Fix duplicate SSB labels in Query Workbench facets and Home Browse by
+    Benchmark. Use canonical display names or add a short qualifier so the
+    two choices are distinguishable before navigation or filtering.
 
-  - id: w6
-    summary: "Centralize public formatting for raw enum labels"
-    needs: [w0]
-    status: pending
-    notes: |
-      Add a shared display formatter for internal enum values shown to users:
-      community-submission, public-curated, not_applicable, validation
-      status, visibility, cost status, and similar raw fields. Apply it to
-      Query rows, filters, exports where appropriate, result receipts, and
-      tooltips.
+- id: w6
+  summary: "Centralize public formatting for raw enum labels"
+  needs: [w0]
+  status: done
+  notes: |
+    Add a shared display formatter for internal enum values shown to users:
+    community-submission, public-curated, not_applicable, validation
+    status, visibility, cost status, and similar raw fields. Apply it to
+    Query rows, filters, exports where appropriate, result receipts, and
+    tooltips.
 
-  - id: w7
-    summary: "Cover Query controls, facets, and label formatting"
-    needs: [w2, w3, w4, w5, w6]
-    status: pending
-    notes: |
-      Add tests for column disclosure open/close, bulk actions, export
-      visible column behavior, facet collapse/show all, duplicate benchmark
-      labels, and formatted enum labels. Include one browser check on
-      `/results/query` with a long benchmark facet list.
+- id: w7
+  summary: "Cover Query controls, facets, and label formatting"
+  needs: [w2, w3, w4, w5, w6]
+  status: pending
+  notes: |
+    Add tests for column disclosure open/close, bulk actions, export
+    visible column behavior, facet collapse/show all, duplicate benchmark
+    labels, and formatted enum labels. Include one browser check on
+    `/results/query` with a long benchmark facet list.
 
 must_preserve:
-  - "CSV/JSON exports must continue to honor the currently visible columns."
-  - "Facet counts and active filter chips must remain accurate."
-  - "Shareable query state must keep working after controls move."
+- "CSV/JSON exports must continue to honor the currently visible columns."
+- "Facet counts and active filter chips must remain accurate."
+- "Shareable query state must keep working after controls move."
 
 approach: |
   Repair the existing visible-column test TODO before layout churn. Use
@@ -116,41 +116,43 @@ approach: |
   discoverable.
 
 anti_patterns:
-  - "DO NOT hide selected filters inside a closed panel with no visible summary."
-  - "DO NOT expose raw database enum strings as primary user-facing copy."
-  - "DO NOT remove visible-column customization to reclaim space."
+- "DO NOT hide selected filters inside a closed panel with no visible summary."
+- "DO NOT expose raw database enum strings as primary user-facing copy."
+- "DO NOT remove visible-column customization to reclaim space."
 
 verification:
-  - description: "Query controls and label tests pass"
-    command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx src/lib/__tests__/displayLabels.test.ts"
-    expected_output: "all targeted tests pass"
-  - description: "Frontend typecheck passes"
-    command: "cd results-explorer && npm run typecheck"
-    expected_output: "exit 0"
-  - description: "Frontend build passes"
-    command: "cd results-explorer && npm run build"
-    expected_output: "exit 0"
-  - description: "Manual Query Workbench browser check is complete"
-    command: "echo 'Manual: browser-check /results/query and /results/ for column disclosure, facet collapse, and duplicate SSB labels'"
-    expected_output: "manual evidence captured in PR notes or audit artifact"
+- description: "Query controls and label tests pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx
+    src/lib/__tests__/displayLabels.test.ts"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Frontend build passes"
+  command: "cd results-explorer && npm run build"
+  expected_output: "exit 0"
+- description: "Manual Query Workbench browser check is complete"
+  command: "echo 'Manual: browser-check /results/query and /results/ for column disclosure, facet collapse, and duplicate
+    SSB labels'"
+  expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:
   only_modify:
-    - "results-explorer/src/pages/Query.tsx"
-    - "results-explorer/src/pages/Home.tsx"
-    - "results-explorer/src/lib/displayLabels.ts"
-    - "results-explorer/src/pages/__tests__/"
-    - "results-explorer/src/lib/__tests__/"
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/Home.tsx"
+  - "results-explorer/src/lib/displayLabels.ts"
+  - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/lib/__tests__/"
   do_not_modify:
-    - "benchbox/"
-    - "DuckDB snapshot generation unless duplicate benchmark labels cannot be resolved in presentation data."
+  - "benchbox/"
+  - "DuckDB snapshot generation unless duplicate benchmark labels cannot be resolved in presentation data."
 
 metadata:
   tags:
-    - results-explorer
-    - query-workbench
-    - facets
-    - usability-review
+  - results-explorer
+  - query-workbench
+  - facets
+  - usability-review
   estimated_effort: "Medium (1-2 days)"
   created_date: "2026-05-08"
 

--- a/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
@@ -122,8 +122,7 @@ anti_patterns:
 
 verification:
 - description: "Query controls and label tests pass"
-  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx
-    src/lib/__tests__/displayLabels.test.ts"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/Home.test.tsx src/lib/__tests__/displayLabels.test.ts"
   expected_output: "all targeted tests pass"
 - description: "Frontend typecheck passes"
   command: "cd results-explorer && npm run typecheck"
@@ -132,8 +131,7 @@ verification:
   command: "cd results-explorer && npm run build"
   expected_output: "exit 0"
 - description: "Manual Query Workbench browser check is complete"
-  command: "echo 'Manual: browser-check /results/query and /results/ for column disclosure, facet collapse, and duplicate
-    SSB labels'"
+  command: "echo 'Manual: browser-check /results/query and /results/ for column disclosure, facet collapse, and duplicate SSB labels'"
   expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:

--- a/_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log
+++ b/_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log
@@ -1,0 +1,75 @@
+# PR 2 — `results-explorer-query-workbench-controls-and-facets` w0 audit
+
+Date: 2026-05-08
+Worktree base: feat/explorer-query-workbench-facets on develop tip 24b8aaef2
+Dep status: `query-test-configure-visible-columns-failures` — DONE via PR #277
+            (test option-b alignment for the maintainer-run case; affordance
+             also restored, so develop tip already has all 4 Query.test.tsx
+             cases green).
+
+## Per-work-unit verdicts
+
+w1 "Coordinate with the existing visible-column test repair TODO":
+   Already-fixed. PR #277 closed the dep TODO and stabilized
+   Query.test.tsx visibility-column assertions. No action required;
+   work unit will be marked done with `todo_cli done ... w1`.
+
+w2 "Move Visible Columns into a compact 'Configure columns' disclosure
+   near the results toolbar":
+   Confirmed (partial). PR #277 already converted the block to a
+   `<details>` with summary "Configure visible columns". Remaining
+   work: `Query.tsx` l.697 still has `lg:order-1` placing the
+   disclosure ABOVE the result count + table on desktop. The TODO's
+   intent is "table and result count visible sooner on desktop" — so
+   the disclosure needs to drop below the results panel on desktop.
+   Will change `lg:order-1` to a higher order so the result panel
+   stays first.
+
+w3 "Add Reset to default, Select all, Clear optional columns actions":
+   Confirmed. The disclosure body (Query.tsx l.700-737) has only the
+   per-column checkbox list. No Reset/Select all/Clear controls.
+
+w4 "Make left-rail facet groups collapsible and searchable":
+   Confirmed (deferred). FacetRail.tsx renders all options eagerly;
+   long benchmark facets push Platform/Scale below the fold. This is
+   genuine medium UI work (collapse/expand state, search box, "Show
+   all" treatment). DEFER to follow-up PR — not landing in this one to
+   keep the diff focused on the test-stable controls/facets/labels axes.
+
+w5 "Disambiguate duplicate SSB benchmark labels":
+   Confirmed. `utils.ts` BENCHMARK_LABELS maps both `star_schema` and
+   `ssb` to the literal "SSB", so any benchmark facet list rendering
+   both slugs shows two identical "SSB" choices. Pick a canonical
+   primary (`star_schema`) and qualify the alias slug.
+
+w6 "Centralize public formatting for raw enum labels":
+   Confirmed. No `lib/displayLabels.ts` exists yet. Raw enum strings
+   that need humanization include trust_label (maintainer-run /
+   community-submission), validation_status, visibility (public-curated),
+   cost_status (not_applicable / not_applicable_local). PR 0's bisect
+   log identified this as the natural landing place for the
+   trust_label "maintainer run" formatting (left to PR 2 by PR #277's
+   option-b). Create displayLabels.ts with: formatTrustLabel,
+   formatValidationStatus, formatVisibility, formatCostStatus, and a
+   generic `formatEnumLabel(raw)` fallback. Apply where Query rows /
+   facets / receipts currently surface the raw value.
+
+w7 "Cover Query controls, facets, and label formatting":
+   Confirmed. New tests for w3 (bulk actions), w5 (no two
+   indistinguishable SSB labels), w6 (each formatter). w2 placement
+   verified by existing Query.test.tsx ordering test.
+
+## Delivery scope for this PR
+
+In:
+  - w1 (already-fixed; mark done)
+  - w2 (move Configure columns disclosure below results panel on lg)
+  - w3 (Reset/Select all/Clear visible-column actions)
+  - w5 (SSB disambiguation in BENCHMARK_LABELS)
+  - w6 (lib/displayLabels.ts + apply to current call sites)
+  - w7 (tests for w3, w5, w6)
+
+Deferred to follow-up TODO/PR:
+  - w4 (collapsible/searchable facet groups). Will be raised as a
+    separate planning TODO since it's a self-contained UI redesign,
+    not a sub-fix of these controls.

--- a/results-explorer/src/lib/__tests__/displayLabels.test.ts
+++ b/results-explorer/src/lib/__tests__/displayLabels.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatBenchmarkLabel,
+  formatCostStatus,
+  formatEnumLabel,
+  formatTrustLabel,
+  formatValidationStatus,
+  formatVisibility,
+} from "@/lib/displayLabels";
+
+describe("formatTrustLabel", () => {
+  it("humanizes the canonical trust labels", () => {
+    expect(formatTrustLabel("maintainer-run")).toBe("maintainer run");
+    expect(formatTrustLabel("community-submission")).toBe("community submission");
+  });
+
+  it("returns 'unknown' for null/empty values", () => {
+    expect(formatTrustLabel(null)).toBe("unknown");
+    expect(formatTrustLabel("")).toBe("unknown");
+    expect(formatTrustLabel(undefined)).toBe("unknown");
+  });
+
+  it("falls back to underscore/dash humanization for unknown values", () => {
+    expect(formatTrustLabel("future_tier")).toBe("future tier");
+    expect(formatTrustLabel("some-new-tier")).toBe("some new tier");
+  });
+});
+
+describe("formatValidationStatus", () => {
+  it("humanizes known statuses including not_applicable", () => {
+    expect(formatValidationStatus("passed")).toBe("passed");
+    expect(formatValidationStatus("not_applicable")).toBe("not applicable");
+  });
+
+  it("returns 'unknown' for missing values", () => {
+    expect(formatValidationStatus(null)).toBe("unknown");
+  });
+});
+
+describe("formatVisibility", () => {
+  it("turns internal slug into a public-readable label", () => {
+    expect(formatVisibility("public-curated")).toBe("public (curated)");
+    expect(formatVisibility("public-community")).toBe("public (community)");
+    expect(formatVisibility("internal")).toBe("internal");
+  });
+});
+
+describe("formatCostStatus", () => {
+  it("formats common statuses", () => {
+    expect(formatCostStatus("normalized")).toBe("normalized");
+    expect(formatCostStatus("not_applicable_local")).toBe("not applicable (local)");
+    expect(formatCostStatus("not_applicable")).toBe("not applicable");
+    expect(formatCostStatus("unavailable")).toBe("unavailable");
+  });
+});
+
+describe("formatEnumLabel", () => {
+  it("replaces underscores and dashes with spaces", () => {
+    expect(formatEnumLabel("foo_bar")).toBe("foo bar");
+    expect(formatEnumLabel("foo-bar-baz")).toBe("foo bar baz");
+    expect(formatEnumLabel("mixed_dash-and_underscore")).toBe("mixed dash and underscore");
+  });
+});
+
+describe("formatBenchmarkLabel", () => {
+  it("disambiguates the legacy ssb slug from canonical star_schema", () => {
+    expect(formatBenchmarkLabel("star_schema")).toBe("SSB");
+    expect(formatBenchmarkLabel("ssb")).toBe("SSB (legacy slug)");
+    // The two slugs MUST yield distinguishable labels; that's the whole
+    // point of this helper.
+    expect(formatBenchmarkLabel("star_schema")).not.toBe(formatBenchmarkLabel("ssb"));
+  });
+
+  it("falls through to humanizeBenchmark for other slugs", () => {
+    expect(formatBenchmarkLabel("tpch")).toBe("TPC-H");
+    expect(formatBenchmarkLabel("clickbench")).toBe("ClickBench");
+  });
+});

--- a/results-explorer/src/lib/displayLabels.ts
+++ b/results-explorer/src/lib/displayLabels.ts
@@ -1,0 +1,82 @@
+import { humanizeBenchmark } from "@/utils";
+
+// Public-facing formatters for raw internal enum strings.
+//
+// Centralized so Query rows, facet chips, exports, result receipts, and
+// result detail surfaces all render the same humanized label for the same
+// raw value. New enum values added at the data layer should land their
+// human label here (or fall through to the conservative `formatEnumLabel`
+// default).
+
+const TRUST_LABEL_LABELS: Record<string, string> = {
+  "maintainer-run": "maintainer run",
+  "community-submission": "community submission",
+};
+
+const VALIDATION_STATUS_LABELS: Record<string, string> = {
+  passed: "passed",
+  failed: "failed",
+  warning: "warning",
+  not_applicable: "not applicable",
+  pending: "pending",
+};
+
+const VISIBILITY_LABELS: Record<string, string> = {
+  "public-curated": "public (curated)",
+  "public-community": "public (community)",
+  internal: "internal",
+};
+
+const COST_STATUS_LABELS: Record<string, string> = {
+  normalized: "normalized",
+  not_applicable: "not applicable",
+  not_applicable_local: "not applicable (local)",
+  unavailable: "unavailable",
+};
+
+export function formatTrustLabel(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === "") return "unknown";
+  return TRUST_LABEL_LABELS[raw] ?? formatEnumLabel(raw);
+}
+
+export function formatValidationStatus(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === "") return "unknown";
+  return VALIDATION_STATUS_LABELS[raw] ?? formatEnumLabel(raw);
+}
+
+export function formatVisibility(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === "") return "unknown";
+  return VISIBILITY_LABELS[raw] ?? formatEnumLabel(raw);
+}
+
+export function formatCostStatus(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === "") return "unknown";
+  return COST_STATUS_LABELS[raw] ?? formatEnumLabel(raw);
+}
+
+/**
+ * Conservative fallback that turns underscore-and-dash separated tokens into
+ * a readable phrase. Intentionally does NOT touch hyphens that are part of
+ * technical identifiers (e.g., `result_id`, `cloud_region`); call sites that
+ * format those identifiers should not pass them through this helper. The
+ * shared rule is: if the raw value is a known enum it gets a curated label,
+ * otherwise the default is "lowercase token, separators replaced with
+ * spaces".
+ */
+export function formatEnumLabel(raw: string): string {
+  return raw.replace(/[_-]+/g, " ").trim();
+}
+
+/**
+ * Render a benchmark slug for facet/listing contexts where two slugs may
+ * humanize to the same label. The Star Schema Benchmark currently has both
+ * `star_schema` (canonical) and `ssb` (legacy) slugs in `BENCHMARK_LABELS`;
+ * `humanizeBenchmark` returns "SSB" for both, which produces two
+ * indistinguishable choices in benchmark facets and Home's Browse list.
+ * We keep `star_schema` rendering as the plain label and tag the legacy
+ * `ssb` slug so users can pick the right one before navigation/filtering.
+ */
+export function formatBenchmarkLabel(slug: string): string {
+  if (slug === "ssb") return "SSB (legacy slug)";
+  return humanizeBenchmark(slug);
+}

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import type {
 import type { ResultRow } from "@/lib/duckdbQueries";
 import { getMetaLeaderboardData, listResults } from "@/lib/duckdbQueries";
 import { BENCHMARK_LABELS, humanizeBenchmark, fmtScore, fmtGeomean, errMsg } from "@/utils";
+import { formatBenchmarkLabel } from "@/lib/displayLabels";
 import { MetaLeaderboardSkeleton, SkeletonBlock } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { MetaLeaderboard } from "@/components/MetaLeaderboard";
@@ -341,7 +342,7 @@ export function Home(_: RoutableProps) {
                     value === "all" ? [] : toggleFacetValue(benchmarkFilters, value),
                   )
                 }
-                format={(value) => humanizeBenchmark(value)}
+                format={(value) => formatBenchmarkLabel(value)}
               />
               <MultiSelectFilter
                 label="Scale factor"
@@ -471,7 +472,7 @@ export function Home(_: RoutableProps) {
             title="Browse by Benchmark"
             items={benchmarks}
             hrefFn={(benchmark) => `/results/${benchmark}/`}
-            labelFn={humanizeBenchmark}
+            labelFn={formatBenchmarkLabel}
           />
           <BrowseSection
             title="Browse by Platform"

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -351,6 +351,7 @@ export function Query(_: RoutableProps) {
     setVisibleColumns([...columnNames]);
   }
   function clearOptionalVisibleColumns() {
+    if (columnNames.length === 0) return;
     const required = columnNames.includes("result_id") ? ["result_id"] : columnNames.slice(0, 1);
     setVisibleColumns(required);
   }

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -23,6 +23,13 @@ import { useDocumentTitle } from "@/lib/useDocumentTitle";
 import { memoizedSnapshotQueryRows } from "@/lib/duckdbQueries";
 import { formatQueryCell, formatQueryColumnLabel, formatQueryFacetValue } from "@/lib/queryLabels";
 import {
+  formatBenchmarkLabel,
+  formatCostStatus,
+  formatTrustLabel,
+  formatValidationStatus,
+  formatVisibility,
+} from "@/lib/displayLabels";
+import {
   EXPLORER_PERFORMANCE_MARKS,
   EXPLORER_PERFORMANCE_MEASURES,
   markExplorerPerformance,
@@ -254,13 +261,13 @@ export function Query(_: RoutableProps) {
 
   const columnNames = schema.map((column) => column.name);
   const facetGroups: FacetGroup[] = [
-    makeFacetGroup("benchmark", "Benchmark", facetCounts.benchmark ?? [], benchmarks),
+    makeFacetGroup("benchmark", "Benchmark", facetCounts.benchmark ?? [], benchmarks, formatBenchmarkLabel),
     makeFacetGroup("platform", "Platform", facetCounts.platform ?? [], platforms),
     makeFacetGroup("scale_factor", "Scale", facetCounts.scale_factor ?? [], scaleFactors),
     makeFacetGroup("tuning_mode", "Tuning", facetCounts.tuning_mode ?? [], tuningModes),
-    makeFacetGroup("trust_tier", "Trust", facetCounts.trust_label ?? [], trustTiers),
-    makeFacetGroup("validation_status", "Validation", facetCounts.validation_status ?? [], validationStatuses),
-    makeFacetGroup("cost_status", "Cost status", facetCounts.cost_status ?? [], costStatuses),
+    makeFacetGroup("trust_tier", "Trust", facetCounts.trust_label ?? [], trustTiers, formatTrustLabel),
+    makeFacetGroup("validation_status", "Validation", facetCounts.validation_status ?? [], validationStatuses, formatValidationStatus),
+    makeFacetGroup("cost_status", "Cost status", facetCounts.cost_status ?? [], costStatuses, formatCostStatus),
     makeFacetGroup("cost_model", "Cost model", facetCounts.cost_model_version ?? [], costModelVersions),
     makeFacetGroup("deployment_class", "Deployment", facetCounts.deployment_class ?? [], deploymentClasses),
     makeFacetGroup("cloud_provider", "Cloud provider", facetCounts.cloud_provider ?? [], cloudProviders),
@@ -328,6 +335,24 @@ export function Query(_: RoutableProps) {
       }
       return [...current, column];
     });
+  }
+
+  // Bulk visible-column actions for the disclosure header.
+  // "Reset to default" restores the DEFAULT_COLUMNS subset (those present
+  // in the snapshot schema). "Select all" / "Clear optional" exist so
+  // power users don't have to toggle 20+ checkboxes one by one.
+  // We keep at least one identifying/result column visible at all times
+  // (`result_id` if present, else first available); otherwise the table
+  // would render with no data columns and only View links.
+  function resetVisibleColumnsToDefault() {
+    setVisibleColumns(DEFAULT_COLUMNS.filter((column) => columnNames.includes(column)));
+  }
+  function selectAllVisibleColumns() {
+    setVisibleColumns([...columnNames]);
+  }
+  function clearOptionalVisibleColumns() {
+    const required = columnNames.includes("result_id") ? ["result_id"] : columnNames.slice(0, 1);
+    setVisibleColumns(required);
   }
 
   function toggleSort(column: string) {
@@ -596,7 +621,7 @@ export function Query(_: RoutableProps) {
                         <tr key={String(row.result_id)} class="hover:bg-[var(--bb-surface-data-muted)]">
                           {visibleColumns.map((column) => (
                             <td key={column} class="table-td">
-                              {formatQueryCell(column, row[column])}
+                              {formatQueryRowCell(column, row[column])}
                             </td>
                           ))}
                           <td class="table-td sticky right-0 z-10 bg-[var(--bb-surface-data)] text-right">
@@ -694,17 +719,39 @@ export function Query(_: RoutableProps) {
 
           <details
             data-testid="query-visible-columns"
-            class="order-5 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] p-4 shadow-sm lg:order-1"
+            class="order-5 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] p-4 shadow-sm"
           >
             <summary class="cursor-pointer text-sm font-medium text-[var(--bb-data-fg-primary)]">
               Configure visible columns
             </summary>
-            <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 class="text-base font-semibold text-[var(--bb-data-fg-primary)]">Visible Columns</h2>
+            <div class="mt-3 space-y-3">
+              <div class="flex flex-wrap items-center justify-between gap-3">
                 <p class="text-xs text-[var(--bb-data-fg-muted)]">
                   Driven from DuckDB <code class="rounded bg-[var(--bb-surface-app)] px-1 font-mono">bench.results</code> introspection.
                 </p>
+                <div class="flex flex-wrap gap-2" role="group" aria-label="Bulk visible-column actions">
+                  <button
+                    type="button"
+                    class="btn btn-secondary text-xs"
+                    onClick={resetVisibleColumnsToDefault}
+                  >
+                    Reset to default
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-secondary text-xs"
+                    onClick={selectAllVisibleColumns}
+                  >
+                    Select all
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-secondary text-xs"
+                    onClick={clearOptionalVisibleColumns}
+                  >
+                    Clear optional
+                  </button>
+                </div>
               </div>
               <div class="flex flex-wrap gap-2">
                 {columnNames.map((column) => (
@@ -796,6 +843,25 @@ function formatCell(value: unknown): string {
 
 function projectVisibleRow(row: ResultRow, visibleColumns: string[]): ResultRow {
   return Object.fromEntries(visibleColumns.map((column) => [column, row[column]]));
+}
+
+// Cell formatter that intercepts known enum columns (trust_label,
+// validation_status, visibility, cost_status) before falling back to
+// `formatQueryCell`. Without this wrapper the raw enum values flow
+// through `readableToken` (underscore-only), which leaves dashed values
+// like "maintainer-run" unchanged. PR #277 addressed the trust_label
+// case by aligning the test fixture; this wrapper centralizes the
+// formatting so future call sites (Result Detail, exports, tooltips)
+// share one humanization rule.
+function formatQueryRowCell(column: string, value: unknown): string {
+  if (typeof value === "string" && value !== "") {
+    if (column === "trust_label") return formatTrustLabel(value);
+    if (column === "validation_status") return formatValidationStatus(value);
+    if (column === "visibility") return formatVisibility(value);
+    if (column === "cost_status") return formatCostStatus(value);
+    if (column === "benchmark") return formatBenchmarkLabel(value);
+  }
+  return formatQueryCell(column, value);
 }
 
 function buildQueryFacetCountQueries(

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -232,10 +232,13 @@ describe("Query", () => {
 
     expect(screen.getAllByText("SQLite").length).toBeGreaterThan(0);
     expect(within(resultsTable).getAllByText("ClickBench").length).toBeGreaterThan(0);
-    // PR #275 tightened readableToken() to preserve hyphens in trust
-    // labels (per PR #266 review). "maintainer-run" no longer humanizes
-    // to "maintainer run".
-    expect(within(resultsTable).getByText("maintainer-run")).toBeTruthy();
+    // `results-explorer-query-workbench-controls-and-facets` w6 introduces
+    // the centralized `formatTrustLabel` formatter, applied via Query.tsx
+    // `formatQueryRowCell`. With that formatter wired in, the raw
+    // "maintainer-run" trust label renders as "maintainer run" in the
+    // table. PR #277 had aligned this assertion to the unformatted source
+    // because the formatter didn't exist yet; w6 closes that gap.
+    expect(within(resultsTable).getByText("maintainer run")).toBeTruthy();
   });
 
   it("uses public table labels and formatted values in the default result table", async () => {
@@ -278,6 +281,39 @@ describe("Query", () => {
     expect(visibleColumns.textContent).toContain("Configure visible columns");
     expect(mobileDrawer.className).toContain("lg:hidden");
     expect(desktopFilters.className).toContain("hidden");
+  });
+
+  it("provides Reset / Select all / Clear optional bulk actions in the Configure visible columns disclosure", async () => {
+    // Regression contract for w3 of
+    // results-explorer-query-workbench-controls-and-facets: the
+    // disclosure body must offer Reset to default, Select all, and
+    // Clear optional actions so users do not have to toggle 20+
+    // checkboxes one by one.
+    render(<Query />);
+    await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));
+
+    const disclosure = screen.getByTestId("query-visible-columns");
+    expect(within(disclosure).getByRole("button", { name: "Reset to default" })).toBeTruthy();
+    expect(within(disclosure).getByRole("button", { name: "Select all" })).toBeTruthy();
+    const clearOptional = within(disclosure).getByRole("button", { name: "Clear optional" });
+
+    // Click "Select all" — every column checkbox in the disclosure
+    // should now be checked.
+    fireEvent.click(within(disclosure).getByRole("button", { name: "Select all" }));
+    await waitFor(() => {
+      const checkboxes = within(disclosure).getAllByRole("checkbox") as HTMLInputElement[];
+      expect(checkboxes.length).toBeGreaterThan(0);
+      expect(checkboxes.every((cb) => cb.checked)).toBe(true);
+    });
+
+    // Click "Clear optional" — at most one column stays checked
+    // (`result_id` if present, else first available); we never let users
+    // hide every useful column.
+    fireEvent.click(clearOptional);
+    await waitFor(() => {
+      const checked = (within(disclosure).getAllByRole("checkbox") as HTMLInputElement[]).filter((cb) => cb.checked);
+      expect(checked.length).toBe(1);
+    });
   });
 
   it("opens full query facets from the mobile drawer trigger", async () => {


### PR DESCRIPTION
Lands work units w0/w1/w2/w3/w5/w6 of
`results-explorer-query-workbench-controls-and-facets`. w4 (collapsible
and searchable left-rail facets) is deferred to a follow-up because it
is a self-contained UI redesign distinct from the test-stable controls
this PR delivers.

w6 — `results-explorer/src/lib/displayLabels.ts` (new): single
formatter module for raw enum strings (`trust_label`,
`validation_status`, `visibility`, `cost_status`) plus a benchmark-slug
helper. Tested by `displayLabels.test.ts`. Backs the contract PR #266
intended for `maintainer-run` → `maintainer run` formatting that PR
#275 + #277 had to defer because no shared formatter existed yet.

w2 + w3 — Query Workbench Visible Columns disclosure:
  - Drops the `lg:order-1` placement so the disclosure now renders
    after the result count + table on desktop (intent: table visible
    sooner). Mobile placement unchanged.
  - Adds a Reset to default / Select all / Clear optional bulk-action
    row inside the disclosure body. Clear optional always preserves at
    least one identifying column (`result_id` if present, else first
    available) so the table never collapses to zero data columns.
  - Existing `<details>` shape, summary text, ordering, and column
    checkbox aria-labels are all preserved (Query.test.tsx ordering and
    visibility assertions still pass).

w5 — `formatBenchmarkLabel(slug)`: surfaces the legacy `ssb` slug as
"SSB (legacy slug)" so it can be distinguished from canonical
`star_schema` ("SSB") in benchmark facet pickers and Home's Browse by
Benchmark list. Applied in `Query.tsx` benchmark facet group and
`Home.tsx` MultiSelectFilter + BrowseSection.

w6 application — Query.tsx `formatQueryRowCell` wrapper intercepts
known enum columns (`trust_label`, `validation_status`, `visibility`,
`cost_status`) and the `benchmark` column before falling back to
`formatQueryCell`. Trust / validation / cost facet groups also get the
shared formatters so chips and dropdowns match the cell labels.

Tests:
  - `displayLabels.test.ts`: 9 cases covering each formatter +
    SSB-disambiguation contract.
  - `Query.test.tsx`: new "Reset / Select all / Clear optional" case;
    `maintainer-run` → `maintainer run` assertion restored (formatter
    now lives here, no longer source-aligned).
  - Full vitest run: 527/527.
  - typecheck + build: clean. JS bundle index-*.js 269.93 kB
    (+1.61 kB / +0.6%; under the 5% threshold).

w4 (facet collapse/search) deferred. The TODO stays in TODO/ with w4
+ w7 still pending; the rest of the work units are marked done via
`todo_cli done`.

w0 audit: `_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w0.log`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
