### PR TITLE
chore(todo): add results explorer UI follow-up contracts

### DIFF
--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-dataset-eligibility-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-dataset-eligibility-contract.yaml
@@ -1,0 +1,199 @@
+id: results-explorer-chart-dataset-eligibility-contract
+title: "Apply eligibility and evidence contracts to every Results Explorer chart dataset"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  Earlier TODOs cover comparison eligibility and rank-chart empty states, but
+  the UI review also found obviously broken AMPLab results included in
+  distribution and chart views. That needs a chart-wide dataset contract, not a
+  rank-only fix. Every chart should declare whether it consumes display-safe,
+  rank-safe, compare-safe, or provenance-only rows, and it should show an empty
+  or excluded-data state when the required evidence is absent.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+  - results-explorer-leaderboard-rank-evidence-semantics
+  - results-explorer-chart-run-identity-label-contract
+
+work:
+- id: w0
+  summary: "Inventory chart data sources and eligibility assumptions"
+  status: pending
+  notes: |
+    For each chart/subtab, document the source query/table and current row
+    filters:
+      - benchmark Overview Performance, Power, Summary, Phases, Sparklines;
+      - Per-query Heatmap and Histogram;
+      - Distribution Box Plot, Percentiles, CDF;
+      - Cost;
+      - Trend;
+      - Rank;
+      - Compare Overview, Per-query, Distribution, and Rank.
+    Record whether invalid/no-timing/unranked/no-query rows currently enter
+    each dataset. Store SQL, route, chart, and sample row evidence in
+    `_project/verification-logs/results-explorer-chart-dataset-eligibility-contract/w0.log`.
+
+- id: w1
+  summary: "Define chart dataset eligibility classes"
+  needs: [w0]
+  status: pending
+  notes: |
+    Define eligibility classes for charts:
+      - display-safe timing chart;
+      - rank-safe chart;
+      - compare-safe chart;
+      - cost-safe chart;
+      - trend-safe chart with stable time axis;
+      - provenance-only excluded-data disclosure.
+    For each chart, document its required class and empty-state behavior. The
+    AMPLab broken-results case must be explicitly assigned to excluded-data or
+    empty-state behavior for every affected chart. Decision gate: no chart code
+    changes until this matrix is documented.
+
+- id: w2
+  summary: "Filter chart queries through the required eligibility class"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update chart query helpers and component inputs so each chart receives only
+    rows matching its declared eligibility class. Preserve excluded rows in a
+    separate disclosure or receipt path when they have provenance value. Do not
+    let chart components silently drop rows without exposing dominant exclusion
+    reasons somewhere on the page.
+
+- id: w3
+  summary: "Add chart empty states and excluded-data summaries"
+  needs: [w2]
+  status: pending
+  notes: |
+    For every chart class, add an empty state that names the missing evidence,
+    such as `No rankable rows for this cohort`, `No valid display timings`, or
+    `No comparable query evidence`. Include counts by exclusion reason when the
+    dataset has submitted rows that are excluded. Avoid rendering all-dash
+    matrices, one-pixel box plots, or misleading winner/tail summaries from
+    insufficient data.
+
+- id: w4
+  summary: "Add fixtures and tests for broken-result chart exclusion"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests using AMPLab-like data with missing timings, zero timings, and
+    unranked submissions. Assert:
+      - distribution charts exclude invalid/no-timing rows;
+      - sparklines and per-query charts only include display-safe rows;
+      - rank charts require rank-safe rows;
+      - compare charts require compare-safe selected rows;
+      - empty states list exclusion reasons instead of rendering misleading
+        chart artifacts.
+
+- id: w5
+  summary: "Browser-check chart subtabs across benchmark and compare routes"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser, inspect every benchmark chart tab/subtab and Compare chart
+    tab using at least one normal cohort and one broken/low-evidence cohort.
+    Click every chart subtab. Decision gate: do not complete if any chart
+    includes invalid evidence as a normal data point, renders an all-dash/empty
+    artifact without explanation, or contradicts the eligibility state shown in
+    the table for the same rows.
+
+prior_art:
+- "results-explorer/src/lib/chartRegistry.ts maps chart tabs and datasets."
+- "results-explorer/src/components/ChartPanel.tsx owns benchmark chart layout and tab switching."
+- "results-explorer/src/components/QueryHeatmap.tsx, DistributionBox.tsx, PercentileLadder.tsx, CDFChart.tsx, CostScatter.tsx, TimeSeries.tsx, and RankTable.tsx render chart families that need class-specific empty states."
+- "results-explorer/src/lib/duckdbQueries.ts provides chart rows and should apply eligibility filters."
+- "results-explorer/src/lib/displayEligibility.ts or equivalent should supply shared eligibility predicates."
+
+must_preserve:
+- "Excluded submitted rows remain auditable through receipt/provenance paths."
+- "Charts must not contradict table row eligibility for the same cohort."
+- "Chart filtering must use read-model eligibility fields, not inferred display strings."
+- "Normal high-evidence cohorts should keep existing chart functionality and interactivity."
+
+approach: |
+  Build a chart-to-eligibility matrix, then route all chart datasets through the
+  matrix. The goal is not to hide bad data; it is to keep invalid evidence out
+  of analytical charts while giving users a visible explanation of what was
+  excluded.
+
+anti_patterns:
+- "DO NOT fix only the AMPLab screenshot path; all chart families need an eligibility class."
+- "DO NOT render a one-pixel or all-dash chart as an empty state."
+- "DO NOT filter invalid rows silently without exposing exclusion counts."
+- "DO NOT duplicate eligibility predicates inside chart components."
+
+verification:
+- description: "Chart eligibility tests pass"
+  command: "cd results-explorer && npm test -- --run src/__tests__/chartRegistry.meta.test.ts src/__tests__/chartRegistry.parity.test.ts src/components/__tests__/ChartPanel.test.tsx src/components/__tests__/charts.smoke.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Frontend typecheck and build pass"
+  command: "cd results-explorer && npm run typecheck && npm run build"
+  expected_output: "both commands exit 0"
+- description: "Browser evidence covers every chart tab and subtab"
+  command: "rg -n \"Overview|Per-query|Distribution|Cost|Trend|Rank|excluded|empty state|PASS|FAIL\" _project/verification-logs/results-explorer-chart-dataset-eligibility-contract/"
+  expected_output: "logs include chart-tab evidence for normal and low-evidence cohorts"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/lib/chartRegistry.ts"
+  - "results-explorer/src/lib/displayEligibility.ts"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/components/CostScatter.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/PercentileLadder.tsx"
+  - "results-explorer/src/components/PowerBar.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/components/QueryHistogram.tsx"
+  - "results-explorer/src/components/QueryTimingChart.tsx"
+  - "results-explorer/src/components/RankTable.tsx"
+  - "results-explorer/src/components/SparklineTable.tsx"
+  - "results-explorer/src/components/StackedPhase.tsx"
+  - "results-explorer/src/components/TimeSeries.tsx"
+  - "results-explorer/src/components/__tests__/ChartPanel.test.tsx"
+  - "results-explorer/src/components/__tests__/DistributionBox.test.tsx"
+  - "results-explorer/src/components/__tests__/NormalizedSpeedupChart.test.tsx"
+  - "results-explorer/src/components/__tests__/QueryDiffTable.test.tsx"
+  - "results-explorer/src/components/__tests__/QueryHeatmap.test.tsx"
+  - "results-explorer/src/components/__tests__/RankTable.test.tsx"
+  - "results-explorer/src/components/__tests__/charts.smoke.test.tsx"
+  - "results-explorer/src/__tests__/chartRegistry.meta.test.ts"
+  - "results-explorer/src/__tests__/chartRegistry.parity.test.ts"
+  - "_project/verification-logs/results-explorer-chart-dataset-eligibility-contract/"
+  do_not_modify:
+  - "benchbox/core/results/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "Every chart declares and uses one eligibility class."
+- "Broken/no-timing rows no longer appear as normal chart data points."
+- "Low-evidence chart states explain what was excluded and why."
+- "Benchmark and Compare charts agree with table eligibility for the same rows."
+
+metadata:
+  tags:
+  - results-explorer
+  - charts
+  - eligibility
+  - evidence
+  estimated_effort: "Medium-Large (2-3 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents analytical charts from making claims from invalid or insufficient
+    evidence.
+  user_impact: |
+    Users see clear empty/excluded states instead of misleading chart artifacts.
+  technical_debt: |
+    Centralizes chart dataset eligibility and removes per-chart implicit
+    filtering rules.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-warning-affordance-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-warning-affordance-contract.yaml
@@ -1,0 +1,179 @@
+id: results-explorer-compare-warning-affordance-contract
+title: "Make Compare warning counts actionable, localized, and consistent"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  Compare guardrail badges can look like buttons without being clickable, and
+  warning counts do not reliably show users where the actual warnings live.
+  Copy issues such as `1 warnings` and duplicated punctuation point to the same
+  deeper issue: warning state is not represented as a structured UI contract.
+
+  This TODO makes warning counts actionable when they imply action, passive
+  when they are only labels, and consistent across guardrails, decision
+  summaries, receipts, shareable URLs, and browser reloads.
+
+deps:
+  needs:
+  - results-explorer-compare-entrypoint-happy-path-gates
+  - results-explorer-compare-disabled-recovery-states
+  - results-explorer-direct-route-and-copy-hardening
+
+work:
+- id: w0
+  summary: "Inventory Compare warning sources, badges, and receipt anchors"
+  status: pending
+  notes: |
+    Inspect Compare with zero warnings, one warning, and multiple warnings.
+    Capture:
+      - warning reason codes and display strings;
+      - guardrail summary badges;
+      - decision summary badges;
+      - comparability receipt sections;
+      - anchor/link targets;
+      - reload/share URL behavior.
+    Store route URLs, selected IDs, DOM text, and screenshots in
+    `_project/verification-logs/results-explorer-compare-warning-affordance-contract/w0.log`.
+
+- id: w1
+  summary: "Define Compare warning UI states and interactions"
+  needs: [w0]
+  status: pending
+  notes: |
+    Define states for:
+      - no warnings;
+      - one warning;
+      - multiple warnings with grouped categories;
+      - blocking incompatibility vs non-blocking warning;
+      - passive computed-from-selected-runs label.
+    For each state, specify whether the visible pill/badge is a button/link or
+    passive text. Decision gate: anything styled as a button must have an
+    action, and anything with a warning count must reveal or navigate to the
+    underlying warnings.
+
+- id: w2
+  summary: "Implement structured warning summary and anchors"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update Compare guardrails and receipt components so warning counts use a
+    shared formatter and anchor model. Clicking a warning count should scroll
+    or focus the Comparability Receipt warning section. The target section must
+    be keyboard-focusable and preserve focus after navigation. Passive labels
+    such as `Computed from selected runs` must be restyled so they do not look
+    like clickable controls.
+
+- id: w3
+  summary: "Centralize warning copy, pluralization, and punctuation"
+  needs: [w1]
+  status: pending
+  notes: |
+    Move warning count formatting, reason titles, reason detail copy, and
+    punctuation into a shared formatter. Cover singular/plural labels,
+    sentence-final punctuation, repeated punctuation, and category summaries.
+    This can reuse `copyFormatters` if introduced by route/copy hardening.
+
+- id: w4
+  summary: "Add accessibility, reload, and interaction tests"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests for:
+      - one warning renders `1 warning`;
+      - multiple warnings render `N warnings`;
+      - clicking the count focuses or scrolls to receipt warnings;
+      - passive labels are not buttons and do not have button styling;
+      - share URL reload preserves warning state and anchors;
+      - screen-reader labels distinguish blocking errors from non-blocking
+        warnings.
+    If no Compare-specific a11y test files exist yet, create focused tests for
+    `Compare` and `ComparabilityReceipt` rather than relying on broad glob
+    commands that may miss the affected components.
+
+- id: w5
+  summary: "Browser-check warning affordances in Compare"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser, complete Compare flows that yield zero, one, and multiple
+    warnings. Click every visible warning badge/link, reload the share URL, and
+    verify the warning targets remain reachable. Decision gate: do not complete
+    if any warning-looking pill is inert, if warning counts fail to reveal
+    details, or if pluralization/punctuation defects remain.
+
+prior_art:
+- "results-explorer/src/pages/Compare.tsx renders Compare guardrail and decision summary surfaces."
+- "results-explorer/src/components/ComparabilityReceipt.tsx renders detailed warning evidence."
+- "results-explorer/src/lib/compareSummary.ts generates warning and winner summary state."
+- "results-explorer/src/lib/copyFormatters.ts should own shared count/pluralization copy if present."
+
+must_preserve:
+- "Shareable Compare URLs continue to reload selected IDs and warning state."
+- "Warning links must not change selected runs or baseline state."
+- "Blocking incompatibilities remain visually distinct from non-blocking warnings."
+- "Keyboard and screen-reader users can reach the warning details."
+
+approach: |
+  Treat warnings as structured state with reason codes, counts, severity, and
+  target anchors. Then render interactive controls only when they actually move
+  the user to the warning evidence.
+
+anti_patterns:
+- "DO NOT style passive status pills like buttons."
+- "DO NOT show a warning count without a way to inspect the warnings."
+- "DO NOT duplicate pluralization and punctuation in separate components."
+- "DO NOT make warning links depend on transient scroll position or unmounted receipt content."
+
+verification:
+- description: "Compare warning tests pass"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Compare.test.tsx src/components/__tests__/ComparabilityReceipt.test.tsx src/lib/__tests__/compareSummary.test.ts"
+  expected_output: "all targeted tests pass"
+- description: "Accessibility tests cover warning affordances"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Compare.a11y.test.tsx src/components/__tests__/ComparabilityReceipt.a11y.test.tsx"
+  expected_output: "Compare-specific accessibility tests pass"
+- description: "Browser evidence confirms warning counts are actionable"
+  command: "rg -n \"0 warnings|1 warning|warnings|receipt|focus|passive label|PASS|FAIL\" _project/verification-logs/results-explorer-compare-warning-affordance-contract/"
+  expected_output: "logs include pass/fail evidence for zero, one, and multiple warning states"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/components/ComparabilityReceipt.tsx"
+  - "results-explorer/src/lib/compareSummary.ts"
+  - "results-explorer/src/lib/copyFormatters.ts"
+  - "results-explorer/src/pages/__tests__/Compare.test.tsx"
+  - "results-explorer/src/pages/__tests__/Compare.a11y.test.tsx"
+  - "results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx"
+  - "results-explorer/src/components/__tests__/ComparabilityReceipt.a11y.test.tsx"
+  - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+  - "_project/verification-logs/results-explorer-compare-warning-affordance-contract/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "Warning counts reveal or navigate to the actual warning details."
+- "Passive labels no longer look like dead buttons."
+- "`1 warning`, `N warnings`, and punctuation are consistent across Compare surfaces."
+- "Warning affordances work after share URL reload and are keyboard accessible."
+
+metadata:
+  tags:
+  - results-explorer
+  - compare
+  - warnings
+  - accessibility
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Makes compare guardrails auditable instead of decorative.
+  user_impact: |
+    Users can understand and inspect warnings before trusting comparison
+    claims.
+  technical_debt: |
+    Replaces scattered warning-count copy with a structured warning UI
+    contract.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml
@@ -8,9 +8,10 @@ category: Testing and Quality Assurance
 description: |
   This is the final gate for the follow-up Results Explorer remediation plan.
   It must run after the data-contract, compare-flow, disabled-state,
