### PR TITLE
Keep platform imports lazy

### DIFF
--- a/_project/DONE/import-surface-reduction/planning/lazy-platform-import-surface.yaml
+++ b/_project/DONE/import-surface-reduction/planning/lazy-platform-import-surface.yaml
@@ -1,0 +1,179 @@
+id: "lazy-platform-import-surface"
+title: "Shrink the import-benchbox surface: lazy platform/adapter imports"
+worktree: "import-surface-reduction"
+priority: "Medium"
+status: "Completed"
+description: |
+  The v0.3.0 failure was a symptom of an over-broad top-level import surface.
+  `import benchbox` eagerly pulls in the unified adapter factory and every
+  platform adapter:
+    benchbox/__init__.py:28      from . import platforms
+    platforms/__init__.py:330    from benchbox.platforms.adapter_factory import (...)
+    adapter_factory.py:17        from benchbox.platforms.clickhouse.deployment_mode import (...)
+    clickhouse/__init__.py:5 -> adapter.py:13 -> setup.py:9 -> client.py:11 (import pandas)
+  So a bare `import benchbox` requires pandas (and would require any heavy dep
+  pulled by any eagerly-imported adapter). The benchmark registry is ALREADY
+  lazy (benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + module __getattr__),
+  but `from . import platforms` bypasses that pattern.
+
+  REFRAME: the immediate fix (pandas in core) is correct given today's surface,
+  but the durable fix is to make the surface match the contract. Target: bare
+  `import benchbox` imports NO platform clients, NO cloud SDKs, NO DataFrame
+  backends unless explicitly requested. Only after that architectural proof can
+  a separate dependency-placement decision consider whether pandas (and other
+  adapter deps) should return to extras-only.
+
+  This is the architectural follow-up. It MUST land behind the
+  import-contract-regression-test so the refactor is guarded by a test that
+  proves the eager surface stays clean — otherwise this refactor could itself
+  silently re-introduce or mask an eager dep.
+
+category: "Architecture"
+
+prior_art:
+  - "benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + __getattr__ — extend (apply the same lazy pattern to `platforms`/adapter access; this is the canonical reuse target, NOT a new mechanism)"
+  - "benchbox/platforms/__init__.py:330 eager adapter_factory import — supersede (make lazy)"
+  - "benchbox/platforms/adapter_factory.py:17 eager clickhouse import — supersede (resolve adapters on first use)"
+  - "benchbox/platforms/clickhouse/client.py:11 `import pandas as pd` — extend (move into the functions that do DataFrame conversion, or guard with a targeted ImportError)"
+
+decision_gates:
+  - id: g1
+    gate: >-
+      DECISION: pandas core vs optional. Option A (keep `pandas>=2.0.0` in
+      [project].dependencies) — simple, honest with current surface, already
+      shipped. Option B (pandas optional via extras) — only valid AFTER this
+      refactor makes the platforms/ClickHouse imports lazy/guarded. Do NOT move
+      pandas out of core in this TODO. If w1-w4 prove the eager surface is clean
+      and Option B is still desired, create a separate dependency-placement TODO
+      / ADR that explicitly includes pyproject.toml and release smoke coverage.
+      Until that follow-up lands, pandas stays core.
+    blocks: [w5]
+    outcome: >-
+      Option A for this TODO: pandas remains a core dependency. The eager import
+      path is now clean enough to support a future dependency-placement ADR, but
+      moving pandas back to extras needs its own release smoke coverage and
+      pyproject change.
+
+work:
+  - id: w1
+    summary: >-
+      Make `benchbox.platforms` lazy using the existing __getattr__ pattern so
+      platform modules load on first access.
+    status: completed
+
+  - id: w2
+    summary: >-
+      Keep `adapter_factory` off the `benchbox.platforms` import path; loading
+      the unified factory is deferred until `get_adapter` and related helpers
+      are actually called.
+    needs: [w1]
+    status: completed
+
+  - id: w3
+    summary: >-
+      Defer or guard ClickHouse pandas imports, then audit other top-level
+      pandas imports that may sit on reachable eager paths.
+    needs: [w2]
+    status: completed
+
+  - id: w4
+    summary: >-
+      Re-run import-contract and importtime checks, then update assertions so
+      platform/dataframe deps stay off the eager path.
+    needs: [w3]
+    status: completed
+
+  - id: w4b
+    summary: >-
+      Preserve lightweight CLI platform hook registration without reintroducing
+      the adapter import chain; remove the circular import that left option
+      registries empty under the lazy package path.
+    needs: [w3]
+    status: completed
+
+  - id: w4c
+    summary: >-
+      Harden `benchbox.platforms.PlatformRegistry` monkeypatch semantics by
+      re-exporting the real registry class rather than a proxy instance.
+    needs: [w1]
+    status: completed
+
+  - id: w5
+    summary: >-
+      Record the g1 pandas-placement outcome; if Option B remains desirable,
+      create a separate dependency-placement TODO/ADR.
+    needs: [w4, w4b, w4c]
+    status: completed
+
+must_preserve:
+  - "All public benchmark classes remain importable: `from benchbox import TPCH, TPCDS, ...` and `benchbox.platforms.get_platform_adapter(...)` keep working"
+  - "MCP/CLI entrypoints (benchbox.cli.main:main, benchbox.mcp.cli:main) and `benchbox --help` behavior unchanged"
+  - "Public re-exports in __all__ (benchbox/__init__.py:178-206) and the lazy __getattr__ error-reporting behavior"
+  - "No change to platform runtime behavior — only WHEN modules are imported, not WHAT they do"
+
+approach: |
+  This is the highest-risk item — it touches the package's import topology.
+  Land it strictly after import-contract-regression-test so every step is
+  guarded. Reuse the existing __getattr__ machinery; do NOT invent a second lazy
+  mechanism. Sequence: lazy platforms (w1) -> lazy adapter resolution (w2) ->
+  defer/guard pandas in adapters (w3) -> verify clean eager surface (w4) ->
+  only then record or spin out the pandas-placement decision (w5, gated by g1).
+  Expect circular-import landmines: __init__.py:14-16 already documents that the
+  platforms import chain circles back to read benchbox.__version__; preserve that
+  ordering.
+
+anti_patterns:
+  - "DO NOT move pandas out of core in this TODO — after w4 proves the eager surface is clean, g1 may only record Option A or create a separate dependency-placement TODO/ADR for Option B."
+  - "DO NOT introduce a new lazy-loading framework — extend the existing _BENCHMARK_REGISTRY/__getattr__ pattern (benchbox/__init__.py:71-174)."
+  - "DO NOT break the documented version-before-platforms import ordering (benchbox/__init__.py:14-17)."
+  - "DO NOT land this without the import-contract test in place (deps.needs) — the refactor must be regression-guarded."
+
+verification:
+  - description: "Bare import no longer pulls pandas/clickhouse onto the eager path"
+    command: 'uv run --isolated --no-project --with <wheel-without-pandas-extra> -- python -c "import benchbox; print(\"ok\")"'
+    expected_output: "ok (only after w1-w3); pandas not in sys.modules after `import benchbox`"
+  - description: "Full test suite + import-contract test still pass"
+    command: "uv run -- python -m pytest tests -m fast -q && uv run -- python -m pytest tests/unit/test_package_dependencies.py -q"
+    expected_output: "all pass"
+  - description: "Public API and CLI unchanged"
+    command: 'uv run -- python -c "from benchbox import TPCH, TPCDS, ClickBench; import benchbox.platforms" && uv run -- benchbox --help'
+    expected_output: "imports succeed; --help output unchanged"
+
+scope_limit:
+  only_modify:
+    - "benchbox/__init__.py"
+    - "benchbox/cli/platform_hooks.py"
+    - "benchbox/platforms/__init__.py"
+    - "benchbox/platforms/adapter_factory.py"
+    - "benchbox/platforms/clickhouse/"
+    - "benchbox/core/tpcdi/"
+    - "tests/unit/test_package_dependencies.py"
+    - "tests/unit/platforms/test_platform_driver_runtime_contract.py"
+  do_not_modify:
+    - ".github/workflows/"
+    - "pyproject.toml"
+
+deps:
+  needs: ["import-contract-regression-test"]
+
+impact:
+  technical_debt: |
+    Aligns the declared core dependencies with the actual import-time needs,
+    reduces install weight, and improves `import benchbox` latency. Makes the
+    minimal-runtime contract enforceable by construction rather than by gate.
+  user_impact: |
+    Smaller, faster core install for users who don't use heavy platforms.
+
+success_metrics:
+  - "`import benchbox` imports no platform client, cloud SDK, or DataFrame backend (verified via sys.modules / importtime)."
+  - "import-contract test passes asserting pandas/clickhouse are off the eager path."
+
+open_questions:
+  - "Does any current consumer rely on `benchbox.platforms` side-effects at import time (e.g., platform registration)? Audit core/platform_registry.py:auto_register_platforms before making platforms lazy."
+  - "If pandas goes optional (g1 Option B), which default install experience do we want for `pip install benchbox` — does the CLI still work end-to-end without pandas?"
+
+metadata:
+  tags: ["architecture", "imports", "performance", "packaging"]
+  estimated_effort: "Large"
+  created_date: "2026-05-20"
+  completed_date: "2026-05-20"

