### PR TITLE
chore(todo): pin post-completion review and tighten dep edges

### DIFF
--- a/_project/TODO/main/planning/results-explorer-post-completion-chart-tabs-and-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-chart-tabs-and-disambiguation.yaml
@@ -1,0 +1,141 @@
+id: results-explorer-post-completion-chart-tabs-and-disambiguation
+title: "Fix post-completion Results Explorer chart tabs and run-label disambiguation"
+worktree: main
+priority: High
+status: Not Started
+category: Frontend UX
+
+description: |
+  The 2026-05-09 post-completion review on develop dbac33ee1 found remaining
+  chart-panel defects: the TPC-H Charts Rank tab does not activate from the
+  default Overview state, the Per-query Heatmap again duplicates the primary
+  benchmark matrix, and Distribution box-plot labels still truncate repeated
+  run identities in a way that leaves multiple indistinguishable DataFusion,
+  Polars, PySpark, Spark, and SQLite labels.
+
+  This item addresses review findings #5, #6, and #7 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md.
+
+deps:
+  needs:
+    - results-explorer-post-completion-compare-summary-semantics
+
+work:
+  - id: w0
+    summary: "Revalidate chart tab activation and duplicate chart scope"
+    status: pending
+    notes: |
+      On current develop, open /results/tpch/, scroll Charts into view, and
+      click Overview, Per-query, Distribution, Trend, and Rank from a fresh
+      page load. Capture selected tab state, visible panel text, table/svg
+      labels, and whether the Per-query panel duplicates the benchmark matrix
+      to _project/verification-logs/results-explorer-post-completion-chart-tabs-and-disambiguation/w0.log.
+
+  - id: w1
+    summary: "Make the Rank chart tab activate from every chart state"
+    needs: [w0]
+    status: pending
+    notes: |
+      Fix ChartPanel tab selection so clicking Rank from default Overview,
+      Distribution, Trend, and Per-query states sets Rank aria-selected=true
+      and renders the Rank table. Add a regression test that clicks Rank first
+      after initial render and asserts that Overview content is gone.
+
+  - id: w2
+    summary: "Remove or rescope the benchmark-detail duplicate Per-query heatmap"
+    needs: [w0]
+    status: pending
+    notes: |
+      On benchmark detail pages, do not render a Charts > Per-query > Heatmap
+      panel that repeats the page-level benchmark matrix directly above it.
+      Either exclude query_heatmap while the primary matrix is visible or
+      replace it with a genuinely different per-query chart. Preserve the
+      histogram if it is the only non-duplicate per-query chart.
+
+  - id: w3
+    summary: "Disambiguate chart run labels before truncation"
+    needs: [w0]
+    status: pending
+    notes: |
+      Update Distribution, Rank, Trend, and Overview chart labels so repeated
+      platform/version names include a visible differentiator before
+      truncation, such as date plus short result id. Example target:
+      "DataFusion 05-06 3b8bbc42" instead of four indistinguishable
+      "DataFusion v53.0.0 ..." labels. Keep full RunIdentity in title or
+      tooltip text.
+
+  - id: w4
+    summary: "Add chart-panel browser and unit coverage"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      Extend ChartPanel, RankTable, DistributionBox, and BenchmarkIndex tests
+      to cover tab activation, per-query heatmap exclusion, and duplicate-run
+      label disambiguation. Add or update a browser fixture that clicks every
+      chart tab and records the active panel.
+
+must_preserve:
+  - "All chart tabs that contain distinct data remain reachable."
+  - "Chart labels stay compact enough to fit at desktop width."
+  - "Full run identity remains available through title/tooltip or accessible label."
+
+approach: |
+  Fix the tab-state bug before changing labels so test failures are easier to
+  localize. Reuse the existing RunIdentity helpers rather than rebuilding label
+  strings in every chart component. Treat the duplicate Per-query heatmap as a
+  scope problem, not a styling problem.
+
+anti_patterns:
+  - "DO NOT make Rank accessible only after another tab is clicked first."
+  - "DO NOT truncate all differentiators away from repeated run labels."
+  - "DO NOT keep two identical matrices on the same benchmark detail page."
+
+verification:
+  - description: "Chart component tests pass"
+    command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/RankTable.test.tsx src/components/__tests__/DistributionBox.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual chart browser check passes"
+    command: "echo 'Manual/browser: on /results/tpch/, every chart tab activates; Per-query does not duplicate the primary matrix; duplicate runs have visible disambiguators'"
+    expected_output: "manual evidence captured in PR notes or verification log"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/ChartPanel.tsx"
+    - "results-explorer/src/components/RankTable.tsx"
+    - "results-explorer/src/components/DistributionBox.tsx"
+    - "results-explorer/src/components/SparklineTable.tsx"
+    - "results-explorer/src/components/TimeSeries.tsx"
+    - "results-explorer/src/lib/runIdentity.ts"
+    - "results-explorer/src/lib/chartRegistry.ts"
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+    - "results-explorer/e2e/"
+    - "_project/verification-logs/results-explorer-post-completion-chart-tabs-and-disambiguation/"
+  do_not_modify:
+    - "benchbox/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - results-explorer
+    - charts
+    - run-identity
+  estimated_effort: "Medium-High (1-3 days)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Keeps chart panels credible and usable for comparing repeated platform runs.
+  user_impact: |
+    Users can activate every chart tab and tell repeated runs apart without
+    reverse-engineering hidden ids.
+  technical_debt: |
+    Forces chart components to share a tested run-label contract.

