### PR TITLE
[codex] Add release hardening TODO plan

### DIFF
--- a/_project/TODO/import-surface-reduction/planning/lazy-platform-import-surface.yaml
+++ b/_project/TODO/import-surface-reduction/planning/lazy-platform-import-surface.yaml
@@ -1,0 +1,155 @@
+id: "lazy-platform-import-surface"
+title: "Shrink the import-benchbox surface: lazy platform/adapter imports"
+worktree: "import-surface-reduction"
+priority: "Medium"
+status: "Not Started"
+description: |
+  The v0.3.0 failure was a symptom of an over-broad top-level import surface.
+  `import benchbox` eagerly pulls in the unified adapter factory and every
+  platform adapter:
+    benchbox/__init__.py:28      from . import platforms
+    platforms/__init__.py:330    from benchbox.platforms.adapter_factory import (...)
+    adapter_factory.py:17        from benchbox.platforms.clickhouse.deployment_mode import (...)
+    clickhouse/__init__.py:5 -> adapter.py:13 -> setup.py:9 -> client.py:11 (import pandas)
+  So a bare `import benchbox` requires pandas (and would require any heavy dep
+  pulled by any eagerly-imported adapter). The benchmark registry is ALREADY
+  lazy (benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + module __getattr__),
+  but `from . import platforms` bypasses that pattern.
+
+  REFRAME: the immediate fix (pandas in core) is correct given today's surface,
+  but the durable fix is to make the surface match the contract. Target: bare
+  `import benchbox` imports NO platform clients, NO cloud SDKs, NO DataFrame
+  backends unless explicitly requested. Only after that architectural proof can
+  a separate dependency-placement decision consider whether pandas (and other
+  adapter deps) should return to extras-only.
+
+  This is the architectural follow-up. It MUST land behind the
+  import-contract-regression-test so the refactor is guarded by a test that
+  proves the eager surface stays clean — otherwise this refactor could itself
+  silently re-introduce or mask an eager dep.
+
+category: "Architecture"
+
+prior_art:
+  - "benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + __getattr__ — extend (apply the same lazy pattern to `platforms`/adapter access; this is the canonical reuse target, NOT a new mechanism)"
+  - "benchbox/platforms/__init__.py:330 eager adapter_factory import — supersede (make lazy)"
+  - "benchbox/platforms/adapter_factory.py:17 eager clickhouse import — supersede (resolve adapters on first use)"
+  - "benchbox/platforms/clickhouse/client.py:11 `import pandas as pd` — extend (move into the functions that do DataFrame conversion, or guard with a targeted ImportError)"
+
+decision_gates:
+  - id: g1
+    gate: >-
+      DECISION: pandas core vs optional. Option A (keep `pandas>=2.0.0` in
+      [project].dependencies) — simple, honest with current surface, already
+      shipped. Option B (pandas optional via extras) — only valid AFTER this
+      refactor makes the platforms/ClickHouse imports lazy/guarded. Do NOT move
+      pandas out of core in this TODO. If w1-w4 prove the eager surface is clean
+      and Option B is still desired, create a separate dependency-placement TODO
+      / ADR that explicitly includes pyproject.toml and release smoke coverage.
+      Until that follow-up lands, pandas stays core.
+    blocks: [w5]
+
+work:
+  - id: w1
+    summary: >-
+      Make `benchbox.platforms` lazy using the existing __getattr__ pattern so
+      platform modules load on first access.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Make adapter_factory resolve ClickHouse (and peer) adapters on first use
+      rather than importing them at module load (adapter_factory.py:17).
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: >-
+      Defer or guard ClickHouse pandas imports, then audit other top-level
+      pandas imports that may sit on reachable eager paths.
+    needs: [w2]
+    status: pending
+
+  - id: w4
+    summary: >-
+      Re-run import-contract and importtime checks, then update assertions so
+      platform/dataframe deps stay off the eager path.
+    needs: [w3]
+    status: pending
+
+  - id: w5
+    summary: >-
+      Record the g1 pandas-placement outcome; if Option B remains desirable,
+      create a separate dependency-placement TODO/ADR.
+    needs: [w4]
+    status: pending
+
+must_preserve:
+  - "All public benchmark classes remain importable: `from benchbox import TPCH, TPCDS, ...` and `benchbox.platforms.get_platform_adapter(...)` keep working"
+  - "MCP/CLI entrypoints (benchbox.cli.main:main, benchbox.mcp.cli:main) and `benchbox --help` behavior unchanged"
+  - "Public re-exports in __all__ (benchbox/__init__.py:178-206) and the lazy __getattr__ error-reporting behavior"
+  - "No change to platform runtime behavior — only WHEN modules are imported, not WHAT they do"
+
+approach: |
+  This is the highest-risk item — it touches the package's import topology.
+  Land it strictly after import-contract-regression-test so every step is
+  guarded. Reuse the existing __getattr__ machinery; do NOT invent a second lazy
+  mechanism. Sequence: lazy platforms (w1) -> lazy adapter resolution (w2) ->
+  defer/guard pandas in adapters (w3) -> verify clean eager surface (w4) ->
+  only then record or spin out the pandas-placement decision (w5, gated by g1).
+  Expect circular-import landmines: __init__.py:14-16 already documents that the
+  platforms import chain circles back to read benchbox.__version__; preserve that
+  ordering.
+
+anti_patterns:
+  - "DO NOT move pandas out of core in this TODO — after w4 proves the eager surface is clean, g1 may only record Option A or create a separate dependency-placement TODO/ADR for Option B."
+  - "DO NOT introduce a new lazy-loading framework — extend the existing _BENCHMARK_REGISTRY/__getattr__ pattern (benchbox/__init__.py:71-174)."
+  - "DO NOT break the documented version-before-platforms import ordering (benchbox/__init__.py:14-17)."
+  - "DO NOT land this without the import-contract test in place (deps.needs) — the refactor must be regression-guarded."
+
+verification:
+  - description: "Bare import no longer pulls pandas/clickhouse onto the eager path"
+    command: 'uv run --isolated --no-project --with <wheel-without-pandas-extra> -- python -c "import benchbox; print(\"ok\")"'
+    expected_output: "ok (only after w1-w3); pandas not in sys.modules after `import benchbox`"
+  - description: "Full test suite + import-contract test still pass"
+    command: "uv run -- python -m pytest tests -m fast -q && uv run -- python -m pytest tests/unit/test_package_dependencies.py -q"
+    expected_output: "all pass"
+  - description: "Public API and CLI unchanged"
+    command: 'uv run -- python -c "from benchbox import TPCH, TPCDS, ClickBench; import benchbox.platforms" && uv run -- benchbox --help'
+    expected_output: "imports succeed; --help output unchanged"
+
+scope_limit:
+  only_modify:
+    - "benchbox/__init__.py"
+    - "benchbox/platforms/__init__.py"
+    - "benchbox/platforms/adapter_factory.py"
+    - "benchbox/platforms/clickhouse/"
+    - "benchbox/core/tpcdi/"
+    - "tests/unit/test_package_dependencies.py"
+  do_not_modify:
+    - ".github/workflows/"
+    - "pyproject.toml"
+
+deps:
+  needs: ["import-contract-regression-test"]
+
+impact:
+  technical_debt: |
+    Aligns the declared core dependencies with the actual import-time needs,
+    reduces install weight, and improves `import benchbox` latency. Makes the
+    minimal-runtime contract enforceable by construction rather than by gate.
+  user_impact: |
+    Smaller, faster core install for users who don't use heavy platforms.
+
+success_metrics:
+  - "`import benchbox` imports no platform client, cloud SDK, or DataFrame backend (verified via sys.modules / importtime)."
+  - "import-contract test passes asserting pandas/clickhouse are off the eager path."
+
+open_questions:
+  - "Does any current consumer rely on `benchbox.platforms` side-effects at import time (e.g., platform registration)? Audit core/platform_registry.py:auto_register_platforms before making platforms lazy."
+  - "If pandas goes optional (g1 Option B), which default install experience do we want for `pip install benchbox` — does the CLI still work end-to-end without pandas?"
+
+metadata:
+  tags: ["architecture", "imports", "performance", "packaging"]
+  estimated_effort: "Large"
+  created_date: "2026-05-20"

