### PR TITLE
Fix prompt code contrast on landing site

### DIFF
--- a/landing/prompts/prompts.css
+++ b/landing/prompts/prompts.css
@@ -141,7 +141,7 @@ body::before {
     padding: var(--space-md);
     font-family: var(--font-mono);
     font-size: 0.85rem;
-    color: var(--text-primary);
+    color: var(--code-fg);
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary
- change the /prompts/ code block foreground token from --text-primary to --code-fg so light mode keeps code text visible on --code-bg
- keep this hotfix CSS-only; the regression test remains in #474 for the normal develop flow

## Validation
- uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q
- git diff --check

Note: make lint-site-theme-tokens cannot run from this release-main tree because _project/scripts/scan_explorer_tokens.py is absent on main.