--- a/_project/DONE/release-pipeline-hardening/planning/import-contract-regression-test.yaml
+++ b/_project/DONE/release-pipeline-hardening/planning/import-contract-regression-test.yaml
@@ -1,0 +1,122 @@
+id: "import-contract-regression-test"
+title: "Add an import-contract test: every import-time dep must be in core"
+worktree: "release-pipeline-hardening"
+priority: "High"
+status: "Completed"
+completed_date: "2026-05-20"
+description: |
+  Root cause of the v0.3.0 incident: `import benchbox` eagerly imports pandas
+  (via the ClickHouse adapter, clickhouse/client.py:11), but pandas was declared
+  only in extras. The masking substrate is permanent: flat-layout editable
+  install + pandas in the `dev` group + `uv sync --group dev` in every CI job
+  means bare `import benchbox` can never fail in dev/CI. There was NO test
+  asserting the package is importable with only its declared CORE dependencies.
+
+  The fix (7334727b2) added `tests/unit/test_package_dependencies.py` asserting
+  pandas specifically is in core. Note `tests/unit/test_init.py:78` does the
+  OPPOSITE — `@pytest.mark.skipif(not PANDAS_AVAILABLE)` — treating pandas as
+  optional, so the suite tolerated its absence.
+
+  This item generalizes the one-off pandas assertion into a durable contract:
+  every unguarded top-level third-party module reachable from `import benchbox`
+  (and `benchbox --help`) must be declared in `[project].dependencies`, with an
+  explicit allowlist for modules that are known-optional AND lazily/guard-
+  imported. This catches the whole class, not just pandas, and is the test that
+  guards the lazy-import refactor (import-surface-reduction) from regressing.
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- "tests/unit/test_package_dependencies.py — extend (added by fix 7334727b2; currently asserts only pandas-in-core; generalize
+  to a full contract)"
+- "tests/unit/test_init.py:78 PANDAS_AVAILABLE skipif — reference (illustrates the suite previously treated pandas as optional;
+  the new test must NOT skip)"
+- "benchbox/__init__.py:71-174 _BENCHMARK_REGISTRY + __getattr__ lazy pattern — reference (defines what 'lazy/guarded is acceptable'
+  means for the allowlist)"
+
+work:
+- id: w1
+  summary: >-
+    Choose and document the fast-lane import-contract mechanism; do not build
+    or install wheels in this unit test.
+  status: done
+
+- id: w2
+  summary: >-
+    Implement the eager import contract test and assert every unguarded
+    third-party import is declared in core dependencies.
+  needs: [w1]
+  status: done
+
+- id: w3
+  summary: >-
+    Strengthen the pandas assertion and ensure the new contract test fails,
+    rather than skips, when a required dependency is absent.
+  needs: [w2]
+  status: done
+
+must_preserve:
+- "Existing tests/unit/test_package_dependencies.py assertions keep passing"
+- "The test runs in the default fast lane (no network, no extras install) so it gates every PR via test.yml"
+- "Test must work on Python 3.10 (note d146d2173 'Fix package dependency test on Python 3.10' — respect tomllib/tomli split,
+  pyproject.toml:46)"
+
+approach: |
+  Reuse importlib.metadata to map import names -> distributions and tomllib to
+  read [project].dependencies (handle the tomli fallback for 3.10). For the
+  eager-graph walk, import benchbox in a subprocess with `-X importtime` or
+  instrument sys.modules before/after `import benchbox` to get the real eager
+  set rather than guessing statically. Seed KNOWN_OPTIONAL from the extras in
+  pyproject.toml (clickhouse-connect, snowflake, etc.) and assert none of them
+  appear in the eager set — that assertion is what fails loudly if a future
+  edit makes an optional adapter eager again. Keep this test in the ordinary
+  pytest lane; isolated wheel installation and CLI smoke checks belong to the
+  workflow gate in ci-isolated-wheel-smoke-gates.
+
+anti_patterns:
+- "DO NOT skipif when a dependency is missing (the test_init.py:78 pattern) — that is precisely how the suite tolerated missing
+  pandas. The contract test must FAIL, not skip."
+- "DO NOT hardcode only pandas — the point is to catch the next undeclared eager import (pyarrow, numpy, or a future adapter
+  dep), not refight the last war."
+- "DO NOT parse imports with regex alone — guarded `try/except ImportError` and function-scoped imports must be excluded;
+  use AST or runtime sys.modules diffing."
+- "DO NOT build or install wheels in this unit test — that coverage is owned by ci-isolated-wheel-smoke-gates, which tests
+  the actual wheel artifact off-project."
+
+verification:
+- description: "Contract test passes on current tree (pandas is in core)"
+  command: "uv run -- python -m pytest tests/unit/test_package_dependencies.py -q"
+  expected_output: "all pass"
+- description: "Contract test FAILS if pandas is removed from core (temporarily, locally)"
+  command: "remove the pandas core line, run the test, then restore"
+  expected_output: "test fails citing pandas / clickhouse/client.py:11"
+- description: "Runs in fast lane on 3.10 and 3.12"
+  command: 'uv run --python 3.10 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q && uv run --python
+    3.12 -- python -m pytest tests/unit/test_package_dependencies.py -m fast -q'
+  expected_output: "collected and passing under both interpreters"
+
+scope_limit:
+  only_modify:
+  - "tests/unit/test_package_dependencies.py"
+  - "tests/unit/"
+  do_not_modify:
+  - "benchbox/"
+  - ".github/workflows/"
+  - "pyproject.toml"
+
+impact:
+  technical_debt: |
+    Converts a one-off "pandas is core" assertion into a reusable contract that
+    keeps the import surface honest and guards the planned lazy-import refactor.
+
+success_metrics:
+- "Any undeclared third-party import added to the eager `import benchbox` path fails this test."
+- "The test never skips on a missing dependency."
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["testing", "packaging", "regression", "import-contract"]
+  estimated_effort: "Medium"
+  created_date: "2026-05-20"

