### PR TITLE
fix(explorer): rebuild local dev snapshot before dev

### DIFF
--- a/_project/DONE/main/active/explorer-dev-snapshot-dx.yaml
+++ b/_project/DONE/main/active/explorer-dev-snapshot-dx.yaml
@@ -2,7 +2,8 @@ id: explorer-dev-snapshot-dx
 title: "Eliminate the stale-snapshot wall blocking explorer `npm run dev`"
 worktree: explorer-dev-snapshot-dx
 priority: Medium
-status: Not Started
+status: Completed
+completed_date: "2026-05-14"
 category: Developer Experience
 
 description: |
@@ -62,17 +63,20 @@ description: |
   path.
 
 prior_art:
-  - "results-explorer/package.json — npm scripts site; reuse existing `dev` / `build` patterns for any new predev hook."
-  - "results-explorer/public/data/results.duckdb — current deployed snapshot (gitignored); a dev-data fallback would mirror this layout."
-  - "results-explorer/scripts/serve-browser-tests.mjs — existing Node-side wrapper around the browser fixture flow; pattern for a Node helper that orchestrates Python + Vite."
-  - "results-explorer/scripts/generate-browser-fixtures.mjs — existing pattern for spawning the Python publish toolchain from Node."
-  - "Makefile — existing target conventions like `uat-explorer-smoke`; pattern for a possible `explorer-dev` target."
-  - "results-data/bundles/ — source-of-truth bundle dir whose mtime can drive a staleness check."
+- "results-explorer/package.json — npm scripts site; reuse existing `dev` / `build` patterns for any new predev hook."
+- "results-explorer/public/data/results.duckdb — current deployed snapshot (gitignored); a dev-data fallback would mirror
+  this layout."
+- "results-explorer/scripts/serve-browser-tests.mjs — existing Node-side wrapper around the browser fixture flow; pattern
+  for a Node helper that orchestrates Python + Vite."
+- "results-explorer/scripts/generate-browser-fixtures.mjs — existing pattern for spawning the Python publish toolchain from
+  Node."
+- "Makefile — existing target conventions like `uat-explorer-smoke`; pattern for a possible `explorer-dev` target."
+- "results-data/bundles/ — source-of-truth bundle dir whose mtime can drive a staleness check."
 
 work:
 - id: w0
   summary: "Pin the schema-bump cadence evidence cited in the description"
-  status: pending
+  status: done
   notes: |
     The description cites PRs #344 / #354 / #380 as recent schema bumps.
     Before implementation, capture a compact pinned snapshot so future
@@ -91,7 +95,7 @@ work:
 - id: w1
   summary: "Pick one of (i), (ii), (iii) with a brief decision note"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
     Capture decision and rationale in the PR description. No separate ADR
     needed — this is a DX choice, not an architectural one. Use the
@@ -112,7 +116,7 @@ work:
 - id: w2
   summary: "Implement the chosen approach"
   needs: [w1]
-  status: pending
+  status: done
   notes: |
     For (ii) specifically:
       - Define a "dev corpus" subset under `results-data/dev-corpus/`
@@ -138,7 +142,7 @@ work:
 - id: w3
   summary: "Update the error-wall remediation message"
   needs: [w2]
-  status: pending
+  status: done
   notes: |
     `results-explorer/src/db.ts:196` currently advises running
     `benchbox explorer build`. After this TODO, the recommended remediation
@@ -154,7 +158,7 @@ work:
 - id: w4
   summary: "Smoke verification + docs update"
   needs: [w3]
-  status: pending
+  status: done
   notes: |
     Smoke commands:
       - `rm -rf results-explorer/public/data && cd results-explorer && npm run dev`
@@ -182,9 +186,12 @@ approach: |
   case".
 
 anti_patterns:
-- "DO NOT remove the runtime guard in `db.ts` that detects schema mismatch — the schema mismatch is real and should still produce an actionable error, just not as the *default* dev experience."
-- "DO NOT couple this work to the schema-versioning refactor in TODO `explorer-read-model-schema-versioning`. That work changes the error shape; this TODO changes when the error fires. Both can land in either order."
-- "DO NOT track the full-corpus `results-explorer/public/data/results.duckdb` in git. The whole point of (ii) is a tiny dev-only snapshot, not the production artifact."
+- "DO NOT remove the runtime guard in `db.ts` that detects schema mismatch — the schema mismatch is real and should still
+  produce an actionable error, just not as the *default* dev experience."
+- "DO NOT couple this work to the schema-versioning refactor in TODO `explorer-read-model-schema-versioning`. That work changes
+  the error shape; this TODO changes when the error fires. Both can land in either order."
+- "DO NOT track the full-corpus `results-explorer/public/data/results.duckdb` in git. The whole point of (ii) is a tiny dev-only
+  snapshot, not the production artifact."
 
 scope_limit:
   only_modify:
