### PR TITLE
docs(blog): critique-followup fixes on v0.3.0 drafts

### DIFF
--- a/_blog/building-benchbox/drafts/12-sketch-functions-databricks-response.md
+++ b/_blog/building-benchbox/drafts/12-sketch-functions-databricks-response.md
@@ -12,7 +12,12 @@ status: draft
 
 > Approximate aggregates answer one query over raw rows. Sketches store compact summary state that can be merged and queried later. BenchBox now tests those workloads separately.
 
-**TL;DR**: Approximate analytics is not just a function-mapping problem. A platform can expose approximate aggregate functions without exposing the full sketch lifecycle: create compact summary state, store it, merge it later, and query the result. BenchBox now separates those claims. `read_primitives` measures one-shot approximate aggregates, including HLL distinct counts, KLL or T-Digest quantiles, vector quantiles, and Top-K. `write_primitives` measures persisted sketch state: store compact summaries, merge them later, validate the extracted answer, and track storage size. The current `develop` branch also adds ClickHouse-native lifecycle coverage, DuckDB-only CPC and REQ variants, parameter sweeps, and a PySpark DataFrame HLL persist-merge path. Tuple sketches and cloud live verification remain deferred.
+**TL;DR**: Approximate analytics is not just a function-mapping problem. A platform can expose approximate aggregate functions without exposing the full sketch lifecycle (build compact state, store it, merge it later, query it). BenchBox now separates those two claims:
+
+- `read_primitives` measures one-shot approximate aggregates: HLL distinct counts, KLL or T-Digest quantiles, vector quantiles, and Top-K.
+- `write_primitives` measures persisted sketch state: store compact summaries, merge them later, validate the extracted answer, and track storage size.
+
+The current `develop` branch also adds ClickHouse-native lifecycle coverage, DuckDB-only CPC and REQ variants, parameter sweeps, and a PySpark DataFrame HLL persist-merge path. Tuple sketches and cloud live verification remain deferred.
 
 ---
 
@@ -22,15 +27,17 @@ A support matrix would have been the obvious first response to Databricks' April
 
 Theta: supported here, substituted there. KLL: supported here, skipped there. Top-K: supported here, missing there. That table is useful, and BenchBox has one now. But it does not answer the question the announcement actually raises.
 
-Sketches become interesting when they stop being a single function call. Build them over partitions. Store them as columns. Merge them across days, regions, campaigns, or partitions. Query the compact state instead of the raw rows. Once that is the claim, a benchmark cannot stop at "which function name maps where?"
+Sketches become interesting when they stop being a single function call: built over partitions, stored as columns, merged across days or regions, and queried against compact state instead of raw rows. Once that is the claim, a benchmark cannot stop at "which function name maps where?"
 
-That is what made the announcement a useful forcing function for BenchBox: one-shot aggregate tests can measure function latency, but they cannot exercise stored, mergeable sketch artifacts.
+The announcement was a useful forcing function for BenchBox: one-shot aggregate tests can measure function latency, but they cannot exercise stored, mergeable sketch artifacts.
+
+A note up front about what BenchBox can and cannot claim here. The catalog covers many platforms and families, but catalog coverage is not the same as live, per-platform verification. Local `read_primitives` paths are straightforward to exercise; chDB gives a local ClickHouse-shaped path for the native `-State` and `-Merge` lifecycle; DuckDB KLL, CPC, and REQ work against the installed community extension, while DuckDB Theta and frequent-items remain blocked by community-extension drift. Snowflake, BigQuery, Databricks, and Redshift lifecycle runs remain credential-gated.
 
 Databricks' SQL docs make that lifecycle explicit for Theta (`theta_sketch_agg`, `theta_union_agg`, `theta_sketch_estimate`), KLL (`kll_sketch_agg_double`, `kll_merge_agg_double`, `kll_sketch_get_quantile_double`), and Top-K (`approx_top_k_accumulate`, `approx_top_k_combine`, `approx_top_k_estimate`).[^2][^3][^4][^5][^6] BenchBox already had a single-query read benchmark. It needed a second benchmark shape for the persist, merge, and requery loop.
 
-## Why Parity Was Only the Starting Point
+## Why parity was only the starting point
 
