### PR TITLE
chore(todo): tighten joinorder planning guardrails

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
@@ -48,16 +48,19 @@ work:
     notes: |
       File: `benchbox/core/joinorder/benchmark.py`
       Replace generator-based ingestion with:
+        from benchbox.cli import config
         from benchbox.core.data_fetch import fetch_data
-        data_dir = fetch_data("joinorder", registry, override_path=cli.data_path)
+        output_dir = config.get_datagen_path("joinorder", 1.0)
+        data_dir = fetch_data("joinorder", registry, output_dir=output_dir)
         # 21 Parquet files at known paths under data_dir
         for table in TABLES:
           platform.load_parquet(table, data_dir / f"{table}.parquet")
 
-      Add `--data-path` CLI flag (and `BENCHBOX_DATA_PATH_JOINORDER`
-      env var) to the run_benchmark entry points (CLI and MCP). Both
-      bypass the auto-download path and read 21 Parquets from the
-      user-supplied directory.
+      Do not add a new dataset-location flag or benchmark-specific env var.
+      Air-gapped users pre-populate the existing datagen directory
+      (`BENCHBOX_OUTPUT_DIR` / `benchmark_runs/datagen/joinorder_1.0/`);
+      `fetch_data()` verifies the manifest checksum through the same
+      code path used after an auto-download.
 
       Update DataFrame queries (`benchbox/core/joinorder/dataframe_queries.py`)
       to read Parquet directly via `ctx.read_parquet(...)`. The 13
@@ -340,10 +343,13 @@ work:
     notes: |
       Files:
         - README.md: clarify joinorder = canonical IMDb 2013, one-time
-          ~1.2 GB download, sf=1 only, mention `--data-path` opt-out
+          ~1.2 GB download, sf=1 only, and existing
+          `BENCHBOX_OUTPUT_DIR` / `benchmark_runs/datagen/` pre-population
+          convention
         - docs/benchmarks/join-order.md: full rewrite — retract
           "realistic data distributions / preserving join characteristics";
-          new flow; sf=1 explanation; citation; license; --data-path
+          new flow; sf=1 explanation; citation; license; datagen directory
+          pre-population for air-gapped environments
         - benchbox/core/joinorder_synthetic/generator.py docstring:
           retract fidelity claims (already done in w2); link to
           canonical joinorder
@@ -404,7 +410,8 @@ work:
         ### Breaking
         - `joinorder` benchmark now uses canonical IMDb 2013 Parquet
           archive (sf=1 only). First-run downloads ~1.2 GB from
