### PR TITLE
chore(todo): scope post-completion TODOs around already-shipped work

### DIFF
--- a/_project/TODO/main/planning/results-explorer-post-completion-chart-tabs-and-disambiguation.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-chart-tabs-and-disambiguation.yaml
@@ -52,17 +52,32 @@ work:
       replace it with a genuinely different per-query chart. Preserve the
       histogram if it is the only non-duplicate per-query chart.
 
+      Prior art: PR #300 already added matrix-view dedup at
+      `results-explorer/src/pages/BenchmarkIndex.tsx`
+      (`excludeChartIds={["query_heatmap"]}` while `viewMode === "matrix"`).
+      If w0 reproduces finding #6 against the current develop tip, the work
+      is to extend the same exclusion to the view modes still showing the
+      duplicate (or to investigate a regression). If w0 cannot reproduce,
+      record the stale finding in the w0 log and skip implementation.
+
   - id: w3
-    summary: "Disambiguate chart run labels before truncation"
+    summary: "Tighten chart run-label truncation so disambiguated suffixes survive"
     needs: [w0]
     status: pending
     notes: |
-      Update Distribution, Rank, Trend, and Overview chart labels so repeated
-      platform/version names include a visible differentiator before
-      truncation, such as date plus short result id. Example target:
-      "DataFusion 05-06 3b8bbc42" instead of four indistinguishable
-      "DataFusion v53.0.0 ..." labels. Keep full RunIdentity in title or
-      tooltip text.
+      Cohort-aware label formatting already ships via
+      `results-explorer/src/lib/runIdentity.ts` and is consumed by
+      Distribution, Rank, Trend, and Overview chart components (PR #286 +
+      #309). Finding #7 is that the *post-formatter* truncation step still
+      collapses repeated platforms to identical prefixes (e.g. four
+      "DataFusion v53.0.0 ..." rows).
+
+      Scope of this work unit is the truncation budget and ordering only:
+      ensure the disambiguating qualifier (date + short result id) survives
+      the truncation, e.g. "DataFusion 05-06 3b8bbc42" rather than the
+      truncated platform/version prefix. Keep full RunIdentity in title or
+      tooltip text. Do not re-apply the formatter; that work is closed in
+      `_project/DONE/main/planning/results-explorer-run-identity-disambiguation.yaml`.
 
   - id: w4
     summary: "Add chart-panel browser and unit coverage"
@@ -129,7 +144,7 @@ metadata:
     - run-identity
   estimated_effort: "Medium-High (1-3 days)"
   created_date: "2026-05-09"
-  last_updated: "2026-05-09T20:51:29-0400"
+  last_updated: "2026-05-10T09:52:56-0400"
 
 impact:
   business_value: |

--- a/_project/TODO/main/planning/results-explorer-post-completion-compare-summary-semantics.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-completion-compare-summary-semantics.yaml
@@ -35,14 +35,24 @@ work:
       _project/verification-logs/results-explorer-post-completion-compare-summary-semantics/w0.log.
 
   - id: w1
-    summary: "Dedupe and label Compare benchmark filter options"
+    summary: "Dedupe Compare benchmark filter options for the legacy SSB slug"
     needs: [w0]
     status: pending
     notes: |
-      Canonicalize legacy benchmark aliases before rendering the Compare picker
-      benchmark select. If a legacy slug must remain visible, label it
-      explicitly as "SSB (legacy slug)" and ensure it filters to a distinct
-      value. Otherwise render exactly one SSB option.
+      Prior art: PR #285 already labels the legacy slug
+      `"SSB (legacy slug)"` in
+      `results-explorer/src/lib/displayLabels.ts`, so the *labeling* half of
+      this work is shipped. Finding #10 reproduces if the Compare picker
+      builds its benchmark options from a source that yields both `ssb` and
+      `star_schema` as separate filter values.
+
+      Scope of this work unit is the filter-option list only: canonicalize
+      legacy aliases before rendering the Compare picker benchmark select so
+      exactly one SSB option appears, or — if both must remain visible for
+      data routing — keep the existing "SSB (legacy slug)" label and ensure
+      each option filters to a distinct, non-overlapping result set. If w0
+      cannot reproduce duplicate options against the current develop tip,
+      record the stale finding in the w0 log and skip implementation.
 
   - id: w2
     summary: "Use run identity and tie-aware language in same-platform summaries"
@@ -139,7 +149,7 @@ metadata:
     - semantics
   estimated_effort: "Medium (1-2 days)"
   created_date: "2026-05-09"
-  last_updated: "2026-05-09T20:51:29-0400"
+  last_updated: "2026-05-10T09:52:56-0400"
 
 impact:
   business_value: |

--- a/_project/audits/results-explorer-post-completion-review-2026-05-09.md
+++ b/_project/audits/results-explorer-post-completion-review-2026-05-09.md
@@ -71,3 +71,36 @@ browser pass to produce
 If a finding here no longer reproduces on a future develop tip, the
 owning TODO's `w0` log records that fact and the finding is treated as
 already-satisfied at gate time.
+
+## Status notes (post-cited-tip changes)
+
+This section records changes that landed on `develop` *after* the cited
+`dbac33ee1` tip but *before* implementation work begins. It does not
+move findings; it just narrows where each `w0` should look.
+
+- **PR #316 (`b94cb59bb`)** — `fix(explorer): close follow-up usability
+  review gaps`. Centralized compare cohort locking via
+  `results-explorer/src/lib/compareCohort.ts`, capped entrypoint
+  selections at four runs, and threaded cohort-aware labels into the
+  remaining Compare chart consumers. Findings to re-verify in light of
+  this PR: #1 (still in BenchmarkIndex), #2/#3 (cohort lock helper now
+  exists; ordering of compatible candidates still unconfirmed), #8/#11
+  (Compare-side cohort labels may already disambiguate same-platform
+  copy in some surfaces).
+- **Already-shipped overlap to confirm in w0, not re-implement**:
+    - Finding #6 (Per-query Heatmap duplicate): matrix-view dedup
+      lives at `results-explorer/src/pages/BenchmarkIndex.tsx`
+      (`excludeChartIds={["query_heatmap"]}`, PR #300). w0 should
+      check whether the duplicate reappears in non-matrix view modes
+      or has regressed.
+    - Finding #10 (duplicate SSB options): legacy slug labeling lives
+      at `results-explorer/src/lib/displayLabels.ts:80`
+      (`"SSB (legacy slug)"`, PR #285). w0 should check whether the
+      Compare picker builds its option list from a source that
+      bypasses the labeler.
+    - Finding #7 (Distribution truncation): cohort-aware formatter
+      already applied to Distribution/Rank/Trend/Overview charts
+      (PRs #286 + #309). The remaining work is post-formatter
+      truncation budget; see
+      `results-explorer-post-completion-chart-tabs-and-disambiguation.yaml`
+      w3 notes.


### PR DESCRIPTION
A /todo review surfaced two stale-claim work units in the post-completion
TODOs and one cross-TODO scope overlap with the now-DONE
results-explorer-run-identity-disambiguation. After rebasing onto
develop (which now includes #316/#320), R1/R2 from the review were
already addressed. The remaining adjustments narrow the implementing
agent's scope so it does not re-implement work that already shipped.

- chart-tabs-and-disambiguation w2: keep the work item but document
  PR #300's existing matrix-view dedup at BenchmarkIndex.tsx, so w0
  reproduces against the right surface or records a stale finding.
- chart-tabs-and-disambiguation w3: reframe from "apply RunIdentity"
  (closed by run-identity-disambiguation w2-w6) to the post-formatter
  truncation budget that finding #7 actually reports.
- compare-summary-semantics w1: keep the work item but document
  PR #285's existing legacy-slug labeling, so the work focuses on the
  picker option list rather than relabeling the slug.
- audits/...post-completion-review-2026-05-09.md: add a "Status notes"
  section flagging PR #316 as intervening work since the cited
  dbac33ee1 tip and listing the three findings whose w0 should
  re-verify against shipped helpers rather than re-implement them.

Verification: validate_todo --strict (both edited files); todo_cli
check-graph (54 items, no cycles, no dangling refs); generate_indexes.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