-  leaderboard/rank, chart-label, theme/density, and route/copy TODOs are
-  implemented. The gate blocks completion if any P0/P1 issue from the latest
-  review still reproduces or if the new checks lack evidence.
+  leaderboard/rank, leaderboard-scope, chart-label, chart-dataset,
+  metric-formatting, warning-affordance, theme/density, and route/copy TODOs
+  are implemented. The gate blocks completion if any P0/P1 issue from the
+  latest review still reproduces or if the new checks lack evidence.
 
 deps:
   needs:
@@ -18,7 +19,11 @@ deps:
   - results-explorer-compare-entrypoint-happy-path-gates
   - results-explorer-compare-disabled-recovery-states
   - results-explorer-leaderboard-rank-evidence-semantics
+  - results-explorer-leaderboard-scope-filter-contract
   - results-explorer-chart-run-identity-label-contract
+  - results-explorer-chart-dataset-eligibility-contract
+  - results-explorer-metric-formatting-contract
+  - results-explorer-compare-warning-affordance-contract
   - results-explorer-surface-theme-and-density-contract
   - results-explorer-direct-route-and-copy-hardening
 
@@ -45,9 +50,16 @@ work:
       - cohorts with 2+ compare-eligible rows;
       - comparison exclusion reasons;
       - missing/unranked/ranked leaderboard states;
