### PR TITLE
test: enforce import dependency contract

### DIFF
--- a/_project/DONE/release-pipeline-hardening/planning/import-contract-regression-test.yaml
+++ b/_project/DONE/release-pipeline-hardening/planning/import-contract-regression-test.yaml
@@ -1,0 +1,122 @@
+id: "import-contract-regression-test"
+title: "Add an import-contract test: every import-time dep must be in core"
+worktree: "release-pipeline-hardening"
+priority: "High"
+status: "Completed"
+completed_date: "2026-05-20"
+description: |
+  Root cause of the v0.3.0 incident: `import benchbox` eagerly imports pandas
+  (via the ClickHouse adapter, clickhouse/client.py:11), but pandas was declared
+  only in extras. The masking substrate is permanent: flat-layout editable
+  install + pandas in the `dev` group + `uv sync --group dev` in every CI job
+  means bare `import benchbox` can never fail in dev/CI. There was NO test
+  asserting the package is importable with only its declared CORE dependencies.
+
+  The fix (7334727b2) added `tests/unit/test_package_dependencies.py` asserting
+  pandas specifically is in core. Note `tests/unit/test_init.py:78` does the
+  OPPOSITE — `@pytest.mark.skipif(not PANDAS_AVAILABLE)` — treating pandas as
+  optional, so the suite tolerated its absence.
+
+  This item generalizes the one-off pandas assertion into a durable contract:
+  every unguarded top-level third-party module reachable from `import benchbox`
+  (and `benchbox --help`) must be declared in `[project].dependencies`, with an
+  explicit allowlist for modules that are known-optional AND lazily/guard-
+  imported. This catches the whole class, not just pandas, and is the test that
+  guards the lazy-import refactor (import-surface-reduction) from regressing.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- "tests/unit/test_package_dependencies.py — extend (added by fix 7334727b2; currently asserts only pandas-in-core; generalize
+  to a full contract)"
+- "tests/unit/test_init.py:78 PANDAS_AVAILABLE skipif — reference (illustrates the suite previously treated pandas as optional;
+  the new test must NOT skip)"
+- "benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + __getattr__ lazy pattern — reference (defines what 'lazy/guarded is acceptable'
+  means for the allowlist)"
+
+work:
+- id: w1
+  summary: >-
+    Choose and document the fast-lane import-contract mechanism; do not build
+    or install wheels in this unit test.
+  status: done
+
+- id: w2
+  summary: >-
+    Implement the eager import contract test and assert every unguarded
+    third-party import is declared in core dependencies.
+  needs: [w1]
+  status: done
+
+- id: w3
+  summary: >-
+    Strengthen the pandas assertion and ensure the new contract test fails,
+    rather than skips, when a required dependency is absent.
+  needs: [w2]
+  status: done
+
+must_preserve:
+- "Existing tests/unit/test_package_dependencies.py assertions keep passing"
+- "The test runs in the default fast lane (no network, no extras install) so it gates every PR via test.yml"
+- "Test must work on Python 3.10 (note d146d2173 'Fix package dependency test on Python 3.10' — respect tomllib/tomli split,
+  pyproject.toml:46)"
+
+approach: |
+  Reuse importlib.metadata to map import names -> distributions and tomllib to
+  read [project].dependencies (handle the tomli fallback for 3.10). For the
+  eager-graph walk, import benchbox in a subprocess with `-X importtime` or
+  instrument sys.modules before/after `import benchbox` to get the real eager
+  set rather than guessing statically. Seed KNOWN_OPTIONAL from the extras in
+  pyproject.toml (clickhouse-connect, snowflake, etc.) and assert none of them
+  appear in the eager set — that assertion is what fails loudly if a future
+  edit makes an optional adapter eager again. Keep this test in the ordinary
+  pytest lane; isolated wheel installation and CLI smoke checks belong to the
+  workflow gate in ci-isolated-wheel-smoke-gates.
+
+anti_patterns:
+- "DO NOT skipif when a dependency is missing (the test_init.py:78 pattern) — that is precisely how the suite tolerated missing
+  pandas. The contract test must FAIL, not skip."
+- "DO NOT hardcode only pandas — the point is to catch the next undeclared eager import (pyarrow, numpy, or a future adapter
+  dep), not refight the last war."
+- "DO NOT parse imports with regex alone — guarded `try/except ImportError` and function-scoped imports must be excluded;
+  use AST or runtime sys.modules diffing."
+- "DO NOT build or install wheels in this unit test — that coverage is owned by ci-isolated-wheel-smoke-gates, which tests
+  the actual wheel artifact off-project."
+
+verification:
+- description: "Contract test passes on current tree (pandas is in core)"
+  command: "uv run -- python -m pytest tests/unit/test_package_dependencies.py -q"
+  expected_output: "all pass"
+- description: "Contract test FAILS if pandas is removed from core (temporarily, locally)"
+  command: "remove the pandas core line, run the test, then restore"
+  expected_output: "test fails citing pandas / clickhouse/client.py:11"
+- description: "Runs in fast lane on 3.10 and 3.12"
+  command: 'uv run --python 3.10 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q && uv run --python
+    3.12 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q'
+  expected_output: "collected and passing under both interpreters"
+
+scope_limit:
+  only_modify:
+  - "tests/unit/test_package_dependencies.py"
+  - "tests/unit/"
+  do_not_modify:
+  - "benchbox/"
+  - ".github/workflows/"
+  - "pyproject.toml"
+
+impact:
+  technical_debt: |
+    Converts a one-off "pandas is core" assertion into a reusable contract that
+    keeps the import surface honest and guards the planned lazy-import refactor.
+
+success_metrics:
+- "Any undeclared third-party import added to the eager `import benchbox` path fails this test."
+- "The test never skips on a missing dependency."
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["testing", "packaging", "regression", "import-contract"]
+  estimated_effort: "Medium"
+  created_date: "2026-05-20"

