### PR TITLE
chore(skills): sync todo skill batch-action refinements

### DIFF
--- a/skill-sync.lock
+++ b/skill-sync.lock
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "lockedAt": "2026-05-07T00:39:26.575Z",
+  "lockedAt": "2026-05-11T13:12:36.876Z",
   "skills": {
     "blog": {
       "source": {
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/blog",
-        "fetchedAt": "2026-05-07T00:39:26.499Z"
+        "fetchedAt": "2026-05-11T13:09:00.700Z"
       },
       "installMode": "mirror",
       "files": {
@@ -30,7 +30,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/code",
-        "fetchedAt": "2026-05-07T00:39:26.505Z"
+        "fetchedAt": "2026-05-11T13:09:00.703Z"
       },
       "installMode": "mirror",
       "files": {
@@ -69,7 +69,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/test",
-        "fetchedAt": "2026-05-07T00:39:26.507Z"
+        "fetchedAt": "2026-05-11T13:09:00.704Z"
       },
       "installMode": "mirror",
       "files": {
@@ -111,7 +111,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/todo",
-        "fetchedAt": "2026-05-07T00:39:26.509Z"
+        "fetchedAt": "2026-05-11T13:12:36.811Z"
       },
       "installMode": "mirror",
       "files": {
@@ -123,13 +123,17 @@
           "sha256": "8c400ff2bfbb6e504c1d9b22d7cc1e28476c0949b93c9a130e4e1c775c6a19da",
           "size": 8773
         },
+        "references/batch.md": {
+          "sha256": "cb0a74170933678e6171741dcfebf407a849dce68dd015e1798823da4cb3d524",
+          "size": 5916
+        },
         "references/structure.md": {
           "sha256": "230c2584a274a10f04c296ce822a5322a41f56ef1c4e87eaf977ee3377d633a6",
           "size": 1464
         },
         "SKILL.md": {
-          "sha256": "63881f543cb04e1a730b1b9850672ddde8a356bc5a9be8a07121c806c2547308",
-          "size": 4889
+          "sha256": "392a117ad4ab93390e67fff4b8c765ee01f5a5b34fdb83eba9edab5c860c00f4",
+          "size": 6890
         },
         "skill.yaml": {
           "sha256": "02fb9215abb958fbb853438905ee2fab5eaf49c9cc820033edb23c992313fe20",
@@ -142,7 +146,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/benchbox",
-        "fetchedAt": "2026-05-07T00:39:26.511Z"
+        "fetchedAt": "2026-05-11T13:09:00.707Z"
       },
       "installMode": "mirror",
       "files": {
@@ -216,7 +220,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/SHARED/verify-framework",
-        "fetchedAt": "2026-05-07T00:39:26.513Z"
+        "fetchedAt": "2026-05-11T13:09:00.708Z"
       },
       "installMode": "mirror",
       "files": {
@@ -402,7 +406,7 @@
         "type": "local",
         "name": "personal",
         "path": "/Users/joe/.skill-sync/skills/SHARED/review-protocol",
-        "fetchedAt": "2026-05-07T00:39:26.517Z"
+        "fetchedAt": "2026-05-11T13:09:00.711Z"
       },
       "installMode": "mirror",
       "files": {


### PR DESCRIPTION
Re-sync skill-sync.lock for the todo skill after refining the new
`batch` action: version bump to 0.6.0, softened review-finding rule
(Critical/Required mandatory; Nit/Consider within scope_limit, skipped
ones logged), genericized commit/PR step via SHARED/commit-framework,
added worktree-refresh/-release and CI-gate guardrails, scheduler
clarifications (`ready` is derived; bounded `waiting`->`blocked`),
one-authorization note, sequential-default rationale, and a
partial-completion resume report. skill.yaml unchanged (no new dep).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
