### PR TITLE
fix(explorer): tighten followups from CLI surface batch review

### DIFF
--- a/_project/scripts/explorer_pipeline/duckdb_builder.py
+++ b/_project/scripts/explorer_pipeline/duckdb_builder.py
@@ -665,9 +665,15 @@ class DuckDBSnapshotBuilder:
         """)
 
     def _create_metadata(self, con: Any) -> None:
-        """Create the one-row read-model metadata table consumed by the browser."""
+        """Create the one-row read-model metadata table consumed by the browser.
+
+        Uses ``IF NOT EXISTS`` to mirror ``docs/development/browser-duckdb-schema.sql``;
+        callers (``build``, ``build_full``) currently always open a fresh DuckDB file,
+        but matching the schema doc means a future reuse on an existing connection
+        won't silently diverge.
+        """
         con.execute("""
-            CREATE TABLE metadata (
+            CREATE TABLE IF NOT EXISTS metadata (
                 read_model_version INTEGER NOT NULL
             )
         """)

--- a/_project/scripts/explorer_publish.py
+++ b/_project/scripts/explorer_publish.py
@@ -8,6 +8,12 @@ from pathlib import Path
 
 import click
 
+# `_project/` is a PEP 420 implicit namespace package (no `__init__.py`) and is
+# excluded from the wheel build (see `tool.setuptools.packages.find` in
+# `pyproject.toml`). When this script is invoked as
+# `python _project/scripts/explorer_publish.py`, only the script's own directory
+# lands on sys.path, so `_project.scripts.explorer_pipeline.*` imports below
+# would fail. Insert the repo root so the namespace package resolves.
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))

--- a/results-explorer/scripts/ensure-dev-snapshot.mjs
+++ b/results-explorer/scripts/ensure-dev-snapshot.mjs
@@ -67,6 +67,13 @@ function rebuildSnapshot() {
     stdio: "inherit",
     env: { ...process.env, PYTHONUNBUFFERED: "1" },
   });
+  if (result.error && result.error.code === "ENOENT") {
+    throw new Error(
+      "Explorer dev snapshot rebuild needs `uv`, which was not found on PATH. " +
+        "Install uv (https://docs.astral.sh/uv/) or set EXPLORER_SKIP_PREDEV=1 to skip " +
+        "the rebuild and accept a stale/missing local snapshot.",
+    );
+  }
   if (result.status !== 0) {
     throw new Error(`Explorer dev snapshot rebuild failed with exit ${result.status ?? "unknown"}`);
   }

--- a/tests/unit/core/explorer_pipeline/README.md
+++ b/tests/unit/core/explorer_pipeline/README.md
@@ -1,0 +1,15 @@
+# Explorer pipeline tests
+
+These tests exercise the Explorer publishing pipeline whose source moved out
+of the BenchBox CLI surface in PR #418.
+
+- Source under test: `_project/scripts/explorer_pipeline/` (and the entry
+  point `_project/scripts/explorer_publish.py`).
+- Why the tests didn't move with the source: `_project/` is intentionally
+  excluded from the BenchBox wheel build (see `tool.setuptools.packages.find`
+  in `pyproject.toml`). Keeping the test tree under `tests/` preserves the
+  existing `make test-*` / pytest collection paths and avoids accidentally
+  shipping test files.
+
+See `docs/development/adr/adr-explorer-cli-surface.md` for the decision that
+relocated the publisher.


### PR DESCRIPTION
- DuckDB metadata DDL uses IF NOT EXISTS to match browser-duckdb-schema.sql
  and keep future connection reuse from silently diverging.
- ensure-dev-snapshot.mjs surfaces a friendly install-uv / EXPLORER_SKIP_PREDEV
  error when uv is not on PATH instead of a bare exit code.
- explorer_publish.py documents why the sys.path insert is needed
  (PEP 420 namespace, _project excluded from the wheel).
- Adds a README in tests/unit/core/explorer_pipeline/ pointing at the new
  source location under _project/scripts/explorer_pipeline/.
