### PR TITLE
Fix dependency bounds version comparison

### DIFF
--- a/scripts/check_dependency_bounds.py
+++ b/scripts/check_dependency_bounds.py
@@ -9,10 +9,9 @@ surfaces that signal.
 Two modes
 ---------
 * ``--fail-on=cap-reached``  (blocking, offline)
-    Exit non-zero if any locked version's major equals the cap major -
-    i.e., uv lock allowed a version at or past our stated ceiling. This
-    should not happen under normal flow; it's a safety net for
-    lockfile-level drift.
+    Exit non-zero if any locked version is at or past the full stated
+    upper bound. This should not happen under normal flow; it's a safety
+    net for lockfile-level drift.
 
 * ``--report-only``  (non-blocking, offline)
     Emit a markdown report listing each capped dep, its locked version,
@@ -21,9 +20,10 @@ Two modes
     requiring a bump/hold decision). Suitable for appending to release
     notes.
 
-Parsing is intentionally restrained: PEP 508 with a single upper bound
-of the form ``<N`` or ``<N.0`` or ``<N.0.0`` (the form we actually use).
-Exotic specifiers fall through untracked rather than being misparsed.
+Parsing is intentionally restrained: PEP 508 with a single exclusive
+upper bound of the form ``<N`` or ``<N.0`` or ``<N.0.0`` or a tighter
+minor/patch cap such as ``<1.4.0`` (the forms we actually use). Exotic
+specifiers fall through untracked rather than being misparsed.
 
 Design notes
 ------------
@@ -48,12 +48,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-_UPPER_BOUND_RE = re.compile(r"<\s*(\d+)(?:\.\d+)*")
+_UPPER_BOUND_RE = re.compile(r"<\s*(\d+(?:\.\d+)*)")
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -64,34 +66,79 @@ class CappedDep:
     name: str
     cap_major: int
     locked_version: str | None
+    cap_version: Version | None = None
+    cap_text: str | None = None
+
+    @property
+    def effective_cap_version(self) -> Version:
+        """Full upper bound used for blocking comparisons."""
+        if self.cap_version is not None:
+            return self.cap_version
+        if self.cap_text is not None:
+            try:
+                return Version(self.cap_text)
+            except InvalidVersion:
+                pass
+        return Version(str(self.cap_major))
+
+    @property
+    def cap_display(self) -> str:
+        """Compact upper-bound display for markdown reports."""
+        if self._is_major_cap:
+            return str(self.cap_major)
+        return self.cap_text or str(self.effective_cap_version)
+
+    @property
+    def locked_parsed(self) -> Version | None:
+        if not self.locked_version:
+            return None
+        try:
+            return Version(self.locked_version)
+        except InvalidVersion:
+            return None
 
     @property
     def locked_major(self) -> int | None:
-        if not self.locked_version:
+        locked = self.locked_parsed
+        if locked is None:
             return None
-        head = self.locked_version.split(".")[0]
-        try:
-            return int(head)
-        except ValueError:
-            return None
+        return locked.major
+
+    @property
+    def _is_major_cap(self) -> bool:
+        release_tail = self.effective_cap_version.release[1:]
+        return all(part == 0 for part in release_tail)
 
     @property
     def cap_reached(self) -> bool:
-        """Locked major >= cap major - bounds violation."""
-        return self.locked_major is not None and self.locked_major >= self.cap_major
+        """Locked version >= full upper bound - bounds violation."""
+        locked = self.locked_parsed
+        return locked is not None and locked >= self.effective_cap_version
 
     @property
     def ceiling_minus_one(self) -> bool:
         """Locked major == cap major - 1 - one bump from decision time."""
-        return self.locked_major is not None and self.locked_major == self.cap_major - 1
+        return self._is_major_cap and self.locked_major is not None and self.locked_major == self.cap_major - 1
 
 
 def _extract_cap_major(spec: str) -> int | None:
     """Return the upper-bound major from a PEP 508 specifier, or None."""
+    parsed = _extract_upper_bound(spec)
+    if parsed is None:
+        return None
+    return parsed[1].major
+
+
+def _extract_upper_bound(spec: str) -> tuple[str, Version] | None:
+    """Return the exclusive upper-bound text and parsed version, or None."""
     m = _UPPER_BOUND_RE.search(spec)
     if not m:
         return None
-    return int(m.group(1))
+    text = m.group(1)
+    try:
+        return text, Version(text)
+    except InvalidVersion:
+        return None
 
 
 def _iter_capped_requirements(pyproject: dict) -> list[tuple[str, str]]:
@@ -139,15 +186,18 @@ def collect_capped_deps(pyproject_path: Path, lock_path: Path) -> list[CappedDep
     for name, spec in _iter_capped_requirements(pyproject):
         if name in seen:
             continue
-        cap_major = _extract_cap_major(spec)
-        if cap_major is None:
+        upper_bound = _extract_upper_bound(spec)
+        if upper_bound is None:
             continue
+        cap_text, cap_version = upper_bound
         seen.add(name)
         capped.append(
             CappedDep(
                 name=name,
-                cap_major=cap_major,
+                cap_major=cap_version.major,
                 locked_version=locked.get(name),
+                cap_version=cap_version,
+                cap_text=cap_text,
             )
         )
     return capped
@@ -169,7 +219,7 @@ def render_report(deps: list[CappedDep]) -> str:
             status = "⚠️ ceiling-minus-one - one major from decision"
         else:
             status = "✅ healthy"
-        lines.append(f"| `{dep.name}` | {locked} | <{dep.cap_major} | {status} |")
+        lines.append(f"| `{dep.name}` | {locked} | <{dep.cap_display} | {status} |")
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/unit/scripts/test_check_dependency_bounds.py
+++ b/tests/unit/scripts/test_check_dependency_bounds.py
@@ -1,11 +1,11 @@
 """Unit tests for scripts/check_dependency_bounds.py.
 
 Pinned invariants:
-  * The PEP 508 parser extracts the upper-bound major from the forms
-    BenchBox actually uses (``<N``, ``<N.0``, ``<N.0.0``).
+  * The PEP 508 parser extracts the full upper bound from the forms
+    BenchBox actually uses (``<N``, ``<N.0``, ``<N.0.0``, ``<N.M.P``).
   * A dep with no upper bound is skipped (not mis-reported).
-  * ``cap-reached`` blocks only when locked_major >= cap_major.
-  * ``ceiling-minus-one`` blocks when locked_major == cap_major - 1.
+  * ``cap-reached`` blocks only when locked_version >= the full upper bound.
+  * ``ceiling-minus-one`` blocks for next-major caps when locked_major == cap_major - 1.
   * ``--report-only`` never fails.
 """
 
@@ -18,6 +18,7 @@ import pytest
 from scripts.check_dependency_bounds import (
     CappedDep,
     _extract_cap_major,
+    _extract_upper_bound,
     _split_requirement,
     collect_capped_deps,
     main,
@@ -43,6 +44,24 @@ class TestUpperBoundExtraction:
     )
     def test_extracts_cap_major(self, spec: str, expected: int | None) -> None:
         assert _extract_cap_major(spec) == expected
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (">=20.0.0,<31.0.0", "31.0.0"),
+            (">=8.0.0,<9.0.0", "9.0.0"),
+            ("<4", "4"),
+            ("<4.0", "4.0"),
+            ("<4.0.0", "4.0.0"),
+            (">=1.0.0,<1.4.0", "1.4.0"),
+            ("~=2.12", None),
+            (">=1.0", None),
+            ("", None),
+        ],
+    )
+    def test_extracts_full_upper_bound(self, spec: str, expected: str | None) -> None:
+        parsed = _extract_upper_bound(spec)
+        assert (None if parsed is None else parsed[0]) == expected
 
 
 class TestRequirementSplit:
@@ -94,6 +113,7 @@ version = "2.31.0"
         deps = collect_capped_deps(py, lk)
         assert [d.name for d in deps] == ["sqlglot"]
         assert deps[0].cap_major == 31
+        assert deps[0].cap_text == "31.0.0"
         assert deps[0].locked_version == "30.2.1"
 
     def test_collects_from_dependency_groups(self, tmp_path: Path) -> None:
@@ -119,6 +139,27 @@ version = "1.5.1"
         assert deps[0].name == "duckdb"
         assert deps[0].cap_major == 2
 
