### PR TITLE
docs: add landing prompts TODO plan with review fixes

### DIFF
--- a/_project/TODO/main/planning/landing-prompts-catalog-generator.yaml
+++ b/_project/TODO/main/planning/landing-prompts-catalog-generator.yaml
@@ -1,0 +1,213 @@
+id: landing-prompts-catalog-generator
+title: "Build the generated catalog contract for the /prompts/ landing route"
+worktree: main
+priority: High
+status: Not Started
+category: Product and Documentation
+
+description: |
+  Implement the data-generation and validation layer for the `/prompts/`
+  landing route after `landing-prompts-decision-gates` resolves the product
+  gates.
+
+  The generator must keep the marketing prompt builder aligned with existing
+  BenchBox runtime metadata without adding a new public CLI or MCP surface.
+  It should fan out from registry/platform/benchmark metadata, validate command
+  shapes against existing Click command definitions where practical, and emit
+  a deterministic include file for the static page.
+
+  MVP must not publish a standalone `recipes.json` endpoint. The generator
+  emits `landing/prompts/catalog.generated.js` (a `window.__BENCHBOX_PROMPT_CATALOG__ = {...};`
+  assignment) that the static route loads via a `<script>` tag. This is page
+  implementation detail, not a public API.
+
+deps:
+  needs:
+    - landing-prompts-decision-gates
+
+work:
+  - id: w1
+    summary: "Read the landing prompts decision record and confirm implementation boundaries"
+    status: pending
+    notes: |
+      Before coding, read `_project/decisions/landing-prompts-route.md`.
+      Confirm chosen public label, default agent, default surface, analytics
+      posture, cloud safety policy, generic-agent semantics, and JSON/API
+      posture. If the decision record is missing or incomplete, stop and
+      return to `landing-prompts-decision-gates`.
+
+  - id: w2
+    summary: "Design the minimal catalog schema with registry-backed keys"
+    needs: [w1]
+    status: pending
+    notes: |
+      Define a compact catalog structure that stores registry keys internally:
+      agents, surfaces, goals, deployment modes, platforms, benchmarks, scale
+      options, warnings, command templates, and MCP references. Use
+      `local`, `self-hosted`, and `managed` internally. UI labels may be
+      friendlier.
+
+  - id: w3
+    summary: "Implement scripts/generate_landing_quickstarts.py"
+    needs: [w2]
+    status: pending
+    notes: |
+      The generator lives at root `scripts/generate_landing_quickstarts.py`
+      and runs in the main project environment (so it can `import benchbox`):
+      `uv run -- python scripts/generate_landing_quickstarts.py ...`. The
+      `_project/scripts/` env does NOT contain benchbox; do not use
+      `--project _project/scripts` for this script.
+
+      It should read a small source file at `landing/prompts/catalog.yaml`,
+      import `PlatformRegistry` and `BENCHMARK_METADATA`, inspect existing
+      CLI/MCP anchors, and emit a single deterministic include file at
+      `landing/prompts/catalog.generated.js` that assigns
+      `window.__BENCHBOX_PROMPT_CATALOG__ = {...};`. The static-route page
+      will load this include via a `<script>` tag. Do NOT write to
+      `landing/prompts/index.html`; the static-route TODO owns that file.
+      Do NOT emit a separate fetchable JSON file (see anti_patterns).
+
+      Support `--write` (regenerate the include), `--check` (fail nonzero if
+      regeneration would change the file), and `--validate-only` (validate
+      source YAML without writing).
+
+      The source YAML should describe patterns and curated marketing choices,
+      not enumerate every derived platform recipe by hand.
+
+  - id: w4
+    summary: "Validate platform, benchmark, deployment, CLI, and MCP references"
+    needs: [w3]
+    status: pending
+    notes: |
+      Add validation that fails when:
+      - a platform ID is not in `PlatformRegistry`
+      - a benchmark ID is not in `BENCHMARK_METADATA`
+      - a deployment mode is not `local`, `self-hosted`, or `managed`
+      - a DataFrame recipe selects a SQL-only platform
+      - a SQL recipe selects a DataFrame-only platform without deliberate mode handling
+      - a compare recipe lacks repeated `-p/--platform` arguments
+      - an MCP recipe references a non-existent MCP prompt or tool
+      - a managed cloud recipe lacks dry-run-first and no-secret warnings
+
+  - id: w5
+    summary: "Add focused generator and catalog tests"
+    needs: [w4]
+    status: pending
+    notes: |
+      Add `tests/unit/landing/test_landing_quickstarts.py` with explicit
+      `pytest.mark.fast` and `pytest.mark.unit`. Tests must cover deterministic
+      regeneration, registry coverage or explicit exclusions, command parsing
+      where practical, MCP reference validation, and cloud safety assertions.
+
+  - id: w6
+    summary: "Add a make target or documented command for stale generated catalog detection"
+    needs: [w5]
+    status: pending
+    notes: |
+      Prefer a small Make target `prompt-quickstarts-check` that invokes
+      `uv run -- python scripts/generate_landing_quickstarts.py --check`,
+      following the convention of other generator/check targets in `Makefile`
+      (e.g. `scripts/check_complexity.py`, `scripts/check_example_syntax.py`).
+      If a Make target is not added, document the exact invocation in
+      `AGENTS.md` and the launch-gates TODO so CI can call it directly.
+
+deferred:
+  - summary: "Publish a documented prompt catalog JSON API"
+    reason: "MVP should avoid adding an unversioned public API. If this becomes a product requirement, create a separate versioned API decision."
+  - summary: "Generate CLI/MCP prompt content by adding public runtime commands"
+    reason: "Out of scope; generator validates and references existing surfaces instead."
+
+prior_art:
+  - "benchbox/core/platform_registry.py:PlatformRegistry.get_all_platform_metadata — reuse as platform source of truth"
+  - "benchbox/core/benchmark_registry.py:BENCHMARK_METADATA — reuse as benchmark source of truth"
+  - "benchbox/cli/commands/run.py:Click run command options — validate emitted run command shape"
+  - "benchbox/cli/commands/compare.py:dual-mode compare command — validate repeated `-p` for platform comparison"
+  - "benchbox/mcp/prompts/registry.py:existing MCP prompt registration — reference existing prompt names where useful"
+  - "benchbox/mcp/tools/benchmark.py:run_benchmark tool schema — validate MCP tool guidance"
+  - "scripts/generate_changelog_entry.py:existing root generator pattern — match invocation style `uv run -- python scripts/...` (NOT `--project _project/scripts`)"
+  - "scripts/check_example_syntax.py:existing --check style root script — reuse CLI shape and exit semantics"
+
+must_preserve:
+  - "No new public CLI commands are introduced."
+  - "No new public MCP tools are introduced."
+  - "No standalone `landing/prompts/recipes.json` or equivalent stable JSON endpoint is shipped for MVP."
+  - "Existing platform and benchmark registries remain the source of truth; catalog YAML is not allowed to duplicate canonical metadata."
+  - "Existing root landing page and results explorer build paths continue to work."
+
+approach: |
+  Keep the generator small and deterministic. Use registry metadata for facts,
+  YAML only for curated marketing choices and explicit exclusions, and tests
+  for cross-surface drift. Treat the browser catalog as generated page data
+  (`catalog.generated.js`), not as a public API.
+
+anti_patterns:
+  - "DO NOT hand-maintain platform capability lists in YAML - because they will drift from `PlatformRegistry` - derive capabilities from the registry and use YAML only for overrides/exclusions."
+  - "DO NOT emit a fetchable `recipes.json` in MVP - because third parties can treat it as an API - emit `catalog.generated.js` as a page implementation include instead."
+  - "DO NOT copy MCP prompt bodies into catalog data - because `benchbox/mcp/prompts/registry.py` already owns MCP guidance - reference existing prompt/tool names and arguments."
+  - "DO NOT use `Server` as an internal deployment value - because it is not a registry literal - use `self-hosted` and map to a friendly label."
+  - "DO NOT make cloud recipes live-run-first - because managed runs can consume money or fail on credentials - make dry-run/setup-first behavior mandatory."
+  - "DO NOT invoke the generator with `uv run --project _project/scripts -- ...` - because that env lacks `benchbox` and the script imports `PlatformRegistry`/`BENCHMARK_METADATA` - always use `uv run -- python scripts/generate_landing_quickstarts.py`."
+
+verification:
+  - description: "Generator check reports generated catalog is current"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --check"
+    expected_output: "exit 0"
+  - description: "Generated include file exists with the expected assignment"
+    command: "test -f landing/prompts/catalog.generated.js && rg -n 'window.__BENCHBOX_PROMPT_CATALOG__' landing/prompts/catalog.generated.js"
+    expected_output: "exit 0; assignment present"
+  - description: "Focused catalog tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q"
+    expected_output: "all tests pass"
+  - description: "No standalone recipes JSON file was added"
+    command: "! test -f landing/prompts/recipes.json"
+    expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"
+    - "scripts/generate_landing_quickstarts.py"
+    - "tests/unit/landing/"
+    - "Makefile"
+  do_not_modify:
+    - "landing/prompts/index.html"
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/prompts.css"
+    - ".github/workflows/docs.yml"
+    - "benchbox/cli/commands/"
+    - "benchbox/mcp/tools/"
+    - "benchbox/mcp/prompts/"
+    - "results-explorer/"
+
+metadata:
+  tags:
+    - landing
+    - prompts
+    - agents
+    - generator
+    - drift-prevention
+  estimated_effort: "Medium"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Enables a marketing prompt builder without turning it into a new supported
+    BenchBox runtime surface.
+  user_impact: |
+    Keeps copied prompts aligned with actual platforms, benchmarks, CLI flags,
+    and MCP capabilities.
+  technical_debt: |
+    Adds a deterministic validation layer so future platform/CLI/MCP changes
+    fail visibly when they affect the landing prompt builder.
+
+success_metrics:
+  - "Catalog generation is deterministic and checkable in CI."
+  - "Every MVP platform is derived from registry metadata or explicitly excluded with a reason."
+  - "Managed cloud recipes fail validation unless they include dependency/status checks, dry-run-first behavior, and no-secret guidance."
+  - "Compare recipes fail validation unless platform comparison is unambiguous."
+
+open_questions:
+  - question: "Should the generator add a Make target or remain a documented script command only?"
+    gating: false
+    affects: ["w6"]
+    default: "Prefer a Make target `prompt-quickstarts-check` to match existing generator/check conventions."

