### PR TITLE
fix(joinorder): enforce foundation gates

### DIFF
--- a/benchbox/core/benchmark_loader.py
+++ b/benchbox/core/benchmark_loader.py
@@ -13,12 +13,14 @@ from typing import Any
 from benchbox.core.benchmark_registry import (
     get_core_benchmark_class_name,
     list_loader_benchmark_ids,
+    validate_scale_factor,
 )
 from benchbox.core.schemas import BenchmarkConfig, SystemProfile
 
 
 def get_benchmark_instance(config: BenchmarkConfig, system_profile: SystemProfile | None) -> Any:
     """Get benchmark instance based on configuration."""
+    validate_scale_factor(config.name, config.scale_factor)
     benchmark_class = get_benchmark_class(config.name)
 
     cpu_cores = 1

--- a/benchbox/core/data_fetch/__init__.py
+++ b/benchbox/core/data_fetch/__init__.py
@@ -30,12 +30,13 @@ from .errors import (
     ManifestValidationError,
 )
 from .manager import ExtractionRequiredError, fetch_data
-from .manifest import DataManifest, TableEntry, load_manifest
+from .manifest import DataManifest, TableEntry, compute_manifest_hash, load_manifest
 
 __all__ = [
     "fetch_data",
     "DataManifest",
     "TableEntry",
+    "compute_manifest_hash",
     "load_manifest",
     "DataFetchError",
     "ManifestValidationError",

--- a/benchbox/core/data_fetch/manifest.py
+++ b/benchbox/core/data_fetch/manifest.py
@@ -46,6 +46,7 @@ or verify the data files. That's manager.py's job.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -63,6 +64,27 @@ _REQUIRED_TOP_KEYS = (
     "archive_sha256",
     "license_file",
 )
+
+
+def _manifest_hash_input(raw: bytes) -> bytes:
+    """Return manifest bytes with the top-level manifest_hash assignment removed."""
+    lines: list[bytes] = []
+    in_top_level = True
+    for line in raw.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith(b"["):
+            in_top_level = False
+        if in_top_level and stripped.startswith(b"manifest_hash"):
+            before_equals = stripped.split(b"=", 1)[0].strip()
+            if before_equals == b"manifest_hash":
+                continue
+        lines.append(line)
+    return b"".join(lines)
+
+
+def compute_manifest_hash(path: str | Path) -> str:
+    """Compute the pinned manifest hash with `manifest_hash` itself excluded."""
+    return hashlib.sha256(_manifest_hash_input(Path(path).read_bytes())).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -110,14 +132,23 @@ def load_manifest(path: str | Path) -> DataManifest:
         raise ManifestValidationError(f"manifest not found at {p}")
 
     try:
-        with p.open("rb") as fh:
-            raw = tomllib.load(fh)
+        raw_bytes = p.read_bytes()
+        raw = tomllib.loads(raw_bytes.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise ManifestValidationError(f"manifest at {p} is not valid UTF-8: {exc}") from exc
     except tomllib.TOMLDecodeError as exc:
         raise ManifestValidationError(f"manifest at {p} is not valid TOML: {exc}") from exc
 
     missing = [k for k in _REQUIRED_TOP_KEYS if k not in raw]
     if missing:
         raise ManifestValidationError(f"manifest at {p} is missing required keys: {sorted(missing)}")
+
+    expected_manifest_hash = str(raw["manifest_hash"])
+    actual_manifest_hash = hashlib.sha256(_manifest_hash_input(raw_bytes)).hexdigest()
+    if expected_manifest_hash != actual_manifest_hash:
+        raise ManifestValidationError(
+            f"manifest_hash mismatch for {p}: expected {expected_manifest_hash}, got {actual_manifest_hash}"
+        )
 
     tables_raw = raw.get("tables", [])
     if not isinstance(tables_raw, list):

--- a/benchbox/core/runner/runner.py
+++ b/benchbox/core/runner/runner.py
@@ -19,6 +19,7 @@ from typing import Any
 from benchbox.core.benchmark_loader import (
     get_benchmark_instance,
 )
+from benchbox.core.benchmark_registry import validate_scale_factor
 from benchbox.core.constants import (
     GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
     GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
@@ -1097,6 +1098,7 @@ def run_benchmark_lifecycle(
     options_map = getattr(benchmark_config, "options", {}) or {}
     verbosity_settings = _resolve_verbosity_settings(verbosity, options_map)
 
+    validate_scale_factor(benchmark_config.name, benchmark_config.scale_factor)
     benchmark = benchmark_instance or get_benchmark_instance(benchmark_config, system_profile)
     if isinstance(benchmark, VerbosityMixin):  # type: ignore[arg-type]
         benchmark.apply_verbosity(verbosity_settings)

--- a/tests/unit/core/data_fetch/test_manager.py
+++ b/tests/unit/core/data_fetch/test_manager.py
@@ -15,6 +15,7 @@ import pytest
 from benchbox.core.data_fetch import (
     ChecksumMismatchError,
     ExtractionRequiredError,
+    compute_manifest_hash,
     fetch_data,
 )
 
@@ -32,13 +33,14 @@ BETA_PAYLOAD = b"beta-table-row-bytes"
 ALPHA_SHA = hashlib.sha256(ALPHA_PAYLOAD).hexdigest()
 BETA_SHA = hashlib.sha256(BETA_PAYLOAD).hexdigest()
 ARCHIVE_SHA = "00" * 32  # placeholder — fake_downloader doesn't recompute
+MANIFEST_HASH_PLACEHOLDER = "a" * 64
 
 
 def _write_manifest(tmp: Path) -> Path:
     """Build a minimal data_manifest.toml with two named tables."""
     body = (
         f'dataset_version    = "test-v1"\n'
-        f'manifest_hash      = "{"a" * 64}"\n'
+        f'manifest_hash      = "{MANIFEST_HASH_PLACEHOLDER}"\n'
         f'data_archive_hash  = "{ARCHIVE_SHA}"\n'
         f'url                = "https://example.com/test.tar.zst"\n'
         f'archive_sha256     = "{ARCHIVE_SHA}"\n'
@@ -56,6 +58,8 @@ def _write_manifest(tmp: Path) -> Path:
     )
     p = tmp / "data_manifest.toml"
     p.write_text(body)
+    manifest_hash = compute_manifest_hash(p)
+    p.write_text(body.replace(MANIFEST_HASH_PLACEHOLDER, manifest_hash))
     return p
 
 

--- a/tests/unit/core/data_fetch/test_manifest.py
+++ b/tests/unit/core/data_fetch/test_manifest.py
@@ -14,6 +14,7 @@ import pytest
 from benchbox.core.data_fetch import (
     DataManifest,
     ManifestValidationError,
+    compute_manifest_hash,
     load_manifest,
 )
 
@@ -23,13 +24,13 @@ pytestmark = [
 ]
 
 
-_HEX_A = "a" * 64
 _HEX_B = "b" * 64
 _HEX_C = "c" * 64
+_HASH_PLACEHOLDER = "0" * 64
 
 _MINIMAL = f"""\
 dataset_version    = "test-v1"
-manifest_hash      = "{_HEX_A}"
+manifest_hash      = "{_HASH_PLACEHOLDER}"
 data_archive_hash  = "{_HEX_B}"
 url                = "https://example.com/test.tar.zst"
 archive_sha256     = "{_HEX_C}"
@@ -56,6 +57,8 @@ retrieval_timestamp = "2026-05-10T14:00:00Z"
 def _write(tmp: Path, body: str) -> Path:
     p = tmp / "data_manifest.toml"
     p.write_text(body)
+    manifest_hash = compute_manifest_hash(p)
+    p.write_text(body.replace(_HASH_PLACEHOLDER, manifest_hash))
     return p
 
 
@@ -64,6 +67,7 @@ def test_load_minimal_manifest(tmp_path: Path) -> None:
     m = load_manifest(p)
     assert isinstance(m, DataManifest)
     assert m.dataset_version == "test-v1"
+    assert m.manifest_hash == compute_manifest_hash(p)
     assert len(m.tables) == 2
     assert m.tables[0].name == "t1"
     assert m.tables[1].row_count == 200
@@ -97,6 +101,18 @@ def test_missing_required_top_key_raises(tmp_path: Path) -> None:
         load_manifest(p)
 
 
+def test_manifest_hash_mismatch_raises(tmp_path: Path) -> None:
+    p = _write(tmp_path, _MINIMAL)
+    p.write_text(
+        p.read_text().replace(
+            'url                = "https://example.com/test.tar.zst"',
+            'url = "https://evil.test/archive.tar.zst"',
+        )
+    )
+    with pytest.raises(ManifestValidationError, match="manifest_hash mismatch"):
+        load_manifest(p)
+
+
 def test_missing_table_field_raises(tmp_path: Path) -> None:
     bad = _MINIMAL.replace('file      = "t1.parquet"\n', "")
     p = _write(tmp_path, bad)
@@ -106,7 +122,8 @@ def test_missing_table_field_raises(tmp_path: Path) -> None:
 
 def test_tables_must_be_array(tmp_path: Path) -> None:
     body = (
-        'dataset_version="x"\nmanifest_hash="x"\ndata_archive_hash="x"\nurl="x"\n'
+        f'dataset_version="x"\nmanifest_hash="{_HASH_PLACEHOLDER}"\n'
+        'data_archive_hash="x"\nurl="x"\n'
         'archive_sha256="x"\nlicense_file="x"\ntables = "this should be a list"\n'
     )
     p = _write(tmp_path, body)

--- a/tests/unit/core/test_joinorder_benchmark.py
+++ b/tests/unit/core/test_joinorder_benchmark.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from benchbox.core.benchmark_loader import get_benchmark_instance
+from benchbox.core.errors import ScaleFactorNotSupportedError
 from benchbox.core.joinorder.benchmark import JoinOrderBenchmark
 from benchbox.core.schemas import BenchmarkConfig, SystemProfile
 
@@ -82,7 +83,7 @@ def test_get_benchmark_instance_handles_joinorder_compression() -> None:
     config = BenchmarkConfig(
         name="joinorder",
         display_name="JoinOrder",
-        scale_factor=0.1,
+        scale_factor=1.0,
         compress_data=True,
         compression_type="zstd",
         compression_level=5,
@@ -103,6 +104,17 @@ def test_get_benchmark_instance_handles_joinorder_compression() -> None:
     assert generator.compression_type == "zstd"
     assert generator.compression_level == 5
     assert generator.force_regenerate is True
+
+
+def test_get_benchmark_instance_rejects_unsupported_joinorder_scale() -> None:
+    config = BenchmarkConfig(
+        name="joinorder",
+        display_name="JoinOrder",
+        scale_factor=0.5,
+    )
+
+    with pytest.raises(ScaleFactorNotSupportedError, match=r"joinorder accepts scale_factor in \[1\.0\]"):
+        get_benchmark_instance(config, _make_system_profile())
 
 
 def test_joinorder_invalid_parallel_raises(tmp_path: Path) -> None:

--- a/tests/unit/core/test_runner_lifecycle.py
+++ b/tests/unit/core/test_runner_lifecycle.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from benchbox.base import BaseBenchmark
+from benchbox.core.errors import ScaleFactorNotSupportedError
 from benchbox.core.nyctaxi.benchmark import NYCTaxiBenchmark
 from benchbox.core.results.models import BenchmarkResults
 from benchbox.core.runner import LifecyclePhases, ValidationOptions, run_benchmark_lifecycle
@@ -40,6 +41,27 @@ def _mk_system_profile():
         timestamp=datetime.now(),
         hostname="host",
     )
+
+
+@pytest.mark.unit
+def test_lifecycle_rejects_unsupported_scale_before_using_supplied_instance():
+    cfg = BenchmarkConfig(
+        name="joinorder",
+        display_name="JoinOrder",
+        scale_factor=0.5,
+        test_execution_type="data_only",
+    )
+    bench = MagicMock()
+
+    with pytest.raises(ScaleFactorNotSupportedError, match=r"joinorder accepts scale_factor in \[1\.0\]"):
+        run_benchmark_lifecycle(
+            benchmark_config=cfg,
+            database_config=None,
+            system_profile=_mk_system_profile(),
+            benchmark_instance=bench,
+        )
+
+    bench.generate_data.assert_not_called()
 
 
 @pytest.mark.unit
@@ -836,7 +858,7 @@ def test_run_benchmark_lifecycle_propagates_capture_plans(tmp_path):
 def test_manifest_reuse_accepts_data_source_alias(tmp_path):
     """Manifest reuse should work when benchmark declares a data-source alias."""
 
-    data_dir = tmp_path / "tpch_sf1"
+    data_dir = tmp_path / "tpch_sf0_1"
     data_dir.mkdir()
     customer_path = data_dir / "customer.tbl"
     contents = "1|cust\n"
@@ -844,7 +866,7 @@ def test_manifest_reuse_accepts_data_source_alias(tmp_path):
 
     manifest = {
         "benchmark": "tpch",
-        "scale_factor": 1.0,
+        "scale_factor": 0.1,
         "tables": {
             "customer": {
                 "formats": {
@@ -863,7 +885,7 @@ def test_manifest_reuse_accepts_data_source_alias(tmp_path):
 
     class AliasBenchmark(BaseBenchmark):
         def __init__(self, output_dir: Path):
-            super().__init__(scale_factor=1.0, output_dir=output_dir)
+            super().__init__(scale_factor=0.1, output_dir=output_dir)
             self.tables = {}
 
         def get_data_source_benchmark(self) -> str:
@@ -884,7 +906,7 @@ def test_manifest_reuse_accepts_data_source_alias(tmp_path):
     cfg = BenchmarkConfig(
         name="read_primitives",
         display_name="Primitives",
-        scale_factor=1.0,
+        scale_factor=0.1,
         compress_data=False,
         options={"force_regenerate": False, "no_regenerate": False},
     )
@@ -907,13 +929,13 @@ def test_manifest_reuse_accepts_data_source_alias(tmp_path):
 def test_no_regenerate_respects_alias_manifest(tmp_path):
     """no_regenerate should pass when shared manifest is valid."""
 
-    data_dir = tmp_path / "tpch_sf1"
+    data_dir = tmp_path / "tpch_sf0_1"
     data_dir.mkdir()
     orders_path = data_dir / "orders.tbl"
     orders_path.write_text("1|order\n")
     manifest = {
         "benchmark": "tpch",
-        "scale_factor": 1.0,
+        "scale_factor": 0.1,
         "tables": {
             "orders": {
                 "formats": {
@@ -932,7 +954,7 @@ def test_no_regenerate_respects_alias_manifest(tmp_path):
 
     class AliasBenchmark(BaseBenchmark):
         def __init__(self, output_dir: Path):
-            super().__init__(scale_factor=1.0, output_dir=output_dir)
+            super().__init__(scale_factor=0.1, output_dir=output_dir)
             self.tables = {}
 
         def get_data_source_benchmark(self) -> str:
@@ -953,7 +975,7 @@ def test_no_regenerate_respects_alias_manifest(tmp_path):
     cfg = BenchmarkConfig(
         name="read_primitives",
         display_name="Primitives",
-        scale_factor=1.0,
+        scale_factor=0.1,
         compress_data=False,
         options={"force_regenerate": False, "no_regenerate": True},
     )


### PR DESCRIPTION
## Summary
- enforce registry scale-factor validation in both the core benchmark loader and lifecycle runner
- validate `data_manifest.toml` `manifest_hash` during parsing and expose `compute_manifest_hash()` for build/test reuse
- add regression coverage for invalid JoinOrder scales, supplied lifecycle instances, and manifest hash mismatch

## Root Cause
PR #332 added reusable helpers, but direct core construction could still bypass the strict scale gate, and `load_manifest()` parsed the stored `manifest_hash` without verifying it. That left cutover work able to trust table/archive hashes but not the manifest identity field.

## Validation
- `uv run -- python -m pytest -n 0 tests/unit/core/data_fetch/ tests/unit/core/test_scale_factor_validation.py tests/unit/core/test_joinorder_benchmark.py tests/unit/core/test_runner_lifecycle.py -q` -> 105 passed
- `uv run ruff check benchbox/core/benchmark_loader.py benchbox/core/runner/runner.py benchbox/core/data_fetch tests/unit/core/data_fetch tests/unit/core/test_joinorder_benchmark.py tests/unit/core/test_runner_lifecycle.py` -> passed
- `uv run ty check` -> exit 0; existing diagnostics remain in test utility files
- `make pr-preflight` -> 22042 passed, 6 skipped in 80.94s

## Notes
- `make pr-open` reported a warn-only textual conflict with PR #323 (`auto-revert/21376cb589c7`); no conflict with `develop` after rebase.