### PR TITLE
chore: shrink dataframe platform returns

### DIFF
--- a/benchbox/platforms/dataframe/pandas_family.py
+++ b/benchbox/platforms/dataframe/pandas_family.py
@@ -926,8 +926,7 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
         """
         by_list = [by] if isinstance(by, str) else list(by)
         # Use size() then reset_index() with name parameter (works on Pandas)
-        result = df.groupby(by_list).size().reset_index(name=name)  # type: ignore[attr-defined]
-        return result  # type: ignore[return-value]
+        return df.groupby(by_list).size().reset_index(name=name)  # type: ignore[attr-defined, return-value]
 
     # =========================================================================
     # GroupBy Aggregation (Platform-Specific)

--- a/benchbox/platforms/dataframe/unified_frame.py
+++ b/benchbox/platforms/dataframe/unified_frame.py
@@ -3274,9 +3274,7 @@ class UnifiedLazyFrame(Generic[DF, Expr]):
         # The right_expr.native gives us the computed PySpark Column
         condition = self._df[left_col] == right_expr.native
 
-        result = self._df.join(renamed_other, condition, spark_how)
-
-        return result
+        return self._df.join(renamed_other, condition, spark_how)
 
     def _pyspark_join_multi_expr(
         self,
@@ -3360,9 +3358,7 @@ class UnifiedLazyFrame(Generic[DF, Expr]):
         for cond in conditions[1:]:
             combined_condition = combined_condition & cond
 
-        result = self._df.join(renamed_other, combined_condition, spark_how)
-
-        return result
+        return self._df.join(renamed_other, combined_condition, spark_how)
 
     def _polars_join_with_exprs(
         self,


### PR DESCRIPTION
## Summary
- Shrinks DataFrame platform adapter helpers by replacing redundant final `result = ...; return result` temporaries with direct returns.
- Keeps PySpark join helper behavior and pandas-family `groupby_size` behavior unchanged.

## Shrink Ledger
| Field | Value |
|---|---:|
| Surface/module | DataFrame platform adapter helpers |
| Original code lines | 2,563 |
| New code lines | 2,560 |
| Lines removed | 3 |
| Reduction | 0.12% |

## Files Changed
- `benchbox/platforms/dataframe/unified_frame.py`
- `benchbox/platforms/dataframe/pandas_family.py`

## Simplification Type
- Mechanical final-return cleanup in platform helper methods.

## Behavior Preserved
- Normalized AST equivalence against the pre-change version matched for both changed files after applying the same final-return normalization.
- Focused DataFrame platform unit tests passed before and after the change.
- No tests, docs, scripts, generated files, lockfiles, or benchmark outputs were changed.

## Verification
- `uv run -- ruff format benchbox/platforms/dataframe/unified_frame.py benchbox/platforms/dataframe/pandas_family.py` - passed
- `uv run -- ruff check benchbox/platforms/dataframe/unified_frame.py benchbox/platforms/dataframe/pandas_family.py` - passed
- `uv run -- python -m compileall -q benchbox/platforms/dataframe/unified_frame.py benchbox/platforms/dataframe/pandas_family.py` - passed
- `git diff --check` - passed
- Normalized AST equivalence check - matched 2 files
- `uv run -- python -m pytest -n 0 tests/unit/platforms/dataframe/test_unified_frame.py tests/unit/platforms/dataframe/test_unified_frame_coverage.py tests/unit/platforms/dataframe/test_unified_frame_operations.py tests/unit/platforms/dataframe/test_pandas_family.py -q` - 152 passed
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight` - passed
  - `ci-lint` passed
  - Fast tests: 22722 passed, 5 skipped, 43 warnings, 4 subtests passed
- `make pr-open` - opened this PR

## Residual Risk
Low. The change is return-only and mechanically equivalent.

## Next Recommended Shrink Target
Move from final-return cleanups to larger duplication surfaces: primitive catalogs/loaders, TPC-DI ETL helpers, platform/base adapter helpers, CLI run wiring, or result/validation infrastructure.
