### PR TITLE
test: lock dependency bounds parser behavior

### DIFF
--- a/_project/DONE/release-pipeline-hardening/planning/dependency-bounds-gate-regression-test.yaml
+++ b/_project/DONE/release-pipeline-hardening/planning/dependency-bounds-gate-regression-test.yaml
@@ -1,0 +1,96 @@
+id: "dependency-bounds-gate-regression-test"
+title: "Lock the dependency-bounds parser against minor/patch-cap regressions"
+worktree: "release-pipeline-hardening"
+priority: "High"
+status: "Completed"
+completed_date: "2026-05-20"
+description: |
+  The dependency-bounds gate is the ESCALATION VECTOR for the v0.3.0 incident.
+  At tag b2559016b, scripts/check_dependency_bounds.py parsed upper bounds with
+  `<\s*(\d+)(?:\.\d+)*` — capturing only the MAJOR digit — and compared
+  "locked major == cap major". For `duckdb>=1.0.0,<1.4.0` this parsed the cap as
+  major `1`; duckdb's locked `1.3.x` also has major `1`, producing a FALSE
+  POSITIVE "cap reached" and FAILING the gate. Because release.yml chains
+  `dependency-bounds -> build -> publish -> test-installation`, the failing gate
+  meant the legitimate release workflow could not run build/publish/
+  test-installation — yet the package reached PyPI anyway (out-of-band publish),
+  so the post-publish smoke that WOULD have caught missing pandas never ran.
+
+  The recovery commit 038ad5488 ("Release v0.3.0 recovery — Fix dependency
+  bounds version comparison") already fixed the parser: regex now
+  `<\s*(\d+(?:\.\d+)*)` (full version) and comparison uses
+  packaging.version.Version. THIS ITEM does not re-fix it — it adds the
+  regression test that pins the fixed behavior so the gate cannot silently
+  fail-open or fail-closed again. A guard that can misfire is worse than no
+  guard, because it reroutes publish around the real checks.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- "scripts/check_dependency_bounds.py — reference only (already fixed by 038ad5488; do NOT re-fix logic, only test it)"
+- "tests/unit/scripts/test_check_dependency_bounds.py — extend (recovery commit 038ad5488 already touched this file; add the
+  minor/patch-cap cases)"
+
+work:
+- id: w1
+  summary: >-
+    Add minor/patch cap regression cases for duckdb<1.4.0 and a major-cap
+    control case for pyarrow<25.0.0.
+  status: done
+
+- id: w2
+  summary: >-
+    Add parser tests proving `_UPPER_BOUND_RE` captures full upper-bound
+    versions and exotic specifiers fall through safely.
+  needs: [w1]
+  status: done
+
+must_preserve:
+- "check_dependency_bounds.py public CLI (--fail-on=cap-reached, --report-only, --output) and offline behavior"
+- "The recovery commit's Version-based comparison logic — tests must lock it, not change it"
+- "All five currently-capped deps remain covered: sqlglot<31, click<9, pydantic<3, pyarrow<25, duckdb<1.4.0 (pyproject.toml:33,36,42,48
+  + dev duckdb)"
+
+approach: |
+  Pure test addition. Read the current (fixed) check_dependency_bounds.py to
+  mirror its CappedDep API (cap_version, cap_text, effective_cap_version,
+  locked_parsed). Construct synthetic CappedDep / lockfile fixtures rather than
+  depending on the live uv.lock so the test is deterministic across dependency
+  bumps. The duckdb<1.4.0 vs 1.3.x case is the exact bug — make it the headline
+  test with a comment linking 038ad5488 and the v0.3.0 incident.
+
+anti_patterns:
+- "DO NOT modify check_dependency_bounds.py logic — it is already fixed (038ad5488). This item is test-only; touching logic
+  risks reintroducing the bug."
+- "DO NOT assert against the live uv.lock — it drifts; use synthetic fixtures so the regression test stays stable."
+
+verification:
+- description: "New regression tests pass against the fixed parser"
+  command: "uv run -- python -m pytest tests/unit/scripts/test_check_dependency_bounds.py -q"
+  expected_output: "all pass, including the duckdb<1.4.0 / 1.3.x case"
+- description: "Reverting the parser to major-only would fail the new test (sanity, local only)"
+  command: "temporarily restore `<\\s*(\\d+)(?:\\.\\d+)*` + major comparison, run tests, then revert"
+  expected_output: "duckdb<1.4.0/1.3.x case fails -> proves the regression test bites"
+
+scope_limit:
+  only_modify:
+  - "tests/unit/scripts/test_check_dependency_bounds.py"
+  do_not_modify:
+  - "scripts/check_dependency_bounds.py"
+  - ".github/workflows/release.yml"
+
+impact:
+  technical_debt: |
+    Prevents the release-gate parser from regressing into the exact misfire that
+    rerouted the v0.3.0 publish around the post-publish smoke.
+
+success_metrics:
+- "A reintroduction of the major-only cap comparison is caught by CI."
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["release", "ci", "testing", "regression"]
+  estimated_effort: "Small"
+  created_date: "2026-05-20"