-          GitHub Release. Use `--data-path` for air-gapped environments.
+          GitHub Release into `benchmark_runs/datagen/joinorder_1.0/`;
+          air-gapped users can pre-populate that datagen directory.
           (#289)
         - The previous uniformly-random synthetic generator has been
           renamed to `joinorder_synthetic` and is internal-only
@@ -545,7 +552,7 @@ must_preserve:
   - "Existing joinorder bundle filenames in published-results branch — those are on the published-results branch, NOT touched here; this TODO only re-tags bundles in the develop tree's results-data/bundles/"
   - "DataFrame mode for the 13 already-translated queries — they continue to work on canonical data because they are schema-correct"
   - "Other benchmarks (tpch, tpcds, etc.) — no behavior change; their scale_options remain unchanged"
-  - "MCP run_benchmark API signature — adding --data-path / env var must be additive only"
+  - "MCP run_benchmark API signature — do not add dataset-location flags or benchmark-specific env vars; reuse the existing BENCHBOX_OUTPUT_DIR/datagen convention"
   - "Result-explorer UI — zero changes; the surface: internal field filters at data layer only"
   - "Existing test suite at fast tier — runs in same time bounds (verbosity tests now hit joinorder_synthetic which generates at sf=0.01 just as before)"
 
@@ -600,7 +607,7 @@ scope_limit:
     - "benchbox/core/joinorder_synthetic/ (new module — receives moved files via git mv)"
     - "benchbox/core/benchmark_registry.py (joinorder + joinorder_synthetic entries)"
     - "benchbox/core/publishing/bundle_publisher.py (dataset_version field)"
-    - "benchbox/cli/* and benchbox/mcp/tools/benchmark.py (--data-path flag, help text)"
+    - "benchbox/cli/* and benchbox/mcp/tools/benchmark.py (joinorder sf=1, first-run download, BENCHBOX_OUTPUT_DIR/datagen help text)"
     - "tests/unit/core/joinorder/ (canonical query coverage test)"
     - "tests/unit/core/joinorder_synthetic/ (moved synthetic tests)"
     - "tests/unit/core/test_core_verbosity.py, test_core_quiet.py (3 line changes — synthetic import)"
@@ -658,8 +665,9 @@ impact:
   user_impact: |
     Breaking change for users running `joinorder` at sf!=1: clear
     error pointing at `joinorder_synthetic`. Otherwise transparent —
-    first run downloads ~1.2 GB silently, subsequent runs cached.
-    `--data-path` opt-out for air-gapped environments.
+    first run downloads ~1.2 GB silently into the existing datagen
+    directory, subsequent runs reuse it. Air-gapped users pre-populate
+    `benchmark_runs/datagen/joinorder_1.0/` under `BENCHBOX_OUTPUT_DIR`.
   technical_debt: |
     Eliminates JOB-correctness debt. Establishes patterns
     (DATA-LICENSE per benchmark, dataset_version in result bundles,

--- a/_project/TODO/main/planning/joinorder-canonical-foundation.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-foundation.yaml
@@ -92,10 +92,14 @@ work:
         2. Data-fetch infrastructure (`benchbox/core/data_fetch/`)
            - Per-benchmark `data_manifest.toml` schema (URL, sha256,
              file layout, version, license file)
-           - Cache: ${BENCHBOX_DATA_CACHE:-~/.cache/benchbox/data}/
-             {benchmark}/{version}/
-           - User-supplied opt-out: `--data-path` CLI flag and
-             `BENCHBOX_DATA_PATH_<BENCHMARK>` env var
+           - Reuse BenchBox's existing datagen path convention:
+             `resolve_benchmark_runs_dir()` +
+             `get_datagen_path(benchmark, sf)`
+           - Add manifest-driven SHA256 verification on top of
+             nyctaxi-style `.exists()` presence checks
+           - No new env vars and no new CLI flags; air-gapped users
+             pre-populate the datagen directory and hit the same
+             checksum gate
            - Failure modes documented: ChecksumMismatchError,
              ManifestValidationError, DataFetchError
         3. Dataset versioning in result bundles
@@ -115,16 +119,14 @@ work:
       Module structure (minimum viable, fully tested):
         benchbox/core/data_fetch/__init__.py    # public API: fetch_data()
         benchbox/core/data_fetch/manifest.py    # parse data_manifest.toml
-        benchbox/core/data_fetch/manager.py     # orchestrate fetch/cache/validate
+        benchbox/core/data_fetch/manager.py     # orchestrate path, fetch, validate
         benchbox/core/data_fetch/downloader.py  # HTTP GET + progress + resume + retry
-        benchbox/core/data_fetch/cache.py       # cache location + lock files
         benchbox/core/data_fetch/errors.py      # exception hierarchy
 
       Tests (mocked HTTP):
         tests/unit/core/data_fetch/test_manifest.py
         tests/unit/core/data_fetch/test_manager.py
         tests/unit/core/data_fetch/test_downloader.py
-        tests/unit/core/data_fetch/test_cache.py
 
       Skeleton is benchmark-agnostic; no joinorder-specific code in
       this module. Joinorder wiring happens in the cutover TODO.
@@ -516,6 +518,7 @@ scope_limit:
     - "benchbox/core/data_fetch/ (new module)"
     - "benchbox/core/benchmark_registry.py (add `surface` field + scale validation hook)"
     - "benchbox/core/errors.py (add ScaleFactorNotSupportedError if not present)"
+    - "benchbox/utils/path_utils.py (only if the datagen verification helper extends existing path utilities)"
     - "benchbox/core/joinorder/data_manifest.toml (new)"
     - "tests/unit/core/data_fetch/ (new)"
     - "tests/unit/core/test_scale_factor_validation.py (new)"
@@ -566,11 +569,12 @@ impact:
     Reusable data-fetch infrastructure pays forward: ClickBench,
     Wikipedia pageviews, GitHub Archive, and any future real-data
     benchmark instantiates the same machinery rather than each one
-    solving downloader/manifest/cache from scratch.
+    solving downloader/manifest/verification from scratch.
   user_impact: |
     Users will need to acquire ~1.5 GB of canonical data on first
-    `joinorder` run (silent download by default, with `--data-path`
-    opt-out for air-gapped environments). In exchange they get
+    `joinorder` run (silent download by default into the existing
+    `BENCHBOX_OUTPUT_DIR` / `benchmark_runs/datagen/` tree; air-gapped
+    users pre-populate that directory). In exchange they get
     results that are bit-comparable across all BenchBox users and
     against the academic literature.
   technical_debt: |
@@ -582,7 +586,7 @@ impact:
 success_metrics:
   - "Bit-reproducible Parquet archive built from Harvard Dataverse pg_dump (DOI:10.7910/DVN/2QYZBT) with full provenance manifest"
   - "Reference cardinalities computed for all 113 canonical JOB queries via PostgreSQL oracle, committed to _project/joinorder/reference_cardinalities.json"
-  - "Reusable benchbox/core/data_fetch/ module: parses manifest, downloads with checksum validation, supports user-path opt-out, all tests pass without network access"
+  - "Reusable benchbox/core/data_fetch/ module: parses manifest, downloads with checksum validation into the existing datagen path, verifies pre-populated data, all tests pass without network access"
   - "scale_factor enforcement is registry-driven and reusable: parametrized tests verify joinorder rejects sf!=1 and other benchmarks accept their declared ranges"
   - "DRAFT GitHub Release at tag data/joinorder-imdb-2013-v1 stages the archive and is ready to be promoted by the cutover TODO"
   - "Tiny canonical fixture (~1MB) is checked in and satisfies all 113 query predicates"
@@ -593,6 +597,7 @@ open_questions:
   - "DuckDB Parquet writer's encoding behavior on edge-case Unicode (combining characters, RTL text). Plan: w8 round-trip gate catches this; if it fails, fall back to Polars or pyarrow for the conversion step."
   - "Whether tiny fixture should be deterministic regen vs frozen sha256 in repo. Plan: deterministic regen via the build pipeline (w14), but the resulting Parquets are checked in (so unit tests don't need the full archive)."
   - "Reference cardinality validation against Leis 2015 published numbers — only some queries have published row counts. Plan: w12 cross-checks where available; remaining queries rely on the Postgres-on-canonical oracle alone."
+  - "Nyctaxi currently uses the same datagen directory convention with `.exists()` skip behavior but not this manifest SHA256 gate. Plan: leave nyctaxi unchanged in Step 1 and file follow-up work if the checksum gate should be generalized there."
 
 context_sections:
   "Research Findings": |
@@ -626,12 +631,14 @@ context_sections:
       1. DATA-LICENSE.md per benchmark with IMDb attribution
          verbatim, Boncz-style scope clause, redistribution
          disclaimer, takedown contact
-      2. `--data-path` opt-out for users in stricter jurisdictions
+      2. Air-gapped/pre-populated datagen directory path for users in
+         stricter jurisdictions, using the existing `BENCHBOX_OUTPUT_DIR`
+         convention and the same manifest checksum verification
       3. Same-day takedown SLA: pull Release asset on objection,
-         fall back to user-supplied path
+         fall back to user-populated datagen directory instructions
       4. No click-through (matches field practice; no legal upside)
 
     See conversation history for the full evidence pack and
     sources. If posture conditions cannot be met before w14
     promotion, fall back to Option C: host conversion scripts
-    only, require user-supplied data path.
+    only, require users to pre-populate the standard datagen directory.

--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -45,6 +45,11 @@ work:
         - any required first-class stats/analyze phase TODO is completed or this
           prototype is explicitly narrowed to a measurement smoke that does not
           claim stats-maintenance conclusions;
+        - the scale-stress decision note contains exactly one `Stats phase gate:
+          completed`, `Stats phase gate: smoke-only`, or `Stats phase gate:
+          dependency:joinorder-statistics-phase-measurement` line; if the
+          dependency gate is used, add that TODO to this item's `deps.needs`
+          before coding;
         - result-bundle labels and manifest fields for replicated_imdb are
           already specified by the decision framework.
 
@@ -163,11 +168,14 @@ anti_patterns:
 
 verification:
   - description: "Decision-framework approved replicated_imdb explicitly (not 'no scaled JOB' or other path)"
-    command: "grep -cE '^Recommendation: replicated_imdb baseline|^Recommendation: staged combination' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    command: "grep -hEc '^Recommendation: (replicated_imdb baseline|staged combination)' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: "1"
-  - description: "Stats/analyze phase handling is decided (either implemented or explicitly scoped out)"
-    command: "grep -cE 'stats/analyze phase|stats_mode:|stats-build phase' _project/decisions/joinorder-scale-stress-*.md | head -1"
-    expected_output: ">= 1"
+  - description: "Stats/analyze phase handling is decided with a concrete gate"
+    command: "grep -hEc '^Stats phase gate: (completed|smoke-only|dependency:joinorder-statistics-phase-measurement)' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
+    expected_output: "1"
+  - description: "Stats/analyze dependency gate is reflected in prototype dependencies before coding"
+    command: "! grep -hEq '^Stats phase gate: dependency:joinorder-statistics-phase-measurement' _project/decisions/joinorder-scale-stress-decision-*.md || rg -n 'joinorder-statistics-phase-measurement' _project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+    expected_output: "no output unless dependency gate is selected; otherwise TODO references the dependency"
   - description: "Replicated archive builder produces deterministic output (re-run same input → same sha256)"
     command: "uv run -- python -m pytest tests/unit/core/joinorder_replicated/test_builder_determinism.py -q"
     expected_output: "all tests pass"
@@ -196,6 +204,7 @@ verification:
 scope_limit:
   only_modify:
     - "benchbox/core/joinorder_replicated/"
+    - "benchbox/core/benchmark_registry.py"
     - "benchbox/cli/"
     - "tests/unit/core/joinorder_replicated/"
     - "tests/unit/core/publishing/test_replicated_imdb_bundle_metadata.py"

--- a/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
+++ b/_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml
@@ -14,6 +14,10 @@ description: |
   This item is deliberately a decision framework, not an implementation. It
   should conclude with a recommendation on which scale-up path, if any, is worth
   prototyping after canonical JOB has a reliable dataset contract and oracle.
+  The primary decision record is
+  `_project/decisions/joinorder-scale-stress-decision-<date>.md`; licensing is
+  captured separately in
+  `_project/decisions/joinorder-scale-stress-licensing-<date>.md`.
 
 deps:
   needs:
@@ -121,6 +125,11 @@ work:
       and make any implementation prototype depend on it before coding. The
       decision must identify required changes to runner phases, result bundles,
       platform adapter hooks, CLI phase parsing, and validation/reporting.
+      The decision note must include exactly one machine-checkable line:
+      `Stats phase gate: completed`, `Stats phase gate: smoke-only`, or
+      `Stats phase gate: dependency:joinorder-statistics-phase-measurement`.
+      Use `smoke-only` only when the prototype is explicitly narrowed so it
+      cannot claim publication-quality stats-maintenance conclusions.
 
   - id: w4
     summary: "Compare scale-up implementation options"
@@ -220,12 +229,13 @@ work:
         - Hosting model (GitHub Release / user-supplied path / both)
         - Takedown contact (inherits from canonical unless changed)
 
-      If w7 chooses "no scaled JOB for now": this work unit's
-      output is a one-line note saying "no derived archive planned;
-      licensing review re-opens when scale-stress work resumes." If the recommendation is replicated_imdb, it must
-      also state whether the statistics/analyze phase blocker is satisfied,
-      deferred with a narrower prototype scope, or represented by a new TODO that
-      the prototype must depend on.
+      If w7 chooses "no scaled JOB for now", still use the four headings above;
+      each section may state that no derived archive is planned and licensing
+      review re-opens when scale-stress work resumes. If the recommendation is
+      replicated_imdb, the licensing note must also state whether the
+      statistics/analyze phase blocker is satisfied, deferred with a narrower
+      prototype scope, or represented by a new TODO that the prototype must
+      depend on.
 
 deferred:
   - summary: "Implement any scaled JOB generator"
@@ -241,12 +251,16 @@ must_preserve:
   - "Query validation must use the canonical oracle contract from joinorder-canonical-foundation when applicable."
   - "A scaled JOB-derived prototype must not start until stats/analyze phase requirements are either satisfied or explicitly scoped out in the decision note."
   - "If w7 mutates the prototype TODO file, the prototype TODO must be quiescent (no in-progress work units) at the time of mutation; otherwise concurrent edits create lost-write risk."
+  - "The scale-stress decision record and licensing record use distinct filename prefixes so verification commands cannot read the wrong document."
 
 approach: |
   Treat this as an architecture/design gate. Read canonical JOB behavior, TPC-DS
   compliance labeling, result-bundle metadata, runner phase handling, and
   platform stats/analyze support before recommending implementation. The output
   should be a decision record plus an updated TODO for the chosen prototype.
+  Write the main decision to
+  `_project/decisions/joinorder-scale-stress-decision-<date>.md`; do not use
+  the licensing filename prefix for the main architecture decision.
 
   Cross-TODO write coordination: w7 may update the prototype TODO file
   (`joinorder-replicated-imdb-scale-prototype.yaml`) to copy the chosen
@@ -265,22 +279,25 @@ anti_patterns:
 
 verification:
   - description: "Decision note covers all required sections (programmatic header check)"
-    command: "grep -cE '^## (Benchmark question|Scale semantics|Statistics phase|Scale-up options|Validation gates|Fixed vs parameterized|Recommendation|CI cost|Licensing posture)' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    command: "grep -hEc '^## (Benchmark question|Scale semantics|Statistics phase|Scale-up options|Validation gates|Fixed vs parameterized|Recommendation|CI cost|Licensing posture)' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: ">= 9"
   - description: "Per-engine stats compatibility matrix lists 4+ engines"
-    command: "grep -cE '^\\| (DuckDB|PostgreSQL|ClickHouse|StarRocks|Spark) ' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    command: "grep -hEc '^\\| (DuckDB|PostgreSQL|ClickHouse|StarRocks|Spark) ' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: ">= 4"
   - description: "Workload labels (canonical_imdb, replicated_imdb, etc.) are defined with comparability rules"
-    command: "grep -cE 'canonical_imdb|replicated_imdb|expanded_imdb|parameterized_imdb|synthetic_schema' _project/decisions/joinorder-scale-stress-*.md | awk '{ s += $1 } END { print s }'"
+    command: "grep -hEc 'canonical_imdb|replicated_imdb|expanded_imdb|parameterized_imdb|synthetic_schema' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: ">= 5"
+  - description: "Stats/analyze prototype gate is concrete and machine-checkable"
+    command: "grep -hEc '^Stats phase gate: (completed|smoke-only|dependency:joinorder-statistics-phase-measurement)' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
+    expected_output: "1"
   - description: "Recommendation is explicit and unambiguous (one of 5 named choices, not 'maybe')"
-    command: "grep -cE '^Recommendation: (no scaled JOB|replicated_imdb baseline|expanded_imdb research|parameterized_imdb|staged combination)' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    command: "grep -hEc '^Recommendation: (no scaled JOB|replicated_imdb baseline|expanded_imdb research|parameterized_imdb|staged combination)' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: "1"
   - description: "Validation gates section explicitly rejects non-empty-only checks"
-    command: "grep -cE 'non-empty (checks|results) (are )?insufficient|q-error|cardinalit' _project/decisions/joinorder-scale-stress-*.md | head -1"
+    command: "grep -hEc 'non-empty (checks|results) (are )?insufficient|q-error|cardinalit' _project/decisions/joinorder-scale-stress-decision-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: ">= 2"
   - description: "Licensing posture for derived workloads is recorded with required fields"
-    command: "test -f _project/decisions/joinorder-scale-stress-licensing-*.md 2>/dev/null && grep -cE '^## (Posture|Hosting model|Attribution|Takedown contact)' _project/decisions/joinorder-scale-stress-licensing-*.md"
+    command: "grep -hEc '^## (Posture|Hosting model|Attribution|Takedown contact)' _project/decisions/joinorder-scale-stress-licensing-*.md | awk '{ s += $1 } END { print s }'"
     expected_output: ">= 4"
   - description: "TODO graph remains valid"
     command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
@@ -291,7 +308,8 @@ verification:
 
 scope_limit:
   only_modify:
-    - "_project/decisions/joinorder-scale-stress-*.md"
+    - "_project/decisions/joinorder-scale-stress-decision-*.md"
+    - "_project/decisions/joinorder-scale-stress-licensing-*.md"
     - "_project/TODO/main/planning/joinorder-scale-stress-decision-framework.yaml"
     - "_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
     - "_project/TODO/main/planning/joinorder-statistics-phase-measurement.yaml"

--- a/_project/TODO/main/planning/joinorder-track2-groundwork.yaml
+++ b/_project/TODO/main/planning/joinorder-track2-groundwork.yaml
@@ -189,6 +189,12 @@ work:
       (foundation TODO created the file as a stub; this work unit
       fills the per-benchmark instantiation guidance)
 
+      Frame the reusable infrastructure as a manifest-driven
+      verification step on top of BenchBox's existing datagen path
+      convention (`resolve_benchmark_runs_dir()` +
+      `get_datagen_path(benchmark, sf)`). Do not describe it as a
+      separate storage root with its own location policy.
+
       Sections:
         1. When to use this infrastructure
            - Real-data benchmarks with stable upstream data sources
@@ -205,7 +211,8 @@ work:
               checksums + DATA-LICENSE.md + reference cardinalities
            e. Stage as DRAFT GitHub Release; publish only after UAT
            f. Add data_manifest.toml in benchbox/core/<benchmark>/
-           g. Wire benchmark to fetch_data() in benchmark.py
+           g. Wire benchmark to `get_datagen_path(benchmark, sf)` +
+              `fetch_data(..., output_dir=...)` in benchmark.py
            h. Add DATA-LICENSE.md (use joinorder's as template)
            i. Add per-benchmark CHANGELOG entry
         3. DATA-LICENSE.md template
@@ -222,7 +229,10 @@ work:
              same engine that will be benchmarked
            - DRAFT-then-promote sequence for the GitHub Release
         5. Infrastructure components reused
-           - benchbox.core.data_fetch (downloader, cache, manifest)
+           - Existing datagen path convention (`BENCHBOX_OUTPUT_DIR`
+             / `benchmark_runs/datagen/<benchmark>_<sf>/`)
+           - benchbox.core.data_fetch (manifest parsing, downloader,
+             manager, errors, SHA256 verification)
            - benchmark_registry surface field (public/internal)
            - bundle_publisher dataset_version field
            - scale_factor enforcement gate


### PR DESCRIPTION
## Summary

- Tighten the PR #314 Step 2 TODO guardrails: distinct decision/licensing filenames, concrete stats/analyze gate, registry scope allowance, and robust verification globs.
- Simplify the Step 1 joinorder data-path plan to reuse the existing BENCHBOX_OUTPUT_DIR / benchmark_runs/datagen convention instead of adding cache/env/flag plumbing.
- Keep the reusable data-fetch scope to manifest parsing, download management, errors, and SHA256 verification over existing datagen paths.

## Validation

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <each edited TODO>`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run _project/scripts/generate_indexes.py`
- `uv run -- python -m pytest -m fast -q` (passed before final YAML-only cleanup; 21953 passed, 5 skipped)
- `make pr-preflight` (passed; content-only path skipped fast tests)

## Notes

- `make pr-open` warned about textual conflicts with PRs #315, #316, and #317; coordinate before landing.