--- a/_project/TODO/main/planning/landing-prompts-decision-gates.yaml
+++ b/_project/TODO/main/planning/landing-prompts-decision-gates.yaml
@@ -1,0 +1,214 @@
+id: landing-prompts-decision-gates
+title: "Decide launch boundaries for the /prompts/ landing route"
+worktree: main
+priority: High
+status: Not Started
+category: Product and Documentation
+
+description: |
+  BenchBox plans to add a `/prompts/` landing route that converts casual
+  landing-page visitors into people who actually try the existing BenchBox
+  CLI or MCP surfaces with agents such as Codex and Claude Code.
+
+  The feature is explicitly a marketing/conversion surface, not a new
+  runtime BenchBox feature. It must not add a new `benchbox prompts ...`
+  command, new MCP prompt-rendering tools, or another public API surface.
+  The page should compose copy-paste prompts from known snippets and
+  validated metadata, while keeping the generated guidance aligned with
+  existing CLI and MCP capabilities.
+
+  This TODO is the mandatory decision gate before implementation. It
+  resolves the public label, default state, analytics posture, cloud safety
+  policy, generic-agent semantics, and JSON/API posture so downstream work
+  can stay narrow and testable.
+
+deps: {}
+
+work:
+  - id: w1
+    summary: "Verify current CLI, MCP, landing, and docs anchors before deciding"
+    status: pending
+    notes: |
+      Re-check the current files because the plan depends on live surfaces:
+      `landing/index.html`, `.github/workflows/docs.yml`,
+      `docs/_templates/page.html`, `benchbox/mcp/prompts/registry.py`,
+      `benchbox/mcp/tools/benchmark.py`, `benchbox/cli/commands/run.py`,
+      `benchbox/cli/commands/compare.py`, `benchbox/core/platform_registry.py`,
+      and `benchbox/core/benchmark_registry.py`.
+
+      Confirm that MCP prompt names and compare CLI behavior still match
+      the assumptions in this TODO chain before documenting final decisions.
+
+  - id: w2
+    summary: "Write a decision record for public label, default state, and page location"
+    needs: [w1]
+    status: pending
+    notes: |
+      Create a compact `_project/decisions/landing-prompts-route.md` with the
+      six required H2 section headings (see verification):
+      - `## Public label` — public label used in nav and page title
+      - `## Default agent and surface` — default agent + default surface + rationale
+      - `## Cloud safety` — required behaviors for managed/cloud platforms
+      - `## Generic-agent semantics` — label and output contract for the
+        non-Codex/non-Claude-Code option
+      - `## Analytics posture` — wired vs explicit deferral, revisit date
+      - `## API and JSON posture` — why no standalone recipes.json in MVP
+
+      Also state why `/prompts/` remains on the landing surface instead of
+      Sphinx, and why no new public CLI/MCP APIs are allowed in MVP.
+
+      Current recommended defaults are not settled. Candidate default state:
+      `Codex + CLI + Test one local SQL platform + DuckDB + TPC-H + scale 0.01`.
+      The decision record may choose Claude Code instead, but must state why.
+
+  - id: w3
+    summary: "Define the cloud-visible MVP safety contract"
+    needs: [w1]
+    status: pending
+    notes: |
+      Cloud platforms must remain visible in MVP, but the decision record must
+      define hard safety behavior under the `## Cloud safety` heading:
+      - use registry vocabulary internally: `local`, `self-hosted`, `managed`
+      - present managed platforms as "Managed cloud" in UI
+      - never make a live cloud run the primary copied command
+      - require dependency/status checks before dry-run
+      - require dry-run before any live run
+      - instruct agents not to ask for or accept pasted secrets in chat
+      - stop and summarize missing credentials/config before proceeding
+
+  - id: w4
+    summary: "Define generic-agent semantics and capability boundaries"
+    needs: [w1]
+    status: pending
+    notes: |
+      User requirement keeps Codex, Claude Code, and generic selectable. The
+      generic option must not imply every chatbot has shell, filesystem, or
+      MCP tool access. Decide whether to label it `Generic agent`,
+      `Generic / manual`, or another term, and define its output contract
+      under the `## Generic-agent semantics` heading.
+
+      Safe default: generic output is a human-readable recipe with commands
+      and steps the user can execute manually, plus optional wording for an
+      agent that has shell access.
+
+  - id: w5
+    summary: "Choose analytics posture (this TODO owns policy; launch-gates records final values)"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Decide whether to wire a privacy-respecting analytics provider for the
+      marketing surface or explicitly defer analytics. If analytics are
+      deferred, record a revisit date and a qualitative fallback review plan.
+
+      This item owns the policy decision; concrete launch values (final
+      kill-criteria thresholds, dashboards, revisit date follow-through) are
+      recorded by `landing-prompts-launch-gates` w6.
+
+  - id: w6
+    summary: "Decision review gate before implementation TODOs move out of planning"
+    needs: [w5]
+    status: pending
+    notes: |
+      Review the decision record against the known risk topics:
+      - existing MCP prompt overlap with `benchbox/mcp/prompts/registry.py`
+      - compare CLI dual-mode (SQL vs DataFrame) in `benchbox/cli/commands/compare.py`
+      - deployment vocabulary (`local`, `self-hosted`, `managed` per
+        `benchbox/core/platform_registry.py` `DeploymentCapability.mode`)
+      - hidden JSON API risk if a standalone `recipes.json` ships
+      - cloud safety (dependency check, dry-run-first, no pasted secrets)
+      - generic-agent ambiguity (shell/MCP capability assumptions)
+      - conversion measurement (analytics wired vs explicit deferral)
+
+      Implementation TODOs should not move to active until this gate is
+      complete.
+
+deferred:
+  - summary: "Add new public `benchbox prompts` CLI commands"
+    reason: "Out of scope because the feature is meant to drive use of existing CLI/MCP surfaces, not add another one."
+  - summary: "Add new MCP prompt-builder tools"
+    reason: "Out of scope for the same reason; MCP mode should reference existing MCP tools/prompts."
+  - summary: "Move the MVP into the results-explorer SPA"
+    reason: "Over-engineered for a lightweight marketing conversion page."
+
+prior_art:
+  - "landing/index.html:static landing surface and nav — reuse for public route placement and visual tone"
+  - ".github/workflows/docs.yml:landing/* copied to site root — reuse deployment path for `/prompts/`"
+  - "docs/_templates/page.html:site-wide docs nav — extend only after the public label is chosen"
+  - "benchbox/mcp/prompts/registry.py:existing MCP prompt names — reuse or reference rather than duplicating MCP semantics"
+  - "benchbox/core/platform_registry.py:DeploymentCapability.mode — reuse `local`, `self-hosted`, and `managed` vocabulary"
+
+must_preserve:
+  - "The plan does not authorize new public CLI commands or new public MCP tools."
+  - "The `/prompts/` route remains a landing conversion surface, not a replacement for reference docs."
+  - "Cloud platforms remain visible in MVP, but live cloud execution is never the primary copied action."
+  - "Existing root landing, docs, blog, and results links continue to work."
+
+approach: |
+  Start with facts from the current repo, then make product decisions in a
+  short `_project/decisions/` document. Treat this decision item as the
+  authorization boundary for the implementation chain. Downstream TODOs should
+  read the decision record first and must not reinterpret unresolved choices.
+
+anti_patterns:
+  - "DO NOT start implementing `landing/prompts/` before this decision item is complete - because unresolved defaults and cloud safety rules will leak into code - write and review the decision record first."
+  - "DO NOT define an internal `server` environment value - because the registry uses `self-hosted` and docs use deployment modes - use registry literals internally and friendly labels in UI."
+  - "DO NOT publish a standalone `recipes.json` in MVP - because that creates a hidden public API - inline generated catalog data unless a documented API decision is made."
+  - "DO NOT make analytics an afterthought - because this is a conversion feature - either wire measurement or record an explicit deferral with revisit criteria."
+
+verification:
+  - description: "Decision record exists and contains the six required section headings"
+    command: "test -f _project/decisions/landing-prompts-route.md && for h in '## Public label' '## Default agent and surface' '## Cloud safety' '## Generic-agent semantics' '## Analytics posture' '## API and JSON posture'; do rg -nF \"$h\" _project/decisions/landing-prompts-route.md >/dev/null || { echo \"missing: $h\"; exit 1; }; done"
+    expected_output: "exit 0; all six required headings present"
+  - description: "No new public CLI/MCP implementation files are modified by this decision-only TODO"
+    command: "! git diff --name-only | rg '^(benchbox/cli/commands|benchbox/mcp/tools)'"
+    expected_output: "exit 0; negated rg finds no matches"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/"
+    - "_project/TODO/main/planning/"
+  do_not_modify:
+    - "benchbox/cli/"
+    - "benchbox/mcp/"
+    - "landing/prompts/"
+    - ".github/workflows/docs.yml"
+
+metadata:
+  tags:
+    - landing
+    - prompts
+    - agents
+    - decision-gate
+    - marketing
+  estimated_effort: "Small"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Prevents a marketing feature from accidentally becoming another supported
+    runtime surface or an unversioned public data API.
+  user_impact: |
+    Ensures the first copied prompt is honest, safe, and aligned with the
+    actual CLI/MCP behavior a new user will experience.
+  technical_debt: |
+    Converts ambiguous product choices into an explicit gate before code is
+    written, reducing churn and drift in the implementation TODOs.
+
+success_metrics:
+  - "A decision record exists before implementation TODOs are activated."
+  - "The decision record explicitly resolves public label, default agent, default surface, analytics posture, generic-agent semantics, cloud safety, and JSON/API posture."
+  - "Implementation TODOs can cite the decision record as their source of truth."
+
+open_questions:
+  - question: "What public label should appear in the nav and page title?"
+    gating: true
+    affects: ["w2", "landing-prompts-static-route"]
+    default: "Use `Prompts` internally until the decision record chooses final copy."
+  - question: "Should Codex or Claude Code be the default agent?"
+    gating: true
+    affects: ["w2", "landing-prompts-static-route"]
+    default: "Use the decision record's explicit rationale; do not infer from implementation preference."
+  - question: "Will analytics be wired for launch or explicitly deferred?"
+    gating: true
+    affects: ["w5", "landing-prompts-launch-gates"]
+    default: "If unresolved, do not launch publicly without an explicit deferral and revisit date."

