### PR TITLE
feat(landing): add /prompts/ static page and prompt builder UI

### DIFF
--- a/_project/DONE/main/landing-prompts-static-route.yaml
+++ b/_project/DONE/main/landing-prompts-static-route.yaml
@@ -2,7 +2,8 @@ id: landing-prompts-static-route
 title: "Implement the static /prompts/ landing route and prompt builder UI"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
+completed_date: "2026-05-13"
 category: Product and Documentation
 
 description: |
@@ -31,7 +32,7 @@ deps:
 work:
   - id: w1
     summary: "Create the /prompts/ static page shell using landing visual conventions"
-    status: pending
+    status: done
     notes: |
       Add `landing/prompts/index.html`, `landing/prompts/prompts.js`, and
       `landing/prompts/prompts.css`. The page must include
@@ -44,7 +45,7 @@ work:
   - id: w2
     summary: "Render the selector controls from generated catalog data"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Controls:
       - Goal: Test one platform / Compare platforms
@@ -63,7 +64,7 @@ work:
   - id: w3
     summary: "Implement state normalization, filtering, and URL deep links"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Normalize invalid combinations when controls change:
       - replace a platform that no longer matches current filters
@@ -80,7 +81,7 @@ work:
   - id: w4
     summary: "Render CLI, MCP, and generic/manual prompt outputs with safety notes"
     needs: [w3]
-    status: pending
+    status: done
     notes: |
       CLI mode emits dependency/status checks, dry-run commands, and live-run
       commands only where safe. MCP mode renders TWO copyable blocks: (a) the
@@ -99,7 +100,7 @@ work:
   - id: w5
     summary: "Add accessible copy interactions and fallback behavior"
     needs: [w4]
-    status: pending
+    status: done
     notes: |
       Copy buttons should work for the main prompt, CLI command block, and MCP
       setup block. Add clear focus states, labels, `aria-live` copy feedback,
@@ -108,7 +109,7 @@ work:
   - id: w6
     summary: "Verify desktop/mobile layout and text overflow"
     needs: [w5]
-    status: pending
+    status: done
     notes: |
       Check at least mobile narrow, tablet, and desktop viewports. The form and
       copied prompt must not overflow or overlap. Long platform names and cloud