--- a/_project/TODO/main/planning/results-explorer-post-completion-compare-selection-recovery.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-compare-selection-recovery.yaml
@@ -1,0 +1,158 @@
+id: results-explorer-post-completion-compare-selection-recovery
+title: "Repair post-completion Results Explorer compare selection recovery"
+worktree: main
+priority: Critical
+status: Not Started
+category: Frontend UX
+
+description: |
+  The 2026-05-09 post-completion Results Explorer review on develop
+  dbac33ee1 found that compare entrypoints are still not reliably usable from
+  every page. Benchmark detail checkboxes render at 0x0 and cannot be clicked;
+  Compare and Query Workbench both hide compatible second choices far below
+  the current viewport after the first selection; and Compare picker checkbox
+  accessible names are still under-disambiguated.
+
+  This item addresses review findings #1, #2, #3, and #11 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Revalidate compare-selection defects on the current develop tip"
+    status: pending
+    notes: |
+      Restart the Results Explorer dev server and drive these routes in a
+      desktop browser: /results/tpch/, /results/compare, and /results/query.
+      Capture checkbox bounding boxes, selected-row state, disabled-row counts,
+      compatible-row positions after the first selection, and button/link
+      state to _project/verification-logs/results-explorer-post-completion-compare-selection-recovery/w0.log.
+      The log must prove whether the 0x0 benchmark checkbox bug and hidden
+      compatible-candidate trap still reproduce before implementation starts.
+
+  - id: w1
+    summary: "Make benchmark-detail compare checkboxes visible and clickable"
+    needs: [w0]
+    status: pending
+    notes: |
+      Fix the BenchmarkIndex matrix/list compare controls so the checkbox
+      column renders visible 16px controls, participates in sticky-left
+      offset calculations, and can be clicked by keyboard, pointer, and test
+      locators. After selecting two compatible TPC-H rows, the page must show
+      an enabled compare action that links to /results/compare?ids=... with
+      the selected result ids. Do not rely on hidden zero-size inputs.
+
+  - id: w2
+    summary: "Move compatible candidates into view in the Compare picker"
+    needs: [w0]
+    status: pending
+    notes: |
+      Once the first Compare picker row is selected, sort or filter compatible
+      rows to the top of the candidate table. Add a visible "Compatible only"
+      state that defaults on while the cohort is locked, keeps the selected
+      row visible, and can be cleared with the existing selection reset. The
+      user must not need to scroll thousands of pixels to find the second
+      compatible run.
+
+  - id: w3
+    summary: "Move compatible candidates into view in Query Workbench"
+    needs: [w0]
+    status: pending
+    notes: |
+      Apply the same cohort-locked compatible-row treatment to Query
+      Workbench. After the first row selection, compatible rows must remain
+      immediately visible or a clearly labelled "Show compatible rows" action
+      must filter the table. Keep the existing disabled-checkbox explanation
+      for incompatible rows, but do not leave every visible row disabled while
+      Compare still says "need 2+".
+
+  - id: w4
+    summary: "Disambiguate compare-selection accessible names everywhere"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      Replace repeated labels such as "Select DuckDB for comparison" with
+      labels that include platform, benchmark, scale, run date, and a short
+      result id. Apply this to Compare picker, Benchmark detail, Query
+      Workbench, and Platform detail where applicable. Preserve compact visual
+      labels; this work is specifically for assistive tech and testability.
+
+  - id: w5
+    summary: "Add end-to-end regression coverage for compare selection starts"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Add browser or Playwright coverage that starts compare from TPC-H
+      Benchmark detail, Compare picker, Query Workbench, and Polars Platform
+      detail. Each case must select two compatible rows and assert that a
+      comparison page opens without requiring manual URL edits or off-screen
+      hunting for compatible rows.
+
+must_preserve:
+  - "Existing /results/compare?ids=... deep links continue to render comparisons."
+  - "Cohort compatibility remains benchmark + scale + phase + primary metric."
+  - "Platform detail compare selection that already generates a URL remains functional."
+  - "Static export behavior remains client-only; no server endpoint is introduced."
+
+approach: |
+  Start with shared compare-selection state and row ordering helpers before
+  touching individual pages. Fix BenchmarkIndex visibility first because it is
+  the only remaining hard blocker. Then reuse the same compatible-row ordering
+  behavior in Compare and Query so the recovery affordance is consistent.
+
+anti_patterns:
+  - "DO NOT use zero-size inputs with no visible proxy control."
+  - "DO NOT strand compatible rows below hundreds of incompatible disabled rows."
+  - "DO NOT relax cohort compatibility just to make two visible rows selectable."
+  - "DO NOT add URL-editing instructions as a fallback."
+
+verification:
+  - description: "Targeted compare-selection tests pass"
+    command: "cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/Compare.test.tsx src/pages/__tests__/Query.test.tsx src/pages/__tests__/PlatformIndex.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Browser compare-selection smoke passes"
+    command: "echo 'Manual/browser: select two compatible rows from /results/tpch/, /results/compare, /results/query, and /results/p/polars/; each opens a valid compare page'"
+    expected_output: "manual evidence captured in PR notes or verification log"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/BenchmarkIndex.tsx"
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/pages/Query.tsx"
+    - "results-explorer/src/pages/PlatformIndex.tsx"
+    - "results-explorer/src/lib/resultLinks.ts"
+    - "results-explorer/src/lib/compareSummary.ts"
+    - "results-explorer/src/pages/__tests__/"
+    - "results-explorer/e2e/"
+    - "results-explorer/scripts/"
+    - "_project/verification-logs/results-explorer-post-completion-compare-selection-recovery/"
+  do_not_modify:
+    - "benchmark_runs/"
+    - "benchbox/"
+
+metadata:
+  tags:
+    - results-explorer
+    - compare
+    - p0
+    - usability-review
+  estimated_effort: "Large (2-4 days)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Restores the core comparison workflow promised by Results Explorer.
+  user_impact: |
+    Database engineers can start a comparison from the pages where they find
+    runs, without invisible controls or off-screen compatible candidates.
+  technical_debt: |
+    Consolidates compare selection behavior and makes it testable by result id.