-The announcement moved Databricks closer to sketch surfaces already present elsewhere in BenchBox's platform matrix. Snowflake already documents DataSketches functions for approximate distinct counts and stateful Top-K functions that accumulate, combine, and estimate stored state.[^7][^8] BigQuery exposes HLL++ sketches and KLL quantile sketches as `BYTES` values that can be initialized, merged, and extracted later.[^9][^10] ClickHouse has long exposed the same lifecycle shape through aggregate-state combinators such as `uniqState` and `uniqMerge`, while DuckDB covers the one-shot approximate aggregate surface with `approx_count_distinct`, `approx_quantile`, and `approx_top_k`.[^11][^12]
+The announcement moved Databricks closer to sketch surfaces already present elsewhere in BenchBox's platform matrix. Snowflake documents DataSketches functions for approximate distinct counts and stateful Top-K functions that accumulate, combine, and estimate stored state.[^7][^8] BigQuery exposes HLL++ sketches and KLL quantile sketches as `BYTES` values that can be initialized, merged, and extracted later.[^9][^10] ClickHouse has long exposed the same lifecycle shape through aggregate-state combinators such as `uniqState` and `uniqMerge`. DuckDB covers the one-shot approximate aggregate surface with `approx_count_distinct`, `approx_quantile`, and `approx_top_k`.[^11][^12]
 
 That competitive context makes the benchmark question sharper. BenchBox needs to show where Databricks now overlaps with existing platform capabilities, where the SQL shapes still differ, and which parts of the lifecycle are actually measurable across platforms.
 
@@ -132,19 +139,13 @@ Approximate analytics has two operational phases: aggregate functions and sketch
 
 The aggregate functions phase is a query like "give me an approximate distinct count now." Most analytical platforms have something here. Some use HLL, some use T-Digest, some use platform-specific Top-K accumulators, and a few still rely on SQL transpilation or hand-written variants. This is the path `read_primitives` measures.
 
-The persisted-state phase asks a different question: can the platform build sketches over partitions, store them, merge them later, and extract answers cheaply? This is the path `write_primitives` measures. The platform matrix narrows at this tier, and the portability story becomes more specific. Some platforms expose Apache DataSketches-family artifacts. Some expose native aggregate-state combinators. Some expose HLL only. A few still do not expose any sketch lifecycle at all.
-
-Verification language has to be precise.
-
-BenchBox can document catalog coverage across different platforms, but that is not the same as saying every platform has been verified live for every family. Local `read_primitives` paths are straightforward to exercise. chDB gives us a local ClickHouse-shaped path for the native `-State` and `-Merge` lifecycle. DuckDB KLL, CPC, and REQ work against the installed community extension, while DuckDB Theta and frequent-items are blocked by community-extension drift until we pin, vendor, or substitute the missing families. Snowflake, BigQuery, Databricks, and Redshift lifecycle runs remain credential-gated.
-
-That distinction matters more than a support badge.
+The persisted-state phase asks a different question: can the platform build sketches over partitions, store them, merge them later, and extract answers cheaply? This is the path `write_primitives` measures. The platform matrix narrows at this tier, and the portability story becomes more specific. Some platforms expose Apache DataSketches-family artifacts. Some expose native aggregate-state combinators. Some expose HLL only. A few still do not expose any sketch lifecycle at all. (See the catalog-versus-live note in the introduction for what BenchBox can claim today.)
 
 DataFrame support needs its own accounting. Polars, PySpark, DataFusion, pandas, Dask, Modin, and cuDF do not expose the same sketch surfaces. On the read side, some rows are sketch-backed and some rows fall back to exact aggregates. A pandas exact `nunique` timing is not semantically comparable to a PySpark HLL timing. On the write side, PySpark now has a CLI-runnable HLL persist-merge path; Top-K is guarded by runtime support; the other DataFrame platforms still lack a comparable sketch persistence API.
 
 The pattern is reusable beyond sketches. Any feature announced as "stored, mergeable, requeryable" needs an execution-model check before we start writing parity tables. Vector indexes, materialized aggregates, search indexes, incremental materialized views, and ML feature stores all have the same shape. The question is not only "what function name maps to what?" It is "does this benchmark have the phases needed to test the claim?"
 
-## Try It Yourself
+## Try it yourself
 
 Run the one-shot approximate aggregate path first:
 
