### PR TITLE
chore(todo): file 5 TODOs to decouple explorer publishing from benchbox CLI

### DIFF
--- a/_project/TODO/main/active/explorer-cli-surface-adr.yaml
+++ b/_project/TODO/main/active/explorer-cli-surface-adr.yaml
@@ -1,0 +1,235 @@
+id: explorer-cli-surface-adr
+title: "ADR: pick a destination for the explorer publish toolchain"
+worktree: explorer-cli-surface-adr
+priority: High
+status: Not Started
+category: Architecture
+
+description: |
+  `benchbox explorer build` (and the hidden `benchbox explorer build-contract`)
+  publish a static read-model for the `results-explorer` React app. They are
+  not benchmark-runner operations, yet they sit on the user-facing `benchbox`
+  CLI surface and ship under `benchbox/cli/commands/explorer.py` alongside a
+  7-file core package at `benchbox/core/explorer_pipeline/`.
+
+  Provenance audit (this session):
+    - Both commands were added in commit `f9d08d38b` ("Migration: populate
+      develop branch from private working tree (Phase 4 w4)", 2026-04-27).
+      That was a bulk migration squash, not a discrete reviewed PR.
+    - The breadcrumb at `.github/workflows/docs.yml:105` attributes them to
+      PR #46, but #46 is `docs(contributing): name the version JSON key +
+      non-uv fallback` — a contributing-results.md docs PR, unrelated to the
+      CLI surface. The in-tree provenance trail lies.
+    - No `_project/specs/` document scopes the explorer CLI surface; Phase-4
+      migration TODO only lists the file paths as "to migrate", not as a
+      command surface to design.
+
+  This TODO is the decision step. It does not move any code. It produces an
+  ADR that locks the destination so downstream migration (TODO
+  `explorer-cli-surface-migration`) has a concrete target.
+
+  The four candidate destinations are:
+
+    1. **hide-only**: `hidden=True` on `explorer_group`. Cheapest. Does not
+       solve intermingling — code stays in `benchbox/`, import surface stays
+       public, only `--help` discoverability changes. Likely rejected.
+    2. **new sibling package** `benchbox_explorer/` with its own
+       `console_script` (e.g. `benchbox-explorer-publish`). Separate pip
+       artifact; clean conceptual boundary; external CI/scripts can still
+       script against a stable binary.
+    3. **`_project/scripts/explorer/`** invoked via `uv run -- python -m
+       _project.scripts.explorer.publish`. In-tree maintainer tool; not
+       installed; tightest "this is not a public surface" signal.
+    4. **co-locate in `results-explorer/`** as a Python sub-package called
+       from `results-explorer/scripts/`. Tightest coupling to the only
+       consumer. Mixes Python and Node trees.
+
+  The ADR must also resolve three gating sub-questions:
+
+    a. Does `benchbox/core/explorer_pipeline/` ALSO relocate, or only the
+       CLI wrapper? Argument for "yes": same intermingling concern; the
+       package serves only the explorer site. Argument for "no": existing
+       tests under `tests/unit/core/explorer_pipeline/` and import sites
+       like `benchbox/cli/help.py` would need follow-up. Decision here
+       shapes the migration cost.
+
+    b. Backwards-compat alias for one release: keep
+       `benchbox explorer build` as a thin deprecation shim that prints a
+       `DeprecationWarning` and forwards to the new entry point, then drop
+       it in the next minor release? Or hard-cut and update all known
+       callers in the same PR? BenchBox is v0.2.x pre-1.0, so a hard cut
+       is defensible; the ADR should still record the call.
+
+    c. End-user error path when a stale snapshot is detected: today,
+       `results-explorer/src/db.ts:196` tells the user to run
+       `benchbox explorer build`. After the move, the message must point
+       at the maintainer-only entry. For non-maintainers (e.g., someone
+       running `npm run dev` against a downloaded snapshot), the message
+       should redirect to "refresh the snapshot from the published site"
+       or similar, not to a CLI they shouldn't be running.
+
+prior_art:
+  - "benchbox/cli/commands/explorer.py — current Click subgroup; supersede or relocate per ADR."
+  - "benchbox/core/explorer_pipeline/ — 7-file core package (contract.py, duckdb_builder.py, models.py, pipeline.py, ranking.py, transformer.py, compare_math.py); reuse intact, only the housing changes."
+  - "benchbox/cli/commands/__init__.py:22 — registration site for `explorer_group`; reuse the registration pattern (or its absence) for whatever replaces it."
+  - "results-explorer/scripts/explorer-build-contract.mjs — Node-side consumer that calls `benchbox explorer build-contract` to fetch the output contract; reference for how an external script binds to the entry point."
+  - "_project/scripts/ — existing in-tree maintainer scripts directory (validate_todo.py, generate_indexes.py, etc.); candidate destination for option 3, reuse layout if chosen."
+  - "docs/development/adr/ — existing ADR location with TEMPLATE-results-data-extraction.md as the structural reference; reuse format."
+
+work:
+- id: w0
+  summary: "Re-validate provenance evidence and pin it in the ADR"
+  status: pending
+  notes: |
+    Before writing the ADR proper, re-run the provenance probes that this
+    TODO's description cites and commit the resulting facts as a
+    "Provenance Facts" section in the ADR. This durability-pins the
+    evidence so future readers do not have to re-derive it.
+
+    Commands:
+      - `git show --stat f9d08d38b -- benchbox/cli/commands/explorer.py`
+        → expect ~221-line file addition under that path.
+      - `git log -1 --format=%s%n%n%b f9d08d38b`
+        → expect title "Migration: populate develop branch from private
+        working tree (Phase 4 w4)".
+      - `gh pr view 46 --json title,body | head -2`
+        → expect title to be `docs(contributing): ...` (NOT the explorer
+        CLI), confirming the breadcrumb at `.github/workflows/docs.yml:105`
+        is mis-attributed.
+      - `git log --all --diff-filter=A --oneline -- benchbox/cli/commands/explorer.py`
+        → expect only `f9d08d38b` and `d28dbe66f` (the consistency-fix PR).
+      - `git blame .github/workflows/docs.yml -L 100,108`
+        → expect `0182c9556c` (v0.2.1 release commit), confirming the
+        misattributed Note line.
+
+    Output: a 5-10 line "Provenance Facts" block at the top of the ADR
+    recording: introduction commit, PR (none / migration squash),
+    breadcrumb misattribution target, and the command set above so a
+    future reader can re-run verbatim.
+
+- id: w1
+  summary: "Inventory every call site of the current CLI surface"
+  needs: [w0]
+  status: pending
+  notes: |
+    Grep targets (run from repo root):
+      - `git grep -n "benchbox explorer build\|benchbox explorer build-contract"`
+      - `git grep -nE "explorer_group|from benchbox\.cli\.commands\.explorer"`
+      - `git grep -nE "from benchbox\.core\.explorer_pipeline"`
+
+    Known seed list to confirm and extend:
+      - `.github/workflows/docs.yml:103`
+      - `results-explorer/scripts/generate-browser-fixtures.mjs:489`
+      - `results-explorer/scripts/explorer-build-contract.mjs:17`
+      - `tests/uat/.../explorer_smoke.py` (UAT W7 phase)
+      - `Makefile` `uat-explorer-smoke` target (line ~1612)
+      - `docs/development/browser-test-architecture.md:35,119,130`
+      - `docs/operations/results-phase-2-runbook.md:109`
+      - `results-explorer/src/db.ts:196` (frontend error remediation text)
+      - audit docs under `_project/audits/results-explorer-*.md`
+      - tests under `tests/unit/cli/test_explorer_build_contract.py`
+
+    Output: a single table in the ADR with each call site, its category
+    (CI / fixture / UAT / docs / runtime / test), and migration cost
+    (one-liner / multi-line / non-trivial).
+
+- id: w2
+  summary: "Inventory imports of `benchbox.core.explorer_pipeline.*` from outside the package"
+  needs: [w1]
+  status: pending
+  notes: |
+    The decision on sub-question (a) (does the pipeline also move?) turns
+    on how leaky the package's public import surface is.
+
+    Grep targets:
+      - `git grep -nE "from benchbox\.core\.explorer_pipeline|import benchbox\.core\.explorer_pipeline"` excluding the package itself.
+
+    Output: list of every import site outside `benchbox/core/explorer_pipeline/`,
+    grouped by importer (CLI / test / other).
+
+- id: w3
+  summary: "Draft the ADR with a 4-option decision matrix"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Path: `docs/development/adr/adr-explorer-cli-surface.md`.
+
+    Structure:
+      - Context (the provenance audit summary, citing this TODO).
+      - Forces: user-vs-maintainer surface separation; CI dependency stability;
+        external script consumers; migration cost; reversibility; consistency
+        with other maintainer tools in `_project/scripts/`.
+      - Options 1-4 with explicit pros/cons and migration-cost estimate from
+        the w1/w2 inventories.
+      - Decision matrix scoring each option on the forces.
+      - Recommendation with rationale.
+      - Resolutions to sub-questions (a), (b), (c) from the description.
+      - Consequences: what TODO `explorer-cli-surface-migration` will do.
+
+- id: w4
+  summary: "Land the ADR on develop"
+  needs: [w3]
+  status: pending
+  notes: |
+    Open a PR with only the ADR (no code moves). On merge, this TODO is
+    Completed and `explorer-cli-surface-migration` is unblocked.
+
+must_preserve:
+- "No code is moved or renamed in this TODO. ADR-only."
+- "Existing CI builds, browser-fixture generation, and UAT explorer-smoke must continue to work unchanged; this TODO does not touch them."
+- "`benchbox --help` output is unchanged in this TODO."
+
+approach: |
+  Read-mostly. Two grep-based inventories (w1, w2) inform an ADR (w3).
+  Use `docs/development/adr/TEMPLATE-results-data-extraction.md` as the
+  structural template if a TEMPLATE-adr.md is not present.
+
+  Do not pre-commit to one of the four options before the inventories are
+  complete; the migration-cost numbers are load-bearing.
+
+anti_patterns:
+- "DO NOT relocate any code in this TODO — moving code without the locked decision creates churn and re-litigates the choice in the migration PR. Defer all moves to `explorer-cli-surface-migration`."
+- "DO NOT make this ADR conditional on Phase 8/9 migration work — the explorer surface should be decided independently of the remaining migration phases (which TODO `migration-phase-api-surface-gate` handles separately)."
+
+scope_limit:
+  only_modify:
+  - "docs/development/adr/adr-explorer-cli-surface.md"
+
+verification:
+- description: "ADR file exists and validates as markdown."
+  command: "test -f docs/development/adr/adr-explorer-cli-surface.md && wc -l docs/development/adr/adr-explorer-cli-surface.md"
+  expected_output: "non-zero line count"
+- description: "ADR records a single recommended option and answers all three sub-questions (a, b, c)."
+  command: "grep -cE '^## (Decision|Recommendation|Sub-question)' docs/development/adr/adr-explorer-cli-surface.md"
+  expected_output: ">= 4"
+- description: "Inventories from w1 and w2 are present in the ADR body."
+  command: "grep -cE 'docs.yml|generate-browser-fixtures|explorer_pipeline' docs/development/adr/adr-explorer-cli-surface.md"
+  expected_output: ">= 3"
+
+success_metrics:
+- "ADR is merged to develop."
+- "TODO `explorer-cli-surface-migration` references the merged ADR and can begin work with no further design questions."
+
+deferred:
+- summary: "Actually move any code per the ADR's recommendation."
+  reason: "Owned by TODO `explorer-cli-surface-migration` (depends on this TODO)."
+- summary: "Revisit the user-vs-maintainer split for other parts of the `benchbox` CLI."
+  reason: "Owned by TODO `migration-phase-api-surface-gate`; this ADR is scoped to the explorer surface only."
+
+open_questions:
+- question: "Should `benchbox/core/explorer_pipeline/` also relocate, or only the CLI wrapper?"
+  gating: true
+  affects: [w3]
+- question: "Is a one-release deprecation alias warranted given v0.2.x pre-1.0 status?"
+  gating: false
+  default: "Hard cut, update all known callers in the migration PR."
+  affects: [w3]
+- question: "What is the right end-user error path when a non-maintainer hits a stale snapshot?"
+  gating: true
+  affects: [w3]
+
+impact: |
+  Unblocks the central decoupling work. Without a locked ADR, the migration
+  TODO will spend half its time re-litigating where things should live and
+  produce a churn-heavy PR. Cost: ~half a session for the inventories +
+  ADR. Reversibility: high — an ADR can be revised.

--- a/_project/TODO/main/active/explorer-cli-surface-migration.yaml
+++ b/_project/TODO/main/active/explorer-cli-surface-migration.yaml
@@ -1,0 +1,216 @@
+id: explorer-cli-surface-migration
+title: "Execute the explorer-CLI-surface ADR and remove explorer from benchbox --help"
+worktree: explorer-cli-surface-migration
+priority: High
+status: Not Started
+category: Refactoring
+
+description: |
+  Execute the decision locked by TODO `explorer-cli-surface-adr`:
+    - Remove `explorer` from the user-facing `benchbox` CLI surface.
+    - Relocate `benchbox/cli/commands/explorer.py` (and, per ADR sub-question
+      a, optionally `benchbox/core/explorer_pipeline/`) to the destination
+      the ADR chose.
+    - Update every call site: CI workflow, browser-fixture generator, UAT
+      explorer-smoke phase, runbook, developer docs, frontend remediation
+      string in `results-explorer/src/db.ts:196`, and audit cross-refs.
+    - Delete the incorrect provenance breadcrumb at
+      `.github/workflows/docs.yml:105` that misattributes the CLI surface
+      to PR #46.
+    - Add a regression test that pins the frontend remediation text to the
+      live invocation of whatever entry point the ADR chose, so renames
+      do not silently rot the user-facing error message.
+
+  This TODO does NOT redesign the read-model contract (TODO
+  `explorer-read-model-schema-versioning`) or address the stale-snapshot
+  dev-DX wall (TODO `explorer-dev-snapshot-dx`). Those are separable.
+
+deps:
+  needs:
+  - explorer-cli-surface-adr
+
+prior_art:
+  - "benchbox/cli/commands/explorer.py — current location; remove and relocate per ADR."
+  - "benchbox/core/explorer_pipeline/ — pipeline package; relocation gated by ADR sub-question (a)."
+  - ".github/workflows/docs.yml:103-105 — CI invocation + the wrong PR #46 attribution comment; update invocation, delete the comment."
+  - "results-explorer/scripts/generate-browser-fixtures.mjs:489 — Node-side caller; update spawn invocation."
+  - "results-explorer/scripts/explorer-build-contract.mjs:17 — EXPECTED_COMMAND constant; update to the new invocation."
+  - "results-explorer/src/db.ts:196 — frontend remediation string; update to the new invocation and pin to it via test."
+  - "docs/development/browser-test-architecture.md:35,119,130 — developer docs referencing the old command."
+  - "docs/operations/results-phase-2-runbook.md:109 — runbook references the old command."
+  - "tests/uat/.../explorer_smoke.py + Makefile target `uat-explorer-smoke` (line ~1612) — UAT phase invocation."
+  - "tests/unit/cli/test_explorer_build_contract.py — existing contract tests; if the CLI moves out of benchbox/cli/, this test file moves with it or is replaced."
+
+work:
+- id: w1
+  summary: "Re-confirm the ADR is merged and read its inventories"
+  status: pending
+  notes: |
+    Read `docs/development/adr/adr-explorer-cli-surface.md` end-to-end.
+    If the inventories of call sites and pipeline imports already exist
+    there, reuse them; do not redo. Build the migration checklist from
+    the ADR's "Consequences" section.
+
+- id: w2
+  summary: "Relocate the CLI entry point per ADR"
+  needs: [w1]
+  status: pending
+  notes: |
+    Move `benchbox/cli/commands/explorer.py` to the ADR's chosen
+    destination. Update:
+      - `benchbox/cli/commands/__init__.py:22,62,106` — remove the
+        `from .explorer import explorer_group` import and `explorer_group`
+        registration + `__all__` entry.
+      - `benchbox/cli/help.py` — any references to explorer commands in
+        the help text.
+    Run `uv run benchbox --help` and confirm `explorer` no longer appears.
+
+- id: w3
+  summary: "Relocate `benchbox/core/explorer_pipeline/` if the ADR requires it"
+  needs: [w1]
+  status: pending
+  notes: |
+    Gated by ADR sub-question (a). If "yes": move the package + its tests
+    under `tests/unit/core/explorer_pipeline/` to the ADR's destination.
+    Update imports in the relocated CLI entry from w2.
+
+    If "no": leave the package in place. Note this in the migration PR
+    description so future readers understand the half-move was deliberate.
+
+- id: w4
+  summary: "Update every call site identified in the ADR inventory"
+  needs: [w2, w3]
+  status: pending
+  notes: |
+    Process each of the call sites from the ADR's w1 inventory. Specifically:
+      - `.github/workflows/docs.yml:103` — replace invocation; DELETE the
+        `# Note: requires 'benchbox explorer' CLI subcommand (added in PR #46)`
+        line at :105 (the attribution is wrong; PR #46 is a docs PR).
+      - `results-explorer/scripts/generate-browser-fixtures.mjs:489`
+      - `results-explorer/scripts/explorer-build-contract.mjs:17`
+        (EXPECTED_COMMAND constant)
+      - `tests/uat/.../explorer_smoke.py` and `Makefile:uat-explorer-smoke`
+      - `docs/development/browser-test-architecture.md`
+      - `docs/operations/results-phase-2-runbook.md:109`
+      - `results-explorer/src/db.ts:196` (remediation string)
+      - audit docs that cite the old command — only the active runbook is
+        load-bearing; historical audits can keep the old command since they
+        record what was run at the time. Decide per-file in the PR review.
+
+- id: w5
+  summary: "Add a regression test pinning the frontend remediation string"
+  needs: [w4]
+  status: pending
+  notes: |
+    The current failure mode: `results-explorer/src/db.ts:196` embeds the
+    string `'benchbox explorer build'`. If the CLI is renamed, nothing
+    forces this string to update. Two options:
+
+      (i) Import the canonical invocation from a shared TS module sourced
+          from the same contract file the Node scripts already use
+          (`results-explorer/scripts/explorer-build-contract.mjs`), so
+          there is one source of truth.
+      (ii) Add a test that asserts the current `db.ts` remediation string
+          matches the exported `EXPECTED_COMMAND` from the contract
+          script.
+
+    Prefer (i). Implement in the Vitest suite under
+    `results-explorer/src/lib/__tests__/`.
+
+- id: w6
+  summary: "Run the full verification matrix and open the PR"
+  needs: [w5]
+  status: pending
+  notes: |
+    Local verification:
+      - `uv run benchbox --help | grep -c explorer` → 0
+      - `cd results-explorer && npm run lint && npm test`
+      - `make lint && make typecheck`
+      - `make test-fast`
+      - Manual: run the relocated entry point against `results-data/` and
+        confirm `results.duckdb` is generated with the expected schema.
+
+    Open PR via `make pr-open`. Title prefix `refactor(explorer):`. Body
+    references the merged ADR and lists each call site touched.
+
+must_preserve:
+- "CI explorer-build step in `.github/workflows/docs.yml` continues to produce a valid `results-explorer/public/data/results.duckdb` (only the invocation changes)."
+- "Browser-fixture generator continues to produce byte-identical fixture sets (verified by `verify-browser-fixtures.mjs`)."
+- "UAT `make uat-explorer-smoke` continues to pass with the new invocation."
+- "Output contract (schema of `results.duckdb` and copied bundles) is unchanged by this TODO."
+- "Existing tests under `tests/unit/core/explorer_pipeline/` continue to pass (relocated if needed but not rewritten)."
+
+approach: |
+  Strictly a relocation + caller-update PR. Read the ADR's "Consequences"
+  list and execute it line-by-line. Do not introduce new behavior, new
+  flags, or new pipeline logic. Schema-versioning and dev-DX are explicit
+  out-of-scope items handled by sibling TODOs.
+
+  Sequencing: relocate (w2, w3) before updating callers (w4) so the
+  callers point at the new live location, not a future path. Add the
+  pinning test (w5) last so it asserts the steady state.
+
+anti_patterns:
+- "DO NOT change the snapshot's output contract or column schema — that work is owned by TODO `explorer-read-model-schema-versioning`."
+- "DO NOT fix the stale-snapshot dev-DX wall in this PR — that's TODO `explorer-dev-snapshot-dx`. Mixing them makes review harder and entangles the rename with behavioral change."
+- "DO NOT keep `benchbox explorer` as a permanent alias unless the ADR explicitly chose option (b) with a deprecation shim. A bare `pass`-through alias defeats the whole point."
+- "DO NOT update historical audit docs that record commands actually run at the time. Only the active runbook and developer docs need updates; history can read 'we ran benchbox explorer build on 2026-05-10'."
+
+scope_limit:
+  only_modify:
+  - "benchbox/cli/commands/__init__.py"
+  - "benchbox/cli/commands/explorer.py"
+  - "benchbox/cli/help.py"
+  - "benchbox/core/explorer_pipeline/**"
+  - "tests/unit/core/explorer_pipeline/**"
+  - "tests/unit/cli/test_explorer_build_contract.py"
+  - "<ADR-chosen destination paths>"
+  - ".github/workflows/docs.yml"
+  - "results-explorer/scripts/generate-browser-fixtures.mjs"
+  - "results-explorer/scripts/explorer-build-contract.mjs"
+  - "results-explorer/src/db.ts"
+  - "results-explorer/src/lib/__tests__/**"
+  - "tests/uat/**"
+  - "Makefile"
+  - "docs/development/browser-test-architecture.md"
+  - "docs/operations/results-phase-2-runbook.md"
+
+verification:
+- description: "`explorer` is no longer in the public `benchbox` CLI surface."
+  command: "uv run benchbox --help | grep -c '^\\s*explorer'"
+  expected_output: "0"
+- description: "Fast tests pass."
+  command: "make test-fast"
+  expected_output: "exit 0"
+- description: "Lint + typecheck pass."
+  command: "make lint && make typecheck"
+  expected_output: "exit 0"
+- description: "Explorer-build pipeline still produces the snapshot via the new invocation."
+  command: "<ADR-chosen new invocation> --data-dir results-data --output /tmp/explorer-migration-smoke && test -f /tmp/explorer-migration-smoke/results.duckdb"
+  expected_output: "exit 0, file exists"
+- description: "Frontend Vitest pin test passes."
+  command: "cd results-explorer && npm test -- --run db-remediation-pin"
+  expected_output: "test exits 0"
+- description: "The wrong PR-#46 attribution is deleted from docs.yml."
+  command: "grep -c 'added in PR #46' .github/workflows/docs.yml"
+  expected_output: "0"
+
+success_metrics:
+- "`benchbox --help` no longer advertises `explorer`."
+- "All identified call sites use the new entry point."
+- "Frontend remediation text and CLI invocation share one source of truth."
+- "CI green on develop after merge."
+
+deferred:
+- summary: "Pre-dev rebuild hook or in-tree dev snapshot."
+  reason: "Owned by TODO `explorer-dev-snapshot-dx`."
+- summary: "Schema versioning for the read-model contract."
+  reason: "Owned by TODO `explorer-read-model-schema-versioning`."
+- summary: "Phase 8/9 migration API-surface gate."
+  reason: "Owned by TODO `migration-phase-api-surface-gate`."
+
+impact: |
+  Resolves the root surface-pollution issue: a maintainer publishing tool
+  stops advertising itself to every benchbox user. Also fixes a concrete
+  trust issue: the in-tree breadcrumb at docs.yml:105 currently lies about
+  PR #46 — that gets deleted in this PR.

--- a/_project/TODO/main/active/explorer-dev-snapshot-dx.yaml
+++ b/_project/TODO/main/active/explorer-dev-snapshot-dx.yaml
@@ -1,0 +1,236 @@
+id: explorer-dev-snapshot-dx
+title: "Eliminate the stale-snapshot wall blocking explorer `npm run dev`"
+worktree: explorer-dev-snapshot-dx
+priority: Medium
+status: Not Started
+category: Developer Experience
+
+description: |
+  A fresh-clone or returning developer runs `cd results-explorer && npm run
+  dev` and is met with a full-screen error wall:
+
+    DuckDB snapshot 'bench.results' is missing required columns: ...
+    Regenerate the snapshot via 'benchbox explorer build' or check the
+    deployed results.duckdb file.
+
+  Root cause is not a code bug — it is an architectural papercut:
+    - `*.duckdb` is gitignored, so the snapshot is never tracked.
+    - CI rebuilds it on every docs deploy
+      (`.github/workflows/docs.yml:103`); local devs never do unless they
+      know to.
+    - `npm run dev` has no predev step that detects staleness.
+    - The runtime guard in `results-explorer/src/db.ts:184-199` correctly
+      refuses to render against a snapshot whose schema doesn't match the
+      frontend's required-column set — so the user sees a 9-column-diff
+      wall the first time the read-model contract bumps.
+
+  Because the read-model contract is changing actively (PRs #344, #354,
+  #380 added eligibility columns in the last 30 days), this wall recurs
+  every few weeks for every developer.
+
+  This TODO closes the recurring DX wall. It is separable from the CLI
+  surface relocation (TODO `explorer-cli-surface-migration`) and the
+  schema versioning work (TODO `explorer-read-model-schema-versioning`).
+
+  Three solution shapes to evaluate:
+
+    (i)  **`predev` npm script** in `results-explorer/package.json` that
+         checks whether `public/data/results.duckdb` is older than the
+         most-recent file under `results-data/bundles/`, and rebuilds via
+         the canonical entry point if so. Pros: zero new files; works with
+         the existing build step. Cons: every `npm run dev` runs an mtime
+         check; spawns the Python entry point when rebuilding (3-5s on
+         the 528-bundle corpus).
+
+    (ii) **Tiny in-tree dev snapshot** under
+         `results-explorer/dev-data/results.duckdb` (5-10 cohorts,
+         deterministic), NOT gitignored, that the explorer falls back to
+         when `public/data/results.duckdb` is missing. Pros: `git clone
+         && npm run dev` works instantly with no Python. Cons: adds a
+         tracked binary (~500KB-2MB depending on corpus) that needs
+         periodic refresh — but only when the schema bumps, not the data.
+
+    (iii) **`make explorer-dev` wrapper target** that runs rebuild then
+         vite. Pros: explicit, documented in Makefile. Cons: requires
+         developer to know about and use the make target; doesn't help
+         someone who runs `npm run dev` from inside `results-explorer/`.
+
+  The right choice depends on how often the schema bumps vs. how often
+  the data bumps; (ii) optimizes for "schema-stable, data-shifting" and
+  (i) optimizes for "schema-shifting, data-stable". (iii) is the most
+  conservative and explicit but doesn't fix the default `npm run dev`
+  path.
+
+prior_art:
+  - "results-explorer/package.json — npm scripts site; reuse existing `dev` / `build` patterns for any new predev hook."
+  - "results-explorer/public/data/results.duckdb — current deployed snapshot (gitignored); a dev-data fallback would mirror this layout."
+  - "results-explorer/scripts/serve-browser-tests.mjs — existing Node-side wrapper around the browser fixture flow; pattern for a Node helper that orchestrates Python + Vite."
+  - "results-explorer/scripts/generate-browser-fixtures.mjs — existing pattern for spawning the Python publish toolchain from Node."
+  - "Makefile — existing target conventions like `uat-explorer-smoke`; pattern for a possible `explorer-dev` target."
+  - "results-data/bundles/ — source-of-truth bundle dir whose mtime can drive a staleness check."
+
+work:
+- id: w0
+  summary: "Pin the schema-bump cadence evidence cited in the description"
+  status: pending
+  notes: |
+    The description cites PRs #344 / #354 / #380 as recent schema bumps.
+    Before implementation, capture a compact pinned snapshot so future
+    readers can re-run the check:
+
+      - `gh pr view 344 --json title,mergedAt`
+      - `gh pr view 354 --json title,mergedAt`
+      - `gh pr view 380 --json title,mergedAt`
+      - `git log --oneline --since=60.days -- results-explorer/src/db.ts benchbox/core/explorer_pipeline/duckdb_builder.py`
+
+    Record one line per PR (title + merge date) and the schema-bump count
+    over the last 60 days in the PR description that lands this TODO's
+    work. Do NOT commit raw stdout to `_project/verification-logs/`;
+    pinned summary is enough.
+
+- id: w1
+  summary: "Pick one of (i), (ii), (iii) with a brief decision note"
+  needs: [w0]
+  status: pending
+  notes: |
+    Capture decision and rationale in the PR description. No separate ADR
+    needed — this is a DX choice, not an architectural one. Use the
+    cadence numbers from w0. Touch on:
+      - Schema-change cadence (from w0).
+      - Data-change cadence: `git log --oneline --since=60.days -- results-data/bundles/ | wc -l`.
+      - Latency budget for `npm run dev` start time.
+      - Onboarding signal: do we want git clone -> npm run dev -> working
+        UI as a baseline?
+
+    The recommendation absent overriding signal is (ii) — a tiny tracked
+    dev snapshot — because:
+      - It makes git clone -> npm run dev work with no Python toolchain.
+      - It survives schema bumps because the developer rebuilding the
+        snapshot is part of the same PR that bumps the schema.
+      - The binary is small and changes rarely (only when schema bumps).
+
+- id: w2
+  summary: "Implement the chosen approach"
+  needs: [w1]
+  status: pending
+  notes: |
+    For (ii) specifically:
+      - Define a "dev corpus" subset under `results-data/dev-corpus/`
+        (e.g., 1-2 cohorts of bundles) that produces a small snapshot.
+      - Add a `make explorer-dev-snapshot` target that rebuilds it.
+      - Track `results-explorer/dev-data/results.duckdb` (with a README
+        explaining when to regen).
+      - Modify `results-explorer/src/db.ts` snapshot URL resolution to
+        try `data/results.duckdb` first, then fall back to
+        `dev-data/results.duckdb` (or a build-time constant chosen by
+        Vite mode).
+
+    For (i):
+      - Add `predev` and `prebuild` npm scripts that check mtime and
+        invoke the publish entry point if needed. Make the check
+        skippable via `EXPLORER_SKIP_PREDEV=1` env var for CI / offline.
+
+    For (iii):
+      - Add the make target and document it in
+        `docs/development/browser-test-architecture.md` and
+        `results-explorer/README.md`.
+
+- id: w3
+  summary: "Update the error-wall remediation message"
+  needs: [w2]
+  status: pending
+  notes: |
+    `results-explorer/src/db.ts:196` currently advises running
+    `benchbox explorer build`. After this TODO, the recommended remediation
+    for a local dev should be the new workflow (predev / make target /
+    fallback note). Update the string accordingly.
+
+    Note: this message will also be touched by TODO
+    `explorer-cli-surface-migration` (to point at the relocated entry).
+    Coordinate via the merge order; whichever lands second resolves the
+    final text. If `explorer-cli-surface-migration` lands first, this
+    TODO updates the dev-workflow phrasing.
+
+- id: w4
+  summary: "Smoke verification + docs update"
+  needs: [w3]
+  status: pending
+  notes: |
+    Smoke commands:
+      - `rm -rf results-explorer/public/data && cd results-explorer && npm run dev`
+        → UI loads on first attempt, no error wall.
+      - For (i): touch results-data/bundles/<any>.json and re-run
+        `npm run dev` → rebuild fires.
+      - For (ii): no rebuild needed; fallback snapshot is served.
+
+    Docs:
+      - Update `results-explorer/README.md` (if present) with the new
+        dev workflow.
+      - Add a one-liner to `CONTRIBUTING.md` or
+        `docs/development/browser-test-architecture.md` explaining the
+        snapshot lifecycle.
+
+must_preserve:
+- "Production builds (CI docs deploy) continue to use the full corpus, not the dev snapshot or fallback."
+- "Browser-fixture generation (`generate-browser-fixtures.mjs`) is unaffected — it has its own snapshot regen."
+- "`results-explorer/public/data/results.duckdb` semantics are unchanged when present."
+
+approach: |
+  Pick one solution shape, implement it minimally, verify with a destructive
+  smoke (rm + npm run dev). Avoid adding configurability that this TODO
+  cannot motivate — if (ii) is chosen, do NOT also implement (i) "just in
+  case".
+
+anti_patterns:
+- "DO NOT remove the runtime guard in `db.ts` that detects schema mismatch — the schema mismatch is real and should still produce an actionable error, just not as the *default* dev experience."
+- "DO NOT couple this work to the schema-versioning refactor in TODO `explorer-read-model-schema-versioning`. That work changes the error shape; this TODO changes when the error fires. Both can land in either order."
+- "DO NOT track the full-corpus `results-explorer/public/data/results.duckdb` in git. The whole point of (ii) is a tiny dev-only snapshot, not the production artifact."
+
+scope_limit:
+  only_modify:
+  - "results-explorer/package.json"
+  - "results-explorer/dev-data/**"
+  - "results-explorer/src/db.ts"
+  - "results-explorer/README.md"
+  - "Makefile"
+  - "docs/development/browser-test-architecture.md"
+  - "CONTRIBUTING.md"
+  - "results-data/dev-corpus/**"
+  - ".gitignore"
+
+verification:
+- description: "Fresh-clone simulation: dev server starts when the public snapshot is missing."
+  command: "rm -f results-explorer/public/data/results.duckdb && cd results-explorer && (timeout 30 npm run dev >/tmp/explorer-dev-smoke.log 2>&1 &) && sleep 8 && curl -fsS -o /dev/null -w '%{http_code}\\n' http://localhost:5173/results/"
+  expected_output: "200"
+- description: "The snapshot URL the app fetches returns 200 after the predev/fallback resolves."
+  command: "curl -fsS -o /dev/null -w '%{http_code}\\n' http://localhost:5173/results/data/results.duckdb"
+  expected_output: "200"
+- description: "Manual smoke (recorded in PR body): the rendered page shows leaderboard rows, not the column-diff Error wall."
+  expected_output: "PR description records the screenshot or the absence of the error string in the HTML body."
+- description: "Frontend tests still pass."
+  command: "cd results-explorer && npm test"
+  expected_output: "exit 0"
+- description: "Production build is unaffected."
+  command: "cd results-explorer && npm run build"
+  expected_output: "exit 0, dist/ produced"
+
+success_metrics:
+- "`git clone && cd results-explorer && npm install && npm run dev` yields a working UI without manual snapshot rebuild."
+- "Schema bumps in subsequent PRs do not silently break local dev (the schema-versioning TODO handles the error shape)."
+
+deferred:
+- summary: "Make the error message itself humane (version-diff vs column-diff)."
+  reason: "Owned by TODO `explorer-read-model-schema-versioning`."
+- summary: "Rename the CLI entry that the docs reference."
+  reason: "Owned by TODO `explorer-cli-surface-migration`."
+
+open_questions:
+- question: "Schema-shifting or data-shifting cadence — which solution shape is right?"
+  gating: true
+  default: "(ii) tiny in-tree dev snapshot; revisit if the schema bumps more than once per quarter."
+  affects: [w1]
+
+impact: |
+  This is the symptom the user actually hit. Without this TODO, every
+  developer (and every Claude session) re-discovers the same wall every
+  few weeks. Cost: small (one-evening implementation per option).

--- a/_project/TODO/main/active/explorer-read-model-schema-versioning.yaml
+++ b/_project/TODO/main/active/explorer-read-model-schema-versioning.yaml
@@ -1,0 +1,187 @@
+id: explorer-read-model-schema-versioning
+title: "Version the explorer read-model and replace the 51-column required-set drift detector"
+worktree: explorer-read-model-schema-versioning
+priority: Medium
+status: Not Started
+category: Correctness
+
+description: |
+  The frontend at `results-explorer/src/db.ts:53-106` hard-codes 51 required
+  column names against `bench.results` and validates the snapshot by
+  computing a set difference. Any backend rename/add/remove silently
+  invalidates every existing snapshot — dev's local copy, downloaded
+  production copies, CI fixture caches — until they regenerate. The error
+  shape is a 9-name diff dump, which is hard to act on and embeds no
+  upgrade hint.
+
+  There is already an `EXPLORER_BUILD_CONTRACT` mechanism (see
+  `benchbox/core/explorer_pipeline/contract.py` and
+  `results-explorer/scripts/explorer-build-contract.mjs`), but it versions
+  the *output file shape*, not the *read-model column set*. The frontend
+  guard does not consult any version field.
+
+  Goal: replace the column-set diff with a real schema version. The
+  frontend error becomes "snapshot read-model v6; UI requires v7. Please
+  rebuild or update." Backend PRs that bump the read-model column set are
+  required to bump `read_model_version`.
+
+  This TODO is independent of CLI relocation (`explorer-cli-surface-
+  migration`) and dev-DX (`explorer-dev-snapshot-dx`), but lands cleaner
+  after the CLI relocation because the verification commands and
+  contract emitter point at the new entry.
+
+deps:
+  needs:
+  - explorer-cli-surface-migration
+
+prior_art:
+  - "benchbox/core/explorer_pipeline/contract.py — existing `EXPLORER_BUILD_CONTRACT` versioning the output shape; EXTEND with a `read_model_version` field rather than introducing a parallel mechanism."
+  - "benchbox/core/explorer_pipeline/duckdb_builder.py — writes the duckdb snapshot; the place to emit a `schema_version` scalar/table."
+  - "results-explorer/scripts/explorer-build-contract.mjs:7 (REQUIRED_OUTPUTS) and the contract-fetching helper — established pattern for the Node side reading contract values; reuse."
+  - "results-explorer/src/db.ts:53-106 (BENCH_RESULTS_REQUIRED_COLUMNS) — the 51-name list to remove."
+  - "results-explorer/src/db.ts:184-199 (verifyBenchResultsColumns) — the function to replace with a version check."
+  - "tests/unit/cli/test_explorer_build_contract.py — existing contract test pattern to extend."
+  - "results-explorer/src/components/__tests__/ — vitest convention for the frontend version-mismatch test."
+
+work:
+- id: w1
+  summary: "Add `read_model_version` to the build contract and the duckdb snapshot"
+  status: pending
+  notes: |
+    In `benchbox/core/explorer_pipeline/contract.py`, add a
+    `read_model_version: int` field (start at 1 to represent the current
+    column set). Increment as a deliberate constant when the column set
+    changes.
+
+    In `benchbox/core/explorer_pipeline/duckdb_builder.py`, write the
+    value as either:
+      (a) a one-row `bench.metadata` table:
+          `CREATE TABLE bench.metadata AS SELECT 1 AS read_model_version;`
+      (b) a DuckDB user-metadata pragma if portable.
+
+    (a) is preferred for portability; the frontend already attaches the
+    `bench` catalog.
+
+    Backfill: existing snapshots have no version → treat as version 0,
+    UI prompts for rebuild.
+
+- id: w2
+  summary: "Replace the frontend column-diff guard with a version check"
+  needs: [w1]
+  status: pending
+  notes: |
+    In `results-explorer/src/db.ts`:
+      - Add a `EXPECTED_READ_MODEL_VERSION` constant sourced from the
+        contract file (so the Node + browser sides share one source of
+        truth, the same way the Node `EXPECTED_COMMAND` is sourced).
+      - Replace `BENCH_RESULTS_REQUIRED_COLUMNS` and
+        `verifyBenchResultsColumns` with a single query:
+        `SELECT read_model_version FROM bench.metadata LIMIT 1`.
+      - On missing table or older version, throw a humane error:
+        "Snapshot read-model v{found}, UI requires v{expected}.
+        Please regenerate via <invocation from
+        `explorer-cli-surface-migration`>, or refresh from the published
+        site."
+      - On version equal, proceed.
+      - On version *newer* than UI expects: log a console warning but
+        proceed (forward-compatible reads).
+
+    Remove the 51-column constant entirely.
+
+- id: w3
+  summary: "Tests: version-mismatch error path + same-version pass path"
+  needs: [w2]
+  status: pending
+  notes: |
+    Frontend vitest under `results-explorer/src/lib/__tests__/`:
+      - Build a tiny in-memory DuckDB with `bench.metadata.read_model_version = 0` → expect humane error containing "v0" and "v1".
+      - Same but with version = 1 → expect no error.
+      - Same but with `bench.metadata` table absent → expect rebuild
+        prompt.
+
+    Backend test under `tests/unit/core/explorer_pipeline/`:
+      - Build snapshot, assert `read_model_version` is present and matches
+        the constant in `contract.py`.
+      - Extend `test_explorer_build_contract.py` to assert
+        `EXPLORER_BUILD_CONTRACT.read_model_version` is exported on the
+        contract.
+
+- id: w4
+  summary: "Add a CONTRIBUTING line gating column-set bumps on version bumps"
+  needs: [w3]
+  status: pending
+  notes: |
+    In `CONTRIBUTING.md` (or `docs/development/browser-duckdb-schema.sql`
+    header if that's where backend schema lives): one-line note —
+    "If you change the column set of `bench.results`, bump
+    `read_model_version` in `benchbox/core/explorer_pipeline/contract.py`."
+
+    Optional: a fast linter / pre-commit check that diffs the column-emitting
+    SQL against the last committed `read_model_version` and fails if the
+    columns changed but the version did not. Defer if non-trivial; the
+    CONTRIBUTING line is enough for v1.
+
+must_preserve:
+- "Existing snapshots produced before this TODO continue to fail informatively (as 'v0 missing or stale')."
+- "The build contract continues to validate via `EXPLORER_BUILD_CONTRACT`; this TODO extends it, does not replace it."
+- "Browser-fixture generator continues to work — only the column-list guard goes away; readiness scans for individual tables stay."
+- "Production CI rebuild does not change behavior — the new version is emitted by the same publish entry point."
+
+approach: |
+  One source of truth for the version constant lives in
+  `benchbox/core/explorer_pipeline/contract.py`. Both the duckdb writer
+  and the Node contract-fetch script consume it. The frontend imports it
+  via the existing contract-fetch path. The 51-column list goes away.
+
+  Sequence: emit + read the new field (w1, w2) before tests (w3),
+  because the tests assert against the live code. Then CONTRIBUTING (w4).
+
+anti_patterns:
+- "DO NOT keep a fallback to the 51-column diff guard 'just in case' — the version check is the contract; the column list is the old contract."
+- "DO NOT version-stamp individual columns or use a semver string. A monotonically-increasing integer is sufficient and simple; semver invites premature bikeshedding."
+- "DO NOT couple this to the dev-DX TODO. The dev-DX TODO is about *when* this error fires; this TODO is about *what shape* the error takes when it fires. Either order of landing is fine."
+- "DO NOT silently auto-rebuild on version mismatch — the user (or CI) must opt in to a rebuild. Auto-rebuild on an outdated snapshot risks long startup pauses and obscures real schema-drift bugs."
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/explorer_pipeline/contract.py"
+  - "benchbox/core/explorer_pipeline/duckdb_builder.py"
+  - "results-explorer/src/db.ts"
+  - "results-explorer/src/lib/__tests__/**"
+  - "results-explorer/scripts/explorer-build-contract.mjs"
+  - "tests/unit/core/explorer_pipeline/**"
+  - "tests/unit/cli/test_explorer_build_contract.py"
+  - "CONTRIBUTING.md"
+  - "docs/development/browser-duckdb-schema.sql"
+
+verification:
+- description: "New `read_model_version` round-trips snapshot -> contract -> frontend."
+  command: "uv run -- python -c 'from benchbox.core.explorer_pipeline.contract import EXPLORER_BUILD_CONTRACT; print(EXPLORER_BUILD_CONTRACT.read_model_version)'"
+  expected_output: "integer >= 1"
+- description: "Backend tests pass."
+  command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline tests/unit/cli/test_explorer_build_contract.py -q"
+  expected_output: "exit 0"
+- description: "Frontend version-mismatch test passes."
+  command: "cd results-explorer && npm test -- --run read-model-version"
+  expected_output: "exit 0"
+- description: "Old (pre-version) snapshot raises the humane v0/v1 error, not a column diff."
+  command: "cd results-explorer && npm test -- --run 'read-model-version-mismatch'"
+  expected_output: "test exits 0 and the asserted error string contains 'read-model v' and 'requires v', and does NOT contain the literal 'is missing required columns'"
+- description: "The 51-column constant has been removed."
+  command: "grep -c 'BENCH_RESULTS_REQUIRED_COLUMNS' results-explorer/src/db.ts"
+  expected_output: "0"
+
+success_metrics:
+- "Schema drift produces a humane v{N} < v{M} error, not a column diff."
+- "The column list is no longer maintained in two places (`db.ts` + `duckdb_builder.py`)."
+- "CONTRIBUTING documents the version-bump rule."
+
+deferred:
+- summary: "Pre-commit lint enforcing version bump on column change."
+  reason: "Nice-to-have; the CONTRIBUTING note + PR-review discipline is the v1 gate. File a follow-up TODO only if column-bumps land without version-bumps in practice."
+
+impact: |
+  Eliminates the recurring 9-column-diff failure mode. Reduces the
+  maintenance burden of keeping `BENCH_RESULTS_REQUIRED_COLUMNS` in sync
+  with the backend. Makes future schema changes a one-line bump in the
+  contract file instead of a 51-line edit.

--- a/_project/TODO/main/active/migration-phase-api-surface-gate.yaml
+++ b/_project/TODO/main/active/migration-phase-api-surface-gate.yaml
@@ -1,0 +1,183 @@
+id: migration-phase-api-surface-gate
+title: "Retro audit Phase-4 API surface + add a surface-diff gate to remaining migration phases"
+worktree: migration-phase-api-surface-gate
+priority: Medium
+status: Not Started
+category: Process
+
+description: |
+  The single-repo migration's Phase-4 commit `f9d08d38b` ("Migration:
+  populate develop branch from private working tree (Phase 4 w4)",
+  2026-04-27) added new public-ish surfaces to the codebase as a side
+  effect of a bulk import — most visibly the `benchbox explorer` CLI
+  subgroup, plus the `benchbox.core.explorer_pipeline` package. Neither
+  was reviewed as a discrete API decision; both arrived inside a 221-line
+  new file in a squash commit. The audit on 2026-05-14 surfaced this as a
+  systematic risk, not a one-off: the migration channel is a stealth
+  surface-expansion pathway, and Phases 8 and 9 are still pending.
+
+  This TODO does two things:
+
+    1. **Retrospectively reconcile** every new public surface introduced
+       by Phase-4 (and its post-migration follow-ons) against an explicit
+       approved-surface inventory. Where surfaces are not approved, either
+       file a sibling TODO to remove/hide them, or document them as
+       deliberate.
+
+    2. **Prospectively gate** Phases 8 and 9 (and any future bulk migrations)
+       with a required "API-surface diff" exit gate: the PR description
+       must enumerate every new CLI command, console_script entry point,
+       importable public Python module, and new file-system convention,
+       with explicit accept/reject per item by the maintainer.
+
+  This is process work, not code. It produces audits and updates to two
+  in-flight planning TODOs. It is independent of all the other explorer
+  TODOs and can land in parallel.
+
+prior_art:
+  - "_project/TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml — current Phase-4 TODO; this surface gate retroactively applies to its scope."
+  - "_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml — needs the new exit gate added."
+  - "_project/TODO/main/planning/single-repo-migration-phase-9-decommission-archive.yaml — needs the new exit gate added."
+  - "_project/DONE/main/planning/single-repo-migration-phase-3-new-release-flow.yaml — closed phase; reference for plan format."
+  - "_project/audits/ — existing directory for audit artifacts; reuse for the Phase-4 retro inventory."
+  - "_project/specs/uat-framework.md — established multi-W spec format; reference for any spec updates."
+
+work:
+- id: w1
+  summary: "Inventory every CLI surface introduced from `f9d08d38b` to HEAD"
+  status: pending
+  notes: |
+    Method:
+      - `git log f9d08d38b..HEAD -- benchbox/cli/` for the post-migration window.
+      - For the migration commit itself: `git diff f9d08d38b^ f9d08d38b -- benchbox/cli/`.
+      - For each new `@click.command` or `@click.group` introduced, record:
+        - command path under `benchbox`
+        - intended audience (end-user benchmarker vs maintainer/CI)
+        - has it been reviewed in a discrete PR?
+        - approve / move / hide recommendation
+
+    Output: a table committed at `_project/audits/phase-4-cli-surface-retro-<DATE>.md`.
+
+- id: w2
+  summary: "Inventory every newly-public Python import surface in the same window"
+  needs: [w1]
+  status: pending
+  notes: |
+    Method:
+      - `git diff f9d08d38b^ f9d08d38b --name-only -- 'benchbox/**/__init__.py'`
+        to find modules that became publicly importable.
+      - For each new package directory, check whether it appears in
+        `__all__` lists or is imported from outside its own tree.
+      - Classify as: public-API (deliberate), internal (move under
+        underscore-prefixed module or restructure), or out-of-place
+        (relocate per a sibling TODO).
+
+    Output: appended to the same audit file from w1.
+
+- id: w3
+  summary: "File sibling TODOs for any unapproved surface uncovered"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Likely small. The explorer surface is already owned by
+    `explorer-cli-surface-adr` + `explorer-cli-surface-migration`, so it
+    does not need a new TODO here — cross-reference instead.
+
+    For each other unapproved surface (if any), file a TODO with a
+    one-line scope and link from this audit.
+
+- id: w4
+  summary: "Add an API-surface-diff exit gate to Phase 8 and Phase 9 plans"
+  needs: [w3]
+  status: pending
+  notes: |
+    For each of:
+      - `_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml`
+      - `_project/TODO/main/planning/single-repo-migration-phase-9-decommission-archive.yaml`
+
+    Add a new work unit (or `success_metrics` entry) requiring the PR
+    description to include a section:
+
+        ## API surface diff
+        - New CLI commands: <list, with audience tag>
+        - New console_script entry points: <list>
+        - New public Python imports: <list>
+        - New file-system conventions (config dirs, env vars, etc.): <list>
+        - Each item is either explicitly approved by the maintainer in
+          this PR or covered by a referenced ADR.
+
+    Without this section, the migration phase is not Done.
+
+- id: w5
+  summary: "Codify the gate in a reusable place"
+  needs: [w4]
+  status: pending
+  notes: |
+    Two reasonable hosts:
+      - `_project/specs/migration-api-surface-gate.md` (new short spec).
+      - A section in an existing migration spec / playbook.
+
+    Pick whichever already exists; do not create a new directory just
+    for this. The spec should be one page: what to enumerate, how to
+    classify, what counts as approval, what to do for genuinely-internal
+    surfaces.
+
+must_preserve:
+- "Phase 4's already-merged commits are not rewritten or reverted by this TODO. The audit is retrospective; remediation flows through other TODOs."
+- "Existing approved CLI surfaces remain as-is — this TODO classifies and gates, it does not remove."
+
+approach: |
+  Pure planning + audit work. Read git history, write markdown, edit two
+  YAML planning files, add a small spec.
+
+  Sequencing matters only for w4 (which needs the inventories from w1/w2);
+  w1/w2/w3 can be a single sitting.
+
+anti_patterns:
+- "DO NOT use this TODO to litigate which surfaces should be public — that's per-surface work owned by sibling TODOs. This TODO only classifies (approved / move / hide) and files the follow-ups."
+- "DO NOT create a parallel review tool or new CI lint for surface diffs. The gate is a checklist in the PR description; complexity here is unwarranted for two remaining phases."
+- "DO NOT extend the audit scope to all of `benchbox/` retroactively — bounded to the Phase-4 commit window so the work is finite."
+
+scope_limit:
+  only_modify:
+  - "_project/audits/phase-4-cli-surface-retro-*.md"
+  - "_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml"
+  - "_project/TODO/main/planning/single-repo-migration-phase-9-decommission-archive.yaml"
+  - "_project/specs/migration-api-surface-gate.md"
+
+verification:
+- description: "Audit file exists and lists the Phase-4 CLI + import surfaces."
+  command: "ls _project/audits/phase-4-cli-surface-retro-*.md"
+  expected_output: "at least one file"
+- description: "Phase 8 plan references the new API-surface-diff gate."
+  command: "grep -c 'API surface diff' _project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml"
+  expected_output: ">= 1"
+- description: "Phase 9 plan references the new API-surface-diff gate."
+  command: "grep -c 'API surface diff' _project/TODO/main/planning/single-repo-migration-phase-9-decommission-archive.yaml"
+  expected_output: ">= 1"
+- description: "TODO graph validates after changes."
+  command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all"
+  expected_output: "exit 0"
+
+success_metrics:
+- "Every Phase-4 CLI command and newly-public Python package is classified (approved / move / hide) in the audit."
+- "Phase 8 and Phase 9 cannot complete without an API-surface diff in their PR."
+- "Future bulk migrations of comparable scope are gated by the same checklist."
+
+deferred:
+- summary: "Auto-generated API surface diff via a tool."
+  reason: "Out of scope for the two remaining phases; revisit if a third bulk migration is anticipated."
+- summary: "Apply the same gate to non-migration PRs."
+  reason: "Most non-migration PRs are scoped and reviewed already; this gate exists to catch bulk-import smuggling, not normal feature work."
+
+open_questions:
+- question: "Is there a Phase 5/6/7 commit window that should also be retro-audited?"
+  gating: false
+  default: "Bounded to Phase-4 in this TODO. If audit reveals smuggling in 5-7, file a sibling TODO."
+  affects: [w1]
+
+impact: |
+  Prevents the next stealth surface expansion. The explorer CLI is fixed
+  by other TODOs; this TODO prevents the same class of issue from
+  recurring in Phases 8 and 9. Low cost (one sitting) for high
+  preventive value.


### PR DESCRIPTION
`benchbox explorer build` (and its hidden `build-contract` sibling) ship
under the user-facing `benchbox` CLI but are static-site publishing tools
for the results-explorer React app. They arrived in the Phase-4 migration
squash (commit f9d08d38b) without a discrete surface review, and the
in-tree breadcrumb at .github/workflows/docs.yml:105 misattributes them
to PR #46 (a docs PR).

Files five planning TODOs in _project/TODO/main/active/:

- explorer-cli-surface-adr (High): pick a destination via ADR.
- explorer-cli-surface-migration (High, deps: ADR): execute the move,
  update every caller, fix the misattribution, pin the frontend
  remediation string to the live CLI invocation.
- explorer-dev-snapshot-dx (Medium): kill the stale-snapshot wall that
  blocks `npm run dev` on every read-model schema bump.
- explorer-read-model-schema-versioning (Medium, deps: migration):
  replace the 51-column required-set drift detector with a versioned
  read_model_version field.
- migration-phase-api-surface-gate (Medium): retro-audit Phase-4 CLI/
  import surfaces and add an API-surface-diff exit gate to Phases 8 + 9
  so this stealth channel cannot recur.

No code changes. Implementation flows through one PR per TODO.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
