### PR TITLE
Release v0.3.0 prompts landing CSS hotfix

### DIFF
--- a/landing/prompts/prompts.css
+++ b/landing/prompts/prompts.css
@@ -141,7 +141,7 @@ body::before {
     padding: var(--space-md);
     font-family: var(--font-mono);
     font-size: 0.85rem;
-    color: var(--text-primary);
+    color: var(--code-fg);
     white-space: pre-wrap;
     word-break: break-word;
     overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary
- hotfix /prompts/ code block foreground token from --text-primary to --code-fg so light mode keeps prompt copy visible on --code-bg
- CSS-only main patch for the live landing site; the regression test remains in #474 for the normal develop flow

## Validation
- uv run -- python -m pytest tests/unit/landing/test_landing_quickstarts.py -q
- git diff --check

Notes:
- This branch uses the v0.3.0-suffix naming required by validate-base for main PRs.
- No version bump, tag movement, or release artifact change is included.