### PR TITLE
chore(todo): review results explorer follow-up todos

### DIFF
--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-run-identity-label-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-run-identity-label-contract.yaml
@@ -1,0 +1,166 @@
+id: results-explorer-chart-run-identity-label-contract
+title: "Normalize chart run identity labels without duplicate or unreadable names"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  Run identity disambiguation improved, but chart labels still duplicate or
+  become unreadably long. Per-query legends can repeat platform names, and box
+  plot/rank labels can truncate different runs to indistinguishable prefixes.
+  This TODO introduces one label contract for charts: labels are compact when
+  unique, disambiguated when needed, and never collapse two result IDs into the
+  same visible label.
+
+deps:
+  needs: []
+
+work:
+- id: w0
+  summary: "Inventory every chart and table label that identifies a run"
+  status: pending
+  notes: |
+    Inspect benchmark matrix headers, chart legends, rank chart headers, box
+    plot axis labels, trend labels, compare cards, and platform detail rows
+    against the checked git SHA and current browser snapshot. Capture the route,
+    cohort/result IDs, viewport, visible label text, and expected
+    disambiguating token for each duplicate or overlong label in
+    `_project/verification-logs/results-explorer-chart-run-identity-label-contract/w0.log`.
+
+- id: w1
+  summary: "Define compact, full, and accessible run identity formats"
+  needs: [w0]
+  status: pending
+  notes: |
+    Create a contract for:
+      - `compact`: platform only when unique in the current cohort;
+      - `disambiguated`: platform + version/date or platform + date + short ID
+        when duplicates exist;
+      - `full`: platform, version, run date, scale, trust/source, and short ID
+        for tooltip, aria-label, or details view.
+    Decision gate: two different result IDs in the same rendered chart must
+    never have the same compact/disambiguated visible label.
+
+- id: w2
+  summary: "Implement a shared run identity formatter"
+  needs: [w1]
+  status: pending
+  notes: |
+    Add or extend a single helper used by all Results Explorer labels. It must
+    handle missing version/date/id, preserve meaningful suffixes under
+    truncation, and expose both visible and accessible strings.
+
+- id: w3
+  summary: "Apply the formatter to all chart labels"
+  needs: [w2]
+  status: pending
+  notes: |
+    Update per-query legends, rank chart headers, distribution/box plot labels,
+    sparklines, trend charts, compare charts, and benchmark matrix headers to
+    use the shared formatter. Avoid independently truncating labels inside
+    chart components unless the helper controls the truncation.
+
+- id: w4
+  summary: "Add tests for duplicate and long label cohorts"
+  needs: [w3]
+  status: pending
+  notes: |
+    Add tests with repeated DataFusion, Polars, PySpark, and Spark runs. Assert:
+      - no duplicate visible chart labels for different result IDs;
+      - long labels preserve the distinguishing suffix or short ID;
+      - aria/title text exposes full identity;
+      - labels stay within chart bounds at standard desktop width.
+
+- id: w5
+  summary: "Browser-check chart labels at benchmark and compare routes"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser, verify labels on benchmark Per-query, Distribution/Box Plot,
+    Rank, Overview/Sparklines, and Compare charts. Decision gate: do not
+    complete this TODO if any chart still displays duplicate labels for
+    different run IDs or truncates away the only disambiguating token.
+
+prior_art:
+- "_project/DONE/main/planning/results-explorer-run-identity-disambiguation.yaml is the prior label contract; extend its formatter and tests instead of starting a second identity system."
+- "results-explorer/src/lib/runIdentity.ts or equivalent helper from prior run-identity work."
+- "results-explorer/src/components/RunIdentity.tsx if present should be reused rather than reimplemented."
+- "results-explorer/src/components/ChartPanel.tsx, RankTable.tsx, DistributionBox.tsx, CDFChart.tsx, PercentileLadder.tsx, PowerBar.tsx, StackedPhase.tsx, SparklineTable.tsx, TimeSeries.tsx, NormalizedSpeedupChart.tsx, and QueryDiffTable.tsx contain per-chart labels and legends."
+- "results-explorer/src/pages/BenchmarkIndex.tsx and Compare.tsx render matrix/chart headers."
+
+must_preserve:
+- "Labels stay compact when there is only one run per platform."
+- "Full identity remains available without making every row or legend overly long."
+- "Chart dimensions do not expand unpredictably because of long labels."
+- "Existing color assignments remain stable after label changes."
+
+approach: |
+  Start with a formatter and tests, then replace component-level ad hoc label
+  assembly. Use cohort context to decide when a platform name is sufficient.
+
+anti_patterns:
+- "DO NOT truncate from the end when the short ID or date is the only distinguishing token."
+- "DO NOT hard-code special handling for DataFusion or Polars; duplicates can happen for any platform."
+- "DO NOT make each chart invent a different label format."
+- "DO NOT solve duplicate labels by showing every metadata field all the time."
+
+verification:
+- description: "Run identity formatter and chart tests pass"
+  command: "cd results-explorer && npm test -- --run src/lib/__tests__/runIdentity.test.ts src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/charts.smoke.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck passes"
+  command: "cd results-explorer && npm run typecheck"
+  expected_output: "exit 0"
+- description: "Browser evidence confirms no duplicate chart labels"
+  command: "rg -n \"Per-query|Box Plot|Rank|Sparklines|duplicate label|PASS|FAIL\" _project/verification-logs/results-explorer-chart-run-identity-label-contract/"
+  expected_output: "logs include pass/fail evidence for chart label uniqueness"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/lib/runIdentity.ts"
+  - "results-explorer/src/lib/__tests__/runIdentity.test.ts"
+  - "results-explorer/src/components/RunIdentity.tsx"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/RankTable.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/components/PercentileLadder.tsx"
+  - "results-explorer/src/components/PowerBar.tsx"
+  - "results-explorer/src/components/StackedPhase.tsx"
+  - "results-explorer/src/components/SparklineTable.tsx"
+  - "results-explorer/src/components/TimeSeries.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/__tests__/"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "_project/verification-logs/results-explorer-chart-run-identity-label-contract/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "No chart shows the same visible label for two different result IDs."
+- "Long run labels preserve a distinguishing date or short ID."
+- "Full identity is available through tooltip/title/aria or details affordance."
+- "All chart components use the same identity formatter."
+
+metadata:
+  tags:
+  - results-explorer
+  - charts
+  - run-identity
+  - labels
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Makes charts trustworthy when multiple submissions exist for the same
+    platform.
+  user_impact: |
+    Users can tell which run won, lost, or was excluded without guessing from
+    color or row position.
+  technical_debt: |
+    Consolidates run-label logic behind one tested formatter.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-disabled-recovery-states.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-disabled-recovery-states.yaml
@@ -1,0 +1,160 @@
+id: results-explorer-compare-disabled-recovery-states
+title: "Make disabled compare rows and zero-selection states explainable and recoverable"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The compare builder and source pages currently expose disabled row checkboxes
+  with the reason hidden in `title` text or not visible at all. When no rows are
+  selectable, the user sees controls but no recovery path. This TODO adds
+  visible, keyboard-accessible reason and recovery states for every page that
+  contains compare selection.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+
+work:
+- id: w0
+  summary: "Inventory every disabled compare control and current reason source"
+  status: pending
+  notes: |
+    Inspect benchmark detail, platform detail, Query Workbench, Compare
+    builder, and result-detail builder state on the checked git SHA after the
+    eligibility repair has regenerated the snapshot. Record route, fixture
+    result IDs, exclusion reason codes, where each disabled reason comes from,
+    whether it is visible, and whether a user can recover by changing filters.
+    Store screenshots or DOM text evidence in
+    `_project/verification-logs/results-explorer-compare-disabled-recovery-states/w0.log`.
+
+- id: w1
+  summary: "Create a shared compare exclusion reason formatter"
+  needs: [w0]
+  status: pending
+  notes: |
+    Add a small shared formatter that maps stable reason codes to:
+      - short row text;
+      - detailed tooltip/help text;
+      - recovery hint when applicable;
+      - severity/category.
+    Cover at least `no_queries`, `no_valid_display_timing`,
+    `missing_timings`, `insufficient_query_coverage`, and any rank-only
+    exclusion code. Include pluralization and punctuation here so pages do not
+    reimplement copy differently.
+
+- id: w2
+  summary: "Show visible disabled reasons in the Compare builder"
+  needs: [w1]
+  status: pending
+  notes: |
+    Add a compact reason column or inline muted reason next to disabled rows in
+    `/results/compare`. The row must not rely on browser `title` as the only
+    explanation. Add a page-level zero-selectable callout with the dominant
+    reason counts and one recovery action, such as clearing filters or choosing
+    another cohort.
+
+- id: w3
+  summary: "Show visible disabled reasons on benchmark, platform, and query pages"
+  needs: [w1]
+  status: pending
+  notes: |
+    For each source page, disabled compare controls need an adjacent row status
+    or an accessible details affordance. Disabled primary buttons must look
+    disabled and state what is missing: not enough selected rows, no eligible
+    rows in current filters, or selected rows from incompatible cohorts.
+
+- id: w4
+  summary: "Add zero-selection and mixed-selection tests"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests for:
+      - all rows disabled with visible reason summary;
+      - some rows enabled and some disabled;
+      - selecting one row updates button copy;
+      - selecting incompatible rows is impossible or explains why;
+      - keyboard focus announces disabled reason text.
+
+- id: w5
+  summary: "Browser-check recovery paths with filters"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser, intentionally filter to a zero-selectable state, confirm the
+    callout appears, use the recovery action, and verify selectable rows return.
+    Decision gate: do not complete this item if a user can still encounter a
+    disabled compare screen with no visible reason or next action.
+
+prior_art:
+- "results-explorer/src/pages/Compare.tsx:disabled checkbox title text and builder row rendering."
+- "results-explorer/src/pages/BenchmarkIndex.tsx:compare selection state on benchmark detail."
+- "results-explorer/src/pages/PlatformIndex.tsx:compare selection state on platform detail."
+- "results-explorer/src/pages/Query.tsx:Query Workbench compare action."
+- "results-explorer/src/lib/displayEligibility.ts or equivalent shared eligibility helper should own reason formatting."
+
+must_preserve:
+- "Ineligible rows remain unselectable."
+- "Reason text must be visible without mouse hover and available to screen readers."
+- "Reason formatting must use stable reason codes, not ad hoc string matching."
+- "Recovery actions must not silently broaden filters without user action."
+
+approach: |
+  Centralize reason copy first, then add compact row-level display and
+  page-level zero-state recovery on each compare surface.
+
+anti_patterns:
+- "DO NOT use only the checkbox `title` attribute for important reasons."
+- "DO NOT make disabled controls visually indistinguishable from enabled controls."
+- "DO NOT show generic `not comparable` copy when the row has a specific machine-readable reason."
+- "DO NOT provide a recovery action that changes selected rows without making the change visible."
+
+verification:
+- description: "Disabled compare reason tests pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Compare.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Query.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Accessibility checks cover visible reasons"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Compare.a11y.test.tsx src/pages/__tests__/BenchmarkIndex.a11y.test.tsx src/pages/__tests__/PlatformIndex.a11y.test.tsx src/pages/__tests__/Query.a11y.test.tsx"
+  expected_output: "focused accessibility tests for visible disabled reasons pass"
+- description: "Browser recovery evidence exists"
+  command: "rg -n \"zero-selectable|disabled reason|clear filters|PASS|FAIL\" _project/verification-logs/results-explorer-compare-disabled-recovery-states/"
+  expected_output: "logs include browser evidence for zero-selection recovery"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/lib/displayEligibility.ts"
+  - "results-explorer/src/lib/compareExclusionReasons.ts"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/PlatformIndex.tsx"
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/components/__tests__/"
+  - "_project/verification-logs/results-explorer-compare-disabled-recovery-states/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "Every disabled compare row has visible explanatory text."
+- "Every zero-selectable compare state has a page-level recovery path."
+- "Button copy distinguishes no selection, one selection, incompatible selection, and ready-to-compare."
+- "Reason copy is centralized and tested."
+
+metadata:
+  tags:
+  - results-explorer
+  - compare
+  - accessibility
+  - recovery-state
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Reduces support and trust issues when real data is excluded from comparison.
+  user_impact: |
+    Users understand why a run cannot be compared and what to do next.
+  technical_debt: |
+    Removes duplicated, inconsistent exclusion copy from individual pages.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-entrypoint-happy-path-gates.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-entrypoint-happy-path-gates.yaml
@@ -1,0 +1,175 @@
+id: results-explorer-compare-entrypoint-happy-path-gates
+title: "Gate every Results Explorer compare entrypoint with browser happy paths"
+worktree: results-explorer-followup-todo-review
+priority: Critical
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Compare controls now exist across the Results Explorer, but the latest review
+  found that none of the visible entrypoints can complete because every row is
+  disabled. After eligibility is repaired, each entrypoint needs a real browser
+  acceptance path that proves the user can discover, select, and complete a
+  comparison without editing the URL.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+
+work:
+- id: w0
+  summary: "Define canonical compare fixtures from the regenerated snapshot"
+  status: pending
+  notes: |
+    Query the regenerated snapshot for at least two stable comparable cohorts
+    and capture the checked git SHA, snapshot file path/checksum, SQL used, and
+    selected fixture rows:
+      - one benchmark-detail cohort;
+      - one platform-detail cohort;
+      - one cohort reachable from Query Workbench filters.
+    Capture result IDs, platform labels, benchmark, scale, phase, metric, and
+    expected compare URL in
+    `_project/verification-logs/results-explorer-compare-entrypoint-happy-path-gates/w0.log`.
+    Decision gate: if no fixture has two comparable rows, stop and return to
+    `results-explorer-comparison-eligibility-contract-repair`.
+
+- id: w1
+  summary: "Prove benchmark detail selection completes a comparison"
+  needs: [w0]
+  status: pending
+  notes: |
+    From `/results/<benchmark>/`, select two eligible rows, confirm the primary
+    compare button enables, click it, and verify the compare page renders:
+      - breadcrumb with benchmark and Compare;
+      - selected platform cards;
+      - decision summary or valid insufficient-evidence state;
+      - chart panel;
+      - comparability receipt;
+      - share URL button.
+
+- id: w2
+  summary: "Prove platform detail selection completes a comparison"
+  needs: [w0]
+  status: pending
+  notes: |
+    From `/results/p/<platform>/`, filter or scroll to two comparable rows from
+    the same cohort, select them, click Compare, and verify the same completion
+    criteria as w1. Confirm page-level filters do not clear selection
+    unexpectedly unless the selected rows leave the visible cohort.
+
+- id: w3
+  summary: "Prove Query Workbench selection completes a comparison"
+  needs: [w0]
+  status: pending
+  notes: |
+    Use Query Workbench filters to surface a comparable cohort, select two
+    eligible rows, verify the `Compare` action enables, click it, and confirm
+    the compare page is shareable and reloadable. Confirm CSV/JSON export
+    controls and SQL scratchpad state are not required to complete the compare
+    flow.
+
+- id: w4
+  summary: "Prove result-detail Compare this result can add a compatible second row"
+  needs: [w0]
+  status: pending
+  notes: |
+    Open a result detail page for a compare-eligible run, click `Compare this
+    result`, verify the builder opens with that run pinned, select a compatible
+    second run, and complete the comparison. The pinned run must be visible,
+    removable only through an explicit action, and not silently dropped by
+    filters.
+
+- id: w5
+  summary: "Prove empty Compare builder can start and complete a comparison"
+  needs: [w0]
+  status: pending
+  notes: |
+    Open `/results/compare` without IDs, use the in-page builder to choose a
+    benchmark/scale/cohort, select two rows, and complete a comparison. The page
+    must not tell users to edit the URL and must provide enough filters to find
+    eligible rows.
+
+- id: w6
+  summary: "Add automated browser coverage for all five compare paths"
+  needs: [w1, w2, w3, w4, w5]
+  status: pending
+  notes: |
+    Add or extend Playwright/browser-use acceptance tests for the five paths
+    above. Tests should assert visible enabled controls, final route state,
+    selected result IDs in the share URL, and a rendered compare summary.
+    Decision gate: this TODO cannot complete with manual-only evidence.
+
+prior_art:
+- "results-explorer/src/pages/BenchmarkIndex.tsx:benchmark selection controls and compare button."
+- "results-explorer/src/pages/PlatformIndex.tsx:platform table selection and filtering."
+- "results-explorer/src/pages/Query.tsx:query workbench row selection."
+- "results-explorer/src/pages/ResultDetail.tsx:Compare this result entrypoint."
+- "results-explorer/src/pages/Compare.tsx:builder, selected-run state, and compare route."
+- "results-explorer/e2e/ or existing browser smoke harness: use for acceptance coverage."
+
+must_preserve:
+- "Compare URLs with explicit IDs remain shareable and reloadable."
+- "Users do not need to edit query parameters manually."
+- "Existing filters and sort controls remain usable while selections are active."
+- "Ineligible rows remain blocked from selection after the eligibility repair."
+
+approach: |
+  Treat compare as a user journey, not a per-page button check. Build fixtures
+  from the generated snapshot, run each path in a browser, then codify the
+  paths as regression tests.
+
+anti_patterns:
+- "DO NOT mark this complete because unit tests pass; every visible entrypoint needs browser proof."
+- "DO NOT use hard-coded stale result IDs without first deriving them from the current snapshot."
+- "DO NOT skip Query Workbench because it is powered by DuckDB; it is one of the advertised compare entrypoints."
+- "DO NOT rely on URL editing as a fallback path."
+
+verification:
+- description: "Compare entrypoint browser suite passes"
+  command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npm run test:e2e -- --project=chromium --grep \"compare entrypoint\""
+  expected_output: "all compare entrypoint tests pass"
+- description: "Frontend unit tests still pass for compare pages"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Query.test.tsx src/pages/__tests__/ResultDetail.test.tsx src/pages/__tests__/Compare.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Manual evidence log exists for the checked SHA"
+  command: "rg -n \"benchmark detail|platform detail|Query Workbench|Compare this result|empty Compare builder|PASS|FAIL\" _project/verification-logs/results-explorer-compare-entrypoint-happy-path-gates/"
+  expected_output: "logs include pass/fail evidence for all five entrypoints"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/PlatformIndex.tsx"
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/ResultDetail.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/e2e/"
+  - "results-explorer/src/pages/__tests__/"
+  - "_project/verification-logs/results-explorer-compare-entrypoint-happy-path-gates/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "docs/development/browser-duckdb-schema.sql"
+
+success_metrics:
+- "Benchmark detail, platform detail, Query Workbench, result detail, and empty Compare builder all complete compare flows."
+- "Each completed compare route is reloadable and shareable."
+- "Browser tests fail if any entrypoint regresses to a dead button or URL-editing instruction."
+
+metadata:
+  tags:
+  - results-explorer
+  - compare
+  - browser-test
+  - release-gate
+  estimated_effort: "Medium (2-3 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Converts the compare feature from exposed controls into a tested,
+    end-to-end user workflow.
+  user_impact: |
+    Analysts can start comparison from wherever they discover a relevant run.
+  technical_debt: |
+    Adds route-level regression coverage for a workflow that previously broke
+    through several independent pages.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-comparison-eligibility-contract-repair.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-comparison-eligibility-contract-repair.yaml
@@ -1,0 +1,193 @@
+id: results-explorer-comparison-eligibility-contract-repair
+title: "Repair Results Explorer comparison eligibility at the read-model contract"
+worktree: results-explorer-followup-todo-review
+priority: Critical
+status: Not Started
+category: Core Functionality
+
+description: |
+  The post-remediation evaluation found a P0 regression: the Results Explorer
+  exposes compare entrypoints, but every public result row is non-comparable.
+  A fresh snapshot reported 525 total results, 0 comparable rows, and 371
+  displayable rows. The dominant exclusion reason was
+  `insufficient_query_coverage`, including normal TPC-H rows that have 22 valid
+  logical query timings but 66 or 88 raw execution samples.
+
+  The suspected root cause is that backend eligibility compares
+  `valid_query_count` against `summary.queries.total`, where `total` can be raw
+  samples/repetitions rather than the logical benchmark query count. This TODO
+  repairs the data contract so comparison eligibility is based on valid
+  display timings over the logical comparable query scope, not raw sample count.
+
+deps:
+  needs: []
+
+work:
+- id: w0
+  summary: "Reproduce and capture the current zero-comparable-row invariant"
+  status: pending
+  notes: |
+    Regenerate or inspect the current browser DuckDB snapshot and capture the
+    checked git SHA, snapshot file path/checksum, SQL used, and:
+      - total result rows;
+      - displayable rows;
+      - compare-eligible rows;
+      - ranking-eligible rows;
+      - counts by `comparison_exclusion_reason`;
+      - at least one TPC-H row showing `valid_query_count=22` with a larger
+        raw `query_count`.
+    Store the SQL and output in
+    `_project/verification-logs/results-explorer-comparison-eligibility-contract-repair/w0.log`.
+    Decision gate: if comparable rows are already nonzero on the checked SHA,
+    continue anyway and prove the logical/raw query-count contract with tests
+    so the regression cannot return.
+
+- id: w1
+  summary: "Document the logical query-count contract used by compare eligibility"
+  needs: [w0]
+  status: pending
+  notes: |
+    Trace query-count fields from bundle summaries through
+    `BundleTransformer`, `timing_eligibility`, DuckDB schema generation, and
+    frontend query helpers. Explicitly identify which field means:
+      - raw execution sample count;
+      - logical benchmark query count;
+      - valid display timing count;
+      - missing logical query count;
+      - comparable query denominator.
+    Add implementation notes to this TODO before editing behavior. Do not
+    proceed to w2 if there is no stable logical denominator available; create
+    it first in the read model.
+
+- id: w2
+  summary: "Change backend comparison eligibility to use logical display-query coverage"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update `timing_eligibility()` and its call sites so a row with all logical
+    query timings present is compare-eligible even when raw sample count is
+    higher due to repetitions. Keep exclusion for rows with no query timings,
+    no valid positive display timings, missing required logical queries, or
+    coverage below the policy threshold. Keep ranking eligibility separate from
+    comparison eligibility: trust or ranking exclusion can block leaderboard
+    rank claims without automatically blocking a valid timing comparison.
+
+- id: w3
+  summary: "Normalize exclusion reason fields and snapshot invariants"
+  needs: [w2]
+  status: pending
+  notes: |
+    Ensure generated rows expose stable, user-facing reason codes for:
+      - no queries;
+      - no valid display timing;
+      - missing timings;
+      - insufficient logical query coverage;
+      - rank-only exclusion;
+      - display-only exclusion.
+    Extend snapshot invariant checks so they fail when every public row is
+    non-comparable, when a fully covered logical cohort is excluded for raw
+    sample count, or when a compare-eligible row lacks valid display timings.
+
+- id: w4
+  summary: "Add focused backend tests for logical-vs-raw query counts"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests with fixtures covering:
+      - TPC-H-like row: 22 valid logical queries, 66 raw samples, compare-safe;
+      - SSB-like row: all logical queries covered, compare-safe;
+      - one valid logical query out of many, compare-excluded;
+      - zero/negative/NaN display timings, compare-excluded;
+      - no query records, compare-excluded;
+      - trust/ranking-excluded but timing-comparable row, compare-safe but not
+        rank-safe.
+
+- id: w5
+  summary: "Regenerate snapshot and prove at least two comparable cohorts exist"
+  needs: [w3, w4]
+  status: pending
+  notes: |
+    Regenerate the Results Explorer DuckDB snapshot from the current corpus and
+    rerun the SQL from w0. Decision gate: do not mark this item complete unless
+    the snapshot has nonzero compare-eligible rows and at least one TPC-H cohort
+    plus one non-TPC-H cohort have two or more compare-eligible rows.
+
+prior_art:
+- "_project/DONE/main/planning/results-explorer-read-model-eligibility-contract.yaml introduced the current explicit display/rank/compare eligibility fields; extend or repair that contract rather than creating a parallel one."
+- "benchbox/core/explorer_pipeline/models.py:timing_eligibility currently owns comparison exclusion decisions."
+- "benchbox/core/explorer_pipeline/transformer.py:BundleTransformer passes query summary counts into eligibility."
+- "benchbox/core/explorer_pipeline/duckdb_builder.py and docs/development/browser-duckdb-schema.sql define the browser snapshot contract."
+- "_project/scripts/results_explorer_snapshot_invariants.py should become the release-blocking check for contradictory eligibility states."
+- "results-explorer/src/lib/duckdbQueries.ts consumes eligibility and reason fields in frontend pages."
+
+must_preserve:
+- "Do not relax comparison eligibility by ignoring missing logical queries."
+- "Do not make invalid zero/negative/NaN timings compare-safe."
+- "Do not conflate validation cleanliness, ranking eligibility, and comparison eligibility."
+- "Do not remove excluded rows from provenance, receipt, or result-detail surfaces."
+- "Do not add frontend-only eligibility derivations that can drift from the DuckDB snapshot."
+
+approach: |
+  Fix the read-model contract first, then regenerate the snapshot and add
+  invariant tests. Only after the backend contract proves that comparable rows
+  exist should frontend entrypoint work proceed.
+
+anti_patterns:
+- "DO NOT special-case TPC-H by name; the fix must apply to any benchmark with repeated raw samples."
+- "DO NOT lower the threshold until rows become comparable; use the policy denominator and fail if data genuinely lacks evidence."
+- "DO NOT hide the zero-comparable state with UI copy; the product needs actual compare-safe rows."
+- "DO NOT change result validation semantics to make compare work; add or correct eligibility semantics instead."
+
+verification:
+- description: "Backend eligibility and snapshot tests pass"
+  command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline -k 'eligibility or read_model or duckdb or transformer' --tb=short"
+  expected_output: "all targeted tests pass"
+- description: "Snapshot invariants pass against the regenerated DuckDB file"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "exit 0 with nonzero comparable rows and no contradictory eligibility states"
+- description: "SQL evidence proves comparable rows exist"
+  command: "rg -n \"compare-eligible rows|TPC-H|SSB|insufficient_query_coverage\" _project/verification-logs/results-explorer-comparison-eligibility-contract-repair/w5.log"
+  expected_output: "w5 log includes nonzero compare-eligible row counts and at least two eligible cohorts"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/explorer_pipeline/models.py"
+  - "benchbox/core/explorer_pipeline/transformer.py"
+  - "benchbox/core/explorer_pipeline/duckdb_builder.py"
+  - "docs/development/browser-duckdb-schema.sql"
+  - "_project/scripts/results_explorer_snapshot_invariants.py"
+  - "tests/unit/core/explorer_pipeline/"
+  - "results-explorer/src/types.ts"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "_project/verification-logs/results-explorer-comparison-eligibility-contract-repair/"
+  do_not_modify:
+  - "results-explorer/src/pages/"
+  - "results-explorer/src/components/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "The snapshot no longer reports zero compare-eligible rows when valid logical query coverage exists."
+- "Rows with full logical query coverage are not excluded because raw sample count is larger."
+- "Comparison, ranking, display, validation, and provenance states remain separately auditable."
+- "Snapshot invariants fail loudly if comparable rows collapse to zero again."
+
+metadata:
+  tags:
+  - results-explorer
+  - compare
+  - duckdb
+  - eligibility
+  - read-model
+  estimated_effort: "Medium (2-3 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Restores the central Results Explorer compare workflow and prevents the
+    site from advertising comparison controls that cannot ever complete.
+  user_impact: |
+    Database engineers can select real comparable runs without understanding
+    raw URL IDs or internal query-count fields.
+  technical_debt: |
+    Replaces a brittle inferred eligibility rule with an explicit, tested data
+    contract.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-direct-route-and-copy-hardening.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-direct-route-and-copy-hardening.yaml
@@ -1,0 +1,162 @@
+id: results-explorer-direct-route-and-copy-hardening
+title: "Harden direct route loading and shared Results Explorer microcopy"
+worktree: results-explorer-followup-todo-review
+priority: Medium
+status: Not Started
+category: Reliability
+
+description: |
+  The review found an intermittent direct-route failure on `/results/p/polars/`
+  where the page briefly rendered as `polars Results` with `No results found`,
+  plus several copy defects such as `1 warnings` pluralization and duplicated
+  punctuation in guardrail text. This TODO adds direct-route regression tests
+  and centralizes small but trust-eroding microcopy states.
+
+deps:
+  needs: []
+
+work:
+- id: w0
+  summary: "Reproduce and instrument direct platform route loading"
+  status: pending
+  notes: |
+    Test hard reload and direct navigation on the checked git SHA, capturing
+    final URL, H1, row count, console/network errors, loading-state transitions,
+    and whether the route matches in-app navigation for:
+      - `/results/p/polars/`;
+      - `/results/p/duckdb/`;
+      - `/results/tpch/`;
+      - `/results/query`;
+      - `/results/compare`.
+    Also capture the exact one-warning and multi-warning Compare copy, including
+    duplicated punctuation and passive badge affordance states. Store results in
+    `_project/verification-logs/results-explorer-direct-route-and-copy-hardening/w0.log`.
+
+- id: w1
+  summary: "Prevent transient empty platform caches from becoming terminal state"
+  needs: [w0]
+  status: pending
+  notes: |
+    Inspect DuckDB loading/caching in platform queries. Ensure route components
+    distinguish loading, not found, empty filtered result, and real no-data
+    states. Do not cache transient zero-row results for a platform if the
+    platform index has not loaded or if DuckDB is still initializing.
+
+- id: w2
+  summary: "Add direct-route parity tests"
+  needs: [w1]
+  status: pending
+  notes: |
+    Add browser or integration tests that hard-load each route in w0 and
+    compare it with in-app navigation. Assert canonical capitalization
+    (`Polars Results`, not `polars Results`), expected row count, visible
+    filters/pivots, and absence of false `No results found` states.
+
+- id: w3
+  summary: "Centralize warning/count/status microcopy"
+  needs: [w0]
+  status: pending
+  notes: |
+    Add or extend a shared formatter for:
+      - `1 warning` vs `N warnings`;
+      - no duplicated punctuation such as `coverage..`;
+      - selected row count states;
+      - compare guardrail badge labels;
+      - missing/unranked status labels if not already covered by the
+        leaderboard semantics TODO.
+
+- id: w4
+  summary: "Apply microcopy formatter to Compare and guardrail surfaces"
+  needs: [w3]
+  status: pending
+  notes: |
+    Update Compare header, Comparability Guardrails, Decision Summary, receipt,
+    and button copy to use shared formatting. Any badge that visually looks
+    clickable must either be a real button/link or be restyled as passive text.
+
+- id: w5
+  summary: "Run direct-route and microcopy browser checks"
+  needs: [w2, w4]
+  status: pending
+  notes: |
+    Browser-check the routes from w0 plus a compare route with exactly one
+    warning and one with multiple warnings. Decision gate: do not complete if
+    any direct route can land in a false empty state, any visible copy shows
+    incorrect pluralization/punctuation, or any passive badge looks like a
+    clickable button.
+
+prior_art:
+- "results-explorer/src/pages/PlatformIndex.tsx owns direct platform detail loading and page heading."
+- "results-explorer/src/lib/duckdbQueries.ts contains platform query caching."
+- "results-explorer/src/pages/Compare.tsx and ComparabilityReceipt components render warning copy."
+- "results-explorer/src/lib/compareSummary.ts may already format guardrail messages."
+
+must_preserve:
+- "Legitimate empty filtered states still render as empty states with reset actions."
+- "Direct URLs remain static-export friendly and do not require server-side routing."
+- "Microcopy changes do not alter eligibility or ranking semantics."
+- "Passive badges are visually distinct from buttons unless they are interactive."
+
+approach: |
+  First prove whether the route failure is reproducible, then add route-state
+  tests that cover both hard reload and in-app navigation. In parallel,
+  centralize the small copy rules that repeatedly surface in compare UI.
+
+anti_patterns:
+- "DO NOT fix direct route failures by adding arbitrary timeouts."
+- "DO NOT cache empty arrays before the route has enough data to know the platform is genuinely empty."
+- "DO NOT leave count/pluralization copy embedded separately in each component."
+- "DO NOT style passive status pills like clickable buttons."
+
+verification:
+- description: "Direct-route tests pass"
+  command: "cd results-explorer && npm run test:e2e:fixtures && npm run build && npm run test:e2e -- --project=chromium --grep \"direct route\""
+  expected_output: "all direct-route tests pass"
+- description: "Microcopy unit tests pass"
+  command: "cd results-explorer && npm test -- --run src/lib/__tests__/copyFormatters.test.ts src/pages/__tests__/Compare.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Browser evidence confirms no false empty states or bad pluralization"
+  command: "rg -n \"Polars Results|No results found|1 warning|warnings|coverage\\.\\.|PASS|FAIL\" _project/verification-logs/results-explorer-direct-route-and-copy-hardening/"
+  expected_output: "logs include route and copy pass/fail evidence"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/src/lib/copyFormatters.ts"
+  - "results-explorer/src/pages/PlatformIndex.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/components/ComparabilityReceipt.tsx"
+  - "results-explorer/src/lib/__tests__/"
+  - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/components/__tests__/"
+  - "results-explorer/e2e/"
+  - "_project/verification-logs/results-explorer-direct-route-and-copy-hardening/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "Hard-loaded platform routes render the same canonical content as in-app navigation."
+- "Transient DuckDB loading cannot surface as a permanent platform `No results found` page."
+- "Warning/count/status copy pluralizes and punctuates correctly."
+- "Passive warning/status badges no longer look like dead buttons."
+
+metadata:
+  tags:
+  - results-explorer
+  - routing
+  - copy
+  - reliability
+  estimated_effort: "Small-Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents direct links and shared compare URLs from appearing broken or
+    careless.
+  user_impact: |
+    Users can trust shared links and understand guardrail copy without
+    guessing which badges are actionable.
+  technical_debt: |
+    Centralizes route-state and microcopy edge cases that previously regressed
+    across components.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml
@@ -1,0 +1,186 @@
+id: results-explorer-followup-remediation-release-gate
+title: "Gate the Results Explorer follow-up remediation with snapshot, browser, and TODO-state evidence"
+worktree: results-explorer-followup-todo-review
+priority: Critical
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  This is the final gate for the follow-up Results Explorer remediation plan.
+  It must run after the data-contract, compare-flow, disabled-state,
+  leaderboard/rank, chart-label, theme/density, and route/copy TODOs are
+  implemented. The gate blocks completion if any P0/P1 issue from the latest
+  review still reproduces or if the new checks lack evidence.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+  - results-explorer-compare-entrypoint-happy-path-gates
+  - results-explorer-compare-disabled-recovery-states
+  - results-explorer-leaderboard-rank-evidence-semantics
+  - results-explorer-chart-run-identity-label-contract
+  - results-explorer-surface-theme-and-density-contract
+  - results-explorer-direct-route-and-copy-hardening
+
+work:
+- id: w0
+  summary: "Confirm dependency TODOs are complete with verification evidence"
+  status: pending
+  notes: |
+    Run `todo_cli.py show` or equivalent for each dependency on the checked git
+    SHA and verify every work unit is done, every verification item has output,
+    and no dependency remains in `_project/TODO`. Capture the dependency state in
+    `_project/verification-logs/results-explorer-followup-remediation-release-gate/w0.log`.
+    Decision gate: if any dependency lacks evidence, stop and return it to the
+    implementation owner.
+
+- id: w1
+  summary: "Run regenerated snapshot invariants and compare SQL smoke"
+  needs: [w0]
+  status: pending
+  notes: |
+    Regenerate or confirm the current Results Explorer DuckDB snapshot, then
+    run snapshot invariants plus SQL that reports:
+      - compare-eligible row count;
+      - cohorts with 2+ compare-eligible rows;
+      - comparison exclusion reasons;
+      - missing/unranked/ranked leaderboard states;
+      - duplicate chart labels if the formatter exposes a check.
+    Decision gate: zero compare-eligible rows, false `No run` badge states, or
+    duplicate chart labels block release.
+
+- id: w2
+  summary: "Run automated backend and frontend suites"
+  needs: [w1]
+  status: pending
+  notes: |
+    Run the targeted backend explorer pipeline tests, Results Explorer unit
+    tests, typecheck, build, and e2e/browser tests introduced by dependent
+    TODOs. Capture command status and failure tails under this gate's
+    verification log directory.
+
+- id: w3
+  summary: "Run comprehensive browser acceptance across all Results Explorer routes"
+  needs: [w2]
+  status: pending
+  notes: |
+    Restart the local dev server from the checked tree and exercise:
+      - `/results/`;
+      - `/results/<benchmark>/` Matrix, Ranks, List, and chart subtabs;
+      - `/results/p/<platform>/` filters and compare selection;
+      - `/results/query` filters, visible columns, SQL disclosure, exports,
+        and compare selection;
+      - `/results/compare` empty builder and explicit IDs;
+      - one result detail page and `Compare this result`.
+    Click every visible button/link/control at least once unless it performs an
+    external/destructive action. Record pass/fail evidence for each route.
+
+- id: w4
+  summary: "Produce final defect register and pass/fail closure artifact"
+  needs: [w3]
+  status: pending
+  notes: |
+    Write `_project/audits/results-explorer-followup-remediation-release-gate-<date>.md`
+    with:
+      - checked SHA;
+      - commands run;
+      - snapshot SQL counts;
+      - route acceptance matrix;
+      - closure status for every known issue;
+      - any new defects with severity, root cause, blind spot, and deeper
+        consideration.
+    Decision gate: any unresolved P0/P1 defect blocks moving this gate to DONE.
+
+- id: w5
+  summary: "Move completed TODOs to DONE only after the gate passes"
+  needs: [w4]
+  status: pending
+  notes: |
+    After the audit passes, use the TODO completion workflow to mark this item
+    and all dependency items Completed, move them to `_project/DONE`, reindex,
+    validate, and confirm no completed follow-up item remains in
+    `_project/TODO`. If the gate fails, leave items open and create narrowly
+    scoped follow-up TODOs for any remaining defects.
+
+prior_art:
+- "_project/DONE/main/planning/results-explorer-contract-release-gate.yaml is the prior release gate pattern."
+- "_project/scripts/todo_cli.py validates TODO schema, dependency graph, and indexes."
+- "_project/scripts/results_explorer_snapshot_invariants.py should own snapshot contract checks."
+- "results-explorer/e2e/ should contain route-level browser tests introduced by the dependent TODOs."
+
+must_preserve:
+- "No dependent TODO is marked complete without evidence from its own verification section."
+- "A P0/P1 browser-visible defect blocks this release gate."
+- "The audit names the exact checked SHA and data snapshot."
+- "TODO movement to DONE happens only after validation and graph checks pass."
+- "Unrelated source, TODO, DONE, and lock files are not modified."
+
+approach: |
+  Treat this as a release gate and bookkeeping item, not an implementation
+  task. It proves that the follow-up remediation is complete on one checked
+  tree and prevents stale TODO completion from masking unresolved defects.
+
+anti_patterns:
+- "DO NOT approve based on PR merge status alone."
+- "DO NOT rely on screenshots without route, SHA, and data snapshot evidence."
+- "DO NOT move TODOs to DONE before snapshot, automated, and browser gates pass."
+- "DO NOT fix newly discovered issues inside this gate; create focused follow-up TODOs unless the fix is trivial copy in the gate artifact."
+
+verification:
+- description: "TODO schema and graph validate"
+  command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate && uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+  expected_output: "both commands exit 0"
+- description: "Snapshot invariants pass"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "exit 0 with nonzero comparable rows and no contradictory leaderboard/rank states"
+- description: "Results Explorer frontend verification passes"
+  command: "cd results-explorer && npm test -- --run && npm run typecheck && npm run build"
+  expected_output: "all frontend checks pass"
+- description: "Browser acceptance evidence exists"
+  command: "rg -n \"Leaderboards|Benchmark|Platform|Query Workbench|Compare|Result detail|PASS|FAIL\" _project/verification-logs/results-explorer-followup-remediation-release-gate/"
+  expected_output: "logs include route acceptance evidence"
+
+scope_limit:
+  only_modify:
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-comparison-eligibility-contract-repair.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-entrypoint-happy-path-gates.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-disabled-recovery-states.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-rank-evidence-semantics.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-run-identity-label-contract.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-surface-theme-and-density-contract.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-direct-route-and-copy-hardening.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml"
+  - "_project/DONE/results-explorer-followup-todo-review/planning/"
+  - "_project/audits/results-explorer-followup-remediation-release-gate-*.md"
+  - "_project/verification-logs/results-explorer-followup-remediation-release-gate/"
+  do_not_modify:
+  - "results-explorer/src/"
+  - "benchbox/"
+  - "docs/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "All follow-up remediation TODOs are complete and moved to DONE only after evidence passes."
+- "Snapshot SQL proves compare eligibility and leaderboard/rank state semantics are valid."
+- "Browser acceptance covers every Results Explorer route and every compare entrypoint."
+- "The final audit lists no unresolved P0/P1 issues."
+
+metadata:
+  tags:
+  - results-explorer
+  - release-gate
+  - verification
+  - todo-cleanup
+  estimated_effort: "Small (0.5-1 day after dependent fixes)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents another cycle where merged PRs or completed TODOs leave the public
+    explorer with major workflow defects.
+  user_impact: |
+    Confirms the explorer is usable for discovery, filtering, comparison, and
+    evidence inspection before completion is claimed.
+  technical_debt: |
+    Adds a repeatable closure gate for future Results Explorer remediation
+    batches.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-rank-evidence-semantics.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-rank-evidence-semantics.yaml
@@ -1,0 +1,161 @@
+id: results-explorer-leaderboard-rank-evidence-semantics
+title: "Separate missing, unranked, and ranked evidence in leaderboards and rank charts"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The latest review found that leaderboard cells can say `No run` while still
+  rendering trust/validation badges, and rank charts can show large all-dash
+  matrices for cohorts where rows are present but not rankable. This exposes a
+  deeper semantic bug: the UI conflates missing evidence, published-but-
+  unranked evidence, and ranked evidence.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+
+work:
+- id: w0
+  summary: "Capture the current missing/unranked/ranked state matrix"
+  status: pending
+  notes: |
+    Query `meta_leaderboard`, `cohort_metadata`, `benchmark_rankings`, and any
+    chart source tables on the checked git SHA and current snapshot. Capture
+    SQL, snapshot path/checksum, row counts, and sample cells where:
+      - `rank IS NULL` and metric data exists;
+      - `rank IS NULL` and no metric data exists;
+      - `rank IS NOT NULL`;
+      - trust or validation badges exist with no rank.
+    Store SQL and row counts in
+    `_project/verification-logs/results-explorer-leaderboard-rank-evidence-semantics/w0.log`.
+
+- id: w1
+  summary: "Define the display contract for missing, unranked, and ranked states"
+  needs: [w0]
+  status: pending
+  notes: |
+    Document exact UI states:
+      - Missing run: no metric, no result link, no trust badges, copy `No run`;
+      - Published but unranked: metric/result exists, no rank, copy
+        `Unranked` or `Excluded`, show reason and optional receipt link;
+      - Ranked: rank and metric displayed with eligibility badges.
+    Decision gate: do not edit components until the contract is documented in
+    implementation notes and accepted by tests.
+
+- id: w2
+  summary: "Update cross-benchmark leaderboard cells to honor the state contract"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update the meta leaderboard so `No run` cells never render trust or
+    validation badges. If a result exists but is unranked, show explicit
+    `Unranked` or `Excluded` state with the reason and a link to the result or
+    receipt only when that link is real.
+
+- id: w3
+  summary: "Update rank charts to avoid authoritative all-dash matrices"
+  needs: [w1]
+  status: pending
+  notes: |
+    Rank charts should require rankable cells before rendering a rank matrix.
+    If every row is unranked/excluded, show an empty state with the dominant
+    exclusion reasons and a link or affordance to inspect submitted evidence.
+    In mixed cohorts, separate or visually de-emphasize excluded rows so they
+    do not read as rankable competitors with missing data.
+
+- id: w4
+  summary: "Add invariant and component tests for contradictory evidence states"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests that fail when:
+      - `No run` renders badges or links;
+      - an unranked result is labelled as missing;
+      - an all-unrankable rank chart renders a normal rank matrix;
+      - rank chart and leaderboard disagree about the same cell state.
+
+- id: w5
+  summary: "Browser-check leaderboard and rank chart semantics"
+  needs: [w4]
+  status: pending
+  notes: |
+    In the browser, check `/results/`, one benchmark rank tab with unranked
+    rows, and one normal ranked benchmark. Capture screenshots or text logs.
+    Decision gate: do not complete if any visible `No run` cell still contains
+    provenance badges or if any all-unrankable cohort appears as a normal rank
+    leaderboard.
+
+prior_art:
+- "results-explorer/src/components/MetaLeaderboard.tsx renders cross-benchmark cells and badge metadata."
+- "results-explorer/src/components/RankTable.tsx and results-explorer/src/components/ChartPanel.tsx own benchmark rank-chart rendering."
+- "results-explorer/src/lib/duckdbQueries.ts provides meta leaderboard and chart rows."
+- "_project/scripts/results_explorer_snapshot_invariants.py should include contradictory cell-state checks."
+
+must_preserve:
+- "True missing runs stay visually lightweight and do not imply submission evidence."
+- "Published but unranked runs remain discoverable for provenance."
+- "Ranked cohorts keep existing rank ordering and metric display."
+- "The same result/cohort state renders consistently across leaderboard, rank chart, and detail pages."
+
+approach: |
+  Treat missing/unranked/ranked as first-class display states. Add data
+  invariants, then update components and charts to consume the explicit state.
+
+anti_patterns:
+- "DO NOT show trust or validation badges inside a `No run` cell."
+- "DO NOT hide unranked submitted evidence entirely; users need to audit why it was excluded."
+- "DO NOT render a rank chart when no row has a rankable value."
+- "DO NOT infer missing state from `rank == null` alone."
+
+verification:
+- description: "Leaderboard and rank component tests pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/MetaLeaderboard.test.tsx src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/charts.smoke.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Snapshot cell-state invariants pass"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "exit 0 and no `No run` cells have badge/link metadata"
+- description: "Browser evidence covers both missing and unranked states"
+  command: "rg -n \"No run|Unranked|Excluded|rank chart|PASS|FAIL\" _project/verification-logs/results-explorer-leaderboard-rank-evidence-semantics/"
+  expected_output: "logs include pass/fail evidence for leaderboard and rank chart states"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/components/MetaLeaderboard.tsx"
+  - "results-explorer/src/components/RankTable.tsx"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/src/lib/displayEligibility.ts"
+  - "results-explorer/src/components/__tests__/"
+  - "_project/scripts/results_explorer_snapshot_invariants.py"
+  - "_project/verification-logs/results-explorer-leaderboard-rank-evidence-semantics/"
+  do_not_modify:
+  - "benchbox/core/results/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "`No run` never appears with trust, validation, receipt, or result-link badges."
+- "Published but unranked cells are explicitly labelled and explain why they are excluded."
+- "All-unrankable rank charts show an explanatory empty state instead of a normal matrix."
+- "Leaderboard and rank chart tests share the same display-state fixtures."
+
+metadata:
+  tags:
+  - results-explorer
+  - leaderboard
+  - rank
+  - evidence
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents public rankings from implying that missing, excluded, and valid
+    evidence are interchangeable.
+  user_impact: |
+    Analysts can distinguish absent coverage from submitted-but-unranked
+    results.
+  technical_debt: |
+    Establishes a shared cell-state contract instead of scattered rank-null
+    checks.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-surface-theme-and-density-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-surface-theme-and-density-contract.yaml
@@ -1,0 +1,170 @@
+id: results-explorer-surface-theme-and-density-contract
+title: "Define and enforce Results Explorer theme and dense-table surface contracts"
+worktree: results-explorer-followup-todo-review
+priority: Medium
+status: Not Started
+category: User Experience
+
+description: |
+  The latest review still found mixed theme surfaces and density traps: dark
+  chrome over light analytical bodies without an explicit design contract, and
+  benchmark matrices whose frozen region remains tall because platform,
+  version, trust, validation, and receipt details compete for primary row
+  space. This TODO sets small, enforceable UI contracts rather than one-off CSS
+  fixes.
+
+deps:
+  needs: []
+
+work:
+- id: w0
+  summary: "Rebind theme and density evidence, then document the surface contract"
+  status: pending
+  notes: |
+    On the checked git SHA, inspect `/results/`, `/results/<benchmark>/`,
+    `/results/p/<platform>/`, `/results/query`, `/results/compare`, and one
+    result detail route at desktop and one narrow viewport. Capture route,
+    viewport, screenshot/text evidence, row-height measurements, sticky
+    alignment state, receipt/provenance reachability, and the specific theme
+    mismatch or density trap in
+    `_project/verification-logs/results-explorer-surface-theme-and-density-contract/w0.log`.
+    Then decide whether the Results Explorer should be:
+      - dark analytical app throughout; or
+      - dark global chrome with a light data workspace.
+    Document the chosen rule in implementation notes and, if appropriate, a
+    small UI README or test fixture. Decision gate: no theme edits until the
+    contract is explicit, because mixed dark/light surfaces can be intentional
+    only if applied consistently.
+
+- id: w1
+  summary: "Apply the theme contract to all Results Explorer routes"
+  needs: [w0]
+  status: pending
+  notes: |
+    Check `/results/`, `/results/<benchmark>/`, `/results/p/<platform>/`,
+    `/results/query`, `/results/compare`, and result detail pages. Ensure
+    backgrounds, cards, controls, tables, chart panels, and error/empty states
+    follow the chosen contract. Remove isolated route-level overrides that
+    produce chrome/body mismatch.
+
+- id: w2
+  summary: "Define the benchmark matrix frozen-region density contract"
+  needs: [w0]
+  status: pending
+  notes: |
+    Decide the maximum primary frozen columns and row height budget for
+    benchmark matrices. Recommended contract:
+      - selection checkbox;
+      - compact platform/run identity;
+      - one primary score or geomean column;
+      - trust, validation, version, receipt, and source details behind compact
+        metadata, hover, or row expansion.
+    Decision gate: do not move metadata until tests identify which fields must
+    remain visible for auditability.
+
+- id: w3
+  summary: "Move secondary metadata out of the default frozen row stack"
+  needs: [w2]
+  status: pending
+  notes: |
+    Update benchmark matrix rows so trust badges, validation state, platform
+    version, and receipt links do not force tall rows in the frozen region.
+    Keep receipt/provenance reachable through a compact details affordance or
+    row expansion. Verify sticky headers and frozen columns stay aligned while
+    horizontally scrolling query columns.
+
+- id: w4
+  summary: "Add visual and DOM assertions for theme and density"
+  needs: [w1, w3]
+  status: pending
+  notes: |
+    Add tests or browser smoke checks asserting:
+      - no route violates the chosen surface theme contract;
+      - benchmark matrix row height stays within the documented budget;
+      - frozen columns and scrolled query headers remain aligned;
+      - receipt/provenance remains reachable after metadata compaction.
+
+- id: w5
+  summary: "Browser-check standard desktop and one narrow viewport"
+  needs: [w4]
+  status: pending
+  notes: |
+    Capture standard desktop evidence for all routes and a narrow viewport
+    spot check for the benchmark matrix. Decision gate: do not complete if
+    theme mismatch remains unexplained or if metadata compaction hides receipt
+    access.
+
+prior_art:
+- "results-explorer/src/index.css and route/component class names define global surface tokens."
+- "results-explorer/src/pages/BenchmarkIndex.tsx renders benchmark matrix rows and frozen columns."
+- "results-explorer/src/components/QueryHeatmap.tsx or matrix components own sticky/frozen behavior."
+- "results-explorer/src/components/RunReceipt.tsx and result detail pages provide provenance destinations."
+
+must_preserve:
+- "Receipt and provenance access remain available from matrix rows."
+- "Theme changes do not reduce contrast below WCAG AA for table text and controls."
+- "Dense rows remain readable and keyboard navigable."
+- "Sticky headers and frozen columns remain aligned during horizontal scroll."
+
+approach: |
+  Make the contract explicit first, then enforce it route by route. Treat row
+  density as information architecture: primary cells stay primary, secondary
+  provenance moves into a compact affordance.
+
+anti_patterns:
+- "DO NOT chase isolated colors without deciding the overall surface contract."
+- "DO NOT remove trust or receipt data to gain density; move it to a lower-priority affordance."
+- "DO NOT fix row height by shrinking text below usable size."
+- "DO NOT accept screenshots only at one scroll position; sticky alignment must be checked after horizontal scroll."
+
+verification:
+- description: "Frontend tests covering benchmark matrix and route layout pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkIndex.test.tsx src/components/__tests__/QueryHeatmap.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend build and typecheck pass"
+  command: "cd results-explorer && npm run typecheck && npm run build"
+  expected_output: "both commands exit 0"
+- description: "Browser evidence confirms theme and density contracts"
+  command: "rg -n \"theme contract|row height|sticky alignment|receipt|PASS|FAIL\" _project/verification-logs/results-explorer-surface-theme-and-density-contract/"
+  expected_output: "logs include route and benchmark matrix evidence"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/index.css"
+  - "results-explorer/src/App.tsx"
+  - "results-explorer/src/pages/"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/components/RunIdentity.tsx"
+  - "results-explorer/src/components/RunReceipt.tsx"
+  - "results-explorer/src/components/__tests__/"
+  - "results-explorer/src/pages/__tests__/"
+  - "_project/verification-logs/results-explorer-surface-theme-and-density-contract/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "Every Results Explorer route follows one documented theme surface contract."
+- "Benchmark matrix frozen rows no longer stack version, trust, validation, and receipt as primary row content."
+- "Horizontal query scrolling keeps headers, frozen cells, and body cells aligned."
+- "Provenance remains reachable from compact rows."
+
+metadata:
+  tags:
+  - results-explorer
+  - theme
+  - density
+  - benchmark-matrix
+  estimated_effort: "Medium (2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Improves perceived polish and information throughput without changing the
+    site architecture.
+  user_impact: |
+    Analysts can scan benchmark matrices faster and avoid context-switching
+    caused by inconsistent visual surfaces.
+  technical_debt: |
+    Turns theme and density preferences into testable contracts instead of
+    screenshot-specific fixes.


### PR DESCRIPTION
## Summary
- Moved the eight Results Explorer follow-up TODOs out of `main/planning` into the claimed `results-explorer-followup-todo-review` worktree bucket.
- Repaired review findings across the TODO set: worktree/path mismatch, unbound review/snapshot evidence, missing evidence-before-edit dependencies, stale prior-art paths, nonexistent scope paths, and fragile verification commands.
- Kept the release-gate TODO aligned with the moved TODO/DONE paths for this worktree.

## Validation
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/results-explorer-followup-todo-review/planning`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex`
- `make pr-preflight` (`/tmp/results-explorer-followup-todo-review-pr-preflight.log`, status 0)