### PR TITLE
chore: shrink tpcdi query catalogs

### DIFF
--- a/benchbox/core/query_manager.py
+++ b/benchbox/core/query_manager.py
@@ -11,6 +11,14 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 
+def copy_query_metadata(metadata: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return a shallow metadata copy that also copies list values."""
+    return {
+        query_id: {key: value.copy() if isinstance(value, list) else value for key, value in query_metadata.items()}
+        for query_id, query_metadata in metadata.items()
+    }
+
+
 class ParameterizedQueryManager(ABC):
     """Base class for query managers with default-parameter expansion."""
 
@@ -58,6 +66,20 @@ class ParameterizedQueryManager(ABC):
     def _query_ids_by_metadata(self, metadata: dict[str, dict[str, Any]], key: str, expected_value: Any) -> list[str]:
         """Return query IDs whose metadata key matches the expected value."""
         return [query_id for query_id, query_metadata in metadata.items() if query_metadata.get(key) == expected_value]
+
+    def _query_ids_for_valid_metadata(
+        self,
+        metadata: dict[str, dict[str, Any]],
+        key: str,
+        value: str,
+        selector_name: str,
+        *,
+        plural: str | None = None,
+    ) -> list[str]:
+        """Validate a metadata selector and return matching query IDs."""
+        valid_values = {query_metadata[key] for query_metadata in metadata.values() if key in query_metadata}
+        self._validate_selector_value(value, valid_values, selector_name, plural=plural)
+        return self._query_ids_by_metadata(metadata, key, value)
 
     @abstractmethod
     def _generate_default_params(self, query_id: str) -> dict[str, Any]:

--- a/benchbox/core/tpcdi/queries.py
+++ b/benchbox/core/tpcdi/queries.py
@@ -27,14 +27,45 @@ This implementation is based on the TPC-DI specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
+from collections import Counter
+from functools import lru_cache
 from typing import Any, Optional
 
-from benchbox.core.query_manager import ParameterizedQueryManager
+from benchbox.core.query_manager import ParameterizedQueryManager, copy_query_metadata
 from benchbox.utils.printing import emit
 
 from .query_analytics import TPCDIAnalyticalQueries
 from .query_etl import TPCDIETLQueries
 from .query_validation import TPCDIValidationQueries
+
+_BASE_QUERY_DATA_JSON = r"""{
+"queries": {
+"V1": "\nSELECT\n    COUNT(*) as total_customers,\n    COUNT(DISTINCT CustomerID) as unique_customers,\n    SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_customers\nFROM DimCustomer;\n",
+"V2": "\nSELECT\n    Status,\n    COUNT(*) as account_count,\n    SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_accounts\nFROM DimAccount\nGROUP BY Status\nORDER BY Status;\n",
+"V3": "\nSELECT\n    Status,\n    Type,\n    COUNT(*) as trade_count,\n    SUM(Quantity) as total_quantity,\n    AVG(TradePrice) as avg_trade_price,\n    SUM(Fee + Commission + Tax) as total_fees\nFROM FactTrade\nGROUP BY Status, Type\nORDER BY Status, Type;\n",
+"A1": "\nSELECT\n    c.Tier,\n    COUNT(DISTINCT c.SK_CustomerID) as customer_count,\n    COUNT(t.TradeID) as trade_count,\n    SUM(t.Quantity * t.TradePrice) as total_value,\n    AVG(t.TradePrice) as avg_trade_price\nFROM DimCustomer c\nLEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\nWHERE c.IsCurrent = 1\nGROUP BY c.Tier\nORDER BY c.Tier;\n",
+"A2": "\nSELECT\n    comp.Industry,\n    comp.SPrating,\n    COUNT(DISTINCT comp.SK_CompanyID) as company_count,\n    COUNT(t.TradeID) as trade_count,\n    AVG(t.TradePrice) as avg_trade_price,\n    SUM(t.Quantity * t.TradePrice) as total_trade_value\nFROM DimCompany comp\nLEFT JOIN FactTrade t ON comp.SK_CompanyID = t.SK_CompanyID\nWHERE comp.IsCurrent = 1\nGROUP BY comp.Industry, comp.SPrating\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_trade_value DESC\nLIMIT {limit_rows};\n",
+"A3": "\nSELECT\n    s.Symbol,\n    s.Name,\n    COUNT(t.TradeID) as trade_count,\n    SUM(t.Quantity) as total_quantity,\n    AVG(t.TradePrice) as avg_price,\n    MIN(t.TradePrice) as min_price,\n    MAX(t.TradePrice) as max_price,\n    SUM(t.Quantity * t.TradePrice) as total_value\nFROM DimSecurity s\nJOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID\nWHERE s.IsCurrent = 1\n  AND t.Status = 'Completed'\nGROUP BY s.Symbol, s.Name\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_value DESC\nLIMIT {limit_rows};\n",
+"A4": "\nSELECT\n    d.CalendarYearID,\n    d.CalendarQtrID,\n    COUNT(t.TradeID) as trade_count,\n    SUM(t.Quantity * t.TradePrice) as total_value,\n    AVG(t.TradePrice) as avg_price,\n    SUM(t.Fee + t.Commission + t.Tax) as total_fees\nFROM DimDate d\nJOIN FactTrade t ON d.SK_DateID = t.SK_CreateDateID\nWHERE d.CalendarYearID >= {start_year}\n  AND d.CalendarYearID <= {end_year}\nGROUP BY d.CalendarYearID, d.CalendarQtrID\nORDER BY d.CalendarYearID, d.CalendarQtrID;\n",
+"A5": "\nSELECT\n    c.Country,\n    c.StateProv,\n    COUNT(DISTINCT c.SK_CustomerID) as customer_count,\n    COUNT(t.TradeID) as trade_count,\n    SUM(t.Quantity * t.TradePrice) as total_trade_value,\n    AVG(c.NetWorth) as avg_net_worth\nFROM DimCustomer c\nLEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\nWHERE c.IsCurrent = 1\nGROUP BY c.Country, c.StateProv\nHAVING customer_count > {min_customers}\nORDER BY total_trade_value DESC\nLIMIT {limit_rows};\n"
+},
+"metadata": {
+"V1": {"relies_on": ["DimCustomer"], "query_type": "validation", "description": "Validates customer dimension data integrity and current status"},
+"V2": {"relies_on": ["DimAccount"], "query_type": "validation", "description": "Validates account dimension data with status breakdown"},
+"V3": {"relies_on": ["FactTrade"], "query_type": "validation", "description": "Validates trade fact table data quality and completeness"},
+"A1": {"relies_on": ["DimCustomer", "FactTrade", "V1", "V3"], "query_type": "analytical", "description": "Analysis of customer trading patterns by tier"},
+"A2": {"relies_on": ["DimCompany", "FactTrade", "V3"], "query_type": "analytical", "description": "Company performance analysis by industry and rating"},
+"A3": {"relies_on": ["DimSecurity", "FactTrade", "V3"], "query_type": "analytical", "description": "Security trading volume and price analysis"},
+"A4": {"relies_on": ["DimDate", "FactTrade", "V3"], "query_type": "analytical", "description": "Time-based trading patterns by year and quarter"},
+"A5": {"relies_on": ["DimCustomer", "FactTrade", "V1", "V3"], "query_type": "analytical", "description": "Geographic distribution of customers and trading activity"}
+}
+}"""
+
+
+@lru_cache(maxsize=1)
+def _base_query_data() -> dict[str, Any]:
+    return json.loads(_BASE_QUERY_DATA_JSON)
 
 
 class TPCDIQueryManager(ParameterizedQueryManager):
@@ -50,265 +81,34 @@ class TPCDIQueryManager(ParameterizedQueryManager):
     """
 
     def __init__(self) -> None:
-        """Initialize the comprehensive TPC-DI query manager."""
-        # Initialize specialized query managers
         self.validation_queries = TPCDIValidationQueries()
         self.analytical_queries = TPCDIAnalyticalQueries()
         self.etl_queries = TPCDIETLQueries()
-
-        # Load base validation and analytical queries.
         self._base_queries = self._load_base_queries()
         self._queries = self._base_queries
         self._base_query_metadata = self._load_base_query_metadata()
-
-        # Build comprehensive query catalog
         self._all_queries = self._build_comprehensive_catalog()
         self._all_metadata = self._build_comprehensive_metadata()
 
     def _load_base_queries(self) -> dict[str, str]:
-        """Load all TPC-DI validation and analytical queries.
-
-        Returns:
-            Dictionary mapping query IDs to SQL text
-        """
-        queries = {}
-
-        # Validation Query 1: Customer dimension validation
-        queries["V1"] = """
-SELECT
-    COUNT(*) as total_customers,
-    COUNT(DISTINCT CustomerID) as unique_customers,
-    SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_customers
-FROM DimCustomer;
-"""
-
-        # Validation Query 2: Account dimension validation
-        queries["V2"] = """
-SELECT
-    Status,
-    COUNT(*) as account_count,
-    SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_accounts
-FROM DimAccount
-GROUP BY Status
-ORDER BY Status;
-"""
-
-        # Validation Query 3: Trade fact validation
-        queries["V3"] = """
-SELECT
-    Status,
-    Type,
-    COUNT(*) as trade_count,
-    SUM(Quantity) as total_quantity,
-    AVG(TradePrice) as avg_trade_price,
-    SUM(Fee + Commission + Tax) as total_fees
-FROM FactTrade
-GROUP BY Status, Type
-ORDER BY Status, Type;
-"""
-
-        # Analytical Query 1: Customer trading analysis
-        queries["A1"] = """
-SELECT
-    c.Tier,
-    COUNT(DISTINCT c.SK_CustomerID) as customer_count,
-    COUNT(t.TradeID) as trade_count,
-    SUM(t.Quantity * t.TradePrice) as total_value,
-    AVG(t.TradePrice) as avg_trade_price
-FROM DimCustomer c
-LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-WHERE c.IsCurrent = 1
-GROUP BY c.Tier
-ORDER BY c.Tier;
-"""
-
-        # Analytical Query 2: Company performance analysis
-        queries["A2"] = """
-SELECT
-    comp.Industry,
-    comp.SPrating,
-    COUNT(DISTINCT comp.SK_CompanyID) as company_count,
-    COUNT(t.TradeID) as trade_count,
-    AVG(t.TradePrice) as avg_trade_price,
-    SUM(t.Quantity * t.TradePrice) as total_trade_value
-FROM DimCompany comp
-LEFT JOIN FactTrade t ON comp.SK_CompanyID = t.SK_CompanyID
-WHERE comp.IsCurrent = 1
-GROUP BY comp.Industry, comp.SPrating
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_trade_value DESC
-LIMIT {limit_rows};
-"""
-
-        # Analytical Query 3: Security trading analysis
-        queries["A3"] = """
-SELECT
-    s.Symbol,
-    s.Name,
-    COUNT(t.TradeID) as trade_count,
-    SUM(t.Quantity) as total_quantity,
-    AVG(t.TradePrice) as avg_price,
-    MIN(t.TradePrice) as min_price,
-    MAX(t.TradePrice) as max_price,
-    SUM(t.Quantity * t.TradePrice) as total_value
-FROM DimSecurity s
-JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID
-WHERE s.IsCurrent = 1
-  AND t.Status = 'Completed'
-GROUP BY s.Symbol, s.Name
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_value DESC
-LIMIT {limit_rows};
-"""
-
-        # Analytical Query 4: Time-based trading analysis
-        queries["A4"] = """
-SELECT
-    d.CalendarYearID,
-    d.CalendarQtrID,
-    COUNT(t.TradeID) as trade_count,
-    SUM(t.Quantity * t.TradePrice) as total_value,
-    AVG(t.TradePrice) as avg_price,
-    SUM(t.Fee + t.Commission + t.Tax) as total_fees
-FROM DimDate d
-JOIN FactTrade t ON d.SK_DateID = t.SK_CreateDateID
-WHERE d.CalendarYearID >= {start_year}
-  AND d.CalendarYearID <= {end_year}
-GROUP BY d.CalendarYearID, d.CalendarQtrID
-ORDER BY d.CalendarYearID, d.CalendarQtrID;
-"""
-
-        # Analytical Query 5: Customer geographic analysis
-        queries["A5"] = """
-SELECT
-    c.Country,
-    c.StateProv,
-    COUNT(DISTINCT c.SK_CustomerID) as customer_count,
-    COUNT(t.TradeID) as trade_count,
-    SUM(t.Quantity * t.TradePrice) as total_trade_value,
-    AVG(c.NetWorth) as avg_net_worth
-FROM DimCustomer c
-LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-WHERE c.IsCurrent = 1
-GROUP BY c.Country, c.StateProv
-HAVING customer_count > {min_customers}
-ORDER BY total_trade_value DESC
-LIMIT {limit_rows};
-"""
-
-        return queries
+        return dict(_base_query_data()["queries"])
 
     def _load_base_query_metadata(self) -> dict[str, dict[str, Any]]:
-        """Load metadata for all TPC-DI queries including dependencies.
-
-        Returns:
-            Dictionary mapping query IDs to their metadata
-        """
-        metadata = {}
-
-        # Validation Query 1: Customer dimension validation
-        metadata["V1"] = {
-            "relies_on": ["DimCustomer"],
-            "query_type": "validation",
-            "description": "Validates customer dimension data integrity and current status",
-        }
-
-        # Validation Query 2: Account dimension validation
-        metadata["V2"] = {
-            "relies_on": ["DimAccount"],
-            "query_type": "validation",
-            "description": "Validates account dimension data with status breakdown",
-        }
-
-        # Validation Query 3: Trade fact validation
-        metadata["V3"] = {
-            "relies_on": ["FactTrade"],
-            "query_type": "validation",
-            "description": "Validates trade fact table data quality and completeness",
-        }
-
-        # Analytical Query 1: Customer trading analysis
-        metadata["A1"] = {
-            "relies_on": ["DimCustomer", "FactTrade", "V1", "V3"],
-            "query_type": "analytical",
-            "description": "Analysis of customer trading patterns by tier",
-        }
-
-        # Analytical Query 2: Company performance analysis
-        metadata["A2"] = {
-            "relies_on": ["DimCompany", "FactTrade", "V3"],
-            "query_type": "analytical",
-            "description": "Company performance analysis by industry and rating",
-        }
-
-        # Analytical Query 3: Security trading analysis
-        metadata["A3"] = {
-            "relies_on": ["DimSecurity", "FactTrade", "V3"],
-            "query_type": "analytical",
-            "description": "Security trading volume and price analysis",
-        }
-
-        # Analytical Query 4: Time-based trading analysis
-        metadata["A4"] = {
-            "relies_on": ["DimDate", "FactTrade", "V3"],
-            "query_type": "analytical",
-            "description": "Time-based trading patterns by year and quarter",
-        }
-
-        # Analytical Query 5: Customer geographic analysis
-        metadata["A5"] = {
-            "relies_on": ["DimCustomer", "FactTrade", "V1", "V3"],
-            "query_type": "analytical",
-            "description": "Geographic distribution of customers and trading activity",
-        }
-
-        return metadata
+        return copy_query_metadata(_base_query_data()["metadata"])
 
     def _build_comprehensive_catalog(self) -> dict[str, str]:
-        """Build comprehensive catalog combining all query types.
-
-        Returns:
-            Dictionary mapping all query IDs to SQL text
-        """
-        catalog = {}
-
-        # Include base queries.
-        catalog.update(self._base_queries)
-
-        # Add extended validation queries
-        catalog.update(self.validation_queries.get_all_queries())
-
-        # Add extended analytical queries
-        catalog.update(self.analytical_queries.get_all_queries())
-
-        # Add ETL validation queries
-        catalog.update(self.etl_queries.get_all_queries())
-
-        return catalog
+        return {
+            **self._base_queries,
+            **self.validation_queries.get_all_queries(),
+            **self.analytical_queries.get_all_queries(),
+            **self.etl_queries.get_all_queries(),
+        }
 
     def _build_comprehensive_metadata(self) -> dict[str, dict[str, Any]]:
-        """Build comprehensive metadata combining all query types.
-
-        Returns:
-            Dictionary mapping all query IDs to their metadata
-        """
-        metadata = {}
-
-        # Add base query metadata.
-        metadata.update(self._base_query_metadata)
-
-        # Add extended validation query metadata
-        for query_id in self.validation_queries._queries:
-            metadata[query_id] = self.validation_queries.get_query_metadata(query_id)
-
-        # Add extended analytical query metadata
-        for query_id in self.analytical_queries._queries:
-            metadata[query_id] = self.analytical_queries.get_query_metadata(query_id)
-
-        # Add ETL validation query metadata
-        for query_id in self.etl_queries._queries:
-            metadata[query_id] = self.etl_queries.get_query_metadata(query_id)
-
+        metadata = dict(self._base_query_metadata)
+        metadata.update(copy_query_metadata(self.validation_queries._query_metadata))
+        metadata.update(copy_query_metadata(self.analytical_queries._query_metadata))
+        metadata.update(copy_query_metadata(self.etl_queries._query_metadata))
         return metadata
 
     def get_query(
@@ -317,21 +117,6 @@ LIMIT {limit_rows};
         params: Optional[dict[str, Any]] = None,
         dialect: Optional[str] = None,
     ) -> str:
-        """Get a TPC-DI query with parameters.
-
-        Args:
-            query_id: Query identifier (V1-V3, A1-A5, VQ1-VQ12, AQ1-AQ10, EQ1-EQ8)
-            params: Optional parameter values. If None, uses defaults.
-            dialect: Optional SQL dialect for query translation
-
-        Returns:
-            SQL query with parameters replaced
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
-        # Route to appropriate query manager
-        query = None
         if query_id in self._base_queries:
             query = super().get_query(query_id, params)
         elif query_id.startswith("VQ"):
@@ -344,300 +129,116 @@ LIMIT {limit_rows};
             available = ", ".join(sorted(self._all_queries.keys()))
             raise ValueError(f"Invalid query ID: {query_id}. Available: {available}")
 
-        # Apply dialect translation if requested
-        if dialect and dialect != "standard" and query:
-            query = self.translate_query_text(query, dialect)
-
-        return query
+        return self.translate_query_text(query, dialect) if dialect and dialect != "standard" else query
 
     def get_all_queries(self) -> dict[str, str]:
-        """Get all TPC-DI queries with default parameters.
-
-        Returns:
-            Dictionary mapping query IDs to parameterized SQL (30 total queries)
-        """
         return self._all_queries.copy()
 
     def _generate_default_params(self, query_id: str) -> dict[str, Any]:
-        """Generate default parameters for a query.
-
-        Args:
-            query_id: Query identifier
-
-        Returns:
-            Dictionary of parameter names to default values
-        """
-        # Default parameters used in TPC-DI specification
-        defaults = {
-            # Thresholds
-            "min_trades": 100,
-            "min_customers": 10,
-            # Years (TPC-DI typically covers 5 years)
-            "start_year": 2015,
-            "end_year": 2019,
-            # Limits
-            "limit_rows": 50,
-        }
-
-        return defaults
+        return {"min_trades": 100, "min_customers": 10, "start_year": 2015, "end_year": 2019, "limit_rows": 50}
 
     def get_query_dependencies(self, query_id: str) -> list[str]:
-        """Get the dependencies for a specific query.
-
-        Args:
-            query_id: Query identifier (V1-V3, A1-A5, VQ1-VQ12, AQ1-AQ10, EQ1-EQ8)
-
-        Returns:
-            List of dependencies (tables and other queries) this query relies on
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
         if query_id not in self._all_metadata:
             available = ", ".join(sorted(self._all_metadata.keys()))
             raise ValueError(f"Invalid query ID: {query_id}. Available: {available}")
-
         return self._all_metadata[query_id]["relies_on"].copy()
 
     def get_query_metadata(self, query_id: str) -> dict[str, Any]:
-        """Get full metadata for a specific query.
-
-        Args:
-            query_id: Query identifier (V1-V3, A1-A5, VQ1-VQ12, AQ1-AQ10, EQ1-EQ8)
-
-        Returns:
-            Dictionary containing query metadata (relies_on, query_type, description, etc.)
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
         return self._get_query_metadata_copy(self._all_metadata, query_id, "query")
 
     def get_queries_by_type(self, query_type: str) -> list[str]:
-        """Get all queries of a specific type.
-
-        Args:
-            query_type: Type of queries to retrieve ("validation", "analytical", "etl_validation")
-
-        Returns:
-            List of query IDs of the specified type
-
-        Raises:
-            ValueError: If query_type is invalid
-        """
-        valid_types = {"validation", "analytical", "etl_validation"}
-        self._validate_selector_value(query_type, valid_types, "query type")
-        return self._query_ids_by_metadata(self._all_metadata, "query_type", query_type)
+        return self._query_ids_for_valid_metadata(self._all_metadata, "query_type", query_type, "query type")
 
     def resolve_query_order(self, query_ids: Optional[list[str]] = None) -> list[str]:
-        """Resolve queries in dependency order using topological sort.
-
-        Args:
-            query_ids: Optional list of specific query IDs to order. If None, orders all queries.
-
-        Returns:
-            List of query IDs in dependency order (dependencies first)
-
-        Raises:
-            ValueError: If there's a circular dependency or invalid query ID
-        """
-        if query_ids is None:
-            query_ids = list(self._all_queries.keys())
-
-        # Validate all query IDs
+        query_ids = list(self._all_queries.keys()) if query_ids is None else query_ids
         for query_id in query_ids:
             if query_id not in self._all_metadata:
                 available = ", ".join(sorted(self._all_metadata.keys()))
                 raise ValueError(f"Invalid query ID: {query_id}. Available: {available}")
 
-        # Filter dependencies to only include queries (not tables)
-        query_dependencies = {}
-        for query_id in query_ids:
-            deps = [
-                dep
-                for dep in self._all_metadata[query_id]["relies_on"]
-                if dep in self._all_metadata  # Only include other queries, not tables
-            ]
-            query_dependencies[query_id] = deps
-
-        # Topological sort using Kahn's algorithm
-        # Count incoming edges for each query
+        query_dependencies = {
+            query_id: [dep for dep in self._all_metadata[query_id]["relies_on"] if dep in self._all_metadata]
+            for query_id in query_ids
+        }
         in_degree = dict.fromkeys(query_ids, 0)
         for query_id in query_ids:
             for dep in query_dependencies[query_id]:
-                if dep in in_degree:  # Only count dependencies that are in our query set
+                if dep in in_degree:
                     in_degree[query_id] += 1
 
-        # Queue of queries with no dependencies
         queue = [query_id for query_id in query_ids if in_degree[query_id] == 0]
         result = []
-
         while queue:
-            # Sort queue for deterministic output
             queue.sort()
             current = queue.pop(0)
             result.append(current)
-
-            # Reduce in-degree for queries that depend on current query
             for query_id in query_ids:
                 if current in query_dependencies[query_id]:
                     in_degree[query_id] -= 1
                     if in_degree[query_id] == 0:
                         queue.append(query_id)
 
-        # Check for circular dependencies
         if len(result) != len(query_ids):
             remaining = [q for q in query_ids if q not in result]
             raise ValueError(f"Circular dependency detected involving queries: {', '.join(remaining)}")
-
         return result
 
     def get_execution_plan(self) -> list[tuple[str, str, list[str]]]:
-        """Get a complete execution plan with queries grouped by type and ordered by dependencies.
-
-        Returns:
-            List of tuples containing (query_id, query_type, dependencies) in execution order
-        """
-        # Get all queries in dependency order
-        ordered_queries = self.resolve_query_order()
-
-        execution_plan = []
-        for query_id in ordered_queries:
-            metadata = self._all_metadata[query_id]
-            execution_plan.append((query_id, metadata["query_type"], metadata["relies_on"].copy()))
-
-        return execution_plan
-
-    # Extended methods for comprehensive query suite management
+        return [
+            (query_id, self._all_metadata[query_id]["query_type"], self._all_metadata[query_id]["relies_on"].copy())
+            for query_id in self.resolve_query_order()
+        ]
 
     def get_validation_queries(self) -> dict[str, str]:
-        """Get all data quality validation queries.
-
-        Returns:
-            Dictionary mapping validation query IDs (VQ1-VQ12) to SQL text
-        """
         return self.validation_queries.get_all_queries()
 
     def get_analytical_queries(self) -> dict[str, str]:
-        """Get all business intelligence analytical queries.
-
-        Returns:
-            Dictionary mapping analytical query IDs (AQ1-AQ10) to SQL text
-        """
         return self.analytical_queries.get_all_queries()
 
     def get_etl_queries(self) -> dict[str, str]:
-        """Get all ETL validation queries.
-
-        Returns:
-            Dictionary mapping ETL query IDs (EQ1-EQ8) to SQL text
-        """
         return self.etl_queries.get_all_queries()
 
     def get_queries_by_category(self, category: str) -> list[str]:
-        """Get queries by detailed category (beyond basic type).
-
-        Args:
-            category: Detailed category (e.g. 'referential_integrity', 'customer_profitability',
-                     'batch_processing', etc.)
-
-        Returns:
-            List of query IDs in the specified category
-        """
         result = []
-
-        # Check validation queries
-        try:
-            result.extend(self.validation_queries.get_queries_by_category(category))
-        except ValueError:
-            pass  # Category not found in validation queries
-
-        # Check analytical queries
-        try:
-            result.extend(self.analytical_queries.get_queries_by_category(category))
-        except ValueError:
-            pass  # Category not found in analytical queries
-
-        # Check ETL queries
-        try:
-            result.extend(self.etl_queries.get_queries_by_category(category))
-        except ValueError:
-            pass  # Category not found in ETL queries
-
+        for query_group in (self.validation_queries, self.analytical_queries, self.etl_queries):
+            try:
+                result.extend(query_group.get_queries_by_category(category))
+            except ValueError:
+                pass
         return result
 
     def get_query_statistics(self) -> dict[str, Any]:
-        """Get comprehensive statistics about the query suite.
-
-        Returns:
-            Dictionary containing query suite statistics
-        """
-        all_queries = self._all_queries
-        all_metadata = self._all_metadata
-
-        # Count by type
-        type_counts = {}
-        for metadata in all_metadata.values():
-            query_type = metadata.get("query_type", "unknown")
-            type_counts[query_type] = type_counts.get(query_type, 0) + 1
-
-        # Count by category (for extended queries)
-        category_counts = {}
-        for metadata in all_metadata.values():
-            category = metadata.get("category", "uncategorized")
-            category_counts[category] = category_counts.get(category, 0) + 1
-
-        # Count by complexity/severity
-        complexity_counts = {}
-        severity_counts = {}
-        for metadata in all_metadata.values():
-            if "complexity" in metadata:
-                complexity = metadata["complexity"]
-                complexity_counts[complexity] = complexity_counts.get(complexity, 0) + 1
-            if "severity" in metadata:
-                severity = metadata["severity"]
-                severity_counts[severity] = severity_counts.get(severity, 0) + 1
-
+        type_counts = Counter(metadata.get("query_type", "unknown") for metadata in self._all_metadata.values())
+        category_counts = Counter(metadata.get("category", "uncategorized") for metadata in self._all_metadata.values())
+        complexity_counts = Counter(
+            metadata["complexity"] for metadata in self._all_metadata.values() if "complexity" in metadata
+        )
+        severity_counts = Counter(
+            metadata["severity"] for metadata in self._all_metadata.values() if "severity" in metadata
+        )
         return {
-            "total_queries": len(all_queries),
+            "total_queries": len(self._all_queries),
             "base_queries": len(self._base_queries),
             "extended_validation_queries": len(self.validation_queries._queries),
             "extended_analytical_queries": len(self.analytical_queries._queries),
             "etl_validation_queries": len(self.etl_queries._queries),
-            "queries_by_type": type_counts,
-            "queries_by_category": category_counts,
-            "queries_by_complexity": complexity_counts,
-            "queries_by_severity": severity_counts,
-            "query_expansion_factor": len(all_queries) / len(self._base_queries),
+            "queries_by_type": dict(type_counts),
+            "queries_by_category": dict(category_counts),
+            "queries_by_complexity": dict(complexity_counts),
+            "queries_by_severity": dict(severity_counts),
+            "query_expansion_factor": len(self._all_queries) / len(self._base_queries),
         }
 
     def translate_query_text(self, query: str, dialect: str) -> str:
-        """Translate a query string to a specific SQL dialect.
-
-        Args:
-            query: SQL query string to translate
-            dialect: Target SQL dialect
-
-        Returns:
-            Translated SQL query string
-
-        Raises:
-            ImportError: If sqlglot is not available
-            Exception: If translation fails
-        """
         try:
             import sqlglot  # type: ignore[import-untyped]
 
-            # TPC-DI queries are generated with ANSI SQL syntax, use 'ansi' as source
-            translated = sqlglot.transpile(  # type: ignore[attr-defined]
-                query, read="ansi", write=dialect
-            )
+            translated = sqlglot.transpile(query, read="ansi", write=dialect)  # type: ignore[attr-defined]
             return translated[0] if translated else query
         except ImportError:
             raise ImportError(
                 "sqlglot is required for SQL dialect translation. Install with: pip install sqlglot"
             ) from None
         except Exception as e:
-            # If translation fails, return the original query with a warning
             emit(f"Warning: Failed to translate query to {dialect}: {e}")
             return query

--- a/benchbox/core/tpcdi/query_analytics.py
+++ b/benchbox/core/tpcdi/query_analytics.py
@@ -15,9 +15,43 @@ This implementation is based on the TPC-DI specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
+from functools import lru_cache
 from typing import Any
 
-from benchbox.core.query_manager import ParameterizedQueryManager
+from benchbox.core.query_manager import ParameterizedQueryManager, copy_query_metadata
+
+_ANALYTICAL_QUERY_DATA_JSON = r"""{
+"queries": {
+"AQ1": "\nSELECT\n    'Customer Profitability Analysis' as analysis_name,\n    c.Tier,\n    c.Country,\n    c.Gender,\n    COUNT(DISTINCT c.SK_CustomerID) as customer_count,\n    COUNT(t.TradeID) as total_trades,\n    SUM(t.Quantity * t.TradePrice) as total_trade_value,\n    SUM(t.Fee + t.Commission + t.Tax) as total_fees_generated,\n    AVG(t.TradePrice) as avg_trade_price,\n    AVG(c.NetWorth) as avg_net_worth,\n    AVG(c.CreditRating) as avg_credit_rating,\n    SUM(t.Quantity * t.TradePrice) / COUNT(DISTINCT c.SK_CustomerID) as revenue_per_customer,\n    SUM(t.Fee + t.Commission + t.Tax) / COUNT(DISTINCT c.SK_CustomerID) as fees_per_customer,\n    COUNT(t.TradeID) / COUNT(DISTINCT c.SK_CustomerID) as trades_per_customer\nFROM DimCustomer c\nLEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\nLEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nWHERE c.IsCurrent = 1\n  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})\n  AND t.Status = 'Completed'\nGROUP BY c.Tier, c.Country, c.Gender\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_fees_generated DESC, total_trade_value DESC\nLIMIT {limit_rows};\n",
+"AQ2": "\nSELECT\n    'Security Performance Analysis' as analysis_name,\n    s.Symbol,\n    s.Name as security_name,\n    comp.Name as company_name,\n    comp.Industry,\n    comp.SPrating,\n    COUNT(t.TradeID) as total_trades,\n    SUM(t.Quantity) as total_volume,\n    AVG(t.TradePrice) as avg_trade_price,\n    MIN(t.TradePrice) as min_trade_price,\n    MAX(t.TradePrice) as max_trade_price,\n    (MAX(t.TradePrice) - MIN(t.TradePrice)) / MIN(t.TradePrice) * 100 as price_volatility_pct,\n    SUM(t.Quantity * t.TradePrice) as total_market_value,\n    AVG(mh.ClosePrice) as avg_market_close,\n    AVG(mh.Volume) as avg_daily_volume,\n    AVG(mh.PERatio) as avg_pe_ratio,\n    AVG(mh.Yield) as avg_dividend_yield,\n    MAX(mh.FiftyTwoWeekHigh) as week52_high,\n    MIN(mh.FiftyTwoWeekLow) as week52_low\nFROM DimSecurity s\nJOIN DimCompany comp ON s.SK_CompanyID = comp.SK_CompanyID\nLEFT JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID\nLEFT JOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID\nLEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nWHERE s.IsCurrent = 1\n  AND comp.IsCurrent = 1\n  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})\n  AND t.Status = 'Completed'\nGROUP BY s.Symbol, s.Name, comp.Name, comp.Industry, comp.SPrating\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_market_value DESC, price_volatility_pct DESC\nLIMIT {limit_rows};\n",
+"AQ3": "\nSELECT\n    'Broker Performance Analysis' as analysis_name,\n    b.FirstName || ' ' || b.LastName as broker_name,\n    b.Branch,\n    b.Office,\n    COUNT(DISTINCT t.SK_CustomerID) as unique_customers,\n    COUNT(t.TradeID) as total_trades,\n    SUM(t.Quantity) as total_quantity_traded,\n    SUM(t.Quantity * t.TradePrice) as total_trade_value,\n    SUM(t.Commission) as total_commission_generated,\n    AVG(t.Commission) as avg_commission_per_trade,\n    AVG(t.TradePrice) as avg_trade_price,\n    SUM(t.Commission) / SUM(t.Quantity * t.TradePrice) * 100 as commission_rate_pct,\n    COUNT(t.TradeID) / COUNT(DISTINCT t.SK_CustomerID) as trades_per_customer,\n    SUM(t.Quantity * t.TradePrice) / COUNT(DISTINCT t.SK_CustomerID) as value_per_customer,\n    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) as sell_trades,\n    COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) as buy_trades,\n    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) / COUNT(t.TradeID) * 100 as sell_ratio_pct\nFROM DimBroker b\nLEFT JOIN FactTrade t ON b.SK_BrokerID = t.SK_BrokerID\nLEFT JOIN TradeType tt ON t.Type = tt.TT_ID\nLEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nWHERE b.IsCurrent = 1\n  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})\n  AND t.Status = 'Completed'\nGROUP BY b.FirstName, b.LastName, b.Branch, b.Office\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_commission_generated DESC, total_trade_value DESC\nLIMIT {limit_rows};\n",
+"AQ4": "\nSELECT\n    'Market Trend Analysis' as analysis_name,\n    d.CalendarYearID,\n    d.CalendarQtrID,\n    d.CalendarMonthID,\n    COUNT(t.TradeID) as monthly_trade_count,\n    COUNT(DISTINCT t.SK_CustomerID) as active_customers,\n    COUNT(DISTINCT t.SK_SecurityID) as securities_traded,\n    SUM(t.Quantity) as monthly_volume,\n    SUM(t.Quantity * t.TradePrice) as monthly_trade_value,\n    AVG(t.TradePrice) as avg_monthly_price,\n    SUM(t.Fee + t.Commission + t.Tax) as monthly_fees,\n    AVG(mh.ClosePrice) as avg_market_close,\n    AVG(mh.Volume) as avg_market_volume,\n    SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) as sell_volume,\n    SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN t.Quantity * t.TradePrice ELSE 0 END) as buy_volume,\n    (SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) -\n     SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN t.Quantity * t.TradePrice ELSE 0 END)) as net_market_flow,\n    LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID) as prev_month_value,\n    (SUM(t.Quantity * t.TradePrice) - LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID)) /\n     LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID) * 100 as month_over_month_growth_pct\nFROM DimDate d\nLEFT JOIN FactTrade t ON d.SK_DateID = t.SK_CreateDateID\nLEFT JOIN FactMarketHistory mh ON d.SK_DateID = mh.SK_DateID\nLEFT JOIN TradeType tt ON t.Type = tt.TT_ID\nWHERE d.CalendarYearID >= {start_year}\n  AND d.CalendarYearID <= {end_year}\n  AND t.Status = 'Completed'\nGROUP BY d.CalendarYearID, d.CalendarQtrID, d.CalendarMonthID\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY d.CalendarYearID, d.CalendarMonthID;\n",
+"AQ5": "\nWITH price_returns AS (\n    SELECT\n        mh.SK_SecurityID,\n        mh.SK_DateID,\n        mh.ClosePrice,\n        mh.PERatio,\n        mh.Yield,\n        (mh.ClosePrice / LAG(mh.ClosePrice) OVER (PARTITION BY mh.SK_SecurityID ORDER BY mh.SK_DateID) - 1) as daily_return\n    FROM FactMarketHistory mh\n)\nSELECT\n    'Portfolio Risk and Return Analysis' as analysis_name,\n    c.SK_CustomerID,\n    c.Tier,\n    c.NetWorth,\n    c.CreditRating,\n    COUNT(DISTINCT h.SK_SecurityID) as portfolio_diversification,\n    SUM(h.CurrentHolding * h.CurrentPrice) as total_portfolio_value,\n    SUM(cb.Cash) as cash_balance,\n    (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) as total_account_value,\n    SUM(h.CurrentHolding * h.CurrentPrice) / (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) * 100 as equity_allocation_pct,\n    SUM(cb.Cash) / (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) * 100 as cash_allocation_pct,\n    AVG(pr.PERatio) as avg_portfolio_pe_ratio,\n    AVG(pr.Yield) as avg_portfolio_yield,\n    STDDEV(pr.daily_return) * 100 as portfolio_volatility_pct,\n    SUM(CASE WHEN comp.SPrating IN ('AAA', 'AA+', 'AA', 'AA-') THEN h.CurrentHolding * h.CurrentPrice ELSE 0 END) /\n        SUM(h.CurrentHolding * h.CurrentPrice) * 100 as high_grade_allocation_pct,\n    COUNT(fw.SK_SecurityID) as watchlist_securities\nFROM DimCustomer c\nLEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID\nLEFT JOIN FactCashBalances cb ON c.SK_CustomerID = cb.SK_CustomerID\nLEFT JOIN price_returns pr ON h.SK_SecurityID = pr.SK_SecurityID AND h.SK_DateID = pr.SK_DateID\nLEFT JOIN DimSecurity s ON h.SK_SecurityID = s.SK_SecurityID\nLEFT JOIN DimCompany comp ON s.SK_CompanyID = comp.SK_CompanyID\nLEFT JOIN FactWatches fw ON c.SK_CustomerID = fw.SK_CustomerID\nWHERE c.IsCurrent = 1\n  AND s.IsCurrent = 1\n  AND comp.IsCurrent = 1\n  AND h.CurrentHolding > 0\nGROUP BY c.SK_CustomerID, c.Tier, c.NetWorth, c.CreditRating\nHAVING SUM(h.CurrentHolding * h.CurrentPrice) > {min_portfolio_value}\nORDER BY total_portfolio_value DESC\nLIMIT {limit_rows};\n",
+"AQ6": "\nSELECT\n    'Industry Sector Performance Analysis' as analysis_name,\n    comp.Industry,\n    COUNT(DISTINCT comp.SK_CompanyID) as companies_in_sector,\n    COUNT(DISTINCT s.SK_SecurityID) as securities_in_sector,\n    COUNT(t.TradeID) as total_sector_trades,\n    SUM(t.Quantity * t.TradePrice) as total_sector_value,\n    AVG(t.TradePrice) as avg_sector_price,\n    SUM(t.Quantity) as total_sector_volume,\n    AVG(comp.MarketCap) as avg_market_cap,\n    AVG(mh.PERatio) as avg_sector_pe_ratio,\n    AVG(mh.Yield) as avg_sector_yield,\n    AVG(mh.ClosePrice) as avg_closing_price,\n    STDDEV(mh.ClosePrice) as price_volatility,\n    COUNT(CASE WHEN comp.SPrating IN ('AAA', 'AA+', 'AA', 'AA-', 'A+', 'A', 'A-') THEN 1 END) as investment_grade_companies,\n    COUNT(CASE WHEN comp.SPrating IN ('BBB+', 'BBB', 'BBB-', 'BB+', 'BB', 'BB-', 'B+', 'B', 'B-', 'CCC') THEN 1 END) as speculative_grade_companies,\n    SUM(t.Quantity * t.TradePrice) / SUM(SUM(t.Quantity * t.TradePrice)) OVER () * 100 as sector_market_share_pct\nFROM DimCompany comp\nJOIN DimSecurity s ON comp.SK_CompanyID = s.SK_CompanyID\nLEFT JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID\nLEFT JOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID\nLEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nWHERE comp.IsCurrent = 1\n  AND s.IsCurrent = 1\n  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})\n  AND t.Status = 'Completed'\nGROUP BY comp.Industry\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY total_sector_value DESC, avg_sector_pe_ratio ASC\nLIMIT {limit_rows};\n",
+"AQ7": "\nSELECT\n    'Customer Lifecycle and Retention Analysis' as analysis_name,\n    customer_tenure_months,\n    customer_count,\n    avg_trades_per_customer,\n    avg_trade_value_per_customer,\n    avg_fees_per_customer,\n    retention_rate_pct,\n    avg_portfolio_value,\n    avg_cash_balance\nFROM (\n    SELECT\n        CASE\n            WHEN months_since_first_trade <= 6 THEN '0-6 months'\n            WHEN months_since_first_trade <= 12 THEN '7-12 months'\n            WHEN months_since_first_trade <= 24 THEN '1-2 years'\n            WHEN months_since_first_trade <= 36 THEN '2-3 years'\n            ELSE '3+ years'\n        END as customer_tenure_months,\n        COUNT(DISTINCT c.SK_CustomerID) as customer_count,\n        AVG(customer_metrics.total_trades) as avg_trades_per_customer,\n        AVG(customer_metrics.total_trade_value) as avg_trade_value_per_customer,\n        AVG(customer_metrics.total_fees) as avg_fees_per_customer,\n        SUM(CASE WHEN customer_metrics.recent_activity = 1 THEN 1 ELSE 0 END) / COUNT(*) * 100 as retention_rate_pct,\n        AVG(customer_metrics.portfolio_value) as avg_portfolio_value,\n        AVG(customer_metrics.cash_balance) as avg_cash_balance\n    FROM DimCustomer c\n    JOIN (\n        SELECT\n            c.SK_CustomerID,\n            MIN(d.DateValue) as first_trade_date,\n            MAX(d.DateValue) as last_trade_date,\n            JULIANDAY(DATE('now')) - JULIANDAY(MIN(d.DateValue)) as days_since_first_trade,\n            (JULIANDAY(DATE('now')) - JULIANDAY(MIN(d.DateValue))) / 30.44 as months_since_first_trade,\n            COUNT(t.TradeID) as total_trades,\n            SUM(t.Quantity * t.TradePrice) as total_trade_value,\n            SUM(t.Fee + t.Commission + t.Tax) as total_fees,\n            CASE WHEN MAX(d.DateValue) >= DATE('now', '-90 days') THEN 1 ELSE 0 END as recent_activity,\n            COALESCE(SUM(h.CurrentHolding * h.CurrentPrice), 0) as portfolio_value,\n            COALESCE(SUM(cb.Cash), 0) as cash_balance\n        FROM DimCustomer c\n        LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\n        LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\n        LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID\n        LEFT JOIN FactCashBalances cb ON c.SK_CustomerID = cb.SK_CustomerID\n        WHERE c.IsCurrent = 1 AND t.Status = 'Completed'\n        GROUP BY c.SK_CustomerID\n        HAVING COUNT(t.TradeID) > 0\n    ) customer_metrics ON c.SK_CustomerID = customer_metrics.SK_CustomerID\n    WHERE c.IsCurrent = 1\n    GROUP BY\n        CASE\n            WHEN customer_metrics.months_since_first_trade <= 6 THEN '0-6 months'\n            WHEN customer_metrics.months_since_first_trade <= 12 THEN '7-12 months'\n            WHEN customer_metrics.months_since_first_trade <= 24 THEN '1-2 years'\n            WHEN customer_metrics.months_since_first_trade <= 36 THEN '2-3 years'\n            ELSE '3+ years'\n        END\n) tenure_analysis\nORDER BY\n    CASE customer_tenure_months\n        WHEN '0-6 months' THEN 1\n        WHEN '7-12 months' THEN 2\n        WHEN '1-2 years' THEN 3\n        WHEN '2-3 years' THEN 4\n        ELSE 5\n    END;\n",
+"AQ8": "\nSELECT\n    'Trading Pattern Analysis' as analysis_name,\n    trading_frequency_profile,\n    customer_count,\n    avg_trades_per_customer,\n    avg_trade_size,\n    avg_holding_period_days,\n    total_commission_generated,\n    avg_portfolio_turnover_rate\nFROM (\n    SELECT\n        CASE\n            WHEN trades_per_month >= 50 THEN 'High Frequency (50+ trades/month)'\n            WHEN trades_per_month >= 10 THEN 'Active (10-49 trades/month)'\n            WHEN trades_per_month >= 2 THEN 'Regular (2-9 trades/month)'\n            WHEN trades_per_month >= 0.5 THEN 'Occasional (0.5-2 trades/month)'\n            ELSE 'Long-term (<0.5 trades/month)'\n        END as trading_frequency_profile,\n        COUNT(DISTINCT customer_id) as customer_count,\n        AVG(total_trades) as avg_trades_per_customer,\n        AVG(avg_trade_size) as avg_trade_size,\n        AVG(avg_holding_period) as avg_holding_period_days,\n        SUM(total_commission) as total_commission_generated,\n        AVG(portfolio_turnover) as avg_portfolio_turnover_rate\n    FROM (\n        SELECT\n            c.SK_CustomerID as customer_id,\n            c.Tier,\n            COUNT(t.TradeID) as total_trades,\n            COUNT(t.TradeID) / GREATEST(JULIANDAY(MAX(d.DateValue)) - JULIANDAY(MIN(d.DateValue)), 1) * 30.44 as trades_per_month,\n            AVG(t.Quantity * t.TradePrice) as avg_trade_size,\n            AVG(CASE WHEN sell_date.DateValue IS NOT NULL\n                     THEN JULIANDAY(sell_date.DateValue) - JULIANDAY(buy_date.DateValue)\n                     ELSE NULL END) as avg_holding_period,\n            SUM(t.Commission) as total_commission,\n            COALESCE(SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) /\n                     NULLIF(SUM(h.CurrentHolding * h.CurrentPrice), 0), 0) as portfolio_turnover\n        FROM DimCustomer c\n        LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\n        LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\n        LEFT JOIN TradeType tt ON t.Type = tt.TT_ID\n        LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID\n        LEFT JOIN DimDate buy_date ON t.SK_CreateDateID = buy_date.SK_DateID AND tt.TT_IS_SELL = 0\n        LEFT JOIN DimDate sell_date ON t.SK_CloseDateID = sell_date.SK_DateID AND tt.TT_IS_SELL = 1\n        WHERE c.IsCurrent = 1\n          AND t.Status = 'Completed'\n          AND d.CalendarYearID >= {start_year}\n        GROUP BY c.SK_CustomerID, c.Tier\n        HAVING COUNT(t.TradeID) > {min_trades}\n    ) customer_trading_patterns\n    GROUP BY\n        CASE\n            WHEN trades_per_month >= 50 THEN 'High Frequency (50+ trades/month)'\n            WHEN trades_per_month >= 10 THEN 'Active (10-49 trades/month)'\n            WHEN trades_per_month >= 2 THEN 'Regular (2-9 trades/month)'\n            WHEN trades_per_month >= 0.5 THEN 'Occasional (0.5-2 trades/month)'\n            ELSE 'Long-term (<0.5 trades/month)'\n        END\n) pattern_analysis\nORDER BY\n    CASE trading_frequency_profile\n        WHEN 'High Frequency (50+ trades/month)' THEN 1\n        WHEN 'Active (10-49 trades/month)' THEN 2\n        WHEN 'Regular (2-9 trades/month)' THEN 3\n        WHEN 'Occasional (0.5-2 trades/month)' THEN 4\n        ELSE 5\n    END;\n",
+"AQ9": "\nSELECT\n    'Market Maker and Liquidity Analysis' as analysis_name,\n    s.Symbol,\n    s.Name as security_name,\n    COUNT(DISTINCT t.SK_BrokerID) as market_makers,\n    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) as total_sell_orders,\n    COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) as total_buy_orders,\n    AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) as avg_sell_price,\n    AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END) as avg_buy_price,\n    (AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) -\n     AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END)) as bid_ask_spread,\n    (AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) -\n     AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END)) /\n     AVG(t.TradePrice) * 100 as bid_ask_spread_pct,\n    SUM(t.Quantity) as total_volume,\n    AVG(mh.Volume) as avg_daily_volume,\n    SUM(t.Quantity) / AVG(mh.Volume) as market_share_of_volume,\n    STDDEV(t.TradePrice) as price_volatility,\n    STDDEV(t.TradePrice) / AVG(t.TradePrice) * 100 as coefficient_of_variation\nFROM DimSecurity s\nJOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID\nJOIN TradeType tt ON t.Type = tt.TT_ID\nJOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID\nJOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nWHERE s.IsCurrent = 1\n  AND t.Status = 'Completed'\n  AND d.CalendarYearID >= {start_year}\n  AND d.CalendarYearID <= {end_year}\nGROUP BY s.Symbol, s.Name\nHAVING COUNT(t.TradeID) > {min_trades}\n  AND COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) > 0\n  AND COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) > 0\nORDER BY market_share_of_volume DESC, bid_ask_spread_pct ASC\nLIMIT {limit_rows};\n",
+"AQ10": "\nSELECT\n    'Regulatory Compliance and Risk Monitoring' as analysis_name,\n    c.SK_CustomerID,\n    c.Tier,\n    c.Country,\n    COUNT(t.TradeID) as total_trades,\n    SUM(t.Quantity * t.TradePrice) as total_trade_value,\n    MAX(t.Quantity * t.TradePrice) as largest_single_trade,\n    COUNT(CASE WHEN t.Quantity * t.TradePrice > {large_trade_threshold} THEN 1 END) as large_trades,\n    COUNT(CASE WHEN d.DateValue = current_date THEN 1 END) as same_day_trades,\n    COUNT(DISTINCT t.SK_SecurityID) as securities_traded,\n    SUM(h.CurrentHolding * h.CurrentPrice) as current_portfolio_value,\n    SUM(h.CurrentHolding * h.CurrentPrice) / c.NetWorth * 100 as portfolio_to_networth_pct,\n    COUNT(CASE WHEN wash_sales.wash_sale_flag = 1 THEN 1 END) as potential_wash_sales,\n    AVG(t.Commission) / AVG(t.Quantity * t.TradePrice) * 100 as avg_commission_rate_pct,\n    CASE\n        WHEN COUNT(CASE WHEN t.Quantity * t.TradePrice > {large_trade_threshold} THEN 1 END) > {large_trade_count_threshold} THEN 'HIGH RISK'\n        WHEN SUM(h.CurrentHolding * h.CurrentPrice) / c.NetWorth > 0.8 THEN 'CONCENTRATION RISK'\n        WHEN COUNT(CASE WHEN wash_sales.wash_sale_flag = 1 THEN 1 END) > 0 THEN 'WASH SALE RISK'\n        WHEN COUNT(CASE WHEN d.DateValue = current_date THEN 1 END) > {same_day_trade_threshold} THEN 'DAY TRADING RISK'\n        ELSE 'NORMAL'\n    END as risk_profile\nFROM DimCustomer c\nLEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID\nLEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID\nLEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID\nLEFT JOIN (\n    SELECT\n        t1.SK_CustomerID,\n        t1.SK_SecurityID,\n        t1.TradeID,\n        CASE WHEN t2.TradeID IS NOT NULL THEN 1 ELSE 0 END as wash_sale_flag\n    FROM FactTrade t1\n    LEFT JOIN DimDate t1_date ON t1.SK_CreateDateID = t1_date.SK_DateID\n    LEFT JOIN FactTrade t2 ON t1.SK_CustomerID = t2.SK_CustomerID\n                          AND t1.SK_SecurityID = t2.SK_SecurityID\n                          AND t1.TradeID != t2.TradeID\n    LEFT JOIN DimDate t2_date ON t2.SK_CreateDateID = t2_date.SK_DateID\n                              AND ABS(JULIANDAY(t1_date.DateValue) - JULIANDAY(t2_date.DateValue)) <= 30\n) wash_sales ON t.TradeID = wash_sales.TradeID\nWHERE c.IsCurrent = 1\n  AND t.Status = 'Completed'\n  AND d.CalendarYearID >= {start_year}\nGROUP BY c.SK_CustomerID, c.Tier, c.Country, c.NetWorth\nHAVING COUNT(t.TradeID) > {min_trades}\nORDER BY\n    CASE risk_profile\n        WHEN 'HIGH RISK' THEN 1\n        WHEN 'CONCENTRATION RISK' THEN 2\n        WHEN 'WASH SALE RISK' THEN 3\n        WHEN 'DAY TRADING RISK' THEN 4\n        ELSE 5\n    END,\n    total_trade_value DESC\nLIMIT {limit_rows};\n"
+},
+"metadata": {
+"AQ1": {"relies_on": ["DimCustomer", "FactTrade", "DimDate"], "query_type": "analytical", "category": "customer_profitability", "description": "Customer profitability analysis by tier and demographics", "complexity": "medium"},
+"AQ2": {"relies_on": ["DimSecurity", "DimCompany", "FactTrade", "FactMarketHistory", "DimDate"], "query_type": "analytical", "category": "security_performance", "description": "Security performance analysis with price movements and volatility", "complexity": "high"},
+"AQ3": {"relies_on": ["DimBroker", "FactTrade", "TradeType", "DimDate"], "query_type": "analytical", "category": "broker_performance", "description": "Broker performance analysis with commission and trade volume metrics", "complexity": "medium"},
+"AQ4": {"relies_on": ["DimDate", "FactTrade", "FactMarketHistory", "TradeType"], "query_type": "analytical", "category": "market_trends", "description": "Market trend analysis with time-series aggregations", "complexity": "high"},
+"AQ5": {"relies_on": ["DimCustomer", "FactHoldings", "FactCashBalances", "FactMarketHistory", "DimSecurity", "DimCompany", "FactWatches"], "query_type": "analytical", "category": "portfolio_analysis", "description": "Portfolio analysis with risk and return calculations", "complexity": "high"},
+"AQ6": {"relies_on": ["DimCompany", "DimSecurity", "FactTrade", "FactMarketHistory", "DimDate"], "query_type": "analytical", "category": "industry_analysis", "description": "Industry sector performance analysis", "complexity": "medium"},
+"AQ7": {"relies_on": ["DimCustomer", "FactTrade", "DimDate", "FactHoldings", "FactCashBalances"], "query_type": "analytical", "category": "customer_lifecycle", "description": "Customer lifecycle and retention analysis", "complexity": "high"},
+"AQ8": {"relies_on": ["DimCustomer", "FactTrade", "DimDate", "TradeType", "FactHoldings"], "query_type": "analytical", "category": "trading_patterns", "description": "Trading pattern analysis - High frequency vs long-term investors", "complexity": "high"},
+"AQ9": {"relies_on": ["DimSecurity", "FactTrade", "TradeType", "FactMarketHistory", "DimDate"], "query_type": "analytical", "category": "market_microstructure", "description": "Market maker analysis - Bid/ask spread and liquidity provision", "complexity": "high"},
+"AQ10": {"relies_on": ["DimCustomer", "FactTrade", "FactHoldings", "DimDate"], "query_type": "analytical", "category": "risk_compliance", "description": "Regulatory compliance and risk monitoring", "complexity": "high"}
+}
+}"""
+
+
+@lru_cache(maxsize=1)
+def _analytical_query_data() -> dict[str, Any]:
+    return json.loads(_ANALYTICAL_QUERY_DATA_JSON)
 
 
 class TPCDIAnalyticalQueries(ParameterizedQueryManager):
@@ -26,677 +60,36 @@ class TPCDIAnalyticalQueries(ParameterizedQueryManager):
     invalid_query_label = "analytical query"
 
     def __init__(self) -> None:
-        """Initialize the analytical query manager."""
         self._queries = self._load_analytical_queries()
         self._query_metadata = self._load_analytical_metadata()
 
     def _load_analytical_queries(self) -> dict[str, str]:
-        """Load all business intelligence analytical queries.
-
-        Returns:
-            Dictionary mapping analytical query IDs to SQL text
-        """
-        queries = {}
-
-        # AQ1: Customer profitability analysis by tier and demographics
-        queries["AQ1"] = """
-SELECT
-    'Customer Profitability Analysis' as analysis_name,
-    c.Tier,
-    c.Country,
-    c.Gender,
-    COUNT(DISTINCT c.SK_CustomerID) as customer_count,
-    COUNT(t.TradeID) as total_trades,
-    SUM(t.Quantity * t.TradePrice) as total_trade_value,
-    SUM(t.Fee + t.Commission + t.Tax) as total_fees_generated,
-    AVG(t.TradePrice) as avg_trade_price,
-    AVG(c.NetWorth) as avg_net_worth,
-    AVG(c.CreditRating) as avg_credit_rating,
-    SUM(t.Quantity * t.TradePrice) / COUNT(DISTINCT c.SK_CustomerID) as revenue_per_customer,
-    SUM(t.Fee + t.Commission + t.Tax) / COUNT(DISTINCT c.SK_CustomerID) as fees_per_customer,
-    COUNT(t.TradeID) / COUNT(DISTINCT c.SK_CustomerID) as trades_per_customer
-FROM DimCustomer c
-LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-WHERE c.IsCurrent = 1
-  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})
-  AND t.Status = 'Completed'
-GROUP BY c.Tier, c.Country, c.Gender
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_fees_generated DESC, total_trade_value DESC
-LIMIT {limit_rows};
-"""
-
-        # AQ2: Security performance analysis with price movements and volatility
-        queries["AQ2"] = """
-SELECT
-    'Security Performance Analysis' as analysis_name,
-    s.Symbol,
-    s.Name as security_name,
-    comp.Name as company_name,
-    comp.Industry,
-    comp.SPrating,
-    COUNT(t.TradeID) as total_trades,
-    SUM(t.Quantity) as total_volume,
-    AVG(t.TradePrice) as avg_trade_price,
-    MIN(t.TradePrice) as min_trade_price,
-    MAX(t.TradePrice) as max_trade_price,
-    (MAX(t.TradePrice) - MIN(t.TradePrice)) / MIN(t.TradePrice) * 100 as price_volatility_pct,
-    SUM(t.Quantity * t.TradePrice) as total_market_value,
-    AVG(mh.ClosePrice) as avg_market_close,
-    AVG(mh.Volume) as avg_daily_volume,
-    AVG(mh.PERatio) as avg_pe_ratio,
-    AVG(mh.Yield) as avg_dividend_yield,
-    MAX(mh.FiftyTwoWeekHigh) as week52_high,
-    MIN(mh.FiftyTwoWeekLow) as week52_low
-FROM DimSecurity s
-JOIN DimCompany comp ON s.SK_CompanyID = comp.SK_CompanyID
-LEFT JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID
-LEFT JOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID
-LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-WHERE s.IsCurrent = 1
-  AND comp.IsCurrent = 1
-  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})
-  AND t.Status = 'Completed'
-GROUP BY s.Symbol, s.Name, comp.Name, comp.Industry, comp.SPrating
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_market_value DESC, price_volatility_pct DESC
-LIMIT {limit_rows};
-"""
-
-        # AQ3: Broker performance analysis with commission and trade volume metrics
-        queries["AQ3"] = """
-SELECT
-    'Broker Performance Analysis' as analysis_name,
-    b.FirstName || ' ' || b.LastName as broker_name,
-    b.Branch,
-    b.Office,
-    COUNT(DISTINCT t.SK_CustomerID) as unique_customers,
-    COUNT(t.TradeID) as total_trades,
-    SUM(t.Quantity) as total_quantity_traded,
-    SUM(t.Quantity * t.TradePrice) as total_trade_value,
-    SUM(t.Commission) as total_commission_generated,
-    AVG(t.Commission) as avg_commission_per_trade,
-    AVG(t.TradePrice) as avg_trade_price,
-    SUM(t.Commission) / SUM(t.Quantity * t.TradePrice) * 100 as commission_rate_pct,
-    COUNT(t.TradeID) / COUNT(DISTINCT t.SK_CustomerID) as trades_per_customer,
-    SUM(t.Quantity * t.TradePrice) / COUNT(DISTINCT t.SK_CustomerID) as value_per_customer,
-    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) as sell_trades,
-    COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) as buy_trades,
-    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) / COUNT(t.TradeID) * 100 as sell_ratio_pct
-FROM DimBroker b
-LEFT JOIN FactTrade t ON b.SK_BrokerID = t.SK_BrokerID
-LEFT JOIN TradeType tt ON t.Type = tt.TT_ID
-LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-WHERE b.IsCurrent = 1
-  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})
-  AND t.Status = 'Completed'
-GROUP BY b.FirstName, b.LastName, b.Branch, b.Office
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_commission_generated DESC, total_trade_value DESC
-LIMIT {limit_rows};
-"""
-
-        # AQ4: Market trend analysis with time-series aggregations
-        queries["AQ4"] = """
-SELECT
-    'Market Trend Analysis' as analysis_name,
-    d.CalendarYearID,
-    d.CalendarQtrID,
-    d.CalendarMonthID,
-    COUNT(t.TradeID) as monthly_trade_count,
-    COUNT(DISTINCT t.SK_CustomerID) as active_customers,
-    COUNT(DISTINCT t.SK_SecurityID) as securities_traded,
-    SUM(t.Quantity) as monthly_volume,
-    SUM(t.Quantity * t.TradePrice) as monthly_trade_value,
-    AVG(t.TradePrice) as avg_monthly_price,
-    SUM(t.Fee + t.Commission + t.Tax) as monthly_fees,
-    AVG(mh.ClosePrice) as avg_market_close,
-    AVG(mh.Volume) as avg_market_volume,
-    SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) as sell_volume,
-    SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN t.Quantity * t.TradePrice ELSE 0 END) as buy_volume,
-    (SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) -
-     SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN t.Quantity * t.TradePrice ELSE 0 END)) as net_market_flow,
-    LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID) as prev_month_value,
-    (SUM(t.Quantity * t.TradePrice) - LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID)) /
-     LAG(SUM(t.Quantity * t.TradePrice)) OVER (ORDER BY d.CalendarYearID, d.CalendarMonthID) * 100 as month_over_month_growth_pct
-FROM DimDate d
-LEFT JOIN FactTrade t ON d.SK_DateID = t.SK_CreateDateID
-LEFT JOIN FactMarketHistory mh ON d.SK_DateID = mh.SK_DateID
-LEFT JOIN TradeType tt ON t.Type = tt.TT_ID
-WHERE d.CalendarYearID >= {start_year}
-  AND d.CalendarYearID <= {end_year}
-  AND t.Status = 'Completed'
-GROUP BY d.CalendarYearID, d.CalendarQtrID, d.CalendarMonthID
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY d.CalendarYearID, d.CalendarMonthID;
-"""
-
-        # AQ5: Portfolio analysis with risk and return calculations
-        queries["AQ5"] = """
-WITH price_returns AS (
-    SELECT
-        mh.SK_SecurityID,
-        mh.SK_DateID,
-        mh.ClosePrice,
-        mh.PERatio,
-        mh.Yield,
-        (mh.ClosePrice / LAG(mh.ClosePrice) OVER (PARTITION BY mh.SK_SecurityID ORDER BY mh.SK_DateID) - 1) as daily_return
-    FROM FactMarketHistory mh
-)
-SELECT
-    'Portfolio Risk and Return Analysis' as analysis_name,
-    c.SK_CustomerID,
-    c.Tier,
-    c.NetWorth,
-    c.CreditRating,
-    COUNT(DISTINCT h.SK_SecurityID) as portfolio_diversification,
-    SUM(h.CurrentHolding * h.CurrentPrice) as total_portfolio_value,
-    SUM(cb.Cash) as cash_balance,
-    (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) as total_account_value,
-    SUM(h.CurrentHolding * h.CurrentPrice) / (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) * 100 as equity_allocation_pct,
-    SUM(cb.Cash) / (SUM(h.CurrentHolding * h.CurrentPrice) + SUM(cb.Cash)) * 100 as cash_allocation_pct,
-    AVG(pr.PERatio) as avg_portfolio_pe_ratio,
-    AVG(pr.Yield) as avg_portfolio_yield,
-    STDDEV(pr.daily_return) * 100 as portfolio_volatility_pct,
-    SUM(CASE WHEN comp.SPrating IN ('AAA', 'AA+', 'AA', 'AA-') THEN h.CurrentHolding * h.CurrentPrice ELSE 0 END) /
-        SUM(h.CurrentHolding * h.CurrentPrice) * 100 as high_grade_allocation_pct,
-    COUNT(fw.SK_SecurityID) as watchlist_securities
-FROM DimCustomer c
-LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID
-LEFT JOIN FactCashBalances cb ON c.SK_CustomerID = cb.SK_CustomerID
-LEFT JOIN price_returns pr ON h.SK_SecurityID = pr.SK_SecurityID AND h.SK_DateID = pr.SK_DateID
-LEFT JOIN DimSecurity s ON h.SK_SecurityID = s.SK_SecurityID
-LEFT JOIN DimCompany comp ON s.SK_CompanyID = comp.SK_CompanyID
-LEFT JOIN FactWatches fw ON c.SK_CustomerID = fw.SK_CustomerID
-WHERE c.IsCurrent = 1
-  AND s.IsCurrent = 1
-  AND comp.IsCurrent = 1
-  AND h.CurrentHolding > 0
-GROUP BY c.SK_CustomerID, c.Tier, c.NetWorth, c.CreditRating
-HAVING SUM(h.CurrentHolding * h.CurrentPrice) > {min_portfolio_value}
-ORDER BY total_portfolio_value DESC
-LIMIT {limit_rows};
-"""
-
-        # AQ6: Industry sector performance analysis
-        queries["AQ6"] = """
-SELECT
-    'Industry Sector Performance Analysis' as analysis_name,
-    comp.Industry,
-    COUNT(DISTINCT comp.SK_CompanyID) as companies_in_sector,
-    COUNT(DISTINCT s.SK_SecurityID) as securities_in_sector,
-    COUNT(t.TradeID) as total_sector_trades,
-    SUM(t.Quantity * t.TradePrice) as total_sector_value,
-    AVG(t.TradePrice) as avg_sector_price,
-    SUM(t.Quantity) as total_sector_volume,
-    AVG(comp.MarketCap) as avg_market_cap,
-    AVG(mh.PERatio) as avg_sector_pe_ratio,
-    AVG(mh.Yield) as avg_sector_yield,
-    AVG(mh.ClosePrice) as avg_closing_price,
-    STDDEV(mh.ClosePrice) as price_volatility,
-    COUNT(CASE WHEN comp.SPrating IN ('AAA', 'AA+', 'AA', 'AA-', 'A+', 'A', 'A-') THEN 1 END) as investment_grade_companies,
-    COUNT(CASE WHEN comp.SPrating IN ('BBB+', 'BBB', 'BBB-', 'BB+', 'BB', 'BB-', 'B+', 'B', 'B-', 'CCC') THEN 1 END) as speculative_grade_companies,
-    SUM(t.Quantity * t.TradePrice) / SUM(SUM(t.Quantity * t.TradePrice)) OVER () * 100 as sector_market_share_pct
-FROM DimCompany comp
-JOIN DimSecurity s ON comp.SK_CompanyID = s.SK_CompanyID
-LEFT JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID
-LEFT JOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID
-LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-WHERE comp.IsCurrent = 1
-  AND s.IsCurrent = 1
-  AND (d.CalendarYearID >= {start_year} AND d.CalendarYearID <= {end_year})
-  AND t.Status = 'Completed'
-GROUP BY comp.Industry
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY total_sector_value DESC, avg_sector_pe_ratio ASC
-LIMIT {limit_rows};
-"""
-
-        # AQ7: Customer lifecycle and retention analysis
-        queries["AQ7"] = """
-SELECT
-    'Customer Lifecycle and Retention Analysis' as analysis_name,
-    customer_tenure_months,
-    customer_count,
-    avg_trades_per_customer,
-    avg_trade_value_per_customer,
-    avg_fees_per_customer,
-    retention_rate_pct,
-    avg_portfolio_value,
-    avg_cash_balance
-FROM (
-    SELECT
-        CASE
-            WHEN months_since_first_trade <= 6 THEN '0-6 months'
-            WHEN months_since_first_trade <= 12 THEN '7-12 months'
-            WHEN months_since_first_trade <= 24 THEN '1-2 years'
-            WHEN months_since_first_trade <= 36 THEN '2-3 years'
-            ELSE '3+ years'
-        END as customer_tenure_months,
-        COUNT(DISTINCT c.SK_CustomerID) as customer_count,
-        AVG(customer_metrics.total_trades) as avg_trades_per_customer,
-        AVG(customer_metrics.total_trade_value) as avg_trade_value_per_customer,
-        AVG(customer_metrics.total_fees) as avg_fees_per_customer,
-        SUM(CASE WHEN customer_metrics.recent_activity = 1 THEN 1 ELSE 0 END) / COUNT(*) * 100 as retention_rate_pct,
-        AVG(customer_metrics.portfolio_value) as avg_portfolio_value,
-        AVG(customer_metrics.cash_balance) as avg_cash_balance
-    FROM DimCustomer c
-    JOIN (
-        SELECT
-            c.SK_CustomerID,
-            MIN(d.DateValue) as first_trade_date,
-            MAX(d.DateValue) as last_trade_date,
-            JULIANDAY(DATE('now')) - JULIANDAY(MIN(d.DateValue)) as days_since_first_trade,
-            (JULIANDAY(DATE('now')) - JULIANDAY(MIN(d.DateValue))) / 30.44 as months_since_first_trade,
-            COUNT(t.TradeID) as total_trades,
-            SUM(t.Quantity * t.TradePrice) as total_trade_value,
-            SUM(t.Fee + t.Commission + t.Tax) as total_fees,
-            CASE WHEN MAX(d.DateValue) >= DATE('now', '-90 days') THEN 1 ELSE 0 END as recent_activity,
-            COALESCE(SUM(h.CurrentHolding * h.CurrentPrice), 0) as portfolio_value,
-            COALESCE(SUM(cb.Cash), 0) as cash_balance
-        FROM DimCustomer c
-        LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-        LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-        LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID
-        LEFT JOIN FactCashBalances cb ON c.SK_CustomerID = cb.SK_CustomerID
-        WHERE c.IsCurrent = 1 AND t.Status = 'Completed'
-        GROUP BY c.SK_CustomerID
-        HAVING COUNT(t.TradeID) > 0
-    ) customer_metrics ON c.SK_CustomerID = customer_metrics.SK_CustomerID
-    WHERE c.IsCurrent = 1
-    GROUP BY
-        CASE
-            WHEN customer_metrics.months_since_first_trade <= 6 THEN '0-6 months'
-            WHEN customer_metrics.months_since_first_trade <= 12 THEN '7-12 months'
-            WHEN customer_metrics.months_since_first_trade <= 24 THEN '1-2 years'
-            WHEN customer_metrics.months_since_first_trade <= 36 THEN '2-3 years'
-            ELSE '3+ years'
-        END
-) tenure_analysis
-ORDER BY
-    CASE customer_tenure_months
-        WHEN '0-6 months' THEN 1
-        WHEN '7-12 months' THEN 2
-        WHEN '1-2 years' THEN 3
-        WHEN '2-3 years' THEN 4
-        ELSE 5
-    END;
-"""
-
-        # AQ8: Trading pattern analysis - High frequency vs long-term investors
-        queries["AQ8"] = """
-SELECT
-    'Trading Pattern Analysis' as analysis_name,
-    trading_frequency_profile,
-    customer_count,
-    avg_trades_per_customer,
-    avg_trade_size,
-    avg_holding_period_days,
-    total_commission_generated,
-    avg_portfolio_turnover_rate
-FROM (
-    SELECT
-        CASE
-            WHEN trades_per_month >= 50 THEN 'High Frequency (50+ trades/month)'
-            WHEN trades_per_month >= 10 THEN 'Active (10-49 trades/month)'
-            WHEN trades_per_month >= 2 THEN 'Regular (2-9 trades/month)'
-            WHEN trades_per_month >= 0.5 THEN 'Occasional (0.5-2 trades/month)'
-            ELSE 'Long-term (<0.5 trades/month)'
-        END as trading_frequency_profile,
-        COUNT(DISTINCT customer_id) as customer_count,
-        AVG(total_trades) as avg_trades_per_customer,
-        AVG(avg_trade_size) as avg_trade_size,
-        AVG(avg_holding_period) as avg_holding_period_days,
-        SUM(total_commission) as total_commission_generated,
-        AVG(portfolio_turnover) as avg_portfolio_turnover_rate
-    FROM (
-        SELECT
-            c.SK_CustomerID as customer_id,
-            c.Tier,
-            COUNT(t.TradeID) as total_trades,
-            COUNT(t.TradeID) / GREATEST(JULIANDAY(MAX(d.DateValue)) - JULIANDAY(MIN(d.DateValue)), 1) * 30.44 as trades_per_month,
-            AVG(t.Quantity * t.TradePrice) as avg_trade_size,
-            AVG(CASE WHEN sell_date.DateValue IS NOT NULL
-                     THEN JULIANDAY(sell_date.DateValue) - JULIANDAY(buy_date.DateValue)
-                     ELSE NULL END) as avg_holding_period,
-            SUM(t.Commission) as total_commission,
-            COALESCE(SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN t.Quantity * t.TradePrice ELSE 0 END) /
-                     NULLIF(SUM(h.CurrentHolding * h.CurrentPrice), 0), 0) as portfolio_turnover
-        FROM DimCustomer c
-        LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-        LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-        LEFT JOIN TradeType tt ON t.Type = tt.TT_ID
-        LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID
-        LEFT JOIN DimDate buy_date ON t.SK_CreateDateID = buy_date.SK_DateID AND tt.TT_IS_SELL = 0
-        LEFT JOIN DimDate sell_date ON t.SK_CloseDateID = sell_date.SK_DateID AND tt.TT_IS_SELL = 1
-        WHERE c.IsCurrent = 1
-          AND t.Status = 'Completed'
-          AND d.CalendarYearID >= {start_year}
-        GROUP BY c.SK_CustomerID, c.Tier
-        HAVING COUNT(t.TradeID) > {min_trades}
-    ) customer_trading_patterns
-    GROUP BY
-        CASE
-            WHEN trades_per_month >= 50 THEN 'High Frequency (50+ trades/month)'
-            WHEN trades_per_month >= 10 THEN 'Active (10-49 trades/month)'
-            WHEN trades_per_month >= 2 THEN 'Regular (2-9 trades/month)'
-            WHEN trades_per_month >= 0.5 THEN 'Occasional (0.5-2 trades/month)'
-            ELSE 'Long-term (<0.5 trades/month)'
-        END
-) pattern_analysis
-ORDER BY
-    CASE trading_frequency_profile
-        WHEN 'High Frequency (50+ trades/month)' THEN 1
-        WHEN 'Active (10-49 trades/month)' THEN 2
-        WHEN 'Regular (2-9 trades/month)' THEN 3
-        WHEN 'Occasional (0.5-2 trades/month)' THEN 4
-        ELSE 5
-    END;
-"""
-
-        # AQ9: Market maker analysis - Bid/ask spread and liquidity provision
-        queries["AQ9"] = """
-SELECT
-    'Market Maker and Liquidity Analysis' as analysis_name,
-    s.Symbol,
-    s.Name as security_name,
-    COUNT(DISTINCT t.SK_BrokerID) as market_makers,
-    COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) as total_sell_orders,
-    COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) as total_buy_orders,
-    AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) as avg_sell_price,
-    AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END) as avg_buy_price,
-    (AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) -
-     AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END)) as bid_ask_spread,
-    (AVG(CASE WHEN tt.TT_IS_SELL = 1 THEN t.TradePrice END) -
-     AVG(CASE WHEN tt.TT_IS_SELL = 0 THEN t.TradePrice END)) /
-     AVG(t.TradePrice) * 100 as bid_ask_spread_pct,
-    SUM(t.Quantity) as total_volume,
-    AVG(mh.Volume) as avg_daily_volume,
-    SUM(t.Quantity) / AVG(mh.Volume) as market_share_of_volume,
-    STDDEV(t.TradePrice) as price_volatility,
-    STDDEV(t.TradePrice) / AVG(t.TradePrice) * 100 as coefficient_of_variation
-FROM DimSecurity s
-JOIN FactTrade t ON s.SK_SecurityID = t.SK_SecurityID
-JOIN TradeType tt ON t.Type = tt.TT_ID
-JOIN FactMarketHistory mh ON s.SK_SecurityID = mh.SK_SecurityID
-JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-WHERE s.IsCurrent = 1
-  AND t.Status = 'Completed'
-  AND d.CalendarYearID >= {start_year}
-  AND d.CalendarYearID <= {end_year}
-GROUP BY s.Symbol, s.Name
-HAVING COUNT(t.TradeID) > {min_trades}
-  AND COUNT(CASE WHEN tt.TT_IS_SELL = 1 THEN 1 END) > 0
-  AND COUNT(CASE WHEN tt.TT_IS_SELL = 0 THEN 1 END) > 0
-ORDER BY market_share_of_volume DESC, bid_ask_spread_pct ASC
-LIMIT {limit_rows};
-"""
-
-        # AQ10: Regulatory compliance and risk monitoring
-        queries["AQ10"] = """
-SELECT
-    'Regulatory Compliance and Risk Monitoring' as analysis_name,
-    c.SK_CustomerID,
-    c.Tier,
-    c.Country,
-    COUNT(t.TradeID) as total_trades,
-    SUM(t.Quantity * t.TradePrice) as total_trade_value,
-    MAX(t.Quantity * t.TradePrice) as largest_single_trade,
-    COUNT(CASE WHEN t.Quantity * t.TradePrice > {large_trade_threshold} THEN 1 END) as large_trades,
-    COUNT(CASE WHEN d.DateValue = current_date THEN 1 END) as same_day_trades,
-    COUNT(DISTINCT t.SK_SecurityID) as securities_traded,
-    SUM(h.CurrentHolding * h.CurrentPrice) as current_portfolio_value,
-    SUM(h.CurrentHolding * h.CurrentPrice) / c.NetWorth * 100 as portfolio_to_networth_pct,
-    COUNT(CASE WHEN wash_sales.wash_sale_flag = 1 THEN 1 END) as potential_wash_sales,
-    AVG(t.Commission) / AVG(t.Quantity * t.TradePrice) * 100 as avg_commission_rate_pct,
-    CASE
-        WHEN COUNT(CASE WHEN t.Quantity * t.TradePrice > {large_trade_threshold} THEN 1 END) > {large_trade_count_threshold} THEN 'HIGH RISK'
-        WHEN SUM(h.CurrentHolding * h.CurrentPrice) / c.NetWorth > 0.8 THEN 'CONCENTRATION RISK'
-        WHEN COUNT(CASE WHEN wash_sales.wash_sale_flag = 1 THEN 1 END) > 0 THEN 'WASH SALE RISK'
-        WHEN COUNT(CASE WHEN d.DateValue = current_date THEN 1 END) > {same_day_trade_threshold} THEN 'DAY TRADING RISK'
-        ELSE 'NORMAL'
-    END as risk_profile
-FROM DimCustomer c
-LEFT JOIN FactTrade t ON c.SK_CustomerID = t.SK_CustomerID
-LEFT JOIN FactHoldings h ON c.SK_CustomerID = h.SK_CustomerID
-LEFT JOIN DimDate d ON t.SK_CreateDateID = d.SK_DateID
-LEFT JOIN (
-    SELECT
-        t1.SK_CustomerID,
-        t1.SK_SecurityID,
-        t1.TradeID,
-        CASE WHEN t2.TradeID IS NOT NULL THEN 1 ELSE 0 END as wash_sale_flag
-    FROM FactTrade t1
-    LEFT JOIN DimDate t1_date ON t1.SK_CreateDateID = t1_date.SK_DateID
-    LEFT JOIN FactTrade t2 ON t1.SK_CustomerID = t2.SK_CustomerID
-                          AND t1.SK_SecurityID = t2.SK_SecurityID
-                          AND t1.TradeID != t2.TradeID
-    LEFT JOIN DimDate t2_date ON t2.SK_CreateDateID = t2_date.SK_DateID
-                              AND ABS(JULIANDAY(t1_date.DateValue) - JULIANDAY(t2_date.DateValue)) <= 30
-) wash_sales ON t.TradeID = wash_sales.TradeID
-WHERE c.IsCurrent = 1
-  AND t.Status = 'Completed'
-  AND d.CalendarYearID >= {start_year}
-GROUP BY c.SK_CustomerID, c.Tier, c.Country, c.NetWorth
-HAVING COUNT(t.TradeID) > {min_trades}
-ORDER BY
-    CASE risk_profile
-        WHEN 'HIGH RISK' THEN 1
-        WHEN 'CONCENTRATION RISK' THEN 2
-        WHEN 'WASH SALE RISK' THEN 3
-        WHEN 'DAY TRADING RISK' THEN 4
-        ELSE 5
-    END,
-    total_trade_value DESC
-LIMIT {limit_rows};
-"""
-
-        return queries
+        return dict(_analytical_query_data()["queries"])
 
     def _load_analytical_metadata(self) -> dict[str, dict[str, Any]]:
-        """Load metadata for analytical queries.
-
-        Returns:
-            Dictionary mapping query IDs to their metadata
-        """
-        metadata = {}
-
-        metadata["AQ1"] = {
-            "relies_on": ["DimCustomer", "FactTrade", "DimDate"],
-            "query_type": "analytical",
-            "category": "customer_profitability",
-            "description": "Customer profitability analysis by tier and demographics",
-            "complexity": "medium",
-        }
-
-        metadata["AQ2"] = {
-            "relies_on": [
-                "DimSecurity",
-                "DimCompany",
-                "FactTrade",
-                "FactMarketHistory",
-                "DimDate",
-            ],
-            "query_type": "analytical",
-            "category": "security_performance",
-            "description": "Security performance analysis with price movements and volatility",
-            "complexity": "high",
-        }
-
-        metadata["AQ3"] = {
-            "relies_on": ["DimBroker", "FactTrade", "TradeType", "DimDate"],
-            "query_type": "analytical",
-            "category": "broker_performance",
-            "description": "Broker performance analysis with commission and trade volume metrics",
-            "complexity": "medium",
-        }
-
-        metadata["AQ4"] = {
-            "relies_on": ["DimDate", "FactTrade", "FactMarketHistory", "TradeType"],
-            "query_type": "analytical",
-            "category": "market_trends",
-            "description": "Market trend analysis with time-series aggregations",
-            "complexity": "high",
-        }
-
-        metadata["AQ5"] = {
-            "relies_on": [
-                "DimCustomer",
-                "FactHoldings",
-                "FactCashBalances",
-                "FactMarketHistory",
-                "DimSecurity",
-                "DimCompany",
-                "FactWatches",
-            ],
-            "query_type": "analytical",
-            "category": "portfolio_analysis",
-            "description": "Portfolio analysis with risk and return calculations",
-            "complexity": "high",
-        }
-
-        metadata["AQ6"] = {
-            "relies_on": [
-                "DimCompany",
-                "DimSecurity",
-                "FactTrade",
-                "FactMarketHistory",
-                "DimDate",
-            ],
-            "query_type": "analytical",
-            "category": "industry_analysis",
-            "description": "Industry sector performance analysis",
-            "complexity": "medium",
-        }
-
-        metadata["AQ7"] = {
-            "relies_on": [
-                "DimCustomer",
-                "FactTrade",
-                "DimDate",
-                "FactHoldings",
-                "FactCashBalances",
-            ],
-            "query_type": "analytical",
-            "category": "customer_lifecycle",
-            "description": "Customer lifecycle and retention analysis",
-            "complexity": "high",
-        }
-
-        metadata["AQ8"] = {
-            "relies_on": [
-                "DimCustomer",
-                "FactTrade",
-                "DimDate",
-                "TradeType",
-                "FactHoldings",
-            ],
-            "query_type": "analytical",
-            "category": "trading_patterns",
-            "description": "Trading pattern analysis - High frequency vs long-term investors",
-            "complexity": "high",
-        }
-
-        metadata["AQ9"] = {
-            "relies_on": [
-                "DimSecurity",
-                "FactTrade",
-                "TradeType",
-                "FactMarketHistory",
-                "DimDate",
-            ],
-            "query_type": "analytical",
-            "category": "market_microstructure",
-            "description": "Market maker analysis - Bid/ask spread and liquidity provision",
-            "complexity": "high",
-        }
-
-        metadata["AQ10"] = {
-            "relies_on": ["DimCustomer", "FactTrade", "FactHoldings", "DimDate"],
-            "query_type": "analytical",
-            "category": "risk_compliance",
-            "description": "Regulatory compliance and risk monitoring",
-            "complexity": "high",
-        }
-
-        return metadata
+        return copy_query_metadata(_analytical_query_data()["metadata"])
 
     def _generate_default_params(self, query_id: str) -> dict[str, Any]:
-        """Generate default parameters for analytical queries.
-
-        Args:
-            query_id: Query identifier
-
-        Returns:
-            Dictionary of parameter names to default values
-        """
-        # Default parameters for analytical queries
-        defaults = {
-            # Time ranges (TPC-DI typically covers 5 years)
+        return {
             "start_year": 2015,
             "end_year": 2019,
-            # Minimum thresholds
             "min_trades": 10,
-            "min_portfolio_value": 10000.00,
-            # Risk and compliance thresholds
-            "large_trade_threshold": 100000.00,  # $100K trades
-            "large_trade_count_threshold": 10,  # More than 10 large trades = high risk
-            "same_day_trade_threshold": 4,  # Day trading pattern detection
-            # Result limits
+            "min_portfolio_value": 10000.0,
+            "large_trade_threshold": 100000.0,
+            "large_trade_count_threshold": 10,
+            "same_day_trade_threshold": 4,
             "limit_rows": 50,
         }
 
-        return defaults
-
     def get_query_metadata(self, query_id: str) -> dict[str, Any]:
-        """Get metadata for an analytical query.
-
-        Args:
-            query_id: Query identifier (AQ1, AQ2, etc.)
-
-        Returns:
-            Dictionary containing query metadata
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
         return self._get_query_metadata_copy(self._query_metadata, query_id, "analytical query")
 
     def get_queries_by_category(self, category: str) -> list[str]:
-        """Get all analytical queries of a specific category.
-
-        Args:
-            category: Category name (customer_profitability, security_performance,
-                     broker_performance, market_trends, portfolio_analysis, etc.)
-
-        Returns:
-            List of query IDs in the specified category
-        """
-        valid_categories = {
-            "customer_profitability",
-            "security_performance",
-            "broker_performance",
-            "market_trends",
-            "portfolio_analysis",
-            "industry_analysis",
-            "customer_lifecycle",
-            "trading_patterns",
-            "market_microstructure",
-            "risk_compliance",
-        }
-        self._validate_selector_value(category, valid_categories, "category", plural="categories")
-        return self._query_ids_by_metadata(self._query_metadata, "category", category)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "category", category, "category", plural="categories"
+        )
 
     def get_queries_by_complexity(self, complexity: str) -> list[str]:
-        """Get all analytical queries of a specific complexity level.
-
-        Args:
-            complexity: Complexity level (low, medium, high)
-
-        Returns:
-            List of query IDs with the specified complexity
-        """
-        valid_complexities = {"low", "medium", "high"}
-        self._validate_selector_value(complexity, valid_complexities, "complexity", plural="complexities")
-        return self._query_ids_by_metadata(self._query_metadata, "complexity", complexity)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "complexity", complexity, "complexity", plural="complexities"
+        )