--- a/landing/prompts/index.html
+++ b/landing/prompts/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Instruct a coding agent to use BenchBox</title>
+        <meta
+            name="description"
+            content="Build a copy-paste prompt that tells a coding agent (or you, from the CLI) how to run a BenchBox benchmark. Pick an agent, surface, platform, benchmark, and scale; copy the prompt."
+        />
+        <link rel="stylesheet" href="../style.css?v=5" />
+        <link rel="stylesheet" href="prompts.css?v=1" />
+    </head>
+
+    <body>
+        <nav class="nav">
+            <div class="nav-container">
+                <a href="https://benchbox.dev/" class="nav-logo">BenchBox</a>
+                <div class="nav-links">
+                    <a href="https://benchbox.dev/">Home</a>
+                    <a href="https://benchbox.dev/docs/">Docs</a>
+                    <a href="https://benchbox.dev/blog/">Blog</a>
+                    <a href="https://benchbox.dev/results/">Results</a>
+                    <a href="https://github.com/joeharris76/benchbox" target="_blank" rel="noopener">GitHub</a>
+                </div>
+            </div>
+        </nav>
+
+        <main class="prompts-main">
+            <header class="prompts-header">
+                <h1>Instruct a coding agent to use BenchBox</h1>
+                <p class="prompts-lede">
+                    Pick an agent, surface, platform, benchmark, and scale. Copy the prompt into your agent (or run
+                    the commands yourself). Defaults to a safe local DuckDB + TPC-H quickstart.
+                </p>
+            </header>
+
+            <noscript>
+                <div class="prompts-noscript">
+                    This builder is interactive and requires JavaScript. With JS disabled you can still get started:
+                    <code>uv add 'benchbox[duckdb]' &amp;&amp; uv run benchbox run -p duckdb -b tpch -s 0.01</code>
+                </div>
+            </noscript>
+
+            <form class="prompts-form" id="prompts-form" aria-label="Prompt builder">
+                <div class="prompts-grid">
+                    <label class="prompts-field">
+                        <span>Goal</span>
+                        <select id="sel-goal" name="goal"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Agent</span>
+                        <select id="sel-agent" name="agent"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Surface</span>
+                        <select id="sel-surface" name="surface"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Interface</span>
+                        <select id="sel-interface" name="interface"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Deployment</span>
+                        <select id="sel-deployment" name="deployment"></select>
+                    </label>
+                    <label class="prompts-field" data-mode="test_one">
+                        <span>Platform</span>
+                        <select id="sel-platform" name="platform"></select>
+                    </label>
+                    <label class="prompts-field" data-mode="compare" hidden>
+                        <span>Platform A</span>
+                        <select id="sel-platformA" name="platformA"></select>
+                    </label>
+                    <label class="prompts-field" data-mode="compare" hidden>
+                        <span>Platform B</span>
+                        <select id="sel-platformB" name="platformB"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Benchmark</span>
+                        <select id="sel-benchmark" name="benchmark"></select>
+                    </label>
+                    <label class="prompts-field">
+                        <span>Scale</span>
+                        <select id="sel-scale" name="scale"></select>
+                    </label>
+                </div>
+            </form>
+
+            <section class="prompts-output">
+                <div class="prompts-block" id="block-prompt" hidden>
+                    <header>
+                        <h2>Agent prompt</h2>
+                        <button type="button" class="prompts-copy" data-copy-target="prompt-text">Copy</button>
+                    </header>
+                    <pre id="prompt-text"></pre>
+                </div>
+
+                <div class="prompts-block" id="block-cli" hidden>
+                    <header>
+                        <h2>CLI commands</h2>
+                        <button type="button" class="prompts-copy" data-copy-target="cli-text">Copy</button>
+                    </header>
+                    <pre id="cli-text"></pre>
+                </div>
+
+                <div class="prompts-block" id="block-mcp-setup" hidden>
+                    <header>
+                        <h2>MCP server setup</h2>
+                        <button type="button" class="prompts-copy" data-copy-target="mcp-setup-text">Copy</button>
+                    </header>
+                    <p class="prompts-block-hint">
+                        Add this entry to your agent's MCP config (e.g.
+                        <code>~/.codex/config.toml</code> or <code>claude_desktop_config.json</code>):
+                    </p>
+                    <pre id="mcp-setup-text"></pre>
+                </div>
+
+                <div class="prompts-block" id="block-mcp-prompt" hidden>
+                    <header>
+                        <h2>MCP prompt</h2>
+                        <button type="button" class="prompts-copy" data-copy-target="mcp-prompt-text">Copy</button>
+                    </header>
+                    <p class="prompts-block-hint">
+                        Paste this into the agent after the MCP server is connected:
+                    </p>
+                    <pre id="mcp-prompt-text"></pre>
+                </div>
+
+                <div class="prompts-block prompts-block--warn" id="block-cloud-safety" hidden>
+                    <header>
+                        <h2>Managed cloud safety</h2>
+                    </header>
+                    <ul id="cloud-safety-list"></ul>
+                </div>
+
+                <div role="status" aria-live="polite" class="prompts-aria" id="copy-status"></div>
+            </section>
+        </main>
+
+        <script src="catalog.generated.js"></script>
+        <script src="prompts.js"></script>
+    </body>
+</html>