--- a/_project/TODO/main/planning/results-explorer-post-completion-compare-summary-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-compare-summary-semantics.yaml
@@ -1,0 +1,152 @@
+id: results-explorer-post-completion-compare-summary-semantics
+title: "Correct post-completion Results Explorer compare summary semantics"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Frontend UX
+
+description: |
+  The 2026-05-09 post-completion review on develop dbac33ee1 found that Compare
+  summaries still make ambiguous or misleading claims. Same-platform comparisons
+  say "Polars is 1.00x faster" and "WINNER Polars" when both selected runs are
+  Polars v1.40.0 from different dates; Query Wins mixes comparable and missing
+  denominators; the empty Compare picker has duplicate SSB benchmark options;
+  and comparability copy says only benchmark and scale even though phase is also
+  required.
+
+  This item addresses review findings #8, #9, #10, and #13 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md. It
+  depends on compare-selection recovery so the Compare route is not edited in
+  two conflicting passes.
+
+deps:
+  needs:
+    - results-explorer-post-completion-compare-selection-recovery
+
+work:
+  - id: w0
+    summary: "Revalidate compare-summary semantic defects on current develop"
+    status: pending
+    notes: |
+      Open /results/compare with a same-platform two-id URL and /results/compare
+      with no ids. Capture decision summary text, winner card text, Query Wins
+      denominator copy, hidden/missing query counts, comparability guardrail
+      text, and benchmark select options to
+      _project/verification-logs/results-explorer-post-completion-compare-summary-semantics/w0.log.
+
+  - id: w1
+    summary: "Dedupe and label Compare benchmark filter options"
+    needs: [w0]
+    status: pending
+    notes: |
+      Canonicalize legacy benchmark aliases before rendering the Compare picker
+      benchmark select. If a legacy slug must remain visible, label it
+      explicitly as "SSB (legacy slug)" and ensure it filters to a distinct
+      value. Otherwise render exactly one SSB option.
+
+  - id: w2
+    summary: "Use run identity and tie-aware language in same-platform summaries"
+    needs: [w0]
+    status: pending
+    notes: |
+      Update CompareSummary so same-platform comparisons name the winning run
+      by compact run identity, not just platform. If geomean speedup rounds to
+      1.00x or falls inside the existing tie threshold, render tie/no-material
+      winner copy instead of "is 1.00x faster".
+
+  - id: w3
+    summary: "Split comparable and missing-query denominators"
+    needs: [w0]
+    status: pending
+    notes: |
+      Rewrite Query Wins and chart count copy so comparable-query counts and
+      excluded/missing-query counts are separate. Example target:
+      "4 fastest of 80 comparable; 69 queries excluded for missing data." Do
+      not add incomparable queries into the denominator used for win rates.
+
+  - id: w4
+    summary: "Make comparability guardrail copy match the actual cohort lock"
+    needs: [w0]
+    status: pending
+    notes: |
+      Update Compare guardrail text from "same benchmark and scale" to "same
+      benchmark, scale, and phase" wherever that is the actual winner-claim
+      requirement. Include primary metric where relevant if the code also
+      enforces it.
+
+  - id: w5
+    summary: "Add compare-summary regression tests"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Add targeted tests for duplicate benchmark options, same-platform
+      same-speed/tie copy, query win denominators, and guardrail text. Include
+      at least one same-platform two-run fixture where platform names alone
+      would be ambiguous.
+
+must_preserve:
+  - "Existing valid Compare deep links keep working."
+  - "Speedup charts still compute from the selected baseline."
+  - "Comparable-only default behavior introduced by prior fixes remains intact."
+
+approach: |
+  Treat this as copy driven by computed state. Fix the underlying summary
+  model first, then update rendered copy. Reuse RunIdentity for same-platform
+  labels and reuse the same comparable/missing query counts that feed the
+  normalized speedup chart.
+
+anti_patterns:
+  - "DO NOT declare a winner when the displayed speedup is exactly 1.00x."
+  - "DO NOT use platform name alone when multiple selected runs share it."
+  - "DO NOT mix missing-query counts into comparable-query win denominators."
+
+verification:
+  - description: "Compare summary tests pass"
+    command: "cd results-explorer && npm test -- --run src/lib/__tests__/compareSummary.test.ts src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/pages/__tests__/Compare.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual same-platform compare copy check passes"
+    command: "echo 'Manual/browser: same-platform compare names runs, handles 1.00x as tie/no material winner, and separates comparable vs missing counts'"
+    expected_output: "manual evidence captured in PR notes or verification log"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/pages/Compare.tsx"
+    - "results-explorer/src/components/CompareSummary.tsx"
+    - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+    - "results-explorer/src/lib/compareSummary.ts"
+    - "results-explorer/src/lib/runIdentity.ts"
+    - "results-explorer/src/lib/displayLabels.ts"
+    - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+    - "results-explorer/src/components/__tests__/CompareSummary.test.tsx"
+    - "results-explorer/src/components/__tests__/NormalizedSpeedupChart.test.tsx"
+    - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+    - "_project/verification-logs/results-explorer-post-completion-compare-summary-semantics/"
+  do_not_modify:
+    - "benchbox/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - results-explorer
+    - compare
+    - copy
+    - semantics
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Prevents Compare from making decision-summary claims that overstate or
+    misidentify winners.
+  user_impact: |
+    Users can interpret same-platform comparisons and query-win counts without
+    ambiguity.
+  technical_debt: |
+    Centralizes summary wording around explicit computed states.

