### PR TITLE
[codex] Plan JOB canonical and scale strategy

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml
@@ -1,0 +1,203 @@
+id: joinorder-canonical-dataset-contract
+title: "Define the canonical JOB dataset contract and validation oracle"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Issue #289 identified that BenchBox's current Join Order Benchmark data is
+  synthetic and independently random, while canonical JOB derives its optimizer
+  signal from the frozen real IMDB dataset and its cross-table correlations.
+
+  This item defines the reusable canonical dataset contract that must exist
+  before any scaled JOB-derived benchmark is credible. It covers the hosted
+  archive format, user-supplied data path, reference validation oracle, encoding
+  and NULL-preservation checks, result-bundle dataset versioning, CI routing, and
+  central scale-factor enforcement.
+
+  This TODO does not implement derived scale-up. It creates the foundation that
+  later scale-stress work must depend on.
+
+deps:
+  needs: []
+
+context_sections:
+  "Why this gates scaled JOB": |
+    A scaled JOB-derived benchmark needs a trusted baseline. Without canonical
+    reference outputs, conversion provenance, encoding checks, and dataset
+    versioning, later scale-up failures cannot be localized to the engine,
+    optimizer statistics, data generator, archive conversion, or query layer.
+  "Issue evidence": |
+    The current generator uses independent random choices for predicate-bearing
+    values and FK relationships. Several embedded query predicates currently
+    cannot match generated rows because fields such as movie_companies.note and
+    cast_info.note are always NULL. Canonical JOB must restore the frozen real
+    data contract before any derived benchmark can claim continuity with JOB.
+
+work:
+  - id: w1
+    summary: "Choose and document the canonical reference oracle"
+    status: pending
+    notes: |
+      Decide the validation oracle for canonical JOB. The preferred shape is:
+        - PostgreSQL as the reference engine for a one-time canonical run.
+        - Normalized result sets for all 113 queries when practical.
+        - Reference cardinalities and pre-aggregate match counts for all 113
+          queries even when full result sets are large.
+      Record the decision in a short design note under `_project/decisions/`.
+      The note must state why non-empty-result checks alone are insufficient.
+
+  - id: w2
+    summary: "Specify the canonical archive and manifest format"
+    needs: [w1]
+    status: pending
+    notes: |
+      Define the downloadable archive layout and user-supplied data contract.
+      Required fields:
+        - dataset_id and dataset_version.
+        - source archive checksum.
+        - per-table file checksums and row counts.
+        - per-column null counts for predicate-bearing columns.
+        - schema version and file format version.
+        - conversion pipeline provenance.
+      The format must support hosted download and `--benchmark-option
+      data_path=/path/to/job_dataset` for air-gapped users.
+
+  - id: w3
+    summary: "Add encoding and NULL-preservation gates to the data-build spec"
+    needs: [w2]
+    status: pending
+    notes: |
+      Specify tests for CSV to Parquet round trips, UTF-8 quirks, normalization,
+      BOM handling, empty-string vs NULL handling, and exact string predicate
+      preservation. The gate must include note columns and other fields that
+      are predicate-bearing in JOB:
+        - movie_companies.note
+        - cast_info.note
+        - person_info.note
+        - movie_info.info
+        - movie_info_idx.info
+        - company_name.name and country_code
+        - keyword.keyword
+        - name.name
+
+  - id: w4
+    summary: "Define dataset versioning requirements for result bundles and explorer comparison"
+    needs: [w2]
+    status: pending
+    notes: |
+      Require every JOB result bundle to record dataset_id, dataset_version,
+      manifest hash, source checksum, conversion script SHA, archive format, and
+      scale mode. The explorer must surface dataset-version mismatches when
+      comparing JOB results so a future archive fix does not make old and new
+      results ambiguous.
+
+  - id: w5
+    summary: "Design central benchmark scale-factor and mode validation"
+    needs: [w2]
+    status: pending
+    notes: |
+      Registry scale_options alone is not enough. Design a central validation
+      hook that lets benchmarks enforce scale and mode constraints at run time.
+      Canonical JOB must accept only SF=1 and the canonical dataset mode.
+      Later derived modes must be explicit, such as replicated_imdb or
+      job_scale_stress, and must never be silently selected by passing a larger
+      scale factor to canonical joinorder.
+
+  - id: w6
+    summary: "Define CI routing for canonical JOB"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      Full canonical JOB is too large for fast tests. Define three tiers:
+        - unit tests use a tiny predicate-satisfying fixture.
+        - UAT/nightly tests use cached canonical Parquet data.
+        - manual benchmark runs can use hosted download or data_path.
+      The fixture must satisfy representative predicates and NULL handling, but
+      must not be labeled canonical.
+
+  - id: w7
+    summary: "Decide DataFrame parity scope for canonical JOB"
+    needs: [w1]
+    status: pending
+    notes: |
+      Current DataFrame coverage is 13 queries while canonical JOB has 113.
+      Decide whether canonical JOB initially supports SQL only, or whether the
+      113-query DataFrame translation becomes a separate dependency. Do not let
+      partial DataFrame support block SQL canonical correctness unless the
+      project explicitly chooses that scope.
+
+deferred:
+  - summary: "Implement derived scale-up modes"
+    reason: "Scale-up requires the canonical dataset contract and oracle defined here first."
+  - summary: "Translate all 113 JOB queries to DataFrame APIs"
+    reason: "This may be a substantial independent task; w7 decides whether it is in scope."
+
+must_preserve:
+  - "Canonical JOB means frozen real IMDB-derived JOB data at SF=1 only; synthetic data must not be mislabeled canonical."
+  - "Air-gapped users must have a documented data_path path, not only a hosted-download path."
+  - "Predicate-bearing string and note columns must preserve exact values and NULL semantics through conversion."
+  - "Existing result bundles must remain interpretable after future dataset archive revisions."
+
+approach: |
+  Treat the canonical dataset as a first-class versioned artifact, not as a
+  helper file downloaded by the generator. Start with a written contract and
+  reference oracle, then implement the loader/archive path in a later TODO or
+  work item. Reuse the TPC-DS compliance-class pattern for methodology labeling,
+  but use JOB-specific labels such as canonical_imdb and synthetic_schema rather
+  than overloading TPC's official/unofficial vocabulary.
+
+anti_patterns:
+  - "DO NOT validate canonical JOB with only non-empty query checks - because that would miss wrong answers and predicate-domain corruption - use reference outputs/cardinalities from a chosen reference engine instead."
+  - "DO NOT coerce empty strings and NULLs through generic CSV/Parquet defaults - because JOB predicates depend on note and string columns - add explicit round-trip and null-count checks."
+  - "DO NOT rely on registry scale_options alone - because current runner paths may bypass it - implement a central validation hook used by CLI and benchmark construction paths."
+  - "DO NOT put full canonical JOB in fast tests - because the dataset is gigabyte-scale - use a tiny predicate-satisfying fixture for unit coverage and full data only in UAT/nightly/manual gates."
+
+verification:
+  - description: "TODO graph remains valid after this planning item is added"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passed"
+  - description: "This item validates individually"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml"
+    expected_output: "is valid"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/joinorder-canonical-dataset-contract-*.md"
+    - "_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml"
+    - "docs/benchmarks/join-order.md"
+    - "docs/usage/data-generation.md"
+    - "benchbox/core/benchmark_registry.py"
+    - "benchbox/core/joinorder/"
+    - "benchbox/cli/"
+    - "tests/unit/core/joinorder/"
+    - "tests/unit/cli/"
+  do_not_modify:
+    - "results-data/bundles/"
+    - "results-explorer/"
+
+success_metrics:
+  - "A written oracle decision exists and names the reference engine plus exact artifacts to store."
+  - "Canonical archive manifest format includes dataset_version, checksums, null counts, provenance, and file format version."
+  - "CLI and benchmark construction paths have a central validation design for canonical JOB SF=1 enforcement."
+  - "CI routing separates tiny fixture tests from full canonical UAT/nightly runs."
+
+metadata:
+  tags:
+    - joinorder
+    - job
+    - canonical-dataset
+    - issue-289
+    - benchmark-validity
+  estimated_effort: "Medium-Large"
+  created_date: "2026-05-09"
+
+impact:
+  business_value: |
+    Restores trust in BenchBox's JOB implementation by making the canonical
+    dataset explicit, reproducible, and distinguishable from synthetic or
+    derived workloads.
+  technical_debt: |
+    Removes ambiguity around data provenance, query validation, scale-factor
+    handling, and result comparability before scale-stress work compounds it.

