### PR TITLE
chore(todo): cross-trio review fixes and resolve canonical-dataset-contract overlap

### DIFF
--- a/_project/DONE/main/planning/joinorder-canonical-dataset-contract.yaml
+++ b/_project/DONE/main/planning/joinorder-canonical-dataset-contract.yaml
@@ -2,8 +2,62 @@ id: joinorder-canonical-dataset-contract
 title: "Define the canonical JOB dataset contract and validation oracle"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
+completed_date: "2026-05-09"
 category: Core Functionality
+
+completion_summary: |
+  Superseded by `joinorder-canonical-foundation` (PR #302) which covers the
+  same design space with stronger work units, concrete verification gates, and
+  pairs the design effort with the implementation work that actually ships
+  canonical JOB. The substantive overlap was identified in a cross-trio
+  review on 2026-05-09:
+
+    - foundation w1 (design doc) covers the four reusable foundations:
+      scale-factor enforcement gate, data-fetch infra, dataset-versioning,
+      registry surface field — same scope as contract w1-w7.
+    - foundation w2 builds the reusable data_fetch module skeleton.
+    - foundation w3 implements the central scale-factor + surface field
+      enforcement (contract w5 only specified the design; foundation
+      implements it).
+    - foundation w4-w7 build the offline conversion pipeline with explicit
+      encoding round-trip and predicate-domain gates (contract w3 only
+      specified the gates).
+    - foundation w8 enforces encoding round-trip; w9 enforces predicate-
+      domain non-emptiness — both as build-time pipeline assertions
+      (contract w3 specified; foundation enforces).
+    - foundation w10-w12 import the 113 queries and compute reference
+      cardinalities via PostgreSQL oracle, with Leis 2015 cross-check
+      (contract w1 chose the oracle; foundation produces the artifacts).
+    - foundation w13-w14 package the canonical archive and tiny fixture
+      (contract w2 specified the archive format; foundation builds it).
+    - foundation w15-w16 stage the DRAFT GitHub Release and wire
+      data_manifest.toml.
+    - cutover w12 wires dataset_version into result-bundle manifests,
+      surfaced at data layer only (no explorer UI changes — resolves the
+      contract w4 requirement vs `do_not_modify: results-explorer/`
+      contradiction by avoiding the conflict).
+    - foundation context_sections.Research Findings pins the licensing
+      decision (AMBIGUOUS-LEANING-LOW posture with 4 hosting conditions)
+      that contract guardrails called for but never produced.
+
+  Critical gaps in the contract TODO that drove the supersession decision:
+
+    1. No work unit produced the implementation that closes #289.
+       Contract was design-only; no companion cutover TODO existed.
+    2. Verification commands only checked YAML validity — an agent could
+       mark the TODO complete with stub deliverables.
+    3. Licensing decision was a guardrail with no work unit to produce it.
+    4. scope_limit allowed implementation paths that work units never
+       referenced (`benchbox/core/joinorder/`, `benchbox/cli/`).
+    5. Internal contradiction: w4 required explorer surfacing of
+       dataset-version mismatches, but `do_not_modify: results-explorer/`
+       prevented it.
+
+  Decision-framework (`joinorder-scale-stress-decision-framework`) and
+  prototype (`joinorder-replicated-imdb-scale-prototype`) TODOs remain
+  active; their `deps.needs` is updated to reference
+  `joinorder-canonical-foundation` instead of this superseded item.
 
 description: |
   Issue #289 identified that BenchBox's current Join Order Benchmark data is

--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -90,7 +90,8 @@ work:
           lookup tables,
         - fixed 113-query result cardinalities are either N times canonical
           or explicitly documented exceptions.
-      Use the canonical oracle artifacts from joinorder-canonical-dataset-contract.
+      Use the canonical oracle artifacts produced by joinorder-canonical-foundation
+      (specifically `_project/joinorder/reference_cardinalities.json` from foundation w11).
 
   - id: w5
     summary: "Run a narrow scale-stress comparison on local engines"
@@ -128,16 +129,30 @@ deferred:
 
 must_preserve:
   - "Canonical joinorder remains SF=1 canonical_imdb and literature-comparable only."
-  - "No hosted replicated_imdb archive may ship unless the IMDb/JOB data licensing decision explicitly approves derived archive redistribution."
-  - "replicated_imdb result bundles record source canonical dataset_version and derived manifest hash."
+  - "No hosted replicated_imdb archive may ship unless the IMDb/JOB data licensing decision explicitly approves derived archive redistribution (decision-framework w8 produces this)."
+  - "replicated_imdb result bundles record source canonical dataset_version, derived manifest hash, replica factor, and builder version."
   - "Predicate-bearing values must not be suffixed or mutated in the replicated baseline."
   - "Lookup tables must not be duplicated unless the schema contract explicitly requires it."
+  - "All replicated_imdb code lives under benchbox/core/joinorder_replicated/ — never in benchbox/core/joinorder/ — to enforce the canonical/derived separation at the module boundary."
+  - "The benchmark identifier registered in benchmark_registry.py is `joinorder_replicated` (not `joinorder` with a derived mode flag); silent selection via canonical joinorder is forbidden."
 
 approach: |
-  Implement this as a derived archive builder, not by teaching canonical
-  JoinOrderGenerator to synthesize larger data. Keep the implementation
-  deterministic and manifest-driven. Use the canonical oracle to prove expected
+  Implement this as a derived archive builder in its own module
+  (`benchbox/core/joinorder_replicated/`), not by teaching canonical
+  JoinOrderGenerator to synthesize larger data. The module separation
+  enforces the canonical/derived boundary at the file-system level —
+  agents working on canonical joinorder cannot accidentally touch
+  replicated logic and vice versa.
+
+  Keep the implementation deterministic and manifest-driven. Use the
+  canonical oracle artifacts (foundation TODO's
+  `_project/joinorder/reference_cardinalities.json`) to prove expected
   query/cardinality scaling before interpreting engine performance.
+
+  Result-bundle tagging: registered as `joinorder_replicated` in
+  benchmark_registry.py with `surface: internal` (matching the
+  joinorder_synthetic precedent — derived/research workloads stay
+  hidden from the public explorer until promoted explicitly).
 
 anti_patterns:
   - "DO NOT start implementation until licensing and stats/analyze phase prerequisites are resolved - because the prototype otherwise cannot produce shippable or interpretable scale-stress evidence."
@@ -147,24 +162,43 @@ anti_patterns:
   - "DO NOT run expensive cloud matrices during the prototype - because the first gate is semantic validity and local measurement - defer cloud until w6 approves continuation."
 
 verification:
-  - description: "Prerequisite decisions approve replication scope, distribution mode, and stats/analyze handling"
-    command: "rg -n \"replicated_imdb|derived archive|distribution mode|stats/analyze|recommended prototype\" _project/decisions/joinorder-scale-stress-*.md _project/decisions/joinorder-imdb-data-licensing-*.md"
-    expected_output: "decisions approve or explicitly constrain replicated_imdb before implementation starts"
+  - description: "Decision-framework approved replicated_imdb explicitly (not 'no scaled JOB' or other path)"
+    command: "grep -cE '^Recommendation: replicated_imdb baseline|^Recommendation: staged combination' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: "1"
+  - description: "Stats/analyze phase handling is decided (either implemented or explicitly scoped out)"
+    command: "grep -cE 'stats/analyze phase|stats_mode:|stats-build phase' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: ">= 1"
+  - description: "Replicated archive builder produces deterministic output (re-run same input → same sha256)"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder_replicated/test_builder_determinism.py -q"
+    expected_output: "all tests pass"
+  - description: "FK integrity is validated across replicas"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder_replicated/test_fk_integrity.py -q"
+    expected_output: "all tests pass"
+  - description: "Predicate-bearing string values unchanged in derived archive (anti-pattern guard)"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder_replicated/test_predicate_preservation.py -q"
+    expected_output: "all tests pass"
+  - description: "Lookup tables remain single-copy (anti-pattern guard)"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder_replicated/test_lookup_table_singleton.py -q"
+    expected_output: "all tests pass"
+  - description: "Result bundles tagged replicated_imdb carry source canonical dataset_version"
+    command: "uv run -- python -m pytest tests/unit/core/publishing/test_replicated_imdb_bundle_metadata.py -q"
+    expected_output: "all tests pass"
+  - description: "Prototype evaluation note covers all required questions"
+    command: "grep -cE '^## (Useful stats or physical-scale|Replication artifacts|Keep as derived baseline|Next step)' _project/decisions/joinorder-replicated-imdb-prototype-*.md | head -1"
+    expected_output: ">= 4"
   - description: "Prototype keeps TODO graph valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
     expected_output: "Graph validation passed"
   - description: "This item validates individually"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
     expected_output: "is valid"
-  - description: "Prototype evaluation exists before this TODO completes"
-    command: "ls _project/decisions/joinorder-replicated-imdb-prototype-*.md"
-    expected_output: "at least one prototype evaluation note"
 
 scope_limit:
   only_modify:
-    - "benchbox/core/joinorder/"
+    - "benchbox/core/joinorder_replicated/"
     - "benchbox/cli/"
-    - "tests/unit/core/joinorder/"
+    - "tests/unit/core/joinorder_replicated/"
+    - "tests/unit/core/publishing/test_replicated_imdb_bundle_metadata.py"
     - "tests/integration/"
     - "docs/benchmarks/join-order.md"
     - "_project/decisions/joinorder-replicated-imdb-prototype-*.md"
@@ -174,6 +208,9 @@ scope_limit:
     - "results-explorer/"
     - "benchbox/core/tpch/"
     - "benchbox/core/tpcds/"
+    - "benchbox/core/joinorder/"
+    - "benchbox/core/joinorder_synthetic/"
+    - "_project/joinorder/reference_cardinalities.json"
 
 success_metrics:
   - "Prerequisite decision notes approve replicated_imdb scope, distribution mode, and stats/analyze phase handling before coding begins."

--- a/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
+++ b/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
@@ -17,7 +17,7 @@ description: |
 
 deps:
   needs:
-    - joinorder-canonical-dataset-contract
+    - joinorder-canonical-foundation
 
 context_sections:
   "Benchmark identity": |
@@ -92,6 +92,30 @@ work:
         - incremental or partition stats where supported.
       Measurements should keep load, stats-build, planning, and execution time
       separate. Capture engine-specific stats metadata where available.
+
+      Per-engine compatibility matrix (REQUIRED — addresses the
+      "engines without ANALYZE" gap):
+        | Engine | Has explicit ANALYZE? | Auto-stats on load? | Sampled mode? |
+        | DuckDB | yes (ANALYZE)         | yes (background)    | n/a           |
+        | PostgreSQL | yes (ANALYZE)     | no                  | yes           |
+        | ClickHouse | partial (per-table) | yes (on insert)   | n/a           |
+        | StarRocks | yes (ANALYZE TABLE)| no                  | yes           |
+        | Spark | yes (ANALYZE TABLE)    | no                  | yes           |
+      Concrete numbers TBD during implementation; bind them in the
+      decision note. For engines without an explicit ANALYZE, the
+      stats-phase wall-clock is reported as zero with `stats_mode:
+      auto-on-load` recorded in result bundle metadata so the
+      attribution is unambiguous.
+
+      Measurement methodology (REQUIRED):
+        - Cold cache vs warm cache: each phase begins with documented
+          cache state (e.g., drop_caches before stats-build, no drop
+          between stats-build and planning).
+        - Per-engine knobs: explicit configuration per engine
+          documented in the decision note (e.g., default_statistics_target
+          for PostgreSQL, sample size for StarRocks).
+        - Idempotence: re-running ANALYZE on already-analyzed data
+          must produce the same plan (sanity check).
       If a first-class stats/analyze phase is required, create
       `_project/TODO/main/planning/joinorder-statistics-phase-measurement.yaml`
       and make any implementation prototype depend on it before coding. The
@@ -155,7 +179,50 @@ work:
         - parameterized_imdb benchmark family,
         - or staged combination.
       The recommendation must name the smallest next prototype and its
-      verification criteria. If the recommendation is replicated_imdb, it must
+      verification criteria.
+
+      CI cost & infrastructure section (REQUIRED):
+        - Estimated dataset size for each scale tier evaluated
+          (e.g., replicated SF=2 ~ 3 GB Parquet, SF=10 ~ 15 GB)
+        - Cache strategy: CI runner cache vs fresh download per run
+          (size × runner-count × frequency = monthly bandwidth)
+        - Download-failure handling: retry policy, fallback if
+          hosted Release is unreachable, abort threshold
+        - Cost ceiling per matrix run (rough $/run for cloud
+          engine matrix if deferred from prototype)
+
+      Licensing posture for derived workloads (REQUIRED):
+        - State whether the chosen scale-up path requires fresh
+          licensing review (e.g., redistributing a synthesized
+          dataset created from canonical IMDb data may need its
+          own DATA-LICENSE.md provenance trail).
+        - For replicated_imdb specifically: derived archive carries
+          source canonical dataset_version; redistribution posture
+          inherits canonical's license review (foundation TODO's
+          context_sections.Research Findings) unless transformation
+          is material.
+        - For parameterized_imdb: queries-only (no derived data
+          archive) — no new license review needed.
+
+  - id: w8
+    summary: "Pin the licensing decision for the recommended scale-up path"
+    needs: [w7]
+    status: pending
+    notes: |
+      Output: `_project/decisions/joinorder-scale-stress-licensing-<date>.md`
+
+      The recommended path from w7 may require its own licensing
+      review (separate from the canonical foundation's). Pin it
+      explicitly so future archive publishers don't have to
+      re-derive the analysis:
+        - Posture (low / ambiguous / high) for the derived form
+        - Required attribution and disclaimers
+        - Hosting model (GitHub Release / user-supplied path / both)
+        - Takedown contact (inherits from canonical unless changed)
+
+      If w7 chooses "no scaled JOB for now": this work unit's
+      output is a one-line note saying "no derived archive planned;
+      licensing review re-opens when scale-stress work resumes." If the recommendation is replicated_imdb, it must
       also state whether the statistics/analyze phase blocker is satisfied,
       deferred with a narrower prototype scope, or represented by a new TODO that
       the prototype must depend on.
@@ -171,14 +238,23 @@ deferred:
 must_preserve:
   - "Canonical joinorder remains fixed to canonical_imdb SF=1 and is never silently replaced by derived scale modes."
   - "Derived workloads must report their data-generation strategy, dataset version, generator version, seed, and stats protocol."
-  - "Query validation must use the canonical oracle contract from joinorder-canonical-dataset-contract when applicable."
+  - "Query validation must use the canonical oracle contract from joinorder-canonical-foundation when applicable."
   - "A scaled JOB-derived prototype must not start until stats/analyze phase requirements are either satisfied or explicitly scoped out in the decision note."
+  - "If w7 mutates the prototype TODO file, the prototype TODO must be quiescent (no in-progress work units) at the time of mutation; otherwise concurrent edits create lost-write risk."
 
 approach: |
   Treat this as an architecture/design gate. Read canonical JOB behavior, TPC-DS
   compliance labeling, result-bundle metadata, runner phase handling, and
   platform stats/analyze support before recommending implementation. The output
   should be a decision record plus an updated TODO for the chosen prototype.
+
+  Cross-TODO write coordination: w7 may update the prototype TODO file
+  (`joinorder-replicated-imdb-scale-prototype.yaml`) to copy the chosen
+  scope and success criteria. Before doing so, verify the prototype is
+  quiescent: status: "Not Started" and no work units in_progress. If the
+  prototype is in flight, w7 instead writes the recommendation to the
+  decision note ONLY and lets the implementing agent on the prototype
+  side update their own TODO at the next checkpoint.
 
 anti_patterns:
   - "DO NOT proceed on intuition that optimizers fail at scale - because this benchmark must justify a distinct workload identity - collect documented examples or local evidence first."
@@ -188,15 +264,24 @@ anti_patterns:
   - "DO NOT fold stats-build timing into load or query execution - because the core research question includes statistics maintenance - require separate stats/analyze phase accounting."
 
 verification:
-  - description: "Decision note includes documented optimizer-at-scale evidence"
-    command: "rg -n \"optimizer.*scale|statistics.*scale|stale stats|sampled stats|planning-time|evidence\" _project/decisions/joinorder-scale-stress-*.md"
-    expected_output: "decision note cites documented or local evidence for scale-specific optimizer/statistics failures"
-  - description: "Decision note covers stats/analyze phase dependency"
-    command: "rg -n \"stats/analyze phase|stats-build|runner phases|result bundles|platform adapter|joinorder-statistics-phase-measurement\" _project/decisions/joinorder-scale-stress-*.md"
-    expected_output: "decision states whether first-class stats measurement is required and what TODO or scope handles it"
-  - description: "Decision note exists and names the recommended prototype path"
-    command: "rg -n \"go/no-go|recommended prototype|replicated_imdb|expanded_imdb|parameterized_imdb|no scaled JOB\" _project/decisions/joinorder-scale-stress-*.md"
-    expected_output: "decision note names the selected path and rejected alternatives"
+  - description: "Decision note covers all required sections (programmatic header check)"
+    command: "grep -cE '^## (Benchmark question|Scale semantics|Statistics phase|Scale-up options|Validation gates|Fixed vs parameterized|Recommendation|CI cost|Licensing posture)' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: ">= 9"
+  - description: "Per-engine stats compatibility matrix lists 4+ engines"
+    command: "grep -cE '^\\| (DuckDB|PostgreSQL|ClickHouse|StarRocks|Spark) ' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: ">= 4"
+  - description: "Workload labels (canonical_imdb, replicated_imdb, etc.) are defined with comparability rules"
+    command: "grep -cE 'canonical_imdb|replicated_imdb|expanded_imdb|parameterized_imdb|synthetic_schema' _project/decisions/joinorder-scale-stress-*.md | awk '{ s += $1 } END { print s }'"
+    expected_output: ">= 5"
+  - description: "Recommendation is explicit and unambiguous (one of 5 named choices, not 'maybe')"
+    command: "grep -cE '^Recommendation: (no scaled JOB|replicated_imdb baseline|expanded_imdb research|parameterized_imdb|staged combination)' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: "1"
+  - description: "Validation gates section explicitly rejects non-empty-only checks"
+    command: "grep -cE 'non-empty (checks|results) (are )?insufficient|q-error|cardinalit' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    expected_output: ">= 2"
+  - description: "Licensing posture for derived workloads is recorded with required fields"
+    command: "test -f _project/decisions/joinorder-scale-stress-licensing-*.md 2>/dev/null && grep -cE '^## (Posture|Hosting model|Attribution|Takedown contact)' _project/decisions/joinorder-scale-stress-licensing-*.md"
+    expected_output: ">= 4"
   - description: "TODO graph remains valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
     expected_output: "Graph validation passed"


### PR DESCRIPTION
## Summary

Applies fixes from a cross-trio review of the parallel JOB planning
landed in #301 (canonical-dataset-contract / scale-stress-decision-framework /
replicated-imdb-scale-prototype) and resolves the structural overlap
with the joinorder-canonical trio landed in #302 / #308.

