### PR TITLE
[codex] Add Results Explorer contract remediation gates

### DIFF
--- a/_project/TODO/main/planning/results-explorer-contract-release-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-contract-release-gate.yaml
@@ -1,0 +1,174 @@
+id: results-explorer-contract-release-gate
+title: "Gate Results Explorer contract remediation before marking follow-up complete"
+worktree: main
+priority: Critical
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The previous Results Explorer effort was moved to DONE while newly verified
+  homepage, AMPLab, and Compare issues still reproduced. This TODO is the
+  final release gate for the contract-first remediation sequence. It must
+  verify that policy, read-model, frontend eligibility, rank/compare gating,
+  and home scope/theme/identity work are complete on the same develop SHA
+  before any item is moved to DONE.
+
+deps:
+  needs:
+  - results-explorer-display-contract-policy-gate
+  - results-explorer-read-model-eligibility-contract
+  - results-explorer-frontend-eligibility-normalization
+  - results-explorer-rank-and-compare-evidence-gates
+  - results-explorer-home-scope-theme-and-identity
+
+work:
+- id: w0
+  summary: "Confirm all dependent TODOs are completed with evidence"
+  status: pending
+  notes: |
+    Use the TODO CLI to show each dependent item. Confirm every work unit is
+    done, every blocker is resolved, and each dependent item has verification
+    evidence. Capture the TODO state to
+    `_project/verification-logs/results-explorer-contract-release-gate/w0.log`.
+
+- id: w1
+  summary: "Run snapshot contract invariants against the regenerated DuckDB file"
+  needs: [w0]
+  status: pending
+  notes: |
+    Run the snapshot invariant checks introduced by
+    `results-explorer-read-model-eligibility-contract` using
+    `_project/scripts/results_explorer_snapshot_invariants.py`. The gate must
+    fail if:
+      - a compare-eligible row has no valid timings;
+      - a rankable row lacks a valid primary metric;
+      - an all-unrankable cohort presents as a normal ranked cohort;
+      - any `No run`/missing cell also renders run badges or links;
+      - home leaderboard counts disagree with rendered cohort/platform scope.
+
+- id: w2
+  summary: "Run automated frontend and pipeline verification"
+  needs: [w1]
+  status: pending
+  notes: |
+    Run the targeted pipeline tests, Results Explorer unit tests, typecheck,
+    and build. Capture command status and failure tails to
+    `_project/verification-logs/results-explorer-contract-release-gate/w2.log`.
+
+- id: w3
+  summary: "Run browser acceptance on the exact high-risk routes"
+  needs: [w2]
+  status: pending
+  notes: |
+    Restart the local dev server from a clean current tree and exercise:
+      - `/results/`;
+      - `/results/amplab/`;
+      - `/results/amplab/?view=ranks`;
+      - AMPLab Compare with the previously failing IDs;
+      - `/results/query`;
+      - one platform detail page with compare selection.
+    Verify no-timing rows, zero timings, rank tabs, winner claims, warning
+    links, home scope copy, theme consistency, score formatting, and run
+    identity labels.
+
+- id: w4
+  summary: "Write the final release-gate audit artifact"
+  needs: [w3]
+  status: pending
+  notes: |
+    Write `_project/audits/results-explorer-contract-release-gate-<date>.md`
+    with the checked SHA, commands run, SQL invariants, browser routes, and a
+    pass/fail table for every issue from the 2026-05-10 follow-up review. Do
+    not approve the gate if any P0/P1 defect still reproduces or if evidence
+    is missing.
+
+- id: w5
+  summary: "Move completed remediation TODOs to DONE only after gate approval"
+  needs: [w4]
+  status: pending
+  notes: |
+    When the audit passes, use the TODO complete workflow to mark each
+    dependent remediation item Completed, move it to `_project/DONE`, regenerate
+    indexes, and verify no completed item remains in `_project/TODO`. If the
+    gate fails, leave items in TODO and create focused follow-up work instead
+    of marking completion.
+
+prior_art:
+- "_project/DONE/main/planning/results-explorer-post-completion-release-gate.yaml:previous release gate — reuse structure but strengthen data-contract checks."
+- "_project/scripts/todo_cli.py:TODO validation and graph checks — use for dependency and DONE-state verification."
+- "results-explorer/e2e/:browser acceptance patterns — extend for high-risk routes."
+- "_project/audits/:release-gate audit artifacts — reuse location and concise pass/fail table style."
+
+must_preserve:
+- "Gate audit must name the exact checked SHA."
+- "A failing P0/P1 contract or browser defect blocks completion."
+- "Completed TODOs must not remain in `_project/TODO` after successful completion."
+- "Unrelated TODO, DONE, and source files are not modified during gate bookkeeping."
+
+approach: |
+  Treat this as a verification and project-state gate only. It should not
+  implement feature fixes. If the gate finds failures, record them and leave
+  dependent TODOs open or create precise follow-up TODOs.
+
+anti_patterns:
+- "DO NOT approve based only on unit tests - because prior completion missed browser-visible and snapshot-visible failures - run SQL and browser checks."
+- "DO NOT move TODOs to DONE before the audit passes - because stale completion state caused this review loop - gate first, complete second."
+- "DO NOT broaden this item into implementation - because dependent TODOs own fixes - this item owns verification and bookkeeping."
+
+verification:
+- description: "TODO dependency graph validates"
+  command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+  expected_output: "dependency graph passes"
+- description: "DuckDB snapshot invariants pass"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "snapshot invariant command exits 0 with no contradictory display/rank/compare states"
+- description: "All TODO files validate"
+  command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate"
+  expected_output: "schema validation passes"
+- description: "Results Explorer frontend verification passes"
+  command: "cd results-explorer && npm test -- --run && npm run typecheck && npm run build"
+  expected_output: "all frontend checks pass"
+- description: "Pipeline/read-model targeted verification passes"
+  command: "uv run -- python -m pytest tests -k 'explorer_pipeline or browser_duckdb or results_explorer' --tb=short"
+  expected_output: "all targeted tests pass"
+
+scope_limit:
+  only_modify:
+  - "_project/TODO/main/planning/results-explorer-display-contract-policy-gate.yaml"
+  - "_project/TODO/main/planning/results-explorer-read-model-eligibility-contract.yaml"
+  - "_project/TODO/main/planning/results-explorer-frontend-eligibility-normalization.yaml"
+  - "_project/TODO/main/planning/results-explorer-rank-and-compare-evidence-gates.yaml"
+  - "_project/TODO/main/planning/results-explorer-home-scope-theme-and-identity.yaml"
+  - "_project/TODO/main/planning/results-explorer-contract-release-gate.yaml"
+  - "_project/DONE/main/planning/"
+  - "_project/audits/results-explorer-contract-release-gate-*.md"
+  - "_project/verification-logs/results-explorer-contract-release-gate/"
+  do_not_modify:
+  - "results-explorer/src/"
+  - "benchbox/"
+  - "docs/development/browser-duckdb-schema.sql"
+
+success_metrics:
+- "Contract remediation is verified against SQL invariants, automated tests, and browser routes."
+- "Every 2026-05-10 follow-up issue is explicitly pass/fail checked."
+- "No dependent remediation TODO is moved to DONE until this gate passes."
+- "Release-gate audit gives enough evidence for a reviewer to reject stale completion."
+
+metadata:
+  tags:
+  - results-explorer
+  - release-gate
+  - todo-cleanup
+  - verification
+  estimated_effort: "Small (0.5-1 day after dependent fixes)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents another Results Explorer completion loop where PRs land but
+    high-severity product issues remain visible.
+  user_impact: |
+    Ensures the shipped explorer is trustworthy across the exact routes that
+    exposed the contract failures.
+  technical_debt: |
+    Adds a hard evidence gate around DONE-state movement and release approval.