--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -1,0 +1,196 @@
+id: joinorder-replicated-imdb-scale-prototype
+title: "Prototype replicated-IMDB scale-up for JOB scale-stress"
+worktree: main
+priority: Medium
+status: Not Started
+category: Benchmark Development
+
+description: |
+  Prototype the lowest-risk derived scale-up mode for JOB: offset-replicating
+  the canonical IMDB tables by integer scale factor while preserving predicate
+  values and consistently offsetting primary and foreign keys.
+
+  This is an infrastructure and measurement baseline for future job_scale_stress
+  work. It is not intended to model "IMDb got 10x larger" perfectly and must be
+  labeled as replicated_imdb, not canonical_imdb.
+
+deps:
+  needs:
+    - joinorder-scale-stress-decision-framework
+
+context_sections:
+  "Why start with replication": |
+    Offset replication preserves canonical intra-replica correlations and gives
+    a deterministic baseline for larger data volumes. It can validate archive
+    scaling, loader behavior, stats/analyze phase measurement, result metadata,
+    and comparison labeling before investing in profiled graph expansion.
+  "Known limitation": |
+    Replication creates disconnected copies of the same graph. It may distort
+    compression, cache behavior, partitioning, and some optimizer heuristics.
+    The prototype must measure and report those limitations, not hide them.
+
+work:
+  - id: w1
+    summary: "Confirm decision-framework approval and prototype scope"
+    status: pending
+    notes: |
+      Do not start implementation unless joinorder-scale-stress-decision-framework
+      chooses replicated_imdb as an approved baseline. Copy the chosen prototype
+      scope and success criteria from that decision note into this TODO before
+      coding.
+
+  - id: w2
+    summary: "Map JOB primary keys, foreign keys, and lookup tables"
+    needs: [w1]
+    status: pending
+    notes: |
+      Build a table-by-table offset map from the canonical schema:
+        - replicated entity/fact tables get PK offsets per replica,
+        - FK columns pointing to replicated tables get matching offsets,
+        - small lookup tables remain single-copy,
+        - self references such as title.episode_of_id are offset,
+        - dual references such as movie_link.movie_id and linked_movie_id are
+          both offset.
+      Document the map in the code or manifest so future schema changes cannot
+      silently corrupt joins.
+
+  - id: w3
+    summary: "Implement a deterministic replicated_imdb archive builder"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add a builder that reads a canonical dataset directory and writes a derived
+      replicated_imdb dataset for integer SF values such as 2, 5, and 10. Keep
+      predicate-bearing values unchanged. Record source dataset_version,
+      replica factor, builder version, seed if any, and per-table checksums in
+      the derived manifest.
+
+  - id: w4
+    summary: "Validate replicated cardinalities and predicate preservation"
+    needs: [w3]
+    status: pending
+    notes: |
+      Validate:
+        - FK integrity,
+        - row counts scale as expected,
+        - predicate-domain frequencies scale as expected for fixed values,
+        - null counts scale for replicated tables and remain unchanged for
+          lookup tables,
+        - fixed 113-query result cardinalities are either N times canonical
+          or explicitly documented exceptions.
+      Use the canonical oracle artifacts from joinorder-canonical-dataset-contract.
+
+  - id: w5
+    summary: "Run a narrow scale-stress comparison on local engines"
+    needs: [w4]
+    status: pending
+    notes: |
+      Run a narrow matrix, likely DuckDB and PostgreSQL first, at canonical SF=1
+      and replicated SF=2. Capture load time, stats/analyze time, planning time,
+      execution time, plan shape, and cardinality estimates where available.
+      This is a measurement smoke, not a leaderboard.
+
+  - id: w6
+    summary: "Write the prototype evaluation and decide whether to continue"
+    needs: [w5]
+    status: pending
+    notes: |
+      Write `_project/decisions/joinorder-replicated-imdb-prototype-<date>.md`.
+      It must answer:
+        - Does replicated_imdb reveal useful stats or physical-scale behavior?
+        - Does replication introduce artifacts too large to accept?
+        - Should BenchBox keep it as a derived baseline?
+        - Should the next step be expanded_imdb graph generation,
+          parameterized queries, or no further scale work?
+
+deferred:
+  - summary: "Profiled graph-expanded IMDB generator"
+    reason: "Only worth implementing after replicated_imdb establishes baseline measurements and gaps."
+  - summary: "Public result explorer support for replicated_imdb cohorts"
+    reason: "Explorer work depends on final result-bundle metadata and prototype evaluation."
+  - summary: "Cloud/distributed platform scale-stress matrix"
+    reason: "Start local to validate semantics and measurement before spending cloud resources."
+
+must_preserve:
+  - "Canonical joinorder remains SF=1 canonical_imdb and literature-comparable only."
+  - "replicated_imdb result bundles record source canonical dataset_version and derived manifest hash."
+  - "Predicate-bearing values must not be suffixed or mutated in the replicated baseline."
+  - "Lookup tables must not be duplicated unless the schema contract explicitly requires it."
+
+approach: |
+  Implement this as a derived archive builder, not by teaching canonical
+  JoinOrderGenerator to synthesize larger data. Keep the implementation
+  deterministic and manifest-driven. Use the canonical oracle to prove expected
+  query/cardinality scaling before interpreting engine performance.
+
+anti_patterns:
+  - "DO NOT suffix predicate string values to make rows unique - because JOB predicates depend on exact values - offset IDs instead."
+  - "DO NOT duplicate lookup tables by default - because lookup predicates should remain stable and FKs can point to the same lookup rows - keep lookup tables single-copy."
+  - "DO NOT publish replicated_imdb results as canonical JOB - because replicated components are an artificial derived scale mode - label result bundles accordingly."
+  - "DO NOT run expensive cloud matrices during the prototype - because the first gate is semantic validity and local measurement - defer cloud until w6 approves continuation."
+
+verification:
+  - description: "Prototype keeps TODO graph valid"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passed"
+  - description: "This item validates individually"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+    expected_output: "is valid"
+  - description: "Prototype evaluation exists before this TODO completes"
+    command: "ls _project/decisions/joinorder-replicated-imdb-prototype-*.md"
+    expected_output: "at least one prototype evaluation note"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/joinorder/"
+    - "benchbox/cli/"
+    - "tests/unit/core/joinorder/"
+    - "tests/integration/"
+    - "docs/benchmarks/join-order.md"
+    - "_project/decisions/joinorder-replicated-imdb-prototype-*.md"
+    - "_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+  do_not_modify:
+    - "results-data/bundles/"
+    - "results-explorer/"
+    - "benchbox/core/tpch/"
+    - "benchbox/core/tpcds/"
+
+success_metrics:
+  - "A deterministic replicated_imdb archive builder exists behind an explicit derived scale mode."
+  - "Derived manifests record source dataset_version, scale factor, builder version, and per-table checksums."
+  - "FK integrity, null-count scaling, predicate frequency scaling, and query cardinality scaling are validated."
+  - "A local SF=1 vs SF=2 measurement report separates load, stats, planning, and execution time."
+  - "The final decision note either approves continuation to expanded_imdb or explains why replicated_imdb is not useful enough."
+
+metadata:
+  tags:
+    - joinorder
+    - replicated-imdb
+    - job-scale-stress
+    - optimizer-statistics
+    - prototype
+  estimated_effort: "Large"
+  created_date: "2026-05-09"
+
+research_value:
+  hypothesis: |
+    Offset replication is not a realistic "IMDb got larger" model, but it may
+    still provide a useful baseline for statistics-build cost, optimizer
+    planning behavior, and physical execution thresholds while preserving
+    canonical within-replica predicate correlations.
+  validation_approach: |
+    Compare canonical SF=1 to replicated SF=2 on local engines with reference
+    cardinalities, stats/analyze timing, plan-shape summaries, and execution
+    telemetry.
+  success_criteria: |
+    The prototype is worth keeping only if it produces interpretable scale
+    stress measurements without confusing users about canonical JOB
+    comparability.
+
+impact:
+  business_value: |
+    Provides a low-risk first scale-stress baseline while protecting canonical
+    JOB semantics and result comparability.
+  technical_debt: |
+    Forces derived-scale metadata, validation, and phase timing to exist before
+    BenchBox invests in a more complex expanded-IMDB generator.