## Overlap resolution

Marks `joinorder-canonical-dataset-contract` as **Completed/Superseded**
and moves it to `_project/DONE/main/planning/`. Reasons (full text in the
moved file's `completion_summary`):

1. Contract was design-only with no companion implementation TODO —
   it could not close #289 on its own.
2. Verification commands only checked YAML validity; deliverables had
   no programmatic gates.
3. Licensing decision was a guardrail with no work unit producing it.
4. `scope_limit` allowed implementation paths that work units never
   referenced.
5. Internal contradiction: w4 required explorer surfacing of
   dataset-version mismatches, but `do_not_modify: results-explorer/`
   prevented it.

`joinorder-canonical-foundation` (already in develop) covers the same
design space + the implementation needed to ship canonical JOB. The
remaining two TODOs (decision-framework, prototype) are kept and updated
to depend on `joinorder-canonical-foundation` instead.

## Critical fixes

- **C2 — verification too weak**: replaced loose `rg` /
  descriptive-`expected_output` patterns with grep-counting against
  expected section headers and pytest assertions on actual deliverables.
  Decision now has 9 specific section gates; prototype now has 8
  deliverable-specific gates including determinism, FK integrity,
  predicate preservation, lookup-singleton, and bundle-metadata
  pytest assertions.
- **C3 — licensing decision missing**: added decision w8 producing
  `_project/decisions/joinorder-scale-stress-licensing-<date>.md` with
  required sections (Posture, Hosting model, Attribution, Takedown
  contact); inherits foundation's posture for replicated_imdb but
  re-opens for materially different transformations.

## High fixes

- **H3 — oracle bootstrap**: explicitly cited foundation w11 as the
  source of canonical oracle artifacts in prototype w4.

## Medium fixes

- **M1 — replicated_imdb in canonical module**: moved `scope_limit`
  to `benchbox/core/joinorder_replicated/`; added must_preserve clause
  enforcing the module boundary; updated approach to register as
  `joinorder_replicated` with `surface: internal`.
- **M3 — engines without ANALYZE**: per-engine compatibility matrix in
  decision w3 covering DuckDB, PostgreSQL, ClickHouse, StarRocks,
  Spark; documented `stats_mode: auto-on-load` for engines without
  explicit ANALYZE; specified cold/warm cache methodology and
  per-engine knobs.
- **M5 — CI cost**: added CI cost & infrastructure section to decision
  w7 covering tier sizes, cache strategy, download-failure handling,
  and cost ceiling.

## Low fixes

- **L1 — cross-TODO write surface**: prototype-quiescence check before
  decision w7 mutates the prototype TODO file (added must_preserve
  clause and approach section).

## Test plan

- [x] All three TODO files validate under `validate_todo.py`
- [x] `todo_cli.py check-graph` confirms no cycles or dangling refs
  after `joinorder-canonical-dataset-contract` was moved to DONE/
- [x] Indexes regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)