### PR TITLE
ci: add hermetic wheel smoke gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,31 @@ jobs:
           path: dist/
           retention-days: 30
 
-  publish:
+  pre-publish-smoke:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist/
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Test wheel import and CLI before publish
+        shell: bash
+        run: |
+          # --no-project plus a temp cwd prevents uv from syncing a checkout env.
+          wheel="$(echo "$PWD"/dist/*.whl)"
+          smoke_dir="$(mktemp -d)"
+          cd "$smoke_dir"
+          uv run --isolated --no-project --with "$wheel" -- python -c "import benchbox; assert 'site-packages' in benchbox.__file__, benchbox.__file__; print(f'BenchBox {benchbox.__version__} imported from wheel')"
+          uv run --isolated --no-project --with "$wheel" -- benchbox --help
+
+  publish:
+    needs: pre-publish-smoke
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.event.inputs.test_pypi == 'true' && 'test-pypi' || 'pypi' }}
@@ -182,7 +205,7 @@ jobs:
 
   # Verify installation works across platforms after publishing
   test-installation:
-    needs: publish
+    needs: [publish, build]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -208,14 +231,14 @@ jobs:
       - name: Test installation from PyPI
         if: github.event.inputs.test_pypi != 'true'
         run: |
-          pip install benchbox
+          pip install "benchbox==${{ needs.build.outputs.version }}"
           python -c "import benchbox; print(f'BenchBox {benchbox.__version__} installed successfully')"
           benchbox --help
 
       - name: Test installation from Test PyPI
         if: github.event.inputs.test_pypi == 'true'
         run: |
-          pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ benchbox
+          pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "benchbox==${{ needs.build.outputs.version }}"
           python -c "import benchbox; print(f'BenchBox {benchbox.__version__} installed successfully')"
           benchbox --help
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,12 +284,13 @@ jobs:
       - name: Test package installation
         shell: bash
         run: |
