### PR TITLE
feat(explorer): add benchmark/platform switchers and place Home filters above matrix

### DIFF
--- a/_project/TODO/main/planning/results-explorer-navigation-and-pivot-controls.yaml
+++ b/_project/TODO/main/planning/results-explorer-navigation-and-pivot-controls.yaml
@@ -22,56 +22,74 @@ deps:
 work:
   - id: w0
     summary: "Rebind navigation and pivot review evidence against develop tip"
-    status: pending
+    status: done
     notes: |
-      Walk Layout subnav transitions (Leaderboards → Query → Platforms →
-      Compare → benchmark detail → platform detail → result detail), Home
-      leaderboard filter placement, and the absence of benchmark/platform
-      switchers on detail pages against the current develop tip. Capture
-      stale active-tab cases, missing pivots, and filter placement defects to
-      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w0.log.
-      Output is the rebind reference for w1-w5 acceptance.
+      Routes walked against develop tip 6c28d2b45 in
+      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log.
+      The original w0.log captured Layout subnav reactivity defects that
+      shipped via #284 (w1). The fresh log covers w2/w3/w4: benchmark
+      switcher absence, platform switcher absence, and Home filter
+      placement.
 
   - id: w1
     summary: "Make the Results subnav active state reactive to route changes"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Refactor active-tab calculation so it updates after client-side route
-      changes. Verify navigation from Leaderboards to Query, Platforms,
-      Compare, benchmark detail, platform detail, and result detail
-      highlights the route the user is actually on.
+      Shipped in #284. `Layout.tsx` now consumes `useRouter` so the
+      active-tab class updates on every client-side route change.
+      Layout regression test added in the same PR keeps the contract.
 
   - id: w2
     summary: "Add a benchmark switcher to Benchmark detail pages"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Add a benchmark switcher to the Benchmark detail header near the
-      breadcrumb or title. It must list all available benchmarks, navigate
-      directly to the chosen benchmark detail route, preserve valid
-      scale/view state when possible, and clear invalid query params rather
-      than producing an empty page.
+      `BenchmarkIndex.tsx` grew a `<select data-testid="benchmark-switcher">`
+      in the controls strip beside the existing Scale/Phase/Tuning/Trust
+      filters. Options come from `BENCHMARK_LABELS` deduplicated by display
+      label so SSB and TSBS DevOps each list once (canonical slug wins).
+      Selecting a sibling calls `route("/results/<slug>/")`, preserving
+      `view=` because UI mode is benchmark-agnostic and dropping
+      benchmark-specific params (sf, phase, tuning, trust). New regression
+      test in `src/pages/__tests__/BenchmarkIndex.test.tsx` asserts the
+      switcher routes to the chosen sibling and clears the
+      benchmark-specific query params. Verification log:
+      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log.
 
   - id: w3
     summary: "Add a platform switcher to Platform detail pages"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Add a platform switcher to the Platform detail header near the
-      breadcrumb or title. It must list all available platforms, navigate
-      directly to the chosen platform route, and preserve applicable filters
-      once platform-page filtering exists.
+      `PlatformIndex.tsx` grew a `<select data-testid="platform-switcher">`
+      in the controls strip beside the existing Tuning filter. Options
+      come from the unique `(platform_id, platform)` pairs in the loaded
+      `getPlatformIndexRows()` payload so the list reflects what the
+      corpus actually contains. Selecting a sibling calls
+      `route("/results/p/<platform_id>/")` without preserving tuning
+      (platform-specific). New regression test in
+      `src/pages/__tests__/PlatformIndex.test.tsx`. Verification log:
+      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log.
 
   - id: w4
     summary: "Move Home leaderboard filters above the affected matrix"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Move the Home leaderboard cohort controls above or into the same panel
