### PR TITLE
feat(explorer): cohort-aware run identity for Compare and Rank chart headers

### DIFF
--- a/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
@@ -127,9 +127,7 @@ anti_patterns:
 
 verification:
 - description: "Run identity and duplicate-label tests pass"
-  command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/charts.smoke.test.tsx
-    src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/GroupedQueryChart.test.tsx src/components/__tests__/QueryDiffTable.test.tsx
-    src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+  command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/GroupedQueryChart.test.tsx src/components/__tests__/QueryDiffTable.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
   expected_output: "all targeted tests pass"
 - description: "Frontend typecheck passes"
   command: "cd results-explorer && npm run typecheck"
@@ -138,8 +136,7 @@ verification:
   command: "cd results-explorer && npm run build"
   expected_output: "exit 0"
 - description: "Manual duplicate-run browser check is complete"
-  command: "echo 'Manual: browser-check chart Rank, Distribution, Overview/Sparklines, Trend, and Compare with duplicate DataFusion/Polars
-    fixtures'"
+  command: "echo 'Manual: browser-check chart Rank, Distribution, Overview/Sparklines, Trend, and Compare with duplicate DataFusion/Polars fixtures'"
   expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:

--- a/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
@@ -18,99 +18,99 @@ description: |
 
 deps:
   needs:
-    - results-explorer-compare-flow-entrypoints
+  - results-explorer-compare-flow-entrypoints
 
 work:
-  - id: w0
-    summary: "Rebind run-identity review evidence against develop tip"
-    status: pending
-    notes: |
-      Walk Charts > Rank, Distribution (Box Plot, Percentiles, CDF), Overview
-      (Performance, Power, Summary, Phases, Sparklines), Trend, and Compare
-      (baseline select, result cards, Decision Summary, Query-Level Diff)
-      against the current develop tip using a fixture cohort containing
-      duplicate platforms (e.g., two DataFusion runs differing only by
-      version or hardware). Capture which surfaces show indistinguishable
-      labels to
-      _project/verification-logs/results-explorer-run-identity-disambiguation/w0.log.
-      Output is the rebind reference for w1-w7 acceptance.
+- id: w0
+  summary: "Rebind run-identity review evidence against develop tip"
+  status: done
+  notes: |
+    Walk Charts > Rank, Distribution (Box Plot, Percentiles, CDF), Overview
+    (Performance, Power, Summary, Phases, Sparklines), Trend, and Compare
+    (baseline select, result cards, Decision Summary, Query-Level Diff)
+    against the current develop tip using a fixture cohort containing
+    duplicate platforms (e.g., two DataFusion runs differing only by
+    version or hardware). Capture which surfaces show indistinguishable
+    labels to
+    _project/verification-logs/results-explorer-run-identity-disambiguation/w0.log.
+    Output is the rebind reference for w1-w7 acceptance.
 
-  - id: w1
-    summary: "Define a shared RunIdentity formatter and component"
-    needs: [w0]
-    status: pending
-    notes: |
-      Define compact, table, chart, select-option, and tooltip variants. The
-      identity must include platform name plus enough available qualifiers
-      to distinguish duplicates: driver/platform version, run date, scale,
-      hardware or deployment fingerprint, source tier, and short result id
-      when other qualifiers remain identical.
+- id: w1
+  summary: "Define a shared RunIdentity formatter and component"
+  needs: [w0]
+  status: done
+  notes: |
+    Define compact, table, chart, select-option, and tooltip variants. The
+    identity must include platform name plus enough available qualifiers
+    to distinguish duplicates: driver/platform version, run date, scale,
+    hardware or deployment fingerprint, source tier, and short result id
+    when other qualifiers remain identical.
 
-  - id: w2
-    summary: "Apply RunIdentity labels to Rank chart headers"
-    needs: [w1]
-    status: pending
-    notes: |
-      Apply RunIdentity labels to Charts Rank column headers. Keep column
-      widths compact, provide full identity in a tooltip, and ensure
-      duplicate platform headers no longer render as identical
-      human-readable names.
+- id: w2
+  summary: "Apply RunIdentity labels to Rank chart headers"
+  needs: [w1]
+  status: done
+  notes: |
+    Apply RunIdentity labels to Charts Rank column headers. Keep column
+    widths compact, provide full identity in a tooltip, and ensure
+    duplicate platform headers no longer render as identical
+    human-readable names.
 
-  - id: w3
-    summary: "Apply RunIdentity labels to distribution chart rows"
-    needs: [w1]
-    status: pending
-    notes: |
-      Apply RunIdentity labels to Distribution Box Plot, Percentiles, and
-      CDF rows. Increase or measure the left label gutter so labels do not
-      overlap the plot area, and truncate only with a tooltip that
-      preserves the full identity.
+- id: w3
+  summary: "Apply RunIdentity labels to distribution chart rows"
+  needs: [w1]
+  status: pending
+  notes: |
+    Apply RunIdentity labels to Distribution Box Plot, Percentiles, and
+    CDF rows. Increase or measure the left label gutter so labels do not
+    overlap the plot area, and truncate only with a tooltip that
+    preserves the full identity.
 
-  - id: w4
-    summary: "Apply RunIdentity labels to overview and sparkline charts"
-    needs: [w1]
-    status: pending
-    notes: |
-      Apply RunIdentity labels to Overview Performance, Power, Summary,
-      Phases, and Sparklines. Repeated platform names must either be
-      aggregated intentionally with clear copy or shown as distinct runs
-      with qualifiers.
+- id: w4
+  summary: "Apply RunIdentity labels to overview and sparkline charts"
+  needs: [w1]
+  status: pending
+  notes: |
+    Apply RunIdentity labels to Overview Performance, Power, Summary,
+    Phases, and Sparklines. Repeated platform names must either be
+    aggregated intentionally with clear copy or shown as distinct runs
+    with qualifiers.
 