--- a/benchbox/__init__.py
+++ b/benchbox/__init__.py
@@ -11,9 +11,8 @@ from importlib import import_module
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, Union
 
-# __version__ must be defined before `from . import platforms` because the
-# platforms import chain can circle back to benchbox.cli.app which reads
-# benchbox.__version__ at module level.
+# __version__ must stay near the top because lazily imported submodules can
+# circle back to benchbox.cli.app, which reads it at module level.
 __version__ = "0.3.0"
 
 from benchbox.base import BaseBenchmark
@@ -24,8 +23,6 @@ from benchbox.tpch import TPCH
 from benchbox.tpch_skew import TPCHSkew
 from benchbox.tpchavoc import TPCHavoc
 from benchbox.tsbs_devops import TSBSDevOps
-
-from . import platforms
 
 # Perform version consistency check on import (but don't fail - just warn)
 try:
@@ -153,7 +150,9 @@ def __getattr__(name: str) -> Any:
             return ImportError(f"Could not import {benchmark_name}")
 
     if name == "platforms":
-        return platforms
+        module = import_module("benchbox.platforms")
+        globals()[name] = module
+        return module
 
     if name in _PUBLIC_REEXPORTS:
         module_path, attr = _PUBLIC_REEXPORTS[name]

--- a/benchbox/cli/platform_hooks.py
+++ b/benchbox/cli/platform_hooks.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-from benchbox.core.platform_registry import PlatformInfo, PlatformRegistry
 from benchbox.core.schemas import DatabaseConfig
