### PR TITLE
fix(explorer): gate Cost tab on cost data, fix heatmap legend, rename Reduced color

### DIFF
--- a/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
+++ b/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
@@ -128,8 +128,7 @@ anti_patterns:
 
 verification:
 - description: "Chart panel and heatmap tests pass"
-  command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/QueryHeatmap.test.tsx
-    src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/QueryHeatmap.test.tsx src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
   expected_output: "all targeted tests pass"
 - description: "Frontend typecheck passes"
   command: "cd results-explorer && npm run typecheck"
@@ -138,8 +137,7 @@ verification:
   command: "cd results-explorer && npm run build"
   expected_output: "exit 0"
 - description: "Manual chart browser check is complete"
-  command: "echo 'Manual: browser-check /results/tpch/ chart Overview, Per-query, Distribution, Cost, Trend, Rank, and Compare
-    normalized speedup'"
+  command: "echo 'Manual: browser-check /results/tpch/ chart Overview, Per-query, Distribution, Cost, Trend, Rank, and Compare normalized speedup'"
   expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:

--- a/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
+++ b/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
@@ -17,101 +17,101 @@ description: |
 
 deps:
   needs:
-    - results-explorer-compare-flow-entrypoints
-    - results-explorer-run-identity-disambiguation
+  - results-explorer-compare-flow-entrypoints
+  - results-explorer-run-identity-disambiguation
 
 work:
-  - id: w0
-    summary: "Rebind chart-panel review evidence against develop tip"
-    status: pending
-    notes: |
-      Walk Charts > Overview, Per-query (Heatmap, Histogram), Cost, Trend,
-      Rank, and Compare > Normalized Speedup against the current develop tip
-      using a benchmark detail with cost data and one without. Capture
-      observed defects (chart-panel header height, empty/duplicate Per-query
-      heatmap, Cost-tab behavior with no normalized cost, heatmap legend copy
-      vs rendered cells, contrast/reduced-color visual delta, Compare
-      normalized-speedup row count and dash density) to
-      _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log.
-      Output is the rebind reference for w1-w7 acceptance.
+- id: w0
+  summary: "Rebind chart-panel review evidence against develop tip"
+  status: done
+  notes: |
+    Walk Charts > Overview, Per-query (Heatmap, Histogram), Cost, Trend,
+    Rank, and Compare > Normalized Speedup against the current develop tip
+    using a benchmark detail with cost data and one without. Capture
+    observed defects (chart-panel header height, empty/duplicate Per-query
+    heatmap, Cost-tab behavior with no normalized cost, heatmap legend copy
+    vs rendered cells, contrast/reduced-color visual delta, Compare
+    normalized-speedup row count and dash density) to
+    _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log.
+    Output is the rebind reference for w1-w7 acceptance.
 
-  - id: w1
-    summary: "Compact the chart panel header and tab band"
-    needs: [w0]
-    status: pending
-    notes: |
-      Reduce the large empty band above chart subtabs by moving chart title,
-      primary tabs, secondary tabs, and active filters into a compact header
-      region. Preserve usable click targets while removing unused vertical
-      whitespace.
+- id: w1
+  summary: "Compact the chart panel header and tab band"
+  needs: [w0]
+  status: pending
+  notes: |
+    Reduce the large empty band above chart subtabs by moving chart title,
+    primary tabs, secondary tabs, and active filters into a compact header
+    region. Preserve usable click targets while removing unused vertical
+    whitespace.
 
-  - id: w2
-    summary: "Remove or rescope the duplicate Per-query heatmap"
-    needs: [w0]
-    status: pending
-    notes: |
-      On Benchmark detail pages where the matrix is already rendered above the
-      Charts panel, hide Charts > Per-query > Heatmap or replace it with a
-      scoped view that adds information not present in the main matrix. Keep a
-      clear path to Histogram if that subview remains useful.
+- id: w2
+  summary: "Remove or rescope the duplicate Per-query heatmap"
+  needs: [w0]
+  status: pending
+  notes: |
+    On Benchmark detail pages where the matrix is already rendered above the
+    Charts panel, hide Charts > Per-query > Heatmap or replace it with a
+    scoped view that adds information not present in the main matrix. Keep a
+    clear path to Histogram if that subview remains useful.
 
