### PR TITLE
fix(explorer): harden review followups

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "examples/**"
       - "landing/**"
+      - "_project/scripts/**"
       - "results-data/**"
       - "results-explorer/**"
       - "scripts/**"
@@ -16,12 +17,13 @@ on:
       - "README.md"
       - "pyproject.toml"
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "benchbox/**"
       - "docs/**"
       - "examples/**"
       - "landing/**"
+      - "_project/scripts/**"
       - "results-data/**"
       - "results-explorer/**"
       - "scripts/**"

--- a/.github/workflows/results-explorer-browser.yml
+++ b/.github/workflows/results-explorer-browser.yml
@@ -6,13 +6,15 @@ on:
     paths:
       - 'results-explorer/**'
       - '_project/scripts/explorer_pipeline/**'
+      - '_project/scripts/explorer_publish.py'
       - 'results-data/**'
       - '.github/workflows/results-explorer-browser.yml'
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
     paths:
       - 'results-explorer/**'
       - '_project/scripts/explorer_pipeline/**'
+      - '_project/scripts/explorer_publish.py'
       - 'results-data/**'
       - '.github/workflows/results-explorer-browser.yml'
   workflow_dispatch:

--- a/_project/scripts/explorer_pipeline/duckdb_builder.py
+++ b/_project/scripts/explorer_pipeline/duckdb_builder.py
@@ -667,16 +667,17 @@ class DuckDBSnapshotBuilder:
     def _create_metadata(self, con: Any) -> None:
         """Create the one-row read-model metadata table consumed by the browser.
 
-        Uses ``IF NOT EXISTS`` to mirror ``docs/development/browser-duckdb-schema.sql``;
-        callers (``build``, ``build_full``) currently always open a fresh DuckDB file,
-        but matching the schema doc means a future reuse on an existing connection
-        won't silently diverge.
+        Uses ``IF NOT EXISTS`` to mirror ``docs/development/browser-duckdb-schema.sql``.
+        Callers (``build``, ``build_full``) currently open a fresh DuckDB file,
+        but keeping this helper single-row idempotent prevents future connection
+        reuse from leaving multiple read-model versions behind.
         """
         con.execute("""
             CREATE TABLE IF NOT EXISTS metadata (
                 read_model_version INTEGER NOT NULL
             )
         """)
+        con.execute("DELETE FROM metadata")
         con.execute("INSERT INTO metadata VALUES (?)", [EXPLORER_READ_MODEL_VERSION])
 
     # ------------------------------------------------------------------

--- a/docs/development/results-explorer-browser-testing.md
+++ b/docs/development/results-explorer-browser-testing.md
@@ -68,8 +68,8 @@ and are both gitignored.
 
 [`.github/workflows/results-explorer-browser.yml`](../../.github/workflows/results-explorer-browser.yml)
 runs on every push and pull request that touches `results-explorer/`,
-`_project/scripts/explorer_pipeline/`, `results-data/`, or the workflow file
-itself.
+`_project/scripts/explorer_pipeline/`, `_project/scripts/explorer_publish.py`,
+`results-data/`, or the workflow file itself.
 
 - **Blocking:** `chromium` job - full suite must pass.
 - **Non-blocking:** `firefox-smoke` and `webkit-smoke` jobs - `@smoke`-tagged

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -142,7 +142,7 @@ A submission PR that adds files outside the allowlist should be redirected to
 | Inventory generator | `scripts/generate_corpus_inventory.py` |
 | Submission validator | `scripts/validate_submission.py` |
 | Validation workflow | `.github/workflows/validate-submission.yml` |
-| Explorer pipeline | `benchbox/core/explorer_pipeline/` |
+| Explorer pipeline | `_project/scripts/explorer_pipeline/` |
 | Contributor guide | `docs/contributing-results.md` |
 
 ## 9. Verification Commands

--- a/docs/visualization-parity.md
+++ b/docs/visualization-parity.md
@@ -22,11 +22,11 @@ Each file is a JSON contract for one chart math helper:
 | `delta_pct.json` | `deltaPct` | `benchbox/core/visualization/ascii/diverging_bar.py` |
 | `sort_by_magnitude_desc.json` | `sortByMagnitudeDesc` | same |
 | `per_query_speedup.json` | `perQuerySpeedup` | N/A - no Python CLI chart; originated in `Compare.tsx`, unified via `chartMath.ts` |