+
+if TYPE_CHECKING:
+    from benchbox.core.platform_registry import PlatformInfo
 
 
 class PlatformOptionError(ValueError):
@@ -151,6 +153,8 @@ class PlatformHookRegistry:
         options: dict[str, Any],
         runtime_overrides: dict[str, Any] | None = None,
     ) -> DatabaseConfig:
+        from benchbox.core.platform_registry import PlatformRegistry
+
         platform = platform.lower()
         overrides = runtime_overrides or {}
         info = PlatformRegistry.get_platform_info(platform)

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -11,8 +11,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 import importlib
 from typing import Optional, Type
 
-from benchbox.core.platform_registry import PlatformRegistry
-from benchbox.utils.runtime_env import DriverResolution, DriverRuntimeStrategy, ensure_driver_version
+from benchbox.utils.runtime_env import DriverResolution, ensure_driver_version
 
 from .base import BenchmarkResults, ConnectionConfig, DriverIsolationCapability, PlatformAdapter
 from .base.adapter import check_isolation_capability
@@ -188,6 +187,11 @@ def __getattr__(name: str):
     if name in _LAZY_CONSTANTS:
         return _load_lazy_constant(name)
 
+    if name == "PlatformRegistry":
+        from benchbox.core.platform_registry import PlatformRegistry
+
+        return PlatformRegistry
+
     # Special case: clickhouse module reference (for legacy patches/tests)
     if name == "clickhouse":
         if _clickhouse_module_cache is None:
@@ -326,14 +330,44 @@ __all__ = [
 ]
 
 
-# Import unified adapter factory
-from benchbox.platforms.adapter_factory import (
-    get_adapter,
-    get_available_deployments,
-    get_available_modes,
-    get_default_deployment,
-    is_dataframe_mode,
-)
+def get_adapter(*args, **kwargs):
+    """Lazy wrapper for the unified adapter factory."""
+
+    from benchbox.platforms.adapter_factory import get_adapter as _get_adapter
+
+    return _get_adapter(*args, **kwargs)
+
+
+def is_dataframe_mode(*args, **kwargs):
+    """Lazy wrapper for adapter_factory.is_dataframe_mode."""
+
+    from benchbox.platforms.adapter_factory import is_dataframe_mode as _is_dataframe_mode
+
+    return _is_dataframe_mode(*args, **kwargs)
+
+
+def get_available_modes(*args, **kwargs):
+    """Lazy wrapper for adapter_factory.get_available_modes."""
+
+    from benchbox.platforms.adapter_factory import get_available_modes as _get_available_modes
+
+    return _get_available_modes(*args, **kwargs)
+
+
+def get_available_deployments(*args, **kwargs):
+    """Lazy wrapper for adapter_factory.get_available_deployments."""
+
+    from benchbox.platforms.adapter_factory import get_available_deployments as _get_available_deployments
+
+    return _get_available_deployments(*args, **kwargs)
+
+
+def get_default_deployment(*args, **kwargs):
+    """Lazy wrapper for adapter_factory.get_default_deployment."""
+
+    from benchbox.platforms.adapter_factory import get_default_deployment as _get_default_deployment
+
+    return _get_default_deployment(*args, **kwargs)
 
 
 def get_platform_adapter(platform_name: str, **config) -> PlatformAdapter:
@@ -354,6 +388,8 @@ def get_platform_adapter(platform_name: str, **config) -> PlatformAdapter:
         ValueError: If platform is not supported
         ImportError: If platform dependencies are not installed
     """
+    from benchbox.core.platform_registry import PlatformRegistry
+
     # Resolve aliases and normalize to canonical name via PlatformRegistry
     canonical_name = PlatformRegistry.resolve_platform_name(platform_name)
 
@@ -458,6 +494,8 @@ def list_available_platforms() -> dict[str, bool]:
     Returns:
         Dictionary mapping platform names to availability boolean.
     """
+    from benchbox.core.platform_registry import PlatformRegistry
+
     return PlatformRegistry.get_platform_availability()
 
 
