### PR TITLE
[codex] Plan site header and theme unification

### DIFF
--- a/_project/TODO/main/planning/benchbox-light-dark-theme-system.yaml
+++ b/_project/TODO/main/planning/benchbox-light-dark-theme-system.yaml
@@ -1,0 +1,360 @@
+id: benchbox-light-dark-theme-system
+title: "Implement comprehensive BenchBox light/dark theming across public site and Results Explorer"
+worktree: main
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  BenchBox currently has incompatible theme models across public surfaces.
+  Landing is effectively dark-only through `landing/style.css`; docs/blog use
+  Furo's light/dark support but force the custom BenchBox nav to stay dark;
+  Results Explorer uses a custom token system and has tests that intentionally
+  pin a mixed dark-shell/light-data workspace. Users should be able to choose
+  light or dark theme consistently across landing, docs/blog, and Results
+  Explorer, with the choice persisted and respected by every page.
+
+  This phase supersedes the previous Results Explorer decision that hard-coded
+  "dark BenchBox shell + light analytical data panels" as the theme contract.
+  That visual treatment can remain the light-theme default if it still works,
+  but the product contract must become a real two-theme system: light and dark
+  tokens for shell, data panels, controls, tables, charts, badges, focus rings,
+  empty/error/loading states, code blocks, and sticky/scrollable surfaces.
+
+  This TODO depends on the shared header phase so the theme toggle and header
+  tokens are implemented once instead of being patched separately into three
+  headers.
+
+deps:
+  needs:
+    - benchbox-site-header-unification
+
+work:
+  - id: w0
+    summary: "Inventory theme assumptions and hard-coded colors across public surfaces"
+    status: pending
+    notes: |
+      Produce a compact inventory covering:
+      - landing `--bg-*`, `--text-*`, `--accent-*`, hard-coded colors, gradients,
+        badges, code blocks, and mobile menu JS-injected styles;
+      - docs/blog Furo `light_css_variables`, `dark_css_variables`, custom CSS,
+        nav overrides, code blocks, tables, admonitions, tags, and blog widgets;
+      - Results Explorer `--bb-*` tokens, `data-surface` usage, direct
+        arbitrary-value classes, raw SVG/chart hex colors, badge tones,
+        skeleton colors, sticky table colors, high/reduced-color modes, and
+        tests pinning mixed-theme behavior.
+
+      Decision gate: do not start retheming until the inventory identifies
+      which tokens are site-wide, which are Results-data-specific, and which
+      are docs/Furo adapter variables.
+
+  - id: w1
+    summary: "Define the site-wide theme contract, persistence, and toggle behavior"
+    needs: [w0]
+    status: pending
+    notes: |
+      Define:
+      - theme values: `light`, `dark`, and optional `system`;
+      - where the selected value is stored (`localStorage` key and fallback);
+      - how early the theme is applied to avoid flash of wrong theme;
+      - whether the toggle lives in the shared global header or in a menu;
+      - accessible label, keyboard behavior, and announced state;
+      - interaction with Furo's existing theme controls on docs/blog;
+      - default behavior for first-time visitors using `prefers-color-scheme`.
+
+      Decision gate: choose whether BenchBox controls Furo's theme directly or
+      maps a BenchBox site preference onto Furo's supported `data-theme`
+      contract. Do not ship two unsynchronized theme toggles on docs/blog.
+
+  - id: w2
+    summary: "Create shared semantic tokens for both themes"
+    needs: [w1]
+    status: pending
+    notes: |
+      Define token names and values for both light and dark modes:
+      - global shell: header, footer, nav, CTA, active state;
+      - app/page background;
+      - data panel, muted panel, elevated panel, sticky cell/header;
+      - primary/muted/subtle/inverse text;
+      - border, strong border, divider, shadow/elevation;
+      - focus-visible rings on light and dark surfaces;
+      - status tones: info, success, warning, danger, neutral;
+      - trust/validation/tuning/computed/visibility badges;
+      - code block and inline code;
+      - chart axis, grid, label, annotation, tooltip, categorical palette,
+        sequential palette, diverging palette, faster/slower fills, missing
+        state, and reduced/high-contrast variants.
+
+      The token contract must make dark mode a first-class mode for dense
+      analytical tables and charts, not a dark shell around light islands.
+
+  - id: w3
+    summary: "Implement shared theme initialization and toggle on static public pages"
+    needs: [w2]
+    status: pending
+    notes: |
+      Update landing and shared header assets so theme selection is applied
+      before first paint as much as static deployment allows. The landing page
+      must support light and dark for:
+      - header and mobile menu;
+      - hero and background treatment;
+      - cards, badges, links, code blocks, copy buttons, and footer;
+      - responsive states and hover/focus states.
+
+      Avoid duplicating logic in every page. Keep the implementation compatible
+      with static hosting and no frontend build step for `landing/`.
+
+  - id: w4
+    summary: "Integrate the shared theme contract with docs/blog and Furo"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Update `docs/conf.py`, `docs/_templates/page.html`, and
+      `docs/_static/custom.css` so docs/blog use the same visible theme choice
+      as the rest of BenchBox. Remove the custom nav forced-dark overrides and
+      align Furo `light_css_variables` and `dark_css_variables` with the shared
+      BenchBox tokens.
+
+      Ensure Furo search, sidebars, API pages, tables, code blocks, admonitions,
+      tags, blog archives, and blog sidebars remain readable in both themes.
+      If Furo's native toggle cannot be synchronized cleanly, document the
+      decision and hide/replace one control so users do not see conflicting
+      theme state.
+
+  - id: w5
+    summary: "Retheme Results Explorer app shell, pages, forms, panels, tables, and states"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Replace the old mixed-theme contract with theme-aware tokens in
+      `results-explorer/src/index.css` and Results components. Cover:
+      - `body`, app shell, global header, secondary Results nav, footer;
+      - Home hero/filter bands and leaderboard surfaces;
+      - Benchmark and platform detail controls, filter panels, compare bars,
+        sticky headers, sticky columns, and large tables;
+      - Compare builder, decision summary, guardrails, receipts, query diff,
+        result cards, and warning callouts;
+      - Query Workbench facets, visible columns, exports, result table,
+        Advanced SQL, starter queries, and SQL result table;
+      - loading, empty, error, warning, disabled, selected, hover, focus, and
+        reduced-color states.
+
+      Remove tests that assert the old hard-coded mixed dark/light background
+      values and replace them with tests that verify both themes.
+
+  - id: w6
+    summary: "Make Results Explorer charts and SVGs theme-aware"
+    needs: [w2, w5]
+    status: pending
+    notes: |
+      Refactor chart color access so components do not embed light-theme hex
+      values for axes, grid lines, labels, annotations, legends, missing states,
+      or fills. Cover at least:
+      - `ChartPanel.tsx`;
+      - `CDFChart.tsx`;
+      - `CostScatter.tsx`;
+      - `DistributionBox.tsx`;
+      - `DivergingBarChart.tsx`;
+      - `NormalizedSpeedupChart.tsx`;
+      - `PercentileLadder.tsx`;
+      - `PowerBar.tsx`;
+      - `QueryHistogram.tsx`;
+      - `QueryTimingChart.tsx`;
+      - `StackedPhase.tsx`;
+      - `TimeSeries.tsx`;
+      - `results-explorer/src/lib/chartTheme.ts`.
+
+      Use a theme-aware chart theme API or CSS-variable reads with SSR/test
+      fallbacks. Keep platform categorical colors stable enough that users can
+      compare charts across tabs, but adjust axis/grid/text colors by theme.
+
+  - id: w7
+    summary: "Upgrade token/literal gates to protect both themes"
+    needs: [w5, w6]
+    status: pending
+    notes: |
+      Update the Results Explorer token scan and documentation so it catches
+      theme bypasses that are currently known gaps:
+      - arbitrary-value Tailwind classes such as `text-[#374151]`;
+      - inline SVG `fill=\"#...\"` and `stroke=\"#...\"` literals outside the
+        approved chart theme source;
+      - raw `rgb()`/`rgba()` colors in public surfaces;
+      - landing/docs header literal colors that should be tokenized.
+
+      Keep a narrow allowlist for intentional palette definitions and document
+      each allowlist reason. The gate should prevent new spot fixes from
+      silently making one theme correct and the other broken.
+
+  - id: w8
+    summary: "Retire stale mixed-theme documentation, tests, and release evidence"
+    needs: [w5, w6, w7]
+    status: pending
+    notes: |
+      Update or supersede artifacts that currently encode the old Results-only
+      mixed theme contract, including:
+      - `_project/analysis/results-explorer-theme-inventory-2026-05-07.md`;
+      - `_project/analysis/results-explorer-retheme-audit-remediation-plan-2026-05-07.md`;
+      - `_project/DONE/results-explorer-contract-followup/planning/results-explorer-home-theme-and-responsive-density-contract.yaml`;
+      - `results-explorer/e2e/routes/home.spec.ts`;
+      - any release-gate reports or operations docs that describe dark shell
+        plus light analytical panels as the final product contract.
+
+      Do not rewrite history in DONE items. Add clear supersession notes where
+      appropriate, and ensure active tests assert the new user-selectable
+      light/dark contract instead of treating mixed surfaces as mandatory.
+
+  - id: w9
+    summary: "Add cross-surface visual, accessibility, and persistence verification"
+    needs: [w3, w4, w5, w6, w7, w8]
+    status: pending
+    notes: |
+      Add or extend browser checks for both light and dark themes at desktop
+      and mobile widths across:
+      - landing `/`;
+      - docs `/docs/`;
+      - blog `/blog/` if locally buildable;
+      - Results `/results/`;
+      - Results benchmark detail;
+      - Results platform detail;
+      - Results compare builder and completed compare;
+      - Results query workbench.
+
+      Verify:
+      - theme toggle changes visible colors on every surface;
+      - persisted choice survives reload and route changes;
+      - first paint does not visibly flash the opposite theme beyond the
+        accepted technical limit;
+      - WCAG contrast passes for text, controls, badges, heatmaps, chart axes,
+        disabled controls, selected rows, and warning/error states;
+      - no chart or table becomes unreadable in either theme;
+      - header remains identical across surfaces in both themes.
+
+deferred:
+  - summary: "User-customizable color palettes beyond light/dark"
+    reason: "Not required for the product contract; light/dark plus reduced/high-contrast states are sufficient for this phase."
+  - summary: "A public design-system documentation site"
+    reason: "Useful later, but current need is a durable implementation and regression gates."
+  - summary: "Replacing Furo entirely"
+    reason: "Docs already rely on Furo; integrate with its theme mechanics instead of creating a new docs frontend."
+
+prior_art:
+  - "benchbox-site-header-unification — dependency that establishes the shared global header before adding a theme toggle"
+  - "landing/style.css:3 — current dark-only landing CSS variables"
+  - "landing/script.js:133 — current JS-injected mobile nav styles that must become theme-aware"
+  - "docs/conf.py:169 — Furo theme configuration and existing light/dark variable hooks"
+  - "docs/_static/custom.css:53 — current forced-dark BenchBox nav override that must be removed or superseded"
+  - "results-explorer/src/index.css:6 — current Results Explorer `--bb-*` token definitions and mixed surface contract"
+  - "results-explorer/src/lib/chartTheme.ts:1 — current chart color source, currently fixed hex values"
+  - "docs/operations/results-explorer-token-scan.md:1 — existing Results token gate and documented arbitrary-value/SVG gaps"
+  - "_project/DONE/main/planning/results-explorer-retheme-theme-system-foundation.yaml:1 — prior Results-only retheme foundation to supersede"
+  - "_project/DONE/results-explorer-contract-followup/planning/results-explorer-home-theme-and-responsive-density-contract.yaml:1 — prior mixed-theme contract to replace with a real theme choice"
+  - "_project/analysis/results-explorer-theme-inventory-2026-05-07.md:106 — prior dark-shell/light-data decision that this TODO must supersede"
+
+must_preserve:
+  - "Users can choose light or dark theme and the choice applies consistently across landing, docs/blog, and Results Explorer."
+  - "Theme choice persists across reloads and navigation."
+  - "System preference is respected for first-time visitors unless the user chooses an explicit theme."
+  - "Header remains identical across surfaces in both light and dark themes."
+  - "Results Explorer dense analytical tables remain scannable and information-dense in both themes."
+  - "Charts, heatmaps, badges, and status states remain distinguishable in both themes and in reduced/high-contrast modes."
+  - "Docs/blog Furo functionality remains intact."
+  - "No Results data/query semantics, compare cohort rules, or result-link behavior changes as part of theming."
+
+approach: |
+  Treat theming as a shared product contract, not a Results-only retheme.
+  First inventory current assumptions, then define semantic tokens and theme
+  persistence, then migrate each surface to the shared tokens. Move chart and
+  SVG colors behind a theme-aware API before claiming dark-mode support. Finish
+  by strengthening token gates and visual/a11y coverage so future PRs cannot
+  regress one theme while testing the other.
+
+anti_patterns:
+  - "DO NOT keep the old mixed dark-shell/light-data contract as the only Results Explorer theme — because users need an actual dark and light choice."
+  - "DO NOT add a toggle that only changes the header or page background — because charts, tables, badges, and controls must also switch."
+  - "DO NOT leave docs/blog with both Furo and BenchBox theme controls showing contradictory state."
+  - "DO NOT hard-code SVG axis/grid/text colors in chart components after this work — because those are exactly where dark mode breaks."
+  - "DO NOT rely only on unit tests for a visual theme change — because contrast, flash, chart legibility, and responsive behavior require browser verification."
+  - "DO NOT solve dark mode by reducing information density or hiding table/chart details."
+
+verification:
+  - description: "Shared theme contract is documented and references all public surfaces"
+    command: "test -f _project/analysis/benchbox-theme-contract.md && rg -n 'landing|docs|blog|Results|light|dark|data-theme|localStorage|chart' _project/analysis/benchbox-theme-contract.md"
+    expected_output: "contract exists and covers shell, static pages, docs/blog, Results, persistence, and charts"
+  - description: "Results Explorer unit and component tests pass"
+    command: "cd results-explorer && npm test"
+    expected_output: "all Vitest tests pass"
+  - description: "Results Explorer builds"
+    command: "cd results-explorer && npm run build"
+    expected_output: "Vite build succeeds"
+  - description: "Docs build succeeds with synchronized theme assets"
+    command: "uv run -- sphinx-build -b html docs docs/_build/html"
+    expected_output: "Sphinx build succeeds"
+  - description: "Token/literal gates pass"
+    command: "make lint-explorer-tokens && make lint-site-theme-tokens"
+    expected_output: "Results and site-wide theme token scans pass with only documented allowlisted palette definitions; if the implementation intentionally replaces these targets, update this verification command in the same PR"
+  - description: "Cross-surface light/dark browser verification passes"
+    command: "Run the light/dark browser verification added by this TODO across landing, docs/blog, and Results routes at desktop and mobile widths"
+    expected_output: "theme toggle, persistence, contrast, charts, tables, and header parity pass in both themes"
+
+scope_limit:
+  only_modify:
+    - "landing/"
+    - "docs/conf.py"
+    - "docs/_templates/"
+    - "docs/_static/"
+    - "results-explorer/src/"
+    - "results-explorer/e2e/"
+    - "results-explorer/package.json"
+    - "results-explorer/package-lock.json"
+    - "_project/scripts/scan_explorer_tokens.py"
+    - "tests/unit/scripts/test_scan_explorer_tokens.py"
+    - "docs/operations/results-explorer-token-scan.md"
+    - "docs/operations/"
+    - "_project/analysis/"
+    - "_project/DONE/results-explorer-contract-followup/planning/results-explorer-home-theme-and-responsive-density-contract.yaml"
+  do_not_modify:
+    - "benchbox/"
+    - "results-data/"
+    - "benchmark_runs/"
+
+metadata:
+  tags:
+    - theme
+    - light-mode
+    - dark-mode
+    - site-shell
+    - landing
+    - docs
+    - results-explorer
+    - charts
+    - accessibility
+  estimated_effort: "Large (~8-12 engineering days; ~5-8 days if docs/blog scope is reduced)"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Turns BenchBox from a collection of visually related surfaces into one
+    coherent public product with user-controlled appearance.
+  user_impact: |
+    Lets users choose comfortable light or dark viewing while preserving dense
+    database-result scanning and trustworthy chart/table interpretation.
+  technical_debt: |
+    Supersedes the Results-only mixed-theme contract, centralizes theme tokens,
+    and closes known token-scan gaps that allow future drift.
+
+success_metrics:
+  - "A user can switch between light and dark on any public surface and see the same choice reflected after navigating to another surface."
+  - "Landing, docs/blog, and Results Explorer render the identical global header in both themes."
+  - "Results Explorer tables, heatmaps, charts, compare views, and Query Workbench remain readable in dark mode without light-only islands."
+  - "Automated checks fail if a public surface reintroduces unapproved literal theme colors."
+  - "Manual/browser QA records passing desktop and mobile evidence for both themes."
+
+open_questions:
+  - question: "Should the public UI expose two choices (`Light`, `Dark`) or three choices (`System`, `Light`, `Dark`)?"
+    gating: true
+    affects: ["w1", "w3", "w4", "w5", "w8"]
+    default: "`System`, `Light`, and `Dark`, with system as first-visit default and explicit choices persisted."
+  - question: "Should Furo's native theme control remain visible or be replaced by the shared BenchBox theme control on docs/blog?"
+    gating: true
+    affects: ["w1", "w4", "w8"]
+    default: "Use one visible control only; synchronize with Furo internals if keeping Furo's control."

