### PR TITLE
fix(results): canonicalize hosted manifest upload

### DIFF
--- a/_project/DONE/main/planning/results-data-byte-stable-bundle-emission.yaml
+++ b/_project/DONE/main/planning/results-data-byte-stable-bundle-emission.yaml
@@ -111,6 +111,11 @@ work:
     No `.plans.json` or `.tuning.json` companions were present in this corpus
     snapshot. Removed the `results-data/bundles/*.json` pre-commit exclusion.
 
+completion_notes:
+- "PR #282 included hook-normalized EOF/trailing-whitespace collateral in `.github/`, `COPYRIGHT.md`, `benchbox/data/coffeeshop/`, `docs/`, `examples/`, `landing/`, and test documentation/fixture files after `uv run -- pre-commit run --all-files` exposed existing drift."
+- "PR #282 included narrow Ruff PLW1514 encoding cleanup in `benchbox/utils/dependency_validation.py`, `scripts/check_example_syntax.py`, `scripts/update_version.py`, `tests/fixtures/result_dict_fixtures.py`, and `tests/unit/platforms/test_compression_support.py`."
+- "Review follow-up: hosted multipart submission manifests now use the same canonical JSON writer as PR-package manifests, with transport-level regression coverage in `tests/unit/cli/test_submit_service.py`."
+
 verification:
 - description: "Bundle hash survives a no-op normalization round-trip."
   command: "uv run -- python -m pytest tests/unit/test_results_exporter.py -k canonical_bundle -v"
@@ -150,11 +155,16 @@ scope_limit:
   only_modify:
   - "benchbox/core/results/"
   - "benchbox/cli/commands/submit.py"
+  - "benchbox/cli/submit_service.py"
   - "tests/unit/test_results_exporter.py"
   - "tests/unit/cli/commands/test_submit.py"
+  - "tests/unit/cli/test_submit_service.py"
   - ".pre-commit-config.yaml"
   - "results-data/bundles/"
   - "_project/TODO/main/planning/results-data-byte-stable-bundle-emission.yaml"
+  - "_project/DONE/main/planning/results-data-byte-stable-bundle-emission.yaml"
+  - "hook-normalized EOF/trailing-whitespace collateral under `.github/`, `COPYRIGHT.md`, `benchbox/data/coffeeshop/`, `docs/`, `examples/`, `landing/`, and test documentation/fixture files"
+  - "Ruff PLW1514 encoding-only cleanup in the small Python read/write sites listed in `completion_notes`"
   do_not_modify:
   - "results-explorer/"
   - "scripts/validate_submission.py"

--- a/benchbox/cli/submit_service.py
+++ b/benchbox/cli/submit_service.py
@@ -12,6 +12,7 @@ from urllib import error, request
 
 import benchbox
 from benchbox.cli.submit_auth import normalize_service_url
+from benchbox.core.results.canonical_json import canonical_json_text
 
 PUBLIC_RESULTS_BASE_URL = "https://benchbox.dev/results/r"
 _TRANSIENT_STATUS_CODES = {500, 502, 503, 504}
@@ -296,7 +297,7 @@ def _multipart_body(
     _add_form_field(parts, boundary, "visibility", visibility)
     _add_file_field(parts, boundary, "bundle", source_path.name, source_path.read_bytes(), "application/json")
     manifest_name = f"{source_path.stem}.manifest.json"
-    manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+    manifest_bytes = canonical_json_text(manifest).encode("utf-8")
     _add_file_field(parts, boundary, "manifest", manifest_name, manifest_bytes, "application/json")
     for companion in companions:
         _add_file_field(

--- a/tests/unit/cli/test_submit_service.py
+++ b/tests/unit/cli/test_submit_service.py
@@ -14,6 +14,7 @@ from benchbox.cli.submit_service import (
     make_idempotency_key,
     submit_hosted_bundle,
 )
+from benchbox.core.results.canonical_json import canonical_json_text
 
 pytestmark = [
     pytest.mark.unit,
@@ -113,6 +114,38 @@ def test_submit_hosted_bundle_posts_multipart_auth_and_idempotency(tmp_path: Pat
     assert b'name="manifest"; filename="tpch_duckdb.manifest.json"' in req.data
     assert b'name="companions[]"; filename="tpch_duckdb.plans.json"' in req.data
     assert b"secret-token" not in req.data
+
+
+def test_submit_hosted_bundle_writes_canonical_manifest_part(tmp_path: Path) -> None:
+    source, companions = _bundle(tmp_path)
+    manifest = {
+        "submitted_by": "José",
+        "submission_path": "hosted-service",
+        "bundle_hash": "a" * 64,
+        "bundle_file": "tpch_duckdb.json",
+    }
+    opener = FakeOpener(FakeResponse(200, {"status": "already_published", "public_result_id": "r1"}))
+
+    submit_hosted_bundle(
+        service_url="https://api.benchbox.dev/v1",
+        token="secret-token",
+        source_path=source,
+        companions=companions,
+        manifest=manifest,
+        bundle_hash="a" * 64,
+        visibility="public",
+        idempotency_key="fixed-key",
+        wait=True,
+        opener=opener,
+        sleep=lambda _seconds: None,
+    )
+
+    manifest_part = canonical_json_text(manifest).encode("utf-8")
+    req = opener.requests[0]
+    assert b'name="manifest"; filename="tpch_duckdb.manifest.json"' in req.data
+    assert manifest_part in req.data
+    assert b"Jos\\u00e9" not in req.data
+    assert req.data.index(b'"bundle_file"') < req.data.index(b'"submitted_by"')
 
 
 def test_submit_hosted_bundle_retries_upload_and_polls_to_publication(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Route hosted multipart submission manifest bytes through `canonical_json_text`, matching PR-package manifest serialization.
- Add transport-level regression coverage for sorted keys, final newline handling, and non-ASCII manifest values.
- Update the completed byte-stable TODO record to document PR #282 collateral and this hosted transport follow-up.

## Root Cause
PR #282 canonicalized exporter and submit command paths, but the hosted transport multipart builder still serialized its manifest part with plain `json.dumps(..., indent=2)`, bypassing sorted keys and `ensure_ascii=False`.

## Validation
- `uv run -- python -m pytest tests/unit/cli/test_submit_service.py -k canonical_manifest -q`
- `uv run -- python _project/scripts/todo_cli.py validate _project/DONE/main/planning/results-data-byte-stable-bundle-emission.yaml`
- `uv run -- ruff check benchbox/cli/submit_service.py tests/unit/cli/test_submit_service.py`
- `uv run -- python -m pytest tests/unit/cli/test_submit_service.py -q`
- `uv run -- python -m pytest tests/unit/cli/commands/test_submit.py -k 'canonical or manifest or companion' -q`
- `uv run -- python -m pytest tests/unit/test_results_exporter.py -k canonical_bundle -q`
- `git diff --check`
- `make pr-preflight`
