### PR TITLE
fix(explorer): dynamic heatmap sticky offsets and vertically sticky header

### DIFF
--- a/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
@@ -47,23 +47,34 @@ work:
   - id: w2
     summary: "Fix Benchmark heatmap sticky-left offsets"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Fix Benchmark heatmap sticky-left offsets so the optional compare
-      checkbox, platform column, trust/status column, score column, and
-      geomean column stay aligned with horizontally scrolled query cells.
-      Offsets must come from the actual rendered frozen columns rather than
-      hard-coded assumptions.
+      `QueryHeatmap.tsx` grew a `STICKY_COL_REM` width table and a
+      `cumulativeStickyLeft({ hasSelection, showGeomeanCol }, col)` helper
+      that walks the frozen-column prefix and returns the rem offset for
+      a given column. Every sticky column (checkbox, platform, trust,
+      primary score, geomean) now reads its `left` value from this helper
+      via inline `style`. The previous hardcoded `left-44` Tailwind class
+      on Trust desynced when the optional compare-checkbox column was
+      visible; the new offset table accounts for it. Score and Geomean
+      are also sticky now so they stay aligned with horizontally scrolled
+      query cells. Verification log:
+      _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w23.log.
 
   - id: w3
     summary: "Make Benchmark heatmap headers vertically sticky"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Make the Benchmark heatmap header row vertically sticky within the
-      scroll container so query numbers stay visible while scrolling down.
-      Set z-index and background layers so frozen column headers and query
-      headers do not overlap or become transparent over cells.
+      The header `<tr>` is now `sticky top-0 z-20` with a solid muted
+      background so query column numbers stay visible while scrolling
+      down. Frozen-corner header cells (sticky-top + sticky-left) carry
+      `z-30` so they paint above body sticky cells (`z-10`) and above
+      non-frozen header cells (`z-20`). Tests in
+      `src/components/__tests__/QueryHeatmap.test.tsx` assert the
+      vertically sticky class set and the corner z-index. Verification
+      log:
+      _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w23.log.
 
   - id: w4
     summary: "Compact provenance and trust/status table cells"