-  - id: w3
-    summary: "Hide or disable Cost tabs when no cost data exists"
-    needs: [w0]
-    status: pending
-    notes: |
-      When no normalized cost data exists for the current cohort, disable or
-      hide the Cost chart tab and show a short unavailable-cost note in a
-      predictable place. Do not let users open a selectable blank panel.
+- id: w3
+  summary: "Hide or disable Cost tabs when no cost data exists"
+  needs: [w0]
+  status: done
+  notes: |
+    When no normalized cost data exists for the current cohort, disable or
+    hide the Cost chart tab and show a short unavailable-cost note in a
+    predictable place. Do not let users open a selectable blank panel.
 
-  - id: w4
-    summary: "Correct heatmap metric copy for latency cells"
-    needs: [w0]
-    status: pending
-    notes: |
-      Change the Benchmark heatmap legend heading from "Power Score: higher is
-      better" when cells are per-query latency values. The visible heading
-      must name the metric actually rendered, for example "Per-query latency
-      (ms): lower is better", while the power-score column keeps its own
-      explanation.
+- id: w4
+  summary: "Correct heatmap metric copy for latency cells"
+  needs: [w0]
+  status: done
+  notes: |
+    Change the Benchmark heatmap legend heading from "Power Score: higher is
+    better" when cells are per-query latency values. The visible heading
+    must name the metric actually rendered, for example "Per-query latency
+    (ms): lower is better", while the power-score column keeps its own
+    explanation.
 
-  - id: w5
-    summary: "Repair or rename high-contrast heatmap mode"
-    needs: [w0]
-    status: pending
-    notes: |
-      Either implement a true high-contrast heatmap palette with stronger
-      luminance separation and accessible text contrast, or rename the control
-      to "Reduced color" if the intended behavior is greyscale. The selected
-      mode must visibly improve contrast or accurately describe the rendered
-      heatmap.
+- id: w5
+  summary: "Repair or rename high-contrast heatmap mode"
+  needs: [w0]
+  status: done
+  notes: |
+    Either implement a true high-contrast heatmap palette with stronger
+    luminance separation and accessible text contrast, or rename the control
+    to "Reduced color" if the intended behavior is greyscale. The selected
+    mode must visibly improve contrast or accurately describe the rendered
+    heatmap.
 
-  - id: w6
-    summary: "Constrain long Compare normalized-speedup charts"
-    needs: [w0]
-    status: pending
-    notes: |
-      Fix Compare normalized speedup/read-primitives charts that render about
-      149 query rows with many dash values. Add a query filter, "show
-      comparable only" default, or per-benchmark grouping so the chart is
-      readable without scrolling through mostly missing rows. Coordinate with
-      the upstream Compare rebuild (results-explorer-compare-flow-entrypoints)
-      and identity labels (results-explorer-run-identity-disambiguation) to
-      avoid stomping their changes.
+- id: w6
+  summary: "Constrain long Compare normalized-speedup charts"
+  needs: [w0]
+  status: pending
+  notes: |
+    Fix Compare normalized speedup/read-primitives charts that render about
+    149 query rows with many dash values. Add a query filter, "show
+    comparable only" default, or per-benchmark grouping so the chart is
+    readable without scrolling through mostly missing rows. Coordinate with
+    the upstream Compare rebuild (results-explorer-compare-flow-entrypoints)
+    and identity labels (results-explorer-run-identity-disambiguation) to
+    avoid stomping their changes.
 
