### PR TITLE
[codex] Restore prompt copy contrast in light mode

### DIFF
--- a/landing/prompts/prompts.css
+++ b/landing/prompts/prompts.css
@@ -141,7 +141,7 @@ body::before {
     padding: var(--space-md);
     font-family: var(--font-mono);
     font-size: 0.85rem;
-    color: var(--text-primary);
+    color: var(--code-fg);
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;

--- a/tests/unit/landing/test_landing_quickstarts.py
+++ b/tests/unit/landing/test_landing_quickstarts.py
@@ -465,6 +465,15 @@ def test_agent_prompt_includes_output_discipline_and_summary_labels():
     assert "capture_plans_footer" in prompts_js
 
 
+def test_prompt_code_blocks_use_code_foreground_token():
+    prompts_css = PROMPTS_CSS_PATH.read_text(encoding="utf-8")
+    pre_rule = prompts_css[prompts_css.index(".prompts-block pre") : prompts_css.index(".prompts-copy")]
+
+    assert "background: var(--code-bg);" in pre_rule
+    assert "color: var(--code-fg);" in pre_rule
+    assert "color: var(--text-primary);" not in pre_rule
+
+
 def test_mcp_prompt_uses_smoke_and_cost_gates():
     prompts_js = PROMPTS_JS_PATH.read_text(encoding="utf-8")
     mcp_block = prompts_js[


### PR DESCRIPTION
## Summary

Fixes the `/prompts/` agent prompt block being effectively invisible in light mode.

## Root Cause

The prompt `<pre>` uses the dark `--code-bg` panel in both themes, but its foreground was `--text-primary`. In light mode that resolves to near-black text on a near-black code panel, so the generated prompt only became readable when selected.

## Changes

- Use `--code-fg` for `/prompts/` prompt/code block text so it pairs with `--code-bg` in light and dark themes.
- Add a landing-page regression assertion that prompt code blocks use the code foreground token instead of page text color.

## Validation

- `uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q` -> `75 passed`
- Headless Chrome computed-style check for `/prompts/` in light mode: `#prompt-text` rendered visible with `rgb(248, 250, 252)` text on `rgb(15, 23, 42)` background.
- `uv run ruff check . && uv run ty check && uv run -- python -m pytest -m fast -q` -> ruff passed, ty completed with existing project-wide warnings, fast pytest passed: `22587 passed, 5 skipped`.
