### PR TITLE
Add follow-up Results Explorer contract TODOs

### DIFF
--- a/_project/TODO/main/planning/results-explorer-corpus-aware-benchmark-switcher.yaml
+++ b/_project/TODO/main/planning/results-explorer-corpus-aware-benchmark-switcher.yaml
@@ -1,0 +1,157 @@
+id: results-explorer-corpus-aware-benchmark-switcher
+title: "Make benchmark detail pivot controls corpus-aware and actionably labeled"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: User Experience
+
+description: |
+  The benchmark detail page now has a benchmark switcher, so the original
+  trapped-page navigation defect is largely remediated. The follow-up
+  functional pass found a remaining usability defect: the switcher exposes the
+  full supported benchmark catalog, including benchmarks with no public result
+  page in the current static corpus. Selecting one of those options navigates
+  to an empty benchmark page such as `/results/amplab/` and requires recovery
+  via `Back to Results`.
+
+  The root cause is that the control appears to source options from the static
+  supported-benchmark catalog instead of the current public result corpus. The
+  blind spot is common in the Results Explorer: fixing "can pivot to a sibling"
+  by adding a selector is not enough if the selector does not distinguish
+  actionable public result pages from no-data placeholders.
+
+  This TODO should make benchmark pivots truthfully actionable. The selector
+  should either list only benchmarks with public results for the current
+  explorer corpus, or it should visibly mark/disable no-result options with an
+  explicit empty-state affordance. Do not remove the empty benchmark route
+  itself; it is still useful for direct links and future corpus growth.
+
+work:
+- id: w0
+  summary: "Confirm the benchmark switcher option source and no-result route behavior"
+  status: pending
+  notes: |
+    Reproduce from `/results/tpch/`:
+    - open the benchmark switcher;
+    - record the options shown;
+    - select one benchmark with public results such as SSB;
+    - select one benchmark with no public results such as AMPLab;
+    - record the resulting route and empty-state recovery controls.
+
+    In code, identify whether the switcher options come from a static label
+    catalog, public corpus summary, or generated route manifest.
+
+- id: w1
+  summary: "Define the actionability contract for benchmark pivot options"
+  needs: [w0]
+  status: pending
+  notes: |
+    Decision gate: choose one contract:
+    - Contract A: benchmark detail switcher lists only benchmarks with public
+      results in the current static corpus.
+    - Contract B: switcher lists all supported benchmarks, but no-result
+      options are disabled or grouped under a clear "No public results yet"
+      label and do not navigate as though results exist.
+    - Contract C: switcher lists all supported benchmarks and navigates to
+      empty pages, but each option includes result availability counts.
+
+    Contract A is preferred for a dense results explorer because users expect
+    a detail-page selector to pivot between comparable pages, not catalog
+    placeholders. If another contract is chosen, document why it better serves
+    result discovery.
+
+- id: w2
+  summary: "Implement the corpus-aware benchmark switcher"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update the benchmark detail page selector so its options reflect the
+    chosen actionability contract. If listing only public-result benchmarks,
+    derive the option set from the same corpus data that powers benchmark
+    index/list counts, not from a manually maintained allowlist.
+
+    Preserve direct routing to no-result benchmark pages and their empty-state
+    recovery. The fix is about the selector's implied actionability, not about
+    hiding valid static routes.
+
+- id: w3
+  summary: "Add tests for public-result and no-result benchmark pivot behavior"
+  needs: [w2]
+  status: pending
+  notes: |
+    Add unit and/or e2e coverage that proves:
+    - TPC-H and SSB remain reachable from the benchmark selector when they
+      have public results;
+    - AMPLab/no-result benchmarks are either absent, disabled, or explicitly
+      labeled according to the chosen contract;
+    - direct navigation to `/results/amplab/` still renders a useful empty
+      state with a route back to Results.
+
+- id: w4
+  summary: "Audit platform and compare pivot controls for the same actionability pattern"
+  needs: [w2]
+  status: pending
+  notes: |
+    Check the platform detail selector, compare builder filters, Query
+    Workbench facets, and Home filters for controls that expose unavailable
+    options as if they are actionable. Do not broaden the implementation
+    unless the same defect is reproduced; record any additional issue as a
+    separate TODO if it exceeds this scope.
+
+deferred:
+- summary: "Add public-result counts to every benchmark catalog option"
+  reason: "Counts may be useful later, but the immediate defect is that the selector implies non-empty sibling pages."
+- summary: "Remove empty benchmark routes from the static export"
+  reason: "Direct empty routes are useful for deep links and future corpus growth; the selector should be fixed instead."
+
+prior_art:
+- "results-explorer/src/pages/BenchmarkDetail.tsx — benchmark detail page and switcher behavior"
+- "results-explorer/src/pages/BenchmarkIndex.tsx — benchmark index availability/count display"
+- "results-explorer/src/lib/corpus.ts — generated/public corpus helpers used by route pages"
+- "results-explorer/src/lib/benchmarks.ts — static benchmark label/catalog helpers"
+- "results-explorer/e2e/routes/benchmark-index.spec.ts — existing benchmark navigation coverage"
+- "_project/DONE/main/planning/results-explorer-contract-release-gate.yaml — prior release-gate TODO for Results Explorer user flows"
+
+must_preserve:
+- "Users can still switch from TPC-H to SSB or any other benchmark with public results without returning to the index."
+- "Direct no-result routes render a clear empty state and recovery path."
+- "The switcher does not show stale hard-coded availability that can drift from the generated corpus."
+- "Compare and Query flows are not changed unless the same actionability defect is reproduced there."
+
+approach: |
+  Make the pivot control derive from result availability, not from the whole
+  supported-benchmark catalog. Decide explicitly whether no-result benchmarks
+  are hidden or shown as unavailable before implementing, then test both the
+  actionable selector path and the direct empty-route path.
+
+anti_patterns:
+- "DO NOT hard-code `TPC-H` and `SSB` as the only public-result options."
+- "DO NOT remove empty routes to make the selector simpler."
+- "DO NOT let a selectable option navigate users into a no-result dead end without making that state explicit."
+- "DO NOT broaden this into a redesign of the benchmark index or Home filter system."
+
+verification:
+- description: "Benchmark detail tests cover corpus-aware pivot options"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/BenchmarkDetail.test.tsx"
+  expected_output: "Benchmark detail tests pass and prove no-result options follow the chosen actionability contract"
+- description: "Benchmark route e2e covers public and no-result routes"
+  command: "cd results-explorer && npx playwright test --project=chromium --workers=1 e2e/routes/benchmark-index.spec.ts"
+  expected_output: "Benchmark e2e passes, including public benchmark switching and direct no-result empty-state recovery"
+- description: "Corpus availability is not hard-coded"
+  command: "rg -n 'AMPLab|TPC-H|SSB|BENCHMARK_LABELS|public results|No public results' results-explorer/src/pages/BenchmarkDetail.tsx results-explorer/src/lib results-explorer/src/pages/__tests__ results-explorer/e2e/routes/benchmark-index.spec.ts"
+  expected_output: "Implementation derives options from corpus helpers; tests may name fixtures but production code does not hard-code the public option set"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/BenchmarkDetail.tsx"
+  - "results-explorer/src/pages/BenchmarkIndex.tsx"
+  - "results-explorer/src/lib/"
+  - "results-explorer/src/pages/__tests__/BenchmarkDetail.test.tsx"
+  - "results-explorer/src/pages/__tests__/BenchmarkIndex.test.tsx"
+  - "results-explorer/e2e/routes/benchmark-index.spec.ts"
+  - "_project/analysis/"
+  do_not_modify:
+  - "benchbox/"
+  - "results-data/"
+  - "landing/"
+  - "docs/"