+    def test_collects_minor_cap_without_truncating_to_major(self, tmp_path: Path) -> None:
+        py, lk = _write(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["duckdb>=1.0.0,<1.4.0"]
+""",
+            """
+[[package]]
+name = "duckdb"
+version = "1.3.2"
+""",
+        )
+        deps = collect_capped_deps(py, lk)
+        assert len(deps) == 1
+        assert deps[0].cap_major == 1
+        assert deps[0].cap_text == "1.4.0"
+        assert deps[0].cap_display == "1.4.0"
+
     def test_deduplicates_multiple_declarations(self, tmp_path: Path) -> None:
         py, lk = _write(
             tmp_path,
@@ -138,17 +179,37 @@ dev = ["click>=8,<9"]
 
 
 class TestSeverityFlags:
-    def test_cap_reached_when_locked_major_at_cap(self) -> None:
-        dep = CappedDep(name="x", cap_major=3, locked_version="3.0.0")
+    def test_cap_reached_when_locked_version_at_full_cap(self) -> None:
+        dep = CappedDep(name="x", cap_major=1, locked_version="1.4.0", cap_text="1.4.0")
         assert dep.cap_reached
         assert not dep.ceiling_minus_one
 
-    def test_cap_reached_when_locked_major_above_cap(self) -> None:
-        dep = CappedDep(name="x", cap_major=3, locked_version="4.1.0")
+    def test_cap_reached_when_locked_version_above_full_cap(self) -> None:
+        dep = CappedDep(name="x", cap_major=1, locked_version="1.4.1", cap_text="1.4.0")
         assert dep.cap_reached
+
+    def test_healthy_when_locked_version_below_minor_cap(self) -> None:
+        dep = CappedDep(name="duckdb", cap_major=1, locked_version="1.3.2", cap_text="1.4.0")
+        assert not dep.cap_reached
+        assert not dep.ceiling_minus_one
 
     def test_ceiling_minus_one_when_locked_major_is_cap_minus_one(self) -> None:
         dep = CappedDep(name="x", cap_major=3, locked_version="2.12.5")
+        assert dep.ceiling_minus_one
+        assert not dep.cap_reached
+
+    @pytest.mark.parametrize(
+        ("name", "cap_major", "locked"),
+        [
+            ("sqlglot", 31, "30.6.0"),
+            ("click", 9, "8.3.2"),
+            ("pydantic", 3, "2.12.5"),
+            ("pyarrow", 25, "24.0.0"),
+            ("roman-numerals", 4, "3.1.0"),
+        ],
+    )
+    def test_known_major_caps_remain_ceiling_minus_one(self, name: str, cap_major: int, locked: str) -> None:
+        dep = CappedDep(name=name, cap_major=cap_major, locked_version=locked, cap_text=f"{cap_major}.0.0")
         assert dep.ceiling_minus_one
         assert not dep.cap_reached
 
@@ -199,6 +260,34 @@ dependencies = ["pydantic>=2{cap}"]
         py, lk = self._fixture(tmp_path, "2.12.5")
         rc = main(["--fail-on=cap-reached", f"--pyproject={py}", f"--lock={lk}"])
         assert rc == 0
+
+    def test_minor_cap_exits_zero_when_below_full_cap(self, tmp_path: Path) -> None:
+        py, lk = _write(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["duckdb>=1.0.0,<1.4.0"]
+""",
+            '[[package]]\nname = "duckdb"\nversion = "1.3.2"\n',
+        )
+        rc = main(["--fail-on=cap-reached", f"--pyproject={py}", f"--lock={lk}"])
+        assert rc == 0
+
+    def test_minor_cap_exits_non_zero_when_at_full_cap(self, tmp_path: Path) -> None:
+        py, lk = _write(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["duckdb>=1.0.0,<1.4.0"]
+""",
+            '[[package]]\nname = "duckdb"\nversion = "1.4.0"\n',
+        )
+        rc = main(["--fail-on=cap-reached", f"--pyproject={py}", f"--lock={lk}"])
+        assert rc == 1
 
     def test_ceiling_minus_one_exits_non_zero_when_at_cap_minus_one(self, tmp_path: Path) -> None:
         py, lk = self._fixture(tmp_path, "2.12.5")


### PR DESCRIPTION
## Summary
- Parse and retain full exclusive upper bounds in scripts/check_dependency_bounds.py.
- Compare locked versions against the full cap for cap-reached failures.
- Preserve existing ceiling-minus-one warning behavior for major-only caps.
- Add focused unit tests for duckdb <1.4.0 and existing major caps.

## Validation
- uv run -- python -m pytest tests/unit/scripts/test_check_dependency_bounds.py -q
- uv run -- python scripts/check_dependency_bounds.py --fail-on=cap-reached
- uv run ruff check scripts/check_dependency_bounds.py tests/unit/scripts/test_check_dependency_bounds.py
- uv run ruff format --check scripts/check_dependency_bounds.py tests/unit/scripts/test_check_dependency_bounds.py
- git diff --check

## Important release constraint
- Do not create v0.3.1.
- The goal is to recover and publish v0.3.0.
- PR #466 is already merged and cannot be reopened.
- Tag v0.3.0 was pushed and release workflow run 26107711800 failed before build/publish.
- PyPI does not have benchbox 0.3.0, and no GitHub Release exists, so v0.3.0 is still recoverable.
- Fix the dependency-bounds bug on a focused branch from develop.
- Open the fix PR against develop.
- After the fix merges to develop, recut the v0.3.0 release branch from develop with the fix included.
- Do not move/delete/re-push tag v0.3.0 unless explicitly authorized after the repaired v0.3.0 release branch is ready.