### PR TITLE
docs(todo): plan prompts-landing improvements as 5 phased TODOs

### DIFF
--- a/_project/TODO/main/planning/prompts-landing-phase1-cli-hygiene.yaml
+++ b/_project/TODO/main/planning/prompts-landing-phase1-cli-hygiene.yaml
@@ -1,0 +1,248 @@
+id: prompts-landing-phase1-cli-hygiene
+title: "Prompts landing — Phase 1: --non-interactive, output discipline, summary, force-datagen footer"
+worktree: main
+priority: High
+status: Not Started
+category: Documentation
+
+description: |
+  The /prompts/ landing route already renders correct flag shapes
+  (check-deps --platform, --dry-run <dir>, two --platform flags in
+  compare; pinned by validate() in
+  scripts/generate_landing_quickstarts.py:468). But the rendered agent
+  prompt is missing several operational guardrails that show up
+  repeatedly in real CLI sessions reviewed in
+  ~/.claude/projects/-Users-joe-Developer-BenchBox/*.jsonl (~18
+  sessions sampled):
+
+  - No `--non-interactive` flag — agents hang on hidden setup prompts.
+  - No output discipline — sessions pipe to `tail -20` and lose context;
+    CLAUDE.md mandates `/tmp/<slug>.log` + tail summary.
+  - No long-run announce — AGENTS.md mandates "Runs >10min: announce
+    command/runtime/log/stop first."
+  - Step 6 says "Summarise" but doesn't say how — no
+    `benchbox results show` / `benchbox report` commands.
+  - No `--force datagen` recovery hint for partial loads (a recurring
+    sticking point — see QuestDB sessions e47108b5, 2fd35b2d).
+
+  This TODO closes that gap with additive, data-driven changes: new
+  CLI template keys in catalog.yaml, tightened validator, augmented
+  prompts.js builder. Pure landing/scripts change; no platform-core
+  touch.
+
+  Decision gates:
+  - D1 (before w2): confirm `runtime_hints` map structure with owner —
+    flat keys (`log_dir`, `log_slug_template`, `long_run_threshold_scale`)
+    vs a sub-map per surface. Default to flat keys unless a second
+    surface needs distinct hints.
+  - D2 (before w3): confirm whether the announce/smoke gating threshold
+    is scale-based, deployment-based, or both. Default plan: gate on
+    `scale > 0.01 OR deployment != "local"`.
+  - D3 (before w5): if any of the 30+ existing tests in
+    tests/unit/landing/ break, stop and re-scope rather than weakening
+    pins.
+
+prior_art:
+  - "landing/prompts/catalog.yaml:74-79 templates.cli — extend with results_show, report, runtime_hints (do not rename existing keys)"
+  - "scripts/generate_landing_quickstarts.py:468-484 validate() flag-shape pins — extend pattern, add --non-interactive presence check the same way"
+  - "landing/prompts/prompts.js:352-378 buildAgentPrompt — extend the same step-list builder; do not introduce a new template engine"
+  - "AGENTS.md / CLAUDE.md Output Discipline + Long-Running UAT sections — reuse the /tmp/<slug>.log + tail summary convention"
+  - "tests/unit/landing/test_landing_quickstarts.py:368 test_static_generated_payload_supports_dropdown_smoke — extend rather than duplicate"
+
+work:
+  - id: w1
+    summary: "Extend catalog.yaml CLI templates with --non-interactive on test_one and compare"
+    status: pending
+    notes: |
+      In landing/prompts/catalog.yaml lines 75-77, append
+      ` --non-interactive` to both `test_one` and `compare` templates.
+      Leave `dependency_check` and `dry_run` untouched.
+
+  - id: w2
+    summary: "Add runtime_hints map + new template keys (results_show, report, force_datagen_footer) to catalog.yaml"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add at top-level of catalog.yaml:
+        runtime_hints:
+          log_dir: "/tmp"
+          log_slug_template: "bench_{platform}_{benchmark}_{scale}"
+          long_run_threshold_scale: "0.1"
+      Add under templates.cli:
+        results_show: "uv run benchbox results show <bundle-path>"
+        report: "uv run benchbox report --result <bundle-path>"
+        force_datagen_footer: "If the load phase fails partway, re-run with `--force datagen` appended."
+      Keep keys snake_case to match existing convention.
+
+  - id: w3
+    summary: "Tighten scripts/generate_landing_quickstarts.py validate() to pin new shape"
+    needs: [w2]
+    status: pending
+    notes: |
+      Extend validate() at line 439:
+      - test_one and compare templates MUST contain ' --non-interactive'.
+      - results_show must contain 'benchbox results show'.
+      - report must contain 'benchbox report'.
+      - runtime_hints.long_run_threshold_scale must be a string that appears
+        in scales[].
+      - runtime_hints.log_dir must start with '/tmp' (be strict; agents
+        treating other dirs as ephemeral is a known footgun).
+      Each rule is a single appended branch; mirror the existing
+      compare-template pin at line 470.
+
+  - id: w4
+    summary: "Augment prompts.js buildAgentPrompt with announce, output-discipline tee, summary, and footer"
+    needs: [w3]
+    status: pending
+    notes: |
+      In landing/prompts/prompts.js:352-378, insert four behavior changes
+      AFTER step 3 (dry-run) and BEFORE the existing live-run step:
+      (a) New step "Announce" — emit exact command + log path
+          (`/tmp/{slug}.log` using runtime_hints.log_slug_template) +
+          interrupt instructions. Gated on
+          `parseFloat(state.scale) >= parseFloat(runtime_hints.long_run_threshold_scale)
+          || state.deployment !== "local"`.
+      (b) Modify the rendered live-run command to append
+          ` 2>&1 | tee /tmp/<slug>.log` (build slug from
+          log_slug_template substituted with platform/benchmark/scale).
+      (c) New step "Discover & summarize" using results_show and report
+          template keys (replaces — not duplicates — the existing
+          "Summarise the result" prose).
+      (d) Append force_datagen_footer as the last line.
+      Do NOT add new form controls — all behavior is selection-derived.
+
+  - id: w5
+    summary: "Add unit tests covering the new pins and rendered prompt shape"
+    needs: [w4]
+    status: pending
+    notes: |
+      Extend tests/unit/landing/test_landing_quickstarts.py:
+      - test_test_one_template_uses_non_interactive
+      - test_compare_template_uses_non_interactive
+      - test_results_show_template_present
+      - test_report_template_present
+      - test_runtime_hints_well_formed (keys present + types)
+      - test_runtime_hints_log_dir_under_tmp
+      - extend test_static_generated_payload_supports_dropdown_smoke at
+        line 368 to assert the new template keys are emitted in
+        catalog.generated.js for the default selection.
+      No snapshot string equality on the rendered agent prompt — test
+      via indexOf-style label presence to avoid brittleness.
+
+  - id: w6
+    summary: "Regenerate catalog.generated.js + verify Make targets are green"
+    needs: [w5]
+    status: pending
+    notes: |
+      uv run -- python scripts/generate_landing_quickstarts.py --write
+      make prompts-landing-check   # MUST pass
+      Visit /prompts/ locally in a browser and copy the default
+      (DuckDB + TPC-H + 0.01) prompt — confirm output is a clean 6-step
+      prompt, NOT bloated. Then switch to MotherDuck + TPC-H + 1.0 and
+      confirm announce + tee + summary + force-datagen footer all
+      render. Capture both rendered prompts in the PR body for
+      reviewer audit.
+
+verification:
+  - description: "Validator passes against new shape"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK"
+  - description: "Make check target green"
+    command: "make prompts-landing-check"
+    expected_output: "check: OK"
+  - description: "Landing tests all pass"
+    command: "uv run -- python -m pytest tests/unit/landing/ -v"
+    expected_output: "all tests pass, 0 failures"
+  - description: "Fast suite green (regression guard)"
+    command: "make test-fast"
+    expected_output: "0 failures"
+
+must_preserve:
+  - "Existing flag pins in scripts/generate_landing_quickstarts.py validate() (lines 468-484) — do not weaken; only add new pins."
+  - "test_static_generated_payload_supports_dropdown_smoke at line 368 — extend, do not replace."
+  - "Default rendered prompt (DuckDB + TPC-H + 0.01 + local + sql) remains short — adding new steps must be gated so this default doesn't grow beyond 7 steps."
+  - "URL query-parameter state contract in prompts.js:31-51 — no new selectors in this phase."
+  - "AUTO-GENERATED banner in catalog.generated.js — keep generator as the only writer."
+
+approach: |
+  Treat the YAML + validator as the contract surface and the JS builder
+  as a consumer. Land the additive YAML keys (w1-w2), tighten the
+  validator to pin them (w3), and only then update the builder (w4).
+  This ordering means the validator catches any builder-vs-data drift
+  introduced by w4. Use the existing flag-shape pins at
+  scripts/generate_landing_quickstarts.py:470-483 as a literal template
+  for the new pins — copy the branch, change the substring.
+
+  For w4, prefer string concatenation into the existing `lines` array
+  in buildAgentPrompt at prompts.js:352-378 over introducing helpers.
+  The function is small and the project rejects abstraction churn.
+
+anti_patterns:
+  - "DO NOT introduce a templating engine (Mustache, EJS, etc.) — the existing renderTemplate() at prompts.js:250 is sufficient; project is intentionally framework-free."
+  - "DO NOT add new dropdowns or form controls for the new behaviors — gate them on existing selection state (scale, deployment). Adding controls explodes the dropdown-smoke matrix."
+  - "DO NOT fetch any external data at page load — landing/ is a static deploy; recipes.json is forbidden (FORBIDDEN_JSON pin at generate_landing_quickstarts.py:35)."
+  - "DO NOT hardcode /tmp/ paths inside prompts.js — read from runtime_hints in catalog.generated.js so future tuning is YAML-only."
+  - "DO NOT use snapshot/golden-string tests on the full rendered prompt — pin only labels via indexOf; full snapshots will rot on every prompt-text tweak."
+  - "DO NOT weaken existing validator pins (e.g., the short-flag rejections at lines 476-479) to fit a new template — extend the validator, not the templates."
+
+scope_limit:
+  only_modify:
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"  # regenerated only
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/a11y-checklist.md"      # only if step labels change tab order
+    - "scripts/generate_landing_quickstarts.py"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+  do_not_modify:
+    - "benchbox/core/platform_registry.py"
+    - "benchbox/core/benchmark_registry.py"
+    - "benchbox/mcp/"
+    - "landing/prompts/index.html"
+    - "landing/prompts/prompts.css"
+
+files_affected:
+  modified:
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"
+    - "landing/prompts/prompts.js"
+    - "scripts/generate_landing_quickstarts.py"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+
+deferred:
+  - summary: "MCP-surface parity"
+    reason: "Tracked separately in prompts-landing-phase5-mcp-parity"
+  - summary: "Cost-acknowledgment gate + smoke-at-0.01 step"
+    reason: "Tracked separately in prompts-landing-phase2-cost-aware-gating (needs a PlatformRegistry capability change)"
+  - summary: "Platform-option hints + TPC-DS SF<1 warning"
+    reason: "Tracked separately in prompts-landing-phase3-platform-footgun-hints"
+  - summary: "Provenance snapshot block + --capture-plans footnote"
+    reason: "Tracked separately in prompts-landing-phase4-provenance"
+
+success_metrics:
+  - "Default DuckDB+TPC-H+0.01+local prompt remains <= 7 numbered steps."
+  - "Managed/cloud (e.g., MotherDuck+TPC-H+1.0) prompt now includes: --non-interactive, /tmp/<slug>.log tee, benchbox results show, benchbox report, --force datagen footer."
+  - "tests/unit/landing/ stays at >= current count + 6 new passing tests."
+  - "make prompts-landing-check green in CI."
+
+open_questions:
+  - question: "Should runtime_hints live at top-level of catalog.yaml or under templates?"
+    gating: false
+    default: "Top-level — non-template policy data (paths, thresholds)."
+  - question: "Should the announce step be unconditional rather than scale-gated?"
+    gating: false
+    default: "Gated. Always-on inflates the default DuckDB+0.01 prompt."
+
+metadata:
+  estimated_effort: "Small (1 session)"
+  tags: [landing, prompts, agent-ux, hygiene]
+
+impact:
+  user_impact: |
+    Anyone copying a prompt from /prompts/ into a coding agent gets a
+    prompt that won't hang on interactive setup, captures output to a
+    discoverable log, and tells the agent how to summarize results
+    rather than leaving "summarise" as a vague instruction.
+  technical_debt: |
+    Tightens validator pins so the next iteration can rely on the new
+    fields being present; reduces drift risk between catalog.yaml and
+    the JS builder.

--- a/_project/TODO/main/planning/prompts-landing-phase2-cost-aware-gating.yaml
+++ b/_project/TODO/main/planning/prompts-landing-phase2-cost-aware-gating.yaml
@@ -1,0 +1,234 @@
+id: prompts-landing-phase2-cost-aware-gating
+title: "Prompts landing — Phase 2: cost-class flag + smoke-at-0.01 + cost-acknowledgment step"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Documentation
+
+description: |
+  Paid managed platforms (motherduck, clickhouse-cloud, snowflake,
+  redshift, bigquery, databricks, athena, firebolt:cloud) charge real
+  money for compute/credits at non-trivial scale. The current /prompts/
+  output instructs an agent to "run live" at the chosen scale with no
+  smoke step and no explicit cost acknowledgment. For an agent invoked
+  by a user who copy-pasted a SF=10 Snowflake prompt, this is a
+  meaningful blast-radius gap.
+
+  This TODO surfaces a cost classification from PlatformRegistry into
+  the browser catalog and uses it (in combination with scale) to
+  inject two new conditional steps into the rendered prompt:
+
+  1. SMOKE — when target scale != "0.01" AND
+     (platform is paid OR deployment is "managed"/"self-hosted"),
+     prepend a SF=0.01 dry-run-or-real smoke step before the target-
+     scale dry-run. Catches plumbing failures cheaply.
+  2. COST ACKNOWLEDGMENT — when any selected platform is paid AND
+     parseFloat(scale) >= 0.1, inject an explicit "ask the user to
+     confirm credit/compute spend" step before the live run.
+
+  Decision gates:
+  - D1 (before w1): cost_class enum (`free | paid_credits | paid_compute`)
+    vs boolean `is_paid`. RECOMMEND enum: MotherDuck has a free tier so a
+    boolean over-asserts. Confirm with owner.
+  - D2 (before w1): does PlatformRegistry already expose anything
+    cost-adjacent (e.g., `requires_credentials`, `cloud` category)?
+    If yes, derive cost_class rather than annotating each platform
+    by hand. Inspect first; only add a new field if no derivable
+    proxy exists with >=95% accuracy.
+  - D3 (before w3): smoke step calls real benchbox at SF=0.01 vs uses
+    --dry-run only. Default: real run at SF=0.01 — that's the value of
+    smoke (catches actual driver/load issues). Document this in the
+    rendered prompt so the user knows we're spending ~free compute.
+
+prior_art:
+  - "benchbox/core/platform_registry.py PlatformRegistry.get_platform_capabilities — extend the capabilities surface with a single cost_class field"
+  - "scripts/generate_landing_quickstarts.py:222-252 _derive_platform_entries — already surfaces multiple capability-derived fields; extend the same pattern"
+  - "scripts/generate_landing_quickstarts.py:39-47 PLATFORM_OVERRIDE_KEYS — add cost_class as an override-eligible key for edge cases (free tiers, BYO-cluster)"
+  - "landing/prompts/prompts.js:186-200 deployment + interface conditional rendering — pattern to mirror for cost gating"
+
+work:
+  - id: w0
+    summary: "Re-validate registry surface before adding a new capability field"
+    status: pending
+    notes: |
+      Grep PlatformRegistry capabilities and metadata for any
+      pre-existing field that can serve as cost proxy
+      (e.g., `category == 'cloud'`, `requires_credentials`,
+      `deployment_modes[*].requires_network`). Capture findings to
+      /tmp/prompts-phase2-w0.log and summarise in this TODO before w1:
+        - command run
+        - existing fields reviewed
+        - decision: derive vs new field
+      If a derivable proxy exists with >=95% accuracy across the
+      8 named paid platforms, SKIP w1 and adapt the plan to use the
+      proxy. Otherwise proceed with w1.
+
+  - id: w1
+    summary: "Add cost_class to PlatformCapabilities (or equivalent) in PlatformRegistry"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add `cost_class: Literal['free','paid_credits','paid_compute'] = 'free'`
+      to the capabilities dataclass. Seed the eight known paid-managed
+      platforms; leave everything else default 'free'. Keep change
+      minimal — one field, default 'free', no method-signature impact.
+      Add a single unit test in tests/unit/core/ that asserts each of
+      the eight expected paid platforms reports the expected class.
+
+  - id: w2
+    summary: "Surface cost_class into the browser catalog via the generator"
+    needs: [w1]
+    status: pending
+    notes: |
+      In _derive_platform_entries (scripts/generate_landing_quickstarts.py:222-252),
+      copy cost_class into the per-platform browser entry. Extend
+      PLATFORM_OVERRIDE_KEYS (line 39) and STRING_PLATFORM_OVERRIDE_KEYS
+      (line 48) to allow cost_class override (a free-tier user may want
+      to mark motherduck as 'free' in their personal fork). Extend
+      _validate_platform_overrides to constrain to the enum.
+
+  - id: w3
+    summary: "Add smoke + cost-acknowledgment steps to buildAgentPrompt"
+    needs: [w2]
+    status: pending
+    notes: |
+      In prompts.js buildAgentPrompt (post Phase 1 ordering):
+      - Determine `isPaid = (platformEntry.cost_class || 'free') !== 'free'
+                  || (platformBEntry && platformBEntry.cost_class !== 'free')`.
+      - Determine `needsSmoke = state.scale !== '0.01'
+                  && (isPaid || state.deployment !== 'local')`.
+      - If needsSmoke: insert SMOKE step before the target dry-run
+        rendering an identical command but with --scale 0.01 and an
+        explicit "abort if smoke fails" instruction.
+      - If isPaid && parseFloat(state.scale) >= 0.1: insert
+        COST ACKNOWLEDGMENT step before the live-run step.
+      Test via the dropdown-smoke pattern at line 368, not snapshots.
+
+  - id: w4
+    summary: "Add validator pins + unit tests for the cost-class surface"
+    needs: [w3]
+    status: pending
+    notes: |
+      tests/unit/landing/test_landing_quickstarts.py additions:
+      - test_known_paid_platforms_carry_cost_class
+      - test_cost_class_override_constrained_to_enum
+      - test_browser_payload_emits_cost_class_for_managed_platforms
+      - extend dropdown-smoke test to verify SMOKE/COST step labels
+        appear in the right scale x deployment x platform combos
+        (and DON'T appear in DuckDB+0.01+local).
+
+  - id: w5
+    summary: "Regenerate + verify"
+    needs: [w4]
+    status: pending
+    notes: |
+      uv run -- python scripts/generate_landing_quickstarts.py --write
+      make prompts-landing-check
+      uv run -- python -m pytest tests/unit/landing/ tests/unit/core/ -v
+      Manually verify two prompt renderings — DuckDB+0.01 (must remain
+      smoke-free, cost-ack-free) and Snowflake+TPC-H+1.0 (must show
+      both). Paste both into the PR body.
+
+verification:
+  - description: "Validator passes"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK"
+  - description: "Make check target green"
+    command: "make prompts-landing-check"
+    expected_output: "check: OK"
+  - description: "Landing + core platform tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/ tests/unit/core/ -v"
+    expected_output: "all tests pass"
+  - description: "Fast suite green"
+    command: "make test-fast"
+    expected_output: "0 failures"
+
+must_preserve:
+  - "PlatformRegistry public API — cost_class is additive with a 'free' default; no method signature changes."
+  - "Phase 1 step ordering (announce, tee, summary, force-datagen footer) — new steps slot in BEFORE live run, AFTER dry-run."
+  - "Default DuckDB+TPC-H+0.01+local prompt remains short (Phase 1 success metric)."
+  - "MCP surface — out of scope for this phase; MCP parity tracked in Phase 5."
+
+approach: |
+  Spend w0 confirming whether a new field is needed; if existing
+  registry data is sufficient, the change becomes purely landing-side.
+  If a new field is required, treat it as a one-line capability
+  addition with a conservative default ('free'), seeded for eight
+  known platforms. Resist the temptation to model cost more richly —
+  the prompt only needs a binary "ask first" gate; the enum exists
+  solely to distinguish 'paid_credits' (Snowflake/BQ) from
+  'paid_compute' (managed Postgres on AWS) for future copy variants,
+  not because today's prompt needs to differentiate them.
+
+  Smoke step intentionally calls real benchbox at SF=0.01 — that is
+  what catches credential/driver/port issues. A dry-run-only smoke
+  would not.
+
+anti_patterns:
+  - "DO NOT model cost as a numeric price — registry has no source of truth for credit/compute pricing; a tag is sufficient."
+  - "DO NOT key the cost-ack gate on 'managed' deployment alone — self-hosted Snowflake-on-AWS exists; self-hosted Postgres does not need a cost-ack. The right gate is cost_class + scale."
+  - "DO NOT add a 'free tier' yes/no field — same information as cost_class with a less expressive default."
+  - "DO NOT bypass w0 — adding a new capability field when an existing one suffices creates maintenance debt across docs, MCP, and tests."
+  - "DO NOT introduce a UI checkbox to opt out of smoke — keep the rule selection-derived; advanced users can edit the copied prompt."
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/platform_registry.py"  # only if w0 confirms new field is needed
+    - "scripts/generate_landing_quickstarts.py"
+    - "landing/prompts/catalog.yaml"  # only platform_overrides entries
+    - "landing/prompts/catalog.generated.js"  # regenerated
+    - "landing/prompts/prompts.js"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+    - "tests/unit/core/test_platform_registry.py"  # or nearest equivalent
+  do_not_modify:
+    - "benchbox/mcp/"
+    - "benchbox/cli/"
+    - "benchbox/platforms/"  # adapters
+    - "landing/prompts/index.html"
+
+files_affected:
+  modified:
+    - "benchbox/core/platform_registry.py"
+    - "scripts/generate_landing_quickstarts.py"
+    - "landing/prompts/catalog.generated.js"
+    - "landing/prompts/prompts.js"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+
+deps:
+  needs:
+    - prompts-landing-phase1-cli-hygiene
+
+deferred:
+  - summary: "Cost-class richer modeling (per-query estimate, credit/$ conversion)"
+    reason: "Out of scope; the prompt only needs a binary gate. Revisit if a billing surface becomes part of /prompts/."
+  - summary: "MCP parity for cost-ack"
+    reason: "Tracked in prompts-landing-phase5-mcp-parity."
+
+success_metrics:
+  - "All eight known paid managed platforms carry a non-'free' cost_class."
+  - "Snowflake+TPC-H+1.0 prompt includes SMOKE and COST ACKNOWLEDGMENT steps."
+  - "DuckDB+TPC-H+0.01+local prompt does NOT include SMOKE or COST steps."
+  - "make prompts-landing-check green; tests/unit/landing/ and tests/unit/core/ green."
+
+open_questions:
+  - question: "Does an existing PlatformRegistry field already serve as a >=95% accurate cost proxy?"
+    gating: true
+    affects: ["w1 (skipped if yes)"]
+    default: "Assume no; add cost_class. w0 is the disambiguation gate."
+  - question: "Should the smoke step run by default for self-hosted-but-free platforms (e.g., Postgres)?"
+    gating: false
+    default: "Yes — smoke catches port/credential issues; free-but-self-hosted still has plumbing risk."
+
+metadata:
+  estimated_effort: "Small-Medium (1-2 sessions; w0 first, then a focused PR)"
+  tags: [landing, prompts, agent-ux, cost-safety, platform-registry]
+
+impact:
+  user_impact: |
+    A user who copies a /prompts/ prompt for a paid platform at
+    non-trivial scale will see the agent ask for explicit cost
+    acknowledgment before spending credits, and run a SF=0.01 smoke
+    first to fail cheap on plumbing issues.
+  technical_debt: |
+    Adds one capability field with a conservative default; no
+    coupling to billing/pricing surfaces.

--- a/_project/TODO/main/planning/prompts-landing-phase3-platform-footgun-hints.yaml
+++ b/_project/TODO/main/planning/prompts-landing-phase3-platform-footgun-hints.yaml
@@ -1,0 +1,237 @@
+id: prompts-landing-phase3-platform-footgun-hints
+title: "Prompts landing — Phase 3: platform-option hints + TPC-DS SF<1 dsdgen warning"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Sampled CLI sessions show two recurring footguns the /prompts/ page
+  does not surface:
+
+  (a) Many local self-hosted platforms need `--platform-option` flags
+      that aren't obvious from CLI help — SingleStore port/password,
+      QuestDB http_port (REST), Doris/StarRocks dual SQL+HTTP ports,
+      Velox Spark Connect endpoint, ClickHouse deployment-mode
+      suffix (`clickhouse:local` vs `clickhouse-cloud`). Real
+      sessions: 5285c89f (singlestore), e47108b5 / 2fd35b2d (questdb),
+      eed8fe29 / b43e249e (doris), 9978f3bd / a970ce74 (starrocks),
+      fceaed01 (velox).
+
+  (b) TPC-DS at scale factor below 1.0 requires the bundled patched
+      dsdgen at `_binaries/tpc-ds/<platform>/dsdgen` (per CLAUDE.md
+      "TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox").
+      The current prompt happily emits `-b tpcds -s 0.1` with no
+      warning.
+
+  Both are self-contained YAML-data + validator + JS-builder changes.
+  No core touch. No new UI controls.
+
+  Decision gates:
+  - D1 (before w1): hint shape — list of strings vs structured
+    `{flag, value, scope}`. Default: list of strings keyed by
+    deployment mode in the override entry, because the JS builder
+    just concatenates them into a sub-bullet group; structure adds
+    cost without rendering value.
+  - D2 (before w3): TPC-DS warning is informational or blocking?
+    Default: informational (the bundled dsdgen IS present in the
+    repo at _binaries/, so the warning serves as an agent-context
+    cue, not a stop step).
+
+prior_art:
+  - "scripts/generate_landing_quickstarts.py:39-47 PLATFORM_OVERRIDE_KEYS — extend with platform_option_hints; mirror the existing safety_terms whitelist pattern"
+  - "landing/prompts/catalog.yaml:47 platform_overrides — currently empty; this TODO is its first real consumer"
+  - "landing/prompts/catalog.yaml:51-63 benchmarks[] — extend with optional requires_bundled_dsdgen_below"
+  - "CLAUDE.md TPC-DS rule — surface that constraint into the prompt rather than relying on the user to know it"
+  - "_binaries/tpc-ds/<platform>/dsdgen — the actual bundled binary the warning will reference"
+
+work:
+  - id: w1
+    summary: "Extend PLATFORM_OVERRIDE_KEYS with platform_option_hints; validate shape"
+    status: pending
+    notes: |
+      In scripts/generate_landing_quickstarts.py:
+      - Add 'platform_option_hints' to PLATFORM_OVERRIDE_KEYS (line 39).
+      - In _validate_platform_overrides, require each entry to be a
+        list of non-empty strings, each containing the substring
+        '--platform-option' (so hints can't drift into being generic
+        prose).
+      - In _apply_platform_override, copy the list onto the entry.
+
+  - id: w2
+    summary: "Seed platform_overrides with the six known footgun platforms"
+    needs: [w1]
+    status: pending
+    notes: |
+      In landing/prompts/catalog.yaml platform_overrides:
+        singlestore:
+          platform_option_hints:
+            - "--platform-option port=13306  # local Docker default"
+            - "--platform-option password=<value>  # local Docker"
+        questdb:
+          platform_option_hints:
+            - "--platform-option http_port=9000  # REST endpoint, distinct from SQL port 8812"
+        doris:
+          platform_option_hints:
+            - "--platform-option port=9030"
+            - "--platform-option http_port=8030"
+        starrocks:
+          platform_option_hints:
+            - "--platform-option port=9030"
+            - "--platform-option http_port=8030"
+        velox:
+          platform_option_hints:
+            - "--platform-option deployment=remote"
+            - "--platform-option endpoint=sc://host:50051  # Spark Connect"
+      Note: clickhouse local-vs-cloud is handled by the existing
+      deployment-mode suffix in the platform ID, NOT a platform-option
+      hint. Do not add a clickhouse entry.
+
+      Verify each port/flag against the platform adapter docstrings
+      before committing; do NOT copy from this TODO blindly — defaults
+      may have changed.
+
+  - id: w3
+    summary: "Add requires_bundled_dsdgen_below to TPC-DS benchmark entry + validator"
+    needs: [w2]
+    status: pending
+    notes: |
+      catalog.yaml benchmarks[] — add to the tpcds entry:
+        requires_bundled_dsdgen_below: "1.0"
+      In validate():
+      - Allow this key only on tpcds and tpch (TPC family).
+      - Value must be a string parseable as float in scales[].
+      - Reject for non-TPC benchmarks.
+
+  - id: w4
+    summary: "Render hints + dsdgen warning in buildAgentPrompt"
+    needs: [w3]
+    status: pending
+    notes: |
+      In prompts.js buildAgentPrompt:
+      (a) After the install step, if
+          platformEntry.platform_option_hints OR
+          platformBEntry.platform_option_hints is non-empty,
+          emit a "Likely required platform options for {label}:"
+          bullet list. Show ONE list per selected platform.
+      (b) Before the dry-run step, if benchmarkEntry has
+          requires_bundled_dsdgen_below AND
+          parseFloat(state.scale) < parseFloat(that),
+          emit a warning step pointing at _binaries/tpc-ds/.
+      Both rules are gated and emit nothing for the default DuckDB+
+      TPC-H+0.01 case.
+
+  - id: w5
+    summary: "Tests + regenerate"
+    needs: [w4]
+    status: pending
+    notes: |
+      tests/unit/landing/test_landing_quickstarts.py:
+      - test_platform_option_hints_must_contain_flag_substring
+      - test_platform_option_hints_only_applied_to_promptable_platforms
+      - test_requires_bundled_dsdgen_below_validated_only_for_tpc
+      - test_tpcds_sub_scale_emits_dsdgen_warning_in_payload (via
+        extending the dropdown-smoke matrix at line 368)
+      - test_tpch_sub_scale_does_not_emit_dsdgen_warning
+      Regenerate + run prompts-landing-check and the landing suite.
+
+verification:
+  - description: "Validator passes against new shape"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK"
+  - description: "Make check green"
+    command: "make prompts-landing-check"
+    expected_output: "check: OK"
+  - description: "Landing tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/ -v"
+    expected_output: "0 failures"
+  - description: "Each seeded platform's hinted port matches the platform adapter's documented default"
+    command: "grep -nE 'port|http_port|endpoint' benchbox/platforms/singlestore.py benchbox/platforms/questdb.py benchbox/platforms/doris.py benchbox/platforms/starrocks.py benchbox/platforms/velox.py 2>/dev/null | head -40"
+    expected_output: "manual review; ports match catalog.yaml hints OR a comment in this TODO records the discrepancy"
+
+must_preserve:
+  - "Existing PLATFORM_OVERRIDE_KEYS members (safety_terms, install_command, etc.)."
+  - "Validator pins for platforms_are_derived (line 433) — overrides remain decoration, not inclusion."
+  - "Phase 1 step ordering — hints render between install and dependency-check; dsdgen warning renders before dry-run."
+  - "tests/unit/landing/test_platform_overrides_apply_without_controlling_inclusion (line 95) — the override pattern remains additive."
+
+approach: |
+  Add hints as YAML data, pin the shape in the validator, render in
+  the JS builder. The reason hints are strings (not structured
+  {flag,value}) is that the renderer only concatenates — structure
+  would force the renderer to know the difference between port,
+  password, endpoint, etc., which doesn't change output.
+
+  For the TPC-DS rule, prefer benchmark-level metadata over a
+  prompt-side hardcoded list because future benchmarks may share the
+  bundled-dsdgen constraint (e.g., TPC-DS variants).
+
+  Verify each seeded port/flag against the actual adapter before
+  committing. If an adapter has moved away from a documented default,
+  fix the hint in this PR.
+
+anti_patterns:
+  - "DO NOT add platform_option_hints for platforms whose required options are obvious from --help (DuckDB, Polars). Hints are for non-obvious defaults only — additive noise hurts UX."
+  - "DO NOT use the override system to hide platforms or change their interface/deployment filter membership — that's already pinned by test_platform_override_cannot_control_filter_membership (line 131)."
+  - "DO NOT generalize requires_bundled_dsdgen_below to other benchmarks without a documented constraint. Keep the whitelist tight (tpcds, possibly tpch)."
+  - "DO NOT render hints as a single flat 'Notes:' blob; per-platform sub-bullets preserve compare-mode clarity (each platform's hints scoped to that platform's section)."
+  - "DO NOT copy hint port numbers from this TODO blindly; verify against benchbox/platforms/<id>.py current defaults."
+
+scope_limit:
+  only_modify:
+    - "scripts/generate_landing_quickstarts.py"
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"  # regenerated
+    - "landing/prompts/prompts.js"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+  do_not_modify:
+    - "benchbox/platforms/"
+    - "benchbox/core/"
+    - "benchbox/mcp/"
+    - "landing/prompts/index.html"
+
+files_affected:
+  modified:
+    - "scripts/generate_landing_quickstarts.py"
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"
+    - "landing/prompts/prompts.js"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+
+deps:
+  needs:
+    - prompts-landing-phase1-cli-hygiene
+
+deferred:
+  - summary: "End-to-end smoke matrix that verifies hinted ports actually connect"
+    reason: "Out of scope for the prompt surface; tracked as a separate CI initiative if/when platform-option drift becomes recurrent."
+  - summary: "Auto-generate hints from adapter docstrings"
+    reason: "Adapters don't currently expose a structured option-defaults surface; manual maintenance is cheaper than building one for a 5-platform set."
+  - summary: "MCP parity for hints + dsdgen warning"
+    reason: "Tracked in prompts-landing-phase5-mcp-parity."
+
+success_metrics:
+  - "Selecting SingleStore at /prompts/ renders the two known --platform-option hints (port + password)."
+  - "Selecting tpcds at scale 0.1 renders the bundled-dsdgen warning."
+  - "Selecting tpch at scale 0.1 does NOT render the warning."
+  - "Validator rejects a hint string that doesn't contain '--platform-option'."
+
+open_questions:
+  - question: "Should hints differ by deployment mode (e.g., singlestore self-hosted vs managed)?"
+    gating: false
+    default: "Not in this phase. Hints are platform-scoped; add deployment scoping only if a real footgun demands it."
+
+metadata:
+  estimated_effort: "Small (1 session)"
+  tags: [landing, prompts, agent-ux, tpcds, platform-options]
+
+impact:
+  user_impact: |
+    Agents copying a Doris or StarRocks prompt no longer need to
+    guess the right SQL/HTTP port split, and agents running TPC-DS
+    at SF<1 get a pointer at the bundled dsdgen instead of failing
+    on a missing binary.
+  technical_debt: |
+    Establishes the platform_overrides surface as the right home
+    for platform-quirk metadata, distinct from PlatformRegistry
+    capabilities (which are runtime truths, not authoring hints).

--- a/_project/TODO/main/planning/prompts-landing-phase4-provenance.yaml
+++ b/_project/TODO/main/planning/prompts-landing-phase4-provenance.yaml
@@ -1,0 +1,185 @@
+id: prompts-landing-phase4-provenance
+title: "Prompts landing — Phase 4: provenance snapshot block + --capture-plans footnote"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Reproducibility of a benchmark run depends on capturing the
+  BenchBox version, system profile, and the exact command line
+  alongside the result bundle. None of the rendered prompts currently
+  tell the agent to do this, so result-bundle archaeology becomes
+  guesswork weeks later (which version of BenchBox? what platform
+  driver? what hardware?).
+
+  This TODO adds a final "Save provenance" step to both the CLI and
+  MCP rendered prompts using `benchbox --version-json` and
+  `benchbox profile`. As a passive bonus, append a single-line
+  footnote telling agents how to opt into `--capture-plans` and
+  inspect with `benchbox show-plan`, without adding any new form
+  control.
+
+  Decision gates:
+  - D1 (before w1): provenance is a single multi-line template
+    rendered verbatim vs three separate template keys composed by
+    the builder. Default: a multi-line YAML literal block under
+    templates.cli.provenance_snapshot — keeps the validator simple
+    and the renderer dumb.
+  - D2 (before w2): where to write the provenance snapshot? Default:
+    next to the result bundle (in the directory benchbox printed at
+    end of run). Agent extracts the bundle path from the run output
+    or `benchbox results list --latest 1`.
+
+prior_art:
+  - "landing/prompts/catalog.yaml:74-79 templates.cli — extend with provenance_snapshot (YAML literal block)"
+  - "Phase 1 templates.cli.results_show and report — reuse the same key-then-substring validator pattern"
+  - "AGENTS.md provenance/reproducibility guidance — surface via the rendered prompt rather than relying on agent recall"
+  - "benchbox --version-json and benchbox profile — existing first-class commands; do not invent new ones"
+
+work:
+  - id: w1
+    summary: "Add provenance_snapshot template key and validator pin"
+    status: pending
+    notes: |
+      In catalog.yaml templates.cli, add:
+        provenance_snapshot: |
+          uv run benchbox --version-json > <bundle-dir>/_provenance/version.json
+          uv run benchbox profile > <bundle-dir>/_provenance/system.txt
+          echo "<exact command line used>" > <bundle-dir>/_provenance/command.txt
+      In validate(): require the key to contain 'benchbox --version-json'
+      AND 'benchbox profile'. Reject otherwise.
+
+  - id: w2
+    summary: "Render provenance step at end of buildAgentPrompt"
+    needs: [w1]
+    status: pending
+    notes: |
+      After Phase 1's summary step but before the force-datagen
+      footer, insert a "Save provenance" step that emits the template
+      verbatim with <bundle-dir> substituted from the agent's earlier
+      capture of the result bundle path. Render unconditionally for
+      CLI — provenance is cheap and universally useful.
+
+  - id: w3
+    summary: "Add --capture-plans footnote (no UI control)"
+    needs: [w2]
+    status: pending
+    notes: |
+      Append a single line to the rendered prompt, after the
+      force-datagen footer:
+        "To capture EXPLAIN plans, add --capture-plans to the live
+         command and inspect with `benchbox show-plan --result
+         <bundle-path> --query Q1`."
+      No form control; advanced users edit the copied prompt.
+
+  - id: w4
+    summary: "Tests"
+    needs: [w3]
+    status: pending
+    notes: |
+      - test_provenance_snapshot_present_in_templates
+      - test_provenance_snapshot_includes_version_and_profile_commands
+      - extend dropdown-smoke test to assert "Save provenance" label
+        appears in the rendered payload for the default state.
+      - test_capture_plans_footnote_present (label, not full string)
+
+  - id: w5
+    summary: "Regenerate + verify"
+    needs: [w4]
+    status: pending
+    notes: |
+      uv run -- python scripts/generate_landing_quickstarts.py --write
+      make prompts-landing-check
+      uv run -- python -m pytest tests/unit/landing/ -v
+      Manually render the default and Snowflake+1.0 prompts; paste
+      both in the PR body.
+
+verification:
+  - description: "Validator passes"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK"
+  - description: "Make check green"
+    command: "make prompts-landing-check"
+    expected_output: "check: OK"
+  - description: "Landing tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/ -v"
+    expected_output: "0 failures"
+  - description: "Provenance commands are real BenchBox subcommands"
+    command: "uv run benchbox --version-json >/dev/null && uv run benchbox profile --help >/dev/null"
+    expected_output: "exit 0"
+
+must_preserve:
+  - "Phase 1's announce/tee/summary step ordering — provenance lands AFTER summary, BEFORE force-datagen footer."
+  - "Default prompt brevity — provenance is one step (4 short shell lines), not a paragraph."
+  - "No new dropdowns or form controls."
+
+approach: |
+  Treat provenance as a fixed template (multi-line YAML literal block)
+  rendered verbatim. The renderer does not need to compose individual
+  commands — the value is in the agent doing all three steps in the
+  right place, not in dynamic substitution.
+
+  --capture-plans intentionally ships as a one-line passive footnote
+  in this phase. A future phase MAY add a checkbox; this phase does
+  not justify the UI matrix expansion.
+
+anti_patterns:
+  - "DO NOT add a 'capture plans' checkbox in this phase — it inflates the dropdown-smoke matrix and the value isn't proven yet."
+  - "DO NOT introduce a benchbox provenance subcommand — composition of existing commands is sufficient and avoids API growth."
+  - "DO NOT write provenance into a fixed path like /tmp/ — the bundle directory is the correct co-location for reproducibility."
+  - "DO NOT skip provenance for local DuckDB runs — even local runs need a version pin for reproducibility weeks later."
+
+scope_limit:
+  only_modify:
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"  # regenerated
+    - "landing/prompts/prompts.js"
+    - "scripts/generate_landing_quickstarts.py"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+  do_not_modify:
+    - "benchbox/"
+    - "landing/prompts/index.html"
+    - "landing/prompts/prompts.css"
+
+files_affected:
+  modified:
+    - "landing/prompts/catalog.yaml"
+    - "landing/prompts/catalog.generated.js"
+    - "landing/prompts/prompts.js"
+    - "scripts/generate_landing_quickstarts.py"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+
+deps:
+  needs:
+    - prompts-landing-phase1-cli-hygiene
+
+deferred:
+  - summary: "--capture-plans dropdown control"
+    reason: "Footnote-only in this phase; promote to a control only if user feedback says it's confusing as a footnote."
+  - summary: "MCP-surface provenance via system_profile MCP tool"
+    reason: "Tracked in prompts-landing-phase5-mcp-parity."
+  - summary: "Auto-derive command.txt content from the rendered prompt's live-run command"
+    reason: "Requires generator-side coupling between provenance template and run template; defer until provenance churn justifies it."
+
+success_metrics:
+  - "Every rendered CLI prompt ends with a Save provenance step and a --capture-plans footnote."
+  - "Default DuckDB+TPC-H+0.01 prompt grows by <=5 lines."
+  - "uv run benchbox --version-json works as the prompt instructs."
+
+open_questions:
+  - question: "Bundle dir vs results-runs root for provenance write path?"
+    gating: false
+    default: "Bundle dir — keeps provenance scoped to the specific run, easier to ship/share."
+
+metadata:
+  estimated_effort: "Small (1 session)"
+  tags: [landing, prompts, reproducibility, provenance]
+
+impact:
+  user_impact: |
+    Result bundles become self-describing: version, system, command.
+    Weeks-later archaeology becomes possible without git-history
+    spelunking.
+  technical_debt: |
+    Composes existing commands; no new BenchBox API surface.

--- a/_project/TODO/main/planning/prompts-landing-phase5-mcp-parity.yaml
+++ b/_project/TODO/main/planning/prompts-landing-phase5-mcp-parity.yaml
@@ -1,0 +1,192 @@
+id: prompts-landing-phase5-mcp-parity
+title: "Prompts landing — Phase 5: MCP-surface parity for hygiene, cost, hints, provenance"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Phases 1-4 augment the CLI-surface prompt produced by
+  buildAgentPrompt at landing/prompts/prompts.js:352-378. The
+  MCP-surface prompt produced by buildMcpPrompt at lines 304-337 is
+  out of date for the same behaviors. A user picking surface=MCP at
+  /prompts/ should get equivalent guardrails — adjusted for MCP
+  semantics (no shell, no `tee`, but yes for smoke calls, cost
+  acknowledgment, and analyze_results / system_profile MCP tools).
+
+  This TODO is intentionally last in the sequence because MCP changes
+  are mechanical mirroring once Phases 1-4 have settled the contract.
+
+  Decision gates:
+  - D1 (before w1): does Phase 1's runtime_hints map need MCP-specific
+    overrides (e.g., no /tmp path because there is no shell)? Default:
+    skip runtime_hints entirely in MCP — substitute MCP-native equivalents
+    (analyze_results prompt + system_profile tool).
+  - D2 (before w3): provenance in MCP — does system_profile MCP tool
+    output a comparable artifact to `benchbox profile`? Confirm
+    output shape before w3; if not, document the gap and defer the
+    MCP provenance step.
+
+prior_art:
+  - "landing/prompts/prompts.js:304-337 buildMcpPrompt — the existing MCP step list to extend"
+  - "landing/prompts/catalog.yaml:83-89 mcp section — already references analyze_results and system_profile; generator validates they exist"
+  - "Phases 1-4 of this TODO group — mirror the same gating logic; do not redefine thresholds"
+
+work:
+  - id: w0
+    summary: "Confirm Phases 1-4 are merged and inventory MCP-side gaps"
+    status: pending
+    notes: |
+      After Phases 1-4 are merged to develop, list each rendered
+      behavior on the CLI side and mark its MCP equivalent:
+        - --non-interactive  -> N/A (MCP tools are non-interactive)
+        - tee /tmp/<slug>.log -> N/A (MCP captures via tool output)
+        - announce step -> RENDER as a "Tell the user before calling
+          run_benchmark with these parameters" instruction
+        - smoke at SF=0.01 -> call run_benchmark twice (smoke then real)
+        - cost ack -> RENDER (same gate)
+        - platform-option hints -> RENDER (translated to MCP arguments)
+        - dsdgen SF<1 warning -> RENDER
+        - results summary -> use analyze_results MCP prompt
+        - provenance -> call system_profile MCP tool; capture version
+          via list_available metadata if --version-json equivalent
+          doesn't exist over MCP
+        - --capture-plans footnote -> RENDER as "pass capture_plans=true"
+      Document the mapping in /tmp/prompts-phase5-w0.log and
+      summarize in this TODO before w1.
+
+  - id: w1
+    summary: "Extend buildMcpPrompt with smoke and cost-acknowledgment steps"
+    needs: [w0]
+    status: pending
+    notes: |
+      Mirror the Phase 2 gating logic in prompts.js buildMcpPrompt
+      around lines 304-337. SMOKE = a run_benchmark call with
+      scale_factor=0.01 BEFORE the target dry-run.
+      COST = an explicit "ask the user to confirm credit/compute
+      spend" step before the live run.
+
+  - id: w2
+    summary: "Render platform-option hints + dsdgen warning in MCP prompt"
+    needs: [w1]
+    status: pending
+    notes: |
+      Platform-option hints translate to "pass platform_options={...}
+      to run_benchmark" — emit the mapped key=value pairs from the
+      Phase 3 hints; strip the `--platform-option ` prefix and rely
+      on the comment portion (after `#`) for the human note.
+      dsdgen warning is identical text.
+
+  - id: w3
+    summary: "Replace 'Summarise' prose with explicit analyze_results call; add system_profile provenance step"
+    needs: [w2]
+    status: pending
+    notes: |
+      Replace lines 318/332 ("Summarise total runtime, per-query timing,
+      and any failures.") with an explicit step that calls the
+      analyze_results MCP prompt with the result-bundle path.
+      Add a final "Save provenance" step that calls the
+      system_profile MCP tool and stashes output alongside the bundle.
+      Add a one-line passive footnote on capture_plans=true.
+
+  - id: w4
+    summary: "Tests + regenerate"
+    needs: [w3]
+    status: pending
+    notes: |
+      tests/unit/landing/test_landing_quickstarts.py additions:
+      - test_mcp_prompt_includes_smoke_for_managed_at_scale
+      - test_mcp_prompt_includes_cost_ack_for_paid_platforms
+      - test_mcp_prompt_emits_platform_options_mapping
+      - test_mcp_prompt_calls_analyze_results
+      - test_mcp_prompt_calls_system_profile
+      - test_mcp_prompt_footnotes_capture_plans
+      Plus regenerate and run prompts-landing-check + landing tests.
+
+verification:
+  - description: "Validator passes"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK"
+  - description: "Make check green"
+    command: "make prompts-landing-check"
+    expected_output: "check: OK"
+  - description: "Landing tests pass"
+    command: "uv run -- python -m pytest tests/unit/landing/ -v"
+    expected_output: "0 failures"
+  - description: "Referenced MCP tools/prompts exist (generator already pins this; re-confirm)"
+    command: "uv run -- python scripts/generate_landing_quickstarts.py --validate-only"
+    expected_output: "validate-only: OK (no mcp.* unknown-name errors)"
+
+must_preserve:
+  - "Existing MCP prompt step ordering (list_available -> check_dependencies -> dry-run -> live -> summary) — new steps slot in around the existing scaffold."
+  - "Phase 2-3 gating thresholds — MCP uses the same scale/deployment/cost-class predicates."
+  - "Generator pins on mcp.* (lines 411-421) — analyze_results and system_profile must remain registered MCP names."
+
+approach: |
+  After w0's inventory clarifies the CLI->MCP mapping table, the
+  remaining work is mechanical mirroring inside buildMcpPrompt. Keep
+  the function's array-of-step-strings structure (no helper
+  extraction) to match buildAgentPrompt's idiom.
+
+  Provenance over MCP is gated on system_profile producing a useful
+  artifact; if it doesn't, document the gap and defer that single
+  step rather than reverse-engineer a parallel surface.
+
+anti_patterns:
+  - "DO NOT translate CLI behaviors literally (e.g., 'tee output to /tmp/log') — MCP has no shell. Translate to MCP-native equivalents or omit."
+  - "DO NOT add new MCP tools to fill gaps in this phase — that's a separate change with its own review burden."
+  - "DO NOT duplicate Phase 2 cost_class derivation logic; reuse the same browser-catalog field."
+  - "DO NOT diverge MCP step labels from CLI step labels — agents reading both surfaces shouldn't have to map vocabulary."
+
+scope_limit:
+  only_modify:
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/catalog.generated.js"  # regenerated
+    - "scripts/generate_landing_quickstarts.py"  # only if new validator pins needed
+    - "tests/unit/landing/test_landing_quickstarts.py"
+  do_not_modify:
+    - "benchbox/mcp/"  # no new MCP tools/prompts in this phase
+    - "benchbox/core/"
+    - "landing/prompts/index.html"
+
+files_affected:
+  modified:
+    - "landing/prompts/prompts.js"
+    - "landing/prompts/catalog.generated.js"
+    - "tests/unit/landing/test_landing_quickstarts.py"
+
+deps:
+  needs:
+    - prompts-landing-phase1-cli-hygiene
+    - prompts-landing-phase2-cost-aware-gating
+    - prompts-landing-phase3-platform-footgun-hints
+    - prompts-landing-phase4-provenance
+
+deferred:
+  - summary: "New MCP tools to fill CLI-only gaps (e.g., MCP-native --capture-plans)"
+    reason: "Outside the landing-page initiative; track separately if a real gap emerges."
+  - summary: "MCP-prompt-level integration tests against a running BenchBox MCP server"
+    reason: "tests/unit/landing/ covers payload shape; live-server integration is its own test surface."
+
+success_metrics:
+  - "An MCP-surface prompt for Snowflake+TPC-H+1.0 includes smoke, cost-ack, analyze_results, system_profile."
+  - "An MCP-surface prompt for DuckDB+TPC-H+0.01+local remains short (no smoke, no cost-ack)."
+  - "All landing tests green; generator --check green."
+
+open_questions:
+  - question: "Does benchbox MCP tool surface have a --version-json equivalent?"
+    gating: true
+    affects: ["w3 provenance step"]
+    default: "If no equivalent exists, MCP provenance step records system_profile output only and notes the version gap in this TODO for a future MCP-tool addition."
+
+metadata:
+  estimated_effort: "Small (1 session) once Phases 1-4 are in"
+  tags: [landing, prompts, mcp, agent-ux]
+
+impact:
+  user_impact: |
+    Users on the MCP surface receive the same operational guardrails
+    as CLI users — no second-class prompt for MCP-driven agents.
+  technical_debt: |
+    Pins the CLI/MCP rendered prompts to a shared semantic contract,
+    enforced via the same test file.


### PR DESCRIPTION
Five planning TODOs that turn the /prompts/ landing-page review
into staged work: Phase 1 universal CLI hygiene (--non-interactive,
output discipline, summary commands, --force datagen footer);
Phase 2 cost-aware gating (cost_class capability + smoke + ack);
Phase 3 platform-option hints + TPC-DS SF<1 dsdgen warning;
Phase 4 provenance snapshot + --capture-plans footnote; Phase 5
MCP-surface parity. Inter-phase deps enforce sequencing: only
Phase 1 is ready; 2-4 unblock after it; 5 needs all four.

Each TODO ships with scope_limit, anti_patterns, must_preserve,
prior_art, and verification gates so an implementer can pick up a
phase without re-deriving the plan. Phase 2's w0 is an explicit
recon gate before touching PlatformRegistry; Phase 5's w0 inventories
the CLI->MCP behavior mapping before mirroring.
