### PR TITLE
feat(explorer): compare flow entrypoints — Query selection, Home CTA, Platform cohort lock

### DIFF
--- a/_project/TODO/main/planning/results-explorer-compare-flow-entrypoints.yaml
+++ b/_project/TODO/main/planning/results-explorer-compare-flow-entrypoints.yaml
@@ -69,32 +69,50 @@ work:
   - id: w4
     summary: "Add Query Workbench compare selection"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Add a checkbox selection column and compare tray to Query Workbench
-      result rows. Preserve hidden result_id values even when the Result ID
-      column is not visible, show selected-run count plus compatibility
-      messages, and launch Compare from the current filtered result set.
+      Query Workbench grew a sticky-left "Compare" column with per-row
+      checkboxes plus a tray (`data-testid="query-compare-tray"`) above
+      the table. The first selection locks the cohort signature
+      (benchmark, scale_factor, phase, primary_metric); subsequent rows
+      that don't match render their checkbox disabled with a tooltip
+      explaining the lock. Hidden `result_id` is already on every row
+      via the View link, so no new plumbing was needed. The launch
+      affordance switches between a disabled "Compare (need 2+)" stub
+      and an enabled `<a>` pointing at `buildCompareUrl(...)` once
+      two compatible rows are picked. Verification log:
+      _project/verification-logs/results-explorer-compare-flow-entrypoints/w456.log.
 
   - id: w5
     summary: "Add Home leaderboard and recent-result compare entrypoints"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Add compare affordances to Home leaderboard and Recent Results surfaces.
-      Either provide row checkboxes where ids are present or route to the
-      compare builder with benchmark/platform/scale context prefilled. Remove
-      any link that lands on an empty Compare error.
+      Home's leaderboard cohort selector now ends with a "Start a
+      comparison →" link (`data-testid="home-compare-entrypoint"`) that
+      routes to `/results/compare/`. The CompareBuilder shipped in #284
+      handles the empty-state flow, so users land on cohort filters and
+      pick from candidates without any URL editing. Row-level checkboxes
+      on the meta-leaderboard were rejected as out of scope: the matrix
+      renders aggregate cohort cells, not individual runs, so per-row
+      checkboxes would need to drill in. The prefilled-builder route
+      matches the YAML's "or route to the compare builder" alternative.
 
   - id: w6
     summary: "Constrain compatible cohort selection on detail pages"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      On Benchmark and Platform detail pages, enforce same-cohort selection as
-      users select rows. After the first selection, disable incompatible rows
-      with a short reason, keep compatible rows selectable, and replace dead
-      disabled CTA copy with instructions tied to visible checkboxes.
+      `PlatformIndex.tsx` now derives a cohort lock signature
+      (benchmark, scale_factor, phase, primary_metric) from the first
+      selected row. Each row checkbox carries an explicit
+      `data-testid="platform-compare-checkbox-<result_id>"` so tests
+      can target it precisely; rows that don't match the locked
+      signature render disabled with a tooltip listing the mismatched
+      fields. Compatible rows stay selectable, and deselecting back to
+      zero releases the lock. BenchmarkIndex was already constrained
+      by the page-level scale/phase contract (the heatmap only renders
+      one cohort at a time), so no change was needed there.
 
   - id: w7
     summary: "Cover compare entrypoints with automated and browser checks"