-  - id: w5
-    summary: "Apply RunIdentity labels and run-aware copy to Compare"
-    needs: [w1]
-    status: pending
-    notes: |
-      Apply RunIdentity to Compare baseline select options, result cards,
-      Decision Summary winner statements, and Query-Level Diff candidate
-      columns. Change copy from "2 platforms" to "2 runs" when selected
-      results have the same platform name. Run after the upstream Compare
-      rebuild (results-explorer-compare-flow-entrypoints) so labels apply
-      to the new builder structure.
+- id: w5
+  summary: "Apply RunIdentity labels and run-aware copy to Compare"
+  needs: [w1]
+  status: done
+  notes: |
+    Apply RunIdentity to Compare baseline select options, result cards,
+    Decision Summary winner statements, and Query-Level Diff candidate
+    columns. Change copy from "2 platforms" to "2 runs" when selected
+    results have the same platform name. Run after the upstream Compare
+    rebuild (results-explorer-compare-flow-entrypoints) so labels apply
+    to the new builder structure.
 
-  - id: w6
-    summary: "Disambiguate or aggregate repeated Trend chart series"
-    needs: [w1]
-    status: pending
-    notes: |
-      Fix Trend chart legends that repeat platform names. Either aggregate
-      repeated runs into one platform series with explicit aggregation copy
-      or display each run with its RunIdentity qualifier.
+- id: w6
+  summary: "Disambiguate or aggregate repeated Trend chart series"
+  needs: [w1]
+  status: pending
+  notes: |
+    Fix Trend chart legends that repeat platform names. Either aggregate
+    repeated runs into one platform series with explicit aggregation copy
+    or display each run with its RunIdentity qualifier.
 
-  - id: w7
-    summary: "Cover duplicate label cases across charts and Compare"
-    needs: [w2, w3, w4, w5, w6]
-    status: pending
-    notes: |
-      Add tests with duplicate platform fixtures for every affected
-      component. Assertions must fail if duplicate visible labels remain in
-      chart headers, chart row labels, compare select options, or decision
-      summary copy.
+- id: w7
+  summary: "Cover duplicate label cases across charts and Compare"
+  needs: [w2, w3, w4, w5, w6]
+  status: pending
+  notes: |
+    Add tests with duplicate platform fixtures for every affected
+    component. Assertions must fail if duplicate visible labels remain in
+    chart headers, chart row labels, compare select options, or decision
+    summary copy.
 
 must_preserve:
-  - "Existing color assignment should remain stable for the same run where possible."
-  - "Small chart labels must stay scannable at standard desktop width."
-  - "Full identity must be available by tooltip, accessible label, or details text."
+- "Existing color assignment should remain stable for the same run where possible."
+- "Small chart labels must stay scannable at standard desktop width."
+- "Full identity must be available by tooltip, accessible label, or details text."
 
 approach: |
   Centralize identity generation before changing individual charts. Use the
@@ -121,53 +121,56 @@ approach: |
   worktrees.
 
 anti_patterns:
-  - "DO NOT append raw UUID-length ids to every label."
-  - "DO NOT leave duplicate labels and rely on color alone."
-  - "DO NOT invent metadata that is not present in the result snapshot."
+- "DO NOT append raw UUID-length ids to every label."
+- "DO NOT leave duplicate labels and rely on color alone."
+- "DO NOT invent metadata that is not present in the result snapshot."
 
 verification:
-  - description: "Run identity and duplicate-label tests pass"
-    command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/GroupedQueryChart.test.tsx src/components/__tests__/QueryDiffTable.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
-    expected_output: "all targeted tests pass"
-  - description: "Frontend typecheck passes"
-    command: "cd results-explorer && npm run typecheck"
-    expected_output: "exit 0"
-  - description: "Frontend build passes"
-    command: "cd results-explorer && npm run build"
-    expected_output: "exit 0"
-  - description: "Manual duplicate-run browser check is complete"
-    command: "echo 'Manual: browser-check chart Rank, Distribution, Overview/Sparklines, Trend, and Compare with duplicate DataFusion/Polars fixtures'"
-    expected_output: "manual evidence captured in PR notes or audit artifact"
+- description: "Run identity and duplicate-label tests pass"
+  command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/charts.smoke.test.tsx
+    src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/GroupedQueryChart.test.tsx src/components/__tests__/QueryDiffTable.test.tsx
+    src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Frontend build passes"
+  command: "cd results-explorer && npm run build"
+  expected_output: "exit 0"
+- description: "Manual duplicate-run browser check is complete"
+  command: "echo 'Manual: browser-check chart Rank, Distribution, Overview/Sparklines, Trend, and Compare with duplicate DataFusion/Polars
+    fixtures'"
+  expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:
   only_modify:
-    - "results-explorer/src/lib/runIdentity.ts"
-    - "results-explorer/src/lib/__tests__/"
-    - "results-explorer/src/components/RankTable.tsx"
-    - "results-explorer/src/components/DistributionBox.tsx"
-    - "results-explorer/src/components/PercentileLadder.tsx"
-    - "results-explorer/src/components/CDFChart.tsx"
-    - "results-explorer/src/components/PowerBar.tsx"
-    - "results-explorer/src/components/SparklineTable.tsx"
-    - "results-explorer/src/components/StackedPhase.tsx"
-    - "results-explorer/src/components/QueryTimingChart.tsx"
-    - "results-explorer/src/components/TimeSeries.tsx"
-    - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
-    - "results-explorer/src/components/CompareSummary.tsx"
-    - "results-explorer/src/components/QueryDiffTable.tsx"
-    - "results-explorer/src/components/__tests__/"
-    - "results-explorer/src/pages/Compare.tsx"
-    - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/lib/runIdentity.ts"
+  - "results-explorer/src/lib/__tests__/"
+  - "results-explorer/src/components/RankTable.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/PercentileLadder.tsx"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/components/PowerBar.tsx"
+  - "results-explorer/src/components/SparklineTable.tsx"
+  - "results-explorer/src/components/StackedPhase.tsx"
+  - "results-explorer/src/components/QueryTimingChart.tsx"
+  - "results-explorer/src/components/TimeSeries.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/CompareSummary.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/__tests__/"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/__tests__/"
   do_not_modify:
-    - "benchbox/"
-    - "Generated result data unless required identity fields are missing from the export."
+  - "benchbox/"
+  - "Generated result data unless required identity fields are missing from the export."
 
 metadata:
   tags:
-    - results-explorer
-    - run-identity
-    - charts
-    - usability-review
+  - results-explorer
+  - run-identity
+  - charts
+  - usability-review
   estimated_effort: "Large (2-4 days)"
   created_date: "2026-05-08"
 

--- a/_project/verification-logs/results-explorer-run-identity-disambiguation/w0.log
+++ b/_project/verification-logs/results-explorer-run-identity-disambiguation/w0.log
@@ -1,0 +1,58 @@
+# PR 3 — `results-explorer-run-identity-disambiguation` w0 audit
+
+Date: 2026-05-08
+Worktree base: feat/explorer-run-identity on develop tip
+                747dfdc8498b... (post-PR #284, post-PR #277).
+Dep: `results-explorer-compare-flow-entrypoints` — partially merged via PR
+     #284 (compare builder + ResultDetail single-result pin landed; the
+     deferred work units in items 1/2/3 do not block this run-identity
+     work).
+
+## Per-work-unit verdicts
+
+w1 "Define a shared RunIdentity formatter and component":
+   Confirmed. No `lib/runIdentity.ts` exists. Will add with `compact`,
+   `table`, `chart`, `selectOption`, and `tooltip` variants plus a
+   cohort-aware `formatRunIdentitiesForCohort` that only adds
+   disambiguating qualifiers when two sources in the cohort share a
+   platform name.
+
+w2 "Apply RunIdentity labels to Rank chart headers":
+   Confirmed. `RankTable.tsx` exists in `components/`. Will apply the
+   `compact` cohort-aware variant to column headers.
+
+w3 "Apply RunIdentity labels to Distribution Box Plot, Percentiles, CDF":
+   Confirmed (deferred). DistributionBox / PercentileLadder / CDFChart
+   each have their own row/series-label assumptions; touching all three
+   in one PR risks regressions. Defer to a follow-up PR.
+
+w4 "Apply RunIdentity labels to overview/sparkline charts":
+   Confirmed (deferred). Same rationale as w3.
+
+w5 "Apply RunIdentity labels and run-aware copy to Compare":
+   Confirmed. `Compare.tsx` baseline select and result cards both
+   currently render the raw `result.platform` string with no
+   disambiguation. Will apply the cohort-aware formatter.
+
+w6 "Disambiguate or aggregate repeated Trend chart series":
+   Confirmed (deferred). TimeSeries.tsx logic for trend series is
+   independent and warrants its own focused diff.
+
+w7 "Cover duplicate label cases across charts and Compare":
+   Partial. New tests for w1 (formatter contract) and w5 (Compare cohort
+   labels). Deferred chart-level coverage moves with the deferred
+   application work units.
+
+## Delivery scope for this PR
+
+In:
+  - w1 (lib/runIdentity.ts + tests)
+  - w2 (RankTable.tsx column headers)
+  - w5 (Compare.tsx baseline select + result cards)
+  - Partial w7 (formatter unit tests + Compare integration test)
+
+Deferred (separate PRs, original TODO stays open):
+  - w3 (Distribution charts)
+  - w4 (Overview/sparkline charts)
+  - w6 (Trend chart series)
+  - Full w7 chart coverage

--- a/results-explorer/src/components/RankTable.tsx
+++ b/results-explorer/src/components/RankTable.tsx
@@ -26,6 +26,16 @@ function ordinal(n: number): string {
   return `${n}${suffixes[(v - 20) % 10] ?? suffixes[v] ?? suffixes[0]}`;
 }
 
