### PR TITLE
chore(todo): plan Step 1 for issue #289 — joinorder canonical IMDb 2013

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
@@ -1,0 +1,581 @@
+id: joinorder-canonical-cutover
+title: "joinorder canonical IMDb 2013 — Code wiring, queries, docs, ship (Step 1, part 2 of 2)"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Step 1 of the dual-track JOB strategy for issue #289
+  (https://github.com/joeharris76/BenchBox/issues/289). Part 2 of 2.
+  Consumes artifacts from `joinorder-canonical-foundation` and lands
+  the user-visible cutover in a single PR against `develop`.
+
+  This TODO does five things in order:
+    1. Wires `joinorder` to canonical IMDb 2013 Parquet via the
+       reusable data_fetch infrastructure produced by the foundation TODO.
+    2. Renames the existing synthetic generator to `joinorder_synthetic`
+       and registers it with `surface: internal` so it is hidden from
+       the result explorer (per Joe's constraint: must not be visible).
+    3. Adds the 100 missing SQL queries to bring coverage to canonical
+       113. DataFrame mode stays at 13 (Track-2 follow-up TODO seeded).
+    4. Updates documentation, ships DATA-LICENSE.md, migrates existing
+       published bundles, lands CHANGELOG entry.
+    5. Promotes the DRAFT GitHub Release to published, runs UAT smoke
+       on at least 2 platforms, opens PR.
+
+  Decisions locked in (from planning, repeated for context):
+    - Hard rename: `joinorder` invocations targeting the synthetic
+      generator break with a clear error pointing at `joinorder_synthetic`.
+      Beta-appropriate; clean break.
+    - Existing 10 published bundles re-tagged in place
+      (joinorder_sf1_* → joinorder_synthetic_sf1_*); explorer filter
+      hides them via the `surface: internal` registry field. No UI
+      changes.
+    - Auto-download UX: silent first-run with progress bar; license
+      surfaced in DATA-LICENSE.md and `--help`, NOT a click-through.
+    - SQL coverage to all 113; DataFrame stays at 13.
+    - Bundle migration is in-PR (atomic with the surface-field change).
+
+deps:
+  needs:
+    - joinorder-canonical-foundation
+
+work:
+  - id: w1
+    summary: "Wire joinorder benchmark to canonical Parquet ingestion via data_fetch"
+    status: pending
+    notes: |
+      File: `benchbox/core/joinorder/benchmark.py`
+      Replace generator-based ingestion with:
+        from benchbox.core.data_fetch import fetch_data
+        data_dir = fetch_data("joinorder", registry, override_path=cli.data_path)
+        # 21 Parquet files at known paths under data_dir
+        for table in TABLES:
+          platform.load_parquet(table, data_dir / f"{table}.parquet")
+
+      Add `--data-path` CLI flag (and `BENCHBOX_DATA_PATH_JOINORDER`
+      env var) to the run_benchmark entry points (CLI and MCP). Both
+      bypass the auto-download path and read 21 Parquets from the
+      user-supplied directory.
+
+      Update DataFrame queries (`benchbox/core/joinorder/dataframe_queries.py`)
+      to read Parquet directly via `ctx.read_parquet(...)`. The 13
+      existing translations work as-is on canonical data because
+      they were schema-correct; only data source changes.
+
+  - id: w2
+    summary: "Rename synthetic generator → `joinorder_synthetic` (separate module, surface: internal)"
+    status: pending
+    notes: |
+      Move (with `git mv` to preserve history):
+        benchbox/core/joinorder/generator.py
+          → benchbox/core/joinorder_synthetic/generator.py
+        benchbox/core/joinorder/queries.py
+          (the 13 currently embedded queries — keep these AS the
+           synthetic surface's query set since canonical 113 lives
+           on joinorder)
+          → benchbox/core/joinorder_synthetic/queries.py
+        benchbox/core/joinorder/dataframe_queries.py
+          (synthetic-shape DataFrame queries — kept for
+           joinorder_synthetic surface)
+          → benchbox/core/joinorder_synthetic/dataframe_queries.py
+        benchbox/core/joinorder/benchmark.py (synthetic-only logic)
+          → benchbox/core/joinorder_synthetic/benchmark.py
+          (then split — canonical version stays at original path,
+           synthetic version moves to new module)
+
+      Register `joinorder_synthetic` in `benchbox/core/benchmark_registry.py`:
+        "joinorder_synthetic": {
+          "scale_options": [0.01, 0.1, 0.5, 1.0, 2.0, ...],
+          "default_scale": 1.0,
+          "surface": "internal",   # hidden from explorer
+          "data_source": "synthetic",
+        }
+      And update joinorder entry to:
+        "joinorder": {
+          "scale_options": [1.0],
+          "default_scale": 1.0,
+          "surface": "public",
+          "data_source": "canonical",
+          "data_manifest": "benchbox/core/joinorder/data_manifest.toml",
+        }
+
+      Update generator docstring to retract fidelity claims:
+        Replace: "creates realistic synthetic data that preserves
+                  the join patterns and selectivity characteristics"
+        With:    "creates synthetic data with uniformly-random
+                  distributions for joinorder schema smoke testing
+                  only. NOT a substitute for canonical JOB — see
+                  benchbox/core/joinorder/ for the canonical
+                  IMDb 2013 implementation."
+
+  - id: w3
+    summary: "Migrate three speed-sensitive tests to use joinorder_synthetic at sf=0.01"
+    status: pending
+    needs: [w2]
+    notes: |
+      Affected tests use `JoinOrderGenerator(scale_factor=0.01)` for
+      log-capture speed (not semantics):
+        tests/unit/core/test_core_verbosity.py:15
+        tests/unit/core/test_core_verbosity.py:26
+        tests/unit/core/test_core_quiet.py:15
+
+      Update each to import from `benchbox.core.joinorder_synthetic`
+      instead of `benchbox.core.joinorder`. No semantic change to
+      the tests; they exercise the verbosity/quiet machinery, not
+      the data.
+
+      Also move generator unit tests:
+        tests/unit/core/joinorder/test_joinorder_generator.py
+          → tests/unit/core/joinorder_synthetic/test_joinorder_generator.py
+        tests/unit/core/joinorder/test_dataframe_queries.py
+          (the synthetic-13-query test)
+          → tests/unit/core/joinorder_synthetic/test_dataframe_queries.py
+
+  - id: w4
+    summary: "Add tiny canonical fixture loader for unit tests"
+    status: pending
+    needs: [w1]
+    notes: |
+      The foundation TODO checked in `tests/fixtures/joinorder_canonical_tiny/`
+      with 21 Parquets. This work unit adds the test helper:
+        tests/conftest.py:
+          @pytest.fixture
+          def joinorder_canonical_tiny(tmp_path):
+            # copy fixture to tmp, return path
+            ...
+
+      Document the fixture's predicate-satisfying property: every
+      embedded canonical query returns >=1 row against this fixture.
+
+  - id: w5
+    summary: "Add unit test: canonical queries return non-zero against tiny fixture"
+    status: pending
+    needs: [w4, w7]
+    notes: |
+      File: `tests/unit/core/joinorder/test_canonical_queries.py`
+
+      For each of 113 canonical JOB queries:
+        - Load tiny fixture into DuckDB
+        - Run query, assert row count >= 1
+        - Cross-check row count against
+          `_project/joinorder/reference_cardinalities.json`'s tiny
+          fixture entries (NB: foundation TODO produced reference
+          cardinalities for full canonical; this test uses a separate
+          tiny-fixture cardinalities file with the same schema —
+          generated by the foundation TODO's tiny-fixture build step).
+
+      This is the validator Joe asked for: "ensure all queries
+      actually work."
+
+  - id: w6
+    summary: "Add 100 missing SQL queries; bring joinorder canonical coverage to 113"
+    status: pending
+    needs: [w1]
+    notes: |
+      Source: gregrahn/join-order-benchmark canonical 113 queries
+      (1a-33c). The 13 currently embedded queries are kept on the
+      `joinorder_synthetic` side (w2) — `joinorder` gets the full
+      canonical 113.
+
+      File: `benchbox/core/joinorder/queries.py`
+      Structure: dict keyed by canonical query id (e.g., "1a", "33c");
+      values are SQL strings or per-dialect translations.
+
+      Per-engine dialect handling:
+        - DuckDB: most queries work as-is (ANSI-compliant)
+        - PostgreSQL: all work as-is (the source dialect)
+        - Other engines: route through existing dialect translator;
+          flag any failures as per-engine follow-up TODOs (NOT in
+          scope of this TODO unless they block UAT smoke)
+
+      Test: `tests/unit/core/joinorder/test_query_coverage.py`
+        - Assert 113 queries registered
+        - Assert canonical id format (e.g., regex ^\d+[a-z]$)
+
+  - id: w7
+    summary: "DataFrame mode: explicit NotImplementedError for the 100 untranslated queries; seed Track-2 TODO"
+    status: pending
+    needs: [w1, w6]
+    notes: |
+      File: `benchbox/core/joinorder/dataframe_queries.py`
+
+      For each of the 100 queries not yet DataFrame-translated:
+        def query_<id>(ctx):
+            raise NotImplementedError(
+              f"DataFrame translation for query {id} not yet "
+              f"available. Track-2 TODO: "
+              f"_project/TODO/main/planning/track2-joinorder-dataframe-coverage.md"
+            )
+
+      Seed the follow-up TODO file (no detailed work plan yet — that
+      is the Track-2 groundwork TODO's job):
+        _project/TODO/main/planning/track2-joinorder-dataframe-coverage.yaml
+        (status: Identified, priority: Medium, summary only)
+
+  - id: w8
+    summary: "Wire dataset_version into result bundle manifests"
+    status: pending
+    needs: [w1]
+    notes: |
+      File: `benchbox/core/publishing/bundle_publisher.py:176-177`
+
+      Add `dataset_version` field to bundle manifest:
+        - For benchmarks with `data_manifest`: sha256 of the
+          data_manifest.toml file
+        - For purely-generated benchmarks (tpch, tpcds): null
+
+      Bundle reader: surface for forensic comparison only — NO
+      explorer UI changes (per Joe's constraint).
+
+      Test: `tests/unit/core/publishing/test_dataset_version_field.py`
+        - joinorder bundles record correct dataset_version
+        - tpch bundles record null dataset_version
+
+  - id: w9
+    summary: "Write DATA-LICENSE.md for joinorder (reusable per-benchmark template)"
+    status: pending
+    needs: [w1]
+    notes: |
+      File: `benchbox/core/joinorder/DATA-LICENSE.md`
+
+      Sections (template shape, reusable for future benchmarks):
+        1. Dataset provenance: Harvard Dataverse DOI:10.7910/DVN/2QYZBT,
+           May 2013 IMDb plain-text "list files" snapshot, parsed via
+           imdbpy into 21-table relational schema, converted to Parquet
+           by BenchBox.
+        2. IMDb attribution string verbatim:
+           "Information courtesy of IMDb (https://www.imdb.com).
+            Used with permission."
+        3. Boncz-style scope clause (research/optimizer use only).
+        4. BenchBox redistribution disclaimer:
+           "BenchBox redistributes a derivative form of this dataset
+            as a convenience for benchmark reproducibility. BenchBox
+            makes no claim of ownership over the underlying IMDb
+            data and will honor takedown requests."
+        5. Takedown contact: <email TBD by Joe before publish>.
+
+      Document the template shape in
+      `_project/design/data-fetch-infra-reuse-guide.md` (foundation TODO
+      created the file; this work unit fills the DATA-LICENSE template
+      section).
+
+  - id: w10
+    summary: "Update documentation: README, docs/benchmarks/join-order.md, MCP/CLI help"
+    status: pending
+    needs: [w2, w9]
+    notes: |
+      Files:
+        - README.md: clarify joinorder = canonical IMDb 2013, one-time
+          ~1.2 GB download, sf=1 only, mention `--data-path` opt-out
+        - docs/benchmarks/join-order.md: full rewrite — retract
+          "realistic data distributions / preserving join characteristics";
+          new flow; sf=1 explanation; citation; license; --data-path
+        - benchbox/core/joinorder_synthetic/generator.py docstring:
+          retract fidelity claims (already done in w2); link to
+          canonical joinorder
+        - benchbox/mcp/tools/benchmark.py:140-174: run_benchmark
+          docstring mentions sf=1 enforcement for joinorder + first-run
+          download
+        - CLI help text in run_benchmark equivalent
+
+  - id: w11
+    summary: "Migrate existing 10 published bundles: rename joinorder_sf1_* → joinorder_synthetic_sf1_*"
+    status: pending
+    needs: [w2, w8]
+    notes: |
+      Script: `_project/scripts/migrate_joinorder_bundles.py`
+
+      For each `results-data/bundles/joinorder_sf1_*`:
+        - `git mv` directory to `joinorder_synthetic_sf1_*`
+        - Update bundle manifest:
+            benchmark_id: joinorder → joinorder_synthetic
+            (preserve all other metadata)
+        - Bump bundle schema version if applicable
+
+      Since `joinorder_synthetic` has `surface: internal` (w2), these
+      bundles are filtered out of the explorer view at the
+      result-publisher layer — no explorer UI changes needed.
+
+      Run the script as part of this TODO's commits; commit the
+      renamed bundles in a single commit titled
+      `chore(joinorder): re-tag synthetic results bundles`.
+
+  - id: w12
+    summary: "CHANGELOG entry"
+    status: pending
+    needs: [w10, w11]
+    notes: |
+      File: `CHANGELOG.md`
+
+      Entry shape (under next unreleased version):
+        ### Breaking
+        - `joinorder` benchmark now uses canonical IMDb 2013 Parquet
+          archive (sf=1 only). First-run downloads ~1.2 GB from
+          GitHub Release. Use `--data-path` for air-gapped environments.
+          (#289)
+        - The previous uniformly-random synthetic generator has been
+          renamed to `joinorder_synthetic` and is internal-only
+          (hidden from result explorer).
+        - Existing `joinorder_sf1_*` published bundles have been
+          re-tagged as `joinorder_synthetic_sf1_*` to reflect their
+          actual provenance.
+
+        ### Added
+        - Reusable `benchbox.core.data_fetch` infrastructure for
+          benchmarks with canonical real-world datasets.
+        - DATA-LICENSE.md per benchmark for real-data provenance.
+        - Reference cardinalities for all 113 canonical JOB queries.
+
+      Per Joe's preference: terse user-facing bullets; no
+      retrospective edits to prior releases.
+
+  - id: w13
+    summary: "Pre-flight + UAT smoke on DuckDB + 1 other engine end-to-end"
+    status: pending
+    needs: [w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12]
+    notes: |
+      Pre-flight:
+        make pr-preflight
+
+      UAT smoke (full canonical joinorder, sf=1, end-to-end):
+        make uat-cell PLATFORM=duckdb BENCHMARK=joinorder SCALE=1
+        make uat-cell PLATFORM=<second_engine> BENCHMARK=joinorder SCALE=1
+
+      Second engine choice: pick from already-supported list with
+      Parquet ingestion (e.g., starrocks, spark, clickhouse-local).
+      The choice doesn't matter for cutover correctness as long as
+      one non-DuckDB engine succeeds end-to-end.
+
+      Verify:
+        - data_fetch downloads from DRAFT Release URL (with auth
+          token; the URL is fetchable while draft)
+        - All 113 SQL queries execute and produce non-zero results
+        - Result bundle records correct dataset_version
+        - Cardinalities match reference_cardinalities.json on full
+          canonical (key gate before publishing)
+
+  - id: w14
+    summary: "Promote DRAFT GitHub Release to published"
+    status: pending
+    needs: [w13]
+    notes: |
+      Only after UAT smoke passes:
+        gh release edit data/joinorder-imdb-2013-v1 --draft=false
+
+      Verify the asset is publicly downloadable without auth:
+        curl -sSL --head <release-asset-url> | head -1
+        # expect: HTTP/2 200
+
+      Update `benchbox/core/joinorder/data_manifest.toml` if the
+      published URL differs from the draft URL (it shouldn't, but
+      verify).
+
+  - id: w15
+    summary: "Open PR via make pr-open"
+    status: pending
+    needs: [w14]
+    notes: |
+      make pr-open
+
+      PR title: "feat(joinorder): canonical IMDb 2013 dataset; rename synthetic"
+
+      PR body sections (use HEREDOC):
+        ## Summary
+        - Closes #289
+        - `joinorder` now uses canonical IMDb 2013 Parquet
+          (sf=1 only; first-run downloads from GitHub Release)
+        - Synthetic generator renamed to `joinorder_synthetic`,
+          hidden from explorer (surface: internal)
+        - SQL coverage extended from 13 → 113 canonical queries
+        - Reusable data_fetch infrastructure added
+
+        ## Breaking
+        - User scripts invoking joinorder at sf!=1 will fail with
+          ScaleFactorNotSupportedError pointing at joinorder_synthetic
+        - Existing joinorder_sf1_* bundles re-tagged
+
+        ## Test plan
+        - [x] make pr-preflight
+        - [x] UAT smoke: DuckDB joinorder sf=1 end-to-end
+        - [x] UAT smoke: <second engine> joinorder sf=1 end-to-end
+        - [x] All 113 query reference cardinalities match
+              against full canonical via Postgres oracle
+        - [x] Tiny fixture covers all 113 query predicates
+
+verification:
+  - description: "joinorder rejects sf!=1 with a clear error"
+    command: "uv run -- python -m pytest tests/unit/core/test_scale_factor_validation.py::test_joinorder_rejects_non_unit_scale -q"
+    expected_output: "1 passed"
+  - description: "joinorder_synthetic accepts sf=0.01 (back-compat for verbosity tests)"
+    command: "uv run -- python -m pytest tests/unit/core/test_core_verbosity.py tests/unit/core/test_core_quiet.py -q"
+    expected_output: "all 3 tests pass"
+  - description: "All 113 SQL queries registered for joinorder"
+    command: "uv run -- python -c 'from benchbox.core.joinorder.queries import QUERY_TEMPLATES; print(len(QUERY_TEMPLATES))'"
+    expected_output: "113"
+  - description: "Tiny fixture predicate-satisfies all 113 queries"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder/test_canonical_queries.py -q"
+    expected_output: "113 passed"
+  - description: "DataFrame queries fail loudly for the 100 untranslated"
+    command: "uv run -- python -c 'from benchbox.core.joinorder.dataframe_queries import query_2a; query_2a(None)' 2>&1 | grep -c 'NotImplementedError\\|track2-joinorder-dataframe-coverage'"
+    expected_output: ">= 1"
+  - description: "joinorder_synthetic is hidden from the result-publisher's public surface"
+    command: "uv run -- python -m pytest tests/unit/core/test_registry_surface_field.py::test_joinorder_synthetic_hidden -q"
+    expected_output: "1 passed"
+  - description: "Bundle migration completed: no joinorder_sf1_* directories remain"
+    command: "ls results-data/bundles/ | grep -c '^joinorder_sf1_'"
+    expected_output: "0"
+  - description: "Bundle migration: 10 joinorder_synthetic_sf1_* directories present"
+    command: "ls results-data/bundles/ | grep -c '^joinorder_synthetic_sf1_'"
+    expected_output: "10"
+  - description: "DATA-LICENSE.md exists for joinorder with required sections"
+    command: "test -f benchbox/core/joinorder/DATA-LICENSE.md && grep -cE 'Information courtesy of IMDb|takedown|Harvard Dataverse|10\\.7910/DVN/2QYZBT' benchbox/core/joinorder/DATA-LICENSE.md"
+    expected_output: ">= 4"
+  - description: "Result bundle manifests record dataset_version for joinorder; null for tpch"
+    command: "uv run -- python -m pytest tests/unit/core/publishing/test_dataset_version_field.py -q"
+    expected_output: "all tests pass"
+  - description: "GitHub Release is published (not draft)"
+    command: "gh release view data/joinorder-imdb-2013-v1 --json isDraft --jq .isDraft"
+    expected_output: "false"
+  - description: "Release asset is publicly downloadable"
+    command: "curl -sSL -o /dev/null -w '%{http_code}' \"$(gh release view data/joinorder-imdb-2013-v1 --json assets --jq '.assets[0].url')\""
+    expected_output: "200"
+  - description: "PR opened against develop with #289 reference"
+    command: "gh pr list --base develop --head chore/joinorder-canonical-cutover --json title,body --jq '.[] | select(.body | contains(\"#289\")) | .title'"
+    expected_output: "feat(joinorder)..."
+
+must_preserve:
+  - "Existing joinorder bundle filenames in published-results branch — those are on the published-results branch, NOT touched here; this TODO only re-tags bundles in the develop tree's results-data/bundles/"
+  - "DataFrame mode for the 13 already-translated queries — they continue to work on canonical data because they are schema-correct"
+  - "Other benchmarks (tpch, tpcds, etc.) — no behavior change; their scale_options remain unchanged"
+  - "MCP run_benchmark API signature — adding --data-path / env var must be additive only"
+  - "Result-explorer UI — zero changes; the surface: internal field filters at data layer only"
+  - "Existing test suite at fast tier — runs in same time bounds (verbosity tests now hit joinorder_synthetic which generates at sf=0.01 just as before)"
+
+approach: |
+  This TODO is the visible cutover. The foundation TODO did the
+  invisible work; here we land everything in one PR so users see a
+  coherent change.
+
+  Sequence rationale:
+    1. w1 (wire) is independent foundation; do first
+    2. w2 (rename) is the schema change; do early so subsequent
+       work units can target the new structure
+    3. w3-w8 are all parallelizable after w1+w2
+    4. w9 (DATA-LICENSE) and w10 (docs) come after the structure
+       settles
+    5. w11 (bundle migration) is mechanical; do once w2 lands
+    6. w12 (CHANGELOG) requires the full picture
+    7. w13 (UAT smoke) gates everything visible
+    8. w14 (promote Release) is a one-liner; gate on UAT
+    9. w15 (open PR) closes the work
+
+  Critical detail: the GitHub Release stays DRAFT until UAT
+  passes. If UAT reveals a bug in the data or pipeline that
+  requires rebuilding the archive, we don't have a public bad
+  version to retract — we just rebuild and re-stage the draft.
+  Promotion is a deliberate gate, not a side-effect.
+
+  Per Joe's CLAUDE.md: write work on a worktree ends at make pr-open,
+  not at git push. This TODO ends at w15 (PR open); reviewing /
+  merging the PR is a separate action.
+
+anti_patterns:
+  - "DO NOT skip the UAT smoke before promoting the GitHub Release — because once the URL is public, retraction is messy and confusing for any user who downloaded during the window — the draft-then-promote sequence is the gate"
+  - "DO NOT add UI changes to the result explorer to hide synthetic bundles — because Joe explicitly said no explorer complexity — the surface: internal registry field filters at the result-publisher layer; explorer reads only filtered data"
+  - "DO NOT translate the 100 missing DataFrame queries in this TODO — because that is significant scope and not required by issue #289 (SQL is the canonical surface) — file Track-2 follow-up TODO instead"
+  - "DO NOT add a click-through license acceptance — because this matches no other JOB ecosystem mirror (gregrahn, CWI, CedarDB) and adds friction without legal upside — DATA-LICENSE.md is sufficient"
+  - "DO NOT amend the existing joinorder bundles' source data hashes when re-tagging — because those bundles' results are bound to the synthetic data they were run against; re-tagging only changes the directory name and benchmark_id field — the original data hash stays for forensic value"
+  - "DO NOT run UAT smoke against ClickHouse-Cloud or other paid tiers — because the cost is not justified for Step 1; DuckDB + one OSS engine is sufficient — paid platform fallout (if any) is a follow-up"
+  - "DO NOT publish the Release without verifying takedown contact email is in DATA-LICENSE.md — because that is the BenchBox-side commitment to the license posture and must be reachable — verify in w14 before promotion"
+  - "DO NOT rebuild the canonical archive in this TODO — because the foundation TODO already did the build with provenance — only the URL pointer changes (draft → published)"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/joinorder/benchmark.py"
+    - "benchbox/core/joinorder/queries.py (new content: 113 queries)"
+    - "benchbox/core/joinorder/dataframe_queries.py (NotImplementedError stubs for 100)"
+    - "benchbox/core/joinorder/DATA-LICENSE.md (new)"
+    - "benchbox/core/joinorder_synthetic/ (new module — receives moved files via git mv)"
+    - "benchbox/core/benchmark_registry.py (joinorder + joinorder_synthetic entries)"
+    - "benchbox/core/publishing/bundle_publisher.py (dataset_version field)"
+    - "benchbox/cli/* and benchbox/mcp/tools/benchmark.py (--data-path flag, help text)"
+    - "tests/unit/core/joinorder/ (canonical query coverage test)"
+    - "tests/unit/core/joinorder_synthetic/ (moved synthetic tests)"
+    - "tests/unit/core/test_core_verbosity.py, test_core_quiet.py (3 line changes — synthetic import)"
+    - "tests/unit/core/publishing/test_dataset_version_field.py (new)"
+    - "tests/conftest.py (joinorder_canonical_tiny fixture)"
+    - "results-data/bundles/joinorder_sf1_* → joinorder_synthetic_sf1_* (rename + manifest field)"
+    - "_project/scripts/migrate_joinorder_bundles.py (new)"
+    - "_project/TODO/main/planning/track2-joinorder-dataframe-coverage.yaml (new seed)"
+    - "README.md, CHANGELOG.md, docs/benchmarks/join-order.md"
+    - "_project/design/data-fetch-infra-reuse-guide.md (DATA-LICENSE template section)"
+  do_not_modify:
+    - "benchbox/core/data_fetch/ (foundation TODO finalized this — only consume here)"
+    - "benchbox/core/joinorder/data_manifest.toml (foundation TODO produced; only consume)"
+    - "_project/joinorder/reference_cardinalities.json (foundation TODO produced)"
+    - "tests/fixtures/joinorder_canonical_tiny/ (foundation TODO produced)"
+    - "Any explorer UI / frontend code (zero UI changes per Joe)"
+    - "tests/unit/generators/test_scale_factor_harmonization.py (already pinned to sf=1 for joinorder; no change needed)"
+    - "Other benchmarks' code paths (tpch, tpcds, etc.) — only their registry default `surface: public` is added by the foundation TODO"
+    - "published-results branch (separate branch; bundle re-tagging here is on develop only)"
+
+deferred:
+  - summary: "Translate the 100 missing DataFrame queries"
+    reason: "Track-2 follow-up. Issue #289 is about SQL canonical fidelity; DataFrame parity is a separate axis. Seeded as track2-joinorder-dataframe-coverage."
+  - summary: "Per-engine SQL dialect translation for the 113 queries on non-DuckDB engines"
+    reason: "Engines that fail UAT smoke get per-engine follow-up TODOs. Step 1 ships with DuckDB as reference and at least one OSS engine validated."
+  - summary: "Statistics-as-phase support in benchmark phase model"
+    reason: "Step 2 (Track 2) — see joinorder-track2-groundwork TODO."
+  - summary: "Re-tagging bundles in published-results branch"
+    reason: "The published-results branch is the community submission target; bundle re-tagging there requires a separate PR with curation review. This TODO only renames in develop's results-data/bundles/ tree."
+  - summary: "Removing joinorder_synthetic in a future release"
+    reason: "Decision deferred. Joe stated no specific deprecation contract. Likely retained as Track-2 testbed; remove decision deferred to post-Step-2."
+
+metadata:
+  tags:
+    - joinorder
+    - issue-289
+    - canonical-imdb-2013
+    - cutover
+    - breaking-change
+  estimated_effort: "Large (1-2 weeks for cutover + UAT)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09"
+
+impact:
+  business_value: |
+    Resolves #289. After this PR merges, `joinorder` results in
+    BenchBox are bit-comparable to academic literature. Engines'
+    cardinality-estimation differences become visible (the entire
+    point of JOB). Future Track-2 work on statistics maintenance
+    builds on a meaningful baseline.
+
+    Reusable data_fetch infrastructure (foundation TODO) gets its
+    first user, validating the design for ClickBench / Wikipedia /
+    GitHub Archive follow-on benchmarks.
+  user_impact: |
+    Breaking change for users running `joinorder` at sf!=1: clear
+    error pointing at `joinorder_synthetic`. Otherwise transparent —
+    first run downloads ~1.2 GB silently, subsequent runs cached.
+    `--data-path` opt-out for air-gapped environments.
+  technical_debt: |
+    Eliminates JOB-correctness debt. Establishes patterns
+    (DATA-LICENSE per benchmark, dataset_version in result bundles,
+    surface: internal for hidden benchmarks) that pay forward.
+
+success_metrics:
+  - "PR closes #289 cleanly with passing pre-flight + UAT smoke"
+  - "joinorder canonical fidelity: all 113 queries return non-zero rows on canonical data; row counts match reference cardinalities computed by foundation TODO"
+  - "joinorder_synthetic is registered, runnable, and hidden from result-publisher public surface"
+  - "Existing 10 joinorder_sf1_* bundles successfully re-tagged in develop tree; no orphans"
+  - "Documentation no longer claims synthetic data preserves join characteristics or realistic distributions"
+  - "GitHub Release at data/joinorder-imdb-2013-v1 is published, publicly downloadable, sha256 verified"
+  - "Three speed-sensitive verbosity tests still run at fast-tier speed via joinorder_synthetic"
+  - "Submission terminal state: merged-to-develop"
+
+open_questions:
+  - "Which non-DuckDB engine to use for UAT smoke (w13). Plan: pick from {starrocks, spark, clickhouse-local} based on Parquet ingestion stability at the time of cutover; document choice in PR body."
+  - "If a per-engine SQL dialect surfaces failures on some of the 113 queries, do we ship with partial coverage flagged or block on full coverage? Plan: ship with partial coverage if DuckDB + one OSS engine pass full 113; per-engine gaps become follow-up TODOs."
+  - "Takedown contact email for DATA-LICENSE.md. Plan: Joe to provide before w14 promotion. Default: joeharris76@gmail.com (matches user.email config) unless Joe specifies a project-specific alias."

--- a/_project/TODO/main/planning/joinorder-canonical-foundation.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-foundation.yaml
@@ -1,0 +1,444 @@
+id: joinorder-canonical-foundation
+title: "joinorder canonical IMDb 2013 — Foundation & archive build (Step 1, part 1 of 2)"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Step 1 of the dual-track JOB strategy responding to GitHub issue #289
+  (https://github.com/joeharris76/BenchBox/issues/289). Splits into two
+  TODOs: this one (foundation + archive build) and
+  `joinorder-canonical-cutover` (code wiring + queries + docs + ship).
+
+  Issue #289 documents that BenchBox's `joinorder` benchmark generates
+  uniformly-random synthetic data, which destroys the cardinality-skew
+  signal JOB was designed to expose (Leis et al. PVLDB 2015). A probe
+  by an external reviewer confirmed 10/13 embedded queries return zero
+  rows on synthetic data because columns like `movie_companies.note`
+  and `cast_info.note` are always NULL, while queries filter on
+  specific note values like `'co-production'`, `'(USA)'`, `'voice'`.
+
+  This TODO produces the artifacts that the cutover TODO consumes:
+    1. Reusable data-fetch / scale-factor / dataset-versioning infrastructure
+       designed for reuse by future real-data benchmarks (ClickBench, etc.).
+    2. A bit-reproducible Parquet archive of the May 2013 IMDb snapshot
+       used by the JOB paper, sourced from Harvard Dataverse pg_dump
+       (doi:10.7910/DVN/2QYZBT), with full provenance and validation.
+    3. Reference cardinalities for all 113 canonical JOB queries,
+       computed via PostgreSQL on the converted data — the oracle for
+       the "do queries actually work" validator.
+    4. A DRAFT GitHub Release staging the archive at tag
+       `data/joinorder-imdb-2013-v1`. Promoted to published only by
+       the cutover TODO, after the code path is verified end-to-end.
+
+  Cutover TODO is gated on this one: the manifest, the archive URL,
+  and the reusable module skeletons are all consumed downstream.
+
+  Decisions locked in (from planning):
+    - Source: Harvard Dataverse pg_dump (institutional stability + DOI).
+    - Hosting: GitHub Releases.
+    - License posture: ship `DATA-LICENSE.md` per benchmark with IMDb
+      attribution + Boncz-style scope clause + takedown commitment.
+      No click-through (matches JOB ecosystem precedent).
+    - Tiny canonical fixture (~1MB): checked into repo for unit tests;
+      regenerated deterministically from full canonical via the build
+      pipeline.
+
+work:
+  - id: w1
+    summary: "Write design doc: reusable foundations (scale-factor gate, data-fetch infra, dataset-versioning, registry surface field)"
+    status: pending
+    notes: |
+      Output: `_project/design/joinorder-step1-foundations.md`
+      Sections:
+        1. Scale-factor enforcement gate
+           - Survey current scale_factor plumbing in benchbox/core/
+             (find the central runner entry point)
+           - Pattern: `validate_scale_factor(benchmark, sf, registry)`
+             raises `ScaleFactorNotSupportedError` when sf not in
+             registry[benchmark].scale_options
+           - Reusable across benchmarks (TPC-DS has scale constraints too)
+        2. Data-fetch infrastructure (`benchbox/core/data_fetch/`)
+           - Per-benchmark `data_manifest.toml` schema (URL, sha256,
+             file layout, version, license file)
+           - Cache: ${BENCHBOX_DATA_CACHE:-~/.cache/benchbox/data}/
+             {benchmark}/{version}/
+           - User-supplied opt-out: `--data-path` CLI flag and
+             `BENCHBOX_DATA_PATH_<BENCHMARK>` env var
+           - Failure modes documented: ChecksumMismatchError,
+             ManifestValidationError, DataFetchError
+        3. Dataset versioning in result bundles
+           - New manifest field `dataset_version` = sha256 of
+             data_manifest.toml; null for purely-generated benchmarks
+           - Surfaced at data layer only — explorer requires zero UI changes
+        4. Registry `surface` field
+           - "public" | "internal" — internal hidden from explorer
+           - joinorder_synthetic uses "internal" (per Joe: must not be
+             visible)
+
+  - id: w2
+    summary: "Build reusable data-fetch module skeleton in benchbox/core/data_fetch/"
+    status: pending
+    needs: [w1]
+    notes: |
+      Module structure (minimum viable, fully tested):
+        benchbox/core/data_fetch/__init__.py    # public API: fetch_data()
+        benchbox/core/data_fetch/manifest.py    # parse data_manifest.toml
+        benchbox/core/data_fetch/manager.py     # orchestrate fetch/cache/validate
+        benchbox/core/data_fetch/downloader.py  # HTTP GET + progress + resume + retry
+        benchbox/core/data_fetch/cache.py       # cache location + lock files
+        benchbox/core/data_fetch/errors.py      # exception hierarchy
+
+      Tests (mocked HTTP):
+        tests/unit/core/data_fetch/test_manifest.py
+        tests/unit/core/data_fetch/test_manager.py
+        tests/unit/core/data_fetch/test_downloader.py
+        tests/unit/core/data_fetch/test_cache.py
+
+      Skeleton is benchmark-agnostic; no joinorder-specific code in
+      this module. Joinorder wiring happens in the cutover TODO.
+
+  - id: w3
+    summary: "Add `surface` field to benchmark registry schema and reusable scale-factor enforcement"
+    status: pending
+    needs: [w1]
+    notes: |
+      Two reusable changes in benchbox/core/benchmark_registry.py:
+        - Add `surface: "public" | "internal"` field; default "public"
+        - Add `validate_scale_factor()` helper used by the runner
+          before generator/load-path
+
+      Also wire the runner to call validate_scale_factor() before any
+      data-generating step. The runner location should be discovered
+      during w1.
+
+      Tests:
+        tests/unit/core/test_scale_factor_validation.py
+          - Parametrized: joinorder is sf=1-only; tpch/tpcds accept
+            their declared ranges; arbitrary sf rejected for joinorder
+        tests/unit/core/test_registry_surface_field.py
+          - "public" benchmarks visible via the result-publisher path
+          - "internal" benchmarks hidden from the same path
+          - Existing benchmarks all default to "public"
+
+  - id: w4
+    summary: "Build offline conversion pipeline: pg_dump → Postgres restore → Parquet"
+    status: pending
+    needs: [w1]
+    notes: |
+      Script: `_project/scripts/build_joinorder_data.py`
+
+      Pipeline (run once on Joe's machine, NOT in CI):
+        1. Download Harvard Dataverse pg_dump
+           (doi:10.7910/DVN/2QYZBT); record upstream sha256
+        2. Restore into ephemeral Postgres container (docker run)
+        3. For each of 21 tables: COPY to CSV with
+           FORMAT csv, ENCODING UTF8 (no NFC/NFD normalization)
+        4. CSV → Parquet via DuckDB:
+           COPY ... TO '...parquet' (FORMAT 'parquet',
+           COMPRESSION 'zstd', ROW_GROUP_SIZE 100000)
+        5. Per-table: row count, sha256, schema (column → type)
+
+      Provenance embedded in `data_manifest.toml`:
+        - script git SHA, DuckDB version, Postgres version
+        - source DOI, retrieval timestamp, upstream pg_dump sha256
+        - per-table file path, row count, sha256, schema
+        - aggregate sha256 (over all per-file hashes) → dataset_version
+
+      Dependencies isolated in `_project/scripts/pyproject.toml`
+      (already established pattern in this repo).
+
+  - id: w5
+    summary: "Encoding round-trip gate (build-time pipeline assertion)"
+    status: pending
+    needs: [w4]
+    notes: |
+      After Parquet conversion, the pipeline MUST assert encoding
+      fidelity. Sample the following classes of rows:
+        - non-ASCII names from `name`, `aka_name` (e.g., accented chars,
+          ideographic chars in actor names)
+        - non-ASCII titles from `title`, `aka_title`
+        - punctuation-heavy notes from `cast_info.note`,
+          `movie_companies.note`
+
+      Round-trip test:
+        Parquet → DuckDB COPY TO csv → COPY back to Postgres TEMP table
+        → assert byte-identical to the original COPY output
+
+      Pipeline aborts (non-zero exit) if any sampled row differs.
+      This catches silent NFC/NFD normalization or encoding drift in
+      the DuckDB writer. Sample size: 100 rows per table from the
+      canonical-tricky set above.
+
+  - id: w6
+    summary: "Predicate-domain validation gate (no-empty-query assertion)"
+    status: pending
+    needs: [w4]
+    notes: |
+      The defect that makes synthetic JOB worthless is that
+      `movie_companies.note` and `cast_info.note` are always NULL,
+      so queries filtering on those values match nothing. The
+      pipeline MUST assert this never happens for canonical data.
+
+      For each of the 113 canonical JOB queries:
+        - Parse the query for predicates on key string columns
+        - Assert there is >= 1 row in the converted data that
+          satisfies that predicate (compute via Postgres)
+        - Aggregate: every query has a non-empty result on canonical data
+
+      Per-column null-fraction assertions against published reference
+      values (Leis 2015, Table 3, and pg_dump-derived counts):
+        - movie_companies.note: NULL fraction roughly 0.6
+        - cast_info.note: NULL fraction roughly 0.85
+        - title.episode_of_id: NULL fraction roughly 0.95
+      Concrete numbers TBD during w4 from the actual restore; bind
+      them then. Pipeline aborts if any column drifts ±5%.
+
+  - id: w7
+    summary: "Compute reference cardinalities for all 113 queries (PostgreSQL oracle)"
+    status: pending
+    needs: [w4, w6]
+    notes: |
+      Source queries: gregrahn/join-order-benchmark canonical 113
+      (1a-33c), checked-in to a build-input directory (NOT yet
+      committed to benchbox/core/joinorder/queries.py — that is the
+      cutover TODO's w7).
+
+      For each query, run against the restored Postgres on the
+      canonical converted data and capture:
+        - row_count (integer)
+        - first_row_sha256 (sha256 of the canonical-ordered first row)
+        - postgres_version
+        - query_id (canonical "1a", "33c" etc.)
+
+      Output: `_project/joinorder/reference_cardinalities.json`
+      (committed to repo). Schema:
+        {
+          "postgres_version": "16.2",
+          "dataset_version": "<sha256>",
+          "queries": {
+            "1a": {"row_count": ..., "first_row_sha256": "..."},
+            ...
+          }
+        }
+
+      Cross-check at least the queries for which the Leis 2015 paper
+      published row counts; flag mismatches in the build log.
+
+  - id: w8
+    summary: "Package archive tarball with manifest + license + checksums"
+    status: pending
+    needs: [w4, w5, w6, w7]
+    notes: |
+      Tarball: `joinorder-imdb-2013-v1.tar.zst`
+      Contents:
+        - 21 *.parquet files
+        - data_manifest.toml (with all provenance fields)
+        - DATA-LICENSE.md (template content, finalized in cutover TODO)
+        - checksums.txt (sha256 per Parquet)
+        - reference_cardinalities.json
+
+      Tarball-level sha256 written separately as
+      `joinorder-imdb-2013-v1.tar.zst.sha256`.
+
+      Tiny fixture: re-run pipeline with sample of full canonical
+      (~50 rows per table, predicate-satisfying) → produces tiny
+      Parquet set checked into `tests/fixtures/joinorder_canonical_tiny/`.
+      Same provenance trail (manifest with dataset_version distinct
+      from full canonical).
+
+  - id: w9
+    summary: "Stage as DRAFT GitHub Release on tag `data/joinorder-imdb-2013-v1`"
+    status: pending
+    needs: [w8]
+    notes: |
+      `gh release create data/joinorder-imdb-2013-v1 \
+        --draft \
+        --title "JoinOrder canonical IMDb 2013 dataset (v1)" \
+        --notes-file _project/joinorder/release-notes.md \
+        joinorder-imdb-2013-v1.tar.zst \
+        joinorder-imdb-2013-v1.tar.zst.sha256`
+
+      Release stays DRAFT until cutover TODO's UAT smoke test
+      verifies the live-download path end-to-end. Promotion to
+      published is done in the cutover TODO's final phase.
+
+      Release notes (`_project/joinorder/release-notes.md`) include:
+        - Provenance (Harvard Dataverse DOI, May 2013 IMDb snapshot)
+        - IMDb attribution string verbatim
+        - Boncz-style scope clause
+        - BenchBox redistribution disclaimer + takedown contact
+        - Per-table row counts and sha256s
+        - Tarball-level sha256
+
+  - id: w10
+    summary: "Add `data_manifest.toml` for joinorder pointing at the staged Release URL"
+    status: pending
+    needs: [w9]
+    notes: |
+      File: `benchbox/core/joinorder/data_manifest.toml`
+      Fields populated from w8 manifest output. URL points at the
+      DRAFT Release asset (which is fetchable via the API even while
+      draft, with a token). The cutover TODO's UAT step verifies
+      the URL resolves end-to-end.
+
+      Add `joinorder-canonical-foundation` checkpoint to commit
+      message body so the cutover TODO can grep for it later.
+
+verification:
+  - description: "Foundation design doc exists with all four sections"
+    command: "test -f _project/design/joinorder-step1-foundations.md && grep -cE '^## (Scale-factor|Data-fetch|Dataset versioning|Registry surface)' _project/design/joinorder-step1-foundations.md"
+    expected_output: ">= 4"
+  - description: "data_fetch module skeleton imports cleanly and tests pass"
+    command: "uv run -- python -c 'from benchbox.core.data_fetch import fetch_data' && uv run -- python -m pytest tests/unit/core/data_fetch/ -q"
+    expected_output: "no import error, all tests pass"
+  - description: "scale_factor validation rejects sf!=1 for joinorder"
+    command: "uv run -- python -m pytest tests/unit/core/test_scale_factor_validation.py::test_joinorder_rejects_non_unit_scale -q"
+    expected_output: "1 passed"
+  - description: "Build pipeline produces archive with all 21 Parquets + manifest + checksums + reference cardinalities"
+    command: "tar -tf joinorder-imdb-2013-v1.tar.zst | sort | grep -cE '\\.parquet$|^data_manifest\\.toml$|^DATA-LICENSE\\.md$|^checksums\\.txt$|^reference_cardinalities\\.json$'"
+    expected_output: ">= 25 (21 parquets + 4 metadata files)"
+  - description: "Encoding round-trip gate is enforced"
+    command: "grep -cE 'def (test_)?encoding_round_trip|encoding[_ ]round[_ ]trip' _project/scripts/build_joinorder_data.py"
+    expected_output: ">= 1"
+  - description: "Reference cardinalities cover all 113 queries"
+    command: "uv run -- python -c 'import json; d = json.load(open(\"_project/joinorder/reference_cardinalities.json\")); print(len(d[\"queries\"]))'"
+    expected_output: "113"
+  - description: "DRAFT GitHub Release exists with archive asset"
+    command: "gh release view data/joinorder-imdb-2013-v1 --json isDraft,assets --jq '{draft: .isDraft, asset_count: (.assets | length)}'"
+    expected_output: "{\"draft\": true, \"asset_count\": 2}"
+  - description: "Tiny fixture is checked in and predicate-satisfying"
+    command: "ls tests/fixtures/joinorder_canonical_tiny/*.parquet | wc -l"
+    expected_output: "21"
+  - description: "data_manifest.toml is wired up for joinorder"
+    command: "test -f benchbox/core/joinorder/data_manifest.toml && grep -cE '^url|^sha256|^version|^dataset_version' benchbox/core/joinorder/data_manifest.toml"
+    expected_output: ">= 4"
+
+must_preserve:
+  - "Existing benchmarks (tpch, tpcds, etc.) continue to accept their declared scale_factor ranges — the new validate_scale_factor() must read each benchmark's scale_options from the registry, not hard-code joinorder"
+  - "Existing benchmark_registry.py entries for non-joinorder benchmarks default to surface=public — no behavior change for them"
+  - "result-publisher continues to publish all current public bundles (no joinorder bundles touched in this TODO; that's the cutover TODO)"
+  - "All current generator-based benchmark code paths in benchbox/core/joinorder/ remain untouched in this TODO — rename happens in the cutover TODO"
+  - "data_fetch module is fully testable without network access — all tests use mocked HTTP"
+
+approach: |
+  This TODO is foundation + offline data prep. Most of the work
+  happens outside the running BenchBox process: a build pipeline
+  that runs once, produces an archive, stages a draft Release.
+
+  Sequence the work to minimize rework:
+    1. Design doc first (w1) — anchors all subsequent decisions
+    2. In parallel: data-fetch module (w2), registry+enforcement (w3),
+       and conversion pipeline (w4)
+    3. Pipeline gates (w5, w6) added before reference cardinalities
+       (w7) so we never compute reference values on broken data
+    4. Tarball packaging (w8) and Release staging (w9, w10) come last
+
+  For the build pipeline (w4-w8), use Docker-Postgres for
+  reproducibility. Document the exact image tag in
+  `data_manifest.toml`. The pipeline script must be idempotent and
+  re-runnable — if Joe needs to rebuild from a clean source 6 months
+  from now, the same script + same upstream pg_dump must produce a
+  byte-identical archive (modulo timestamps in the manifest).
+
+  Reusable infrastructure: design every module in `benchbox/core/data_fetch/`
+  to be benchmark-agnostic. The cutover TODO will instantiate it for
+  joinorder. Future TODOs will instantiate for ClickBench, etc.
+
+anti_patterns:
+  - "DO NOT compute reference cardinalities by re-running the queries on the BenchBox-converted Parquet via DuckDB — because that loses the independent-oracle property — use Postgres on the restored pg_dump as the oracle, then validate that DuckDB on the converted Parquet matches"
+  - "DO NOT skip the encoding round-trip gate — because silent NFC/NFD normalization in the Parquet writer will break predicate matching on accented names without producing any error message — fail loud at build time"
+  - "DO NOT hard-code joinorder-specific logic in benchbox/core/data_fetch/ — because the whole point is reuse for ClickBench / future real-data benchmarks — keep the module benchmark-agnostic; joinorder-specific config goes in benchbox/core/joinorder/data_manifest.toml"
+  - "DO NOT commit the full canonical Parquet archive to git — because it is ~1.5 GB and slows every clone — only the tiny fixture (~1MB) is checked in; the full archive lives only on the GitHub Release"
+  - "DO NOT publish the GitHub Release as non-draft in this TODO — because the live URL is consumed by code that doesn't exist yet — staging stays draft until cutover TODO's UAT smoke test passes"
+  - "DO NOT add joinorder-specific exception classes — because the data_fetch infrastructure is meant for reuse — exceptions live in benchbox/core/data_fetch/errors.py and are benchmark-agnostic"
+
+scope_limit:
+  only_modify:
+    - "_project/design/joinorder-step1-foundations.md (new)"
+    - "_project/design/data-fetch-infra-reuse-guide.md (new — design doc consumed by Track-2 groundwork TODO)"
+    - "_project/scripts/build_joinorder_data.py (new)"
+    - "_project/scripts/pyproject.toml (add deps if needed)"
+    - "_project/joinorder/reference_cardinalities.json (new)"
+    - "_project/joinorder/release-notes.md (new)"
+    - "benchbox/core/data_fetch/ (new module)"
+    - "benchbox/core/benchmark_registry.py (add `surface` field + scale validation hook)"
+    - "benchbox/core/errors.py (add ScaleFactorNotSupportedError if not present)"
+    - "benchbox/core/joinorder/data_manifest.toml (new)"
+    - "tests/unit/core/data_fetch/ (new)"
+    - "tests/unit/core/test_scale_factor_validation.py (new)"
+    - "tests/unit/core/test_registry_surface_field.py (new)"
+    - "tests/fixtures/joinorder_canonical_tiny/ (new — 21 tiny Parquets)"
+  do_not_modify:
+    - "benchbox/core/joinorder/generator.py (rename happens in cutover TODO)"
+    - "benchbox/core/joinorder/benchmark.py (cutover TODO)"
+    - "benchbox/core/joinorder/queries.py (cutover TODO)"
+    - "benchbox/core/joinorder/dataframe_queries.py (cutover TODO)"
+    - "results-data/bundles/ (cutover TODO does the rename)"
+    - "docs/benchmarks/join-order.md (cutover TODO)"
+    - "README.md, CHANGELOG.md (cutover TODO)"
+
+deferred:
+  - summary: "Wire joinorder benchmark to canonical data path"
+    reason: "Cutover TODO (joinorder-canonical-cutover). This TODO produces the artifacts; cutover consumes them."
+  - summary: "Add the 100 missing SQL queries to benchbox/core/joinorder/queries.py"
+    reason: "Cutover TODO. Reference cardinalities for all 113 are computed here, but checked-in to the joinorder package only after the rename to keep the rename atomic."
+  - summary: "Bundle migration (re-tag joinorder_sf1_* → joinorder_synthetic_sf1_*)"
+    reason: "Cutover TODO. Rename only after `joinorder_synthetic` exists in the registry."
+  - summary: "Promote draft GitHub Release to published"
+    reason: "Cutover TODO's final phase, after end-to-end UAT smoke."
+  - summary: "Statistics-as-phase support in the benchmark phase model"
+    reason: "Step 2 (Track 2). This is the foundation for measuring statistics maintenance interplay; deferred to track2 groundwork TODO."
+
+metadata:
+  tags:
+    - joinorder
+    - issue-289
+    - canonical-imdb-2013
+    - data-fetch-infra
+    - reusable-infra
+  estimated_effort: "Large (1-2 weeks for the offline pipeline + design + skeleton)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09"
+
+impact:
+  business_value: |
+    Restores `joinorder` as a credible JOB implementation in BenchBox.
+    Issue #289 documents that the current implementation produces
+    misleading results because uniformly-random data destroys the
+    cardinality-skew signal JOB was designed to expose. Anyone
+    publishing "JOB-on-engine-X via BenchBox" today is making claims
+    that don't transfer to literature. This is a benchmark-validity
+    defect, not a feature gap.
+
+    Reusable data-fetch infrastructure pays forward: ClickBench,
+    Wikipedia pageviews, GitHub Archive, and any future real-data
+    benchmark instantiates the same machinery rather than each one
+    solving downloader/manifest/cache from scratch.
+  user_impact: |
+    Users will need to acquire ~1.5 GB of canonical data on first
+    `joinorder` run (silent download by default, with `--data-path`
+    opt-out for air-gapped environments). In exchange they get
+    results that are bit-comparable across all BenchBox users and
+    against the academic literature.
+  technical_debt: |
+    Eliminates the "this is JOB" branding on a workload that isn't
+    JOB. Establishes patterns (data_manifest, dataset_version,
+    DATA-LICENSE.md, scale_factor enforcement) that will repeat for
+    every real-data benchmark.
+
+success_metrics:
+  - "Bit-reproducible Parquet archive built from Harvard Dataverse pg_dump (DOI:10.7910/DVN/2QYZBT) with full provenance manifest"
+  - "Reference cardinalities computed for all 113 canonical JOB queries via PostgreSQL oracle, committed to _project/joinorder/reference_cardinalities.json"
+  - "Reusable benchbox/core/data_fetch/ module: parses manifest, downloads with checksum validation, supports user-path opt-out, all tests pass without network access"
+  - "scale_factor enforcement is registry-driven and reusable: parametrized tests verify joinorder rejects sf!=1 and other benchmarks accept their declared ranges"
+  - "DRAFT GitHub Release at tag data/joinorder-imdb-2013-v1 stages the archive and is ready to be promoted by the cutover TODO"
+  - "Tiny canonical fixture (~1MB) is checked in and satisfies all 113 query predicates"
+  - "Build pipeline encoding round-trip gate is enforced and would fail on silent NFC/NFD normalization"
+
+open_questions:
+  - "Harvard Dataverse pg_dump may differ from CWI mirror. Plan: cross-check row counts against Leis 2015 Table 3 in w4; if material drift, document the chosen snapshot and rationale in the manifest."
+  - "DuckDB Parquet writer's encoding behavior on edge-case Unicode (combining characters, RTL text). Plan: w5 round-trip gate catches this; if it fails, fall back to Polars or pyarrow for the conversion step."
+  - "Whether tiny fixture should be deterministic regen vs frozen sha256 in repo. Plan: deterministic regen via the build pipeline, but the resulting Parquets are checked in (so unit tests don't need the full archive)."
+  - "Reference cardinality validation against Leis 2015 published numbers — only some queries have published row counts. Plan: w7 cross-checks where available; remaining queries rely on the Postgres-on-canonical oracle alone."

--- a/_project/TODO/main/planning/joinorder-track2-groundwork.yaml
+++ b/_project/TODO/main/planning/joinorder-track2-groundwork.yaml
@@ -1,0 +1,335 @@
+id: joinorder-track2-groundwork
+title: "joinorder Track-2 groundwork: statistics-as-phase survey, scaling-strategy options, infra reuse guide"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Documentation
+
+description: |
+  Step 2 prep work for the dual-track JOB strategy (issue #289
+  https://github.com/joeharris76/BenchBox/issues/289). Track 1
+  restores `joinorder` as canonical IMDb 2013. Track 2 is the
+  future evaluation of "scaled JOB likely for evaluating the
+  interplay of statistics maintenance and predicate selectivity."
+
+  This TODO produces design artifacts and seeds future TODOs.
+  No code changes. Lays groundwork so when Track 2 is picked up
+  (months from now), the starting point is concrete.
+
+  Three deliverables:
+    1. Phase-model survey + statistics-as-phase gap analysis.
+       Without separating "compute statistics" from load and
+       query phases, Track 2 cannot measure what it set out to
+       measure. Surveys current phase model, identifies the gap,
+       sketches the change, files Track-2 TODO seed.
+    2. Scaling-strategy options analysis. Track 2 wants scaled
+       JOB. The plan-deepening question is "scaled how?" —
+       correlated synthetic, sampled-from-real, real with
+       multiple snapshots, etc. Document options + tradeoffs.
+    3. Reusable data-fetch infrastructure reuse guide. The
+       foundation TODO built reusable infra for joinorder.
+       Document how a future benchmark (ClickBench, Wikipedia,
+       GitHub Archive) instantiates it.
+
+  Parallelizable with `joinorder-canonical-cutover` once
+  `joinorder-canonical-foundation` is done. The reuse guide (3)
+  consumes foundation outputs; the other two are independent.
+
+deps:
+  needs:
+    - joinorder-canonical-foundation
+
+work:
+  - id: w1
+    summary: "Phase-model survey: document current phase boundaries and stats-as-phase gap"
+    status: pending
+    notes: |
+      Output: `_project/design/track2-joinorder-stats-as-phase.md`
+
+      Sections:
+        1. Current phase model
+           - Survey benchbox/core/benchmark.py and platform-specific
+             benchmark phases. Document each phase, its boundary
+             (what counts as "in" vs "out"), and how its time is
+             measured.
+           - Specifically: where does ANALYZE / COMPUTE STATISTICS /
+             auto-statistics gathering land today? Likely rolled
+             into either load (if the engine auto-analyzes after
+             COPY) or query (if first-query triggers stats). Document
+             which engines do which.
+        2. Why this matters for Track 2
+           - Track 2 wants to evaluate "interplay of statistics
+             maintenance and predicate selectivity." If stats time
+             is silently rolled into load or query, the measurement
+             is invalid before it starts.
+           - Specific failure mode: an engine with sophisticated
+             auto-stats that takes 30s to build looks 30s slower at
+             load OR 30s slower at first-query — neither attribution
+             is correct.
+        3. Proposed change
+           - New phase between load and query: "statistics" (or
+             similar name).
+           - Per-engine knob: explicit ANALYZE / COMPUTE STATISTICS
+             call in this phase; if engine auto-analyzes during
+             load, document and don't double-build.
+           - Phase ordering: load → statistics → query.
+           - Result-bundle manifest carries per-phase timing
+             separately.
+        4. Migration strategy
+           - Backwards compat: existing benchmarks default to no
+             explicit statistics phase (legacy load-includes-stats
+             behavior).
+           - Opt-in: joinorder, tpch, tpcds enable the new phase
+             once Track 2 is implemented.
+           - Existing result bundles: dataset_version + benchmark
+             schema version distinguish pre- vs post-phase-model.
+        5. Open design questions
+           - Should auto-analyze be detected and disabled, or just
+             documented? (My lean: documented, not disabled —
+             auto-analyze IS what production engines do, so
+             measuring it is realistic.)
+           - Per-table vs whole-database ANALYZE — JOB has 21
+             tables; do we measure each, or aggregate?
+           - When stats are persisted between runs, does subsequent
+             query phase see them or not? (Cold-stats vs warm-stats
+             modes.)
+
+  - id: w2
+    summary: "Seed Track-2 TODO: stats-as-phase implementation"
+    status: pending
+    needs: [w1]
+    notes: |
+      File: `_project/TODO/main/planning/track2-joinorder-stats-phase.yaml`
+      Status: Identified
+      Priority: Medium (becomes Track-2's leading work)
+
+      Contents:
+        - Reference w1's design doc as the implementation spec
+        - Initial work units: phase-model schema change, per-engine
+          ANALYZE knob, result-bundle field, opt-in mechanism
+        - deps.needs: joinorder-canonical-cutover (because the
+          phase model change touches joinorder benchmark.py;
+          should land after the rename + canonical wiring)
+        - Acknowledge this is a Track-2 (future) TODO; stays in
+          planning/ with status Identified
+
+  - id: w3
+    summary: "Scaling-strategy options for Track 2"
+    status: pending
+    notes: |
+      Output: `_project/design/track2-joinorder-scaling-strategy.md`
+
+      Goal: enumerate options for "scaled JOB" with tradeoffs.
+      Track 2 plan-deepening before the work is picked up.
+
+      Options to evaluate:
+        A) Correlated synthetic generator
+           - Add Zipf / power-law / cross-table correlations to
+             the synthetic generator (joinorder_synthetic gets a
+             new mode; or new benchmark joinorder_correlated)
+           - Tradeoff: scalable, license-clean, but the
+             correlations are GUESSES — not the real correlations
+             JOB measures
+        B) Sampled-from-real (downsample canonical)
+           - Take a fraction of canonical IMDb 2013, preserve
+             all referential integrity
+           - Tradeoff: real correlations preserved on a smaller
+             scale; but cardinality distributions may shift
+             unevenly
+        C) Real with multiple snapshots (current IMDb)
+           - Use datasets.imdbws.com (post-2017 format) with
+             different snapshot dates as scale axis
+           - Tradeoff: real, growing data; but not the JOB-paper
+             dataset, so query results diverge from literature
+        D) Real with augmentation (canonical + synthetic
+           additions)
+           - Start from canonical, layer synthetic correlated
+             rows on top
+           - Tradeoff: preserves real backbone; synthetic part is
+             still a guess
+        E) Skip scaling; focus on stats-maintenance interplay at
+           sf=1 only
+           - Track 2 reframed: not "scaled JOB" but
+             "stats-maintenance JOB" at canonical scale
+           - Tradeoff: simpler scope; loses the scaling axis but
+             gains correctness
+
+      Decision matrix dimensions:
+        - Real-data fidelity (correlations, skew)
+        - Scalability axis available
+        - License posture
+        - Implementation complexity
+        - Comparability with existing JOB literature
+
+      Output: recommendation with reasoning, NOT a final decision.
+      Final decision happens when Track 2 is picked up.
+
+  - id: w4
+    summary: "Seed Track-2 TODO: scaling-strategy work"
+    status: pending
+    needs: [w3]
+    notes: |
+      File: `_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml`
+      Status: Identified
+      Priority: Medium
+
+      Stub TODO with the analysis from w3 as context. Final
+      design picked when Track 2 starts; this is a placeholder
+      so the work is tracked.
+
+  - id: w5
+    summary: "Reusable data-fetch infrastructure reuse guide"
+    status: pending
+    notes: |
+      Output: `_project/design/data-fetch-infra-reuse-guide.md`
+      (foundation TODO created the file as a stub; this work unit
+      fills the per-benchmark instantiation guidance)
+
+      Sections:
+        1. When to use this infrastructure
+           - Real-data benchmarks with stable upstream data sources
+           - Datasets larger than what is reasonable to commit to
+             git (~50 MB+)
+           - Datasets where provenance / license attribution matter
+        2. Step-by-step: instantiating for a new benchmark
+           a. Decide canonical source (DOI, archived snapshot URL)
+           b. Build offline conversion pipeline (script in
+              _project/scripts/build_<benchmark>_data.py)
+           c. Compute reference cardinalities via independent
+              oracle (Postgres for SQL workloads)
+           d. Package archive: per-table Parquet + manifest +
+              checksums + DATA-LICENSE.md + reference cardinalities
+           e. Stage as DRAFT GitHub Release; publish only after UAT
+           f. Add data_manifest.toml in benchbox/core/<benchmark>/
+           g. Wire benchmark to fetch_data() in benchmark.py
+           h. Add DATA-LICENSE.md (use joinorder's as template)
+           i. Add per-benchmark CHANGELOG entry
+        3. DATA-LICENSE.md template
+           - Reproduce the joinorder DATA-LICENSE.md structure
+             with placeholders
+           - Required sections: provenance, attribution, scope
+             clause, redistribution disclaimer, takedown contact
+        4. Common pitfalls (from joinorder Step 1)
+           - Encoding round-trip gates needed (NFC/NFD silent
+             normalization)
+           - Predicate-domain validation needed (queries-empty-by-
+             construction defect)
+           - Reference cardinalities via independent oracle, not
+             same engine that will be benchmarked
+           - DRAFT-then-promote sequence for the GitHub Release
+        5. Infrastructure components reused
+           - benchbox.core.data_fetch (downloader, cache, manifest)
+           - benchmark_registry surface field (public/internal)
+           - bundle_publisher dataset_version field
+           - scale_factor enforcement gate
+
+verification:
+  - description: "Phase-model survey doc exists with all five sections"
+    command: "test -f _project/design/track2-joinorder-stats-as-phase.md && grep -cE '^## (Current phase model|Why this matters|Proposed change|Migration strategy|Open design questions)' _project/design/track2-joinorder-stats-as-phase.md"
+    expected_output: ">= 5"
+  - description: "Track-2 stats-phase TODO seeded"
+    command: "test -f _project/TODO/main/planning/track2-joinorder-stats-phase.yaml && uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/track2-joinorder-stats-phase.yaml"
+    expected_output: "validation passes"
+  - description: "Scaling-strategy doc enumerates all five options with tradeoffs"
+    command: "grep -cE '^### Option [A-E]' _project/design/track2-joinorder-scaling-strategy.md"
+    expected_output: "5"
+  - description: "Track-2 scaling-strategy TODO seeded"
+    command: "test -f _project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml && uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml"
+    expected_output: "validation passes"
+  - description: "Data-fetch infra reuse guide has step-by-step instantiation section"
+    command: "grep -cE '^## (When to use|Step-by-step|DATA-LICENSE|Common pitfalls|Infrastructure components)' _project/design/data-fetch-infra-reuse-guide.md"
+    expected_output: ">= 5"
+
+must_preserve:
+  - "All Track 1 work (foundation + cutover TODOs) is unblocked by this TODO — this is a parallel-track docs effort, not a gate"
+  - "Existing TODO numbering and slug conventions — new Track-2 TODOs follow the existing track2-<area>-<topic> pattern"
+  - "Foundation TODO outputs (data_fetch module, registry surface field, etc.) are not modified here, only documented"
+
+approach: |
+  Pure documentation effort. No code changes; no test changes.
+  Outputs are markdown design docs and YAML TODO seeds.
+
+  Parallelize freely after the foundation TODO is done. The
+  three deliverables are independent of each other:
+    - Phase-model survey (w1, w2) is independent
+    - Scaling-strategy (w3, w4) is independent
+    - Reuse guide (w5) is independent and consumes foundation
+      outputs
+
+  Recommendation depth: each design doc should be at "principal
+  engineer evaluation" depth — multiple options, tradeoffs,
+  evidence, recommendation. Not deep enough to make final
+  decisions for Track 2, but deep enough that whoever picks up
+  Track 2 has a clear starting point.
+
+  TODO seeds (w2, w4) stay in planning/ with status Identified.
+  They do not block on Track 1 closing; they document Track-2
+  intent.
+
+anti_patterns:
+  - "DO NOT make implementation decisions for Track 2 in this TODO — because Track 2 is months away and context will shift — present options with tradeoffs, recommend the leading candidate, but do not lock in"
+  - "DO NOT write the Track-2 TODOs at full implementation detail — because they are seeds, not implementation plans — keep them at status: Identified with summary work units only"
+  - "DO NOT block Track 1 (cutover) on this TODO's completion — because docs effort can stretch arbitrarily and Track 1 has user-visible value — this TODO is parallel"
+  - "DO NOT propose a phase-model change that requires changes to in-flight result bundles — because that would invalidate historical comparisons unnecessarily — the migration strategy section must preserve old bundles' interpretability"
+
+scope_limit:
+  only_modify:
+    - "_project/design/track2-joinorder-stats-as-phase.md (new)"
+    - "_project/design/track2-joinorder-scaling-strategy.md (new)"
+    - "_project/design/data-fetch-infra-reuse-guide.md (foundation TODO created stub; fill in step-by-step + template + pitfalls sections)"
+    - "_project/TODO/main/planning/track2-joinorder-stats-phase.yaml (new seed)"
+    - "_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml (new seed)"
+  do_not_modify:
+    - "Any code under benchbox/"
+    - "Any test files under tests/"
+    - "joinorder-canonical-foundation or joinorder-canonical-cutover TODO files"
+    - "Track-1 design doc (_project/design/joinorder-step1-foundations.md)"
+    - "Existing benchmarks' phase-model implementation (deferred to Track 2)"
+
+deferred:
+  - summary: "Implement the new statistics phase in benchmark phase model"
+    reason: "Track 2 work — captured in track2-joinorder-stats-phase TODO seeded by this work."
+  - summary: "Build a correlated synthetic generator"
+    reason: "Track 2 work, AND only one of the scaling-strategy options (A) — final choice deferred to Track 2 kick-off."
+  - summary: "Add ClickBench / Wikipedia / GitHub Archive benchmarks"
+    reason: "Existing benchmark-expansion TODOs cover these; the data-fetch reuse guide produced here unblocks them but does not implement."
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - documentation
+    - design-doc
+    - reusable-infra
+  estimated_effort: "Medium (3-5 days for three design docs at depth)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09"
+
+impact:
+  business_value: |
+    Lays groundwork for Track 2 ("scaled JOB for statistics
+    maintenance × predicate selectivity") so when it is picked
+    up, the starting point is concrete: the phase-model gap is
+    surveyed, scaling-strategy options are weighed, and the
+    reusable infra is documented for future benchmarks.
+
+    Reuse guide pays forward immediately: ClickBench, Wikipedia
+    pageviews, GitHub Archive (existing benchmark-expansion TODOs)
+    can instantiate the same data_fetch / DATA-LICENSE /
+    dataset_version machinery rather than rebuilding from scratch.
+  technical_debt: |
+    Documents the patterns from Track 1 so they don't fade out of
+    the codebase's institutional memory. Future agents picking up
+    real-data benchmarks land on the reuse guide, not on a
+    code-archeology expedition.
+
+success_metrics:
+  - "Phase-model survey doc identifies where stats time lands today across at least 4 supported engines (DuckDB, PostgreSQL, ClickHouse, StarRocks or Spark)"
+  - "Scaling-strategy doc enumerates 5 options with explicit tradeoffs and a recommended leading candidate (with reasoning)"
+  - "Reuse guide is concrete enough that a hypothetical ClickBench TODO can follow it step-by-step without re-deriving patterns"
+  - "Track-2 TODO seeds (stats-phase, scaling-strategy) validate cleanly under validate_todo.py"
+  - "No Track-1 work blocked or delayed by this TODO"
+
+open_questions:
+  - "Whether the phase-model change should land before or after Track 2 implementation begins. Plan: design here, implement in Track 2's first work unit."
+  - "Whether to invite Joe to nominate a leading scaling-strategy option before Track 2 picks it up, or wait for Track 2 kickoff. Plan: present the recommendation in w3, but final lock-in happens when Track 2 starts."


### PR DESCRIPTION
Three TODOs convert the dual-track JOB strategy into actionable work
with guardrails and gates:

- joinorder-canonical-foundation (High): reusable data_fetch infra,
  scale-factor enforcement gate, registry surface field, offline
  Parquet conversion pipeline with encoding+predicate-domain gates,
  reference cardinalities for all 113 queries, DRAFT GitHub Release
  staging.
- joinorder-canonical-cutover (High, needs foundation): wire joinorder
  to canonical Parquet via data_fetch; rename synthetic generator to
  joinorder_synthetic with surface=internal (hidden from explorer);
  extend SQL coverage 13 → 113; bundle migration; DATA-LICENSE.md;
  promote draft Release; PR.
- joinorder-track2-groundwork (Medium-High, needs foundation): Step 2
  prep — phase-model survey for stats-as-phase gap, scaling-strategy
  options analysis, reusable data-fetch infra reuse guide.

Closes the planning phase for #289. Implementation follows.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