--- a/_project/TODO/main/planning/results-explorer-display-contract-policy-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-display-contract-policy-gate.yaml
@@ -1,0 +1,196 @@
+id: results-explorer-display-contract-policy-gate
+title: "Define Results Explorer display, ranking, and comparison eligibility contract"
+worktree: main
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  The 2026-05-10 Results Explorer follow-up review found that the frontend
+  renders rows that are public but not meaningfully rankable or comparable.
+  AMPLab cohorts show the failure mode clearly: some rows have no non-null
+  query timings, some rows have `display_ms = 0.0`, every AMPLab row is
+  `is_ranking_eligible=false`, and Compare still emits winner language from
+  a single comparable query.
+
+  This TODO is the decision gate for the whole remediation sequence. It must
+  define the contract before implementation begins: what "published",
+  "displayable", "has timing data", "rankable", "comparable", "passed",
+  "No run", and "sub-millisecond" mean in the Results Explorer. Later TODOs
+  must consume this contract rather than inventing per-component exceptions.
+
+context_sections:
+  evidence_source: |
+    Observed against local `develop` after rebase on 2026-05-10:
+    - `/results/`
+    - `/results/amplab/`
+    - `/results/compare?ids=61ba4644,e16ac6db,07650b37`
+    Snapshot inspected: `results-explorer/public/data/results.duckdb`.
+  observed_failures: |
+    - Home benchmark filters imply corpus-wide scope but are derived from
+      `meta_leaderboard.cohorts`.
+    - AMPLab no-timing rows appear in matrix/rank/chart/compare surfaces.
+    - Compare claims a 1.59x winner while 7 of 8 queries are excluded.
+    - `display_ms = 0.0` is shown as `<1 ms`, `0 ms`, missing, or excluded
+      depending on component.
+    - Static status badges look actionable but do not navigate to details.
+
+work:
+- id: w0
+  summary: "Re-capture the current broken-state SQL and browser evidence"
+  status: pending
+  notes: |
+    Capture the current evidence before any code changes. Store command output
+    under `_project/verification-logs/results-explorer-display-contract-policy-gate/w0.log`.
+    Include:
+      - `git rev-parse HEAD`;
+      - SQL counts for no-geomean rows by benchmark/scale/phase;
+      - AMPLab SF0.01 power rows from `benchmark_rankings`;
+      - per-result non-null timing counts from `benchmark_matrix_cells`;
+      - zero-valued rows from `query_display_timings`;
+      - browser observations for `/results/`, `/results/amplab/`, and the
+        AMPLab Compare URL.
+    The log must include the checked SHA plus route-level PASS/FAIL notes.
+    If screenshots or browser traces are captured separately, store them under
+    the same verification-log directory and reference their paths from `w0.log`.
+
+- id: w1
+  summary: "Write the Results Explorer eligibility vocabulary and state table"
+  needs: [w0]
+  status: pending
+  notes: |
+    Create a short decision artifact under `_project/analysis/` that defines
+    each state and its source of truth:
+      - publishable;
+      - displayable;
+      - has_display_timing;
+      - valid_query_count;
+      - rankable;
+      - comparable;
+      - validation passed;
+      - trusted / trust tier;
+      - missing run;
+      - missing timing;
+      - sub-millisecond timing.
+    The table must explicitly say which states may be inferred by the frontend
+    and which must be emitted by the pipeline/read model.
+
+- id: w2
+  summary: "Make a decision on zero and sub-millisecond timing semantics"
+  needs: [w1]
+  status: pending
+  notes: |
+    Decide whether `display_ms = 0.0` means invalid data, measured
+    sub-millisecond data, or a legacy rounding artifact. Document the rule and
+    the migration behavior. The safe default is: positive fractional timings
+    may display as `<1 ms`; exact zero timings are invalid for ranking and
+    comparison until the pipeline can prove they were measured positive values.
+
+- id: w3
+  summary: "Define evidence thresholds for Compare winner language"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Define the minimum comparable query coverage required before Compare may
+    emit winner language such as "X is faster". The rule must include both an
+    absolute floor and a percentage floor, for example: at least 2 comparable
+    queries and at least 50% of the cohort query set. If the threshold is not
+    met, Compare must show insufficient-evidence copy and suppress winner
+    claims.
+
+- id: w4
+  summary: "Define page-level behavior for excluded rows and unrankable cohorts"
+  needs: [w1, w2, w3]
+  status: pending
+  notes: |
+    Specify how each page treats rows that are public but not display-safe:
+      - Home meta leaderboard;
+      - benchmark matrix/rank/list pages;
+      - chart panels;
+      - platform detail tables;
+      - Compare selection;
+      - Query Workbench result rows.
+    The rule must distinguish hiding from default-visible exclusion disclosure.
+    Provenance should remain accessible, but no-timing rows must not look like
+    valid ranked/comparable evidence.
+
+- id: w5
+  summary: "Review the policy with the current TODO sequence before implementation"
+  needs: [w4]
+  status: pending
+  notes: |
+    Before starting dependent implementation TODOs, update their guardrails if
+    the decisions in w1-w4 change the proposed scope. This is the decision gate:
+    do not implement spot fixes in `results-explorer/src/` until this policy
+    item is complete.
+
+prior_art:
+- "benchbox/core/explorer_pipeline/transformer.py:_query_display_ms — reuse as the canonical per-query display reduction entry point."
+- "benchbox/core/explorer_pipeline/ranking.py:rank_platforms — extend for rankability semantics rather than ranking in the frontend."
+- "benchbox/core/results/status.py:validation status helpers — reuse for validation/pass semantics but do not overload them as rankability."
+- "docs/development/browser-duckdb-schema.sql:read-model schema — extend as the contract surface consumed by the frontend."
+- "_project/planning/visible_metrics.yaml:visible metric catalog — extend with eligibility and exclusion fields."
+
+must_preserve:
+- "Public result provenance remains accessible from receipt/detail pages."
+- "Validation status continues to mean validation status only; it must not be redefined as ranking/comparison eligibility."
+- "No timing values are fabricated to make charts or rankings look cleaner."
+- "Existing result detail URLs and receipt anchors remain stable."
+
+approach: |
+  Treat this item as architecture and policy. Gather durable evidence first,
+  then decide the vocabulary and thresholds. Use the decision artifact as the
+  contract for all dependent implementation TODOs. Prefer a stricter
+  suppress-and-explain policy where evidence is ambiguous; users can inspect
+  provenance, but the product must not make unsupported winner or rank claims.
+
+anti_patterns:
+- "DO NOT fix individual screenshots before defining eligibility semantics - because each component currently applies a different local rule - define the shared contract first."
+- "DO NOT treat `validation_status=passed` as proof of timing quality - because AMPLab has passed rows with no display timings - add separate timing/ranking/comparison states."
+- "DO NOT replace zero timings with arbitrary epsilon values - because that corrupts benchmark metrics - preserve true values and mark invalid/excluded where needed."
+- "DO NOT hide excluded rows without a provenance path - because users still need to audit submitted results - quarantine them with reasons instead."
+
+verification:
+- description: "Evidence log captures current broken state and browser routes"
+  command: "test -s _project/verification-logs/results-explorer-display-contract-policy-gate/w0.log && rg -n \"HEAD|/results/|/results/amplab/|/results/compare\\?ids=61ba4644,e16ac6db,07650b37|no_geomean|eligible|PASS|FAIL\" _project/verification-logs/results-explorer-display-contract-policy-gate/w0.log"
+  expected_output: "w0.log includes checked SHA, SQL counts, and route-level browser PASS/FAIL notes"
+- description: "TODO graph validates after creating this policy gate"
+  command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate"
+  expected_output: "validation passes"
+
+scope_limit:
+  only_modify:
+  - "_project/TODO/main/planning/results-explorer-display-contract-policy-gate.yaml"
+  - "_project/analysis/"
+  - "_project/verification-logs/results-explorer-display-contract-policy-gate/"
+  do_not_modify:
+  - "results-explorer/src/"
+  - "benchbox/"
+  - "results-explorer/public/data/results.duckdb"
+
+success_metrics:
+- "A reviewer can tell exactly when a result is public, displayable, rankable, comparable, or excluded."
+- "Zero/sub-millisecond timing policy is documented before frontend behavior changes."
+- "Compare winner-claim threshold is documented before Compare code changes."
+- "Dependent TODOs explicitly depend on this item."
+
+metadata:
+  tags:
+  - results-explorer
+  - data-contract
+  - policy-gate
+  - compare
+  - leaderboard
+  estimated_effort: "Small (0.5-1 day)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents the public results site from making unsupported ranking or
+    comparison claims.
+  user_impact: |
+    Gives database engineers a trustworthy distinction between published
+    provenance and valid comparison evidence.
+  technical_debt: |
+    Replaces component-local interpretations with a single contract that the
+    pipeline and frontend can share.

