### PR TITLE
chore(audits): revert release-gate over-claim; restate decision as CONDITIONAL

### DIFF
--- a/_project/TODO/main/planning/results-explorer-followup-usability-release-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-followup-usability-release-gate.yaml
@@ -2,7 +2,7 @@ id: results-explorer-followup-usability-release-gate
 title: "Verify Results Explorer follow-up usability fixes before release"
 worktree: main
 priority: High
-status: Completed
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -49,23 +49,37 @@ work:
 - id: w3
   summary: "Browser-drive all primary Results Explorer routes"
   needs: [w2]
-  status: done
+  status: pending
   notes: |
     Browser-drive `/results/`, `/results/query`, `/results/compare`, a
     benchmark detail, a platform detail, a result detail, and every chart
     tab/subtab. Click each visible button/toggle once, verify active nav and
     breadcrumbs, test compare selection end to end, and test horizontal and
     vertical scrolling in dense tables.
+    Correction (2026-05-09): the original PR #296 marked this work unit
+    `done` but the manual browser drive was not actually executed — only
+    documented as deferred in the audit doc's "Browser-drive evidence"
+    section. Per the parent brief's "Do not claim verification passed
+    for a manual check you did not actually drive" rule, the status is
+    reverted to pending. To complete: either translate the route walk
+    into a Playwright spec under `results-explorer/e2e/` and run it,
+    or drive the routes manually in a desktop browser and append the
+    observed states to the audit doc's evidence map.
 
 - id: w4
   summary: "Capture before-release screenshots for repaired states"
   needs: [w3]
-  status: done
+  status: pending
   notes: |
     Capture desktop screenshots for Compare builder, Query controls,
     Benchmark heatmap scrolled horizontally and vertically, Platform
     filters, duplicate-run chart labels, chart panel tabs, and sparse
     Result Detail metadata.
+    Correction (2026-05-09): the original PR #296 marked this work unit
+    `done` but no screenshots were captured. Status reverted to pending.
+    To complete: capture the listed screenshots against a live
+    DuckDB-backed dataset on a desktop viewport and link them from the
+    audit doc.
 
 - id: w5
   summary: "Validate TODO graph, reindex, and close ready items"
@@ -75,6 +89,10 @@ work:
     Run TODO validation and reindexing after implementation TODO statuses
     are updated. Move completed implementation items only after their
     verification evidence is attached or referenced in work notes.
+    PR #296 ran `todo_cli.py check-graph` on `61e267cec` (51 items, no
+    cycles, no dangling references) and regenerated the DONE indexes.
+    The work unit stays `done` because the graph operations were
+    actually executed; only the manual w3/w4 evidence was overstated.
 
 must_preserve:
 - "No release approval unless Critical (P0) or High (P1) defects from the matrix are fixed or explicitly blocked."

--- a/_project/audits/results-explorer-followup-usability-release-2026-05-08.md
+++ b/_project/audits/results-explorer-followup-usability-release-2026-05-08.md
@@ -3,6 +3,18 @@
 Date: 2026-05-09
 Develop tip at gate run: `61e267cec` (post-PR #295).
 
+**Correction posted 2026-05-09 (after self-audit):** The original
+release-gate PR #296 over-claimed completion of the gate's manual
+work units (w3 browser-drive, w4 screenshots). Those work units were
+documented as deferred in the "Browser-drive evidence" and
+"Browser-drive evidence (w3) and screenshots (w4)" sections below
+but were also marked `status: done` in the YAML, which contradicts
+the brief's "Do not claim verification passed for a manual check you
+did not actually drive" rule. The YAML has been reverted: the
+release-gate TODO is now back under `_project/TODO/main/planning/`,
+w3 and w4 are `status: pending`, and the gate decision below is
+restated as **CONDITIONAL** until the manual evidence lands.
+
 This matrix is the closure record for the 2026-05-08 Results Explorer
 follow-up review (chat-only, never committed to `_project/audits/`).
 Each defect was rebound against develop tip in the implementing TODO's
@@ -138,7 +150,34 @@ After PR #295 merged:
 
 ## Decision
 
-**APPROVED.** No P0 or P1 defects are blocked; every fixed defect has
-an implementing PR, file, and test in the evidence matrix; deferred
-defects retain their original TODO IDs so future audits can re-bind
-against the same matrix structure.
+**CONDITIONAL** (revised 2026-05-09).
+
+Conditions outstanding:
+
+1. Release-gate w3 (Browser-drive primary Results Explorer routes) —
+   not executed; evidence map in this doc lists the routes and
+   expected states. Either run as a Playwright spec under
+   `results-explorer/e2e/` or drive manually and append observed
+   states.
+2. Release-gate w4 (Capture before-release screenshots) — not
+   executed. Capture against a live DuckDB-backed dataset on a
+   desktop viewport.
+3. Seven P1 defects deferred under their original TODOs (compare-flow
+   w4–w6, navigation w2–w4, table-sticky w2–w5, run-identity w3/w4/w6,
+   chart-panel w1/w2/w6, query-workbench w4). The gate's
+   `must_preserve` rule says these are acceptable only if
+   "explicitly blocked"; they are not blocked, they are simply not
+   yet implemented. Either implement before release or get explicit
+   sign-off that they ship in a follow-up wave.
+
+What did land cleanly:
+
+- 15 of 29 matrix defects fixed by PRs #284 / #285 / #286 / #290 / #295.
+- Item 7 (`result-detail-metadata-density`) fully complete and in
+  `_project/DONE/main/planning/`.
+- Automated gate run on `61e267cec`: vitest 545/545, typecheck 0,
+  build clean, `todo_cli check-graph` clean.
+
+The matrix and severity rollup above are accurate; the headline
+verdict was the only thing overstated. Once the three conditions
+above are addressed, this audit can be re-decided as APPROVED.


### PR DESCRIPTION
Self-audit follow-up to PR #296. The release gate's w3 (browser-drive
primary Results Explorer routes) and w4 (capture before-release
screenshots) were marked `status: done` in the YAML but neither was
actually executed — the audit doc itself documented them as deferred
in the "Browser-drive evidence" section. Per the parent brief's
"Do not claim verification passed for a manual check you did not
actually drive" rule, the YAML claim is overstated.

Corrections:

  - `results-explorer-followup-usability-release-gate.yaml` moved from
    `_project/DONE/main/planning/` back to `_project/TODO/main/planning/`.
  - Top-level `status:` reverted from `Completed` to `In Progress`.
  - w3 and w4 reverted from `done` to `pending` with notes describing
    the original over-claim and what needs to happen to actually
    complete each work unit.
  - w5 stays `done` because the graph operations (validate, reindex)
    were actually executed; only the manual w3/w4 evidence was
    overstated.

Audit doc:

  - Added a "Correction posted 2026-05-09" preamble at the top so
    future readers see the revision before consuming the matrix.
  - Decision section rewritten from APPROVED to CONDITIONAL with the
    three outstanding conditions enumerated (w3, w4, and the seven
    deferred P1 defects from items 1, 2, 3, 5, 6).
  - Matrix and severity rollup are unchanged — those were accurate.

DONE indexes regenerated to reflect the YAML's removal from DONE/.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
