### PR TITLE
feat(explorer): compact chart panel header and drop duplicated per-query heatmap

### DIFF
--- a/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
+++ b/_project/TODO/main/planning/results-explorer-chart-panel-scope-and-labeling.yaml
@@ -38,22 +38,41 @@ work:
 - id: w1
   summary: "Compact the chart panel header and tab band"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
-    Reduce the large empty band above chart subtabs by moving chart title,
-    primary tabs, secondary tabs, and active filters into a compact header
-    region. Preserve usable click targets while removing unused vertical
-    whitespace.
+    ChartPanel header restructured from a two-column "title left, controls
+    stacked right" layout into a single `flex flex-wrap items-center`
+    band. Title, group tablist, active-group subtabs, and the Compare
+    baseline select share one row and wrap together on narrow screens.
+    The empty band that sat to the right of the H2 (caused by
+    `sm:items-start` against a tall right column) is gone; the baseline
+    select uses `ml-auto` to float right when present. Click targets
+    keep `min-h-9` so accessibility is not regressed. The
+    "responsive segmented chart controls" test was updated to assert
+    `flex flex-wrap` instead of the prior mobile grid (no assertion
+    weakened — the contract is still "controls render with short
+    visible labels at a touch-friendly height"). Verification log:
+    _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w1.log.
 
 - id: w2
   summary: "Remove or rescope the duplicate Per-query heatmap"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
-    On Benchmark detail pages where the matrix is already rendered above the
-    Charts panel, hide Charts > Per-query > Heatmap or replace it with a
-    scoped view that adds information not present in the main matrix. Keep a
-    clear path to Histogram if that subview remains useful.
+    ChartPanel grew an `excludeChartIds?: readonly string[]` prop. Excluded
+    ids are filtered from the `applicableCharts` result before grouping
+    so they do not appear in the tablist, subtabs, or initial-active
+    selection. BenchmarkIndex now passes
+    `excludeChartIds={["query_heatmap"]}` whenever
+    `viewMode === "matrix"` so the page-level QueryHeatmap above the
+    Charts panel is not duplicated as a Per-query > Heatmap subtab. In
+    ranks/list view modes the chart panel keeps its full set so the
+    heatmap stays accessible. Histogram remains available in the
+    Per-query group either way. Test added in
+    src/components/__tests__/ChartPanel.test.tsx asserts the Heatmap
+    button disappears while the Per-query group is still selectable.
+    Verification log:
+    _project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w2.log.
 
 - id: w3
   summary: "Hide or disable Cost tabs when no cost data exists"

--- a/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w1.log
+++ b/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w1.log
@@ -1,0 +1,52 @@
+# w1 — Compact the chart panel header and tab band
+
+Branch: feat/explorer-chart-panel-header
+Develop tip at start: 6c28d2b45 (PR #298 merged)
+
+## Current state on develop tip
+
+Inspected: results-explorer/src/components/ChartPanel.tsx lines 141-224.
+
+The header uses
+`<div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">`
+with the H2 on the left and a right-aligned column that stacks (group
+tablist, optional baseline select, active-group chart subtabs) using
+`flex-col`. On wide screens, the H2 row is short while the right column
+runs tall, leaving an empty band below the title and to the left of the
+subtabs.
+
+## Defects vs the w0 review
+
+- D1 (header): "Empty band above chart subtabs" — the right column
+  stacks vertically (`gap-2 sm:items-end`) while the title row only
+  shows H2. The visual result is a tall right column floating next to a
+  small left H2 with empty space below it.
+
+## Planned change for w1
+
+Restructure the header into a single flex-wrap row so the title, group
+tabs, chart subtabs, and baseline select share a single horizontal
+band when there is room. Drop the right-side stack (`flex-col`) and
+its `sm:items-end` alignment that drove the dead space. Use `ml-auto`
+on the baseline select so it floats right when shown.
+
+- `flex flex-wrap items-center gap-x-4 gap-y-2 mb-3`
+- H2 stays first; tablist (`role="tablist"`) immediately follows.
+- Active-group subtabs (`role="group"`) follow in the same row.
+- Baseline select (when present) gets `ml-auto` to push to the right.
+
+Existing roles, aria-labels, and accessible names are preserved so
+ChartPanel.test.tsx assertions continue to pass without weakening.
+
+## Manual route walk
+
+Walked /results/tpch/?phase=power on develop tip with the local dev
+server. The right-side column visibly stacks with empty space to its
+left below the H2 row. Baseline select on Compare appears mid-stack on
+narrow viewports; on wide viewports it sits below the group tablist.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`

--- a/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w2.log
+++ b/_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w2.log
@@ -1,0 +1,56 @@
+# w2 — Remove or rescope the duplicate Per-query heatmap
+
+Branch: feat/explorer-chart-panel-header
+Develop tip at start: 6c28d2b45 (PR #298 merged)
+
+## Current state on develop tip
+
+On Benchmark detail (results-explorer/src/pages/BenchmarkIndex.tsx):
+
+- viewMode === "matrix" renders `<QueryHeatmap summary=... />` at line
+  562 as the page-level matrix view.
+- Below at line 600-610, `<ChartPanel context={{ kind: "summary",
+  summary: filteredSummary, ... }} />` is rendered unconditionally
+  whenever `filteredSummary` is set and viewMode !== "list".
+- ChartPanel's `applicableCharts(context)` returns
+  `query_heatmap` (Per-query > Heatmap subtab) for any cohort with
+  query timings. So when viewMode === "matrix", the chart panel exposes
+  a heatmap subtab that renders the same matrix already shown above.
+
+## Defect vs the w0 review
+
+- D2 (per-query heatmap duplicate): On Benchmark detail with viewMode
+  === "matrix", the user can click Charts > Per-query > Heatmap and see
+  the same heatmap that is already the main matrix. The Histogram
+  subview is not duplicative and stays useful.
+
+## Planned change for w2
+
+1. Add an optional `excludeChartIds?: readonly string[]` prop to
+   `ChartPanel`. When provided, filter the
+   `applicableCharts(context)` result so excluded ids do not appear in
+   the tablist, subtabs, or `preferredChartId` resolution.
+2. On `BenchmarkIndex.tsx`, pass `excludeChartIds={viewMode === "matrix"
+   ? ["query_heatmap"] : undefined}` so the duplicate is hidden only
+   when the page already shows a matrix above. In ranks/list view modes
+   the chart panel keeps its full set so users still have access to the
+   heatmap when they switch to a non-matrix page view.
+3. Histogram remains in the Per-query group; the group itself only
+   disappears if both members are excluded (which does not happen
+   here).
+
+## Manual route walk
+
+- /results/tpch/?phase=power, default viewMode=matrix: Charts panel
+  shows Per-query group with both Heatmap and Histogram subtabs.
+  Selecting Heatmap renders the same heatmap as the page matrix above.
+- /results/tpch/?phase=power&view=ranks: matrix is replaced with the
+  rank table; Per-query > Heatmap is the only place to see a heatmap.
+- /results/tpch/?phase=power&view=list: ChartPanel is hidden entirely
+  by the existing `viewMode !== "list"` gate.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -41,6 +41,11 @@ interface ChartPanelProps {
   // page-level decision summary correctly avoided them.
   suppressWinnerClaims?: boolean;
   suppressionReason?: string;
+  // w2 (chart-panel-scope-and-labeling): hosts that already render a
+  // chart at page level (e.g. BenchmarkIndex matrix view rendering
+  // QueryHeatmap above the panel) pass the duplicated chart ids here so
+  // the panel does not expose the same view as a redundant subtab.
+  excludeChartIds?: readonly string[];
 }
 
 interface CompareQueryRow {
@@ -61,8 +66,14 @@ export function ChartPanel({
   onBaselineIndexChange,
   suppressWinnerClaims = false,
   suppressionReason,
+  excludeChartIds,
 }: ChartPanelProps) {
-  const charts = useMemo(() => applicableCharts(context), [context]);
+  const charts = useMemo(() => {
+    const applicable = applicableCharts(context);
+    if (!excludeChartIds || excludeChartIds.length === 0) return applicable;
+    const exclude = new Set(excludeChartIds);
+    return applicable.filter((entry) => !exclude.has(entry.id));
+  }, [context, excludeChartIds]);
   const chartGroups = useMemo(() => groupChartsByQuestion(charts), [charts]);
   const summary = useMemo(() => buildRenderableSummary(context), [context]);
   const historical = useMemo(
@@ -140,87 +151,85 @@ export function ChartPanel({
 
   return (
     <section class="card">
-      <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
         <h2 class="text-base font-semibold text-[var(--bb-data-fg-primary)]">Charts</h2>
-        <div class="flex w-full min-w-0 flex-col items-stretch gap-2 sm:w-auto sm:items-end">
-          {chartGroups.length > 1 && (
-            <div
-              class="grid w-full grid-cols-2 gap-1 rounded-md panel-muted p-1 sm:flex sm:w-auto sm:flex-wrap sm:justify-end"
-              role="tablist"
-              aria-label="Chart question groups"
+        {chartGroups.length > 1 && (
+          <div
+            class="flex flex-wrap items-center gap-1 rounded-md panel-muted p-1"
+            role="tablist"
+            aria-label="Chart question groups"
+          >
+            {chartGroups.map((group) => {
+              const selected = group.id === activeGroup.id;
+              return (
+                <button
+                  key={group.id}
+                  role="tab"
+                  type="button"
+                  aria-selected={selected}
+                  aria-controls="chart-panel-chart"
+                  aria-label={group.label}
+                  class={`min-h-9 rounded px-2 py-1 text-xs font-medium transition-colors sm:px-3 ${
+                    selected
+                      ? "bg-[var(--bb-surface-data)] text-[var(--bb-data-fg-primary)] shadow-sm"
+                      : "text-[var(--bb-data-fg-muted)] hover:bg-[var(--bb-surface-data)] hover:text-[var(--bb-data-fg-primary)]"
+                  }`}
+                  onClick={() => selectGroup(group)}
+                  title={group.description}
+                >
+                  {group.label}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {activeGroupCharts.length > 1 && (
+          <div
+            class="flex flex-wrap items-center gap-1 rounded-md panel-muted p-1"
+            role="group"
+            aria-label={`${activeGroup.label} charts`}
+          >
+            {activeGroupCharts.map((chart) => {
+              const selected = activeChart.id === chart.id;
+              return (
+                <button
+                  key={chart.id}
+                  type="button"
+                  class={`min-h-9 rounded px-2 py-1 text-xs font-medium transition-colors sm:px-3 ${
+                    selected
+                      ? "bg-[var(--bb-surface-data)] text-[var(--bb-data-fg-primary)] shadow-sm"
+                      : "text-[var(--bb-data-fg-muted)] hover:bg-[var(--bb-surface-data)] hover:text-[var(--bb-data-fg-primary)]"
+                  }`}
+                  onClick={() => setActiveId(chart.id)}
+                  aria-pressed={selected}
+                  aria-label={chart.title}
+                  title={chart.description}
+                >
+                  {chartButtonLabel(chart)}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {showBaseline && summary && summary.platforms.length > 1 && (
+          <div class="ml-auto flex items-center gap-2">
+            <label class="text-xs text-[var(--bb-data-fg-muted)]" for="chart-panel-baseline">
+              Baseline:
+            </label>
+            <select
+              id="chart-panel-baseline"
+              class="min-w-0 max-w-full rounded border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-xs text-[var(--bb-data-fg-primary)]"
+              value={String(baselineIdx)}
+              onChange={(event) => setBaselineIdx(Number((event.target as HTMLSelectElement).value))}
             >
-              {chartGroups.map((group) => {
-                const selected = group.id === activeGroup.id;
-                return (
-                  <button
-                    key={group.id}
-                    role="tab"
-                    type="button"
-                    aria-selected={selected}
-                    aria-controls="chart-panel-chart"
-                    aria-label={group.label}
-                    class={`min-h-9 min-w-0 rounded px-2 py-1.5 text-center text-xs font-medium transition-colors sm:px-3 ${
-                      selected
-                        ? "bg-[var(--bb-surface-data)] text-[var(--bb-data-fg-primary)] shadow-sm"
-                        : "text-[var(--bb-data-fg-muted)] hover:bg-[var(--bb-surface-data)] hover:text-[var(--bb-data-fg-primary)]"
-                    }`}
-                    onClick={() => selectGroup(group)}
-                    title={group.description}
-                  >
-                    {group.label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-          {showBaseline && summary && summary.platforms.length > 1 && (
-            <div class="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
-              <label class="text-xs text-[var(--bb-data-fg-muted)]" for="chart-panel-baseline">
-                Baseline:
-              </label>
-              <select
-                id="chart-panel-baseline"
-                class="min-w-0 max-w-full rounded border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-xs text-[var(--bb-data-fg-primary)]"
-                value={String(baselineIdx)}
-                onChange={(event) => setBaselineIdx(Number((event.target as HTMLSelectElement).value))}
-              >
-                {summary.platforms.map((platform, index) => (
-                  <option key={platform.result_id} value={String(index)}>
-                    {platform.platform}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-          {activeGroupCharts.length > 1 && (
-            <div
-              class="grid w-full grid-cols-2 gap-1 rounded-md panel-muted p-1 sm:flex sm:w-auto sm:flex-wrap sm:justify-end"
-              role="group"
-              aria-label={`${activeGroup.label} charts`}
-            >
-              {activeGroupCharts.map((chart) => {
-                const selected = activeChart.id === chart.id;
-                return (
-                  <button
-                    key={chart.id}
-                    type="button"
-                    class={`min-h-9 min-w-0 rounded px-2 py-1.5 text-center text-xs font-medium transition-colors sm:px-3 ${
-                      selected
-                        ? "bg-[var(--bb-surface-data)] text-[var(--bb-data-fg-primary)] shadow-sm"
-                        : "text-[var(--bb-data-fg-muted)] hover:bg-[var(--bb-surface-data)] hover:text-[var(--bb-data-fg-primary)]"
-                    }`}
-                    onClick={() => setActiveId(chart.id)}
-                    aria-pressed={selected}
-                    aria-label={chart.title}
-                    title={chart.description}
-                  >
-                    {chartButtonLabel(chart)}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
+              {summary.platforms.map((platform, index) => (
+                <option key={platform.result_id} value={String(index)}>
+                  {platform.platform}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
 
       <div id="chart-panel-chart" role="tabpanel" aria-label={`${activeGroup.label} chart`} data-chart-container>

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -195,6 +195,28 @@ describe("ChartPanel", () => {
     expect(screen.queryByRole("button", { name: "Sparkline Table" })).toBeNull();
   });
 
+  it("hides charts whose ids are listed in excludeChartIds", () => {
+    render(
+      <ChartPanel
+        context={{
+          kind: "summary",
+          summary: makeSummary(),
+          historical: [
+            makeHistoricalEntry(),
+            makeHistoricalEntry({ result_id: "hist-2", run_date: "2026-04-18T12:00:00Z" }),
+          ],
+        }}
+        excludeChartIds={["query_heatmap"]}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Per-query" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Query Heatmap" })).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Per-query" }));
+    expect(screen.queryByRole("button", { name: "Query Heatmap" })).toBeNull();
+    expect(screen.getByRole("tabpanel", { name: "Per-query chart" })).toBeTruthy();
+  });
+
   it("uses responsive segmented chart controls with short visible labels", () => {
     render(
       <ChartPanel
@@ -210,13 +232,13 @@ describe("ChartPanel", () => {
     );
 
     const groupTabs = screen.getByRole("tablist", { name: "Chart question groups" });
-    expect(groupTabs.className).toContain("grid");
-    expect(groupTabs.className).toContain("grid-cols-2");
+    expect(groupTabs.className).toContain("flex");
+    expect(groupTabs.className).toContain("flex-wrap");
     expect(screen.getByRole("tab", { name: "Per-query" }).className).toContain("min-h-9");
 
     const chartControls = screen.getByRole("group", { name: "Overview charts" });
-    expect(chartControls.className).toContain("grid");
-    expect(chartControls.className).toContain("grid-cols-2");
+    expect(chartControls.className).toContain("flex");
+    expect(chartControls.className).toContain("flex-wrap");
 
     const sparkline = screen.getByRole("button", { name: "Sparkline Table" });
     const stacked = screen.getByRole("button", { name: "Stacked Phase Breakdown" });

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -605,6 +605,7 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
               summary: filteredSummary,
               historical: historicalEntries,
             }}
+            excludeChartIds={viewMode === "matrix" ? ["query_heatmap"] : undefined}
           />
         </div>
       )}


### PR DESCRIPTION
Closes the w1 and w2 work units of
results-explorer-chart-panel-scope-and-labeling. Defects this
addresses were captured against develop tip in
_project/verification-logs/results-explorer-chart-panel-scope-and-labeling/w1.log
and w2.log.

Changes:

  - `ChartPanel.tsx` header is now a single `flex flex-wrap` band that
    holds the H2, the chart-question tablist, the active-group subtabs,
    and the Compare baseline select on one row. The previous "title on
    the left, controls stacked vertically on the right with
    `sm:items-start` and `sm:items-end`" layout left an empty band
    below the H2 on wide screens; that band is gone. Baseline select
    floats right via `ml-auto` when shown. Click targets keep
    `min-h-9` so touch accessibility is not regressed.
  - `ChartPanel` grew an `excludeChartIds?: readonly string[]` prop.
    Excluded ids are filtered out of `applicableCharts(context)`
    before grouping, so they disappear from the tablist, subtabs, and
    initial-active selection.
  - `BenchmarkIndex.tsx` passes
    `excludeChartIds={["query_heatmap"]}` to the page's ChartPanel
    when `viewMode === "matrix"`. The page-level QueryHeatmap matrix
    above the panel is no longer duplicated by a Per-query > Heatmap
    subtab. The Histogram subview remains available, and ranks/list
    view modes keep the full chart set since they do not render a
    page-level heatmap.

Tests:

  - New ChartPanel test asserts that excluding `query_heatmap` removes
    the Heatmap button while keeping the Per-query group selectable.
  - The "responsive segmented chart controls" test was updated to
    assert the new `flex flex-wrap` layout. The previous assertion
    targeted a `grid grid-cols-2` pattern that belonged to the old
    mobile-stacked design; the contract being asserted (controls
    render with short visible labels at a touch-friendly height)
    survives intact.

Verification:

  - `npm test -- --run` (546/546)
  - `npm run typecheck` and `npm run build` clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
