### PR TITLE
docs(explorer-tokens): apply PR #294 review nits (purpose framing, TODO path, regex test prune)

### DIFF
--- a/docs/operations/results-explorer-token-scan.md
+++ b/docs/operations/results-explorer-token-scan.md
@@ -85,16 +85,20 @@ skins, deliberate palette exports for design tooling, and similar.
 - **PR-time** — `.github/workflows/pr.yml` job `explorer-tokens` is gated
   in two tiers. The **outer job** runs on any PR where
   `needs.ci-paths.outputs.needs-code-ci == 'true'` (i.e., any PR in the
-  code-CI tier — Python, infra, explorer, etc.); the runner spins up so
-  the `ci-required-result` aggregator always has a real status to read.
-  The **inner scan step** then `git diff`s against the base ref and only
-  invokes `make lint-explorer-tokens` when at least one path under
+  code-CI tier — Python, infra, explorer, etc.). The **inner scan step**
+  then `git diff`s against the base ref and only invokes
+  `make lint-explorer-tokens` when at least one path under
   `results-explorer/src/` changed. The aggregator at
   `pr.yml`'s `ci-required-result` job treats `success` and `skipped` for
-  this check as passing; `failure` blocks the PR. The
-  `explorer-tokens-path-classifier-output` TODO removes the inner tier
-  by promoting `explorer-paths-needed` into the `ci-paths` classifier
-  output.
+  this check as passing; `failure` blocks the PR. The two-tier shape
+  exists because `ci-paths` does not yet emit an `explorer-paths-needed`
+  output, so the cheapest available correctness gate is to spin the
+  outer job on every code-CI PR and have its inner step diff-check the
+  paths. The `explorer-tokens-path-classifier-output` TODO collapses
+  this to a single tier by promoting `explorer-paths-needed` into the
+  `ci-paths` classifier output, after which the outer job can be gated
+  directly on the path predicate and skip cleanly when no
+  `results-explorer/src/` files changed.
 - **Post-merge** — `.github/workflows/develop-post-merge.yml` job
   `explorer-tokens` runs unconditionally on every push to develop and
   re-runs the gate against the merged develop tree so that a squash
@@ -132,12 +136,16 @@ token), the on-call workflow is:
 2. **Allowlist the line** with `// allow-explorer-token-literal: <reason>`
    (or the `/* … */` form for CSS), where `<reason>` is concrete enough
    that a reviewer six months from now can decide whether to remove the
-   marker. Format suggestion: `hotfix-YYYY-MM-DD followup-needed-issue-NNN`.
-3. **File a regex-fix TODO** under `_project/TODO/main/bugs/` describing
-   the false-positive shape, so the allowlist can be removed once the
-   regex is tightened. Use `_project/scripts/scan_explorer_tokens.py` as
-   the single source of truth — adjust `UTILITIES`, `PALETTES`, `STOPS`,
-   or `LITERAL_RE` itself.
+   marker. The marker regex (`ALLOW_MARKER_RE`) only requires a
+   non-empty reason; for hotfix allowlists, the team convention is
+   `hotfix-YYYY-MM-DD followup-needed-issue-NNN` so a sweep can find
+   them later — but the format is not enforced by the gate.
+3. **File a regex-fix TODO** under `_project/TODO/main/planning/`
+   (`category: Bug`) describing the false-positive shape, so the
+   allowlist can be removed once the regex is tightened. Use
+   `_project/scripts/scan_explorer_tokens.py` as the single source of
+   truth — adjust `UTILITIES`, `PALETTES`, `STOPS`, or `LITERAL_RE`
+   itself.
 
 The gate is intentionally conservative: matching a literal in a comment
 or string is the documented contract (see

--- a/tests/unit/scripts/test_scan_explorer_tokens.py
+++ b/tests/unit/scripts/test_scan_explorer_tokens.py
@@ -84,21 +84,11 @@ def test_literal_re_matches_when_followed_by_dash_word() -> None:
     assert scan.LITERAL_RE.findall('<div class="text-gray-700-typography" />') == ["text-gray-700"]
 
 
-def test_literal_re_reports_every_match_on_a_line() -> None:
-    # Tailwind classes are typically space-joined inside a single string,
-    # so multiple literals can share a line. `findall` must return all of
-    # them so the gate's stderr report points to every offending token,
-    # not just the first. scan_file relies on this so a contributor
-    # debugging "what does the gate want me to fix?" sees the full set.
-    line = '<div class="text-gray-700 bg-blue-500 border-red-300" />'
-    assert scan.LITERAL_RE.findall(line) == [
-        "text-gray-700",
-        "bg-blue-500",
-        "border-red-300",
-    ]
-
-
 def test_scan_file_reports_every_match_on_a_line(tmp_path: Path) -> None:
+    # Tailwind classes are typically space-joined inside a single string,
+    # so multiple literals can share a line. `scan_file` must surface all
+    # of them in one hit tuple so a contributor debugging "what does the
+    # gate want me to fix?" sees the full set, not just the first.
     target = tmp_path / "Component.tsx"
     target.write_text(
         '<div class="text-gray-700 bg-blue-500 border-red-300" />\n',


### PR DESCRIPTION
Tightens three items surfaced in the PR #294 review:

- docs/operations/results-explorer-token-scan.md: rewrite the two-tier
  PR-time wiring rationale. The previous "so the aggregator always has
  a real status to read" framing was misleading — the aggregator's
  success-or-skipped clause at pr.yml:279-280 already handles a single-
  tier shape. The actual reason is that ci-paths does not yet emit an
  explorer-paths-needed output, which is what the
  explorer-tokens-path-classifier-output TODO addresses.
- docs/operations/results-explorer-token-scan.md: fix the runbook's
  reference to _project/TODO/main/bugs/ (no such directory). Bug-class
  TODOs live in _project/TODO/main/planning/ with category: Bug.
- docs/operations/results-explorer-token-scan.md: clarify that the
  hotfix-YYYY-MM-DD allow-marker format is a team convention for
  sweep-friendliness, not a regex contract. ALLOW_MARKER_RE only
  enforces a non-empty reason (see test_allow_marker_requires_non_empty_reason).
- tests/unit/scripts/test_scan_explorer_tokens.py: drop the regex-level
  test_literal_re_reports_every_match_on_a_line; it tested stdlib
  re.findall semantics rather than project behavior. The companion
  test_scan_file_reports_every_match_on_a_line is the load-bearing
  contract test (scan_file surfaces all matches per hit tuple) and
  remains.

Verification: 27 targeted tests pass (was 28; -1 = the dropped tautological
test). ruff check + format clean. make lint-explorer-tokens clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
