### PR TITLE
docs(blog): clarity and conciseness pass on v0.3.0 drafts

### DIFF
--- a/_blog/building-benchbox/drafts/13-v0-3-0-release-overview.md
+++ b/_blog/building-benchbox/drafts/13-v0-3-0-release-overview.md
@@ -10,31 +10,15 @@ status: draft
 
 # BenchBox v0.3.0: JoinOrder fix, sketch coverage, and /prompts/
 
-> BenchBox v0.3.0 fixes an important JoinOrder comparability issue and adds broader coverage for approximate aggregates and sketch workflows.
-
-**TL;DR**: `joinorder` now uses the real IMDb 2013 Join Order Benchmark dataset at scale factor 1 instead of synthetic data. The release also expands approximate-aggregate and sketch-lifecycle coverage in the primitives benchmarks and ships `/prompts/`, a static landing page that turns benchmark choices into copyable instructions for coding agents.
+**TL;DR**: `joinorder` now uses the real IMDb 2013 Join Order Benchmark dataset at scale factor 1, replacing synthetic data. The release also expands approximate-aggregate and sketch-lifecycle coverage in the primitives benchmarks and ships `/prompts/`, a static landing page that turns benchmark choices into copyable instructions for coding agents.
 
 ---
 
-BenchBox v0.3.0 is built around a narrower goal than v0.2.1. The previous release expanded the catalog with new platforms, new benchmarks, and harmonized scale factors. This release focuses on benchmark trust: when BenchBox says it is running a known workload, the data and query contract should match what users expect.
+v0.3.0 focuses on benchmark trust. v0.2.1 expanded the catalog with new platforms, benchmarks, and harmonized scale factors; this release narrows in on making sure that when BenchBox says it is running a known workload, the data and query contract match what users expect.
 