--- a/_project/TODO/main/planning/landing-prompts-launch-gates.yaml
+++ b/_project/TODO/main/planning/landing-prompts-launch-gates.yaml
@@ -1,0 +1,204 @@
+id: landing-prompts-launch-gates
+title: "Wire /prompts/ into docs, CI, accessibility checks, and launch measurement"
+worktree: main
+priority: High
+status: Not Started
+category: Product and Documentation
+
+description: |
+  Launch the `/prompts/` landing route responsibly after the decision,
+  generator, and static route TODOs are complete.
+
+  This item covers integration points that make the page discoverable and
+  maintainable: nav links, docs workflow checks, accessibility/mobile smoke
+  checks, analytics or explicit analytics deferral, and launch/kill criteria.
+  It should not expand the feature scope or add new runtime BenchBox surfaces.
+
+deps:
+  needs:
+    - landing-prompts-static-route
+
+work:
+  - id: w1
+    summary: "Add /prompts/ links to landing and docs navigation using the chosen public label"
+    status: pending
+    notes: |
+      Update `landing/index.html` and `docs/_templates/page.html` after the
+      decision record chooses the public label. Keep nav concise. Add a root
+      landing CTA near the MCP/agent section that drives users to `/prompts/`.
+
+  - id: w2
+    summary: "Wire generated catalog validation into docs CI"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add the generator `--check` command to `.github/workflows/docs.yml` in a
+      stage that already installs project dependencies. Prefer failing before
+      site assembly. Use the same invocation as local:
+      `uv run -- python scripts/generate_landing_quickstarts.py --check`
+      (NOT `--project _project/scripts`, which lacks `benchbox`). If the
+      catalog-generator TODO added a `make prompt-quickstarts-check` target,
+      call that instead. Keep output compact; redirect noisy logs if needed.
+
+  - id: w3
+    summary: "Add launch smoke checks for routing, copy behavior, and mobile layout"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add the narrowest practical smoke coverage. At minimum verify the page
+      exists in assembled site output, selector state can render the default
+      prompt, and mobile/desktop layouts avoid obvious overflow. For
+      accessibility, add a manual checklist file at
+      `landing/prompts/a11y-checklist.md` (focus order, label coverage,
+      `aria-live` copy feedback, color contrast, keyboard-only flow) and file
+      a follow-up TODO for automated a11y tooling if it is not added now.
+
+  - id: w4
+    summary: "Implement analytics hooks or record an explicit analytics deferral"
+    needs: [w1]
+    status: pending
+    notes: |
+      Follow the decision record. If analytics are approved, instrument:
+      page load, agent selection, surface selection, prompt copy, CLI command
+      copy, MCP setup copy, docs link click, and cloud platform selection.
+
+      If analytics are deferred, add a durable note to the decision record or
+      launch notes with revisit date, owner, and qualitative review plan.
+
+  - id: w5
+    summary: "Run final docs build and prompt-specific verification"
+    needs: [w3, w4]
+    status: pending
+    notes: |
+      Run the focused generator/tests first, then docs build. Do not run live
+      cloud tests. Do not commit browser screenshots or raw stdout logs unless
+      they are deliberate product docs assets.
+
+  - id: w6
+    summary: "Record final launch values, known limits, and kill criteria"
+    needs: [w5]
+    status: pending
+    notes: |
+      Following the policy set by `landing-prompts-decision-gates` w5, record
+      the concrete launch values in a compact launch note or update to the
+      decision record:
+      - final public label
+      - default state
+      - analytics or deferral status (with revisit date)
+      - cloud safety behavior
+      - known limitations
+      - kill criteria thresholds (prompt-copy events, MCP-vs-CLI selection
+        ratio, docs-click-throughs) and reevaluation date
+
+deferred:
+  - summary: "Automated cross-browser matrix for `/prompts/`"
+    reason: "MVP should start with focused smoke/a11y checks; full browser matrix can follow if the route becomes high traffic."
+  - summary: "A/B testing prompt copy"
+    reason: "Useful later, but premature before baseline copy/click measurement exists."
+  - summary: "Standalone public catalog API documentation"
+    reason: "Not applicable while catalog data is inline implementation detail."
+  - summary: "Automated a11y tooling (pa11y/axe)"
+    reason: "Filed as follow-up unless added during w3; manual checklist covers MVP."
+
+prior_art:
+  - ".github/workflows/docs.yml:docs build and landing assembly — extend with prompt catalog check"
+  - "landing/index.html:site-wide nav and MCP section — extend with `/prompts/` CTA"
+  - "docs/_templates/page.html:docs nav — extend after label decision"
+  - "docs/conf.py:custom CSS/JS wiring for docs — consider only for docs nav, not prompt page runtime"
+  - "tests/docs/test_sphinx_warnings.py:slow docs verification pattern — reuse for docs build expectations if needed"
+  - "results-explorer/docs and browser tests — reference for visual QA discipline, not as required MVP scope"
+
+must_preserve:
+  - "Docs build and GitHub Pages assembly continue to publish root landing, `/docs/`, `/blog/`, and `/results/`."
+  - "The docs workflow remains reasonably fast; prompt checks should fail early and emit compact output."
+  - "No live cloud platform tests are introduced by launch verification."
+  - "No raw screenshots, browser reports, or generated evidence blobs are committed without a durable reader-facing purpose."
+  - "Existing unrelated worktree changes are not reverted or staged as part of this TODO."
+
+approach: |
+  Treat launch integration as a release gate, not a place to expand product
+  scope. Make the route discoverable, wire stale-catalog checks into CI, verify
+  the page works at a basic level, and record how the team will judge whether
+  the marketing surface is worth maintaining.
+
+anti_patterns:
+  - "DO NOT add CI checks that depend on live cloud credentials - because this is a static marketing route - keep verification local/static."
+  - "DO NOT silently ship without analytics or an explicit analytics deferral - because this feature's value is conversion - make measurement posture visible."
+  - "DO NOT add `/prompts/` to docs nav with a temporary label after the decision record chooses a final label - because public nav copy is part of the launch contract - use the selected label consistently."
+  - "DO NOT commit screenshot batches or raw logs - because project artifact hygiene forbids durable raw evidence without a reader-facing consumer - summarize evidence instead."
+  - "DO NOT invoke the generator with `uv run --project _project/scripts -- ...` in CI - because that env lacks `benchbox` - use `uv run -- python scripts/generate_landing_quickstarts.py --check`."
+
+verification:
+  - description: "Generator check passes in the same form CI will run"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --check"
+    expected_output: "exit 0"
+  - description: "Focused prompt route tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q"
+    expected_output: "all tests pass"
+  - description: "Docs build succeeds"
+    command: "cd docs && uv run sphinx-build -b html --keep-going . _build/html"
+    expected_output: "build succeeds without new prompt-related warnings"
+  - description: "Docs workflow contains the prompt catalog check (and uses the correct uv form)"
+    command: "rg -n 'generate_landing_quickstarts.py --check|prompt-quickstarts-check' .github/workflows/docs.yml && ! rg -n '--project _project/scripts.*generate_landing_quickstarts' .github/workflows/docs.yml"
+    expected_output: "exit 0; check is present and uses main-project uv env"
+  - description: "Manual a11y checklist is present (or automated a11y tooling is wired)"
+    command: "test -f landing/prompts/a11y-checklist.md || rg -n 'pa11y|axe-core' .github/workflows/docs.yml"
+    expected_output: "exit 0; at least one a11y path exists"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/docs.yml"
+    - "landing/index.html"
+    - "landing/prompts/a11y-checklist.md"
+    - "docs/_templates/page.html"
+    - "docs/conf.py"
+    - "tests/unit/landing/"
+    - "_project/decisions/"
+  do_not_modify:
+    - "landing/prompts/index.html"
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/prompts.css"
+    - "landing/prompts/catalog.generated.js"
+    - "landing/prompts/catalog.yaml"
+    - "scripts/generate_landing_quickstarts.py"
+    - "benchbox/cli/"
+    - "benchbox/mcp/"
+    - "benchbox/core/"
+    - "results-explorer/"
+
+metadata:
+  tags:
+    - landing
+    - prompts
+    - launch
+    - docs-ci
+    - analytics
+  estimated_effort: "Small to Medium"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Makes the prompt builder discoverable and gives the team enough evidence
+    to decide whether it improves conversion.
+  user_impact: |
+    Lets visitors find the agent prompt builder from the main landing and docs
+    navigation without searching.
+  technical_debt: |
+    Prevents stale generated catalog data from shipping and records launch
+    criteria before the page becomes unattended marketing surface area.
+
+success_metrics:
+  - "`/prompts/` is linked from root landing and docs nav with the chosen public label."
+  - "Docs CI fails if generated prompt catalog data is stale or invalid."
+  - "Launch notes record measurement posture, known limits, revisit date, and kill criteria."
+  - "No live cloud tests, new CLI commands, or new MCP tools are introduced."
+
+open_questions:
+  - question: "Should `/prompts/` be indexed for SEO?"
+    gating: true
+    affects: ["w6"]
+    default: "Allow indexing if public label and copy are final; otherwise use conservative metadata until launch review."
+  - question: "Should automated a11y checks be added now or filed as a follow-up?"
+    gating: false
+    affects: ["w3"]
+    default: "Do manual a11y checklist in MVP if adding tooling would broaden scope; file follow-up for automation."