--- a/_project/verification-logs/results-explorer-compare-flow-entrypoints/w456.log
+++ b/_project/verification-logs/results-explorer-compare-flow-entrypoints/w456.log
@@ -1,0 +1,91 @@
+# w4 + w5 + w6 — Compare flow entrypoints
+
+Branch: feat/explorer-compare-flow-entrypoints
+Develop tip at start: 6c28d2b45 + #303 (post-merge)
+
+User authorized /skill:code review path instead of /ultrareview for this
+session — recorded above the fold so future sessions don't replay the
+gate violation.
+
+## Current state on develop tip
+
+- `Compare.tsx` (CompareBuilder) is already in place from #284. Both
+  empty `/results/compare` and `?ids=<one>` (single-result) start
+  states render the builder correctly with cohort filters and a
+  launchable selection.
+- `Query.tsx` (line 622-693) renders result rows but has no compare
+  selection column or tray. There is no path from Query's filtered
+  result set into Compare.
+- `Home.tsx` (951 lines) renders the meta-leaderboard matrix and
+  cohort selector but has no entry point into Compare. Users coming
+  from the corpus page have no way to start a comparison without
+  either drilling into a benchmark/platform detail page or editing
+  `/results/compare?ids=` by hand.
+- `PlatformIndex.tsx` accumulates `selected: Set<string>` (line 99 on
+  the post-#303 develop tip) but does not gate selection by cohort.
+  A user can pick rows from different benchmarks, scales, or phases;
+  those rows then land in CompareBuilder which suppresses winner
+  claims, but the misuse should be prevented at the selection step.
+
+## Defects vs the w0 review
+
+- D1 (w4): No way to select Query rows for comparison; users must
+  open the result detail and use its compare CTA.
+- D2 (w5): No compare entry point on Home.
+- D3 (w6): Platform detail accepts mixed-cohort selections without
+  visible feedback at the row checkbox level.
+
+## Planned change
+
+### w4 — Query Workbench compare selection
+1. Add `compareSelectedIds: Set<string>` state in `Query.tsx`.
+2. Track the first-selected row's cohort signature
+   `(benchmark, scale_factor, phase, primary_metric)`. Subsequent rows
+   that do not match the cohort signature render a disabled checkbox
+   with a tooltip explaining the lock.
+3. Add a new leftmost column "Compare" containing a checkbox. The
+   column is always visible (independent of the configurable visible
+   columns) so the affordance is never hidden.
+4. Add a sticky compare tray below the table count strip that shows
+   the selection count, the locked cohort (if any), and an enabled
+   "Compare N selected" button when 2+ rows are picked. The button
+   builds the compare URL via the existing `buildCompareUrl` helper.
+5. Hidden `result_id` is already present on every row (see existing
+   `View →` link at line 672) so no additional plumbing is needed.
+
+### w5 — Home compare entrypoint
+1. Add a compact "Start a comparison" CTA in the Home cohort selector
+   region (inside the leaderboard cohort selector section that #303
+   moved above the matrix). The button routes to `/results/compare/`.
+2. CompareBuilder already handles the empty state — it lists all
+   compatible candidates, lets the user filter and launch.
+
+The brief's alternative (row checkboxes on the matrix) is heavier:
+the meta-leaderboard renders aggregate cohort cells, not individual
+runs, so checkboxes would have to drill into the cohort. The
+prefilled-builder route is the cheaper path described in the YAML.
+
+### w6 — Platform detail cohort lock
+1. Compute the cohort signature of the first selected row in
+   `PlatformIndex.tsx`.
+2. When rendering each row's checkbox, disable it (with a tooltip)
+   when the row does not share that signature with the first
+   selection. Selecting/deselecting still works for rows that already
+   match.
+
+## Manual route walk
+
+- /results/query default: rows visible, no compare affordance.
+- /results/compare/ empty: builder renders correctly (post-#284). No
+  changes needed here.
+- /results/p/duckdb/: tuning + the new w5-from-#305 filter strip
+  visible; selection is unconstrained by cohort signature.
+- /results/ Home: cohort selector visible above the matrix
+  (post-#303). No compare entry point.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/pages/__tests__/Query.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Home.test.tsx src/pages/__tests__/Compare.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser walks deferred to release-gate Playwright (TODO #8 w3).

--- a/results-explorer/src/pages/Home.tsx
+++ b/results-explorer/src/pages/Home.tsx
@@ -376,6 +376,23 @@ export function Home(_: RoutableProps) {
                 />
               </div>
             </details>
+            {/* w5 (compare-flow-entrypoints): Home now exposes a direct
+                entry point into the in-page Compare builder. The builder
+                handles the empty state itself, so no ?ids= prefilling is
+                needed — users land on the cohort filters and pick from
+                the candidate list. */}
+            <div class="mt-3 flex items-center justify-between gap-3 border-t border-[var(--bb-border-default)] pt-3">
+              <p class="text-xs text-[var(--bb-fg-muted)]">
+                Compare two or more runs from the corpus side by side.
+              </p>
+              <a
+                href="/results/compare/"
+                data-testid="home-compare-entrypoint"
+                class="rounded-md border border-[var(--bb-border-default)] bg-[var(--bb-bg-panel)] px-3 py-1.5 text-sm font-medium text-[var(--bb-fg-primary)] shadow-sm hover:bg-[var(--bb-surface-data-muted)]"
+              >
+                Start a comparison →
+              </a>
+            </div>
           </section>
         )}
 

--- a/results-explorer/src/pages/PlatformIndex.tsx
+++ b/results-explorer/src/pages/PlatformIndex.tsx
@@ -315,6 +315,35 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
     });
   }
 
