### PR TITLE
feat(explorer): collapsible Query facet groups with default-collapsed secondaries

### DIFF
--- a/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
+++ b/_project/TODO/main/planning/results-explorer-query-workbench-controls-and-facets.yaml
@@ -67,12 +67,22 @@ work:
 - id: w4
   summary: "Make left-rail facet groups collapsible and searchable"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
-    Make desktop and mobile facet groups collapsible. Long groups such as
-    Benchmark must show a compact top segment with "Show all" or internal
-    search, avoid pushing Platform and Scale below the fold, and keep
-    active facets visible even when collapsed.
+    FacetGroupSection grew a per-group expand/collapse toggle (chevron
+    button with aria-expanded/aria-controls) and an optional
+    `defaultCollapsed` flag. Selected option chips render inline when a
+    group is collapsed so active facets stay visible without expanding.
+    Query.tsx now opts the long groups (Benchmark, Platform, Cloud region,
+    Instance/warehouse) into the existing `searchable` affordance and
+    default-collapses every secondary group beyond Benchmark/Platform/
+    Scale so Platform and Scale stay above the fold. FacetDrawer (mobile)
+    inherits the same behavior via FacetRail. Tests added in
+    src/components/__tests__/FacetRail.test.tsx cover default-collapsed
+    rendering, toggle behavior, and search-after-expand. The Query
+    integration test was updated to expand secondary groups before
+    clicking nested checkboxes (no assertion weakened). Verification log:
+    _project/verification-logs/results-explorer-query-workbench-controls-and-facets/w4.log.
 
 - id: w5
   summary: "Disambiguate duplicate SSB benchmark labels"

