### PR TITLE
chore(explorer-tokens): apply review followups from PR #277/#292

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,12 @@ repos:
       # Stdlib-only (no uv sync at commit time); runs only when files
       # under results-explorer/src/ change. See
       # docs/operations/results-explorer-token-scan.md.
+      #
+      # `pass_filenames: false` is intentional: the gate scans the entire
+      # results-explorer/src/ tree, not just changed files, so a literal
+      # added in one PR but never staged again still trips a later commit
+      # that touches a sibling file. Sub-second runtime makes the
+      # whole-tree rescan acceptable at commit time.
       - id: explorer-tokens
         name: results-explorer token-scan
         entry: python3 _project/scripts/scan_explorer_tokens.py

--- a/docs/operations/results-explorer-token-scan.md
+++ b/docs/operations/results-explorer-token-scan.md
@@ -43,6 +43,22 @@ A regex match for any combination of:
 Files scanned: `*.tsx`, `*.ts`, `*.jsx`, `*.js`, `*.css`, `*.html` under
 `results-explorer/src/`.
 
+### Known coverage gaps
+
+The regex matches *named-palette* utilities only. The following do **not**
+trip the gate today:
+
+- **Arbitrary-value classes** — `text-[#374151]` (the literal hex
+  equivalent of `text-gray-700`), `bg-[rgb(55,65,81)]`, etc. A
+  contributor reaching for the hex equivalent of a token bypasses the
+  scan. The blind-spot scenario was named-palette literals (PR #271
+  retokenized `text-gray-700`-style classes), so this is acceptable for
+  the current contract; widen the regex to a `text-\[` shape if a
+  future incident shows arbitrary-value bypass in the wild.
+- **Concatenated classnames** — `"text-gray-" + n` or
+  `` `text-${color}-700` `` are not matched (the regex needs a literal
+  contiguous token).
+
 ## Allowlisting an intentional literal
 
 Append an inline marker on the same line as the literal:
@@ -66,13 +82,67 @@ skins, deliberate palette exports for design tooling, and similar.
 
 ## CI wiring
 
-- **PR-time** — `.github/workflows/pr.yml` job `explorer-tokens` runs when
-  `results-explorer/src/` is in the PR diff. It is a required
-  `ci-required-result` input.
+- **PR-time** — `.github/workflows/pr.yml` job `explorer-tokens` is gated
+  in two tiers. The **outer job** runs on any PR where
+  `needs.ci-paths.outputs.needs-code-ci == 'true'` (i.e., any PR in the
+  code-CI tier — Python, infra, explorer, etc.); the runner spins up so
+  the `ci-required-result` aggregator always has a real status to read.
+  The **inner scan step** then `git diff`s against the base ref and only
+  invokes `make lint-explorer-tokens` when at least one path under
+  `results-explorer/src/` changed. The aggregator at
+  `pr.yml`'s `ci-required-result` job treats `success` and `skipped` for
+  this check as passing; `failure` blocks the PR. The
+  `explorer-tokens-path-classifier-output` TODO removes the inner tier
+  by promoting `explorer-paths-needed` into the `ci-paths` classifier
+  output.
 - **Post-merge** — `.github/workflows/develop-post-merge.yml` job