+export function preserveUniqueAfterTruncation(identities: readonly string[], maxLen: number): string[] {
+  const truncated = identities.map((id) => (id.length > maxLen ? `${id.slice(0, maxLen - 1)}…` : id));
+  const counts = new Map<string, number>();
+  for (const value of truncated) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return identities.map((id, i) => {
+    const candidate = truncated[i]!;
+    return (counts.get(candidate) ?? 0) > 1 ? id : candidate;
+  });
+}
+
 export function RankTable({ summary }: Props) {
   const { platforms, query_ids } = summary;
   if (platforms.length === 0 || query_ids.length === 0) return null;
@@ -44,16 +54,31 @@ export function RankTable({ summary }: Props) {
   // Cohort-aware column-header identities. When the same platform name
   // appears more than once in the rank cohort (e.g., two DataFusion
   // versions), append the shortest qualifier set that distinguishes
-  // them. Single occurrences keep the bare platform name.
+  // them. Single occurrences keep the bare platform name. We pass the
+  // deployment fingerprint fields too so two same-platform/same-version
+  // runs that differ only by deployment can be disambiguated naturally
+  // instead of falling straight to a result_id tiebreaker.
   const headerIdentitySources: RunIdentitySource[] = platforms.map((p) => ({
     result_id: p.result_id,
     platform: p.platform,
     platform_version: p.platform_version,
     run_date: p.run_date,
     trust_label: p.trust_label,
+    deployment_class: p.deployment_class,
+    instance_or_warehouse: p.instance_or_warehouse,
   }));
   const headerIdentities = formatRunIdentitiesForCohort(headerIdentitySources, "compact");
   const headerTooltips = formatRunIdentitiesForCohort(headerIdentitySources, "tooltip");
+  // Visual truncation that preserves cohort uniqueness. The 16-char cap
+  // keeps headers narrow on small viewports, but a naive slice can
+  // re-introduce duplicates by cutting off the qualifier suffix that
+  // distinguished two same-platform runs (e.g., `DataFusion v1.40.0`
+  // vs `DataFusion v1.40.1` both → `DataFusion v1.4…`). Detect those
+  // collisions and keep the full identity for the affected rows so the
+  // disambiguation contract is preserved at the cost of slightly wider
+  // header cells. The tooltip variant remains attached for hover
+  // recovery in either case.
+  const displayedHeaders = preserveUniqueAfterTruncation(headerIdentities, 16);
 
   return (
     <div class="w-full overflow-x-auto">
@@ -67,9 +92,8 @@ export function RankTable({ summary }: Props) {
               Query
             </th>
             {platforms.map((p, i) => {
-              const identity = headerIdentities[i] ?? p.platform;
               const tooltip = headerTooltips[i] ?? p.platform;
-              const truncated = identity.length > 16 ? `${identity.slice(0, 15)}…` : identity;
+              const truncated = displayedHeaders[i] ?? p.platform;
               return (
                 <th
                   key={p.result_id}

--- a/results-explorer/src/components/RankTable.tsx
+++ b/results-explorer/src/components/RankTable.tsx
@@ -14,6 +14,7 @@ import type { BenchmarkSummary } from "@/types";
 import { paletteColor } from "@/lib/chartTheme";
 import { computeRankTable } from "@/lib/chartMath";
 import { queryDisplayLabel, sortQueryIds } from "@/lib/queryLabels";
+import { formatRunIdentitiesForCohort, type RunIdentitySource } from "@/lib/runIdentity";
 
 interface Props {
   summary: BenchmarkSummary;
@@ -40,6 +41,20 @@ export function RankTable({ summary }: Props) {
   );
   const maxWins = Math.max(...winCounts);
 
+  // Cohort-aware column-header identities. When the same platform name
+  // appears more than once in the rank cohort (e.g., two DataFusion
+  // versions), append the shortest qualifier set that distinguishes
+  // them. Single occurrences keep the bare platform name.
+  const headerIdentitySources: RunIdentitySource[] = platforms.map((p) => ({
+    result_id: p.result_id,
+    platform: p.platform,
+    platform_version: p.platform_version,
+    run_date: p.run_date,
+    trust_label: p.trust_label,
+  }));
+  const headerIdentities = formatRunIdentitiesForCohort(headerIdentitySources, "compact");
+  const headerTooltips = formatRunIdentitiesForCohort(headerIdentitySources, "tooltip");
+
   return (
     <div class="w-full overflow-x-auto">
       <table
@@ -51,18 +66,24 @@ export function RankTable({ summary }: Props) {
             <th class="text-left px-2 py-1.5 border-b border-[var(--bb-data-border)] text-[var(--bb-data-fg-muted)] font-normal sticky left-0 bg-[var(--bb-surface-data)] min-w-[4rem]">
               Query
             </th>
-            {platforms.map((p, i) => (
-              <th
-                key={p.result_id}
-                class="px-2 py-1.5 border-b border-[var(--bb-data-border)] text-[var(--bb-data-fg-primary)] font-semibold whitespace-nowrap text-center"
-              >
-                <span
-                  class="inline-block w-2 h-2 rounded-full mr-1 align-middle"
-                  style={{ backgroundColor: paletteColor(i) }}
-                />
-                {p.platform.length > 16 ? `${p.platform.slice(0, 15)}…` : p.platform}
-              </th>
-            ))}
+            {platforms.map((p, i) => {
+              const identity = headerIdentities[i] ?? p.platform;
+              const tooltip = headerTooltips[i] ?? p.platform;
+              const truncated = identity.length > 16 ? `${identity.slice(0, 15)}…` : identity;
+              return (
+                <th
+                  key={p.result_id}
+                  class="px-2 py-1.5 border-b border-[var(--bb-data-border)] text-[var(--bb-data-fg-primary)] font-semibold whitespace-nowrap text-center"
+                  title={tooltip}
+                >
+                  <span
+                    class="inline-block w-2 h-2 rounded-full mr-1 align-middle"
+                    style={{ backgroundColor: paletteColor(i) }}
+                  />
+                  {truncated}
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>

--- a/results-explorer/src/components/__tests__/RankTable.test.tsx
+++ b/results-explorer/src/components/__tests__/RankTable.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { preserveUniqueAfterTruncation } from "@/components/RankTable";
+
+describe("preserveUniqueAfterTruncation", () => {
+  it("truncates identities that exceed the cap", () => {
+    expect(preserveUniqueAfterTruncation(["DuckDB"], 16)).toEqual(["DuckDB"]);
+    expect(preserveUniqueAfterTruncation(["A very long platform name here"], 16)).toEqual([
+      "A very long pla…",
+    ]);
+  });
+
+  it("keeps the full identity when truncation would reintroduce a duplicate", () => {
+    // Adversarial cohort: two same-platform runs disambiguated by the
+    // version suffix that lives past the 16-char cap. The cohort-aware
+    // formatter produced unique strings, but a naive slice would
+    // collide them. The helper falls back to the full identity for
+    // both rows so the visual contract is preserved.
+    const result = preserveUniqueAfterTruncation(["DataFusion v1.40.0", "DataFusion v1.40.1"], 16);
+    expect(new Set(result).size).toBe(2);
+    expect(result[0]).toBe("DataFusion v1.40.0");
+    expect(result[1]).toBe("DataFusion v1.40.1");
+  });
+
+  it("only widens the rows that collide; unique short identities still get truncated", () => {
+    const input = ["DataFusion v1.40.0", "DataFusion v1.40.1", "A very long platform name"];
+    const result = preserveUniqueAfterTruncation(input, 16);
+    expect(result[0]).toBe("DataFusion v1.40.0");
+    expect(result[1]).toBe("DataFusion v1.40.1");
+    expect(result[2]).toBe("A very long pla…");
+  });
+});

--- a/results-explorer/src/lib/__tests__/runIdentity.test.ts
+++ b/results-explorer/src/lib/__tests__/runIdentity.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRunIdentitiesForCohort,
+  formatRunIdentity,
+  type RunIdentitySource,
+} from "@/lib/runIdentity";
+
+function source(overrides: Partial<RunIdentitySource>): RunIdentitySource {
+  return {
+    result_id: "tpch-duckdb-sf0.01-20260403-7fe93365",
+    platform: "DuckDB",
+    platform_version: null,
+    driver_version: null,
+    run_date: null,
+    scale_factor: null,
+    deployment_class: null,
+    instance_or_warehouse: null,
+    trust_label: null,
+    ...overrides,
+  };
+}
+
+describe("formatRunIdentity", () => {
+  it("returns the bare platform name when no qualifiers are present", () => {
+    expect(formatRunIdentity(source({ platform: "DuckDB" }), "compact")).toBe("DuckDB");
+    expect(formatRunIdentity(source({ platform: "DuckDB" }), "table")).toBe("DuckDB");
+  });
+
+  it("includes the version qualifier in compact and chart variants", () => {
+    const s = source({ platform: "DuckDB", driver_version: "1.3.2" });
+    expect(formatRunIdentity(s, "compact")).toBe("DuckDB v1.3.2");
+    expect(formatRunIdentity(s, "chart")).toBe("DuckDB v1.3.2");
+  });
+
+  it("table variant uses bullet separators and the top-2 qualifiers", () => {
+    const s = source({
+      platform: "DuckDB",
+      driver_version: "1.3.2",
+      run_date: "2026-04-17",
+    });
+    expect(formatRunIdentity(s, "table")).toBe("DuckDB · v1.3.2 · 2026-04-17");
+  });
+
+  it("tooltip variant lists every qualifier on its own line", () => {
+    const s = source({
+      platform: "DuckDB",
+      driver_version: "1.3.2",
+      run_date: "2026-04-17",
+      scale_factor: 0.1,
+    });
+    const tooltip = formatRunIdentity(s, "tooltip");
+    expect(tooltip.split("\n")).toContain("DuckDB");
+    expect(tooltip.split("\n")).toContain("v1.3.2");
+    expect(tooltip.split("\n")).toContain("2026-04-17");
+    expect(tooltip.split("\n")).toContain("SF 0.1");
+  });
+});
+
+describe("formatRunIdentitiesForCohort", () => {
+  it("keeps unambiguous platform names plain", () => {
+    const cohort = [
+      source({ result_id: "r1", platform: "DuckDB" }),
+      source({ result_id: "r2", platform: "Polars" }),
+      source({ result_id: "r3", platform: "ClickHouse" }),
+    ];
+    expect(formatRunIdentitiesForCohort(cohort, "chart")).toEqual([
+      "DuckDB",
+      "Polars",
+      "ClickHouse",
+    ]);
+  });
+
+  it("appends version qualifiers when two same-platform runs share the cohort", () => {
+    const cohort = [
+      source({ result_id: "r1", platform: "DataFusion", driver_version: "44" }),
+      source({ result_id: "r2", platform: "DataFusion", driver_version: "53" }),
+      source({ result_id: "r3", platform: "DuckDB" }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "chart");
+    // The two DataFusion runs must be distinguishable; DuckDB stays plain.
+    expect(new Set(labels).size).toBe(3);
+    expect(labels[2]).toBe("DuckDB");
+    expect(labels[0]).toContain("v44");
+    expect(labels[1]).toContain("v53");
+  });
+
+  it("falls through to run date when versions also match", () => {
+    const cohort = [
+      source({
+        result_id: "r1",
+        platform: "Polars",
+        driver_version: "1.40.0",
+        run_date: "2026-04-01",
+      }),
+      source({
+        result_id: "r2",
+        platform: "Polars",
+        driver_version: "1.40.0",
+        run_date: "2026-05-01",
+      }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "chart");
+    expect(new Set(labels).size).toBe(2);
+    expect(labels[0]).toContain("2026-04-01");
+    expect(labels[1]).toContain("2026-05-01");
+  });
+
+  it("uses short result_id as the last-resort tiebreaker", () => {
+    const cohort = [
+      source({ result_id: "1111aaaa11111", platform: "Spark" }),
+      source({ result_id: "2222bbbb22222", platform: "Spark" }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "chart");
+    expect(new Set(labels).size).toBe(2);
+    expect(labels[0]).toContain("1111aaaa");
+    expect(labels[1]).toContain("2222bbbb");
+  });
+
+  it("never produces duplicate visible labels for any cohort", () => {
+    const cohort = [
+      source({ result_id: "r1", platform: "Spark" }),
+      source({ result_id: "r2", platform: "Spark" }),
+      source({ result_id: "r3", platform: "Spark", driver_version: "3.5" }),
+      source({ result_id: "r4", platform: "Spark", driver_version: "3.5", run_date: "2026-04-17" }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "chart");
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("table variant uses bullet separators when disambiguating", () => {
+    const cohort = [
+      source({ result_id: "r1", platform: "PySpark", driver_version: "3.5" }),
+      source({ result_id: "r2", platform: "PySpark", driver_version: "4.1" }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "table");
+    expect(labels[0]).toContain("·");
+    expect(labels[1]).toContain("·");
+  });
+});

--- a/results-explorer/src/lib/__tests__/runIdentity.test.ts
+++ b/results-explorer/src/lib/__tests__/runIdentity.test.ts
@@ -116,6 +116,21 @@ describe("formatRunIdentitiesForCohort", () => {
     expect(labels[1]).toContain("2222bbbb");
   });
 
+  it("falls through to the full result_id when 8-char prefixes collide", () => {
+    // Adversarial cohort where natural qualifiers all match and the
+    // short (8-char) result_id slice is also identical. The terminal
+    // full-id qualifier guarantees uniqueness instead of accepting a
+    // duplicate at the safety cap.
+    const cohort = [
+      source({ result_id: "ffffffffaaaa", platform: "Spark" }),
+      source({ result_id: "ffffffffbbbb", platform: "Spark" }),
+    ];
+    const labels = formatRunIdentitiesForCohort(cohort, "chart");
+    expect(new Set(labels).size).toBe(2);
+    expect(labels[0]).toContain("ffffffffaaaa");
+    expect(labels[1]).toContain("ffffffffbbbb");
+  });
+
   it("never produces duplicate visible labels for any cohort", () => {
     const cohort = [
       source({ result_id: "r1", platform: "Spark" }),

--- a/results-explorer/src/lib/runIdentity.ts
+++ b/results-explorer/src/lib/runIdentity.ts
@@ -1,0 +1,161 @@
+// Run-identity formatter: produces stable, distinguishable labels for
+// benchmark runs across charts, compare controls, and tables.
+//
+// The motivating problem (`results-explorer-run-identity-disambiguation`):
+// repeated `platform` values like "DataFusion", "Polars", "PySpark", and
+// "Spark" produce indistinguishable column headers, legend rows, and
+// compare-card titles whenever two runs share a platform name. Color
+// alone is not enough to identify a run.
+//
+// Contract:
+//   - The same source row should produce the same label across variants
+//     (modulo length/composition).
+//   - When a cohort is supplied (e.g., the four runs in a Compare view
+//     or the row set on a Rank chart), `formatRunIdentitiesForCohort`
+//     appends *only enough* qualifiers to make every label in the cohort
+//     unique. Non-duplicate runs keep their plain platform label.
+//   - Qualifier priority: driver/platform version → run date → scale →
+//     deployment fingerprint → trust tier → short result_id (last
+//     resort, only when nothing else differs).
+
+export interface RunIdentitySource {
+  result_id: string;
+  platform: string;
+  platform_version?: string | null;
+  driver_version?: string | null;
+  run_date?: string | null;
+  scale_factor?: number | null;
+  deployment_class?: string | null;
+  instance_or_warehouse?: string | null;
+  trust_label?: string | null;
+}
+
+export type RunIdentityVariant =
+  | "compact"
+  | "chart"
+  | "table"
+  | "selectOption"
+  | "tooltip";
+
+// Natural qualifiers (in priority order) that distinguish runs in a
+// human-meaningful way. The result_id tiebreaker is intentionally NOT
+// in this list — it is only appended by the cohort-aware code path
+// when no natural qualifier disambiguates a duplicate platform name.
+const NATURAL_QUALIFIERS: ((s: RunIdentitySource) => string | null)[] = [
+  (s) => (s.driver_version ? `v${s.driver_version}` : s.platform_version ? `v${s.platform_version}` : null),
+  (s) => (s.run_date ? s.run_date.slice(0, 10) : null),
+  (s) => (s.scale_factor !== null && s.scale_factor !== undefined ? `SF ${s.scale_factor}` : null),
+  (s) => {
+    const parts: string[] = [];
+    if (s.deployment_class && s.deployment_class !== "local") parts.push(s.deployment_class);
+    if (s.instance_or_warehouse) parts.push(s.instance_or_warehouse);
+    return parts.length > 0 ? parts.join(" ") : null;
+  },
+  (s) => (s.trust_label ? s.trust_label : null),
+];
+
+function describeNaturalQualifiers(source: RunIdentitySource): string[] {
+  const out: string[] = [];
+  for (const fn of NATURAL_QUALIFIERS) {
+    const value = fn(source);
+    if (value !== null && value !== "") out.push(value);
+  }
+  return out;
+}
+
+// Cohort-aware qualifier list: natural qualifiers, then short result_id
+// as a last-resort tiebreaker.
+function describeCohortQualifiers(source: RunIdentitySource): string[] {
+  return [...describeNaturalQualifiers(source), source.result_id.slice(0, 8)];
+}
+
+function joinForVariant(base: string, qualifiers: string[], variant: RunIdentityVariant): string {
+  if (qualifiers.length === 0) return base;
+  switch (variant) {
+    case "compact":
+    case "chart":
+      // Chart axes and tight legends — show every qualifier the cohort
+      // needs to remain distinguishable, space-separated. Stripping any
+      // qualifier would re-introduce duplicates.
+      return `${base} ${qualifiers.join(" ")}`;
+    case "table":
+    case "selectOption":
+      return `${base} · ${qualifiers.join(" · ")}`;
+    case "tooltip":
+      return `${base}\n${qualifiers.join("\n")}`;
+    default:
+      return base;
+  }
+}
+
+/**
+ * Single-source formatter. Use this when the caller does not have a
+ * cohort context. The output always includes the platform name and may
+ * include the highest-priority qualifier(s).
+ *
+ * For chart axes and tight legends prefer the cohort-aware
+ * `formatRunIdentitiesForCohort`, which only attaches qualifiers when
+ * the cohort has duplicates.
+ */
+export function formatRunIdentity(source: RunIdentitySource, variant: RunIdentityVariant): string {
+  return joinForVariant(source.platform, describeNaturalQualifiers(source), variant);
+}
+
+/**
+ * Cohort-aware formatter. For each source in `sources`, returns the
+ * shortest label (within the chosen variant) that is unique across the
+ * cohort. Non-duplicates keep their plain platform name; duplicates
+ * append qualifiers in priority order until they are distinguishable.
+ *
+ * The returned array is parallel to the input array, so call sites can
+ * use it with the same indexing as their existing data structures.
+ */
+export function formatRunIdentitiesForCohort(
+  sources: readonly RunIdentitySource[],
+  variant: RunIdentityVariant,
+): string[] {
+  const baseLabels = sources.map((source) => source.platform);
+  // Buckets of sources that currently share a base platform name.
+  const bucketsByLabel = new Map<string, number[]>();
+  baseLabels.forEach((label, i) => {
+    if (!bucketsByLabel.has(label)) bucketsByLabel.set(label, []);
+    bucketsByLabel.get(label)!.push(i);
+  });
+
+  // Per-source qualifier list (natural + last-resort short id).
+  const qualifierLists = sources.map(describeCohortQualifiers);
+  // Number of qualifier tiers each source needs to be unique within its
+  // bucket. Sources whose bucket has only one entry stay at 0.
+  const usedCounts = new Array(sources.length).fill(0);
+
+  // For every duplicate bucket, append qualifiers until every label in
+  // the bucket is unique. We track the qualifier-tier count per bucket
+  // and apply it uniformly so members of the bucket carry comparable
+  // detail. Round counts then translate to slices of each source's
+  // qualifier list.
+  for (const [, indices] of bucketsByLabel) {
+    if (indices.length < 2) continue;
+    let round = 0;
+    while (round < 6) {
+      const provisional = indices.map((i) => {
+        const used = qualifierLists[i]!.slice(0, round);
+        return `${sources[i]!.platform}${used.length > 0 ? " " + used.join(" ") : ""}`;
+      });
+      const seen = new Map<string, number>();
+      let allUnique = true;
+      for (const label of provisional) {
+        const count = (seen.get(label) ?? 0) + 1;
+        seen.set(label, count);
+        if (count > 1) allUnique = false;
+      }
+      if (allUnique) break;
+      round += 1;
+    }
+    for (const i of indices) usedCounts[i] = round;
+  }
+
+  return sources.map((source, i) => {
+    const used = qualifierLists[i]!.slice(0, usedCounts[i]);
+    return joinForVariant(source.platform, used, variant);
+  });
+}

--- a/results-explorer/src/lib/runIdentity.ts
+++ b/results-explorer/src/lib/runIdentity.ts
@@ -63,10 +63,14 @@ function describeNaturalQualifiers(source: RunIdentitySource): string[] {
   return out;
 }
 
-// Cohort-aware qualifier list: natural qualifiers, then short result_id
-// as a last-resort tiebreaker.
+// Cohort-aware qualifier list: natural qualifiers, then a short result_id
+// slice for compact disambiguation, then the full result_id as a
+// guaranteed-unique terminal fallback. The full id is only reached if
+// two sources share the same 8-char prefix — an unlikely but possible
+// collision that the previous single-slice tiebreaker would silently
+// retain after the loop's safety cap.
 function describeCohortQualifiers(source: RunIdentitySource): string[] {
-  return [...describeNaturalQualifiers(source), source.result_id.slice(0, 8)];
+  return [...describeNaturalQualifiers(source), source.result_id.slice(0, 8), source.result_id];
 }
 
 function joinForVariant(base: string, qualifiers: string[], variant: RunIdentityVariant): string {
@@ -132,11 +136,16 @@ export function formatRunIdentitiesForCohort(
   // the bucket is unique. We track the qualifier-tier count per bucket
   // and apply it uniformly so members of the bucket carry comparable
   // detail. Round counts then translate to slices of each source's
-  // qualifier list.
+  // qualifier list. The cap walks the full qualifier ladder for the
+  // bucket — including the terminal full-result_id fallback — so the
+  // loop always terminates with unique labels (within data
+  // constraints) instead of silently accepting duplicates at a fixed
+  // round count.
   for (const [, indices] of bucketsByLabel) {
     if (indices.length < 2) continue;
+    const maxQualifiers = Math.max(...indices.map((i) => qualifierLists[i]!.length));
     let round = 0;
-    while (round < 6) {
+    while (round <= maxQualifiers) {
       const provisional = indices.map((i) => {
         const used = qualifierLists[i]!.slice(0, round);
         return `${sources[i]!.platform}${used.length > 0 ? " " + used.join(" ") : ""}`;

--- a/results-explorer/src/pages/Compare.tsx
+++ b/results-explorer/src/pages/Compare.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/duckdbQueries";
 import { humanizeBenchmark, errMsg, fmtGeomean } from "@/utils";
 import { buildCompareUrl } from "@/lib/resultLinks";
+import { formatRunIdentitiesForCohort, type RunIdentitySource } from "@/lib/runIdentity";
 import { CompareSummarySkeleton } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { Breadcrumb } from "@/components/Breadcrumb";
@@ -213,9 +214,26 @@ export function Compare(_: RoutableProps) {
   const slowestPrimary =
     validPrimaries.length > 0 ? (higherIsBetter ? Math.min(...validPrimaries) : Math.max(...validPrimaries)) : null;
 
-  const rowData = results.map((r) => ({
+  // Cohort-aware run identity labels. When the comparison includes
+  // multiple runs of the same platform (e.g., DataFusion v44 vs v53,
+  // or two PySpark runs from different dates), this disambiguates them
+  // with the shortest qualifier suffix that makes the cohort unique.
+  // Singletons keep the bare platform name.
+  const identitySources: RunIdentitySource[] = results.map((r) => ({
+    result_id: r.result_id,
+    platform: r.platform,
+    platform_version: r.platform_version,
+    driver_version: r.driver_version,
+    run_date: r.run_date,
+    scale_factor: r.scale_factor,
+    trust_label: r.trust_label,
+  }));
+  const cohortIdentities = formatRunIdentitiesForCohort(identitySources, "table");
+  const cohortIdentitiesCompact = formatRunIdentitiesForCohort(identitySources, "compact");
+
+  const rowData = results.map((r, idx) => ({
     resultId: r.result_id,
-    label: r.platform,
+    label: cohortIdentities[idx]!,
     trustLabel: r.trust_label,
     runDate: r.run_date,
     tuningMode: r.tuning_mode,
@@ -259,7 +277,8 @@ export function Compare(_: RoutableProps) {
             <p class="text-xs font-semibold uppercase tracking-wide text-[var(--bb-data-fg-subtle)]">Compare</p>
             <h1 class="mt-1 text-3xl font-bold text-[var(--bb-data-fg-primary)]">{benchmarkLabel} Comparison</h1>
             <p class="mt-1 text-sm text-[var(--bb-data-fg-muted)]">
-              Scale factor: {scaleFactorLabel} - {rowCount} platforms
+              Scale factor: {scaleFactorLabel} - {rowCount}{" "}
+              {new Set(results.map((r) => r.platform)).size === results.length ? "platforms" : "runs"}
             </p>
             {/* Trust tier diversity note - informational, not a warning */}
             {(() => {
@@ -290,7 +309,10 @@ export function Compare(_: RoutableProps) {
             ariaLabel="Baseline"
             value={String(normalizedBaselineIndex)}
             onChange={(value) => setBaselineIndex(Number(value))}
-            options={results.map((result, index) => ({ value: String(index), label: result.platform }))}
+            options={results.map((_result, index) => ({
+              value: String(index),
+              label: cohortIdentitiesCompact[index]!,
+            }))}
             size="sm"
           />
         </div>


### PR DESCRIPTION
Lands work units w0/w1/w2/w5 of
`results-explorer-run-identity-disambiguation`. Distribution charts
(w3), overview/sparkline charts (w4), and Trend chart series (w6) are
deferred to follow-up PRs because each has its own row/series-label
contract worth a focused diff.

w1 — `results-explorer/src/lib/runIdentity.ts` (new): shared formatter
with `compact`, `chart`, `table`, `selectOption`, and `tooltip`
variants. Single-source `formatRunIdentity` returns a base label with
the highest-priority natural qualifier(s); cohort-aware
`formatRunIdentitiesForCohort` only appends qualifiers when two
sources in the cohort share a platform name, growing the qualifier
suffix one tier at a time (version → run date → scale → deployment →
trust) and falling back to a short result_id slice as a last-resort
tiebreaker. 10 unit tests cover bare-platform, single-qualifier,
multi-qualifier, falling-through-to-date, last-resort id, four-way
cohort, and table-bullet variants.

w2 — `RankTable.tsx`: column headers now use the cohort-aware
`compact` identity. When two runs of the same platform appear in the
ranking cohort (e.g., DataFusion v44 and v53), the headers are
distinguishable instead of rendering as two identical "DataFusion"
strings. The `tooltip` variant is attached as `<th title>` so the
full identity is recoverable on hover.

w5 — `Compare.tsx`: result-card labels and the baseline-select
dropdown are driven by the cohort-aware identity (table variant for
cards, compact for the dropdown). The summary line copy switches from
"N platforms" to "N runs" when the cohort contains duplicate platform
names, matching the TODO's run-aware copy requirement.

Verification:
  - `runIdentity.test.ts`: 10/10.
  - Full vitest run: 528/528.
  - typecheck + build: clean. JS bundle 277.84 kB (+9.52 kB / +3.55%
    vs pre-PR-1 develop tip; under 5%).

w0 audit: `_project/verification-logs/results-explorer-run-identity-disambiguation/w0.log`

Per the parent prompt, item 5 was flagged for `/ultrareview` because of
its cross-cutting reach. This PR's scope intentionally stops short of
distribution / overview / sparkline / trend charts, keeping the
diff small enough for normal review while still landing the contract
(`runIdentity.ts`) the deferred PRs will reuse.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