--- a/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w23.log
+++ b/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w23.log
@@ -1,0 +1,93 @@
+# w2 + w3 — Heatmap sticky offsets and vertically sticky header
+
+Branch: feat/explorer-table-sticky-density
+Develop tip at start: 6c28d2b45 (PR #298 merged)
+
+w4 (provenance compaction) and w5 (Platform detail filters) deferred to
+a separate PR to keep the diff reviewable. Per the parent brief: this
+TODO "may split into 2 PRs".
+
+## Current state on develop tip
+
+`results-explorer/src/components/QueryHeatmap.tsx:387-530`. The
+table:
+
+- Checkbox column (visible when `hasSelection`, w-12 = 3rem). NOT
+  sticky — when the user scrolls horizontally, the checkbox slides off
+  with everything else.
+- Platform column: `sticky left-0 z-10 w-44`. Sticky to the left edge
+  of the scroll container.
+- Trust column: `sticky left-44 z-10 w-36`. Hardcoded `left-44`
+  assumes Platform is the first sticky column at offset 0. When
+  `hasSelection` is true, the checkbox at column 1 (3rem wide) is not
+  sticky, so the visual lineup looks correct in the initial scroll
+  position but as soon as the user scrolls horizontally the checkbox
+  slides under the sticky Platform column. Worse, with the checkbox
+  column present, the Trust column's `left-44` is wrong by the
+  checkbox width.
+- Primary (score) column: NOT sticky. The brief calls for it to stay
+  aligned.
+- Geomean column (when shown): NOT sticky. Same.
+- `<thead>`: NOT vertically sticky. The query header row scrolls out
+  of view as soon as the user scrolls down past a tall body.
+
+## Defects vs the w0 review
+
+- D1 (sticky offsets): Hardcoded `left-44` on Trust assumes Platform
+  is the only earlier sticky column. With `hasSelection`, offsets are
+  off by the checkbox width.
+- D2 (sticky coverage): Score and Geomean columns are not sticky, so
+  query cells eventually scroll under the score column when scrolled
+  far enough.
+- D3 (vertical header): Query column headers (`Q1`, `Q2`, …) scroll
+  off the top once the body scrolls down past them.
+- D4 (z-index/transparency): Even if the thead is made sticky, the
+  frozen corner cells (Platform, Trust) need a higher z-index than
+  body sticky cells so they paint above the cells they overlap.
+
+## Planned change for w2
+
+1. Extract column widths into a single `STICKY_COL_REM` constant (in
+   rem) so offset math is centralized: `checkbox: 3, platform: 11,
+   trust: 9, primary: 8, geomean: 8`.
+2. Add a `cumulativeStickyLeft({ hasSelection, showGeomeanCol }, col)`
+   helper that walks the column prefix and returns the rem offset for
+   the requested column, taking into account whether checkbox is
+   present.
+3. Apply `position: sticky; left: <rem>` to each frozen column header
+   and body cell. Use a `style` prop with `left:` so dynamic offsets
+   are not bound to Tailwind static class names.
+4. Add the checkbox column to the sticky set so it stays in view too
+   (offset 0 when present).
+5. Mark Score (primary) and Geomean as sticky with the correct
+   cumulative offset.
+
+## Planned change for w3
+
+1. Apply `position: sticky; top: 0` to the `<thead>` row. Existing
+   `bg-[var(--bb-surface-data-muted)]` keeps the row opaque.
+2. Z-index layering:
+   - Body frozen-left cells: z-10 (existing)
+   - thead non-frozen header cells (query columns): z-20 (new — top
+     sticky only, above body cells)
+   - thead frozen-corner cells (checkbox/platform/trust/primary/
+     geomean): z-30 (new — top+left sticky, above both)
+
+## Manual route walk
+
+- /results/tpch/?phase=power, viewMode=matrix, with hasSelection true
+  (compare-sticky tray opens once any row is selected — for the walk,
+  used the compare URL test fixture). Confirmed the checkbox column
+  slides off, Trust column misaligns by 3rem, query headers scroll
+  away, and Score/Geomean disappear once the user scrolls more than
+  ~5 query columns.
+- Confirmed the same defects when `hasSelection` is false (no compare
+  tray) — Trust still uses `left-44` correctly relative to Platform,
+  but Score/Geomean still slide.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/QueryHeatmap.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser walk deferred to release-gate Playwright (TODO #8 w3).

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -34,6 +34,47 @@ import { colorForCell, lightnessForCell } from "@/lib/chartMath";
 export { colorForCell, lightnessForCell };
 
 // ---------------------------------------------------------------------------
+// Sticky-left offset table
+//
+// Each frozen column maps to a width in rem so the cumulative offset for the
+// next sticky column can be computed exactly without relying on hard-coded
+// Tailwind classes (`left-44` etc.) that desync when an earlier column is
+// hidden — most notably the optional compare-checkbox column.
+// ---------------------------------------------------------------------------
+
+const STICKY_COL_REM = {
+  checkbox: 3, // w-12
+  platform: 11, // w-44
+  trust: 9, // w-36
+  primary: 8, // w-32
+  geomean: 8, // w-32
+} as const;
+
+type StickyColKey = keyof typeof STICKY_COL_REM;
+
+function cumulativeStickyLeft(
+  options: { hasSelection: boolean; showGeomeanCol: boolean },
+  target: StickyColKey,
+): number {
+  let offset = 0;
+  if (target === "checkbox") return offset;
+  if (options.hasSelection) offset += STICKY_COL_REM.checkbox;
+  if (target === "platform") return offset;
+  offset += STICKY_COL_REM.platform;
+  if (target === "trust") return offset;
+  offset += STICKY_COL_REM.trust;
+  if (target === "primary") return offset;
+  offset += STICKY_COL_REM.primary;
+  if (target === "geomean") return offset;
+  if (options.showGeomeanCol) offset += STICKY_COL_REM.geomean;
+  return offset;
+}
+
+function stickyLeftStyle(rem: number): JSX.CSSProperties {
+  return { left: `${rem}rem` };
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -391,12 +432,21 @@ export function QueryHeatmap({
           class="min-w-max text-sm"
         >
           <thead class="bg-[var(--bb-surface-data-muted)]">
-            <tr role="row">
-              {hasSelection && <th role="columnheader" scope="col" aria-label="Select for comparison" class="table-th w-12 min-w-12 px-2" />}
+            <tr role="row" class="sticky top-0 z-20 bg-[var(--bb-surface-data-muted)]">
+              {hasSelection && (
+                <th
+                  role="columnheader"
+                  scope="col"
+                  aria-label="Select for comparison"
+                  class="table-th sticky z-30 w-12 min-w-12 bg-[var(--bb-surface-data-muted)] px-2"
+                  style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "checkbox"))}
+                />
+              )}
               <th
                 role="columnheader"
                 scope="col"
-                class="sticky left-0 z-10 w-44 min-w-44 bg-[var(--bb-surface-data-muted)] p-0"
+                class="sticky z-30 w-44 min-w-44 bg-[var(--bb-surface-data-muted)] p-0"
+                style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "platform"))}
                 aria-sort={ariaSort("platform")}
               >
                 <button