--- a/_project/TODO/release-pipeline-hardening/planning/ci-isolated-wheel-smoke-gates.yaml
+++ b/_project/TODO/release-pipeline-hardening/planning/ci-isolated-wheel-smoke-gates.yaml
@@ -1,0 +1,147 @@
+id: "ci-isolated-wheel-smoke-gates"
+title: "Make the install/publish smoke gates hermetic and pre-publish"
+worktree: "release-pipeline-hardening"
+priority: "Critical"
+status: "Not Started"
+description: |
+  v0.3.0 shipped to PyPI with pandas missing from core dependencies. A clean
+  `pip install benchbox` then `import benchbox` failed with
+  `ModuleNotFoundError: No module named 'pandas'` because the eager import
+  chain `benchbox/__init__.py:28 -> platforms/__init__.py:330 ->
+  adapter_factory.py:17 -> clickhouse/__init__.py:5 -> adapter.py:13 ->
+  setup.py:9 -> clickhouse/client.py:11 (import pandas)` requires pandas, while
+  pandas was declared only in extras at tag b2559016b.
+
+  The pipeline had NO gate that actually tested the built wheel in a clean,
+  off-project environment before publishing:
+
+  1. Pre-merge `test-package` (.github/workflows/test.yml:284-292) builds a
+     wheel into a clean `test-venv`, but then runs
+     `uv run --python test-venv python -c "import benchbox"`. EMPIRICALLY
+     VERIFIED (2026-05-20): `uv run` invoked inside the project ignores
+     `--python test-venv`, deletes/recreates the project `.venv`, syncs all
+     deps + the `dev` group (199 packages incl. pandas), and imports against
+     THAT. The wheel install is dead code; the import always passes against the
+     dev env. Reproduce:
+       cd <repo>; uv venv /tmp/tv; \
+       uv pip install --python /tmp/tv dist/*.whl; \
+       uv run --python /tmp/tv python -c "import benchbox"
+     -> prints "Removed virtual environment at: .venv / Creating ... / Installed
+     199 packages" then "import OK". Direct `/tmp/tv/bin/python -c "import
+     benchbox"` FAILS with the pandas chain (proves the venv itself is correct).
+
+  2. The only true isolated `pip install benchbox` smoke is the
+     `test-installation` job (.github/workflows/release.yml:184) which has
+     `needs: publish` -> runs AFTER the PyPI upload. PyPI versions are
+     immutable, so it can only signal a post-mortem (hence the same-version
+     `wheel_build_number` repair path, release.yml:13-17,91-98). It also runs
+     `pip install benchbox` unpinned, so it can test a cached/older release.
+
+  This item makes the install gate hermetic, off-repo, exact-versioned, and
+  PRE-publish. Fix #2 (release.yml) added pandas to core, which unbroke install
+  but closed none of these gate gaps.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+  - ".github/workflows/test.yml:256-299 test-package job — extend (replace its broken uv-run import step; keep the build step)"
+  - ".github/workflows/release.yml:184-221 test-installation job — extend (keep as post-publish propagation check; add the new pre-publish gate before publish)"
+  - "Verified working isolated invocation: `uv run --no-project --with <wheel> -- python -c 'import benchbox'` (failed on broken v0.3.0 wheel, passed on repaired wheel) — reuse as the canonical hermetic smoke"
+
+work:
+  - id: w1
+    summary: >-
+      Define one hermetic smoke snippet for import and CLI help, then prove it
+      passes on the repaired wheel and fails on a pandas-stripped wheel.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Replace test-package's broken import step with the w1 snippet, preserving
+      wheel build/upload while ensuring import runs against the wheel-only env.
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: >-
+      Add a release.yml pre-publish smoke gate after build/twine check and make
+      publish depend on that gate.
+    needs: [w1]
+    status: pending
+
+  - id: w4
+    summary: >-
+      Pin post-publish install smoke to the exact release version and document
+      it as propagation/user-path verification, not the first import gate.
+    needs: []
+    status: pending
+
+decision_gates:
+  - id: g1
+    gate: >-
+      Before wiring the snippet into BOTH gates (w2, w3), w1 must demonstrate it
+      FAILS on a pandas-stripped wheel. If it cannot be made to fail on the
+      known-bad artifact, the snippet is not hermetic — stop and fix the snippet
+      before proceeding. Do not merge w2/w3 on a snippet that has only been seen
+      to pass.
+    blocks: [w2, w3]
+
+must_preserve:
+  - "test-package still builds the wheel via `uv build` and uploads the dist artifact (test.yml:294-299)"
+  - "The post-publish test-installation job continues to run on the full OS/Python matrix (release.yml:187-197) as a propagation check"
+  - "release.yml job graph stays acyclic: dependency-bounds -> build -> (pre-publish smoke) -> publish -> github-release/test-installation"
+  - "Windows runners: keep `shell: bash` on the smoke step so glob + mktemp behave (test.yml:285 already does this)"
+
+approach: |
+  Author the snippet once and paste it identically into both workflows so they
+  cannot drift. The `cd "$(mktemp -d)"` + `--no-project` + `--isolated` triple
+  is defense-in-depth: --no-project disables project discovery, mktemp cwd means
+  even a future flag regression finds no pyproject.toml, and the
+  `'site-packages' in __file__` assertion makes any re-entry into the checkout
+  fail loudly instead of silently passing. Validate w1 empirically (both
+  polarities) before touching either workflow — the whole point of this item is
+  that "looks like it passes" was exactly the trap last time.
+
+anti_patterns:
+  - "DO NOT use `uv run --python <venv>` to run the import — VERIFIED it re-syncs the project env (199 pkgs incl. pandas) and tests the wrong environment. Use `uv run --isolated --no-project --with <wheel>` or the venv's own interpreter directly."
+  - "DO NOT rely on a passing run alone as proof — a green smoke against the dev env is exactly the false signal that shipped v0.3.0. Prove it fails on a known-bad wheel (g1)."
+  - "DO NOT keep the post-publish job as the only isolated gate — it is structurally too late (PyPI is immutable). The pre-publish gate (w3) is the real barrier."
+  - "DO NOT leave `pip install benchbox` unpinned in the post-publish smoke — it can resolve a different version than the one just published."
+
+verification:
+  - description: "Snippet passes on the current (repaired) wheel"
+    command: 'uv build --wheel --out-dir /tmp/bbw && cd "$(mktemp -d)" && uv run --isolated --no-project --with /tmp/bbw/*.whl -- python -c "import benchbox; print(benchbox.__version__)"'
+    expected_output: "prints 0.3.0 (or current version), exit 0"
+  - description: "Snippet FAILS on a pandas-stripped wheel (proves the gate bites)"
+    command: "build a wheel from a tree with the `pandas>=2.0.0` core line removed, run the same snippet"
+    expected_output: "ModuleNotFoundError: No module named 'pandas' via clickhouse/client.py:11, exit non-zero"
+  - description: "Workflows are valid YAML and the publish job depends on the new pre-publish gate"
+    command: "uv run -- python -c \"import yaml,sys; [yaml.safe_load(open(f)) for f in ['.github/workflows/test.yml','.github/workflows/release.yml']]; print('yaml ok')\""
+    expected_output: "yaml ok; manual review confirms publish.needs includes the pre-publish smoke"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/test.yml"
+    - ".github/workflows/release.yml"
+  do_not_modify:
+    - "pyproject.toml"
+    - "benchbox/"
+
+impact:
+  user_impact: |
+    Prevents shipping an un-importable package to PyPI. Users doing a plain
+    `pip install benchbox` get a working import + CLI, which is the v0.3.0
+    failure that triggered this work.
+  technical_debt: |
+    Removes a long-standing false-confidence gate (test-package was effectively
+    a no-op for wheel correctness) and converts post-publish verification into a
+    real pre-publish barrier.
+
+success_metrics:
+  - "A wheel missing any import-time core dependency fails CI before merge AND before publish."
+  - "Post-publish smoke installs the exact released version."
+
+metadata:
+  tags: ["release", "ci", "packaging", "regression"]
+  estimated_effort: "Small"
+  created_date: "2026-05-20"

--- a/_project/TODO/release-pipeline-hardening/planning/dependency-bounds-gate-regression-test.yaml
+++ b/_project/TODO/release-pipeline-hardening/planning/dependency-bounds-gate-regression-test.yaml
@@ -1,0 +1,92 @@
+id: "dependency-bounds-gate-regression-test"
+title: "Lock the dependency-bounds parser against minor/patch-cap regressions"
+worktree: "release-pipeline-hardening"
+priority: "High"
+status: "Not Started"
+description: |
+  The dependency-bounds gate is the ESCALATION VECTOR for the v0.3.0 incident.
+  At tag b2559016b, scripts/check_dependency_bounds.py parsed upper bounds with
+  `<\s*(\d+)(?:\.\d+)*` — capturing only the MAJOR digit — and compared
+  "locked major == cap major". For `duckdb>=1.0.0,<1.4.0` this parsed the cap as
+  major `1`; duckdb's locked `1.3.x` also has major `1`, producing a FALSE
+  POSITIVE "cap reached" and FAILING the gate. Because release.yml chains
+  `dependency-bounds -> build -> publish -> test-installation`, the failing gate
+  meant the legitimate release workflow could not run build/publish/
+  test-installation — yet the package reached PyPI anyway (out-of-band publish),
+  so the post-publish smoke that WOULD have caught missing pandas never ran.
+
+  The recovery commit 038ad5488 ("Release v0.3.0 recovery — Fix dependency
+  bounds version comparison") already fixed the parser: regex now
+  `<\s*(\d+(?:\.\d+)*)` (full version) and comparison uses
+  packaging.version.Version. THIS ITEM does not re-fix it — it adds the
+  regression test that pins the fixed behavior so the gate cannot silently
+  fail-open or fail-closed again. A guard that can misfire is worse than no
+  guard, because it reroutes publish around the real checks.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+  - "scripts/check_dependency_bounds.py — reference only (already fixed by 038ad5488; do NOT re-fix logic, only test it)"
+  - "tests/unit/scripts/test_check_dependency_bounds.py — extend (recovery commit 038ad5488 already touched this file; add the minor/patch-cap cases)"
+
+work:
+  - id: w1
+    summary: >-
+      Add minor/patch cap regression cases for duckdb<1.4.0 and a major-cap
+      control case for pyarrow<25.0.0.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Add parser tests proving `_UPPER_BOUND_RE` captures full upper-bound
+      versions and exotic specifiers fall through safely.
+    needs: [w1]
+    status: pending
+
+must_preserve:
+  - "check_dependency_bounds.py public CLI (--fail-on=cap-reached, --report-only, --output) and offline behavior"
+  - "The recovery commit's Version-based comparison logic — tests must lock it, not change it"
+  - "All five currently-capped deps remain covered: sqlglot<31, click<9, pydantic<3, pyarrow<25, duckdb<1.4.0 (pyproject.toml:33,36,42,48 + dev duckdb)"
+
+approach: |
+  Pure test addition. Read the current (fixed) check_dependency_bounds.py to
+  mirror its CappedDep API (cap_version, cap_text, effective_cap_version,
+  locked_parsed). Construct synthetic CappedDep / lockfile fixtures rather than
+  depending on the live uv.lock so the test is deterministic across dependency
+  bumps. The duckdb<1.4.0 vs 1.3.x case is the exact bug — make it the headline
+  test with a comment linking 038ad5488 and the v0.3.0 incident.
+
+anti_patterns:
+  - "DO NOT modify check_dependency_bounds.py logic — it is already fixed (038ad5488). This item is test-only; touching logic risks reintroducing the bug."
+  - "DO NOT assert against the live uv.lock — it drifts; use synthetic fixtures so the regression test stays stable."
+
+verification:
+  - description: "New regression tests pass against the fixed parser"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_check_dependency_bounds.py -q"
+    expected_output: "all pass, including the duckdb<1.4.0 / 1.3.x case"
+  - description: "Reverting the parser to major-only would fail the new test (sanity, local only)"
+    command: "temporarily restore `<\\s*(\\d+)(?:\\.\\d+)*` + major comparison, run tests, then revert"
+    expected_output: "duckdb<1.4.0/1.3.x case fails -> proves the regression test bites"
+
+scope_limit:
+  only_modify:
+    - "tests/unit/scripts/test_check_dependency_bounds.py"
+  do_not_modify:
+    - "scripts/check_dependency_bounds.py"
+    - ".github/workflows/release.yml"
+
+impact:
+  technical_debt: |
+    Prevents the release-gate parser from regressing into the exact misfire that
+    rerouted the v0.3.0 publish around the post-publish smoke.
+
+success_metrics:
+  - "A reintroduction of the major-only cap comparison is caught by CI."
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["release", "ci", "testing", "regression"]
+  estimated_effort: "Small"
+  created_date: "2026-05-20"

--- a/_project/TODO/release-pipeline-hardening/planning/import-contract-regression-test.yaml
+++ b/_project/TODO/release-pipeline-hardening/planning/import-contract-regression-test.yaml
@@ -1,0 +1,112 @@
+id: "import-contract-regression-test"
+title: "Add an import-contract test: every import-time dep must be in core"
+worktree: "release-pipeline-hardening"
+priority: "High"
+status: "Not Started"
+description: |
+  Root cause of the v0.3.0 incident: `import benchbox` eagerly imports pandas
+  (via the ClickHouse adapter, clickhouse/client.py:11), but pandas was declared
+  only in extras. The masking substrate is permanent: flat-layout editable
+  install + pandas in the `dev` group + `uv sync --group dev` in every CI job
+  means bare `import benchbox` can never fail in dev/CI. There was NO test
+  asserting the package is importable with only its declared CORE dependencies.
+
+  The fix (7334727b2) added `tests/unit/test_package_dependencies.py` asserting
+  pandas specifically is in core. Note `tests/unit/test_init.py:78` does the
+  OPPOSITE — `@pytest.mark.skipif(not PANDAS_AVAILABLE)` — treating pandas as
+  optional, so the suite tolerated its absence.
+
+  This item generalizes the one-off pandas assertion into a durable contract:
+  every unguarded top-level third-party module reachable from `import benchbox`
+  (and `benchbox --help`) must be declared in `[project].dependencies`, with an
+  explicit allowlist for modules that are known-optional AND lazily/guard-
+  imported. This catches the whole class, not just pandas, and is the test that
+  guards the lazy-import refactor (import-surface-reduction) from regressing.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+  - "tests/unit/test_package_dependencies.py — extend (added by fix 7334727b2; currently asserts only pandas-in-core; generalize to a full contract)"
+  - "tests/unit/test_init.py:78 PANDAS_AVAILABLE skipif — reference (illustrates the suite previously treated pandas as optional; the new test must NOT skip)"
+  - "benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + __getattr__ lazy pattern — reference (defines what 'lazy/guarded is acceptable' means for the allowlist)"
+
+work:
+  - id: w1
+    summary: >-
+      Choose and document the fast-lane import-contract mechanism; do not build
+      or install wheels in this unit test.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Implement the eager import contract test and assert every unguarded
+      third-party import is declared in core dependencies.
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: >-
+      Strengthen the pandas assertion and ensure the new contract test fails,
+      rather than skips, when a required dependency is absent.
+    needs: [w2]
+    status: pending
+
+must_preserve:
+  - "Existing tests/unit/test_package_dependencies.py assertions keep passing"
+  - "The test runs in the default fast lane (no network, no extras install) so it gates every PR via test.yml"
+  - "Test must work on Python 3.10 (note d146d2173 'Fix package dependency test on Python 3.10' — respect tomllib/tomli split, pyproject.toml:46)"
+
+approach: |
+  Reuse importlib.metadata to map import names -> distributions and tomllib to
+  read [project].dependencies (handle the tomli fallback for 3.10). For the
+  eager-graph walk, import benchbox in a subprocess with `-X importtime` or
+  instrument sys.modules before/after `import benchbox` to get the real eager
+  set rather than guessing statically. Seed KNOWN_OPTIONAL from the extras in
+  pyproject.toml (clickhouse-connect, snowflake, etc.) and assert none of them
+  appear in the eager set — that assertion is what fails loudly if a future
+  edit makes an optional adapter eager again. Keep this test in the ordinary
+  pytest lane; isolated wheel installation and CLI smoke checks belong to the
+  workflow gate in ci-isolated-wheel-smoke-gates.
+
+anti_patterns:
+  - "DO NOT skipif when a dependency is missing (the test_init.py:78 pattern) — that is precisely how the suite tolerated missing pandas. The contract test must FAIL, not skip."
+  - "DO NOT hardcode only pandas — the point is to catch the next undeclared eager import (pyarrow, numpy, or a future adapter dep), not refight the last war."
+  - "DO NOT parse imports with regex alone — guarded `try/except ImportError` and function-scoped imports must be excluded; use AST or runtime sys.modules diffing."
+  - "DO NOT build or install wheels in this unit test — that coverage is owned by ci-isolated-wheel-smoke-gates, which tests the actual wheel artifact off-project."
+
+verification:
+  - description: "Contract test passes on current tree (pandas is in core)"
+    command: "uv run -- python -m pytest tests/unit/test_package_dependencies.py -q"
+    expected_output: "all pass"
+  - description: "Contract test FAILS if pandas is removed from core (temporarily, locally)"
+    command: "remove the pandas core line, run the test, then restore"
+    expected_output: "test fails citing pandas / clickhouse/client.py:11"
+  - description: "Runs in fast lane on 3.10 and 3.12"
+    command: 'uv run --python 3.10 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q && uv run --python 3.12 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q'
+    expected_output: "collected and passing under both interpreters"
+
+scope_limit:
+  only_modify:
+    - "tests/unit/test_package_dependencies.py"
+    - "tests/unit/"
+  do_not_modify:
+    - "benchbox/"
+    - ".github/workflows/"
+    - "pyproject.toml"
+
+impact:
+  technical_debt: |
+    Converts a one-off "pandas is core" assertion into a reusable contract that
+    keeps the import surface honest and guards the planned lazy-import refactor.
+
+success_metrics:
+  - "Any undeclared third-party import added to the eager `import benchbox` path fails this test."
+  - "The test never skips on a missing dependency."
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["testing", "packaging", "regression", "import-contract"]
+  estimated_effort: "Medium"
+  created_date: "2026-05-20"

--- a/_project/TODO/release-pipeline-hardening/planning/release-artifact-attestation-and-publish-policy.yaml
+++ b/_project/TODO/release-pipeline-hardening/planning/release-artifact-attestation-and-publish-policy.yaml
@@ -1,0 +1,117 @@
+id: "release-artifact-attestation-and-publish-policy"
+title: "Attest release artifacts before publish and document the no-bypass policy"
+worktree: "release-pipeline-hardening"
+priority: "Medium-High"
+status: "Not Started"
+description: |
+  The v0.3.0 incident was not only a missing dependency and weak install smoke
+  coverage. The dependency-bounds false positive blocked the legitimate release
+  workflow, yet the package still reached PyPI out-of-band. That means the
+  release process lacked a durable artifact attestation and a policy barrier
+  saying "only publish the artifact that passed the pre-publish gates."
+
+  ci-isolated-wheel-smoke-gates makes the normal workflow hermetic and
+  pre-publish. This item closes the remaining bypass blind spot: every release
+  artifact must carry a compact, reviewable attestation that records the exact
+  wheel/sdist path, version, metadata dependency excerpt, isolated import smoke,
+  isolated CLI smoke, and the git SHA used to produce it. Manual or emergency
+  release repair must either use the same attested artifact path or document why
+  the gate could not run before any upload.
+
+category: "Release Engineering"
+
+prior_art:
+  - ".github/workflows/release.yml:build job — extend (emit the attestation after build, metadata inspection, twine check, and pre-publish smoke)"
+  - ".github/workflows/release.yml:publish job — extend (consume the attestation artifact and publish only artifacts produced by the gated build job)"
+  - "_project/TODO/release-pipeline-hardening/planning/ci-isolated-wheel-smoke-gates.yaml — depends on (pre-publish import/CLI smoke must exist before this attestation is meaningful)"
+
+work:
+  - id: w1
+    summary: >-
+      Define the compact release attestation format with exact artifact, hash,
+      metadata, smoke-result, version, and SHA fields.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Emit the attestation from release.yml after the pre-publish smoke gate
+      passes and before publish. Upload it as a workflow artifact and print a
+      short summary in the GitHub Actions step summary.
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: >-
+      Make publish consume the attestation and fail on missing, mismatched, or
+      incomplete artifact evidence.
+    needs: [w2]
+    status: pending
+
+  - id: w4
+    summary: >-
+      Document the no-bypass policy and equivalent evidence requirements for
+      manual or emergency release repair.
+    needs: [w1]
+    status: pending
+
+must_preserve:
+  - "Existing release.yml build -> pre-publish smoke -> publish job ordering from ci-isolated-wheel-smoke-gates"
+  - "No secrets or PyPI tokens in attestation output, step summaries, or artifacts"
+  - "No raw stdout transcript committed to the repo; durable summaries only"
+  - "The same-version repair flow remains possible, but must produce its own attestation for the repaired wheel"
+
+approach: |
+  Keep the attestation simple and machine-checkable: a small JSON or YAML file
+  generated in the release workflow, plus a human-readable step summary. Prefer
+  shell/Python snippets already available in the workflow over a new dependency.
+  Hash the exact files in dist/, inspect wheel METADATA with unzip, and reuse the
+  isolated smoke output from ci-isolated-wheel-smoke-gates. The publish job should
+  validate the attestation before upload so a future bounds-gate or workflow
+  misfire cannot silently route around the only artifact that passed smoke.
+
+anti_patterns:
+  - "DO NOT make attestation a post-publish-only artifact — the point is to gate publish."
+  - "DO NOT attest a version range or package name only — attest exact artifact filenames, hashes, version, and git SHA."
+  - "DO NOT include PyPI tokens, environment dumps, or raw long logs in the committed policy text."
+  - "DO NOT allow a manual publish path with weaker evidence than the automated release path."
+
+verification:
+  - description: "Attestation is generated before publish and references the exact dist artifacts"
+    command: "dry-run the release build/pre-publish path or inspect workflow graph after editing"
+    expected_output: "attestation artifact contains SHA/version/filename/hash/Requires-Dist/smoke summaries for each upload candidate"
+  - description: "Publish fails if attestation is missing or mismatched"
+    command: "run the workflow validation/unit test added with the implementation, or locally exercise the validation snippet against a mismatched fixture"
+    expected_output: "non-zero exit with a clear mismatch message"
+  - description: "Manual release policy is discoverable"
+    command: "review the release documentation section added by this item"
+    expected_output: "documents required evidence for any manual/emergency upload"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/release.yml"
+    - "docs/"
+    - "README.md"
+    - "_project/TODO/release-pipeline-hardening/planning/release-artifact-attestation-and-publish-policy.yaml"
+  do_not_modify:
+    - "benchbox/"
+    - "pyproject.toml"
+
+impact:
+  user_impact: |
+    Reduces the chance that a broken package can be uploaded through an
+    emergency/manual path after a release-gate failure.
+  technical_debt: |
+    Turns release evidence into an explicit artifact instead of relying on
+    scattered CI logs or operator memory.
+
+success_metrics:
+  - "Every publish job validates an attestation for the exact artifacts it uploads."
+  - "A manual/emergency publish has an explicit documented evidence checklist."
+
+deps:
+  needs: ["ci-isolated-wheel-smoke-gates"]
+
+metadata:
+  tags: ["release", "ci", "attestation", "packaging"]
+  estimated_effort: "Medium"
+  created_date: "2026-05-20"

--- a/_project/TODO/release-pipeline-hardening/planning/relocate-reverse-dependency-audit.yaml
+++ b/_project/TODO/release-pipeline-hardening/planning/relocate-reverse-dependency-audit.yaml
@@ -1,0 +1,111 @@
+id: "relocate-reverse-dependency-audit"
+title: "Make dependency audit release-visible and add imported-but-undeclared direction"
+worktree: "release-pipeline-hardening"
+priority: "Medium-High"
+status: "Not Started"
+description: |
+  The dependency audit failed the v0.3.0 incident twice over:
+
+  1. WRONG DIRECTION. `make audit-deps` (Makefile:429-432) "checks that every
+     declared dep has an import site or is allowlisted. Fails if an UNUSED dep
+     is introduced." That is declared-but-unused — the OPPOSITE of the v0.3.0
+     bug (pandas was imported-but-undeclared). It could never have caught a
+     missing declaration.
+
+  2. SKIPPED ON RELEASE. The script lives at
+     `_project/scripts/dependency_audit/check_deps.py`, but `_project/` is
+     pruned on curated release branches (VERIFIED absent at tag b2559016b and
+     absent locally). lint.yml:56-62 explicitly skips it: "if [ -d
+     _project/scripts ]; then make audit-deps; else echo '... absent on curated
+     release branches; skipping dependency audit.'" So on the release-cut PR
+     (base=main) the audit does not run at all.
+
+  This item makes the release-relevant audit run on release branches (relocate
+  out of pruned _project/) and adds the missing imported-but-undeclared
+  direction so the audit covers BOTH failure modes. Note: the
+  import-contract-regression-test item already covers the eager `import
+  benchbox` path; this audit complements it by covering the broader declared
+  surface and the CLI path.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+  - "_project/scripts/dependency_audit/check_deps.py — supersede/relocate (declared-but-unused direction; lives under pruned _project/, never runs on release). Relocate the release-relevant part to scripts/ or tests/."
+  - "Makefile:429-432 audit-deps target — extend (repoint to the relocated script)"
+  - ".github/workflows/lint.yml:56-62 + pr.yml:183 — extend (remove the `_project/scripts` existence guard for the relocated check so it runs on release branches)"
+  - "import-contract-regression-test (this worktree) — reference (covers eager import path; avoid duplicating its scope — this item owns the declared-surface + CLI direction)"
+
+work:
+  - id: w1
+    summary: >-
+      Decide the release-visible home for the audit and relocate the
+      release-relevant logic out of pruned _project paths.
+    status: pending
+
+  - id: w2
+    summary: >-
+      Add a whole-tree imported-but-undeclared audit direction while preserving
+      existing declared-but-unused detection.
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: >-
+      Wire the relocated audit into CI without the _project skip guard and
+      verify it still runs in a curated checkout.
+    needs: [w1]
+    status: pending
+
+must_preserve:
+  - "Existing declared-but-unused detection keeps working (do not regress the original audit purpose)"
+  - "Developer-only portions of the audit may stay in _project/; only the release-relevant check must relocate"
+  - "lint.yml and pr.yml triggers (push/PR to main) unchanged"
+
+approach: |
+  Prefer a tests/ unit test for the relocated, release-relevant portion — it
+  then runs automatically in the existing pytest lane on every main PR without a
+  bespoke Makefile/CI guard, sidestepping the `_project/` pruning problem
+  entirely. Keep `make audit-deps` for the richer developer-side report. Reuse
+  the import-name -> distribution mapping approach from the import-contract test
+  to avoid two divergent import scanners.
+
+anti_patterns:
+  - "DO NOT leave the release-relevant audit under _project/ — VERIFIED it is pruned on release branches and the CI guard silently skips it there."
+  - "DO NOT only check declared-but-unused — that direction is blind to the v0.3.0 failure (imported-but-undeclared). Cover both."
+  - "DO NOT duplicate the eager-import scanner from import-contract-regression-test — depend on that item for shared import-name/distribution mapping, and keep this audit focused on whole-tree declared-surface coverage."
+
+verification:
+  - description: "Relocated audit runs even without _project/ present"
+    command: "rename _project temporarily, run the relocated check (or its pytest), confirm it executes"
+    expected_output: "audit runs and passes; no 'skipping' message"
+  - description: "Imported-but-undeclared direction catches a synthetic violation"
+    command: "add a throwaway top-level `import <undeclared-pkg>` in a benchbox module, run the audit"
+    expected_output: "audit fails naming the undeclared module; remove the throwaway after"
+
+scope_limit:
+  only_modify:
+    - "scripts/"
+    - "tests/"
+    - "Makefile"
+    - ".github/workflows/lint.yml"
+    - ".github/workflows/pr.yml"
+  do_not_modify:
+    - "benchbox/"
+    - "pyproject.toml"
+
+impact:
+  technical_debt: |
+    Closes the audit's two-way blind spot and makes it actually run where
+    releases are cut.
+
+success_metrics:
+  - "Both an unused declaration and an undeclared import are caught on a main PR."
+  - "The audit runs on curated release branches (no silent skip)."
+
+deps:
+  needs: ["import-contract-regression-test"]
+
+metadata:
+  tags: ["ci", "dependencies", "audit", "release"]
+  estimated_effort: "Medium"
+  created_date: "2026-05-20"


### PR DESCRIPTION
## Summary

Adds the validated TODO plan for the BenchBox v0.3.0 missing-pandas release incident follow-up. The plan now covers hermetic wheel smoke gates, import-contract regression coverage, dependency-bounds parser regression tests, release-visible reverse dependency audit, lazy import-surface reduction, and the missing release-artifact attestation/manual-publish guard.

## Why

The prior TODO set covered most of the synthesized prevention plan but still had internal conflicts and one missing final-plan item. This PR fixes those planning gaps before implementation starts.

## Validation

- `uv run --project ~/.claude/tools/todo todo-validate --all --root /Users/joe/Developer/BenchBox.todo-release-hardening-fixes`
- `uv run --project ~/.claude/tools/todo todo-cli check-graph`
- `uv run --project ~/.claude/tools/todo todo-cli ready`
- `uv run --project ~/.claude/tools/todo todo-index`
- commit hooks: codespell, check yaml, eof, trailing whitespace, large files, merge conflicts, private key
- push hooks: timing policy fast-lane collect, pr-preflight fast tests

## Notes

No package code, tags, release branches, publish actions, or version changes are included.