--- a/landing/prompts/prompts.css
+++ b/landing/prompts/prompts.css
@@ -1,0 +1,163 @@
+/* Page-specific styles for /prompts/ — reuses ../style.css variables. */
+
+.prompts-main {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: var(--space-xl) var(--space-lg) var(--space-3xl);
+}
+
+.prompts-header h1 {
+    font-size: clamp(1.5rem, 3vw, 2.25rem);
+    margin-bottom: var(--space-sm);
+}
+
+.prompts-lede {
+    color: var(--text-secondary);
+    margin-bottom: var(--space-xl);
+    max-width: 60ch;
+}
+
+.prompts-noscript {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    margin-bottom: var(--space-lg);
+}
+
+.prompts-form {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-lg);
+    padding: var(--space-lg);
+    margin-bottom: var(--space-xl);
+}
+
+.prompts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: var(--space-md);
+}
+
+.prompts-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.prompts-field > span {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.prompts-field select {
+    appearance: none;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-sm);
+    padding: var(--space-sm) var(--space-md);
+    font: inherit;
+    cursor: pointer;
+}
+
+.prompts-field select:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.prompts-output {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+}
+
+.prompts-block {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-md);
+    padding: var(--space-md) var(--space-lg) var(--space-lg);
+}
+
+.prompts-block header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--space-sm);
+}
+
+.prompts-block h2 {
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+.prompts-block-hint {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: var(--space-sm);
+}
+
+.prompts-block pre {
+    background: var(--code-bg);
+    border: 1px solid var(--code-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-md);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    max-width: 100%;
+}
+
+.prompts-copy {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-sm);
+    padding: var(--space-xs) var(--space-md);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.prompts-copy:hover,
+.prompts-copy:focus-visible {
+    background: var(--accent-secondary);
+    color: #fff;
+    outline: none;
+}
+
+.prompts-block--warn {
+    border-color: #d29922;
+}
+
+.prompts-block--warn h2::before {
+    content: "⚠ ";
+}
+
+.prompts-block--warn ul {
+    color: var(--text-secondary);
+    padding-left: var(--space-lg);
+    font-size: 0.9rem;
+}
+
+.prompts-aria {
+    position: absolute;
+    left: -10000px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+@media (max-width: 540px) {
+    .prompts-main {
+        padding: var(--space-md);
+    }
+    .prompts-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/landing/prompts/prompts.js
+++ b/landing/prompts/prompts.js
@@ -1,0 +1,371 @@
+/* /prompts/ landing route — state + rendering for the prompt builder.
+ *
+ * Reads `window.__BENCHBOX_PROMPT_CATALOG__` (set by catalog.generated.js),
+ * syncs selection state to URL query parameters, filters platform options
+ * by selected interface + deployment, and renders agent / CLI / MCP output
+ * blocks. No framework — plain vanilla JS so the page stays a static
+ * deploy under `landing/`.
+ *
+ * URL parameters (pinned by `landing-prompts-static-route` w3):
+ *   goal, agent, surface, interface, deployment, platform, platformA,
+ *   platformB, benchmark, scale.
+ */
+(function () {
+    "use strict";
+
+    var catalog = window.__BENCHBOX_PROMPT_CATALOG__;
+    if (!catalog) {
+        console.error("__BENCHBOX_PROMPT_CATALOG__ missing — catalog.generated.js failed to load");
+        return;
+    }
+
+    var $ = function (id) { return document.getElementById(id); };
+    var qs = function (s) { return document.querySelectorAll(s); };
+
+    var SELECTORS = ["goal", "agent", "surface", "interface", "deployment", "platform", "platformA", "platformB", "benchmark", "scale"];
+
+    function getStateFromURL() {
+        var params = new URLSearchParams(window.location.search);
+        var state = {};
+        SELECTORS.forEach(function (k) {
+            var v = params.get(k);
+            if (v !== null && v !== "") state[k] = v;
+        });
+        return state;
+    }
+
+    function writeStateToURL(state) {
+        var params = new URLSearchParams();
+        SELECTORS.forEach(function (k) {
+            if (state[k] !== undefined && state[k] !== null && state[k] !== "") {
+                params.set(k, String(state[k]));
+            }
+        });
+        var qs = params.toString();
+        var newUrl = window.location.pathname + (qs ? "?" + qs : "");
+        window.history.replaceState({}, "", newUrl);
+    }
+
+    function findById(list, id) {
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].id === id) return list[i];
+        }
+        return null;
+    }
+
+    function platformsForFilters(iface, deployment) {
+        return catalog.platforms.filter(function (p) {
+            return p.interfaces.indexOf(iface) !== -1 && p.deployments.indexOf(deployment) !== -1;
+        });
+    }
+
+    function benchmarksForInterface(iface) {
+        return catalog.benchmarks.filter(function (b) { return b.interfaces.indexOf(iface) !== -1; });
+    }
+
+    function fillSelect(el, items, currentValue, labelFn) {
+        var current = currentValue;
+        el.innerHTML = "";
+        items.forEach(function (item) {
+            var opt = document.createElement("option");
+            opt.value = item.id || String(item);
+            opt.textContent = labelFn ? labelFn(item) : (item.label || item.id || String(item));
+            el.appendChild(opt);
+        });
+        var ids = items.map(function (i) { return i.id || String(i); });
+        if (current && ids.indexOf(String(current)) !== -1) {
+            el.value = String(current);
+        } else {
+            el.value = ids[0] || "";
+        }
+    }
+
+    function deriveCompareDefaults(state) {
+        var pool = platformsForFilters(state["interface"], state.deployment);
+        if (pool.length < 2) return [null, null];
+        var a = state.platformA && pool.some(function (p) { return p.id === state.platformA; }) ? state.platformA : pool[0].id;
+        var b = state.platformB && state.platformB !== a && pool.some(function (p) { return p.id === state.platformB; }) ? state.platformB : (pool.find(function (p) { return p.id !== a; }) || pool[0]).id;
+        return [a, b];
+    }
+
+    function normaliseState(raw) {
+        var defaults = catalog.defaults;
+        var state = {};
+        ["goal", "agent", "surface", "interface", "deployment", "benchmark"].forEach(function (k) {
+            state[k] = raw[k] || defaults[k];
+        });
+        // scale stored as string in URL, lookup against numeric scales
+        var scaleStr = raw.scale || String(defaults.scale);
+        var scaleNum = parseFloat(scaleStr);
+        state.scale = catalog.scales.indexOf(scaleNum) !== -1 ? scaleNum : defaults.scale;
+
+        // benchmark must support selected interface
+        if (!benchmarksForInterface(state["interface"]).some(function (b) { return b.id === state.benchmark; })) {
+            var bb = benchmarksForInterface(state["interface"])[0] || catalog.benchmarks[0];
+            state.benchmark = bb.id;
+        }
+
+        // platform filtering
+        var pool = platformsForFilters(state["interface"], state.deployment);
+        if (pool.length === 0) {
+            // fall back: relax deployment first
+            state.deployment = defaults.deployment;
+            pool = platformsForFilters(state["interface"], state.deployment);
+        }
+        if (pool.length === 0) {
+            state["interface"] = defaults["interface"];
+            pool = platformsForFilters(state["interface"], state.deployment);
+        }
+
+        if (state.goal === "compare") {
+            var pair = deriveCompareDefaults(Object.assign({}, raw, state));
+            state.platformA = pair[0];
+            state.platformB = pair[1];
+            state.platform = undefined;
+        } else {
+            var p = raw.platform && pool.some(function (pp) { return pp.id === raw.platform; }) ? raw.platform : (pool[0] && pool[0].id) || defaults.platform;
+            state.platform = p;
+            state.platformA = undefined;
+            state.platformB = undefined;
+        }
+        return state;
+    }
+
+    function renderSelectors(state) {
+        fillSelect($("sel-goal"), catalog.goals, state.goal);
+        fillSelect($("sel-agent"), catalog.agents, state.agent);
+        fillSelect($("sel-surface"), catalog.surfaces, state.surface);
+        fillSelect($("sel-interface"), catalog.interfaces, state["interface"]);
+        fillSelect($("sel-deployment"), catalog.deployments, state.deployment);
+        fillSelect($("sel-benchmark"), benchmarksForInterface(state["interface"]), state.benchmark);
+        fillSelect($("sel-scale"), catalog.scales.map(function (s) { return { id: String(s), label: String(s) }; }), String(state.scale));
+
+        var pool = platformsForFilters(state["interface"], state.deployment);
+
+        qs('[data-mode="test_one"]').forEach(function (el) { el.hidden = state.goal === "compare"; });
+        qs('[data-mode="compare"]').forEach(function (el) { el.hidden = state.goal !== "compare"; });
+
+        if (state.goal === "compare") {
+            fillSelect($("sel-platformA"), pool, state.platformA);
+            // exclude A from B options if possible
+            var poolB = pool.filter(function (p) { return p.id !== state.platformA; });
+            if (poolB.length === 0) poolB = pool;
+            fillSelect($("sel-platformB"), poolB, state.platformB);
+        } else {
+            fillSelect($("sel-platform"), pool, state.platform);
+        }
+    }
+
+    function renderOutput(state) {
+        // Decide which output blocks to show by agent + surface
+        var isCompare = state.goal === "compare";
+        var platform = isCompare ? state.platformA : state.platform;
+        var platformB = isCompare ? state.platformB : null;
+        var platformEntry = findById(catalog.platforms, platform);
+        var platformBEntry = isCompare ? findById(catalog.platforms, platformB) : null;
+        var benchmarkEntry = findById(catalog.benchmarks, state.benchmark);
+        var managed = state.deployment === "managed";
+
+        var cliCmd = isCompare
+            ? renderTemplate(catalog.templates.cli.compare, { platform_a: platform, platform_b: platformB, benchmark: state.benchmark, scale: state.scale })
+            : renderTemplate(catalog.templates.cli.test_one, { platform: platform, benchmark: state.benchmark, scale: state.scale });
+
+        var depCheck = renderTemplate(catalog.templates.cli.dependency_check, { platform: platform });
+        var depCheckB = isCompare ? renderTemplate(catalog.templates.cli.dependency_check, { platform: platformB }) : null;
+        var dryRun = isCompare
+            ? cliCmd + " --dry-run"
+            : renderTemplate(catalog.templates.cli.dry_run, { platform: platform, benchmark: state.benchmark, scale: state.scale });
+
+        // CLI block content
+        var cliLines = [];
+        cliLines.push("# 1. Install BenchBox with the platform extra(s)");
+        cliLines.push("uv add 'benchbox[" + platform + "]'" + (isCompare ? " 'benchbox[" + platformB + "]'" : ""));
+        cliLines.push("");
+        cliLines.push("# 2. Check dependencies / readiness");
+        cliLines.push(depCheck);
+        if (depCheckB) cliLines.push(depCheckB);
+        cliLines.push("");
+        cliLines.push("# 3. Dry run (inspect the plan, no live execution)");
+        cliLines.push(dryRun);
+        if (managed) {
+            cliLines.push("");
+            cliLines.push("# 4. After credentials are configured outside this chat, run live:");
+        } else {
+            cliLines.push("");
+            cliLines.push("# 4. Run the benchmark");
+        }
+        cliLines.push(cliCmd);
+        $("cli-text").textContent = cliLines.join("\n");
+
+        // MCP setup + prompt blocks
+        var mcpTomlLines = [
+            "[mcp_servers.benchbox]",
+            'command = "uv"',
+            'args = ["run", "--", "python", "-m", "benchbox.mcp"]'
+        ];
+        $("mcp-setup-text").textContent = mcpTomlLines.join("\n");
+
+        var mcpToolName = catalog.mcp.run_tool;
+        var mcpPromptName = isCompare ? catalog.mcp.prompts.compare_platforms : catalog.mcp.prompts.benchmark_run;
+        var mcpPromptText;
+        if (isCompare) {
+            mcpPromptText = [
+                "Use the BenchBox MCP server to compare " + platformLabel(platformEntry) + " and " + platformLabel(platformBEntry) + ".",
+                "Steps:",
+                "  1. Call the `" + catalog.mcp.list_tool + "` tool to confirm both platforms are available.",
+                "  2. Use the `" + mcpPromptName + "` prompt with benchmark=" + state.benchmark + ", platforms=\"" + platform + "," + platformB + "\", scale_factor=" + state.scale + ".",
+                "  3. Run the `" + mcpToolName + "` tool for each platform with the same benchmark and scale.",
+                "  4. Summarise total runtime, per-query timing, and any failures.",
+                managed ? "  • Stop and ask the user if credentials or config for a managed platform are missing — do not request secrets in chat." : ""
+            ].filter(Boolean).join("\n");
+        } else {
+            mcpPromptText = [
+                "Use the BenchBox MCP server to run " + (benchmarkEntry ? benchmarkEntry.label : state.benchmark) + " on " + platformLabel(platformEntry) + ".",
+                "Steps:",
+                "  1. Call the `" + catalog.mcp.list_tool + "` tool to confirm the platform is installed.",
+                "  2. Use the `" + mcpPromptName + "` prompt with platform=" + platform + ", benchmark=" + state.benchmark + ", scale_factor=" + state.scale + ".",
+                "  3. Run the `" + mcpToolName + "` tool with the same arguments.",
+                "  4. Summarise total runtime and any failures.",
+                managed ? "  • Stop and ask the user if credentials or config are missing — do not request secrets in chat." : ""
+            ].filter(Boolean).join("\n");
+        }
+        $("mcp-prompt-text").textContent = mcpPromptText;
+
+        // Agent / generic prompt block
+        $("prompt-text").textContent = buildAgentPrompt(state, platform, platformB, platformEntry, platformBEntry, benchmarkEntry, cliCmd, dryRun, depCheck, depCheckB, managed);
+
+        // Visibility rules:
+        // - Agent prompt: shown for codex / claude-code (anything that isn't generic), or for generic when surface != CLI-only.
+        // - CLI block: shown for surface=CLI OR generic agent (manual recipe lives here).
+        // - MCP blocks: shown for surface=MCP.
+        // - Cloud safety: shown for deployment=managed.
+        $("block-prompt").hidden = state.agent === "generic" && state.surface === "cli";
+        $("block-cli").hidden = state.surface === "mcp" && state.agent !== "generic";
+        $("block-mcp-setup").hidden = state.surface !== "mcp";
+        $("block-mcp-prompt").hidden = state.surface !== "mcp";
+
+        var safetyList = $("cloud-safety-list");
+        safetyList.innerHTML = "";
+        if (managed && platformEntry && platformEntry.safety_terms) {
+            ["dependency", "dry_run", "no_secrets"].forEach(function (k) {
+                if (platformEntry.safety_terms[k]) {
+                    var li = document.createElement("li");
+                    li.textContent = platformEntry.safety_terms[k];
+                    safetyList.appendChild(li);
+                }
+            });
+            $("block-cloud-safety").hidden = false;
+        } else {
+            $("block-cloud-safety").hidden = true;
+        }
+    }
+
+    function platformLabel(entry) { return entry ? (entry.label || entry.id) : "the selected platform"; }
+
+    function renderTemplate(tpl, vars) {
+        return tpl.replace(/\{([a-z_]+)\}/g, function (_, k) {
+            return vars[k] !== undefined ? String(vars[k]) : "{" + k + "}";
+        });
+    }
+
+    function buildAgentPrompt(state, platform, platformB, platformEntry, platformBEntry, benchmarkEntry, cliCmd, dryRun, depCheck, depCheckB, managed) {
+        var pretty = benchmarkEntry ? benchmarkEntry.label : state.benchmark;
+        var agentLine;
+        if (state.agent === "codex") {
+            agentLine = "You are Codex with shell access. Help me run a BenchBox benchmark end-to-end.";
+        } else if (state.agent === "claude-code") {
+            agentLine = "You are Claude Code with shell access. Help me run a BenchBox benchmark end-to-end.";
+        } else {
+            agentLine = "Here is a manual recipe for running a BenchBox benchmark. Follow each step in your terminal.";
+        }
+
+        var lines = [agentLine, ""];
+        if (state.goal === "compare") {
+            lines.push("Goal: compare " + platformLabel(platformEntry) + " and " + platformLabel(platformBEntry) + " on " + pretty + " at scale factor " + state.scale + " (" + state["interface"].toUpperCase() + " interface, " + state.deployment + " deployment).");
+        } else {
+            lines.push("Goal: run " + pretty + " on " + platformLabel(platformEntry) + " at scale factor " + state.scale + " (" + state["interface"].toUpperCase() + " interface, " + state.deployment + " deployment).");
+        }
+        lines.push("");
+        lines.push("Steps:");
+        lines.push("  1. Install: `uv add 'benchbox[" + platform + "]'" + (platformB ? " 'benchbox[" + platformB + "]'" : "") + "`.");
+        lines.push("  2. Check dependencies: `" + depCheck + "`" + (depCheckB ? " and `" + depCheckB + "`" : "") + ". Stop and report if anything is missing.");
+        lines.push("  3. Dry run first: `" + dryRun + "`. Inspect the plan.");
+        if (managed) {
+            lines.push("  4. Make sure managed-platform credentials are configured outside this conversation (env vars, config files). Do NOT ask me to paste secrets here.");
+            lines.push("  5. Once credentials are confirmed, run live: `" + cliCmd + "`.");
+        } else {
+            lines.push("  4. Run live: `" + cliCmd + "`.");
+        }
+        lines.push("  " + (managed ? "6" : "5") + ". Summarise the result: total runtime, per-query timing, and any failures.");
+        return lines.join("\n");
+    }
+
+    function readStateFromForm() {
+        return {
+            goal: $("sel-goal").value,
+            agent: $("sel-agent").value,
+            surface: $("sel-surface").value,
+            "interface": $("sel-interface").value,
+            deployment: $("sel-deployment").value,
+            platform: $("sel-platform").value,
+            platformA: $("sel-platformA").value,
+            platformB: $("sel-platformB").value,
+            benchmark: $("sel-benchmark").value,
+            scale: parseFloat($("sel-scale").value)
+        };
+    }
+
+    function applyAndRender(raw) {
+        var state = normaliseState(raw);
+        renderSelectors(state);
+        renderOutput(state);
+        writeStateToURL(state);
+        return state;
+    }
+
+    function attachHandlers() {
+        var form = $("prompts-form");
+        form.addEventListener("change", function () {
+            applyAndRender(readStateFromForm());
+        });
+
+        qs(".prompts-copy").forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                var targetId = btn.getAttribute("data-copy-target");
+                var node = $(targetId);
+                if (!node) return;
+                var text = node.textContent;
+                var done = function (ok) {
+                    var status = $("copy-status");
+                    if (status) status.textContent = ok ? "Copied " + targetId : "Copy failed";
+                    btn.textContent = ok ? "Copied" : "Copy";
+                    setTimeout(function () { btn.textContent = "Copy"; }, 1500);
+                };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(text).then(function () { done(true); }, function () { done(false); });
+                } else {
+                    try {
+                        var ta = document.createElement("textarea");
+                        ta.value = text;
+                        document.body.appendChild(ta);
+                        ta.select();
+                        document.execCommand("copy");
+                        document.body.removeChild(ta);
+                        done(true);
+                    } catch (e) { done(false); }
+                }
+            });
+        });
+    }
+
+    function init() {
+        attachHandlers();
+        applyAndRender(getStateFromURL());
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
Static, plain-JS prompt builder for the /prompts/ route. Loads
window.__BENCHBOX_PROMPT_CATALOG__ from the previously-merged
catalog.generated.js include and renders four output blocks:

- Agent prompt (Codex / Claude Code / generic manual recipe)
- CLI commands (install + dependency-check + dry-run + live)
- MCP server setup snippet (uv run -- python -m benchbox.mcp)
- MCP prompt referencing existing run_benchmark / list_available
  tools and benchmark_run / compare_platforms prompts by name

URL params (pinned, do not rename without bumping the route's contract):
  goal, agent, surface, interface, deployment, platform, platformA,
  platformB, benchmark, scale.

Managed-cloud selections surface a yellow safety block listing the
catalog-declared dependency / dry-run / no-pasted-secrets terms; the
agent prompt explicitly tells the agent not to ask for secrets in chat
and to stop if credentials are missing.

No package manager, no build step, no external JS — reuses the existing
landing CSS variables from ../style.css and adds prompts.css for
page-specific selectors and output panels. Includes a no-JS fallback
message and a single `aria-live` region for copy feedback.

Verified locally: catalog tests still pass; JS parses; nav files and
root landing untouched (those land in launch-gates).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