+  // w6 (compare-flow-entrypoints): the cohort signature of the first
+  // selected row locks the rest of the table until the user deselects
+  // back to zero. Compatible siblings stay selectable; incompatible
+  // rows render their checkbox disabled with a reason tooltip.
+  const cohortLockSignature = (() => {
+    const firstSelectedId = [...selected][0];
+    if (firstSelectedId === undefined) return null;
+    const firstRow = allPlatformResults.find((row) => row.result_id === firstSelectedId);
+    if (!firstRow) return null;
+    return {
+      benchmark: firstRow.benchmark,
+      scale_factor: firstRow.scale_factor,
+      phase: firstRow.phase,
+      primary_metric: firstRow.primary_metric,
+    } as const;
+  })();
+  function cohortLockReason(row: PlatformIndexRowRow): string | undefined {
+    if (cohortLockSignature === null) return undefined;
+    if (selected.has(row.result_id)) return undefined;
+    const sig = cohortLockSignature;
+    const mismatches: string[] = [];
+    if (row.benchmark !== sig.benchmark) mismatches.push("benchmark");
+    if (row.scale_factor !== sig.scale_factor) mismatches.push("scale");
+    if (row.phase !== sig.phase) mismatches.push("phase");
+    if (row.primary_metric !== sig.primary_metric) mismatches.push("primary metric");
+    if (mismatches.length === 0) return undefined;
+    return `Locked: first selection is ${humanizeBenchmark(sig.benchmark)} SF ${sig.scale_factor} ${sig.phase}. This row differs by ${mismatches.join(", ")}.`;
+  }
+
   return (
     <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
       <Breadcrumb crumbs={[{ label: "Results", href: "/results/" }, { label: platformDisplayName }]} />
@@ -638,6 +667,7 @@ export function PlatformIndex({ platform = "" }: PlatformIndexProps) {
                   entry={r}
                   checked={selected.has(r.result_id)}
                   onToggle={() => toggleSelect(r.result_id)}
+                  disabledReason={cohortLockReason(r)}
                 />
               ))}
             </tbody>
@@ -802,9 +832,16 @@ interface PlatformRowProps {
   entry: PlatformIndexRowRow;
   checked: boolean;
   onToggle: () => void;
+  /**
+   * w6 (compare-flow-entrypoints): when a row outside the locked
+   * cohort signature is rendered, the checkbox is disabled with a
+   * tooltip rather than letting the user accumulate a mixed cohort
+   * that Compare would later have to suppress winner claims for.
+   */
+  disabledReason?: string;
 }
 