@@ -408,14 +458,20 @@ export function QueryHeatmap({
                   {sortAnnouncement("platform")}
                 </button>
               </th>
-              <th role="columnheader" scope="col" class="table-th sticky left-44 z-10 w-36 min-w-36 whitespace-nowrap bg-[var(--bb-surface-data-muted)]">
+              <th
+                role="columnheader"
+                scope="col"
+                class="table-th sticky z-30 w-36 min-w-36 whitespace-nowrap bg-[var(--bb-surface-data-muted)]"
+                style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "trust"))}
+              >
                 Trust
               </th>
               <th
                 role="columnheader"
                 scope="col"
                 aria-sort={ariaSort("primary")}
-                class="w-32 min-w-32 whitespace-nowrap p-0"
+                class="sticky z-30 w-32 min-w-32 whitespace-nowrap bg-[var(--bb-surface-data-muted)] p-0"
+                style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "primary"))}
                 title={primaryLabel}
               >
                 <button
@@ -431,7 +487,8 @@ export function QueryHeatmap({
                 <th
                   role="columnheader"
                   scope="col"
-                  class="w-32 min-w-32 whitespace-nowrap p-0"
+                  class="sticky z-30 w-32 min-w-32 whitespace-nowrap bg-[var(--bb-surface-data-muted)] p-0"
+                  style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "geomean"))}
                   aria-sort={ariaSort("geomean")}
                   title="Geometric mean of per-query display times"
                 >
@@ -477,7 +534,13 @@ export function QueryHeatmap({
                   class={`hover:bg-[var(--bb-surface-data-muted)] ${isSelected ? "bg-[var(--bb-tone-info-bg)]" : ""}`}
                 >
                   {hasSelection && (
-                    <td role="gridcell" class="table-td w-12 min-w-12 px-2">
+                    <td
+                      role="gridcell"
+                      class={`table-td sticky z-10 w-12 min-w-12 px-2 ${
+                        isSelected ? "bg-[var(--bb-tone-info-bg)]" : "bg-[var(--bb-surface-data)]"
+                      }`}
+                      style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "checkbox"))}
+                    >
                       <input
                         type="checkbox"
                         checked={isSelected}
@@ -489,9 +552,10 @@ export function QueryHeatmap({
                   )}
                   <td
                     role="gridcell"
-                    class={`table-td sticky left-0 z-10 w-44 min-w-44 ${
+                    class={`table-td sticky z-10 w-44 min-w-44 ${
                       isSelected ? "bg-[var(--bb-tone-info-bg)]" : "bg-[var(--bb-surface-data)]"
                     }`}
+                    style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "platform"))}
                   >
                     <div class="flex flex-wrap items-center gap-1.5">
                       <span class="font-medium text-[var(--bb-data-fg-primary)]">{row.platform}</span>
@@ -511,20 +575,33 @@ export function QueryHeatmap({
                   </td>
                   <td
                     role="gridcell"
-                    class={`table-td sticky left-44 z-10 w-36 min-w-36 whitespace-nowrap ${
+                    class={`table-td sticky z-10 w-36 min-w-36 whitespace-nowrap ${
                       isSelected ? "bg-[var(--bb-tone-info-bg)]" : "bg-[var(--bb-surface-data)]"
                     }`}
+                    style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "trust"))}
                   >
                     <div class="flex flex-wrap gap-1">
                       <TrustBadge trustLabel={row.trust_label} compact />
                       <ValidationBadge validationStatus={row.validation_status} showMissing />
                     </div>
                   </td>
-                  <td role="gridcell" class="table-td w-32 min-w-32 whitespace-nowrap font-mono">
+                  <td
+                    role="gridcell"
+                    class={`table-td sticky z-10 w-32 min-w-32 whitespace-nowrap font-mono ${
+                      isSelected ? "bg-[var(--bb-tone-info-bg)]" : "bg-[var(--bb-surface-data)]"
+                    }`}
+                    style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "primary"))}
+                  >
                     {fmtPrimary(getPrimaryValue(row))}
                   </td>
                   {showGeomeanCol && (
-                    <td role="gridcell" class="table-td w-32 min-w-32 whitespace-nowrap font-mono text-[var(--bb-data-fg-muted)]">
+                    <td
+                      role="gridcell"
+                      class={`table-td sticky z-10 w-32 min-w-32 whitespace-nowrap font-mono text-[var(--bb-data-fg-muted)] ${
+                        isSelected ? "bg-[var(--bb-tone-info-bg)]" : "bg-[var(--bb-surface-data)]"
+                      }`}
+                      style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "geomean"))}
+                    >
                       {fmtGeomean(row.display_geomean_ms)}
                     </td>
                   )}

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -12,7 +12,7 @@
  * No hardcoded expected values remain here - the fixtures are the contract.
  */
 