-      - duplicate chart labels if the formatter exposes a check.
-    Decision gate: zero compare-eligible rows, false `No run` badge states, or
-    duplicate chart labels block release.
+      - leaderboard benchmark/platform/tuning scope counts;
+      - duplicate chart labels if the formatter exposes a check;
+      - chart dataset eligibility counts by chart class;
+      - metric-formatting samples for large scores, latency, coverage, and
+        speedup;
+      - compare warning counts and receipt-anchor targets.
+    Decision gate: zero compare-eligible rows, false `No run` badge states,
+    unexplained leaderboard scope counts, duplicate chart labels, invalid chart
+    datasets, misleading metric formatting, or inert warning affordances block
+    release.
 
 - id: w2
   summary: "Run automated backend and frontend suites"
@@ -73,7 +85,9 @@ work:
       - `/results/compare` empty builder and explicit IDs;
       - one result detail page and `Compare this result`.
     Click every visible button/link/control at least once unless it performs an
-    external/destructive action. Record pass/fail evidence for each route.
+    external/destructive action. Record pass/fail evidence for each route,
+    including leaderboard scope explanations, metric formatting, all chart
+    dataset empty/excluded states, and Compare warning anchors.
 
 - id: w4
   summary: "Produce final defect register and pass/fail closure artifact"