-  `explorer-tokens` re-runs the gate against the merged develop tree so
-  that a squash race that reintroduces literals trips the auto-revert
-  path even when each PR-time scan passed against its own pre-merge tree.
+  `explorer-tokens` runs unconditionally on every push to develop and
+  re-runs the gate against the merged develop tree so that a squash
+  race that reintroduces literals trips the auto-revert path even when
+  each PR-time scan passed against its own pre-merge tree.
+
+## What happens when the post-merge gate trips
+
+The post-merge `explorer-tokens` job feeds three downstream consumers in
+`.github/workflows/develop-post-merge.yml`:
+
+1. **`auto-revert-on-failure`** — `if:` includes
+   `needs.explorer-tokens.result == 'failure'`. When red, it opens an
+   auto-revert PR on the offending squash commit, applies the
+   `incident:develop-red` label, and adds the original PR's author as a
+   reviewer. Conflicts on the revert open a tracking issue with
+   `incident:develop-red-revert-conflict`. **The auto-revert is a PR,
+   not a direct push** — landing the revert still requires explicit
+   merge.
+2. **`metrics`** — the `post_merge_red` shell flag flips true; the
+   `develop_red_detected_at` jq filter selects the earliest
+   `completed_at` across `lint`, `fast-test`, and `explorer-tokens` as
+   the red-detection timestamp.
+3. The dev-loop metrics row is emitted to the `metrics` artifact under
+   `dev-loop-metrics/<sha>.json`.
+
+### When the gate is wrong (false positive)
+
+If the regex flags a legitimate literal at an inopportune moment (e.g.,
+3am hotfix, a docs/comment string that happens to spell a Tailwind
+token), the on-call workflow is:
+
+1. **Close the auto-revert PR** if one was opened — the `incident:develop-red`
+   label makes it discoverable via `gh pr list --label incident:develop-red`.
+2. **Allowlist the line** with `// allow-explorer-token-literal: <reason>`
+   (or the `/* … */` form for CSS), where `<reason>` is concrete enough
+   that a reviewer six months from now can decide whether to remove the
+   marker. Format suggestion: `hotfix-YYYY-MM-DD followup-needed-issue-NNN`.
+3. **File a regex-fix TODO** under `_project/TODO/main/bugs/` describing
+   the false-positive shape, so the allowlist can be removed once the
+   regex is tightened. Use `_project/scripts/scan_explorer_tokens.py` as
+   the single source of truth — adjust `UTILITIES`, `PALETTES`, `STOPS`,
+   or `LITERAL_RE` itself.
+
+The gate is intentionally conservative: matching a literal in a comment
+or string is the documented contract (see
+`tests/unit/scripts/test_scan_explorer_tokens.py::test_literal_re_matches_inside_comments_and_strings_by_design`).
+The allowlist is the operational answer.
 
 ## Extending or removing the gate
 

--- a/tests/unit/scripts/test_scan_explorer_tokens.py
+++ b/tests/unit/scripts/test_scan_explorer_tokens.py
@@ -84,6 +84,36 @@ def test_literal_re_matches_when_followed_by_dash_word() -> None:
     assert scan.LITERAL_RE.findall('<div class="text-gray-700-typography" />') == ["text-gray-700"]
 
 
+def test_literal_re_reports_every_match_on_a_line() -> None:
+    # Tailwind classes are typically space-joined inside a single string,
+    # so multiple literals can share a line. `findall` must return all of
+    # them so the gate's stderr report points to every offending token,
+    # not just the first. scan_file relies on this so a contributor
+    # debugging "what does the gate want me to fix?" sees the full set.
+    line = '<div class="text-gray-700 bg-blue-500 border-red-300" />'
+    assert scan.LITERAL_RE.findall(line) == [
+        "text-gray-700",
+        "bg-blue-500",
+        "border-red-300",
+    ]
+
+
+def test_scan_file_reports_every_match_on_a_line(tmp_path: Path) -> None:
+    target = tmp_path / "Component.tsx"
+    target.write_text(
+        '<div class="text-gray-700 bg-blue-500 border-red-300" />\n',
+        encoding="utf-8",
+    )
+    hits = scan.scan_file(target)
+    assert len(hits) == 1
+    lineno, line, matches = hits[0]
+    assert lineno == 1
+    assert matches == ["text-gray-700", "bg-blue-500", "border-red-300"]
+    assert "text-gray-700" in line
+    assert "bg-blue-500" in line
+    assert "border-red-300" in line
+
+
 def test_allow_marker_requires_non_empty_reason() -> None:
     assert scan.ALLOW_MARKER_RE.search("// allow-explorer-token-literal: legacy alias")
     assert scan.ALLOW_MARKER_RE.search("/* allow-explorer-token-literal: x */")

--- a/tests/unit/workflows/test_develop_post_merge_metrics.py
+++ b/tests/unit/workflows/test_develop_post_merge_metrics.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 pytestmark = [
     pytest.mark.unit,
@@ -140,8 +141,6 @@ def test_auto_revert_triggers_on_explorer_tokens_failure() -> None:
     # post-merge red events open a revert PR. Adding `explorer-tokens`
     # to the trigger was the blind-spot remediation; this test prevents
     # an inadvertent removal during a future `if:` cleanup.
-    import yaml
-
     workflow_yaml = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml").read_text(encoding="utf-8")
     )
@@ -149,3 +148,21 @@ def test_auto_revert_triggers_on_explorer_tokens_failure() -> None:
     assert "explorer-tokens" in auto_revert["needs"]
     # The `if:` is a single string after yaml.safe_load.
     assert "needs.explorer-tokens.result == 'failure'" in auto_revert["if"]
