### PR TITLE
[codex] Strengthen JOB scale TODO guardrails

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml
@@ -11,10 +11,11 @@ description: |
   signal from the frozen real IMDB dataset and its cross-table correlations.
 
   This item defines the reusable canonical dataset contract that must exist
-  before any scaled JOB-derived benchmark is credible. It covers the hosted
-  archive format, user-supplied data path, reference validation oracle, encoding
-  and NULL-preservation checks, result-bundle dataset versioning, CI routing, and
-  central scale-factor enforcement.
+  before any scaled JOB-derived benchmark is credible. It covers legal and
+  redistribution constraints, the hosted archive format or user-supplied data
+  path, reference validation oracle, encoding and NULL-preservation checks,
+  result-bundle dataset versioning, CI routing, and central scale-factor
+  enforcement.
 
   This TODO does not implement derived scale-up. It creates the foundation that
   later scale-stress work must depend on.
@@ -34,10 +35,32 @@ context_sections:
     cannot match generated rows because fields such as movie_companies.note and
     cast_info.note are always NULL. Canonical JOB must restore the frozen real
     data contract before any derived benchmark can claim continuity with JOB.
+  "Licensing boundary": |
+    IMDb's current public dataset terms allow local non-commercial use subject to
+    conditions, but hosted redistribution, republishing, alteration, CI caching,
+    and derived archives need an explicit project decision before BenchBox ships
+    any downloadable canonical or scaled IMDb artifact.
 
 work:
+  - id: w0
+    summary: "Resolve the IMDb/JOB data licensing and redistribution gate"
+    status: pending
+    notes: |
+      Write `_project/decisions/joinorder-imdb-data-licensing-<date>.md`
+      before designing the hosted archive. The decision must state:
+        - whether BenchBox may host a canonical Parquet archive;
+        - whether BenchBox may host derived replicated or expanded IMDb archives;
+        - whether CI runners may cache canonical or derived data;
+        - what attribution, terms-acceptance, and non-commercial-use language is
+          required;
+        - the fallback path if hosted redistribution is not approved.
+      Approved fallback shapes include user-supplied `data_path`, a reproducible
+      local conversion script, checksums/manifests, and documentation that points
+      users to their own accepted download path.
+
   - id: w1
     summary: "Choose and document the canonical reference oracle"
+    needs: [w0]
     status: pending
     notes: |
       Decide the validation oracle for canonical JOB. The preferred shape is:
@@ -63,6 +86,9 @@ work:
         - conversion pipeline provenance.
       The format must support hosted download and `--benchmark-option
       data_path=/path/to/job_dataset` for air-gapped users.
+      If w0 does not approve hosted redistribution, specify only the local
+      conversion and user-supplied data-path contract; do not leave "hosted
+      archive" language ambiguous.
 
   - id: w3
     summary: "Add encoding and NULL-preservation gates to the data-build spec"
@@ -92,6 +118,9 @@ work:
       scale mode. The explorer must surface dataset-version mismatches when
       comparing JOB results so a future archive fix does not make old and new
       results ambiguous.
+      Include license/distribution mode in the manifest and result bundle so
+      hosted, user-built, and derived archives cannot be compared as if they were
+      the same artifact.
 
   - id: w5
     summary: "Design central benchmark scale-factor and mode validation"
@@ -135,6 +164,7 @@ deferred:
     reason: "This may be a substantial independent task; w7 decides whether it is in scope."
 
 must_preserve:
+  - "No hosted canonical or derived IMDb archive may ship unless the licensing decision explicitly approves that distribution mode."
   - "Canonical JOB means frozen real IMDB-derived JOB data at SF=1 only; synthetic data must not be mislabeled canonical."
   - "Air-gapped users must have a documented data_path path, not only a hosted-download path."
   - "Predicate-bearing string and note columns must preserve exact values and NULL semantics through conversion."
@@ -149,12 +179,25 @@ approach: |
   than overloading TPC's official/unofficial vocabulary.
 
 anti_patterns:
+  - "DO NOT publish or cache IMDb-derived archives before the licensing decision is written - because non-commercial local use is not the same as redistributing a transformed benchmark dataset - ship scripts/manifests/data_path docs instead when redistribution is not approved."
   - "DO NOT validate canonical JOB with only non-empty query checks - because that would miss wrong answers and predicate-domain corruption - use reference outputs/cardinalities from a chosen reference engine instead."
   - "DO NOT coerce empty strings and NULLs through generic CSV/Parquet defaults - because JOB predicates depend on note and string columns - add explicit round-trip and null-count checks."
   - "DO NOT rely on registry scale_options alone - because current runner paths may bypass it - implement a central validation hook used by CLI and benchmark construction paths."
   - "DO NOT put full canonical JOB in fast tests - because the dataset is gigabyte-scale - use a tiny predicate-satisfying fixture for unit coverage and full data only in UAT/nightly/manual gates."
 
 verification:
+  - description: "Licensing decision exists and declares allowed distribution modes"
+    command: "rg -n \"hosted archive|derived archive|CI cache|user-supplied data_path|distribution mode\" _project/decisions/joinorder-imdb-data-licensing-*.md"
+    expected_output: "decision covers hosting, derived archives, CI caching, and fallback data_path"
+  - description: "Oracle decision names reference engine and stored artifacts"
+    command: "rg -n \"reference engine|PostgreSQL|reference cardinalities|normalized result sets|non-empty\" _project/decisions/joinorder-canonical-dataset-contract-*.md"
+    expected_output: "decision names the oracle and rejects non-empty-only validation"
+  - description: "Manifest contract covers provenance, checksums, nulls, and dataset versioning"
+    command: "rg -n \"dataset_version|manifest hash|source checksum|null counts|conversion pipeline|file format version\" _project/decisions/joinorder-canonical-dataset-contract-*.md"
+    expected_output: "manifest contract includes all required provenance and integrity fields"
+  - description: "Scale-factor enforcement design covers CLI and benchmark construction paths"
+    command: "rg -n \"central validation|scale factor|SF=1|CLI|benchmark construction\" _project/decisions/joinorder-canonical-dataset-contract-*.md"
+    expected_output: "decision covers central SF=1 enforcement"
   - description: "TODO graph remains valid after this planning item is added"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
     expected_output: "Graph validation passed"
@@ -164,6 +207,7 @@ verification:
 
 scope_limit:
   only_modify:
+    - "_project/decisions/joinorder-imdb-data-licensing-*.md"
     - "_project/decisions/joinorder-canonical-dataset-contract-*.md"
     - "_project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml"
     - "docs/benchmarks/join-order.md"
@@ -178,6 +222,7 @@ scope_limit:
     - "results-explorer/"
 
 success_metrics:
+  - "A written IMDb/JOB data licensing decision declares whether hosted canonical archives, derived archives, and CI caches are permitted."
   - "A written oracle decision exists and names the reference engine plus exact artifacts to store."
   - "Canonical archive manifest format includes dataset_version, checksums, null counts, provenance, and file format version."
   - "CLI and benchmark construction paths have a central validation design for canonical JOB SF=1 enforcement."

--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -31,13 +31,22 @@ context_sections:
 
 work:
   - id: w1
-    summary: "Confirm decision-framework approval and prototype scope"
+    summary: "Confirm licensing, stats-phase, and decision-framework prerequisites"
     status: pending
     notes: |
       Do not start implementation unless joinorder-scale-stress-decision-framework
       chooses replicated_imdb as an approved baseline. Copy the chosen prototype
       scope and success criteria from that decision note into this TODO before
       coding.
+
+      Also confirm:
+        - the IMDb/JOB data licensing decision allows the intended local or
+          hosted derived-data workflow;
+        - any required first-class stats/analyze phase TODO is completed or this
+          prototype is explicitly narrowed to a measurement smoke that does not
+          claim stats-maintenance conclusions;
+        - result-bundle labels and manifest fields for replicated_imdb are
+          already specified by the decision framework.
 
   - id: w2
     summary: "Map JOB primary keys, foreign keys, and lookup tables"
@@ -64,6 +73,9 @@ work:
       predicate-bearing values unchanged. Record source dataset_version,
       replica factor, builder version, seed if any, and per-table checksums in
       the derived manifest.
+      If hosted redistribution is not approved, the builder must be documented as
+      a local user-run conversion path and must not produce a BenchBox-hosted
+      derived archive.
 
   - id: w4
     summary: "Validate replicated cardinalities and predicate preservation"
@@ -89,6 +101,9 @@ work:
       and replicated SF=2. Capture load time, stats/analyze time, planning time,
       execution time, plan shape, and cardinality estimates where available.
       This is a measurement smoke, not a leaderboard.
+      If first-class stats/analyze phase accounting is not yet implemented, the
+      report must mark stats/analyze timing as unavailable or manually captured
+      and must not use it as publication-quality evidence.
 
   - id: w6
     summary: "Write the prototype evaluation and decide whether to continue"
@@ -113,6 +128,7 @@ deferred:
 
 must_preserve:
   - "Canonical joinorder remains SF=1 canonical_imdb and literature-comparable only."