--- a/_project/TODO/main/planning/results-explorer-frontend-eligibility-normalization.yaml
+++ b/_project/TODO/main/planning/results-explorer-frontend-eligibility-normalization.yaml
@@ -1,0 +1,195 @@
+id: results-explorer-frontend-eligibility-normalization
+title: "Normalize Results Explorer frontend eligibility and timing semantics"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  After the read model exposes explicit display, ranking, and comparison
+  eligibility, the frontend must stop applying local, inconsistent rules.
+  Today, zero timings and no-timing rows are interpreted differently by
+  heatmaps, compare summaries, diff tables, box plots, CDFs, sparklines, rank
+  tables, and meta leaderboards.
+
+  This TODO adds a shared frontend eligibility layer and migrates display
+  components to consume it before any page-specific visual cleanup proceeds.
+
+context_sections:
+  evidence_binding: |
+    This TODO is pinned to the policy evidence captured by
+    `results-explorer-display-contract-policy-gate` w0 at
+    `_project/verification-logs/results-explorer-display-contract-policy-gate/w0.log`
+    and to the eligibility decision artifact produced under `_project/analysis/`.
+    Before editing frontend code, record the checked policy SHA or artifact path
+    in implementation notes so these changes are not based on stale review
+    memory.
+
+deps:
+  needs:
+  - results-explorer-read-model-eligibility-contract
+
+work:
+- id: w1
+  summary: "Add a shared frontend eligibility and timing helper"
+  status: pending
+  notes: |
+    Create a small shared helper, for example
+    `results-explorer/src/lib/displayEligibility.ts`, that wraps the read-model
+    fields and policy decisions. It should provide functions such as:
+      - `isTimingDisplayable(row)`;
+      - `isRankable(row)`;
+      - `isComparable(row)`;
+      - `validTimingValues(values)`;
+      - `formatTimingExclusion(row)`;
+      - `formatCohortExclusion(summary)`.
+    The helper must not recompute policy from scratch when a read-model field
+    exists.
+
+- id: w2
+  summary: "Replace local zero/null timing predicates in chart math consumers"
+  needs: [w1]
+  status: pending
+  notes: |
+    Migrate `DistributionBox`, `CDFChart`, `NormalizedSpeedupChart`,
+    `ChartPanel`, `SparklineTable`, and related chart math consumers to the
+    shared valid-timing rule. The same input row must either be included or
+    excluded consistently across chart types, with the same explanation.
+
+- id: w3
+  summary: "Replace local eligibility checks in QueryHeatmap and RankTable"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update matrix, rank, and mobile-card rendering so no-timing rows are not
+    shown as normal evidence. If rows remain visible for provenance, render
+    them as excluded with an explicit reason and prevent them from influencing
+    sort/rank/heatmap semantics.
+
+- id: w4
+  summary: "Replace local eligibility checks in CompareSummary and QueryDiffTable"
+  needs: [w1]
+  status: pending
+  notes: |
+    Make Compare use the same valid-timing predicate for:
+      - primary metric winner selection;
+      - comparable query counts;
+      - query wins/ties/losses;
+      - diff table ratios;
+      - percentiles and tail shape;
+      - cost/performance summary.
+    Compare must not include zero timings in one section and exclude them in
+    another unless the policy explicitly says why.
+
+- id: w5
+  summary: "Update typed query models and tests for eligibility fields"
+  needs: [w1, w2, w3, w4]
+  status: pending
+  notes: |
+    Update `types.ts`, DuckDB query helpers, and component test fixtures so
+    new eligibility fields are present everywhere. Test fixtures must include:
+      - normal rankable row;
+      - public but unrankable row;
+      - no-timing row;
+      - zero-timing row;
+      - excluded compare candidate.
+
+- id: w6
+  summary: "Add frontend regression tests for inconsistent timing semantics"
+  needs: [w5]
+  status: pending
+  notes: |
+    Add targeted tests proving the same row is treated consistently by heatmap,
+    rank table, box plot, CDF, compare summary, and query diff. Include an
+    AMPLab-shaped fixture where 7/8 queries are zero or excluded and assert
+    that Compare suppresses unsupported winner language.
+
+prior_art:
+- "results-explorer/src/lib/chartMath.ts:valid-value filters — supersede ad hoc filtering with policy-backed helpers."
+- "results-explorer/src/components/QueryHeatmap.tsx:matrix sorting and selection — extend with eligibility helper."
+- "results-explorer/src/lib/compareSummary.ts:query record and percentiles — migrate to shared timing predicate."
+- "results-explorer/src/lib/duckdbQueries.ts:typed read-model access — consume new read-model fields from the backend TODO."
+- "results-explorer/src/components/StatusBadge.tsx:badge primitive — preserve as passive metadata only."
+
+must_preserve:
+- "Existing chart components still render valid rankable cohorts."
+- "Keyboard navigation and row selection behavior remain accessible for comparable rows."
+- "Result receipt/detail links remain available for excluded provenance rows."
+- "High-contrast/reduced-color chart paths continue to work."
+
+approach: |
+  Introduce the helper first, then migrate consumers in narrow slices. Tests
+  should pin behavior before broad visual refactoring. Keep policy decisions
+  out of components; components should ask whether a row is displayable,
+  rankable, or comparable and render the supplied reason.
+
+anti_patterns:
+- "DO NOT keep `value > 0` or `value >= 0` checks scattered across components - because the current bug is inconsistent local predicates - route through the shared helper."
+- "DO NOT make charts silently drop rows without an excluded-count or reason - because users need to know why rows disappeared - expose the reason near the surface."
+- "DO NOT disable selection only visually - because screen-reader and keyboard users could still activate it - use real disabled state and accessible reason copy."
+
+verification:
+- description: "Frontend unit tests for eligibility consumers pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/DistributionBox.test.tsx src/components/__tests__/NormalizedSpeedupChart.test.tsx src/components/__tests__/QueryHeatmap.test.tsx src/components/__tests__/CompareSummary.test.tsx src/components/__tests__/QueryDiffTable.test.tsx src/lib/__tests__/compareSummary.test.ts src/lib/__tests__/duckdbQueries.test.ts src/__tests__/chartMath.scale.test.ts"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Frontend build passes"
+  command: "cd results-explorer && npm run build"
+  expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/lib/displayEligibility.ts"
+  - "results-explorer/src/lib/chartMath.ts"
+  - "results-explorer/src/lib/compareSummary.ts"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/src/types.ts"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/CompareSummary.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/components/SparklineTable.tsx"
+  - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
+  - "results-explorer/src/components/__tests__/CompareSummary.test.tsx"
+  - "results-explorer/src/components/__tests__/DistributionBox.test.tsx"
+  - "results-explorer/src/components/__tests__/NormalizedSpeedupChart.test.tsx"
+  - "results-explorer/src/components/__tests__/QueryDiffTable.test.tsx"
+  - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+  - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+  - "results-explorer/src/lib/__tests__/duckdbQueries.test.ts"
+  - "results-explorer/src/__tests__/chartMath.scale.test.ts"
+  - "_project/TODO/main/planning/results-explorer-frontend-eligibility-normalization.yaml"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "docs/development/browser-duckdb-schema.sql"
+  - "results-explorer/public/data/results.duckdb"
+
+success_metrics:
+- "Zero, null, and excluded timings are handled consistently across all chart and compare surfaces."
+- "No-timing rows cannot appear as normal ranked/comparable evidence."
+- "Compare suppresses winner claims when evidence coverage fails the policy threshold."
+- "Tests include AMPLab-shaped zero/no-timing regression fixtures."
+
+metadata:
+  tags:
+  - results-explorer
+  - frontend
+  - eligibility
+  - charts
+  - compare
+  estimated_effort: "Medium (2-3 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Makes the Results Explorer UI internally consistent and defensible.
+  user_impact: |
+    Users see the same data-quality meaning across tables, charts, and compare
+    summaries.
+  technical_debt: |
+    Removes scattered timing and eligibility predicates from components.