-| `geomean_ms.json` | `geomeanMs` | `benchbox/core/explorer_pipeline/transformer.py` `_display_geomean_ms` |
-| `box_stats.json` | `computeBoxStats` | `benchbox/core/explorer_pipeline/transformer.py` `_compute_box_stats` |
-| `cdf_ecdf.json` | `computeECDFPoints` | `benchbox/core/explorer_pipeline/transformer.py` `_compute_ecdf` |
-| `rank_table.json` | `computeRankTable` | `benchbox/core/explorer_pipeline/transformer.py` `_compute_ranks` |
-| `percentile_ladder.json` | `computePercentile` | `benchbox/core/explorer_pipeline/transformer.py` `_compute_percentile` |
+| `geomean_ms.json` | `geomeanMs` | `_project/scripts/explorer_pipeline/transformer.py` `_display_geomean_ms` |
+| `box_stats.json` | `computeBoxStats` | `_project/scripts/explorer_pipeline/transformer.py` `_compute_box_stats` |
+| `cdf_ecdf.json` | `computeECDFPoints` | `_project/scripts/explorer_pipeline/transformer.py` `_compute_ecdf` |
+| `rank_table.json` | `computeRankTable` | `_project/scripts/explorer_pipeline/transformer.py` `_compute_ranks` |
+| `percentile_ladder.json` | `computePercentile` | `_project/scripts/explorer_pipeline/transformer.py` `_compute_percentile` |
 
 ## Policy
 

--- a/results-explorer/scripts/ensure-dev-snapshot.mjs
+++ b/results-explorer/scripts/ensure-dev-snapshot.mjs
@@ -5,6 +5,8 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 
+import { EXPECTED_READ_MODEL_VERSION } from "./explorer-build-contract.mjs";
+
 const here = fileURLToPath(new URL(".", import.meta.url));
 const explorerRoot = resolve(here, "..");
 const repoRoot = resolve(explorerRoot, "..");
