### PR TITLE
[codex] Harden release pipeline follow-ups

### DIFF
--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -28,19 +28,18 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from benchbox.cli.shared import console
-from benchbox.core.results.exporter import ResultExporter
+from benchbox.core.results.exporter import SIGNIFICANT_IMPROVEMENT_ASSESSMENT, ResultExporter
 from benchbox.core.results.loader import (
     ResultLoadError,
     UnsupportedSchemaError,
     load_result_file,
 )
 
-_SIGNIFICANT_IMPROVEMENT_ASSESSMENT = "significant_improvement"
 _MAX_BOUNDED_QUERY_REGRESSIONS = 2
 _MAX_BOUNDED_QUERY_REGRESSION_FRACTION = 0.10
 _MAX_BOUNDED_QUERY_REGRESSION_MULTIPLIER = 2.5
 _MAX_BOUNDED_QUERY_SLOWDOWN_MS = 2.0
-_MAX_BOUNDED_TOTAL_QUERY_SLOWDOWN_MS = 4.0
+_MAX_BOUNDED_TOTAL_QUERY_SLOWDOWN_MS = 3.0
 
 
 class ResultFileMetadata:
@@ -1449,7 +1448,7 @@ def _bounded_query_regressions_allowed(
 
     summary = comparison.get("summary", {})
     assessment = str(summary.get("overall_assessment", "")).lower()
-    if assessment != _SIGNIFICANT_IMPROVEMENT_ASSESSMENT:
+    if assessment != SIGNIFICANT_IMPROVEMENT_ASSESSMENT:
         return False, "per-query regression exceeded the threshold without significant aggregate improvement"
 
     aggregate_changes = _aggregate_change_percentages(comparison)
@@ -1463,6 +1462,7 @@ def _bounded_query_regressions_allowed(
     if query_count <= 0 or len(query_regressions) / query_count > _MAX_BOUNDED_QUERY_REGRESSION_FRACTION:
         return False, "per-query regressions exceeded the bounded-noise fraction"
 
+    # Keep the waiver stricter when callers choose a stricter regression threshold.
     max_allowed_change = threshold_pct * _MAX_BOUNDED_QUERY_REGRESSION_MULTIPLIER
     if any(regression["change_percent"] > max_allowed_change for regression in query_regressions):
         return False, "per-query regression percent exceeded the bounded-noise cap"

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -51,6 +51,8 @@ from benchbox.utils.cloud_storage import create_path_handler, is_cloud_path
 
 logger = logging.getLogger(__name__)
 
+SIGNIFICANT_IMPROVEMENT_ASSESSMENT = "significant_improvement"
+
 ResultLike = BenchmarkResults
 QueryResultLike = "QueryResult | dict[str, Any]"
 
@@ -756,7 +758,7 @@ class ResultExporter:
         avg_change = sum(time_changes) / len(time_changes)
 
         if avg_change < -10:
-            return "significant_improvement"
+            return SIGNIFICANT_IMPROVEMENT_ASSESSMENT
         if avg_change < -5:
             return "improvement"
         if avg_change > 10:

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -8,8 +8,9 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import functools
 import importlib
-from typing import Optional, Type
+from typing import Any, Literal, Optional, Type
 
 from benchbox.utils.runtime_env import DriverResolution, ensure_driver_version
 
@@ -330,44 +331,51 @@ __all__ = [
 ]
 
 
-def get_adapter(*args, **kwargs):
+def _adapter_factory_function(name: str):
+    function = getattr(importlib.import_module(".adapter_factory", __package__), name)
+    globals()[name].__wrapped__ = function
+    functools.update_wrapper(globals()[name], function)
+    return function
+
+
+def get_adapter(
+    platform: str,
+    mode: Optional[Literal["sql", "dataframe"]] = None,
+    deployment: Optional[str] = None,
+    **config: Any,
+) -> Any:
     """Lazy wrapper for the unified adapter factory."""
 
-    from benchbox.platforms.adapter_factory import get_adapter as _get_adapter
+    _get_adapter = _adapter_factory_function("get_adapter")
+    return _get_adapter(platform, mode=mode, deployment=deployment, **config)
 
-    return _get_adapter(*args, **kwargs)
 
-
-def is_dataframe_mode(*args, **kwargs):
+def is_dataframe_mode(platform: str, mode: Optional[str] = None) -> bool:
     """Lazy wrapper for adapter_factory.is_dataframe_mode."""
 
-    from benchbox.platforms.adapter_factory import is_dataframe_mode as _is_dataframe_mode
+    _is_dataframe_mode = _adapter_factory_function("is_dataframe_mode")
+    return _is_dataframe_mode(platform, mode=mode)
 
-    return _is_dataframe_mode(*args, **kwargs)
 
-
-def get_available_modes(*args, **kwargs):
+def get_available_modes(platform: str) -> list[str]:
     """Lazy wrapper for adapter_factory.get_available_modes."""
 
-    from benchbox.platforms.adapter_factory import get_available_modes as _get_available_modes
+    _get_available_modes = _adapter_factory_function("get_available_modes")
+    return _get_available_modes(platform)
 
-    return _get_available_modes(*args, **kwargs)
 
-
-def get_available_deployments(*args, **kwargs):
+def get_available_deployments(platform: str) -> list[str]:
     """Lazy wrapper for adapter_factory.get_available_deployments."""
 
-    from benchbox.platforms.adapter_factory import get_available_deployments as _get_available_deployments
+    _get_available_deployments = _adapter_factory_function("get_available_deployments")
+    return _get_available_deployments(platform)
 
-    return _get_available_deployments(*args, **kwargs)
 
-
-def get_default_deployment(*args, **kwargs):
+def get_default_deployment(platform: str) -> Optional[str]:
     """Lazy wrapper for adapter_factory.get_default_deployment."""
 
-    from benchbox.platforms.adapter_factory import get_default_deployment as _get_default_deployment
-
-    return _get_default_deployment(*args, **kwargs)
+    _get_default_deployment = _adapter_factory_function("get_default_deployment")
+    return _get_default_deployment(platform)
 
 
 def get_platform_adapter(platform_name: str, **config) -> PlatformAdapter:

--- a/scripts/check_dependency_audit.py
+++ b/scripts/check_dependency_audit.py
@@ -6,6 +6,11 @@ Checks both directions that matter for release safety:
   sites and is not an explicit CLI/plugin/guarded-optional exception.
 * imported-but-undeclared: source imports a third-party module that has no
   matching pyproject.toml declaration.
+
+The scan intentionally covers release-visible source plus tests, scripts, and
+docs configuration. A dependency used only by tests still counts as "used" for
+this audit; classification between core, optional, and test-only dependencies is
+covered by separate package metadata guardrails.
 """
 
 from __future__ import annotations

--- a/tests/unit/cli/test_compare_command_behavioral.py
+++ b/tests/unit/cli/test_compare_command_behavioral.py
@@ -232,12 +232,58 @@ class TestCheckRegression:
                 "average_query_time": {"baseline": 0.010, "current": 0.007, "change_percent": -29.81},
             },
             "query_comparisons": [
-                {"query_id": "18", "baseline_time_ms": 10.0, "current_time_ms": 12.0, "change_percent": 20.0},
-                {"query_id": "8", "baseline_time_ms": 9.0, "current_time_ms": 11.0, "change_percent": 22.22},
+                {"query_id": "18", "baseline_time_ms": 10.0, "current_time_ms": 11.4, "change_percent": 14.0},
+                {"query_id": "8", "baseline_time_ms": 10.0, "current_time_ms": 11.5, "change_percent": 15.0},
             ],
         }
 
         assert _check_regression(comparison, 0.10) is False
+
+    def test_bounded_micro_regressions_require_significant_assessment(self):
+        from benchbox.cli.commands.compare import _evaluate_regression_gate
+
+        comparison = {
+            "summary": {
+                "total_queries_compared": 22,
+                "overall_assessment": "improvement",
+            },
+            "performance_changes": {
+                "total_execution_time": {"change_percent": -30.0},
+                "average_query_time": {"change_percent": -30.0},
+            },
+            "query_comparisons": [
+                {"query_id": "8", "baseline_time_ms": 10.0, "current_time_ms": 11.5, "change_percent": 15.0},
+            ],
+        }
+
+        decision = _evaluate_regression_gate(comparison, 0.10)
+
+        assert decision["failed"] is True
+        assert (
+            decision["rule"] == "per-query regression exceeded the threshold without significant aggregate improvement"
+        )
+
+    def test_significant_assessment_requires_all_aggregate_metrics_over_threshold(self):
+        from benchbox.cli.commands.compare import _evaluate_regression_gate
+
+        comparison = {
+            "summary": {
+                "total_queries_compared": 22,
+                "overall_assessment": "significant_improvement",
+            },
+            "performance_changes": {
+                "total_execution_time": {"change_percent": -30.0},
+                "average_query_time": {"change_percent": -5.0},
+            },
+            "query_comparisons": [
+                {"query_id": "8", "baseline_time_ms": 10.0, "current_time_ms": 11.5, "change_percent": 15.0},
+            ],
+        }
+
+        decision = _evaluate_regression_gate(comparison, 0.10)
+
+        assert decision["failed"] is True
+        assert decision["rule"] == "aggregate improvement was not strong enough to waive bounded per-query noise"
 
     def test_significant_aggregate_improvement_still_fails_above_percent_cap(self):
         from benchbox.cli.commands.compare import _check_regression
@@ -259,7 +305,7 @@ class TestCheckRegression:
         assert _check_regression(comparison, 0.10) is True
 
     def test_significant_aggregate_improvement_still_fails_material_query_regression(self):
-        from benchbox.cli.commands.compare import _check_regression
+        from benchbox.cli.commands.compare import _evaluate_regression_gate
 
         comparison = {
             "summary": {
@@ -271,11 +317,37 @@ class TestCheckRegression:
                 "average_query_time": {"change_percent": -30.0},
             },
             "query_comparisons": [
-                {"query_id": "8", "baseline_time_ms": 9.0, "current_time_ms": 12.0, "change_percent": 33.33},
+                {"query_id": "8", "baseline_time_ms": 12.0, "current_time_ms": 14.5, "change_percent": 20.83},
             ],
         }
 
-        assert _check_regression(comparison, 0.10) is True
+        decision = _evaluate_regression_gate(comparison, 0.10)
+
+        assert decision["failed"] is True
+        assert decision["rule"] == "per-query absolute slowdown exceeded the bounded-noise cap"
+
+    def test_significant_aggregate_improvement_still_fails_total_query_slowdown_budget(self):
+        from benchbox.cli.commands.compare import _evaluate_regression_gate
+
+        comparison = {
+            "summary": {
+                "total_queries_compared": 22,
+                "overall_assessment": "significant_improvement",
+            },
+            "performance_changes": {
+                "total_execution_time": {"change_percent": -30.0},
+                "average_query_time": {"change_percent": -30.0},
+            },
+            "query_comparisons": [
+                {"query_id": "8", "baseline_time_ms": 10.0, "current_time_ms": 11.6, "change_percent": 16.0},
+                {"query_id": "18", "baseline_time_ms": 10.0, "current_time_ms": 11.6, "change_percent": 16.0},
+            ],
+        }
+
+        decision = _evaluate_regression_gate(comparison, 0.10)
+
+        assert decision["failed"] is True
+        assert decision["rule"] == "total per-query slowdown exceeded the bounded-noise budget"
 
     def test_significant_aggregate_improvement_still_fails_too_many_query_regressions(self):
         from benchbox.cli.commands.compare import _check_regression

--- a/tests/unit/platforms/test_platform_driver_runtime_contract.py
+++ b/tests/unit/platforms/test_platform_driver_runtime_contract.py
@@ -1,3 +1,4 @@
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -82,6 +83,25 @@ def test_platforms_reexports_real_platform_registry_class():
     from benchbox.core.platform_registry import PlatformRegistry
 
     assert platforms.PlatformRegistry is PlatformRegistry
+
+
+def test_lazy_adapter_factory_wrappers_preserve_introspection():
+    import benchbox.platforms as platforms
+    from benchbox.platforms import adapter_factory
+
+    assert inspect.signature(platforms.get_adapter) == inspect.signature(adapter_factory.get_adapter)
+    assert inspect.signature(platforms.is_dataframe_mode) == inspect.signature(adapter_factory.is_dataframe_mode)
+    assert inspect.signature(platforms.get_available_modes) == inspect.signature(adapter_factory.get_available_modes)
+    assert inspect.signature(platforms.get_available_deployments) == inspect.signature(
+        adapter_factory.get_available_deployments
+    )
+    assert inspect.signature(platforms.get_default_deployment) == inspect.signature(
+        adapter_factory.get_default_deployment
+    )
+
+    platforms.get_available_modes("duckdb")
+
+    assert platforms.get_available_modes.__wrapped__ is adapter_factory.get_available_modes
 
 
 def test_dataframe_adapter_rejects_requested_version_for_non_package_platform():

--- a/tests/unit/test_package_dependencies.py
+++ b/tests/unit/test_package_dependencies.py
@@ -55,6 +55,38 @@ PROHIBITED_EAGER_IMPORTS = {
     "pyspark",
 }
 
+OPTIONAL_DISTRIBUTION_IMPORT_NAMES = {
+    "chdb": {"chdb"},
+    "clickhouse-connect": {"clickhouse_connect"},
+    "clickhouse-driver": {"clickhouse_driver"},
+    "dask": {"dask", "distributed"},
+    "databricks-connect": {"databricks"},
+    "databricks-sdk": {"databricks"},
+    "databricks-sql-connector": {"databricks"},
+    "datafusion": {"datafusion"},
+    "delta-spark": {"delta"},
+    "deltalake": {"deltalake"},
+    "firebolt-sdk": {"firebolt"},
+    "google-cloud-bigquery": {"google"},
+    "google-cloud-dataproc": {"google"},
+    "google-cloud-storage": {"google"},
+    "influxdb3-python": {"influxdb_client_3"},
+    "modin": {"modin"},
+    "polars": {"polars"},
+    "presto-python-client": {"prestodb"},
+    "pyathena": {"pyathena"},
+    "pyiceberg": {"pyiceberg"},
+    "pymysql": {"pymysql"},
+    "pyodbc": {"pyodbc"},
+    "pyspark": {"pyspark"},
+    "redshift-connector": {"redshift_connector"},
+    "singlestoredb": {"singlestoredb"},
+    "snowflake-connector-python": {"snowflake"},
+    "snowflake-snowpark-python": {"snowflake"},
+    "trino": {"trino"},
+    "vortex-data": {"vortex"},
+}
+
 
 def _pyproject() -> dict:
     return tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
@@ -152,10 +184,22 @@ def _import_names_for_distributions(
     distribution_names: set[str], package_distributions: dict[str, list[str]]
 ) -> set[str]:
     import_names = set()
+    for distribution_name in distribution_names:
+        import_names.add(distribution_name.replace("-", "_"))
+        import_names.update(OPTIONAL_DISTRIBUTION_IMPORT_NAMES.get(distribution_name, set()))
     for import_name, distributions in package_distributions.items():
         if any(canonicalize_name(distribution) in distribution_names for distribution in distributions):
             import_names.add(import_name)
     return import_names
+
+
+def test_optional_import_name_mapping_does_not_depend_on_installed_extras() -> None:
+    import_names = _import_names_for_distributions(
+        {"clickhouse-connect", "clickhouse-driver", "datafusion", "polars", "snowflake-connector-python"},
+        {},
+    )
+
+    assert {"clickhouse_connect", "clickhouse_driver", "datafusion", "polars", "snowflake"} <= import_names
 
 
 def test_pandas_is_core_dependency_while_top_level_import_path_requires_it() -> None:

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from importlib import import_module
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,16 @@ def _assert_canonical_json_file(path: Path) -> None:
     assert not raw.endswith(b"\n\n")
     assert raw == _eof_fixed(raw)
     assert raw == canonical_json_bytes(json.loads(raw))
+
+
+def test_significant_improvement_assessment_constant_matches_compare_gate():
+    compare_module = import_module("benchbox.cli.commands.compare")
+
+    assert (
+        compare_module.SIGNIFICANT_IMPROVEMENT_ASSESSMENT
+        == exporter_module.SIGNIFICANT_IMPROVEMENT_ASSESSMENT
+        == "significant_improvement"
+    )
 
 
 def test_exporter_serializes_execution_phases(tmp_path):


### PR DESCRIPTION
## Summary

- Tightens the bounded performance-smoke total query slowdown cap so it is reachable, and documents the threshold-relative percent cap.
- Shares the significant-improvement assessment literal between result export and compare gating.
- Adds isolated regression-gate coverage for the assessment guard, weak aggregate deny path, absolute slowdown cap, and total slowdown budget.
- Hardens optional dependency import-name detection when optional extras are not installed, preserves lazy platform wrapper introspection, and clarifies dependency-audit scan scope.

## Validation

- `uv run ruff check benchbox/cli/commands/compare.py benchbox/core/results/exporter.py benchbox/platforms/__init__.py scripts/check_dependency_audit.py tests/unit/cli/test_compare_command_behavioral.py tests/unit/test_package_dependencies.py tests/unit/test_results_exporter.py tests/unit/platforms/test_platform_driver_runtime_contract.py tests/unit/scripts/test_check_dependency_audit.py`
- `uv run ruff format --check benchbox/cli/commands/compare.py benchbox/core/results/exporter.py benchbox/platforms/__init__.py scripts/check_dependency_audit.py tests/unit/cli/test_compare_command_behavioral.py tests/unit/test_package_dependencies.py tests/unit/test_results_exporter.py tests/unit/platforms/test_platform_driver_runtime_contract.py`
- `uv run -- python -m pytest tests/unit/cli/test_compare_command_behavioral.py tests/unit/test_results_exporter.py tests/unit/test_package_dependencies.py tests/unit/platforms/test_platform_driver_runtime_contract.py tests/unit/scripts/test_check_dependency_audit.py -q` — 113 passed.
- GitHub Actions on PR #486 passed on commit `a67f33053a118bdc22a9183facbb68c5c6415cca`: lint, tests, compatibility matrix, documentation checks, validate-base, and performance smoke.