--- a/_project/TODO/main/planning/results-explorer-post-completion-leaderboard-data-consistency.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-leaderboard-data-consistency.yaml
@@ -1,0 +1,122 @@
+id: results-explorer-post-completion-leaderboard-data-consistency
+title: "Fix post-completion Results Explorer leaderboard data consistency"
+worktree: main
+priority: High
+status: Not Started
+category: Frontend UX
+
+description: |
+  The 2026-05-09 post-completion review on develop dbac33ee1 found that the
+  Cross-Benchmark Leaderboard still renders a linked "No run" cell for TPC-H
+  Polars SF 0.1, while the linked result detail page renders a valid Polars
+  TPC-H SF 0.1 power score. The leaderboard and detail page therefore
+  contradict each other about the same result.
+
+  This item addresses review finding #4 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md.
+
+deps:
+  needs:
+    - results-explorer-post-completion-compare-selection-recovery
+
+work:
+  - id: w0
+    summary: "Revalidate the linked No run leaderboard contradiction"
+    status: pending
+    notes: |
+      On current develop, open /results/ and capture every linked "No run"
+      cell, its href, the linked detail page primary metric, and whether the
+      leaderboard source row contains a score. Capture stdout to
+      _project/verification-logs/results-explorer-post-completion-leaderboard-data-consistency/w0.log.
+
+  - id: w1
+    summary: "Trace the meta-leaderboard score source and availability rules"
+    needs: [w0]
+    status: pending
+    notes: |
+      Inspect MetaLeaderboard, Home, result link helpers, and the snapshot read
+      model to determine why a row can have a detail href but render "No run".
+      Record whether the bug is caused by a missing primary metric mapping,
+      mismatched phase/scale key, stale aggregation, or an intentionally
+      excluded score.
+
+  - id: w2
+    summary: "Make leaderboard cells agree with detail-page run availability"
+    needs: [w1]
+    status: pending
+    notes: |
+      If the run has a valid primary metric, render the value in the leaderboard
+      cell and include it in ranking/scoring as appropriate. If the run is not
+      eligible for the cohort, render a non-linked unavailable state with a
+      truthful reason. Do not render a linked "No run" cell.
+
+  - id: w3
+    summary: "Add regression coverage for linked unavailable cells"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add tests that fail when a leaderboard cell is both linked to a result
+      detail page and labelled "No run". Include the TPC-H Polars SF 0.1 case
+      or an equivalent fixture that exercises the same data path.
+
+must_preserve:
+  - "Meta-leaderboard modes Times, Ranks, and Speedup keep their existing semantics."
+  - "Missing cohorts that truly have no published result still render as unavailable."
+  - "Result detail links continue to point at canonical result ids."
+
+approach: |
+  Treat this as a data-contract bug rather than a copy tweak. First prove which
+  source says the run exists and which source says it does not. Then make the
+  rendered cell depend on one coherent availability decision.
+
+anti_patterns:
+  - "DO NOT hide the link without checking whether the run should contribute to the leaderboard."
+  - "DO NOT special-case Polars or TPC-H by display name."
+  - "DO NOT change generated result fixtures unless the read model cannot represent the truth."
+
+verification:
+  - description: "Meta-leaderboard tests pass"
+    command: "cd results-explorer && npm test -- --run src/components/__tests__/MetaLeaderboard.test.tsx src/components/__tests__/MetaLeaderboard.a11y.test.tsx src/pages/__tests__/Home.test.tsx"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual leaderboard consistency check passes"
+    command: "echo 'Manual/browser: /results/ has no linked No run cells; TPC-H Polars SF 0.1 agrees with its detail page'"
+    expected_output: "manual evidence captured in PR notes or verification log"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/MetaLeaderboard.tsx"
+    - "results-explorer/src/pages/Home.tsx"
+    - "results-explorer/src/lib/resultLinks.ts"
+    - "results-explorer/src/lib/displayLabels.ts"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+    - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+    - "results-explorer/src/pages/__tests__/Home.test.tsx"
+    - "_project/verification-logs/results-explorer-post-completion-leaderboard-data-consistency/"
+  do_not_modify:
+    - "benchbox/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - results-explorer
+    - leaderboard
+    - data-consistency
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Keeps public leaderboard claims trustworthy.
+  user_impact: |
+    Users no longer see one page claim a run is missing while another page
+    shows a valid score for the same run.
+  technical_debt: |
+    Clarifies the availability contract between result details and aggregate
+    leaderboard cells.