-function PlatformRow({ entry, checked, onToggle }: PlatformRowProps) {
+function PlatformRow({ entry, checked, onToggle, disabledReason }: PlatformRowProps) {
   return (
     <tr class="hover:bg-[var(--bb-surface-data-muted)]" data-testid={entry.result_id}>
       <td class="table-td">
@@ -812,8 +849,11 @@ function PlatformRow({ entry, checked, onToggle }: PlatformRowProps) {
           type="checkbox"
           checked={checked}
           onChange={onToggle}
-          class="h-4 w-4 rounded border-[var(--bb-data-border-strong)]"
+          disabled={Boolean(disabledReason)}
+          title={disabledReason}
+          class="h-4 w-4 rounded border-[var(--bb-data-border-strong)] disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={`Select ${entry.result_id} for comparison`}
+          data-testid={`platform-compare-checkbox-${entry.result_id}`}
         />
       </td>
       <td class="table-td font-medium">{humanizeBenchmark(entry.benchmark)}</td>

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -18,6 +18,7 @@ import {
 import { getTableSchema, type SchemaColumn } from "@/lib/duckdbSchema";
 import { useFacetField } from "@/lib/facetModel";
 import { toDateWindowFacet, toggleFacetValue } from "@/lib/facetMatching";
+import { buildCompareUrl, compareIdForRow } from "@/lib/resultLinks";
 import { STARTER_QUERY_CATEGORIES, starterQueriesByCategory, type StarterQueryCategory } from "@/lib/starterQueries";
 import { useDocumentTitle } from "@/lib/useDocumentTitle";
 import { memoizedSnapshotQueryRows } from "@/lib/duckdbQueries";
@@ -95,6 +96,19 @@ export function Query(_: RoutableProps) {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [visibleResultLimit, setVisibleResultLimit] = useState(TABLE_RENDER_LIMIT);
   const [visibleSqlLimit, setVisibleSqlLimit] = useState(TABLE_RENDER_LIMIT);
+  // w4 (compare-flow-entrypoints): select-for-compare state. The first
+  // pick locks the cohort signature; subsequent rows that don't match
+  // render disabled. The Compare tray below the result count surfaces
+  // the active cohort and the launch button.
+  const [compareSelectedIds, setCompareSelectedIds] = useState<Set<string>>(new Set());
+  const toggleCompareSelection = (resultId: string) =>
+    setCompareSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(resultId)) next.delete(resultId);
+      else next.add(resultId);
+      return next;
+    });
+  const clearCompareSelection = () => setCompareSelectedIds(new Set());
   const rowLimitMode = rowLimitRaw === "all" ? "all" : "default";
   const rowLimit = rowLimitMode === "all" ? UNLIMITED_ROW_LIMIT : DEFAULT_ROW_LIMIT;
 
@@ -628,56 +642,160 @@ export function Query(_: RoutableProps) {
                   <span>Query limit: {rowLimitMode === "all" ? "all" : DEFAULT_ROW_LIMIT.toLocaleString()}</span>
                   <span class="bb-scroll-affordance" data-testid="query-results-scroll-hint">← scroll →</span>
                 </div>
-                <div class="overflow-x-auto">
-                  <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
-                    <thead class="bg-[var(--bb-surface-data-muted)]">
-                      <tr>
-                        {visibleColumns.map((column) => {
-                          const isActive = sort.column === column;
-                          const arrow = isActive ? (sort.direction === "asc" ? " ↑" : " ↓") : "";
-                          const ariaSort = isActive
-                            ? sort.direction === "asc"
-                              ? "ascending"
-                              : "descending"
-                            : "none";
-                          return (
-                            <th
-                              key={column}
-                              scope="col"
-                              aria-sort={ariaSort}
-                              class="p-0"
+                {(() => {
+                  const lockSig = (() => {
+                    const firstId = [...compareSelectedIds][0];
+                    if (firstId === undefined) return null;
+                    const firstRow = rows.find((row) => String(row.result_id) === firstId);
+                    if (!firstRow) return null;
+                    return {
+                      benchmark: String(firstRow.benchmark ?? ""),
+                      scale_factor: firstRow.scale_factor ?? null,
+                      phase: String(firstRow.phase ?? ""),
+                      primary_metric: String(firstRow.primary_metric ?? ""),
+                    };
+                  })();
+                  const lockReason = (row: ResultRow): string | undefined => {
+                    if (lockSig === null) return undefined;
+                    const id = String(row.result_id);
+                    if (compareSelectedIds.has(id)) return undefined;
+                    const mismatches: string[] = [];
+                    if (String(row.benchmark ?? "") !== lockSig.benchmark) mismatches.push("benchmark");
+                    if ((row.scale_factor ?? null) !== lockSig.scale_factor) mismatches.push("scale");
+                    if (String(row.phase ?? "") !== lockSig.phase) mismatches.push("phase");
+                    if (String(row.primary_metric ?? "") !== lockSig.primary_metric)
+                      mismatches.push("primary metric");
+                    if (mismatches.length === 0) return undefined;
+                    return `Locked: first selection is ${formatBenchmarkLabel(lockSig.benchmark)} SF ${lockSig.scale_factor} ${lockSig.phase}. This row differs by ${mismatches.join(", ")}.`;
+                  };
+                  const selectedCompareIds = [...compareSelectedIds]
+                    .map((id) => {
+                      const row = rows.find((r) => String(r.result_id) === id);
+                      return row ? compareIdForRow(row as Parameters<typeof compareIdForRow>[0]) : id;
+                    });
+                  const compareUrl = compareSelectedIds.size >= 2 ? buildCompareUrl(selectedCompareIds) : null;
+                  return (
+                    <>
+                      <div
+                        class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-2 text-sm text-[var(--bb-data-fg-muted)]"
+                        data-testid="query-compare-tray"
+                      >
+                        <span>
+                          {compareSelectedIds.size === 0 ? (
+                            "Select two or more rows to compare. The first pick locks the cohort."
+                          ) : compareSelectedIds.size === 1 ? (
+                            "1 result selected — pick a compatible second row to enable Compare."
+                          ) : (
+                            `${compareSelectedIds.size} results selected.`
+                          )}
+                        </span>
+                        <span class="flex items-center gap-2">
+                          {compareSelectedIds.size > 0 && (
+                            <button
+                              type="button"
+                              class="rounded-md border border-[var(--bb-data-border-strong)] bg-[var(--bb-surface-data)] px-3 py-1 text-xs font-medium hover:bg-[var(--bb-surface-data-muted)]"
+                              onClick={clearCompareSelection}
+                              data-testid="query-compare-clear"
                             >
-                              <button
-                                type="button"
-                                class="table-th block w-full cursor-pointer select-none border-0 bg-transparent text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--bb-accent)]"
-                                onClick={() => toggleSort(column)}
-                              >
-                                {formatQueryColumnLabel(column)}{arrow}
-                              </button>
-                            </th>
-                          );
-                        })}
-                        <th class="table-th sticky right-0 z-10 bg-[var(--bb-surface-data-muted)]" />
-                      </tr>
-                    </thead>
-                    <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
-                      {visibleRows.map((row) => (
-                        <tr key={String(row.result_id)} class="hover:bg-[var(--bb-surface-data-muted)]">
-                          {visibleColumns.map((column) => (
-                            <td key={column} class="table-td">
-                              {formatQueryRowCell(column, row[column])}
-                            </td>
-                          ))}
-                          <td class="table-td sticky right-0 z-10 bg-[var(--bb-surface-data)] text-right">
-                            <a href={`/results/r/${row.result_id}`} class="text-xs font-medium no-underline">
-                              View →
+                              Clear selection
+                            </button>
+                          )}
+                          {compareUrl ? (
+                            <a
+                              href={compareUrl}
+                              class="rounded-md bg-[var(--bb-accent)] px-3 py-1 text-xs font-medium text-white shadow-sm"
+                              data-testid="query-compare-launch"
+                            >
+                              Compare {compareSelectedIds.size} selected →
                             </a>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled
+                              class="rounded-md border border-[var(--bb-data-border)] bg-[var(--bb-surface-data)] px-3 py-1 text-xs font-medium text-[var(--bb-data-fg-subtle)]"
+                              data-testid="query-compare-launch-disabled"
+                            >
+                              Compare (need 2+)
+                            </button>
+                          )}
+                        </span>
+                      </div>
+                      <div class="overflow-x-auto">
+                        <table class="min-w-full w-max divide-y divide-[var(--bb-data-border)]">
+                          <thead class="bg-[var(--bb-surface-data-muted)]">
+                            <tr>
+                              <th
+                                scope="col"
+                                class="table-th sticky left-0 z-10 w-12 min-w-12 bg-[var(--bb-surface-data-muted)] text-left"
+                              >
+                                <span class="sr-only">Compare</span>
+                              </th>
+                              {visibleColumns.map((column) => {
+                                const isActive = sort.column === column;
+                                const arrow = isActive ? (sort.direction === "asc" ? " ↑" : " ↓") : "";
+                                const ariaSort = isActive
+                                  ? sort.direction === "asc"
+                                    ? "ascending"
+                                    : "descending"
+                                  : "none";
+                                return (
+                                  <th
+                                    key={column}
+                                    scope="col"
+                                    aria-sort={ariaSort}
+                                    class="p-0"
+                                  >
+                                    <button
+                                      type="button"
+                                      class="table-th block w-full cursor-pointer select-none border-0 bg-transparent text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--bb-accent)]"
+                                      onClick={() => toggleSort(column)}
+                                    >
+                                      {formatQueryColumnLabel(column)}{arrow}
+                                    </button>
+                                  </th>
+                                );
+                              })}
+                              <th class="table-th sticky right-0 z-10 bg-[var(--bb-surface-data-muted)]" />
+                            </tr>
+                          </thead>
+                          <tbody class="divide-y divide-[var(--bb-data-border)] bg-[var(--bb-surface-data)]">
+                            {visibleRows.map((row) => {
+                              const id = String(row.result_id);
+                              const isSelected = compareSelectedIds.has(id);
+                              const reason = lockReason(row);
+                              return (
+                                <tr key={id} class="hover:bg-[var(--bb-surface-data-muted)]">
+                                  <td class="table-td sticky left-0 z-10 bg-[var(--bb-surface-data)]">
+                                    <input
+                                      type="checkbox"
+                                      checked={isSelected}
+                                      disabled={Boolean(reason)}
+                                      title={reason}
+                                      onChange={() => toggleCompareSelection(id)}
+                                      class="h-4 w-4 rounded border-[var(--bb-data-border-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+                                      aria-label={`Select ${id} for comparison`}
+                                      data-testid={`query-compare-checkbox-${id}`}
+                                    />
+                                  </td>
+                                  {visibleColumns.map((column) => (
+                                    <td key={column} class="table-td">
+                                      {formatQueryRowCell(column, row[column])}
+                                    </td>
+                                  ))}
+                                  <td class="table-td sticky right-0 z-10 bg-[var(--bb-surface-data)] text-right">
+                                    <a href={`/results/r/${row.result_id}`} class="text-xs font-medium no-underline">
+                                      View →
+                                    </a>
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    </>
+                  );
+                })()}
                 {visibleRows.length < rows.length && (
                   <div class="border-t border-[var(--bb-data-border)] bg-[var(--bb-surface-data-muted)] px-4 py-3 text-center">
                     <button

--- a/results-explorer/src/pages/__tests__/Home.test.tsx
+++ b/results-explorer/src/pages/__tests__/Home.test.tsx
@@ -441,6 +441,16 @@ describe("Home", () => {
     await waitFor(() => expect(new URL(window.location.href).searchParams.get("mode")).toBe("ranks"));
   });
 
+  it("renders a Compare entrypoint inside the leaderboard cohort selector", async () => {
+    render(<Home />);
+    await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());
+
+    const entrypoint = screen.getByTestId("home-compare-entrypoint");
+    expect(entrypoint).toHaveAttribute("href", "/results/compare/");
+    const selector = screen.getByRole("region", { name: "Leaderboard cohort selector" });
+    expect(selector.contains(entrypoint)).toBe(true);
+  });
+
   it("renders a compact run-compare-submit workflow near the leaderboard", async () => {
     render(<Home />);
     await waitFor(() => expect(screen.getByText("Cross-Benchmark Leaderboard")).toBeTruthy());

--- a/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
+++ b/results-explorer/src/pages/__tests__/PlatformIndex.test.tsx
@@ -165,6 +165,61 @@ describe("PlatformIndex - sortable table headers", () => {
     expect(screen.queryByTestId("platform-filter-reset")).toBeNull();
   });
 
+  it("locks the cohort signature after the first compare selection", async () => {
+    const cohortRows: PlatformIndexRowRow[] = [
+      makeRow({
+        result_id: "r-tpch-a",
+        short_id: "tpcha000",
+        benchmark: "tpch",
+        scale_factor: 0.1,
+        phase: "power",
+        run_date: "2026-04-01",
+        primary_metric: "display_geomean_ms",
+      }),
+      makeRow({
+        result_id: "r-tpch-b",
+        short_id: "tpchb000",
+        benchmark: "tpch",
+        scale_factor: 0.1,
+        phase: "power",
+        run_date: "2026-04-02",
+        primary_metric: "display_geomean_ms",
+      }),
+      makeRow({
+        result_id: "r-clickbench",
+        short_id: "click000",
+        benchmark: "clickbench",
+        scale_factor: 0.1,
+        phase: "power",
+        run_date: "2026-04-03",
+        primary_metric: "display_geomean_ms",
+      }),
+    ];
+    vi.mocked(getPlatformIndexRows).mockResolvedValue(cohortRows);
+
+    render(<PlatformIndex platform="duckdb" />);
+    await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());
+
+    const checkboxA = screen.getByTestId("platform-compare-checkbox-r-tpch-a") as HTMLInputElement;
+    const checkboxB = screen.getByTestId("platform-compare-checkbox-r-tpch-b") as HTMLInputElement;
+    const checkboxClickbench = screen.getByTestId(
+      "platform-compare-checkbox-r-clickbench",
+    ) as HTMLInputElement;
+
+    expect(checkboxA.disabled).toBe(false);
+    expect(checkboxB.disabled).toBe(false);
+    expect(checkboxClickbench.disabled).toBe(false);
+
+    fireEvent.click(checkboxA);
+    expect(checkboxA.checked).toBe(true);
+    expect(checkboxB.disabled).toBe(false);
+    expect(checkboxClickbench.disabled).toBe(true);
+    expect(checkboxClickbench.title).toContain("differs by benchmark");
+
+    fireEvent.click(checkboxA);
+    expect(checkboxClickbench.disabled).toBe(false);
+  });
+
   it("hides the platform filter strip when the cohort has fewer than 25 rows", async () => {
     render(<PlatformIndex platform="duckdb" />);
     await waitFor(() => expect(screen.getByText("DuckDB Results")).toBeTruthy());

--- a/results-explorer/src/pages/__tests__/Query.test.tsx
+++ b/results-explorer/src/pages/__tests__/Query.test.tsx
@@ -224,6 +224,27 @@ beforeEach(() => {
 // develop until restored. See TODO
 // query-test-configure-visible-columns-failures.
 describe("Query", () => {
+  it("renders the compare tray and enables launch only after two compatible selections", async () => {
+    render(<Query />);
+    await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));
+
+    const tray = screen.getByTestId("query-compare-tray");
+    expect(tray.textContent).toContain("Select two or more rows");
+    expect(screen.getByTestId("query-compare-launch-disabled")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("query-compare-checkbox-r1"));
+    expect(screen.getByTestId("query-compare-tray").textContent).toContain("1 result selected");
+    expect(screen.getByTestId("query-compare-launch-disabled")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("query-compare-checkbox-r2"));
+    expect(screen.getByTestId("query-compare-tray").textContent).toContain("2 results selected");
+    const launch = screen.getByTestId("query-compare-launch") as HTMLAnchorElement;
+    expect(launch.href).toContain("/results/compare?ids=");
+
+    fireEvent.click(screen.getByTestId("query-compare-clear"));
+    expect(screen.getByTestId("query-compare-tray").textContent).toContain("Select two or more rows");
+  });
+
   it("loads facet counts and table rows from DuckDB", async () => {
     render(<Query />);
     await waitFor(() => expect(screen.getAllByText("DuckDB").length).toBeGreaterThan(0));


### PR DESCRIPTION
Closes the w4, w5, and w6 work units of
results-explorer-compare-flow-entrypoints. Defects this addresses were
captured in
_project/verification-logs/results-explorer-compare-flow-entrypoints/w456.log.

User explicitly authorized routing this through /skill:code review
instead of /ultrareview for this session even though Compare.tsx
adjacents are touched.

Changes:

  - `Query.tsx` grows a sticky-left "Compare" column and a tray
    (`data-testid="query-compare-tray"`) above the table. The first
    selected row locks the cohort signature (benchmark, scale_factor,
    phase, primary_metric); subsequent rows that don't match render
    disabled with a tooltip listing the mismatched fields.
    `compareIdForRow` + `buildCompareUrl` from `lib/resultLinks` build
    the launch URL when 2+ compatible rows are picked. Hidden
    `result_id` is reused from the existing View link plumbing.
  - `Home.tsx` adds a "Start a comparison →" link
    (`data-testid="home-compare-entrypoint"`) inside the leaderboard
    cohort selector, routing to `/results/compare/`. CompareBuilder
    (shipped in #284) handles the empty-state flow.
  - `PlatformIndex.tsx` derives a cohort lock signature from the first
    selected row. Each row checkbox now carries
    `data-testid="platform-compare-checkbox-<result_id>"`. Rows that
    don't match the locked signature render disabled with a reason
    tooltip; deselecting back to zero releases the lock.

Tests:

  - Three new regression tests:
    - `Query.test.tsx`: tray default copy, +1 / +2 selection state,
      launch href construction, clear selection.
    - `Home.test.tsx`: compare entrypoint link is present inside the
      cohort selector and routes to `/results/compare/`.
    - `PlatformIndex.test.tsx`: first selection locks subsequent
      mismatched rows, deselecting releases the lock.

Verification:

  - `npm test -- --run` (559/559)
  - `npm run typecheck` and `npm run build` clean.
  - Browser walks deferred to release-gate Playwright (TODO #8 w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