--- a/benchbox/core/tpcdi/query_etl.py
+++ b/benchbox/core/tpcdi/query_etl.py
@@ -15,9 +15,39 @@ This implementation is based on the TPC-DI specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
+from functools import lru_cache
 from typing import Any
 
-from benchbox.core.query_manager import ParameterizedQueryManager
+from benchbox.core.query_manager import ParameterizedQueryManager, copy_query_metadata
+
+_ETL_QUERY_DATA_JSON = r"""{
+"queries": {
+"EQ1": "\nSELECT\n    'Batch Processing Validation' as validation_name,\n    batch_id,\n    table_name,\n    records_loaded,\n    processing_time_seconds,\n    records_per_second,\n    error_count,\n    warning_count,\n    CASE\n        WHEN error_count = 0 AND records_per_second > {min_throughput} THEN 'PASS'\n        WHEN error_count = 0 AND records_per_second <= {min_throughput} THEN 'SLOW'\n        ELSE 'FAIL'\n    END as batch_status\nFROM (\n    SELECT\n        1 as batch_id,\n        'DimCustomer' as table_name,\n        COUNT(*) as records_loaded,\n        60.0 as processing_time_seconds,  -- Simulated processing time\n        COUNT(*) / 60.0 as records_per_second,\n        SUM(CASE WHEN Status IS NULL OR CustomerID IS NULL THEN 1 ELSE 0 END) as error_count,\n        SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) as warning_count\n    FROM DimCustomer\n    WHERE BatchID = 1\n    UNION ALL\n    SELECT\n        1 as batch_id,\n        'DimAccount' as table_name,\n        COUNT(*) as records_loaded,\n        45.0 as processing_time_seconds,\n        COUNT(*) / 45.0 as records_per_second,\n        SUM(CASE WHEN Status IS NULL OR AccountID IS NULL THEN 1 ELSE 0 END) as error_count,\n        SUM(CASE WHEN SK_CustomerID IS NULL THEN 1 ELSE 0 END) as warning_count\n    FROM DimAccount\n    WHERE BatchID = 1\n    UNION ALL\n    SELECT\n        1 as batch_id,\n        'FactTrade' as table_name,\n        COUNT(*) as records_loaded,\n        120.0 as processing_time_seconds,\n        COUNT(*) / 120.0 as records_per_second,\n        SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL THEN 1 ELSE 0 END) as error_count,\n        SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 THEN 1 ELSE 0 END) as warning_count\n    FROM FactTrade\n    WHERE BatchID = 1\n) batch_metrics\nORDER BY batch_id, table_name;\n",
+"EQ2": "\nSELECT\n    'Incremental Load Validation' as validation_name,\n    table_name,\n    batch_id,\n    new_records,\n    updated_records,\n    unchanged_records,\n    total_records,\n    new_records / total_records * 100 as new_record_pct,\n    updated_records / total_records * 100 as updated_record_pct,\n    CASE\n        WHEN (new_records + updated_records) > 0 AND unchanged_records >= 0 THEN 'PASS'\n        WHEN (new_records + updated_records) = 0 THEN 'NO CHANGES'\n        ELSE 'FAIL'\n    END as incremental_status\nFROM (\n    SELECT\n        'DimCustomer' as table_name,\n        BatchID as batch_id,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,\n        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records\n    FROM DimCustomer\n    WHERE BatchID >= {min_batch_id}\n    GROUP BY BatchID\n    UNION ALL\n    SELECT\n        'DimAccount' as table_name,\n        BatchID as batch_id,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,\n        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records\n    FROM DimAccount\n    WHERE BatchID >= {min_batch_id}\n    GROUP BY BatchID\n    UNION ALL\n    SELECT\n        'DimSecurity' as table_name,\n        BatchID as batch_id,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,\n        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,\n        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records\n    FROM DimSecurity\n    WHERE BatchID >= {min_batch_id}\n    GROUP BY BatchID\n) incremental_metrics\nORDER BY batch_id, table_name;\n",
+"EQ3": "\nSELECT\n    'Data Transformation Validation' as validation_name,\n    transformation_type,\n    source_records,\n    target_records,\n    transformation_success_rate,\n    data_quality_score,\n    CASE\n        WHEN transformation_success_rate >= {success_rate_threshold} AND data_quality_score >= {quality_score_threshold} THEN 'PASS'\n        WHEN transformation_success_rate >= {success_rate_threshold} THEN 'QUALITY ISSUES'\n        ELSE 'TRANSFORMATION FAILURE'\n    END as transformation_status\nFROM (\n    SELECT\n        'Customer Demographics' as transformation_type,\n        (SELECT COUNT(*) FROM (\n            -- Simulated source data count\n            SELECT COUNT(*) as source_count FROM DimCustomer WHERE BatchID = 1\n        )) as source_records,\n        COUNT(*) as target_records,\n        COUNT(*) / (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1) * 100 as transformation_success_rate,\n        100 - (SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score\n    FROM DimCustomer\n    WHERE BatchID = 1\n    UNION ALL\n    SELECT\n        'Account Information' as transformation_type,\n        (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1) as source_records,\n        COUNT(*) as target_records,\n        100.0 as transformation_success_rate,  -- Assume 100% transformation success\n        100 - (SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score\n    FROM DimAccount\n    WHERE BatchID = 1\n    UNION ALL\n    SELECT\n        'Trade Transactions' as transformation_type,\n        (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1) as source_records,\n        COUNT(*) as target_records,\n        100.0 as transformation_success_rate,\n        100 - (SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR TradePrice <= 0 THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score\n    FROM FactTrade\n    WHERE BatchID = 1\n    UNION ALL\n    SELECT\n        'Market History Data' as transformation_type,\n        (SELECT COUNT(*) FROM FactMarketHistory WHERE BatchID = 1) as source_records,\n        COUNT(*) as target_records,\n        100.0 as transformation_success_rate,\n        100 - (SUM(CASE WHEN SK_SecurityID IS NULL OR ClosePrice <= 0 OR Volume < 0 THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score\n    FROM FactMarketHistory\n    WHERE BatchID = 1\n) transformation_metrics;\n",
+"EQ4": "\nSELECT\n    'SCD Type 2 Processing Validation' as validation_name,\n    table_name,\n    business_key_count,\n    total_scd_records,\n    current_records,\n    historical_records,\n    scd_processing_errors,\n    CASE\n        WHEN scd_processing_errors = 0 AND current_records = business_key_count THEN 'PASS'\n        WHEN scd_processing_errors = 0 THEN 'HISTORICAL DATA ISSUES'\n        ELSE 'SCD PROCESSING ERRORS'\n    END as scd_status\nFROM (\n    SELECT\n        'DimCustomer' as table_name,\n        COUNT(DISTINCT CustomerID) as business_key_count,\n        COUNT(*) as total_scd_records,\n        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,\n        -- Count SCD processing errors\n        (SELECT COUNT(*) FROM (\n            SELECT CustomerID\n            FROM DimCustomer\n            WHERE IsCurrent = 1\n            GROUP BY CustomerID\n            HAVING COUNT(*) > 1  -- Multiple current records for same business key\n        ) errors) +\n        (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate >= EndDate) as scd_processing_errors\n    FROM DimCustomer\n    UNION ALL\n    SELECT\n        'DimAccount' as table_name,\n        COUNT(DISTINCT AccountID) as business_key_count,\n        COUNT(*) as total_scd_records,\n        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,\n        (SELECT COUNT(*) FROM (\n            SELECT AccountID\n            FROM DimAccount\n            WHERE IsCurrent = 1\n            GROUP BY AccountID\n            HAVING COUNT(*) > 1\n        ) errors) +\n        (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate >= EndDate) as scd_processing_errors\n    FROM DimAccount\n    UNION ALL\n    SELECT\n        'DimSecurity' as table_name,\n        COUNT(DISTINCT Symbol) as business_key_count,\n        COUNT(*) as total_scd_records,\n        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,\n        (SELECT COUNT(*) FROM (\n            SELECT Symbol\n            FROM DimSecurity\n            WHERE IsCurrent = 1\n            GROUP BY Symbol\n            HAVING COUNT(*) > 1\n        ) errors) +\n        (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate >= EndDate) as scd_processing_errors\n    FROM DimSecurity\n    UNION ALL\n    SELECT\n        'DimCompany' as table_name,\n        COUNT(DISTINCT CompanyID) as business_key_count,\n        COUNT(*) as total_scd_records,\n        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,\n        (SELECT COUNT(*) FROM (\n            SELECT CompanyID\n            FROM DimCompany\n            WHERE IsCurrent = 1\n            GROUP BY CompanyID\n            HAVING COUNT(*) > 1\n        ) errors) +\n        (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate >= EndDate) as scd_processing_errors\n    FROM DimCompany\n    UNION ALL\n    SELECT\n        'DimBroker' as table_name,\n        COUNT(DISTINCT BrokerID) as business_key_count,\n        COUNT(*) as total_scd_records,\n        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,\n        (SELECT COUNT(*) FROM (\n            SELECT BrokerID\n            FROM DimBroker\n            WHERE IsCurrent = 1\n            GROUP BY BrokerID\n            HAVING COUNT(*) > 1\n        ) errors) +\n        (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate >= EndDate) as scd_processing_errors\n    FROM DimBroker\n) scd_validation\nORDER BY table_name;\n",
+"EQ5": "\nSELECT\n    'Data Lineage and Audit Trail Validation' as validation_name,\n    batch_id,\n    total_records_processed,\n    records_with_audit_trail,\n    audit_coverage_pct,\n    batch_consistency_score,\n    CASE\n        WHEN audit_coverage_pct >= {audit_coverage_threshold} AND batch_consistency_score >= {consistency_score_threshold} THEN 'PASS'\n        WHEN audit_coverage_pct >= {audit_coverage_threshold} THEN 'CONSISTENCY ISSUES'\n        ELSE 'AUDIT TRAIL INCOMPLETE'\n    END as audit_status\nFROM (\n    SELECT\n        batch_summary.batch_id,\n        batch_summary.total_records_processed,\n        batch_summary.records_with_audit_trail,\n        batch_summary.records_with_audit_trail / batch_summary.total_records_processed * 100 as audit_coverage_pct,\n        -- Calculate consistency score based on batch ID consistency across related tables\n        100 - (batch_inconsistencies.inconsistent_records / batch_summary.total_records_processed * 100) as batch_consistency_score\n    FROM (\n        SELECT\n            1 as batch_id,\n            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1) +\n            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1) +\n            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1) as total_records_processed,\n            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1 AND BatchID IS NOT NULL) +\n            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1 AND BatchID IS NOT NULL) +\n            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1 AND BatchID IS NOT NULL) as records_with_audit_trail\n    ) batch_summary\n    CROSS JOIN (\n        SELECT\n            -- Count records with inconsistent batch references\n            (SELECT COUNT(*) FROM FactTrade ft\n             LEFT JOIN DimCustomer dc ON ft.SK_CustomerID = dc.SK_CustomerID\n             WHERE ft.BatchID != dc.BatchID AND dc.IsCurrent = 1) +\n            (SELECT COUNT(*) FROM FactTrade ft\n             LEFT JOIN DimAccount da ON ft.SK_AccountID = da.SK_AccountID\n             WHERE ft.BatchID != da.BatchID AND da.IsCurrent = 1) as inconsistent_records\n    ) batch_inconsistencies\n    UNION ALL\n    SELECT\n        batch_summary.batch_id,\n        batch_summary.total_records_processed,\n        batch_summary.records_with_audit_trail,\n        batch_summary.records_with_audit_trail / batch_summary.total_records_processed * 100 as audit_coverage_pct,\n        100 - (batch_inconsistencies.inconsistent_records / batch_summary.total_records_processed * 100) as batch_consistency_score\n    FROM (\n        SELECT\n            2 as batch_id,\n            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 2) +\n            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 2) +\n            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 2) as total_records_processed,\n            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 2 AND BatchID IS NOT NULL) +\n            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 2 AND BatchID IS NOT NULL) +\n            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 2 AND BatchID IS NOT NULL) as records_with_audit_trail\n    ) batch_summary\n    CROSS JOIN (\n        SELECT\n            (SELECT COUNT(*) FROM FactTrade ft\n             LEFT JOIN DimCustomer dc ON ft.SK_CustomerID = dc.SK_CustomerID\n             WHERE ft.BatchID = 2 AND ft.BatchID != dc.BatchID AND dc.IsCurrent = 1) as inconsistent_records\n    ) batch_inconsistencies\n) audit_validation\nWHERE total_records_processed > 0\nORDER BY batch_id;\n",
+"EQ6": "\nSELECT\n    'ETL Performance Metrics Validation' as validation_name,\n    etl_phase,\n    total_records_processed,\n    processing_time_minutes,\n    records_per_minute,\n    memory_usage_mb,\n    cpu_utilization_pct,\n    io_operations,\n    performance_rating,\n    CASE\n        WHEN performance_rating >= {performance_rating_threshold} THEN 'OPTIMAL'\n        WHEN performance_rating >= {performance_rating_threshold} * 0.7 THEN 'ACCEPTABLE'\n        ELSE 'NEEDS OPTIMIZATION'\n    END as performance_status\nFROM (\n    SELECT\n        'Data Extraction' as etl_phase,\n        10000 as total_records_processed,  -- Simulated metrics\n        2.5 as processing_time_minutes,\n        10000 / 2.5 as records_per_minute,\n        256 as memory_usage_mb,\n        45 as cpu_utilization_pct,\n        5000 as io_operations,\n        -- Performance rating formula (0-100 scale)\n        LEAST(100, (10000 / 2.5) / 100 * 50 + (100 - 45) * 0.3 + (1000 - 256) / 10 * 0.2) as performance_rating\n    UNION ALL\n    SELECT\n        'Data Transformation' as etl_phase,\n        10000 as total_records_processed,\n        8.0 as processing_time_minutes,\n        10000 / 8.0 as records_per_minute,\n        512 as memory_usage_mb,\n        75 as cpu_utilization_pct,\n        15000 as io_operations,\n        LEAST(100, (10000 / 8.0) / 100 * 50 + (100 - 75) * 0.3 + (1000 - 512) / 10 * 0.2) as performance_rating\n    UNION ALL\n    SELECT\n        'Data Loading' as etl_phase,\n        10000 as total_records_processed,\n        5.0 as processing_time_minutes,\n        10000 / 5.0 as records_per_minute,\n        128 as memory_usage_mb,\n        30 as cpu_utilization_pct,\n        25000 as io_operations,\n        LEAST(100, (10000 / 5.0) / 100 * 50 + (100 - 30) * 0.3 + (1000 - 128) / 10 * 0.2) as performance_rating\n    UNION ALL\n    SELECT\n        'Data Validation' as etl_phase,\n        10000 as total_records_processed,\n        3.0 as processing_time_minutes,\n        10000 / 3.0 as records_per_minute,\n        64 as memory_usage_mb,\n        20 as cpu_utilization_pct,\n        8000 as io_operations,\n        LEAST(100, (10000 / 3.0) / 100 * 50 + (100 - 20) * 0.3 + (1000 - 64) / 10 * 0.2) as performance_rating\n) performance_metrics\nORDER BY\n    CASE etl_phase\n        WHEN 'Data Extraction' THEN 1\n        WHEN 'Data Transformation' THEN 2\n        WHEN 'Data Loading' THEN 3\n        WHEN 'Data Validation' THEN 4\n    END;\n",
+"EQ7": "\nSELECT\n    'ETL Data Quality Score Calculation' as validation_name,\n    table_name,\n    total_records,\n    null_key_fields,\n    invalid_values,\n    constraint_violations,\n    business_rule_violations,\n    completeness_score,\n    validity_score,\n    consistency_score,\n    overall_quality_score,\n    CASE\n        WHEN overall_quality_score >= {excellent_quality_threshold} THEN 'EXCELLENT'\n        WHEN overall_quality_score >= {good_quality_threshold} THEN 'GOOD'\n        WHEN overall_quality_score >= {acceptable_quality_threshold} THEN 'ACCEPTABLE'\n        ELSE 'POOR'\n    END as quality_rating\nFROM (\n    SELECT\n        'DimCustomer' as table_name,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_fields,\n        SUM(CASE WHEN Gender NOT IN ('M', 'F') OR Tier NOT IN (1,2,3) THEN 1 ELSE 0 END) as invalid_values,\n        SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) as constraint_violations,\n        SUM(CASE WHEN (Tier = 1 AND NetWorth < 1000000) OR (Tier = 3 AND NetWorth > 250000) THEN 1 ELSE 0 END) as business_rule_violations,\n        (COUNT(*) - SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,\n        (COUNT(*) - SUM(CASE WHEN Gender NOT IN ('M', 'F') OR Tier NOT IN (1,2,3) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,\n        (COUNT(*) - SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) -\n         SUM(CASE WHEN (Tier = 1 AND NetWorth < 1000000) OR (Tier = 3 AND NetWorth > 250000) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score\n    FROM DimCustomer\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT\n        'DimAccount' as table_name,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_fields,\n        SUM(CASE WHEN Status NOT IN ('Active', 'Inactive', 'Closed') THEN 1 ELSE 0 END) as invalid_values,\n        SUM(CASE WHEN TaxStatus NOT IN (0, 1, 2) THEN 1 ELSE 0 END) as constraint_violations,\n        0 as business_rule_violations,  -- No specific business rules for accounts\n        (COUNT(*) - SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,\n        (COUNT(*) - SUM(CASE WHEN Status NOT IN ('Active', 'Inactive', 'Closed') THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,\n        (COUNT(*) - SUM(CASE WHEN TaxStatus NOT IN (0, 1, 2) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score\n    FROM DimAccount\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT\n        'FactTrade' as table_name,\n        COUNT(*) as total_records,\n        SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END) as null_key_fields,\n        SUM(CASE WHEN Status NOT IN ('Pending', 'Completed', 'Cancelled') OR Type NOT IN ('Buy', 'Sell') THEN 1 ELSE 0 END) as invalid_values,\n        SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 OR Fee < 0 OR Commission < 0 THEN 1 ELSE 0 END) as constraint_violations,\n        SUM(CASE WHEN TradePrice > 10000 OR Quantity > 1000000 THEN 1 ELSE 0 END) as business_rule_violations,  -- Unreasonably large trades\n        (COUNT(*) - SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,\n        (COUNT(*) - SUM(CASE WHEN Status NOT IN ('Pending', 'Completed', 'Cancelled') OR Type NOT IN ('Buy', 'Sell') THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,\n        (COUNT(*) - SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 OR Fee < 0 OR Commission < 0 THEN 1 ELSE 0 END) -\n         SUM(CASE WHEN TradePrice > 10000 OR Quantity > 1000000 THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score\n    FROM FactTrade\n) quality_metrics,\n(\n    SELECT\n        -- Calculate overall quality score as weighted average\n        (completeness_score * 0.4 + validity_score * 0.3 + consistency_score * 0.3) as overall_quality_score\n    FROM (VALUES (0)) as dummy  -- Dummy to allow calculation in same query\n) quality_calculation\nORDER BY overall_quality_score DESC;\n",
+"EQ8": "\nSELECT\n    'ETL Error Tracking and Recovery Validation' as validation_name,\n    error_category,\n    error_count,\n    resolved_errors,\n    unresolved_errors,\n    error_resolution_rate_pct,\n    avg_resolution_time_hours,\n    impact_severity,\n    CASE\n        WHEN error_resolution_rate_pct >= {error_resolution_threshold} AND unresolved_errors = 0 THEN 'EXCELLENT'\n        WHEN error_resolution_rate_pct >= {error_resolution_threshold} THEN 'GOOD'\n        WHEN error_resolution_rate_pct >= 50 THEN 'NEEDS IMPROVEMENT'\n        ELSE 'CRITICAL'\n    END as error_management_status\nFROM (\n    SELECT\n        'Data Quality Errors' as error_category,\n        50 as error_count,  -- Simulated error counts\n        45 as resolved_errors,\n        5 as unresolved_errors,\n        45 / 50 * 100 as error_resolution_rate_pct,\n        2.5 as avg_resolution_time_hours,\n        'Medium' as impact_severity\n    UNION ALL\n    SELECT\n        'Transformation Errors' as error_category,\n        15 as error_count,\n        13 as resolved_errors,\n        2 as unresolved_errors,\n        13 / 15 * 100 as error_resolution_rate_pct,\n        4.0 as avg_resolution_time_hours,\n        'High' as impact_severity\n    UNION ALL\n    SELECT\n        'Loading Errors' as error_category,\n        8 as error_count,\n        8 as resolved_errors,\n        0 as unresolved_errors,\n        100.0 as error_resolution_rate_pct,\n        1.5 as avg_resolution_time_hours,\n        'Low' as impact_severity\n    UNION ALL\n    SELECT\n        'Referential Integrity Errors' as error_category,\n        3 as error_count,\n        2 as resolved_errors,\n        1 as unresolved_errors,\n        2 / 3 * 100 as error_resolution_rate_pct,\n        8.0 as avg_resolution_time_hours,\n        'Critical' as impact_severity\n    UNION ALL\n    SELECT\n        'Business Rule Violations' as error_category,\n        25 as error_count,\n        20 as resolved_errors,\n        5 as unresolved_errors,\n        20 / 25 * 100 as error_resolution_rate_pct,\n        3.0 as avg_resolution_time_hours,\n        'Medium' as impact_severity\n) error_tracking\nORDER BY\n    CASE impact_severity\n        WHEN 'Critical' THEN 1\n        WHEN 'High' THEN 2\n        WHEN 'Medium' THEN 3\n        WHEN 'Low' THEN 4\n    END,\n    error_count DESC;\n"
+},
+"metadata": {
+"EQ1": {"relies_on": ["DimCustomer", "DimAccount", "FactTrade"], "query_type": "etl_validation", "category": "batch_processing", "description": "Validates batch processing performance and record counts", "frequency": "per_batch"},
+"EQ2": {"relies_on": ["DimCustomer", "DimAccount", "DimSecurity"], "query_type": "etl_validation", "category": "incremental_loads", "description": "Validates incremental load processing with new vs updated records", "frequency": "per_incremental_batch"},
+"EQ3": {"relies_on": ["DimCustomer", "DimAccount", "FactTrade", "FactMarketHistory"], "query_type": "etl_validation", "category": "transformations", "description": "Validates data transformation success rates and quality", "frequency": "per_batch"},
+"EQ4": {"relies_on": ["DimCustomer", "DimAccount", "DimSecurity", "DimCompany", "DimBroker"], "query_type": "etl_validation", "category": "scd_processing", "description": "Validates SCD Type 2 processing accuracy and consistency", "frequency": "per_batch"},
+"EQ5": {"relies_on": ["DimCustomer", "DimAccount", "FactTrade"], "query_type": "etl_validation", "category": "audit_trail", "description": "Validates data lineage and audit trail completeness", "frequency": "per_batch"},
+"EQ6": {"relies_on": [], "query_type": "etl_validation", "category": "performance", "description": "Validates ETL performance metrics and throughput", "frequency": "per_etl_run"},
+"EQ7": {"relies_on": ["DimCustomer", "DimAccount", "FactTrade"], "query_type": "etl_validation", "category": "quality_scoring", "description": "Calculates comprehensive data quality scores for ETL monitoring", "frequency": "per_batch"},
+"EQ8": {"relies_on": [], "query_type": "etl_validation", "category": "error_management", "description": "Validates ETL error tracking and recovery processes", "frequency": "continuous"}
+}
+}"""
+
+
+@lru_cache(maxsize=1)
+def _etl_query_data() -> dict[str, Any]:
+    return json.loads(_ETL_QUERY_DATA_JSON)
 
 
 class TPCDIETLQueries(ParameterizedQueryManager):