@@ -46,7 +48,62 @@ async function snapshotIsFresh() {
   if (!existsSync(snapshotPath)) return false;
   const snapshotMtime = statSync(snapshotPath).mtimeMs;
   const sourceMtime = await newestMtimeMs([...sourceRoots, ...sourceFiles]);
-  return snapshotMtime >= sourceMtime;
+  if (snapshotMtime < sourceMtime) return false;
+
+  const readModelVersion = readSnapshotReadModelVersion();
+  if (readModelVersion !== EXPECTED_READ_MODEL_VERSION) {
+    log(
+      `snapshot read-model v${readModelVersion ?? "unknown"} does not match ` +
+        `expected v${EXPECTED_READ_MODEL_VERSION}`,
+    );
+    return false;
+  }
+  return true;
+}
+
+function runUv(args, action) {
+  if (action === "validation") {
+    log("validating snapshot read-model version");
+  } else {
+    log(`uv ${args.join(" ")}`);
+  }
+  const result = spawnSync("uv", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, PYTHONUNBUFFERED: "1" },
+    stdio: action === "rebuild" ? "inherit" : "pipe",
+  });
+  if (result.error && result.error.code === "ENOENT") {
+    throw new Error(
+      `Explorer dev snapshot ${action} needs \`uv\`, which was not found on PATH. ` +
+        "Install uv (https://docs.astral.sh/uv/) or set EXPLORER_SKIP_PREDEV=1 to skip " +
+        "the rebuild and accept a stale/missing local snapshot.",
+    );
+  }
+  return result;
+}
+
+function readSnapshotReadModelVersion() {
+  const probe = [
+    "run",
+    "--",
+    "python",
+    "-c",
+    [
+      "import duckdb, sys",
+      "path = sys.argv[1]",
+      "with duckdb.connect(path, read_only=True) as con:",
+      "    row = con.execute('SELECT read_model_version FROM metadata LIMIT 1').fetchone()",
+      "print(row[0] if row else 0)",
+    ].join("\n"),
+    snapshotPath,
+  ];
+  const result = runUv(probe, "validation");
+  if (result.status !== 0) {
+    return null;
+  }
+  const version = Number(result.stdout.trim());
+  return Number.isInteger(version) && version >= 0 ? version : null;
 }
 
 function rebuildSnapshot() {
@@ -61,19 +118,7 @@ function rebuildSnapshot() {
     "--output",
     "results-explorer/public/data",
   ];
-  log(`uv ${args.join(" ")}`);
-  const result = spawnSync("uv", args, {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: { ...process.env, PYTHONUNBUFFERED: "1" },
-  });
-  if (result.error && result.error.code === "ENOENT") {
-    throw new Error(
-      "Explorer dev snapshot rebuild needs `uv`, which was not found on PATH. " +
-        "Install uv (https://docs.astral.sh/uv/) or set EXPLORER_SKIP_PREDEV=1 to skip " +
-        "the rebuild and accept a stale/missing local snapshot.",
-    );
-  }
+  const result = runUv(args, "rebuild");
   if (result.status !== 0) {
     throw new Error(`Explorer dev snapshot rebuild failed with exit ${result.status ?? "unknown"}`);
   }

--- a/results-explorer/src/db.ts
+++ b/results-explorer/src/db.ts
@@ -121,6 +121,15 @@ export async function _verifyReadModelVersionForTest(
   return verifyReadModelVersion(conn);
 }
 
+// Exported for unit-test coverage of initialization ordering. The version
+// guard must run before schema-readiness probes so stale snapshots fail with
+// the actionable read-model message instead of a lower-level DuckDB error.
+export async function _validateAttachedSnapshotForTest(
+  conn: DuckDBConnection,
+): Promise<void> {
+  return validateAttachedSnapshot(conn);
+}
+
 export const _EXPECTED_READ_MODEL_VERSION_FOR_TEST = EXPECTED_READ_MODEL_VERSION;
 
 async function verifyReadModelVersion(conn: DuckDBConnection): Promise<void> {
@@ -142,9 +151,30 @@ async function readSnapshotReadModelVersion(conn: DuckDBConnection): Promise<num
     const row = result.toArray()[0]?.toJSON();
     const version = Number(row?.read_model_version ?? 0);
     return Number.isInteger(version) && version >= 0 ? version : 0;
-  } catch {
-    return 0;
+  } catch (error: unknown) {
+    if (isMissingReadModelMetadataError(error)) {
+      return 0;
+    }
+    throw error;
   }
+}
+
+function isMissingReadModelMetadataError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /Table with name metadata does not exist/i.test(message) ||
+    /Catalog Error:.*metadata/i.test(message) ||
+    /Referenced column "?read_model_version"? not found/i.test(message) ||
+    /Binder Error:.*read_model_version/i.test(message)
+  );
+}
+
+async function validateAttachedSnapshot(conn: DuckDBConnection): Promise<void> {
+  await verifyReadModelVersion(conn);
+  // COUNT(*) can be satisfied from metadata for this projection view.
+  // Run the same projection PlatformIndex uses so a cold HTTP-backed
+  // snapshot is query-ready before the cached DB instance is exposed.
+  await waitForSnapshotRows(conn);
 }
 
 function throwReadModelVersionError(found: number): never {
@@ -237,11 +267,7 @@ export async function getDb(): Promise<duckdb.AsyncDuckDB> {
     const conn = await db.connect();
     try {
       await conn.query("ATTACH 'results.duckdb' AS bench (READ_ONLY)");
-      // COUNT(*) can be satisfied from metadata for this projection view.
-      // Run the same projection PlatformIndex uses so a cold HTTP-backed
-      // snapshot is query-ready before the cached DB instance is exposed.
-      await waitForSnapshotRows(conn);
-      await verifyReadModelVersion(conn);
+      await validateAttachedSnapshot(conn);
     } finally {
       await conn.close();
     }

--- a/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
+++ b/results-explorer/src/lib/__tests__/read-model-version-mismatch.test.ts
@@ -7,6 +7,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   _EXPECTED_READ_MODEL_VERSION_FOR_TEST,
+  _validateAttachedSnapshotForTest,
   _verifyReadModelVersionForTest,
 } from "@/db";
 
@@ -50,6 +51,21 @@ describe("read-model version guard", () => {
     ).rejects.not.toThrow(/is missing required columns/);
   });
 
