### PR TITLE
chore(explorer): PR #291 review follow-ups (stale order class, test asymmetry, TODO numbers)

### DIFF
--- a/_project/DONE/main/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
+++ b/_project/DONE/main/results-explorer-query-visible-columns-desktop-order-vs-test-name.yaml
@@ -85,11 +85,14 @@ description: |
      state-dependence:** PR #277 (concurrent, may land before this
      TODO is actioned) restructures `query-visible-columns` from a
      div into a default-collapsed `<details>`/`<summary>` affordance,
-     which collapses the visible-columns block from ≈494px to ≈30px
+     which collapses the visible-columns block from ≈494px to ≈54px
      by default at lg:order-1. Once PR #277 is in develop, the live
-     panel.top drops to ≈445 and the brittleness rationale evaporates;
+     panel.top drops to ≈457 and the brittleness rationale evaporates;
      only the semantic mismatch (1) remains. Re-measure with the live
-     DOM probe before deciding which resolution to pick.
+     DOM probe before deciding which resolution to pick. (Numbers in
+     this block corrected post-PR-291 against the captured w0.log to
+     match the observed measurement at the time; the original draft
+     estimated 30px / 445 from a smaller probe.)
 
   Resolving (1) structurally also resolves (2) regardless of PR #277's
   merge state: if `query-visible-columns` drops `lg:order-1` (or moves

--- a/results-explorer/e2e/responsive.spec.ts
+++ b/results-explorer/e2e/responsive.spec.ts
@@ -114,11 +114,9 @@ test.describe("responsive explorer assertions", () => {
       const drawerTrigger = page.locator('[data-testid="query-mobile-filter-drawer"] button[data-result-count]').first();
       await expect(drawerTrigger).toHaveAttribute("data-result-count", /\d+/);
 
-      if (viewport.width <= 768) {
-        const resultPanelY = await topOf(page.getByTestId("query-results-panel"));
-        const visibleColumnsY = await topOf(page.getByTestId("query-visible-columns"));
-        expect(resultPanelY).toBeLessThan(visibleColumnsY);
-      }
+      const resultPanelY = await topOf(page.getByTestId("query-results-panel"));
+      const visibleColumnsY = await topOf(page.getByTestId("query-visible-columns"));
+      expect(resultPanelY).toBeLessThan(visibleColumnsY);
     });
 
     test(`compare route keeps decision summary and query evidence reachable at ${viewport.name}`, async ({ page }) => {

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -503,7 +503,7 @@ export function Query(_: RoutableProps) {
         <section class="flex min-w-0 flex-col gap-4 lg:col-start-2">
           <div
             data-testid="query-result-summary"
-            class="order-1 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] p-4 shadow-sm lg:order-2"
+            class="order-1 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] p-4 shadow-sm"
           >
             <div class="text-sm text-[var(--bb-data-fg-muted)]">
               {rows.length} matching result bundle(s)


### PR DESCRIPTION
## Summary

Review-driven follow-ups from `/code review` on the PR #276/#278/#281/#291 chain. Three small, independently revertible fixes — no functional change to the layout PR #291 just landed; tightens code, test, and historical trail.

## Changes

| Commit | What | Why |
|---|---|---|
| `9679587df` | Drop `lg:order-2` from `query-result-summary` (`Query.tsx:506`) | After PR #291 removed `lg:order-1` from `query-visible-columns`, `lg:order-2` lost its partner — no sibling carries `lg:order-1` at any viewport, so the override is functionally inert. Removes a phantom of the old layout. |
| `d5d12e11b` | Drop `if (viewport.width <= 768)` guard on the panel-before-visible-columns assertion (`responsive.spec.ts:117–121`) | PR #291 made the ordering structurally true at every viewport. Extending the assertion enforces the test name's "rows before deep controls" contract at desktop and wide; anyone reintroducing an `lg:order-N < 5` override on visible-columns will trip the test instead of silently regressing. |
| `ee52f6a1c` | Correct stale draft numbers in DONE TODO description | The `description` carried draft estimates (≈30px collapsed visible-columns, ≈445 panel.top post-#277) that diverged from the captured `w0.log` measurement (54px / 457). Aligns the historical-premise prose with the verification log already cited in the same TODO. |

## Test plan

- [x] `npx playwright test --project=chromium e2e/responsive.spec.ts --grep 'query workbench renders summary' --workers=1` → 4/4 passed at mobile/tablet/desktop/wide (`/tmp/pr291-followup-grep.log`)
- [x] Full responsive grep `--grep 'responsive|layout|a11y|mobile' --workers=1` → 24 passed, 2 skipped (tag-gated capture specs), 0 failed (`/tmp/pr291-followup-full.log`)
- [x] `make pr-preflight-fast-tests` → 21938 passed, 5 skipped (`/tmp/pr291-followup-preflight.log`)

## Notes

- All three fixes were called out as soft observations in the `/code review` of PR #291; none are regressions in PR #291's behaviour.
- Per `~/.claude/skills/SHARED/review-protocol/SKILL.md` §1, the review itself produced findings only; this PR is the explicit authorized turn that lands the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)