### PR TITLE
chore: shrink tpchavoc dataframe returns

### DIFF
--- a/benchbox/core/tpchavoc/dataframe_queries/q01.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q01.py
@@ -48,7 +48,7 @@ def q1_v2_expression_impl(ctx: DataFrameContext) -> Any:
 
     # Pre-filter first, then aggregate
     filtered = lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-    result = (
+    return (
         filtered.group_by("l_returnflag", "l_linestatus")
         .agg(
             col("l_quantity").sum().alias("sum_qty"),
@@ -62,7 +62,6 @@ def q1_v2_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -78,7 +77,7 @@ def q1_v2_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -92,7 +91,6 @@ def q1_v2_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +116,7 @@ def q1_v3_expression_impl(ctx: DataFrameContext) -> Any:
         "l_orderkey",
         "l_shipdate",
     ]
-    result = (
+    return (
         lineitem.select(needed_cols)
         .filter(col("l_shipdate") <= lit(cutoff_date))
         .group_by("l_returnflag", "l_linestatus")
@@ -134,7 +132,6 @@ def q1_v3_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -158,7 +155,7 @@ def q1_v3_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -172,7 +169,6 @@ def q1_v3_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -202,8 +198,7 @@ def q1_v4_expression_impl(ctx: DataFrameContext) -> Any:
         col("l_orderkey").count().alias("count_order"),
     )
     # Step 3: sort
-    result = step2.sort("l_returnflag", "l_linestatus")
-    return result
+    return step2.sort("l_returnflag", "l_linestatus")
 
 
 def q1_v4_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -228,8 +223,7 @@ def q1_v4_pandas_impl(ctx: DataFrameContext) -> Any:
         count_order=("l_orderkey", "count"),
     )
     # Step 4: sort
-    result = aggregated.sort_values(["l_returnflag", "l_linestatus"])
-    return result
+    return aggregated.sort_values(["l_returnflag", "l_linestatus"])
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +239,7 @@ def q1_v5_expression_impl(ctx: DataFrameContext) -> Any:
     params = get_tpch_parameters(1)
     cutoff_date = params["cutoff_date"]
 
-    result = (
+    return (
         lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
         .with_columns(
             (col("l_extendedprice") * (lit(1) - col("l_discount"))).alias("disc_price"),
@@ -264,7 +258,6 @@ def q1_v5_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -277,7 +270,7 @@ def q1_v5_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -291,7 +284,6 @@ def q1_v5_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -359,7 +351,7 @@ def q1_v7_expression_impl(ctx: DataFrameContext) -> Any:
     cutoff_date = params["cutoff_date"]
 
     # Group by in reversed key order, then re-sort correctly
-    result = (
+    return (
         lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
         .group_by("l_linestatus", "l_returnflag")
         .agg(
@@ -386,7 +378,6 @@ def q1_v7_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -442,7 +433,7 @@ def q1_v8_expression_impl(ctx: DataFrameContext) -> Any:
     cutoff_date = params["cutoff_date"]
 
     # Compound predicate in a single filter call
-    result = (
+    return (
         lineitem.filter((col("l_shipdate") <= lit(cutoff_date)) & (col("l_quantity") > lit(0)))
         .filter(col("l_extendedprice") > lit(0))
         .group_by("l_returnflag", "l_linestatus")
@@ -458,7 +449,6 @@ def q1_v8_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v8_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -474,7 +464,7 @@ def q1_v8_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -488,7 +478,6 @@ def q1_v8_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +493,7 @@ def q1_v9_expression_impl(ctx: DataFrameContext) -> Any:
     params = get_tpch_parameters(1)
     cutoff_date = params["cutoff_date"]
 
-    result = (
+    return (
         lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
         .group_by("l_returnflag", "l_linestatus")
         .agg(
@@ -519,7 +508,6 @@ def q1_v9_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort(["l_returnflag", "l_linestatus"], descending=[False, False])
     )
-    return result
 
 
 def q1_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -531,7 +519,7 @@ def q1_v9_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -545,7 +533,6 @@ def q1_v9_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"], ascending=[True, True])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +552,7 @@ def q1_v10_expression_impl(ctx: DataFrameContext) -> Any:
     disc_price_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
     charge_alt = disc_price_alt * (lit(1) + col("l_tax"))
 
-    result = (
+    return (
         lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
         .group_by("l_returnflag", "l_linestatus")
         .agg(
@@ -580,7 +567,6 @@ def q1_v10_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .sort("l_returnflag", "l_linestatus")
     )
-    return result
 
 
 def q1_v10_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -593,7 +579,7 @@ def q1_v10_pandas_impl(ctx: DataFrameContext) -> Any:
     filtered["disc_price"] = filtered["l_extendedprice"] - filtered["l_extendedprice"] * filtered["l_discount"]
     filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
 
-    result = (
+    return (
         filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
@@ -607,7 +593,6 @@ def q1_v10_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result
 
 
 # ---------------------------------------------------------------------------

--- a/benchbox/core/tpchavoc/dataframe_queries/q02.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q02.py
@@ -65,7 +65,7 @@ def q2_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("ps_supplycost").min().alias("min_cost"))
     )
 
-    result = (
+    return (
         filtered_part.join(partsupp, left_on="p_partkey", right_on="ps_partkey")
         .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
         .join(nation, left_on="s_nationkey", right_on="n_nationkey")
@@ -85,7 +85,6 @@ def q2_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
         .limit(100)
     )
-    return result
 
 
 def q2_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -118,12 +117,11 @@ def q2_v2_pandas_impl(ctx: DataFrameContext) -> Any:
     joined = joined.merge(min_cost, left_on="p_partkey", right_on="ps_partkey")
     joined = joined[joined["ps_supplycost"] == joined["min_cost"]]
 
-    result = (
+    return (
         joined[["s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment"]]
         .sort_values(["s_acctbal", "n_name", "s_name", "p_partkey"], ascending=[False, True, True, True])
         .head(100)
     )
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +157,7 @@ def q3_v3_expression_impl_q2(ctx: DataFrameContext) -> Any:
         .agg(col("ps_supplycost").min().alias("min_cost"))
     )
 
-    result = (
+    return (
         part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
         .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
         .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
@@ -171,7 +169,6 @@ def q3_v3_expression_impl_q2(ctx: DataFrameContext) -> Any:
         .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
         .limit(100)
     )
-    return result
 
 
 def q2_v3_expression_impl(ctx: DataFrameContext) -> Any:
@@ -253,12 +250,11 @@ def q2_v4_expression_impl(ctx: DataFrameContext) -> Any:
     with_nation = with_supplier.join(nation_in_region, left_on="s_nationkey", right_on="n_nationkey")
     with_min = with_nation.join(min_cost_per_part, left_on="p_partkey", right_on="ps_partkey")
     at_min_cost = with_min.filter(col("ps_supplycost") == col("min_cost"))
-    result = (
+    return (
         at_min_cost.select("s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment")
         .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
         .limit(100)
     )
-    return result
 
 
 def q2_v4_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -320,7 +316,7 @@ def q2_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("ps_supplycost").min().alias("min_cost"))
     )
 
-    result = (
+    return (
         part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
         .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
         .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
@@ -333,7 +329,6 @@ def q2_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
         .limit(100)
     )
-    return result
 
 
 def q2_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -444,7 +439,7 @@ def q2_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("ps_supplycost").min().alias("min_cost"))
     )
 
-    result = (
+    return (
         part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
         .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
         .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
@@ -457,7 +452,6 @@ def q2_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
         .limit(100)
     )
-    return result
 
 
 def q2_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -565,7 +559,7 @@ def q2_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("ps_supplycost").min().alias("min_cost"))
     )
 
-    result = (
+    return (
         part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
         .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
         .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
@@ -581,7 +575,6 @@ def q2_v9_expression_impl(ctx: DataFrameContext) -> Any:
         )
         .limit(100)
     )
-    return result
 
 
 def q2_v9_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q03.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q03.py
@@ -54,7 +54,7 @@ def q3_v2_expression_impl(ctx: DataFrameContext) -> Any:
     filtered_orders = orders.filter(col("o_orderdate") < lit(order_date))
     filtered_lineitem = lineitem.filter(col("l_shipdate") > lit(order_date))
 
-    result = (
+    return (
         filtered_customer.join(filtered_orders, left_on="c_custkey", right_on="o_custkey")
         .join(filtered_lineitem, left_on="o_orderkey", right_on="l_orderkey")
         .group_by("o_orderkey", "o_orderdate", "o_shippriority")
@@ -62,7 +62,6 @@ def q3_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -106,7 +105,7 @@ def q3_v3_expression_impl(ctx: DataFrameContext) -> Any:
     segment = params["segment"]
     order_date = params["order_date"]
 
-    result = (
+    return (
         customer.select("c_custkey", "c_mktsegment")
         .filter(col("c_mktsegment") == lit(segment))
         .join(
@@ -126,7 +125,6 @@ def q3_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -186,8 +184,7 @@ def q3_v4_expression_impl(ctx: DataFrameContext) -> Any:
         (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue")
     )
     # Step 5: sort and limit
-    result = aggregated.sort(["revenue", "o_orderdate"], descending=[True, False]).limit(10)
-    return result
+    return aggregated.sort(["revenue", "o_orderdate"], descending=[True, False]).limit(10)
 
 
 def q3_v4_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -227,7 +224,7 @@ def q3_v5_expression_impl(ctx: DataFrameContext) -> Any:
     segment = params["segment"]
     order_date = params["order_date"]
 
-    result = (
+    return (
         customer.filter(col("c_mktsegment") == lit(segment))
         .join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter(col("o_orderdate") < lit(order_date))
@@ -239,7 +236,6 @@ def q3_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -312,7 +308,7 @@ def q3_v7_expression_impl(ctx: DataFrameContext) -> Any:
     orders_lineitem = orders.filter(col("o_orderdate") < lit(order_date)).join(
         lineitem.filter(col("l_shipdate") > lit(order_date)), left_on="o_orderkey", right_on="l_orderkey"
     )
-    result = (
+    return (
         customer.filter(col("c_mktsegment") == lit(segment))
         .join(orders_lineitem, left_on="c_custkey", right_on="o_custkey")
         .group_by("o_orderkey", "o_orderdate", "o_shippriority")
@@ -320,7 +316,6 @@ def q3_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -366,7 +361,7 @@ def q3_v8_expression_impl(ctx: DataFrameContext) -> Any:
     segment = params["segment"]
     order_date = params["order_date"]
 
-    result = (
+    return (
         customer.filter(col("c_mktsegment") == lit(segment))
         .join(orders, left_on="c_custkey", right_on="o_custkey")
         .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
@@ -377,7 +372,6 @@ def q3_v8_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v8_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -420,7 +414,7 @@ def q3_v9_expression_impl(ctx: DataFrameContext) -> Any:
     segment = params["segment"]
     order_date = params["order_date"]
 
-    result = (
+    return (
         customer.filter(col("c_mktsegment") == lit(segment))
         .join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter(col("o_orderdate") < lit(order_date))
@@ -431,7 +425,6 @@ def q3_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -476,7 +469,7 @@ def q3_v10_expression_impl(ctx: DataFrameContext) -> Any:
 
     revenue_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
 
-    result = (
+    return (
         customer.filter(col("c_mktsegment") == lit(segment))
         .join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter(col("o_orderdate") < lit(order_date))
@@ -487,7 +480,6 @@ def q3_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .sort(["revenue", "o_orderdate"], descending=[True, False])
         .limit(10)
     )
-    return result
 
 
 def q3_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q04.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q04.py
@@ -54,13 +54,12 @@ def q4_v2_expression_impl(ctx: DataFrameContext) -> Any:
     # Pre-filter lineitem
     late_orders = lineitem.filter(col("l_commitdate") < col("l_receiptdate")).select("l_orderkey").unique()
 
-    result = (
+    return (
         filtered_orders.join(late_orders, left_on="o_orderkey", right_on="l_orderkey", how="semi")
         .group_by("o_orderpriority")
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority")
     )
-    return result
 
 
 def q4_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -112,7 +111,7 @@ def q4_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .unique()
     )
 
-    result = (
+    return (
         orders.select("o_orderkey", "o_orderdate", "o_orderpriority")
         .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(late_orders, left_on="o_orderkey", right_on="l_orderkey", how="semi")
@@ -120,7 +119,6 @@ def q4_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority")
     )
-    return result
 
 
 def q4_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -220,14 +218,13 @@ def q4_v5_expression_impl(ctx: DataFrameContext) -> Any:
     lineitem_with_flag = lineitem.with_columns((col("l_commitdate") < col("l_receiptdate")).alias("is_late"))
     late_orders = lineitem_with_flag.filter(col("is_late")).select("l_orderkey").unique()
 
-    result = (
+    return (
         orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(late_orders, left_on="o_orderkey", right_on="l_orderkey", how="semi")
         .group_by("o_orderpriority")
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority")
     )
-    return result
 
 
 def q4_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -299,7 +296,7 @@ def q4_v7_expression_impl(ctx: DataFrameContext) -> Any:
     # Use inner join + unique instead of semi-join (equivalent result)
     late_orders = lineitem.filter(col("l_commitdate") < col("l_receiptdate")).select("l_orderkey").unique()
 
-    result = (
+    return (
         orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(late_orders, left_on="o_orderkey", right_on="l_orderkey")
         .select("o_orderkey", "o_orderpriority")
@@ -308,7 +305,6 @@ def q4_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority")
     )
-    return result
 
 
 def q4_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -350,14 +346,13 @@ def q4_v8_expression_impl(ctx: DataFrameContext) -> Any:
     late_orders = lineitem.filter(col("l_commitdate") < col("l_receiptdate")).select("l_orderkey").unique()
 
     date_filter = (col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date))
-    result = (
+    return (
         orders.filter(date_filter)
         .join(late_orders, left_on="o_orderkey", right_on="l_orderkey", how="semi")
         .group_by("o_orderpriority")
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority")
     )
-    return result
 
 
 def q4_v8_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -398,14 +393,13 @@ def q4_v9_expression_impl(ctx: DataFrameContext) -> Any:
 
     late_orders = lineitem.filter(col("l_commitdate") < col("l_receiptdate")).select("l_orderkey").unique()
 
-    result = (
+    return (
         orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(late_orders, left_on="o_orderkey", right_on="l_orderkey", how="semi")
         .group_by("o_orderpriority")
         .agg(col("o_orderkey").count().alias("order_count"))
         .sort("o_orderpriority", descending=False)
     )
-    return result
 
 
 def q4_v9_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q05.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q05.py
@@ -56,7 +56,7 @@ def q5_v2_expression_impl(ctx: DataFrameContext) -> Any:
     filtered_region = region.filter(col("r_name") == lit(region_name))
     filtered_orders = orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
 
-    result = (
+    return (
         filtered_region.join(nation, left_on="r_regionkey", right_on="n_regionkey")
         .join(customer, left_on="n_nationkey", right_on="c_nationkey")
         .join(filtered_orders, left_on="c_custkey", right_on="o_custkey")
@@ -66,7 +66,6 @@ def q5_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -119,7 +118,7 @@ def q5_v3_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         region.select("r_regionkey", "r_name")
         .filter(col("r_name") == lit(region_name))
         .join(nation.select("n_regionkey", "n_nationkey", "n_name"), left_on="r_regionkey", right_on="n_regionkey")
@@ -145,7 +144,6 @@ def q5_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -237,7 +235,7 @@ def q5_v5_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         region.filter(col("r_name") == lit(region_name))
         .join(nation, left_on="r_regionkey", right_on="n_regionkey")
         .join(customer, left_on="n_nationkey", right_on="c_nationkey")
@@ -250,7 +248,6 @@ def q5_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("revenue").sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -342,14 +339,13 @@ def q5_v7_expression_impl(ctx: DataFrameContext) -> Any:
     customer_orders = asia_customers.join(orders, left_on="c_custkey", right_on="o_custkey").filter(
         (col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date))
     )
-    result = (
+    return (
         customer_orders.join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
         .join(supplier, left_on=["l_suppkey", "n_nationkey"], right_on=["s_suppkey", "s_nationkey"])
         .group_by("n_name")
         .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -441,7 +437,7 @@ def q5_v9_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         region.filter(col("r_name") == lit(region_name))
         .join(nation, left_on="r_regionkey", right_on="n_regionkey")
         .join(customer, left_on="n_nationkey", right_on="c_nationkey")
@@ -453,7 +449,6 @@ def q5_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -508,7 +503,7 @@ def q5_v10_expression_impl(ctx: DataFrameContext) -> Any:
 
     revenue_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
 
-    result = (
+    return (
         region.filter(col("r_name") == lit(region_name))
         .join(nation, left_on="r_regionkey", right_on="n_regionkey")
         .join(customer, left_on="n_nationkey", right_on="c_nationkey")
@@ -520,7 +515,6 @@ def q5_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(revenue_alt.sum().alias("revenue"))
         .sort("revenue", descending=True)
     )
-    return result
 
 
 def q5_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q07.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q07.py
@@ -59,7 +59,7 @@ def q7_v2_expression_impl(ctx: DataFrameContext) -> Any:
     # Pre-filter lineitem by date
     filtered_lineitem = lineitem.filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
 
-    result = (
+    return (
         supplier.join(n1, left_on="s_nationkey", right_on="n1_nationkey")
         .join(filtered_lineitem, left_on="s_suppkey", right_on="l_suppkey")
         .join(orders, left_on="l_orderkey", right_on="o_orderkey")
@@ -77,7 +77,6 @@ def q7_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort("supp_nation", "cust_nation", "l_year")
     )
-    return result
 
 
 def q7_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -144,7 +143,7 @@ def q7_v3_expression_impl(ctx: DataFrameContext) -> Any:
     n1 = nation.select(col("n_nationkey").alias("n1_nationkey"), col("n_name").alias("supp_nation"))
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("cust_nation"))
 
-    result = (
+    return (
         supplier.select("s_suppkey", "s_nationkey")
         .join(n1, left_on="s_nationkey", right_on="n1_nationkey")
         .join(
@@ -168,7 +167,6 @@ def q7_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort("supp_nation", "cust_nation", "l_year")
     )
-    return result
 
 
 def q7_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -246,7 +244,7 @@ def q7_v5_expression_impl(ctx: DataFrameContext) -> Any:
     n1 = nation.select(col("n_nationkey").alias("n1_nationkey"), col("n_name").alias("supp_nation"))
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("cust_nation"))
 
-    result = (
+    return (
         supplier.join(n1, left_on="s_nationkey", right_on="n1_nationkey")
         .join(lineitem, left_on="s_suppkey", right_on="l_suppkey")
         .filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
@@ -266,7 +264,6 @@ def q7_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort("supp_nation", "cust_nation", "l_year")
     )
-    return result
 
 
 def q7_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -368,7 +365,7 @@ def q7_v7_expression_impl(ctx: DataFrameContext) -> Any:
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("cust_nation"))
 
     # Swapped: lineitem → supplier instead of supplier → lineitem
-    result = (
+    return (
         lineitem.filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(n1, left_on="s_nationkey", right_on="n1_nationkey")
@@ -387,7 +384,6 @@ def q7_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort("supp_nation", "cust_nation", "l_year")
     )
-    return result
 
 
 def q7_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -464,7 +460,7 @@ def q7_v9_expression_impl(ctx: DataFrameContext) -> Any:
     n1 = nation.select(col("n_nationkey").alias("n1_nationkey"), col("n_name").alias("supp_nation"))
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("cust_nation"))
 
-    result = (
+    return (
         supplier.join(n1, left_on="s_nationkey", right_on="n1_nationkey")
         .join(lineitem, left_on="s_suppkey", right_on="l_suppkey")
         .filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
@@ -483,7 +479,6 @@ def q7_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort(["supp_nation", "cust_nation", "l_year"], descending=[False, False, False])
     )
-    return result
 
 
 def q7_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -549,7 +544,7 @@ def q7_v10_expression_impl(ctx: DataFrameContext) -> Any:
     # Alternative: price - price*disc
     volume_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
 
-    result = (
+    return (
         supplier.join(n1, left_on="s_nationkey", right_on="n1_nationkey")
         .join(lineitem, left_on="s_suppkey", right_on="l_suppkey")
         .filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
@@ -568,7 +563,6 @@ def q7_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("volume").sum().alias("revenue"))
         .sort("supp_nation", "cust_nation", "l_year")
     )
-    return result
 
 
 def q7_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q08.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q08.py
@@ -62,7 +62,7 @@ def q8_v2_expression_impl(ctx: DataFrameContext) -> Any:
     filtered_part = part.filter(col("p_type") == lit(target_type))
     filtered_orders = orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") <= lit(end_date)))
 
-    result = (
+    return (
         filtered_part.join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(n2, left_on="s_nationkey", right_on="n2_nationkey")
@@ -84,7 +84,6 @@ def q8_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .select("o_year", "mkt_share")
         .sort("o_year")
     )
-    return result
 
 
 def q8_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -223,7 +222,7 @@ def q8_v5_expression_impl(ctx: DataFrameContext) -> Any:
 
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("nation"))
 
-    result = (
+    return (
         part.filter(col("p_type") == lit(target_type))
         .join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
@@ -248,7 +247,6 @@ def q8_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .select("o_year", "mkt_share")
         .sort("o_year")
     )
-    return result
 
 
 def q8_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -362,7 +360,7 @@ def q8_v7_expression_impl(ctx: DataFrameContext) -> Any:
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("nation"))
 
     # Swapped: start from lineitem→part instead of part→lineitem
-    result = (
+    return (
         lineitem.join(part.filter(col("p_type") == lit(target_type)), left_on="l_partkey", right_on="p_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(n2, left_on="s_nationkey", right_on="n2_nationkey")
@@ -385,7 +383,6 @@ def q8_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .select("o_year", "mkt_share")
         .sort("o_year")
     )
-    return result
 
 
 def q8_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -430,7 +427,7 @@ def q8_v9_expression_impl(ctx: DataFrameContext) -> Any:
 
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("nation"))
 
-    result = (
+    return (
         part.filter(col("p_type") == lit(target_type))
         .join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
@@ -454,7 +451,6 @@ def q8_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .select("o_year", "mkt_share")
         .sort("o_year", descending=False)
     )
-    return result
 
 
 def q8_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -487,7 +483,7 @@ def q8_v10_expression_impl(ctx: DataFrameContext) -> Any:
     n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("nation"))
     volume_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
 
-    result = (
+    return (
         part.filter(col("p_type") == lit(target_type))
         .join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
@@ -511,7 +507,6 @@ def q8_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .select("o_year", "mkt_share")
         .sort("o_year")
     )
-    return result
 
 
 def q8_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q09.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q09.py
@@ -54,7 +54,7 @@ def q9_v2_expression_impl(ctx: DataFrameContext) -> Any:
     # Pre-filter part by name
     filtered_part = part.filter(col("p_name").str.contains(color))
 
-    result = (
+    return (
         filtered_part.join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(partsupp, left_on=["l_suppkey", "p_partkey"], right_on=["ps_suppkey", "ps_partkey"])
@@ -70,7 +70,6 @@ def q9_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("amount").sum().alias("sum_profit"))
         .sort(["nation", "o_year"], descending=[False, True])
     )
-    return result
 
 
 def q9_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -122,7 +121,7 @@ def q9_v3_expression_impl(ctx: DataFrameContext) -> Any:
     params = get_tpch_parameters(9)
     color = params["color"]
 
-    result = (
+    return (
         part.select("p_partkey", "p_name")
         .filter(col("p_name").str.contains(color))
         .join(
@@ -148,7 +147,6 @@ def q9_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("amount").sum().alias("sum_profit"))
         .sort(["nation", "o_year"], descending=[False, True])
     )
-    return result
 
 
 def q9_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -289,7 +287,7 @@ def q9_v7_expression_impl(ctx: DataFrameContext) -> Any:
     color = params["color"]
 
     # Swapped: start from lineitem→part
-    result = (
+    return (
         lineitem.join(part.filter(col("p_name").str.contains(color)), left_on="l_partkey", right_on="p_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
         .join(partsupp, left_on=["l_suppkey", "p_partkey"], right_on=["ps_suppkey", "ps_partkey"])
@@ -305,7 +303,6 @@ def q9_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("amount").sum().alias("sum_profit"))
         .sort(["nation", "o_year"], descending=[False, True])
     )
-    return result
 
 
 def q9_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -397,7 +394,7 @@ def q9_v9_expression_impl(ctx: DataFrameContext) -> Any:
     params = get_tpch_parameters(9)
     color = params["color"]
 
-    result = (
+    return (
         part.filter(col("p_name").str.contains(color))
         .join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
@@ -414,7 +411,6 @@ def q9_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("amount").sum().alias("sum_profit"))
         .sort(["nation", "o_year"], descending=[False, True])
     )
-    return result
 
 
 def q9_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -443,7 +439,7 @@ def q9_v10_expression_impl(ctx: DataFrameContext) -> Any:
         "l_quantity"
     )
 
-    result = (
+    return (
         part.filter(col("p_name").str.contains(color))
         .join(lineitem, left_on="p_partkey", right_on="l_partkey")
         .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
@@ -458,7 +454,6 @@ def q9_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .agg(col("amount").sum().alias("sum_profit"))
         .sort(["nation", "o_year"], descending=[False, True])
     )
-    return result
 
 
 def q9_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q10.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q10.py
@@ -53,7 +53,7 @@ def q10_v2_expression_impl(ctx: DataFrameContext) -> Any:
     filtered_orders = orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
     filtered_lineitem = lineitem.filter(col("l_returnflag") == lit("R"))
 
-    result = (
+    return (
         customer.join(filtered_orders, left_on="c_custkey", right_on="o_custkey")
         .join(filtered_lineitem, left_on="o_orderkey", right_on="l_orderkey")
         .join(nation, left_on="c_nationkey", right_on="n_nationkey")
@@ -62,7 +62,6 @@ def q10_v2_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -110,7 +109,7 @@ def q10_v3_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         customer.select("c_custkey", "c_name", "c_acctbal", "c_phone", "c_address", "c_comment", "c_nationkey")
         .join(
             orders.select("o_custkey", "o_orderkey", "o_orderdate").filter(
@@ -132,7 +131,6 @@ def q10_v3_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v3_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -211,7 +209,7 @@ def q10_v5_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         customer.join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
@@ -223,7 +221,6 @@ def q10_v5_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -299,7 +296,7 @@ def q10_v7_expression_impl(ctx: DataFrameContext) -> Any:
     end_date = params["end_date"]
 
     # Swapped: start from orders→customer
-    result = (
+    return (
         orders.filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(customer, left_on="o_custkey", right_on="c_custkey")
         .join(lineitem.filter(col("l_returnflag") == lit("R")), left_on="o_orderkey", right_on="l_orderkey")
@@ -309,7 +306,6 @@ def q10_v7_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v7_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -357,7 +353,7 @@ def q10_v8_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         customer.join(orders, left_on="c_custkey", right_on="o_custkey")
         .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
         # Combine both filters in single call after all joins
@@ -372,7 +368,6 @@ def q10_v8_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v8_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -421,7 +416,7 @@ def q10_v9_expression_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    result = (
+    return (
         customer.join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
@@ -432,7 +427,6 @@ def q10_v9_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -481,7 +475,7 @@ def q10_v10_expression_impl(ctx: DataFrameContext) -> Any:
 
     revenue_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
 
-    result = (
+    return (
         customer.join(orders, left_on="c_custkey", right_on="o_custkey")
         .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
         .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
@@ -492,7 +486,6 @@ def q10_v10_expression_impl(ctx: DataFrameContext) -> Any:
         .sort("revenue", descending=True)
         .limit(20)
     )
-    return result
 
 
 def q10_v10_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q14.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q14.py
@@ -166,7 +166,7 @@ def q14_v4_expression_impl(ctx: DataFrameContext) -> Any:
     # Step 2: join with part
     step2 = step1.join(part, left_on="l_partkey", right_on="p_partkey")
     # Step 3: calculate promo revenue
-    result = step2.select(
+    return step2.select(
         (
             lit(100.0)
             * (col("l_extendedprice") * (lit(1) - col("l_discount")))
@@ -175,7 +175,6 @@ def q14_v4_expression_impl(ctx: DataFrameContext) -> Any:
             / (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum()
         ).alias("promo_revenue")
     )
-    return result
 
 
 def q14_v4_pandas_impl(ctx: DataFrameContext) -> Any:

--- a/benchbox/core/tpchavoc/dataframe_queries/q15.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q15.py
@@ -180,12 +180,11 @@ def q15_v4_expression_impl(ctx: DataFrameContext) -> Any:
     # Step 4: filter to top suppliers
     top_revenue = revenue.filter(col("total_revenue") == lit(max_revenue))
     # Step 5: join with suppliers
-    result = (
+    return (
         supplier.join(top_revenue, left_on="s_suppkey", right_on="supplier_no")
         .select("s_suppkey", "s_name", "s_address", "s_phone", "total_revenue")
         .sort("s_suppkey")
     )
-    return result
 
 
 def q15_v4_pandas_impl(ctx: DataFrameContext) -> Any:


### PR DESCRIPTION
## Summary
- Shrinks TPC-Havoc DataFrame variant implementations by replacing redundant final `result = ...; return result` temporaries with direct returns.
- Keeps query implementations, registry metadata, and benchmark semantics unchanged.

## Shrink Ledger
| Field | Value |
|---|---:|
| Surface/module | TPC-Havoc DataFrame variant implementations |
| Original code lines | 4,674 |
| New code lines | 4,607 |
| Lines removed | 67 |
| Reduction | 1.43% |

## Files Changed
- `benchbox/core/tpchavoc/dataframe_queries/q01.py`
- `benchbox/core/tpchavoc/dataframe_queries/q02.py`
- `benchbox/core/tpchavoc/dataframe_queries/q03.py`
- `benchbox/core/tpchavoc/dataframe_queries/q04.py`
- `benchbox/core/tpchavoc/dataframe_queries/q05.py`
- `benchbox/core/tpchavoc/dataframe_queries/q07.py`
- `benchbox/core/tpchavoc/dataframe_queries/q08.py`
- `benchbox/core/tpchavoc/dataframe_queries/q09.py`
- `benchbox/core/tpchavoc/dataframe_queries/q10.py`
- `benchbox/core/tpchavoc/dataframe_queries/q14.py`
- `benchbox/core/tpchavoc/dataframe_queries/q15.py`

## Simplification Type
- Mechanical final-return cleanup: each affected function now returns the exact expression previously assigned to `result` immediately before return.

## Behavior Preserved
- Runtime TPC-Havoc DataFrame registry metadata snapshot matched before and after the rewrite.
- Normalized AST equivalence against the pre-change version matched for all changed files after applying the same final-return normalization.
- Focused TPC-Havoc unit tests passed.
- No tests, docs, scripts, generated files, lockfiles, or benchmark outputs were changed.

## Verification
- `uv run -- ruff check benchbox/core/tpchavoc/dataframe_queries/q*.py` - passed
- `uv run -- python -m compileall -q benchbox/core/tpchavoc/dataframe_queries` - passed
- `git diff --check` - passed
- Registry metadata snapshot comparison - matched
- Normalized AST equivalence check - matched 11 files
- `uv run -- python -m pytest -n 0 tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q` - 33 passed, 1 warning
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight` - passed
  - `ci-lint` passed
  - Fast tests: 22721 passed, 5 skipped, 43 warnings, 4 subtests passed
- `make pr-open` - opened this PR

## Residual Risk
Low. The change is a mechanical return-only rewrite with AST equivalence and registry metadata preservation checks.

## Next Recommended Shrink Target
Finish the remaining isolated DataFrame query return cleanup, then inspect larger repeated adapter and benchmark helper surfaces.