--- a/_project/TODO/main/planning/results-explorer-home-scope-theme-and-identity.yaml
+++ b/_project/TODO/main/planning/results-explorer-home-scope-theme-and-identity.yaml
@@ -1,0 +1,181 @@
+id: results-explorer-home-scope-theme-and-identity
+title: "Fix Results Explorer home scope, theme consistency, formatting, and run identity density"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The Results Explorer home page and benchmark chart labels still contain
+  misleading scope and density problems after the earlier follow-up PRs. The
+  home page presents meta-leaderboard filters as "All benchmarks" even though
+  the dropdown only contains ranked cohorts, shows only a small platform subset
+  without clear scope copy, mixes dark and light page sections, and renders
+  large power scores with noisy decimals. AMPLab chart labels also over-expand
+  run identity by repeating cohort-invariant qualifiers.
+
+  This TODO handles scope, copy, theme, formatting, and identity density after
+  eligibility semantics are normalized. It must not hide the deeper eligibility
+  fixes behind superficial retheme changes.
+
+context_sections:
+  evidence_binding: |
+    This TODO is pinned to the route evidence captured by
+    `results-explorer-display-contract-policy-gate` w0 and the frontend
+    eligibility helper behavior from
+    `results-explorer-frontend-eligibility-normalization`. Before editing,
+    record the checked policy artifact path and frontend commit/SHA in
+    implementation notes.
+
+deps:
+  needs:
+  - results-explorer-frontend-eligibility-normalization
+
+work:
+- id: w1
+  summary: "Clarify home leaderboard scope and filter labels"
+  status: pending
+  notes: |
+    Update the home page so filters derived from `meta_leaderboard.cohorts`
+    are labeled as leaderboard/cohort filters, not corpus-wide filters. Add
+    visible scope copy such as "Showing N ranked platforms across M leaderboard
+    cohorts" and ensure counts match the rendered table.
+
+- id: w2
+  summary: "Separate public corpus browse counts from leaderboard cohort counts"
+  needs: [w1]
+  status: pending
+  notes: |
+    The page may show both all public benchmarks and leaderboard cohorts, but
+    the UI must not imply they are the same set. If a benchmark appears in
+    Browse by Benchmark but not in the leaderboard filter, show why it is not
+    currently a ranked cohort or keep the two sections visually and textually
+    separate.
+
+- id: w3
+  summary: "Resolve home theme ownership for dark and data surfaces"
+  needs: [w1]
+  status: pending
+  notes: |
+    Decide whether the home results page should be fully dark-themed or use a
+    deliberate light data surface below a dark hero/filter band. Apply the
+    chosen rule consistently to the meta leaderboard, controls, table, browse
+    sections, and empty/excluded states. Do not leave an accidental half-theme.
+
+- id: w4
+  summary: "Apply metric-specific formatting for power scores and timing values"
+  needs: [w1]
+  status: pending
+  notes: |
+    Format large power scores for scanning, for example zero decimals above
+    1,000 and exact value in tooltip/detail. Keep latency formatting consistent
+    with the valid timing policy from the frontend eligibility TODO.
+
+- id: w5
+  summary: "Reduce run identity labels by removing cohort-invariant qualifiers"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update run identity rendering so chart/table labels include only qualifiers
+    needed to distinguish runs in the current context. On a single benchmark
+    and scale page, do not repeat benchmark or scale in every row. Prefer
+    compact labels like `DataFusion 2026-05-02 (a276dae0)` with full identity
+    available via tooltip or receipt link.
+
+- id: w6
+  summary: "Add regression coverage for home scope, theme, formatting, and identity"
+  needs: [w2, w3, w4, w5]
+  status: pending
+  notes: |
+    Add tests for:
+      - home filter options are clearly labeled as leaderboard cohorts;
+      - visible scope counts match rendered rows/columns;
+      - power score formatting removes noisy decimals on large values;
+      - run identity labels omit invariant qualifiers while remaining unique;
+      - theme classes/tokens are consistent across home sections.
+
+prior_art:
+- "results-explorer/src/pages/Home.tsx:home filters and browse sections — extend copy and scope labels."
+- "results-explorer/src/components/MetaLeaderboard.tsx:meta leaderboard controls and cells — update scope copy and formatting."
+- "results-explorer/src/lib/runIdentity.ts:cohort-aware formatter — refine qualifier selection rather than adding another formatter."
+- "results-explorer/src/utils.ts:fmtScore/fmtMs — extend metric-aware formatting policy."
+- "results-explorer/src/components/DistributionBox.tsx:label truncation handling — preserve unique labels after shortening."
+
+must_preserve:
+- "Home meta leaderboard remains keyboard-accessible."
+- "Existing `/results/?mode=...` URL behavior remains stable."
+- "Run labels remain unique when duplicate platform names appear."
+- "Exact values remain available in detail/tooltip even when display formatting is compact."
+- "Visual changes do not alter read-model eligibility semantics."
+
+approach: |
+  First fix scope language and counts so users understand the data subset.
+  Then align theme surfaces and formatting. Finally tune run identity density
+  using the existing formatter, with tests to prove labels remain unique.
+
+anti_patterns:
+- "DO NOT relabel sparse meta-leaderboard data as the whole corpus - because that caused the misleading home dropdowns - use explicit cohort scope copy."
+- "DO NOT solve long labels by truncating away the only distinguishing token - because duplicate platforms become ambiguous - preserve date or short-id disambiguators."
+- "DO NOT make a one-off power-score formatter inside MetaLeaderboard - because score formatting appears on multiple surfaces - use shared metric formatting."
+- "DO NOT retheme by adding local hard-coded colors - because the previous half-theme came from inconsistent surface ownership - use existing tokens or extend them deliberately."
+
+verification:
+- description: "Home and identity tests pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Home.test.tsx src/components/__tests__/MetaLeaderboard.test.tsx src/components/__tests__/DistributionBox.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Browser spot check captures home and AMPLab chart labels"
+  command: "cd results-explorer && npm run build && cd .. && test -s _project/verification-logs/results-explorer-home-scope-theme-and-identity/browser-smoke.md && rg -n \"/results/|/results/amplab/|scope|theme|identity|PASS|FAIL\" _project/verification-logs/results-explorer-home-scope-theme-and-identity/browser-smoke.md"
+  expected_output: "build exits 0 and browser-smoke.md records route-level PASS/FAIL evidence for /results/ and /results/amplab/"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/Home.tsx"
+  - "results-explorer/src/components/MetaLeaderboard.tsx"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/lib/runIdentity.ts"
+  - "results-explorer/src/utils.ts"
+  - "results-explorer/src/pages/__tests__/Home.test.tsx"
+  - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
+  - "results-explorer/src/components/__tests__/DistributionBox.test.tsx"
+  - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+  - "results-explorer/src/lib/__tests__/runIdentity.test.ts"
+  - "results-explorer/src/__tests__/chartTheme.test.ts"
+  - "results-explorer/src/__tests__/utils.test.ts"
+  - "_project/TODO/main/planning/results-explorer-home-scope-theme-and-identity.yaml"
+  - "_project/verification-logs/results-explorer-home-scope-theme-and-identity/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "docs/development/browser-duckdb-schema.sql"
+  - "results-explorer/public/data/results.duckdb"
+
+success_metrics:
+- "Home filters no longer imply that leaderboard cohorts equal the full public corpus."
+- "Rendered platform/cohort counts match visible rows and columns."
+- "Home results surfaces use a deliberate, consistent theme."
+- "Large power scores are scan-friendly while exact values remain available."
+- "Duplicate platform run labels are unique without unnecessary repeated qualifiers."
+
+metadata:
+  tags:
+  - results-explorer
+  - home
+  - theme
+  - run-identity
+  - leaderboard
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Makes the landing leaderboard credible by accurately describing its scope.
+  user_impact: |
+    Users can tell what subset they are looking at and can scan values and run
+    identities without confusion.
+  technical_debt: |
+    Consolidates formatting and identity decisions instead of adding local copy
+    patches.