+
+
+def test_post_merge_explorer_tokens_job_runs_unconditionally() -> None:
+    # The post-merge `explorer-tokens` job must have no `if:` so it always
+    # runs against the merged develop tree. If a future cleanup added an
+    # `if:` (e.g. mirroring the PR-time path-gated form), the post-merge
+    # re-scan would silently stop firing while the auto-revert wiring would
+    # still reference `needs.explorer-tokens.result == 'failure'` — a state
+    # that could no longer occur. The whole blind-spot remediation
+    # (squash-race regressions tripping auto-revert) depends on this job
+    # running on every push to develop.
+    workflow_yaml = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml").read_text(encoding="utf-8")
+    )
+    job = workflow_yaml["jobs"]["explorer-tokens"]
+    assert job.get("if") is None, (
+        f"post-merge explorer-tokens job must have no `if:` (always runs); found: {job.get('if')!r}"
+    )

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -91,10 +91,18 @@ def test_ci_required_result_fails_on_explorer_tokens_failure() -> None:
 
 
 def test_ci_required_result_treats_explorer_tokens_skipped_as_success() -> None:
-    # PRs in the code-CI tier that don't touch results-explorer/src (e.g.
-    # benchbox/, tests/) cause the explorer-tokens job to be skipped. The
-    # aggregator must accept "skipped" as success here — otherwise every
-    # Python-only PR would be blocked.
+    # Defensive: pin the `|| "skipped"` clause in the aggregator's
+    # explorer-tokens check. The (NEEDS_CODE_CI="true",
+    # EXPLORER_TOKENS_RESULT="skipped") combination is not produced by any
+    # real PR shape today: the explorer-tokens job's `if:` is gated on
+    # `needs-code-ci == 'true'`, so when needs-code-ci is true the job runs
+    # (its inner detection step skips the scan when no results-explorer/src
+    # paths changed, but the *job* still concludes "success", not
+    # "skipped"). The only path that yields EXPLORER_TOKENS_RESULT="skipped"
+    # is needs-code-ci="false", but the aggregator early-exits at the
+    # NEEDS_CODE_CI=false branch before reading EXPLORER_TOKENS_RESULT. The
+    # `|| "skipped"` clause is therefore belt-and-braces — this test pins
+    # it so a future cleanup that drops the clause is a deliberate choice.
     result = _run_ci_required_result(
         NEEDS_CODE_CI="true",
         SAFE_CONTENT_ONLY="false",
@@ -127,8 +135,6 @@ def test_ci_required_result_explorer_tokens_in_needs() -> None:
     # `ci-required-result.needs:` list, the aggregator wouldn't observe its
     # status at all (always "" → handled as not-success in the bash logic).
     # Lock the wiring in place.
-    import yaml
-
     workflow_yaml = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8"))
     needs = workflow_yaml["jobs"]["ci-required-result"]["needs"]
     assert "explorer-tokens" in needs


### PR DESCRIPTION
Test improvements (locks in workflow guardrails more durably):
- test_pr_workflow_path_classifier.py: reframe the comment on
  `test_ci_required_result_treats_explorer_tokens_skipped_as_success`
  as defensive — the (NEEDS_CODE_CI=true, EXPLORER_TOKENS_RESULT=skipped)
  combination is unreachable in real workflows (the job's `if:` gating
  on needs-code-ci means the job runs whenever code-CI runs and
  concludes "success" even when its inner scan step skips); the test
  pins the `|| "skipped"` belt-and-braces clause regardless.
- test_pr_workflow_path_classifier.py / test_develop_post_merge_metrics.py:
  drop redundant inline `import yaml` and lift to module top.
- test_develop_post_merge_metrics.py: add
  `test_post_merge_explorer_tokens_job_runs_unconditionally` — the
  post-merge job must have no `if:` so the auto-revert wiring's
  `needs.explorer-tokens.result == 'failure'` reference remains
  reachable.
- test_scan_explorer_tokens.py: add multi-literal-per-line coverage
  for both `LITERAL_RE.findall` and `scan_file()` so future
  contributors see every offending token in the gate's stderr.

Documentation:
- docs/operations/results-explorer-token-scan.md: clarify the PR-time
  two-tier gating (outer job runs on any code-CI PR; inner scan step
  is diff-gated); document known coverage gaps (arbitrary-value
  classes like text-[#374151]; concatenated classnames); add an
  on-call false-positive runbook with auto-revert mechanics, label
  references, and an allowlist format suggestion.
- .pre-commit-config.yaml: comment on why the hook uses
  `pass_filenames: false` (whole-tree rescan catches literals planted
  in sibling files).

No functional change to scan_explorer_tokens.py or to the workflows;
this is review-followup polish for the now-merged PR #277 (gate) and
PR #292 (workflow guardrails).
