### PR TITLE
chore: shrink write primitives catalog

### DIFF
--- a/benchbox/core/write_primitives/catalog/operations.yaml
+++ b/benchbox/core/write_primitives/catalog/operations.yaml
@@ -11,4238 +11,2110 @@
 # Note: expected_rows_affected: null indicates data-dependent operations where exact
 # row count varies by scale factor or data overlap. These operations are validated
 # through validation_queries instead of fixed row counts.
+# NOTE: Catalog body is compact YAML; parsed data must remain identical.
 
 version: 1
-
 operations:
-  # ============================================================================
-  # INSERT OPERATIONS (12 operations)
-  # ============================================================================
-
-  - id: insert_single_row
-    category: insert
-    description: Tests single row INSERT performance with all columns specified
-    write_sql: |
-      INSERT INTO insert_ops_lineitem
-      VALUES (
-        9000001, 1, 1, 1,
-        10.0, 1000.0, 0.05, 0.02,
-        'N', 'O',
-        DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',
-        'DELIVER IN PERSON', 'TRUCK', 'test insert'
-      )
-    validation_queries:
-      - id: verify_values
-        sql: |
-          SELECT l_quantity, l_extendedprice, l_discount
-          FROM insert_ops_lineitem
-          WHERE l_orderkey = 9000001
-        expected_rows: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey = 9000001
-    expected_rows_affected: 1
-
-  - id: insert_batch_values_10
-    category: insert
-    description: Tests small batch INSERT using VALUES clause with 10 rows
-    write_sql: |
-      INSERT INTO insert_ops_lineitem VALUES
-        (9000010, 1, 1, 1, 10.0, 1000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 1'),
-        (9000011, 2, 2, 1, 20.0, 2000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 2'),
-        (9000012, 3, 3, 1, 30.0, 3000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 3'),
-        (9000013, 4, 4, 1, 40.0, 4000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 4'),
-        (9000014, 5, 5, 1, 50.0, 5000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 5'),
-        (9000015, 6, 6, 1, 60.0, 6000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 6'),
-        (9000016, 7, 7, 1, 70.0, 7000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 7'),
-        (9000017, 8, 8, 1, 80.0, 8000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 8'),
-        (9000018, 9, 9, 1, 90.0, 9000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 9'),
-        (9000019, 10, 10, 1, 100.0, 10000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 10')
-    validation_queries:
-      - id: verify_batch
-        sql: SELECT l_orderkey, l_quantity FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000010 AND 9000019 ORDER BY l_orderkey
-        expected_rows: 10
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000010 AND 9000019
-    expected_rows_affected: 10
-
-  - id: insert_select_simple
-    category: insert
-    description: Tests INSERT INTO...SELECT with simple WHERE filter
-    write_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 1 AND 10;
-      INSERT INTO insert_ops_lineitem
-      SELECT * FROM lineitem
-      WHERE l_orderkey BETWEEN 1 AND 10
-    validation_queries:
-      - id: verify_insert_select
-        sql: |
-          SELECT l_orderkey, l_linenumber
-          FROM insert_ops_lineitem
-          WHERE l_orderkey BETWEEN 1 AND 10
-          ORDER BY l_orderkey, l_linenumber
-        expected_rows: null  # Varies by data
-        expected_rows_min: 1  # At least one row should be inserted
-        expected_rows_max: 200  # Reasonable upper bound for orders 1-10
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 1 AND 10
-    expected_rows_affected: null  # Varies by data
-    platform_overrides:
-      starrocks: null
-
-  - id: insert_batch_values_100
-    category: insert
-    description: Tests medium batch INSERT using VALUES clause with 100 rows to measure batch overhead
-    write_sql: |
-      INSERT INTO insert_ops_lineitem
-      SELECT 9000100 + n, 1, 1, 1, 10.0 * n, 1000.0 * n, 0.05, 0.02, 'N', 'O',
-             DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',
-             'DELIVER IN PERSON', 'TRUCK', 'batch_' || CAST(n AS VARCHAR)
-      FROM (SELECT unnest(generate_series(0, 99)) AS n) t
-    validation_queries:
-      - id: verify_batch_100
-        sql: SELECT COUNT(*) as cnt FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000100 AND 9000199
-        expected_rows: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000100 AND 9000199
-    expected_rows_affected: 100
-    platform_overrides:
-      starrocks: null
-
-  - id: insert_batch_values_1000
-    category: insert
-    description: Tests large batch INSERT with 1000 rows to measure large batch processing and memory overhead
-    write_sql: |
-      INSERT INTO insert_ops_lineitem
-      SELECT 9001000 + n, 1, 1, 1, 10.0 * n, 1000.0 * n, 0.05, 0.02, 'N', 'O',
-             DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',
-             'DELIVER IN PERSON', 'TRUCK', 'large_batch_' || CAST(n AS VARCHAR)
-      FROM (SELECT unnest(generate_series(0, 999)) AS n) t
-    validation_queries:
-      - id: verify_batch_1000
-        sql: SELECT COUNT(*) as cnt FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9001000 AND 9001999
-        expected_rows: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9001000 AND 9001999
-    expected_rows_affected: 1000
-    platform_overrides:
-      starrocks: null
-
-  - id: insert_select_with_join
-    category: insert
-    description: Tests INSERT INTO...SELECT with JOIN to measure join overhead during data insertion
-    write_sql: |
-      INSERT INTO insert_ops_orders_summary (o_orderkey, o_custkey, o_orderdate, o_totalprice, customer_name)
-      SELECT o.o_orderkey, o.o_custkey, o.o_orderdate, o.o_totalprice, c.c_name
-      FROM orders o
-      JOIN customer c ON o.o_custkey = c.c_custkey
-      WHERE o.o_orderkey BETWEEN 1 AND 100
-    validation_queries:
-      - id: verify_joined_insert
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM insert_ops_orders_summary
-          WHERE o_orderkey BETWEEN 1 AND 100
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_orders_summary WHERE o_orderkey BETWEEN 1 AND 100
-    expected_rows_affected: null
-
-  - id: insert_select_aggregated
-    category: insert
-    description: Tests INSERT INTO...SELECT with GROUP BY aggregation to measure aggregation overhead
-    write_sql: |
-      INSERT INTO insert_ops_orders_summary (o_custkey, o_totalprice, order_count)
-      SELECT o_custkey, SUM(o_totalprice), COUNT(*)
-      FROM orders
-      WHERE o_orderkey <= 1000
-      GROUP BY o_custkey
-    validation_queries:
-      - id: verify_aggregated_insert
-        sql: |
-          SELECT COUNT(*) as customer_count, SUM(order_count) as total_orders
-          FROM insert_ops_orders_summary
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_orders_summary
-    expected_rows_affected: null
-
-  - id: insert_select_from_multiple
-    category: insert
-    description: Tests INSERT INTO...SELECT from 3 plus tables with multiple JOINs to measure complex query overhead
-    write_sql: |
-      INSERT INTO insert_ops_lineitem_enriched
-        (l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice,
-         o_orderdate, c_name, s_name, p_name)
-      SELECT l.l_orderkey, l.l_partkey, l.l_suppkey, l.l_quantity, l.l_extendedprice,
-             o.o_orderdate, c.c_name, s.s_name, p.p_name
-      FROM lineitem l
-      JOIN orders o ON l.l_orderkey = o.o_orderkey
-      JOIN customer c ON o.o_custkey = c.c_custkey
-      JOIN supplier s ON l.l_suppkey = s.s_suppkey
-      JOIN part p ON l.l_partkey = p.p_partkey
-      WHERE l.l_orderkey BETWEEN 1 AND 50
-    validation_queries:
-      - id: verify_multi_join_insert
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM insert_ops_lineitem_enriched
-          WHERE l_orderkey BETWEEN 1 AND 50
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem_enriched WHERE l_orderkey BETWEEN 1 AND 50
-    expected_rows_affected: null
-
-  - id: insert_with_default_values
-    category: insert
-    description: Tests INSERT with DEFAULT keyword to measure default value processing overhead
-    write_sql: |
-      INSERT INTO write_ops_log (log_id, operation_id, operation_category, timestamp, rows_affected, duration_ms, success)
-      VALUES (1, 'test_insert', 'insert', CURRENT_TIMESTAMP, 0, 0.0, true)
-    validation_queries:
-      - id: verify_default_insert
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM write_ops_log
-          WHERE operation_id = 'test_insert' AND operation_category = 'insert'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM write_ops_log WHERE operation_id = 'test_insert' AND operation_category = 'insert'
-    expected_rows_affected: null
-
-  - id: insert_select_union
-    category: insert
-    description: Tests INSERT INTO...SELECT with UNION to measure set operation overhead during insertion
-    write_sql: |
-      DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 50;
-      INSERT INTO insert_ops_orders
-      SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 25
-      UNION ALL
-      SELECT * FROM orders WHERE o_orderkey BETWEEN 26 AND 50
-    validation_queries:
-      - id: verify_union_insert
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM insert_ops_orders
-          WHERE o_orderkey BETWEEN 1 AND 50
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 50
-    expected_rows_affected: null
-
-  - id: insert_on_conflict_ignore
-    category: insert
-    description: Tests INSERT with conflict handling using ON CONFLICT DO NOTHING to measure constraint checking overhead
-    write_sql: |
-      INSERT INTO insert_ops_orders
-      SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10
-      ON CONFLICT (o_orderkey) DO NOTHING
-    validation_queries:
-      - id: verify_conflict_handling
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM insert_ops_orders
-          WHERE o_orderkey BETWEEN 1 AND 10
-        expected_rows: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 10
-    expected_rows_affected: null
-    platform_overrides:
-      duckdb: |
-        INSERT OR IGNORE INTO insert_ops_orders
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10
-      sqlite: |
-        INSERT OR IGNORE INTO insert_ops_orders
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10
-      datafusion: null
-      starrocks: null
-
-  - id: insert_returning_clause
-    category: insert
-    description: Tests INSERT...RETURNING to measure overhead of returning inserted row data
-    write_sql: |
-      INSERT INTO insert_ops_lineitem
-      VALUES (9000500, 1, 1, 1, 10.0, 1000.0, 0.05, 0.02, 'N', 'O',
-              DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',
-              'DELIVER IN PERSON', 'TRUCK', 'returning_test')
-      RETURNING l_orderkey, l_partkey, l_quantity
-    validation_queries:
-      - id: verify_returning_insert
-        sql: |
-          SELECT l_orderkey, l_quantity
-          FROM insert_ops_lineitem
-          WHERE l_orderkey = 9000500
-        expected_rows: 1
-    cleanup_sql: |
-      DELETE FROM insert_ops_lineitem WHERE l_orderkey = 9000500
-    expected_rows_affected: 1
-    platform_overrides:
-      mysql: null  # MySQL doesn't support RETURNING
-      bigquery: null  # BigQuery doesn't support RETURNING in same way
-      datafusion: null
-      starrocks: null
-
-  # ============================================================================
-  # UPDATE OPERATIONS (15 operations)
-  # ============================================================================
-
-  - id: update_single_row_pk
-    category: update
-    description: Tests single row UPDATE by primary key to measure index lookup plus update cost
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice * 1.1,
-          o_comment = 'updated_single'
-      WHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)
-    validation_queries:
-      - id: verify_update
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM update_ops_orders
-          WHERE o_comment = 'updated_single'
-        expected_rows: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice / 1.1,
-          o_comment = ''
-      WHERE o_comment = 'updated_single'
-    expected_rows_affected: 1
-    platform_overrides:
-      datafusion: null
-
-  - id: update_selective_10pct
-    category: update
-    description: Tests UPDATE affecting approximately 10 percent of table rows to measure selective update performance
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = 'selective_10pct'
-      WHERE o_orderkey <= (
-        SELECT CAST(MAX(o_orderkey) * 0.1 AS INTEGER)
-        FROM update_ops_orders
-      )
-    validation_queries:
-      - id: count_updated
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'selective_10pct'
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = ''
-      WHERE o_comment = 'selective_10pct'
-    expected_rows_affected: null  # Varies
-    platform_overrides:
-      datafusion: null
-
-  - id: update_with_subquery
-    category: update
-    description: Tests UPDATE with correlated subquery to measure subquery execution cost per row
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = (
-        SELECT SUM(l_extendedprice * (1 - l_discount))
-        FROM lineitem
-        WHERE l_orderkey = update_ops_orders.o_orderkey
-      )
-      WHERE EXISTS (
-        SELECT 1 FROM lineitem WHERE l_orderkey = update_ops_orders.o_orderkey
-      )
-      AND o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_calculation
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM update_ops_orders o
-          WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    cleanup_sql: |
-      -- Recalculate to restore
-      UPDATE update_ops_orders
-      SET o_totalprice = (
-        SELECT SUM(l_extendedprice * (1 - l_discount))
-        FROM lineitem
-        WHERE l_orderkey = update_ops_orders.o_orderkey
-      )
-      WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_bulk_50pct
-    category: update
-    description: Tests UPDATE affecting approximately 50 percent of table rows to measure large-scale update performance
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = 'bulk_50pct_update'
-      WHERE o_orderkey <= (
-        SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER)
-        FROM update_ops_orders
-      )
-    validation_queries:
-      - id: count_updated_50pct
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'bulk_50pct_update'
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'bulk_50pct_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_bulk_all
-    category: update
-    description: Tests UPDATE of entire table to measure full table scan and update overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = 'bulk_all_update'
-    validation_queries:
-      - id: verify_all_updated
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'bulk_all_update'
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_comment = ''
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_with_join
-    category: update
-    description: Tests UPDATE with JOIN syntax to measure join overhead during updates
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = 'joined_update'
-      FROM customer
-      WHERE update_ops_orders.o_custkey = customer.c_custkey
-        AND customer.c_mktsegment = 'BUILDING'
-        AND update_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_joined_update
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'joined_update'
-        expected_rows_min: 0
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'joined_update'
-    expected_rows_affected: null
-    platform_overrides:
-      mysql: |
-        UPDATE update_ops_orders
-        JOIN customer ON update_ops_orders.o_custkey = customer.c_custkey
-        SET update_ops_orders.o_comment = 'joined_update'
-        WHERE customer.c_mktsegment = 'BUILDING'
-          AND update_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-      datafusion: null
-
-  - id: update_from_select
-    category: update
-    description: Tests UPDATE...FROM...WHERE EXISTS to measure correlated EXISTS overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = 'exists_update'
-      WHERE EXISTS (
-        SELECT 1 FROM lineitem
-        WHERE lineitem.l_orderkey = update_ops_orders.o_orderkey
-          AND lineitem.l_quantity > 40
-      )
-      AND o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_exists_update
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'exists_update'
-        expected_rows_min: 0
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'exists_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_set_multiple_columns
-    category: update
-    description: Tests UPDATE of 5 plus columns to measure multi-column update overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice * 1.05,
-          o_orderpriority = '1-URGENT',
-          o_comment = 'multi_col_update',
-          o_shippriority = 1,
-          o_clerk = 'Clerk#000000001'
-      WHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)
-    validation_queries:
-      - id: verify_multi_column
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM update_ops_orders
-          WHERE o_comment = 'multi_col_update'
-        expected_rows: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice / 1.05,
-          o_orderpriority = '5-LOW',
-          o_comment = '',
-          o_shippriority = 0,
-          o_clerk = 'Clerk#000000000'
-      WHERE o_comment = 'multi_col_update'
-    expected_rows_affected: 1
-    platform_overrides:
-      datafusion: null
-
-  - id: update_with_case_expression
-    category: update
-    description: Tests UPDATE using CASE WHEN expression to measure conditional logic overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_orderpriority = CASE
-        WHEN o_totalprice < 100000 THEN '5-LOW'
-        WHEN o_totalprice < 200000 THEN '4-NOT SPECIFIED'
-        WHEN o_totalprice < 300000 THEN '3-MEDIUM'
-        WHEN o_totalprice < 400000 THEN '2-HIGH'
-        ELSE '1-URGENT'
-      END,
-      o_comment = 'case_update'
-      WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_case_update
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'case_update'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_orderpriority = '5-LOW', o_comment = '' WHERE o_comment = 'case_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_computed_column
-    category: update
-    description: Tests UPDATE with mathematical expressions to measure computation overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice * 1.1 + 50.0 - (o_totalprice * 0.02),
-          o_comment = 'computed_update'
-      WHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_computed
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'computed_update'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = (o_totalprice + (o_totalprice * 0.02) - 50.0) / 1.1,
-          o_comment = ''
-      WHERE o_comment = 'computed_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_string_manipulation
-    category: update
-    description: Tests UPDATE with string functions CONCAT SUBSTRING to measure string processing overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_comment = CONCAT('Updated:', SUBSTRING(o_orderpriority, 1, 5), '|', CAST(o_orderkey AS VARCHAR))
-      WHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_string_ops
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM update_ops_orders
-          WHERE o_comment LIKE 'Updated:%'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders SET o_comment = '' WHERE o_comment LIKE 'Updated:%'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_date_arithmetic
-    category: update
-    description: Tests UPDATE with date calculations to measure temporal operation overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_orderdate = o_orderdate + INTERVAL '7' DAY,
-          o_comment = 'date_update'
-      WHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_date_ops
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'date_update'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_orderdate = o_orderdate - INTERVAL '7' DAY,
-          o_comment = ''
-      WHERE o_comment = 'date_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_conditional_multi_column
-    category: update
-    description: Tests complex conditional UPDATE with multiple column updates to measure combined overhead
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = CASE
-          WHEN o_orderpriority = '1-URGENT' THEN o_totalprice * 1.2
-          WHEN o_orderpriority = '2-HIGH' THEN o_totalprice * 1.1
-          ELSE o_totalprice
-        END,
-        o_orderpriority = CASE
-          WHEN o_totalprice > 250000 THEN '1-URGENT'
-          ELSE o_orderpriority
-        END,
-        o_comment = 'complex_conditional'
-      WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_complex_conditional
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'complex_conditional'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = CASE
-          WHEN o_orderpriority = '1-URGENT' THEN o_totalprice / 1.2
-          WHEN o_orderpriority = '2-HIGH' THEN o_totalprice / 1.1
-          ELSE o_totalprice
-        END,
-        o_orderpriority = '5-LOW',
-        o_comment = ''
-      WHERE o_comment = 'complex_conditional'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_with_aggregate
-    category: update
-    description: Tests UPDATE using aggregated subquery to measure aggregation overhead per row
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = (
-        SELECT AVG(l_extendedprice)
-        FROM lineitem
-        WHERE l_orderkey = update_ops_orders.o_orderkey
-      ),
-      o_comment = 'agg_update'
-      WHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = update_ops_orders.o_orderkey)
-        AND o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)
-    validation_queries:
-      - id: verify_agg_update
-        sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'agg_update'
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = (
-        SELECT SUM(l_extendedprice * (1 - l_discount))
-        FROM lineitem
-        WHERE l_orderkey = update_ops_orders.o_orderkey
-      ),
-      o_comment = ''
-      WHERE o_comment = 'agg_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: update_returning
-    category: update
-    description: Tests UPDATE...RETURNING to measure overhead of returning updated row data
-    write_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice * 1.15,
-          o_comment = 'returning_update'
-      WHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)
-      RETURNING o_orderkey, o_totalprice, o_comment
-    validation_queries:
-      - id: verify_returning_update
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM update_ops_orders
-          WHERE o_comment = 'returning_update'
-        expected_rows: 1
-    cleanup_sql: |
-      UPDATE update_ops_orders
-      SET o_totalprice = o_totalprice / 1.15,
-          o_comment = ''
-      WHERE o_comment = 'returning_update'
-    expected_rows_affected: 1
-    platform_overrides:
-      mysql: null  # MySQL doesn't support RETURNING
-      bigquery: null  # BigQuery doesn't support RETURNING
-      datafusion: null
-      starrocks: null
-
-  # ============================================================================
-  # DELETE OPERATIONS (14 operations)
-  # ============================================================================
-
-  - id: delete_single_row_pk
-    category: delete
-    description: Tests single row DELETE by primary key to measure index-based deletion
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey = (SELECT MAX(o_orderkey) FROM delete_ops_orders)
-    validation_queries:
-      - id: verify_table_integrity
-        sql: |
-          -- Validate table still accessible and structure is intact after DELETE
-          -- Note: Full validation of DELETE correctness requires pre-write state - future enhancement
-          SELECT o_orderkey, o_custkey
-          FROM delete_ops_orders
-          LIMIT 1
-        expected_rows: null
-        expected_rows_min: 0  # Table might be empty
-        expected_rows_max: 1  # LIMIT 1, so at most 1 row
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: 1
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_selective_10pct
-    category: delete
-    description: Tests DELETE affecting approximately 10 percent of rows to measure selective deletion performance
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey > (
-        SELECT CAST(MAX(o_orderkey) * 0.9 AS INTEGER)
-        FROM delete_ops_orders
-      )
-    validation_queries:
-      - id: verify_table_integrity
-        sql: |
-          -- Validate table still accessible after bulk DELETE
-          -- Note: Full validation requires pre-write state - future enhancement
-          SELECT COUNT(*) as remaining_count
-          FROM delete_ops_orders
-        expected_rows: null
-        expected_rows_min: 0  # Could delete all rows
-        expected_rows_max: 1  # COUNT always returns 1 row
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_with_subquery
-    category: delete
-    description: Tests DELETE with WHERE...IN subquery to measure subquery evaluation overhead
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey IN (
-        SELECT o_orderkey
-        FROM delete_ops_orders
-        WHERE o_orderpriority = '1-URGENT'
-        LIMIT 10
-      )
-    validation_queries:
-      - id: verify_table_integrity
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_with_join
-    category: delete
-    description: Tests DELETE with JOIN to measure join-based deletion performance
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE EXISTS (
-        SELECT 1 FROM customer
-        WHERE customer.c_custkey = delete_ops_orders.o_custkey
-          AND customer.c_mktsegment = 'AUTOMOBILE'
-      )
-      AND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 20 FROM delete_ops_orders)
-    validation_queries:
-      - id: verify_delete_with_join
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      mysql: |
-        DELETE delete_ops_orders FROM delete_ops_orders
-        JOIN customer ON customer.c_custkey = delete_ops_orders.o_custkey
-        WHERE customer.c_mktsegment = 'AUTOMOBILE'
-          AND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 20 FROM delete_ops_orders)
-      datafusion: null
-
-  - id: delete_bulk_25pct
-    category: delete
-    description: Tests DELETE affecting approximately 25 percent of rows to measure medium bulk deletion
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey > (
-        SELECT CAST(MAX(o_orderkey) * 0.75 AS INTEGER)
-        FROM delete_ops_orders
-      )
-    validation_queries:
-      - id: verify_25pct_delete
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_bulk_50pct
-    category: delete
-    description: Tests DELETE affecting approximately 50 percent of rows to measure large bulk deletion
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey > (
-        SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER)
-        FROM delete_ops_orders
-      )
-    validation_queries:
-      - id: verify_50pct_delete
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_bulk_75pct
-    category: delete
-    description: Tests DELETE affecting approximately 75 percent of rows to measure very large bulk deletion
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey > (
-        SELECT CAST(MAX(o_orderkey) * 0.25 AS INTEGER)
-        FROM delete_ops_orders
-      )
-    validation_queries:
-      - id: verify_75pct_delete
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_with_not_exists
-    category: delete
-    description: Tests DELETE using NOT EXISTS to measure anti-join deletion performance
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE NOT EXISTS (
-        SELECT 1 FROM lineitem
-        WHERE lineitem.l_orderkey = delete_ops_orders.o_orderkey
-      )
-      AND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM delete_ops_orders)
-    validation_queries:
-      - id: verify_not_exists_delete
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_with_aggregation
-    category: delete
-    description: Tests DELETE using aggregate in WHERE clause to measure aggregation evaluation overhead
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_totalprice < (
-        SELECT AVG(o_totalprice) FROM delete_ops_orders
-      )
-      AND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 30 FROM delete_ops_orders)
-    validation_queries:
-      - id: verify_agg_delete
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_returning
-    category: delete
-    description: Tests DELETE...RETURNING to measure overhead of returning deleted row data
-    write_sql: |
-      DELETE FROM delete_ops_orders
-      WHERE o_orderkey = (SELECT MAX(o_orderkey) FROM delete_ops_orders)
-      RETURNING o_orderkey, o_custkey, o_totalprice
-    validation_queries:
-      - id: verify_delete_returning
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: 1
-    platform_overrides:
-      mysql: null  # MySQL doesn't support RETURNING
-      bigquery: null  # BigQuery doesn't support RETURNING
-      datafusion: null
-      starrocks: null
-
-  - id: delete_cascade_simulation
-    category: delete
-    description: Tests multi-table DELETE simulation to measure cascading deletion overhead
-    write_sql: |
-      DELETE FROM delete_ops_lineitem
-      WHERE l_orderkey IN (
-        SELECT o_orderkey FROM delete_ops_orders
-        WHERE o_orderpriority = '1-URGENT'
-        LIMIT 5
-      )
-    validation_queries:
-      - id: verify_cascade_delete
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM delete_ops_lineitem l
-          WHERE l_orderkey IN (
-            SELECT o_orderkey FROM delete_ops_orders
-            WHERE o_orderpriority = '1-URGENT'
-            LIMIT 5
-          )
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback for cleanup
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: delete_all_truncate_comparison
-    category: delete
-    description: Tests DELETE star versus TRUNCATE to measure full table deletion methods
-    write_sql: |
-      DELETE FROM delete_ops_lineitem
-    validation_queries:
-      - id: verify_all_deleted
-        sql: SELECT COUNT(*) as cnt FROM delete_ops_lineitem
-        expected_rows: 1
-    cleanup_sql: null  # Data gone, will be regenerated via reset
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  # ============================================================================
-  # BULK_LOAD OPERATIONS (36 operations)
-  # ============================================================================
-
-  # --------------------
-  # CSV OPERATIONS (12 operations: 3 sizes × 4 compression variants)
-  # --------------------
-
-  - id: bulk_load_csv_small_uncompressed
-    category: bulk_load
-    description: Tests bulk load from small CSV file 1K rows uncompressed to measure baseline CSV parsing overhead
-    file_dependencies:
-      - csv_small_1k.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' (FORMAT CSV, HEADER true)
-      mysql: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        LOAD DATA LOCAL INFILE '{file_path}/csv_small_1k.csv'
-        INTO TABLE bulk_load_ops_target
-        FIELDS TERMINATED BY ','
-        LINES TERMINATED BY '\n'
-        IGNORE 1 ROWS
-      sqlite: |
-        DELETE FROM bulk_load_ops_target;
-        .mode csv
-        .import {file_path}/csv_small_1k.csv bulk_load_ops_target
-      starrocks: null
-
-  - id: bulk_load_csv_small_gzip
-    category: bulk_load
-    description: Tests bulk load from small CSV file 1K rows gzip compressed to measure gzip decompression overhead
-    file_dependencies:
-      - csv_small_1k.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  - id: bulk_load_csv_small_zstd
-    category: bulk_load
-    description: Tests bulk load from small CSV file 1K rows zstd compressed to measure zstd decompression overhead
-    file_dependencies:
-      - csv_small_1k.csv.zst
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-      starrocks: null
-
-  - id: bulk_load_csv_small_bzip2
-    category: bulk_load
-    description: Tests bulk load from small CSV file 1K rows bzip2 compressed to measure bzip2 decompression overhead
-    file_dependencies:
-      - csv_small_1k.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        -- DuckDB does not support bzip2 compression - use gzip instead
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  - id: bulk_load_csv_medium_uncompressed
-    category: bulk_load
-    description: Tests bulk load from medium CSV file 100K rows uncompressed to measure medium dataset processing
-    file_dependencies:
-      - csv_medium_100k.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' (FORMAT CSV, HEADER true)
-      mysql: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        LOAD DATA LOCAL INFILE '{file_path}/csv_medium_100k.csv'
-        INTO TABLE bulk_load_ops_target
-        FIELDS TERMINATED BY ','
-        LINES TERMINATED BY '\n'
-        IGNORE 1 ROWS
-      starrocks: null
-
-  - id: bulk_load_csv_medium_gzip
-    category: bulk_load
-    description: Tests bulk load from medium CSV file 100K rows gzip compressed to measure compression benefit on medium data
-    file_dependencies:
-      - csv_medium_100k.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  - id: bulk_load_csv_medium_zstd
-    category: bulk_load
-    description: Tests bulk load from medium CSV file 100K rows zstd compressed to measure zstd efficiency on medium data
-    file_dependencies:
-      - csv_medium_100k.csv.zst
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-      starrocks: null
-
-  - id: bulk_load_csv_medium_bzip2
-    category: bulk_load
-    description: Tests bulk load from medium CSV file 100K rows bzip2 compressed to measure bzip2 efficiency on medium data
-    file_dependencies:
-      - csv_medium_100k.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        -- DuckDB does not support bzip2 compression - use gzip instead
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  - id: bulk_load_csv_large_uncompressed
-    category: bulk_load
-    description: Tests bulk load from large CSV file 1M rows uncompressed to measure large dataset processing limits
-    file_dependencies:
-      - csv_large_1m.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv' (FORMAT CSV, HEADER true)
-      mysql: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        LOAD DATA LOCAL INFILE '{file_path}/csv_large_1m.csv'
-        INTO TABLE bulk_load_ops_target
-        FIELDS TERMINATED BY ','
-        LINES TERMINATED BY '\n'
-        IGNORE 1 ROWS
-      starrocks: null
-
-  - id: bulk_load_csv_large_gzip
-    category: bulk_load
-    description: Tests bulk load from large CSV file 1M rows gzip compressed to measure compression benefit on large data
-    file_dependencies:
-      - csv_large_1m.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  - id: bulk_load_csv_large_zstd
-    category: bulk_load
-    description: Tests bulk load from large CSV file 1M rows zstd compressed to measure zstd efficiency on large data
-    file_dependencies:
-      - csv_large_1m.csv.zst
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')
-      starrocks: null
-
-  - id: bulk_load_csv_large_bzip2
-    category: bulk_load
-    description: Tests bulk load from large CSV file 1M rows bzip2 compressed to measure bzip2 efficiency on large data
-    file_dependencies:
-      - csv_large_1m.csv.gz
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      duckdb: |
-        -- DuckDB does not support bzip2 compression - use gzip instead
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')
-      starrocks: null
-
-  # --------------------
-  # PARQUET OPERATIONS (12 operations: 3 sizes × 4 compression variants)
-  # --------------------
-
-  - id: bulk_load_parquet_small_uncompressed
-    category: bulk_load
-    description: Tests bulk load from small Parquet file 1K rows uncompressed to measure Parquet columnar format overhead
-    file_dependencies:
-      - parquet_small_1k.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_small_snappy
-    category: bulk_load
-    description: Tests bulk load from small Parquet file 1K rows snappy compressed to measure Snappy decompression overhead
-    file_dependencies:
-      - parquet_small_1k_snappy.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_snappy.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_small_gzip
-    category: bulk_load
-    description: Tests bulk load from small Parquet file 1K rows gzip compressed to measure gzip in Parquet context
-    file_dependencies:
-      - parquet_small_1k_gzip.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_gzip.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_small_zstd
-    category: bulk_load
-    description: Tests bulk load from small Parquet file 1K rows zstd compressed to measure zstd in Parquet context
-    file_dependencies:
-      - parquet_small_1k_zstd.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_zstd.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_medium_uncompressed
-    category: bulk_load
-    description: Tests bulk load from medium Parquet file 100K rows uncompressed to measure columnar format efficiency
-    file_dependencies:
-      - parquet_medium_100k.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_medium_snappy
-    category: bulk_load
-    description: Tests bulk load from medium Parquet file 100K rows snappy compressed to measure Snappy efficiency
-    file_dependencies:
-      - parquet_medium_100k_snappy.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_snappy.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_medium_gzip
-    category: bulk_load
-    description: Tests bulk load from medium Parquet file 100K rows gzip compressed to measure compression trade-offs
-    file_dependencies:
-      - parquet_medium_100k_gzip.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_gzip.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_medium_zstd
-    category: bulk_load
-    description: Tests bulk load from medium Parquet file 100K rows zstd compressed to measure zstd columnar efficiency
-    file_dependencies:
-      - parquet_medium_100k_zstd.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_zstd.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_large_uncompressed
-    category: bulk_load
-    description: Tests bulk load from large Parquet file 1M rows uncompressed to measure large columnar dataset processing
-    file_dependencies:
-      - parquet_large_1m.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_large_snappy
-    category: bulk_load
-    description: Tests bulk load from large Parquet file 1M rows snappy compressed to measure Snappy on large data
-    file_dependencies:
-      - parquet_large_1m_snappy.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_snappy.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_large_gzip
-    category: bulk_load
-    description: Tests bulk load from large Parquet file 1M rows gzip compressed to measure gzip on large data
-    file_dependencies:
-      - parquet_large_1m_gzip.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_gzip.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      starrocks: null
-
-  - id: bulk_load_parquet_large_zstd
-    category: bulk_load
-    description: Tests bulk load from large Parquet file 1M rows zstd compressed to measure zstd on large data
-    file_dependencies:
-      - parquet_large_1m_zstd.parquet
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_zstd.parquet' (FORMAT PARQUET)
-    validation_queries:
-      - id: verify_row_count
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000000
-    platform_overrides:
-      starrocks: null
-
-  # --------------------
-  # SPECIAL BULK LOAD OPERATIONS (12 operations)
-  # --------------------
-
-  - id: bulk_load_column_subset
-    category: bulk_load
-    description: Tests bulk load with column subset selection to measure partial schema load overhead
-    file_dependencies:
-      - csv_medium_100k.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      INSERT INTO bulk_load_ops_target (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate)
-      SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate
-      FROM read_csv_auto('{file_path}/csv_medium_100k.csv')
-    validation_queries:
-      - id: verify_partial_load
-        sql: |
-          SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-          WHERE o_orderkey IS NOT NULL
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        INSERT INTO bulk_load_ops_target (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate)
-        SELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate
-        FROM read_csv_auto('{file_path}/csv_medium_100k.csv')
-      starrocks: null
-
-  - id: bulk_load_with_transformation
-    category: bulk_load
-    description: Tests bulk load with inline type conversion and transformation to measure ETL overhead
-    file_dependencies:
-      - csv_small_1k.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      INSERT INTO bulk_load_ops_target
-      SELECT
-        CAST(o_orderkey AS INTEGER),
-        CAST(o_custkey AS INTEGER),
-        UPPER(o_orderstatus),
-        CAST(o_totalprice AS DECIMAL(15,2)),
-        CAST(o_orderdate AS DATE),
-        o_orderpriority,
-        o_clerk,
-        o_shippriority,
-        CONCAT('TRANSFORMED: ', o_comment)
-      FROM read_csv_auto('{file_path}/csv_small_1k.csv')
-    validation_queries:
-      - id: verify_transformation
-        sql: |
-          SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-          WHERE o_comment LIKE 'TRANSFORMED:%'
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        INSERT INTO bulk_load_ops_target
-        SELECT
-          CAST(o_orderkey AS INTEGER),
-          CAST(o_custkey AS INTEGER),
-          UPPER(o_orderstatus),
-          CAST(o_totalprice AS DECIMAL(15,2)),
-          CAST(o_orderdate AS DATE),
-          o_orderpriority,
-          o_clerk,
-          o_shippriority,
-          CONCAT('TRANSFORMED: ', o_comment)
-        FROM read_csv_auto('{file_path}/csv_small_1k.csv')
-      starrocks: null
-
-  - id: bulk_load_error_handling_skip_bad_rows
-    category: bulk_load
-    description: Tests bulk load with error tolerance to skip malformed rows and measure error handling overhead
-    file_dependencies:
-      - csv_with_errors.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_with_errors.csv'
-      (FORMAT CSV, HEADER true, IGNORE_ERRORS true)
-    validation_queries:
-      - id: verify_error_skip
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: null
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_with_errors.csv'
-        (FORMAT CSV, HEADER true, IGNORE_ERRORS true)
-      datafusion: null
-      starrocks: null
-
-  - id: bulk_load_parallel_multi_file
-    category: bulk_load
-    description: Tests bulk load from multiple files in parallel to measure parallel ingestion capability
-    file_dependencies:
-      - csv_parallel_part1.csv
-      - csv_parallel_part2.csv
-      - csv_parallel_part3.csv
-      - csv_parallel_part4.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_parallel_part*.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_multi_file
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 4000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_parallel_part*.csv' (FORMAT CSV, HEADER true)
-      starrocks: null
-
-  - id: bulk_load_upsert_mode
-    category: bulk_load
-    description: Tests bulk load with UPSERT semantics using MERGE to measure conflict resolution overhead
-    file_dependencies:
-      - csv_upsert_data.csv
-    write_sql: |
-      MERGE INTO bulk_load_ops_target AS target
-      USING (
-        SELECT * FROM read_csv_auto('{file_path}/csv_upsert_data.csv')
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET
-          o_custkey = source.o_custkey,
-          o_orderstatus = source.o_orderstatus,
-          o_totalprice = source.o_totalprice,
-          o_orderdate = source.o_orderdate,
-          o_orderpriority = source.o_orderpriority,
-          o_clerk = source.o_clerk,
-          o_shippriority = source.o_shippriority,
-          o_comment = source.o_comment
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_upsert
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: bulk_load_append_mode
-    category: bulk_load
-    description: Tests bulk load in append mode without TRUNCATE to measure incremental load overhead
-    file_dependencies:
-      - csv_small_1k.csv
-    write_sql: |
-      COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_append
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-        expected_rows_min: 1000
-    cleanup_sql: |
-      DELETE FROM bulk_load_ops_target WHERE o_orderkey IN (
-        SELECT o_orderkey FROM (
-          SELECT o_orderkey FROM bulk_load_ops_target ORDER BY o_orderkey DESC LIMIT 1000
-        ) t
-      )
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' (FORMAT CSV, HEADER true)
-      starrocks: null
-
-  - id: bulk_load_replace_mode
-    category: bulk_load
-    description: Tests bulk load with TRUNCATE before load to measure replace semantics overhead
-    file_dependencies:
-      - csv_medium_100k.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_replace
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 100000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' (FORMAT CSV, HEADER true)
-      starrocks: null
-
-  - id: bulk_load_delimited_custom
-    category: bulk_load
-    description: Tests bulk load with custom delimiter pipe character to measure delimiter parsing flexibility
-    file_dependencies:
-      - csv_custom_delim.psv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_custom_delim.psv'
-      WITH (FORMAT CSV, DELIMITER '|', HEADER true)
-    validation_queries:
-      - id: verify_custom_delim
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_custom_delim.psv'
-        (FORMAT CSV, DELIMITER '|', HEADER true)
-      mysql: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        LOAD DATA LOCAL INFILE '{file_path}/csv_custom_delim.psv'
-        INTO TABLE bulk_load_ops_target
-        FIELDS TERMINATED BY '|'
-        LINES TERMINATED BY '\n'
-        IGNORE 1 ROWS
-      starrocks: null
-
-  - id: bulk_load_quoted_fields
-    category: bulk_load
-    description: Tests bulk load with quoted string fields to measure quote escaping overhead
-    file_dependencies:
-      - csv_quoted_fields.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_quoted_fields.csv'
-      WITH (FORMAT CSV, HEADER true, QUOTE '"', ESCAPE '"')
-    validation_queries:
-      - id: verify_quoted
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_quoted_fields.csv'
-        (FORMAT CSV, HEADER true, QUOTE '"', ESCAPE '"')
-      starrocks: null
-
-  - id: bulk_load_null_handling
-    category: bulk_load
-    description: Tests bulk load with NULL value representation to measure NULL parsing overhead
-    file_dependencies:
-      - csv_with_nulls.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_with_nulls.csv'
-      WITH (FORMAT CSV, HEADER true, NULL 'NULL')
-    validation_queries:
-      - id: verify_nulls
-        sql: |
-          SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-          WHERE o_comment IS NULL OR o_clerk IS NULL
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_with_nulls.csv'
-        (FORMAT CSV, HEADER true, NULLSTR 'NULL')
-      starrocks: null
-
-  - id: bulk_load_encoding_utf8
-    category: bulk_load
-    description: Tests bulk load with explicit UTF-8 encoding to measure character encoding overhead
-    file_dependencies:
-      - csv_utf8_encoded.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_utf8_encoded.csv'
-      WITH (FORMAT CSV, HEADER true)
-    validation_queries:
-      - id: verify_encoding
-        sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_utf8_encoded.csv'
-        (FORMAT CSV, HEADER true)
-      starrocks: null
-
-  - id: bulk_load_date_format_custom
-    category: bulk_load
-    description: Tests bulk load with custom date format specification to measure date parsing flexibility
-    file_dependencies:
-      - csv_custom_dates.csv
-    write_sql: |
-      TRUNCATE TABLE bulk_load_ops_target;
-      COPY bulk_load_ops_target FROM '{file_path}/csv_custom_dates.csv'
-      WITH (FORMAT CSV, HEADER true, DATEFORMAT '%Y/%m/%d')
-    validation_queries:
-      - id: verify_date_format
-        sql: |
-          SELECT COUNT(*) as cnt FROM bulk_load_ops_target
-          WHERE o_orderdate IS NOT NULL
-        expected_rows: 1
-    cleanup_sql: |
-      TRUNCATE TABLE bulk_load_ops_target
-    expected_rows_affected: 1000
-    platform_overrides:
-      duckdb: |
-        TRUNCATE TABLE bulk_load_ops_target;
-        COPY bulk_load_ops_target FROM '{file_path}/csv_custom_dates.csv'
-        (FORMAT CSV, HEADER true, DATEFORMAT '%Y/%m/%d')
-      starrocks: null
-
-  # ============================================================================
-  # MERGE OPERATIONS (20 operations)
-  # ============================================================================
-
-  - id: merge_simple_upsert_small
-    category: merge
-    description: Tests simple MERGE upsert with 10 rows to measure baseline MERGE overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_totalprice = source.o_totalprice,
-                   o_comment = 'merged_update'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_orderkey BETWEEN 1 AND 10
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 10
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_upsert_with_delete
-    category: merge
-    description: Tests MERGE with DELETE clause for unmatched target rows to measure tri-directional merge overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 20
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_matched'
-      WHEN NOT MATCHED BY TARGET THEN INSERT
-      WHEN NOT MATCHED BY SOURCE AND target.o_orderkey <= 25 THEN
-        DELETE
-    validation_queries:
-      - id: verify_merge_delete
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_orderkey BETWEEN 1 AND 25
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: null  # Uses transaction rollback
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_overlap_10pct
-    category: merge
-    description: Tests MERGE with approximately 10 percent row overlap to measure low collision overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders
-        WHERE o_orderkey > (
-          SELECT CAST(MAX(o_orderkey) * 0.9 AS INTEGER) FROM merge_ops_target
-        )
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_10pct'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_merge_overlap
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_10pct'
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_overlap_50pct
-    category: merge
-    description: Tests MERGE with approximately 50 percent row overlap to measure medium collision overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders
-        WHERE o_orderkey > (
-          SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER) FROM merge_ops_target
-        )
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_50pct'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_merge_50pct
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_50pct'
-        expected_rows_min: 0
-    cleanup_sql: null  # Uses transaction rollback
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_overlap_90pct
-    category: merge
-    description: Tests MERGE with approximately 90 percent row overlap to measure high collision overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders
-        WHERE o_orderkey <= (
-          SELECT CAST(MAX(o_orderkey) * 0.95 AS INTEGER) FROM merge_ops_target
-        )
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_90pct'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_merge_90pct
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_90pct'
-        expected_rows_min: 1
-    cleanup_sql: null  # Uses transaction rollback
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_no_overlap_all_insert
-    category: merge
-    description: Tests MERGE with zero overlap all inserts to measure pure insert path performance
-    write_sql: |
-      MERGE INTO merge_ops_source AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 100
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_matched'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_all_insert
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_source
-          WHERE o_orderkey BETWEEN 1 AND 100
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_source WHERE o_orderkey BETWEEN 1 AND 100
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_full_overlap_all_update
-    category: merge
-    description: Tests MERGE with full overlap all updates to measure pure update path performance
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT o_orderkey, o_totalprice * 1.1 AS o_totalprice, 'merge_all_update' AS o_comment
-        FROM merge_ops_target
-        WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM merge_ops_target)
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_totalprice = source.o_totalprice,
-                   o_comment = source.o_comment
-    validation_queries:
-      - id: verify_all_update
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_all_update'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target
-      SET o_totalprice = o_totalprice / 1.1,
-          o_comment = ''
-      WHERE o_comment = 'merge_all_update'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_with_join_condition
-    category: merge
-    description: Tests MERGE with complex join condition involving multiple columns to measure matching overhead
-    write_sql: |
-      MERGE INTO merge_ops_lineitem_target AS target
-      USING (
-        SELECT l.*, o.o_custkey
-        FROM lineitem l
-        JOIN orders o ON l.l_orderkey = o.o_orderkey
-        WHERE l.l_orderkey BETWEEN 1 AND 10
-      ) AS source
-      ON target.l_orderkey = source.l_orderkey
-         AND target.l_linenumber = source.l_linenumber
-      WHEN MATCHED THEN
-        UPDATE SET l_comment = 'merge_multi_key'
-      WHEN NOT MATCHED THEN
-        INSERT VALUES (source.l_orderkey, source.l_partkey, source.l_suppkey, source.l_linenumber,
-                       source.l_quantity, source.l_extendedprice, source.l_discount, source.l_tax,
-                       source.l_returnflag, source.l_linestatus, source.l_shipdate, source.l_commitdate,
-                       source.l_receiptdate, source.l_shipinstruct, source.l_shipmode, source.l_comment)
-    validation_queries:
-      - id: verify_join_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_lineitem_target
-          WHERE l_orderkey BETWEEN 1 AND 10
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_lineitem_target WHERE l_orderkey BETWEEN 1 AND 10
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_from_subquery_aggregated
-    category: merge
-    description: Tests MERGE with aggregated subquery source to measure aggregation plus merge overhead
-    write_sql: |
-      MERGE INTO merge_ops_summary_target AS target
-      USING (
-        SELECT o_custkey, SUM(o_totalprice) AS total_price, COUNT(*) AS order_count
-        FROM orders
-        WHERE o_orderkey <= 500
-        GROUP BY o_custkey
-      ) AS source
-      ON target.o_custkey = source.o_custkey
-      WHEN MATCHED THEN
-        UPDATE SET o_totalprice = source.total_price,
-                   order_count = source.order_count
-      WHEN NOT MATCHED THEN
-        INSERT VALUES (NULL, source.o_custkey, NULL, source.total_price, NULL, source.order_count)
-    validation_queries:
-      - id: verify_agg_merge
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_summary_target WHERE order_count > 0
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_summary_target
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_conditional_update
-    category: merge
-    description: Tests MERGE with conditional WHEN MATCHED clause to measure predicate evaluation overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 50
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED AND source.o_totalprice > 100000 THEN
-        UPDATE SET o_comment = 'merge_high_value',
-                   o_orderpriority = '1-URGENT'
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_low_value'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_conditional
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_comment LIKE 'merge_%'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target SET o_comment = '', o_orderpriority = '5-LOW'
-      WHERE o_comment LIKE 'merge_%'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_conditional_insert
-    category: merge
-    description: Tests MERGE with conditional WHEN NOT MATCHED clause to measure insert filtering overhead
-    write_sql: |
-      MERGE INTO merge_ops_source AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 100
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_matched'
-      WHEN NOT MATCHED AND source.o_totalprice > 50000 THEN
-        INSERT VALUES (source.o_orderkey, source.o_custkey, source.o_orderstatus,
-                       source.o_totalprice, source.o_orderdate, source.o_orderpriority,
-                       source.o_clerk, source.o_shippriority, 'high_value_insert')
-    validation_queries:
-      - id: verify_filtered_insert
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_source
-          WHERE o_comment = 'high_value_insert'
-        expected_rows: 1
-        expected_rows_min: 0
-    cleanup_sql: |
-      DELETE FROM merge_ops_source WHERE o_orderkey BETWEEN 1 AND 100
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_multi_column_update
-    category: merge
-    description: Tests MERGE updating 5 plus columns to measure multi-column update overhead in MERGE
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          o_orderkey,
-          o_totalprice * 1.05 AS o_totalprice,
-          '1-URGENT' AS o_orderpriority,
-          'Clerk#000000999' AS o_clerk,
-          o_shippriority + 1 AS o_shippriority,
-          'merge_multi_col' AS o_comment
-        FROM merge_ops_target
-        WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM merge_ops_target)
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET
-          o_totalprice = source.o_totalprice,
-          o_orderpriority = source.o_orderpriority,
-          o_clerk = source.o_clerk,
-          o_shippriority = source.o_shippriority,
-          o_comment = source.o_comment
-    validation_queries:
-      - id: verify_multi_col_merge
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_multi_col'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target
-      SET o_totalprice = o_totalprice / 1.05,
-          o_orderpriority = '5-LOW',
-          o_clerk = 'Clerk#000000001',
-          o_shippriority = 0,
-          o_comment = ''
-      WHERE o_comment = 'merge_multi_col'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_computed_values
-    category: merge
-    description: Tests MERGE with computed values using expressions to measure computation overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          o_orderkey,
-          o_totalprice * 1.15 + 100.0 AS computed_price,
-          CASE
-            WHEN o_totalprice < 100000 THEN '5-LOW'
-            WHEN o_totalprice < 250000 THEN '3-MEDIUM'
-            ELSE '1-URGENT'
-          END AS computed_priority
-        FROM orders
-        WHERE o_orderkey BETWEEN 1 AND 50
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_totalprice = source.computed_price,
-                   o_orderpriority = source.computed_priority,
-                   o_comment = 'merge_computed'
-      WHEN NOT MATCHED THEN
-        INSERT VALUES (source.o_orderkey, 1, 'O', source.computed_price, CURRENT_DATE,
-                       source.computed_priority, 'Clerk#000000001', 0, 'merge_computed')
-    validation_queries:
-      - id: verify_computed_merge
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_computed'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target
-      SET o_totalprice = (o_totalprice - 100.0) / 1.15,
-          o_orderpriority = '5-LOW',
-          o_comment = ''
-      WHERE o_comment = 'merge_computed'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_string_operations
-    category: merge
-    description: Tests MERGE with string manipulation functions to measure string processing overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          o_orderkey,
-          CONCAT('ORDER-', CAST(o_orderkey AS VARCHAR), '-', o_orderpriority) AS computed_comment
-        FROM orders
-        WHERE o_orderkey BETWEEN 1 AND 50
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = source.computed_comment
-    validation_queries:
-      - id: verify_string_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_comment LIKE 'ORDER-%'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target SET o_comment = '' WHERE o_comment LIKE 'ORDER-%'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_date_arithmetic
-    category: merge
-    description: Tests MERGE with date calculations to measure temporal operation overhead in MERGE
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          o_orderkey,
-          o_orderdate + INTERVAL '30' DAY AS shifted_date,
-          'merge_date_shift' AS marker
-        FROM orders
-        WHERE o_orderkey BETWEEN 1 AND 50
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_orderdate = source.shifted_date,
-                   o_comment = source.marker
-    validation_queries:
-      - id: verify_date_merge
-        sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_date_shift'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      UPDATE merge_ops_target
-      SET o_orderdate = o_orderdate - INTERVAL '30' DAY,
-          o_comment = ''
-      WHERE o_comment = 'merge_date_shift'
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_with_cte_source
-    category: merge
-    description: Tests MERGE with CTE as source to measure CTE materialization overhead
-    write_sql: |
-      WITH enriched_orders AS (
-        SELECT
-          o.o_orderkey,
-          o.o_totalprice,
-          c.c_name,
-          c.c_mktsegment
-        FROM orders o
-        JOIN customer c ON o.o_custkey = c.c_custkey
-        WHERE o.o_orderkey BETWEEN 1 AND 50
-      )
-      MERGE INTO merge_ops_summary_target AS target
-      USING enriched_orders AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_totalprice = source.o_totalprice,
-                   customer_name = source.c_name
-      WHEN NOT MATCHED THEN
-        INSERT VALUES (source.o_orderkey, NULL, NULL, source.o_totalprice, source.c_name, NULL)
-    validation_queries:
-      - id: verify_cte_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_summary_target
-          WHERE o_orderkey BETWEEN 1 AND 50
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_summary_target WHERE o_orderkey BETWEEN 1 AND 50
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_returning_clause
-    category: merge
-    description: Tests MERGE...RETURNING to measure overhead of returning merged row data
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_returning'
-      WHEN NOT MATCHED THEN INSERT
-      RETURNING o_orderkey, o_totalprice, o_comment
-    validation_queries:
-      - id: verify_returning_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_orderkey BETWEEN 1 AND 10
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 10
-    expected_rows_affected: null
-    platform_overrides:
-      mysql: null  # MySQL doesn't support MERGE
-      bigquery: null  # BigQuery MERGE doesn't support RETURNING
-      datafusion: null
-      starrocks: null
-
-  - id: merge_error_handling
-    category: merge
-    description: Tests MERGE with potential constraint violations to measure error handling overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 50
-        UNION ALL
-        SELECT * FROM orders WHERE o_orderkey BETWEEN 45 AND 55
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET o_comment = 'merge_with_dups'
-      WHEN NOT MATCHED THEN INSERT
-    validation_queries:
-      - id: verify_error_merge
-        sql: |
-          SELECT COUNT(*) as cnt FROM merge_ops_target
-          WHERE o_orderkey BETWEEN 1 AND 55
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 55
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: delete_gdpr_suppliers_1pct
-    category: delete
-    description: Tests GDPR-compliant deletion with IN subquery to measure deletion-by-list performance (1% of suppliers)
-    write_sql: |
-      DELETE FROM delete_ops_lineitem
-      WHERE l_suppkey IN (
-        SELECT DISTINCT l_suppkey
-        FROM lineitem
-        WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)
-      )
-    validation_queries:
-      - id: verify_gdpr_deletion
-        sql: |
-          SELECT
-            CASE
-              WHEN COUNT(DISTINCT l_suppkey) = 0 THEN 1
-              ELSE 0
-            END as validation_passed
-          FROM delete_ops_lineitem
-          WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      INSERT INTO delete_ops_lineitem
-      SELECT * FROM lineitem
-      WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)
-    expected_rows_affected: null  # Data-dependent: varies by scale factor (~1% of suppliers)
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: delete_gdpr_suppliers_5pct
-    category: delete
-    description: Tests GDPR-compliant deletion with IN subquery at medium scale to measure deletion-by-list performance (5% of suppliers)
-    write_sql: |
-      DELETE FROM delete_ops_lineitem
-      WHERE l_suppkey IN (
-        SELECT DISTINCT l_suppkey
-        FROM lineitem
-        WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)
-      )
-    validation_queries:
-      - id: verify_gdpr_deletion_medium
-        sql: |
-          SELECT
-            CASE
-              WHEN COUNT(DISTINCT l_suppkey) = 0 THEN 1
-              ELSE 0
-            END as validation_passed
-          FROM delete_ops_lineitem
-          WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      INSERT INTO delete_ops_lineitem
-      SELECT * FROM lineitem
-      WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)
-    expected_rows_affected: null  # Data-dependent: varies by scale factor (~5% of suppliers)
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: merge_etl_aggregation_pattern
-    category: merge
-    description: Tests ETL aggregation pattern with running totals and aggregate computations to measure aggregation overhead in MERGE
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          l_orderkey,
-          SUM(l_extendedprice * (1 - l_discount)) as computed_revenue,
-          MAX(l_shipdate) as latest_ship_date,
-          COUNT(*) as line_count
-        FROM lineitem
-        WHERE l_orderkey BETWEEN 1 AND 1000
-        GROUP BY l_orderkey
-      ) AS source
-      ON target.o_orderkey = source.l_orderkey
-      WHEN MATCHED THEN
-        UPDATE SET
-          o_totalprice = target.o_totalprice + source.computed_revenue,
-          o_comment = 'etl_agg_lines_' || CAST(source.line_count AS VARCHAR)
-      WHEN NOT MATCHED THEN
-        INSERT VALUES (source.l_orderkey, 1, 'O', source.computed_revenue, DATE '1998-01-01', '1-URGENT', 'Clerk#000000001', 0, 'etl_new')
-    validation_queries:
-      - id: verify_etl_aggregation
-        sql: |
-          SELECT COUNT(*) as updated_count
-          FROM merge_ops_target
-          WHERE o_comment LIKE 'etl_agg%' OR o_comment = 'etl_new'
-        expected_rows: 1
-        expected_rows_min: 1
-      - id: verify_etl_aggregation_values
-        sql: |
-          SELECT
-            CASE
-              WHEN COUNT(*) > 0 AND MIN(o_totalprice) IS NOT NULL THEN 1
-              ELSE 0
-            END as has_valid_aggregations
-          FROM merge_ops_target
-          WHERE o_comment LIKE 'etl_agg%'
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_target
-      WHERE o_comment LIKE 'etl_agg%' OR o_comment = 'etl_new'
-    expected_rows_affected: null  # Data-dependent: varies by overlap between orderkeys 1-1000 and existing data
-    platform_overrides:
-      datafusion: null
-
-  - id: merge_deduplication_window_function
-    category: merge
-    description: Tests MERGE with window function deduplication using ROW_NUMBER to measure duplicate elimination overhead
-    write_sql: |
-      MERGE INTO merge_ops_target AS target
-      USING (
-        SELECT
-          o_orderkey,
-          o_custkey,
-          o_orderstatus,
-          o_totalprice,
-          o_orderdate,
-          o_orderpriority,
-          o_clerk,
-          o_shippriority,
-          o_comment,
-          ROW_NUMBER() OVER (
-            PARTITION BY o_orderkey
-            ORDER BY o_orderdate DESC, o_totalprice DESC
-          ) as rn
-        FROM orders
-        WHERE o_orderkey BETWEEN 1 AND 500
-      ) AS source
-      ON target.o_orderkey = source.o_orderkey
-      WHEN MATCHED AND source.rn = 1 THEN
-        UPDATE SET
-          o_totalprice = source.o_totalprice,
-          o_comment = 'dedup_update'
-      WHEN NOT MATCHED AND source.rn = 1 THEN
-        INSERT VALUES (
-          source.o_orderkey, source.o_custkey, source.o_orderstatus,
-          source.o_totalprice, source.o_orderdate, source.o_orderpriority,
-          source.o_clerk, source.o_shippriority, 'dedup_insert'
-        )
-    validation_queries:
-      - id: verify_deduplication
-        sql: |
-          SELECT COUNT(*) as dedup_count
-          FROM merge_ops_target
-          WHERE o_comment IN ('dedup_update', 'dedup_insert')
-        expected_rows: 1
-        expected_rows_min: 1
-      - id: verify_no_duplicates
-        sql: |
-          SELECT
-            CASE
-              WHEN MAX(dup_count) = 1 THEN 1
-              ELSE 0
-            END as no_duplicates
-          FROM (
-            SELECT o_orderkey, COUNT(*) as dup_count
-            FROM merge_ops_target
-            WHERE o_comment IN ('dedup_update', 'dedup_insert')
-            GROUP BY o_orderkey
-          )
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DELETE FROM merge_ops_target
-      WHERE o_comment IN ('dedup_update', 'dedup_insert')
-    expected_rows_affected: null  # Data-dependent: varies by overlap between orderkeys 1-500 and existing data
-    platform_overrides:
-      datafusion: null
-
-  # ============================================================================
-  # DDL OPERATIONS (12 operations)
-  # ============================================================================
-  #
-  # IMPORTANT: DDL operations modify database schemas (ALTER TABLE, DROP TABLE, etc.)
-  # and have requires_setup: false to avoid conflicts with staging table setup.
-  #
-  # When running these operations, be aware that:
-  # 1. Schema modifications (e.g., ALTER ADD COLUMN) will persist and affect subsequent
-  #    operations that attempt to reinitialize staging tables.
-  # 2. Operations following DDL modifications may fail during setup because the column
-  #    count or schema no longer matches the base table definition.
-  # 3. For comprehensive testing, DDL operations should ideally be run in isolation
-  #    or at the end of a test suite to avoid schema drift issues.
-  # 4. Transaction operations (ROLLBACK, COMMIT) may fail after DDL operations have
-  #    modified staging table schemas.
-  #
-  # This is expected behavior and reflects real-world considerations when mixing
-  # DDL and DML operations in database workloads.
-
-  - id: ddl_create_table_simple
-    category: ddl
-    description: Tests CREATE TABLE with simple schema with 5 columns and no constraints
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_simple (
-        id INTEGER,
-        name VARCHAR(100),
-        value DECIMAL(15,2),
-        created DATE,
-        status VARCHAR(10)
-      )
-    validation_queries:
-      - id: table_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_simple'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_simple
-    expected_rows_affected: 0
-
-  - id: ddl_truncate_table_small
-    category: ddl
-    requires_setup: false
-    description: Tests TRUNCATE TABLE on small staging table to measure fast delete baseline
-    write_sql: |
-      TRUNCATE TABLE ddl_truncate_target
-    validation_queries:
-      - id: verify_empty
-        sql: SELECT * FROM ddl_truncate_target
-        expected_rows: 0
-    cleanup_sql: null  # Data is gone, will be regenerated
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-
-  - id: ddl_create_table_as_select_simple
-    category: ddl
-    description: Tests CREATE TABLE AS SELECT with simple SELECT to measure table creation from query results
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE orders_1995 AS
-      SELECT *
-      FROM orders
-      WHERE o_orderdate >= DATE '1995-01-01'
-        AND o_orderdate < DATE '1996-01-01'
-    validation_queries:
-      - id: verify_ctas
-        sql: SELECT o_orderkey FROM orders_1995 LIMIT 10
-        expected_rows: null  # Varies by data
-        expected_rows_min: 0  # Might have no orders in 1995
-        expected_rows_max: 10  # LIMIT 10, so at most 10 rows
-    cleanup_sql: |
-      DROP TABLE IF EXISTS orders_1995
-    expected_rows_affected: null
-
-  - id: ddl_create_table_with_constraints
-    category: ddl
-    description: Tests CREATE TABLE with PRIMARY KEY and NOT NULL constraints to measure constraint overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_constrained (
-        id INTEGER PRIMARY KEY,
-        name VARCHAR(100) NOT NULL,
-        value DECIMAL(15,2) NOT NULL,
-        created DATE NOT NULL,
-        status VARCHAR(10)
-      )
-    validation_queries:
-      - id: table_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_constrained'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_constrained
-    expected_rows_affected: 0
-    platform_overrides:
-      datafusion: null
-
-  - id: ddl_create_table_with_index
-    category: ddl
-    description: Tests CREATE TABLE followed by CREATE INDEX to measure index creation overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_indexed (
-        id INTEGER,
-        name VARCHAR(100),
-        value DECIMAL(15,2)
-      );
-      CREATE INDEX idx_test_value ON test_indexed(value)
-    validation_queries:
-      - id: index_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_indexed'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_indexed
-    expected_rows_affected: 0
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: ddl_alter_table_add_column
-    category: ddl
-    description: Tests ALTER TABLE ADD COLUMN to measure schema modification overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_alter (
-        id INTEGER,
-        name VARCHAR(100)
-      );
-      ALTER TABLE test_alter ADD COLUMN created DATE
-    validation_queries:
-      - id: column_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_alter'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_alter
-    expected_rows_affected: 0
-    platform_overrides:
-      datafusion: null
-
-  - id: ddl_alter_table_drop_column
-    category: ddl
-    description: Tests ALTER TABLE DROP COLUMN to measure column removal overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_drop_col (
-        id INTEGER,
-        name VARCHAR(100),
-        temp_col VARCHAR(50)
-      );
-      ALTER TABLE test_drop_col DROP COLUMN temp_col
-    validation_queries:
-      - id: table_modified
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_drop_col'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_drop_col
-    expected_rows_affected: 0
-    platform_overrides:
-      datafusion: null
-
-  - id: ddl_alter_table_rename_column
-    category: ddl
-    description: Tests ALTER TABLE RENAME COLUMN to measure column renaming overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_rename_col (
-        id INTEGER,
-        old_name VARCHAR(100)
-      );
-      ALTER TABLE test_rename_col RENAME COLUMN old_name TO new_name
-    validation_queries:
-      - id: column_renamed
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_rename_col'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_rename_col
-    expected_rows_affected: 0
-    platform_overrides:
-      mysql: |
-        CREATE TABLE test_rename_col (
-          id INTEGER,
-          old_name VARCHAR(100)
-        );
-        ALTER TABLE test_rename_col CHANGE old_name new_name VARCHAR(100)
-      starrocks: null
-      datafusion: null
-
-  - id: ddl_create_index_on_existing
-    category: ddl
-    description: Tests CREATE INDEX on populated table to measure index building on existing data
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_idx_existing AS SELECT * FROM orders WHERE o_orderkey <= 100;
-      CREATE INDEX idx_existing_price ON test_idx_existing(o_totalprice)
-    validation_queries:
-      - id: index_created
-        sql: SELECT COUNT(*) as cnt FROM test_idx_existing
-        expected_rows: 1
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_idx_existing
-    expected_rows_affected: null
-    platform_overrides:
-      datafusion: null
-      starrocks: null
-
-  - id: ddl_drop_index
-    category: ddl
-    description: Tests DROP INDEX to measure index removal overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_drop_idx (id INTEGER, value DECIMAL(15,2));
-      CREATE INDEX idx_test_drop ON test_drop_idx(value);
-      DROP INDEX idx_test_drop
-    validation_queries:
-      - id: table_still_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.tables
-          WHERE table_name = 'test_drop_idx'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS test_drop_idx
-    expected_rows_affected: 0
-    platform_overrides:
-      mysql: |
-        CREATE TABLE test_drop_idx (id INTEGER, value DECIMAL(15,2));
-        CREATE INDEX idx_test_drop ON test_drop_idx(value);
-        DROP INDEX idx_test_drop ON test_drop_idx
-      datafusion: null
-      starrocks: null
-
-  - id: ddl_create_view_simple
-    category: ddl
-    description: Tests CREATE VIEW with simple SELECT to measure view creation overhead
-    requires_setup: false
-    write_sql: |
-      CREATE VIEW orders_view AS
-      SELECT o_orderkey, o_custkey, o_totalprice, o_orderdate
-      FROM orders
-      WHERE o_orderkey <= 1000
-    validation_queries:
-      - id: view_exists
-        sql: |
-          SELECT table_name
-          FROM information_schema.views
-          WHERE table_name = 'orders_view'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP VIEW IF EXISTS orders_view
-    expected_rows_affected: 0
-
-  - id: ddl_drop_table
-    category: ddl
-    description: Tests DROP TABLE to measure table removal overhead
-    requires_setup: false
-    write_sql: |
-      CREATE TABLE test_drop AS SELECT * FROM orders WHERE o_orderkey <= 50;
-      DROP TABLE test_drop
-    validation_queries:
-      - id: table_dropped
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM information_schema.tables
-          WHERE table_name = 'test_drop'
-        expected_rows: 1
-    cleanup_sql: null  # Table is already dropped
-    expected_rows_affected: null
-
-  # ============================================================================
-  # SKETCH OPERATIONS (8 operations) — DataSketches persist + merge + requery
-  # ============================================================================
-  #
-  # Lifecycle: build sketches into a BINARY column with one query, then merge
-  # them across partitions in a later query and extract a scalar estimate.
-  # Each op is fully self-contained (CREATE, populate, query, DROP) — no
-  # cross-op dependency. Sketch tables are NOT in STAGING_TABLES; this avoids
-  # adding BINARY-column DDL to the bootstrap loop on dialects without a
-  # binary type (DataFusion/SQLite).
-  #
-  # First-pass support: DuckDB (datasketches community extension), with
-  # Databricks / Snowflake / BigQuery platform_overrides written from
-  # documented function names but not locally verifiable. ClickHouse,
-  # DataFusion, Redshift, SQLite, and Starrocks skip via null overrides.
-  # ClickHouse-native -State/-Merge variants are explicitly deferred
-  # (see TODO `deferred:` block).
-
-  - id: sketch_ddl_create_persistent_table
-    category: sketch
-    description: Tests CREATE/DROP overhead for a sketch persistence table with BINARY columns
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE,
-        region VARCHAR(25),
-        user_sketch BLOB,
-        rev_sketch BLOB
-      );
-    validation_queries:
-      - id: table_exists
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM information_schema.tables
-          WHERE table_name = 'sketch_ops_daily_users'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_daily_users
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE,
-          region STRING,
-          user_sketch BINARY,
-          rev_sketch BINARY
-        ) USING DELTA;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE,
-          region VARCHAR(25),
-          user_sketch BINARY,
-          rev_sketch BINARY
-        );
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE,
-          region STRING,
-          user_sketch BYTES,
-          rev_sketch BYTES
-        );
-      # ClickHouse uses parameterised AggregateFunction columns rather
-      # than a portable BINARY surface. The DDL stores theta-equivalent
-      # state via uniq's AggregateFunction(uniq, UInt64); KLL-equivalent
-      # and topK-equivalent live in their own per-family tables created
-      # by the matching insert ops.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date Date,
-          region String,
-          user_sketch AggregateFunction(uniq, UInt64),
-          rev_sketch AggregateFunction(uniq, UInt64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-      datafusion: null  # No DML
-      # Redshift's HLLSKETCH covers HLL only — no Theta / KLL / Top-K
-      # equivalents. DDL must use DISTSTYLE EVEN (HLLSKETCH cannot be
-      # DISTKEY/SORTKEY) and queries must group by a non-sketch column
-      # (HLLSKETCH is rejected in GROUP BY/ORDER BY/DISTINCT).
-      redshift: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE,
-          region VARCHAR(25),
-          user_sketch HLLSKETCH,
-          rev_sketch HLLSKETCH
-        )
-        DISTSTYLE EVEN;
-      sqlite: null      # No BINARY type useful for sketches
-      starrocks: null   # Defer pending DataSketches UDAF support
-
-  - id: sketch_insert_theta_per_partition
-    category: sketch
-    description: Builds per-partition Theta sketches over l_orderkey + l_extendedprice and persists them
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE,
-        region VARCHAR(25),
-        user_sketch BLOB,
-        rev_sketch BLOB
-      );
-      INSERT INTO sketch_ops_daily_users
-      SELECT
-        l_shipdate AS activity_date,
-        l_returnflag AS region,
-        datasketch_theta(l_orderkey) AS user_sketch,
-        datasketch_theta(CAST(l_extendedprice AS INTEGER)) AS rev_sketch
-      FROM lineitem
-      GROUP BY l_shipdate, l_returnflag;
-    validation_queries:
-      - id: rows_persisted
-        sql: |
-          SELECT COUNT(*) as partitions FROM sketch_ops_daily_users
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_daily_users
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY
-        ) USING DELTA;
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               theta_sketch_agg(l_orderkey),
-               theta_sketch_agg(CAST(l_extendedprice AS INT))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY
-        );
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               DATASKETCHES_THETA_ACCUMULATE(l_orderkey),
-               DATASKETCHES_THETA_ACCUMULATE(CAST(l_extendedprice AS INTEGER))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES
-        );
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               HLL_COUNT.INIT(l_orderkey),
-               HLL_COUNT.INIT(CAST(l_extendedprice AS INT64))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      # ClickHouse uses uniqState combinator + AggregateFunction(uniq, UInt64)
-      # column type. Cast Decimal to UInt64 because uniq aggregate doesn't
-      # accept Decimal directly. -State produces the per-partition state
-      # that the matching merge query unions via uniqMerge.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date Date, region String,
-          user_sketch AggregateFunction(uniq, UInt64),
-          rev_sketch AggregateFunction(uniq, UInt64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               uniqState(toUInt64(l_orderkey)),
-               uniqState(toUInt64(l_extendedprice))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      datafusion: null
-      # Redshift HLL substitution: HLL_CREATE_SKETCH builds an HLLSKETCH
-      # per (date, region) partition. Same persist+merge+requery shape
-      # as DataSketches Theta, different sketch family (HLL only — see
-      # cross-platform doc). DISTSTYLE EVEN required (HLLSKETCH cannot
-      # be DISTKEY/SORTKEY); cast Decimal to BIGINT before HLL hashing.
-      redshift: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25),
-          user_sketch HLLSKETCH, rev_sketch HLLSKETCH
-        ) DISTSTYLE EVEN;
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               HLL_CREATE_SKETCH(l_orderkey),
-               HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))
-        FROM lineitem
-        GROUP BY l_shipdate, l_returnflag;
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_insert_kll_per_partition
-    category: sketch
-    description: Builds per-partition KLL quantile sketches over l_extendedprice
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-      CREATE TABLE sketch_ops_kll_partitions (
-        activity_date DATE,
-        region VARCHAR(25),
-        price_sketch BLOB
-      );
-      INSERT INTO sketch_ops_kll_partitions
-      SELECT
-        l_shipdate,
-        l_returnflag,
-        datasketch_kll(200, l_extendedprice)
-      FROM lineitem
-      GROUP BY l_shipdate, l_returnflag;
-    validation_queries:
-      - id: kll_partitions_persisted
-        sql: |
-          SELECT COUNT(*) as partitions FROM sketch_ops_kll_partitions
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region STRING, price_sketch BINARY
-        ) USING DELTA;
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag, kll_sketch_agg_double(CAST(l_extendedprice AS DOUBLE))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region VARCHAR(25), price_sketch BINARY
-        );
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               DATASKETCHES_KLL_ACCUMULATE(CAST(l_extendedprice AS DOUBLE))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region STRING, price_sketch BYTES
-        );
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               KLL_QUANTILES.INIT_INT64(CAST(l_extendedprice AS INT64))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      # ClickHouse uses quantileTDigestState combinator; the column type
-      # must be parameterised with the target quantile because quantileTDigest
-      # is fundamentally one-quantile-per-aggregate. Median (0.5) here.
-      # Decimal cast to Float64 because quantileTDigest accepts Float64.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date Date, region String,
-          price_sketch AggregateFunction(quantileTDigest(0.5), Float64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               quantileTDigestState(0.5)(toFloat64(l_extendedprice))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      datafusion: null
-      redshift: null  # Redshift has no KLL or T-Digest sketch family
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_insert_topk_per_shard
-    category: sketch
-    description: Builds per-shard frequent-items (Top-K accumulator) sketches over l_shipmode
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_topk;
-      CREATE TABLE sketch_ops_topk (
-        shard_id INTEGER,
-        topk_sketch BLOB
-      );
-      INSERT INTO sketch_ops_topk
-      SELECT
-        CAST(l_orderkey % 8 AS INTEGER) AS shard_id,
-        datasketch_frequent_items(8, l_shipmode) AS topk_sketch
-      FROM lineitem
-      GROUP BY l_orderkey % 8;
-    validation_queries:
-      - id: topk_shards_persisted
-        sql: |
-          SELECT COUNT(*) as shards FROM sketch_ops_topk
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_topk
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (
-          shard_id INT, topk_sketch BINARY
-        ) USING DELTA;
-        INSERT INTO sketch_ops_topk
-        SELECT CAST(l_orderkey % 8 AS INT),
-               approx_top_k_accumulate(l_shipmode)
-        FROM lineitem GROUP BY l_orderkey % 8;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (
-          shard_id INTEGER, topk_sketch BINARY
-        );
-        INSERT INTO sketch_ops_topk
-        SELECT MOD(l_orderkey, 8),
-               APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)
-        FROM lineitem GROUP BY MOD(l_orderkey, 8);
-      bigquery: null  # No native top-K accumulator function
-      # ClickHouse uses topKState(K) combinator; column type is
-      # AggregateFunction(topK(K), T). K=8 matches DuckDB's topk parameter.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (
-          shard_id Int32,
-          topk_sketch AggregateFunction(topK(8), String)
-        ) ENGINE = MergeTree() ORDER BY shard_id;
-        INSERT INTO sketch_ops_topk
-        SELECT toInt32(l_orderkey % 8),
-               topKState(8)(l_shipmode)
-        FROM lineitem GROUP BY l_orderkey % 8;
-      datafusion: null
-      redshift: null  # Redshift has no top-K function family
-      sqlite: null
-      starrocks: null
-
-  # ★ HEADLINE TEST — theta_union merge + estimate
-  - id: sketch_query_theta_union_merge
-    category: sketch
-    description: ★ Headline — populate theta sketches per partition, then merge across all partitions in a single query and emit an approximate distinct count (compare to aggregation_distinct in read_primitives). BigQuery substitutes HLL_COUNT for Theta (no native Theta surface) — the persist + merge + requery shape is identical, but the underlying sketch family differs.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB
-      );
-      INSERT INTO sketch_ops_daily_users
-      SELECT l_shipdate, l_returnflag,
-             datasketch_theta(l_orderkey),
-             datasketch_theta(CAST(l_extendedprice AS INTEGER))
-      FROM lineitem
-      GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_theta_estimate(datasketch_theta(user_sketch)) AS distinct_orders
-      FROM sketch_ops_daily_users;
-    validation_queries:
-      - id: theta_estimate_in_range
-        sql: |
-          SELECT datasketch_theta_estimate(datasketch_theta(user_sketch)) AS distinct_orders
-          FROM sketch_ops_daily_users
-        # SF=0.01: lineitem has 15000 distinct l_orderkeys; theta merge
-        # observed at 14836.89 (deterministic over 5 runs). Bounds are
-        # intentionally tighter than the original [14000, 16000] while
-        # still catching only material regressions. ClickHouse uniq is
-        # HyperLogLog++ with default precision (m=2^17, RSE ~0.4%);
-        # observed estimate stays well within [14500, 15500].
-        expected_value_min: 14500
-        expected_value_max: 15500
-        platform_overrides:
-          clickhouse: |
-            SELECT uniqMerge(user_sketch) AS distinct_orders
-            FROM sketch_ops_daily_users
-          redshift: |
-            SELECT HLL_CARDINALITY(HLL_COMBINE(user_sketch)) AS distinct_orders
-            FROM sketch_ops_daily_users
-      # Storage-size validation: octet_length() of the merged sketch state
-      # certifies the persisted bytes haven't regressed to zero or grown
-      # unbounded. Split into two engine-specific validations so each engine
-      # gets bounds tight enough to flag material regressions (a wide
-      # cross-engine envelope would let DuckDB grow 5x silently before
-      # alarming). Each variant skips all non-target engines via explicit
-      # null overrides.
-      - id: theta_storage_size_duckdb
-        sql: |
-          SELECT octet_length(datasketch_theta(user_sketch)) AS sketch_bytes
-          FROM sketch_ops_daily_users
-        # DuckDB DataSketches Theta lg_k=12 → ~16KB merged at SF=0.01.
-        # Bounds tight enough to flag a 2x growth (e.g. accidental lg_k=14
-        # bump) while tolerating modest encoding-format drift.
-        expected_value_min: 4000
-        expected_value_max: 32000
-        platform_overrides:
-          clickhouse: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-      - id: theta_storage_size_clickhouse
-        # Default sql is ClickHouse-only; every non-clickhouse engine is
-        # explicitly skipped below so the default body is never executed
-        # off-target. ClickHouse AggregateFunction columns aren't a
-        # length() input directly; toString() serializes the merged state
-        # to its bytes-of-string representation, which is correlated with
-        # but not identical to the on-disk binary state size — stable
-        # enough for regression detection across runs.
-        sql: |
-          SELECT length(toString(uniqMergeState(user_sketch))) AS sketch_bytes
-          FROM sketch_ops_daily_users
-        # ClickHouse uniq HLL++ default precision → 60003 bytes
-        # (verified clickhouse-local 25.4.2, SF=0.01, 2026-05-04).
-        # Bounds tight enough that a regression to <16KB or growth past
-        # 100KB alarms; wide enough to absorb encoding drift.
-        expected_value_min: 16000
-        expected_value_max: 100000
-        platform_overrides:
-          duckdb: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_daily_users
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY
-        ) USING DELTA;
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag, theta_sketch_agg(l_orderkey),
-               theta_sketch_agg(CAST(l_extendedprice AS INT))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT theta_sketch_estimate(theta_union_agg(user_sketch)) AS distinct_orders
-        FROM sketch_ops_daily_users;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY
-        );
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag, DATASKETCHES_THETA_ACCUMULATE(l_orderkey),
-               DATASKETCHES_THETA_ACCUMULATE(CAST(l_extendedprice AS INTEGER))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT DATASKETCHES_THETA_ESTIMATE(DATASKETCHES_THETA_COMBINE(user_sketch)) AS distinct_orders
-        FROM sketch_ops_daily_users;
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES
-        );
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag, HLL_COUNT.INIT(l_orderkey),
-               HLL_COUNT.INIT(CAST(l_extendedprice AS INT64))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT HLL_COUNT.MERGE(user_sketch) AS distinct_orders
-        FROM sketch_ops_daily_users;
-      # Full persist+merge+requery cycle for ClickHouse. uniqState builds
-      # the per-partition state into AggregateFunction(uniq, UInt64); the
-      # final SELECT uses uniqMerge to union states across rows and
-      # extract the distinct estimate.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date Date, region String,
-          user_sketch AggregateFunction(uniq, UInt64),
-          rev_sketch AggregateFunction(uniq, UInt64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               uniqState(toUInt64(l_orderkey)),
-               uniqState(toUInt64(l_extendedprice))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT uniqMerge(user_sketch) AS distinct_orders
-        FROM sketch_ops_daily_users;
-      datafusion: null
-      # Redshift HLL substitution: full persist+merge+requery cycle in
-      # one op, mirroring the DuckDB Theta path. HLL_COMBINE unions
-      # per-partition HLLSKETCH rows; HLL_CARDINALITY extracts the
-      # final BIGINT estimate. Family substitution documented in the
-      # cross-platform doc.
-      #
-      # Tolerance bounds for the merged distinct estimate come from the
-      # operation-level validation_query [14500, 15500]. Redshift HLL uses
-      # default logm=15, so m=32768 and classic HLL RSE is about
-      # 1.04/sqrt(m)=0.57%; for SF=0.01's 15000 distinct l_orderkeys,
-      # 1σ is ~86 rows. The current ±500 bounds are still conservative
-      # (~5.8σ) while no longer being the old ±1000 (~11.6σ) envelope.
-      # Re-tune with observed Redshift values in
-      # write-primitives-sketch-cloud-verification when creds become
-      # available.
-      redshift: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25),
-          user_sketch HLLSKETCH, rev_sketch HLLSKETCH
-        ) DISTSTYLE EVEN;
-        INSERT INTO sketch_ops_daily_users
-        SELECT l_shipdate, l_returnflag,
-               HLL_CREATE_SKETCH(l_orderkey),
-               HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT HLL_CARDINALITY(HLL_COMBINE(user_sketch)) AS distinct_orders
-        FROM sketch_ops_daily_users;
-      sqlite: null
-      starrocks: null
-
-  # ★ HEADLINE TEST — kll merge + get_quantile
-  - id: sketch_query_kll_quantiles_merge
-    category: sketch
-    description: ★ Headline — populate KLL sketches per partition, merge across partitions, extract median price (compare to statistical_percentiles in read_primitives)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-      CREATE TABLE sketch_ops_kll_partitions (
-        activity_date DATE, region VARCHAR(25), price_sketch BLOB
-      );
-      INSERT INTO sketch_ops_kll_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_kll(200, l_extendedprice)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_kll_quantile(datasketch_kll(200, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-      FROM sketch_ops_kll_partitions;
-    validation_queries:
-      - id: kll_median_in_range
-        sql: |
-          SELECT datasketch_kll_quantile(datasketch_kll(200, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-          FROM sketch_ops_kll_partitions
-        # SF=0.01: median l_extendedprice merged across partitions
-        # observed at 34027–34362 over 5 runs (varies with merge order).
-        # [30000, 40000] is generous and tolerant of SF=0.1 drift while
-        # still catching a sketch regressing to 0 or a wildly off median.
-        # ClickHouse quantileTDigest at default compression (100) easily
-        # produces a median in the same range.
-        expected_value_min: 30000
-        expected_value_max: 40000
-        platform_overrides:
-          databricks: |
-            SELECT kll_sketch_get_quantile_double(kll_merge_agg_double(price_sketch), 0.5) AS median_price
-            FROM sketch_ops_kll_partitions
-          clickhouse: |
-            SELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price
-            FROM sketch_ops_kll_partitions
-      # See theta_storage_size_duckdb above for why the storage-size check
-      # is split into per-engine variants — same rationale here.
-      - id: kll_storage_size_duckdb
-        sql: |
-          SELECT octet_length(datasketch_kll(200, price_sketch::sketch_kll_double)) AS sketch_bytes
-          FROM sketch_ops_kll_partitions
-        # DuckDB DataSketches KLL k=200 → ~3KB merged at SF=0.01.
-        # Tight bounds to flag any 2x growth without false-failing on
-        # within-family encoding drift.
-        expected_value_min: 1000
-        expected_value_max: 6000
-        platform_overrides:
-          clickhouse: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-      - id: kll_storage_size_clickhouse
-        sql: |
-          SELECT length(toString(quantileTDigestMergeState(0.5)(price_sketch))) AS sketch_bytes
-          FROM sketch_ops_kll_partitions
-        # ClickHouse quantileTDigest at compression=100 → 4314 bytes merged
-        # (verified clickhouse-local 25.4.2, SF=0.01, 2026-05-04).
-        # Bounds tight to its observed range.
-        expected_value_min: 1500
-        expected_value_max: 8000
-        platform_overrides:
-          duckdb: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region STRING, price_sketch BINARY
-        ) USING DELTA;
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag, kll_sketch_agg_double(CAST(l_extendedprice AS DOUBLE))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT kll_sketch_get_quantile_double(kll_merge_agg_double(price_sketch), 0.5) AS median_price
-        FROM sketch_ops_kll_partitions;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region VARCHAR(25), price_sketch BINARY
-        );
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               DATASKETCHES_KLL_ACCUMULATE(CAST(l_extendedprice AS DOUBLE))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT DATASKETCHES_KLL_GET_QUANTILE(DATASKETCHES_KLL_COMBINE(price_sketch), 0.5) AS median_price
-        FROM sketch_ops_kll_partitions;
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date DATE, region STRING, price_sketch BYTES
-        );
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               KLL_QUANTILES.INIT_INT64(CAST(l_extendedprice AS INT64))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT KLL_QUANTILES.MERGE_POINT_INT64(price_sketch, 0.5) AS median_price
-        FROM sketch_ops_kll_partitions;
-      # ClickHouse quantileTDigest with -State/-Merge combinators. The
-      # quantile parameter (0.5 = median) is bound at column-type
-      # creation time because quantileTDigest is a quantile-specific
-      # aggregate.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-        CREATE TABLE sketch_ops_kll_partitions (
-          activity_date Date, region String,
-          price_sketch AggregateFunction(quantileTDigest(0.5), Float64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-        INSERT INTO sketch_ops_kll_partitions
-        SELECT l_shipdate, l_returnflag,
-               quantileTDigestState(0.5)(toFloat64(l_extendedprice))
-        FROM lineitem GROUP BY l_shipdate, l_returnflag;
-        SELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price
-        FROM sketch_ops_kll_partitions;
-      datafusion: null
-      redshift: null  # Redshift has no KLL or T-Digest sketch family
-      sqlite: null
-      starrocks: null
-
-  # ★ HEADLINE TEST — frequent-items combine + estimate
-  - id: sketch_query_topk_combine
-    category: sketch
-    description: ★ Headline — populate per-shard frequent-items sketches, combine across shards, count the frequent items (cross-reference approx_top_k_lineitem latency in read_primitives)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_topk;
-      CREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);
-      INSERT INTO sketch_ops_topk
-      SELECT CAST(l_orderkey % 8 AS INTEGER),
-             datasketch_frequent_items(8, l_shipmode)
-      FROM lineitem GROUP BY l_orderkey % 8;
-      SELECT LENGTH(datasketch_frequent_items_get_frequent(
-        datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'
-      )) AS frequent_count
-      FROM sketch_ops_topk;
-    validation_queries:
-      - id: topk_frequent_count_in_range
-        sql: |
-          SELECT LENGTH(datasketch_frequent_items_get_frequent(
-            datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'
-          )) AS frequent_count
-          FROM sketch_ops_topk
-        # SF=0.01: lineitem has exactly 7 distinct l_shipmode values; the
-        # frequent-items merge reports all 7 deterministically across runs.
-        # Lower bound at 6 catches a sketch losing one mode; upper at 8
-        # would flag a frequent-items false-positive (NO_FALSE_POSITIVES
-        # mode should not return more than 7). ClickHouse topK(8) is
-        # also bounded by K=8, so the same [6, 8] envelope holds.
-        expected_value_min: 6
-        expected_value_max: 8
-        platform_overrides:
-          clickhouse: |
-            SELECT length(topKMerge(8)(topk_sketch)) AS frequent_count
-            FROM sketch_ops_topk
-      # See theta_storage_size_duckdb above for why the storage-size check
-      # is split into per-engine variants.
-      - id: topk_storage_size_duckdb
-        sql: |
-          SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes
-          FROM sketch_ops_topk
-        # DuckDB DataSketches frequent-items lg_max_map_size=8 (256 buckets)
-        # → ~600B merged at SF=0.01.
-        expected_value_min: 300
-        expected_value_max: 1200
-        platform_overrides:
-          clickhouse: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-      - id: topk_storage_size_clickhouse
-        sql: |
-          SELECT length(toString(topKMergeState(8)(topk_sketch))) AS sketch_bytes
-          FROM sketch_ops_topk
-        # ClickHouse topK(8) merged state → 317 bytes at SF=0.01
-        # (verified clickhouse-local 25.4.2, 2026-05-04).
-        # Tighter than the DataSketches frequent-items size; still loose
-        # enough to absorb encoding drift.
-        expected_value_min: 150
-        expected_value_max: 800
-        platform_overrides:
-          duckdb: null
-          databricks: null
-          snowflake: null
-          bigquery: null
-          redshift: null
-          datafusion: null
-          sqlite: null
-          starrocks: null
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_topk
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (shard_id INT, topk_sketch BINARY) USING DELTA;
-        INSERT INTO sketch_ops_topk
-        SELECT CAST(l_orderkey % 8 AS INT),
-               approx_top_k_accumulate(l_shipmode)
-        FROM lineitem GROUP BY l_orderkey % 8;
-        SELECT SIZE(approx_top_k_estimate(approx_top_k_combine(topk_sketch))) AS frequent_count
-        FROM sketch_ops_topk;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BINARY);
-        INSERT INTO sketch_ops_topk
-        SELECT MOD(l_orderkey, 8),
-               APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)
-        FROM lineitem GROUP BY MOD(l_orderkey, 8);
-        SELECT ARRAY_SIZE(APPROX_TOP_K_ESTIMATE(APPROX_TOP_K_COMBINE(topk_sketch))) AS frequent_count
-        FROM sketch_ops_topk;
-      bigquery: null  # No native top-K accumulator
-      # ClickHouse topK with -State/-Merge combinators. K=8 matches
-      # DuckDB's frequent-items parameter; length() of the merged TopK
-      # array gives the count of frequent items.
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_topk;
-        CREATE TABLE sketch_ops_topk (
-          shard_id Int32,
-          topk_sketch AggregateFunction(topK(8), String)
-        ) ENGINE = MergeTree() ORDER BY shard_id;
-        INSERT INTO sketch_ops_topk
-        SELECT toInt32(l_orderkey % 8),
-               topKState(8)(l_shipmode)
-        FROM lineitem GROUP BY l_orderkey % 8;
-        SELECT length(topKMerge(8)(topk_sketch)) AS frequent_count
-        FROM sketch_ops_topk;
-      datafusion: null
-      redshift: null  # Redshift has no top-K function family
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_drop_persistent_table
-    category: sketch
-    description: Tests DROP TABLE on a sketch-bearing BINARY-column table to measure cleanup overhead
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB
-      );
-      DROP TABLE sketch_ops_daily_users;
-    validation_queries:
-      - id: table_dropped
-        sql: |
-          SELECT COUNT(*) as cnt
-          FROM information_schema.tables
-          WHERE table_name = 'sketch_ops_daily_users'
-        expected_rows: 1
-    cleanup_sql: null  # Table is already dropped
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY
-        ) USING DELTA;
-        DROP TABLE sketch_ops_daily_users;
-      snowflake: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY
-        );
-        DROP TABLE sketch_ops_daily_users;
-      bigquery: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES
-        );
-        DROP TABLE sketch_ops_daily_users;
-      clickhouse: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date Date, region String,
-          user_sketch AggregateFunction(uniq, UInt64),
-          rev_sketch AggregateFunction(uniq, UInt64)
-        ) ENGINE = MergeTree() ORDER BY (activity_date, region);
-        DROP TABLE sketch_ops_daily_users;
-      datafusion: null
-      redshift: |
-        DROP TABLE IF EXISTS sketch_ops_daily_users;
-        CREATE TABLE sketch_ops_daily_users (
-          activity_date DATE, region VARCHAR(25),
-          user_sketch HLLSKETCH, rev_sketch HLLSKETCH
-        ) DISTSTYLE EVEN;
-        DROP TABLE sketch_ops_daily_users;
-      sqlite: null
-      starrocks: null
-
-  # ----------------------------------------------------------------------
-  # CPC family (DuckDB-only): alternative HLL with smaller serialized size
-  # at the cost of slower update/merge. Apache DataSketches calls this
-  # "Compressed Probabilistic Counting". 1252 bytes merged at SF=0.01
-  # vs Theta's ~16KB — see docs for the storage tradeoff.
-  # ----------------------------------------------------------------------
-
-  - id: sketch_cpc_create_persistent_table
-    category: sketch
-    description: Tests CREATE/DROP overhead for a CPC sketch table (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_cpc_partitions;
-      CREATE TABLE sketch_cpc_partitions (
-        activity_date DATE,
-        region VARCHAR(25),
-        user_sketch BLOB
-      );
-    validation_queries:
-      - id: cpc_table_exists
-        sql: |
-          SELECT COUNT(*) as cnt FROM information_schema.tables
-          WHERE table_name = 'sketch_cpc_partitions'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_cpc_partitions
-    expected_rows_affected: null
-    platform_overrides:
+- id: insert_single_row
+  category: insert
+  description: Tests single row INSERT performance with all columns specified
+  write_sql: "INSERT INTO insert_ops_lineitem\nVALUES (\n  9000001, 1, 1, 1,\n  10.0, 1000.0, 0.05, 0.02,\n  'N', 'O',\n  DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',\n  'DELIVER IN PERSON', 'TRUCK', 'test insert'\n)\n"
+  validation_queries:
+  - id: verify_values
+    sql: "SELECT l_quantity, l_extendedprice, l_discount\nFROM insert_ops_lineitem\nWHERE l_orderkey = 9000001\n"
+    expected_rows: 1
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey = 9000001\n"
+  expected_rows_affected: 1
+- id: insert_batch_values_10
+  category: insert
+  description: Tests small batch INSERT using VALUES clause with 10 rows
+  write_sql: "INSERT INTO insert_ops_lineitem VALUES\n  (9000010, 1, 1, 1, 10.0, 1000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 1'),\n  (9000011, 2, 2, 1, 20.0, 2000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 2'),\n  (9000012, 3, 3, 1, 30.0, 3000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 3'),\n  (9000013, 4, 4, 1, 40.0, 4000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 4'),\n  (9000014, 5, 5, 1, 50.0, 5000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 5'),\n  (9000015, 6, 6, 1, 60.0, 6000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 6'),\n  (9000016, 7, 7, 1, 70.0, 7000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 7'),\n  (9000017, 8, 8, 1, 80.0, 8000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 8'),\n  (9000018, 9, 9, 1, 90.0, 9000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 9'),\n  (9000019, 10, 10, 1, 100.0, 10000.0, 0.05, 0.02, 'N', 'O', DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20', 'DELIVER IN PERSON', 'TRUCK', 'batch 10')\n"
+  validation_queries:
+  - id: verify_batch
+    sql: SELECT l_orderkey, l_quantity FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000010 AND 9000019 ORDER BY l_orderkey
+    expected_rows: 10
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000010 AND 9000019\n"
+  expected_rows_affected: 10
+- id: insert_select_simple
+  category: insert
+  description: Tests INSERT INTO...SELECT with simple WHERE filter
+  write_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 1 AND 10;\nINSERT INTO insert_ops_lineitem\nSELECT * FROM lineitem\nWHERE l_orderkey BETWEEN 1 AND 10\n"
+  validation_queries:
+  - id: verify_insert_select
+    sql: "SELECT l_orderkey, l_linenumber\nFROM insert_ops_lineitem\nWHERE l_orderkey BETWEEN 1 AND 10\nORDER BY l_orderkey, l_linenumber\n"
+    expected_rows: null
+    expected_rows_min: 1
+    expected_rows_max: 200
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 1 AND 10\n"
+  expected_rows_affected: null
+  platform_overrides:
+    starrocks: null
+- id: insert_batch_values_100
+  category: insert
+  description: Tests medium batch INSERT using VALUES clause with 100 rows to measure batch overhead
+  write_sql: "INSERT INTO insert_ops_lineitem\nSELECT 9000100 + n, 1, 1, 1, 10.0 * n, 1000.0 * n, 0.05, 0.02, 'N', 'O',\n       DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',\n       'DELIVER IN PERSON', 'TRUCK', 'batch_' || CAST(n AS VARCHAR)\nFROM (SELECT unnest(generate_series(0, 99)) AS n) t\n"
+  validation_queries:
+  - id: verify_batch_100
+    sql: SELECT COUNT(*) as cnt FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000100 AND 9000199
+    expected_rows: 1
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9000100 AND 9000199\n"
+  expected_rows_affected: 100
+  platform_overrides:
+    starrocks: null
+- id: insert_batch_values_1000
+  category: insert
+  description: Tests large batch INSERT with 1000 rows to measure large batch processing and memory overhead
+  write_sql: "INSERT INTO insert_ops_lineitem\nSELECT 9001000 + n, 1, 1, 1, 10.0 * n, 1000.0 * n, 0.05, 0.02, 'N', 'O',\n       DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',\n       'DELIVER IN PERSON', 'TRUCK', 'large_batch_' || CAST(n AS VARCHAR)\nFROM (SELECT unnest(generate_series(0, 999)) AS n) t\n"
+  validation_queries:
+  - id: verify_batch_1000
+    sql: SELECT COUNT(*) as cnt FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9001000 AND 9001999
+    expected_rows: 1
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey BETWEEN 9001000 AND 9001999\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    starrocks: null
+- id: insert_select_with_join
+  category: insert
+  description: Tests INSERT INTO...SELECT with JOIN to measure join overhead during data insertion
+  write_sql: "INSERT INTO insert_ops_orders_summary (o_orderkey, o_custkey, o_orderdate, o_totalprice, customer_name)\nSELECT o.o_orderkey, o.o_custkey, o.o_orderdate, o.o_totalprice, c.c_name\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nWHERE o.o_orderkey BETWEEN 1 AND 100\n"
+  validation_queries:
+  - id: verify_joined_insert
+    sql: "SELECT COUNT(*) as cnt\nFROM insert_ops_orders_summary\nWHERE o_orderkey BETWEEN 1 AND 100\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM insert_ops_orders_summary WHERE o_orderkey BETWEEN 1 AND 100\n"
+  expected_rows_affected: null
+- id: insert_select_aggregated
+  category: insert
+  description: Tests INSERT INTO...SELECT with GROUP BY aggregation to measure aggregation overhead
+  write_sql: "INSERT INTO insert_ops_orders_summary (o_custkey, o_totalprice, order_count)\nSELECT o_custkey, SUM(o_totalprice), COUNT(*)\nFROM orders\nWHERE o_orderkey <= 1000\nGROUP BY o_custkey\n"
+  validation_queries:
+  - id: verify_aggregated_insert
+    sql: "SELECT COUNT(*) as customer_count, SUM(order_count) as total_orders\nFROM insert_ops_orders_summary\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM insert_ops_orders_summary\n"
+  expected_rows_affected: null
+- id: insert_select_from_multiple
+  category: insert
+  description: Tests INSERT INTO...SELECT from 3 plus tables with multiple JOINs to measure complex query overhead
+  write_sql: "INSERT INTO insert_ops_lineitem_enriched\n  (l_orderkey, l_partkey, l_suppkey, l_quantity, l_extendedprice,\n   o_orderdate, c_name, s_name, p_name)\nSELECT l.l_orderkey, l.l_partkey, l.l_suppkey, l.l_quantity, l.l_extendedprice,\n       o.o_orderdate, c.c_name, s.s_name, p.p_name\nFROM lineitem l\nJOIN orders o ON l.l_orderkey = o.o_orderkey\nJOIN customer c ON o.o_custkey = c.c_custkey\nJOIN supplier s ON l.l_suppkey = s.s_suppkey\nJOIN part p ON l.l_partkey = p.p_partkey\nWHERE l.l_orderkey BETWEEN 1 AND 50\n"
+  validation_queries:
+  - id: verify_multi_join_insert
+    sql: "SELECT COUNT(*) as cnt\nFROM insert_ops_lineitem_enriched\nWHERE l_orderkey BETWEEN 1 AND 50\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM insert_ops_lineitem_enriched WHERE l_orderkey BETWEEN 1 AND 50\n"
+  expected_rows_affected: null
+- id: insert_with_default_values
+  category: insert
+  description: Tests INSERT with DEFAULT keyword to measure default value processing overhead
+  write_sql: "INSERT INTO write_ops_log (log_id, operation_id, operation_category, timestamp, rows_affected, duration_ms, success)\nVALUES (1, 'test_insert', 'insert', CURRENT_TIMESTAMP, 0, 0.0, true)\n"
+  validation_queries:
+  - id: verify_default_insert
+    sql: "SELECT COUNT(*) as cnt\nFROM write_ops_log\nWHERE operation_id = 'test_insert' AND operation_category = 'insert'\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM write_ops_log WHERE operation_id = 'test_insert' AND operation_category = 'insert'\n"
+  expected_rows_affected: null
+- id: insert_select_union
+  category: insert
+  description: Tests INSERT INTO...SELECT with UNION to measure set operation overhead during insertion
+  write_sql: "DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 50;\nINSERT INTO insert_ops_orders\nSELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 25\nUNION ALL\nSELECT * FROM orders WHERE o_orderkey BETWEEN 26 AND 50\n"
+  validation_queries:
+  - id: verify_union_insert
+    sql: "SELECT COUNT(*) as cnt\nFROM insert_ops_orders\nWHERE o_orderkey BETWEEN 1 AND 50\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 50\n"
+  expected_rows_affected: null
+- id: insert_on_conflict_ignore
+  category: insert
+  description: Tests INSERT with conflict handling using ON CONFLICT DO NOTHING to measure constraint checking overhead
+  write_sql: "INSERT INTO insert_ops_orders\nSELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10\nON CONFLICT (o_orderkey) DO NOTHING\n"
+  validation_queries:
+  - id: verify_conflict_handling
+    sql: "SELECT COUNT(*) as cnt\nFROM insert_ops_orders\nWHERE o_orderkey BETWEEN 1 AND 10\n"
+    expected_rows: 1
+  cleanup_sql: "DELETE FROM insert_ops_orders WHERE o_orderkey BETWEEN 1 AND 10\n"
+  expected_rows_affected: null
+  platform_overrides:
+    duckdb: "INSERT OR IGNORE INTO insert_ops_orders\nSELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10\n"
+    sqlite: "INSERT OR IGNORE INTO insert_ops_orders\nSELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10\n"
+    datafusion: null
+    starrocks: null
+- id: insert_returning_clause
+  category: insert
+  description: Tests INSERT...RETURNING to measure overhead of returning inserted row data
+  write_sql: "INSERT INTO insert_ops_lineitem\nVALUES (9000500, 1, 1, 1, 10.0, 1000.0, 0.05, 0.02, 'N', 'O',\n        DATE '1998-01-01', DATE '1998-01-15', DATE '1998-01-20',\n        'DELIVER IN PERSON', 'TRUCK', 'returning_test')\nRETURNING l_orderkey, l_partkey, l_quantity\n"
+  validation_queries:
+  - id: verify_returning_insert
+    sql: "SELECT l_orderkey, l_quantity\nFROM insert_ops_lineitem\nWHERE l_orderkey = 9000500\n"
+    expected_rows: 1
+  cleanup_sql: "DELETE FROM insert_ops_lineitem WHERE l_orderkey = 9000500\n"
+  expected_rows_affected: 1
+  platform_overrides:
+    mysql: null
+    bigquery: null
+    datafusion: null
+    starrocks: null
+- id: update_single_row_pk
+  category: update
+  description: Tests single row UPDATE by primary key to measure index lookup plus update cost
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice * 1.1,\n    o_comment = 'updated_single'\nWHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_update
+    sql: "SELECT COUNT(*) as cnt\nFROM update_ops_orders\nWHERE o_comment = 'updated_single'\n"
+    expected_rows: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice / 1.1,\n    o_comment = ''\nWHERE o_comment = 'updated_single'\n"
+  expected_rows_affected: 1
+  platform_overrides:
+    datafusion: null
+- id: update_selective_10pct
+  category: update
+  description: Tests UPDATE affecting approximately 10 percent of table rows to measure selective update performance
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = 'selective_10pct'\nWHERE o_orderkey <= (\n  SELECT CAST(MAX(o_orderkey) * 0.1 AS INTEGER)\n  FROM update_ops_orders\n)\n"
+  validation_queries:
+  - id: count_updated
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'selective_10pct'
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_comment = ''\nWHERE o_comment = 'selective_10pct'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_with_subquery
+  category: update
+  description: Tests UPDATE with correlated subquery to measure subquery execution cost per row
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = (\n  SELECT SUM(l_extendedprice * (1 - l_discount))\n  FROM lineitem\n  WHERE l_orderkey = update_ops_orders.o_orderkey\n)\nWHERE EXISTS (\n  SELECT 1 FROM lineitem WHERE l_orderkey = update_ops_orders.o_orderkey\n)\nAND o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_calculation
+    sql: "SELECT COUNT(*) as cnt\nFROM update_ops_orders o\nWHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  cleanup_sql: "-- Recalculate to restore\nUPDATE update_ops_orders\nSET o_totalprice = (\n  SELECT SUM(l_extendedprice * (1 - l_discount))\n  FROM lineitem\n  WHERE l_orderkey = update_ops_orders.o_orderkey\n)\nWHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_bulk_50pct
+  category: update
+  description: Tests UPDATE affecting approximately 50 percent of table rows to measure large-scale update performance
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = 'bulk_50pct_update'\nWHERE o_orderkey <= (\n  SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER)\n  FROM update_ops_orders\n)\n"
+  validation_queries:
+  - id: count_updated_50pct
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'bulk_50pct_update'
+  cleanup_sql: "UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'bulk_50pct_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_bulk_all
+  category: update
+  description: Tests UPDATE of entire table to measure full table scan and update overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = 'bulk_all_update'\n"
+  validation_queries:
+  - id: verify_all_updated
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'bulk_all_update'
+  cleanup_sql: "UPDATE update_ops_orders SET o_comment = ''\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_with_join
+  category: update
+  description: Tests UPDATE with JOIN syntax to measure join overhead during updates
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = 'joined_update'\nFROM customer\nWHERE update_ops_orders.o_custkey = customer.c_custkey\n  AND customer.c_mktsegment = 'BUILDING'\n  AND update_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_joined_update
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'joined_update'
+    expected_rows_min: 0
+  cleanup_sql: "UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'joined_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    mysql: "UPDATE update_ops_orders\nJOIN customer ON update_ops_orders.o_custkey = customer.c_custkey\nSET update_ops_orders.o_comment = 'joined_update'\nWHERE customer.c_mktsegment = 'BUILDING'\n  AND update_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+    datafusion: null
+- id: update_from_select
+  category: update
+  description: Tests UPDATE...FROM...WHERE EXISTS to measure correlated EXISTS overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = 'exists_update'\nWHERE EXISTS (\n  SELECT 1 FROM lineitem\n  WHERE lineitem.l_orderkey = update_ops_orders.o_orderkey\n    AND lineitem.l_quantity > 40\n)\nAND o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_exists_update
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'exists_update'
+    expected_rows_min: 0
+  cleanup_sql: "UPDATE update_ops_orders SET o_comment = '' WHERE o_comment = 'exists_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_set_multiple_columns
+  category: update
+  description: Tests UPDATE of 5 plus columns to measure multi-column update overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice * 1.05,\n    o_orderpriority = '1-URGENT',\n    o_comment = 'multi_col_update',\n    o_shippriority = 1,\n    o_clerk = 'Clerk#000000001'\nWHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_multi_column
+    sql: "SELECT COUNT(*) as cnt\nFROM update_ops_orders\nWHERE o_comment = 'multi_col_update'\n"
+    expected_rows: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice / 1.05,\n    o_orderpriority = '5-LOW',\n    o_comment = '',\n    o_shippriority = 0,\n    o_clerk = 'Clerk#000000000'\nWHERE o_comment = 'multi_col_update'\n"
+  expected_rows_affected: 1
+  platform_overrides:
+    datafusion: null
+- id: update_with_case_expression
+  category: update
+  description: Tests UPDATE using CASE WHEN expression to measure conditional logic overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_orderpriority = CASE\n  WHEN o_totalprice < 100000 THEN '5-LOW'\n  WHEN o_totalprice < 200000 THEN '4-NOT SPECIFIED'\n  WHEN o_totalprice < 300000 THEN '3-MEDIUM'\n  WHEN o_totalprice < 400000 THEN '2-HIGH'\n  ELSE '1-URGENT'\nEND,\no_comment = 'case_update'\nWHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_case_update
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'case_update'
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders SET o_orderpriority = '5-LOW', o_comment = '' WHERE o_comment = 'case_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_computed_column
+  category: update
+  description: Tests UPDATE with mathematical expressions to measure computation overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice * 1.1 + 50.0 - (o_totalprice * 0.02),\n    o_comment = 'computed_update'\nWHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_computed
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'computed_update'
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = (o_totalprice + (o_totalprice * 0.02) - 50.0) / 1.1,\n    o_comment = ''\nWHERE o_comment = 'computed_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_string_manipulation
+  category: update
+  description: Tests UPDATE with string functions CONCAT SUBSTRING to measure string processing overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_comment = CONCAT('Updated:', SUBSTRING(o_orderpriority, 1, 5), '|', CAST(o_orderkey AS VARCHAR))\nWHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_string_ops
+    sql: "SELECT COUNT(*) as cnt\nFROM update_ops_orders\nWHERE o_comment LIKE 'Updated:%'\n"
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders SET o_comment = '' WHERE o_comment LIKE 'Updated:%'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_date_arithmetic
+  category: update
+  description: Tests UPDATE with date calculations to measure temporal operation overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_orderdate = o_orderdate + INTERVAL '7' DAY,\n    o_comment = 'date_update'\nWHERE o_orderkey BETWEEN (SELECT MIN(o_orderkey) FROM update_ops_orders) AND (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_date_ops
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'date_update'
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_orderdate = o_orderdate - INTERVAL '7' DAY,\n    o_comment = ''\nWHERE o_comment = 'date_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_conditional_multi_column
+  category: update
+  description: Tests complex conditional UPDATE with multiple column updates to measure combined overhead
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = CASE\n    WHEN o_orderpriority = '1-URGENT' THEN o_totalprice * 1.2\n    WHEN o_orderpriority = '2-HIGH' THEN o_totalprice * 1.1\n    ELSE o_totalprice\n  END,\n  o_orderpriority = CASE\n    WHEN o_totalprice > 250000 THEN '1-URGENT'\n    ELSE o_orderpriority\n  END,\n  o_comment = 'complex_conditional'\nWHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_complex_conditional
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'complex_conditional'
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = CASE\n    WHEN o_orderpriority = '1-URGENT' THEN o_totalprice / 1.2\n    WHEN o_orderpriority = '2-HIGH' THEN o_totalprice / 1.1\n    ELSE o_totalprice\n  END,\n  o_orderpriority = '5-LOW',\n  o_comment = ''\nWHERE o_comment = 'complex_conditional'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_with_aggregate
+  category: update
+  description: Tests UPDATE using aggregated subquery to measure aggregation overhead per row
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = (\n  SELECT AVG(l_extendedprice)\n  FROM lineitem\n  WHERE l_orderkey = update_ops_orders.o_orderkey\n),\no_comment = 'agg_update'\nWHERE EXISTS (SELECT 1 FROM lineitem WHERE l_orderkey = update_ops_orders.o_orderkey)\n  AND o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM update_ops_orders)\n"
+  validation_queries:
+  - id: verify_agg_update
+    sql: SELECT COUNT(*) as cnt FROM update_ops_orders WHERE o_comment = 'agg_update'
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = (\n  SELECT SUM(l_extendedprice * (1 - l_discount))\n  FROM lineitem\n  WHERE l_orderkey = update_ops_orders.o_orderkey\n),\no_comment = ''\nWHERE o_comment = 'agg_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: update_returning
+  category: update
+  description: Tests UPDATE...RETURNING to measure overhead of returning updated row data
+  write_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice * 1.15,\n    o_comment = 'returning_update'\nWHERE o_orderkey = (SELECT MIN(o_orderkey) FROM update_ops_orders)\nRETURNING o_orderkey, o_totalprice, o_comment\n"
+  validation_queries:
+  - id: verify_returning_update
+    sql: "SELECT COUNT(*) as cnt\nFROM update_ops_orders\nWHERE o_comment = 'returning_update'\n"
+    expected_rows: 1
+  cleanup_sql: "UPDATE update_ops_orders\nSET o_totalprice = o_totalprice / 1.15,\n    o_comment = ''\nWHERE o_comment = 'returning_update'\n"
+  expected_rows_affected: 1
+  platform_overrides:
+    mysql: null
+    bigquery: null
+    datafusion: null
+    starrocks: null
+- id: delete_single_row_pk
+  category: delete
+  description: Tests single row DELETE by primary key to measure index-based deletion
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey = (SELECT MAX(o_orderkey) FROM delete_ops_orders)\n"
+  validation_queries:
+  - id: verify_table_integrity
+    sql: "-- Validate table still accessible and structure is intact after DELETE\n-- Note: Full validation of DELETE correctness requires pre-write state - future enhancement\nSELECT o_orderkey, o_custkey\nFROM delete_ops_orders\nLIMIT 1\n"
+    expected_rows: null
+    expected_rows_min: 0
+    expected_rows_max: 1
+  cleanup_sql: null
+  expected_rows_affected: 1
+  platform_overrides:
+    datafusion: null
+- id: delete_selective_10pct
+  category: delete
+  description: Tests DELETE affecting approximately 10 percent of rows to measure selective deletion performance
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey > (\n  SELECT CAST(MAX(o_orderkey) * 0.9 AS INTEGER)\n  FROM delete_ops_orders\n)\n"
+  validation_queries:
+  - id: verify_table_integrity
+    sql: "-- Validate table still accessible after bulk DELETE\n-- Note: Full validation requires pre-write state - future enhancement\nSELECT COUNT(*) as remaining_count\nFROM delete_ops_orders\n"
+    expected_rows: null
+    expected_rows_min: 0
+    expected_rows_max: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_with_subquery
+  category: delete
+  description: Tests DELETE with WHERE...IN subquery to measure subquery evaluation overhead
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey IN (\n  SELECT o_orderkey\n  FROM delete_ops_orders\n  WHERE o_orderpriority = '1-URGENT'\n  LIMIT 10\n)\n"
+  validation_queries:
+  - id: verify_table_integrity
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_with_join
+  category: delete
+  description: Tests DELETE with JOIN to measure join-based deletion performance
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE EXISTS (\n  SELECT 1 FROM customer\n  WHERE customer.c_custkey = delete_ops_orders.o_custkey\n    AND customer.c_mktsegment = 'AUTOMOBILE'\n)\nAND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 20 FROM delete_ops_orders)\n"
+  validation_queries:
+  - id: verify_delete_with_join
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    mysql: "DELETE delete_ops_orders FROM delete_ops_orders\nJOIN customer ON customer.c_custkey = delete_ops_orders.o_custkey\nWHERE customer.c_mktsegment = 'AUTOMOBILE'\n  AND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 20 FROM delete_ops_orders)\n"
+    datafusion: null
+- id: delete_bulk_25pct
+  category: delete
+  description: Tests DELETE affecting approximately 25 percent of rows to measure medium bulk deletion
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey > (\n  SELECT CAST(MAX(o_orderkey) * 0.75 AS INTEGER)\n  FROM delete_ops_orders\n)\n"
+  validation_queries:
+  - id: verify_25pct_delete
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_bulk_50pct
+  category: delete
+  description: Tests DELETE affecting approximately 50 percent of rows to measure large bulk deletion
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey > (\n  SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER)\n  FROM delete_ops_orders\n)\n"
+  validation_queries:
+  - id: verify_50pct_delete
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_bulk_75pct
+  category: delete
+  description: Tests DELETE affecting approximately 75 percent of rows to measure very large bulk deletion
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey > (\n  SELECT CAST(MAX(o_orderkey) * 0.25 AS INTEGER)\n  FROM delete_ops_orders\n)\n"
+  validation_queries:
+  - id: verify_75pct_delete
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_with_not_exists
+  category: delete
+  description: Tests DELETE using NOT EXISTS to measure anti-join deletion performance
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE NOT EXISTS (\n  SELECT 1 FROM lineitem\n  WHERE lineitem.l_orderkey = delete_ops_orders.o_orderkey\n)\nAND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM delete_ops_orders)\n"
+  validation_queries:
+  - id: verify_not_exists_delete
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_with_aggregation
+  category: delete
+  description: Tests DELETE using aggregate in WHERE clause to measure aggregation evaluation overhead
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_totalprice < (\n  SELECT AVG(o_totalprice) FROM delete_ops_orders\n)\nAND delete_ops_orders.o_orderkey <= (SELECT MIN(o_orderkey) + 30 FROM delete_ops_orders)\n"
+  validation_queries:
+  - id: verify_agg_delete
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_returning
+  category: delete
+  description: Tests DELETE...RETURNING to measure overhead of returning deleted row data
+  write_sql: "DELETE FROM delete_ops_orders\nWHERE o_orderkey = (SELECT MAX(o_orderkey) FROM delete_ops_orders)\nRETURNING o_orderkey, o_custkey, o_totalprice\n"
+  validation_queries:
+  - id: verify_delete_returning
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_orders
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: 1
+  platform_overrides:
+    mysql: null
+    bigquery: null
+    datafusion: null
+    starrocks: null
+- id: delete_cascade_simulation
+  category: delete
+  description: Tests multi-table DELETE simulation to measure cascading deletion overhead
+  write_sql: "DELETE FROM delete_ops_lineitem\nWHERE l_orderkey IN (\n  SELECT o_orderkey FROM delete_ops_orders\n  WHERE o_orderpriority = '1-URGENT'\n  LIMIT 5\n)\n"
+  validation_queries:
+  - id: verify_cascade_delete
+    sql: "SELECT COUNT(*) as cnt\nFROM delete_ops_lineitem l\nWHERE l_orderkey IN (\n  SELECT o_orderkey FROM delete_ops_orders\n  WHERE o_orderpriority = '1-URGENT'\n  LIMIT 5\n)\n"
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: delete_all_truncate_comparison
+  category: delete
+  description: Tests DELETE star versus TRUNCATE to measure full table deletion methods
+  write_sql: "DELETE FROM delete_ops_lineitem\n"
+  validation_queries:
+  - id: verify_all_deleted
+    sql: SELECT COUNT(*) as cnt FROM delete_ops_lineitem
+    expected_rows: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: bulk_load_csv_small_uncompressed
+  category: bulk_load
+  description: Tests bulk load from small CSV file 1K rows uncompressed to measure baseline CSV parsing overhead
+  file_dependencies:
+  - csv_small_1k.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' (FORMAT CSV, HEADER true)\n"
+    mysql: "TRUNCATE TABLE bulk_load_ops_target;\nLOAD DATA LOCAL INFILE '{file_path}/csv_small_1k.csv'\nINTO TABLE bulk_load_ops_target\nFIELDS TERMINATED BY ','\nLINES TERMINATED BY '\\n'\nIGNORE 1 ROWS\n"
+    sqlite: "DELETE FROM bulk_load_ops_target;\n.mode csv\n.import {file_path}/csv_small_1k.csv bulk_load_ops_target\n"
+    starrocks: null
+- id: bulk_load_csv_small_gzip
+  category: bulk_load
+  description: Tests bulk load from small CSV file 1K rows gzip compressed to measure gzip decompression overhead
+  file_dependencies:
+  - csv_small_1k.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_csv_small_zstd
+  category: bulk_load
+  description: Tests bulk load from small CSV file 1K rows zstd compressed to measure zstd decompression overhead
+  file_dependencies:
+  - csv_small_1k.csv.zst
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+    starrocks: null
+- id: bulk_load_csv_small_bzip2
+  category: bulk_load
+  description: Tests bulk load from small CSV file 1K rows bzip2 compressed to measure bzip2 decompression overhead
+  file_dependencies:
+  - csv_small_1k.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "-- DuckDB does not support bzip2 compression - use gzip instead\nTRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_csv_medium_uncompressed
+  category: bulk_load
+  description: Tests bulk load from medium CSV file 100K rows uncompressed to measure medium dataset processing
+  file_dependencies:
+  - csv_medium_100k.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' (FORMAT CSV, HEADER true)\n"
+    mysql: "TRUNCATE TABLE bulk_load_ops_target;\nLOAD DATA LOCAL INFILE '{file_path}/csv_medium_100k.csv'\nINTO TABLE bulk_load_ops_target\nFIELDS TERMINATED BY ','\nLINES TERMINATED BY '\\n'\nIGNORE 1 ROWS\n"
+    starrocks: null
+- id: bulk_load_csv_medium_gzip
+  category: bulk_load
+  description: Tests bulk load from medium CSV file 100K rows gzip compressed to measure compression benefit on medium data
+  file_dependencies:
+  - csv_medium_100k.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_csv_medium_zstd
+  category: bulk_load
+  description: Tests bulk load from medium CSV file 100K rows zstd compressed to measure zstd efficiency on medium data
+  file_dependencies:
+  - csv_medium_100k.csv.zst
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+    starrocks: null
+- id: bulk_load_csv_medium_bzip2
+  category: bulk_load
+  description: Tests bulk load from medium CSV file 100K rows bzip2 compressed to measure bzip2 efficiency on medium data
+  file_dependencies:
+  - csv_medium_100k.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "-- DuckDB does not support bzip2 compression - use gzip instead\nTRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_csv_large_uncompressed
+  category: bulk_load
+  description: Tests bulk load from large CSV file 1M rows uncompressed to measure large dataset processing limits
+  file_dependencies:
+  - csv_large_1m.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv' (FORMAT CSV, HEADER true)\n"
+    mysql: "TRUNCATE TABLE bulk_load_ops_target;\nLOAD DATA LOCAL INFILE '{file_path}/csv_large_1m.csv'\nINTO TABLE bulk_load_ops_target\nFIELDS TERMINATED BY ','\nLINES TERMINATED BY '\\n'\nIGNORE 1 ROWS\n"
+    starrocks: null
+- id: bulk_load_csv_large_gzip
+  category: bulk_load
+  description: Tests bulk load from large CSV file 1M rows gzip compressed to measure compression benefit on large data
+  file_dependencies:
+  - csv_large_1m.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' WITH (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_csv_large_zstd
+  category: bulk_load
+  description: Tests bulk load from large CSV file 1M rows zstd compressed to measure zstd efficiency on large data
+  file_dependencies:
+  - csv_large_1m.csv.zst
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.zst' WITH (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.zst' (FORMAT CSV, HEADER true, COMPRESSION 'zstd')\n"
+    starrocks: null
+- id: bulk_load_csv_large_bzip2
+  category: bulk_load
+  description: Tests bulk load from large CSV file 1M rows bzip2 compressed to measure bzip2 efficiency on large data
+  file_dependencies:
+  - csv_large_1m.csv.gz
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    duckdb: "-- DuckDB does not support bzip2 compression - use gzip instead\nTRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_large_1m.csv.gz' (FORMAT CSV, HEADER true, COMPRESSION 'gzip')\n"
+    starrocks: null
+- id: bulk_load_parquet_small_uncompressed
+  category: bulk_load
+  description: Tests bulk load from small Parquet file 1K rows uncompressed to measure Parquet columnar format overhead
+  file_dependencies:
+  - parquet_small_1k.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_small_snappy
+  category: bulk_load
+  description: Tests bulk load from small Parquet file 1K rows snappy compressed to measure Snappy decompression overhead
+  file_dependencies:
+  - parquet_small_1k_snappy.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_snappy.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_small_gzip
+  category: bulk_load
+  description: Tests bulk load from small Parquet file 1K rows gzip compressed to measure gzip in Parquet context
+  file_dependencies:
+  - parquet_small_1k_gzip.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_gzip.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_small_zstd
+  category: bulk_load
+  description: Tests bulk load from small Parquet file 1K rows zstd compressed to measure zstd in Parquet context
+  file_dependencies:
+  - parquet_small_1k_zstd.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_small_1k_zstd.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_medium_uncompressed
+  category: bulk_load
+  description: Tests bulk load from medium Parquet file 100K rows uncompressed to measure columnar format efficiency
+  file_dependencies:
+  - parquet_medium_100k.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_medium_snappy
+  category: bulk_load
+  description: Tests bulk load from medium Parquet file 100K rows snappy compressed to measure Snappy efficiency
+  file_dependencies:
+  - parquet_medium_100k_snappy.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_snappy.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_medium_gzip
+  category: bulk_load
+  description: Tests bulk load from medium Parquet file 100K rows gzip compressed to measure compression trade-offs
+  file_dependencies:
+  - parquet_medium_100k_gzip.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_gzip.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_medium_zstd
+  category: bulk_load
+  description: Tests bulk load from medium Parquet file 100K rows zstd compressed to measure zstd columnar efficiency
+  file_dependencies:
+  - parquet_medium_100k_zstd.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_medium_100k_zstd.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_large_uncompressed
+  category: bulk_load
+  description: Tests bulk load from large Parquet file 1M rows uncompressed to measure large columnar dataset processing
+  file_dependencies:
+  - parquet_large_1m.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_large_snappy
+  category: bulk_load
+  description: Tests bulk load from large Parquet file 1M rows snappy compressed to measure Snappy on large data
+  file_dependencies:
+  - parquet_large_1m_snappy.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_snappy.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_large_gzip
+  category: bulk_load
+  description: Tests bulk load from large Parquet file 1M rows gzip compressed to measure gzip on large data
+  file_dependencies:
+  - parquet_large_1m_gzip.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_gzip.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_parquet_large_zstd
+  category: bulk_load
+  description: Tests bulk load from large Parquet file 1M rows zstd compressed to measure zstd on large data
+  file_dependencies:
+  - parquet_large_1m_zstd.parquet
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/parquet_large_1m_zstd.parquet' (FORMAT PARQUET)\n"
+  validation_queries:
+  - id: verify_row_count
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000000
+  platform_overrides:
+    starrocks: null
+- id: bulk_load_column_subset
+  category: bulk_load
+  description: Tests bulk load with column subset selection to measure partial schema load overhead
+  file_dependencies:
+  - csv_medium_100k.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nINSERT INTO bulk_load_ops_target (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate)\nSELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate\nFROM read_csv_auto('{file_path}/csv_medium_100k.csv')\n"
+  validation_queries:
+  - id: verify_partial_load
+    sql: "SELECT COUNT(*) as cnt FROM bulk_load_ops_target\nWHERE o_orderkey IS NOT NULL\n"
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nINSERT INTO bulk_load_ops_target (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate)\nSELECT o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderdate\nFROM read_csv_auto('{file_path}/csv_medium_100k.csv')\n"
+    starrocks: null
+- id: bulk_load_with_transformation
+  category: bulk_load
+  description: Tests bulk load with inline type conversion and transformation to measure ETL overhead
+  file_dependencies:
+  - csv_small_1k.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nINSERT INTO bulk_load_ops_target\nSELECT\n  CAST(o_orderkey AS INTEGER),\n  CAST(o_custkey AS INTEGER),\n  UPPER(o_orderstatus),\n  CAST(o_totalprice AS DECIMAL(15,2)),\n  CAST(o_orderdate AS DATE),\n  o_orderpriority,\n  o_clerk,\n  o_shippriority,\n  CONCAT('TRANSFORMED: ', o_comment)\nFROM read_csv_auto('{file_path}/csv_small_1k.csv')\n"
+  validation_queries:
+  - id: verify_transformation
+    sql: "SELECT COUNT(*) as cnt FROM bulk_load_ops_target\nWHERE o_comment LIKE 'TRANSFORMED:%'\n"
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nINSERT INTO bulk_load_ops_target\nSELECT\n  CAST(o_orderkey AS INTEGER),\n  CAST(o_custkey AS INTEGER),\n  UPPER(o_orderstatus),\n  CAST(o_totalprice AS DECIMAL(15,2)),\n  CAST(o_orderdate AS DATE),\n  o_orderpriority,\n  o_clerk,\n  o_shippriority,\n  CONCAT('TRANSFORMED: ', o_comment)\nFROM read_csv_auto('{file_path}/csv_small_1k.csv')\n"
+    starrocks: null
+- id: bulk_load_error_handling_skip_bad_rows
+  category: bulk_load
+  description: Tests bulk load with error tolerance to skip malformed rows and measure error handling overhead
+  file_dependencies:
+  - csv_with_errors.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_with_errors.csv'\n(FORMAT CSV, HEADER true, IGNORE_ERRORS true)\n"
+  validation_queries:
+  - id: verify_error_skip
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: null
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_with_errors.csv'\n(FORMAT CSV, HEADER true, IGNORE_ERRORS true)\n"
+    datafusion: null
+    starrocks: null
+- id: bulk_load_parallel_multi_file
+  category: bulk_load
+  description: Tests bulk load from multiple files in parallel to measure parallel ingestion capability
+  file_dependencies:
+  - csv_parallel_part1.csv
+  - csv_parallel_part2.csv
+  - csv_parallel_part3.csv
+  - csv_parallel_part4.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_parallel_part*.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_multi_file
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 4000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_parallel_part*.csv' (FORMAT CSV, HEADER true)\n"
+    starrocks: null
+- id: bulk_load_upsert_mode
+  category: bulk_load
+  description: Tests bulk load with UPSERT semantics using MERGE to measure conflict resolution overhead
+  file_dependencies:
+  - csv_upsert_data.csv
+  write_sql: "MERGE INTO bulk_load_ops_target AS target\nUSING (\n  SELECT * FROM read_csv_auto('{file_path}/csv_upsert_data.csv')\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET\n    o_custkey = source.o_custkey,\n    o_orderstatus = source.o_orderstatus,\n    o_totalprice = source.o_totalprice,\n    o_orderdate = source.o_orderdate,\n    o_orderpriority = source.o_orderpriority,\n    o_clerk = source.o_clerk,\n    o_shippriority = source.o_shippriority,\n    o_comment = source.o_comment\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_upsert
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: bulk_load_append_mode
+  category: bulk_load
+  description: Tests bulk load in append mode without TRUNCATE to measure incremental load overhead
+  file_dependencies:
+  - csv_small_1k.csv
+  write_sql: "COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_append
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+    expected_rows_min: 1000
+  cleanup_sql: "DELETE FROM bulk_load_ops_target WHERE o_orderkey IN (\n  SELECT o_orderkey FROM (\n    SELECT o_orderkey FROM bulk_load_ops_target ORDER BY o_orderkey DESC LIMIT 1000\n  ) t\n)\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "COPY bulk_load_ops_target FROM '{file_path}/csv_small_1k.csv' (FORMAT CSV, HEADER true)\n"
+    starrocks: null
+- id: bulk_load_replace_mode
+  category: bulk_load
+  description: Tests bulk load with TRUNCATE before load to measure replace semantics overhead
+  file_dependencies:
+  - csv_medium_100k.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' WITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_replace
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 100000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_medium_100k.csv' (FORMAT CSV, HEADER true)\n"
+    starrocks: null
+- id: bulk_load_delimited_custom
+  category: bulk_load
+  description: Tests bulk load with custom delimiter pipe character to measure delimiter parsing flexibility
+  file_dependencies:
+  - csv_custom_delim.psv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_custom_delim.psv'\nWITH (FORMAT CSV, DELIMITER '|', HEADER true)\n"
+  validation_queries:
+  - id: verify_custom_delim
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_custom_delim.psv'\n(FORMAT CSV, DELIMITER '|', HEADER true)\n"
+    mysql: "TRUNCATE TABLE bulk_load_ops_target;\nLOAD DATA LOCAL INFILE '{file_path}/csv_custom_delim.psv'\nINTO TABLE bulk_load_ops_target\nFIELDS TERMINATED BY '|'\nLINES TERMINATED BY '\\n'\nIGNORE 1 ROWS\n"
+    starrocks: null
+- id: bulk_load_quoted_fields
+  category: bulk_load
+  description: Tests bulk load with quoted string fields to measure quote escaping overhead
+  file_dependencies:
+  - csv_quoted_fields.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_quoted_fields.csv'\nWITH (FORMAT CSV, HEADER true, QUOTE '\"', ESCAPE '\"')\n"
+  validation_queries:
+  - id: verify_quoted
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_quoted_fields.csv'\n(FORMAT CSV, HEADER true, QUOTE '\"', ESCAPE '\"')\n"
+    starrocks: null
+- id: bulk_load_null_handling
+  category: bulk_load
+  description: Tests bulk load with NULL value representation to measure NULL parsing overhead
+  file_dependencies:
+  - csv_with_nulls.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_with_nulls.csv'\nWITH (FORMAT CSV, HEADER true, NULL 'NULL')\n"
+  validation_queries:
+  - id: verify_nulls
+    sql: "SELECT COUNT(*) as cnt FROM bulk_load_ops_target\nWHERE o_comment IS NULL OR o_clerk IS NULL\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_with_nulls.csv'\n(FORMAT CSV, HEADER true, NULLSTR 'NULL')\n"
+    starrocks: null
+- id: bulk_load_encoding_utf8
+  category: bulk_load
+  description: Tests bulk load with explicit UTF-8 encoding to measure character encoding overhead
+  file_dependencies:
+  - csv_utf8_encoded.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_utf8_encoded.csv'\nWITH (FORMAT CSV, HEADER true)\n"
+  validation_queries:
+  - id: verify_encoding
+    sql: SELECT COUNT(*) as cnt FROM bulk_load_ops_target
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_utf8_encoded.csv'\n(FORMAT CSV, HEADER true)\n"
+    starrocks: null
+- id: bulk_load_date_format_custom
+  category: bulk_load
+  description: Tests bulk load with custom date format specification to measure date parsing flexibility
+  file_dependencies:
+  - csv_custom_dates.csv
+  write_sql: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_custom_dates.csv'\nWITH (FORMAT CSV, HEADER true, DATEFORMAT '%Y/%m/%d')\n"
+  validation_queries:
+  - id: verify_date_format
+    sql: "SELECT COUNT(*) as cnt FROM bulk_load_ops_target\nWHERE o_orderdate IS NOT NULL\n"
+    expected_rows: 1
+  cleanup_sql: "TRUNCATE TABLE bulk_load_ops_target\n"
+  expected_rows_affected: 1000
+  platform_overrides:
+    duckdb: "TRUNCATE TABLE bulk_load_ops_target;\nCOPY bulk_load_ops_target FROM '{file_path}/csv_custom_dates.csv'\n(FORMAT CSV, HEADER true, DATEFORMAT '%Y/%m/%d')\n"
+    starrocks: null
+- id: merge_simple_upsert_small
+  category: merge
+  description: Tests simple MERGE upsert with 10 rows to measure baseline MERGE overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_totalprice = source.o_totalprice,\n             o_comment = 'merged_update'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_orderkey BETWEEN 1 AND 10\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 10\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_upsert_with_delete
+  category: merge
+  description: Tests MERGE with DELETE clause for unmatched target rows to measure tri-directional merge overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 20\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_matched'\nWHEN NOT MATCHED BY TARGET THEN INSERT\nWHEN NOT MATCHED BY SOURCE AND target.o_orderkey <= 25 THEN\n  DELETE\n"
+  validation_queries:
+  - id: verify_merge_delete
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_orderkey BETWEEN 1 AND 25\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_overlap_10pct
+  category: merge
+  description: Tests MERGE with approximately 10 percent row overlap to measure low collision overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders\n  WHERE o_orderkey > (\n    SELECT CAST(MAX(o_orderkey) * 0.9 AS INTEGER) FROM merge_ops_target\n  )\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_10pct'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_merge_overlap
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_10pct'
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_overlap_50pct
+  category: merge
+  description: Tests MERGE with approximately 50 percent row overlap to measure medium collision overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders\n  WHERE o_orderkey > (\n    SELECT CAST(MAX(o_orderkey) * 0.5 AS INTEGER) FROM merge_ops_target\n  )\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_50pct'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_merge_50pct
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_50pct'
+    expected_rows_min: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_overlap_90pct
+  category: merge
+  description: Tests MERGE with approximately 90 percent row overlap to measure high collision overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders\n  WHERE o_orderkey <= (\n    SELECT CAST(MAX(o_orderkey) * 0.95 AS INTEGER) FROM merge_ops_target\n  )\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_90pct'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_merge_90pct
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_90pct'
+    expected_rows_min: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_no_overlap_all_insert
+  category: merge
+  description: Tests MERGE with zero overlap all inserts to measure pure insert path performance
+  write_sql: "MERGE INTO merge_ops_source AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 100\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_matched'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_all_insert
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_source\nWHERE o_orderkey BETWEEN 1 AND 100\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_source WHERE o_orderkey BETWEEN 1 AND 100\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_full_overlap_all_update
+  category: merge
+  description: Tests MERGE with full overlap all updates to measure pure update path performance
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT o_orderkey, o_totalprice * 1.1 AS o_totalprice, 'merge_all_update' AS o_comment\n  FROM merge_ops_target\n  WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 100 FROM merge_ops_target)\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_totalprice = source.o_totalprice,\n             o_comment = source.o_comment\n"
+  validation_queries:
+  - id: verify_all_update
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_all_update'
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target\nSET o_totalprice = o_totalprice / 1.1,\n    o_comment = ''\nWHERE o_comment = 'merge_all_update'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_with_join_condition
+  category: merge
+  description: Tests MERGE with complex join condition involving multiple columns to measure matching overhead
+  write_sql: "MERGE INTO merge_ops_lineitem_target AS target\nUSING (\n  SELECT l.*, o.o_custkey\n  FROM lineitem l\n  JOIN orders o ON l.l_orderkey = o.o_orderkey\n  WHERE l.l_orderkey BETWEEN 1 AND 10\n) AS source\nON target.l_orderkey = source.l_orderkey\n   AND target.l_linenumber = source.l_linenumber\nWHEN MATCHED THEN\n  UPDATE SET l_comment = 'merge_multi_key'\nWHEN NOT MATCHED THEN\n  INSERT VALUES (source.l_orderkey, source.l_partkey, source.l_suppkey, source.l_linenumber,\n                 source.l_quantity, source.l_extendedprice, source.l_discount, source.l_tax,\n                 source.l_returnflag, source.l_linestatus, source.l_shipdate, source.l_commitdate,\n                 source.l_receiptdate, source.l_shipinstruct, source.l_shipmode, source.l_comment)\n"
+  validation_queries:
+  - id: verify_join_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_lineitem_target\nWHERE l_orderkey BETWEEN 1 AND 10\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_lineitem_target WHERE l_orderkey BETWEEN 1 AND 10\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_from_subquery_aggregated
+  category: merge
+  description: Tests MERGE with aggregated subquery source to measure aggregation plus merge overhead
+  write_sql: "MERGE INTO merge_ops_summary_target AS target\nUSING (\n  SELECT o_custkey, SUM(o_totalprice) AS total_price, COUNT(*) AS order_count\n  FROM orders\n  WHERE o_orderkey <= 500\n  GROUP BY o_custkey\n) AS source\nON target.o_custkey = source.o_custkey\nWHEN MATCHED THEN\n  UPDATE SET o_totalprice = source.total_price,\n             order_count = source.order_count\nWHEN NOT MATCHED THEN\n  INSERT VALUES (NULL, source.o_custkey, NULL, source.total_price, NULL, source.order_count)\n"
+  validation_queries:
+  - id: verify_agg_merge
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_summary_target WHERE order_count > 0
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_summary_target\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_conditional_update
+  category: merge
+  description: Tests MERGE with conditional WHEN MATCHED clause to measure predicate evaluation overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 50\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED AND source.o_totalprice > 100000 THEN\n  UPDATE SET o_comment = 'merge_high_value',\n             o_orderpriority = '1-URGENT'\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_low_value'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_conditional
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_comment LIKE 'merge_%'\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target SET o_comment = '', o_orderpriority = '5-LOW'\nWHERE o_comment LIKE 'merge_%'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_conditional_insert
+  category: merge
+  description: Tests MERGE with conditional WHEN NOT MATCHED clause to measure insert filtering overhead
+  write_sql: "MERGE INTO merge_ops_source AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 100\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_matched'\nWHEN NOT MATCHED AND source.o_totalprice > 50000 THEN\n  INSERT VALUES (source.o_orderkey, source.o_custkey, source.o_orderstatus,\n                 source.o_totalprice, source.o_orderdate, source.o_orderpriority,\n                 source.o_clerk, source.o_shippriority, 'high_value_insert')\n"
+  validation_queries:
+  - id: verify_filtered_insert
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_source\nWHERE o_comment = 'high_value_insert'\n"
+    expected_rows: 1
+    expected_rows_min: 0
+  cleanup_sql: "DELETE FROM merge_ops_source WHERE o_orderkey BETWEEN 1 AND 100\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_multi_column_update
+  category: merge
+  description: Tests MERGE updating 5 plus columns to measure multi-column update overhead in MERGE
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    o_orderkey,\n    o_totalprice * 1.05 AS o_totalprice,\n    '1-URGENT' AS o_orderpriority,\n    'Clerk#000000999' AS o_clerk,\n    o_shippriority + 1 AS o_shippriority,\n    'merge_multi_col' AS o_comment\n  FROM merge_ops_target\n  WHERE o_orderkey <= (SELECT MIN(o_orderkey) + 50 FROM merge_ops_target)\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET\n    o_totalprice = source.o_totalprice,\n    o_orderpriority = source.o_orderpriority,\n    o_clerk = source.o_clerk,\n    o_shippriority = source.o_shippriority,\n    o_comment = source.o_comment\n"
+  validation_queries:
+  - id: verify_multi_col_merge
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_multi_col'
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target\nSET o_totalprice = o_totalprice / 1.05,\n    o_orderpriority = '5-LOW',\n    o_clerk = 'Clerk#000000001',\n    o_shippriority = 0,\n    o_comment = ''\nWHERE o_comment = 'merge_multi_col'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_computed_values
+  category: merge
+  description: Tests MERGE with computed values using expressions to measure computation overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    o_orderkey,\n    o_totalprice * 1.15 + 100.0 AS computed_price,\n    CASE\n      WHEN o_totalprice < 100000 THEN '5-LOW'\n      WHEN o_totalprice < 250000 THEN '3-MEDIUM'\n      ELSE '1-URGENT'\n    END AS computed_priority\n  FROM orders\n  WHERE o_orderkey BETWEEN 1 AND 50\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_totalprice = source.computed_price,\n             o_orderpriority = source.computed_priority,\n             o_comment = 'merge_computed'\nWHEN NOT MATCHED THEN\n  INSERT VALUES (source.o_orderkey, 1, 'O', source.computed_price, CURRENT_DATE,\n                 source.computed_priority, 'Clerk#000000001', 0, 'merge_computed')\n"
+  validation_queries:
+  - id: verify_computed_merge
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_computed'
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target\nSET o_totalprice = (o_totalprice - 100.0) / 1.15,\n    o_orderpriority = '5-LOW',\n    o_comment = ''\nWHERE o_comment = 'merge_computed'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_string_operations
+  category: merge
+  description: Tests MERGE with string manipulation functions to measure string processing overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    o_orderkey,\n    CONCAT('ORDER-', CAST(o_orderkey AS VARCHAR), '-', o_orderpriority) AS computed_comment\n  FROM orders\n  WHERE o_orderkey BETWEEN 1 AND 50\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = source.computed_comment\n"
+  validation_queries:
+  - id: verify_string_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_comment LIKE 'ORDER-%'\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target SET o_comment = '' WHERE o_comment LIKE 'ORDER-%'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_date_arithmetic
+  category: merge
+  description: Tests MERGE with date calculations to measure temporal operation overhead in MERGE
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    o_orderkey,\n    o_orderdate + INTERVAL '30' DAY AS shifted_date,\n    'merge_date_shift' AS marker\n  FROM orders\n  WHERE o_orderkey BETWEEN 1 AND 50\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_orderdate = source.shifted_date,\n             o_comment = source.marker\n"
+  validation_queries:
+  - id: verify_date_merge
+    sql: SELECT COUNT(*) as cnt FROM merge_ops_target WHERE o_comment = 'merge_date_shift'
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "UPDATE merge_ops_target\nSET o_orderdate = o_orderdate - INTERVAL '30' DAY,\n    o_comment = ''\nWHERE o_comment = 'merge_date_shift'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_with_cte_source
+  category: merge
+  description: Tests MERGE with CTE as source to measure CTE materialization overhead
+  write_sql: "WITH enriched_orders AS (\n  SELECT\n    o.o_orderkey,\n    o.o_totalprice,\n    c.c_name,\n    c.c_mktsegment\n  FROM orders o\n  JOIN customer c ON o.o_custkey = c.c_custkey\n  WHERE o.o_orderkey BETWEEN 1 AND 50\n)\nMERGE INTO merge_ops_summary_target AS target\nUSING enriched_orders AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_totalprice = source.o_totalprice,\n             customer_name = source.c_name\nWHEN NOT MATCHED THEN\n  INSERT VALUES (source.o_orderkey, NULL, NULL, source.o_totalprice, source.c_name, NULL)\n"
+  validation_queries:
+  - id: verify_cte_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_summary_target\nWHERE o_orderkey BETWEEN 1 AND 50\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_summary_target WHERE o_orderkey BETWEEN 1 AND 50\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_returning_clause
+  category: merge
+  description: Tests MERGE...RETURNING to measure overhead of returning merged row data
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 10\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_returning'\nWHEN NOT MATCHED THEN INSERT\nRETURNING o_orderkey, o_totalprice, o_comment\n"
+  validation_queries:
+  - id: verify_returning_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_orderkey BETWEEN 1 AND 10\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 10\n"
+  expected_rows_affected: null
+  platform_overrides:
+    mysql: null
+    bigquery: null
+    datafusion: null
+    starrocks: null
+- id: merge_error_handling
+  category: merge
+  description: Tests MERGE with potential constraint violations to measure error handling overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 1 AND 50\n  UNION ALL\n  SELECT * FROM orders WHERE o_orderkey BETWEEN 45 AND 55\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED THEN\n  UPDATE SET o_comment = 'merge_with_dups'\nWHEN NOT MATCHED THEN INSERT\n"
+  validation_queries:
+  - id: verify_error_merge
+    sql: "SELECT COUNT(*) as cnt FROM merge_ops_target\nWHERE o_orderkey BETWEEN 1 AND 55\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_target WHERE o_orderkey BETWEEN 1 AND 55\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: delete_gdpr_suppliers_1pct
+  category: delete
+  description: Tests GDPR-compliant deletion with IN subquery to measure deletion-by-list performance (1% of suppliers)
+  write_sql: "DELETE FROM delete_ops_lineitem\nWHERE l_suppkey IN (\n  SELECT DISTINCT l_suppkey\n  FROM lineitem\n  WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)\n)\n"
+  validation_queries:
+  - id: verify_gdpr_deletion
+    sql: "SELECT\n  CASE\n    WHEN COUNT(DISTINCT l_suppkey) = 0 THEN 1\n    ELSE 0\n  END as validation_passed\nFROM delete_ops_lineitem\nWHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "INSERT INTO delete_ops_lineitem\nSELECT * FROM lineitem\nWHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.01 FROM lineitem)\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: delete_gdpr_suppliers_5pct
+  category: delete
+  description: Tests GDPR-compliant deletion with IN subquery at medium scale to measure deletion-by-list performance (5% of suppliers)
+  write_sql: "DELETE FROM delete_ops_lineitem\nWHERE l_suppkey IN (\n  SELECT DISTINCT l_suppkey\n  FROM lineitem\n  WHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)\n)\n"
+  validation_queries:
+  - id: verify_gdpr_deletion_medium
+    sql: "SELECT\n  CASE\n    WHEN COUNT(DISTINCT l_suppkey) = 0 THEN 1\n    ELSE 0\n  END as validation_passed\nFROM delete_ops_lineitem\nWHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "INSERT INTO delete_ops_lineitem\nSELECT * FROM lineitem\nWHERE l_suppkey <= (SELECT MAX(l_suppkey) * 0.05 FROM lineitem)\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: merge_etl_aggregation_pattern
+  category: merge
+  description: Tests ETL aggregation pattern with running totals and aggregate computations to measure aggregation overhead in MERGE
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    l_orderkey,\n    SUM(l_extendedprice * (1 - l_discount)) as computed_revenue,\n    MAX(l_shipdate) as latest_ship_date,\n    COUNT(*) as line_count\n  FROM lineitem\n  WHERE l_orderkey BETWEEN 1 AND 1000\n  GROUP BY l_orderkey\n) AS source\nON target.o_orderkey = source.l_orderkey\nWHEN MATCHED THEN\n  UPDATE SET\n    o_totalprice = target.o_totalprice + source.computed_revenue,\n    o_comment = 'etl_agg_lines_' || CAST(source.line_count AS VARCHAR)\nWHEN NOT MATCHED THEN\n  INSERT VALUES (source.l_orderkey, 1, 'O', source.computed_revenue, DATE '1998-01-01', '1-URGENT', 'Clerk#000000001', 0, 'etl_new')\n"
+  validation_queries:
+  - id: verify_etl_aggregation
+    sql: "SELECT COUNT(*) as updated_count\nFROM merge_ops_target\nWHERE o_comment LIKE 'etl_agg%' OR o_comment = 'etl_new'\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  - id: verify_etl_aggregation_values
+    sql: "SELECT\n  CASE\n    WHEN COUNT(*) > 0 AND MIN(o_totalprice) IS NOT NULL THEN 1\n    ELSE 0\n  END as has_valid_aggregations\nFROM merge_ops_target\nWHERE o_comment LIKE 'etl_agg%'\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_target\nWHERE o_comment LIKE 'etl_agg%' OR o_comment = 'etl_new'\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: merge_deduplication_window_function
+  category: merge
+  description: Tests MERGE with window function deduplication using ROW_NUMBER to measure duplicate elimination overhead
+  write_sql: "MERGE INTO merge_ops_target AS target\nUSING (\n  SELECT\n    o_orderkey,\n    o_custkey,\n    o_orderstatus,\n    o_totalprice,\n    o_orderdate,\n    o_orderpriority,\n    o_clerk,\n    o_shippriority,\n    o_comment,\n    ROW_NUMBER() OVER (\n      PARTITION BY o_orderkey\n      ORDER BY o_orderdate DESC, o_totalprice DESC\n    ) as rn\n  FROM orders\n  WHERE o_orderkey BETWEEN 1 AND 500\n) AS source\nON target.o_orderkey = source.o_orderkey\nWHEN MATCHED AND source.rn = 1 THEN\n  UPDATE SET\n    o_totalprice = source.o_totalprice,\n    o_comment = 'dedup_update'\nWHEN NOT MATCHED AND source.rn = 1 THEN\n  INSERT VALUES (\n    source.o_orderkey, source.o_custkey, source.o_orderstatus,\n    source.o_totalprice, source.o_orderdate, source.o_orderpriority,\n    source.o_clerk, source.o_shippriority, 'dedup_insert'\n  )\n"
+  validation_queries:
+  - id: verify_deduplication
+    sql: "SELECT COUNT(*) as dedup_count\nFROM merge_ops_target\nWHERE o_comment IN ('dedup_update', 'dedup_insert')\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  - id: verify_no_duplicates
+    sql: "SELECT\n  CASE\n    WHEN MAX(dup_count) = 1 THEN 1\n    ELSE 0\n  END as no_duplicates\nFROM (\n  SELECT o_orderkey, COUNT(*) as dup_count\n  FROM merge_ops_target\n  WHERE o_comment IN ('dedup_update', 'dedup_insert')\n  GROUP BY o_orderkey\n)\n"
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DELETE FROM merge_ops_target\nWHERE o_comment IN ('dedup_update', 'dedup_insert')\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: ddl_create_table_simple
+  category: ddl
+  description: Tests CREATE TABLE with simple schema with 5 columns and no constraints
+  requires_setup: false
+  write_sql: "CREATE TABLE test_simple (\n  id INTEGER,\n  name VARCHAR(100),\n  value DECIMAL(15,2),\n  created DATE,\n  status VARCHAR(10)\n)\n"
+  validation_queries:
+  - id: table_exists
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_simple'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_simple\n"
+  expected_rows_affected: 0
+- id: ddl_truncate_table_small
+  category: ddl
+  requires_setup: false
+  description: Tests TRUNCATE TABLE on small staging table to measure fast delete baseline
+  write_sql: "TRUNCATE TABLE ddl_truncate_target\n"
+  validation_queries:
+  - id: verify_empty
+    sql: SELECT * FROM ddl_truncate_target
+    expected_rows: 0
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+- id: ddl_create_table_as_select_simple
+  category: ddl
+  description: Tests CREATE TABLE AS SELECT with simple SELECT to measure table creation from query results
+  requires_setup: false
+  write_sql: "CREATE TABLE orders_1995 AS\nSELECT *\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01'\n"
+  validation_queries:
+  - id: verify_ctas
+    sql: SELECT o_orderkey FROM orders_1995 LIMIT 10
+    expected_rows: null
+    expected_rows_min: 0
+    expected_rows_max: 10
+  cleanup_sql: "DROP TABLE IF EXISTS orders_1995\n"
+  expected_rows_affected: null
+- id: ddl_create_table_with_constraints
+  category: ddl
+  description: Tests CREATE TABLE with PRIMARY KEY and NOT NULL constraints to measure constraint overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_constrained (\n  id INTEGER PRIMARY KEY,\n  name VARCHAR(100) NOT NULL,\n  value DECIMAL(15,2) NOT NULL,\n  created DATE NOT NULL,\n  status VARCHAR(10)\n)\n"
+  validation_queries:
+  - id: table_exists
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_constrained'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_constrained\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    datafusion: null
+- id: ddl_create_table_with_index
+  category: ddl
+  description: Tests CREATE TABLE followed by CREATE INDEX to measure index creation overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_indexed (\n  id INTEGER,\n  name VARCHAR(100),\n  value DECIMAL(15,2)\n);\nCREATE INDEX idx_test_value ON test_indexed(value)\n"
+  validation_queries:
+  - id: index_exists
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_indexed'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_indexed\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: ddl_alter_table_add_column
+  category: ddl
+  description: Tests ALTER TABLE ADD COLUMN to measure schema modification overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_alter (\n  id INTEGER,\n  name VARCHAR(100)\n);\nALTER TABLE test_alter ADD COLUMN created DATE\n"
+  validation_queries:
+  - id: column_exists
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_alter'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_alter\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    datafusion: null
+- id: ddl_alter_table_drop_column
+  category: ddl
+  description: Tests ALTER TABLE DROP COLUMN to measure column removal overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_drop_col (\n  id INTEGER,\n  name VARCHAR(100),\n  temp_col VARCHAR(50)\n);\nALTER TABLE test_drop_col DROP COLUMN temp_col\n"
+  validation_queries:
+  - id: table_modified
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_drop_col'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_drop_col\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    datafusion: null
+- id: ddl_alter_table_rename_column
+  category: ddl
+  description: Tests ALTER TABLE RENAME COLUMN to measure column renaming overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_rename_col (\n  id INTEGER,\n  old_name VARCHAR(100)\n);\nALTER TABLE test_rename_col RENAME COLUMN old_name TO new_name\n"
+  validation_queries:
+  - id: column_renamed
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_rename_col'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_rename_col\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    mysql: "CREATE TABLE test_rename_col (\n  id INTEGER,\n  old_name VARCHAR(100)\n);\nALTER TABLE test_rename_col CHANGE old_name new_name VARCHAR(100)\n"
+    starrocks: null
+    datafusion: null
+- id: ddl_create_index_on_existing
+  category: ddl
+  description: Tests CREATE INDEX on populated table to measure index building on existing data
+  requires_setup: false
+  write_sql: "CREATE TABLE test_idx_existing AS SELECT * FROM orders WHERE o_orderkey <= 100;\nCREATE INDEX idx_existing_price ON test_idx_existing(o_totalprice)\n"
+  validation_queries:
+  - id: index_created
+    sql: SELECT COUNT(*) as cnt FROM test_idx_existing
+    expected_rows: 1
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_idx_existing\n"
+  expected_rows_affected: null
+  platform_overrides:
+    datafusion: null
+    starrocks: null
+- id: ddl_drop_index
+  category: ddl
+  description: Tests DROP INDEX to measure index removal overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_drop_idx (id INTEGER, value DECIMAL(15,2));\nCREATE INDEX idx_test_drop ON test_drop_idx(value);\nDROP INDEX idx_test_drop\n"
+  validation_queries:
+  - id: table_still_exists
+    sql: "SELECT table_name\nFROM information_schema.tables\nWHERE table_name = 'test_drop_idx'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS test_drop_idx\n"
+  expected_rows_affected: 0
+  platform_overrides:
+    mysql: "CREATE TABLE test_drop_idx (id INTEGER, value DECIMAL(15,2));\nCREATE INDEX idx_test_drop ON test_drop_idx(value);\nDROP INDEX idx_test_drop ON test_drop_idx\n"
+    datafusion: null
+    starrocks: null
+- id: ddl_create_view_simple
+  category: ddl
+  description: Tests CREATE VIEW with simple SELECT to measure view creation overhead
+  requires_setup: false
+  write_sql: "CREATE VIEW orders_view AS\nSELECT o_orderkey, o_custkey, o_totalprice, o_orderdate\nFROM orders\nWHERE o_orderkey <= 1000\n"
+  validation_queries:
+  - id: view_exists
+    sql: "SELECT table_name\nFROM information_schema.views\nWHERE table_name = 'orders_view'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP VIEW IF EXISTS orders_view\n"
+  expected_rows_affected: 0
+- id: ddl_drop_table
+  category: ddl
+  description: Tests DROP TABLE to measure table removal overhead
+  requires_setup: false
+  write_sql: "CREATE TABLE test_drop AS SELECT * FROM orders WHERE o_orderkey <= 50;\nDROP TABLE test_drop\n"
+  validation_queries:
+  - id: table_dropped
+    sql: "SELECT COUNT(*) as cnt\nFROM information_schema.tables\nWHERE table_name = 'test_drop'\n"
+    expected_rows: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+- id: sketch_ddl_create_persistent_table
+  category: sketch
+  description: Tests CREATE/DROP overhead for a sketch persistence table with BINARY columns
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch BLOB,\n  rev_sketch BLOB\n);\n"
+  validation_queries:
+  - id: table_exists
+    sql: "SELECT COUNT(*) as cnt\nFROM information_schema.tables\nWHERE table_name = 'sketch_ops_daily_users'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_daily_users\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region STRING,\n  user_sketch BINARY,\n  rev_sketch BINARY\n) USING DELTA;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch BINARY,\n  rev_sketch BINARY\n);\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region STRING,\n  user_sketch BYTES,\n  rev_sketch BYTES\n);\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date Date,\n  region String,\n  user_sketch AggregateFunction(uniq, UInt64),\n  rev_sketch AggregateFunction(uniq, UInt64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\n"
+    datafusion: null
+    redshift: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch HLLSKETCH,\n  rev_sketch HLLSKETCH\n)\nDISTSTYLE EVEN;\n"
+    sqlite: null
+    starrocks: null
+- id: sketch_insert_theta_per_partition
+  category: sketch
+  description: Builds per-partition Theta sketches over l_orderkey + l_extendedprice and persists them
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch BLOB,\n  rev_sketch BLOB\n);\nINSERT INTO sketch_ops_daily_users\nSELECT\n  l_shipdate AS activity_date,\n  l_returnflag AS region,\n  datasketch_theta(l_orderkey) AS user_sketch,\n  datasketch_theta(CAST(l_extendedprice AS INTEGER)) AS rev_sketch\nFROM lineitem\nGROUP BY l_shipdate, l_returnflag;\n"
+  validation_queries:
+  - id: rows_persisted
+    sql: "SELECT COUNT(*) as partitions FROM sketch_ops_daily_users\n"
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_daily_users\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY\n) USING DELTA;\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       theta_sketch_agg(l_orderkey),\n       theta_sketch_agg(CAST(l_extendedprice AS INT))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       DATASKETCHES_THETA_ACCUMULATE(l_orderkey),\n       DATASKETCHES_THETA_ACCUMULATE(CAST(l_extendedprice AS INTEGER))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       HLL_COUNT.INIT(l_orderkey),\n       HLL_COUNT.INIT(CAST(l_extendedprice AS INT64))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date Date, region String,\n  user_sketch AggregateFunction(uniq, UInt64),\n  rev_sketch AggregateFunction(uniq, UInt64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       uniqState(toUInt64(l_orderkey)),\n       uniqState(toUInt64(l_extendedprice))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    datafusion: null
+    redshift: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25),\n  user_sketch HLLSKETCH, rev_sketch HLLSKETCH\n) DISTSTYLE EVEN;\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       HLL_CREATE_SKETCH(l_orderkey),\n       HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))\nFROM lineitem\nGROUP BY l_shipdate, l_returnflag;\n"
+    sqlite: null
+    starrocks: null
+- id: sketch_insert_kll_per_partition
+  category: sketch
+  description: Builds per-partition KLL quantile sketches over l_extendedprice
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE,\n  region VARCHAR(25),\n  price_sketch BLOB\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT\n  l_shipdate,\n  l_returnflag,\n  datasketch_kll(200, l_extendedprice)\nFROM lineitem\nGROUP BY l_shipdate, l_returnflag;\n"
+  validation_queries:
+  - id: kll_partitions_persisted
+    sql: "SELECT COUNT(*) as partitions FROM sketch_ops_kll_partitions\n"
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_kll_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region STRING, price_sketch BINARY\n) USING DELTA;\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag, kll_sketch_agg_double(CAST(l_extendedprice AS DOUBLE))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BINARY\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       DATASKETCHES_KLL_ACCUMULATE(CAST(l_extendedprice AS DOUBLE))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region STRING, price_sketch BYTES\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       KLL_QUANTILES.INIT_INT64(CAST(l_extendedprice AS INT64))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date Date, region String,\n  price_sketch AggregateFunction(quantileTDigest(0.5), Float64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       quantileTDigestState(0.5)(toFloat64(l_extendedprice))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_insert_topk_per_shard
+  category: sketch
+  description: Builds per-shard frequent-items (Top-K accumulator) sketches over l_shipmode
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (\n  shard_id INTEGER,\n  topk_sketch BLOB\n);\nINSERT INTO sketch_ops_topk\nSELECT\n  CAST(l_orderkey % 8 AS INTEGER) AS shard_id,\n  datasketch_frequent_items(8, l_shipmode) AS topk_sketch\nFROM lineitem\nGROUP BY l_orderkey % 8;\n"
+  validation_queries:
+  - id: topk_shards_persisted
+    sql: "SELECT COUNT(*) as shards FROM sketch_ops_topk\n"
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_topk\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (\n  shard_id INT, topk_sketch BINARY\n) USING DELTA;\nINSERT INTO sketch_ops_topk\nSELECT CAST(l_orderkey % 8 AS INT),\n       approx_top_k_accumulate(l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (\n  shard_id INTEGER, topk_sketch BINARY\n);\nINSERT INTO sketch_ops_topk\nSELECT MOD(l_orderkey, 8),\n       APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)\nFROM lineitem GROUP BY MOD(l_orderkey, 8);\n"
+    bigquery: null
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (\n  shard_id Int32,\n  topk_sketch AggregateFunction(topK(8), String)\n) ENGINE = MergeTree() ORDER BY shard_id;\nINSERT INTO sketch_ops_topk\nSELECT toInt32(l_orderkey % 8),\n       topKState(8)(l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\n"
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_theta_union_merge
+  category: sketch
+  description: ★ Headline — populate theta sketches per partition, then merge across all partitions in a single query and emit an approximate distinct count (compare to aggregation_distinct in read_primitives). BigQuery substitutes HLL_COUNT for Theta (no native Theta surface) — the persist + merge + requery shape is identical, but the underlying sketch family differs.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       datasketch_theta(l_orderkey),\n       datasketch_theta(CAST(l_extendedprice AS INTEGER))\nFROM lineitem\nGROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_theta_estimate(datasketch_theta(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+  validation_queries:
+  - id: theta_estimate_in_range
+    sql: "SELECT datasketch_theta_estimate(datasketch_theta(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 14500
+    expected_value_max: 15500
+    platform_overrides:
+      clickhouse: "SELECT uniqMerge(user_sketch) AS distinct_orders\nFROM sketch_ops_daily_users\n"
+      redshift: "SELECT HLL_CARDINALITY(HLL_COMBINE(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users\n"
+  - id: theta_storage_size_duckdb
+    sql: "SELECT octet_length(datasketch_theta(user_sketch)) AS sketch_bytes\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 4000
+    expected_value_max: 32000
+    platform_overrides:
+      clickhouse: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  - id: sketch_cpc_insert_per_partition
-    category: sketch
-    description: Builds per-partition CPC sketches over l_orderkey (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_cpc_partitions;
-      CREATE TABLE sketch_cpc_partitions (
-        activity_date DATE,
-        region VARCHAR(25),
-        user_sketch BLOB
-      );
-      INSERT INTO sketch_cpc_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_cpc(11, l_orderkey)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-    validation_queries:
-      - id: cpc_rows_persisted
-        sql: |
-          SELECT COUNT(*) as partitions FROM sketch_cpc_partitions
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_cpc_partitions
-    expected_rows_affected: null
+  - id: theta_storage_size_clickhouse
+    sql: "SELECT length(toString(uniqMergeState(user_sketch))) AS sketch_bytes\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 16000
+    expected_value_max: 100000
     platform_overrides:
+      duckdb: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  - id: sketch_cpc_query_union_merge
-    category: sketch
-    description: Headline CPC — populate per-partition CPC sketches, union them across partitions, emit distinct estimate (DuckDB-only). Side-by-side with sketch_query_theta_union_merge for HLL-family algorithm comparison and storage-cost tradeoff.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_cpc_partitions;
-      CREATE TABLE sketch_cpc_partitions (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB
-      );
-      INSERT INTO sketch_cpc_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_cpc(11, l_orderkey)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_cpc_estimate(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS distinct_orders
-      FROM sketch_cpc_partitions;
-    validation_queries:
-      - id: cpc_estimate_in_range
-        sql: |
-          SELECT datasketch_cpc_estimate(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS distinct_orders
-          FROM sketch_cpc_partitions
-        # SF=0.01: lineitem has 15000 distinct l_orderkeys; CPC at lg_k=11
-        # observed at 15137.39 in synthetic verification. Bounds match
-        # sketch_query_theta_union_merge so cross-family regressions are
-        # comparable.
-        expected_value_min: 14000
-        expected_value_max: 16000
-      - id: cpc_storage_size
-        sql: |
-          SELECT octet_length(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS sketch_bytes
-          FROM sketch_cpc_partitions
-        # CPC at lg_k=11 observed ~1.2KB merged — dramatically smaller
-        # than Theta's ~16KB at lg_k=12. Wide bounds tolerate variation
-        # while flagging no-op or unbounded growth.
-        expected_value_min: 400
-        expected_value_max: 4000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_cpc_partitions
-    expected_rows_affected: null
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_daily_users\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY\n) USING DELTA;\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag, theta_sketch_agg(l_orderkey),\n       theta_sketch_agg(CAST(l_extendedprice AS INT))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT theta_sketch_estimate(theta_union_agg(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag, DATASKETCHES_THETA_ACCUMULATE(l_orderkey),\n       DATASKETCHES_THETA_ACCUMULATE(CAST(l_extendedprice AS INTEGER))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT DATASKETCHES_THETA_ESTIMATE(DATASKETCHES_THETA_COMBINE(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag, HLL_COUNT.INIT(l_orderkey),\n       HLL_COUNT.INIT(CAST(l_extendedprice AS INT64))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT HLL_COUNT.MERGE(user_sketch) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date Date, region String,\n  user_sketch AggregateFunction(uniq, UInt64),\n  rev_sketch AggregateFunction(uniq, UInt64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       uniqState(toUInt64(l_orderkey)),\n       uniqState(toUInt64(l_extendedprice))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT uniqMerge(user_sketch) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+    datafusion: null
+    redshift: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25),\n  user_sketch HLLSKETCH, rev_sketch HLLSKETCH\n) DISTSTYLE EVEN;\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       HLL_CREATE_SKETCH(l_orderkey),\n       HLL_CREATE_SKETCH(CAST(l_extendedprice AS BIGINT))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT HLL_CARDINALITY(HLL_COMBINE(user_sketch)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+    sqlite: null
+    starrocks: null
+- id: sketch_query_kll_quantiles_merge
+  category: sketch
+  description: ★ Headline — populate KLL sketches per partition, merge across partitions, extract median price (compare to statistical_percentiles in read_primitives)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BLOB\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag, datasketch_kll(200, l_extendedprice)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_kll_quantile(datasketch_kll(200, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+  validation_queries:
+  - id: kll_median_in_range
+    sql: "SELECT datasketch_kll_quantile(datasketch_kll(200, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 30000
+    expected_value_max: 40000
     platform_overrides:
+      databricks: "SELECT kll_sketch_get_quantile_double(kll_merge_agg_double(price_sketch), 0.5) AS median_price\nFROM sketch_ops_kll_partitions\n"
+      clickhouse: "SELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price\nFROM sketch_ops_kll_partitions\n"
+  - id: kll_storage_size_duckdb
+    sql: "SELECT octet_length(datasketch_kll(200, price_sketch::sketch_kll_double)) AS sketch_bytes\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 1000
+    expected_value_max: 6000
+    platform_overrides:
+      clickhouse: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  - id: sketch_cpc_drop_persistent_table
-    category: sketch
-    description: Tests DROP TABLE on a CPC-bearing BLOB-column table (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_cpc_partitions;
-      CREATE TABLE sketch_cpc_partitions (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB
-      );
-      DROP TABLE sketch_cpc_partitions;
-    validation_queries:
-      - id: cpc_table_dropped
-        sql: |
-          SELECT COUNT(*) as cnt FROM information_schema.tables
-          WHERE table_name = 'sketch_cpc_partitions'
-        expected_rows: 1
-    cleanup_sql: null
-    expected_rows_affected: null
+  - id: kll_storage_size_clickhouse
+    sql: "SELECT length(toString(quantileTDigestMergeState(0.5)(price_sketch))) AS sketch_bytes\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 1500
+    expected_value_max: 8000
     platform_overrides:
+      duckdb: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  # ----------------------------------------------------------------------
-  # REQ family (DuckDB-only): relative-error quantile sketch (vs KLL's
-  # normalized-rank error). Apache DataSketches "Relative Error Quantile".
-  # ~2.5KB merged at SF=0.01 — slightly smaller than KLL k=200.
-  # ----------------------------------------------------------------------
-
-  - id: sketch_req_create_persistent_table
-    category: sketch
-    description: Tests CREATE/DROP overhead for a REQ sketch table (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_req_partitions;
-      CREATE TABLE sketch_req_partitions (
-        activity_date DATE,
-        region VARCHAR(25),
-        price_sketch BLOB
-      );
-    validation_queries:
-      - id: req_table_exists
-        sql: |
-          SELECT COUNT(*) as cnt FROM information_schema.tables
-          WHERE table_name = 'sketch_req_partitions'
-        expected_rows: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_req_partitions
-    expected_rows_affected: null
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_kll_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region STRING, price_sketch BINARY\n) USING DELTA;\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag, kll_sketch_agg_double(CAST(l_extendedprice AS DOUBLE))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT kll_sketch_get_quantile_double(kll_merge_agg_double(price_sketch), 0.5) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BINARY\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       DATASKETCHES_KLL_ACCUMULATE(CAST(l_extendedprice AS DOUBLE))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT DATASKETCHES_KLL_GET_QUANTILE(DATASKETCHES_KLL_COMBINE(price_sketch), 0.5) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region STRING, price_sketch BYTES\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       KLL_QUANTILES.INIT_INT64(CAST(l_extendedprice AS INT64))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT KLL_QUANTILES.MERGE_POINT_INT64(price_sketch, 0.5) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date Date, region String,\n  price_sketch AggregateFunction(quantileTDigest(0.5), Float64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag,\n       quantileTDigestState(0.5)(toFloat64(l_extendedprice))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT quantileTDigestMerge(0.5)(price_sketch) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_topk_combine
+  category: sketch
+  description: ★ Headline — populate per-shard frequent-items sketches, combine across shards, count the frequent items (cross-reference approx_top_k_lineitem latency in read_primitives)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);\nINSERT INTO sketch_ops_topk\nSELECT CAST(l_orderkey % 8 AS INTEGER),\n       datasketch_frequent_items(8, l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\nSELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk;\n"
+  validation_queries:
+  - id: topk_frequent_count_in_range
+    sql: "SELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk\n"
+    expected_value_min: 6
+    expected_value_max: 8
     platform_overrides:
+      clickhouse: "SELECT length(topKMerge(8)(topk_sketch)) AS frequent_count\nFROM sketch_ops_topk\n"
+  - id: topk_storage_size_duckdb
+    sql: "SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes\nFROM sketch_ops_topk\n"
+    expected_value_min: 300
+    expected_value_max: 1200
+    platform_overrides:
+      clickhouse: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  - id: sketch_req_insert_per_partition
-    category: sketch
-    description: Builds per-partition REQ quantile sketches over l_extendedprice (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_req_partitions;
-      CREATE TABLE sketch_req_partitions (
-        activity_date DATE,
-        region VARCHAR(25),
-        price_sketch BLOB
-      );
-      INSERT INTO sketch_req_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_req(12, l_extendedprice::FLOAT)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-    validation_queries:
-      - id: req_rows_persisted
-        sql: |
-          SELECT COUNT(*) as partitions FROM sketch_req_partitions
-        expected_rows_min: 1
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_req_partitions
-    expected_rows_affected: null
+  - id: topk_storage_size_clickhouse
+    sql: "SELECT length(toString(topKMergeState(8)(topk_sketch))) AS sketch_bytes\nFROM sketch_ops_topk\n"
+    expected_value_min: 150
+    expected_value_max: 800
     platform_overrides:
+      duckdb: null
       databricks: null
       snowflake: null
       bigquery: null
-      clickhouse: null
-      datafusion: null
       redshift: null
+      datafusion: null
       sqlite: null
       starrocks: null
-      trino: null
-
-  - id: sketch_req_query_quantile_merge
-    category: sketch
-    description: Headline REQ — populate per-partition REQ sketches, merge across partitions, extract median (DuckDB-only). Side-by-side with sketch_query_kll_quantiles_merge for relative-error vs normalized-rank error comparison.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_req_partitions;
-      CREATE TABLE sketch_req_partitions (
-        activity_date DATE, region VARCHAR(25), price_sketch BLOB
-      );
-      INSERT INTO sketch_req_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_req(12, l_extendedprice::FLOAT)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_req_quantile(datasketch_req(12, price_sketch::sketch_req_float), 0.5::DOUBLE, true) AS median_price
-      FROM sketch_req_partitions;
-    validation_queries:
-      - id: req_median_in_range
-        sql: |
-          SELECT datasketch_req_quantile(datasketch_req(12, price_sketch::sketch_req_float), 0.5::DOUBLE, true) AS median_price
-          FROM sketch_req_partitions
-        # SF=0.01: KLL median was 34027–34362; REQ relative-error sketch
-        # produces a median in the same range. Use the same bounds as
-        # KLL so cross-family regressions are easy to compare.
-        expected_value_min: 30000
-        expected_value_max: 40000
-      - id: req_storage_size
-        sql: |
-          SELECT octet_length(datasketch_req(12, price_sketch::sketch_req_float)) AS sketch_bytes
-          FROM sketch_req_partitions
-        # REQ at k=12 observed ~2.5KB merged — slightly smaller than
-        # KLL k=200. Wide bounds tolerate encoding drift.
-        expected_value_min: 1000
-        expected_value_max: 8000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_req_partitions
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-      trino: null
-
-  - id: sketch_req_drop_persistent_table
-    category: sketch
-    description: Tests DROP TABLE on a REQ-bearing BLOB-column table (DuckDB-only)
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_req_partitions;
-      CREATE TABLE sketch_req_partitions (
-        activity_date DATE, region VARCHAR(25), price_sketch BLOB
-      );
-      DROP TABLE sketch_req_partitions;
-    validation_queries:
-      - id: req_table_dropped
-        sql: |
-          SELECT COUNT(*) as cnt FROM information_schema.tables
-          WHERE table_name = 'sketch_req_partitions'
-        expected_rows: 1
-    cleanup_sql: null
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-      trino: null
-  # ----------------------------------------------------------------------
-  # Sketch parameter-sweep variants (DuckDB-only).
-  # Each variant pins the sketch parameter explicitly so users can
-  # measure the size / accuracy / latency tradeoff across the recommended
-  # parameter range, vs guessing.
-  #
-  # Theta (lg_k) and frequent-items (lg_max_map_size) variants share the
-  # extension-drift fate of their parent ops — see
-  # `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
-  # KLL variants are end-to-end verified on the installed extension at
-  # the time of authoring (k=100: ~2KB merged, k=1000: ~18KB merged).
-  # ----------------------------------------------------------------------
-
-  - id: sketch_query_theta_union_merge_lgk10
-    category: sketch
-    description: Theta sweep variant — lg_k=10 (1024 entries, ~5KB serialized, ~3.1% RSE). Smaller and lossier than the default lg_k=12.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB
-      );
-      INSERT INTO sketch_ops_daily_users
-      SELECT l_shipdate, l_returnflag,
-             datasketch_theta(10, l_orderkey),
-             datasketch_theta(10, CAST(l_extendedprice AS INTEGER))
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_theta_estimate(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS distinct_orders
-      FROM sketch_ops_daily_users;
-    validation_queries:
-      - id: theta_lgk10_estimate_in_range
-        sql: |
-          SELECT datasketch_theta_estimate(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS distinct_orders
-          FROM sketch_ops_daily_users
-        # Wider than default lg_k=12 because lg_k=10 has ~3.1% RSE.
-        # SF=0.01 true=15000; bound generously to absorb the larger error.
-        expected_value_min: 13500
-        expected_value_max: 16500
-      - id: theta_lgk10_storage_size
-        sql: |
-          SELECT octet_length(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS sketch_bytes
-          FROM sketch_ops_daily_users
-        # Theta lg_k=10 → 1024 entries; spec ~5KB merged. Bounds remain
-        # spec-derived: DuckDB 1.3.2 datasketches build (2e38607) does
-        # not export `datasketch_theta`; see
-        # `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
-        expected_value_min: 1000
-        expected_value_max: 12000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_daily_users
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_query_theta_union_merge_lgk14
-    category: sketch
-    description: Theta sweep variant — lg_k=14 (16384 entries, ~64KB serialized, ~0.8% RSE). Larger and tighter than default lg_k=12.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_daily_users;
-      CREATE TABLE sketch_ops_daily_users (
-        activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB
-      );
-      INSERT INTO sketch_ops_daily_users
-      SELECT l_shipdate, l_returnflag,
-             datasketch_theta(14, l_orderkey),
-             datasketch_theta(14, CAST(l_extendedprice AS INTEGER))
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_theta_estimate(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS distinct_orders
-      FROM sketch_ops_daily_users;
-    validation_queries:
-      - id: theta_lgk14_estimate_in_range
-        sql: |
-          SELECT datasketch_theta_estimate(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS distinct_orders
-          FROM sketch_ops_daily_users
-        # Tighter than default because lg_k=14 has ~0.8% RSE.
-        expected_value_min: 14700
-        expected_value_max: 15300
-      - id: theta_lgk14_storage_size
-        sql: |
-          SELECT octet_length(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS sketch_bytes
-          FROM sketch_ops_daily_users
-        # Theta lg_k=14 → 16384 entries; spec ~64KB merged. Bounds remain
-        # spec-derived for the same DuckDB extension-drift reason as
-        # `theta_lgk10_storage_size`.
-        expected_value_min: 16000
-        expected_value_max: 130000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_daily_users
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_query_kll_quantiles_merge_k100
-    category: sketch
-    description: KLL sweep variant — k=100 (~1.5KB, ~1.65% normalized rank error). Smaller and lossier than default k=200.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-      CREATE TABLE sketch_ops_kll_partitions (
-        activity_date DATE, region VARCHAR(25), price_sketch BLOB
-      );
-      INSERT INTO sketch_ops_kll_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_kll(100, l_extendedprice)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_kll_quantile(datasketch_kll(100, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-      FROM sketch_ops_kll_partitions;
-    validation_queries:
-      - id: kll_k100_median_in_range
-        sql: |
-          SELECT datasketch_kll_quantile(datasketch_kll(100, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-          FROM sketch_ops_kll_partitions
-        expected_value_min: 30000
-        expected_value_max: 40000
-      - id: kll_k100_storage_size
-        sql: |
-          SELECT octet_length(datasketch_kll(100, price_sketch::sketch_kll_double)) AS sketch_bytes
-          FROM sketch_ops_kll_partitions
-        # KLL k=100 → 2508 bytes merged (verified DuckDB 1.3.2,
-        # datasketches extension 2e38607, SF=0.01, 2026-05-04).
-        # Bounds wider than ±50% of observation to absorb encoding drift.
-        expected_value_min: 500
-        expected_value_max: 5000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_query_kll_quantiles_merge_k1000
-    category: sketch
-    description: KLL sweep variant — k=1000 (~15KB, ~0.59% normalized rank error). Larger and tighter than default k=200.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions;
-      CREATE TABLE sketch_ops_kll_partitions (
-        activity_date DATE, region VARCHAR(25), price_sketch BLOB
-      );
-      INSERT INTO sketch_ops_kll_partitions
-      SELECT l_shipdate, l_returnflag, datasketch_kll(1000, l_extendedprice)
-      FROM lineitem GROUP BY l_shipdate, l_returnflag;
-      SELECT datasketch_kll_quantile(datasketch_kll(1000, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-      FROM sketch_ops_kll_partitions;
-    validation_queries:
-      - id: kll_k1000_median_in_range
-        sql: |
-          SELECT datasketch_kll_quantile(datasketch_kll(1000, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price
-          FROM sketch_ops_kll_partitions
-        expected_value_min: 30000
-        expected_value_max: 40000
-      - id: kll_k1000_storage_size
-        sql: |
-          SELECT octet_length(datasketch_kll(1000, price_sketch::sketch_kll_double)) AS sketch_bytes
-          FROM sketch_ops_kll_partitions
-        # KLL k=1000 → 21220 bytes merged (verified DuckDB 1.3.2,
-        # datasketches extension 2e38607, SF=0.01, 2026-05-04).
-        # Bounds wider than ±50% of observation to absorb encoding drift.
-        expected_value_min: 5000
-        expected_value_max: 40000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_kll_partitions
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_query_topk_combine_lgmm8
-    category: sketch
-    description: Top-K sweep variant — explicit lg_max_map_size=8 (256 buckets, ~600B). Same parameter as the default headline op; provided for sweep-symmetry comparisons.
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_topk;
-      CREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);
-      INSERT INTO sketch_ops_topk
-      SELECT CAST(l_orderkey % 8 AS INTEGER),
-             datasketch_frequent_items(8, l_shipmode)
-      FROM lineitem GROUP BY l_orderkey % 8;
-      SELECT LENGTH(datasketch_frequent_items_get_frequent(
-        datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'
-      )) AS frequent_count
-      FROM sketch_ops_topk;
-    validation_queries:
-      - id: topk_lgmm8_frequent_count_in_range
-        sql: |
-          SELECT LENGTH(datasketch_frequent_items_get_frequent(
-            datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'
-          )) AS frequent_count
-          FROM sketch_ops_topk
-        expected_value_min: 6
-        expected_value_max: 8
-      - id: topk_lgmm8_storage_size
-        sql: |
-          SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes
-          FROM sketch_ops_topk
-        # Spec: lg_max_map_size=8 → 256 buckets, ~600B. Bounds remain
-        # spec-derived: blocked by the same DuckDB extension drift as
-        # `topk_lgmm10_storage_size`. Retune empirically once Top-K
-        # functions land in the extension build.
-        expected_value_min: 200
-        expected_value_max: 2000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_topk
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  - id: sketch_query_topk_combine_lgmm10
-    category: sketch
-    description: Top-K sweep variant — lg_max_map_size=10 (1024 buckets, ~2KB). Larger than default lgmm=8; should still report 7 frequent items deterministically (lineitem has 7 distinct shipmodes).
-    requires_setup: false
-    write_sql: |
-      INSTALL datasketches FROM community;
-      LOAD datasketches;
-      DROP TABLE IF EXISTS sketch_ops_topk;
-      CREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);
-      INSERT INTO sketch_ops_topk
-      SELECT CAST(l_orderkey % 8 AS INTEGER),
-             datasketch_frequent_items(10, l_shipmode)
-      FROM lineitem GROUP BY l_orderkey % 8;
-      SELECT LENGTH(datasketch_frequent_items_get_frequent(
-        datasketch_frequent_items(10, topk_sketch), 'NO_FALSE_POSITIVES'
-      )) AS frequent_count
-      FROM sketch_ops_topk;
-    validation_queries:
-      - id: topk_lgmm10_frequent_count_in_range
-        sql: |
-          SELECT LENGTH(datasketch_frequent_items_get_frequent(
-            datasketch_frequent_items(10, topk_sketch), 'NO_FALSE_POSITIVES'
-          )) AS frequent_count
-          FROM sketch_ops_topk
-        # Same envelope as default — lineitem has 7 distinct shipmodes;
-        # larger map shouldn't change the count.
-        expected_value_min: 6
-        expected_value_max: 8
-      - id: topk_lgmm10_storage_size
-        sql: |
-          SELECT octet_length(datasketch_frequent_items(10, topk_sketch)) AS sketch_bytes
-          FROM sketch_ops_topk
-        # Spec: lg_max_map_size=10 → 1024 buckets, ~2KB.
-        # Bounds remain spec-derived: the DuckDB 1.3.2 datasketches
-        # community extension build (2e38607) does not export
-        # `datasketch_frequent_items`, so live SF=0.01 measurement is
-        # blocked by the upstream extension drift tracked in
-        # `_project/blind-spots/2026-05-02-155524-duckdb-datasketches-extension-drift.md`.
-        # Retune empirically once Top-K functions land in the extension build.
-        expected_value_min: 500
-        expected_value_max: 5000
-    cleanup_sql: |
-      DROP TABLE IF EXISTS sketch_ops_topk
-    expected_rows_affected: null
-    platform_overrides:
-      databricks: null
-      snowflake: null
-      bigquery: null
-      clickhouse: null
-      datafusion: null
-      redshift: null
-      sqlite: null
-      starrocks: null
-
-  # ----------------------------------------------------------------------
-  # DataFrame aggregate-state ops (AGGREGATE_PERSIST + AGGREGATE_MERGE
-  # cycle). These dispatch through `manager.execute_aggregate_persist`
-  # followed by `manager.execute_aggregate_merge` on the active platform's
-  # DataFrameWriteOperationsManager rather than through the SQL parity
-  # path. Engines without a DataFrame-layer sketch surface short-circuit
-  # via `supports_operation` and surface a structured "unsupported"
-  # failure.
-  #
-  # Today only PySpark advertises `supports_aggregate_persist` /
-  # `supports_aggregate_merge`. Top-K requires Spark 4.1+ (see
-  # `pyspark_supports_approx_top_k`); HLL works on Spark 3.5+.
-  # ----------------------------------------------------------------------
-
-  - id: sketch_df_hll_persist_merge
-    category: sketch
-    description: ★ Headline DataFrame — PySpark HLL persist+merge cycle. Builds per-group HLL sketches of l_orderkey via `F.hll_sketch_agg`, persists state to Parquet, then merges via `F.hll_union_agg` and extracts the distinct-count estimate via `F.hll_sketch_estimate`. Pairs with the SQL-side `sketch_query_theta_union_merge` so users can compare DataFrame and SQL paths against the same true-distinct=15000 baseline at SF=0.01.
-    requires_setup: false
-    write_sql: ""  # placeholder — dispatched via aggregate_state below
-    aggregate_state:
-      sketch_type: hll
-      source_table: lineitem
-      target_subdir: write_primitives/sketch_df_hll_persist_merge
-      group_cols: [l_shipdate, l_returnflag]
-      value_col: l_orderkey
-      sketch_alias: user_sketch
-      supported_platforms: [pyspark]
-    validation_queries:
-      - id: hll_distinct_in_range
-        sql: |
-          -- Aggregate-state validation runs against the merge-extract
-          -- scalar in `metrics.aggregate_value`, not against this SQL.
-          -- The placeholder SELECT keeps the loader's "validation has SQL"
-          -- contract honored without committing to a SQL execution path.
-          SELECT 1
-        # SF=0.01 true distinct l_orderkeys = 15000. Spark
-        # `hll_sketch_agg` default lg_k=12 has ~1.6% RSE; ±5% bound
-        # absorbs RSE plus per-run merge-order variation.
-        expected_value_min: 14250
-        expected_value_max: 15750
-    cleanup_sql: null
-    expected_rows_affected: null
-    platform_overrides: {}
-
-  - id: sketch_df_topk_persist_merge
-    category: sketch
-    description: ★ Headline DataFrame — PySpark Top-K persist+merge cycle. Spark 4.1+ only — `F.approx_top_k_accumulate` is the per-group state builder; `F.approx_top_k_combine` + `F.approx_top_k_estimate` perform the merge+extract. Reports the count of frequent items (lineitem has 7 distinct l_shipmodes; SF=0.01 returns 7 deterministically). Skipped cleanly on Spark 3.5.x via `pyspark_supports_approx_top_k` runtime guard.
-    requires_setup: false
-    write_sql: ""  # placeholder — dispatched via aggregate_state below
-    aggregate_state:
-      sketch_type: topk
-      source_table: lineitem
-      target_subdir: write_primitives/sketch_df_topk_persist_merge
-      # The persist builder shards by `l_orderkey % 8` internally; the
-      # catalog still names a real grouping column so the spec serializes
-      # cleanly across both the SQL- and DataFrame-side ops.
-      group_cols: [l_shipmode]
-      value_col: l_shipmode
-      sketch_alias: topk_sketch
-      supported_platforms: [pyspark]
-    validation_queries:
-      - id: topk_frequent_count_in_range
-        sql: |
-          SELECT 1
-        # lineitem has exactly 7 distinct l_shipmode values; the merge
-        # reports all 7 deterministically. [6, 8] catches both a sketch
-        # losing one mode and a Spark approx_top_k false-positive.
-        expected_value_min: 6
-        expected_value_max: 8
-    cleanup_sql: null
-    expected_rows_affected: null
-    platform_overrides: {}
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_topk\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (shard_id INT, topk_sketch BINARY) USING DELTA;\nINSERT INTO sketch_ops_topk\nSELECT CAST(l_orderkey % 8 AS INT),\n       approx_top_k_accumulate(l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\nSELECT SIZE(approx_top_k_estimate(approx_top_k_combine(topk_sketch))) AS frequent_count\nFROM sketch_ops_topk;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BINARY);\nINSERT INTO sketch_ops_topk\nSELECT MOD(l_orderkey, 8),\n       APPROX_TOP_K_ACCUMULATE(l_shipmode, 1024)\nFROM lineitem GROUP BY MOD(l_orderkey, 8);\nSELECT ARRAY_SIZE(APPROX_TOP_K_ESTIMATE(APPROX_TOP_K_COMBINE(topk_sketch))) AS frequent_count\nFROM sketch_ops_topk;\n"
+    bigquery: null
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (\n  shard_id Int32,\n  topk_sketch AggregateFunction(topK(8), String)\n) ENGINE = MergeTree() ORDER BY shard_id;\nINSERT INTO sketch_ops_topk\nSELECT toInt32(l_orderkey % 8),\n       topKState(8)(l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\nSELECT length(topKMerge(8)(topk_sketch)) AS frequent_count\nFROM sketch_ops_topk;\n"
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_drop_persistent_table
+  category: sketch
+  description: Tests DROP TABLE on a sketch-bearing BINARY-column table to measure cleanup overhead
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB\n);\nDROP TABLE sketch_ops_daily_users;\n"
+  validation_queries:
+  - id: table_dropped
+    sql: "SELECT COUNT(*) as cnt\nFROM information_schema.tables\nWHERE table_name = 'sketch_ops_daily_users'\n"
+    expected_rows: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BINARY, rev_sketch BINARY\n) USING DELTA;\nDROP TABLE sketch_ops_daily_users;\n"
+    snowflake: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BINARY, rev_sketch BINARY\n);\nDROP TABLE sketch_ops_daily_users;\n"
+    bigquery: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region STRING, user_sketch BYTES, rev_sketch BYTES\n);\nDROP TABLE sketch_ops_daily_users;\n"
+    clickhouse: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date Date, region String,\n  user_sketch AggregateFunction(uniq, UInt64),\n  rev_sketch AggregateFunction(uniq, UInt64)\n) ENGINE = MergeTree() ORDER BY (activity_date, region);\nDROP TABLE sketch_ops_daily_users;\n"
+    datafusion: null
+    redshift: "DROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25),\n  user_sketch HLLSKETCH, rev_sketch HLLSKETCH\n) DISTSTYLE EVEN;\nDROP TABLE sketch_ops_daily_users;\n"
+    sqlite: null
+    starrocks: null
+- id: sketch_cpc_create_persistent_table
+  category: sketch
+  description: Tests CREATE/DROP overhead for a CPC sketch table (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_cpc_partitions;\nCREATE TABLE sketch_cpc_partitions (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch BLOB\n);\n"
+  validation_queries:
+  - id: cpc_table_exists
+    sql: "SELECT COUNT(*) as cnt FROM information_schema.tables\nWHERE table_name = 'sketch_cpc_partitions'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_cpc_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_cpc_insert_per_partition
+  category: sketch
+  description: Builds per-partition CPC sketches over l_orderkey (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_cpc_partitions;\nCREATE TABLE sketch_cpc_partitions (\n  activity_date DATE,\n  region VARCHAR(25),\n  user_sketch BLOB\n);\nINSERT INTO sketch_cpc_partitions\nSELECT l_shipdate, l_returnflag, datasketch_cpc(11, l_orderkey)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+  validation_queries:
+  - id: cpc_rows_persisted
+    sql: "SELECT COUNT(*) as partitions FROM sketch_cpc_partitions\n"
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_cpc_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_cpc_query_union_merge
+  category: sketch
+  description: Headline CPC — populate per-partition CPC sketches, union them across partitions, emit distinct estimate (DuckDB-only). Side-by-side with sketch_query_theta_union_merge for HLL-family algorithm comparison and storage-cost tradeoff.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_cpc_partitions;\nCREATE TABLE sketch_cpc_partitions (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB\n);\nINSERT INTO sketch_cpc_partitions\nSELECT l_shipdate, l_returnflag, datasketch_cpc(11, l_orderkey)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_cpc_estimate(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS distinct_orders\nFROM sketch_cpc_partitions;\n"
+  validation_queries:
+  - id: cpc_estimate_in_range
+    sql: "SELECT datasketch_cpc_estimate(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS distinct_orders\nFROM sketch_cpc_partitions\n"
+    expected_value_min: 14000
+    expected_value_max: 16000
+  - id: cpc_storage_size
+    sql: "SELECT octet_length(datasketch_cpc_union(11, user_sketch::sketch_cpc)) AS sketch_bytes\nFROM sketch_cpc_partitions\n"
+    expected_value_min: 400
+    expected_value_max: 4000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_cpc_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_cpc_drop_persistent_table
+  category: sketch
+  description: Tests DROP TABLE on a CPC-bearing BLOB-column table (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_cpc_partitions;\nCREATE TABLE sketch_cpc_partitions (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB\n);\nDROP TABLE sketch_cpc_partitions;\n"
+  validation_queries:
+  - id: cpc_table_dropped
+    sql: "SELECT COUNT(*) as cnt FROM information_schema.tables\nWHERE table_name = 'sketch_cpc_partitions'\n"
+    expected_rows: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_req_create_persistent_table
+  category: sketch
+  description: Tests CREATE/DROP overhead for a REQ sketch table (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_req_partitions;\nCREATE TABLE sketch_req_partitions (\n  activity_date DATE,\n  region VARCHAR(25),\n  price_sketch BLOB\n);\n"
+  validation_queries:
+  - id: req_table_exists
+    sql: "SELECT COUNT(*) as cnt FROM information_schema.tables\nWHERE table_name = 'sketch_req_partitions'\n"
+    expected_rows: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_req_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_req_insert_per_partition
+  category: sketch
+  description: Builds per-partition REQ quantile sketches over l_extendedprice (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_req_partitions;\nCREATE TABLE sketch_req_partitions (\n  activity_date DATE,\n  region VARCHAR(25),\n  price_sketch BLOB\n);\nINSERT INTO sketch_req_partitions\nSELECT l_shipdate, l_returnflag, datasketch_req(12, l_extendedprice::FLOAT)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\n"
+  validation_queries:
+  - id: req_rows_persisted
+    sql: "SELECT COUNT(*) as partitions FROM sketch_req_partitions\n"
+    expected_rows_min: 1
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_req_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_req_query_quantile_merge
+  category: sketch
+  description: Headline REQ — populate per-partition REQ sketches, merge across partitions, extract median (DuckDB-only). Side-by-side with sketch_query_kll_quantiles_merge for relative-error vs normalized-rank error comparison.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_req_partitions;\nCREATE TABLE sketch_req_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BLOB\n);\nINSERT INTO sketch_req_partitions\nSELECT l_shipdate, l_returnflag, datasketch_req(12, l_extendedprice::FLOAT)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_req_quantile(datasketch_req(12, price_sketch::sketch_req_float), 0.5::DOUBLE, true) AS median_price\nFROM sketch_req_partitions;\n"
+  validation_queries:
+  - id: req_median_in_range
+    sql: "SELECT datasketch_req_quantile(datasketch_req(12, price_sketch::sketch_req_float), 0.5::DOUBLE, true) AS median_price\nFROM sketch_req_partitions\n"
+    expected_value_min: 30000
+    expected_value_max: 40000
+  - id: req_storage_size
+    sql: "SELECT octet_length(datasketch_req(12, price_sketch::sketch_req_float)) AS sketch_bytes\nFROM sketch_req_partitions\n"
+    expected_value_min: 1000
+    expected_value_max: 8000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_req_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_req_drop_persistent_table
+  category: sketch
+  description: Tests DROP TABLE on a REQ-bearing BLOB-column table (DuckDB-only)
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_req_partitions;\nCREATE TABLE sketch_req_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BLOB\n);\nDROP TABLE sketch_req_partitions;\n"
+  validation_queries:
+  - id: req_table_dropped
+    sql: "SELECT COUNT(*) as cnt FROM information_schema.tables\nWHERE table_name = 'sketch_req_partitions'\n"
+    expected_rows: 1
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+    trino: null
+- id: sketch_query_theta_union_merge_lgk10
+  category: sketch
+  description: Theta sweep variant — lg_k=10 (1024 entries, ~5KB serialized, ~3.1% RSE). Smaller and lossier than the default lg_k=12.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       datasketch_theta(10, l_orderkey),\n       datasketch_theta(10, CAST(l_extendedprice AS INTEGER))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_theta_estimate(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+  validation_queries:
+  - id: theta_lgk10_estimate_in_range
+    sql: "SELECT datasketch_theta_estimate(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS distinct_orders\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 13500
+    expected_value_max: 16500
+  - id: theta_lgk10_storage_size
+    sql: "SELECT octet_length(datasketch_theta(10, user_sketch::sketch_theta_uint64)) AS sketch_bytes\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 1000
+    expected_value_max: 12000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_daily_users\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_theta_union_merge_lgk14
+  category: sketch
+  description: Theta sweep variant — lg_k=14 (16384 entries, ~64KB serialized, ~0.8% RSE). Larger and tighter than default lg_k=12.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_daily_users;\nCREATE TABLE sketch_ops_daily_users (\n  activity_date DATE, region VARCHAR(25), user_sketch BLOB, rev_sketch BLOB\n);\nINSERT INTO sketch_ops_daily_users\nSELECT l_shipdate, l_returnflag,\n       datasketch_theta(14, l_orderkey),\n       datasketch_theta(14, CAST(l_extendedprice AS INTEGER))\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_theta_estimate(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS distinct_orders\nFROM sketch_ops_daily_users;\n"
+  validation_queries:
+  - id: theta_lgk14_estimate_in_range
+    sql: "SELECT datasketch_theta_estimate(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS distinct_orders\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 14700
+    expected_value_max: 15300
+  - id: theta_lgk14_storage_size
+    sql: "SELECT octet_length(datasketch_theta(14, user_sketch::sketch_theta_uint64)) AS sketch_bytes\nFROM sketch_ops_daily_users\n"
+    expected_value_min: 16000
+    expected_value_max: 130000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_daily_users\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_kll_quantiles_merge_k100
+  category: sketch
+  description: KLL sweep variant — k=100 (~1.5KB, ~1.65% normalized rank error). Smaller and lossier than default k=200.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BLOB\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag, datasketch_kll(100, l_extendedprice)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_kll_quantile(datasketch_kll(100, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+  validation_queries:
+  - id: kll_k100_median_in_range
+    sql: "SELECT datasketch_kll_quantile(datasketch_kll(100, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 30000
+    expected_value_max: 40000
+  - id: kll_k100_storage_size
+    sql: "SELECT octet_length(datasketch_kll(100, price_sketch::sketch_kll_double)) AS sketch_bytes\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 500
+    expected_value_max: 5000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_kll_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_kll_quantiles_merge_k1000
+  category: sketch
+  description: KLL sweep variant — k=1000 (~15KB, ~0.59% normalized rank error). Larger and tighter than default k=200.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_kll_partitions;\nCREATE TABLE sketch_ops_kll_partitions (\n  activity_date DATE, region VARCHAR(25), price_sketch BLOB\n);\nINSERT INTO sketch_ops_kll_partitions\nSELECT l_shipdate, l_returnflag, datasketch_kll(1000, l_extendedprice)\nFROM lineitem GROUP BY l_shipdate, l_returnflag;\nSELECT datasketch_kll_quantile(datasketch_kll(1000, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions;\n"
+  validation_queries:
+  - id: kll_k1000_median_in_range
+    sql: "SELECT datasketch_kll_quantile(datasketch_kll(1000, price_sketch::sketch_kll_double), 0.5::DOUBLE, true) AS median_price\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 30000
+    expected_value_max: 40000
+  - id: kll_k1000_storage_size
+    sql: "SELECT octet_length(datasketch_kll(1000, price_sketch::sketch_kll_double)) AS sketch_bytes\nFROM sketch_ops_kll_partitions\n"
+    expected_value_min: 5000
+    expected_value_max: 40000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_kll_partitions\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_topk_combine_lgmm8
+  category: sketch
+  description: Top-K sweep variant — explicit lg_max_map_size=8 (256 buckets, ~600B). Same parameter as the default headline op; provided for sweep-symmetry comparisons.
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);\nINSERT INTO sketch_ops_topk\nSELECT CAST(l_orderkey % 8 AS INTEGER),\n       datasketch_frequent_items(8, l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\nSELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk;\n"
+  validation_queries:
+  - id: topk_lgmm8_frequent_count_in_range
+    sql: "SELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(8, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk\n"
+    expected_value_min: 6
+    expected_value_max: 8
+  - id: topk_lgmm8_storage_size
+    sql: "SELECT octet_length(datasketch_frequent_items(8, topk_sketch)) AS sketch_bytes\nFROM sketch_ops_topk\n"
+    expected_value_min: 200
+    expected_value_max: 2000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_topk\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_query_topk_combine_lgmm10
+  category: sketch
+  description: Top-K sweep variant — lg_max_map_size=10 (1024 buckets, ~2KB). Larger than default lgmm=8; should still report 7 frequent items deterministically (lineitem has 7 distinct shipmodes).
+  requires_setup: false
+  write_sql: "INSTALL datasketches FROM community;\nLOAD datasketches;\nDROP TABLE IF EXISTS sketch_ops_topk;\nCREATE TABLE sketch_ops_topk (shard_id INTEGER, topk_sketch BLOB);\nINSERT INTO sketch_ops_topk\nSELECT CAST(l_orderkey % 8 AS INTEGER),\n       datasketch_frequent_items(10, l_shipmode)\nFROM lineitem GROUP BY l_orderkey % 8;\nSELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(10, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk;\n"
+  validation_queries:
+  - id: topk_lgmm10_frequent_count_in_range
+    sql: "SELECT LENGTH(datasketch_frequent_items_get_frequent(\n  datasketch_frequent_items(10, topk_sketch), 'NO_FALSE_POSITIVES'\n)) AS frequent_count\nFROM sketch_ops_topk\n"
+    expected_value_min: 6
+    expected_value_max: 8
+  - id: topk_lgmm10_storage_size
+    sql: "SELECT octet_length(datasketch_frequent_items(10, topk_sketch)) AS sketch_bytes\nFROM sketch_ops_topk\n"
+    expected_value_min: 500
+    expected_value_max: 5000
+  cleanup_sql: "DROP TABLE IF EXISTS sketch_ops_topk\n"
+  expected_rows_affected: null
+  platform_overrides:
+    databricks: null
+    snowflake: null
+    bigquery: null
+    clickhouse: null
+    datafusion: null
+    redshift: null
+    sqlite: null
+    starrocks: null
+- id: sketch_df_hll_persist_merge
+  category: sketch
+  description: ★ Headline DataFrame — PySpark HLL persist+merge cycle. Builds per-group HLL sketches of l_orderkey via `F.hll_sketch_agg`, persists state to Parquet, then merges via `F.hll_union_agg` and extracts the distinct-count estimate via `F.hll_sketch_estimate`. Pairs with the SQL-side `sketch_query_theta_union_merge` so users can compare DataFrame and SQL paths against the same true-distinct=15000 baseline at SF=0.01.
+  requires_setup: false
+  write_sql: ''
+  aggregate_state:
+    sketch_type: hll
+    source_table: lineitem
+    target_subdir: write_primitives/sketch_df_hll_persist_merge
+    group_cols:
+    - l_shipdate
+    - l_returnflag
+    value_col: l_orderkey
+    sketch_alias: user_sketch
+    supported_platforms:
+    - pyspark
+  validation_queries:
+  - id: hll_distinct_in_range
+    sql: "-- Aggregate-state validation runs against the merge-extract\n-- scalar in `metrics.aggregate_value`, not against this SQL.\n-- The placeholder SELECT keeps the loader's \"validation has SQL\"\n-- contract honored without committing to a SQL execution path.\nSELECT 1\n"
+    expected_value_min: 14250
+    expected_value_max: 15750
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides: {}
+- id: sketch_df_topk_persist_merge
+  category: sketch
+  description: ★ Headline DataFrame — PySpark Top-K persist+merge cycle. Spark 4.1+ only — `F.approx_top_k_accumulate` is the per-group state builder; `F.approx_top_k_combine` + `F.approx_top_k_estimate` perform the merge+extract. Reports the count of frequent items (lineitem has 7 distinct l_shipmodes; SF=0.01 returns 7 deterministically). Skipped cleanly on Spark 3.5.x via `pyspark_supports_approx_top_k` runtime guard.
+  requires_setup: false
+  write_sql: ''
+  aggregate_state:
+    sketch_type: topk
+    source_table: lineitem
+    target_subdir: write_primitives/sketch_df_topk_persist_merge
+    group_cols:
+    - l_shipmode
+    value_col: l_shipmode
+    sketch_alias: topk_sketch
+    supported_platforms:
+    - pyspark
+  validation_queries:
+  - id: topk_frequent_count_in_range
+    sql: "SELECT 1\n"
+    expected_value_min: 6
+    expected_value_max: 8
+  cleanup_sql: null
+  expected_rows_affected: null
+  platform_overrides: {}


### PR DESCRIPTION
## Summary
- Shrinks the Write Primitives runtime operation catalog by compacting its YAML representation while preserving the exact parsed operation data.
- Keeps operation IDs, SQL text, validations, cleanup SQL, platform overrides, aggregate-state specs, categories, and public manager outputs unchanged.

## Shrink Ledger
| Field | Value |
|---|---:|
| Surface/module | Write Primitives runtime operation catalog |
| Original code lines | 3,834 |
| New code lines | 2,105 |
| Lines removed | 1,729 |
| Reduction | 45.10% |

## Files Changed
- `benchbox/core/write_primitives/catalog/operations.yaml`

## Simplification Type
- Compact YAML serialization of identical operation catalog data; original catalog header retained.

## Behavior Preserved
- `yaml.safe_load()` normalized payload snapshot matched before and after.
- `WriteOperationsManager` public output snapshot matched before and after, including catalog version, all operations, categories, and category-filtered operation mappings.
- Focused write-primitives catalog/core tests passed after the rewrite.
- No tests, docs, scripts, generated files, lockfiles, or benchmark outputs were changed.

## Verification
- Parsed YAML payload comparison - matched
- Write operations manager public output comparison - matched
- `git diff --check` - passed
- `uv run -- python -m pytest -n 0 tests/unit/benchmarks/test_write_primitives_core.py tests/unit/core/write_primitives/test_catalog_loader.py tests/unit/core/write_primitives/test_aggregate_state_catalog.py tests/unit/core/write_primitives/test_doc_yaml_consistency.py tests/unit/core/write_primitives/test_redshift_sketch_overrides.py tests/unit/core/write_primitives/test_sketch_storage_smoke.py -q` - 71 passed
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight` - passed
  - Fast tests: 22715 passed, 5 skipped, 43 warnings, 4 subtests passed
- `make pr-open` - opened this PR

## Residual Risk
Low for runtime behavior because the parsed catalog and manager outputs are identical. Moderate for human editability because SQL bodies are now compact escaped strings rather than block scalars.

## Next Recommended Shrink Target
Apply the same parsed-object equality workflow to transaction primitives, then move to structural reductions in TPC-DI ETL, platform/base adapters, CLI run wiring, and result/validation infrastructure.