@@ -201,9 +202,9 @@ The public reference docs are the best place to start:
 - [`read_primitives` approximate aggregate functions](https://github.com/joeharris76/BenchBox/blob/develop/docs/benchmarks/read-primitives-approximate-functions.md)[^13]
 - [`write_primitives` sketch persistence operations](https://github.com/joeharris76/BenchBox/blob/develop/docs/benchmarks/write-primitives-sketch-functions.md)[^14]
 
-## Test Environment
+## Test environment
 
-This draft was reviewed against `origin/develop` at commit `46b90052f`, with package version `0.2.1` in `pyproject.toml`.
+This draft was reviewed against `origin/develop` at commit `c48c299b4`. The v0.3.0 version bump has not yet landed on `develop`, so `pyproject.toml` still reads `0.2.1`; the public release will pin against the bump commit.
 
 Evidence status for this draft:
 
@@ -247,7 +248,7 @@ The support matrix separates catalog support from live verification. Cloud verif
 
 [^9]: BigQuery, [HyperLogLog++ functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/hll_functions), accessed May 18, 2026.
 
-[^10]: BigQuery, [KLL quantile functions](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/kll_functions), accessed May 18, 2026.
+[^10]: BigQuery, [KLL quantile functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/kll_functions), accessed May 18, 2026.
 
 [^11]: ClickHouse, ["Using Aggregate Combinators in ClickHouse"](https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states), accessed May 18, 2026.
 

--- a/_blog/building-benchbox/drafts/13-v0-3-0-release-overview.md
+++ b/_blog/building-benchbox/drafts/13-v0-3-0-release-overview.md
@@ -14,9 +14,11 @@ status: draft
 
 ---
 
-The largest change is JoinOrder. A community report ([issue #289](https://github.com/joeharris76/BenchBox/issues/289)) flagged that BenchBox's old JoinOrder data was uniformly-random synthetic data and did not exercise the real-world correlations that the Join Order Benchmark was designed around. Thanks to `@partychicken` for raising the issue. v0.3.0 fixes this by making `joinorder` use the real IMDb 2013 JOB dataset at scale factor 1. The companion post, [Reworking JoinOrder around the IMDb 2013 dataset](./14-joinorder-canonical-rework.md), walks through the data contract, scale-factor decision, and provenance work in detail.
+The headline addition is a new [`/prompts/`](https://benchbox.dev/prompts/) page on the landing site. It composes copyable instructions for coding agents so that a first BenchBox run, local or cloud, lands with safer defaults and the right setup steps in the right order. No new runtime command, no MCP tool change, no JSON catalog: the page is purely a prompt builder over BenchBox's existing CLI and MCP surfaces.
 
-The second theme is approximate analytics. BenchBox now covers more of the path that modern platforms expose for approximate aggregates and sketches: one-shot approximate read queries, persisted sketch state, merge queries, storage-size checks, and parameter sweeps where the platform surface supports them. A new `/prompts/` page on the landing site rounds out the release by helping visitors generate copyable agent instructions for first BenchBox runs.
+The biggest data-contract change is JoinOrder. A community report ([issue #289](https://github.com/joeharris76/BenchBox/issues/289)) flagged that BenchBox's old JoinOrder data was uniformly-random synthetic data and did not exercise the real-world correlations that the Join Order Benchmark was designed around. Thanks to `@partychicken` for raising the issue. v0.3.0 fixes this by making `joinorder` use the real IMDb 2013 JOB dataset at scale factor 1. The companion post, [Reworking JoinOrder around the IMDb 2013 dataset](./14-joinorder-canonical-rework.md), walks through the data contract, scale-factor decision, and provenance work in detail.
+
+The third theme is approximate analytics. BenchBox now covers more of the path that modern platforms expose for approximate aggregates and sketches: one-shot approximate read queries, persisted sketch state, merge queries, storage-size checks, and parameter sweeps where the platform surface supports them. The architecture deep-dive in [Splitting approximate analytics across BenchBox read and write benchmarks](./12-sketch-functions-databricks-response.md) covers why the work split across `read_primitives` and `write_primitives`.
 
 ## At a glance
 
@@ -102,7 +104,7 @@ BenchBox surfaces these differences as skips with reasons rather than hiding the
 
 ## Other notable changes
 
-Validation queries can now use `ValidationQuery.platform_overrides`, which lets a benchmark declare platform-specific validation SQL or an explicit skip. That's useful for sketch state, since platforms expose different storage and merge functions. PySpark also gained aggregate persist/merge manager hooks and factory helpers for DataFrame sketch workflows, giving the DataFrame path a foundation for sketch lifecycle work without treating every sketch workload as SQL-only.
+Validation queries can now use `ValidationQuery.platform_overrides`, which lets a benchmark declare platform-specific validation SQL or an explicit skip. That's useful for sketch state, since platforms expose different storage and merge functions. PySpark also gained a CLI-runnable HLL persist-merge path (`sketch_df_hll_persist_merge`) on the DataFrame write side; Top-K is runtime-gated and skips when the active Spark distribution lacks the `approx_top_k_*` Python functions.
 
 ## Try it yourself
 
@@ -117,7 +119,27 @@ For JoinOrder, the public benchmark is the full fixed dataset:
 uv run benchbox run --platform duckdb --benchmark joinorder --scale 1
 ```
 
-The first JoinOrder run downloads and verifies the dataset before executing queries. For the new prompt page, visit `/prompts/`.
+The first JoinOrder run downloads and verifies the dataset before executing queries.
+
+For the new approximate aggregate queries:
+
+```bash
+uv run -- benchbox run --platform duckdb --benchmark read_primitives \
+  --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby \
+  --scale 1 \
+  --non-interactive
+```
+
+For a locally-runnable slice of the sketch lifecycle (KLL on DuckDB's community extension):
+
+```bash
+uv run -- benchbox run --platform duckdb --benchmark write_primitives \
+  --queries sketch_insert_kll_per_partition,sketch_query_kll_quantiles_merge \
+  --scale 0.01 \
+  --non-interactive
+```
+
+The deep-dive post has the full set of invocations including ClickHouse-native and PySpark DataFrame paths. For the new prompt page, visit `/prompts/`.
 
 ## Changed behavior to be aware of
 

--- a/_blog/building-benchbox/drafts/14-joinorder-canonical-rework.md
+++ b/_blog/building-benchbox/drafts/14-joinorder-canonical-rework.md
@@ -110,9 +110,7 @@ Stricter approaches we may consider later:
 - direct Dataverse fetch with local conversion
 - a bring-your-own dataset path for environments with stricter policies
 
-Users in stricter redistribution environments should review `benchbox/core/joinorder/DATA-LICENSE.md` and the documented BYO data path before relying on the default hosted archive.
-
-These would improve the provenance story, but they also add setup cost. For v0.3.0, the default path prioritizes a verified first run against the real JOB dataset.
+These would improve the provenance story, but they also add setup cost. For v0.3.0, the default path prioritizes a verified first run against the real JOB dataset. Users in stricter redistribution environments should review `benchbox/core/joinorder/DATA-LICENSE.md` and the documented BYO data path before relying on the default hosted archive.
 
 ## What users need to change
 
@@ -135,11 +133,7 @@ The main lesson is simple: benchmark names define contracts. When users see `joi
 
 There is also a provenance lesson worth calling out: dataset version, manifest hash, and archive hash are easy to overlook until someone asks why two published results disagree. They matter when an auditor needs to reconstruct the data contract behind a result.
 
-## Bottom line
-
-BenchBox v0.3.0 aligns `joinorder` with the published JOB contract: real IMDb 2013 JOB data, all 113 queries, fixed scale, and auditable dataset identity. The change came from community feedback; the implementation adds more than the initial report requested, especially around dataset identity, but the core correction is the one issue #289 identified.
-
-If you use JoinOrder to evaluate optimizers, upgrade with care. Pre-v0.3.0 results were generated-data results and should not be compared directly with new IMDb-backed runs; the new `joinorder` is a stricter baseline.
+The implementation adds more than the initial report requested, especially around dataset identity, but the core correction is the one issue #289 identified. If you use JoinOrder to evaluate optimizers, upgrade with care: pre-v0.3.0 results were generated-data results and should not be compared directly with new IMDb-backed runs; the new `joinorder` is a stricter baseline.
 
 ---
 
@@ -155,7 +149,7 @@ If you use JoinOrder to evaluate optimizers, upgrade with care. Pre-v0.3.0 resul
 - JoinOrder data manifest: `benchbox/core/joinorder/data_manifest.toml`
 - JoinOrder data license note: `benchbox/core/joinorder/DATA-LICENSE.md`
 - JoinOrder licensing decision: `_project/decisions/joinorder-canonical-data-licensing-2026-05-12.md`
-- Release overview: [BenchBox v0.3.0: JoinOrder fix, sketch coverage, and /prompts/](./13-v0-3-0-release-overview.md)
+- Release overview: [BenchBox v0.3.0: JoinOrder fix, approximate analytics, and agent prompt composer](./13-v0-3-0-release-overview.md)
 
 [^issue-289]: GitHub issue #289, "[JOB] Uniformly random data generation undermines the benchmark's core motivation - real-world data correlations matter," filed by `@partychicken` on May 9, 2026. The issue asks BenchBox to remove synthetic scaling for JOB and use the original frozen IMDb dataset.
 [^job-2015]: Leis, V., Gubichev, A., Mirchev, A., Boncz, P., Kemper, A., and Neumann, T. "How Good Are Query Optimizers, Really?" PVLDB 9(3), 204-215, 2015.


### PR DESCRIPTION
Post 12: fix broken BigQuery KLL footnote URL, update Test Environment
commit pin from a stale ref to c48c299b4 with an honest v0.3.0-bump
caveat, sentence-case the H2 headings for consistency, restructure the
TL;DR as a short lead + bulleted body, split the 5-platform run-on at
line 33, tame the staccato run at line 25, and promote the
catalog-versus-live verification note into the introduction.

Post 13: reorder the intro to lead with /prompts/ (matching the title,
meta description, and at-a-glance table), reconcile the PySpark
write-side claim with post 12's evidence table (CLI-runnable HLL
persist-merge path, runtime-gated Top-K), add a deep-dive link to
post 12 from the approximate-analytics framing, and add copy-paste
read_primitives and write_primitives invocations under Try it yourself.

Post 14: move the orphaned BYO-data sentence below its paragraph so
"These" refers to the bullets again, drop the redundant Bottom line
section (folding its forward-looking guidance into What we learned),
and update the stale companion-link text in References to match the
new post 13 title.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