--- a/_project/TODO/main/planning/results-explorer-rank-and-compare-evidence-gates.yaml
+++ b/_project/TODO/main/planning/results-explorer-rank-and-compare-evidence-gates.yaml
@@ -1,0 +1,180 @@
+id: results-explorer-rank-and-compare-evidence-gates
+title: "Gate ranking and comparison surfaces on sufficient valid evidence"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Benchmark rank tabs and Compare winner claims currently appear even when the
+  underlying cohort is not rankable or the selected runs have too little
+  comparable query evidence. The AMPLab SF0.01 power example shows both issues:
+  every row is unrankable, several rows have no timings, and Compare makes a
+  winner claim from only one comparable query.
+
+  This TODO applies the shared eligibility contract to user-facing benchmark
+  and Compare workflows. It should land after frontend eligibility
+  normalization so page behavior depends on one shared helper.
+
+context_sections:
+  evidence_binding: |
+    This TODO is pinned to the policy evidence captured by
+    `results-explorer-display-contract-policy-gate` w0 and to the frontend
+    helper behavior from `results-explorer-frontend-eligibility-normalization`.
+    Before implementation, record the policy artifact path and checked SHA in
+    implementation notes, then use AMPLab as the explicit route fixture.
+
+deps:
+  needs:
+  - results-explorer-frontend-eligibility-normalization
+
+work:
+- id: w1
+  summary: "Suppress or relabel rank tabs for all-unrankable cohorts"
+  status: pending
+  notes: |
+    On benchmark detail pages, if the summary reports `total_ranked = 0` or
+    equivalent cohort exclusion state, do not present `Ranks` as an authoritative
+    leaderboard. Either hide the tab or relabel it as a non-leaderboard timing
+    view with explicit copy. Direct navigation to a rank view must show the same
+    explanation, not an empty or misleading table.
+
+- id: w2
+  summary: "Move no-timing benchmark rows into an excluded-runs disclosure"
+  needs: [w1]
+  status: pending
+  notes: |
+    Public rows with no valid timing data should not appear as normal matrix,
+    rank, sparkline, distribution, or compare rows. Keep provenance accessible
+    in a disclosure titled like "Excluded runs" with per-row reasons and receipt
+    links. The default analysis view should contain only display-safe rows.
+
+- id: w3
+  summary: "Disable compare selection for non-comparable rows everywhere"
+  needs: [w2]
+  status: pending
+  notes: |
+    Benchmark pages, platform pages, and Query Workbench must disable or omit
+    compare selection controls for rows with `comparison_exclusion_reason`.
+    The user should see why the row cannot be compared, and keyboard/screen
+    reader users must not be able to select it accidentally.
+
+- id: w4
+  summary: "Suppress Compare winner claims when evidence threshold is not met"
+  needs: [w3]
+  status: pending
+  notes: |
+    Compare must apply the policy threshold from
+    `results-explorer-display-contract-policy-gate`. If selected runs do not
+    meet the comparable-query threshold, show a decision summary state such as
+    "Insufficient comparable query evidence" and move raw differences into the
+    query diff table without winner language.
+
+- id: w5
+  summary: "Make compare warnings actionable and locally visible"
+  needs: [w4]
+  status: pending
+  notes: |
+    Change static warning count badges into real links or buttons that jump to
+    the Comparability Receipt. The guardrail summary should name the first few
+    warning classes, for example date window, platform version, cost, or query
+    coverage, so the user knows what to inspect.
+
+- id: w6
+  summary: "Add rank and compare route-level tests"
+  needs: [w1, w2, w3, w4, w5]
+  status: pending
+  notes: |
+    Add tests for:
+      - all-unrankable benchmark cohort;
+      - no-timing rows excluded from default analysis view;
+      - disabled compare selection for excluded rows;
+      - Compare winner suppression at 1/8 comparable queries;
+      - warning-count link scrolls or anchors to the receipt;
+      - direct URL navigation to rank/compare states preserves the gate.
+
+prior_art:
+- "results-explorer/src/pages/BenchmarkIndex.tsx:view mode and compare selection — extend with eligibility gates."
+- "results-explorer/src/pages/Compare.tsx:CompareGuardrailSummary and baseline controls — extend with actionable warnings."
+- "results-explorer/src/components/ComparabilityReceipt.tsx:warning details — link to this from summary badges."
+- "results-explorer/src/components/QueryHeatmap.tsx:selection checkboxes — disable based on comparability."
+- "results-explorer/src/lib/compareSummary.ts:winner query record — use policy threshold before headline generation."
+
+must_preserve:
+- "Comparable rows still support the existing end-to-end Compare flow."
+- "Receipt links remain available for excluded rows."
+- "Compare URLs with valid IDs remain shareable."
+- "Raw query evidence remains visible even when winner claims are suppressed."
+
+approach: |
+  Use the shared frontend eligibility helper rather than checking individual
+  fields in each page. Start with benchmark route gating, then compare
+  selection, then Compare summary language. Treat AMPLab as the main regression
+  route because it exercises every gate.
+
+anti_patterns:
+- "DO NOT make winner copy conditional only on primary metric presence - because query coverage can be too weak even when geomean exists - apply the evidence threshold."
+- "DO NOT leave disabled rows without a reason - because users need to understand whether data is missing, invalid, or merely unrankable - show the exclusion reason."
+- "DO NOT make warning badges visually look clickable unless they are actual links/buttons - because this was one of the observed usability failures - use semantic controls."
+
+verification:
+- description: "Benchmark and Compare tests pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/Compare.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Browser smoke covers AMPLab rank and compare gates"
+  command: "cd results-explorer && npm run build && cd .. && test -s _project/verification-logs/results-explorer-rank-and-compare-evidence-gates/browser-smoke.md && rg -n \"/results/amplab/|view=ranks|compare|Insufficient comparable query evidence|Excluded runs|PASS|FAIL\" _project/verification-logs/results-explorer-rank-and-compare-evidence-gates/browser-smoke.md"
+  expected_output: "build exits 0 and browser-smoke.md records rank and compare PASS/FAIL evidence"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/PlatformIndex.tsx"
+  - "results-explorer/src/components/ComparabilityReceipt.tsx"
+  - "results-explorer/src/components/CompareSummary.tsx"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/lib/compareSummary.ts"
+  - "results-explorer/src/lib/displayEligibility.ts"
+  - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+  - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+  - "results-explorer/src/pages/__tests__/PlatformIndex.test.tsx"
+  - "results-explorer/src/pages/__tests__/Query.test.tsx"
+  - "results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx"
+  - "results-explorer/src/components/__tests__/CompareSummary.test.tsx"
+  - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+  - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+  - "_project/TODO/main/planning/results-explorer-rank-and-compare-evidence-gates.yaml"
+  - "_project/verification-logs/results-explorer-rank-and-compare-evidence-gates/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "docs/development/browser-duckdb-schema.sql"
+
+success_metrics:
+- "All-unrankable cohorts no longer show an authoritative Ranks leaderboard."
+- "No-timing rows are excluded from default analysis surfaces but remain auditable."
+- "Non-comparable rows cannot be selected for Compare."
+- "Compare suppresses winner claims when query coverage is insufficient."
+- "Warning counts provide a clear path to actual warning details."
+
+metadata:
+  tags:
+  - results-explorer
+  - compare
+  - ranking
+  - evidence-gate
+  estimated_effort: "Medium (2-3 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents unsupported benchmark winner and rank claims from appearing on the
+    public site.
+  user_impact: |
+    Analysts can distinguish valid comparisons from provenance-only submitted
+    rows.
+  technical_debt: |
+    Centralizes rank and compare gates around shared eligibility state.

