### PR TITLE
docs/agents default write workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ Do not use `git add -A`; stage explicit paths only. Repo `origin` is
 release. Dev PRs target `develop`, squash-merge, linear history. `develop` is
 PR-gated; do not direct-push routine work.
 
-Standard one-shot flow from a feature branch:
+Push-to-PR gate (the implement-to-PR ritual is in "Default write-task
+close-out" below):
 
 ```bash
 make pr-preflight
@@ -156,6 +157,13 @@ over global `/commit-push-pr`.
 
 Release flow is `make release-cut VERSION=X.Y.Z` then
 `make release-finalize VERSION=X.Y.Z`; see `docs/operations/release-guide.md`.
+
+## Default write-task close-out
+
+After implementing, self-review with the `code` skill's `review` action and
+fix every finding — issues, considerations, AND nits — before `make pr-open`.
+The review-fix loop is part of "implement", not optional polish; skip only
+when the user explicitly opts out (typo fix, already-reviewed change).
 
 ## Planning & TODOs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Landing changes requires explicit user authorization in a separate turn;
 this fires before any "auto-commit" or "file-first capture" mandate
 elsewhere.** Conversely, write work on a worktree ends at `make pr-open`,
 not at `git push` — `make pr-open` is in the pre-approved set.
+Default write-task close-out: implement → `code review` (fix every finding,
+incl. nits) → `make pr-open` (see AGENTS.md).
 TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox.
 No `-o "addopts="` with pytest.
 **Efficiency**: long output → `/tmp/<slug>.log`, report summary + tail.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,6 +6,7 @@ This file provides guidance to Gemini when working with BenchBox.
 - **Single repo, single remote**: `origin` → `joeharris76/BenchBox`. Canonical clone: `/Users/joe/Developer/BenchBox`. There is no `private` / `public` remote; the pre-migration two-remote setup is retired (see `_project/decisions/single-repo-migration.md` for history).
 - **Branches**: `develop` is the long-lived dev branch; `main` is release-only. Dev PRs target `develop`, squash-merge.
 - **One-shot PR flow**: from a feature branch, `make pr-preflight && make pr-open`. Opens the PR vs `develop` with `gh pr create --fill` and enables auto-merge once CI is green. Walk away — don't poll.
+- **Default write-task close-out**: implement → `code review` (fix every finding, incl. nits) → `make pr-open`. Skip only if the user explicitly opts out (typo fix, already-reviewed change).
 - **Review protocol**: review, audit, research, compare, to-spec, security
   review, and L2 blind-spot audit actions are read-only plus local capture per
   the synced `SHARED/review-protocol` skill. Local capture does not authorize


### PR DESCRIPTION
- **docs(agents): codify default write-task close-out**
- **docs(gemini): mirror default write-task close-out**