+  - "No hosted replicated_imdb archive may ship unless the IMDb/JOB data licensing decision explicitly approves derived archive redistribution."
   - "replicated_imdb result bundles record source canonical dataset_version and derived manifest hash."
   - "Predicate-bearing values must not be suffixed or mutated in the replicated baseline."
   - "Lookup tables must not be duplicated unless the schema contract explicitly requires it."
@@ -124,12 +140,16 @@ approach: |
   query/cardinality scaling before interpreting engine performance.
 
 anti_patterns:
+  - "DO NOT start implementation until licensing and stats/analyze phase prerequisites are resolved - because the prototype otherwise cannot produce shippable or interpretable scale-stress evidence."
   - "DO NOT suffix predicate string values to make rows unique - because JOB predicates depend on exact values - offset IDs instead."
   - "DO NOT duplicate lookup tables by default - because lookup predicates should remain stable and FKs can point to the same lookup rows - keep lookup tables single-copy."
   - "DO NOT publish replicated_imdb results as canonical JOB - because replicated components are an artificial derived scale mode - label result bundles accordingly."
   - "DO NOT run expensive cloud matrices during the prototype - because the first gate is semantic validity and local measurement - defer cloud until w6 approves continuation."
 
 verification:
+  - description: "Prerequisite decisions approve replication scope, distribution mode, and stats/analyze handling"
+    command: "rg -n \"replicated_imdb|derived archive|distribution mode|stats/analyze|recommended prototype\" _project/decisions/joinorder-scale-stress-*.md _project/decisions/joinorder-imdb-data-licensing-*.md"
+    expected_output: "decisions approve or explicitly constrain replicated_imdb before implementation starts"
   - description: "Prototype keeps TODO graph valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
     expected_output: "Graph validation passed"
@@ -156,6 +176,7 @@ scope_limit:
     - "benchbox/core/tpcds/"
 
 success_metrics:
+  - "Prerequisite decision notes approve replicated_imdb scope, distribution mode, and stats/analyze phase handling before coding begins."
   - "A deterministic replicated_imdb archive builder exists behind an explicit derived scale mode."
   - "Derived manifests record source dataset_version, scale factor, builder version, and per-table checksums."
   - "FK integrity, null-count scaling, predicate frequency scaling, and query cardinality scaling are validated."

--- a/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
+++ b/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
@@ -32,8 +32,25 @@ context_sections:
     as canonical joinorder and must not claim literature comparability.
 
 work:
+  - id: w0
+    summary: "Collect evidence for optimizer and statistics failures at scale"
+    status: pending
+    notes: |
+      Before choosing a scaled JOB-derived path, collect evidence that the target
+      problem is real and distinct from canonical JOB. Include at least three of:
+        - documented optimizer/cardinality/statistics failures that appear only
+          or primarily at larger data scales;
+        - BenchBox-local observations from prior large-scale runs;
+        - engine documentation describing sampled, stale, partition, or
+          incremental statistics limits;
+        - academic or vendor papers on optimizer search, planning-time, or
+          statistics-maintenance breakdowns at scale.
+      The decision note must separate this evidence from the original JOB paper's
+      fixed-dataset cardinality-estimation problem.
+
   - id: w1
     summary: "Write the benchmark question and non-goals"
+    needs: [w0]
     status: pending
     notes: |
       Produce a short decision note that separates:
@@ -75,6 +92,11 @@ work:
         - incremental or partition stats where supported.
       Measurements should keep load, stats-build, planning, and execution time
       separate. Capture engine-specific stats metadata where available.
+      If a first-class stats/analyze phase is required, create
+      `_project/TODO/main/planning/joinorder-statistics-phase-measurement.yaml`
+      and make any implementation prototype depend on it before coding. The
+      decision must identify required changes to runner phases, result bundles,
+      platform adapter hooks, CLI phase parsing, and validation/reporting.
 
   - id: w4
     summary: "Compare scale-up implementation options"
@@ -133,11 +155,16 @@ work:
         - parameterized_imdb benchmark family,
         - or staged combination.
       The recommendation must name the smallest next prototype and its
-      verification criteria.
+      verification criteria. If the recommendation is replicated_imdb, it must
+      also state whether the statistics/analyze phase blocker is satisfied,
+      deferred with a narrower prototype scope, or represented by a new TODO that
+      the prototype must depend on.
 
 deferred:
   - summary: "Implement any scaled JOB generator"
     reason: "This item is the decision framework. Implementation belongs in a follow-up TODO after w7 chooses a path."
+  - summary: "Implement first-class statistics/analyze phase accounting"
+    reason: "This decision item must decide whether that is required and create a dedicated TODO if so."
   - summary: "Build dashboard/explorer UI for scale-stress metrics"
     reason: "Explorer work depends on final result-bundle fields and benchmark labels."
 
