### PR TITLE
docs(planning): add prior-art search guardrail (AGENTS.md + TODO template)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,20 @@ uv run --project _project/scripts -- python _project/scripts/todo_cli.py list|sh
 Indexes under `_project/{TODO|DONE}/_indexes/` are generated. Guardrails:
 `must_preserve`, `approach`, `anti_patterns`, `verification`, `scope_limit`.
 
+## Reuse anchors
+
+Search these before designing new BenchBox infrastructure:
+
+| Concept | File |
+|---|---|
+| Per-benchmark data path | `benchbox/utils/path_utils.py:resolve_benchmark_runs_dir`, `benchbox/cli/config.py:get_datagen_path` |
+| External data download + cache | `benchbox/core/nyctaxi/downloader.py` |
+| Verbosity / quiet | `benchbox/utils/verbosity.py` |
+| Compression | `benchbox/utils/compression_mixin.py` |
+| Result bundle publishing | `benchbox/core/publishing/` |
+
+Add anchors as patterns are extracted.
+
 ## Skills & Workflow
 
 High-level wrappers remain stable: `code`, `test`, `todo`, `blog`, `docs`,

--- a/_project/TODO_ENTRY_TEMPLATE.yaml
+++ b/_project/TODO_ENTRY_TEMPLATE.yaml
@@ -114,6 +114,14 @@ files_affected:
 # IMPLEMENTATION GUARDRAILS (optional - constrain AI agent behavior)
 # ============================================================================
 
+# Existing patterns considered for reuse, one bullet each:
+# "<path>:<concept> — reuse / extend / supersede". Required when this
+# TODO adds a new module, env var, or file-system convention; in those
+# cases /todo review treats absence as a Required finding.
+prior_art:
+  - "<e.g., benchbox/utils/path_utils.py:resolve_benchmark_runs_dir — reuse for per-benchmark data dir>"
+  - "<e.g., benchbox/core/nyctaxi/downloader.py:.exists()-skip — extend with manifest-checksum verification>"
+
 # Existing behaviors that must NOT break. Name specific files, functions,
 # classes, or observable behaviors - not vague "don't break things".
 # Different from success_metrics (project-level outcomes); this is about


### PR DESCRIPTION
## Summary

Adds a "prior-art search" guardrail across three layers to catch the
plan-vs-codebase mistakes that plan-vs-plan reviews can't detect.

## Changes (BenchBox project side, this PR)

- **`AGENTS.md`**: new "Reuse anchors" section (table) listing five
  existing patterns future agents should grep before designing new
  infrastructure: `path_utils.resolve_benchmark_runs_dir` +
  `get_datagen_path`, `nyctaxi/downloader.py`, `verbosity.py`,
  `compression_mixin.py`, `publishing/`.
- **`_project/TODO_ENTRY_TEMPLATE.yaml`**: new `prior_art:` field,
  required when a TODO adds a new module / env var / file-system
  convention. Format: `<path>:<concept> — reuse / extend / supersede`.

## Companion changes (synced separately via skill-sync)

- **`~/.claude/CLAUDE.md`**: new step `0.5` "Prior-art search (L0.5)"
  in the Research process under Analysis Style. Plans for new
  infrastructure MUST include a "Prior art" section.
- **`~/.claude/skills/todo/SKILL.md`**: Create action notes require
  `prior_art` when adding new modules/conventions; Review action
  treats missing `prior_art` as a Required finding (score 0/3).

## Why

While planning canonical JOB ingestion (Step 1, issue #289), I
designed a parallel cache concept (`BENCHBOX_DATA_CACHE`,
`--data-path`, per-benchmark env vars) without checking that
`nyctaxi/downloader.py` already uses
`resolve_benchmark_runs_dir()` + `get_datagen_path()`. Plan-vs-plan
reviews from `/todo review`, the cross-trio review, and codex's PR
#315 review all evaluated the plan against itself rather than
against the codebase — none could catch the duplication.

The three-layer guardrail closes the gap:
- L1 = the universal principle (cross-project)
- L2 = the project-specific anchor table (saves grep work)
- L3 = the enforcement gate (catches missed cases)

Removing any layer creates a hole the others don't fill.

## Test plan

- [x] `validate_todo.py --all` passes after template change
- [x] `todo_cli.py check-graph` passes
- [x] AGENTS.md renders cleanly (markdown table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)