@@ -200,7 +207,8 @@ scope_limit:
 
 verification:
 - description: "Fresh-clone simulation: dev server starts when the public snapshot is missing."
-  command: "rm -f results-explorer/public/data/results.duckdb && cd results-explorer && (timeout 30 npm run dev >/tmp/explorer-dev-smoke.log 2>&1 &) && sleep 8 && curl -fsS -o /dev/null -w '%{http_code}\\n' http://localhost:5173/results/"
+  command: "rm -f results-explorer/public/data/results.duckdb && cd results-explorer && (timeout 30 npm run dev >/tmp/explorer-dev-smoke.log
+    2>&1 &) && sleep 8 && curl -fsS -o /dev/null -w '%{http_code}\\n' http://localhost:5173/results/"
   expected_output: "200"
 - description: "The snapshot URL the app fetches returns 200 after the predev/fallback resolves."
   command: "curl -fsS -o /dev/null -w '%{http_code}\\n' http://localhost:5173/results/data/results.duckdb"

--- a/docs/development/browser-test-architecture.md
+++ b/docs/development/browser-test-architecture.md
@@ -34,6 +34,11 @@ considered binding.
   `_project/scripts/explorer_pipeline/pipeline.py` via
   `uv run -- python _project/scripts/explorer_publish.py build
   --data-dir <bundles> --output <dist-data>`.
+- Local `npm run dev` first runs `npm run dev:snapshot`, which rebuilds
+  `results-explorer/public/data/results.duckdb` when the local snapshot is
+  missing or older than `results-data/bundles/` or the Explorer publish
+  pipeline. Set `EXPLORER_SKIP_PREDEV=1` only when intentionally testing a
+  missing or stale snapshot error path.
 - Unit and component coverage lives under `results-explorer/src/__tests__/`,
   `results-explorer/src/components/__tests__/`,
   `results-explorer/src/lib/__tests__/`, and

--- a/results-explorer/.gitignore
+++ b/results-explorer/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 .vite/
 *.local
+public/data/
 
 # Browser-functional test artifacts
 # See docs/development/browser-test-architecture.md

--- a/results-explorer/package.json
+++ b/results-explorer/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev:snapshot": "node scripts/ensure-dev-snapshot.mjs",
+    "predev": "npm run dev:snapshot",
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",

--- a/results-explorer/scripts/ensure-dev-snapshot.mjs
+++ b/results-explorer/scripts/ensure-dev-snapshot.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { existsSync, statSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const explorerRoot = resolve(here, "..");
+const repoRoot = resolve(explorerRoot, "..");
+const snapshotPath = resolve(explorerRoot, "public", "data", "results.duckdb");
+const sourceRoots = [
+  resolve(repoRoot, "results-data", "bundles"),
+  resolve(repoRoot, "_project", "scripts", "explorer_pipeline"),
+];
+const sourceFiles = [
+  resolve(repoRoot, "_project", "scripts", "explorer_publish.py"),
+  resolve(explorerRoot, "scripts", "explorer-build-contract.mjs"),
+];
+
+function log(message) {
+  console.log(`[explorer-dev-snapshot] ${message}`);
+}
+
+async function newestMtimeMs(paths) {
+  let newest = 0;
+  for (const item of paths) {
+    newest = Math.max(newest, await newestPathMtimeMs(item));
+  }
+  return newest;
+}
+
+async function newestPathMtimeMs(path) {
+  if (!existsSync(path)) return 0;
+  const stat = statSync(path);
+  if (!stat.isDirectory()) return stat.mtimeMs;
+
+  let newest = stat.mtimeMs;
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    newest = Math.max(newest, await newestPathMtimeMs(join(path, entry.name)));
+  }
+  return newest;
+}
+
+async function snapshotIsFresh() {
+  if (!existsSync(snapshotPath)) return false;
+  const snapshotMtime = statSync(snapshotPath).mtimeMs;
+  const sourceMtime = await newestMtimeMs([...sourceRoots, ...sourceFiles]);
+  return snapshotMtime >= sourceMtime;
+}
+
+function rebuildSnapshot() {
+  const args = [
+    "run",
+    "--",
+    "python",
+    "_project/scripts/explorer_publish.py",
+    "build",
+    "--data-dir",
+    "results-data",
+    "--output",
+    "results-explorer/public/data",
+  ];
+  log(`uv ${args.join(" ")}`);
+  const result = spawnSync("uv", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: { ...process.env, PYTHONUNBUFFERED: "1" },
+  });
+  if (result.status !== 0) {
+    throw new Error(`Explorer dev snapshot rebuild failed with exit ${result.status ?? "unknown"}`);
+  }
+}
+
+if (process.env.EXPLORER_SKIP_PREDEV === "1") {
+  log("skipped by EXPLORER_SKIP_PREDEV=1");
+} else if (await snapshotIsFresh()) {
+  log("snapshot is current");
+} else {
+  log("snapshot missing or stale; rebuilding");
+  rebuildSnapshot();
+}

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -148,10 +148,12 @@ async function readSnapshotReadModelVersion(conn: DuckDBConnection): Promise<num
 }
 
 function throwReadModelVersionError(found: number): never {
+  const remediation = import.meta.env.DEV
+    ? "Restart npm run dev or run npm run dev:snapshot to rebuild the local Explorer data."
+    : "Refresh the published snapshot or ask a maintainer to rebuild the Explorer data.";
   throw new Error(
     `DuckDB snapshot read-model v${found}; UI requires v${EXPECTED_READ_MODEL_VERSION}. ` +
-      "Refresh the published snapshot or ask a maintainer to rebuild the Explorer data. Check the deployed " +
-      "results.duckdb file.",
+      `${remediation} Check the deployed results.duckdb file.`,
   );
 }
 