-import { fireEvent, render, screen } from "@testing-library/preact";
+import { fireEvent, render, screen, within } from "@testing-library/preact";
 import { describe, it, expect } from "vitest";
 import { expectNoAxeViolations } from "@/testing/axe-helper";
 import { QueryHeatmap } from "@/components/QueryHeatmap";
@@ -118,6 +118,37 @@ describe("QueryHeatmap rendering", () => {
     );
     expect(labels).toStrictEqual(["Q1", "Q2", "Q10"]);
     expect(screen.getByRole("button", { name: /^Q10/ })).toBeTruthy();
+  });
+
+  it("applies cumulative sticky-left offsets to the frozen header columns", () => {
+    const { container } = render(<QueryHeatmap summary={makeSummary()} />);
+    const trustHeader = within(container.querySelector("thead")!).getByRole("columnheader", { name: "Trust" });
+    const primaryHeader = container.querySelector("thead")!.querySelector('[aria-sort]:not([aria-sort=""])')!;
+    expect(trustHeader.getAttribute("style")).toContain("left: 11rem");
+    const platformHeader = within(container.querySelector("thead")!).getByRole("columnheader", { name: /^Platform/ });
+    expect(platformHeader.getAttribute("style")).toContain("left: 0rem");
+    expect(platformHeader.className).toContain("sticky");
+    expect(primaryHeader.getAttribute("style")?.includes("left:")).toBe(true);
+  });
+
+  it("shifts sticky offsets right by the checkbox column width when selection is enabled", () => {
+    const { container } = render(
+      <QueryHeatmap summary={makeSummary()} selectedIds={new Set()} onSelectionChange={() => {}} />,
+    );
+    const platformHeader = within(container.querySelector("thead")!).getByRole("columnheader", { name: /^Platform/ });
+    const trustHeader = within(container.querySelector("thead")!).getByRole("columnheader", { name: "Trust" });
+    expect(platformHeader.getAttribute("style")).toContain("left: 3rem");
+    expect(trustHeader.getAttribute("style")).toContain("left: 14rem");
+  });
+
+  it("makes the header row vertically sticky and layers it above body sticky cells", () => {
+    const { container } = render(<QueryHeatmap summary={makeSummary()} />);
+    const headerRow = container.querySelector("thead tr")!;
+    expect(headerRow.className).toContain("sticky");
+    expect(headerRow.className).toContain("top-0");
+    expect(headerRow.className).toMatch(/\bz-(20|30|40)\b/);
+    const platformHeader = within(container.querySelector("thead")!).getByRole("columnheader", { name: /^Platform/ });
+    expect(platformHeader.className).toMatch(/\bz-30\b/);
   });
 
   it("renders compact receipt links and validation status badges", () => {


### PR DESCRIPTION
Closes the w2 and w3 work units of
results-explorer-table-sticky-density-and-semantics. Defects this
addresses were captured against develop tip in
_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w23.log.

w4 (provenance compaction) and w5 (Platform detail filters) ship in a
separate PR per the parent brief's note that this TODO "may split into
2 PRs" — both touch larger UX surfaces and benefit from focused review.

Changes:

  - `QueryHeatmap.tsx` exposes a `STICKY_COL_REM` width table and a
    `cumulativeStickyLeft({ hasSelection, showGeomeanCol }, col)` helper
    that walks the frozen-column prefix. Every sticky column
    (checkbox, platform, trust, primary score, geomean) now applies
    its `left` value via inline `style` so the offsets stay correct
    when the optional compare-checkbox column toggles on/off. The
    previous hardcoded `left-44` Tailwind class desynced as soon as
    `hasSelection` was true.
  - Score and Geomean columns are now sticky too, so they stay aligned
    with horizontally scrolled query cells (the brief explicitly calls
    them out alongside checkbox/platform/trust).
  - The header `<tr>` carries `sticky top-0 z-20` so query numbers
    remain visible during vertical scroll. Frozen-corner header cells
    (sticky-top + sticky-left) use `z-30` so they paint above body
    sticky cells (`z-10`) and above non-frozen header cells (`z-20`),
    avoiding the transparency-bleed pattern called out in w0.

Tests:

  - Three new assertions in `QueryHeatmap.test.tsx`: cumulative offset
    application on the default render, the +3rem shift when the
    selection column is enabled, and the vertically sticky header
    class set with z-30 frozen corners.

Verification:

  - `npm test -- --run` (551/551)
  - `npm run typecheck` and `npm run build` clean.
  - Browser walks deferred to release-gate Playwright (TODO #8 w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