--- a/tests/unit/test_package_dependencies.py
+++ b/tests/unit/test_package_dependencies.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import ast
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 try:
     import tomllib
@@ -18,15 +23,107 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "benchbox"
+STDLIB_MODULES = frozenset(getattr(sys, "stdlib_module_names", ()))
+
+ENTRYPOINTS = {
+    "import benchbox": "import benchbox",
+    "benchbox --help": """
+from click.testing import CliRunner
+from benchbox.cli.main import cli
+
+result = CliRunner().invoke(cli, ["--help"])
+if result.exit_code != 0:
+    raise RuntimeError(result.output)
+""",
+}
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 
 def _core_dependencies() -> dict[str, Requirement]:
-    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject = _pyproject()
     dependencies = {}
     for entry in pyproject["project"]["dependencies"]:
         requirement = Requirement(entry)
-        dependencies[requirement.name.lower()] = requirement
+        dependencies[canonicalize_name(requirement.name)] = requirement
     return dependencies
+
+
+def _optional_dependency_names() -> set[str]:
+    optional = set()
+    for entries in _pyproject()["project"].get("optional-dependencies", {}).values():
+        for entry in entries:
+            optional.add(canonicalize_name(Requirement(entry).name))
+    return optional
+
+
+def _packages_distributions() -> dict[str, list[str]]:
+    script = """
+import importlib.metadata
+import json
+
+print(json.dumps(importlib.metadata.packages_distributions(), sort_keys=True))
+"""
+    output = subprocess.check_output([sys.executable, "-c", script], cwd=REPO_ROOT, text=True)
+    return json.loads(output)
+
+
+def _loaded_benchbox_modules(statement: str) -> dict[str, str]:
+    script = f"""
+import json
+import sys
+
+{statement}
+
+modules = {{
+    name: module.__file__
+    for name, module in sys.modules.items()
+    if name.startswith("benchbox") and getattr(module, "__file__", None)
+}}
+print(json.dumps(modules, sort_keys=True))
+"""
+    output = subprocess.check_output([sys.executable, "-c", script], cwd=REPO_ROOT, text=True)
+    return json.loads(output)
+
+
+def _top_level_import_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.partition(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.add(node.module.partition(".")[0])
+    return imports
+
+
+def _direct_third_party_imports(statement: str) -> set[str]:
+    imported = set()
+    for raw_path in _loaded_benchbox_modules(statement).values():
+        path = Path(raw_path).resolve()
+        if not path.is_relative_to(PACKAGE_ROOT):
+            continue
+        for import_name in _top_level_import_names(path):
+            if import_name == "benchbox" or import_name in STDLIB_MODULES or import_name.startswith("_"):
+                continue
+            imported.add(import_name)
+    return imported
+
+
+def _canonical_distribution_names(import_name: str, package_distributions: dict[str, list[str]]) -> set[str]:
+    distributions = package_distributions.get(import_name, [import_name])
+    return {canonicalize_name(distribution) for distribution in distributions}
+
+
+def _import_names_for_distributions(distribution_names: set[str], package_distributions: dict[str, list[str]]) -> set[str]:
+    import_names = set()
+    for import_name, distributions in package_distributions.items():
+        if any(canonicalize_name(distribution) in distribution_names for distribution in distributions):
+            import_names.add(import_name)
+    return import_names
 
 
 def test_pandas_is_core_dependency_while_top_level_import_path_requires_it() -> None:
@@ -34,3 +131,30 @@ def test_pandas_is_core_dependency_while_top_level_import_path_requires_it() -> 
 
     assert "pandas" in dependencies
     assert str(dependencies["pandas"].specifier) == ">=2.0.0"
+
+
+@pytest.mark.parametrize(("entrypoint", "statement"), ENTRYPOINTS.items(), ids=list(ENTRYPOINTS))
+def test_eager_third_party_imports_are_declared_core_dependencies(entrypoint: str, statement: str) -> None:
+    core_dependency_names = set(_core_dependencies())
+    package_distributions = _packages_distributions()
+    imported = _direct_third_party_imports(statement)
+
+    undeclared = {
+        import_name: sorted(_canonical_distribution_names(import_name, package_distributions))
+        for import_name in imported
+        if not (_canonical_distribution_names(import_name, package_distributions) & core_dependency_names)
+    }
+
+    assert not undeclared, f"{entrypoint} has undeclared eager third-party imports: {undeclared}"
+
+
+@pytest.mark.parametrize(("entrypoint", "statement"), ENTRYPOINTS.items(), ids=list(ENTRYPOINTS))
+def test_optional_only_dependencies_stay_off_eager_import_paths(entrypoint: str, statement: str) -> None:
+    core_dependency_names = set(_core_dependencies())
+    optional_only_names = _optional_dependency_names() - core_dependency_names
+    package_distributions = _packages_distributions()
+    optional_only_import_names = _import_names_for_distributions(optional_only_names, package_distributions)
+
+    imported_optional_only = _direct_third_party_imports(statement) & optional_only_import_names
+
+    assert not imported_optional_only, f"{entrypoint} eagerly imports optional-only dependencies: {sorted(imported_optional_only)}"


### PR DESCRIPTION
## Summary
- replace the pandas-only dependency assertion with a runtime-loaded import contract
- inspect top-level imports from eager BenchBox modules for `import benchbox` and `benchbox --help`
- assert direct eager third-party imports map to core dependencies and optional-only deps stay off eager paths

## Verification
- `uv run -- python -m pytest tests/unit/test_package_dependencies.py -q`
- `uv run --python 3.10 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q`
- `uv run --python 3.12 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q`
- temporarily removed the core `pandas>=2.0.0` line; tests failed on `pandas` as undeclared/optional-only, then `pyproject.toml` was restored
- `uv run --project ~/.claude/tools/todo todo-index`
- `uv run --project ~/.claude/tools/todo todo-cli check-graph`

## Notes
- This intentionally does not build or install wheels; wheel isolation is covered by PR #476.
- `todo-validate --all` is unavailable in this checkout because it resolves a missing shared schema path.