@@ -146,7 +160,11 @@ scope_limit:
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-entrypoint-happy-path-gates.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-disabled-recovery-states.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-rank-evidence-semantics.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-scope-filter-contract.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-run-identity-label-contract.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-chart-dataset-eligibility-contract.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-metric-formatting-contract.yaml"
+  - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-compare-warning-affordance-contract.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-surface-theme-and-density-contract.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-direct-route-and-copy-hardening.yaml"
   - "_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-followup-remediation-release-gate.yaml"
@@ -162,7 +180,8 @@ scope_limit:
 success_metrics:
 - "All follow-up remediation TODOs are complete and moved to DONE only after evidence passes."
 - "Snapshot SQL proves compare eligibility and leaderboard/rank state semantics are valid."
-- "Browser acceptance covers every Results Explorer route and every compare entrypoint."
+- "Browser acceptance covers every Results Explorer route, chart tab, warning affordance, and compare entrypoint."
+- "Leaderboard scope counts, metric formatting, chart eligibility, and warning interactions are explicitly checked."
 - "The final audit lists no unresolved P0/P1 issues."
 
 metadata:

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-scope-filter-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-leaderboard-scope-filter-contract.yaml
@@ -1,0 +1,195 @@
+id: results-explorer-leaderboard-scope-filter-contract
+title: "Make Results Explorer leaderboard scope, filter availability, and tuning labels explicit"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The latest review raised unresolved UI questions on the Leaderboards page:
+  only SSB and TPC-H appear in the benchmark filter, only four platforms render
+  in the cross-benchmark table, and the tuning filter shows `All tuning`
+  without explaining whether tuning labels are absent, hidden, or collapsed.
+  These are not just copy issues. They reveal a scope contract gap between the
+  corpus, the rankable leaderboard subset, the public-coverage subset, and the
+  filter controls.
+
+  This TODO makes the homepage leaderboard scope auditable and explicit. Users
+  should understand why an option is present, absent, disabled, or counted, and
+  the UI should not silently imply that the whole corpus is represented when it
+  is only showing rankable/public-coverage cohorts.
+
+deps:
+  needs:
+  - results-explorer-leaderboard-rank-evidence-semantics
+
+work:
+- id: w0
+  summary: "Rebind leaderboard scope evidence on the checked snapshot"
+  status: pending
+  notes: |
+    Query the current DuckDB snapshot on the checked git SHA and capture:
+      - total benchmark count in the corpus;
+      - benchmarks with any published result;
+      - benchmarks with rankable cohorts;
+      - benchmarks included in the cross-benchmark leaderboard;
+      - total platform count in the corpus;
+      - platforms with any public result;
+      - platforms included in the visible leaderboard table;
+      - tuning mode values, including null/empty/unknown counts.
+    Store SQL, snapshot path/checksum, checked SHA, and output in
+    `_project/verification-logs/results-explorer-leaderboard-scope-filter-contract/w0.log`.
+    Decision gate: if the UI intentionally shows only rankable/public-coverage
+    cohorts, record the exact inclusion rule before editing controls.
+
+- id: w1
+  summary: "Define filter option states and scope copy"
+  needs: [w0]
+  status: pending
+  notes: |
+    Define a small homepage contract for each filter family:
+      - visible selectable option;
+      - disabled option with explanation;
+      - omitted option with explicit count in scope copy;
+      - empty/unknown tuning label;
+      - public-coverage vs full-corpus counts.
+    The header and table count must answer the observed questions directly:
+    why only these benchmarks, why only these platforms, and whether tuning
+    labels are unavailable or filtered out. Decision gate: do not implement
+    until the contract names the denominator for every displayed count.
+
+- id: w2
+  summary: "Update benchmark and platform filters to expose availability"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update the Leaderboards filters so users can see whether SSB/TPC-H are the
+    only eligible leaderboard cohorts or merely the currently selected subset.
+    If other benchmarks/platforms exist but are not leaderboard-eligible, show
+    a compact availability message or disabled options with reason text instead
+    of silently omitting them. Counts such as `Showing 4 of 4 platforms` must
+    specify the denominator, for example `4 leaderboard-eligible platforms`
+    when the full corpus is larger.
+
+- id: w3
+  summary: "Add explicit tuning-mode labels and unknown handling"
+  needs: [w1]
+  status: pending
+  notes: |
+    Replace ambiguous `All tuning` with copy that distinguishes all tuning
+    modes from unknown/unlabelled tuning metadata. If tuning labels are absent
+    for the visible cohorts, show `Tuning: not labelled` or an equivalent
+    passive state with a short explanation. If tuning labels exist, expose
+    selectable labels and counts without changing the cohort metric contract.
+
+- id: w4
+  summary: "Add tests for leaderboard scope counts and filter states"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Add tests for:
+      - full corpus contains more benchmarks/platforms than leaderboard scope;
+      - filters show, disable, or explain unavailable options according to the
+        contract;
+      - tuning labels render labelled and unlabelled states correctly;
+      - table count copy names the correct denominator;
+      - changing filters updates counts without implying hidden full-corpus
+        coverage.
+    Include one fixture where the full corpus contains benchmarks/platforms
+    that are not leaderboard-eligible, so the test proves the scope copy rather
+    than simply matching the current small seed corpus.
+
+- id: w5
+  summary: "Browser-check the Leaderboards page answers the scope questions"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser at standard desktop width, verify the Leaderboards page
+    answers:
+      - why the benchmark filter has the displayed options;
+      - why the table has the displayed platforms;
+      - what `public coverage` means for the current table;
+      - whether tuning metadata is labelled or unavailable.
+    Capture text evidence and screenshots in the verification log directory.
+    Decision gate: do not complete if the page still leaves those questions to
+    inference or if counts disagree with the SQL from w0.
+
+prior_art:
+- "results-explorer/src/components/MetaLeaderboard.tsx renders the cross-benchmark leaderboard and scope counts."
+- "results-explorer/src/lib/duckdbQueries.ts owns leaderboard, cohort, platform, and filter option queries."
+- "docs/development/browser-duckdb-schema.sql documents table fields that can expose corpus vs leaderboard scope."
+- "_project/scripts/results_explorer_snapshot_invariants.py can host count consistency checks."
+
+must_preserve:
+- "Do not broaden the leaderboard to unrankable or non-public cohorts just to make filters look complete."
+- "Do not hide the distinction between full corpus, public result corpus, and leaderboard-eligible subset."
+- "Do not remove existing benchmark, scale, phase, trust, tuning, date, or deployment filters."
+- "Counts shown in the UI must be derivable from the current snapshot."
+
+approach: |
+  Treat filter options as evidence states, not static lists. First identify the
+  denominator and inclusion rule from the snapshot, then update filter copy and
+  option states so the visible UI can explain its scope.
+
+anti_patterns:
+- "DO NOT add a generic `limited data` note without naming which denominator is limited."
+- "DO NOT silently omit unavailable benchmarks or platforms when the UI claims `All benchmarks` or `All public coverage`."
+- "DO NOT use tuning labels as free-form display strings without normalizing empty and unknown values."
+- "DO NOT make disabled options look selectable."
+
+verification:
+- description: "Leaderboard scope and filter tests pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/MetaLeaderboard.test.tsx src/pages/__tests__/Home.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Snapshot scope/count invariants pass"
+  command: "uv run -- python _project/scripts/results_explorer_snapshot_invariants.py results-explorer/public/data/results.duckdb"
+  expected_output: "exit 0 with consistent leaderboard scope, platform, benchmark, and tuning counts"
+- description: "Browser evidence confirms scope questions are answered"
+  command: "rg -n \"benchmark options|platform scope|public coverage|tuning|PASS|FAIL\" _project/verification-logs/results-explorer-leaderboard-scope-filter-contract/"
+  expected_output: "logs include pass/fail evidence for benchmark, platform, public-coverage, and tuning explanations"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/components/MetaLeaderboard.tsx"
+  - "results-explorer/src/pages/Home.tsx"
+  - "results-explorer/src/lib/duckdbQueries.ts"
+  - "results-explorer/src/lib/copyFormatters.ts"
+  - "results-explorer/src/lib/facetDisplay.ts"
+  - "results-explorer/src/lib/displayLabels.ts"
+  - "results-explorer/src/components/__tests__/MetaLeaderboard.test.tsx"
+  - "results-explorer/src/components/__tests__/MetaLeaderboard.a11y.test.tsx"
+  - "results-explorer/src/pages/__tests__/Home.test.tsx"
+  - "results-explorer/src/lib/__tests__/duckdbQueries.test.ts"
+  - "results-explorer/src/lib/__tests__/facetDisplay.test.ts"
+  - "_project/scripts/results_explorer_snapshot_invariants.py"
+  - "_project/verification-logs/results-explorer-leaderboard-scope-filter-contract/"
+  do_not_modify:
+  - "benchbox/core/results/"
+  - "benchmark_runs/"
+
+success_metrics:
+- "Leaderboard benchmark filters explain why only specific benchmark options are visible or selectable."
+- "Platform counts name the correct denominator and do not imply full-corpus coverage when showing a subset."
+- "Tuning controls distinguish labelled, all, and unavailable/unknown tuning metadata."
+- "Browser evidence shows the page answers the previously annotated scope questions without external context."
+
+metadata:
+  tags:
+  - results-explorer
+  - leaderboard
+  - filters
+  - scope
+  - tuning
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Prevents users from mistaking a scoped leaderboard subset for complete
+    corpus coverage.
+  user_impact: |
+    Analysts can tell whether missing benchmarks or platforms are unavailable,
+    filtered out, unrankable, or outside the current public-coverage view.
+  technical_debt: |
+    Turns homepage filter availability into a tested data contract instead of
+    hard-coded option behavior.

