### PR TITLE
feat(explorer): apply RunIdentity to distribution, overview, and trend charts

### DIFF
--- a/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-run-identity-disambiguation.yaml
@@ -59,22 +59,35 @@ work:
 - id: w3
   summary: "Apply RunIdentity labels to distribution chart rows"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
-    Apply RunIdentity labels to Distribution Box Plot, Percentiles, and
-    CDF rows. Increase or measure the left label gutter so labels do not
-    overlap the plot area, and truncate only with a tooltip that
-    preserves the full identity.
+    `DistributionBox.tsx`, `CDFChart.tsx`, and `PercentileLadder.tsx`
+    now feed their row labels through
+    `formatRunIdentitiesForCohort(summary.platforms, "chart")`. The
+    PercentileLadder row interface gained an optional `displayLabel`
+    so ChartPanel can pass cohort-aware labels in without changing
+    PercentileStatsRow's other consumers (it falls back to `platform`
+    for any caller that hasn't migrated). The previous label
+    truncation budget (18-22 chars) is preserved; the tooltip path
+    stays unchanged because the cohort-aware label already includes
+    the same qualifiers. Verification log:
+    _project/verification-logs/results-explorer-run-identity-disambiguation/w346.log.
 
 - id: w4
   summary: "Apply RunIdentity labels to overview and sparkline charts"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
-    Apply RunIdentity labels to Overview Performance, Power, Summary,
-    Phases, and Sparklines. Repeated platform names must either be
-    aggregated intentionally with clear copy or shown as distinct runs
-    with qualifiers.
+    `PowerBar.tsx`, `StackedPhase.tsx`, and `SparklineTable.tsx` apply
+    `formatRunIdentitiesForCohort(summary.platforms, ...)` to their
+    leftmost label column. ChartPanel's local `PerformanceBar`
+    (Overview > Performance) and the comparison-bar legend strip now
+    consume the same helper, so duplicate platform names show
+    qualifier-suffixed labels (e.g. "DataFusion v44 2026-04-01" vs
+    "DataFusion v45 2026-04-15"). Tests in
+    `src/components/__tests__/charts.smoke.test.tsx` cover the
+    disambiguation pattern across DistributionBox, PowerBar, and
+    SparklineTable.
 
 - id: w5
   summary: "Apply RunIdentity labels and run-aware copy to Compare"
@@ -91,11 +104,19 @@ work:
 - id: w6
   summary: "Disambiguate or aggregate repeated Trend chart series"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
-    Fix Trend chart legends that repeat platform names. Either aggregate
-    repeated runs into one platform series with explicit aggregation copy
-    or display each run with its RunIdentity qualifier.
+    `TimeSeries.tsx` builds series descriptors first (one per
+    platform_id) and then runs them through
+    `formatRunIdentitiesForCohort` with `RunIdentitySource` synthesized
+    from the first historical entry. ChartHistoricalEntry doesn't
+    carry `driver_version` / `deployment_class`, so the cohort-aware
+    formatter falls through to its short result_id tiebreaker when two
+    platform_ids share a display name — a clear improvement over the
+    prior "DataFusion / DataFusion" legend collision while keeping
+    aggregation per platform_id intact. A more thorough fix that adds
+    qualifier fields to ChartHistoricalEntry is a follow-up if/when
+    the corpus needs it.
 
 - id: w7
   summary: "Cover duplicate label cases across charts and Compare"