-      as the matrix they affect. Active filter state must be visible before
-      the table so the user does not have to scroll past the matrix to
-      understand how to change benchmark, scale, or platform context.
+      `Home.tsx` now renders the "Leaderboard cohort selector"
+      `<section>` immediately above `<MetaLeaderboard>` in the main
+      content column. The hero's `ActiveLeaderboardSummary` (read-state)
+      stays where it was; pairing it with the editable filter section
+      directly above the matrix gives the user a top-of-page edit path
+      without scrolling. `<CoverageEmptyState>` remains in the matrix
+      slot so the empty hint stays where the matrix would have been.
+      The Home document-order test was updated to assert
+      `selector → leaderboard → workflow/recent` (the previous order
+      `leaderboard → selector` directly contradicted w4's intent — no
+      assertion was weakened, only the ordering relationship was
+      inverted to match the new contract). Verification log:
+      _project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log.
 
   - id: w5
     summary: "Cover nav and sibling pivots with regression tests"

--- a/_project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log
+++ b/_project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log
@@ -1,0 +1,94 @@
+# w2 + w3 + w4 — Navigation switchers and Home filter placement
+
+Branch: feat/explorer-nav-pivot-switchers
+Develop tip at start: 6c28d2b45 (PR #298 merged)
+
+These three work units are intentionally bundled in one PR. They are
+independent UI controls (no shared component) but they all live in the
+same TODO and share the same verification block. The change cost is
+small enough that splitting them into three review cycles costs more
+than it saves.
+
+## w2 — Benchmark switcher on Benchmark detail
+
+### Current state on develop tip
+
+`results-explorer/src/pages/BenchmarkIndex.tsx:362-394`. The page
+renders a Breadcrumb and an `<h1>{title} Results</h1>` followed by a
+right-side row of Scale and Phase filters. There is no in-page control
+to pivot to a sibling benchmark — users must back out to the Home
+leaderboard or edit the URL.
+
+`src/utils.ts:5` exposes `BENCHMARK_LABELS` mapping every known
+benchmark slug to its display label. Two slugs share a display label
+("star_schema" and "ssb" both render "SSB") because the canonical
+route slug (`star_schema`) and the legacy slug (`ssb`) both exist. A
+similar collision exists between `tsbs-devops` and `tsbs_devops`.
+
+### Planned change
+
+Add a Benchmark `<select>` to the right-side controls strip on
+BenchmarkIndex. Options come from `BENCHMARK_LABELS`, deduplicated by
+display label (canonical slug wins). Selecting a sibling benchmark
+navigates to `/results/<slug>/` — view= is preserved (UI-level state
+is universal across benchmarks) but scale= and phase= are dropped
+because they are benchmark-specific and may not be valid for the new
+route. Per the YAML's "clear invalid query params rather than
+producing an empty page" rule, dropping benchmark-specific params is
+the safer default than guessing whether they apply.
+
+## w3 — Platform switcher on Platform detail
+
+### Current state on develop tip
+
+`results-explorer/src/pages/PlatformIndex.tsx:245-274`. Same shape as
+BenchmarkIndex: Breadcrumb + `<h1>{platformDisplayName} Results</h1>`
++ right-side controls (currently only the Tuning filter when multiple
+modes exist). No platform pivot.
+
+The platforms list is available from `rows` (from
+`getPlatformIndexRows()`) once the page loads — `rows[i].platform_id`
+is the URL slug, `rows[i].platform` is the display name.
+
+### Planned change
+
+Add a Platform `<select>` to the controls strip with options derived
+from the unique `(platform_id, platform)` pairs in `rows`. Selecting a
+sibling navigates to `/results/p/<platform_id>/`. Tuning state is
+dropped on platform switch because tuning modes are platform-specific.
+
+## w4 — Home filters above the matrix
+
+### Current state on develop tip
+
+`results-explorer/src/pages/Home.tsx:283-380`. Page order:
+
+1. Hero with `BenchBox Database Leaderboards` title and an
+   `ActiveLeaderboardSummary` row.
+2. `<MetaLeaderboard>` matrix.
+3. `<CoverageEmptyState>` (only when cohorts are empty).
+4. Cohort selector `<section aria-label="Leaderboard cohort selector">`
+   with Benchmark, Scale, Phase, and the advanced-filters disclosure.
+
+The filter section is the last block in the main column. A user
+encountering an unexpected matrix has to scroll past the matrix to
+discover how to change the benchmark/scale/phase context.
+
+### Planned change
+
+Move the cohort selector section directly above the
+`<MetaLeaderboard>`. The hero's `ActiveLeaderboardSummary` already
+shows the active state above the matrix; pairing it with the editable
+filter controls keeps the read-state and edit-state side by side.
+`<CoverageEmptyState>` stays where the matrix would have been so the
+empty hint still appears in the matrix slot.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Home.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser smoke (deferred to release-gate w3 — added as a Playwright
+  spec there): /results/tpch/ → switch to /results/clickbench/;
+  /results/p/duckdb/ → switch to /results/p/datafusion/;
+  /results/ → confirm filter section renders above the matrix.

--- a/results-explorer/src/pages/BenchmarkIndex.tsx
+++ b/results-explorer/src/pages/BenchmarkIndex.tsx
@@ -1,10 +1,11 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
 import type { RoutableProps } from "preact-router";
+import { route } from "preact-router";
 import type { BenchmarkSummary, PlatformRow, SortDirection, SortState } from "@/types";
 import type { ResultRow } from "@/lib/duckdbQueries";
 import { getBenchmarkSummaryFromDuckDB, listResults } from "@/lib/duckdbQueries";
-import { humanizeBenchmark, isKnownBenchmark, fmtScore, fmtGeomean, errMsg, complianceLabel } from "@/utils";
+import { BENCHMARK_LABELS, humanizeBenchmark, isKnownBenchmark, fmtScore, fmtGeomean, errMsg, complianceLabel } from "@/utils";
 import { facetsToWhereClause, useFacetState, type FacetKey, type FacetState } from "@/lib/facetModel";
 import { hasActiveFacets, matchesFacetRow, singleFacetValue } from "@/lib/facetMatching";
 import { buildCompareUrl, compareIdForRow, displayCompareId } from "@/lib/resultLinks";
@@ -76,6 +77,27 @@ function benchmarkContextNote(benchmark: string): string | null {
     return "Star Schema Benchmark (SSB): the route keeps the canonical star_schema slug while the published benchmark label uses SSB.";
   }
   return null;
+}
+
+/**
+ * Distinct benchmark slugs paired with display labels for the in-page
+ * sibling switcher. Two slugs sometimes share a display label
+ * (`star_schema` and `ssb` both render "SSB"; `tsbs-devops` and
+ * `tsbs_devops` both render "TSBS DevOps") because legacy and
+ * canonical routes coexist. We keep the first slug encountered so the
+ * switcher lists each benchmark family exactly once and the canonical
+ * route wins (BENCHMARK_LABELS is declared with the canonical slug
+ * first).
+ */
+function uniqueBenchmarkOptions(): { value: string; label: string }[] {
+  const seen = new Set<string>();
+  const options: { value: string; label: string }[] = [];
+  for (const [value, label] of Object.entries(BENCHMARK_LABELS)) {
+    if (seen.has(label)) continue;
+    seen.add(label);
+    options.push({ value, label });
+  }
+  return options.sort((a, b) => a.label.localeCompare(b.label));
 }
 
 function benchmarkCompareGuidanceMessage(
@@ -372,6 +394,39 @@ export function BenchmarkIndex({ benchmark = "" }: BenchmarkIndexProps) {
         <h1 class="text-3xl font-bold text-[var(--bb-data-fg-primary)]">{title} Results</h1>
 
         <div class="flex flex-wrap items-center gap-3">
+          {/* Benchmark switcher (sibling pivot). View mode is the only piece
+              of UI state that survives the switch; scale, phase, and tuning
+              are benchmark-specific so we drop them rather than risk an
+              empty page on the destination. */}
+          <div class="flex items-center gap-2">
+            <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="benchmark-switcher">
+              Benchmark:
+            </label>
+            <select
+              id="benchmark-switcher"
+              data-testid="benchmark-switcher"
+              class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm shadow-sm"
+              value={benchmark}
+              onChange={(event) => {
+                const next = (event.target as HTMLSelectElement).value;
+                if (next === benchmark) return;
+                const params = new URLSearchParams();
+                if (viewMode !== "matrix") params.set("view", viewMode);
+                const query = params.toString();
+                route(`/results/${next}/${query ? `?${query}` : ""}`);
+              }}
+            >
+              {uniqueBenchmarkOptions().map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+              {!Object.prototype.hasOwnProperty.call(BENCHMARK_LABELS, benchmark) && (
+                <option value={benchmark}>{title}</option>
+              )}
+            </select>
+          </div>
+
           {/* Scale factor filter */}
           {scaleFactors.length > 1 && (
             <div class="flex items-center gap-2">

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -303,32 +303,13 @@ export function Home(_: RoutableProps) {
       </section>
 
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        {filteredMetaLeaderboard && (
-          <MetaLeaderboard
-            data={filteredMetaLeaderboard}
-            mode={mode}
-            onModeChange={(value) => setModeRaw(value)}
-            cohortHref={buildCohortHref}
-            platformHref={buildPlatformHref}
-            resultMetadataById={resultById}
-          />
-        )}
-
-        {filteredMetaLeaderboard && filteredMetaLeaderboard.cohorts.length === 0 && (
-          <CoverageEmptyState
-            activeFacets={activeFacetSummaries}
-            canClearScale={scaleFilters.length > 0}
-            canClearPlatform={facets.platform.length > 0}
-            onClearScale={() => setFacet("scale_factor", [])}
-            onClearPlatform={() => setFacet("platform", [])}
-            onReset={resetFacets}
-          />
-        )}
-
+        {/* Cohort selector renders above the matrix so users can change
+            benchmark/scale/phase context without scrolling past the
+            matrix to find the controls. */}
         {filteredMetaLeaderboard && (
           <section
             aria-label="Leaderboard cohort selector"
-            class="mb-8 rounded-lg border border-[var(--bb-border-default)] bg-[var(--bb-bg-panel)] p-3"
+            class="mb-6 rounded-lg border border-[var(--bb-border-default)] bg-[var(--bb-bg-panel)] p-3"
           >
             <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
               <MultiSelectFilter
@@ -396,6 +377,28 @@ export function Home(_: RoutableProps) {
               </div>
             </details>
           </section>
+        )}
+
+        {filteredMetaLeaderboard && (
+          <MetaLeaderboard
+            data={filteredMetaLeaderboard}
+            mode={mode}
+            onModeChange={(value) => setModeRaw(value)}
+            cohortHref={buildCohortHref}
+            platformHref={buildPlatformHref}
+            resultMetadataById={resultById}
+          />
+        )}
+
+        {filteredMetaLeaderboard && filteredMetaLeaderboard.cohorts.length === 0 && (
+          <CoverageEmptyState
+            activeFacets={activeFacetSummaries}
+            canClearScale={scaleFilters.length > 0}
+            canClearPlatform={facets.platform.length > 0}
+            onClearScale={() => setFacet("scale_factor", [])}
+            onClearPlatform={() => setFacet("platform", [])}
+            onReset={resetFacets}
+          />
         )}
 
         {filteredMetaLeaderboard && <FlywheelStrip />}

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import type { RoutableProps } from "preact-router";
+import { route } from "preact-router";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 import { getPlatformIndexRows } from "@/lib/duckdbQueries";
 import { useFacetState, type FacetKey, type FacetState } from "@/lib/facetModel";
@@ -157,6 +158,19 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   // old links constructed from the display name.
   const allPlatformResults = rows.filter((r) => r.platform_id === platform || r.platform === platform);
 
+  // Distinct platform options for the in-page sibling pivot, sorted by
+  // display name. Each row carries (platform_id, platform); we keep the
+  // first display name encountered for each id.
+  const platformOptions = (() => {
+    const byId = new Map<string, string>();
+    for (const row of rows) {
+      if (!byId.has(row.platform_id)) byId.set(row.platform_id, row.platform);
+    }
+    return [...byId.entries()]
+      .map(([platform_id, platform]) => ({ platform_id, platform }))
+      .sort((a, b) => a.platform.localeCompare(b.platform));
+  })();
+
   // Unique non-null tuning modes - only show filter when multiple modes present.
   const tuningModes = [
     ...new Set(allPlatformResults.map((r) => r.tuning_mode).filter((m): m is string => m !== null)),
@@ -249,7 +263,36 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
       <div class="mt-6 mb-6 flex flex-wrap items-center justify-between gap-4">
         <h1 class="text-3xl font-bold text-[var(--bb-data-fg-primary)]">{platformDisplayName} Results</h1>
 
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-4">
+          {/* Platform switcher (sibling pivot). Tuning is platform-specific
+              so we do not preserve it across the switch. */}
+          {platformOptions.length > 1 && (
+            <div class="flex items-center gap-2">
+              <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="platform-switcher">
+                Platform:
+              </label>
+              <select
+                id="platform-switcher"
+                data-testid="platform-switcher"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm shadow-sm"
+                value={platform}
+                onChange={(event) => {
+                  const next = (event.target as HTMLSelectElement).value;
+                  if (next === platform) return;
+                  route(`/results/p/${next}/`);
+                }}
+              >
+                {platformOptions.map((option) => (
+                  <option key={option.platform_id} value={option.platform_id}>
+                    {option.platform}
+                  </option>
+                ))}
+                {!platformOptions.some((option) => option.platform_id === platform) && (
+                  <option value={platform}>{platformDisplayName}</option>
+                )}
+              </select>
+            </div>
+          )}
           {tuningModes.length > 1 && (
             <div class="flex items-center gap-2">
               <label class="text-sm font-medium text-[var(--bb-data-fg-primary)]" for="tuning-filter">

--- a/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx
@@ -9,7 +9,7 @@
  *   (e) axe-core: no serious/critical violations on a fully-loaded matrix
  */
 
-import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/preact";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { BenchmarkSummary } from "@/types";
 import { expectNoAxeViolations } from "@/testing/axe-helper";
@@ -21,6 +21,14 @@ import { expectNoAxeViolations } from "@/testing/axe-helper";
 vi.mock("@/db", () => ({
   queryRows: vi.fn(),
 }));
+
+vi.mock("preact-router", async () => {
+  const actual = await vi.importActual<typeof import("preact-router")>("preact-router");
+  return {
+    ...actual,
+    route: vi.fn(),
+  };
+});
 
 vi.mock("@/components/QueryHeatmap", async () => {
   const actual = await vi.importActual<typeof import("@/components/QueryHeatmap")>("@/components/QueryHeatmap");
@@ -382,6 +390,25 @@ describe("BenchmarkIndex", () => {
     expect(guidance.textContent).toContain("Select two or more platforms");
     const disabledAction = screen.getByRole("button", { name: "Select 2 comparable results" }) as HTMLButtonElement;
     expect(disabledAction.disabled).toBe(true);
+  });
+
+  it("renders a Benchmark switcher that routes to a sibling and clears benchmark-specific params", async () => {
+    const preactRouter = await import("preact-router");
+    const routeMock = vi.mocked(preactRouter.route);
+    routeMock.mockClear();
+    window.history.replaceState(null, "", "/results/tpch/?sf=10&phase=power&view=ranks");
+
+    render(<BenchmarkIndex benchmark="tpch" />);
+    await waitFor(() => expect(screen.getByText("TPC-H Results")).toBeTruthy());
+
+    const switcher = screen.getByTestId("benchmark-switcher") as HTMLSelectElement;
+    expect(switcher.value).toBe("tpch");
+    expect(within(switcher).getByRole("option", { name: "ClickBench" })).toBeTruthy();
+    expect(within(switcher).getByRole("option", { name: "TPC-H" })).toBeTruthy();
+
+    fireEvent.change(switcher, { target: { value: "clickbench" } });
+    expect(routeMock).toHaveBeenCalledTimes(1);
+    expect(routeMock).toHaveBeenCalledWith("/results/clickbench/?view=ranks");
   });
 
   it("labels the Star Schema Benchmark and SSB equivalence explicitly", async () => {

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -405,8 +405,8 @@ describe("Home", () => {
     expect(within(activeSummary).getByText("All scales")).toBeTruthy();
     expect(within(activeSummary).getByText("All phases")).toBeTruthy();
     expectDocumentOrder(headline, activeSummary);
-    expectDocumentOrder(activeSummary, leaderboard);
-    expectDocumentOrder(leaderboard, selector);
+    expectDocumentOrder(activeSummary, selector);
+    expectDocumentOrder(selector, leaderboard);
     expectDocumentOrder(leaderboard, workflow);
     expectDocumentOrder(leaderboard, recentHeading);
   });

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -6,7 +6,7 @@
  * that default switches direction on repeated clicks of the same key.
  */
 
-import { render, screen, fireEvent, waitFor } from "@testing-library/preact";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/preact";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 
@@ -15,6 +15,14 @@ vi.mock("@/lib/duckdbQueries", async () => {
   return {
     ...actual,
     getPlatformIndexRows: vi.fn(),
+  };
+});
+
+vi.mock("preact-router", async () => {
+  const actual = await vi.importActual<typeof import("preact-router")>("preact-router");
+  return {
+    ...actual,
+    route: vi.fn(),
   };
 });
 
@@ -102,6 +110,29 @@ describe("PlatformIndex - sortable table headers", () => {
     await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
     await waitFor(() => expect(document.title).toBe("DuckDB · BenchBox Results"));
     expect(getRowOrder(container)).toEqual(["r-tpch-fast", "r-ssb-mid", "r-tpch-slow", "r-null-geo"]);
+  });
+
+  it("renders a Platform switcher that routes to a sibling without preserving tuning", async () => {
+    const preactRouter = await import("preact-router");
+    const routeMock = vi.mocked(preactRouter.route);
+    routeMock.mockClear();
+
+    const multiPlatformRows = [
+      ...ROWS,
+      makeRow({ result_id: "r-pg", short_id: "pg00000a", platform_id: "postgres", platform: "Postgres" }),
+    ];
+    vi.mocked(getPlatformIndexRows).mockResolvedValue(multiPlatformRows);
+
+    render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    const switcher = screen.getByTestId("platform-switcher") as HTMLSelectElement;
+    expect(switcher.value).toBe("duckdb");
+    expect(within(switcher).getByRole("option", { name: "Postgres" })).toBeTruthy();
+
+    fireEvent.change(switcher, { target: { value: "postgres" } });
+    expect(routeMock).toHaveBeenCalledTimes(1);
+    expect(routeMock).toHaveBeenCalledWith("/results/p/postgres/");
   });
 
   it("shows persistent compare guidance and cohort labels before selection", async () => {


### PR DESCRIPTION
Closes the w2, w3, and w4 work units of
results-explorer-navigation-and-pivot-controls. Defects this addresses
were captured against develop tip in
_project/verification-logs/results-explorer-navigation-and-pivot-controls/w234.log.

Changes:

  - `BenchmarkIndex.tsx` grew a `<select data-testid="benchmark-switcher">`
    in the controls strip. Options come from `BENCHMARK_LABELS` deduped
    by display label so SSB and TSBS DevOps each appear once. Selecting
    a sibling calls `route("/results/<slug>/")`, preserving `view=`
    (UI-level state, benchmark-agnostic) and dropping `sf`, `phase`,
    `tuning`, and `trust` (benchmark-specific) so the destination does
    not load with a query param that may be invalid for the new
    cohort.
  - `PlatformIndex.tsx` grew a `<select data-testid="platform-switcher">`
    sourced from the loaded platform rows. Selecting a sibling calls
    `route("/results/p/<platform_id>/")` without preserving tuning,
    which is platform-specific.
  - `Home.tsx` now renders the "Leaderboard cohort selector" section
    directly above `<MetaLeaderboard>` so the user can change
    benchmark/scale/phase context without scrolling past the matrix.
    `<CoverageEmptyState>` stays in the matrix slot for the empty
    cohort case.

Tests:

  - New regression tests in `BenchmarkIndex.test.tsx` and
    `PlatformIndex.test.tsx` mock `preact-router.route` and assert each
    switcher routes to the chosen sibling. The benchmark switcher test
    also asserts that benchmark-specific URL params (`sf`, `phase`) are
    cleared while `view=` is preserved.
  - `Home.test.tsx` document-order assertion inverted from
    `leaderboard → selector` to `selector → leaderboard`. The previous
    order encoded the regressed UX (filters below matrix); flipping it
    to match w4's intent does not weaken any other assertion in the
    test.

Verification:

  - `npm test -- --run` (547/547)
  - `npm run typecheck` and `npm run build` clean.
  - Browser-driven walks (open /results/tpch/, switch to /results/clickbench/;
    similar on /results/p/...; confirm Home filter ordering) deferred to
    the release-gate Playwright spec planned in TODO #8 (release-gate w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
