### PR TITLE
feat(explorer): add Platform detail filter strip with reset (>=25 rows)

### DIFF
--- a/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
@@ -79,12 +79,25 @@ work:
   - id: w5
     summary: "Add filters to large Platform detail tables"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Add visible filters to Platform detail tables with >= 25 rows:
-      benchmark, scale, phase, date range, trust tier, validation status,
-      and metric contract. The count label must update from "Showing 70 of
-      70 results" to the filtered count and provide one-click reset.
+      `PlatformIndex.tsx` renders a "Platform result filters" section
+      (`data-testid="platform-detail-filters"`) above the compare-guidance
+      strip whenever `allPlatformResults.length >= 25`. Six selects map
+      to the FacetKeys already plumbed through `useFacetState` /
+      `matchesFacetRow`: benchmark, scale_factor, phase, trust_tier,
+      validation_status, and date_window. Option lists for the first five
+      come from the unfiltered cohort (so the user always sees every
+      available value). Date window uses the canonical four-bucket
+      DateWindowFacet set. A Reset button (only when at least one of the
+      six facets is active) clears them all in one action. The existing
+      "Showing X of Y results" line is unchanged structurally — it
+      already reads from `platformResults` (filtered length), so it
+      flips from "30 of 30" to the filtered count as soon as a select
+      fires. `metric_contract` is intentionally omitted (no single
+      facet for it; a follow-up if/when the corpus needs it).
+      Verification log:
+      _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w5.log.
 
   - id: w6
     summary: "Make Query Workbench sort headers semantic and keyboard accessible"