--- a/tests/unit/scripts/test_check_dependency_bounds.py
+++ b/tests/unit/scripts/test_check_dependency_bounds.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 from scripts.check_dependency_bounds import (
     CappedDep,
@@ -62,6 +63,33 @@ class TestUpperBoundExtraction:
     def test_extracts_full_upper_bound(self, spec: str, expected: str | None) -> None:
         parsed = _extract_upper_bound(spec)
         assert (None if parsed is None else parsed[0]) == expected
+        if expected is not None:
+            assert parsed is not None
+            assert parsed[1] == Version(expected)
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            (">=1.0.0,<1.4.0", "1.4.0"),
+            (">=1.0.0,<1.3.5", "1.3.5"),
+            (">=21.0.0,<25.0.0", "25.0.0"),
+        ],
+    )
+    def test_extracts_minor_and_patch_caps_without_major_truncation(self, spec: str, expected: str) -> None:
+        parsed = _extract_upper_bound(spec)
+        assert parsed == (expected, Version(expected))
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "<=1.4.0",
+            "!=1.4.0",
+            "~=1.4",
+            ">=1.0.0,<=1.4.0",
+        ],
+    )
+    def test_exotic_or_nonexclusive_specifiers_are_not_misparsed(self, spec: str) -> None:
+        assert _extract_upper_bound(spec) is None
 
 
 class TestRequirementSplit:
@@ -158,7 +186,30 @@ version = "1.3.2"
         assert len(deps) == 1
         assert deps[0].cap_major == 1
         assert deps[0].cap_text == "1.4.0"
+        assert deps[0].cap_version == Version("1.4.0")
         assert deps[0].cap_display == "1.4.0"
+
+    def test_collects_patch_cap_without_truncating_to_major_or_minor(self, tmp_path: Path) -> None:
+        py, lk = _write(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.0.0"
+dependencies = ["duckdb>=1.0.0,<1.3.5"]
+""",
+            """
+[[package]]
+name = "duckdb"
+version = "1.3.4"
+""",
+        )
+        deps = collect_capped_deps(py, lk)
+        assert len(deps) == 1
+        assert deps[0].cap_major == 1
+        assert deps[0].cap_text == "1.3.5"
+        assert deps[0].cap_version == Version("1.3.5")
+        assert not deps[0].cap_reached
 
     def test_deduplicates_multiple_declarations(self, tmp_path: Path) -> None:
         py, lk = _write(
@@ -189,8 +240,36 @@ class TestSeverityFlags:
         assert dep.cap_reached
 
     def test_healthy_when_locked_version_below_minor_cap(self) -> None:
-        dep = CappedDep(name="duckdb", cap_major=1, locked_version="1.3.2", cap_text="1.4.0")
+        dep = CappedDep(
+            name="duckdb",
+            cap_major=1,
+            locked_version="1.3.2",
+            cap_version=Version("1.4.0"),
+            cap_text="1.4.0",
+        )
         assert not dep.cap_reached
+        assert not dep.ceiling_minus_one
+
+    def test_healthy_when_locked_version_below_patch_cap(self) -> None:
+        dep = CappedDep(
+            name="duckdb",
+            cap_major=1,
+            locked_version="1.3.4",
+            cap_version=Version("1.3.5"),
+            cap_text="1.3.5",
+        )
+        assert not dep.cap_reached
+        assert not dep.ceiling_minus_one
+
+    def test_major_cap_control_still_blocks_at_full_cap(self) -> None:
+        dep = CappedDep(
+            name="pyarrow",
+            cap_major=25,
+            locked_version="25.0.0",
+            cap_version=Version("25.0.0"),
+            cap_text="25.0.0",
+        )
+        assert dep.cap_reached
         assert not dep.ceiling_minus_one
 
     def test_ceiling_minus_one_when_locked_major_is_cap_minus_one(self) -> None:


### PR DESCRIPTION
## Summary
- add full-version parser assertions for minor and patch upper bounds
- add duckdb minor/patch cap collection and pyarrow major-cap control coverage
- verify unsupported/nonexclusive specifiers fall through without being reported as exclusive caps

## Verification
- `uv run -- python -m pytest tests/unit/scripts/test_check_dependency_bounds.py -q`
- temporary major-only parser regex sanity failed the new parser tests, then `scripts/check_dependency_bounds.py` was restored before commit
- `uv run --project ~/.claude/tools/todo todo-index`
- `uv run --project ~/.claude/tools/todo todo-cli check-graph`

## Notes
- No changes to `scripts/check_dependency_bounds.py`; this PR is test-only by TODO guardrail.
- `todo-validate --all` is unavailable in this checkout because it resolves a missing shared schema path.