--- a/_project/TODO/main/planning/results-explorer-read-model-eligibility-contract.yaml
+++ b/_project/TODO/main/planning/results-explorer-read-model-eligibility-contract.yaml
@@ -1,0 +1,196 @@
+id: results-explorer-read-model-eligibility-contract
+title: "Add explicit eligibility and exclusion semantics to the Results Explorer read model"
+worktree: main
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  The Results Explorer DuckDB snapshot currently exposes enough raw data for
+  pages to infer eligibility, but it does not provide a single authoritative
+  row-level contract for display, ranking, and comparison. Frontend components
+  therefore render no-timing rows, zero timings, and all-unrankable cohorts as
+  if they were normal.
+
+  This TODO implements the backend/read-model side of the policy defined by
+  `results-explorer-display-contract-policy-gate`. The output should be a
+  browser DuckDB snapshot that explicitly identifies timing availability,
+  ranking eligibility, comparison eligibility, and exclusion reasons so the
+  frontend does not invent these semantics locally.
+
+deps:
+  needs:
+  - results-explorer-display-contract-policy-gate
+
+work:
+- id: w1
+  summary: "Map the policy gate decisions onto concrete read-model fields"
+  status: pending
+  notes: |
+    Convert the policy artifact into a field list for each relevant table.
+    At minimum evaluate:
+      - `has_display_timing`;
+      - `valid_query_count`;
+      - `missing_query_count`;
+      - `zero_timing_count`;
+      - `ranking_exclusion_reason`;
+      - `comparison_exclusion_reason`;
+      - `display_exclusion_reason`;
+      - `cohort_ranked_count`.
+    Decide exact field names, types, nullability, and which tables own each
+    field. Prefer fields in canonical pipeline outputs over frontend-only
+    derivation.
+
+- id: w2
+  summary: "Extend pipeline models and transformer outputs with eligibility fields"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update explorer pipeline models and `BundleTransformer` output so each
+    result row carries timing and exclusion metadata. Use `_query_display_ms()`
+    as the canonical place to distinguish missing, zero, failed, skipped, and
+    measured-positive timing rows. Do not change result validation semantics
+    except where the policy requires a separate publish/rank/compare status.
+
+- id: w3
+  summary: "Extend ranking generation with unrankable cohort metadata"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Update ranking generation so rows and cohorts explicitly expose why they
+    are not ranked. A cohort with `total_ranked = 0` must be machine-detectable
+    without recomputing from row fields. Rows with null/non-positive primary
+    metrics or `is_ranking_eligible=false` must have a specific exclusion
+    reason that the UI can render.
+
+- id: w4
+  summary: "Update browser DuckDB schema and snapshot writer"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Update `docs/development/browser-duckdb-schema.sql` and snapshot generation
+    so the new eligibility/exclusion fields are available in all tables needed
+    by explorer pages:
+      - `results`;
+      - `benchmark_rankings`;
+      - `benchmark_matrix_cells` if cell-level timing state is needed;
+      - `platform_index_rows`;
+      - `cohort_metadata`;
+      - `meta_leaderboard`;
+      - `result_detail_metrics`.
+
+- id: w5
+  summary: "Add snapshot invariant checks for invalid display-safe states"
+  needs: [w4]
+  status: pending
+  notes: |
+    Add a repeatable check that fails the build or release gate if the snapshot
+    contains contradictory states. Required checks:
+      - compare-eligible rows must have enough valid timings;
+      - rankable rows must have a valid primary metric;
+      - no ranked cohort can report `total_ranked = 0` without an explicit
+        unrankable cohort state;
+      - no row can be both `has_display_timing=false` and compare-eligible;
+      - no result can have `query_count=0` and appear as normal ranked evidence.
+    Implement this as
+    `_project/scripts/results_explorer_snapshot_invariants.py` with a DuckDB
+    path argument so release gates can re-run the exact same invariant suite.
+
+- id: w6
+  summary: "Regenerate fixture snapshot and verify AMPLab state is explicit"
+  needs: [w5]
+  status: pending
+  notes: |
+    Regenerate the local Results Explorer snapshot. Verify that AMPLab no-timing
+    rows are still present for provenance but have explicit exclusion reasons,
+    that zero timings follow the policy decision, and that all-unrankable
+    cohorts are detectable from snapshot fields.
+
+prior_art:
+- "benchbox/core/explorer_pipeline/transformer.py:_query_display_ms and _display_geomean_ms — extend rather than adding a parallel timing reducer."
+- "benchbox/core/explorer_pipeline/ranking.py:rank_platforms — extend for row/cohort exclusion reasons."
+- "benchbox/core/results/status.py:bundle_is_clean_pass and result_is_clean_pass — reuse for validation cleanliness without conflating with eligibility."
+- "docs/development/browser-duckdb-schema.sql:browser snapshot DDL — update as the frontend contract."
+- "results-explorer/src/lib/duckdbQueries.ts:typed query helpers — later TODO consumes the new fields from here."
+
+must_preserve:
+- "Existing generated snapshot tables remain readable by current explorer tests until frontend migration lands."
+- "Result detail and receipt pages can still show provenance for excluded rows."
+- "Measured positive sub-millisecond timings remain representable as positive values."
+- "No arbitrary replacement or rounding of zero timings is introduced."
+- "Ranking rules keep standard competition ranking for rows that remain rankable."
+
+approach: |
+  Implement the read-model fields from the policy gate first, then update
+  tests and snapshot checks before changing frontend components. Keep frontend
+  compatibility in mind, but prefer additive schema changes until all dependent
+  code migrates. Treat AMPLab as a regression fixture because it exercises
+  no-timing rows, zero timings, and all-unrankable cohorts in one place.
+
+anti_patterns:
+- "DO NOT derive rankability separately in each React component - because pages will diverge again - emit explicit read-model fields."
+- "DO NOT remove bad rows from the snapshot entirely - because receipt/provenance still matters - mark them excluded from ranking/comparison."
+- "DO NOT redefine `validation_status=passed` to mean compare-safe - because validation and timing quality are separate concerns - add separate fields."
+- "DO NOT silently ignore zero timings in some aggregate and include them in another - because Compare and charts will contradict each other - centralize the valid-timing predicate."
+
+verification:
+- description: "Explorer pipeline and schema-focused tests pass"
+  command: "uv run -- python -m pytest tests -k 'explorer_pipeline or browser_duckdb or results_explorer' --tb=short"
+  expected_output: "all targeted tests pass"
+- description: "Timing policy remains strict"
+  command: "uv run -- python _project/scripts/timing_policy_check.py --strict"
+  expected_output: "strict timing policy passes"
+- description: "DuckDB snapshot invariants pass"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "snapshot invariant command exits 0 and reports no contradictory display/rank/compare states"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/explorer_pipeline/contract.py"
+  - "benchbox/core/explorer_pipeline/duckdb_builder.py"
+  - "benchbox/core/explorer_pipeline/models.py"
+  - "benchbox/core/explorer_pipeline/ranking.py"
+  - "benchbox/core/explorer_pipeline/transformer.py"
+  - "benchbox/core/results/status.py"
+  - "docs/development/browser-duckdb-schema.sql"
+  - "results-explorer/src/types.ts"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "tests/unit/core/explorer_pipeline/conftest.py"
+  - "tests/unit/core/explorer_pipeline/test_duckdb_browser_contract.py"
+  - "tests/unit/core/explorer_pipeline/test_duckdb_builder.py"
+  - "tests/unit/core/explorer_pipeline/test_ranking.py"
+  - "tests/unit/core/explorer_pipeline/test_read_model_contract.py"
+  - "tests/unit/core/explorer_pipeline/test_transformer.py"
+  - "tests/unit/explorer/test_results_explorer_audit_manifest.py"
+  - "_project/scripts/results_explorer_snapshot_invariants.py"
+  - "_project/TODO/main/planning/results-explorer-read-model-eligibility-contract.yaml"
+  - "_project/verification-logs/results-explorer-read-model-eligibility-contract/"
+  do_not_modify:
+  - "results-explorer/src/pages/"
+  - "results-explorer/src/components/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "DuckDB snapshot exposes explicit display/rank/compare eligibility fields."
+- "AMPLab no-timing rows have machine-readable exclusion reasons."
+- "All-unrankable cohorts can be detected without frontend recomputation."
+- "Snapshot invariant checks catch compare-eligible rows with no valid timings."
+
+metadata:
+  tags:
+  - results-explorer
+  - read-model
+  - duckdb
+  - eligibility
+  - pipeline
+  estimated_effort: "Medium-Large (2-4 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Establishes trustworthy public ranking and comparison semantics at the
+    data layer.
+  user_impact: |
+    Prevents users from seeing invalid rows as ranked or comparable evidence.
+  technical_debt: |
+    Moves repeated frontend inference into one pipeline/read-model contract.


### PR DESCRIPTION
## Summary

Adds the Results Explorer remediation TODO sequence as tracked planning items and incorporates the review fixes before implementation starts:

- makes browser/evidence artifacts explicit for policy, home, rank/compare, and release gates
- binds downstream TODOs to the policy evidence artifact so they are not implemented from stale review memory
- replaces placeholder snapshot verification with a named invariant script contract
- narrows broad implementation scopes to concrete files and tests where the TODOs already identify the intended surface

## Validation

- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex`
- `git diff --cached --check`
- commit hooks: `check yaml`, EOF, trailing whitespace, large-file, merge-conflict, private-key checks
- pre-push hooks: timing policy fast-lane collect and pr-preflight fast tests

## Notes

The review mentioned a stale requested path, `results-explorer-rank-compare-evidence-gates.yaml`. This PR keeps the canonical tracked TODO as `results-explorer-rank-and-compare-evidence-gates.yaml` to avoid duplicating the item.