--- a/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w5.log
+++ b/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w5.log
@@ -1,0 +1,76 @@
+# w5 — Add filters to large Platform detail tables
+
+Branch: feat/explorer-platform-filters-density
+Develop tip at start: 6c28d2b45 (PR #298 merged; #304 still open)
+
+w4 (provenance compaction) is deferred to a follow-up PR after #304
+merges, since both touch QueryHeatmap.tsx and a concurrent edit would
+collide on the rebase.
+
+## Current state on develop tip
+
+`results-explorer/src/pages/PlatformIndex.tsx`. The page already
+plumbs facets via `useFacetState()` and applies them via
+`matchesFacetRow(row, facets, { keys: PLATFORM_RESULT_FACET_KEYS })`
+at line 166. PLATFORM_RESULT_FACET_KEYS already lists benchmark,
+scale_factor, phase, trust_tier, validation_status, date_window plus
+others.
+
+Despite the underlying state being available, the only visible filter
+control is the Tuning select (only when >1 tuning mode exists). On a
+DuckDB platform page with 70 results across multiple benchmarks/
+phases/scales, the user cannot narrow by benchmark/scale/phase from
+the UI.
+
+The count strip at line 309-313 reads:
+
+  > Showing 70 of 70 results
+
+There is no reset affordance.
+
+## Defects vs the w0 review
+
+- D1: No filter UI on Platform detail despite filter state being
+  fully wired into the data layer.
+- D2: Static "Showing 70 of 70" count even when no filters could
+  apply — but the count itself is already derived from the filtered
+  array, so once filters render and fire, the count updates without
+  further changes. The defect is purely the absence of UI.
+- D3: No one-click reset.
+
+## Planned change
+
+1. Above the existing compare-guidance section, render a "Filters"
+   strip when `allPlatformResults.length >= 25`. Below 25 rows the
+   strip is omitted to avoid extra chrome on platforms with sparse
+   coverage (the brief explicitly thresholds on >=25).
+2. Six selects: Benchmark, Scale, Phase, Trust, Validation, Date
+   window. Each pulls option values from the actual rendered rows
+   (so the user sees only meaningful choices) except Date window
+   which uses the canonical four-bucket DateWindowFacet set.
+3. A "Reset" button shown only when at least one of those facets is
+   active. Clears the six w5 facets in one action; leaves the existing
+   tuning filter and any compare selection untouched (out of scope).
+4. The existing count strip at line 311 already reads from
+   `platformResults` (filtered length), so once filters fire the
+   "Showing X of Y" updates from "70 of 70" to "filtered of total"
+   automatically. No structural change needed there.
+
+`metric_contract` from the brief is omitted — there is no single
+facet for it; a metric-contract filter would require deriving from
+`primary_metric` plus units. Documented as a follow-up if the corpus
+ever needs it.
+
+## Manual route walk
+
+- /results/p/duckdb/ (70 rows across multiple benchmarks): Tuning
+  select renders; no other filter controls.
+- /results/p/<low-volume>/ (<25 rows): No filter strip needed; matches
+  the <25 threshold.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/pages/__tests__/PlatformIndex.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser walks deferred to release-gate Playwright (TODO #8 w3).

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -3,8 +3,9 @@ import type { RoutableProps } from "preact-router";
 import { route } from "preact-router";
 import type { PlatformIndexRowRow } from "@/lib/duckdbQueries";
 import { getPlatformIndexRows } from "@/lib/duckdbQueries";
-import { useFacetState, type FacetKey, type FacetState } from "@/lib/facetModel";
-import { hasActiveFacets, matchesFacetRow, singleFacetValue } from "@/lib/facetMatching";
+import { useFacetState, type DateWindowFacet, type FacetKey, type FacetState } from "@/lib/facetModel";
+import { hasActiveFacets, matchesFacetRow, singleFacetValue, toDateWindowFacet } from "@/lib/facetMatching";
+import { formatTrustLabel, formatValidationStatus } from "@/lib/displayLabels";
 import { buildCompareUrl, compareIdForRow, displayCompareId } from "@/lib/resultLinks";
 import { humanizeBenchmark, fmtScore, fmtGeomean, errMsg } from "@/utils";
 import { LoadingSpinner } from "@/components/LoadingSpinner";
@@ -101,6 +102,40 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const { facets, setFacet } = useFacetState();
   const tuningFilter = singleFacetValue(facets.tuning_mode, "all") ?? "all";
   const setTuningFilter = (value: string) => setFacet("tuning_mode", value === "all" ? [] : [value]);
+  // w5 (table-sticky-density-and-semantics): single-select filters for the
+  // Platform detail table. Each maps to a FacetKey already plumbed through
+  // useFacetState/matchesFacetRow so the filtered count strip updates as
+  // soon as the user picks a value.
+  const benchmarkFilter = singleFacetValue(facets.benchmark, "all") ?? "all";
+  const scaleFilter = singleFacetValue(facets.scale_factor, "all") ?? "all";
+  const phaseFilter = singleFacetValue(facets.phase, "all") ?? "all";
+  const trustFilter = singleFacetValue(facets.trust_tier, "all") ?? "all";
+  const validationFilter = singleFacetValue(facets.validation_status, "all") ?? "all";
+  const dateWindowFilter: DateWindowFacet = facets.date_window;
+  // Helper for the five string-array facets that share the "all means
+  // empty array" pattern. date_window has its own DateWindowFacet shape
+  // and uses toDateWindowFacet directly.
+  const setSingleArrayFacet = (
+    key: "benchmark" | "scale_factor" | "phase" | "trust_tier" | "validation_status",
+    value: string,
+  ) => setFacet(key, value === "all" ? [] : [value]);
+  const w5FilterKeys: FacetKey[] = [
+    "benchmark",
+    "scale_factor",
+    "phase",
+    "trust_tier",
+    "validation_status",
+    "date_window",
+  ];
+  const hasW5Filters = hasActiveFacets(facets, w5FilterKeys);
+  const resetW5Filters = () => {
+    setFacet("benchmark", []);
+    setFacet("scale_factor", []);
+    setFacet("phase", []);
+    setFacet("trust_tier", []);
+    setFacet("validation_status", []);
+    setFacet("date_window", "all");
+  };
   // Default: geomean_ms ascending (fastest first), nulls last. The empty-state
   // ordering is observable behaviour — must_preserve in the parent TODO.
   const [sort, setSort] = useState<SortState<PlatformSortKey>>({
@@ -175,6 +210,30 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
   const tuningModes = [
     ...new Set(allPlatformResults.map((r) => r.tuning_mode).filter((m): m is string => m !== null)),
   ].sort();
+
+  // w5: derived option lists for the new filter strip. Each list is built
+  // from the unfiltered cohort (allPlatformResults) so the user can always
+  // see every available value, even after narrowing.
+  const benchmarkOptions = [...new Set(allPlatformResults.map((r) => r.benchmark))].sort();
+  const scaleOptions = [
+    ...new Set(allPlatformResults.map((r) => r.scale_factor)),
+  ].sort((a, b) => a - b);
+  const phaseOptions = [...new Set(allPlatformResults.map((r) => r.phase))].sort();
+  const trustOptions = [
+    ...new Set(
+      allPlatformResults
+        .map((r) => r.trust_label)
+        .filter((label): label is string => label !== null && label !== undefined),
+    ),
+  ].sort();
+  const validationOptions = [
+    ...new Set(
+      allPlatformResults
+        .map((r) => r.validation_status)
+        .filter((status): status is string => status !== null && status !== undefined),
+    ),
+  ].sort();
+  const showW5Filters = allPlatformResults.length >= 25;
 
   const platformResultsRaw = allPlatformResults.filter((row) =>
     matchesFacetRow(row, facets, { keys: PLATFORM_RESULT_FACET_KEYS }),
@@ -315,6 +374,151 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
           )}
         </div>
       </div>
+
+      {showW5Filters && (
+        <section
+          class="mb-4 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 shadow-sm"
+          data-testid="platform-detail-filters"
+          aria-label="Platform result filters"
+        >
+          <div class="flex flex-wrap items-end gap-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-benchmark">
+                Benchmark
+              </label>
+              <select
+                id="platform-filter-benchmark"
+                data-testid="platform-filter-benchmark"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={benchmarkFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("benchmark", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All benchmarks</option>
+                {benchmarkOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {humanizeBenchmark(value)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-scale">
+                Scale
+              </label>
+              <select
+                id="platform-filter-scale"
+                data-testid="platform-filter-scale"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={scaleFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("scale_factor", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All scales</option>
+                {scaleOptions.map((value) => (
+                  <option key={String(value)} value={String(value)}>
+                    SF {value}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-phase">
+                Phase
+              </label>
+              <select
+                id="platform-filter-phase"
+                data-testid="platform-filter-phase"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={phaseFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("phase", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All phases</option>
+                {phaseOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {value.charAt(0).toUpperCase() + value.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-trust">
+                Trust tier
+              </label>
+              <select
+                id="platform-filter-trust"
+                data-testid="platform-filter-trust"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={trustFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("trust_tier", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All trust tiers</option>
+                {trustOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {formatTrustLabel(value)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-validation">
+                Validation
+              </label>
+              <select
+                id="platform-filter-validation"
+                data-testid="platform-filter-validation"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={validationFilter}
+                onChange={(event) =>
+                  setSingleArrayFacet("validation_status", (event.target as HTMLSelectElement).value)
+                }
+              >
+                <option value="all">All validation</option>
+                {validationOptions.map((value) => (
+                  <option key={value} value={value}>
+                    {formatValidationStatus(value)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-xs font-medium text-[var(--bb-data-fg-muted)]" for="platform-filter-date-window">
+                Date window
+              </label>
+              <select
+                id="platform-filter-date-window"
+                data-testid="platform-filter-date-window"
+                class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-2 py-1 text-sm shadow-sm"
+                value={dateWindowFilter}
+                onChange={(event) =>
+                  setFacet("date_window", toDateWindowFacet((event.target as HTMLSelectElement).value))
+                }
+              >
+                <option value="all">All time</option>
+                <option value="30d">Last 30 days</option>
+                <option value="90d">Last 90 days</option>
+                <option value="365d">Last 365 days</option>
+              </select>
+            </div>
+            {hasW5Filters && (
+              <button
+                type="button"
+                data-testid="platform-filter-reset"
+                class="ml-auto rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1.5 text-sm font-medium text-[var(--bb-data-fg-primary)] shadow-sm hover:bg-[var(--bb-surface-data-muted)]"
+                onClick={resetW5Filters}
+              >
+                Reset filters
+              </button>
+            )}
+          </div>
+        </section>
+      )}
 
       <section
         class="mb-4 rounded-lg border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-4 py-3 shadow-sm"

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -135,6 +135,42 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(routeMock).toHaveBeenCalledWith("/results/p/postgres/");
   });
 
+  it("renders the platform filter strip when the cohort has >=25 rows and reset clears it", async () => {
+    const denseRows: PlatformIndexRowRow[] = Array.from({ length: 30 }, (_, idx) =>
+      makeRow({
+        result_id: `r-dense-${idx}`,
+        short_id: `dense${String(idx).padStart(4, "0")}`,
+        benchmark: idx < 18 ? "tpch" : "clickbench",
+        scale_factor: idx % 2 === 0 ? 0.1 : 1,
+        run_date: "2026-04-10",
+        geomean_ms: 10 + idx,
+      }),
+    );
+    vi.mocked(getPlatformIndexRows).mockResolvedValue(denseRows);
+
+    render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    const filterStrip = screen.getByTestId("platform-detail-filters");
+    expect(filterStrip).toBeTruthy();
+    expect(screen.getByText("Showing 30 of 30 results")).toBeTruthy();
+
+    fireEvent.change(screen.getByTestId("platform-filter-benchmark"), {
+      target: { value: "clickbench" },
+    });
+    await waitFor(() => expect(screen.getByText("Showing 12 of 12 results")).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId("platform-filter-reset"));
+    await waitFor(() => expect(screen.getByText("Showing 30 of 30 results")).toBeTruthy());
+    expect(screen.queryByTestId("platform-filter-reset")).toBeNull();
+  });
+
+  it("hides the platform filter strip when the cohort has fewer than 25 rows", async () => {
+    render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+    expect(screen.queryByTestId("platform-detail-filters")).toBeNull();
+  });
+
   it("shows persistent compare guidance and cohort labels before selection", async () => {
     render(<PlatformIndex platform="duckdb" />);
     await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());


### PR DESCRIPTION
Closes the w5 work unit of
results-explorer-table-sticky-density-and-semantics. w4 (provenance
compaction) is deferred to a follow-up PR after #304 merges, since both
edit QueryHeatmap.tsx and a parallel diff would conflict on rebase.

Defects this addresses were captured against develop tip in
_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w5.log.

Changes:

  - `PlatformIndex.tsx` renders a `<section
    data-testid="platform-detail-filters">` above the existing
    compare-guidance strip whenever the unfiltered cohort has 25+
    rows. Six native `<select>` controls cover Benchmark, Scale,
    Phase, Trust tier, Validation, and Date window — each mapped to
    a FacetKey already plumbed through `useFacetState` and
    `matchesFacetRow`. Option lists for the first five are derived
    from the loaded rows so the user only sees values that exist in
    the cohort. The date window uses the canonical four-bucket
    DateWindowFacet set.
  - A Reset button (`data-testid="platform-filter-reset"`) renders
    only when at least one of the six w5 facets is active and clears
    them in one action.
  - The existing "Showing X of Y results" line is unchanged: it
    already reads from `platformResults` (filtered length), so it
    flips from "30 of 30" to the filtered count as soon as a select
    fires.

  - `metric_contract` from the brief is intentionally omitted — there
    is no single facet for it on this page; a follow-up TODO can plumb
    a derived `primary_metric` filter if the corpus eventually needs
    one.

Tests:

  - Two new regression tests in `PlatformIndex.test.tsx`: render
    visibility against a 30-row fixture (filter strip shows; Reset
    clears), and visibility absence against the default 4-row fixture.

Verification:

  - `npm test -- --run` (551/551)
  - `npm run typecheck` and `npm run build` clean.
  - Browser walks deferred to release-gate Playwright (TODO #8 w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