--- a/_project/TODO/main/planning/results-explorer-global-header-visual-parity-gate.yaml
+++ b/_project/TODO/main/planning/results-explorer-global-header-visual-parity-gate.yaml
@@ -1,0 +1,178 @@
+id: results-explorer-global-header-visual-parity-gate
+title: "Add a visual parity gate for the shared BenchBox global header"
+worktree: main
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The visible global header on Results now has the same major labels as the
+  landing/docs/blog header, but the implementation is still structurally
+  separate: landing/docs/prompts consume the shared static `benchbox-site-header`
+  contract, while Results renders a hand-built Preact/Tailwind header in
+  `results-explorer/src/components/Layout.tsx`. Current tests assert labels,
+  destinations, and basic mobile behavior, but they do not prove pixel or DOM
+  parity with the landing header.
+
+  The root cause is that "identical header" was verified semantically instead
+  of visually and structurally. This leaves the same blind spot that caused the
+  original complaint: Results can drift in height, spacing, active underline,
+  theme toggle placement, CTA styling, focus rings, or mobile menu behavior
+  while every label-based test remains green.
+
+  This TODO should create a durable cross-surface header parity gate. The
+  preferred implementation is for Results to consume a generated/shared header
+  contract or a deliberately tested mirror of the shared static header. If a
+  single shared runtime component is not practical because Results is a Vite
+  app and landing/docs are static/Sphinx surfaces, the PR must document that
+  constraint and add a parity test strong enough to catch visual drift.
+
+work:
+- id: w0
+  summary: "Inventory the rendered and source-level header contract across landing, docs, blog, prompts, and Results"
+  status: pending
+  notes: |
+    Compare:
+    - `landing/shared/site-header.css`;
+    - `landing/index.html`;
+    - `docs/_templates/page.html`;
+    - `prompts/index.html`;
+    - `results-explorer/src/components/Layout.tsx`;
+    - existing header tests under `results-explorer/e2e/routes/header.spec.ts`
+      and `results-explorer/src/components/__tests__/Layout.test.tsx`.
+
+    Capture a compact matrix in the PR covering class names, header height,
+    max width, padding, link order, CTA treatment, active state, theme toggle,
+    focus-visible treatment, and mobile behavior. Include whether each surface
+    consumes the shared static contract or manually mirrors it.
+
+- id: w1
+  summary: "Choose the implementation strategy for Results header parity"
+  needs: [w0]
+  status: pending
+  notes: |
+    Decision gate: choose one strategy before editing:
+    - Strategy A: Results imports shared header CSS/assets and renders markup
+      that uses the same `benchbox-site-header` class contract.
+    - Strategy B: Results keeps a Preact wrapper but renders a generated or
+      test-enforced mirror of the same class contract.
+    - Strategy C: Results cannot consume the class contract; document why and
+      add screenshot/perceptual parity tests across surfaces.
+
+    Strategy A is preferred if it can be done without breaking Vite, static
+    deployment, or theme initialization. Strategy C is acceptable only with a
+    clear technical reason and strong visual regression coverage.
+
+- id: w2
+  summary: "Align Results global header markup/classes or add an explicit tested mirror"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update `results-explorer/src/components/Layout.tsx` and related styles so
+    Results no longer invents untested local header spacing, CTA treatment, or
+    theme toggle placement. Keep the Results secondary nav separate below the
+    global header with its own aria label and active-state tests.
+
+    Preserve the SPA routing behavior and current theme toggle behavior. Do
+    not move Results-specific navigation items into the global header.
+
+- id: w3
+  summary: "Add cross-surface desktop and mobile header parity tests"
+  needs: [w2]
+  status: pending
+  notes: |
+    Extend browser coverage so it compares the global header on:
+    - landing `/`;
+    - docs `/docs/` if locally served in the test harness;
+    - blog `/blog/` if locally served in the test harness;
+    - prompts `/prompts/` if that surface remains public;
+    - Results `/results/`.
+
+    Assert at minimum:
+    - identical visible global labels and order;
+    - identical CTA label and target;
+    - identical active-link semantics for current page;
+    - identical theme-toggle placement/accessible label;
+    - matching header bounding-box height within a very small tolerance;
+    - no Results secondary-nav nodes inside the global header.
+
+    Add screenshots or DOM snapshots only if they are kept as stable test
+    artifacts and do not commit large raw evidence outside the established
+    snapshot path.
+
+- id: w4
+  summary: "Run parity checks in both light and dark themes"
+  needs: [w3]
+  status: pending
+  notes: |
+    Verify the parity gate in `light`, `dark`, and `system` when the harness
+    can control `prefers-color-scheme`. Confirm that the header remains
+    visually identical across surfaces after switching theme and after a page
+    reload that restores persisted theme state.
+
+deferred:
+- summary: "Full public-site visual regression suite"
+  reason: "This TODO is scoped to the shared global header; broader page visual diffs belong in a separate release-gate TODO."
+- summary: "Rework Results secondary navigation information architecture"
+  reason: "The secondary Results nav is intentionally separate from global-header parity."
+
+prior_art:
+- "landing/shared/site-header.css — shared static header style contract used outside Results"
+- "landing/index.html — landing header consumer and canonical first-viewport behavior"
+- "docs/_templates/page.html — docs/blog header template integration"
+- "prompts/index.html — additional public surface using the shared header contract"
+- "results-explorer/src/components/Layout.tsx — current Preact header implementation that can drift from shared static markup"
+- "results-explorer/e2e/routes/header.spec.ts — current semantic header coverage"
+- "results-explorer/src/components/__tests__/Layout.test.tsx — current Layout/header unit coverage"
+- "_project/DONE/main/planning/benchbox-site-header-unification.yaml:w5 — completed TODO that required cross-surface parity tests"
+
+must_preserve:
+- "The global header is identical between landing, docs/blog, prompts, and Results at the user-visible level."
+- "Results keeps its secondary `Leaderboards / Benchmarks / Platforms / Compare / Query` nav outside the global header."
+- "Theme selection and persistence continue to work in the header."
+- "The header remains keyboard navigable with visible focus in light and dark themes."
+- "Static landing/docs/blog deployment does not gain a hard dependency on the Results Vite bundle."
+
+approach: |
+  Close the gap between semantic parity and visual parity. Prefer one shared
+  class/asset contract for all surfaces; when that is impossible, make the
+  mirror explicit and test it with bounding-box and screenshot/DOM assertions.
+  Treat the parity test as the release gate that prevents future drift.
+
+anti_patterns:
+- "DO NOT rely only on link-label tests; they already missed spacing and visual-contract drift."
+- "DO NOT move Results subnav links into the global header to make tests easier."
+- "DO NOT create another independent header stylesheet for Results without a parity gate."
+- "DO NOT make the header identical only in dark mode; parity must hold in both light and dark themes."
+- "DO NOT commit broad screenshot batches outside the established visual-test artifact path."
+
+verification:
+- description: "Header unit and route tests pass"
+  command: "cd results-explorer && npm test -- --run src/components/__tests__/Layout.test.tsx && npx playwright test --project=chromium --workers=1 e2e/routes/header.spec.ts"
+  expected_output: "Layout/header tests pass and include cross-surface parity assertions where the harness supports them"
+- description: "Header source no longer has untested independent contracts"
+  command: "rg -n 'benchbox-site-header|site-header|Run benchmark|Instruct an agent|theme' landing docs prompts results-explorer/src/components/Layout.tsx results-explorer/e2e/routes/header.spec.ts"
+  expected_output: "Output shows Results either consumes the shared class contract or has an explicit tested mirror"
+- description: "Results Explorer still builds"
+  command: "cd results-explorer && npm run build"
+  expected_output: "Vite build succeeds"
+
+scope_limit:
+  only_modify:
+  - "landing/shared/"
+  - "landing/index.html"
+  - "landing/style.css"
+  - "docs/_templates/"
+  - "docs/_static/"
+  - "prompts/"
+  - "results-explorer/src/components/Layout.tsx"
+  - "results-explorer/src/index.css"
+  - "results-explorer/src/components/__tests__/Layout.test.tsx"
+  - "results-explorer/e2e/routes/header.spec.ts"
+  - "results-explorer/e2e/"
+  - "_project/analysis/"
+  do_not_modify:
+  - "benchbox/"
+  - "results-data/"
+  - "results-explorer/src/pages/"
+  - "results-explorer/src/lib/corpus.ts"

