### PR TITLE
fix(todo): restore single-line seed-path literal in joinorder-cutover

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-cutover.yaml
@@ -313,8 +313,7 @@ work:
             raise NotImplementedError(
               f"DataFrame translation for query <id> not yet "
               f"available. Track-2 TODO: "
-              f"_project/TODO/main/planning/"
-              f"track2-joinorder-dataframe-coverage.yaml"
+              f"_project/TODO/main/planning/track2-joinorder-dataframe-coverage.yaml"
             )
 
         def q<id>_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -607,7 +606,7 @@ verification:
     command: "uv run -- python -m pytest tests/unit/core/joinorder/test_canonical_queries.py -q"
     expected_output: "113 passed"
   - description: "DataFrame queries fail loudly for an untranslated query (q13a_expression_impl raises NotImplementedError pointing at Track-2 seed)"
-    command: "uv run -- python -c 'from benchbox.core.joinorder.dataframe_queries import q13a_expression_impl; q13a_expression_impl(None)' 2>&1 | grep -c 'track2-joinorder-dataframe-coverage'"
+    command: "uv run -- python -c 'from benchbox.core.joinorder.dataframe_queries import q13a_expression_impl; q13a_expression_impl(None)' 2>&1 | grep -c '_project/TODO/main/planning/track2-joinorder-dataframe-coverage.yaml'"
     expected_output: ">= 1"
   - description: "DataFrame default query list exposes only implemented queries"
     command: "uv run -- python -m pytest tests/unit/core/joinorder/test_dataframe_query_capabilities.py -q"


### PR DESCRIPTION
PR #322 reflowed the embedded `NotImplementedError` snippet in
`joinorder-canonical-cutover.yaml` w11 across two f-string fragments
(`f"_project/TODO/main/planning/" f"track2-joinorder-dataframe-coverage.yaml"`),
which caused
`tests/unit/test_todo_executable_docs.py::test_joinorder_dataframe_followup_path_uses_seeded_yaml`
to fail on every PR opened against develop tip 21376cb58 — the test
asserts the full literal `f"_project/TODO/main/planning/track2-joinorder-dataframe-coverage.yaml"`
appears in the YAML, but the wrap split it.

Two changes restore the single-literal contract the test enforces:
- Collapse the multi-line f-string back to one line in w11's embedded
  snippet so the seeded path is one continuous f-string literal again.
- Update the w17 verification command's `grep -c '...'` argument to
  use the full path-prefixed pattern the test expects.

The runtime behavior is unchanged (Python still concatenates adjacent
string literals at parse time; the resulting message is identical).

This unblocks PRs #324, #325, #326, and #327, which were stuck behind
this pre-existing develop CI failure.

Verification: uv run -- python -m pytest
tests/unit/test_todo_executable_docs.py::test_joinorder_dataframe_followup_path_uses_seeded_yaml
(passed); make pr-preflight (21954 passed).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