--- a/_project/TODO/main/planning/landing-prompts-static-route.yaml
+++ b/_project/TODO/main/planning/landing-prompts-static-route.yaml
@@ -1,0 +1,218 @@
+id: landing-prompts-static-route
+title: "Implement the static /prompts/ landing route and prompt builder UI"
+worktree: main
+priority: High
+status: Not Started
+category: Product and Documentation
+
+description: |
+  Build the public `/prompts/` landing route after the decision gate and
+  generated catalog contract are complete.
+
+  The page should be a lightweight static landing experience, not a
+  results-explorer-style app and not a Sphinx reference page. It should let a
+  visitor choose goal, agent, surface, interface, deployment mode, platform,
+  benchmark, and scale, then copy a prompt that helps them try the existing
+  BenchBox CLI or MCP surface.
+
+  The page consumes the generator's `landing/prompts/catalog.generated.js`
+  via a `<script>` tag (which sets `window.__BENCHBOX_PROMPT_CATALOG__`); it
+  does not fetch a separate JSON file or re-derive catalog facts in the
+  browser.
+
+  The route must remain a marketing conversion surface. It must not introduce
+  new CLI/MCP APIs, collect credentials, or make managed cloud execution look
+  frictionless.
+
+deps:
+  needs:
+    - landing-prompts-catalog-generator
+
+work:
+  - id: w1
+    summary: "Create the /prompts/ static page shell using landing visual conventions"
+    status: pending
+    notes: |
+      Add `landing/prompts/index.html`, `landing/prompts/prompts.js`, and
+      `landing/prompts/prompts.css`. The page must include
+      `<script src="catalog.generated.js"></script>` (or equivalent relative
+      include) before `prompts.js` so the catalog assignment is available.
+      Reuse the landing theme and nav conventions without pulling in the
+      results explorer build stack. The builder should be usable in the first
+      viewport and should not start with a long marketing hero.
+
+  - id: w2
+    summary: "Render the selector controls from generated catalog data"
+    needs: [w1]
+    status: pending
+    notes: |
+      Controls:
+      - Goal: Test one platform / Compare platforms
+      - Agent: Codex / Claude Code / Generic (final label from decision record)
+      - Surface: CLI / MCP
+      - Interface: SQL / DataFrame
+      - Deployment: Local / Self-hosted / Managed cloud
+      - Platform or Platform A/B
+      - Benchmark
+      - Scale
+
+      Read from `window.__BENCHBOX_PROMPT_CATALOG__`. Use registry keys
+      internally (`local`, `self-hosted`, `managed`) and display friendlier
+      labels in the UI.
+
+  - id: w3
+    summary: "Implement state normalization, filtering, and URL deep links"
+    needs: [w2]
+    status: pending
+    notes: |
+      Normalize invalid combinations when controls change:
+      - replace a platform that no longer matches current filters
+      - prevent duplicate Platform A/B in compare mode
+      - restrict DataFrame selections to compatible platforms/benchmarks
+      - preserve state in query parameters for shareable links
+      - fall back to safe defaults if URL state is invalid
+
+      Pin the URL parameter names so future copy/PR changes don't break old
+      links: `goal`, `agent`, `surface`, `interface`, `deployment`,
+      `platform` (or `platformA` and `platformB` when goal=compare),
+      `benchmark`, `scale`. All values are registry keys, not display labels.
+
+  - id: w4
+    summary: "Render CLI, MCP, and generic/manual prompt outputs with safety notes"
+    needs: [w3]
+    status: pending
+    notes: |
+      CLI mode emits dependency/status checks, dry-run commands, and live-run
+      commands only where safe. MCP mode renders TWO copyable blocks: (a) the
+      `claude_desktop_config.json` / Codex MCP setup snippet that references
+      the existing `benchbox-mcp` entry-point, and (b) a natural-language
+      prompt the user pastes into the agent that references existing MCP
+      tools/prompts by name (e.g. `run_benchmark`). Do not invent new MCP
+      surfaces.
+
+      Generic/manual mode must avoid assuming shell or MCP access unless the
+      text explicitly says the user or agent has those capabilities.
+
+      Managed cloud selections must make the dry-run/setup prompt primary and
+      place any live-run command behind an explicit after-setup section.
+
+  - id: w5
+    summary: "Add accessible copy interactions and fallback behavior"
+    needs: [w4]
+    status: pending
+    notes: |
+      Copy buttons should work for the main prompt, CLI command block, and MCP
+      setup block. Add clear focus states, labels, `aria-live` copy feedback,
+      and a no-JS fallback message. Do not rely on external JS frameworks.
+
+  - id: w6
+    summary: "Verify desktop/mobile layout and text overflow"
+    needs: [w5]
+    status: pending
+    notes: |
+      Check at least mobile narrow, tablet, and desktop viewports. The form and
+      copied prompt must not overflow or overlap. Long platform names and cloud
+      warnings should wrap cleanly.
+
+deferred:
+  - summary: "Add a full TypeScript/Preact implementation"
+    reason: "Overkill for MVP; plain static JS is sufficient unless the UI grows substantially."
+  - summary: "Add browser-side LLM generation"
+    reason: "The feature should compose known snippets, not generate unbounded prompt text."
+  - summary: "Collect cloud credentials or environment values in the browser"
+    reason: "Unsafe and unnecessary; prompts should direct users to configure credentials outside chat/browser."
+
+prior_art:
+  - "landing/index.html:current static landing layout and code block patterns — reuse visual conventions"
+  - "landing/style.css:dark theme variables and responsive grid patterns — extend for page-specific controls"
+  - "landing/script.js:copy button behavior — reuse concept but isolate prompt-page JS"
+  - ".github/workflows/docs.yml:landing/* to site root — preserve deployment behavior"
+  - "results-explorer/package.json:Vite/Preact stack — do not reuse for this small static builder"
+  - "docs/guides/mcp-integration.md:Codex and Claude Code MCP setup examples — link or summarize accurately"
+
+must_preserve:
+  - "Root landing page remains available at `/` and keeps existing sections working."
+  - "Results explorer remains isolated under `/results/`; do not change its build, routes, or package files."
+  - "The prompt page does not fetch a standalone public catalog JSON file in MVP."
+  - "MCP guidance references existing MCP capabilities; it does not claim new prompt-builder tools exist."
+  - "Cloud prompts do not ask users to paste secrets into chat."
+  - "Nav edits to root `landing/index.html` and `docs/_templates/page.html` are owned by `landing-prompts-launch-gates`; this TODO does not touch them."
+
+approach: |
+  Build a small static route that consumes the generator's
+  `catalog.generated.js` include. Keep page JS focused on state, filtering,
+  rendering, copy behavior, and URL persistence. Let the generator own facts
+  and safety assertions; let the UI own presentation and interaction.
+
+anti_patterns:
+  - "DO NOT create a landing hero before the builder - because the feature's goal is immediate conversion - make the builder the first useful screen."
+  - "DO NOT add a package manager or frontend build step - because `landing/` currently deploys as static files - use plain HTML/CSS/JS unless a later decision changes the architecture."
+  - "DO NOT use internal deployment labels directly in visible copy when they are awkward - because users need plain language - map `self-hosted` to `Self-hosted` and `managed` to `Managed cloud`."
+  - "DO NOT hide cloud platforms - because the MVP requirement says cloud is visible - instead make setup/dry-run constraints prominent."
+  - "DO NOT make generic-agent output assume Codex/Claude tools - because generic users may only have a chatbot - generate manual-safe instructions."
+  - "DO NOT modify `landing/index.html` (root nav) or `docs/_templates/page.html` from this TODO - because nav edits are launch-gates' responsibility - keep this PR scoped to `landing/prompts/`."
+
+verification:
+  - description: "Prompt page loads the generated catalog include"
+    command: "test -f landing/prompts/index.html && rg -n 'catalog.generated.js' landing/prompts/index.html"
+    expected_output: "exit 0; include reference present"
+  - description: "Prompt page JS and CSS exist"
+    command: "test -f landing/prompts/prompts.js && test -f landing/prompts/prompts.css"
+    expected_output: "exit 0"
+  - description: "Catalog tests still pass after UI integration"
+    command: "uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q"
+    expected_output: "all tests pass"
+  - description: "No results-explorer files or root landing/docs nav files changed for this static page"
+    command: "! git diff --name-only | rg '^(results-explorer/|landing/index\\.html$|landing/style\\.css$|landing/script\\.js$|docs/_templates/page\\.html$)'"
+    expected_output: "exit 0; negated rg finds no matches"
+
+scope_limit:
+  only_modify:
+    - "landing/prompts/index.html"
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/prompts.css"
+    - "tests/unit/landing/"
+  do_not_modify:
+    - "landing/index.html"
+    - "landing/style.css"
+    - "landing/script.js"
+    - "docs/_templates/page.html"
+    - "results-explorer/"
+    - "benchbox/cli/"
+    - "benchbox/mcp/"
+    - "benchbox/core/platform_registry.py"
+    - "benchbox/core/benchmark_registry.py"
+
+metadata:
+  tags:
+    - landing
+    - prompts
+    - agents
+    - frontend
+    - accessibility
+  estimated_effort: "Medium"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Creates the actual marketing surface that lets visitors copy a prompt and
+    try BenchBox quickly.
+  user_impact: |
+    Reduces first-run friction by turning BenchBox's CLI/MCP choices into a
+    guided prompt and command preview.
+  technical_debt: |
+    Keeps the implementation small and isolated instead of adding another SPA
+    or public runtime surface.
+
+success_metrics:
+  - "`/prompts/` loads as a static route from the landing deployment."
+  - "Default state renders a copyable first prompt without user interaction."
+  - "Codex, Claude Code, generic/manual, CLI, MCP, local, self-hosted, managed, SQL, and DataFrame selections render coherent output."
+  - "Managed cloud selections show setup/dry-run-first guidance before any live-run command."
+  - "URL query parameters can reproduce a selected prompt configuration."
+
+open_questions:
+  - question: "Should the root landing page embed a compact builder teaser or only link to `/prompts/`?"
+    gating: false
+    affects: ["landing-prompts-launch-gates"]
+    default: "Link from root landing first; consider embedded teaser after copy-rate data exists."