--- a/_project/TODO/main/planning/results-explorer-post-completion-release-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-release-gate.yaml
@@ -1,0 +1,145 @@
+id: results-explorer-post-completion-release-gate
+title: "Gate post-completion Results Explorer follow-up fixes before release"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  After the 2026-05-09 post-completion Results Explorer review, the remaining
+  issues span compare selection, leaderboard consistency, chart behavior,
+  compare summary semantics, and result receipt copy. This gate verifies that
+  all post-completion TODOs are actually complete on the same develop SHA and
+  that no stale TODO state is left behind.
+
+  This item covers the final release acceptance pass for review findings #1
+  through #13 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md.
+
+deps:
+  needs:
+    - results-explorer-post-completion-compare-selection-recovery
+    - results-explorer-post-completion-leaderboard-data-consistency
+    - results-explorer-post-completion-chart-tabs-and-disambiguation
+    - results-explorer-post-completion-compare-summary-semantics
+    - results-explorer-post-completion-result-receipt-cost-copy
+
+work:
+  - id: w0
+    summary: "Confirm all dependent TODO work units are completed"
+    status: pending
+    notes: |
+      Use the TODO CLI to show each dependent item. Verify every work unit is
+      done, every blocker is resolved, and each dependent item either lives in
+      DONE or has status Completed with a pending move. Capture the TODO state
+      to _project/verification-logs/results-explorer-post-completion-release-gate/w0.log.
+
+  - id: w1
+    summary: "Run the full Results Explorer automated verification ladder"
+    needs: [w0]
+    status: pending
+    notes: |
+      Run the full Results Explorer checks from a clean current develop tree:
+      npm test -- --run, npm run typecheck, and npm run build. Capture command
+      status and failure tails if any to the release-gate verification log.
+
+  - id: w2
+    summary: "Run browser acceptance across all formerly failing routes"
+    needs: [w1]
+    status: pending
+    notes: |
+      Restart the Vite dev server and exercise /results/, /results/tpch/,
+      /results/query, /results/compare, /results/p/polars/, and
+      /results/r/tpch-polars-sf0.1-20260502-0093bb7a. Verify that each
+      formerly failing finding has a concrete pass/fail observation, including
+      compare entrypoints, linked No run cells, chart tab activation, duplicate
+      chart scope, run-label disambiguation, same-platform compare copy, query
+      denominator copy, duplicate SSB options, guardrail text, and cost enum
+      leakage.
+
+  - id: w3
+    summary: "Write a compact release-gate audit artifact"
+    needs: [w2]
+    status: pending
+    notes: |
+      Write _project/audits/results-explorer-post-completion-release-gate-<gate-date>.md
+      where <gate-date> is the YYYY-MM-DD on which this gate actually runs (not
+      the originating-review date). Include the develop SHA at gate time, the
+      originating review SHA dbac33ee1, commands run, browser routes checked, a
+      defect-by-defect pass/fail table for findings #1-#13, and any residual
+      risks. Do not mark the audit APPROVED if any P0/P1 defect still
+      reproduces.
+
+  - id: w4
+    summary: "Move completed post-completion TODOs to DONE and reindex"
+    needs: [w3]
+    status: pending
+    notes: |
+      When the audit passes, use the TODO complete workflow to mark each
+      post-completion item Completed, move it to _project/DONE, regenerate
+      indexes, and verify no completed item remains in _project/TODO. Do not
+      leave status Not Started on items whose PRs have landed.
+
+must_preserve:
+  - "Release gate audit must reflect the actual checked develop SHA."
+  - "A failing P0 or P1 browser finding blocks approval."
+  - "Existing unrelated TODO and DONE items are not modified."
+
+approach: |
+  Treat this as a verification and bookkeeping gate, not an implementation
+  track. Use the dependent TODOs for fixes, then run one complete acceptance
+  pass and update TODO/DONE state only when evidence supports completion.
+
+anti_patterns:
+  - "DO NOT mark the gate approved based only on unit tests."
+  - "DO NOT leave completed post-completion TODOs in _project/TODO."
+  - "DO NOT rewrite unrelated historical Results Explorer TODOs during this gate."
+
+verification:
+  - description: "Full Results Explorer test suite passes"
+    command: "cd results-explorer && npm test -- --run"
+    expected_output: "all tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "TODO graph and indexes validate"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph && uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate"
+    expected_output: "graph and schema checks pass"
+
+scope_limit:
+  only_modify:
+    - "_project/TODO/main/planning/results-explorer-post-completion-compare-selection-recovery.yaml"
+    - "_project/TODO/main/planning/results-explorer-post-completion-leaderboard-data-consistency.yaml"
+    - "_project/TODO/main/planning/results-explorer-post-completion-chart-tabs-and-disambiguation.yaml"
+    - "_project/TODO/main/planning/results-explorer-post-completion-compare-summary-semantics.yaml"
+    - "_project/TODO/main/planning/results-explorer-post-completion-result-receipt-cost-copy.yaml"
+    - "_project/TODO/main/planning/results-explorer-post-completion-release-gate.yaml"
+    - "_project/DONE/main/planning/"
+    - "_project/audits/results-explorer-post-completion-release-gate-*.md"
+    - "_project/verification-logs/results-explorer-post-completion-release-gate/"
+  do_not_modify:
+    - "results-explorer/src/"
+    - "benchbox/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - results-explorer
+    - release-gate
+    - todo-cleanup
+  estimated_effort: "Small (0.5-1 day after dependent fixes)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Prevents another "completed" effort from shipping with unresolved review
+    defects and stale TODO state.
+  user_impact: |
+    Ensures the final accepted Results Explorer experience matches the review
+    findings and fixes, not just PR titles.
+  technical_debt: |
+    Adds an explicit DONE-tree and release-gate check to close the loop.