-          # Use bash on all platforms so glob expansion works cross-platform.
-          # GitHub Actions Windows runners have Git Bash available.
-          uv venv test-venv
-          uv pip install --python test-venv dist/*.whl
-          uv run --python test-venv python -c "import benchbox; print('Package installation successful')"
-          uv run --python test-venv benchbox --help
+          # Use bash on all platforms so glob expansion and mktemp work cross-platform.
+          # --no-project plus a temp cwd prevents uv from syncing the checkout env.
+          wheel="$(echo "$PWD"/dist/*.whl)"
+          smoke_dir="$(mktemp -d)"
+          cd "$smoke_dir"
+          uv run --isolated --no-project --with "$wheel" -- python -c "import benchbox; assert 'site-packages' in benchbox.__file__, benchbox.__file__; print(f'BenchBox {benchbox.__version__} imported from wheel')"
+          uv run --isolated --no-project --with "$wheel" -- benchbox --help
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/_project/DONE/release-pipeline-hardening/planning/ci-isolated-wheel-smoke-gates.yaml
+++ b/_project/DONE/release-pipeline-hardening/planning/ci-isolated-wheel-smoke-gates.yaml
@@ -1,0 +1,157 @@
+id: "ci-isolated-wheel-smoke-gates"
+title: "Make the install/publish smoke gates hermetic and pre-publish"
+worktree: "release-pipeline-hardening"
+priority: "Critical"
+status: "Completed"
+completed_date: "2026-05-20"
+description: |
+  v0.3.0 shipped to PyPI with pandas missing from core dependencies. A clean
+  `pip install benchbox` then `import benchbox` failed with
+  `ModuleNotFoundError: No module named 'pandas'` because the eager import
+  chain `benchbox/__init__.py:28 -> platforms/__init__.py:330 ->
+  adapter_factory.py:17 -> clickhouse/__init__.py:5 -> adapter.py:13 ->
+  setup.py:9 -> clickhouse/client.py:11 (import pandas)` requires pandas, while
+  pandas was declared only in extras at tag b2559016b.
+
+  The pipeline had NO gate that actually tested the built wheel in a clean,
+  off-project environment before publishing:
+
+  1. Pre-merge `test-package` (.github/workflows/test.yml:284-292) builds a
+     wheel into a clean `test-venv`, but then runs
+     `uv run --python test-venv python -c "import benchbox"`. EMPIRICALLY
+     VERIFIED (2026-05-20): `uv run` invoked inside the project ignores
+     `--python test-venv`, deletes/recreates the project `.venv`, syncs all
+     deps + the `dev` group (199 packages incl. pandas), and imports against
+     THAT. The wheel install is dead code; the import always passes against the
+     dev env. Reproduce:
+       cd <repo>; uv venv /tmp/tv; \
+       uv pip install --python /tmp/tv dist/*.whl; \
+       uv run --python /tmp/tv python -c "import benchbox"
+     -> prints "Removed virtual environment at: .venv / Creating ... / Installed
+     199 packages" then "import OK". Direct `/tmp/tv/bin/python -c "import
+     benchbox"` FAILS with the pandas chain (proves the venv itself is correct).
+
+  2. The only true isolated `pip install benchbox` smoke is the
+     `test-installation` job (.github/workflows/release.yml:184) which has
+     `needs: publish` -> runs AFTER the PyPI upload. PyPI versions are
+     immutable, so it can only signal a post-mortem (hence the same-version
+     `wheel_build_number` repair path, release.yml:13-17,91-98). It also runs
+     `pip install benchbox` unpinned, so it can test a cached/older release.
+
+  This item makes the install gate hermetic, off-repo, exact-versioned, and
+  PRE-publish. Fix #2 (release.yml) added pandas to core, which unbroke install
+  but closed none of these gate gaps.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- ".github/workflows/test.yml:256-299 test-package job — extend (replace its broken uv-run import step; keep the build step)"
+- ".github/workflows/release.yml:184-221 test-installation job — extend (keep as post-publish propagation check; add the new
+  pre-publish gate before publish)"
+- "Verified working isolated invocation: `uv run --no-project --with <wheel> -- python -c 'import benchbox'` (failed on broken
+  v0.3.0 wheel, passed on repaired wheel) — reuse as the canonical hermetic smoke"
+
+work:
+- id: w1
+  summary: >-
+    Define one hermetic smoke snippet for import and CLI help, then prove it
+    passes on the repaired wheel and fails on a pandas-stripped wheel.
+  status: done
+
+- id: w2
+  summary: >-
+    Replace test-package's broken import step with the w1 snippet, preserving
+    wheel build/upload while ensuring import runs against the wheel-only env.
+  needs: [w1]
+  status: done
+
+- id: w3
+  summary: >-
+    Add a release.yml pre-publish smoke gate after build/twine check and make
+    publish depend on that gate.
+  needs: [w1]
+  status: done
+
+- id: w4
+  summary: >-
+    Pin post-publish install smoke to the exact release version and document
+    it as propagation/user-path verification, not the first import gate.
+  needs: []
+  status: done
+
+decision_gates:
+- id: g1
+  gate: >-
+    Before wiring the snippet into BOTH gates (w2, w3), w1 must demonstrate it
+    FAILS on a pandas-stripped wheel. If it cannot be made to fail on the
+    known-bad artifact, the snippet is not hermetic — stop and fix the snippet
+    before proceeding. Do not merge w2/w3 on a snippet that has only been seen
+    to pass.
+  blocks: [w2, w3]
+
+must_preserve:
+- "test-package still builds the wheel via `uv build` and uploads the dist artifact (test.yml:294-299)"
+- "The post-publish test-installation job continues to run on the full OS/Python matrix (release.yml:187-197) as a propagation
+  check"
+- "release.yml job graph stays acyclic: dependency-bounds -> build -> (pre-publish smoke) -> publish -> github-release/test-installation"
+- "Windows runners: keep `shell: bash` on the smoke step so glob + mktemp behave (test.yml:285 already does this)"
+
+approach: |
+  Author the snippet once and paste it identically into both workflows so they
+  cannot drift. The `cd "$(mktemp -d)"` + `--no-project` + `--isolated` triple
+  is defense-in-depth: --no-project disables project discovery, mktemp cwd means
+  even a future flag regression finds no pyproject.toml, and the
+  `'site-packages' in __file__` assertion makes any re-entry into the checkout
+  fail loudly instead of silently passing. Validate w1 empirically (both
+  polarities) before touching either workflow — the whole point of this item is
+  that "looks like it passes" was exactly the trap last time.
+
+anti_patterns:
+- "DO NOT use `uv run --python <venv>` to run the import — VERIFIED it re-syncs the project env (199 pkgs incl. pandas) and
+  tests the wrong environment. Use `uv run --isolated --no-project --with <wheel>` or the venv's own interpreter directly."
+- "DO NOT rely on a passing run alone as proof — a green smoke against the dev env is exactly the false signal that shipped
+  v0.3.0. Prove it fails on a known-bad wheel (g1)."
+- "DO NOT keep the post-publish job as the only isolated gate — it is structurally too late (PyPI is immutable). The pre-publish
+  gate (w3) is the real barrier."
+- "DO NOT leave `pip install benchbox` unpinned in the post-publish smoke — it can resolve a different version than the one
+  just published."
+
+verification:
+- description: "Snippet passes on the current (repaired) wheel"
+  command: 'uv build --wheel --out-dir /tmp/bbw && cd "$(mktemp -d)" && uv run --isolated --no-project --with /tmp/bbw/*.whl
+    -- python -c "import benchbox; print(benchbox.__version__)"'
+  expected_output: "prints 0.3.0 (or current version), exit 0"
+- description: "Snippet FAILS on a pandas-stripped wheel (proves the gate bites)"
+  command: "build a wheel from a tree with the `pandas>=2.0.0` core line removed, run the same snippet"
+  expected_output: "ModuleNotFoundError: No module named 'pandas' via clickhouse/client.py:11, exit non-zero"
+- description: "Workflows are valid YAML and the publish job depends on the new pre-publish gate"
+  command: "uv run -- python -c \"import yaml,sys; [yaml.safe_load(open(f)) for f in ['.github/workflows/test.yml','.github/workflows/release.yml']];
+    print('yaml ok')\""
+  expected_output: "yaml ok; manual review confirms publish.needs includes the pre-publish smoke"
+
+scope_limit:
+  only_modify:
+  - ".github/workflows/test.yml"
+  - ".github/workflows/release.yml"
+  do_not_modify:
+  - "pyproject.toml"
+  - "benchbox/"
+
+impact:
+  user_impact: |
+    Prevents shipping an un-importable package to PyPI. Users doing a plain
+    `pip install benchbox` get a working import + CLI, which is the v0.3.0
+    failure that triggered this work.
+  technical_debt: |
+    Removes a long-standing false-confidence gate (test-package was effectively
+    a no-op for wheel correctness) and converts post-publish verification into a
+    real pre-publish barrier.
+
+success_metrics:
+- "A wheel missing any import-time core dependency fails CI before merge AND before publish."
+- "Post-publish smoke installs the exact released version."
+
+metadata:
+  tags: ["release", "ci", "packaging", "regression"]
+  estimated_effort: "Small"
+  created_date: "2026-05-20"


### PR DESCRIPTION
## Summary
- replace the pre-merge package smoke with an off-project `uv run --isolated --no-project --with <wheel>` import and CLI check
- add a release pre-publish smoke job between build and publish
- pin post-publish installation smoke to `benchbox==${{ needs.build.outputs.version }}`

## Verification
- `uv run -- python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/test.yml','.github/workflows/release.yml']]; print('yaml ok')"`
- `uv build --wheel --out-dir /tmp/bbw && cd "$(mktemp -d)" && uv run --isolated --no-project --with /tmp/bbw/*.whl -- python -c "import benchbox; assert 'site-packages' in benchbox.__file__, benchbox.__file__; print(benchbox.__version__)"`
- `cd "$(mktemp -d)" && uv run --isolated --no-project --with /tmp/bbw/*.whl -- benchbox --help`
- pandas-stripped temp wheel fails with `ModuleNotFoundError: No module named 'pandas'` via `benchbox/platforms/clickhouse/client.py:11`

## Notes
- `todo-validate --all` is unavailable in this checkout because it resolves a missing schema path under `~/.claude/skills`; `todo-index` and `todo-cli check-graph` passed instead.