--- a/_project/TODO/main/planning/benchbox-site-header-unification.yaml
+++ b/_project/TODO/main/planning/benchbox-site-header-unification.yaml
@@ -1,0 +1,247 @@
+id: benchbox-site-header-unification
+title: "Unify BenchBox site header across landing, docs/blog, and Results Explorer"
+worktree: main
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The public BenchBox site currently ships multiple independent header
+  implementations. The landing page uses `landing/index.html` and
+  `landing/style.css`; docs/blog inject a Furo-adjacent header from
+  `docs/_templates/page.html` and `docs/_static/custom.css`; Results Explorer
+  renders a separate Preact header in `results-explorer/src/components/Layout.tsx`.
+  Those headers differ in link set, CTA presence, max width, fixed/sticky/static
+  positioning, spacing, mobile behavior, active state, and theme assumptions.
+
+  This is a product-shell defect: the user should experience one BenchBox
+  global header everywhere, including `/`, `/docs/`, `/blog/`, and `/results/`.
+  Results Explorer may keep a secondary Results-specific navigation row below
+  the global header, but the global header itself must be identical in content,
+  layout, spacing, colors, active-link behavior, and responsive behavior.
+
+  This phase intentionally solves only the shared header contract. It should
+  not attempt the full light/dark retheme; it must, however, avoid introducing
+  new header styling that will block the follow-up theme phase.
+
+deps:
+  needs: []
+
+work:
+  - id: w0
+    summary: "Capture current header variants and define the exact global-header contract"
+    status: pending
+    notes: |
+      Inspect the current landing, docs/blog, and Results Explorer header
+      implementations and capture a compact comparison matrix covering:
+      - link order and labels;
+      - external URL casing and target behavior;
+      - CTA presence and destination;
+      - max width, height, padding, gap, typography, border, backdrop, and z-index;
+      - fixed vs sticky vs static positioning;
+      - active-link semantics for Home, Docs, Blog, Results, and GitHub;
+      - mobile breakpoint behavior and keyboard/focus behavior.
+
+      Decision gate: choose the canonical header contract before editing code.
+      The default should be the public landing header shape unless a specific
+      accessibility or routing issue requires a documented adjustment. Record
+      the chosen contract in a short analysis note or in the implementation PR
+      description; do not let each surface make local design choices.
+
+  - id: w1
+    summary: "Create a shared static header asset contract for non-React pages"
+    needs: [w0]
+    status: pending
+    notes: |
+      Extract the canonical header markup and CSS into reusable site-shell
+      assets that landing and docs/blog can consume without duplicating class
+      definitions. Prefer a small shared CSS file and template/include strategy
+      that works with the existing static landing deployment and Sphinx/Furo
+      docs build.
+
+      Preferred durable home: keep static shared shell assets under
+      `landing/shared/` and copy/reference them from docs as part of the normal
+      docs static build, or document why that path is not viable before choosing
+      a different location. The implementation must leave a clear source of
+      truth so the next header change has one obvious file to edit.
+
+      The shared contract must include:
+      - the exact global link set and order;
+      - active-state attributes/classes that can be applied by page context;
+      - mobile menu behavior if the canonical header needs it;
+      - no hard dependency on the Results Explorer Vite build;
+      - no duplicated magic numbers between landing and docs custom CSS.
+
+      Decision gate: if true shared includes are impractical because of the
+      deployment pipeline, document the constraint and keep one generated source
+      of truth or a test-enforced mirror. Do not manually fork the header again.
+
+  - id: w2
+    summary: "Apply the shared header to the landing page"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace the landing page's local header markup/styles with the shared
+      global-header contract while preserving landing-only section links only
+      if the contract explicitly allows an in-page secondary section nav. If
+      section links remain, they must be visually distinct from the global
+      header and must not appear as global site navigation on other surfaces.
+
+      Preserve existing copy buttons, smooth-scroll behavior, mobile menu
+      behavior, and first-viewport hero layout. Any JS moved from
+      `landing/script.js` must remain static-file friendly.
+
+  - id: w3
+    summary: "Apply the shared header to docs and blog without breaking Furo controls"
+    needs: [w1]
+    status: pending
+    notes: |
+      Replace the docs/blog custom nav in `docs/_templates/page.html` and
+      `docs/_static/custom.css` with the shared global-header contract. Keep
+      Furo's sidebars, search, edit/view buttons, keyboard navigation, and
+      built-in theme controls working.
+
+      Remove or revise the existing docs CSS that forces the BenchBox nav to
+      stay dark under `[data-theme=\"light\"]`, because phase 2 will make the
+      header theme-aware. For this phase, preserve the current visual result
+      unless the chosen canonical contract says otherwise.
+
+  - id: w4
+    summary: "Apply the shared global header to Results Explorer and preserve the Results subnav"
+    needs: [w1]
+    status: pending
+    notes: |
+      Refactor `results-explorer/src/components/Layout.tsx` so the global
+      header matches the canonical shared header. Keep the Results Explorer
+      secondary nav (`Leaderboards`, `Benchmarks`, `Platforms`, `Compare`,
+      `Query`) below the global header as a separate product nav with its own
+      aria-label and active-state tests.
+
+      The Results global header must not invent different spacing, link order,
+      CTA text, max width, border treatment, or mobile behavior. It may use a
+      Preact component wrapper only to integrate routing and active state.
+
+  - id: w5
+    summary: "Add cross-surface header parity tests and screenshots"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Add verification that compares the global header across:
+      - landing `/`;
+      - docs `/docs/`;
+      - blog `/blog/` if locally buildable;
+      - Results `/results/`.
+
+      At minimum, assert identical visible global nav labels/order, CTA label
+      and URL, logo URL, active-link semantics, and mobile behavior. Add
+      desktop and mobile visual screenshots or DOM snapshots sufficient to
+      catch future drift. Results-specific secondary nav must be asserted as
+      separate from the global header, not as a reason for global-header drift.
+
+deferred:
+  - summary: "Full light/dark theme switching"
+    reason: "Owned by dependent TODO `benchbox-light-dark-theme-system`; this phase must avoid blocking it but should not implement it opportunistically."
+  - summary: "Redesign the Results Explorer information architecture"
+    reason: "The request is header parity, not new navigation architecture. Keep the Results secondary nav unless a concrete usability defect requires a separate TODO."
+
+prior_art:
+  - "landing/index.html:20 — current public landing header markup; candidate canonical global link set"
+  - "landing/style.css:55 — current landing nav spacing, fixed positioning, backdrop, and responsive rules"
+  - "landing/script.js:3 — current landing smooth-scroll and mobile menu behavior"
+  - "landing/shared/ — preferred new home for shared static shell CSS/JS if this TODO creates reusable assets"
+  - "docs/_templates/page.html:14 — current Sphinx/Furo injected site navigation"
+  - "docs/_static/custom.css:10 — current docs nav CSS, including forced dark overrides"
+  - "results-explorer/src/components/Layout.tsx:18 — current Results Explorer global header and secondary nav"
+  - "results-explorer/src/components/__tests__/Layout.test.tsx:30 — current Results header/link/active-state unit coverage"
+  - "results-explorer/e2e/routes/home.spec.ts:28 — existing mixed-theme assertion that phase 2 must supersede"
+
+must_preserve:
+  - "One global BenchBox header contract applies to landing, docs/blog, and Results Explorer."
+  - "Results Explorer keeps a clearly separate secondary Results navigation row unless a separate IA decision changes it."
+  - "Existing public URLs continue to work: `/`, `/docs/`, `/blog/`, `/results/`, GitHub, and installation/run-benchmark destination."
+  - "Docs/blog Furo search, sidebar, edit/view buttons, keyboard navigation, and built-in theme controls remain functional."
+  - "Landing smooth-scroll/copy interactions and mobile navigation remain functional."
+  - "Header changes do not alter Results Explorer data queries, result routes, compare flow, or DuckDB loading."
+
+approach: |
+  Start by deciding the canonical global header from real rendered surfaces,
+  then make every surface consume or test-enforce that contract. Treat Results
+  Explorer's secondary nav as a product-specific child nav, not as part of the
+  global shell. Keep CSS token names compatible with the follow-up light/dark
+  theme work so phase 2 can swap values without rewriting header markup again.
+
+anti_patterns:
+  - "DO NOT copy-paste three visually similar headers and call them unified — because the current defect is independent implementations drifting."
+  - "DO NOT make the Results global header almost identical except for spacing or CTA behavior — because the user requirement is identical."
+  - "DO NOT use the Results secondary nav to justify changing the global header — because the secondary nav is a separate product navigation layer."
+  - "DO NOT remove Furo's theme controls or search while harmonizing docs/blog — because docs usability is outside the header defect."
+  - "DO NOT start the full dark/light retheme in this phase — because phase 1 needs a stable shell contract first."
+
+verification:
+  - description: "Results Explorer layout tests pass after header refactor"
+    command: "cd results-explorer && npm test -- src/components/__tests__/Layout.test.tsx"
+    expected_output: "Layout tests pass and assert global-header parity plus Results subnav separation"
+  - description: "Landing header source uses the shared header contract"
+    command: "rg -n 'benchbox-site-header|site-header|nav-logo|Run benchmark|Results' landing docs/_templates docs/_static results-explorer/src/components/Layout.tsx"
+    expected_output: "review output shows one shared/global header contract, not divergent local implementations"
+  - description: "Docs build still succeeds"
+    command: "uv run -- sphinx-build -b html docs docs/_build/html"
+    expected_output: "Sphinx build succeeds without template or static asset errors"
+  - description: "Results Explorer builds"
+    command: "cd results-explorer && npm run build"
+    expected_output: "Vite build succeeds"
+  - description: "Cross-surface visual parity check passes"
+    command: "Run the header parity browser check added by this TODO for landing, docs/blog, and Results at desktop and mobile widths"
+    expected_output: "global header labels, spacing, active state, CTA, logo, and mobile behavior match across surfaces"
+
+scope_limit:
+  only_modify:
+    - "landing/"
+    - "landing/shared/"
+    - "docs/_templates/"
+    - "docs/_static/"
+    - "docs/conf.py"
+    - "results-explorer/src/components/Layout.tsx"
+    - "results-explorer/src/components/__tests__/Layout.test.tsx"
+    - "results-explorer/e2e/"
+    - "tests/"
+    - "_project/analysis/"
+  do_not_modify:
+    - "benchbox/"
+    - "results-data/"
+    - "results-explorer/src/db.ts"
+    - "results-explorer/src/lib/duckdbQueries.ts"
+
+metadata:
+  tags:
+    - site-shell
+    - header
+    - landing
+    - docs
+    - results-explorer
+    - accessibility
+  estimated_effort: "Small to Medium (~1-2 days)"
+  created_date: "2026-05-13"
+
+impact:
+  business_value: |
+    Removes a high-visibility brand and trust defect: BenchBox should look like
+    one product as users move from marketing content to docs and public results.
+  user_impact: |
+    Gives users stable navigation and active-state semantics across all public
+    surfaces.
+  technical_debt: |
+    Replaces drifting header copies with a shared/test-enforced shell contract,
+    setting up the later theme system.
+
+success_metrics:
+  - "The global header is visually and semantically identical on landing, docs/blog, and Results Explorer at desktop width."
+  - "The global header mobile behavior is identical across all public surfaces."
+  - "Results Explorer secondary nav remains visible and correctly active, but is visually separate from the global header."
+  - "A future change to only one header implementation fails a parity test or documented review gate."
+
+open_questions:
+  - question: "Should landing page section anchors remain inside the global header or move to a landing-only secondary section nav?"
+    gating: true
+    affects: ["w0", "w2"]
+    default: "Move section anchors out of the global header contract so global site navigation remains identical everywhere."


### PR DESCRIPTION
## What changed

Adds two planning TODOs:

- `benchbox-site-header-unification`: Phase 1 plan to make the global BenchBox header identical across landing, docs/blog, and Results Explorer while preserving the Results secondary nav as a separate product nav.
- `benchbox-light-dark-theme-system`: Phase 2 plan for comprehensive light/dark theming across landing, docs/blog, and Results Explorer, dependent on the header unification work.

## Why

The Results Explorer header drifted from the public landing page because the site has separate header and theme implementations. The previous Results Explorer mixed dark-shell/light-data contract is also too narrow now that users need explicit light/dark theme choice across the product.

## TODO review fixes applied

`$todo review` found and I fixed these issues before publishing:

- Named a durable preferred home for shared static header assets (`landing/shared/`) instead of leaving the shared-header location ambiguous.
- Added explicit work to retire/supersede stale mixed-theme documentation, tests, and release evidence.
- Updated theme verification so it requires both the existing Results token gate and a new site-wide theme token gate.

## Validation

- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex`
- commit hooks passed: YAML, whitespace, large-file, merge-conflict, private-key, codespell checks