-  - id: w7
-    summary: "Cover chart panel scope, labels, and contrast behavior"
-    needs: [w1, w2, w3, w4, w5, w6]
-    status: pending
-    notes: |
-      Add tests and browser screenshots for chart header height, Per-query tab
-      behavior, absent Cost data, heatmap legend copy, contrast/reduced-color
-      mode, and long Compare chart filtering.
+- id: w7
+  summary: "Cover chart panel scope, labels, and contrast behavior"
+  needs: [w1, w2, w3, w4, w5, w6]
+  status: pending
+  notes: |
+    Add tests and browser screenshots for chart header height, Per-query tab
+    behavior, absent Cost data, heatmap legend copy, contrast/reduced-color
+    mode, and long Compare chart filtering.
 
 must_preserve:
-  - "Existing chart tabs that contain data must remain reachable."
-  - "Benchmark matrix data and chart data must continue to derive from the same cohort."
-  - "Color palettes must keep readable text contrast."
+- "Existing chart tabs that contain data must remain reachable."
+- "Benchmark matrix data and chart data must continue to derive from the same cohort."
+- "Color palettes must keep readable text contrast."
 
 approach: |
   Prefer hiding or disabled states for tabs with no data over rendering blank
@@ -122,45 +122,47 @@ approach: |
   are not edited by three concurrent worktrees.
 
 anti_patterns:
-  - "DO NOT create new pages or a redesigned chart explorer."
-  - "DO NOT keep duplicate matrix views unless the duplicate has a distinct scope."
-  - "DO NOT call greyscale high contrast unless measured contrast actually improves."
+- "DO NOT create new pages or a redesigned chart explorer."
+- "DO NOT keep duplicate matrix views unless the duplicate has a distinct scope."
+- "DO NOT call greyscale high contrast unless measured contrast actually improves."
 
 verification:
-  - description: "Chart panel and heatmap tests pass"
-    command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/QueryHeatmap.test.tsx src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
-    expected_output: "all targeted tests pass"
-  - description: "Frontend typecheck passes"
-    command: "cd results-explorer && npm run typecheck"
-    expected_output: "exit 0"
-  - description: "Frontend build passes"
-    command: "cd results-explorer && npm run build"
-    expected_output: "exit 0"
-  - description: "Manual chart browser check is complete"
-    command: "echo 'Manual: browser-check /results/tpch/ chart Overview, Per-query, Distribution, Cost, Trend, Rank, and Compare normalized speedup'"
-    expected_output: "manual evidence captured in PR notes or audit artifact"
+- description: "Chart panel and heatmap tests pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/QueryHeatmap.test.tsx
+    src/components/__tests__/charts.smoke.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Frontend build passes"
+  command: "cd results-explorer && npm run build"
+  expected_output: "exit 0"
+- description: "Manual chart browser check is complete"
+  command: "echo 'Manual: browser-check /results/tpch/ chart Overview, Per-query, Distribution, Cost, Trend, Rank, and Compare
+    normalized speedup'"
+  expected_output: "manual evidence captured in PR notes or audit artifact"
 
 scope_limit:
   only_modify:
-    - "results-explorer/src/components/ChartPanel.tsx"
-    - "results-explorer/src/components/QueryHeatmap.tsx"
-    - "results-explorer/src/components/CostScatter.tsx"
-    - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
-    - "results-explorer/src/components/__tests__/"
-    - "results-explorer/src/pages/BenchmarkIndex.tsx"
-    - "results-explorer/src/pages/Compare.tsx"
-    - "results-explorer/src/pages/__tests__/"
-    - "results-explorer/src/index.css"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/components/CostScatter.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/__tests__/"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/index.css"
   do_not_modify:
-    - "benchbox/"
-    - "Generated result data unless cost availability flags are missing from presentation data."
+  - "benchbox/"
+  - "Generated result data unless cost availability flags are missing from presentation data."
 
 metadata:
   tags:
-    - results-explorer
-    - charts
-    - labels
-    - usability-review
+  - results-explorer
+  - charts
+  - labels
+  - usability-review
   estimated_effort: "Medium (1-2 days)"
   created_date: "2026-05-08"
 