--- a/_project/TODO/main/planning/results-explorer-post-completion-result-receipt-cost-copy.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-result-receipt-cost-copy.yaml
@@ -1,0 +1,118 @@
+id: results-explorer-post-completion-result-receipt-cost-copy
+title: "Clean post-completion Results Explorer result receipt cost copy"
+worktree: main
+priority: Medium
+status: Not Started
+category: Frontend UX
+
+description: |
+  The 2026-05-09 post-completion review on develop dbac33ee1 found that result
+  receipts still leak raw enum values in the Cost section, for example
+  "compute only, billing: not_applicable, region: not_applicable" on
+  /results/r/tpch-polars-sf0.1-20260502-0093bb7a.
+
+  This item addresses review finding #12 recorded in
+  _project/audits/results-explorer-post-completion-review-2026-05-09.md.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Revalidate cost-copy enum leakage on current develop"
+    status: pending
+    notes: |
+      Open at least one local/no-cloud result detail and one costed/cloud-like
+      result detail if available. Capture the rendered Cost section text and
+      underlying cost fields to
+      _project/verification-logs/results-explorer-post-completion-result-receipt-cost-copy/w0.log.
+
+  - id: w1
+    summary: "Map not-applicable cost fields to user-facing labels"
+    needs: [w0]
+    status: pending
+    notes: |
+      Extend the existing cost display helper so sentinel values such as
+      not_applicable, unknown, or empty strings do not render as raw enum text.
+      Local runs should render concise copy such as "local run" or
+      "not applicable" only where the field itself is useful.
+
+  - id: w2
+    summary: "Apply cost display mapping to Run Receipt"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update RunReceipt/ResultDetail cost fields to use the centralized display
+      helper. Hide billing unit and region fragments when they are not
+      applicable, but keep meaningful cost model/version/source information
+      visible.
+
+  - id: w3
+    summary: "Add hygiene tests for user-facing cost strings"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add tests that assert raw enum strings like not_applicable do not appear
+      in rendered cost receipt copy. Include a positive case where real billing
+      or region data still renders when present.
+
+must_preserve:
+  - "Cost model version/source remains visible when recorded."
+  - "Local normalized-cost status remains distinguishable from missing cost data."
+  - "Result receipt field grouping remains unchanged."
+
+approach: |
+  Reuse and extend results-explorer/src/lib/costDisplay.ts rather than adding
+  display conditionals directly inside RunReceipt. Keep the mapping small and
+  explicit so raw values remain available in data but not in user-facing copy.
+
+anti_patterns:
+  - "DO NOT globally strip underscores from every enum value."
+  - "DO NOT hide the whole Cost section when only billing or region is not applicable."
+  - "DO NOT change cost data generation to solve a presentation-only copy issue."
+
+verification:
+  - description: "Cost display and receipt tests pass"
+    command: "cd results-explorer && npm test -- --run src/lib/__tests__/costDisplay.test.ts src/components/__tests__/RunReceipt.test.tsx src/pages/__tests__/ResultDetail.test.tsx src/__tests__/userFacingStringHygiene.test.ts"
+    expected_output: "all targeted tests pass"
+  - description: "Frontend typecheck passes"
+    command: "cd results-explorer && npm run typecheck"
+    expected_output: "exit 0"
+  - description: "Frontend build passes"
+    command: "cd results-explorer && npm run build"
+    expected_output: "exit 0"
+  - description: "Manual receipt cost-copy check passes"
+    command: "echo 'Manual/browser: result receipt Cost section does not render not_applicable raw enum values'"
+    expected_output: "manual evidence captured in PR notes or verification log"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/lib/costDisplay.ts"
+    - "results-explorer/src/lib/__tests__/costDisplay.test.ts"
+    - "results-explorer/src/components/RunReceipt.tsx"
+    - "results-explorer/src/components/__tests__/RunReceipt.test.tsx"
+    - "results-explorer/src/pages/ResultDetail.tsx"
+    - "results-explorer/src/pages/__tests__/ResultDetail.test.tsx"
+    - "results-explorer/src/__tests__/userFacingStringHygiene.test.ts"
+    - "_project/verification-logs/results-explorer-post-completion-result-receipt-cost-copy/"
+  do_not_modify:
+    - "benchbox/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - results-explorer
+    - result-detail
+    - cost
+    - copy
+  estimated_effort: "Small (0.5-1 day)"
+  created_date: "2026-05-09"
+  last_updated: "2026-05-09T20:51:29-0400"
+
+impact:
+  business_value: |
+    Keeps receipts polished and understandable for public result inspection.
+  user_impact: |
+    Users see human-readable cost scope instead of internal enum names.
+  technical_debt: |
+    Moves cost-string normalization into one tested helper.