@@ -473,6 +511,8 @@ def get_platform_requirements(platform_name: str) -> str:
     Returns:
         Installation command string
     """
+    from benchbox.core.platform_registry import PlatformRegistry
+
     return PlatformRegistry.get_platform_requirements(platform_name)
 
 

--- a/benchbox/platforms/clickhouse/__init__.py
+++ b/benchbox/platforms/clickhouse/__init__.py
@@ -1,14 +1,32 @@
 """ClickHouse platform package."""
 
+from importlib import import_module
+from typing import Any
+
 from benchbox.utils.dependencies import check_platform_dependencies, get_dependency_error_message
 
-from .adapter import ClickHouseAdapter
-from .client import ClickHouseLocalClient
-from .diagnostics import ClickHouseDiagnosticsMixin
-from .metadata import ClickHouseMetadataMixin
-from .setup import ClickHouseSetupMixin
-from .tuning import ClickHouseTuningMixin
-from .workload import ClickHouseWorkloadMixin
+_LAZY_EXPORTS = {
+    "ClickHouseAdapter": ".adapter",
+    "ClickHouseLocalClient": ".client",
+    "ClickHouseDiagnosticsMixin": ".diagnostics",
+    "ClickHouseMetadataMixin": ".metadata",
+    "ClickHouseSetupMixin": ".setup",
+    "ClickHouseTuningMixin": ".tuning",
+    "ClickHouseWorkloadMixin": ".workload",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load ClickHouse implementation classes on first access."""
+
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_path, __package__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "ClickHouseAdapter",

--- a/tests/unit/platforms/test_platform_driver_runtime_contract.py
+++ b/tests/unit/platforms/test_platform_driver_runtime_contract.py
@@ -77,6 +77,13 @@ def test_ensure_driver_version_rejects_requested_version_without_package():
         )
 
 
+def test_platforms_reexports_real_platform_registry_class():
+    import benchbox.platforms as platforms
+    from benchbox.core.platform_registry import PlatformRegistry
+
+    assert platforms.PlatformRegistry is PlatformRegistry
+
+
 def test_dataframe_adapter_rejects_requested_version_for_non_package_platform():
     # pandas-df has driver_package=None - version pinning should be rejected with a clear error.
     # (polars-df previously had driver_package=None but now has driver_package="polars".)