-The largest change is JoinOrder. A community report pointed out that BenchBox's old JoinOrder data was uniformly-random synthetic data and did not exercise the real-world correlations that the Join Order Benchmark was designed around. v0.3.0 fixes that by making `joinorder` use the real IMDb 2013 JOB dataset at scale factor 1.
+The largest change is JoinOrder. A community report ([issue #289](https://github.com/joeharris76/BenchBox/issues/289)) flagged that BenchBox's old JoinOrder data was uniformly-random synthetic data and did not exercise the real-world correlations that the Join Order Benchmark was designed around. v0.3.0 fixes this by making `joinorder` use the real IMDb 2013 JOB dataset at scale factor 1. The companion post, [Reworking JoinOrder around the IMDb 2013 dataset](./14-joinorder-canonical-rework.md), walks through the data contract, scale-factor decision, and provenance work in detail.
 
-When we use the word "canonical" for JoinOrder, we mean the fixed IMDb 2013 dataset and JOB query set used by the benchmark papers, not a synthetic approximation.
-
-The second theme is approximate analytics. BenchBox now covers more of the path that modern engines expose for approximate aggregates and sketches: one-shot approximate read queries, persisted sketch state, merge queries, storage-size checks, and parameter sweeps where the engine surface supports them.
-
-The landing site release also adds a `/prompts/` page. It is not a new BenchBox runtime command. It helps a visitor choose a platform, benchmark, scale, and interface, then copy a prompt into a coding agent that can run BenchBox through the CLI or MCP.
-
-## Release highlights
-
-- **JoinOrder now uses the real IMDb 2013 JOB dataset.** This fixes a user-raised comparability issue where synthetic data was being used for JoinOrder runs.
-- **All 113 Join Order Benchmark SQL queries are included.** Query IDs follow the expected JOB shape, such as `1a`, `2b`, and `15a`.
-- **JoinOrder is fixed at scale factor 1.** JOB is a fixed dataset, so `joinorder` no longer pretends that smaller synthetic scales are comparable to the real workload.
-- **Result bundles can carry dataset identity.** Manifest-backed datasets can record `dataset_version`, `manifest_hash`, and `data_archive_hash`.
-- **`read_primitives` adds approximate aggregate coverage** for approximate distinct counts, approximate quantiles, and approximate top-k.
-- **`write_primitives` adds sketch lifecycle coverage** for persist, merge, requery, storage-size validation, and parameter sweeps where supported.
-- **`/prompts/` helps users start agent-assisted BenchBox runs** with copyable CLI or MCP instructions and safer defaults for local and cloud runs.
+The second theme is approximate analytics. BenchBox now covers more of the path that modern engines expose for approximate aggregates and sketches: one-shot approximate read queries, persisted sketch state, merge queries, storage-size checks, and parameter sweeps where the engine surface supports them. A new `/prompts/` page on the landing site rounds out the release by helping visitors generate copyable agent instructions for first BenchBox runs.
 
 ## At a glance
 
@@ -49,34 +33,11 @@ The landing site release also adds a `/prompts/` page. It is not a new BenchBox 
 
 ## JoinOrder now means the real JOB dataset
 
-On May 9, 2026, GitHub user `@partychicken` filed issue #289 about BenchBox's JoinOrder data generation.[^issue-289] The report was direct: JOB was designed around real IMDb data because real-world correlations, skew, and non-uniform distributions are exactly what make join order optimization hard. The synthetic data BenchBox was generating was useful for development, but it did not preserve that property.
+In v0.3.0, `joinorder` switches to the real IMDb 2013 dataset, accepts only `--scale 1`, and ships with all 113 JOB SQL queries (IDs in the familiar `1a`, `2b`, `15a` shape, registered and parse-checked in the test suite). The previous synthetic data path is renamed `joinorder_synthetic` and kept out of the released benchmark list; old synthetic result bundles are renamed in step so they aren't confused with results from the real dataset.
 
-v0.3.0 changes the public behavior of `joinorder`:
+This is a breaking change. Before v0.3.0, it was easy to produce a result labeled "JoinOrder" that was not comparable to the workload described by the JOB papers, and that ambiguity now disappears. There is no small public JoinOrder scale in this release; a smaller workload may follow later, but it needs its own validated data contract, not a random slice of the real one.
 
-- `joinorder` uses the real IMDb 2013 Join Order Benchmark dataset.
-- It accepts only `--scale 1`.
-- The old synthetic data path is renamed `joinorder_synthetic` and kept out of the released benchmark list.
-- Old synthetic result bundles have been renamed so they are not confused with results from the real IMDb dataset.
-
-This is a breaking change, but it is the right kind of breaking change. The previous behavior made it too easy to produce a result labeled "JoinOrder" that was not comparable to the workload described by the JOB papers. After v0.3.0, the benchmark name carries a clearer contract.
-
-The tradeoff is also explicit: there is no small public JoinOrder scale in this release. A small workload may be useful later, but it needs its own validated data contract. Taking a random slice or generating smaller synthetic tables would bring back the same comparability problem under a different label.
-
-We wrote a deeper post on this change in [Reworking JoinOrder around the IMDb 2013 dataset](./14-joinorder-canonical-rework.md).
-
-## Query coverage and dataset identity
-
-The data change is paired with query coverage. BenchBox now includes all 113 Join Order Benchmark SQL queries. The query manager exposes the expected IDs, and the test suite checks that all 113 are registered and parse as PostgreSQL-flavored JOB SQL.
-
-The release also adds provenance plumbing for real-world benchmark datasets. Manifest-backed result bundles can carry:
-
-- `dataset_version`: which dataset contract the result used
-- `manifest_hash`: which manifest described the dataset
-- `data_archive_hash`: which logical archive content was verified
-
-Those fields do not make benchmark results universal. Hardware, engine version, platform settings, query selection, and run methodology still matter. They do make one important question easier to answer later: "Which data did this result use?"
-
-That matters for JoinOrder because the dataset itself is part of the benchmark. If two results are labeled `joinorder`, but one used synthetic data and the other used the real IMDb dataset, those results should not be compared or aggregated.
+Result bundles for manifest-backed datasets can also now record `dataset_version`, `manifest_hash`, and `data_archive_hash`. Hardware, engine version, and methodology still matter, but these fields make one question easier to answer later: which data did this result use? See the companion post for the full rationale.
 
 ## More approximate aggregate coverage
 
@@ -90,32 +51,42 @@ That matters for JoinOrder because the dataset itself is part of the benchmark. 
 | `approx_quantiles_array` | Multiple approximate quantiles from one aggregate |
 | `approx_top_k_lineitem` | Approximate most-frequent values |
 
-This also fixes a naming problem. The older `intrinsic_appx_median` query used an exact percentile expression despite the "appx" name. In v0.3.0, that work is named `approx_quantile_groupby`, and the supported PySpark and DataFusion paths use sketch-backed quantile implementations.
+This also fixes a naming problem. The older `intrinsic_appx_median` query used an exact percentile expression despite the "appx" name; in v0.3.0 it becomes `approx_quantile_groupby`, with sketch-backed implementations on the PySpark and DataFusion paths.
 
-DataFrame support is more explicit as well. Polars, PySpark, and DataFusion expose sketch-backed APIs for `approx_count_distinct_*`, while Pandas, Modin, and cuDF fall back to exact implementations where a sketch API is not available. Dask uses HLL for the single-value distinct query, but still falls back to exact implementations for the grouped distinct and quantile cases. The five query IDs do not all mean sketch-backed execution on every DataFrame platform, and two (`approx_quantiles_array`, `approx_top_k_lineitem`) remain PySpark-only at the DataFrame layer. The documentation calls that out so users do not accidentally compare exact and approximate implementations as if they were the same workload.
+DataFrame coverage is uneven by design, because engines expose different APIs. The five query IDs do not all mean sketch-backed execution on every DataFrame platform:
+
+| Engine | `approx_count_distinct_*` | `approx_quantile_groupby` | `approx_quantiles_array` | `approx_top_k_lineitem` |
+| --- | --- | --- | --- | --- |
+| Polars | Sketch | Exact | n/a | n/a |
+| PySpark | Sketch | Sketch | Sketch | Sketch |
+| DataFusion | Sketch | Sketch | n/a | n/a |
+| Dask | HLL (simple) / exact (groupby) | Exact | n/a | n/a |
+| Pandas, Modin, cuDF | Exact | Exact | n/a | n/a |
+
+The documentation flags the splits so users don't accidentally compare exact and approximate implementations as if they were the same workload.
 
 ## Sketch workflows now cover persistence and merge
 
-Approximate aggregate functions are useful, but they are only one part of the modern sketch workflow. Many engines also let users build sketch state, store it, merge it later, and extract an estimate without scanning raw rows again.
+Approximate aggregate functions are useful, but they are only one part of the modern sketch workflow. Many engines also let users build sketch state, store it, merge it later, and extract an estimate without scanning raw rows again. v0.3.0 moves that lifecycle into `write_primitives`, which is the right home because it involves creating tables, storing state, and reading state back later.
 
-That lifecycle belongs in `write_primitives`, not `read_primitives`, because it involves creating tables, storing state, and reading that state back later. v0.3.0 adds sketch workloads for:
+The new workloads cover persist, merge, and requery behavior, with storage-size validation alongside timing because persisted sketches have two costs that matter: how long they take to merge, and how much state they store. Parameter sweeps make the tradeoff visible where supported. KLL configurations, for example, can be compared by size and accuracy settings instead of treated as one fixed black box.
 
-- DataSketches-style Theta, KLL, and Top-K workflows where engines expose them, with documented substitutions and skips for BigQuery, Redshift, ClickHouse, and current DuckDB extension drift
-- DuckDB CPC and REQ variants
-- ClickHouse aggregate-state sketch variants
-- Redshift HLL coverage where Redshift has native support
+Engine support is genuinely uneven:
 
-The new workloads cover persist, merge, and requery behavior. They also add storage-size validation for the main sketch operations, because persisted sketches have two important costs: how long they take to merge and how much state they store.
+| Engine | Theta | KLL | Top-K | HLL | CPC / REQ | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Apache DataSketches engines | yes | yes | yes | yes | n/a | Portable binary state |
+| ClickHouse | yes* | yes* | yes* | yes* | n/a | Aggregate-state functions; format not portable across engines |
+| Redshift | no | no | no | yes | n/a | Native HLL only |
+| DuckDB | drift | ✅ | drift | ✅ | ✅ | Community `datasketches` extension; Theta + frequent-items skipped until extension catches up |
 
-Parameter sweeps make the tradeoff visible where supported. For example, KLL configurations can be compared by size and accuracy settings instead of treated as one fixed black box. That matters when a team is deciding whether sketch state is worth storing in production tables.
-
-The exact support matrix differs by engine. Some engines expose portable Apache DataSketches binary state. ClickHouse exposes a similar lifecycle through aggregate-state functions, but its binary format is not portable across engines. Redshift exposes HLL, but not KLL or Top-K. DuckDB sits in a third category: the community `datasketches` extension is the source of its Theta/KLL/Top-K coverage, but the currently-loaded build only exports CPC, REQ, KLL, and HLL. Theta and frequent-items (Top-K) are tracked as upstream-extension drift, so on DuckDB those parts of the workload show up as skipped rather than measured until the extension catches up. BenchBox keeps those differences visible instead of hiding them behind a single "supported" label.
+BenchBox surfaces these differences as skips with reasons rather than hiding them behind a single "supported" label.
 
 ## A page for agent-assisted runs
 
 The landing site release adds [Instruct an agent](/prompts/), a page with the heading "Instruct a coding agent to use BenchBox."
 
-The page is for a common first-run workflow: a user wants a coding agent to set up and run a benchmark correctly. Instead of asking the user to hand-write an instruction from memory, the page lets them choose:
+The page is for a common first-run workflow: a user wants a coding agent to set up and run a benchmark correctly. Instead of hand-writing an instruction from memory, the page lets them choose:
 
 - goal: test one platform or compare platforms
 - surface: CLI or MCP
@@ -125,40 +96,28 @@ The page is for a common first-run workflow: a user wants a coding agent to set 
 
 It then emits a copyable prompt. If MCP is selected, it includes the MCP configuration shape. If a managed cloud platform is selected, the generated instruction starts with dependency and status checks, then a dry run, before any live benchmark command.
 
-The default path is intentionally conservative: local DuckDB, TPC-H, and SF 0.01. For managed platforms, the prompt tells the agent not to ask for secrets in chat or the browser. If credentials are missing, the agent should stop and summarize what is missing instead of guessing.
+The default path is intentionally conservative: local DuckDB, TPC-H, and SF 0.01. For managed platforms, the prompt tells the agent not to ask for secrets in chat or the browser; if credentials are missing, the agent should stop and summarize what is missing instead of guessing.
 
-The page does not change how BenchBox runs benchmarks. There is no new `benchbox prompts` command, no new MCP prompt-rendering tool, and no public JSON catalog. Platform inclusion comes from BenchBox runtime metadata, while hand-authored configuration is used for labels and safety copy.
+The page does not change how BenchBox runs benchmarks. There is no new `benchbox prompts` command, no new MCP prompt-rendering tool, and no public JSON catalog. Platform inclusion comes from BenchBox runtime metadata; hand-authored configuration supplies labels and safety copy.
 
-## Smaller changes worth knowing
+## Other notable changes
 
-Two implementation changes are worth calling out because they affect future benchmark coverage.
-
-First, validation queries can now use `ValidationQuery.platform_overrides`. That lets a benchmark declare engine-specific validation SQL or an explicit skip, which is useful for sketch state because engines expose different storage and merge functions.
-
-Second, PySpark gained aggregate persist/merge support for DataFrame sketch workflows. That gives the DataFrame path a way to run sketch lifecycle work through DataFrame managers rather than treating every sketch workload as SQL-only.
+Validation queries can now use `ValidationQuery.platform_overrides`, which lets a benchmark declare engine-specific validation SQL or an explicit skip. That's useful for sketch state, since engines expose different storage and merge functions. PySpark also gained aggregate persist/merge support for DataFrame sketch workflows, giving the DataFrame path a way to run sketch lifecycle work through DataFrame managers rather than treating every sketch workload as SQL-only.
 
 ## Try it yourself
-
-For a quick smoke run:
 
 ```bash
 uv add "benchbox[duckdb]"
 uv run benchbox run --platform duckdb --benchmark tpch --scale 0.01
 ```
 
-For the new prompt page:
-
-```text
-/prompts/
-```
-
-For JoinOrder, remember that the public benchmark is the full fixed dataset:
+For JoinOrder, the public benchmark is the full fixed dataset:
 
 ```bash
 uv run benchbox run --platform duckdb --benchmark joinorder --scale 1
 ```
 
-The first JoinOrder run downloads and verifies the dataset before executing queries.
+The first JoinOrder run downloads and verifies the dataset before executing queries. For the new prompt page, visit `/prompts/`.
 
 ## Changed behavior to be aware of
 
@@ -166,12 +125,6 @@ The first JoinOrder run downloads and verifies the dataset before executing quer
 - **Old JoinOrder synthetic results are not comparable to v0.3.0 JoinOrder results.** Treat them as a different workload.
 - **The old synthetic data path is now `joinorder_synthetic`.** It remains useful for development and smoke coverage, but it is not the released comparable benchmark.
 - **Approximate DataFrame paths differ by engine.** Some are sketch-backed; others are exact fallbacks. Check the coverage matrix before comparing them.
-
-## Bottom line
-
-v0.3.0 is a benchmark-trust release. The JoinOrder fix makes a well-known optimizer benchmark mean what readers expect it to mean. The approximate and sketch additions make more of the modern analytics surface measurable without one-off query files. The prompt page makes the first agent-assisted run easier to start without adding a new runtime API.
-
-If you ran `joinorder` before v0.3.0, treat old results as synthetic and do not compare them directly with the new IMDb-backed runs. If you use the approximate or sketch workloads, check the support notes for each engine and benchmark the capability you actually intend to rely on.
 
 ---
 
@@ -184,5 +137,3 @@ If you ran `joinorder` before v0.3.0, treat old results as synthetic and do not 
 - Approximate functions reference: `docs/benchmarks/read-primitives-approximate-functions.md`
 - Sketch functions reference: `docs/benchmarks/write-primitives-sketch-functions.md`
 - Prompt route decision: `_project/decisions/landing-prompts-route.md`
-
-[^issue-289]: GitHub issue #289, "[JOB] Uniformly random data generation undermines the benchmark's core motivation - real-world data correlations matter," filed by `@partychicken` on May 9, 2026.

--- a/_blog/building-benchbox/drafts/14-joinorder-canonical-rework.md
+++ b/_blog/building-benchbox/drafts/14-joinorder-canonical-rework.md
@@ -16,31 +16,21 @@ status: draft
 
 ---
 
-On May 9, 2026, GitHub user `@partychicken` filed issue #289 against BenchBox.[^issue-289] The report was not about a typo or a missing query. It was about the benchmark contract.
+On May 9, 2026, GitHub user `@partychicken` filed issue #289 against BenchBox.[^issue-289] The report was about the benchmark contract: BenchBox had a JoinOrder-shaped workload (the schema, queries wired through the framework, and generated data for smoke tests), but the data was not the real IMDb dataset used by the Join Order Benchmark papers. With generated data that doesn't preserve real-world correlations, an optimizer can look better than it should because the data is easier than the benchmark was designed to be.
 
-BenchBox had a JoinOrder-shaped workload: the schema existed, queries could be wired through the framework, and generated data made smoke tests easy. But the data was not the real IMDb dataset used by the Join Order Benchmark papers. That distinction matters because JOB is not just a schema and query list. It is a workload designed around real-world data correlations that make cardinality estimation hard.
+v0.3.0 fixes this. `joinorder` now means the real IMDb 2013 Join Order Benchmark dataset, at one fixed scale. The old generated workload is still useful for development, but it has a different name and should not be used as published JOB evidence. Throughout this post, "canonical" means the reference JOB data contract: the fixed IMDb 2013 dataset and the 113-query workload used by the JOB papers, not any future reduced dataset, generated test fixture, or schema-compatible approximation.
 
-The reporter made the risk explicit: with generated data that does not preserve those correlations, an optimizer can look better than it should because the data is easier than the benchmark was designed to be.
+## Why real-world data matters for JOB
 
-v0.3.0 fixes that. `joinorder` now means the real IMDb 2013 Join Order Benchmark dataset, at one fixed scale. The old generated workload is still useful for development, but it has a different name and should not be used as published JOB evidence.
+The original JOB paper, "How Good Are Query Optimizers, Really?", chose IMDb deliberately.[^job-2015] The follow-up VLDB Journal paper kept that focus on real-world optimizer behavior.[^job-2018] IMDb data has skew, correlations, and uneven distributions: exactly the properties that make cardinality estimates fail in interesting ways.
 
-In this post, "canonical" means the reference JOB data contract: the fixed IMDb 2013 dataset and the 113-query workload used by the Join Order Benchmark papers. It does not mean every future reduced dataset, generated test fixture, or schema-compatible approximation.
+If an optimizer assumes predicates are independent when the real data says otherwise, it picks a poor join order. Exposing that failure mode is the signal JOB was built to send. Uniformly random synthetic data erases it: independence assumptions become accidentally accurate, and every query still runs to completion while the benchmark quietly stops measuring what it was designed to measure.
 
-## What the report changed
-
-The original JOB paper, "How Good Are Query Optimizers, Really?", chose IMDb deliberately.[^job-2015] The follow-up VLDB Journal paper kept that focus on real-world optimizer behavior.[^job-2018] IMDb data has skew, correlations, and uneven distributions. Those properties are exactly what make optimizer cardinality estimates fail in interesting ways. If an optimizer thinks predicates are independent when the real data says otherwise, it may pick a very poor join order. That failure mode is the signal JOB was built to expose, and uniformly random synthetic data erases it: independence assumptions can become accidentally accurate, simple statistical assumptions can look better than they should, and the benchmark stops measuring what it was designed to measure even while every query runs to completion.
-
-Issue #289 argued that generated JoinOrder data removes the hard part:
+Issue #289 stated the consequence directly:
 
 > In other words, uniform random generation removes the very property that JOB was designed to test.
 
-That sentence is the core of the change. BenchBox's generated data was not useless. It helped exercise loaders, table creation, query registration, and basic platform tests. But it was not a comparable JOB run. A result produced on that data should not sit next to a result produced on the real IMDb dataset as if they measured the same workload.
-
-The report also proposed the shape of the fix:
-
-> remove/disable the scaling capability for the JOB workload. Instead, BenchBox could simply reference and ingest the original frozen IMDB dataset.
-
-That is the direction v0.3.0 takes.
+BenchBox's generated data wasn't useless. It helped exercise loaders, table creation, query registration, and basic platform tests. But it was not a comparable JOB run, and the report proposed the right shape of fix:
 
 | What the report asked for | What v0.3.0 ships |
 | --- | --- |
@@ -49,15 +39,13 @@ That is the direction v0.3.0 takes.
 | Keep JOB faithful to its purpose | All 113 JOB SQL queries are embedded and checked |
 | Avoid misleading results | The generated workload is renamed `joinorder_synthetic` |
 
-We are grateful for the report because it forced a useful distinction: schema-compatible data is not the same thing as benchmark-compatible data.
+The report forced a useful distinction: schema-compatible data is not the same thing as benchmark-compatible data.
 
 ## Why scale factor 1 is intentional
 
-Most BenchBox benchmarks support scale factors because the data generator can produce a smaller or larger version of the workload. That makes iteration easier. It also lets users run smoke tests before spending time on larger data.
+Most BenchBox benchmarks support scale factors because the data generator can produce a smaller or larger version of the workload, which makes iteration easier and lets users run smoke tests before larger runs.
 
-JoinOrder is different. The public benchmark now uses a fixed real-world dataset. That is why `joinorder --scale 0.01` is not part of v0.3.0.
-
-A smaller public JOB workload would need more than fewer rows. It would need:
+JoinOrder is different. The public benchmark now uses a fixed real-world dataset, which is why `joinorder --scale 0.01` is not part of v0.3.0. A smaller public JOB workload would need more than fewer rows:
 
 - correlated data that preserves the properties JOB is meant to expose
 - reference cardinalities for the smaller data
@@ -65,15 +53,13 @@ A smaller public JOB workload would need more than fewer rows. It would need:
 - a stable data-delivery contract
 - tests that prove the query semantics still match the intended workload
 
-Without those pieces, a smaller workload would create a false sense of comparability. It might be fast and convenient, but it would not be the Join Order Benchmark in the sense users expect.
-
-The generated data remains useful for development and smoke-test coverage. It now has the explicit name `joinorder_synthetic`. That label is important. It keeps test data from being confused with comparable benchmark data.
+Without those pieces, a smaller workload would create a false sense of comparability: fast and convenient, but not the Join Order Benchmark in the sense users expect. The generated data remains useful for development and smoke-test coverage; the explicit `joinorder_synthetic` name keeps it from being confused with comparable benchmark data.
 
 ## What the reference dataset means in BenchBox
 
 In v0.3.0, the reference JoinOrder dataset means three things.
 
-First, the dataset is fixed. BenchBox's package is derived from the Harvard Dataverse `imdb_pg11` archive, DOI `10.7910/DVN/2QYZBT`, restored into PostgreSQL and converted to the 21-table JOB schema. The manifest identifies that BenchBox data contract as:
+First, the dataset is fixed. BenchBox's package is derived from the Harvard Dataverse `imdb_pg11` archive, DOI `10.7910/DVN/2QYZBT`, restored into PostgreSQL and converted to the 21-table JOB schema. The manifest identifies the BenchBox data contract as:
 
 ```toml
 dataset_version = "joinorder-imdb-2013-v1"
@@ -87,16 +73,14 @@ This is not a legal claim about IMDb redistribution. It is an engineering statem
 
 ## Query coverage changed too
 
-The data change would be incomplete without the query set. v0.3.0 includes all 113 JOB SQL queries.
+The data change would be incomplete without the query set. v0.3.0 includes all 113 JOB SQL queries, with IDs in the familiar JOB shape (such as `1a`, `2b`, and `15a`). The test suite checks that all 113 queries are registered and parse as PostgreSQL-flavored SQL.
 
-The query manager exposes IDs in the familiar JOB shape, such as `1a`, `2b`, and `15a`. The test suite checks that all 113 queries are registered and parse as PostgreSQL-flavored SQL.
-
-The release also adds reference cardinalities and predicate-focused fixture tests. Those checks help protect the two most important parts of the benchmark:
+The release also adds reference cardinalities and predicate-focused fixture tests. Those checks protect the two most important parts of the benchmark:
 
 1. The query catalog should contain the workload users expect.
 2. The predicates should keep the intended semantics as the code evolves.
 
-DataFrame query coverage exists for the same query IDs, but that statement needs careful interpretation. Query ID coverage is not the same as saying every DataFrame platform produces equally comparable JOB results. Platform capability, expression support, and execution behavior still matter. The release makes the workload available; users should still interpret cross-engine comparisons with the usual benchmark care.
+DataFrame query coverage exists for the same query IDs, with one caveat: query ID coverage is not the same as saying every DataFrame platform produces equally comparable JOB results. Platform capability, expression support, and execution behavior still matter, and cross-engine comparisons need the usual benchmark care.
 
 ## Result identity is part of the fix
 
@@ -108,27 +92,25 @@ v0.3.0 adds three fields that result bundles can use for manifest-backed dataset
 - `manifest_hash`: the manifest that described the expected data
 - `data_archive_hash`: the logical archive content
 
-For JoinOrder, this helps separate three cases that should not be mixed:
+For JoinOrder, these fields separate three cases that should not be mixed:
 
 1. old BenchBox generated data
 2. the real IMDb 2013 JOB dataset
 3. any future reduced or alternate dataset, if one is ever added
 
-Those fields are not a replacement for full methodology. Hardware, engine version, adapter configuration, query selection, concurrency, and measurement mode still matter. But dataset identity removes one common ambiguity: readers can tell which data contract a result used.
+The fields are not a replacement for full methodology. Hardware, engine version, adapter configuration, query selection, concurrency, and measurement mode still matter. But the fields do remove one common ambiguity: readers can tell which data contract a result used.
 
 ## Provenance and redistribution
 
-Real-world datasets bring provenance questions that generated benchmark data does not. BenchBox documents the JoinOrder dataset version, archive hash, manifest hash, Dataverse source, and IMDb attribution. The data license note records the source and what users should know about redistribution.
+v0.3.0 treats the current re-hosted Parquet archive as an accepted release-risk decision, not as BenchBox-cleared for broad commercial redistribution. The decision is documented alongside the dataset version, archive hash, manifest hash, Dataverse source, and IMDb attribution, so users understand what is being downloaded and measured.
 
-We should be precise here. v0.3.0 treats the current re-hosted Parquet archive as an accepted release-risk decision by the project, not as BenchBox-cleared for broad commercial redistribution. It makes that decision explicit and documents the data identity so users understand what is being downloaded and measured.
-
-There are stricter approaches we may consider later:
+Stricter approaches we may consider later:
 
 - written permission for the redistributed archive
 - direct Dataverse fetch with local conversion
 - a bring-your-own dataset path for environments with stricter policies
 
-Those would improve the provenance story, but they also add setup cost. For v0.3.0, the default path prioritizes a verified first run against the real JOB dataset.
+These would improve the provenance story, but they also add setup cost. For v0.3.0, the default path prioritizes a verified first run against the real JOB dataset.
 
 ## What users need to change
 
@@ -147,21 +129,15 @@ If your automation used a smaller JoinOrder scale, update it. `joinorder` now ac
 
 ## What we learned
 
-The main lesson is simple: benchmark names are promises.
-
-When users see `joinorder`, they bring expectations from the Join Order Benchmark papers. They expect a workload shaped by real IMDb correlations, not just tables with familiar names. Generated data can be useful, but if it does not preserve the property the benchmark exists to test, it needs a different label.
+The main lesson is simple: benchmark names are promises. When users see `joinorder`, they bring expectations from the JOB papers: a workload shaped by real IMDb correlations, not just tables with familiar names. Generated data can be useful, but if it does not preserve the property the benchmark exists to test, it needs a different label.
 
 There's also a provenance lesson worth calling out: dataset version, manifest hash, and archive hash are boring fields until someone asks why two published results disagree. They earn their place by being there when an auditor needs them.
 
-Finally, convenience has a limit. It stops where it makes results misleading. A small generated JoinOrder run is convenient. It is not a substitute for the real JOB dataset. v0.3.0 draws that boundary.
-
 ## Bottom line
 
-BenchBox v0.3.0 turns `joinorder` into the benchmark users expected: real IMDb 2013 JOB data, all 113 queries, fixed scale, and auditable dataset identity.
+BenchBox v0.3.0 turns `joinorder` into the benchmark users expected: real IMDb 2013 JOB data, all 113 queries, fixed scale, and auditable dataset identity. The change came from community feedback; the implementation goes a little further than the initial report, especially around dataset identity, but the core correction is the one issue #289 identified.
 
-That came from community feedback. The implementation goes beyond the initial report in a few places, especially around dataset identity, but the core correction is the one issue #289 identified: JOB needs real-world data because real-world correlations are the benchmark.
-
-If you use JoinOrder to evaluate optimizers, upgrade with care. Old generated-data results belong in a separate bucket. New `joinorder` results use the real JOB dataset and should be treated as a new, stricter baseline.
+If you use JoinOrder to evaluate optimizers, upgrade with care. Pre-v0.3.0 results were generated-data results and should not be compared directly with new IMDb-backed runs; the new `joinorder` is a stricter baseline.
 
 ---
 


### PR DESCRIPTION
Trims redundant summary surfaces in post 13 (release overview) and
collapses repeated intro framing in post 14 (JoinOrder rework).
Converts prose support matrices to scannable tables, splits a 5-clause
run-on, replaces em-dashes with style-guide-compliant punctuation, and
deduplicates material across the companion posts.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