--- a/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
+++ b/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
@@ -1,0 +1,222 @@
+id: joinorder-scale-stress-decision-framework
+title: "Design the JOB scale-stress benchmark decision framework"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Benchmark Development
+
+description: |
+  Define whether and how BenchBox should add a scaled JOB-derived benchmark for
+  evaluating the interplay of optimizer statistics maintenance, predicate
+  selectivity, cardinality estimation, planning limits, and physical execution
+  thresholds at large data scales.
+
+  This item is deliberately a decision framework, not an implementation. It
+  should conclude with a recommendation on which scale-up path, if any, is worth
+  prototyping after canonical JOB has a reliable dataset contract and oracle.
+
+deps:
+  needs:
+    - joinorder-canonical-dataset-contract
+
+context_sections:
+  "Benchmark identity": |
+    Canonical JOB evaluates optimizer/cardinality behavior on a fixed real
+    correlated dataset. A scaled JOB-derived workload evaluates a related but
+    different question: how optimizers behave as correlated predicates and join
+    graphs grow past statistics, sampling, planning-time, memory, and
+    distributed-execution thresholds.
+  "Required distinction": |
+    Any scale-up must be labeled derived, for example job_scale_stress,
+    replicated_imdb, expanded_imdb, or parameterized_imdb. It must not publish
+    as canonical joinorder and must not claim literature comparability.
+
+work:
+  - id: w1
+    summary: "Write the benchmark question and non-goals"
+    status: pending
+    notes: |
+      Produce a short decision note that separates:
+        - canonical JOB comparability,
+        - physical scale stress,
+        - statistics maintenance stress,
+        - predicate selectivity drift,
+        - optimizer search/planning-time limits,
+        - distributed skew and spill behavior.
+      Explicitly state that scaled JOB-derived results are not canonical JOB
+      results.
+
+  - id: w2
+    summary: "Define scale semantics and workload labels"
+    needs: [w1]
+    status: pending
+    notes: |
+      Decide whether scale factor means total rows, title count, all major
+      entity classes, bytes, or expected query cardinality. Define labels and
+      result-bundle fields for at least:
+        - canonical_imdb
+        - replicated_imdb
+        - expanded_imdb
+        - parameterized_imdb
+        - synthetic_schema
+      Document how each label affects comparability and publication.
+
+  - id: w3
+    summary: "Specify statistics-maintenance phases and measurements"
+    needs: [w1]
+    status: pending
+    notes: |
+      Decide whether BenchBox needs a first-class stats/analyze phase before
+      scale-stress work can be meaningful. The decision must cover:
+        - no/default stats,
+        - fresh sampled stats,
+        - fresh full or high-quality stats where supported,
+        - stale stats after loading additional scale,
+        - incremental or partition stats where supported.
+      Measurements should keep load, stats-build, planning, and execution time
+      separate. Capture engine-specific stats metadata where available.
+
+  - id: w4
+    summary: "Compare scale-up implementation options"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Compare at least these options:
+        - offset replication of canonical IMDB,
+        - predicate-preserving augmentation,
+        - profiled graph expansion,
+        - parameterized JOB-like query generation,
+        - newer real IMDb snapshot if legally and technically viable.
+      For each option, evaluate correlation fidelity, implementation cost,
+      validation oracle availability, statistics-stress usefulness, and risk of
+      misleading users.
+
+  - id: w5
+    summary: "Define validation gates for any scaled JOB-derived workload"
+    needs: [w4]
+    status: pending
+    notes: |
+      The validation gate must include:
+        - FK integrity,
+        - per-table row counts,
+        - predicate-domain frequencies,
+        - per-column null counts,
+        - fixed-query result cardinalities,
+        - pre-aggregate match counts,
+        - important join-subgraph cardinalities,
+        - q-error profile where a reference estimator or engine output exists,
+        - plan shape and planning-time summaries.
+      Non-empty checks are explicitly insufficient.
+
+  - id: w6
+    summary: "Decide fixed 113 queries versus parameterized JOB-like queries"
+    needs: [w5]
+    status: pending
+    notes: |
+      Decide whether the first scaled workload should:
+        - keep the fixed 113 JOB queries and study what happens as the database
+          grows around those fixed literals, or
+        - generate parameterized JOB-like queries whose predicates are sampled
+          from the scaled graph.
+      If both are useful, define separate result labels and do not mix them in
+      one leaderboard/cohort.
+
+  - id: w7
+    summary: "Produce a go/no-go recommendation and prototype scope"
+    needs: [w6]
+    status: pending
+    notes: |
+      End with a written recommendation:
+        - no scaled JOB for now,
+        - replicated_imdb baseline only,
+        - expanded_imdb research prototype,
+        - parameterized_imdb benchmark family,
+        - or staged combination.
+      The recommendation must name the smallest next prototype and its
+      verification criteria.
+
+deferred:
+  - summary: "Implement any scaled JOB generator"
+    reason: "This item is the decision framework. Implementation belongs in a follow-up TODO after w7 chooses a path."
+  - summary: "Build dashboard/explorer UI for scale-stress metrics"
+    reason: "Explorer work depends on final result-bundle fields and benchmark labels."
+
+must_preserve:
+  - "Canonical joinorder remains fixed to canonical_imdb SF=1 and is never silently replaced by derived scale modes."
+  - "Derived workloads must report their data-generation strategy, dataset version, generator version, seed, and stats protocol."
+  - "Query validation must use the canonical oracle contract from joinorder-canonical-dataset-contract when applicable."
+
+approach: |
+  Treat this as an architecture/design gate. Read canonical JOB behavior, TPC-DS
+  compliance labeling, result-bundle metadata, runner phase handling, and
+  platform stats/analyze support before recommending implementation. The output
+  should be a decision record plus an updated TODO for the chosen prototype.
+
+anti_patterns:
+  - "DO NOT call a scaled derived workload 'JOB' without a qualifier - because users may assume literature comparability - use explicit labels such as replicated_imdb or job_scale_stress."
+  - "DO NOT choose offset replication only because it is easiest - because it may hide the statistics/predicate-selectivity problem - evaluate whether it answers the benchmark question."
+  - "DO NOT build graph expansion before defining validation gates - because synthetic correlations can look plausible while destroying the JOB signal - define measurement gates first."
+  - "DO NOT fold stats-build timing into load or query execution - because the core research question includes statistics maintenance - require separate stats/analyze phase accounting."
+
+verification:
+  - description: "Decision note exists and names the recommended prototype path"
+    command: "ls _project/decisions/joinorder-scale-stress-*.md"
+    expected_output: "at least one decision note"
+  - description: "TODO graph remains valid"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passed"
+  - description: "This item validates individually"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml"
+    expected_output: "is valid"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/joinorder-scale-stress-*.md"
+    - "_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml"
+    - "_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+    - "docs/benchmarks/join-order.md"
+    - "docs/development/"
+  do_not_modify:
+    - "benchbox/core/joinorder/"
+    - "benchbox/cli/"
+    - "results-data/bundles/"
+    - "results-explorer/"
+
+success_metrics:
+  - "The benchmark question for scale-stress JOB is written and clearly separated from canonical JOB."
+  - "Scale-mode labels and result-bundle metadata are specified."
+  - "Statistics-maintenance phases and required timings are specified."
+  - "A go/no-go recommendation selects the smallest next prototype and rejects at least one unsuitable option with rationale."
+
+metadata:
+  tags:
+    - joinorder
+    - job-scale-stress
+    - optimizer-statistics
+    - benchmark-design
+    - issue-289
+  estimated_effort: "Medium"
+  created_date: "2026-05-09"
+
+research_value:
+  hypothesis: |
+    A JOB-derived scaled benchmark can expose optimizer failures that are
+    adjacent to, but distinct from, canonical JOB: statistics maintenance,
+    stale or sampled stats, planning-time limits, and physical-plan threshold
+    behavior under correlated predicate selectivity.
+  validation_approach: |
+    Compare scale-up strategies against canonical oracle artifacts and collect
+    cardinality, q-error, plan-shape, stats-time, and execution telemetry before
+    choosing an implementation path.
+  success_criteria: |
+    The chosen prototype has a clear workload identity, validation oracle,
+    scale semantics, and stats protocol. If those cannot be defined, scaled JOB
+    is deferred rather than shipped ambiguously.
+
+impact:
+  business_value: |
+    Creates a disciplined path for a valuable optimizer-stress benchmark without
+    diluting canonical JOB or publishing misleading results.
+  technical_debt: |
+    Prevents a second round of benchmark-validity debt by forcing scale
+    semantics, statistics phases, and validation gates before implementation.


### PR DESCRIPTION
## Summary

- Add a guarded TODO for the JOB canonical dataset contract and result oracle work.
- Add a decision-framework TODO for whether scaled JOB is useful and what it should measure.
- Add a gated prototype TODO for a replicated/derived IMDb scale-up experiment.

## Verification

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py cleanup --dry-run`
- `git diff --cached --check`
- Commit hooks: codespell, check yaml, end-of-file, trim whitespace, added large files, merge conflict, private key
- Push hooks: timing policy fast-lane collect, pr-preflight fast tests