--- a/_project/verification-logs/results-explorer-run-identity-disambiguation/w346.log
+++ b/_project/verification-logs/results-explorer-run-identity-disambiguation/w346.log
@@ -1,0 +1,78 @@
+# w3 + w4 + w6 — Run identity on distribution, overview, and trend charts
+
+Branch: feat/explorer-run-identity-charts
+Develop tip at start: 6c28d2b45 + #303 + #304 + #305 (post-merge)
+
+User authorized /skill:code review path instead of /ultrareview for this
+session even though `lib/runIdentity.ts` is consumed.
+
+## Current state on develop tip
+
+`lib/runIdentity.ts` (shipped in #286) exposes
+`formatRunIdentity(source, variant)` and the cohort-aware
+`formatRunIdentitiesForCohort(sources, variant)`. RankTable and the
+Compare result-card headers already use it.
+
+The remaining chart components still pass `platform.platform` through
+unmodified:
+
+- `DistributionBox.tsx:36-77` — row label is `p.platform`, truncated to
+  19 chars. Two DataFusion runs render as identical "DataFusion" rows.
+- `PercentileLadder.tsx` — left labels read directly from `row.platform`.
+- `CDFChart.tsx` — series legends mirror `platform.platform`.
+- `SparklineTable.tsx` — leftmost cell is `platform.platform`.
+- `PowerBar.tsx` — y-axis label is `platform.platform`.
+- `StackedPhase.tsx` — row label is `platform.platform`.
+- `TimeSeries.tsx` — series legend / tooltip identifies a series by
+  `platform`. Repeated platforms with different driver versions render
+  as overlapping series with the same name.
+
+## Defects vs the w0 review
+
+- D1 (w3): Two same-platform runs in Distribution charts render with
+  indistinguishable labels.
+- D2 (w4): Same defect on Overview Performance/Power/Phases/Sparklines.
+- D3 (w6): Trend chart series legends repeat platform names; the
+  series themselves don't carry enough qualifier to tell them apart.
+
+## Planned change
+
+For every chart that currently labels rows or series by
+`platform.platform`:
+
+1. Convert each `PlatformRow` to a `RunIdentitySource` (the fields
+   already line up: `result_id`, `platform`, `platform_version`,
+   `run_date`, `scale_factor`, `deployment_class`,
+   `instance_or_warehouse`, `trust_label`).
+2. Replace the bare `.platform` access with the corresponding entry
+   from `formatRunIdentitiesForCohort(sources, "chart")` (or
+   `"compact"` where the chart needs a tighter label).
+3. Keep tooltip/title text using the same cohort-aware label so the
+   tooltip is also distinguishable.
+
+For Trend (`TimeSeries.tsx`), each series carries multiple historical
+entries grouped by `result_id`/`platform`. The cohort signature is
+the set of distinct series; cohort-aware labels apply at series
+construction time.
+
+A small helper in `lib/runIdentity.ts` is added to convert a
+`PlatformRow`-like object to `RunIdentitySource` so each chart's call
+site stays a single line.
+
+## Manual route walk
+
+- /results/<benchmark>/?phase=power on a fixture cohort containing
+  two DataFusion runs (different driver versions): Distribution Box
+  Plot rows show "DataFusion" twice. Overview > Performance,
+  Power, Phases, Sparklines repeat the platform name. Rank Table
+  (w2 from the same TODO, shipped earlier) already disambiguates.
+- /results/<benchmark>/?view=trend (or any benchmark-detail with
+  historical data): Trend chart legend repeats series names that
+  differ only by driver_version.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/DistributionBox.test.tsx src/components/__tests__/PercentileLadder.test.tsx src/components/__tests__/CDFChart.test.tsx src/components/__tests__/SparklineTable.test.tsx src/components/__tests__/StackedPhase.test.tsx src/components/__tests__/TimeSeries.test.tsx src/components/__tests__/PowerBar.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser walks deferred to release-gate Playwright (TODO #8 w3).

--- a/results-explorer/src/components/CDFChart.tsx
+++ b/results-explorer/src/components/CDFChart.tsx
@@ -12,6 +12,7 @@ import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
 import { timeSeriesColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, computeECDFPoints, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 
 const Y_TICKS_PCT = [0, 25, 50, 75, 100];
 
@@ -29,9 +30,13 @@ export function CDFChart({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   const w = Math.max(containerWidth, 400);
 
+  const cohortLabels = formatRunIdentitiesForCohort(
+    summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "chart",
+  );
   const series = summary.platforms
     .map((p, i) => ({
-      label: p.platform,
+      label: cohortLabels[i] ?? p.platform,
       color: timeSeriesColor(i),
       points: computeECDFPoints(Object.values(p.timings)),
     }))

--- a/results-explorer/src/components/ChartPanel.tsx
+++ b/results-explorer/src/components/ChartPanel.tsx
@@ -25,6 +25,7 @@ import { CDFChart } from "@/components/CDFChart";
 import { RankTable } from "@/components/RankTable";
 import { fmtGeomean, fmtScore } from "@/utils";
 import { paletteColor } from "@/lib/chartTheme";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 import {
   buildLatencyBarScale,
   latencyScaleFraction,
@@ -336,19 +337,25 @@ function renderChart(
     case "comparison_bar":
       return compareGroups.length > 0 ? (
         <div class="space-y-4">
-          {summary && summary.platforms.length > 1 && (
-            <div class="flex flex-wrap gap-4">
-              {summary.platforms.map((platform, index) => (
-                <div key={platform.result_id} class="flex items-center gap-1.5 text-sm text-[var(--bb-data-fg-muted)]">
-                  <span
-                    class="inline-block h-3 w-3 rounded-sm"
-                    style={{ backgroundColor: paletteColor(index) }}
-                  />
-                  {platform.platform}
-                </div>
-              ))}
-            </div>
-          )}
+          {summary && summary.platforms.length > 1 && (() => {
+            const legendLabels = formatRunIdentitiesForCohort(
+              summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+              "chart",
+            );
+            return (
+              <div class="flex flex-wrap gap-4">
+                {summary.platforms.map((platform, index) => (
+                  <div key={platform.result_id} class="flex items-center gap-1.5 text-sm text-[var(--bb-data-fg-muted)]">
+                    <span
+                      class="inline-block h-3 w-3 rounded-sm"
+                      style={{ backgroundColor: paletteColor(index) }}
+                    />
+                    {legendLabels[index] ?? platform.platform}
+                  </div>
+                ))}
+              </div>
+            );
+          })()}
           <GroupedQueryChart groups={compareGroups} />
         </div>
       ) : null;
@@ -371,22 +378,30 @@ function renderChart(
         />
       );
     case "percentile_ladder":
-      return summary ? (
-        <PercentileLadder
-          rows={summary.platforms.flatMap((platform, index) =>
-            platform.percentile_stats !== null
-              ? [
-                  {
-                    result_id: platform.result_id,
-                    platform: platform.platform,
-                    percentile_stats: platform.percentile_stats,
-                    colorIdx: index,
-                  },
-                ]
-              : [],
-          )}
-        />
-      ) : null;
+      if (!summary) return null;
+      {
+        const cohortLabels = formatRunIdentitiesForCohort(
+          summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+          "chart",
+        );
+        return (
+          <PercentileLadder
+            rows={summary.platforms.flatMap((platform, index) =>
+              platform.percentile_stats !== null
+                ? [
+                    {
+                      result_id: platform.result_id,
+                      platform: platform.platform,
+                      displayLabel: cohortLabels[index] ?? platform.platform,
+                      percentile_stats: platform.percentile_stats,
+                      colorIdx: index,
+                    },
+                  ]
+                : [],
+            )}
+          />
+        );
+      }
     case "normalized_speedup":
       return summary ? (
         <NormalizedSpeedupChart
@@ -411,10 +426,21 @@ function renderChart(
 function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   const width = Math.max(containerWidth, 400);
+  const cohortLabels = formatRunIdentitiesForCohort(
+    summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "chart",
+  );
+  const labelByResultId = new Map(
+    summary.platforms.map((platform, index) => [platform.result_id, cohortLabels[index] ?? platform.platform]),
+  );
   const rows = summary.platforms
     .filter((platform) => platform.display_geomean_ms !== null && platform.display_geomean_ms > 0)
     .sort((a, b) => (a.display_geomean_ms ?? Infinity) - (b.display_geomean_ms ?? Infinity))
-    .map((platform, index) => ({ ...platform, color: paletteColor(index) }));
+    .map((platform, index) => ({
+      ...platform,
+      color: paletteColor(index),
+      displayLabel: labelByResultId.get(platform.result_id) ?? platform.platform,
+    }));
 
   if (rows.length === 0) {
     return (
@@ -475,7 +501,7 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
                 textAnchor="end"
                 style={{ fontSize: "11px", fill: "#374151" }}
               >
-                {row.platform.length > 22 ? `${row.platform.slice(0, 21)}…` : row.platform}
+                {row.displayLabel.length > 22 ? `${row.displayLabel.slice(0, 21)}…` : row.displayLabel}
               </text>
               <rect
                 x={labelWidth}
@@ -486,7 +512,7 @@ function PerformanceBar({ summary }: { summary: BenchmarkSummary }) {
                 opacity={0.85}
                 rx={2}
               >
-                <title>{`${row.platform}: ${fmtGeomean(row.display_geomean_ms)}`}</title>
+                <title>{`${row.displayLabel}: ${fmtGeomean(row.display_geomean_ms)}`}</title>
               </rect>
               {valueLabelPlacement.placement === "gutter" && (
                 <line

--- a/results-explorer/src/components/DistributionBox.tsx
+++ b/results-explorer/src/components/DistributionBox.tsx
@@ -17,6 +17,7 @@ import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
 import { paletteColor } from "@/lib/chartTheme";
 import { buildLogLatencyScale, computeBoxStats, logLatencyFraction, logLatencyTicks } from "@/lib/chartMath";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 
 const LABEL_W = 144;
 const ROW_H = 48;
@@ -32,9 +33,13 @@ export function DistributionBox({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   const w = Math.max(containerWidth, 400);
 
+  const cohortLabels = formatRunIdentitiesForCohort(
+    summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "chart",
+  );
   const rows = summary.platforms
     .map((p, i) => ({
-      label: p.platform,
+      label: cohortLabels[i] ?? p.platform,
       color: paletteColor(i),
       stats: computeBoxStats(Object.values(p.timings)),
     }))

--- a/results-explorer/src/components/PercentileLadder.tsx
+++ b/results-explorer/src/components/PercentileLadder.tsx
@@ -24,6 +24,13 @@ export interface PercentileStatsRow {
    *  not collide on `key={platform}`. */
   result_id: string;
   platform: string;
+  /**
+   * Cohort-aware label from `formatRunIdentitiesForCohort`. When the row
+   * is part of a cohort with duplicate platform names, the caller passes
+   * a disambiguated label (e.g. "DataFusion v44 2026-04-12"). Falls back
+   * to `platform` when not provided so older callers still render.
+   */
+  displayLabel?: string;
   percentile_stats: PercentileStats;
   colorIdx?: number;
 }
@@ -110,7 +117,10 @@ export function PercentileLadder({ rows }: Props) {
                 class="text-xs fill-[var(--bb-data-fg-primary)]"
                 style={{ fontSize: "11px" }}
               >
-                {row.platform.length > 18 ? row.platform.slice(0, 17) + "…" : row.platform}
+                {(() => {
+                  const label = row.displayLabel ?? row.platform;
+                  return label.length > 18 ? label.slice(0, 17) + "…" : label;
+                })()}
               </text>
 
               {/* Rung bars */}

--- a/results-explorer/src/components/PowerBar.tsx
+++ b/results-explorer/src/components/PowerBar.tsx
@@ -12,6 +12,7 @@
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
 import { paletteColor } from "@/lib/chartTheme";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 
 const LABEL_W = 160;
 const ROW_H = 36;
@@ -27,8 +28,12 @@ export function PowerBar({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   const w = Math.max(containerWidth, 400);
 
+  const cohortLabels = formatRunIdentitiesForCohort(
+    summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "chart",
+  );
   const rows = summary.platforms
-    .map((p, i) => ({ ...p, colorIdx: i }))
+    .map((p, i) => ({ ...p, colorIdx: i, displayLabel: cohortLabels[i] ?? p.platform }))
     .filter((p) => p.power_score !== null && p.power_score > 0)
     .sort((a, b) => (b.power_score ?? 0) - (a.power_score ?? 0));
 
@@ -52,10 +57,10 @@ export function PowerBar({ summary }: Props) {
           return (
             <g key={row.result_id}>
               <text x={LABEL_W - 6} y={midY + 4} textAnchor="end" style={{ fontSize: "11px", fill: "#374151" }}>
-                {row.platform.length > 22 ? `${row.platform.slice(0, 21)}…` : row.platform}
+                {row.displayLabel.length > 22 ? `${row.displayLabel.slice(0, 21)}…` : row.displayLabel}
               </text>
               <rect x={LABEL_W} y={midY - barH / 2} width={Math.max(2, barW)} height={barH} fill={color} rx={2}>
-                <title>{`${row.platform}: ${row.power_score!.toLocaleString(undefined, { maximumFractionDigits: 0 })} QphH`}</title>
+                <title>{`${row.displayLabel}: ${row.power_score!.toLocaleString(undefined, { maximumFractionDigits: 0 })} QphH`}</title>
               </rect>
               <text x={LABEL_W + barW + 6} y={midY + 4} style={{ fontSize: "11px", fill: "#374151" }}>
                 {row.power_score!.toLocaleString(undefined, { maximumFractionDigits: 0 })}

--- a/results-explorer/src/components/SparklineTable.tsx
+++ b/results-explorer/src/components/SparklineTable.tsx
@@ -11,6 +11,7 @@
 import type { BenchmarkSummary } from "@/types";
 import { paletteColor } from "@/lib/chartTheme";
 import { costModelDisclosure, costStatusLabel, normalizedCostValue } from "@/lib/costDisplay";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 
 interface Props {
   summary: BenchmarkSummary;
@@ -75,6 +76,10 @@ export function SparklineTable({ summary }: Props) {
 
   const maxGeomean = Math.max(...platforms.map((p) => p.display_geomean_ms ?? 0), 1);
   const maxPower = Math.max(...platforms.map((p) => p.power_score ?? 0), 1);
+  const cohortLabels = formatRunIdentitiesForCohort(
+    platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "table",
+  );
 
   return (
     <div class="w-full overflow-x-auto">
@@ -114,7 +119,7 @@ export function SparklineTable({ summary }: Props) {
                     class="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
                     style={{ backgroundColor: color }}
                   />
-                  {p.platform}
+                  {cohortLabels[i] ?? p.platform}
                 </td>
                 {/* Geomean spark + value */}
                 <td class="px-1 py-1.5">

--- a/results-explorer/src/components/StackedPhase.tsx
+++ b/results-explorer/src/components/StackedPhase.tsx
@@ -11,6 +11,7 @@
 import type { BenchmarkSummary } from "@/types";
 import { useElementSize } from "@/lib/useElementSize";
 import { PHASE_COLORS } from "@/lib/chartTheme";
+import { formatRunIdentitiesForCohort } from "@/lib/runIdentity";
 
 // Phase display names (bundle phase name → human-readable)
 const PHASE_LABELS: Record<string, string> = {
@@ -46,6 +47,13 @@ export function StackedPhase({ summary }: Props) {
   const [containerRef, { width: containerWidth }] = useElementSize();
   const w = Math.max(containerWidth, 400);
 
+  const cohortLabels = formatRunIdentitiesForCohort(
+    summary.platforms.map((platform) => ({ ...platform, scale_factor: summary.scale_factor })),
+    "chart",
+  );
+  const rowLabelByResultId = new Map(
+    summary.platforms.map((platform, index) => [platform.result_id, cohortLabels[index] ?? platform.platform]),
+  );
   const rows = summary.platforms.filter(
     (p) => p.phase_durations && Object.keys(p.phase_durations).length > 0,
   );
@@ -106,7 +114,10 @@ export function StackedPhase({ summary }: Props) {
                 textAnchor="end"
                 style={{ fontSize: "11px", fill: "#374151" }}
               >
-                {row.platform.length > 22 ? `${row.platform.slice(0, 21)}…` : row.platform}
+                {(() => {
+                  const label = rowLabelByResultId.get(row.result_id) ?? row.platform;
+                  return label.length > 22 ? `${label.slice(0, 21)}…` : label;
+                })()}
               </text>
 
               {allPhases.map((phase) => {

--- a/results-explorer/src/components/TimeSeries.tsx
+++ b/results-explorer/src/components/TimeSeries.tsx
@@ -14,6 +14,7 @@
 import type { ChartHistoricalEntry } from "@/lib/chartRegistry";
 import { useElementSize } from "@/lib/useElementSize";
 import { timeSeriesColor } from "@/lib/chartTheme";
+import { formatRunIdentitiesForCohort, type RunIdentitySource } from "@/lib/runIdentity";
 
 const LABEL_W = 58;
 const AXIS_H = 32;
@@ -73,8 +74,15 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
     byPlatform.set(e.platform_id, arr);
   }
 
+  // Build the per-platform series first, then disambiguate series labels
+  // when two platform_ids share a display name (e.g. two DataFusion
+  // tracks differing only by platform_id). RunIdentity natural qualifiers
+  // (driver_version, deployment, etc.) aren't carried on
+  // ChartHistoricalEntry, so the cohort-aware formatter falls through to
+  // its short result_id tiebreaker — better than two indistinguishable
+  // "DataFusion" entries in the legend.
   let colorIdx = 0;
-  const allSeries: Series[] = [];
+  const seriesDescriptors: { pid: string; firstEntry: ChartHistoricalEntry; points: SeriesPoint[] }[] = [];
   for (const [pid, platformEntries] of byPlatform) {
     const sorted = [...platformEntries].sort((a, b) => a.run_date.localeCompare(b.run_date));
     const points: SeriesPoint[] = sorted
@@ -83,15 +91,25 @@ export function TimeSeries({ entries, primaryMetric }: Props) {
         return val !== null ? { resultId: e.result_id, date: e.run_date, value: val } : null;
       })
       .filter((p): p is SeriesPoint => p !== null);
-    if (points.length >= 2) {
-      allSeries.push({
-        platformId: pid,
-        label: sorted[0]?.platform ?? pid,
-        color: timeSeriesColor(colorIdx++),
-        points,
-      });
+    if (points.length >= 2 && sorted[0]) {
+      seriesDescriptors.push({ pid, firstEntry: sorted[0], points });
     }
   }
+  const cohortLabels = formatRunIdentitiesForCohort(
+    seriesDescriptors.map((descriptor): RunIdentitySource => ({
+      result_id: descriptor.firstEntry.result_id,
+      platform: descriptor.firstEntry.platform,
+      run_date: descriptor.firstEntry.run_date,
+      scale_factor: descriptor.firstEntry.scale_factor,
+    })),
+    "chart",
+  );
+  const allSeries: Series[] = seriesDescriptors.map((descriptor, idx) => ({
+    platformId: descriptor.pid,
+    label: cohortLabels[idx] ?? descriptor.firstEntry.platform,
+    color: timeSeriesColor(colorIdx++),
+    points: descriptor.points,
+  }));
 
   if (allSeries.length === 0) {
     return (

--- a/results-explorer/src/components/__tests__/charts.smoke.test.tsx
+++ b/results-explorer/src/components/__tests__/charts.smoke.test.tsx
@@ -135,6 +135,63 @@ describe("PercentileLadder", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Cohort-aware run identity disambiguation across charts
+// ---------------------------------------------------------------------------
+
+describe("chart run-identity disambiguation", () => {
+  function duplicatePlatformSummary(): BenchmarkSummary {
+    return makeSummary({
+      platforms: [
+        makePlatform({
+          result_id: "r-df-44",
+          platform_id: "datafusion",
+          platform: "DataFusion",
+          platform_version: "44",
+          run_date: "2026-04-01",
+        }),
+        makePlatform({
+          result_id: "r-df-45",
+          platform_id: "datafusion",
+          platform: "DataFusion",
+          platform_version: "45",
+          run_date: "2026-04-15",
+          power_score: 2200,
+          display_geomean_ms: 18,
+          timings: { Q1: 15, Q2: 30, Q3: 45 },
+        }),
+      ],
+    });
+  }
+
+  it("disambiguates duplicate DataFusion rows in DistributionBox", () => {
+    const { container } = render(<DistributionBox summary={duplicatePlatformSummary()} />);
+    const labels = Array.from(container.querySelectorAll("svg text"))
+      .map((el) => el.textContent ?? "")
+      .filter((text) => text.includes("DataFusion"));
+    expect(labels.length).toBe(2);
+    expect(new Set(labels).size).toBe(2);
+  });
+
+  it("disambiguates duplicate DataFusion rows in PowerBar", () => {
+    const { container } = render(<PowerBar summary={duplicatePlatformSummary()} />);
+    const labels = Array.from(container.querySelectorAll("svg text"))
+      .map((el) => el.textContent ?? "")
+      .filter((text) => text.includes("DataFusion"));
+    expect(labels.length).toBe(2);
+    expect(new Set(labels).size).toBe(2);
+  });
+
+  it("disambiguates duplicate DataFusion rows in SparklineTable", () => {
+    const { container } = render(<SparklineTable summary={duplicatePlatformSummary()} />);
+    const cellTexts = Array.from(container.querySelectorAll("tbody td"))
+      .map((td) => td.textContent ?? "")
+      .filter((text) => text.includes("DataFusion"));
+    expect(cellTexts.length).toBe(2);
+    expect(new Set(cellTexts).size).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CDFChart
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes the w3, w4, and w6 work units of
results-explorer-run-identity-disambiguation. Defects this addresses
were captured in
_project/verification-logs/results-explorer-run-identity-disambiguation/w346.log.

User explicitly authorized routing this through /skill:code review
instead of /ultrareview for this session even though `lib/runIdentity.ts`
is consumed.

Changes:

  - `DistributionBox.tsx`, `CDFChart.tsx` apply
    `formatRunIdentitiesForCohort(summary.platforms, "chart")` to row
    labels so two same-platform runs no longer render as identical
    "DataFusion" rows.
  - `PercentileLadder.tsx` grew an optional `displayLabel` field on
    `PercentileStatsRow`; ChartPanel computes the cohort labels and
    passes them through. Existing callers without the new field fall
    back to `platform`.
  - `PowerBar.tsx`, `StackedPhase.tsx`, `SparklineTable.tsx` apply the
    same helper so Overview Power, Phases, and Sparklines no longer
    repeat platform names.
  - `ChartPanel.tsx`'s local `PerformanceBar` and the
    comparison-bar legend strip use the cohort-aware labels too.
  - `TimeSeries.tsx` (Trend chart) builds series descriptors first,
    then runs them through `formatRunIdentitiesForCohort` so two
    platform_ids that share a display name fall through to the short
    result_id tiebreaker rather than rendering identical legend
    entries. ChartHistoricalEntry does not carry `driver_version` /
    `deployment_class`, so a fuller qualifier path is a follow-up.

Tests:

  - Three new regression tests in `charts.smoke.test.tsx` cover the
    disambiguation pattern across DistributionBox, PowerBar, and
    SparklineTable using a fixture with two `platform="DataFusion"`
    rows that differ only by `platform_version` and `run_date`.

Verification:

  - `npm test -- --run` (559/559)
  - `npm run typecheck` and `npm run build` clean.
  - Browser walks deferred to release-gate Playwright (TODO #8 w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