--- a/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-metric-formatting-contract.yaml
+++ b/_project/TODO/results-explorer-followup-todo-review/planning/results-explorer-metric-formatting-contract.yaml
@@ -1,0 +1,206 @@
+id: results-explorer-metric-formatting-contract
+title: "Centralize Results Explorer metric formatting for precision, units, and mode-specific labels"
+worktree: results-explorer-followup-todo-review
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The latest review found large power scores rendered with noisy decimals and
+  several places where unit/mode copy can become misleading. This is a broader
+  formatting contract gap: latency, power score, rank, speedup, cost, coverage,
+  and tail metrics are formatted independently across tables, charts, compare
+  summaries, and receipts.
+
+  This TODO creates one metric-formatting contract so values are precise enough
+  to compare, compact enough to scan, and labelled consistently with the active
+  mode.
+
+deps:
+  needs:
+  - results-explorer-comparison-eligibility-contract-repair
+
+work:
+- id: w0
+  summary: "Inventory metric values, labels, and units across routes"
+  status: pending
+  notes: |
+    Capture the current formatting for:
+      - leaderboard table cells and headers;
+      - benchmark matrix metric columns;
+      - platform detail table metrics;
+      - Query Workbench table columns and exports;
+      - Compare decision summary, cards, charts, and receipt;
+      - chart axes, legends, and footnotes.
+    Record examples for large power scores, small millisecond values, seconds,
+    speedups, ranks, coverage fractions, cost, and missing values in
+    `_project/verification-logs/results-explorer-metric-formatting-contract/w0.log`.
+
+- id: w1
+  summary: "Define metric format rules by semantic metric type"
+  needs: [w0]
+  status: pending
+  notes: |
+    Define rules for:
+      - latency/display timing: ms under 1000, seconds above threshold, no
+        unsupported precision;
+      - power score: compact integers or significant figures for large values,
+        no gratuitous decimals;
+      - speedup/ratio: fixed or significant precision such as `1.59x`;
+      - ranks: integer ordinal or integer rank only;
+      - coverage: `covered/total` with explicit denominator;
+      - cost: currency precision based on magnitude;
+      - missing values: `No run`, `Unavailable`, `Unranked`, or em dash only
+        when each state matches the evidence contract.
+    Decision gate: every visible numeric format must have a semantic metric
+    type, not just a component-local formatter.
+
+- id: w2
+  summary: "Implement shared metric formatter helpers"
+  needs: [w1]
+  status: pending
+  notes: |
+    Add or extend shared helpers that accept metric type, value, unit,
+    comparison direction, and display context. The helper should return value
+    text, unit text when separate, accessible text, and sortable raw value when
+    needed. Avoid changing raw data values or export semantics unless the
+    export explicitly promises visible-formatted values.
+
+- id: w3
+  summary: "Apply metric formatting across tables, charts, and compare surfaces"
+  needs: [w2]
+  status: pending
+  notes: |
+    Replace ad hoc numeric formatting in Leaderboards, Benchmark detail,
+    Platform detail, Query Workbench, Compare, chart footnotes, and receipt
+    summaries. Headers must match the rendered values: do not show `higher is
+    better` above latency cells, and do not render decimals on large power
+    scores unless the contract requires them.
+
+- id: w4
+  summary: "Add tests for precision, labels, missing states, and exports"
+  needs: [w3]
+  status: pending
+  notes: |
+    Add tests asserting:
+      - large power scores do not show unnecessary decimals;
+      - latency cells and axes display the correct unit and precision;
+      - speedup ratios keep meaningful precision;
+      - coverage denominators match scope rules;
+      - missing/unranked states use the correct copy;
+      - formatted text does not alter raw numeric sort order;
+      - export copy remains documented and consistent.
+
+- id: w5
+  summary: "Browser-check metric formatting on high-risk routes"
+  needs: [w4]
+  status: pending
+  notes: |
+    In a browser, verify `/results/`, one TPC-H benchmark page, one AMPLab
+    benchmark page, one platform page, Query Workbench, and Compare. Decision
+    gate: do not complete if any large numeric score still shows gratuitous
+    decimals, if a header contradicts cell units/direction, or if sorting uses
+    formatted strings instead of raw values.
+
+prior_art:
+- "results-explorer/src/utils.ts currently provides fmtScore, fmtScoreExact, fmtTime, and fmtGeomean."
+- "results-explorer/src/lib/queryLabels.ts formats Query Workbench visible cells and labels."
+- "results-explorer/src/lib/costDisplay.ts formats cost values and scope text."
+- "results-explorer/src/lib/compareSummary.ts formats speedup and decision summary metrics."
+- "results-explorer/src/components/MetaLeaderboard.tsx, QueryHeatmap.tsx, DistributionBox.tsx, and SparklineTable.tsx format high-risk table/chart values."
+- "results-explorer/src/pages/Query.tsx controls visible column labels and CSV/JSON export messaging."
+
+must_preserve:
+- "Formatting changes must not alter raw values stored in DuckDB."
+- "Numeric sort and comparison logic must use raw numbers, not formatted strings."
+- "Exports must remain explicit about whether they use raw values or visible columns."
+- "Metric direction labels must match the values currently rendered."
+
+approach: |
+  Build a metric-type formatter contract first, then replace ad hoc component
+  formatting. Keep raw values separate from display strings so precision
+  cleanup cannot corrupt sorting, ranking, or compare math.
+
+anti_patterns:
+- "DO NOT fix a single large-number example with a one-off `.toFixed(0)`."
+- "DO NOT infer units from column labels when the read model already carries metric metadata."
+- "DO NOT round values before ranking or comparison."
+- "DO NOT use an em dash for every non-value state when `No run`, `Unranked`, or `Unavailable` carry different meanings."
+
+verification:
+- description: "Metric formatter tests pass"
+  command: "cd results-explorer && npm test -- --run src/__tests__/utils.test.ts src/lib/__tests__/metricFormatters.test.ts src/lib/__tests__/queryLabels.test.ts src/lib/__tests__/costDisplay.test.ts"
+  expected_output: "all metric formatter tests pass"
+- description: "Route/component tests covering formatted values pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/MetaLeaderboard.test.tsx src/pages/__tests__/BenchmarkIndex.test.tsx src/pages/__tests__/PlatformIndex.test.tsx src/pages/__tests__/Query.test.tsx src/pages/__tests__/Compare.test.tsx"
+  expected_output: "all targeted tests pass"
+- description: "Browser evidence confirms metric formatting"
+  command: "rg -n \"power score|latency|speedup|coverage|gratuitous decimals|PASS|FAIL\" _project/verification-logs/results-explorer-metric-formatting-contract/"
+  expected_output: "logs include pass/fail evidence for metric formatting on high-risk routes"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/utils.ts"
+  - "results-explorer/src/__tests__/utils.test.ts"
+  - "results-explorer/src/lib/metricFormatters.ts"
+  - "results-explorer/src/lib/__tests__/metricFormatters.test.ts"
+  - "results-explorer/src/lib/queryLabels.ts"
+  - "results-explorer/src/lib/__tests__/queryLabels.test.ts"
+  - "results-explorer/src/lib/costDisplay.ts"
+  - "results-explorer/src/lib/__tests__/costDisplay.test.ts"
+  - "results-explorer/src/lib/compareSummary.ts"
+  - "results-explorer/src/lib/__tests__/compareSummary.test.ts"
+  - "results-explorer/src/components/MetaLeaderboard.tsx"
+  - "results-explorer/src/components/ChartPanel.tsx"
+  - "results-explorer/src/components/CompareSummary.tsx"
+  - "results-explorer/src/components/CostScatter.tsx"
+  - "results-explorer/src/components/CDFChart.tsx"
+  - "results-explorer/src/components/DistributionBox.tsx"
+  - "results-explorer/src/components/NormalizedSpeedupChart.tsx"
+  - "results-explorer/src/components/PercentileLadder.tsx"
+  - "results-explorer/src/components/PowerBar.tsx"
+  - "results-explorer/src/components/QueryDiffTable.tsx"
+  - "results-explorer/src/components/QueryHeatmap.tsx"
+  - "results-explorer/src/components/QueryHistogram.tsx"
+  - "results-explorer/src/components/QueryTimingChart.tsx"
+  - "results-explorer/src/components/RankTable.tsx"
+  - "results-explorer/src/components/SparklineTable.tsx"
+  - "results-explorer/src/components/StackedPhase.tsx"
+  - "results-explorer/src/components/TimeSeries.tsx"
+  - "results-explorer/src/pages/Home.tsx"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/pages/PlatformIndex.tsx"
+  - "results-explorer/src/pages/Query.tsx"
+  - "results-explorer/src/pages/Compare.tsx"
+  - "results-explorer/src/pages/ResultDetail.tsx"
+  - "results-explorer/src/pages/__tests__/"
+  - "results-explorer/src/components/__tests__/"
+  - "_project/verification-logs/results-explorer-metric-formatting-contract/"
+  do_not_modify:
+  - "benchbox/core/explorer_pipeline/"
+  - "results-explorer/public/data/"
+
+success_metrics:
+- "Large power scores render without noisy decimals while preserving raw sort/comparison values."
+- "Every metric header, unit, direction label, and cell value agrees."
+- "Formatting rules are centralized by metric type and tested with edge cases."
+- "Browser evidence covers leaderboard, benchmark, platform, query, and compare surfaces."
+
+metadata:
+  tags:
+  - results-explorer
+  - metrics
+  - formatting
+  - units
+  estimated_effort: "Medium (1-2 days)"
+  created_date: "2026-05-11"
+
+impact:
+  business_value: |
+    Improves trust in benchmark claims by making values readable and labelled
+    correctly.
+  user_impact: |
+    Users can compare metrics quickly without questioning whether a value is a
+    latency, power score, rank, speedup, or missing state.
+  technical_debt: |
+    Removes scattered number formatting from Results Explorer components.


### PR DESCRIPTION
## Summary
- add UI-focused TODOs for leaderboard scope/filter clarity, metric formatting, chart dataset eligibility, and Compare warning affordances
- wire those TODOs into the Results Explorer follow-up release gate
- keep the PR scoped to TODO YAML planning files only

## Verification
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex
- commit hooks passed on commit