+  it("does not mask unexpected DuckDB failures as stale v0", async () => {
+    const conn = {
+      async query(_sql: string): Promise<QueryResult> {
+        throw new Error("IO Error: could not read DuckDB file");
+      },
+    };
+
+    await expect(
+      _verifyReadModelVersionForTest(conn as unknown as Parameters<typeof _verifyReadModelVersionForTest>[0]),
+    ).rejects.toThrow(/could not read DuckDB file/);
+    await expect(
+      _verifyReadModelVersionForTest(conn as unknown as Parameters<typeof _verifyReadModelVersionForTest>[0]),
+    ).rejects.not.toThrow(/read-model v0/);
+  });
+
   it("rejects an older read-model version with a humane dev remediation message", async () => {
     const conn = makeConn(0);
     await expect(
@@ -76,5 +92,30 @@ describe("read-model version guard", () => {
     ).resolves.toBeUndefined();
 
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("Proceeding with forward-compatible reads"));
+  });
+
+  it("validates the read-model version before probing schema readiness", async () => {
+    const queries: string[] = [];
+    const conn = {
+      async query(sql: string): Promise<QueryResult> {
+        queries.push(sql);
+        if (sql.includes("bench.metadata")) {
+          return {
+            toArray: () => [
+              {
+                toJSON: () => ({ read_model_version: 0 }),
+              },
+            ],
+          };
+        }
+        throw new Error("Catalog Error: Table with name results does not exist");
+      },
+    };
+
+    await expect(
+      _validateAttachedSnapshotForTest(conn as unknown as Parameters<typeof _validateAttachedSnapshotForTest>[0]),
+    ).rejects.toThrow(/read-model v0; UI requires v1/);
+
+    expect(queries).toEqual(["SELECT read_model_version FROM bench.metadata LIMIT 1"]);
   });
 });

--- a/tests/unit/core/explorer_pipeline/test_duckdb_builder.py
+++ b/tests/unit/core/explorer_pipeline/test_duckdb_builder.py
@@ -53,6 +53,17 @@ class TestDuckDBSnapshotBuilder:
 
         assert version == EXPLORER_READ_MODEL_VERSION
 
+    def test_metadata_creation_remains_single_row_when_reused(self, tmp_path: Path) -> None:
+        builder = DuckDBSnapshotBuilder()
+        out = tmp_path / "results.duckdb"
+
+        with duckdb.connect(str(out)) as con:
+            builder._create_metadata(con)
+            builder._create_metadata(con)
+            rows = con.execute("SELECT read_model_version FROM metadata").fetchall()
+
+        assert rows == [(EXPLORER_READ_MODEL_VERSION,)]
+
     def test_results_table_has_correct_columns(self, tmp_path: Path) -> None:
         builder = DuckDBSnapshotBuilder()
         out = tmp_path / "results.duckdb"


### PR DESCRIPTION
## Summary

- Run Results Explorer browser/docs workflows for PRs targeting `develop`, and include the maintainer publisher script in workflow path filters.
- Validate DuckDB read-model versions before schema readiness probes, and preserve unexpected DuckDB failures instead of mapping everything to stale v0.
- Make Explorer metadata creation single-row/idempotent and make `npm run dev:snapshot` verify the snapshot read-model version before accepting mtime freshness.
- Clean stale active docs that still referenced the retired `benchbox/core/explorer_pipeline/` path.

## Root cause

The previous follow-up fixed individual symptoms, but the batch still had composition gaps: stale snapshots could fail before the version guard, dev snapshot freshness was only timestamp-based, metadata was not safe under future reuse, and the workflows that would catch browser/docs issues were not attached to the `develop` PR path used by these changes.

## Verification

- `uv run -- python -m pytest tests/unit/core/explorer_pipeline/test_duckdb_builder.py::TestDuckDBSnapshotBuilder::test_metadata_creation_remains_single_row_when_reused tests/unit/core/explorer_pipeline/test_duckdb_builder.py::TestDuckDBSnapshotBuilder::test_writes_read_model_version_metadata -q`
- `npm test -- read-model-version-mismatch.test.ts snapshotReadiness.test.ts`
- `node scripts/ensure-dev-snapshot.mjs`
- `npm run typecheck`
- `uv run -- python -m pytest tests/unit/core/explorer_pipeline/test_duckdb_builder.py tests/unit/cli/test_explorer_build_contract.py -q`
- `npm run build`
- `uv run -- ruff check _project/scripts/explorer_pipeline/duckdb_builder.py tests/unit/core/explorer_pipeline/test_duckdb_builder.py`
- `uv run -- pre-commit run check-yaml --files .github/workflows/docs.yml .github/workflows/results-explorer-browser.yml`
- `uv run -- pre-commit run markdownlint --files docs/development/results-explorer-browser-testing.md docs/operations/results-phase-2-runbook.md docs/visualization-parity.md`
- `make pr-preflight` (`22495 passed, 5 skipped`; log: `/tmp/explorer-review-followups-pr-preflight.log`)