--- a/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
+++ b/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
@@ -50,14 +50,14 @@ describe("read-model version guard", () => {
     ).rejects.not.toThrow(/is missing required columns/);
   });
 
-  it("rejects an older read-model version with a humane remediation message", async () => {
+  it("rejects an older read-model version with a humane dev remediation message", async () => {
     const conn = makeConn(0);
     await expect(
       _verifyReadModelVersionForTest(conn as unknown as Parameters<typeof _verifyReadModelVersionForTest>[0]),
     ).rejects.toThrow(/read-model v0; UI requires v1/);
     await expect(
       _verifyReadModelVersionForTest(conn as unknown as Parameters<typeof _verifyReadModelVersionForTest>[0]),
-    ).rejects.toThrow(/ask a maintainer to rebuild the Explorer data/);
+    ).rejects.toThrow(/npm run dev:snapshot/);
   });
 
   it("resolves when the snapshot version matches the UI contract", async () => {


### PR DESCRIPTION
## Summary

- Adds `results-explorer` `predev` / `dev:snapshot` scripts that rebuild `public/data/results.duckdb` when the local snapshot is missing or stale.
- Ignores generated `results-explorer/public/data/` artifacts.
- Updates the read-model mismatch remediation message to point local developers at `npm run dev:snapshot`.
- Moves `explorer-dev-snapshot-dx` to DONE.

## Decision Note

Chosen shape: `(i) predev rebuild check`.

Evidence:
- PR #344 `feat(explorer): add read-model eligibility contract` merged 2026-05-11T12:33:20Z.
- PR #354 `fix(explorer): repair comparison eligibility coverage` merged 2026-05-11T21:31:54Z.
- PR #380 `fix(joinorder): mark dataframe partial coverage` merged 2026-05-12T18:33:53Z.
- `git log --since=60.days -- results-explorer/src/db.ts _project/scripts/explorer_pipeline/duckdb_builder.py` returned 11 commits.
- `git log --since=60.days -- results-data/bundles/ | wc -l` returned 8 commits.

Rationale:
- Directly fixes the default `cd results-explorer && npm run dev` path.
- Avoids committing a DuckDB binary that would need periodic refresh.
- Reuses the canonical publisher and leaves CI docs deploy behavior unchanged.

## Verification

- `rm -rf results-explorer/public/data && cd results-explorer && npm run dev -- --host 127.0.0.1 --port 5173 --strictPort` smoke: `/results/` returned 200 and `/results/data/results.duckdb` returned 200.
- Dev rebuild processed 528 results across 58 cohorts.
- `node results-explorer/scripts/ensure-dev-snapshot.mjs`
- `EXPLORER_SKIP_PREDEV=1 node results-explorer/scripts/ensure-dev-snapshot.mjs`
- `cd results-explorer && npm test` -> 65 files, 702 tests passed.
- `cd results-explorer && npm run build`
- `cd results-explorer && npm run typecheck`
- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `make pr-preflight` -> 22488 passed, 5 skipped.