--- a/_project/audits/results-explorer-post-completion-review-2026-05-09.md
+++ b/_project/audits/results-explorer-post-completion-review-2026-05-09.md
@@ -1,3 +1,7 @@
+---
+develop_sha: dbac33ee16d93b4b651d6b26d1dec02bd5c74e5a
+---
+
 # Results Explorer Post-Completion Review — 2026-05-09
 
 **Develop SHA reviewed:** `dbac33ee1`

--- a/_project/audits/results-explorer-post-completion-review-2026-05-09.md
+++ b/_project/audits/results-explorer-post-completion-review-2026-05-09.md
@@ -1,0 +1,69 @@
+# Results Explorer Post-Completion Review — 2026-05-09
+
+**Develop SHA reviewed:** `dbac33ee1`
+**Reviewer date:** 2026-05-09
+**Scope:** Post-completion acceptance pass over the Results Explorer follow-up
+work that landed before `dbac33ee1`. Findings here are the originating
+record for the six `_project/TODO/main/planning/results-explorer-post-completion-*.yaml`
+items; numeric finding ids in those TODO descriptions resolve to the table
+below.
+
+## Methodology
+
+- Started a clean Vite dev server from `dbac33ee1` and exercised the
+  routes listed under each finding from a desktop browser.
+- Recorded selected-tab state, table contents, accessible names, link
+  targets, and rendered copy where the observation was about UX.
+- Cross-referenced linked detail pages against leaderboard/cell state
+  for data-consistency findings.
+- A defect was recorded only when the observed behaviour was
+  reproducible from a fresh page load on `dbac33ee1`.
+
+## Severity legend
+
+- **P0** — blocks the canonical workflow that the page exists to
+  support (e.g. cannot start a comparison from where compatible runs
+  are surfaced).
+- **P1** — produces incorrect or self-contradicting claims to the
+  user, but the page still partially functions.
+- **P2** — degrades trust or polish; defensible but visible.
+
+## Findings
+
+| # | Title | Area | Severity | Route(s) | Observation | Owning TODO |
+|---|---|---|---|---|---|---|
+| 1 | Benchmark-detail compare checkboxes render at 0×0 and cannot be clicked | Compare entrypoint | P0 | `/results/tpch/` | Compare-selection checkbox column is present in DOM but bounding boxes are 0×0; no visible proxy control; selecting two rows never enables a compare action. | compare-selection-recovery |
+| 2 | Compare picker hides compatible second choices below the viewport after the first selection | Compare picker | P0 | `/results/compare` | After picking one row, compatible rows are not promoted; user must scroll past hundreds of disabled incompatible rows to find a second compatible run. | compare-selection-recovery |
+| 3 | Query Workbench leaves every visible row disabled while Compare still says "need 2+" | Compare entrypoint | P0 | `/results/query` | Same off-screen-compatibles trap as #2 plus a misleading Compare prompt; the page never recovers from the first selection. | compare-selection-recovery |
+| 4 | Cross-Benchmark Leaderboard renders linked "No run" for TPC-H Polars SF 0.1 | Leaderboard data | P1 | `/results/`, `/results/r/tpch-polars-sf0.1-20260502-0093bb7a` | Leaderboard cell links to a result detail that *does* render a valid Polars TPC-H SF 0.1 power score. Two pages contradict each other on the same run. | leaderboard-data-consistency |
+| 5 | TPC-H Charts Rank tab does not activate from the default Overview state | Chart panel state | P1 | `/results/tpch/` | Clicking Rank from a fresh page load does not set `aria-selected=true` on Rank or render the Rank table; Overview content stays. | chart-tabs-and-disambiguation |
+| 6 | Per-query Heatmap on benchmark detail duplicates the page-level benchmark matrix | Chart scope | P2 | `/results/tpch/` | Charts > Per-query > Heatmap renders the same matrix already shown directly above it on benchmark detail. | chart-tabs-and-disambiguation |
+| 7 | Distribution box-plot labels truncate repeated run identities | Run-label disambiguation | P1 | `/results/tpch/` | Multiple DataFusion, Polars, PySpark, Spark, and SQLite labels truncate to identical strings; full RunIdentity is hidden. | chart-tabs-and-disambiguation |
+| 8 | Same-platform compare summary says "Polars is 1.00× faster" with "WINNER Polars" | Compare summary semantics | P1 | `/results/compare` | Two Polars v1.40.0 runs from different dates produce a winner card and a 1.00× speedup statement. | compare-summary-semantics |
+| 9 | Query Wins denominator mixes comparable and missing-data queries | Compare summary semantics | P1 | `/results/compare` | The denominator used for win rates includes queries that were excluded for missing data, depressing or inflating apparent win rates. | compare-summary-semantics |
+| 10 | Compare picker shows duplicate SSB benchmark options | Compare picker filter | P2 | `/results/compare` (no ids) | Legacy SSB slugs are not canonicalized before render; two options appear with no way to tell them apart. | compare-summary-semantics |
+| 11 | Compare picker checkbox accessible names are under-disambiguated | Compare picker a11y | P1 | `/results/compare` | "Select DuckDB for comparison" repeats across many distinct candidate runs; assistive tech and locator-driven tests cannot distinguish them. | compare-selection-recovery |
+| 12 | Result receipt Cost section leaks raw `not_applicable` enum values | Result receipt copy | P2 | `/results/r/tpch-polars-sf0.1-20260502-0093bb7a` | Cost line renders "compute only, billing: not_applicable, region: not_applicable" verbatim. | result-receipt-cost-copy |
+| 13 | Comparability guardrail copy says only "benchmark and scale" | Compare summary semantics | P2 | `/results/compare` | Cohort lock is benchmark + scale + phase (and primary metric where enforced); the copy under-states the actual gate. | compare-summary-semantics |
+
+## Owning TODO map
+
+- `results-explorer-post-completion-compare-selection-recovery.yaml` → #1, #2, #3, #11
+- `results-explorer-post-completion-leaderboard-data-consistency.yaml` → #4
+- `results-explorer-post-completion-chart-tabs-and-disambiguation.yaml` → #5, #6, #7
+- `results-explorer-post-completion-compare-summary-semantics.yaml` → #8, #9, #10, #13
+- `results-explorer-post-completion-result-receipt-cost-copy.yaml` → #12
+- `results-explorer-post-completion-release-gate.yaml` → acceptance gate over #1–#13
+
+## Acceptance contract
+
+Each TODO carries a `w0` work unit that re-validates its findings on the
+current develop tip and writes stdout to
+`_project/verification-logs/<id>/w0.log`. Implementation work is gated on
+that log; the release-gate TODO consumes the per-item logs plus a fresh
+browser pass to produce
+`_project/audits/results-explorer-post-completion-release-gate-<gate-date>.md`.
+
+If a finding here no longer reproduces on a future develop tip, the
+owning TODO's `w0` log records that fact and the finding is treated as
+already-satisfied at gate time.


### PR DESCRIPTION
Review of the six results-explorer-post-completion-* TODO YAMLs surfaced
two structural defects:

- R1 (cited-but-unbound evidence): every description referenced "review
  findings #1-#13" but no audit document existed. Created
  _project/audits/results-explorer-post-completion-review-2026-05-09.md
  with the methodology, severity legend, and a defect table that pins
  each finding to its owning TODO. Each TODO description now cites the
  audit path instead of "the post-completion evaluation".

- R2 (missing dependency edges): three pairs of independent items
  shared scope on runIdentity.ts, resultLinks.ts, and displayLabels.ts.
  Added two dep edges so the run-identity and result-link contracts
  land once before downstream items consume them:
    chart-tabs-and-disambiguation -> compare-summary-semantics
    leaderboard-data-consistency  -> compare-selection-recovery

Also retargeted release-gate w3's audit filename from a hard-coded
2026-05-09 date to <gate-date> with the originating-review SHA captured
inside, and widened scope_limit accordingly.

Validation: todo_cli check-graph (54 items, no cycles), validate_todo
--strict on all six files (all valid).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