@@ -145,6 +172,7 @@ must_preserve:
   - "Canonical joinorder remains fixed to canonical_imdb SF=1 and is never silently replaced by derived scale modes."
   - "Derived workloads must report their data-generation strategy, dataset version, generator version, seed, and stats protocol."
   - "Query validation must use the canonical oracle contract from joinorder-canonical-dataset-contract when applicable."
+  - "A scaled JOB-derived prototype must not start until stats/analyze phase requirements are either satisfied or explicitly scoped out in the decision note."
 
 approach: |
   Treat this as an architecture/design gate. Read canonical JOB behavior, TPC-DS
@@ -153,15 +181,22 @@ approach: |
   should be a decision record plus an updated TODO for the chosen prototype.
 
 anti_patterns:
+  - "DO NOT proceed on intuition that optimizers fail at scale - because this benchmark must justify a distinct workload identity - collect documented examples or local evidence first."
   - "DO NOT call a scaled derived workload 'JOB' without a qualifier - because users may assume literature comparability - use explicit labels such as replicated_imdb or job_scale_stress."
   - "DO NOT choose offset replication only because it is easiest - because it may hide the statistics/predicate-selectivity problem - evaluate whether it answers the benchmark question."
   - "DO NOT build graph expansion before defining validation gates - because synthetic correlations can look plausible while destroying the JOB signal - define measurement gates first."
   - "DO NOT fold stats-build timing into load or query execution - because the core research question includes statistics maintenance - require separate stats/analyze phase accounting."
 
 verification:
+  - description: "Decision note includes documented optimizer-at-scale evidence"
+    command: "rg -n \"optimizer.*scale|statistics.*scale|stale stats|sampled stats|planning-time|evidence\" _project/decisions/joinorder-scale-stress-*.md"
+    expected_output: "decision note cites documented or local evidence for scale-specific optimizer/statistics failures"
+  - description: "Decision note covers stats/analyze phase dependency"
+    command: "rg -n \"stats/analyze phase|stats-build|runner phases|result bundles|platform adapter|joinorder-statistics-phase-measurement\" _project/decisions/joinorder-scale-stress-*.md"
+    expected_output: "decision states whether first-class stats measurement is required and what TODO or scope handles it"
   - description: "Decision note exists and names the recommended prototype path"
-    command: "ls _project/decisions/joinorder-scale-stress-*.md"
-    expected_output: "at least one decision note"
+    command: "rg -n \"go/no-go|recommended prototype|replicated_imdb|expanded_imdb|parameterized_imdb|no scaled JOB\" _project/decisions/joinorder-scale-stress-*.md"
+    expected_output: "decision note names the selected path and rejected alternatives"
   - description: "TODO graph remains valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
     expected_output: "Graph validation passed"
@@ -174,6 +209,7 @@ scope_limit:
     - "_project/decisions/joinorder-scale-stress-*.md"
     - "_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml"
     - "_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+    - "_project/TODO/main/planning/joinorder-statistics-phase-measurement.yaml"
     - "docs/benchmarks/join-order.md"
     - "docs/development/"
   do_not_modify:
@@ -183,9 +219,10 @@ scope_limit:
     - "results-explorer/"
 
 success_metrics:
+  - "The decision note cites documented or local evidence for optimizer/statistics failures that appear at scale."
   - "The benchmark question for scale-stress JOB is written and clearly separated from canonical JOB."
   - "Scale-mode labels and result-bundle metadata are specified."
-  - "Statistics-maintenance phases and required timings are specified."
+  - "Statistics-maintenance phases and required timings are specified, including any follow-up TODO needed for first-class stats/analyze phase accounting."
   - "A go/no-go recommendation selects the smallest next prototype and rejects at least one unsuitable option with rationale."
 
 metadata:


### PR DESCRIPTION
## Summary

- Add an explicit IMDb/JOB data licensing and redistribution gate before hosted canonical or derived archives.
- Strengthen TODO verification from schema-only checks to decision-note content checks for oracle, manifest, scale enforcement, evidence, stats phase handling, and prototype prerequisites.
- Make stats/analyze phase accounting and optimizer-at-scale evidence explicit blockers for scaled JOB-derived work.
- Require replicated_imdb prototype prerequisites for licensing, stats-phase scope, and decision-framework approval before implementation starts.

## Why

The TODO review found that the initial plan was valid YAML but could still allow weak completion: hosted data could proceed without a redistribution decision, decision notes could be empty shells, and the replicated prototype could start before stats/analyze measurement support was resolved.

## Verification

- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-canonical-dataset-contract.yaml`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml`
- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py cleanup --dry-run`
- `git diff --check origin/develop..HEAD`
- Commit hooks and push hooks passed.
