### PR TITLE
chore: shrink tpch skew dataframe registry

### DIFF
--- a/benchbox/core/tpch_skew/dataframe_queries/queries.py
+++ b/benchbox/core/tpch_skew/dataframe_queries/queries.py
@@ -11,6 +11,8 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from benchbox.core.dataframe.query import DataFrameQuery
 from benchbox.core.tpch.dataframe_queries import TPCH_DATAFRAME_QUERIES
 from benchbox.core.tpch_skew.dataframe_queries.registry import register_query
@@ -23,19 +25,7 @@ def _register_all_queries() -> None:
     functions but are registered in the TPC-H Skew registry.
     """
     for tpch_query in TPCH_DATAFRAME_QUERIES.get_all_queries():
-        skew_query = DataFrameQuery(
-            query_id=tpch_query.query_id,
-            query_name=tpch_query.query_name,
-            description=tpch_query.description,
-            categories=tpch_query.categories,
-            expression_impl=tpch_query.expression_impl,
-            pandas_impl=tpch_query.pandas_impl,
-            sql_equivalent=tpch_query.sql_equivalent,
-            expected_row_count=tpch_query.expected_row_count,
-            scale_factor_dependent=tpch_query.scale_factor_dependent,
-            timeout_seconds=tpch_query.timeout_seconds,
-            skip_platforms=tpch_query.skip_platforms,
-        )
+        skew_query: DataFrameQuery = replace(tpch_query)
         register_query(skew_query)
 
 


### PR DESCRIPTION
Surface/module shrunk: TPC-H Skew DataFrame query registry.
Files changed: benchbox/core/tpch_skew/dataframe_queries/queries.py.
Original code lines: 21.
New code lines: 10.
Lines removed: 11.
Reduction: 52.4%.
Simplification type: replaced repeated dataclass field copy with dataclasses.replace while retaining the DataFrameQuery import that preserves the existing import-order behavior.
Behavior preserved: the TPCH skew registry still creates separate query objects, keeps all 22 query IDs and fields identical to baseline, preserves shared expression/pandas implementation references, and preserves categories/skip_platform list references.
Verification: diff -u /tmp/tpch_skew_registry_before.json /tmp/tpch_skew_registry_after.json; uv run -- ruff format benchbox/core/tpch_skew/dataframe_queries/queries.py; uv run -- ruff check benchbox/core/tpch_skew/dataframe_queries/queries.py; git diff --check -- benchbox/core/tpch_skew/dataframe_queries/queries.py; uv run -- python -m pytest tests/unit/core/tpch_skew/test_tpch_skew_dataframe_queries.py -q (40 passed); make pr-preflight (22707 passed, 5 skipped, 47 warnings, 4 subtests passed in 98.93s).
Residual risk: low; the preserved DataFrameQuery import is intentional because removing it changed fresh-interpreter import behavior during review.
Next recommended shrink target: a larger non-overlapping DataFrame query registry or adapter boilerplate cluster after pending shrink PRs merge.