--- a/_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w4.log
+++ b/_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w4.log
@@ -1,0 +1,86 @@
+# w4 — Make left-rail facet groups collapsible and searchable
+
+Branch: feat/explorer-query-facets-disclosure
+Develop tip at start: 6c28d2b45 (PR #298 merged)
+
+## Current state on develop tip (rebound 2026-05-09)
+
+Inspected: results-explorer/src/components/FacetRail.tsx,
+results-explorer/src/pages/Query.tsx (lines 263-296),
+results-explorer/src/components/__tests__/FacetRail.test.tsx.
+
+- `FacetRail` renders a left rail of `FacetGroupSection`s. Each group
+  always renders fully expanded — there is no collapse affordance.
+- `FacetGroup` already supports `searchable?: boolean`. The component
+  renders a search input when set; filters options by display label or
+  raw value on input.
+- `FacetGroupSection` does not truncate long option lists; large groups
+  render every option and push later groups (Platform, Scale, Trust,
+  Validation, Cost, Deployment, Cloud, Storage, Has-cost, Date-window)
+  far below the fold.
+- `Query.tsx` builds 14+ facet groups via `makeFacetGroup`. None set
+  `searchable: true`, so the existing search affordance is unused on the
+  Query page even for groups with many options (Benchmark, Platform,
+  Cloud region, Instance/warehouse).
+- The Drawer (mobile) wraps the same `FacetRail`, so any change to
+  collapse behavior applies to both desktop and mobile.
+
+## Defects vs the w0 review
+
+- D1 (collapse): No way to collapse a group. Long groups dominate the
+  rail and force scrolling past Benchmark to reach Platform/Scale.
+- D2 (search): Production never enables `searchable`, even though the
+  capability exists. Long lists have no in-group filter.
+- D3 (active-while-collapsed): Implicit — once D1 is fixed, selected
+  options must remain visible without expanding.
+
+## Planned change for w4
+
+1. Add per-group expanded/collapsed state to `FacetGroupSection`. Add a
+   chevron toggle in the section header. State is local to the
+   component (not persisted across navigation; restoring state per
+   browser session is out of scope for this work unit).
+2. When a group is collapsed:
+   - Hide the search input and the option list.
+   - Render any currently selected options as inline chips so active
+     facets remain visible without expanding.
+   - Empty collapsed groups (no selection) show only the header and a
+     count of the total options available so the user knows expanding
+     it is meaningful.
+3. Add an optional `defaultCollapsed?: boolean` to `FacetGroup`. Apply
+   `defaultCollapsed: true` on Query for groups beyond a stable
+   "primary" prefix (Benchmark, Platform, Scale stay expanded; the rest
+   start collapsed) so Platform and Scale are above the fold.
+4. Apply `searchable: true` to Benchmark, Platform, Cloud region, and
+   Instance/warehouse on Query so long lists have search when expanded.
+5. Add tests asserting:
+   - Toggle button collapses and expands a group.
+   - Selected option chips render in the collapsed header.
+   - Default-collapsed groups render in a collapsed state on initial
+     mount.
+   - Expanded long-list searchable groups continue to filter by search.
+   - Drawer (mobile) inherits the same behavior.
+
+## Manual route walk
+
+Walked /results/query against develop tip in the locally running
+preview (`npm run dev`) prior to changes:
+
+- Default desktop view: Benchmark group expanded with ~16 visible
+  options. Platform header is visible only after scrolling past the
+  Benchmark list. Cloud region group with 8+ entries duplicates the
+  effect lower in the rail.
+- No collapse control on any group.
+- No in-group search anywhere on /results/query, despite the underlying
+  component supporting it.
+- Selected facets render as active chips at the rail summary; that
+  surface is unaffected by the planned change.
+
+## Verification commands (post-implementation)
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/FacetRail.test.tsx src/pages/__tests__/Query.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser smoke: `/results/query` — collapse Benchmark, expand Cloud
+  region, type "us-" in Cloud region search, confirm only matching
+  options render. Mobile drawer: same checks via the Filters drawer.

--- a/results-explorer/src/components/FacetRail.tsx
+++ b/results-explorer/src/components/FacetRail.tsx
@@ -15,6 +15,7 @@ export interface FacetGroup {
   selected: string[];
   searchable?: boolean;
   emptyLabel?: string;
+  defaultCollapsed?: boolean;
 }
 
 export interface ActiveFacetChip {
@@ -262,65 +263,104 @@ function FacetGroupSection({
   onToggle: (groupKey: string, value: string) => void;
 }) {
   const [search, setSearch] = useState("");
-  const options = useMemo(() => {
+  const [expanded, setExpanded] = useState(!group.defaultCollapsed);
+  const labelledOptions = useMemo(
+    () =>
+      group.options.map((option) => ({
+        ...option,
+        displayLabel: formatFacetDisplayValue(group.key, option.value, option.label),
+      })),
+    [group.key, group.options],
+  );
+  const filteredOptions = useMemo(() => {
     const needle = search.trim().toLowerCase();
-    const labelled = group.options.map((option) => ({
-      ...option,
-      displayLabel: formatFacetDisplayValue(group.key, option.value, option.label),
-    }));
-    if (needle === "") return labelled;
-    return labelled.filter(
+    if (needle === "") return labelledOptions;
+    return labelledOptions.filter(
       (option) =>
         option.displayLabel.toLowerCase().includes(needle) || option.value.toLowerCase().includes(needle),
     );
-  }, [group.options, search]);
+  }, [labelledOptions, search]);
+  const selectedSummary = useMemo(
+    () => labelledOptions.filter((option) => group.selected.includes(option.value)),
+    [labelledOptions, group.selected],
+  );
+  const panelId = `facet-${group.key}-panel`;
 
   return (
     <section class="rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] p-4 shadow-sm">
-      <div class="mb-3 flex items-center justify-between gap-2">
-        <h3 class="text-sm font-semibold text-[var(--bb-data-fg-primary)]">{group.label}</h3>
-        {group.selected.length > 0 && (
-          <span class="rounded-full bg-[var(--bb-surface-app)] px-2 py-0.5 text-xs text-[var(--bb-data-fg-muted)]">
-            {group.selected.length}
+      <div class="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          class="flex flex-1 items-center justify-between gap-2 rounded-md text-left"
+          aria-expanded={expanded}
+          aria-controls={panelId}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          <h3 class="text-sm font-semibold text-[var(--bb-data-fg-primary)]">{group.label}</h3>
+          <span class="inline-flex items-center gap-2">
+            {group.selected.length > 0 && (
+              <span class="rounded-full bg-[var(--bb-surface-app)] px-2 py-0.5 text-xs text-[var(--bb-data-fg-muted)]">
+                {group.selected.length}
+              </span>
+            )}
+            <span aria-hidden="true" class="text-xs text-[var(--bb-data-fg-muted)]">
+              {expanded ? "▾" : "▸"}
+            </span>
           </span>
-        )}
+        </button>
       </div>
-      {group.searchable && (
-        <label class="mb-3 block">
-          <span class="sr-only">Search {group.label}</span>
-          <input
-            type="search"
-            class="w-full rounded-md border border-[var(--bb-data-border-strong)] px-3 py-1.5 text-sm"
-            placeholder={`Search ${group.label.toLowerCase()}`}
-            value={search}
-            onInput={(event) => setSearch((event.currentTarget as HTMLInputElement).value)}
-          />
-        </label>
+      {!expanded && selectedSummary.length > 0 && (
+        <div class="mt-2 flex flex-wrap gap-1" data-testid={`facet-${group.key}-selected-summary`}>
+          {selectedSummary.map((option) => (
+            <span
+              key={option.value}
+              class="rounded-full bg-[var(--bb-tone-info-bg)] px-2 py-0.5 text-[11px] text-[var(--bb-tone-info-fg)]"
+            >
+              {option.displayLabel}
+            </span>
+          ))}
+        </div>
       )}
-      {options.length === 0 ? (
-        <p class="text-sm text-[var(--bb-data-fg-subtle)]">{group.emptyLabel ?? "No facet values"}</p>
-      ) : (
-        <div class="space-y-2">
-          {options.map((option) => {
-            const checked = group.selected.includes(option.value);
-            return (
-              <label key={option.value} class="flex items-center justify-between gap-2 text-sm text-[var(--bb-data-fg-muted)]">
-                <span class="inline-flex min-w-0 items-center gap-2">
-                  <input
-                    type="checkbox"
-                    aria-label={formatFacetAccessibleName(group.label, option.displayLabel, option.count)}
-                    checked={checked}
-                    disabled={option.disabled}
-                    onChange={() => onToggle(group.key, option.value)}
-                  />
-                  <span class="truncate">{option.displayLabel}</span>
-                </span>
-                {option.count !== undefined && (
-                  <span class="shrink-0 text-xs text-[var(--bb-data-fg-subtle)]">{option.count.toLocaleString()}</span>
-                )}
-              </label>
-            );
-          })}
+      {expanded && (
+        <div id={panelId} class="mt-3">
+          {group.searchable && (
+            <label class="mb-3 block">
+              <span class="sr-only">Search {group.label}</span>
+              <input
+                type="search"
+                class="w-full rounded-md border border-[var(--bb-data-border-strong)] px-3 py-1.5 text-sm"
+                placeholder={`Search ${group.label.toLowerCase()}`}
+                value={search}
+                onInput={(event) => setSearch((event.currentTarget as HTMLInputElement).value)}
+              />
+            </label>
+          )}
+          {filteredOptions.length === 0 ? (
+            <p class="text-sm text-[var(--bb-data-fg-subtle)]">{group.emptyLabel ?? "No facet values"}</p>
+          ) : (
+            <div class="space-y-2">
+              {filteredOptions.map((option) => {
+                const checked = group.selected.includes(option.value);
+                return (
+                  <label key={option.value} class="flex items-center justify-between gap-2 text-sm text-[var(--bb-data-fg-muted)]">
+                    <span class="inline-flex min-w-0 items-center gap-2">
+                      <input
+                        type="checkbox"
+                        aria-label={formatFacetAccessibleName(group.label, option.displayLabel, option.count)}
+                        checked={checked}
+                        disabled={option.disabled}
+                        onChange={() => onToggle(group.key, option.value)}
+                      />
+                      <span class="truncate">{option.displayLabel}</span>
+                    </span>
+                    {option.count !== undefined && (
+                      <span class="shrink-0 text-xs text-[var(--bb-data-fg-subtle)]">{option.count.toLocaleString()}</span>
+                    )}
+                  </label>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/results-explorer/src/components/__tests__/FacetRail.test.tsx
+++ b/results-explorer/src/components/__tests__/FacetRail.test.tsx
@@ -94,6 +94,117 @@ describe("FacetRail", () => {
   });
 });
 
+describe("FacetRail collapsible groups", () => {
+  const COLLAPSE_GROUPS: FacetGroup[] = [
+    {
+      key: "benchmark",
+      label: "Benchmark",
+      selected: ["tpch"],
+      searchable: true,
+      options: [
+        { value: "tpch", label: "TPC-H", count: 12 },
+        { value: "clickbench", label: "ClickBench", count: 4 },
+        { value: "tpcds", label: "TPC-DS", count: 6 },
+      ],
+    },
+    {
+      key: "trust_tier",
+      label: "Trust",
+      selected: ["official"],
+      defaultCollapsed: true,
+      options: [
+        { value: "official", label: "Official", count: 5 },
+        { value: "community-submission", label: "Community", count: 2 },
+      ],
+    },
+    {
+      key: "deployment_class",
+      label: "Deployment",
+      selected: [],
+      defaultCollapsed: true,
+      options: [
+        { value: "local-laptop", label: "Local laptop", count: 8 },
+        { value: "cloud-instance", label: "Cloud instance", count: 4 },
+      ],
+    },
+  ];
+
+  it("renders default-collapsed groups without their option list and shows selected chips", () => {
+    render(
+      <FacetRail
+        groups={COLLAPSE_GROUPS}
+        resultCount={20}
+        activeChips={[]}
+        onToggle={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const trustToggle = screen.getByRole("button", { name: /^Trust/ });
+    expect(trustToggle).toHaveAttribute("aria-expanded", "false");
+    const trustSection = trustToggle.closest("section")!;
+    expect(within(trustSection).queryByRole("checkbox")).toBeNull();
+    const selectedSummary = within(trustSection).getByTestId(
+      "facet-trust_tier-selected-summary",
+    );
+    expect(within(selectedSummary).getByText("Official")).toBeTruthy();
+
+    const deploymentToggle = screen.getByRole("button", { name: /^Deployment/ });
+    expect(deploymentToggle).toHaveAttribute("aria-expanded", "false");
+    const deploymentSection = deploymentToggle.closest("section")!;
+    expect(within(deploymentSection).queryByText("Local laptop")).toBeNull();
+
+    const benchmarkToggle = screen.getByRole("button", { name: /^Benchmark/ });
+    expect(benchmarkToggle).toHaveAttribute("aria-expanded", "true");
+    const benchmarkSection = benchmarkToggle.closest("section")!;
+    expect(within(benchmarkSection).getAllByRole("checkbox").length).toBe(3);
+  });
+
+  it("toggles a group expanded and collapsed via its header button", () => {
+    render(
+      <FacetRail
+        groups={COLLAPSE_GROUPS}
+        resultCount={20}
+        activeChips={[]}
+        onToggle={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const trustToggle = screen.getByRole("button", { name: /^Trust/ });
+    fireEvent.click(trustToggle);
+    expect(trustToggle).toHaveAttribute("aria-expanded", "true");
+    const trustSection = trustToggle.closest("section")!;
+    expect(within(trustSection).getAllByRole("checkbox").length).toBe(2);
+
+    fireEvent.click(trustToggle);
+    expect(trustToggle).toHaveAttribute("aria-expanded", "false");
+    expect(within(trustSection).queryByRole("checkbox")).toBeNull();
+  });
+
+  it("preserves searchable behavior on expanded groups", () => {
+    render(
+      <FacetRail
+        groups={COLLAPSE_GROUPS}
+        resultCount={20}
+        activeChips={[]}
+        onToggle={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const benchmarkSection = screen
+      .getByRole("button", { name: /^Benchmark/ })
+      .closest("section")!;
+    fireEvent.input(within(benchmarkSection).getByRole("searchbox"), {
+      target: { value: "tpc-d" },
+    });
+    expect(within(benchmarkSection).getByText("TPC-DS")).toBeTruthy();
+    expect(within(benchmarkSection).queryByText("TPC-H")).toBeNull();
+    expect(within(benchmarkSection).queryByText("ClickBench")).toBeNull();
+  });
+});
+
 describe("FacetDrawer", () => {
   it("shows a closed summary and opens the facet dialog", () => {
     const onOpenChange = vi.fn();

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -261,37 +261,65 @@ export function Query(_: RoutableProps) {
 
   const columnNames = schema.map((column) => column.name);
   const facetGroups: FacetGroup[] = [
-    makeFacetGroup("benchmark", "Benchmark", facetCounts.benchmark ?? [], benchmarks, formatBenchmarkLabel),
-    makeFacetGroup("platform", "Platform", facetCounts.platform ?? [], platforms),
+    makeFacetGroup("benchmark", "Benchmark", facetCounts.benchmark ?? [], benchmarks, {
+      formatLabel: formatBenchmarkLabel,
+      searchable: true,
+    }),
+    makeFacetGroup("platform", "Platform", facetCounts.platform ?? [], platforms, {
+      searchable: true,
+    }),
     makeFacetGroup("scale_factor", "Scale", facetCounts.scale_factor ?? [], scaleFactors),
-    makeFacetGroup("tuning_mode", "Tuning", facetCounts.tuning_mode ?? [], tuningModes),
-    makeFacetGroup("trust_tier", "Trust", facetCounts.trust_label ?? [], trustTiers, formatTrustLabel),
-    makeFacetGroup("validation_status", "Validation", facetCounts.validation_status ?? [], validationStatuses, formatValidationStatus),
-    makeFacetGroup("cost_status", "Cost status", facetCounts.cost_status ?? [], costStatuses, formatCostStatus),
-    makeFacetGroup("cost_model", "Cost model", facetCounts.cost_model_version ?? [], costModelVersions),
-    makeFacetGroup("deployment_class", "Deployment", facetCounts.deployment_class ?? [], deploymentClasses),
-    makeFacetGroup("cloud_provider", "Cloud provider", facetCounts.cloud_provider ?? [], cloudProviders),
-    makeFacetGroup("cloud_region", "Cloud region", facetCounts.cloud_region ?? [], cloudRegions),
+    makeFacetGroup("tuning_mode", "Tuning", facetCounts.tuning_mode ?? [], tuningModes, {
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("trust_tier", "Trust", facetCounts.trust_label ?? [], trustTiers, {
+      formatLabel: formatTrustLabel,
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("validation_status", "Validation", facetCounts.validation_status ?? [], validationStatuses, {
+      formatLabel: formatValidationStatus,
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("cost_status", "Cost status", facetCounts.cost_status ?? [], costStatuses, {
+      formatLabel: formatCostStatus,
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("cost_model", "Cost model", facetCounts.cost_model_version ?? [], costModelVersions, {
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("deployment_class", "Deployment", facetCounts.deployment_class ?? [], deploymentClasses, {
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("cloud_provider", "Cloud provider", facetCounts.cloud_provider ?? [], cloudProviders, {
+      defaultCollapsed: true,
+    }),
+    makeFacetGroup("cloud_region", "Cloud region", facetCounts.cloud_region ?? [], cloudRegions, {
+      searchable: true,
+      defaultCollapsed: true,
+    }),
     makeFacetGroup(
       "instance_or_warehouse",
       "Instance / warehouse",
       facetCounts.instance_or_warehouse ?? [],
       instanceOrWarehouses,
+      { searchable: true, defaultCollapsed: true },
     ),
-    makeFacetGroup("storage_format", "Storage", facetCounts.storage_format ?? [], storageFormats),
+    makeFacetGroup("storage_format", "Storage", facetCounts.storage_format ?? [], storageFormats, {
+      defaultCollapsed: true,
+    }),
     makeFacetGroup(
       "has_cost",
       "Has cost",
       [{ value: "all", count: rows.length }, ...(facetCounts.has_cost ?? [])],
       [hasCost],
-      formatHasCostLabel,
+      { formatLabel: formatHasCostLabel, defaultCollapsed: true },
     ),
     makeFacetGroup(
       "date_window",
       "Date window",
       [{ value: "all", count: rows.length }, ...(facetCounts.date_window ?? [])],
       [dateWindow],
-      formatDateWindowLabel,
+      { formatLabel: formatDateWindowLabel, defaultCollapsed: true },
     ),
   ].filter((group) => group.options.length > 0);
   const activeFilterChips: ActiveFacetChip[] = [
@@ -808,17 +836,27 @@ export function Query(_: RoutableProps) {
   );
 }
 
+interface MakeFacetGroupOptions {
+  formatLabel?: (value: string) => string;
+  searchable?: boolean;
+  defaultCollapsed?: boolean;
+}
+
 function makeFacetGroup(
   key: string,
   label: string,
   buckets: FacetBucket[],
   selected: string[],
-  formatLabel: (value: string) => string = (value) => formatQueryFacetValue(key, value),
+  options: MakeFacetGroupOptions = {},
 ): FacetGroup {
+  const formatLabel =
+    options.formatLabel ?? ((value: string) => formatQueryFacetValue(key, value));
   return {
     key,
     label,
     selected,
+    searchable: options.searchable,
+    defaultCollapsed: options.defaultCollapsed,
     options: buckets.map((bucket) => ({
       value: bucket.value,
       label: formatLabel(bucket.value),

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -448,6 +448,10 @@ describe("Query", () => {
     const deployment = within(desktopFilters).getByRole("heading", { name: "Deployment" }).closest("section")!;
     const cloudProvider = within(desktopFilters).getByRole("heading", { name: "Cloud provider" }).closest("section")!;
     const shape = within(desktopFilters).getByRole("heading", { name: "Instance / warehouse" }).closest("section")!;
+    fireEvent.click(within(costStatus).getByRole("button", { name: /^Cost status/ }));
+    fireEvent.click(within(deployment).getByRole("button", { name: /^Deployment/ }));
+    fireEvent.click(within(cloudProvider).getByRole("button", { name: /^Cloud provider/ }));
+    fireEvent.click(within(shape).getByRole("button", { name: /^Instance \/ warehouse/ }));
     fireEvent.click(within(costStatus).getByLabelText(/^Cost status: normalized/i));
     fireEvent.click(within(deployment).getByLabelText(/^Deployment: cloud/i));
     fireEvent.click(within(cloudProvider).getByLabelText(/^Cloud provider: aws/i));


### PR DESCRIPTION
Closes the w4 work unit of
results-explorer-query-workbench-controls-and-facets so Query Workbench
keeps Platform and Scale above the fold when long secondary groups are
present. Defects this addresses were captured against develop tip in
_project/verification-logs/results-explorer-query-workbench-controls-and-facets/w4.log.

Changes:

  - `FacetRail.tsx` `FacetGroupSection` grew a per-group expand/collapse
    toggle (chevron button with `aria-expanded` + `aria-controls`) and
    an optional `defaultCollapsed` flag on `FacetGroup`.
  - When a group is collapsed, selected option chips render inline
    (data-testid `facet-<key>-selected-summary`) so active facets stay
    visible without expanding.
  - `Query.tsx` opts long groups (Benchmark, Platform, Cloud region,
    Instance / warehouse) into the existing `searchable` affordance —
    previously the capability existed but Query never enabled it — and
    default-collapses every secondary group beyond Benchmark, Platform,
    and Scale. `makeFacetGroup` was reshaped to accept a single options
    object so the call sites stay readable; only Query.tsx calls it.
  - FacetDrawer (mobile) inherits the same behavior via FacetRail.

Tests:

  - New FacetRail tests cover default-collapsed render, toggle
    expand/collapse, search-after-expand, and an explicit assertion
    that selected option chips render inside the
    `facet-<key>-selected-summary` block while collapsed.
  - The existing Query integration test was updated to expand
    secondary groups before clicking nested checkboxes; no assertion
    weakened.

Verification:

  - `npm test -- --run src/components/__tests__/FacetRail.test.tsx` (6/6)
  - `npm test -- --run src/pages/__tests__/Query.test.tsx` (19/19)
  - `npm test -- --run` (548/548)
  - `npm run typecheck` and `npm run build` clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