--- a/_project/TODO/main/planning/results-explorer-post-theme-release-gate-reconciliation.yaml
+++ b/_project/TODO/main/planning/results-explorer-post-theme-release-gate-reconciliation.yaml
@@ -1,0 +1,168 @@
+id: results-explorer-post-theme-release-gate-reconciliation
+title: "Reconcile Results Explorer post-theme copy, tests, and stale theme-contract evidence"
+worktree: main
+priority: High
+status: Not Started
+category: User Experience
+
+description: |
+  The post-theme Results Explorer implementation is mostly functional, but the
+  comprehensive route gate is not clean: `results-explorer/e2e/routes/home.spec.ts`
+  still expects the old Corpus Summary label `leaderboard cohorts` while the
+  Home page and unit tests now render `leaderboard rankings`. The visible page
+  also renders `1 leaderboard rankings`, which is grammatically wrong and
+  reveals that corpus-summary labels are static strings rather than count-aware
+  UI copy.
+
+  The same drift exists in durable project evidence. Older analysis files and
+  at least one test name still describe the retired "dark BenchBox shell +
+  light analytical data panels" contract even though the current product
+  contract is user-selectable light/dark theming. These stale artifacts are a
+  root cause for repeated retheme regressions: implementers can follow an old
+  "final decision" and reintroduce mixed-theme assumptions.
+
+  This TODO is a release-gate cleanup and evidence-hardening pass. It should
+  not redesign Home, the theme system, or the corpus model. It should make the
+  current intended contract explicit, update assertions to match it, add
+  count-aware corpus summary labels, and add a compact stale-contract scan so
+  future PRs cannot silently revive the old contract.
+
+work:
+- id: w0
+  summary: "Revalidate the failing Home e2e assertion against current UI and unit-test contracts"
+  status: pending
+  notes: |
+    Re-run the targeted route tests and capture a compact summary in the PR:
+    - checked SHA;
+    - exact failing assertion if it still fails;
+    - current rendered Corpus Summary text from `/results/`;
+    - current unit-test expectation in `src/pages/__tests__/Home.test.tsx`.
+
+    Decision gate: before editing the e2e, decide whether the intended user
+    copy is `leaderboard ranking(s)`, `ranked leaderboard(s)`, or `leaderboard
+    cohort(s)`. The chosen copy must be used consistently in Home, unit tests,
+    and e2e tests.
+
+- id: w1
+  summary: "Make Corpus Summary labels count-aware and update Home tests"
+  needs: [w0]
+  status: pending
+  notes: |
+    Replace static Corpus Summary labels that can produce mismatched singular
+    and plural copy, including the visible `1 leaderboard rankings` case.
+    Prefer a small local formatter such as `formatCountLabel(count, singular,
+    plural)` or an existing equivalent if one exists.
+
+    Update Home unit tests to cover at least:
+    - singular leaderboard ranking;
+    - plural public result bundles;
+    - zero/no ranked leaderboard state if the fixture can express it cheaply.
+
+    Keep copy factual; do not rename the metric in a way that implies more
+    public ranked cohorts than the current corpus actually exposes.
+
+- id: w2
+  summary: "Update stale e2e expectations and add a route-gate assertion for the chosen copy"
+  needs: [w1]
+  status: pending
+  notes: |
+    Update `results-explorer/e2e/routes/home.spec.ts` so it asserts the chosen
+    Corpus Summary wording and no longer expects the stale `leaderboard cohorts`
+    string. Keep the assertion user-visible, not implementation-specific.
+
+    Run the same targeted e2e command that previously failed:
+    `npx playwright test --project=chromium --workers=1 e2e/routes/header.spec.ts e2e/routes/home.spec.ts e2e/routes/benchmark-index.spec.ts e2e/routes/platform-index.spec.ts e2e/routes/result-detail.spec.ts e2e/routes/compare.spec.ts e2e/routes/query.spec.ts`.
+
+- id: w3
+  summary: "Supersede stale mixed-theme evidence and rename stale tests without rewriting history"
+  needs: [w0]
+  status: pending
+  notes: |
+    Grep for phrases that encode the retired mixed-theme contract, including:
+    - `dark BenchBox shell + light analytical data panels`;
+    - `mixed dark/light`;
+    - `light data surface contract`;
+    - `light analytical data`.
+
+    For active source and tests, rename or rewrite the stale language so it
+    describes the current light/dark product contract. For historical
+    `_project/DONE` artifacts, do not rewrite completed work; add concise
+    supersession notes only where the file still reads like the current source
+    of truth. For `_project/analysis/results-explorer-theme-inventory-2026-05-07.md`,
+    add a top-level supersession note pointing to the current theme contract
+    if one is not already present.
+
+- id: w4
+  summary: "Add a compact stale-contract scan to the Results Explorer release gate"
+  needs: [w3]
+  status: pending
+  notes: |
+    Add or extend a low-cost check that fails on new active-source references
+    to the retired mixed-theme contract, while allowing historical artifacts
+    only when they include an explicit supersession note. The check can live
+    in an existing Results Explorer token/contract scan or a small project
+    script if that is the established pattern.
+
+    Decision gate: keep the allowlist narrow and file-specific. Do not create
+    a broad grep that blocks legitimate historical discussion in DONE items
+    or forces unrelated documentation churn.
+
+deferred:
+- summary: "Change what the Corpus Summary measures"
+  reason: "This TODO only reconciles copy/tests for the current corpus metrics; changing the metric definition needs a separate data-contract decision."
+- summary: "Redesign Home filter layout or leaderboard density"
+  reason: "The comprehensive functional pass did not find a new blocking layout defect here beyond count-aware copy and stale gates."
+
+prior_art:
+- "results-explorer/src/pages/Home.tsx:501 — current Corpus Summary `leaderboard rankings` label"
+- "results-explorer/src/pages/__tests__/Home.test.tsx — unit tests already expect the new Home copy"
+- "results-explorer/e2e/routes/home.spec.ts:20 — stale e2e expectation for `leaderboard cohorts`"
+- "_project/analysis/benchbox-theme-contract.md — current cross-surface theme contract"
+- "_project/analysis/results-explorer-theme-inventory-2026-05-07.md — historical mixed-theme inventory that needs explicit supersession"
+- "_project/DONE/main/planning/benchbox-light-dark-theme-system.yaml:w8 — completed work item requiring stale mixed-theme artifacts to be retired or superseded"
+
+must_preserve:
+- "The Results Explorer Home page remains leaderboard-first and keeps existing benchmark/scale/phase filter behavior."
+- "The current user-selectable light/dark theme contract remains the source of truth."
+- "Historical DONE items are not rewritten to pretend earlier decisions were never made."
+- "The route test remains a user-visible regression test, not a brittle implementation snapshot."
+
+approach: |
+  Treat the failing e2e as a contract drift symptom, not just a one-line test
+  edit. First choose the intended user-facing copy, then update the component,
+  unit tests, e2e tests, and stale evidence together. Add a small guard so
+  the old mixed-theme contract cannot re-enter active source or test names.
+
+anti_patterns:
+- "DO NOT simply change the e2e string without fixing the visible `1 leaderboard rankings` copy."
+- "DO NOT reintroduce `leaderboard cohorts` unless the Home metric is actually redefined as cohorts."
+- "DO NOT rewrite DONE history wholesale; add supersession notes where needed."
+- "DO NOT add a broad grep gate that blocks legitimate historical analysis without a path to annotate it."
+- "DO NOT change corpus fixture contents to make the grammar problem disappear."
+
+verification:
+- description: "Home unit coverage proves count-aware Corpus Summary labels"
+  command: "cd results-explorer && npm test -- --run src/pages/__tests__/Home.test.tsx"
+  expected_output: "Home tests pass and cover singular/plural Corpus Summary labels"
+- description: "Targeted Results Explorer route gate is green"
+  command: "cd results-explorer && npx playwright test --project=chromium --workers=1 e2e/routes/header.spec.ts e2e/routes/home.spec.ts e2e/routes/benchmark-index.spec.ts e2e/routes/platform-index.spec.ts e2e/routes/result-detail.spec.ts e2e/routes/compare.spec.ts e2e/routes/query.spec.ts"
+  expected_output: "All targeted route tests pass; the prior `leaderboard cohorts` failure is gone"
+- description: "No unsuperseded active mixed-theme contract language remains"
+  command: "rg -n 'dark BenchBox shell \\+ light analytical data panels|mixed dark/light|light data surface contract|light analytical data' results-explorer _project/analysis _project/DONE"
+  expected_output: "Only explicitly superseded historical references remain; active source/test names describe the current light/dark contract"
+
+scope_limit:
+  only_modify:
+  - "results-explorer/src/pages/Home.tsx"
+  - "results-explorer/src/pages/__tests__/Home.test.tsx"
+  - "results-explorer/e2e/routes/home.spec.ts"
+  - "results-explorer/e2e/"
+  - "results-explorer/src/"
+  - "_project/analysis/"
+  - "_project/DONE/"
+  - "_project/scripts/"
+  do_not_modify:
+  - "benchbox/"
+  - "results-data/"
+  - "landing/"
+  - "docs/"


### PR DESCRIPTION
## Summary
- Adds TODO for post-theme Results Explorer release-gate/copy/stale-contract reconciliation.
- Adds TODO for global header visual parity across landing/docs/blog/prompts/Results.
- Adds TODO for corpus-aware benchmark detail switcher behavior.

## Evaluation findings captured
- Targeted route e2e currently fails because Home e2e expects `leaderboard cohorts` while UI/unit tests use `leaderboard rankings`.
- Home corpus summary renders count-insensitive copy such as `1 leaderboard rankings`.
- Results global header remains a separate implementation from the shared static site header, leaving visual parity drift unguarded.
- Benchmark detail switcher exposes no-result benchmark routes as if they are actionable sibling result pages.
- Historical mixed-theme contract language still exists and needs explicit supersession/guarding.

## Verification
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py reindex`
- `make pr-preflight` failed on unrelated repo-wide fast-lane threshold: 22501 tests collected vs limit 22500.
- `git push` pre-push hooks passed, including fast-lane collect and pr-preflight hook.

## TODO review
- Initial schema statuses were invalid; fixed to `Not Started` and `pending`.
- Final TODO review found no remaining required issues: each item has revalidation, decision gates, prior art, guardrails, anti-patterns, verification, and scope limits.