### PR DESCRIPTION
Four planning TODOs for the /prompts/ landing route, addressing the
review of the prior (closed) PR #396:

- decision-gates: replaces the loose-regex check with a strict
  six-heading verification of _project/decisions/landing-prompts-route.md
  and adds the negation form `! ... | rg ...` so a clean state exits 0.
  Drops the unpinned "adversarial review findings" reference.
- catalog-generator: pins the generator at root scripts/ invoked via
  `uv run -- python scripts/...` (the `_project/scripts` env lacks
  `benchbox`, which the generator must import). Specifies the output
  artifact `landing/prompts/catalog.generated.js`
  (`window.__BENCHBOX_PROMPT_CATALOG__ = {...}`) so the static-route
  TODO has a concrete include to load. Drops `.github/workflows/docs.yml`
  from scope_limit (owned by launch-gates).
- static-route: drops `landing/index.html` and `docs/_templates/page.html`
  from scope_limit (nav edits are launch-gates), pins URL parameter
  names, and pins MCP block format (config snippet + natural-language
  prompt referencing existing tools/prompts).
- launch-gates: fixes the CI invocation to `uv run -- python scripts/...`
  and adds a verification that the workflow does NOT use the wrong
  `--project _project/scripts` form. Adds a manual a11y checklist path
  with a verification gate.

Validation:
- validate_todo.py on each new TODO: PASS
- todo_cli.py check-graph: PASS (56 items, no cycles, no dangling refs)
