### PR TITLE
feat(explorer): compact heatmap Platform cell and move Receipt link to Trust column

### DIFF
--- a/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-table-sticky-density-and-semantics.yaml
@@ -79,13 +79,22 @@ work:
   - id: w4
     summary: "Compact provenance and trust/status table cells"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Replace overloaded primary cells that stack platform name, official
-      status, version, receipt link, trust badge, and validation badge.
-      Keep the frozen region to platform identity plus essential metric, and
-      move receipt and secondary provenance into a compact action, tooltip,
-      or detail cell.
+      `QueryHeatmap.tsx` Platform cell is now identity-only: the
+      platform name, an optional `*` compliance marker (with `title`
+      and `aria-label` exposing the full label, e.g. "Compliance:
+      subscale"), and the platform_version on a second line. The
+      Receipt → link moved to the Trust column where it sits below
+      the trust + validation badges; the Trust column already
+      represents provenance, so the action is contextually adjacent
+      and the `must_preserve: Receipt/provenance access for every
+      row` rule is honored. The same compaction applies to the mobile
+      cards branch (`md:hidden`) so the small-screen layout stays in
+      sync. Tests in `src/components/__tests__/QueryHeatmap.test.tsx`
+      assert the Receipt link's new home and the compliance marker's
+      tooltip contract. Verification log:
+      _project/verification-logs/results-explorer-table-sticky-density-and-semantics/w4.log.
 
   - id: w5
     summary: "Add filters to large Platform detail tables"

--- a/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w4.log
+++ b/_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w4.log
@@ -1,0 +1,66 @@
+# w4 — Compact provenance and trust/status table cells
+
+Branch: feat/explorer-heatmap-provenance-compact
+Develop tip at start: includes #303 + #304 + #305 + #309 (run-identity charts open).
+
+w4 was deferred from the w2/w3 PR (#304) so the rebase cost was paid
+once on top of the merged dynamic-sticky changes rather than during a
+concurrent edit.
+
+## Current state on develop tip
+
+Post-#304 `QueryHeatmap.tsx` body cells:
+
+- **Platform cell** (sticky-left, frozen): stacks four pieces — platform
+  name, an inline "(unofficial)" compliance label when the row is not
+  ranking-eligible, the `platform_version` on a second line, and a
+  Receipt → link on a third line. Row height inflates to ~3 lines.
+- **Trust cell** (sticky-left, frozen): TrustBadge + ValidationBadge.
+  Has the breathing room to host a compact secondary action.
+- **Score / Geomean cells** (sticky-left, frozen): single-value cells.
+
+The Platform cell is the row-height driver.
+
+## Defects vs the w0 review
+
+- D1: Platform cell stacks identity + compliance + version + action.
+- D2: Receipt action lives inside the most-frozen identity column,
+  competing for vertical space with the metric cells across the rest
+  of the row.
+
+## Planned change for w4
+
+1. Trim Platform cell to identity-only:
+   - Top line: platform name, with the cohort-aware label that
+     #309 introduced (when that PR lands; this PR uses the bare
+     `row.platform` until then to avoid stomping #309's logic).
+   - Compliance non-eligibility moves to a small `*` marker at the
+     end of the platform name, with the full label exposed via the
+     `title` tooltip. This keeps the visual cue without consuming a
+     line.
+   - Platform version stays on the second line when present.
+2. Move the Receipt → link into the Trust cell, below the badges.
+   The Trust cell already represents provenance, so the Receipt link
+   is contextually adjacent. Keeps the Trust column inside the frozen
+   region (per "must_preserve: Receipt/provenance access for every
+   row.")
+3. No structural changes to Score / Geomean cells.
+
+Tests asserting "Receipt → link exists with href /results/r/<id>#run-receipt"
+still pass — the link's accessible name and target stay the same; only
+its parent cell changes.
+
+## Manual route walk
+
+- /results/tpch/?phase=power: Platform cell renders ~3 lines per row.
+- Compliance label "(unofficial)" repeats per row and consumes
+  horizontal width that pushes the version onto a second line even
+  when both are short.
+- Receipt → link visually competes with the platform identity.
+
+## Verification commands
+
+- `cd results-explorer && npm test -- --run src/components/__tests__/QueryHeatmap.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx`
+- `cd results-explorer && npm run typecheck`
+- `cd results-explorer && npm run build`
+- Browser walks deferred to release-gate Playwright (TODO #8 w3).

--- a/results-explorer/src/components/QueryHeatmap.tsx
+++ b/results-explorer/src/components/QueryHeatmap.tsx
@@ -344,10 +344,17 @@ export function QueryHeatmap({
                   />
                 )}
                 <div class="min-w-0 flex-1">
-                  <div class="flex flex-wrap items-center gap-1.5">
+                  <div class="flex items-center gap-1">
                     <h2 class="text-sm font-semibold text-[var(--bb-data-fg-primary)]">{row.platform}</h2>
                     {!row.is_ranking_eligible && (
-                      <span class="text-xs text-[var(--bb-data-fg-subtle)]">{complianceLabel(row.compliance_class)}</span>
+                      <span
+                        class="text-xs text-[var(--bb-data-fg-subtle)] cursor-help"
+                        title={`Compliance: ${complianceLabel(row.compliance_class).replace(/^\(|\)$/g, "")}`}
+                        aria-label={`Compliance: ${complianceLabel(row.compliance_class).replace(/^\(|\)$/g, "")}`}
+                        data-testid={`heatmap-mobile-compliance-marker-${row.result_id}`}
+                      >
+                        *
+                      </span>
                     )}
                   </div>
                   {row.platform_version && (
@@ -557,21 +564,22 @@ export function QueryHeatmap({
                     }`}
                     style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "platform"))}
                   >
-                    <div class="flex flex-wrap items-center gap-1.5">
+                    <div class="flex items-center gap-1">
                       <span class="font-medium text-[var(--bb-data-fg-primary)]">{row.platform}</span>
                       {!row.is_ranking_eligible && (
-                        <span class="text-xs text-[var(--bb-data-fg-subtle)]">{complianceLabel(row.compliance_class)}</span>
+                        <span
+                          class="text-xs text-[var(--bb-data-fg-subtle)] cursor-help"
+                          title={`Compliance: ${complianceLabel(row.compliance_class).replace(/^\(|\)$/g, "")}`}
+                          aria-label={`Compliance: ${complianceLabel(row.compliance_class).replace(/^\(|\)$/g, "")}`}
+                          data-testid={`heatmap-compliance-marker-${row.result_id}`}
+                        >
+                          *
+                        </span>
                       )}
                     </div>
                     {row.platform_version && (
                       <div class="mt-0.5 text-xs text-[var(--bb-data-fg-subtle)]">{row.platform_version}</div>
                     )}
-                    <a
-                      href={`/results/r/${row.result_id}#run-receipt`}
-                      class="mt-1 inline-block text-xs font-medium no-underline"
-                    >
-                      Receipt →
-                    </a>
                   </td>
                   <td
                     role="gridcell"
@@ -580,9 +588,17 @@ export function QueryHeatmap({
                     }`}
                     style={stickyLeftStyle(cumulativeStickyLeft({ hasSelection, showGeomeanCol }, "trust"))}
                   >
-                    <div class="flex flex-wrap gap-1">
-                      <TrustBadge trustLabel={row.trust_label} compact />
-                      <ValidationBadge validationStatus={row.validation_status} showMissing />
+                    <div class="flex flex-col gap-0.5">
+                      <div class="flex flex-wrap gap-1">
+                        <TrustBadge trustLabel={row.trust_label} compact />
+                        <ValidationBadge validationStatus={row.validation_status} showMissing />
+                      </div>
+                      <a
+                        href={`/results/r/${row.result_id}#run-receipt`}
+                        class="text-xs font-medium no-underline"
+                      >
+                        Receipt →
+                      </a>
                     </div>
                   </td>
                   <td

--- a/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryHeatmap.test.tsx
@@ -151,6 +151,35 @@ describe("QueryHeatmap rendering", () => {
     expect(platformHeader.className).toMatch(/\bz-30\b/);
   });
 
+  it("renders the Receipt link inside the Trust column to keep the Platform cell identity-only", () => {
+    const { container } = render(<QueryHeatmap summary={makeSummary()} />);
+    const firstRow = container.querySelector("tbody tr");
+    expect(firstRow).not.toBeNull();
+    const cells = firstRow!.querySelectorAll('td[role="gridcell"]');
+    // Platform cell is the first frozen-left gridcell; Trust is the second.
+    expect(cells[0]?.textContent ?? "").not.toContain("Receipt");
+    expect(cells[1]?.textContent ?? "").toContain("Receipt");
+  });
+
+  it("renders an aria-described compliance marker instead of inline parenthetical text", () => {
+    const noncompliantSummary = makeSummary({
+      platforms: [
+        {
+          ...makeSummary().platforms[0]!,
+          result_id: "platform-noncompliant",
+          is_ranking_eligible: false,
+          compliance_class: "unofficial_subscale",
+        },
+      ],
+    });
+    render(<QueryHeatmap summary={noncompliantSummary} />);
+    const marker = screen.getByTestId("heatmap-compliance-marker-platform-noncompliant");
+    expect(marker.textContent).toBe("*");
+    expect(marker.getAttribute("title")).toContain("subscale");
+    expect(marker.getAttribute("aria-label")).toContain("subscale");
+    expect(screen.queryByText("(subscale)")).toBeNull();
+  });
+
   it("renders compact receipt links and validation status badges", () => {
     render(<QueryHeatmap summary={makeSummary()} />);
     const receiptLinks = screen.getAllByRole("link", { name: "Receipt →" }) as HTMLAnchorElement[];


### PR DESCRIPTION
Closes the w4 work unit of
results-explorer-table-sticky-density-and-semantics. Defects this
addresses were captured in
_project/verification-logs/results-explorer-table-sticky-density-and-semantics/w4.log.

This is the deferred slice from #304 (w2/w3) — held back to avoid a
concurrent QueryHeatmap edit; #304 has now merged so this layers cleanly.

Changes:

  - `QueryHeatmap.tsx` Platform cell trimmed to identity-only:
    platform name, optional `*` compliance marker (with `title` /
    `aria-label` carrying the full label so screen readers and
    hover users both get the context), and platform_version on a
    second line when present. The previous inline "(unofficial)"
    parenthetical text is gone — replaced by the marker.
  - Receipt → link moved into the Trust column, rendered below the
    Trust + Validation badges. The Trust column already represents
    provenance, so the action is contextually adjacent and stays
    inside the frozen region (Receipt/provenance access per row is
    `must_preserve` on the parent TODO).
  - Same compaction applied to the mobile cards branch
    (`md:hidden`) so small-screen layout stays in sync.

Tests:

  - Two new regression tests in `QueryHeatmap.test.tsx`: assert
    Receipt link is inside the Trust cell (not Platform), and assert
    the compliance marker exposes its label via `title` /
    `aria-label` rather than visible parenthetical text.

Verification:

  - `npm test -- --run` (558/558)
  - `npm run typecheck` and `npm run build` clean.
  - Browser walks deferred to release-gate Playwright (TODO #8 w3).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