@@ -26,731 +56,40 @@ class TPCDIETLQueries(ParameterizedQueryManager):
     invalid_query_label = "ETL query"
 
     def __init__(self) -> None:
-        """Initialize the ETL query manager."""
         self._queries = self._load_etl_queries()
         self._query_metadata = self._load_etl_metadata()
 
     def _load_etl_queries(self) -> dict[str, str]:
-        """Load all ETL validation queries.
-
-        Returns:
-            Dictionary mapping ETL query IDs to SQL text
-        """
-        queries = {}
-
-        # EQ1: Batch processing validation - Record counts and processing times
-        queries["EQ1"] = """
-SELECT
-    'Batch Processing Validation' as validation_name,
-    batch_id,
-    table_name,
-    records_loaded,
-    processing_time_seconds,
-    records_per_second,
-    error_count,
-    warning_count,
-    CASE
-        WHEN error_count = 0 AND records_per_second > {min_throughput} THEN 'PASS'
-        WHEN error_count = 0 AND records_per_second <= {min_throughput} THEN 'SLOW'
-        ELSE 'FAIL'
-    END as batch_status
-FROM (
-    SELECT
-        1 as batch_id,
-        'DimCustomer' as table_name,
-        COUNT(*) as records_loaded,
-        60.0 as processing_time_seconds,  -- Simulated processing time
-        COUNT(*) / 60.0 as records_per_second,
-        SUM(CASE WHEN Status IS NULL OR CustomerID IS NULL THEN 1 ELSE 0 END) as error_count,
-        SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) as warning_count
-    FROM DimCustomer
-    WHERE BatchID = 1
-    UNION ALL
-    SELECT
-        1 as batch_id,
-        'DimAccount' as table_name,
-        COUNT(*) as records_loaded,
-        45.0 as processing_time_seconds,
-        COUNT(*) / 45.0 as records_per_second,
-        SUM(CASE WHEN Status IS NULL OR AccountID IS NULL THEN 1 ELSE 0 END) as error_count,
-        SUM(CASE WHEN SK_CustomerID IS NULL THEN 1 ELSE 0 END) as warning_count
-    FROM DimAccount
-    WHERE BatchID = 1
-    UNION ALL
-    SELECT
-        1 as batch_id,
-        'FactTrade' as table_name,
-        COUNT(*) as records_loaded,
-        120.0 as processing_time_seconds,
-        COUNT(*) / 120.0 as records_per_second,
-        SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL THEN 1 ELSE 0 END) as error_count,
-        SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 THEN 1 ELSE 0 END) as warning_count
-    FROM FactTrade
-    WHERE BatchID = 1
-) batch_metrics
-ORDER BY batch_id, table_name;
-"""
-
-        # EQ2: Incremental load validation - New vs updated records
-        queries["EQ2"] = """
-SELECT
-    'Incremental Load Validation' as validation_name,
-    table_name,
-    batch_id,
-    new_records,
-    updated_records,
-    unchanged_records,
-    total_records,
-    new_records / total_records * 100 as new_record_pct,
-    updated_records / total_records * 100 as updated_record_pct,
-    CASE
-        WHEN (new_records + updated_records) > 0 AND unchanged_records >= 0 THEN 'PASS'
-        WHEN (new_records + updated_records) = 0 THEN 'NO CHANGES'
-        ELSE 'FAIL'
-    END as incremental_status
-FROM (
-    SELECT
-        'DimCustomer' as table_name,
-        BatchID as batch_id,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,
-        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records
-    FROM DimCustomer
-    WHERE BatchID >= {min_batch_id}
-    GROUP BY BatchID
-    UNION ALL
-    SELECT
-        'DimAccount' as table_name,
-        BatchID as batch_id,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,
-        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records
-    FROM DimAccount
-    WHERE BatchID >= {min_batch_id}
-    GROUP BY BatchID
-    UNION ALL
-    SELECT
-        'DimSecurity' as table_name,
-        BatchID as batch_id,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate = '9999-12-31' THEN 1 ELSE 0 END) as new_records,
-        SUM(CASE WHEN EffectiveDate >= '{batch_start_date}' AND EndDate != '9999-12-31' THEN 1 ELSE 0 END) as updated_records,
-        SUM(CASE WHEN EffectiveDate < '{batch_start_date}' THEN 1 ELSE 0 END) as unchanged_records
-    FROM DimSecurity
-    WHERE BatchID >= {min_batch_id}
-    GROUP BY BatchID
-) incremental_metrics
-ORDER BY batch_id, table_name;
-"""
-
-        # EQ3: Data transformation validation - Source to target mapping
-        queries["EQ3"] = """
-SELECT
-    'Data Transformation Validation' as validation_name,
-    transformation_type,
-    source_records,
-    target_records,
-    transformation_success_rate,
-    data_quality_score,
-    CASE
-        WHEN transformation_success_rate >= {success_rate_threshold} AND data_quality_score >= {quality_score_threshold} THEN 'PASS'
-        WHEN transformation_success_rate >= {success_rate_threshold} THEN 'QUALITY ISSUES'
-        ELSE 'TRANSFORMATION FAILURE'
-    END as transformation_status
-FROM (
-    SELECT
-        'Customer Demographics' as transformation_type,
-        (SELECT COUNT(*) FROM (
-            -- Simulated source data count
-            SELECT COUNT(*) as source_count FROM DimCustomer WHERE BatchID = 1
-        )) as source_records,
-        COUNT(*) as target_records,
-        COUNT(*) / (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1) * 100 as transformation_success_rate,
-        100 - (SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score
-    FROM DimCustomer
-    WHERE BatchID = 1
-    UNION ALL
-    SELECT
-        'Account Information' as transformation_type,
-        (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1) as source_records,
-        COUNT(*) as target_records,
-        100.0 as transformation_success_rate,  -- Assume 100% transformation success
-        100 - (SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score
-    FROM DimAccount
-    WHERE BatchID = 1
-    UNION ALL
-    SELECT
-        'Trade Transactions' as transformation_type,
-        (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1) as source_records,
-        COUNT(*) as target_records,
-        100.0 as transformation_success_rate,
-        100 - (SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR TradePrice <= 0 THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score
-    FROM FactTrade
-    WHERE BatchID = 1
-    UNION ALL
-    SELECT
-        'Market History Data' as transformation_type,
-        (SELECT COUNT(*) FROM FactMarketHistory WHERE BatchID = 1) as source_records,
-        COUNT(*) as target_records,
-        100.0 as transformation_success_rate,
-        100 - (SUM(CASE WHEN SK_SecurityID IS NULL OR ClosePrice <= 0 OR Volume < 0 THEN 1 ELSE 0 END) / COUNT(*) * 100) as data_quality_score
-    FROM FactMarketHistory
-    WHERE BatchID = 1
-) transformation_metrics;
-"""
-
-        # EQ4: SCD Type 2 processing validation
-        queries["EQ4"] = """
-SELECT
-    'SCD Type 2 Processing Validation' as validation_name,
-    table_name,
-    business_key_count,
-    total_scd_records,
-    current_records,
-    historical_records,
-    scd_processing_errors,
-    CASE
-        WHEN scd_processing_errors = 0 AND current_records = business_key_count THEN 'PASS'
-        WHEN scd_processing_errors = 0 THEN 'HISTORICAL DATA ISSUES'
-        ELSE 'SCD PROCESSING ERRORS'
-    END as scd_status
-FROM (
-    SELECT
-        'DimCustomer' as table_name,
-        COUNT(DISTINCT CustomerID) as business_key_count,
-        COUNT(*) as total_scd_records,
-        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,
-        -- Count SCD processing errors
-        (SELECT COUNT(*) FROM (
-            SELECT CustomerID
-            FROM DimCustomer
-            WHERE IsCurrent = 1
-            GROUP BY CustomerID
-            HAVING COUNT(*) > 1  -- Multiple current records for same business key
-        ) errors) +
-        (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate >= EndDate) as scd_processing_errors
-    FROM DimCustomer
-    UNION ALL
-    SELECT
-        'DimAccount' as table_name,
-        COUNT(DISTINCT AccountID) as business_key_count,
-        COUNT(*) as total_scd_records,
-        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,
-        (SELECT COUNT(*) FROM (
-            SELECT AccountID
-            FROM DimAccount
-            WHERE IsCurrent = 1
-            GROUP BY AccountID
-            HAVING COUNT(*) > 1
-        ) errors) +
-        (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate >= EndDate) as scd_processing_errors
-    FROM DimAccount
-    UNION ALL
-    SELECT
-        'DimSecurity' as table_name,
-        COUNT(DISTINCT Symbol) as business_key_count,
-        COUNT(*) as total_scd_records,
-        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,
-        (SELECT COUNT(*) FROM (
-            SELECT Symbol
-            FROM DimSecurity
-            WHERE IsCurrent = 1
-            GROUP BY Symbol
-            HAVING COUNT(*) > 1
-        ) errors) +
-        (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate >= EndDate) as scd_processing_errors
-    FROM DimSecurity
-    UNION ALL
-    SELECT
-        'DimCompany' as table_name,
-        COUNT(DISTINCT CompanyID) as business_key_count,
-        COUNT(*) as total_scd_records,
-        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,
-        (SELECT COUNT(*) FROM (
-            SELECT CompanyID
-            FROM DimCompany
-            WHERE IsCurrent = 1
-            GROUP BY CompanyID
-            HAVING COUNT(*) > 1
-        ) errors) +
-        (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate >= EndDate) as scd_processing_errors
-    FROM DimCompany
-    UNION ALL
-    SELECT
-        'DimBroker' as table_name,
-        COUNT(DISTINCT BrokerID) as business_key_count,
-        COUNT(*) as total_scd_records,
-        SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-        SUM(CASE WHEN IsCurrent = 0 THEN 1 ELSE 0 END) as historical_records,
-        (SELECT COUNT(*) FROM (
-            SELECT BrokerID
-            FROM DimBroker
-            WHERE IsCurrent = 1
-            GROUP BY BrokerID
-            HAVING COUNT(*) > 1
-        ) errors) +
-        (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate >= EndDate) as scd_processing_errors
-    FROM DimBroker
-) scd_validation
-ORDER BY table_name;
-"""
-
-        # EQ5: Data lineage and audit trail validation
-        queries["EQ5"] = """
-SELECT
-    'Data Lineage and Audit Trail Validation' as validation_name,
-    batch_id,
-    total_records_processed,
-    records_with_audit_trail,
-    audit_coverage_pct,
-    batch_consistency_score,
-    CASE
-        WHEN audit_coverage_pct >= {audit_coverage_threshold} AND batch_consistency_score >= {consistency_score_threshold} THEN 'PASS'
-        WHEN audit_coverage_pct >= {audit_coverage_threshold} THEN 'CONSISTENCY ISSUES'
-        ELSE 'AUDIT TRAIL INCOMPLETE'
-    END as audit_status
-FROM (
-    SELECT
-        batch_summary.batch_id,
-        batch_summary.total_records_processed,
-        batch_summary.records_with_audit_trail,
-        batch_summary.records_with_audit_trail / batch_summary.total_records_processed * 100 as audit_coverage_pct,
-        -- Calculate consistency score based on batch ID consistency across related tables
-        100 - (batch_inconsistencies.inconsistent_records / batch_summary.total_records_processed * 100) as batch_consistency_score
-    FROM (
-        SELECT
-            1 as batch_id,
-            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1) +
-            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1) +
-            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1) as total_records_processed,
-            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 1 AND BatchID IS NOT NULL) +
-            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 1 AND BatchID IS NOT NULL) +
-            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 1 AND BatchID IS NOT NULL) as records_with_audit_trail
-    ) batch_summary
-    CROSS JOIN (
-        SELECT
-            -- Count records with inconsistent batch references
-            (SELECT COUNT(*) FROM FactTrade ft
-             LEFT JOIN DimCustomer dc ON ft.SK_CustomerID = dc.SK_CustomerID
-             WHERE ft.BatchID != dc.BatchID AND dc.IsCurrent = 1) +
-            (SELECT COUNT(*) FROM FactTrade ft
-             LEFT JOIN DimAccount da ON ft.SK_AccountID = da.SK_AccountID
-             WHERE ft.BatchID != da.BatchID AND da.IsCurrent = 1) as inconsistent_records
-    ) batch_inconsistencies
-    UNION ALL
-    SELECT
-        batch_summary.batch_id,
-        batch_summary.total_records_processed,
-        batch_summary.records_with_audit_trail,
-        batch_summary.records_with_audit_trail / batch_summary.total_records_processed * 100 as audit_coverage_pct,
-        100 - (batch_inconsistencies.inconsistent_records / batch_summary.total_records_processed * 100) as batch_consistency_score
-    FROM (
-        SELECT
-            2 as batch_id,
-            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 2) +
-            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 2) +
-            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 2) as total_records_processed,
-            (SELECT COUNT(*) FROM DimCustomer WHERE BatchID = 2 AND BatchID IS NOT NULL) +
-            (SELECT COUNT(*) FROM DimAccount WHERE BatchID = 2 AND BatchID IS NOT NULL) +
-            (SELECT COUNT(*) FROM FactTrade WHERE BatchID = 2 AND BatchID IS NOT NULL) as records_with_audit_trail
-    ) batch_summary
-    CROSS JOIN (
-        SELECT
-            (SELECT COUNT(*) FROM FactTrade ft
-             LEFT JOIN DimCustomer dc ON ft.SK_CustomerID = dc.SK_CustomerID
-             WHERE ft.BatchID = 2 AND ft.BatchID != dc.BatchID AND dc.IsCurrent = 1) as inconsistent_records
-    ) batch_inconsistencies
-) audit_validation
-WHERE total_records_processed > 0
-ORDER BY batch_id;
-"""
-
-        # EQ6: ETL performance metrics and throughput validation
-        queries["EQ6"] = """
-SELECT
-    'ETL Performance Metrics Validation' as validation_name,
-    etl_phase,
-    total_records_processed,
-    processing_time_minutes,
-    records_per_minute,
-    memory_usage_mb,
-    cpu_utilization_pct,
-    io_operations,
-    performance_rating,
-    CASE
-        WHEN performance_rating >= {performance_rating_threshold} THEN 'OPTIMAL'
-        WHEN performance_rating >= {performance_rating_threshold} * 0.7 THEN 'ACCEPTABLE'
-        ELSE 'NEEDS OPTIMIZATION'
-    END as performance_status
-FROM (
-    SELECT
-        'Data Extraction' as etl_phase,
-        10000 as total_records_processed,  -- Simulated metrics
-        2.5 as processing_time_minutes,
-        10000 / 2.5 as records_per_minute,
-        256 as memory_usage_mb,
-        45 as cpu_utilization_pct,
-        5000 as io_operations,
-        -- Performance rating formula (0-100 scale)
-        LEAST(100, (10000 / 2.5) / 100 * 50 + (100 - 45) * 0.3 + (1000 - 256) / 10 * 0.2) as performance_rating
-    UNION ALL
-    SELECT
-        'Data Transformation' as etl_phase,
-        10000 as total_records_processed,
-        8.0 as processing_time_minutes,
-        10000 / 8.0 as records_per_minute,
-        512 as memory_usage_mb,
-        75 as cpu_utilization_pct,
-        15000 as io_operations,
-        LEAST(100, (10000 / 8.0) / 100 * 50 + (100 - 75) * 0.3 + (1000 - 512) / 10 * 0.2) as performance_rating
-    UNION ALL
-    SELECT
-        'Data Loading' as etl_phase,
-        10000 as total_records_processed,
-        5.0 as processing_time_minutes,
-        10000 / 5.0 as records_per_minute,
-        128 as memory_usage_mb,
-        30 as cpu_utilization_pct,
-        25000 as io_operations,
-        LEAST(100, (10000 / 5.0) / 100 * 50 + (100 - 30) * 0.3 + (1000 - 128) / 10 * 0.2) as performance_rating
-    UNION ALL
-    SELECT
-        'Data Validation' as etl_phase,
-        10000 as total_records_processed,
-        3.0 as processing_time_minutes,
-        10000 / 3.0 as records_per_minute,
-        64 as memory_usage_mb,
-        20 as cpu_utilization_pct,
-        8000 as io_operations,
-        LEAST(100, (10000 / 3.0) / 100 * 50 + (100 - 20) * 0.3 + (1000 - 64) / 10 * 0.2) as performance_rating
-) performance_metrics
-ORDER BY
-    CASE etl_phase
-        WHEN 'Data Extraction' THEN 1
-        WHEN 'Data Transformation' THEN 2
-        WHEN 'Data Loading' THEN 3
-        WHEN 'Data Validation' THEN 4
-    END;
-"""
-
-        # EQ7: Data quality score calculation for ETL monitoring
-        queries["EQ7"] = """
-SELECT
-    'ETL Data Quality Score Calculation' as validation_name,
-    table_name,
-    total_records,
-    null_key_fields,
-    invalid_values,
-    constraint_violations,
-    business_rule_violations,
-    completeness_score,
-    validity_score,
-    consistency_score,
-    overall_quality_score,
-    CASE
-        WHEN overall_quality_score >= {excellent_quality_threshold} THEN 'EXCELLENT'
-        WHEN overall_quality_score >= {good_quality_threshold} THEN 'GOOD'
-        WHEN overall_quality_score >= {acceptable_quality_threshold} THEN 'ACCEPTABLE'
-        ELSE 'POOR'
-    END as quality_rating
-FROM (
-    SELECT
-        'DimCustomer' as table_name,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_fields,
-        SUM(CASE WHEN Gender NOT IN ('M', 'F') OR Tier NOT IN (1,2,3) THEN 1 ELSE 0 END) as invalid_values,
-        SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) as constraint_violations,
-        SUM(CASE WHEN (Tier = 1 AND NetWorth < 1000000) OR (Tier = 3 AND NetWorth > 250000) THEN 1 ELSE 0 END) as business_rule_violations,
-        (COUNT(*) - SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,
-        (COUNT(*) - SUM(CASE WHEN Gender NOT IN ('M', 'F') OR Tier NOT IN (1,2,3) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,
-        (COUNT(*) - SUM(CASE WHEN CreditRating < 300 OR CreditRating > 850 THEN 1 ELSE 0 END) -
-         SUM(CASE WHEN (Tier = 1 AND NetWorth < 1000000) OR (Tier = 3 AND NetWorth > 250000) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score
-    FROM DimCustomer
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT
-        'DimAccount' as table_name,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_fields,
-        SUM(CASE WHEN Status NOT IN ('Active', 'Inactive', 'Closed') THEN 1 ELSE 0 END) as invalid_values,
-        SUM(CASE WHEN TaxStatus NOT IN (0, 1, 2) THEN 1 ELSE 0 END) as constraint_violations,
-        0 as business_rule_violations,  -- No specific business rules for accounts
-        (COUNT(*) - SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,
-        (COUNT(*) - SUM(CASE WHEN Status NOT IN ('Active', 'Inactive', 'Closed') THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,
-        (COUNT(*) - SUM(CASE WHEN TaxStatus NOT IN (0, 1, 2) THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score
-    FROM DimAccount
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT
-        'FactTrade' as table_name,
-        COUNT(*) as total_records,
-        SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END) as null_key_fields,
-        SUM(CASE WHEN Status NOT IN ('Pending', 'Completed', 'Cancelled') OR Type NOT IN ('Buy', 'Sell') THEN 1 ELSE 0 END) as invalid_values,
-        SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 OR Fee < 0 OR Commission < 0 THEN 1 ELSE 0 END) as constraint_violations,
-        SUM(CASE WHEN TradePrice > 10000 OR Quantity > 1000000 THEN 1 ELSE 0 END) as business_rule_violations,  -- Unreasonably large trades
-        (COUNT(*) - SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END)) / COUNT(*) * 100 as completeness_score,
-        (COUNT(*) - SUM(CASE WHEN Status NOT IN ('Pending', 'Completed', 'Cancelled') OR Type NOT IN ('Buy', 'Sell') THEN 1 ELSE 0 END)) / COUNT(*) * 100 as validity_score,
-        (COUNT(*) - SUM(CASE WHEN TradePrice <= 0 OR Quantity <= 0 OR Fee < 0 OR Commission < 0 THEN 1 ELSE 0 END) -
-         SUM(CASE WHEN TradePrice > 10000 OR Quantity > 1000000 THEN 1 ELSE 0 END)) / COUNT(*) * 100 as consistency_score
-    FROM FactTrade
-) quality_metrics,
-(
-    SELECT
-        -- Calculate overall quality score as weighted average
-        (completeness_score * 0.4 + validity_score * 0.3 + consistency_score * 0.3) as overall_quality_score
-    FROM (VALUES (0)) as dummy  -- Dummy to allow calculation in same query
-) quality_calculation
-ORDER BY overall_quality_score DESC;
-"""
-
-        # EQ8: ETL error tracking and recovery validation
-        queries["EQ8"] = """
-SELECT
-    'ETL Error Tracking and Recovery Validation' as validation_name,
-    error_category,
-    error_count,
-    resolved_errors,
-    unresolved_errors,
-    error_resolution_rate_pct,
-    avg_resolution_time_hours,
-    impact_severity,
-    CASE
-        WHEN error_resolution_rate_pct >= {error_resolution_threshold} AND unresolved_errors = 0 THEN 'EXCELLENT'
-        WHEN error_resolution_rate_pct >= {error_resolution_threshold} THEN 'GOOD'
-        WHEN error_resolution_rate_pct >= 50 THEN 'NEEDS IMPROVEMENT'
-        ELSE 'CRITICAL'
-    END as error_management_status
-FROM (
-    SELECT
-        'Data Quality Errors' as error_category,
-        50 as error_count,  -- Simulated error counts
-        45 as resolved_errors,
-        5 as unresolved_errors,
-        45 / 50 * 100 as error_resolution_rate_pct,
-        2.5 as avg_resolution_time_hours,
-        'Medium' as impact_severity
-    UNION ALL
-    SELECT
-        'Transformation Errors' as error_category,
-        15 as error_count,
-        13 as resolved_errors,
-        2 as unresolved_errors,
-        13 / 15 * 100 as error_resolution_rate_pct,
-        4.0 as avg_resolution_time_hours,
-        'High' as impact_severity
-    UNION ALL
-    SELECT
-        'Loading Errors' as error_category,
-        8 as error_count,
-        8 as resolved_errors,
-        0 as unresolved_errors,
-        100.0 as error_resolution_rate_pct,
-        1.5 as avg_resolution_time_hours,
-        'Low' as impact_severity
-    UNION ALL
-    SELECT
-        'Referential Integrity Errors' as error_category,
-        3 as error_count,
-        2 as resolved_errors,
-        1 as unresolved_errors,
-        2 / 3 * 100 as error_resolution_rate_pct,
-        8.0 as avg_resolution_time_hours,
-        'Critical' as impact_severity
-    UNION ALL
-    SELECT
-        'Business Rule Violations' as error_category,
-        25 as error_count,
-        20 as resolved_errors,
-        5 as unresolved_errors,
-        20 / 25 * 100 as error_resolution_rate_pct,
-        3.0 as avg_resolution_time_hours,
-        'Medium' as impact_severity
-) error_tracking
-ORDER BY
-    CASE impact_severity
-        WHEN 'Critical' THEN 1
-        WHEN 'High' THEN 2
-        WHEN 'Medium' THEN 3
-        WHEN 'Low' THEN 4
-    END,
-    error_count DESC;
-"""
-
-        return queries
+        return dict(_etl_query_data()["queries"])
 
     def _load_etl_metadata(self) -> dict[str, dict[str, Any]]:
-        """Load metadata for ETL queries.
-
-        Returns:
-            Dictionary mapping query IDs to their metadata
-        """
-        metadata = {}
-
-        metadata["EQ1"] = {
-            "relies_on": ["DimCustomer", "DimAccount", "FactTrade"],
-            "query_type": "etl_validation",
-            "category": "batch_processing",
-            "description": "Validates batch processing performance and record counts",
-            "frequency": "per_batch",
-        }
-
-        metadata["EQ2"] = {
-            "relies_on": ["DimCustomer", "DimAccount", "DimSecurity"],
-            "query_type": "etl_validation",
-            "category": "incremental_loads",
-            "description": "Validates incremental load processing with new vs updated records",
-            "frequency": "per_incremental_batch",
-        }
-
-        metadata["EQ3"] = {
-            "relies_on": [
-                "DimCustomer",
-                "DimAccount",
-                "FactTrade",
-                "FactMarketHistory",
-            ],
-            "query_type": "etl_validation",
-            "category": "transformations",
-            "description": "Validates data transformation success rates and quality",
-            "frequency": "per_batch",
-        }
-
-        metadata["EQ4"] = {
-            "relies_on": [
-                "DimCustomer",
-                "DimAccount",
-                "DimSecurity",
-                "DimCompany",
-                "DimBroker",
-            ],
-            "query_type": "etl_validation",
-            "category": "scd_processing",
-            "description": "Validates SCD Type 2 processing accuracy and consistency",
-            "frequency": "per_batch",
-        }
-
-        metadata["EQ5"] = {
-            "relies_on": ["DimCustomer", "DimAccount", "FactTrade"],
-            "query_type": "etl_validation",
-            "category": "audit_trail",
-            "description": "Validates data lineage and audit trail completeness",
-            "frequency": "per_batch",
-        }
-
-        metadata["EQ6"] = {
-            "relies_on": [],  # Uses simulated performance metrics
-            "query_type": "etl_validation",
-            "category": "performance",
-            "description": "Validates ETL performance metrics and throughput",
-            "frequency": "per_etl_run",
-        }
-
-        metadata["EQ7"] = {
-            "relies_on": ["DimCustomer", "DimAccount", "FactTrade"],
-            "query_type": "etl_validation",
-            "category": "quality_scoring",
-            "description": "Calculates comprehensive data quality scores for ETL monitoring",
-            "frequency": "per_batch",
-        }
-
-        metadata["EQ8"] = {
-            "relies_on": [],  # Uses simulated error tracking data
-            "query_type": "etl_validation",
-            "category": "error_management",
-            "description": "Validates ETL error tracking and recovery processes",
-            "frequency": "continuous",
-        }
-
-        return metadata
+        return copy_query_metadata(_etl_query_data()["metadata"])
 
     def _generate_default_params(self, query_id: str) -> dict[str, Any]:
-        """Generate default parameters for ETL queries.
-
-        Args:
-            query_id: Query identifier
-
-        Returns:
-            Dictionary of parameter names to default values
-        """
-        # Default parameters for ETL validation queries
-        defaults = {
-            # Performance thresholds
-            "min_throughput": 100,  # Records per second
-            "performance_rating_threshold": 70,  # Performance rating out of 100
-            # Success rate thresholds
-            "success_rate_threshold": 95.0,  # Transformation success rate %
-            "quality_score_threshold": 90.0,  # Data quality score %
-            "audit_coverage_threshold": 95.0,  # Audit trail coverage %
-            "consistency_score_threshold": 90.0,  # Batch consistency score %
-            "error_resolution_threshold": 85.0,  # Error resolution rate %
-            # Quality score thresholds
+        return {
+            "min_throughput": 100,
+            "performance_rating_threshold": 70,
+            "success_rate_threshold": 95.0,
+            "quality_score_threshold": 90.0,
+            "audit_coverage_threshold": 95.0,
+            "consistency_score_threshold": 90.0,
+            "error_resolution_threshold": 85.0,
             "excellent_quality_threshold": 95.0,
             "good_quality_threshold": 85.0,
             "acceptable_quality_threshold": 75.0,
-            # Batch parameters
             "min_batch_id": 1,
             "batch_start_date": "2023-01-01",
         }
 
-        return defaults
-
     def get_query_metadata(self, query_id: str) -> dict[str, Any]:
-        """Get metadata for an ETL validation query.
-
-        Args:
-            query_id: Query identifier (EQ1, EQ2, etc.)
-
-        Returns:
-            Dictionary containing query metadata
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
         return self._get_query_metadata_copy(self._query_metadata, query_id, "ETL query")
 
     def get_queries_by_category(self, category: str) -> list[str]:
-        """Get all ETL validation queries of a specific category.
-
-        Args:
-            category: Category name (batch_processing, incremental_loads, transformations,
-                     scd_processing, audit_trail, performance, quality_scoring, error_management)
-
-        Returns:
-            List of query IDs in the specified category
-        """
-        valid_categories = {
-            "batch_processing",
-            "incremental_loads",
-            "transformations",
-            "scd_processing",
-            "audit_trail",
-            "performance",
-            "quality_scoring",
-            "error_management",
-        }
-        self._validate_selector_value(category, valid_categories, "category", plural="categories")
-        return self._query_ids_by_metadata(self._query_metadata, "category", category)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "category", category, "category", plural="categories"
+        )
 
     def get_queries_by_frequency(self, frequency: str) -> list[str]:
-        """Get all ETL validation queries of a specific execution frequency.
-
-        Args:
-            frequency: Execution frequency (per_batch, per_incremental_batch, per_etl_run, continuous)
-
-        Returns:
-            List of query IDs with the specified frequency
-        """
-        valid_frequencies = {
-            "per_batch",
-            "per_incremental_batch",
-            "per_etl_run",
-            "continuous",
-        }
-        self._validate_selector_value(frequency, valid_frequencies, "frequency", plural="frequencies")
-        return self._query_ids_by_metadata(self._query_metadata, "frequency", frequency)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "frequency", frequency, "frequency", plural="frequencies"
+        )

--- a/benchbox/core/tpcdi/query_validation.py
+++ b/benchbox/core/tpcdi/query_validation.py
@@ -15,9 +15,47 @@ This implementation is based on the TPC-DI specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import json
+from functools import lru_cache
 from typing import Any
 
-from benchbox.core.query_manager import ParameterizedQueryManager
+from benchbox.core.query_manager import ParameterizedQueryManager, copy_query_metadata
+
+_VALIDATION_QUERY_DATA_JSON = r"""{
+"queries": {
+"VQ1": "\nSELECT\n    'Core Tables Referential Integrity' as validation_name,\n    SUM(CASE WHEN orphaned_customers > 0 THEN 1 ELSE 0 END) +\n    SUM(CASE WHEN orphaned_accounts > 0 THEN 1 ELSE 0 END) +\n    SUM(CASE WHEN orphaned_securities > 0 THEN 1 ELSE 0 END) as integrity_violations,\n    COUNT(*) as total_checks\nFROM (\n    SELECT\n        (SELECT COUNT(*) FROM FactTrade f\n         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID\n         WHERE c.SK_CustomerID IS NULL) as orphaned_customers,\n        (SELECT COUNT(*) FROM FactTrade f\n         LEFT JOIN DimAccount a ON f.SK_AccountID = a.SK_AccountID\n         WHERE a.SK_AccountID IS NULL) as orphaned_accounts,\n        (SELECT COUNT(*) FROM FactTrade f\n         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID\n         WHERE s.SK_SecurityID IS NULL) as orphaned_securities\n) checks;\n",
+"VQ2": "\nSELECT\n    'Extended Tables Referential Integrity' as validation_name,\n    SUM(CASE WHEN orphaned_cash_balances > 0 THEN 1 ELSE 0 END) +\n    SUM(CASE WHEN orphaned_holdings > 0 THEN 1 ELSE 0 END) +\n    SUM(CASE WHEN orphaned_market_history > 0 THEN 1 ELSE 0 END) +\n    SUM(CASE WHEN orphaned_watches > 0 THEN 1 ELSE 0 END) as integrity_violations,\n    4 as total_checks\nFROM (\n    SELECT\n        (SELECT COUNT(*) FROM FactCashBalances f\n         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID\n         WHERE c.SK_CustomerID IS NULL) as orphaned_cash_balances,\n        (SELECT COUNT(*) FROM FactHoldings f\n         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID\n         WHERE s.SK_SecurityID IS NULL) as orphaned_holdings,\n        (SELECT COUNT(*) FROM FactMarketHistory f\n         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID\n         WHERE s.SK_SecurityID IS NULL) as orphaned_market_history,\n        (SELECT COUNT(*) FROM FactWatches f\n         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID\n         WHERE c.SK_CustomerID IS NULL) as orphaned_watches\n) checks;\n",
+"VQ3": "\nSELECT\n    'Data Completeness - Core Tables' as validation_name,\n    table_name,\n    total_records,\n    null_key_columns,\n    CASE WHEN null_key_columns = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM (\n    SELECT 'DimCustomer' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_columns\n    FROM DimCustomer\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT 'DimAccount' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_columns\n    FROM DimAccount\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT 'DimSecurity' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN Symbol IS NULL OR Name IS NULL OR ExchangeID IS NULL THEN 1 ELSE 0 END) as null_key_columns\n    FROM DimSecurity\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT 'DimCompany' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN CompanyID IS NULL OR Name IS NULL OR Industry IS NULL THEN 1 ELSE 0 END) as null_key_columns\n    FROM DimCompany\n    WHERE IsCurrent = 1\n    UNION ALL\n    SELECT 'FactTrade' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END) as null_key_columns\n    FROM FactTrade\n) completeness_check\nORDER BY table_name;\n",
+"VQ4": "\nSELECT\n    'SCD Type 2 Current Record Validation' as validation_name,\n    table_name,\n    total_records,\n    current_records,\n    multiple_current_per_business_key,\n    CASE WHEN multiple_current_per_business_key = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM (\n    SELECT 'DimCustomer' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n           (SELECT COUNT(*) FROM (\n               SELECT CustomerID, COUNT(*) as current_count\n               FROM DimCustomer\n               WHERE IsCurrent = 1\n               GROUP BY CustomerID\n               HAVING COUNT(*) > 1\n           ) violations) as multiple_current_per_business_key\n    FROM DimCustomer\n    UNION ALL\n    SELECT 'DimAccount' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n           (SELECT COUNT(*) FROM (\n               SELECT AccountID, COUNT(*) as current_count\n               FROM DimAccount\n               WHERE IsCurrent = 1\n               GROUP BY AccountID\n               HAVING COUNT(*) > 1\n           ) violations) as multiple_current_per_business_key\n    FROM DimAccount\n    UNION ALL\n    SELECT 'DimSecurity' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n           (SELECT COUNT(*) FROM (\n               SELECT Symbol, COUNT(*) as current_count\n               FROM DimSecurity\n               WHERE IsCurrent = 1\n               GROUP BY Symbol\n               HAVING COUNT(*) > 1\n           ) violations) as multiple_current_per_business_key\n    FROM DimSecurity\n    UNION ALL\n    SELECT 'DimCompany' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n           (SELECT COUNT(*) FROM (\n               SELECT CompanyID, COUNT(*) as current_count\n               FROM DimCompany\n               WHERE IsCurrent = 1\n               GROUP BY CompanyID\n               HAVING COUNT(*) > 1\n           ) violations) as multiple_current_per_business_key\n    FROM DimCompany\n    UNION ALL\n    SELECT 'DimBroker' as table_name,\n           COUNT(*) as total_records,\n           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,\n           (SELECT COUNT(*) FROM (\n               SELECT BrokerID, COUNT(*) as current_count\n               FROM DimBroker\n               WHERE IsCurrent = 1\n               GROUP BY BrokerID\n               HAVING COUNT(*) > 1\n           ) violations) as multiple_current_per_business_key\n    FROM DimBroker\n) scd_validation\nORDER BY table_name;\n",
+"VQ5": "\nSELECT\n    'SCD Type 2 Date Range Validation' as validation_name,\n    table_name,\n    invalid_date_ranges,\n    overlapping_date_ranges,\n    future_effective_dates,\n    CASE WHEN (invalid_date_ranges + overlapping_date_ranges + future_effective_dates) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM (\n    SELECT 'DimCustomer' as table_name,\n           (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate >= EndDate) as invalid_date_ranges,\n           (SELECT COUNT(*) FROM DimCustomer c1\n            JOIN DimCustomer c2 ON c1.CustomerID = c2.CustomerID\n                AND c1.SK_CustomerID != c2.SK_CustomerID\n                AND c1.EffectiveDate < c2.EndDate\n                AND c2.EffectiveDate < c1.EndDate) as overlapping_date_ranges,\n           (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates\n    UNION ALL\n    SELECT 'DimAccount' as table_name,\n           (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate >= EndDate) as invalid_date_ranges,\n           (SELECT COUNT(*) FROM DimAccount a1\n            JOIN DimAccount a2 ON a1.AccountID = a2.AccountID\n                AND a1.SK_AccountID != a2.SK_AccountID\n                AND a1.EffectiveDate < a2.EndDate\n                AND a2.EffectiveDate < a1.EndDate) as overlapping_date_ranges,\n           (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates\n    UNION ALL\n    SELECT 'DimSecurity' as table_name,\n           (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate >= EndDate) as invalid_date_ranges,\n           (SELECT COUNT(*) FROM DimSecurity s1\n            JOIN DimSecurity s2 ON s1.Symbol = s2.Symbol\n                AND s1.SK_SecurityID != s2.SK_SecurityID\n                AND s1.EffectiveDate < s2.EndDate\n                AND s2.EffectiveDate < s1.EndDate) as overlapping_date_ranges,\n           (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates\n    UNION ALL\n    SELECT 'DimCompany' as table_name,\n           (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate >= EndDate) as invalid_date_ranges,\n           (SELECT COUNT(*) FROM DimCompany comp1\n            JOIN DimCompany comp2 ON comp1.CompanyID = comp2.CompanyID\n                AND comp1.SK_CompanyID != comp2.SK_CompanyID\n                AND comp1.EffectiveDate < comp2.EndDate\n                AND comp2.EffectiveDate < comp1.EndDate) as overlapping_date_ranges,\n           (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates\n    UNION ALL\n    SELECT 'DimBroker' as table_name,\n           (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate >= EndDate) as invalid_date_ranges,\n           (SELECT COUNT(*) FROM DimBroker b1\n            JOIN DimBroker b2 ON b1.BrokerID = b2.BrokerID\n                AND b1.SK_BrokerID != b2.SK_BrokerID\n                AND b1.EffectiveDate < b2.EndDate\n                AND b2.EffectiveDate < b1.EndDate) as overlapping_date_ranges,\n           (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates\n) date_validation\nORDER BY table_name;\n",
+"VQ6": "\nSELECT\n    'Trade-Holdings Consistency Validation' as validation_name,\n    customer_id,\n    security_id,\n    total_buy_quantity,\n    total_sell_quantity,\n    net_position,\n    current_holdings,\n    position_discrepancy,\n    CASE WHEN ABS(position_discrepancy) <= {tolerance_threshold} THEN 'PASS' ELSE 'FAIL' END as status\nFROM (\n    SELECT\n        ft.SK_CustomerID as customer_id,\n        ft.SK_SecurityID as security_id,\n        SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE 0 END) as total_buy_quantity,\n        SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity ELSE 0 END) as total_sell_quantity,\n        SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE -ft.Quantity END) as net_position,\n        COALESCE(fh.CurrentHolding, 0) as current_holdings,\n        (SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE -ft.Quantity END) - COALESCE(fh.CurrentHolding, 0)) as position_discrepancy\n    FROM FactTrade ft\n    JOIN TradeType tt ON ft.Type = tt.TT_ID\n    LEFT JOIN FactHoldings fh ON ft.SK_CustomerID = fh.SK_CustomerID\n                              AND ft.SK_SecurityID = fh.SK_SecurityID\n    WHERE ft.Status = 'Completed'\n    GROUP BY ft.SK_CustomerID, ft.SK_SecurityID, fh.CurrentHolding\n) position_check\nWHERE ABS(position_discrepancy) > 0\nORDER BY ABS(position_discrepancy) DESC\nLIMIT {limit_rows};\n",
+"VQ7": "\nSELECT\n    'Customer Tier-NetWorth Validation' as validation_name,\n    Tier,\n    COUNT(*) as customer_count,\n    MIN(NetWorth) as min_net_worth,\n    MAX(NetWorth) as max_net_worth,\n    AVG(NetWorth) as avg_net_worth,\n    SUM(CASE\n        WHEN Tier = 1 AND NetWorth < {tier1_min_networth} THEN 1\n        WHEN Tier = 2 AND (NetWorth < {tier2_min_networth} OR NetWorth >= {tier2_max_networth}) THEN 1\n        WHEN Tier = 3 AND NetWorth >= {tier3_max_networth} THEN 1\n        ELSE 0\n    END) as tier_violations,\n    CASE WHEN SUM(CASE\n        WHEN Tier = 1 AND NetWorth < {tier1_min_networth} THEN 1\n        WHEN Tier = 2 AND (NetWorth < {tier2_min_networth} OR NetWorth >= {tier2_max_networth}) THEN 1\n        WHEN Tier = 3 AND NetWorth >= {tier3_max_networth} THEN 1\n        ELSE 0\n    END) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM DimCustomer\nWHERE IsCurrent = 1\nGROUP BY Tier\nORDER BY Tier;\n",
+"VQ8": "\nSELECT\n    'Credit Rating Validation' as validation_name,\n    COUNT(*) as total_customers,\n    SUM(CASE WHEN CreditRating < {min_credit_rating} OR CreditRating > {max_credit_rating} THEN 1 ELSE 0 END) as invalid_credit_ratings,\n    MIN(CreditRating) as min_credit_rating,\n    MAX(CreditRating) as max_credit_rating,\n    AVG(CreditRating) as avg_credit_rating,\n    CASE WHEN SUM(CASE WHEN CreditRating < {min_credit_rating} OR CreditRating > {max_credit_rating} THEN 1 ELSE 0 END) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM DimCustomer\nWHERE IsCurrent = 1;\n",
+"VQ9": "\nSELECT\n    'Trade Price Reasonableness Validation' as validation_name,\n    COUNT(*) as total_trades,\n    SUM(CASE WHEN TradePrice <= 0 THEN 1 ELSE 0 END) as negative_or_zero_prices,\n    SUM(CASE WHEN TradePrice > {max_reasonable_price} THEN 1 ELSE 0 END) as extremely_high_prices,\n    SUM(CASE WHEN Fee < 0 OR Commission < 0 OR Tax < 0 THEN 1 ELSE 0 END) as negative_fees,\n    MIN(TradePrice) as min_trade_price,\n    MAX(TradePrice) as max_trade_price,\n    AVG(TradePrice) as avg_trade_price,\n    CASE WHEN (\n        SUM(CASE WHEN TradePrice <= 0 THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN TradePrice > {max_reasonable_price} THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN Fee < 0 OR Commission < 0 OR Tax < 0 THEN 1 ELSE 0 END)\n    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM FactTrade;\n",
+"VQ10": "\nSELECT\n    'Date Dimension Business Day Validation' as validation_name,\n    COUNT(*) as total_dates,\n    SUM(CASE WHEN HolidayFlag = 1 AND DayOfWeekNum NOT IN (1,7) THEN 1 ELSE 0 END) as holiday_weekday_conflicts,\n    SUM(CASE WHEN DayOfWeekNum IN (1,7) AND HolidayFlag = 0 THEN 0 ELSE 1 END) as weekend_flag_errors,\n    SUM(CASE WHEN CalendarYearID != CAST(SUBSTR(CAST(DateValue AS VARCHAR), 1, 4) AS INTEGER) THEN 1 ELSE 0 END) as year_mismatch_errors,\n    SUM(CASE WHEN CalendarQtrID NOT BETWEEN 1 AND 4 THEN 1 ELSE 0 END) as invalid_quarter_errors,\n    CASE WHEN (\n        SUM(CASE WHEN HolidayFlag = 1 AND DayOfWeekNum NOT IN (1,7) THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN DayOfWeekNum IN (1,7) AND HolidayFlag = 0 THEN 0 ELSE 1 END) +\n        SUM(CASE WHEN CalendarYearID != CAST(SUBSTR(CAST(DateValue AS VARCHAR), 1, 4) AS INTEGER) THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN CalendarQtrID NOT BETWEEN 1 AND 4 THEN 1 ELSE 0 END)\n    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM DimDate;\n",
+"VQ11": "\nSELECT\n    'Market History Consistency Validation' as validation_name,\n    COUNT(*) as total_market_records,\n    SUM(CASE WHEN ClosePrice <= 0 OR DayHigh <= 0 OR DayLow <= 0 THEN 1 ELSE 0 END) as invalid_prices,\n    SUM(CASE WHEN DayHigh < DayLow THEN 1 ELSE 0 END) as high_low_inconsistencies,\n    SUM(CASE WHEN ClosePrice > DayHigh OR ClosePrice < DayLow THEN 1 ELSE 0 END) as close_price_range_violations,\n    SUM(CASE WHEN Volume < 0 THEN 1 ELSE 0 END) as negative_volume,\n    SUM(CASE WHEN FiftyTwoWeekHigh < FiftyTwoWeekLow THEN 1 ELSE 0 END) as week52_range_violations,\n    CASE WHEN (\n        SUM(CASE WHEN ClosePrice <= 0 OR DayHigh <= 0 OR DayLow <= 0 THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN DayHigh < DayLow THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN ClosePrice > DayHigh OR ClosePrice < DayLow THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN Volume < 0 THEN 1 ELSE 0 END) +\n        SUM(CASE WHEN FiftyTwoWeekHigh < FiftyTwoWeekLow THEN 1 ELSE 0 END)\n    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status\nFROM FactMarketHistory;\n",
+"VQ12": "\nSELECT\n    'Cash Balance Consistency Validation' as validation_name,\n    cb.SK_CustomerID,\n    cb.SK_AccountID,\n    cb.Cash as current_cash_balance,\n    SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax\n             WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)\n             ELSE 0 END) as calculated_cash_impact,\n    ABS(cb.Cash - SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax\n                           WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)\n                           ELSE 0 END)) as balance_discrepancy,\n    CASE WHEN ABS(cb.Cash - SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax\n                                     WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)\n                                     ELSE 0 END)) <= {balance_tolerance} THEN 'PASS' ELSE 'FAIL' END as status\nFROM FactCashBalances cb\nLEFT JOIN FactTrade ft ON cb.SK_CustomerID = ft.SK_CustomerID AND cb.SK_AccountID = ft.SK_AccountID\nLEFT JOIN TradeType tt ON ft.Type = tt.TT_ID\nWHERE ft.Status = 'Completed'\nGROUP BY cb.SK_CustomerID, cb.SK_AccountID, cb.Cash\nHAVING COUNT(ft.TradeID) > 0\nORDER BY balance_discrepancy DESC\nLIMIT {limit_rows};\n"
+},
+"metadata": {
+"VQ1": {"relies_on": ["FactTrade", "DimCustomer", "DimAccount", "DimSecurity"], "query_type": "validation", "category": "referential_integrity", "description": "Validates referential integrity between core fact and dimension tables", "severity": "critical"},
+"VQ2": {"relies_on": ["FactCashBalances", "FactHoldings", "FactMarketHistory", "FactWatches", "DimCustomer", "DimSecurity"], "query_type": "validation", "category": "referential_integrity", "description": "Validates referential integrity for extended fact tables", "severity": "critical"},
+"VQ3": {"relies_on": ["DimCustomer", "DimAccount", "DimSecurity", "DimCompany", "FactTrade"], "query_type": "validation", "category": "completeness", "description": "Validates data completeness across core dimension and fact tables", "severity": "high"},
+"VQ4": {"relies_on": ["DimCustomer", "DimAccount", "DimSecurity", "DimCompany", "DimBroker"], "query_type": "validation", "category": "scd_type2", "description": "Validates SCD Type 2 current record flag consistency", "severity": "high"},
+"VQ5": {"relies_on": ["DimCustomer", "DimAccount", "DimSecurity", "DimCompany", "DimBroker"], "query_type": "validation", "category": "scd_type2", "description": "Validates SCD Type 2 effective date range consistency", "severity": "high"},
+"VQ6": {"relies_on": ["FactTrade", "FactHoldings", "TradeType"], "query_type": "validation", "category": "consistency", "description": "Validates consistency between trade transactions and current holdings", "severity": "medium"},
+"VQ7": {"relies_on": ["DimCustomer"], "query_type": "validation", "category": "business_rules", "description": "Validates customer tier and net worth correlation business rules", "severity": "medium"},
+"VQ8": {"relies_on": ["DimCustomer"], "query_type": "validation", "category": "business_rules", "description": "Validates credit rating range business rules", "severity": "medium"},
+"VQ9": {"relies_on": ["FactTrade"], "query_type": "validation", "category": "business_rules", "description": "Validates trade price and fee reasonableness business rules", "severity": "medium"},
+"VQ10": {"relies_on": ["DimDate"], "query_type": "validation", "category": "consistency", "description": "Validates date dimension business day and calendar consistency", "severity": "low"},
+"VQ11": {"relies_on": ["FactMarketHistory"], "query_type": "validation", "category": "consistency", "description": "Validates market history price and volume consistency", "severity": "medium"},
+"VQ12": {"relies_on": ["FactCashBalances", "FactTrade", "TradeType"], "query_type": "validation", "category": "consistency", "description": "Validates cash balance consistency with trade transactions", "severity": "medium"}
+}
+}"""
+
+
+@lru_cache(maxsize=1)
+def _validation_query_data() -> dict[str, Any]:
+    return json.loads(_VALIDATION_QUERY_DATA_JSON)
 
 
 class TPCDIValidationQueries(ParameterizedQueryManager):
@@ -26,601 +64,38 @@ class TPCDIValidationQueries(ParameterizedQueryManager):
     invalid_query_label = "validation query"
 
     def __init__(self) -> None:
-        """Initialize the validation query manager."""
         self._queries = self._load_validation_queries()
         self._query_metadata = self._load_validation_metadata()
 
     def _load_validation_queries(self) -> dict[str, str]:
-        """Load all data quality validation queries.
-
-        Returns:
-            Dictionary mapping validation query IDs to SQL text
-        """
-        queries = {}
-
-        # VQ1: Referential integrity validation - Core dimension tables
-        queries["VQ1"] = """
-SELECT
-    'Core Tables Referential Integrity' as validation_name,
-    SUM(CASE WHEN orphaned_customers > 0 THEN 1 ELSE 0 END) +
-    SUM(CASE WHEN orphaned_accounts > 0 THEN 1 ELSE 0 END) +
-    SUM(CASE WHEN orphaned_securities > 0 THEN 1 ELSE 0 END) as integrity_violations,
-    COUNT(*) as total_checks
-FROM (
-    SELECT
-        (SELECT COUNT(*) FROM FactTrade f
-         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID
-         WHERE c.SK_CustomerID IS NULL) as orphaned_customers,
-        (SELECT COUNT(*) FROM FactTrade f
-         LEFT JOIN DimAccount a ON f.SK_AccountID = a.SK_AccountID
-         WHERE a.SK_AccountID IS NULL) as orphaned_accounts,
-        (SELECT COUNT(*) FROM FactTrade f
-         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID
-         WHERE s.SK_SecurityID IS NULL) as orphaned_securities
-) checks;
-"""
-
-        # VQ2: Extended tables referential integrity validation
-        queries["VQ2"] = """
-SELECT
-    'Extended Tables Referential Integrity' as validation_name,
-    SUM(CASE WHEN orphaned_cash_balances > 0 THEN 1 ELSE 0 END) +
-    SUM(CASE WHEN orphaned_holdings > 0 THEN 1 ELSE 0 END) +
-    SUM(CASE WHEN orphaned_market_history > 0 THEN 1 ELSE 0 END) +
-    SUM(CASE WHEN orphaned_watches > 0 THEN 1 ELSE 0 END) as integrity_violations,
-    4 as total_checks
-FROM (
-    SELECT
-        (SELECT COUNT(*) FROM FactCashBalances f
-         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID
-         WHERE c.SK_CustomerID IS NULL) as orphaned_cash_balances,
-        (SELECT COUNT(*) FROM FactHoldings f
-         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID
-         WHERE s.SK_SecurityID IS NULL) as orphaned_holdings,
-        (SELECT COUNT(*) FROM FactMarketHistory f
-         LEFT JOIN DimSecurity s ON f.SK_SecurityID = s.SK_SecurityID
-         WHERE s.SK_SecurityID IS NULL) as orphaned_market_history,
-        (SELECT COUNT(*) FROM FactWatches f
-         LEFT JOIN DimCustomer c ON f.SK_CustomerID = c.SK_CustomerID
-         WHERE c.SK_CustomerID IS NULL) as orphaned_watches
-) checks;
-"""
-
-        # VQ3: Data completeness validation - Core tables
-        queries["VQ3"] = """
-SELECT
-    'Data Completeness - Core Tables' as validation_name,
-    table_name,
-    total_records,
-    null_key_columns,
-    CASE WHEN null_key_columns = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM (
-    SELECT 'DimCustomer' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN CustomerID IS NULL OR TaxID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_columns
-    FROM DimCustomer
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT 'DimAccount' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN AccountID IS NULL OR SK_CustomerID IS NULL OR Status IS NULL THEN 1 ELSE 0 END) as null_key_columns
-    FROM DimAccount
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT 'DimSecurity' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN Symbol IS NULL OR Name IS NULL OR ExchangeID IS NULL THEN 1 ELSE 0 END) as null_key_columns
-    FROM DimSecurity
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT 'DimCompany' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN CompanyID IS NULL OR Name IS NULL OR Industry IS NULL THEN 1 ELSE 0 END) as null_key_columns
-    FROM DimCompany
-    WHERE IsCurrent = 1
-    UNION ALL
-    SELECT 'FactTrade' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN TradeID IS NULL OR SK_CustomerID IS NULL OR SK_SecurityID IS NULL THEN 1 ELSE 0 END) as null_key_columns
-    FROM FactTrade
-) completeness_check
-ORDER BY table_name;
-"""
-
-        # VQ4: SCD Type 2 validation - Current record flags
-        queries["VQ4"] = """
-SELECT
-    'SCD Type 2 Current Record Validation' as validation_name,
-    table_name,
-    total_records,
-    current_records,
-    multiple_current_per_business_key,
-    CASE WHEN multiple_current_per_business_key = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM (
-    SELECT 'DimCustomer' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-           (SELECT COUNT(*) FROM (
-               SELECT CustomerID, COUNT(*) as current_count
-               FROM DimCustomer
-               WHERE IsCurrent = 1
-               GROUP BY CustomerID
-               HAVING COUNT(*) > 1
-           ) violations) as multiple_current_per_business_key
-    FROM DimCustomer
-    UNION ALL
-    SELECT 'DimAccount' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-           (SELECT COUNT(*) FROM (
-               SELECT AccountID, COUNT(*) as current_count
-               FROM DimAccount
-               WHERE IsCurrent = 1
-               GROUP BY AccountID
-               HAVING COUNT(*) > 1
-           ) violations) as multiple_current_per_business_key
-    FROM DimAccount
-    UNION ALL
-    SELECT 'DimSecurity' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-           (SELECT COUNT(*) FROM (
-               SELECT Symbol, COUNT(*) as current_count
-               FROM DimSecurity
-               WHERE IsCurrent = 1
-               GROUP BY Symbol
-               HAVING COUNT(*) > 1
-           ) violations) as multiple_current_per_business_key
-    FROM DimSecurity
-    UNION ALL
-    SELECT 'DimCompany' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-           (SELECT COUNT(*) FROM (
-               SELECT CompanyID, COUNT(*) as current_count
-               FROM DimCompany
-               WHERE IsCurrent = 1
-               GROUP BY CompanyID
-               HAVING COUNT(*) > 1
-           ) violations) as multiple_current_per_business_key
-    FROM DimCompany
-    UNION ALL
-    SELECT 'DimBroker' as table_name,
-           COUNT(*) as total_records,
-           SUM(CASE WHEN IsCurrent = 1 THEN 1 ELSE 0 END) as current_records,
-           (SELECT COUNT(*) FROM (
-               SELECT BrokerID, COUNT(*) as current_count
-               FROM DimBroker
-               WHERE IsCurrent = 1
-               GROUP BY BrokerID
-               HAVING COUNT(*) > 1
-           ) violations) as multiple_current_per_business_key
-    FROM DimBroker
-) scd_validation
-ORDER BY table_name;
-"""
-
-        # VQ5: SCD Type 2 validation - Effective date ranges
-        queries["VQ5"] = """
-SELECT
-    'SCD Type 2 Date Range Validation' as validation_name,
-    table_name,
-    invalid_date_ranges,
-    overlapping_date_ranges,
-    future_effective_dates,
-    CASE WHEN (invalid_date_ranges + overlapping_date_ranges + future_effective_dates) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM (
-    SELECT 'DimCustomer' as table_name,
-           (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate >= EndDate) as invalid_date_ranges,
-           (SELECT COUNT(*) FROM DimCustomer c1
-            JOIN DimCustomer c2 ON c1.CustomerID = c2.CustomerID
-                AND c1.SK_CustomerID != c2.SK_CustomerID
-                AND c1.EffectiveDate < c2.EndDate
-                AND c2.EffectiveDate < c1.EndDate) as overlapping_date_ranges,
-           (SELECT COUNT(*) FROM DimCustomer WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates
-    UNION ALL
-    SELECT 'DimAccount' as table_name,
-           (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate >= EndDate) as invalid_date_ranges,
-           (SELECT COUNT(*) FROM DimAccount a1
-            JOIN DimAccount a2 ON a1.AccountID = a2.AccountID
-                AND a1.SK_AccountID != a2.SK_AccountID
-                AND a1.EffectiveDate < a2.EndDate
-                AND a2.EffectiveDate < a1.EndDate) as overlapping_date_ranges,
-           (SELECT COUNT(*) FROM DimAccount WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates
-    UNION ALL
-    SELECT 'DimSecurity' as table_name,
-           (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate >= EndDate) as invalid_date_ranges,
-           (SELECT COUNT(*) FROM DimSecurity s1
-            JOIN DimSecurity s2 ON s1.Symbol = s2.Symbol
-                AND s1.SK_SecurityID != s2.SK_SecurityID
-                AND s1.EffectiveDate < s2.EndDate
-                AND s2.EffectiveDate < s1.EndDate) as overlapping_date_ranges,
-           (SELECT COUNT(*) FROM DimSecurity WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates
-    UNION ALL
-    SELECT 'DimCompany' as table_name,
-           (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate >= EndDate) as invalid_date_ranges,
-           (SELECT COUNT(*) FROM DimCompany comp1
-            JOIN DimCompany comp2 ON comp1.CompanyID = comp2.CompanyID
-                AND comp1.SK_CompanyID != comp2.SK_CompanyID
-                AND comp1.EffectiveDate < comp2.EndDate
-                AND comp2.EffectiveDate < comp1.EndDate) as overlapping_date_ranges,
-           (SELECT COUNT(*) FROM DimCompany WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates
-    UNION ALL
-    SELECT 'DimBroker' as table_name,
-           (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate >= EndDate) as invalid_date_ranges,
-           (SELECT COUNT(*) FROM DimBroker b1
-            JOIN DimBroker b2 ON b1.BrokerID = b2.BrokerID
-                AND b1.SK_BrokerID != b2.SK_BrokerID
-                AND b1.EffectiveDate < b2.EndDate
-                AND b2.EffectiveDate < b1.EndDate) as overlapping_date_ranges,
-           (SELECT COUNT(*) FROM DimBroker WHERE EffectiveDate > CURRENT_DATE) as future_effective_dates
-) date_validation
-ORDER BY table_name;
-"""
-
-        # VQ6: Data consistency validation - Trade quantities and holdings
-        queries["VQ6"] = """
-SELECT
-    'Trade-Holdings Consistency Validation' as validation_name,
-    customer_id,
-    security_id,
-    total_buy_quantity,
-    total_sell_quantity,
-    net_position,
-    current_holdings,
-    position_discrepancy,
-    CASE WHEN ABS(position_discrepancy) <= {tolerance_threshold} THEN 'PASS' ELSE 'FAIL' END as status
-FROM (
-    SELECT
-        ft.SK_CustomerID as customer_id,
-        ft.SK_SecurityID as security_id,
-        SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE 0 END) as total_buy_quantity,
-        SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity ELSE 0 END) as total_sell_quantity,
-        SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE -ft.Quantity END) as net_position,
-        COALESCE(fh.CurrentHolding, 0) as current_holdings,
-        (SUM(CASE WHEN tt.TT_IS_SELL = 0 THEN ft.Quantity ELSE -ft.Quantity END) - COALESCE(fh.CurrentHolding, 0)) as position_discrepancy
-    FROM FactTrade ft
-    JOIN TradeType tt ON ft.Type = tt.TT_ID
-    LEFT JOIN FactHoldings fh ON ft.SK_CustomerID = fh.SK_CustomerID
-                              AND ft.SK_SecurityID = fh.SK_SecurityID
-    WHERE ft.Status = 'Completed'
-    GROUP BY ft.SK_CustomerID, ft.SK_SecurityID, fh.CurrentHolding
-) position_check
-WHERE ABS(position_discrepancy) > 0
-ORDER BY ABS(position_discrepancy) DESC
-LIMIT {limit_rows};
-"""
-
-        # VQ7: Business rule validation - Customer tier and net worth correlation
-        queries["VQ7"] = """
-SELECT
-    'Customer Tier-NetWorth Validation' as validation_name,
-    Tier,
-    COUNT(*) as customer_count,
-    MIN(NetWorth) as min_net_worth,
-    MAX(NetWorth) as max_net_worth,
-    AVG(NetWorth) as avg_net_worth,
-    SUM(CASE
-        WHEN Tier = 1 AND NetWorth < {tier1_min_networth} THEN 1
-        WHEN Tier = 2 AND (NetWorth < {tier2_min_networth} OR NetWorth >= {tier2_max_networth}) THEN 1
-        WHEN Tier = 3 AND NetWorth >= {tier3_max_networth} THEN 1
-        ELSE 0
-    END) as tier_violations,
-    CASE WHEN SUM(CASE
-        WHEN Tier = 1 AND NetWorth < {tier1_min_networth} THEN 1
-        WHEN Tier = 2 AND (NetWorth < {tier2_min_networth} OR NetWorth >= {tier2_max_networth}) THEN 1
-        WHEN Tier = 3 AND NetWorth >= {tier3_max_networth} THEN 1
-        ELSE 0
-    END) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM DimCustomer
-WHERE IsCurrent = 1
-GROUP BY Tier
-ORDER BY Tier;
-"""
-
-        # VQ8: Business rule validation - Credit rating ranges
-        queries["VQ8"] = """
-SELECT
-    'Credit Rating Validation' as validation_name,
-    COUNT(*) as total_customers,
-    SUM(CASE WHEN CreditRating < {min_credit_rating} OR CreditRating > {max_credit_rating} THEN 1 ELSE 0 END) as invalid_credit_ratings,
-    MIN(CreditRating) as min_credit_rating,
-    MAX(CreditRating) as max_credit_rating,
-    AVG(CreditRating) as avg_credit_rating,
-    CASE WHEN SUM(CASE WHEN CreditRating < {min_credit_rating} OR CreditRating > {max_credit_rating} THEN 1 ELSE 0 END) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM DimCustomer
-WHERE IsCurrent = 1;
-"""
-
-        # VQ9: Business rule validation - Trade price reasonableness
-        queries["VQ9"] = """
-SELECT
-    'Trade Price Reasonableness Validation' as validation_name,
-    COUNT(*) as total_trades,
-    SUM(CASE WHEN TradePrice <= 0 THEN 1 ELSE 0 END) as negative_or_zero_prices,
-    SUM(CASE WHEN TradePrice > {max_reasonable_price} THEN 1 ELSE 0 END) as extremely_high_prices,
-    SUM(CASE WHEN Fee < 0 OR Commission < 0 OR Tax < 0 THEN 1 ELSE 0 END) as negative_fees,
-    MIN(TradePrice) as min_trade_price,
-    MAX(TradePrice) as max_trade_price,
-    AVG(TradePrice) as avg_trade_price,
-    CASE WHEN (
-        SUM(CASE WHEN TradePrice <= 0 THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN TradePrice > {max_reasonable_price} THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN Fee < 0 OR Commission < 0 OR Tax < 0 THEN 1 ELSE 0 END)
-    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM FactTrade;
-"""
-
-        # VQ10: Date dimension validation - Business day consistency
-        queries["VQ10"] = """
-SELECT
-    'Date Dimension Business Day Validation' as validation_name,
-    COUNT(*) as total_dates,
-    SUM(CASE WHEN HolidayFlag = 1 AND DayOfWeekNum NOT IN (1,7) THEN 1 ELSE 0 END) as holiday_weekday_conflicts,
-    SUM(CASE WHEN DayOfWeekNum IN (1,7) AND HolidayFlag = 0 THEN 0 ELSE 1 END) as weekend_flag_errors,
-    SUM(CASE WHEN CalendarYearID != CAST(SUBSTR(CAST(DateValue AS VARCHAR), 1, 4) AS INTEGER) THEN 1 ELSE 0 END) as year_mismatch_errors,
-    SUM(CASE WHEN CalendarQtrID NOT BETWEEN 1 AND 4 THEN 1 ELSE 0 END) as invalid_quarter_errors,
-    CASE WHEN (
-        SUM(CASE WHEN HolidayFlag = 1 AND DayOfWeekNum NOT IN (1,7) THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN DayOfWeekNum IN (1,7) AND HolidayFlag = 0 THEN 0 ELSE 1 END) +
-        SUM(CASE WHEN CalendarYearID != CAST(SUBSTR(CAST(DateValue AS VARCHAR), 1, 4) AS INTEGER) THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN CalendarQtrID NOT BETWEEN 1 AND 4 THEN 1 ELSE 0 END)
-    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM DimDate;
-"""
-
-        # VQ11: Extended fact table validation - Market history consistency
-        queries["VQ11"] = """
-SELECT
-    'Market History Consistency Validation' as validation_name,
-    COUNT(*) as total_market_records,
-    SUM(CASE WHEN ClosePrice <= 0 OR DayHigh <= 0 OR DayLow <= 0 THEN 1 ELSE 0 END) as invalid_prices,
-    SUM(CASE WHEN DayHigh < DayLow THEN 1 ELSE 0 END) as high_low_inconsistencies,
-    SUM(CASE WHEN ClosePrice > DayHigh OR ClosePrice < DayLow THEN 1 ELSE 0 END) as close_price_range_violations,
-    SUM(CASE WHEN Volume < 0 THEN 1 ELSE 0 END) as negative_volume,
-    SUM(CASE WHEN FiftyTwoWeekHigh < FiftyTwoWeekLow THEN 1 ELSE 0 END) as week52_range_violations,
-    CASE WHEN (
-        SUM(CASE WHEN ClosePrice <= 0 OR DayHigh <= 0 OR DayLow <= 0 THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN DayHigh < DayLow THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN ClosePrice > DayHigh OR ClosePrice < DayLow THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN Volume < 0 THEN 1 ELSE 0 END) +
-        SUM(CASE WHEN FiftyTwoWeekHigh < FiftyTwoWeekLow THEN 1 ELSE 0 END)
-    ) = 0 THEN 'PASS' ELSE 'FAIL' END as status
-FROM FactMarketHistory;
-"""
-
-        # VQ12: Cash balances validation - Account balance consistency
-        queries["VQ12"] = """
-SELECT
-    'Cash Balance Consistency Validation' as validation_name,
-    cb.SK_CustomerID,
-    cb.SK_AccountID,
-    cb.Cash as current_cash_balance,
-    SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax
-             WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)
-             ELSE 0 END) as calculated_cash_impact,
-    ABS(cb.Cash - SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax
-                           WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)
-                           ELSE 0 END)) as balance_discrepancy,
-    CASE WHEN ABS(cb.Cash - SUM(CASE WHEN tt.TT_IS_SELL = 1 THEN ft.Quantity * ft.TradePrice - ft.Fee - ft.Commission - ft.Tax
-                                     WHEN tt.TT_IS_SELL = 0 THEN -(ft.Quantity * ft.TradePrice + ft.Fee + ft.Commission + ft.Tax)
-                                     ELSE 0 END)) <= {balance_tolerance} THEN 'PASS' ELSE 'FAIL' END as status
-FROM FactCashBalances cb
-LEFT JOIN FactTrade ft ON cb.SK_CustomerID = ft.SK_CustomerID AND cb.SK_AccountID = ft.SK_AccountID
-LEFT JOIN TradeType tt ON ft.Type = tt.TT_ID
-WHERE ft.Status = 'Completed'
-GROUP BY cb.SK_CustomerID, cb.SK_AccountID, cb.Cash
-HAVING COUNT(ft.TradeID) > 0
-ORDER BY balance_discrepancy DESC
-LIMIT {limit_rows};
-"""
-
-        return queries
+        return dict(_validation_query_data()["queries"])
 
     def _load_validation_metadata(self) -> dict[str, dict[str, Any]]:
-        """Load metadata for validation queries.
-
-        Returns:
-            Dictionary mapping query IDs to their metadata
-        """
-        metadata = {}
-
-        metadata["VQ1"] = {
-            "relies_on": ["FactTrade", "DimCustomer", "DimAccount", "DimSecurity"],
-            "query_type": "validation",
-            "category": "referential_integrity",
-            "description": "Validates referential integrity between core fact and dimension tables",
-            "severity": "critical",
-        }
-
-        metadata["VQ2"] = {
-            "relies_on": [
-                "FactCashBalances",
-                "FactHoldings",
-                "FactMarketHistory",
-                "FactWatches",
-                "DimCustomer",
-                "DimSecurity",
-            ],
-            "query_type": "validation",
-            "category": "referential_integrity",
-            "description": "Validates referential integrity for extended fact tables",
-            "severity": "critical",
-        }
-
-        metadata["VQ3"] = {
-            "relies_on": [
-                "DimCustomer",
-                "DimAccount",
-                "DimSecurity",
-                "DimCompany",
-                "FactTrade",
-            ],
-            "query_type": "validation",
-            "category": "completeness",
-            "description": "Validates data completeness across core dimension and fact tables",
-            "severity": "high",
-        }
-
-        metadata["VQ4"] = {
-            "relies_on": [
-                "DimCustomer",
-                "DimAccount",
-                "DimSecurity",
-                "DimCompany",
-                "DimBroker",
-            ],
-            "query_type": "validation",
-            "category": "scd_type2",
-            "description": "Validates SCD Type 2 current record flag consistency",
-            "severity": "high",
-        }
-
-        metadata["VQ5"] = {
-            "relies_on": [
-                "DimCustomer",
-                "DimAccount",
-                "DimSecurity",
-                "DimCompany",
-                "DimBroker",
-            ],
-            "query_type": "validation",
-            "category": "scd_type2",
-            "description": "Validates SCD Type 2 effective date range consistency",
-            "severity": "high",
-        }
-
-        metadata["VQ6"] = {
-            "relies_on": ["FactTrade", "FactHoldings", "TradeType"],
-            "query_type": "validation",
-            "category": "consistency",
-            "description": "Validates consistency between trade transactions and current holdings",
-            "severity": "medium",
-        }
-
-        metadata["VQ7"] = {
-            "relies_on": ["DimCustomer"],
-            "query_type": "validation",
-            "category": "business_rules",
-            "description": "Validates customer tier and net worth correlation business rules",
-            "severity": "medium",
-        }
-
-        metadata["VQ8"] = {
-            "relies_on": ["DimCustomer"],
-            "query_type": "validation",
-            "category": "business_rules",
-            "description": "Validates credit rating range business rules",
-            "severity": "medium",
-        }
-
-        metadata["VQ9"] = {
-            "relies_on": ["FactTrade"],
-            "query_type": "validation",
-            "category": "business_rules",
-            "description": "Validates trade price and fee reasonableness business rules",
-            "severity": "medium",
-        }
-
-        metadata["VQ10"] = {
-            "relies_on": ["DimDate"],
-            "query_type": "validation",
-            "category": "consistency",
-            "description": "Validates date dimension business day and calendar consistency",
-            "severity": "low",
-        }
-
-        metadata["VQ11"] = {
-            "relies_on": ["FactMarketHistory"],
-            "query_type": "validation",
-            "category": "consistency",
-            "description": "Validates market history price and volume consistency",
-            "severity": "medium",
-        }
-
-        metadata["VQ12"] = {
-            "relies_on": ["FactCashBalances", "FactTrade", "TradeType"],
-            "query_type": "validation",
-            "category": "consistency",
-            "description": "Validates cash balance consistency with trade transactions",
-            "severity": "medium",
-        }
-
-        return metadata
+        return copy_query_metadata(_validation_query_data()["metadata"])
 
     def _generate_default_params(self, query_id: str) -> dict[str, Any]:
-        """Generate default parameters for validation queries.
-
-        Args:
-            query_id: Query identifier
-
-        Returns:
-            Dictionary of parameter names to default values
-        """
-        # Default parameters for validation queries
-        defaults = {
-            # Tolerance thresholds
-            "tolerance_threshold": 100,  # Quantity tolerance for position discrepancies
-            "balance_tolerance": 1000.00,  # Dollar tolerance for cash balance discrepancies
-            # Business rule thresholds
-            "tier1_min_networth": 1000000,  # Tier 1 customers: $1M+ net worth
-            "tier2_min_networth": 250000,  # Tier 2 customers: $250K-$1M net worth
+        return {
+            "tolerance_threshold": 100,
+            "balance_tolerance": 1000.0,
+            "tier1_min_networth": 1000000,
+            "tier2_min_networth": 250000,
             "tier2_max_networth": 1000000,
-            "tier3_max_networth": 250000,  # Tier 3 customers: <$250K net worth
-            # Credit rating range (FICO scores)
+            "tier3_max_networth": 250000,
             "min_credit_rating": 300,
             "max_credit_rating": 850,
-            # Trade price reasonableness
-            "max_reasonable_price": 10000.00,  # $10,000 per share max
-            # Result limits
+            "max_reasonable_price": 10000.0,
             "limit_rows": 100,
         }
 
-        return defaults
-
     def get_query_metadata(self, query_id: str) -> dict[str, Any]:
-        """Get metadata for a validation query.
-
-        Args:
-            query_id: Query identifier (VQ1, VQ2, etc.)
-
-        Returns:
-            Dictionary containing query metadata
-
-        Raises:
-            ValueError: If query_id is invalid
-        """
         return self._get_query_metadata_copy(self._query_metadata, query_id, "validation query")
 
     def get_queries_by_category(self, category: str) -> list[str]:
-        """Get all validation queries of a specific category.
-
-        Args:
-            category: Category name (referential_integrity, completeness, scd_type2,
-                     consistency, business_rules)
-
-        Returns:
-            List of query IDs in the specified category
-        """
-        valid_categories = {
-            "referential_integrity",
-            "completeness",
-            "scd_type2",
-            "consistency",
-            "business_rules",
-        }
-        self._validate_selector_value(category, valid_categories, "category", plural="categories")
-        return self._query_ids_by_metadata(self._query_metadata, "category", category)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "category", category, "category", plural="categories"
+        )
 
     def get_queries_by_severity(self, severity: str) -> list[str]:
-        """Get all validation queries of a specific severity level.
-
-        Args:
-            severity: Severity level (critical, high, medium, low)
-
-        Returns:
-            List of query IDs with the specified severity
-        """
-        valid_severities = {"critical", "high", "medium", "low"}
-        self._validate_selector_value(severity, valid_severities, "severity", plural="severities")
-        return self._query_ids_by_metadata(self._query_metadata, "severity", severity)
+        return self._query_ids_for_valid_metadata(
+            self._query_metadata, "severity", severity, "severity", plural="severities"
+        )


### PR DESCRIPTION
## Shrink Ledger

- Surface/module: TPC-DI query catalogs
- Files changed: `benchbox/core/query_manager.py`, `benchbox/core/tpcdi/queries.py`, `benchbox/core/tpcdi/query_analytics.py`, `benchbox/core/tpcdi/query_etl.py`, `benchbox/core/tpcdi/query_validation.py`
- Original code lines: 734
- New code lines: 329
- Lines removed: 405
- Reduction: 55.18%
- Simplification type: compact lazy JSON-backed static query/metadata catalogs plus shared metadata-copy and selector-validation helpers

## Behavior Preserved

- Query template, rendered SQL, metadata, dependency, selector, execution-plan, and statistics snapshot unchanged
- Snapshot SHA before and after: `66db72b3a75ca8f17580a3233926f554d21646383b8b37fd1e70055cd738d38c`
- JSON parsing is lazy and cached, preserving the old no-catalog-build-at-import performance shape

## Verification

- `uv run -- ruff check benchbox/core/query_manager.py benchbox/core/tpcdi/query_analytics.py benchbox/core/tpcdi/query_validation.py benchbox/core/tpcdi/query_etl.py benchbox/core/tpcdi/queries.py`
- `uv run -- python -m pytest -n 0 tests/unit/test_tpcdi_phase2_queries.py tests/unit/core/tpcdi/test_config_schema_queries_coverage.py -q` - 37 passed
- `uv run -- python -m pytest -n 0 tests/unit/test_tpcdi_phase2_queries.py tests/unit/core/tpcdi -q` - 338 passed
- `uv run -- python -m pytest -n 0 tests/test_tpcdi.py tests/unit/test_tpcdi_phase1.py tests/unit/tpcdi -q` - 219 passed, 3 deselected
- `uv run -- python -m pytest -n 0 tests/unit/tpchavoc/test_query_manager.py tests/unit/core/ai_primitives/test_query_manager.py tests/unit/core/test_tpcds_queries.py tests/unit/tpch/test_tpch_queries.py -q` - 54 passed
- `git diff --check`
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight` - 22,716 passed, 5 skipped, 43 warnings, 4 subtests passed in 240.19s

## Residual Risk

- Static query data is denser to review, but generated snapshots and focused suites prove public query behavior is unchanged.
- No safety boundary, subprocess, credential, filesystem, timing, publishing, or validation behavior is changed.

## Next Recommended Shrink Target

- Continue through bundled static benchmark catalogs under `benchbox/core/`, prioritizing large query/catalog resources with deterministic parse/render snapshot coverage.
