### PR TITLE
chore: shrink datavault dataframe returns

### DIFF
--- a/benchbox/core/datavault/dataframe_queries/queries.py
+++ b/benchbox/core/datavault/dataframe_queries/queries.py
@@ -134,14 +134,13 @@ def q2_expression_impl(ctx: DataFrameContext) -> Any:
     )
 
     # Filter to only minimum-cost suppliers
-    result = (
+    return (
         part_supplier.join(min_cost, left_on="p_partkey", right_on="p_partkey")
         .filter(col("ps_supplycost") == col("min_cost"))
         .select("s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment")
         .sort([("s_acctbal", "desc"), ("n_name", "asc"), ("s_name", "asc"), ("p_partkey", "asc")])
         .limit(100)
     )
-    return result
 
 
 def q2_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -1037,10 +1036,9 @@ def q14_expression_impl(ctx: DataFrameContext) -> Any:
     revenue_expr = col("l_extendedprice") * (lit(1) - col("l_discount"))
     promo_expr = ctx.when(col("p_type").str.starts_with("PROMO")).then(revenue_expr).otherwise(lit(0))
 
-    result = df.agg(
+    return df.agg(
         (promo_expr.sum() * lit(100.0) / revenue_expr.sum()).alias("promo_revenue"),
     )
-    return result
 
 
 def q14_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -1094,14 +1092,13 @@ def q15_expression_impl(ctx: DataFrameContext) -> Any:
 
     max_rev = ctx.scalar(revenue.agg(col("total_revenue").max().alias("max_rev")), "max_rev")
 
-    result = (
+    return (
         hs.join(ss, left_on="hk_supplier", right_on="hk_supplier")
         .join(revenue, left_on="hk_supplier", right_on="hk_supplier")
         .filter(col("total_revenue") == lit(max_rev))
         .select("s_suppkey", "s_name", "s_address", "s_phone", "total_revenue")
         .sort("s_suppkey")
     )
-    return result
 
 
 def q15_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -1213,12 +1210,11 @@ def q17_expression_impl(ctx: DataFrameContext) -> Any:
     # Average quantity per part
     avg_qty = df.group_by("hk_part").agg((col("l_quantity").mean() * lit(0.2)).alias("avg_qty"))
 
-    result = (
+    return (
         df.join(avg_qty, left_on="hk_part", right_on="hk_part")
         .filter(col("l_quantity") < col("avg_qty"))
         .agg((col("l_extendedprice").sum() / lit(7.0)).alias("avg_yearly"))
     )
-    return result
 
 
 def q17_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -1367,10 +1363,9 @@ def q19_expression_impl(ctx: DataFrameContext) -> Any:
         & deliver
     )
 
-    result = df.filter(cond1 | cond2 | cond3).agg(
+    return df.filter(cond1 | cond2 | cond3).agg(
         (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"),
     )
-    return result
 
 
 def q19_pandas_impl(ctx: DataFrameContext) -> Any:


### PR DESCRIPTION
## Summary
- Shrinks the Data Vault DataFrame query implementations by replacing redundant final `result = ...; return result` temporaries with direct returns.
- Keeps Data Vault query registry metadata and returned expressions unchanged.

## Shrink Ledger
| Field | Value |
|---|---:|
| Surface/module | Data Vault DataFrame query implementations |
| Original code lines | 1,191 |
| New code lines | 1,186 |
| Lines removed | 5 |
| Reduction | 0.42% |

## Files Changed
- `benchbox/core/datavault/dataframe_queries/queries.py`

## Simplification Type
- Mechanical final-return cleanup in five expression-family query functions.

## Behavior Preserved
- Runtime Data Vault DataFrame registry metadata snapshot matched before and after the rewrite.
- Normalized AST equivalence against the pre-change version matched after applying the same final-return normalization.
- Focused Data Vault DataFrame unit tests passed before and after the change.
- No tests, docs, scripts, generated files, lockfiles, or benchmark outputs were changed.

## Verification
- `uv run -- ruff format benchbox/core/datavault/dataframe_queries/queries.py` - passed
- `uv run -- ruff check benchbox/core/datavault/dataframe_queries/queries.py` - passed
- `uv run -- python -m compileall -q benchbox/core/datavault/dataframe_queries/queries.py` - passed
- `git diff --check` - passed
- Registry metadata snapshot comparison - matched
- Normalized AST equivalence check - matched 1 file
- `uv run -- python -m pytest -n 0 tests/unit/core/datavault/test_datavault_dataframe_queries.py -q` - 64 passed
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight` - passed on retry after an unrelated shared test lock cleared
  - `ci-lint` passed
  - Fast tests: 22721 passed, 5 skipped, 43 warnings, 4 subtests passed
- `make pr-open` - opened this PR

## Residual Risk
Low. The change is return-only and mechanically equivalent. `make pr-open` warned about textual conflict with #543, but #543 touches UAT/docs/scripts/test files and does not overlap this Datavault runtime file.

## Next Recommended Shrink Target
Move from final-return cleanups to larger duplication surfaces: primitive catalogs/loaders, TPC-DI ETL helpers, platform/base adapter helpers, CLI run wiring, or result/validation infrastructure.