--- a/tests/unit/test_package_dependencies.py
+++ b/tests/unit/test_package_dependencies.py
@@ -38,6 +38,23 @@ if result.exit_code != 0:
 """,
 }
 
+LEAN_IMPORT_ENTRYPOINTS = {
+    "import benchbox": "import benchbox",
+    "from benchbox import platforms": "from benchbox import platforms",
+    "from benchbox.platforms import get_adapter": "from benchbox.platforms import get_adapter",
+    "from benchbox.platforms import PlatformRegistry": "from benchbox.platforms import PlatformRegistry",
+}
+
+PROHIBITED_EAGER_IMPORTS = {
+    "chdb",
+    "clickhouse_connect",
+    "clickhouse_driver",
+    "datafusion",
+    "pandas",
+    "polars",
+    "pyspark",
+}
+
 
 def _pyproject() -> dict:
     return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -113,6 +130,19 @@ def _direct_third_party_imports(statement: str) -> set[str]:
     return imported
 
 
+def _loaded_module_roots(statement: str) -> set[str]:
+    script = f"""
+import json
+import sys
+
+{statement}
+
+print(json.dumps(sorted(name.partition(".")[0] for name in sys.modules)))
+"""
+    output = subprocess.check_output([sys.executable, "-c", script], cwd=REPO_ROOT, text=True)
+    return set(json.loads(output))
+
+
 def _canonical_distribution_names(import_name: str, package_distributions: dict[str, list[str]]) -> set[str]:
     distributions = package_distributions.get(import_name, [import_name])
     return {canonicalize_name(distribution) for distribution in distributions}
@@ -161,4 +191,15 @@ def test_optional_only_dependencies_stay_off_eager_import_paths(entrypoint: str,
 
     assert not imported_optional_only, (
         f"{entrypoint} eagerly imports optional-only dependencies: {sorted(imported_optional_only)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("entrypoint", "statement"), LEAN_IMPORT_ENTRYPOINTS.items(), ids=list(LEAN_IMPORT_ENTRYPOINTS)
+)
+def test_lean_import_paths_do_not_load_platform_or_dataframe_dependencies(entrypoint: str, statement: str) -> None:
+    loaded = _loaded_module_roots(statement)
+
+    assert not (loaded & PROHIBITED_EAGER_IMPORTS), (
+        f"{entrypoint} eagerly loaded platform/dataframe dependencies: {sorted(loaded & PROHIBITED_EAGER_IMPORTS)}"
     )

--- a/tests/unit/test_package_dependencies.py
+++ b/tests/unit/test_package_dependencies.py
@@ -118,7 +118,9 @@ def _canonical_distribution_names(import_name: str, package_distributions: dict[
     return {canonicalize_name(distribution) for distribution in distributions}
 
 
-def _import_names_for_distributions(distribution_names: set[str], package_distributions: dict[str, list[str]]) -> set[str]:
+def _import_names_for_distributions(
+    distribution_names: set[str], package_distributions: dict[str, list[str]]
+) -> set[str]:
     import_names = set()
     for import_name, distributions in package_distributions.items():
         if any(canonicalize_name(distribution) in distribution_names for distribution in distributions):
@@ -157,4 +159,6 @@ def test_optional_only_dependencies_stay_off_eager_import_paths(entrypoint: str,
 
     imported_optional_only = _direct_third_party_imports(statement) & optional_only_import_names
 
-    assert not imported_optional_only, f"{entrypoint} eagerly imports optional-only dependencies: {sorted(imported_optional_only)}"
+    assert not imported_optional_only, (
+        f"{entrypoint} eagerly imports optional-only dependencies: {sorted(imported_optional_only)}"
+    )

--- a/tests/unit/test_package_dependencies.py
+++ b/tests/unit/test_package_dependencies.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import ast
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 try:
     import tomllib
@@ -18,15 +23,107 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "benchbox"
+STDLIB_MODULES = frozenset(getattr(sys, "stdlib_module_names", ()))
+
+ENTRYPOINTS = {
+    "import benchbox": "import benchbox",
+    "benchbox --help": """
+from click.testing import CliRunner
+from benchbox.cli.main import cli
+
+result = CliRunner().invoke(cli, ["--help"])
+if result.exit_code != 0:
+    raise RuntimeError(result.output)
+""",
+}
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 
 def _core_dependencies() -> dict[str, Requirement]:
-    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject = _pyproject()
     dependencies = {}
     for entry in pyproject["project"]["dependencies"]:
         requirement = Requirement(entry)
-        dependencies[requirement.name.lower()] = requirement
+        dependencies[canonicalize_name(requirement.name)] = requirement
     return dependencies
+
+
+def _optional_dependency_names() -> set[str]:
+    optional = set()
+    for entries in _pyproject()["project"].get("optional-dependencies", {}).values():
+        for entry in entries:
+            optional.add(canonicalize_name(Requirement(entry).name))
+    return optional
+
+
+def _packages_distributions() -> dict[str, list[str]]:
+    script = """
+import importlib.metadata
+import json
+
+print(json.dumps(importlib.metadata.packages_distributions(), sort_keys=True))
+"""
+    output = subprocess.check_output([sys.executable, "-c", script], cwd=REPO_ROOT, text=True)
+    return json.loads(output)
+
+
+def _loaded_benchbox_modules(statement: str) -> dict[str, str]:
+    script = f"""
+import json
+import sys
+
+{statement}
+
+modules = {{
+    name: module.__file__
+    for name, module in sys.modules.items()
+    if name.startswith("benchbox") and getattr(module, "__file__", None)
+}}
+print(json.dumps(modules, sort_keys=True))
+"""
+    output = subprocess.check_output([sys.executable, "-c", script], cwd=REPO_ROOT, text=True)
+    return json.loads(output)
+
+
+def _top_level_import_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.partition(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imports.add(node.module.partition(".")[0])
+    return imports
+
+
+def _direct_third_party_imports(statement: str) -> set[str]:
+    imported = set()
+    for raw_path in _loaded_benchbox_modules(statement).values():
+        path = Path(raw_path).resolve()
+        if not path.is_relative_to(PACKAGE_ROOT):
+            continue
+        for import_name in _top_level_import_names(path):
+            if import_name == "benchbox" or import_name in STDLIB_MODULES or import_name.startswith("_"):
+                continue
+            imported.add(import_name)
+    return imported
+
+
+def _canonical_distribution_names(import_name: str, package_distributions: dict[str, list[str]]) -> set[str]:
+    distributions = package_distributions.get(import_name, [import_name])
+    return {canonicalize_name(distribution) for distribution in distributions}
+
+
+def _import_names_for_distributions(distribution_names: set[str], package_distributions: dict[str, list[str]]) -> set[str]:
+    import_names = set()
+    for import_name, distributions in package_distributions.items():
+        if any(canonicalize_name(distribution) in distribution_names for distribution in distributions):
+            import_names.add(import_name)
+    return import_names
 
 
 def test_pandas_is_core_dependency_while_top_level_import_path_requires_it() -> None:
@@ -34,3 +131,30 @@ def test_pandas_is_core_dependency_while_top_level_import_path_requires_it() -> 
 
     assert "pandas" in dependencies
     assert str(dependencies["pandas"].specifier) == ">=2.0.0"
+
+
+@pytest.mark.parametrize(("entrypoint", "statement"), ENTRYPOINTS.items(), ids=list(ENTRYPOINTS))
+def test_eager_third_party_imports_are_declared_core_dependencies(entrypoint: str, statement: str) -> None:
+    core_dependency_names = set(_core_dependencies())
+    package_distributions = _packages_distributions()
+    imported = _direct_third_party_imports(statement)
+
+    undeclared = {
+        import_name: sorted(_canonical_distribution_names(import_name, package_distributions))
+        for import_name in imported
+        if not (_canonical_distribution_names(import_name, package_distributions) & core_dependency_names)
+    }
+
+    assert not undeclared, f"{entrypoint} has undeclared eager third-party imports: {undeclared}"
+
+
+@pytest.mark.parametrize(("entrypoint", "statement"), ENTRYPOINTS.items(), ids=list(ENTRYPOINTS))
+def test_optional_only_dependencies_stay_off_eager_import_paths(entrypoint: str, statement: str) -> None:
+    core_dependency_names = set(_core_dependencies())
+    optional_only_names = _optional_dependency_names() - core_dependency_names
+    package_distributions = _packages_distributions()
+    optional_only_import_names = _import_names_for_distributions(optional_only_names, package_distributions)
+
+    imported_optional_only = _direct_third_party_imports(statement) & optional_only_import_names
+
+    assert not imported_optional_only, f"{entrypoint} eagerly imports optional-only dependencies: {sorted(imported_optional_only)}"


### PR DESCRIPTION
## Summary
- removes the eager `benchbox.platforms` import from `benchbox.__init__` and lazy-loads the package through `__getattr__`
- defers adapter factory and ClickHouse implementation imports so `import benchbox` and selected platform symbols do not load pandas/clickhouse/polars/datafusion/pyspark/chdb
- preserves CLI platform hook registration and hardens `benchbox.platforms.PlatformRegistry` to resolve to the real registry class
- completes `_project/DONE/import-surface-reduction/planning/lazy-platform-import-surface.yaml`

## Review Follow-up Addressed
- fixed the empty option/config registry regression by removing the `platform_hooks -> core.platform_registry -> benchbox.platforms` circular import at module load
- replaced the proxy-style `PlatformRegistry` re-export with direct lazy resolution of the real class
- added regression coverage for lean import paths and registry class identity

## Verification
- `uv run ruff check benchbox/__init__.py benchbox/cli/platform_hooks.py benchbox/platforms/__init__.py benchbox/platforms/clickhouse/__init__.py tests/unit/test_package_dependencies.py tests/unit/platforms/test_platform_driver_runtime_contract.py`
- `uv run -- python -m pytest tests/unit/test_package_dependencies.py tests/unit/cli/test_platform_hooks.py tests/unit/platforms/test_platform_driver_runtime_contract.py tests/unit/platforms/test_dataframe_factory.py::TestPlatformHookRegistration tests/unit/platforms/dataframe/test_pandas_family_adapters.py -q` (101 passed)
- `uv run -- python -m pytest tests -m fast -q` (22209 passed, 5 skipped)
- `uv run ty check` (exit 0; existing warnings only)
- temp-cwd package smoke: `uv run --isolated --no-project --with /Users/joe/Developer/BenchBox -- python ...` imports wheel/site-packages and confirms prohibited platform/dataframe modules are absent
- TODO graph: `uv run --project ~/.claude/tools/todo todo-index` and `uv run --project ~/.claude/tools/todo todo-cli check-graph`

Note: unrelated local perf-smoke edits in `benchbox/cli/commands/compare.py` and `tests/unit/cli/test_compare_command_behavioral.py` were left out of this PR.