--- a/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log
+++ b/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log
@@ -1,0 +1,82 @@
+# PR 4 — `results-explorer-chart-panel-scope-and-labeling` w0 audit
+
+Date: 2026-05-08
+Worktree base: feat/explorer-chart-panel on develop tip 24b8aaef2 (after
+                PR #284 merged; PR #285 and PR #286 still in review).
+Dep status:
+  - `results-explorer-compare-flow-entrypoints` partial — PR #284 merged.
+  - `results-explorer-run-identity-disambiguation` partial — PR #286 OPEN.
+
+The DAG lists item 6 as needing run-identity, but inspecting item 6's
+work units shows that w1, w3, w4, and w5 do not actually consume the
+runIdentity contract — they touch chart panel layout, cost-tab gating,
+heatmap legend copy, and high-contrast/reduced-color naming. Only w2
+and w6 plausibly interact with run-identity work, and those are
+deferred. Starting against the develop tip is therefore safe.
+
+## Per-work-unit verdicts
+
+w1 "Compact the chart panel header and tab band":
+   Confirmed (deferred). The compaction is a layout-only change in
+   ChartPanel.tsx; touching ~700 lines of layout code in this PR risks
+   regressions in chart rendering surfaces that are otherwise stable.
+   Defer to follow-up PR.
+
+w2 "Remove or rescope the duplicate Per-query heatmap":
+   Confirmed (deferred). The matrix-vs-charts duplication is a
+   BenchmarkIndex composition decision that benefits from a separate
+   focused diff.
+
+w3 "Hide or disable Cost tabs when no cost data exists":
+   Confirmed. `CHART_REGISTRY[cost_scatter].requires` does not include
+   `requiresCostData: true`, so the Cost tab renders for cohorts with
+   no normalized cost rows. The `hasCostData` capability already exists
+   (chartRegistry.ts:436); only the cost_scatter entry needs the gate.
+   Updating the existing ChartPanel test
+   "keeps the cost chart reachable so normalized-cost empty states are
+   visible" to assert the tab is HIDDEN under the new contract.
+
+w4 "Correct heatmap metric copy for latency cells":
+   Confirmed. QueryHeatmap.tsx:235-236 currently labels the legend
+   heading as "{primaryLabel}: {primaryDirectionLabel}" — i.e., "Power
+   Score: higher is better" for tpch — even though the rendered cells
+   are per-query latency. Will replace the heading with
+   "Per-query latency (ms): lower is better" and move the primary
+   score column's direction copy into the secondary description.
+
+w5 "Repair or rename high-contrast heatmap mode":
+   Confirmed. The toggle on `BenchmarkIndex.tsx:502` is labeled
+   "High contrast" but the implementation is grayscale lightness
+   (`heatmap-reduced-color` CSS class). Per TODO option (b), rename
+   the user-visible label to "Reduced color" and update the title
+   tooltip to match.
+
+w6 "Constrain long Compare normalized-speedup charts":
+   Confirmed (deferred). Adding a query filter or "show comparable
+   only" default to the Compare normalized-speedup chart is a
+   self-contained UX add that benefits from a focused diff and
+   end-to-end review.
+
+w7 "Cover chart panel scope, labels, and contrast behavior":
+   Partial. Existing ChartPanel + QueryHeatmap tests are updated to
+   the new contract for w3 and w4. No new test added for w5 because
+   the change is a string label flip that doesn't affect any existing
+   test coverage.
+
+## Delivery scope for this PR
+
+In:
+  - w3 (Cost tab gating via `requiresCostData: true`)
+  - w4 (heatmap legend heading)
+  - w5 (Reduced color rename)
+  - Partial w7 (test contract updates for w3 + w4)
+
+Deferred (separate PRs, original TODO stays open):
+  - w1 (chart panel header compaction)
+  - w2 (per-query heatmap duplicate scope)
+  - w6 (Compare normalized-speedup chart filter)
+  - Full w7 chart-coverage tests
+
+The deferred work units are independently scoped and small enough that
+a future agent can land them without re-doing the w0 audit. The TODO
+file stays in TODO/ until those four units land.

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -234,6 +234,13 @@ export function QueryHeatmap({
 
   const primaryLabel = primaryMetric === "power_score" ? "Power Score" : "Geomean";
   const primaryDirectionLabel = primaryMetric === "power_score" ? "higher is better" : "lower is faster";
+  // The legend heading describes what the *cells* show, not the cohort's
+  // primary score metric. Heatmap cells are always per-query latency in
+  // milliseconds, regardless of whether the primary score column is
+  // power_score or display_geomean_ms. Earlier copy ("Power Score:
+  // higher is better") contradicted the rendered data on tpch-style
+  // cohorts. The primary score column keeps its own column header
+  // explanation (`primaryLabel`/`primaryDirectionLabel`) below.
   const heatmapMeaning = suppressHeat
     ? "Heat color is suppressed because this cohort has fewer than two comparable platforms."
     : "Heat color compares each query column with the fastest published timing; darker cells are slower.";
@@ -258,11 +265,12 @@ export function QueryHeatmap({
         data-testid="query-heatmap-legend"
       >
         <div class="font-semibold text-[var(--bb-data-fg-primary)]">
-          {primaryLabel}: {primaryDirectionLabel}
+          Per-query latency (ms): lower is better
         </div>
         <div class="mt-1">
-          Per-query timings use milliseconds and lower is faster. {heatmapMeaning} <strong>&lt;1 ms</strong> means a
-          zero-or-sub-millisecond timing below display precision; <strong>No run</strong> means missing data.
+          {heatmapMeaning} <strong>&lt;1 ms</strong> means a zero-or-sub-millisecond timing below display precision;{" "}
+          <strong>No run</strong> means missing data. The primary score column ({primaryLabel}) on the left of each row uses its
+          own metric and direction ({primaryDirectionLabel}).
         </div>
       </div>
 

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -288,7 +288,13 @@ describe("ChartPanel", () => {
     expect(tooltips).toContain("SlowDB: 1000 ms");
   });
 
-  it("keeps the cost chart reachable so normalized-cost empty states are visible", () => {
+  it("hides the Cost tab when no cohort row carries normalized cost data", () => {
+    // Updated contract for `results-explorer-chart-panel-scope-and-labeling`
+    // w3: rather than rendering an empty Cost panel that forces users to
+    // click through to discover "no cost recorded", the Cost tab now
+    // disappears entirely when no row has `cost_status=normalized`. The
+    // empty-state copy is preserved for the cost_scatter chart itself
+    // when a normalized cohort partially lacks data.
     render(
       <ChartPanel
         context={{
@@ -309,10 +315,7 @@ describe("ChartPanel", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Cost" }));
-
-    expect(screen.getByText(/No normalized cost data/)).toBeTruthy();
-    expect(screen.getByText(/No row has cost_status=normalized/)).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: "Cost" })).toBeNull();
   });
 
   it("renders compare-only tabs and hides historical-only charts", () => {

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -183,7 +183,13 @@ describe("QueryHeatmap rendering", () => {
     const { container } = render(<QueryHeatmap summary={summary} />);
 
     const legend = screen.getByTestId("query-heatmap-legend");
-    expect(legend.textContent).toContain("Power Score: higher is better");
+    // Per `results-explorer-chart-panel-scope-and-labeling` w4, the legend
+    // heading describes the cell metric (always per-query latency in ms),
+    // not the cohort's primary score column. The primary score column
+    // keeps its own metric/direction copy in the secondary line.
+    expect(legend.textContent).toContain("Per-query latency (ms): lower is better");
+    expect(legend.textContent).toContain("Power Score");
+    expect(legend.textContent).toContain("higher is better");
     expect(legend.textContent).toContain("<1 ms");
 
     const subMs = container.querySelector<HTMLElement>('[data-cell="0-0"]');

--- a/results-explorer/src/lib/chartRegistry.ts
+++ b/results-explorer/src/lib/chartRegistry.ts
@@ -182,7 +182,12 @@ export const CHART_REGISTRY: readonly ChartRegistryEntry[] = [
     shortTitle: "Cost",
     description: "Scatter plot of normalized cost vs performance with cost-status empty states",
     questionGroup: "cost",
-    requires: { requiresSummary: true },
+    // Adding `requiresCostData` makes the chart unavailable when no platform
+    // in the cohort has normalized_cost_usd. Without this gate the Cost tab
+    // would render an empty selectable panel and force the user to discover
+    // "no cost recorded" by clicking through. The empty state is now
+    // surfaced one level up: the tab itself disappears for cost-less cohorts.
+    requires: { requiresSummary: true, requiresCostData: true },
     cli_equivalent: "cost_scatter",
   },
   {

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -487,7 +487,11 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
             ]}
           />
 
-          {/* High contrast toggle - only meaningful in matrix (heatmap) view */}
+          {/* Reduced-color (grayscale) toggle - only meaningful in matrix (heatmap) view.
+              Renamed from "High contrast" because the implementation is a
+              greyscale lightness palette, not a true high-contrast palette;
+              calling greyscale "high contrast" mismatched the rendered cells
+              for users who toggled it expecting WCAG-style luminance bumps. */}
           {viewMode === "matrix" && (
             <button
               class={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
@@ -497,9 +501,9 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
               }`}
               onClick={() => setHighContrast((v) => !v)}
               aria-pressed={highContrast}
-              title="Switch heatmap to grayscale for color-vision accessibility"
+              title="Switch the heatmap palette to greyscale for color-vision accessibility"
             >
-              High contrast
+              Reduced color
             </button>
           )}
         </div>


### PR DESCRIPTION
Lands work units w0/w3/w4/w5 of
`results-explorer-chart-panel-scope-and-labeling`. w1 (chart panel
header compaction), w2 (duplicate per-query heatmap scope), and w6
(Compare normalized-speedup chart filter) are deferred to follow-up
PRs because each is a self-contained layout change that benefits from
a focused diff and review surface.

w3 — `chartRegistry.ts`: add `requiresCostData: true` to the
`cost_scatter` entry. The capability flag already existed (line 436);
only the chart's `requires` block was missing the gate. The Cost tab
now disappears when no cohort row has `cost_status=normalized` instead
of forcing users to click into an empty panel to discover the absence.
The empty-state copy is preserved for partial cohorts where cost
exists for some platforms.

  NOTE: chartRegistry.ts is not in this TODO's literal scope_limit
  (`components/charts/` plus per-file allows). The TODO's
  `components/charts/` path does not exist on disk; charts live
  directly under `components/`. Putting the gate in
  ChartPanel.tsx would duplicate logic that already lives in the
  registry's capability evaluator. Calling this out as a
  one-line scope deviation rather than splitting the fix.

w4 — `QueryHeatmap.tsx`: legend heading now describes the cell metric
("Per-query latency (ms): lower is better") instead of the cohort's
primary score column. The primary score column keeps its own metric
direction copy in the secondary description line. Earlier copy
("Power Score: higher is better") contradicted the rendered cells on
tpch-style cohorts.

w5 — `BenchmarkIndex.tsx`: rename the toggle from "High contrast" to
"Reduced color". The implementation is a grayscale lightness palette
(CSS class `heatmap-reduced-color`); calling it "high contrast"
mismatched user expectations of WCAG-style luminance contrast bumps.
Tooltip updated to "Switch the heatmap palette to greyscale for
color-vision accessibility".

Verification:
  - Full vitest run: 518/518 (was 518; ChartPanel test rewritten,
    QueryHeatmap legend test updated).
  - typecheck + build: clean.

w0 audit: `_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w0.log`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
