### PR TITLE
chore: shrink read primitives catalog

### DIFF
--- a/benchbox/core/read_primitives/catalog/queries.yaml
+++ b/benchbox/core/read_primitives/catalog/queries.yaml
@@ -33,1140 +33,160 @@
 
 version: 1
 queries:
-- id: aggregation_distinct
-  category: aggregation
-  sql: "\n-- Distinct count of high cardinality key on a large table\nSELECT COUNT(DISTINCT o_custkey) as unique_customers\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01';\n"
-- id: aggregation_distinct_groupby
-  category: aggregation
-  sql: "\n-- Distinct count of high cardinality keys in low cardinality groups.\nSELECT\n    l_returnflag,\n    l_linestatus,\n    COUNT(DISTINCT l_orderkey) as unique_orders,\n    COUNT(DISTINCT l_partkey) as unique_parts\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-- id: approx_count_distinct_simple
-  category: aggregation
-  sql: "\n-- Approximate distinct count (HLL) on a high-cardinality key\n-- Companion to aggregation_distinct; tests one-shot approx-distinct latency.\n-- Cross-dialect rewrites are handled by sqlglot:\n--   ClickHouse: uniq(o_custkey)\n--   Redshift:   APPROXIMATE COUNT(DISTINCT o_custkey)\nSELECT APPROX_COUNT_DISTINCT(o_custkey) as unique_customers\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01';\n"
-  result_contract:
-    capability: approximate_distinct_count
-    columns:
-    - unique_customers
-  skip_on:
-  - sqlite
-- id: approx_count_distinct_groupby
-  category: aggregation
-  sql: "\n-- Approximate distinct counts (HLL) per low-cardinality group\n-- Companion to aggregation_distinct_groupby. Cross-dialect rewrites\n-- (ClickHouse uniq, Redshift APPROXIMATE COUNT(DISTINCT)) are handled\n-- by sqlglot.\nSELECT\n    l_returnflag,\n    l_linestatus,\n    APPROX_COUNT_DISTINCT(l_orderkey) as unique_orders,\n    APPROX_COUNT_DISTINCT(l_partkey) as unique_parts\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-  result_contract:
-    capability: approximate_distinct_count
-    row_identity:
-    - l_returnflag
-    - l_linestatus
-    columns:
-    - l_returnflag
-    - l_linestatus
-    - unique_orders
-    - unique_parts
-  skip_on:
-  - sqlite
-- id: aggregation_groupby_large
-  category: aggregation
-  sql: "\n-- Aggregates within high cardinality grouping\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    SUM(l_quantity) as total_qty,\n    AVG(l_extendedprice) as avg_price\nFROM lineitem\nGROUP BY l_orderkey, l_partkey, l_suppkey;\n"
-- id: aggregation_groupby_small
-  category: aggregation
-  sql: "\n-- Aggregates within low cardinality grouping\nSELECT\n    n_regionkey,\n    COUNT(*) as nation_count,\n    MAX(n_name) as last_nation\nFROM nation\nGROUP BY n_regionkey;\n"
-- id: aggregation_materialize
-  category: aggregation
-  sql: "\n-- Nested aggregation requiring CTE materialization\nWITH order_totals AS (\n    SELECT\n        o_custkey,\n        SUM(o_totalprice) as customer_total\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT AVG(customer_total) as avg_customer_spending\nFROM order_totals;\n"
-- id: aggregation_materialize_subquery
-  category: aggregation
-  sql: "\n-- Complex nested aggregation requiring materialization of a subquery with joins\nSELECT\n    c_mktsegment,\n    AVG(order_total) as avg_segment_order\nFROM (\n    SELECT\n        c.c_mktsegment,\n        o.o_orderkey,\n        SUM(l.l_extendedprice * (1 - l.l_discount)) as order_total\n    FROM customer c\n    JOIN orders o ON c.c_custkey = o.o_custkey\n    JOIN lineitem l ON o.o_orderkey = l.l_orderkey\n    GROUP BY c.c_mktsegment, o.o_orderkey\n) subq\nGROUP BY c_mktsegment;\n"
-- id: aggregation_partition
-  category: aggregation
-  sql: "\n-- Aggregates over the partition key\nSELECT\n    l_shipdate,\n    l_shipmode,\n    SUM(l_quantity) as daily_quantity,\n    COUNT(*) as shipment_count\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\nGROUP BY l_shipdate, l_shipmode;\n"
-- id: aggregation_selective
-  category: aggregation
-  sql: "\n-- Aggregate on a small subset of rows\nSELECT\n    SUM(l_extendedprice * l_discount) as total_discount_amount\nFROM lineitem\nWHERE l_discount > 0.05\n  AND l_quantity < 24;\n"
-- id: aggregation_simple
-  category: aggregation
-  sql: "\n-- Aggregate over all rows in table\nSELECT\n    COUNT(*) as total_orders,\n    SUM(o_totalprice) as total_revenue\nFROM orders;\n"
-- id: broadcast_join_two_tables
-  category: broadcast
-  sql: "\n-- One small table broadcast to join with one large table. Hint is optional.\nSELECT /*+ BROADCAST(n) */\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey;\n"
-- id: broadcast_join_three_tables
-  category: broadcast
-  sql: "\n-- Two small tables broadcast to join with one large table. Hints are optional.\nSELECT /*+ BROADCAST(n), BROADCAST(r) */\n    r.r_name,\n    n.n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r.r_name, n.n_name;\n"
-- id: broadcast_join_four_tables
-  category: broadcast
-  sql: "\n-- Three small tables broadcast to join with one large table. Hints are optional.\nSELECT /*+ BROADCAST(n), BROADCAST(r), BROADCAST(p) */\n    r.r_name,\n    p.p_type,\n    SUM(ps.ps_supplycost * ps.ps_availqty) as total_value\nFROM partsupp ps\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nJOIN part p ON ps.ps_partkey = p.p_partkey\nWHERE p.p_size = 15\nGROUP BY r.r_name, p.p_type;\n"
-- id: predicate_ordering_aggregation
-  category: predicate
-  sql: "\n-- Order filter predicates by selectivity for aggregation\nSELECT\n    SUM(l_extendedprice) as total_price\nFROM lineitem\nWHERE l_shipdate >= DATE '1994-01-01'\n  AND l_shipdate < DATE '1995-01-01'\n  AND l_discount BETWEEN 0.05 AND 0.07\n  AND l_quantity < 24;\n"
-- id: predicate_ordering_aggregation_groupby
-  category: predicate
-  sql: "\n-- Order filter predicates by selectivity for aggregation within a low cardinality grouping\nSELECT\n    l_returnflag,\n    SUM(l_quantity) as total_qty\nFROM lineitem\nWHERE l_shipdate <= DATE '1998-09-01'\n  AND l_discount > 0.05\n  AND l_tax < 0.08\n  AND l_quantity BETWEEN 10 AND 30\nGROUP BY l_returnflag;\n"
-- id: predicate_ordering_costs
-  category: predicate
-  sql: "\n-- Order filter predicates by selectivity with result projection only\nSELECT *\nFROM lineitem\nWHERE l_quantity > 45\n  AND l_extendedprice > 50000\n  AND l_discount < 0.05\n  AND l_shipinstruct = 'DELIVER IN PERSON'\n  AND l_shipmode IN ('AIR', 'AIR REG')\nLIMIT 100;\n"
-- id: predicate_ordering_subquery
-  category: predicate
-  sql: "\n-- Order filter predicates by selectivity with subquery predicate\nSELECT\n    o_orderkey,\n    o_totalprice\nFROM orders\nWHERE o_totalprice > 100000\n  AND o_orderdate >= DATE '1995-01-01'\n  AND o_custkey IN (\n    SELECT c_custkey\n    FROM customer\n    WHERE c_mktsegment = 'BUILDING'\n      AND c_nationkey = 1\n  );\n"
-- id: count_star
-  category: count
-  sql: "\n-- metadata-based count optimization vs full table scan performance\nSELECT COUNT(*) as total_lineitems\nFROM lineitem;\n"
-- id: decimal_arithmetic
-  category: decimal
-  sql: "\n-- decimal precision arithmetic with complex expressions\nSELECT\n    l_orderkey,\n    l_extendedprice * (1 - l_discount) * (1 + l_tax) as final_price,\n    l_extendedprice / l_quantity as unit_price\nFROM lineitem\nWHERE l_quantity > 0\nLIMIT 1000;\n"
-- id: empty_build_join
-  category: empty
-  sql: "\n-- join when build side produces no rows (edge case handling)\nSELECT l.*\nFROM lineitem l\nLEFT JOIN (\n    SELECT * FROM orders WHERE o_totalprice < 0\n) o ON l.l_orderkey = o.o_orderkey;\n"
-- id: exchange_broadcast
-  category: exchange
-  sql: "\n-- One small table is copied to all nodes that have the large table. The `BROADCAST(small_parts)` hint is optional\nSELECT /*+ BROADCAST(small_parts) */\n    l.l_orderkey,\n    SUM(l.l_quantity) as total_qty\nFROM lineitem l\nJOIN (\n    SELECT p_partkey\n    FROM part\n    WHERE p_size = 1\n) small_parts ON l.l_partkey = small_parts.p_partkey\nGROUP BY l.l_orderkey;\n"
-- id: exchange_merge
-  category: exchange
-  sql: "\n-- Sorted data from multiple nodes is combined while keeping the sort order.\nSELECT\n    o.o_orderkey,\n    l.l_linenumber,\n    l.l_quantity\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nORDER BY o.o_orderkey, l.l_linenumber;\n"
-- id: exchange_shuffle
-  category: exchange
-  sql: "\n-- Data is redistributed based on the join keys so matching rows end up on the same node\nSELECT\n    ps1.ps_partkey,\n    ps1.ps_suppkey as supp1,\n    ps2.ps_suppkey as supp2\nFROM partsupp ps1\nJOIN partsupp ps2 ON ps1.ps_partkey = ps2.ps_partkey\nWHERE ps1.ps_suppkey < ps2.ps_suppkey\n  AND ps1.ps_supplycost > 100;\n"
-- id: filter_bigint_in_list_selective
-  category: filter
-  sql: "\n-- IN-list predicate with highly selective integer values\nSELECT *\nFROM orders\nWHERE o_orderkey IN (1, 100, 1000, 10000, 100000);\n"
-- id: filter_bigint_non_selective
-  category: filter
-  sql: "\n-- range predicate with low selectivity on large table\nSELECT COUNT(*)\nFROM lineitem\nWHERE l_orderkey > 1000;\n"
-- id: filter_bigint_selective
-  category: filter
-  sql: "\n-- equality predicate with high selectivity on integer column\nSELECT *\nFROM orders\nWHERE o_orderkey = 1234567;\n"
-- id: filter_decimal_in_list_selective
-  category: filter
-  sql: "\n-- IN-list predicate with decimal values and selectivity\nSELECT *\nFROM lineitem\nWHERE l_extendedprice IN (1000.00, 5000.00, 10000.00, 50000.00);\n"
-- id: filter_decimal_non_selective
-  category: filter
-  sql: "\n-- range predicate on decimal column with low selectivity\nSELECT COUNT(*)\nFROM lineitem\nWHERE l_extendedprice > 1000.00;\n"
-- id: filter_decimal_selective
-  category: filter
-  sql: "\n-- compound equality predicate with multiple decimal columns\nSELECT *\nFROM lineitem\nWHERE l_extendedprice = 12345.67\n  AND l_discount = 0.05;\n"
-- id: filter_in_predicate_selective
-  category: filter
-  sql: "\n-- IN predicate with subquery and selective filtering\nSELECT *\nFROM part\nWHERE p_partkey IN (\n    SELECT l_partkey\n    FROM lineitem\n    WHERE l_quantity > 45\n);\n"
-- id: filter_string_like
-  category: filter
-  sql: "\n-- LIKE predicate with substring pattern matching\nSELECT *\nFROM part\nWHERE p_name LIKE '%COPPER%';\n"
-- id: filter_string_non_selective
-  category: filter
-  sql: "\n-- string comparison with low selectivity (most rows match)\nSELECT COUNT(*)\nFROM customer\nWHERE c_mktsegment >= 'A';\n"
-- id: filter_string_selective
-  category: filter
-  sql: "\n-- Exact string equality with high selectivity on varchar column\nSELECT *\nFROM customer\nWHERE c_name = 'Customer#000001234';\n"
-- id: groupby_bigint_highndv
-  category: groupby
-  sql: "\n-- GROUP BY with high distinct value count (many groups)\nSELECT\n    l_orderkey,\n    COUNT(*) as line_count\nFROM lineitem\nGROUP BY l_orderkey;\n"
-- id: groupby_bigint_lowndv
-  category: groupby
-  sql: "\n-- GROUP BY with low distinct value count (few groups)\nSELECT\n    o_orderpriority,\n    COUNT(*) as order_count\nFROM orders\nGROUP BY o_orderpriority;\n"
-- id: groupby_bigint_pk
-  category: groupby
-  sql: "\n-- GROUP BY on primary key (one row per group)\nSELECT\n    c_custkey,\n    MAX(c_name) as customer_name\nFROM customer\nGROUP BY c_custkey;\n"
-- id: groupby_decimal_highndv
-  category: groupby
-  sql: "\n-- GROUP BY with high cardinality decimal column\nSELECT\n    l_extendedprice,\n    COUNT(*) as price_frequency\nFROM lineitem\nGROUP BY l_extendedprice;\n"
-- id: groupby_decimal_lowndv
-  category: groupby
-  sql: "\n-- GROUP BY with low cardinality decimal column\nSELECT\n    l_discount,\n    COUNT(*) as discount_frequency,\n    AVG(l_quantity) as avg_qty\nFROM lineitem\nGROUP BY l_discount;\n"
-- id: approx_quantile_groupby
-  category: statistical
-  sql: "\n-- Approximate single-quantile per group (T-Digest / KLL family)\n-- Hard rename of the prior intrinsic_appx_median entry, which used\n-- exact PERCENTILE_CONT despite the \"appx\" name.\nSELECT\n    l_shipmode,\n    APPROX_QUANTILE(l_quantity, 0.5) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"
-  result_contract:
-    capability: approximate_quantile_groupby
-    row_identity:
-    - l_shipmode
-    columns:
-    - l_shipmode
-    - median_quantity
-  variants:
-    bigquery: "\nSELECT\n    l_shipmode,\n    APPROX_QUANTILES(l_quantity, 100)[OFFSET(50)] as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"
-    clickhouse: "\nSELECT\n    l_shipmode,\n    quantileTDigest(0.5)(toFloat64(l_quantity)) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"
-    datafusion: "\nSELECT\n    l_shipmode,\n    approx_percentile_cont(l_quantity, 0.5) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"
-    redshift: "\nSELECT\n    l_shipmode,\n    APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY l_quantity) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"
-  skip_on:
-  - sqlite
-- id: intrinsic_to_date
-  category: intrinsic
-  sql: "\n-- Date parsing and conversion function performance\nSELECT\n    COUNT(*) as orders_by_month\nFROM orders\nWHERE o_orderdate = TO_DATE('1995-03-15', 'yyyy-MM-dd');\n"
-  result_contract:
-    capability: date_parse_filter
-    columns:
-    - orders_by_month
-  variants:
-    datafusion: "\nSELECT\n    COUNT(*) as orders_by_month\nFROM orders\nWHERE o_orderdate = TO_DATE('1995-03-15');\n"
-- id: limit
-  category: limit
-  sql: "\n-- LIMIT clause with ordering on large result set\nSELECT *\nFROM lineitem\nORDER BY l_orderkey, l_linenumber\nLIMIT 100;\n"
-- id: long_predicate
-  category: long
-  sql: "\n-- Query with many conjunctive predicates across multiple tables\nSELECT COUNT(*)\nFROM lineitem l\nJOIN orders o ON l.l_orderkey = o.o_orderkey\nJOIN customer c ON o.o_custkey = c.c_custkey\nWHERE l.l_shipdate >= DATE '1994-01-01'\n  AND l.l_shipdate < DATE '1995-01-01'\n  AND l.l_discount BETWEEN 0.05 AND 0.07\n  AND l.l_quantity < 24\n  AND o.o_orderpriority = '1-URGENT'\n  AND c.c_mktsegment = 'BUILDING'\n  AND l.l_returnflag = 'R'\n  AND l.l_linestatus = 'F'\n  AND o.o_totalprice > 100000\n  AND c.c_nationkey IN (1, 2, 3, 4, 5);\n"
-- id: min_max_runtime_filter
-  category: filter
-  sql: "\n-- Bloom filter and runtime filter effectiveness for join optimization\nSELECT\n    l.*\nFROM lineitem l\nWHERE l.l_orderkey IN (\n    SELECT o_orderkey\n    FROM orders\n    WHERE o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1995-03-31'\n);\n"
-- id: orderby_all
-  category: orderby
-  sql: "\n-- Sort on full table with simple integer ordering\nSELECT *\nFROM customer\nORDER BY c_custkey;\n"
-- id: orderby_bigint
-  category: orderby
-  sql: "\n-- Sort with aggregation results on integer column\nSELECT\n    l_orderkey,\n    SUM(l_quantity) as total_qty\nFROM lineitem\nGROUP BY l_orderkey\nORDER BY l_orderkey;\n"
-- id: orderby_bigint_expression
-  category: orderby
-  sql: "\n-- Sort on computed expressions with DESC ordering\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_quantity * l_extendedprice as total_value\nFROM lineitem\nORDER BY l_quantity * l_extendedprice DESC\nLIMIT 100;\n"
-- id: orderby_decimal16
-  category: orderby
-  sql: "\n-- Multi-column sort with mixed ASC/DESC on decimal columns\nSELECT\n    l_orderkey,\n    l_extendedprice,\n    l_discount\nFROM lineitem\nORDER BY l_extendedprice DESC, l_discount ASC\nLIMIT 100;\n"
-- id: orderby_multicol
-  category: orderby
-  sql: "\n-- Complex multi-column sort with string, date, and decimal columns\nSELECT *\nFROM orders\nORDER BY o_orderpriority, o_orderdate DESC, o_totalprice DESC\nLIMIT 100;\n"
-- id: orderby_shortstrings
-  category: orderby
-  sql: "\n-- Sort on short string columns with DISTINCT operation\nSELECT DISTINCT l_returnflag, l_linestatus\nFROM lineitem\nORDER BY l_returnflag, l_linestatus;\n"
-- id: shuffle_1mb_rows
-  category: shuffle
-  sql: "\n-- Self-join with hash collision handling on large table\nSELECT\n    l1.l_orderkey,\n    COUNT(*) as match_count\nFROM lineitem l1\nJOIN lineitem l2 ON l1.l_partkey = l2.l_partkey\nWHERE l1.l_orderkey != l2.l_orderkey\n  AND l1.l_shipdate = l2.l_shipdate\nGROUP BY l1.l_orderkey\nLIMIT 10000;\n"
-- id: shuffle_full_join_one_to_many_string_with_groupby
-  category: shuffle
-  sql: "\n-- FULL OUTER JOIN with string grouping and aggregation\nSELECT\n    c.c_mktsegment,\n    COUNT(o.o_orderkey) as order_count,\n    COUNT(c.c_custkey) as customer_count\nFROM customer c\nFULL OUTER JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"
-- id: shuffle_inner_join_one_to_many_string_with_groupby
-  category: shuffle
-  sql: "\n-- Standard inner join with one-to-many relationship\nSELECT\n    c.c_mktsegment,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue\nFROM customer c\nINNER JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"
-- id: shuffle_inner_join_union_all_with_groupby
-  category: shuffle
-  sql: "\n-- Complex join with UNION ALL and different data sources\nSELECT\n    source_type,\n    COUNT(*) as record_count\nFROM (\n    SELECT 'ORDER' as source_type, o_custkey as cust_id\n    FROM orders\n    WHERE o_orderdate >= DATE '1995-01-01'\n    UNION ALL\n    SELECT 'LINEITEM' as source_type, o_custkey as cust_id\n    FROM orders o\n    JOIN lineitem l ON o.o_orderkey = l.l_orderkey\n    WHERE l.l_shipdate >= DATE '1995-01-01'\n) combined\nGROUP BY source_type;\n"
-- id: shuffle_left_join_one_to_many_string_with_groupby
-  category: shuffle
-  sql: "\n-- LEFT JOIN with preservation of all left-side rows\nSELECT\n    c.c_mktsegment,\n    COUNT(o.o_orderkey) as order_count,\n    COUNT(*) as total_rows\nFROM customer c\nLEFT JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"
-- id: string_equal_predicate
-  category: string
-  sql: "\n-- Exact string equality with selective matching\nSELECT COUNT(*)\nFROM part\nWHERE p_brand = 'Brand#23';\n"
-- id: string_equal_predicate_lower
-  category: string
-  sql: "\n-- Equality predicate after applying case conversion to the base table\nSELECT COUNT(*)\nFROM part\nWHERE LOWER(p_brand) = 'brand#23';\n"
-- id: string_in_predicate
-  category: string
-  sql: "\n-- IN predicate with string values\nSELECT COUNT(*)\nFROM orders\nWHERE o_orderpriority IN ('1-URGENT', '2-HIGH');\n"
-- id: string_like_predicate_center
-  category: string
-  sql: "\n-- Case sensitive matching pattern in any location\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%STEEL%';\n"
-- id: string_like_predicate_center_insensitive
-  category: string
-  sql: "\n-- Case insensitive matching pattern in any location\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%steel%';\n"
-- id: string_like_predicate_multi
-  category: string
-  sql: "\n-- Case sensitive matching multipart pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%STEEL%BRASS%';\n"
-- id: string_ilike_predicate_multi
-  category: string
-  sql: "\n-- Case insensitive matching multipart pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%sTeEl%bRaSs%';\n"
-- id: string_like_predicate_end
-  category: string
-  sql: "\n-- Case sensitive matching suffix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%COPPER';\n"
-- id: string_ilike_predicate_end
-  category: string
-  sql: "\n-- Case insensitive matching suffix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%copper';\n"
-- id: string_like_predicate_start
-  category: string
-  sql: "\n-- Case sensitive matching prefix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE 'STANDARD%';\n"
-- id: string_ilike_predicate_start
-  category: string
-  sql: "\n-- Case insensitive matching prefix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name ILIKE 'standard%';\n"
-- id: topn_ordered_allcols
-  category: topn
-  sql: "\n-- Top-10 limit returning all columns after ordering over all table rows\nSELECT *\nFROM lineitem\nORDER BY l_extendedprice DESC\nLIMIT 10;\n"
-- id: topn_aggregate_2columns
-  category: topn
-  sql: "\n-- Top 10 limit returning 2 columns after aggregation and computed ordering\nSELECT\n    l_orderkey,\n    SUM(l_quantity) as total_quantity\nFROM lineitem\nGROUP BY l_orderkey\nORDER BY total_quantity DESC\nLIMIT 10;\n"
-- id: approx_top_k_lineitem
-  category: topn
-  sql: "\n-- Approximate Top-K aggregate returning the most-frequent values as an array.\n-- Result shapes diverge across engines: DuckDB / ClickHouse / Snowflake return\n-- ARRAY of values; BigQuery's APPROX_TOP_COUNT returns ARRAY<STRUCT<value,count>>.\n-- Validation enforces capability + array type_class, not deep equality.\nSELECT APPROX_TOP_K(l_shipmode, 5) as top_shipmodes\nFROM lineitem;\n"
-  result_contract:
-    capability: approximate_top_k
-    columns:
-    - name: top_shipmodes
-      type_class: array
-  variants:
-    clickhouse: "\nSELECT topK(5)(l_shipmode) as top_shipmodes\nFROM lineitem;\n"
-  skip_on:
-  - redshift
-  - datafusion
-  - sqlite
-- id: window_growing_frame
-  category: window
-  sql: "\n-- Running sum window aggregation with growing frame size\nSELECT\n    l_orderkey,\n    l_linenumber,\n    l_quantity,\n    SUM(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n    ) as running_quantity\nFROM lineitem\nWHERE l_orderkey <= 1000;\n"
-- id: window_lead_lag_same_frame
-  category: window
-  sql: "\n-- Offset window functions over the same frame with 'natural' ordering\nSELECT\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    LAG(o_totalprice, 1) OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_orderdate\n    ) as prev_order_price,\n    LEAD(o_totalprice, 1) OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_orderdate\n    ) as next_order_price\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01';\n"
-- id: window_row_number
-  category: window
-  sql: "\n-- Row number calculation window function with different ordering\nSELECT\n    o_custkey,\n    o_orderkey,\n    o_totalprice,\n    ROW_NUMBER() OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_totalprice DESC\n    ) as order_rank\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01';\n"
-- id: window_multiple_orderings
-  category: window
-  sql: "\n-- Ranking window aggregations with multiple frame orderings\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_quantity,\n    l_extendedprice,\n    DENSE_RANK() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice DESC) as price_rank,\n    PERCENT_RANK() OVER (PARTITION BY l_orderkey ORDER BY l_quantity) as quantity_percentile,\n    CUME_DIST() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice) as price_distribution\nFROM lineitem\nWHERE l_orderkey <= 10000\nORDER BY l_orderkey, price_rank;\n"
-  result_contract:
-    capability: window_rank_distribution
-    columns:
-    - l_orderkey
-    - l_partkey
-    - l_quantity
-    - l_extendedprice
-    - price_rank
-    - quantity_percentile
-    - price_distribution
-  variants:
-    clickhouse: "\n-- ClickHouse window function names are case-sensitive (dense_rank,\n-- percent_rank, cume_dist). Wrap in a subquery so the outer ORDER BY\n-- references a materialized column.\nSELECT *\nFROM (\n    SELECT\n        l_orderkey,\n        l_partkey,\n        l_quantity,\n        l_extendedprice,\n        dense_rank() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice DESC) as price_rank,\n        percent_rank() OVER (PARTITION BY l_orderkey ORDER BY l_quantity) as quantity_percentile,\n        cume_dist() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice) as price_distribution\n    FROM lineitem\n    WHERE l_orderkey <= 10000\n) t\nORDER BY l_orderkey, price_rank;\n"
-- id: window_moving_frame
-  category: window
-  sql: "\n-- Window aggregations with complex moving frame definitions\nSELECT\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    -- Moving average with preceding rows\n    AVG(o_totalprice) OVER (\n        ORDER BY o_orderdate\n        ROWS BETWEEN 5 PRECEDING AND CURRENT ROW\n    ) as moving_avg_6_orders,\n    -- Running total with range-based frame\n    SUM(o_totalprice) OVER (\n        ORDER BY o_orderdate\n        RANGE BETWEEN INTERVAL '30' DAY PRECEDING AND CURRENT ROW\n    ) as monthly_running_total\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01'\nORDER BY o_orderdate;\n"
-  skip_on:
-  - clickhouse
-  - redshift
-- id: window_unbounded_frame
-  category: window
-  sql: "\n-- Window aggregations with the same unbounded frame definition\nSELECT\n    l_orderkey,\n    l_linenumber,\n    l_shipdate,\n    l_quantity,\n    FIRST_VALUE(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    ) as first_line_qty,\n    LAST_VALUE(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    ) as last_line_qty\nFROM lineitem\nWHERE l_orderkey BETWEEN 1 AND 5000;\n"
-- id: json_extract_simple
-  category: json
-  sql: "\n-- Extract from JSON with simple path expressions\nSELECT\n    o_orderkey,\n    JSON_EXTRACT(o_comment, '$.priority') as order_priority,\n    JSON_EXTRACT(o_comment, '$.notes') as order_notes\nFROM orders\nWHERE JSON_EXTRACT(o_comment, '$.priority') IS NOT NULL\nLIMIT 1000;\n"
-  skip_on:
-  - duckdb
-  - datafusion
-  - redshift
-  description: TPC-H o_comment contains plain text, not valid JSON
-- id: json_extract_nested
-  category: json
-  sql: "\n-- Extract from JSON with complex path expressions\nSELECT\n    c_custkey,\n    JSON_EXTRACT(c_comment, '$.profile.segment') as customer_segment,\n    JSON_EXTRACT(c_comment, '$.profile.preferences[0]') as primary_preference,\n    JSON_EXTRACT(c_comment, '$.history.last_order.date') as last_order_date\nFROM customer\nWHERE JSON_VALID(c_comment)\nLIMIT 500;\n"
-  result_contract:
-    capability: json_nested_path_extraction
-    row_identity:
-    - c_custkey
-    columns:
-    - c_custkey
-    - name: customer_segment
-      type_class: json
-    - name: primary_preference
-      type_class: json
-    - name: last_order_date
-      type_class: json
-  variants:
-    clickhouse: "\n-- ClickHouse JSON access uses JSONExtract*(json, path...) with positional\n-- path components; isValidJSON replaces JSON_VALID. TPC-H c_comment is\n-- plain text so isValidJSON gates rows out (matches duckdb behavior).\nSELECT\n    c_custkey,\n    JSONExtractRaw(c_comment, 'profile', 'segment') as customer_segment,\n    JSONExtractRaw(c_comment, 'profile', 'preferences', 1) as primary_preference,\n    JSONExtractRaw(c_comment, 'history', 'last_order', 'date') as last_order_date\nFROM customer\nWHERE isValidJSON(c_comment)\nLIMIT 500;\n"
-  skip_on:
-  - datafusion
-  - redshift
-- id: json_aggregates
-  category: json
-  sql: "\n-- Create JSON array and object with JSON aggregate functions\nSELECT\n    p_brand,\n    JSON_ARRAYAGG(p_name) as part_names,\n    JSON_OBJECTAGG(p_partkey, p_retailprice) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n"
-  result_contract:
-    capability: json_array_object_aggregation
-    row_identity:
-    - p_brand
-    columns:
-    - p_brand
-    - name: part_names
-      type_class: json
-    - name: part_prices
-      type_class: json
-    - part_count
-  variants:
-    duckdb: "\n-- DuckDB uses JSON_GROUP_ARRAY and JSON_GROUP_OBJECT instead\nSELECT\n    p_brand,\n    JSON_GROUP_ARRAY(p_name) as part_names,\n    JSON_GROUP_OBJECT(p_partkey, p_retailprice) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n"
-    clickhouse: "\n-- ClickHouse has no JSON_ARRAYAGG/JSON_OBJECTAGG; build arrays/maps with\n-- groupArray + mapFromArrays then serialize via toJSONString.\nSELECT\n    p_brand,\n    toJSONString(groupArray(p_name)) as part_names,\n    toJSONString(mapFromArrays(groupArray(p_partkey), groupArray(p_retailprice))) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n"
-  skip_on:
-  - datafusion
-  - redshift
-- id: fulltext_simple_search
-  category: fulltext
-  sql: "\n-- Basic full-text search capabilities on text columns\nSELECT\n    p_partkey,\n    p_name,\n    p_mfgr,\n    p_comment\nFROM part\nWHERE MATCH(p_name, p_comment) AGAINST ('STEEL COPPER' IN NATURAL LANGUAGE MODE)\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - clickhouse
-  - datafusion
-  - databricks
-  - duckdb
-  - redshift
-  - snowflake
-- id: fulltext_boolean_search
-  category: fulltext
-  sql: "\n-- Boolean full-text search with operators\nSELECT\n    c_custkey,\n    c_name,\n    c_comment,\n    MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE) as relevance_score\nFROM customer\nWHERE MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE)\nORDER BY relevance_score DESC\nLIMIT 50;\n"
-  skip_on:
-  - bigquery
-  - clickhouse
-  - datafusion
-  - databricks
-  - duckdb
-  - redshift
-  - snowflake
-- id: fulltext_phrase_search
-  category: fulltext
-  sql: "\n-- Phrase-based full-text search with ranking\nSELECT\n    s_suppkey,\n    s_name,\n    s_comment,\n    MATCH(s_comment) AGAINST ('\"Customer Complaints\"' IN BOOLEAN MODE) as phrase_match_score\nFROM supplier\nWHERE MATCH(s_comment) AGAINST ('\"Customer Complaints\"' IN BOOLEAN MODE)\nORDER BY phrase_match_score DESC;\n"
-  skip_on:
-  - bigquery
-  - clickhouse
-  - datafusion
-  - databricks
-  - duckdb
-  - redshift
-  - snowflake
-- id: statistical_percentiles
-  category: statistical
-  sql: "\n-- Percentile calculation functions for distribution analysis\nSELECT\n    l_returnflag,\n    l_linestatus,\n    COUNT(*) as record_count,\n    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY l_quantity) as quantity_q1,\n    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l_quantity) as quantity_median,\n    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY l_quantity) as quantity_q3,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) as price_p95\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-  result_contract:
-    capability: exact_continuous_percentiles
-    row_identity:
-    - l_returnflag
-    - l_linestatus
-    columns:
-    - l_returnflag
-    - l_linestatus
-    - record_count
-    - quantity_q1
-    - quantity_median
-    - quantity_q3
-    - price_p95
-  variants:
-    redshift: "\n-- Redshift supports PERCENTILE_CONT only as a window function, not aggregate\nSELECT DISTINCT\n    l_returnflag,\n    l_linestatus,\n    COUNT(*) OVER (PARTITION BY l_returnflag, l_linestatus) as record_count,\n    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_q1,\n    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_median,\n    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_q3,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) OVER (PARTITION BY l_returnflag, l_linestatus) as price_p95\nFROM lineitem;\n"
-  skip_on:
-  - clickhouse
-- id: approx_quantiles_array
-  category: statistical
-  sql: "\n-- Approximate quantiles returned as a single array per group\n-- Companion to statistical_percentiles, but exercises the\n-- vector-quantile path (one sketch evaluation per group instead of\n-- four PERCENTILE_CONT calls).\nSELECT\n    l_returnflag,\n    l_linestatus,\n    APPROX_QUANTILE(l_quantity, [0.25, 0.5, 0.75, 0.95]) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-  result_contract:
-    capability: approximate_quantile_array
-    row_identity:
-    - l_returnflag
-    - l_linestatus
-    columns:
-    - l_returnflag
-    - l_linestatus
-    - name: quantity_quantiles
-      type_class: array
-  variants:
-    bigquery: "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    [\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(25)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(50)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(75)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(95)]\n    ] as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-    clickhouse: "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    quantilesTDigest(0.25, 0.5, 0.75, 0.95)(toFloat64(l_quantity)) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-    snowflake: "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    ARRAY_CONSTRUCT(\n      APPROX_PERCENTILE(l_quantity, 0.25),\n      APPROX_PERCENTILE(l_quantity, 0.5),\n      APPROX_PERCENTILE(l_quantity, 0.75),\n      APPROX_PERCENTILE(l_quantity, 0.95)\n    ) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"
-  skip_on:
-  - redshift
-  - datafusion
-  - sqlite
-- id: statistical_variance_stddev
-  category: statistical
-  sql: "\n-- Variance and standard deviation calculations\nSELECT\n    o_orderpriority,\n    COUNT(*) as order_count,\n    AVG(o_totalprice) as avg_price,\n    VARIANCE(o_totalprice) as price_variance,\n    STDDEV(o_totalprice) as price_stddev,\n    STDDEV_POP(o_totalprice) as price_stddev_pop,\n    STDDEV_SAMP(o_totalprice) as price_stddev_samp\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY o_orderpriority;\n"
-- id: statistical_correlation
-  category: statistical
-  skip_on:
-  - redshift
-  sql: "\n-- Correlation analysis between numeric columns\nSELECT\n    CORR(l_quantity, l_extendedprice) as qty_price_correlation,\n    COVAR_POP(l_quantity, l_discount) as qty_discount_covariance,\n    COVAR_SAMP(l_tax, l_extendedprice) as tax_price_covariance,\n    REGR_SLOPE(l_extendedprice, l_quantity) as price_qty_slope,\n    REGR_INTERCEPT(l_extendedprice, l_quantity) as price_qty_intercept,\n    REGR_R2(l_extendedprice, l_quantity) as regression_r_squared\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01';\n"
-  result_contract:
-    capability: correlation_covariance_regression
-    columns:
-    - qty_price_correlation
-    - qty_discount_covariance
-    - tax_price_covariance
-    - price_qty_slope
-    - price_qty_intercept
-    - regression_r_squared
-  variants:
-    clickhouse: "\n-- ClickHouse's corr/covarPop/covarSamp reject Decimal arguments\n-- (ILLEGAL_TYPE_OF_ARGUMENT); cast columns to Float64 first.\n-- REGR_SLOPE/INTERCEPT/R2 are not available; compute manually from\n-- corr() and stddevSamp() over the cast columns.\nSELECT\n    corr(toFloat64(l_quantity), toFloat64(l_extendedprice)) as qty_price_correlation,\n    covarPop(toFloat64(l_quantity), toFloat64(l_discount)) as qty_discount_covariance,\n    covarSamp(toFloat64(l_tax), toFloat64(l_extendedprice)) as tax_price_covariance,\n    corr(toFloat64(l_extendedprice), toFloat64(l_quantity)) * stddevSamp(toFloat64(l_extendedprice)) / nullif(stddevSamp(toFloat64(l_quantity)), 0) as price_qty_slope,\n    avg(toFloat64(l_extendedprice)) - corr(toFloat64(l_extendedprice), toFloat64(l_quantity)) * stddevSamp(toFloat64(l_extendedprice)) / nullif(stddevSamp(toFloat64(l_quantity)), 0) * avg(toFloat64(l_quantity)) as price_qty_intercept,\n    pow(corr(toFloat64(l_extendedprice), toFloat64(l_quantity)), 2) as regression_r_squared\nFROM lineitem\nWHERE l_shipdate >= toDate('1995-01-01')\n  AND l_shipdate < toDate('1996-01-01');\n"
-- id: olap_cube_analysis
-  category: olap
-  sql: "\n-- CUBE operation for multidimensional analysis\nSELECT\n    n.n_name as nation,\n    r.r_name as region,\n    EXTRACT(YEAR FROM o.o_orderdate) as order_year,\n    EXTRACT(QUARTER FROM o.o_orderdate) as order_quarter,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue,\n    AVG(o.o_totalprice) as avg_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nWHERE o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1997-01-01'\nGROUP BY CUBE(n.n_name, r.r_name,\n              EXTRACT(YEAR FROM o.o_orderdate),\n              EXTRACT(QUARTER FROM o.o_orderdate));\n"
-- id: olap_rollup_analysis
-  category: olap
-  sql: "\n-- ROLLUP operation for hierarchical aggregation\nSELECT\n    r.r_name as region,\n    n.n_name as nation,\n    c.c_mktsegment as market_segment,\n    COUNT(DISTINCT c.c_custkey) as customer_count,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue,\n    AVG(o.o_totalprice) as avg_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nWHERE o.o_orderdate >= DATE '1995-01-01'\nGROUP BY ROLLUP(r.r_name, n.n_name, c.c_mktsegment)\nORDER BY r.r_name NULLS LAST, n.n_name NULLS LAST, c.c_mktsegment NULLS LAST;\n"
-- id: timeseries_trend_analysis
-  category: timeseries
-  skip_on:
-  - redshift
-  sql: "\n-- Time series trend analysis with linear regression\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n"
-  result_contract:
-    capability: monthly_time_series_regression
-    row_identity:
-    - order_month
-    columns:
-    - order_month
-    - order_count
-    - monthly_revenue
-    - avg_order_value
-    - revenue_trend_slope
-    - prev_month_revenue
-    - mom_growth_pct
-  variants:
-    duckdb: "\n-- DuckDB doesn't allow nested aggregates, use CTE to pre-aggregate\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n"
-    clickhouse: "\n-- ClickHouse: use toStartOfMonth for DATE_TRUNC, toUnixTimestamp for EPOCH.\n-- REGR_SLOPE not available; compute slope manually from corr/stddev.\n-- Cast revenue/epoch to Float64 in the CTE because corr/stddev reject\n-- Decimal/UInt arguments (ILLEGAL_TYPE_OF_ARGUMENT).\nWITH monthly_totals AS (\n  SELECT\n    toStartOfMonth(o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    toFloat64(SUM(o_totalprice)) as monthly_revenue,\n    toFloat64(AVG(o_totalprice)) as avg_order_value,\n    toFloat64(toUnixTimestamp(toStartOfMonth(o_orderdate))) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= toDate('1995-01-01')\n    AND o_orderdate < toDate('1997-01-01')\n  GROUP BY toStartOfMonth(o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  corr(monthly_revenue, month_epoch) OVER () * stddevSamp(monthly_revenue) OVER () / nullif(stddevSamp(month_epoch) OVER (), 0) as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / nullif(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n"
-    datafusion: "\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n"
-- id: max_by_simple
-  category: max
-  sql: "\n-- Find the customer with the highest account balance in each nation\nSELECT\n    n_name,\n    MAX_BY(c_name, c_acctbal) as richest_customer,\n    MAX(c_acctbal) as max_balance\nFROM customer c\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nGROUP BY n_name\nORDER BY max_balance DESC, n_name;\n"
-  result_contract:
-    capability: arg_max_aggregate
-    row_identity:
-    - n_name
-    columns:
-    - n_name
-    - richest_customer
-    - max_balance
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal DESC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as richest_customer,\n  c_acctbal as max_balance\nFROM ranked\nWHERE rn = 1\nORDER BY max_balance DESC, n_name;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal DESC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as richest_customer,\n  c_acctbal as max_balance\nFROM ranked\nWHERE rn = 1\nORDER BY max_balance DESC, n_name;\n"
-- id: min_by_simple
-  category: min
-  sql: "\n-- Find the customer with the lowest account balance in each nation\nSELECT\n    n_name,\n    MIN_BY(c_name, c_acctbal) as poorest_customer,\n    MIN(c_acctbal) as min_balance\nFROM customer c\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nGROUP BY n_name\nORDER BY min_balance ASC, n_name;\n"
-  result_contract:
-    capability: arg_min_aggregate
-    row_identity:
-    - n_name
-    columns:
-    - n_name
-    - poorest_customer
-    - min_balance
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal ASC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as poorest_customer,\n  c_acctbal as min_balance\nFROM ranked\nWHERE rn = 1\nORDER BY min_balance ASC, n_name;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal ASC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as poorest_customer,\n  c_acctbal as min_balance\nFROM ranked\nWHERE rn = 1\nORDER BY min_balance ASC, n_name;\n"
-- id: max_by_complex
-  category: max
-  sql: "\n-- Find the most expensive order for each customer segment\nSELECT\n    c_mktsegment,\n    MAX_BY(o_orderkey, o_totalprice) as most_expensive_order_id,\n    MAX_BY(o_orderdate, o_totalprice) as most_expensive_order_date,\n    MAX(o_totalprice) as max_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nGROUP BY c_mktsegment\nORDER BY max_order_value DESC, c_mktsegment;\n"
-  result_contract:
-    capability: arg_max_aggregate
-    row_identity:
-    - c_mktsegment
-    columns:
-    - c_mktsegment
-    - most_expensive_order_id
-    - most_expensive_order_date
-    - max_order_value
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    c.c_mktsegment,\n    o.o_orderkey,\n    o.o_orderdate,\n    o.o_totalprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY c.c_mktsegment\n      ORDER BY o.o_totalprice DESC, o.o_orderkey\n    ) as rn\n  FROM orders o\n  JOIN customer c ON o.o_custkey = c.c_custkey\n)\nSELECT\n  c_mktsegment,\n  o_orderkey as most_expensive_order_id,\n  o_orderdate as most_expensive_order_date,\n  o_totalprice as max_order_value\nFROM ranked\nWHERE rn = 1\nORDER BY max_order_value DESC, c_mktsegment;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    c.c_mktsegment,\n    o.o_orderkey,\n    o.o_orderdate,\n    o.o_totalprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY c.c_mktsegment\n      ORDER BY o.o_totalprice DESC, o.o_orderkey\n    ) as rn\n  FROM orders o\n  JOIN customer c ON o.o_custkey = c.c_custkey\n)\nSELECT\n  c_mktsegment,\n  o_orderkey as most_expensive_order_id,\n  o_orderdate as most_expensive_order_date,\n  o_totalprice as max_order_value\nFROM ranked\nWHERE rn = 1\nORDER BY max_order_value DESC, c_mktsegment;\n"
-- id: min_by_complex
-  category: min
-  sql: "\n-- Find the cheapest part for each brand\nSELECT\n    p_brand,\n    MIN_BY(p_name, p_retailprice) as cheapest_part_name,\n    MIN_BY(p_type, p_retailprice) as cheapest_part_type,\n    MIN(p_retailprice) as min_price\nFROM part\nGROUP BY p_brand\nORDER BY min_price ASC, p_brand;\n"
-  result_contract:
-    capability: arg_min_aggregate
-    row_identity:
-    - p_brand
-    columns:
-    - p_brand
-    - cheapest_part_name
-    - cheapest_part_type
-    - min_price
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    p_brand,\n    p_name,\n    p_type,\n    p_retailprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY p_brand\n      ORDER BY p_retailprice ASC, p_name\n    ) as rn\n  FROM part\n)\nSELECT\n  p_brand,\n  p_name as cheapest_part_name,\n  p_type as cheapest_part_type,\n  p_retailprice as min_price\nFROM ranked\nWHERE rn = 1\nORDER BY min_price ASC, p_brand;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    p_brand,\n    p_name,\n    p_type,\n    p_retailprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY p_brand\n      ORDER BY p_retailprice ASC, p_name\n    ) as rn\n  FROM part\n)\nSELECT\n  p_brand,\n  p_name as cheapest_part_name,\n  p_type as cheapest_part_type,\n  p_retailprice as min_price\nFROM ranked\nWHERE rn = 1\nORDER BY min_price ASC, p_brand;\n"
-- id: max_by_with_ties
-  category: max
-  sql: "\n-- Find the supplier with the highest supply cost for each part (handling ties)\nSELECT\n    p_partkey,\n    p_name,\n    MAX_BY(s_name, ps_supplycost) as supplier_name,\n    MAX(ps_supplycost) as max_supply_cost\nFROM partsupp ps\nJOIN part p ON ps.ps_partkey = p.p_partkey\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nGROUP BY p_partkey, p_name\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n"
-  result_contract:
-    capability: arg_max_aggregate
-    row_identity:
-    - p_partkey
-    - p_name
-    columns:
-    - p_partkey
-    - p_name
-    - supplier_name
-    - max_supply_cost
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost DESC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as max_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost DESC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as max_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n"
-- id: min_by_with_ties
-  category: min
-  sql: "\n-- Find the supplier with the lowest supply cost for each part (handling ties)\nSELECT\n    p_partkey,\n    p_name,\n    MIN_BY(s_name, ps_supplycost) as supplier_name,\n    MIN(ps_supplycost) as min_supply_cost\nFROM partsupp ps\nJOIN part p ON ps.ps_partkey = p.p_partkey\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nGROUP BY p_partkey, p_name\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n"
-  result_contract:
-    capability: arg_min_aggregate
-    row_identity:
-    - p_partkey
-    - p_name
-    columns:
-    - p_partkey
-    - p_name
-    - supplier_name
-    - min_supply_cost
-  variants:
-    datafusion: "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost ASC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as min_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n"
-    redshift: "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost ASC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as min_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n"
-- id: qualify_row_number
-  category: qualify
-  sql: "\n-- Find the top 3 orders by total price for each customer using QUALIFY\nSELECT\n    c_custkey,\n    c_name,\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    ROW_NUMBER() OVER (PARTITION BY c_custkey ORDER BY o_totalprice DESC) as order_rank\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY ROW_NUMBER() OVER (PARTITION BY c_custkey ORDER BY o_totalprice DESC) <= 3\nORDER BY c_custkey, order_rank;\n"
-- id: qualify_dense_rank
-  category: qualify
-  sql: "\n-- Find the top 2 most expensive parts in each category using QUALIFY\nSELECT\n    p_type,\n    p_name,\n    p_retailprice,\n    DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) as price_rank\nFROM part\nQUALIFY DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) <= 2\nORDER BY p_type, price_rank, p_name;\n"
-  result_contract:
-    capability: qualify_dense_rank_filter
-    row_identity:
-    - p_type
-    - p_name
-    - p_retailprice
-    columns:
-    - p_type
-    - p_name
-    - p_retailprice
-    - price_rank
-  variants:
-    redshift: "\n-- Redshift QUALIFY with DENSE_RANK requires subquery workaround\nSELECT p_type, p_name, p_retailprice, price_rank\nFROM (\n    SELECT\n        p_type,\n        p_name,\n        p_retailprice,\n        DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) as price_rank\n    FROM part\n) ranked\nWHERE price_rank <= 2\nORDER BY p_type, price_rank, p_name;\n"
-- id: qualify_percentile
-  category: qualify
-  sql: "\n-- Find orders in the top 10% by value for each order priority using QUALIFY\nSELECT\n    o_orderpriority,\n    o_orderkey,\n    o_totalprice,\n    PERCENT_RANK() OVER (PARTITION BY o_orderpriority ORDER BY o_totalprice) as price_percentile\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY PERCENT_RANK() OVER (PARTITION BY o_orderpriority ORDER BY o_totalprice) >= 0.9\nORDER BY o_orderpriority, o_totalprice DESC;\n"
-- id: qualify_ntile
-  category: qualify
-  sql: "\n-- Find orders in the top quartile by value for each market segment using QUALIFY\nSELECT\n    c_mktsegment,\n    o_orderkey,\n    o_totalprice,\n    NTILE(4) OVER (PARTITION BY c_mktsegment ORDER BY o_totalprice) as quartile\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY NTILE(4) OVER (PARTITION BY c_mktsegment ORDER BY o_totalprice) = 4\nORDER BY c_mktsegment, o_totalprice DESC;\n"
-- id: qualify_cume_dist
-  category: qualify
-  sql: "\n-- Find lineitems with quantity in the top 5% of their shipment date using QUALIFY\nSELECT\n    l_shipdate,\n    l_orderkey,\n    l_linenumber,\n    l_quantity,\n    CUME_DIST() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) as quantity_cumulative_dist\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\nQUALIFY CUME_DIST() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) >= 0.95\nORDER BY l_shipdate, l_quantity DESC, l_orderkey, l_linenumber;\n"
-  result_contract:
-    capability: qualify_cume_dist_filter
-    row_identity:
-    - l_shipdate
-    - l_orderkey
-    - l_linenumber
-    columns:
-    - l_shipdate
-    - l_orderkey
-    - l_linenumber
-    - l_quantity
-    - quantity_cumulative_dist
-  variants:
-    clickhouse: "\n-- ClickHouse does not support QUALIFY; rewrite using subquery WHERE filter.\n-- Window function names are case-sensitive (cume_dist, not CUME_DIST).\nSELECT l_shipdate, l_orderkey, l_linenumber, l_quantity, quantity_cumulative_dist\nFROM (\n  SELECT\n      l_shipdate,\n      l_orderkey,\n      l_linenumber,\n      l_quantity,\n      cume_dist() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) as quantity_cumulative_dist\n  FROM lineitem\n  WHERE l_shipdate >= toDate('1995-01-01')\n    AND l_shipdate < toDate('1996-01-01')\n) t\nWHERE quantity_cumulative_dist >= 0.95\nORDER BY l_shipdate, l_quantity DESC, l_orderkey, l_linenumber;\n"
-- id: qualify_lag_lead
-  category: qualify
-  sql: "\n-- Find orders where the price increased from the previous order for each customer using QUALIFY\nSELECT\n    c_custkey,\n    c_name,\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    LAG(o_totalprice) OVER (PARTITION BY c_custkey ORDER BY o_orderdate) as prev_order_price\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY o_totalprice > LAG(o_totalprice) OVER (PARTITION BY c_custkey ORDER BY o_orderdate)\nORDER BY c_custkey, o_orderdate;\n"
-- id: optimizer_exists_to_semijoin
-  category: optimizer
-  sql: "\n-- Test EXISTS subquery decorrelation to semijoin optimization\n-- Good optimizers should convert the EXISTS to a semijoin for better performance\nSELECT\n    c_custkey,\n    c_name,\n    c_mktsegment,\n    c_nationkey\nFROM customer c\nWHERE EXISTS (\n    SELECT 1 \n    FROM orders o \n    WHERE o.o_custkey = c.c_custkey \n      AND o.o_orderdate >= DATE '1995-01-01'\n      AND o.o_orderdate < DATE '1996-01-01'\n      AND o.o_totalprice > 100000\n)\nORDER BY c_custkey\nLIMIT 1000;\n"
-- id: optimizer_distinct_elimination
-  category: optimizer
-  sql: "\n-- Test DISTINCT elimination optimization\n-- Good optimizers should eliminate the DISTINCT when it's redundant due to primary key\nSELECT DISTINCT\n    o_orderkey,\n    o_custkey,\n    o_orderdate,\n    o_totalprice\nFROM orders o\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01'\n  AND o_totalprice > 50000\nORDER BY o_orderkey\nLIMIT 2000;\n"
-- id: optimizer_common_subexpression
-  category: optimizer
-  sql: "\n-- Test Common Subexpression Elimination (CSE) optimization\n-- Good optimizers should compute the complex expression once and reuse it\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    l_linenumber,\n    l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) as revenue_with_tax,\n    CASE \n        WHEN l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 50000 THEN 'High Value'\n        WHEN l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 10000 THEN 'Medium Value'\n        ELSE 'Low Value'\n    END as value_category,\n    ROUND(l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax), 2) as rounded_revenue\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\n  AND l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 1000\nORDER BY l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) DESC\nLIMIT 5000;\n"
-- id: optimizer_predicate_pushdown
-  category: optimizer
-  sql: "\n-- Test predicate pushdown through joins optimization\n-- Good optimizers should push predicates down past joins to reduce intermediate results\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    o.o_orderdate,\n    o.o_totalprice\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_nationkey = 15  -- Should push down before join to reduce customer rows\n  AND o.o_orderdate >= DATE '1995-01-01'  -- Should push down before join to reduce order rows\n  AND o.o_orderdate < DATE '1996-01-01'\n  AND c.c_mktsegment = 'BUILDING'  -- Additional selectivity on customer\nORDER BY o.o_totalprice DESC\nLIMIT 1000;\n"
-- id: optimizer_join_reordering
-  category: optimizer
-  sql: "\n-- Test join reordering optimization\n-- Good optimizers should reorder joins based on cardinality (nation smallest, then customer, then orders)\nSELECT\n    n.n_name,\n    c.c_name,\n    COUNT(o.o_orderkey) as order_count,\n    SUM(o.o_totalprice) as total_value\nFROM orders o  -- Largest table listed first (suboptimal order)\nJOIN customer c ON o.o_custkey = c.c_custkey  -- Medium table\nJOIN nation n ON c.c_nationkey = n.n_nationkey  -- Smallest table\nWHERE n.n_regionkey = 1  -- High selectivity on smallest table\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nGROUP BY n.n_name, c.c_name\nHAVING COUNT(o.o_orderkey) > 5\nORDER BY total_value DESC\nLIMIT 100;\n"
-- id: optimizer_limit_pushdown
-  category: optimizer
-  sql: "\n-- Test limit pushdown through operations optimization\n-- Good optimizers should push partial limits down to reduce work in upstream operations\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    o.o_orderdate,\n    o.o_totalprice,\n    o.o_orderpriority\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_mktsegment = 'BUILDING'\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nORDER BY o.o_totalprice DESC\nLIMIT 100;  -- Should push partial limit down through join\n"
-- id: optimizer_aggregate_pushdown
-  category: optimizer
-  sql: "\n-- Test aggregate pushdown through joins optimization\n-- Good optimizers should partially compute aggregates before joins when possible\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_nationkey,\n    COUNT(o.o_orderkey) as order_count,\n    SUM(o.o_totalprice) as total_spent,\n    AVG(o.o_totalprice) as avg_order_value\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_nationkey = 15\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nGROUP BY c.c_custkey, c.c_name, c.c_mktsegment, c.c_nationkey\nHAVING SUM(o.o_totalprice) > 500000  -- HAVING can influence pushdown strategy\nORDER BY total_spent DESC\nLIMIT 50;\n"
-- id: optimizer_scalar_subquery_flattening
-  category: optimizer
-  sql: "\n-- Test scalar subquery flattening optimization\n-- Good optimizers should convert scalar subqueries to joins for better performance\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_acctbal,\n    (SELECT AVG(o.o_totalprice) \n     FROM orders o \n     WHERE o.o_custkey = c.c_custkey \n       AND o.o_orderdate >= DATE '1995-01-01') as avg_order_value,\n    (SELECT COUNT(o.o_orderkey)\n     FROM orders o \n     WHERE o.o_custkey = c.c_custkey \n       AND o.o_orderdate >= DATE '1995-01-01') as order_count\nFROM customer c\nWHERE c.c_nationkey = 15\n  AND c.c_acctbal > 5000\nORDER BY avg_order_value DESC, c.c_name\nLIMIT 100;\n"
-  skip_on:
-  - clickhouse
-  - datafusion
-  description: 'ClickHouse and DataFusion do not support correlated subqueries (ClickHouse: NOT_IMPLEMENTED Code 48; DataFusion: planner rejects). The point of this query is to measure the optimizer''s ability to auto-flatten correlated scalar subqueries into joins, so a pre-flattened LEFT JOIN rewrite would only measure plain join execution and defeat the test.'
-  result_contract:
-    capability: scalar_subquery_flattening
-    row_identity:
-    - c_name
-    - c_mktsegment
-    - c_acctbal
-    columns:
-    - c_name
-    - c_mktsegment
-    - c_acctbal
-    - avg_order_value
-    - order_count
-- id: optimizer_constant_folding
-  category: optimizer
-  sql: "\n-- Test constant folding and expression simplification optimization\n-- Good optimizers should pre-compute constants and simplify expressions at compile time\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    l_linenumber,\n    l_quantity * (1.0 + 0.0) as simplified_qty,  -- Should fold to l_quantity\n    l_extendedprice * (2 * 3 + 4) as constant_folded,  -- Should fold to l_extendedprice * 10\n    l_discount + 0.0 - 0.0 as zero_folded,  -- Should fold to l_discount\n    CASE WHEN 1 = 1 THEN l_tax ELSE 0 END as condition_folded,  -- Should fold to l_tax\n    l_quantity / 1.0 as division_folded,  -- Should fold to l_quantity\n    l_extendedprice + (5 - 5) as addition_folded  -- Should fold to l_extendedprice\nFROM lineitem\nWHERE l_quantity * 1 > 10  -- Should simplify to l_quantity > 10\n  AND l_shipdate >= DATE '1995-01-01'\n  AND l_discount + 0 < 0.1  -- Should simplify to l_discount < 0.1\nORDER BY l_quantity * (1 + 0) DESC  -- Should simplify to l_quantity DESC\nLIMIT 1000;\n"
-- id: optimizer_column_pruning
-  category: optimizer
-  sql: "\n-- Test column pruning (projection pushdown) optimization\n-- Good optimizers should only read columns needed for the query result\nSELECT\n    c.c_name  -- Only need c_name from customer table\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey  -- Only need c_custkey for join from customer\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey  -- Only need o_orderkey for join from orders\nWHERE o.o_orderdate >= DATE '1995-01-01'  -- Only need o_orderdate for filtering\n  AND o.o_orderdate < DATE '1996-01-01'\n  AND l.l_quantity > 40  -- Only need l_quantity for filtering\n  AND c.c_nationkey = 15  -- Only need c_nationkey for filtering\nORDER BY c.c_name\nLIMIT 500;\n"
-- id: optimizer_in_to_exists
-  category: optimizer
-  sql: "\n-- Test IN-to-EXISTS transformation optimization\n-- Good optimizers should transform IN subqueries to EXISTS when beneficial\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_nationkey,\n    c.c_acctbal\nFROM customer c\nWHERE c.c_custkey IN (\n    SELECT o.o_custkey\n    FROM orders o\n    WHERE o.o_orderdate >= DATE '1995-01-01'\n      AND o.o_orderdate < DATE '1996-01-01'\n      AND o.o_totalprice > 100000\n)\n  AND c.c_nationkey IN (1, 2, 3, 4, 5)  -- Additional IN predicate\nORDER BY c.c_acctbal DESC\nLIMIT 200;\n"
-- id: optimizer_union_optimization
-  category: optimizer
-  sql: "\n-- Test union/set operation optimization\n-- Good optimizers should optimize UNION ALL operations and eliminate redundant sorting\nSELECT c_name, c_mktsegment, 'high_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal > 8000\n  AND c_nationkey IN (1, 2, 3)\nUNION ALL\nSELECT c_name, c_mktsegment, 'medium_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal BETWEEN 4000 AND 8000\n  AND c_nationkey IN (1, 2, 3)\nUNION ALL\nSELECT c_name, c_mktsegment, 'low_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal BETWEEN 1000 AND 4000\n  AND c_nationkey IN (1, 2, 3)\nORDER BY c_acctbal DESC\nLIMIT 300;\n"
-- id: optimizer_runtime_filter
-  category: optimizer
-  sql: "\n-- Test runtime filter generation optimization\n-- Good optimizers should generate bloom filters or hash filters for selective joins\nSELECT\n    l.l_orderkey,\n    l.l_partkey,\n    l.l_suppkey,\n    l.l_quantity,\n    l.l_extendedprice,\n    p.p_name,\n    p.p_type\nFROM lineitem l\nJOIN part p ON l.l_partkey = p.p_partkey\nWHERE p.p_type LIKE '%STEEL%'  -- Selective filter should generate runtime filter\n  AND p.p_size BETWEEN 10 AND 20\n  AND l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1996-01-01'\n  AND l.l_quantity > 20\nORDER BY l.l_extendedprice DESC\nLIMIT 1000;\n"
-- id: optimizer_groupjoin
-  category: optimizer
-  sql: "\n-- Test group-join (join+aggregate fusion) optimization\n-- Good optimizers fuse the JOIN and GROUP BY into a single grouped-join pass,\n-- avoiding full intermediate materialization of all lineitem rows per order\nSELECT\n    o.o_orderkey,\n    o.o_custkey,\n    o.o_orderdate,\n    COUNT(l.l_linenumber) AS line_count,\n    SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nGROUP BY o.o_orderkey, o.o_custkey, o.o_orderdate\nORDER BY revenue DESC\nLIMIT 100;\n"
-- id: any_value_simple
-  category: aggregation
-  sql: "\n-- Select any customer name per market segment (faster than MIN/MAX)\nSELECT\n    c_mktsegment,\n    ANY_VALUE(c_name) as sample_customer,\n    COUNT(*) as customer_count\nFROM customer\nGROUP BY c_mktsegment;\n"
-  result_contract:
-    capability: arbitrary_value_aggregate
-    row_identity:
-    - c_mktsegment
-    columns:
-    - c_mktsegment
-    - sample_customer
-    - customer_count
-  variants:
-    clickhouse: "\nSELECT\n    c_mktsegment,\n    any(c_name) as sample_customer,\n    COUNT(*) as customer_count\nFROM customer\nGROUP BY c_mktsegment;\n"
-  skip_on:
-  - datafusion
-- id: any_value_with_filter
-  category: aggregation
-  sql: "\n-- Any value with additional aggregates\nSELECT\n    n_regionkey,\n    ANY_VALUE(n_name) as sample_nation,\n    ANY_VALUE(n_comment) as sample_comment,\n    COUNT(*) as nation_count\nFROM nation\nGROUP BY n_regionkey;\n"
-  result_contract:
-    capability: arbitrary_value_aggregate
-    row_identity:
-    - n_regionkey
-    columns:
-    - n_regionkey
-    - sample_nation
-    - sample_comment
-    - nation_count
-  variants:
-    clickhouse: "\nSELECT\n    n_regionkey,\n    any(n_name) as sample_nation,\n    any(n_comment) as sample_comment,\n    COUNT(*) as nation_count\nFROM nation\nGROUP BY n_regionkey;\n"
-  skip_on:
-  - datafusion
-- id: groupby_all_simple
-  category: aggregation
-  sql: "\n-- Automatic grouping by all non-aggregate columns\nSELECT\n    l_returnflag,\n    l_linestatus,\n    SUM(l_quantity) as total_qty,\n    AVG(l_extendedprice) as avg_price\nFROM lineitem\nGROUP BY ALL;\n"
-- id: groupby_all_complex
-  category: aggregation
-  sql: "\n-- GROUP BY ALL with multiple non-aggregate expressions\nSELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    o_orderpriority,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY ALL\nORDER BY order_month, o_orderpriority;\n"
-  result_contract:
-    capability: group_by_all_expansion
-    row_identity:
-    - order_month
-    - o_orderpriority
-    columns:
-    - order_month
-    - o_orderpriority
-    - order_count
-    - monthly_revenue
-  variants:
-    datafusion: "\nSELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    o_orderpriority,\n    COUNT(o_orderkey) as order_count,\n    SUM(o_totalprice) as monthly_revenue\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY DATE_TRUNC('month', o_orderdate), o_orderpriority\nORDER BY order_month, o_orderpriority;\n"
-- id: orderby_all_simple
-  category: orderby
-  sql: "\n-- Order by all columns in SELECT list\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY ALL;\n"
-  result_contract:
-    capability: order_by_all_expansion
-    row_identity:
-    - r_name
-    - n_name
-    columns:
-    - r_name
-    - n_name
-    - supplier_count
-  variants:
-    datafusion: "\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY r_name, n_name, supplier_count;\n"
-    redshift: "\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY r_name, n_name, supplier_count;\n"
-- id: orderby_all_desc
-  category: orderby
-  sql: "\n-- ORDER BY ALL with direction\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY ALL DESC\nLIMIT 100;\n"
-  result_contract:
-    capability: order_by_all_desc_expansion
-    row_identity:
-    - p_brand
-    - p_type
-    columns:
-    - p_brand
-    - p_type
-    - avg_price
-  variants:
-    datafusion: "\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY p_brand DESC, p_type DESC, avg_price DESC\nLIMIT 100;\n"
-    redshift: "\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY p_brand DESC, p_type DESC, avg_price DESC\nLIMIT 100;\n"
-- id: array_agg_simple
-  category: array
-  sql: "\n-- Aggregate part keys into arrays per supplier\nSELECT\n    ps_suppkey,\n    ARRAY_AGG(ps_partkey ORDER BY ps_partkey) as supplied_parts,\n    COUNT(*) as part_count\nFROM partsupp\nGROUP BY ps_suppkey\nHAVING COUNT(*) <= 10\nORDER BY ps_suppkey\nLIMIT 100;\n"
-  result_contract:
-    capability: ordered_array_aggregation
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - name: supplied_parts
-      type_class: array
-      order_sensitive: true
-    - part_count
-  variants:
-    clickhouse: "\nSELECT\n    ps_suppkey,\n    arraySort(groupArray(ps_partkey)) as supplied_parts,\n    COUNT(*) as part_count\nFROM partsupp\nGROUP BY ps_suppkey\nHAVING COUNT(*) <= 10\nORDER BY ps_suppkey\nLIMIT 100;\n"
-  skip_on:
-  - redshift
-- id: array_agg_distinct
-  category: array
-  sql: "\n-- Distinct array aggregation\nSELECT\n    c_mktsegment,\n    ARRAY_AGG(DISTINCT c_nationkey ORDER BY c_nationkey) as nation_keys\nFROM customer\nGROUP BY c_mktsegment\nORDER BY c_mktsegment;\n"
-  result_contract:
-    capability: ordered_distinct_array_aggregation
-    row_identity:
-    - c_mktsegment
-    columns:
-    - c_mktsegment
-    - name: nation_keys
-      type_class: array
-      order_sensitive: true
-  variants:
-    clickhouse: "\nSELECT\n    c_mktsegment,\n    arraySort(groupUniqArray(c_nationkey)) as nation_keys\nFROM customer\nGROUP BY c_mktsegment\nORDER BY c_mktsegment;\n"
-  skip_on:
-  - redshift
-- id: array_unnest
-  category: array
-  sql: "\n-- Unnest/explode array back to rows\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    UNNEST(parts) as part_key\nFROM supplier_parts;\n"
-  result_contract:
-    capability: array_unnest
-    row_identity:
-    - ps_suppkey
-    - part_key
-    columns:
-    - ps_suppkey
-    - part_key
-  variants:
-    bigquery: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_key\nFROM supplier_parts, UNNEST(parts) as part_key;\n"
-    clickhouse: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    arrayJoin(parts) as part_key\nFROM supplier_parts;\n"
-  skip_on:
-  - redshift
-- id: array_contains
-  category: array
-  sql: "\n-- Check if array contains a value\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    ARRAY_CONTAINS(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n"
-  result_contract:
-    capability: array_membership_predicate
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - has_part_100
-  variants:
-    duckdb: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    list_contains(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    has(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n"
-    bigquery: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    100 IN UNNEST(parts) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n"
-  skip_on:
-  - datafusion
-  - redshift
-- id: array_length
-  category: array
-  sql: "\n-- Get array length/cardinality\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    CARDINALITY(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n"
-  result_contract:
-    capability: array_cardinality
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - num_parts
-  variants:
-    duckdb: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    len(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    length(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n"
-  skip_on:
-  - datafusion
-  - redshift
-- id: array_slice
-  category: array
-  sql: "\n-- Get array slice/subset\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice ORDER BY o_totalprice DESC) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    ARRAY_SLICE(prices, 1, 3) as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  result_contract:
-    capability: ordered_array_slice
-    row_identity:
-    - o_custkey
-    columns:
-    - o_custkey
-    - name: top_3_orders
-      type_class: array
-      order_sensitive: true
-  variants:
-    duckdb: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice ORDER BY o_totalprice DESC) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    prices[1:3] as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        arrayReverseSort(groupArray(o_totalprice)) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    arraySlice(prices, 1, 3) as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  skip_on:
-  - redshift
-- id: array_min_max
-  category: array
-  sql: "\n-- Get min/max from array\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    ARRAY_MIN(prices) as min_order,\n    ARRAY_MAX(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  result_contract:
-    capability: array_min_max
-    row_identity:
-    - o_custkey
-    columns:
-    - o_custkey
-    - min_order
-    - max_order
-  variants:
-    duckdb: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    list_min(prices) as min_order,\n    list_max(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        groupArray(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    arrayMin(prices) as min_order,\n    arrayMax(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - redshift
-- id: array_sort
-  category: array
-  sql: "\n-- Sort array elements\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    ARRAY_SORT(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n"
-  result_contract:
-    capability: array_sort
-    row_identity:
-    - p_brand
-    columns:
-    - p_brand
-    - name: sorted_sizes
-      type_class: array
-      order_sensitive: true
-  variants:
-    duckdb: "\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    list_sort(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n"
-    clickhouse: "\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        groupArray(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    arraySort(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n"
-  skip_on:
-  - bigquery
-  - redshift
-- id: array_distinct
-  category: array
-  sql: "\n-- Get distinct array elements\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    ARRAY_DISTINCT(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n"
-  result_contract:
-    capability: distinct_array_values
-    row_identity:
-    - l_orderkey
-    columns:
-    - l_orderkey
-    - name: unique_modes
-      type_class: array
-  variants:
-    duckdb: "\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    list_distinct(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        groupArray(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    arrayDistinct(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - redshift
-- id: struct_construction
-  category: struct
-  sql: "\n-- Construct struct/row from columns\nSELECT\n    c_custkey,\n    STRUCT(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n"
-  result_contract:
-    capability: positional_struct_construction
-    row_identity:
-    - c_custkey
-    columns:
-    - c_custkey
-    - name: contact_info
-      type_class: struct
-    - c_acctbal
-  variants:
-    clickhouse: "\nSELECT\n    c_custkey,\n    tuple(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n"
-    duckdb: "\nSELECT\n    c_custkey,\n    ROW(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n"
-  skip_on:
-  - redshift
-- id: struct_access
-  category: struct
-  sql: "\n-- Access struct fields\nWITH customer_info AS (\n    SELECT\n        c_custkey,\n        STRUCT(c_name AS name, c_phone AS phone, c_acctbal AS balance) as info\n    FROM customer\n    WHERE c_nationkey = 1\n)\nSELECT\n    c_custkey,\n    info.name,\n    info.balance\nFROM customer_info\nWHERE info.balance > 5000\nORDER BY c_custkey\nLIMIT 100;\n"
-  result_contract:
-    capability: struct_field_access
-    row_identity:
-    - c_custkey
-    columns:
-    - c_custkey
-    - name
-    - balance
-  variants:
-    clickhouse: "\nWITH customer_info AS (\n    SELECT\n        c_custkey,\n        tuple(c_name, c_phone, c_acctbal) as info\n    FROM customer\n    WHERE c_nationkey = 1\n)\nSELECT\n    c_custkey,\n    info.1 as name,\n    info.3 as balance\nFROM customer_info\nWHERE info.3 > 5000\nORDER BY c_custkey\nLIMIT 100;\n"
-  skip_on:
-  - redshift
-- id: array_of_struct
-  category: struct
-  sql: "\n-- Array of structs - orders with line items summary\nSELECT\n    o_orderkey,\n    ARRAY_AGG(\n        STRUCT(l_linenumber, l_partkey, l_quantity, l_extendedprice)\n        ORDER BY l_linenumber\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = DATE '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n"
-  result_contract:
-    capability: ordered_array_of_structs
-    row_identity:
-    - o_orderkey
-    columns:
-    - o_orderkey
-    - name: line_items
-      type_class: array
-      order_sensitive: true
-  variants:
-    duckdb: "\nSELECT\n    o_orderkey,\n    ARRAY_AGG(\n        struct_pack(\n            l_linenumber := l_linenumber,\n            l_partkey := l_partkey,\n            l_quantity := l_quantity,\n            l_extendedprice := l_extendedprice\n        )\n        ORDER BY l_linenumber\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = DATE '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n"
-    clickhouse: "\nSELECT\n    o_orderkey,\n    arraySort(\n        x -> x.1,\n        groupArray(\n            CAST(\n                (l_linenumber, l_partkey, l_quantity, l_extendedprice),\n                'Tuple(l_linenumber Int32, l_partkey Int32, l_quantity Decimal(15,2), l_extendedprice Decimal(15,2))'\n            )\n        )\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n"
-  skip_on:
-  - redshift
-- id: map_construction
-  category: map
-  sql: "\n-- Construct map from key-value pairs\nSELECT\n    ps_suppkey,\n    MAP_FROM_ENTRIES(\n        ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n"
-  result_contract:
-    capability: map_construction
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - name: part_costs
-      type_class: map
-  variants:
-    duckdb: "\nSELECT\n    ps_suppkey,\n    map_from_entries(\n        list(struct_pack(k := CAST(ps_partkey AS VARCHAR), v := ps_supplycost))\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n"
-    datafusion: "\nSELECT\n    ps_suppkey,\n    MAP(\n        ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n        ARRAY_AGG(ps_supplycost)\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n"
-    clickhouse: "\nSELECT\n    ps_suppkey,\n    CAST(\n        (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n        'Map(String, Decimal(15,2))'\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n"
-  skip_on:
-  - bigquery
-  - redshift
-- id: map_access
-  category: map
-  sql: "\n-- Access map values by key\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP_FROM_ENTRIES(\n            ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_costs['1'] as cost_for_part_1,\n    part_costs['5'] as cost_for_part_5\nFROM supplier_costs\nORDER BY ps_suppkey\nLIMIT 10;\n"
-  result_contract:
-    capability: map_key_access
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - cost_for_part_1
-    - cost_for_part_5
-  variants:
-    datafusion: "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP(\n            ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n            ARRAY_AGG(ps_supplycost)\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_EXTRACT(part_costs, '1')[1] as cost_for_part_1,\n    MAP_EXTRACT(part_costs, '5')[1] as cost_for_part_5\nFROM supplier_costs\nORDER BY ps_suppkey\nLIMIT 10;\n"
-    clickhouse: "\n-- ClickHouse builds Map via CAST((Array(K), Array(V)) AS Map(K, V));\n-- match the map_construction / map_keys_values convention.\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        CAST(\n            (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n            'Map(String, Decimal(15,2))'\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_costs['1'] as cost_for_part_1,\n    part_costs['5'] as cost_for_part_5\nFROM supplier_costs\nLIMIT 10;\n"
-  skip_on:
-  - bigquery
-  - redshift
-- id: map_keys_values
-  category: map
-  sql: "\n-- Extract map keys and values\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP_FROM_ENTRIES(\n            ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_KEYS(part_costs) as part_ids,\n    MAP_VALUES(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n"
-  result_contract:
-    capability: map_keys_values
-    row_identity:
-    - ps_suppkey
-    columns:
-    - ps_suppkey
-    - name: part_ids
-      type_class: array
-    - name: costs
-      type_class: array
-  variants:
-    datafusion: "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP(\n            ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n            ARRAY_AGG(ps_supplycost)\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_KEYS(part_costs) as part_ids,\n    MAP_VALUES(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n"
-    clickhouse: "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        CAST(\n            (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n            'Map(String, Decimal(15,2))'\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    mapKeys(part_costs) as part_ids,\n    mapValues(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n"
-  skip_on:
-  - bigquery
-  - redshift
-- id: list_transform
-  category: lambda
-  sql: "\n-- Transform each array element\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    TRANSFORM(prices, x -> x * 1.1) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n"
-  result_contract:
-    capability: array_lambda_transform
-    row_identity:
-    - p_brand
-    columns:
-    - p_brand
-    - name: prices_with_tax
-      type_class: array
-  variants:
-    duckdb: "\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    list_transform(prices, x -> x * 1.1) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n"
-    clickhouse: "\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        groupArray(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    arrayMap(x -> x * 1.1, prices) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - redshift
-- id: list_filter
-  category: lambda
-  sql: "\n-- Filter array elements by condition\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    FILTER(prices, x -> x > 100000) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  result_contract:
-    capability: array_lambda_filter
-    row_identity:
-    - o_custkey
-    columns:
-    - o_custkey
-    - name: large_orders
-      type_class: array
-  variants:
-    duckdb: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    list_filter(prices, x -> x > 100000) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        groupArray(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    arrayFilter(x -> x > 100000, prices) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - redshift
-- id: list_reduce
-  category: lambda
-  sql: "\n-- Reduce array to single value\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    REDUCE(qtys, 0, (acc, x) -> acc + x) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n"
-  result_contract:
-    capability: array_lambda_reduce
-    row_identity:
-    - l_orderkey
-    columns:
-    - l_orderkey
-    - total_qty
-  variants:
-    duckdb: "\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    list_reduce(qtys, (acc, x) -> acc + x) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n"
-    clickhouse: "\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        groupArray(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    arrayReduce('sum', qtys) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - redshift
-- id: asof_join_basic
-  category: timeseries
-  sql: "\n-- ASOF join: find closest prior order for each lineitem shipment\nSELECT\n    l.l_orderkey,\n    l.l_shipdate,\n    o.o_orderdate,\n    o.o_totalprice,\n    l.l_shipdate - o.o_orderdate as days_to_ship\nFROM lineitem l\nASOF JOIN orders o\n    ON l.l_orderkey = o.o_orderkey\n    AND l.l_shipdate >= o.o_orderdate\nWHERE l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1995-02-01'\nORDER BY l.l_orderkey, l.l_shipdate\nLIMIT 100;\n"
-  result_contract:
-    capability: asof_temporal_join
-    columns:
-    - l_orderkey
-    - l_shipdate
-    - o_orderdate
-    - o_totalprice
-    - days_to_ship
-  variants:
-    snowflake: "\nSELECT\n    l.l_orderkey,\n    l.l_shipdate,\n    o.o_orderdate,\n    o.o_totalprice,\n    l.l_shipdate - o.o_orderdate as days_to_ship\nFROM lineitem l\nASOF JOIN orders o\n    MATCH_CONDITION (l.l_shipdate >= o.o_orderdate)\n    ON l.l_orderkey = o.o_orderkey\nWHERE l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1995-02-01'\nORDER BY l.l_orderkey, l.l_shipdate\nLIMIT 100;\n"
-  skip_on:
-  - bigquery
-  - datafusion
-  - databricks
-  - redshift
-- id: pivot_basic
-  category: pivot
-  sql: "\n-- Pivot ship modes into columns\nSELECT *\nFROM (\n    SELECT\n        l_returnflag,\n        l_shipmode,\n        l_quantity\n    FROM lineitem\n    WHERE l_shipdate >= DATE '1995-01-01'\n      AND l_shipdate < DATE '1995-04-01'\n)\nPIVOT (\n    SUM(l_quantity)\n    FOR l_shipmode IN ('AIR', 'RAIL', 'SHIP', 'TRUCK')\n);\n"
-  skip_on:
-  - clickhouse
-- id: unpivot_basic
-  category: pivot
-  sql: "\n-- Unpivot part dimensions into rows\nSELECT\n    p_partkey,\n    dimension_name,\n    dimension_value\nFROM (\n    SELECT\n        p_partkey,\n        CAST(p_size AS DECIMAL(15, 2)) as p_size,\n        p_retailprice\n    FROM part\n    WHERE p_partkey <= 100\n)\nUNPIVOT (\n    dimension_value\n    FOR dimension_name IN (p_size, p_retailprice)\n)\nORDER BY p_partkey, dimension_name;\n"
-  result_contract:
-    capability: unpivot_rows
-    row_identity:
-    - p_partkey
-    - dimension_name
-    columns:
-    - p_partkey
-    - dimension_name
-    - dimension_value
-  variants:
-    datafusion: "\nSELECT\n    p_partkey,\n    'p_size' as dimension_name,\n    CAST(p_size AS DECIMAL(15, 2)) as dimension_value\nFROM part\nWHERE p_partkey <= 100\nUNION ALL\nSELECT\n    p_partkey,\n    'p_retailprice' as dimension_name,\n    p_retailprice as dimension_value\nFROM part\nWHERE p_partkey <= 100\nORDER BY p_partkey, dimension_name;\n"
-  skip_on:
-  - clickhouse
-- id: filter_selective
-  category: filter
-  sql: "\n-- Selective compound filter on lineitem\nSELECT l_orderkey, l_partkey, l_quantity, l_extendedprice\nFROM lineitem\nWHERE l_quantity > 45\n  AND l_extendedprice > 50000\n  AND l_discount < 0.05;\n"
-- id: filter_non_selective
-  category: filter
-  sql: "\n-- Non-selective broad filter on lineitem\nSELECT l_orderkey, l_partkey, l_quantity, l_extendedprice\nFROM lineitem\nWHERE l_quantity > 1;\n"
-- id: orderby_simple
-  category: orderby
-  sql: "\n-- Simple single-column sort with limit\nSELECT o_orderkey, o_orderdate, o_totalprice\nFROM orders\nORDER BY o_orderdate\nLIMIT 100;\n"
-- id: orderby_multi
-  category: orderby
-  sql: "\n-- Multi-column sort with limit\nSELECT l_orderkey, l_linenumber, l_shipdate, l_quantity\nFROM lineitem\nORDER BY l_shipdate, l_orderkey, l_linenumber\nLIMIT 100;\n"
-- id: orderby_desc
-  category: orderby
-  sql: "\n-- Descending sort with limit\nSELECT o_orderkey, o_totalprice, o_orderdate\nFROM orders\nORDER BY o_totalprice DESC\nLIMIT 100;\n"
-- id: string_like
-  category: string
-  sql: "\n-- String contains (LIKE %pattern%)\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_name LIKE '%blue%';\n"
-- id: string_starts_with
-  category: string
-  sql: "\n-- String prefix match\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_type LIKE 'STANDARD%';\n"
-- id: string_ends_with
-  category: string
-  sql: "\n-- String suffix match\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_type LIKE '%BRASS';\n"
-- id: string_concat
-  category: string
-  sql: "\n-- String concatenation\nSELECT c_custkey, c_name || ' - ' || c_mktsegment as customer_info\nFROM customer\nLIMIT 100;\n"
-- id: string_substring
-  category: string
-  sql: "\n-- Substring extraction\nSELECT c_custkey, SUBSTRING(c_phone FROM 1 FOR 3) as country_code\nFROM customer\nLIMIT 100;\n"
-- id: shuffle_join
-  category: shuffle
-  sql: "\n-- Inner join with aggregation\nSELECT o.o_orderkey, SUM(l.l_quantity) as total_qty\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nGROUP BY o.o_orderkey;\n"
-- id: topn
-  category: topn
-  sql: "\n-- Top-N by value (descending sort + limit)\nSELECT l_orderkey, l_partkey, l_extendedprice\nFROM lineitem\nORDER BY l_extendedprice DESC\nLIMIT 10;\n"
-- id: window_rank
-  category: window
-  sql: "\n-- RANK window function with QUALIFY filter\nSELECT l_orderkey, l_returnflag, l_quantity,\n       RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\nFROM lineitem\nQUALIFY RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n"
-  result_contract:
-    capability: qualify_rank_filter
-    columns:
-    - l_orderkey
-    - l_returnflag
-    - l_quantity
-    - qty_rank
-  variants:
-    datafusion: "\nSELECT l_orderkey, l_returnflag, l_quantity, qty_rank\nFROM (\n    SELECT l_orderkey, l_returnflag, l_quantity,\n           RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\n    FROM lineitem\n) ranked\nWHERE qty_rank <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n"
-    redshift: "\n-- Redshift QUALIFY with RANK requires subquery workaround\nSELECT l_orderkey, l_returnflag, l_quantity, qty_rank\nFROM (\n    SELECT l_orderkey, l_returnflag, l_quantity,\n           RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\n    FROM lineitem\n) ranked\nWHERE qty_rank <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n"
-- id: window_sum
-  category: window
-  sql: "\n-- Partitioned window SUM\nSELECT l_orderkey, l_linenumber, l_extendedprice,\n       SUM(l_extendedprice) OVER (PARTITION BY l_orderkey) as order_total\nFROM lineitem;\n"
-- id: window_running_sum
-  category: window
-  sql: "\n-- Cumulative running sum\nSELECT o_orderkey, o_orderdate, o_totalprice,\n       SUM(o_totalprice) OVER (ORDER BY o_orderdate) as cumulative_revenue\nFROM orders\nORDER BY o_orderdate\nLIMIT 100;\n"
-  skip_on:
-  - redshift
-- id: limit_ordered
-  category: limit
-  sql: "\n-- LIMIT clause with ordering on large result set\nSELECT *\nFROM lineitem\nORDER BY l_orderkey, l_linenumber\nLIMIT 100;\n"
+- {"id": "aggregation_distinct", "category": "aggregation", "sql": "\n-- Distinct count of high cardinality key on a large table\nSELECT COUNT(DISTINCT o_custkey) as unique_customers\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01';\n"}
+- {"id": "aggregation_distinct_groupby", "category": "aggregation", "sql": "\n-- Distinct count of high cardinality keys in low cardinality groups.\nSELECT\n    l_returnflag,\n    l_linestatus,\n    COUNT(DISTINCT l_orderkey) as unique_orders,\n    COUNT(DISTINCT l_partkey) as unique_parts\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"}
+- {"id": "approx_count_distinct_simple", "category": "aggregation", "sql": "\n-- Approximate distinct count (HLL) on a high-cardinality key\n-- Companion to aggregation_distinct; tests one-shot approx-distinct latency.\n-- Cross-dialect rewrites are handled by sqlglot:\n--   ClickHouse: uniq(o_custkey)\n--   Redshift:   APPROXIMATE COUNT(DISTINCT o_custkey)\nSELECT APPROX_COUNT_DISTINCT(o_custkey) as unique_customers\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01';\n", "result_contract": {"capability": "approximate_distinct_count", "columns": ["unique_customers"]}, "skip_on": ["sqlite"]}
+- {"id": "approx_count_distinct_groupby", "category": "aggregation", "sql": "\n-- Approximate distinct counts (HLL) per low-cardinality group\n-- Companion to aggregation_distinct_groupby. Cross-dialect rewrites\n-- (ClickHouse uniq, Redshift APPROXIMATE COUNT(DISTINCT)) are handled\n-- by sqlglot.\nSELECT\n    l_returnflag,\n    l_linestatus,\n    APPROX_COUNT_DISTINCT(l_orderkey) as unique_orders,\n    APPROX_COUNT_DISTINCT(l_partkey) as unique_parts\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n", "result_contract": {"capability": "approximate_distinct_count", "row_identity": ["l_returnflag", "l_linestatus"], "columns": ["l_returnflag", "l_linestatus", "unique_orders", "unique_parts"]}, "skip_on": ["sqlite"]}
+- {"id": "aggregation_groupby_large", "category": "aggregation", "sql": "\n-- Aggregates within high cardinality grouping\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    SUM(l_quantity) as total_qty,\n    AVG(l_extendedprice) as avg_price\nFROM lineitem\nGROUP BY l_orderkey, l_partkey, l_suppkey;\n"}
+- {"id": "aggregation_groupby_small", "category": "aggregation", "sql": "\n-- Aggregates within low cardinality grouping\nSELECT\n    n_regionkey,\n    COUNT(*) as nation_count,\n    MAX(n_name) as last_nation\nFROM nation\nGROUP BY n_regionkey;\n"}
+- {"id": "aggregation_materialize", "category": "aggregation", "sql": "\n-- Nested aggregation requiring CTE materialization\nWITH order_totals AS (\n    SELECT\n        o_custkey,\n        SUM(o_totalprice) as customer_total\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT AVG(customer_total) as avg_customer_spending\nFROM order_totals;\n"}
+- {"id": "aggregation_materialize_subquery", "category": "aggregation", "sql": "\n-- Complex nested aggregation requiring materialization of a subquery with joins\nSELECT\n    c_mktsegment,\n    AVG(order_total) as avg_segment_order\nFROM (\n    SELECT\n        c.c_mktsegment,\n        o.o_orderkey,\n        SUM(l.l_extendedprice * (1 - l.l_discount)) as order_total\n    FROM customer c\n    JOIN orders o ON c.c_custkey = o.o_custkey\n    JOIN lineitem l ON o.o_orderkey = l.l_orderkey\n    GROUP BY c.c_mktsegment, o.o_orderkey\n) subq\nGROUP BY c_mktsegment;\n"}
+- {"id": "aggregation_partition", "category": "aggregation", "sql": "\n-- Aggregates over the partition key\nSELECT\n    l_shipdate,\n    l_shipmode,\n    SUM(l_quantity) as daily_quantity,\n    COUNT(*) as shipment_count\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\nGROUP BY l_shipdate, l_shipmode;\n"}
+- {"id": "aggregation_selective", "category": "aggregation", "sql": "\n-- Aggregate on a small subset of rows\nSELECT\n    SUM(l_extendedprice * l_discount) as total_discount_amount\nFROM lineitem\nWHERE l_discount > 0.05\n  AND l_quantity < 24;\n"}
+- {"id": "aggregation_simple", "category": "aggregation", "sql": "\n-- Aggregate over all rows in table\nSELECT\n    COUNT(*) as total_orders,\n    SUM(o_totalprice) as total_revenue\nFROM orders;\n"}
+- {"id": "broadcast_join_two_tables", "category": "broadcast", "sql": "\n-- One small table broadcast to join with one large table. Hint is optional.\nSELECT /*+ BROADCAST(n) */\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey;\n"}
+- {"id": "broadcast_join_three_tables", "category": "broadcast", "sql": "\n-- Two small tables broadcast to join with one large table. Hints are optional.\nSELECT /*+ BROADCAST(n), BROADCAST(r) */\n    r.r_name,\n    n.n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r.r_name, n.n_name;\n"}
+- {"id": "broadcast_join_four_tables", "category": "broadcast", "sql": "\n-- Three small tables broadcast to join with one large table. Hints are optional.\nSELECT /*+ BROADCAST(n), BROADCAST(r), BROADCAST(p) */\n    r.r_name,\n    p.p_type,\n    SUM(ps.ps_supplycost * ps.ps_availqty) as total_value\nFROM partsupp ps\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nJOIN part p ON ps.ps_partkey = p.p_partkey\nWHERE p.p_size = 15\nGROUP BY r.r_name, p.p_type;\n"}
+- {"id": "predicate_ordering_aggregation", "category": "predicate", "sql": "\n-- Order filter predicates by selectivity for aggregation\nSELECT\n    SUM(l_extendedprice) as total_price\nFROM lineitem\nWHERE l_shipdate >= DATE '1994-01-01'\n  AND l_shipdate < DATE '1995-01-01'\n  AND l_discount BETWEEN 0.05 AND 0.07\n  AND l_quantity < 24;\n"}
+- {"id": "predicate_ordering_aggregation_groupby", "category": "predicate", "sql": "\n-- Order filter predicates by selectivity for aggregation within a low cardinality grouping\nSELECT\n    l_returnflag,\n    SUM(l_quantity) as total_qty\nFROM lineitem\nWHERE l_shipdate <= DATE '1998-09-01'\n  AND l_discount > 0.05\n  AND l_tax < 0.08\n  AND l_quantity BETWEEN 10 AND 30\nGROUP BY l_returnflag;\n"}
+- {"id": "predicate_ordering_costs", "category": "predicate", "sql": "\n-- Order filter predicates by selectivity with result projection only\nSELECT *\nFROM lineitem\nWHERE l_quantity > 45\n  AND l_extendedprice > 50000\n  AND l_discount < 0.05\n  AND l_shipinstruct = 'DELIVER IN PERSON'\n  AND l_shipmode IN ('AIR', 'AIR REG')\nLIMIT 100;\n"}
+- {"id": "predicate_ordering_subquery", "category": "predicate", "sql": "\n-- Order filter predicates by selectivity with subquery predicate\nSELECT\n    o_orderkey,\n    o_totalprice\nFROM orders\nWHERE o_totalprice > 100000\n  AND o_orderdate >= DATE '1995-01-01'\n  AND o_custkey IN (\n    SELECT c_custkey\n    FROM customer\n    WHERE c_mktsegment = 'BUILDING'\n      AND c_nationkey = 1\n  );\n"}
+- {"id": "count_star", "category": "count", "sql": "\n-- metadata-based count optimization vs full table scan performance\nSELECT COUNT(*) as total_lineitems\nFROM lineitem;\n"}
+- {"id": "decimal_arithmetic", "category": "decimal", "sql": "\n-- decimal precision arithmetic with complex expressions\nSELECT\n    l_orderkey,\n    l_extendedprice * (1 - l_discount) * (1 + l_tax) as final_price,\n    l_extendedprice / l_quantity as unit_price\nFROM lineitem\nWHERE l_quantity > 0\nLIMIT 1000;\n"}
+- {"id": "empty_build_join", "category": "empty", "sql": "\n-- join when build side produces no rows (edge case handling)\nSELECT l.*\nFROM lineitem l\nLEFT JOIN (\n    SELECT * FROM orders WHERE o_totalprice < 0\n) o ON l.l_orderkey = o.o_orderkey;\n"}
+- {"id": "exchange_broadcast", "category": "exchange", "sql": "\n-- One small table is copied to all nodes that have the large table. The `BROADCAST(small_parts)` hint is optional\nSELECT /*+ BROADCAST(small_parts) */\n    l.l_orderkey,\n    SUM(l.l_quantity) as total_qty\nFROM lineitem l\nJOIN (\n    SELECT p_partkey\n    FROM part\n    WHERE p_size = 1\n) small_parts ON l.l_partkey = small_parts.p_partkey\nGROUP BY l.l_orderkey;\n"}
+- {"id": "exchange_merge", "category": "exchange", "sql": "\n-- Sorted data from multiple nodes is combined while keeping the sort order.\nSELECT\n    o.o_orderkey,\n    l.l_linenumber,\n    l.l_quantity\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nORDER BY o.o_orderkey, l.l_linenumber;\n"}
+- {"id": "exchange_shuffle", "category": "exchange", "sql": "\n-- Data is redistributed based on the join keys so matching rows end up on the same node\nSELECT\n    ps1.ps_partkey,\n    ps1.ps_suppkey as supp1,\n    ps2.ps_suppkey as supp2\nFROM partsupp ps1\nJOIN partsupp ps2 ON ps1.ps_partkey = ps2.ps_partkey\nWHERE ps1.ps_suppkey < ps2.ps_suppkey\n  AND ps1.ps_supplycost > 100;\n"}
+- {"id": "filter_bigint_in_list_selective", "category": "filter", "sql": "\n-- IN-list predicate with highly selective integer values\nSELECT *\nFROM orders\nWHERE o_orderkey IN (1, 100, 1000, 10000, 100000);\n"}
+- {"id": "filter_bigint_non_selective", "category": "filter", "sql": "\n-- range predicate with low selectivity on large table\nSELECT COUNT(*)\nFROM lineitem\nWHERE l_orderkey > 1000;\n"}
+- {"id": "filter_bigint_selective", "category": "filter", "sql": "\n-- equality predicate with high selectivity on integer column\nSELECT *\nFROM orders\nWHERE o_orderkey = 1234567;\n"}
+- {"id": "filter_decimal_in_list_selective", "category": "filter", "sql": "\n-- IN-list predicate with decimal values and selectivity\nSELECT *\nFROM lineitem\nWHERE l_extendedprice IN (1000.00, 5000.00, 10000.00, 50000.00);\n"}
+- {"id": "filter_decimal_non_selective", "category": "filter", "sql": "\n-- range predicate on decimal column with low selectivity\nSELECT COUNT(*)\nFROM lineitem\nWHERE l_extendedprice > 1000.00;\n"}
+- {"id": "filter_decimal_selective", "category": "filter", "sql": "\n-- compound equality predicate with multiple decimal columns\nSELECT *\nFROM lineitem\nWHERE l_extendedprice = 12345.67\n  AND l_discount = 0.05;\n"}
+- {"id": "filter_in_predicate_selective", "category": "filter", "sql": "\n-- IN predicate with subquery and selective filtering\nSELECT *\nFROM part\nWHERE p_partkey IN (\n    SELECT l_partkey\n    FROM lineitem\n    WHERE l_quantity > 45\n);\n"}
+- {"id": "filter_string_like", "category": "filter", "sql": "\n-- LIKE predicate with substring pattern matching\nSELECT *\nFROM part\nWHERE p_name LIKE '%COPPER%';\n"}
+- {"id": "filter_string_non_selective", "category": "filter", "sql": "\n-- string comparison with low selectivity (most rows match)\nSELECT COUNT(*)\nFROM customer\nWHERE c_mktsegment >= 'A';\n"}
+- {"id": "filter_string_selective", "category": "filter", "sql": "\n-- Exact string equality with high selectivity on varchar column\nSELECT *\nFROM customer\nWHERE c_name = 'Customer#000001234';\n"}
+- {"id": "groupby_bigint_highndv", "category": "groupby", "sql": "\n-- GROUP BY with high distinct value count (many groups)\nSELECT\n    l_orderkey,\n    COUNT(*) as line_count\nFROM lineitem\nGROUP BY l_orderkey;\n"}
+- {"id": "groupby_bigint_lowndv", "category": "groupby", "sql": "\n-- GROUP BY with low distinct value count (few groups)\nSELECT\n    o_orderpriority,\n    COUNT(*) as order_count\nFROM orders\nGROUP BY o_orderpriority;\n"}
+- {"id": "groupby_bigint_pk", "category": "groupby", "sql": "\n-- GROUP BY on primary key (one row per group)\nSELECT\n    c_custkey,\n    MAX(c_name) as customer_name\nFROM customer\nGROUP BY c_custkey;\n"}
+- {"id": "groupby_decimal_highndv", "category": "groupby", "sql": "\n-- GROUP BY with high cardinality decimal column\nSELECT\n    l_extendedprice,\n    COUNT(*) as price_frequency\nFROM lineitem\nGROUP BY l_extendedprice;\n"}
+- {"id": "groupby_decimal_lowndv", "category": "groupby", "sql": "\n-- GROUP BY with low cardinality decimal column\nSELECT\n    l_discount,\n    COUNT(*) as discount_frequency,\n    AVG(l_quantity) as avg_qty\nFROM lineitem\nGROUP BY l_discount;\n"}
+- {"id": "approx_quantile_groupby", "category": "statistical", "sql": "\n-- Approximate single-quantile per group (T-Digest / KLL family)\n-- Hard rename of the prior intrinsic_appx_median entry, which used\n-- exact PERCENTILE_CONT despite the \"appx\" name.\nSELECT\n    l_shipmode,\n    APPROX_QUANTILE(l_quantity, 0.5) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n", "result_contract": {"capability": "approximate_quantile_groupby", "row_identity": ["l_shipmode"], "columns": ["l_shipmode", "median_quantity"]}, "variants": {"bigquery": "\nSELECT\n    l_shipmode,\n    APPROX_QUANTILES(l_quantity, 100)[OFFSET(50)] as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n", "clickhouse": "\nSELECT\n    l_shipmode,\n    quantileTDigest(0.5)(toFloat64(l_quantity)) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n", "datafusion": "\nSELECT\n    l_shipmode,\n    approx_percentile_cont(l_quantity, 0.5) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n", "redshift": "\nSELECT\n    l_shipmode,\n    APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY l_quantity) as median_quantity\nFROM lineitem\nGROUP BY l_shipmode;\n"}, "skip_on": ["sqlite"]}
+- {"id": "intrinsic_to_date", "category": "intrinsic", "sql": "\n-- Date parsing and conversion function performance\nSELECT\n    COUNT(*) as orders_by_month\nFROM orders\nWHERE o_orderdate = TO_DATE('1995-03-15', 'yyyy-MM-dd');\n", "result_contract": {"capability": "date_parse_filter", "columns": ["orders_by_month"]}, "variants": {"datafusion": "\nSELECT\n    COUNT(*) as orders_by_month\nFROM orders\nWHERE o_orderdate = TO_DATE('1995-03-15');\n"}}
+- {"id": "limit", "category": "limit", "sql": "\n-- LIMIT clause with ordering on large result set\nSELECT *\nFROM lineitem\nORDER BY l_orderkey, l_linenumber\nLIMIT 100;\n"}
+- {"id": "long_predicate", "category": "long", "sql": "\n-- Query with many conjunctive predicates across multiple tables\nSELECT COUNT(*)\nFROM lineitem l\nJOIN orders o ON l.l_orderkey = o.o_orderkey\nJOIN customer c ON o.o_custkey = c.c_custkey\nWHERE l.l_shipdate >= DATE '1994-01-01'\n  AND l.l_shipdate < DATE '1995-01-01'\n  AND l.l_discount BETWEEN 0.05 AND 0.07\n  AND l.l_quantity < 24\n  AND o.o_orderpriority = '1-URGENT'\n  AND c.c_mktsegment = 'BUILDING'\n  AND l.l_returnflag = 'R'\n  AND l.l_linestatus = 'F'\n  AND o.o_totalprice > 100000\n  AND c.c_nationkey IN (1, 2, 3, 4, 5);\n"}
+- {"id": "min_max_runtime_filter", "category": "filter", "sql": "\n-- Bloom filter and runtime filter effectiveness for join optimization\nSELECT\n    l.*\nFROM lineitem l\nWHERE l.l_orderkey IN (\n    SELECT o_orderkey\n    FROM orders\n    WHERE o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1995-03-31'\n);\n"}
+- {"id": "orderby_all", "category": "orderby", "sql": "\n-- Sort on full table with simple integer ordering\nSELECT *\nFROM customer\nORDER BY c_custkey;\n"}
+- {"id": "orderby_bigint", "category": "orderby", "sql": "\n-- Sort with aggregation results on integer column\nSELECT\n    l_orderkey,\n    SUM(l_quantity) as total_qty\nFROM lineitem\nGROUP BY l_orderkey\nORDER BY l_orderkey;\n"}
+- {"id": "orderby_bigint_expression", "category": "orderby", "sql": "\n-- Sort on computed expressions with DESC ordering\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_quantity * l_extendedprice as total_value\nFROM lineitem\nORDER BY l_quantity * l_extendedprice DESC\nLIMIT 100;\n"}
+- {"id": "orderby_decimal16", "category": "orderby", "sql": "\n-- Multi-column sort with mixed ASC/DESC on decimal columns\nSELECT\n    l_orderkey,\n    l_extendedprice,\n    l_discount\nFROM lineitem\nORDER BY l_extendedprice DESC, l_discount ASC\nLIMIT 100;\n"}
+- {"id": "orderby_multicol", "category": "orderby", "sql": "\n-- Complex multi-column sort with string, date, and decimal columns\nSELECT *\nFROM orders\nORDER BY o_orderpriority, o_orderdate DESC, o_totalprice DESC\nLIMIT 100;\n"}
+- {"id": "orderby_shortstrings", "category": "orderby", "sql": "\n-- Sort on short string columns with DISTINCT operation\nSELECT DISTINCT l_returnflag, l_linestatus\nFROM lineitem\nORDER BY l_returnflag, l_linestatus;\n"}
+- {"id": "shuffle_1mb_rows", "category": "shuffle", "sql": "\n-- Self-join with hash collision handling on large table\nSELECT\n    l1.l_orderkey,\n    COUNT(*) as match_count\nFROM lineitem l1\nJOIN lineitem l2 ON l1.l_partkey = l2.l_partkey\nWHERE l1.l_orderkey != l2.l_orderkey\n  AND l1.l_shipdate = l2.l_shipdate\nGROUP BY l1.l_orderkey\nLIMIT 10000;\n"}
+- {"id": "shuffle_full_join_one_to_many_string_with_groupby", "category": "shuffle", "sql": "\n-- FULL OUTER JOIN with string grouping and aggregation\nSELECT\n    c.c_mktsegment,\n    COUNT(o.o_orderkey) as order_count,\n    COUNT(c.c_custkey) as customer_count\nFROM customer c\nFULL OUTER JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"}
+- {"id": "shuffle_inner_join_one_to_many_string_with_groupby", "category": "shuffle", "sql": "\n-- Standard inner join with one-to-many relationship\nSELECT\n    c.c_mktsegment,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue\nFROM customer c\nINNER JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"}
+- {"id": "shuffle_inner_join_union_all_with_groupby", "category": "shuffle", "sql": "\n-- Complex join with UNION ALL and different data sources\nSELECT\n    source_type,\n    COUNT(*) as record_count\nFROM (\n    SELECT 'ORDER' as source_type, o_custkey as cust_id\n    FROM orders\n    WHERE o_orderdate >= DATE '1995-01-01'\n    UNION ALL\n    SELECT 'LINEITEM' as source_type, o_custkey as cust_id\n    FROM orders o\n    JOIN lineitem l ON o.o_orderkey = l.l_orderkey\n    WHERE l.l_shipdate >= DATE '1995-01-01'\n) combined\nGROUP BY source_type;\n"}
+- {"id": "shuffle_left_join_one_to_many_string_with_groupby", "category": "shuffle", "sql": "\n-- LEFT JOIN with preservation of all left-side rows\nSELECT\n    c.c_mktsegment,\n    COUNT(o.o_orderkey) as order_count,\n    COUNT(*) as total_rows\nFROM customer c\nLEFT JOIN orders o ON c.c_custkey = o.o_custkey\nGROUP BY c.c_mktsegment;\n"}
+- {"id": "string_equal_predicate", "category": "string", "sql": "\n-- Exact string equality with selective matching\nSELECT COUNT(*)\nFROM part\nWHERE p_brand = 'Brand#23';\n"}
+- {"id": "string_equal_predicate_lower", "category": "string", "sql": "\n-- Equality predicate after applying case conversion to the base table\nSELECT COUNT(*)\nFROM part\nWHERE LOWER(p_brand) = 'brand#23';\n"}
+- {"id": "string_in_predicate", "category": "string", "sql": "\n-- IN predicate with string values\nSELECT COUNT(*)\nFROM orders\nWHERE o_orderpriority IN ('1-URGENT', '2-HIGH');\n"}
+- {"id": "string_like_predicate_center", "category": "string", "sql": "\n-- Case sensitive matching pattern in any location\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%STEEL%';\n"}
+- {"id": "string_like_predicate_center_insensitive", "category": "string", "sql": "\n-- Case insensitive matching pattern in any location\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%steel%';\n"}
+- {"id": "string_like_predicate_multi", "category": "string", "sql": "\n-- Case sensitive matching multipart pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%STEEL%BRASS%';\n"}
+- {"id": "string_ilike_predicate_multi", "category": "string", "sql": "\n-- Case insensitive matching multipart pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%sTeEl%bRaSs%';\n"}
+- {"id": "string_like_predicate_end", "category": "string", "sql": "\n-- Case sensitive matching suffix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%COPPER';\n"}
+- {"id": "string_ilike_predicate_end", "category": "string", "sql": "\n-- Case insensitive matching suffix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE '%copper';\n"}
+- {"id": "string_like_predicate_start", "category": "string", "sql": "\n-- Case sensitive matching prefix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name LIKE 'STANDARD%';\n"}
+- {"id": "string_ilike_predicate_start", "category": "string", "sql": "\n-- Case insensitive matching prefix pattern\nSELECT COUNT(*)\nFROM part\nWHERE p_name ILIKE 'standard%';\n"}
+- {"id": "topn_ordered_allcols", "category": "topn", "sql": "\n-- Top-10 limit returning all columns after ordering over all table rows\nSELECT *\nFROM lineitem\nORDER BY l_extendedprice DESC\nLIMIT 10;\n"}
+- {"id": "topn_aggregate_2columns", "category": "topn", "sql": "\n-- Top 10 limit returning 2 columns after aggregation and computed ordering\nSELECT\n    l_orderkey,\n    SUM(l_quantity) as total_quantity\nFROM lineitem\nGROUP BY l_orderkey\nORDER BY total_quantity DESC\nLIMIT 10;\n"}
+- {"id": "approx_top_k_lineitem", "category": "topn", "sql": "\n-- Approximate Top-K aggregate returning the most-frequent values as an array.\n-- Result shapes diverge across engines: DuckDB / ClickHouse / Snowflake return\n-- ARRAY of values; BigQuery's APPROX_TOP_COUNT returns ARRAY<STRUCT<value,count>>.\n-- Validation enforces capability + array type_class, not deep equality.\nSELECT APPROX_TOP_K(l_shipmode, 5) as top_shipmodes\nFROM lineitem;\n", "result_contract": {"capability": "approximate_top_k", "columns": [{"name": "top_shipmodes", "type_class": "array"}]}, "variants": {"clickhouse": "\nSELECT topK(5)(l_shipmode) as top_shipmodes\nFROM lineitem;\n"}, "skip_on": ["redshift", "datafusion", "sqlite"]}
+- {"id": "window_growing_frame", "category": "window", "sql": "\n-- Running sum window aggregation with growing frame size\nSELECT\n    l_orderkey,\n    l_linenumber,\n    l_quantity,\n    SUM(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n    ) as running_quantity\nFROM lineitem\nWHERE l_orderkey <= 1000;\n"}
+- {"id": "window_lead_lag_same_frame", "category": "window", "sql": "\n-- Offset window functions over the same frame with 'natural' ordering\nSELECT\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    LAG(o_totalprice, 1) OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_orderdate\n    ) as prev_order_price,\n    LEAD(o_totalprice, 1) OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_orderdate\n    ) as next_order_price\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01';\n"}
+- {"id": "window_row_number", "category": "window", "sql": "\n-- Row number calculation window function with different ordering\nSELECT\n    o_custkey,\n    o_orderkey,\n    o_totalprice,\n    ROW_NUMBER() OVER (\n        PARTITION BY o_custkey\n        ORDER BY o_totalprice DESC\n    ) as order_rank\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01';\n"}
+- {"id": "window_multiple_orderings", "category": "window", "sql": "\n-- Ranking window aggregations with multiple frame orderings\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_quantity,\n    l_extendedprice,\n    DENSE_RANK() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice DESC) as price_rank,\n    PERCENT_RANK() OVER (PARTITION BY l_orderkey ORDER BY l_quantity) as quantity_percentile,\n    CUME_DIST() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice) as price_distribution\nFROM lineitem\nWHERE l_orderkey <= 10000\nORDER BY l_orderkey, price_rank;\n", "result_contract": {"capability": "window_rank_distribution", "columns": ["l_orderkey", "l_partkey", "l_quantity", "l_extendedprice", "price_rank", "quantity_percentile", "price_distribution"]}, "variants": {"clickhouse": "\n-- ClickHouse window function names are case-sensitive (dense_rank,\n-- percent_rank, cume_dist). Wrap in a subquery so the outer ORDER BY\n-- references a materialized column.\nSELECT *\nFROM (\n    SELECT\n        l_orderkey,\n        l_partkey,\n        l_quantity,\n        l_extendedprice,\n        dense_rank() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice DESC) as price_rank,\n        percent_rank() OVER (PARTITION BY l_orderkey ORDER BY l_quantity) as quantity_percentile,\n        cume_dist() OVER (PARTITION BY l_orderkey ORDER BY l_extendedprice) as price_distribution\n    FROM lineitem\n    WHERE l_orderkey <= 10000\n) t\nORDER BY l_orderkey, price_rank;\n"}}
+- {"id": "window_moving_frame", "category": "window", "sql": "\n-- Window aggregations with complex moving frame definitions\nSELECT\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    -- Moving average with preceding rows\n    AVG(o_totalprice) OVER (\n        ORDER BY o_orderdate\n        ROWS BETWEEN 5 PRECEDING AND CURRENT ROW\n    ) as moving_avg_6_orders,\n    -- Running total with range-based frame\n    SUM(o_totalprice) OVER (\n        ORDER BY o_orderdate\n        RANGE BETWEEN INTERVAL '30' DAY PRECEDING AND CURRENT ROW\n    ) as monthly_running_total\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01'\nORDER BY o_orderdate;\n", "skip_on": ["clickhouse", "redshift"]}
+- {"id": "window_unbounded_frame", "category": "window", "sql": "\n-- Window aggregations with the same unbounded frame definition\nSELECT\n    l_orderkey,\n    l_linenumber,\n    l_shipdate,\n    l_quantity,\n    FIRST_VALUE(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    ) as first_line_qty,\n    LAST_VALUE(l_quantity) OVER (\n        PARTITION BY l_orderkey\n        ORDER BY l_linenumber\n        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\n    ) as last_line_qty\nFROM lineitem\nWHERE l_orderkey BETWEEN 1 AND 5000;\n"}
+- {"id": "json_extract_simple", "category": "json", "sql": "\n-- Extract from JSON with simple path expressions\nSELECT\n    o_orderkey,\n    JSON_EXTRACT(o_comment, '$.priority') as order_priority,\n    JSON_EXTRACT(o_comment, '$.notes') as order_notes\nFROM orders\nWHERE JSON_EXTRACT(o_comment, '$.priority') IS NOT NULL\nLIMIT 1000;\n", "skip_on": ["duckdb", "datafusion", "redshift"], "description": "TPC-H o_comment contains plain text, not valid JSON"}
+- {"id": "json_extract_nested", "category": "json", "sql": "\n-- Extract from JSON with complex path expressions\nSELECT\n    c_custkey,\n    JSON_EXTRACT(c_comment, '$.profile.segment') as customer_segment,\n    JSON_EXTRACT(c_comment, '$.profile.preferences[0]') as primary_preference,\n    JSON_EXTRACT(c_comment, '$.history.last_order.date') as last_order_date\nFROM customer\nWHERE JSON_VALID(c_comment)\nLIMIT 500;\n", "result_contract": {"capability": "json_nested_path_extraction", "row_identity": ["c_custkey"], "columns": ["c_custkey", {"name": "customer_segment", "type_class": "json"}, {"name": "primary_preference", "type_class": "json"}, {"name": "last_order_date", "type_class": "json"}]}, "variants": {"clickhouse": "\n-- ClickHouse JSON access uses JSONExtract*(json, path...) with positional\n-- path components; isValidJSON replaces JSON_VALID. TPC-H c_comment is\n-- plain text so isValidJSON gates rows out (matches duckdb behavior).\nSELECT\n    c_custkey,\n    JSONExtractRaw(c_comment, 'profile', 'segment') as customer_segment,\n    JSONExtractRaw(c_comment, 'profile', 'preferences', 1) as primary_preference,\n    JSONExtractRaw(c_comment, 'history', 'last_order', 'date') as last_order_date\nFROM customer\nWHERE isValidJSON(c_comment)\nLIMIT 500;\n"}, "skip_on": ["datafusion", "redshift"]}
+- {"id": "json_aggregates", "category": "json", "sql": "\n-- Create JSON array and object with JSON aggregate functions\nSELECT\n    p_brand,\n    JSON_ARRAYAGG(p_name) as part_names,\n    JSON_OBJECTAGG(p_partkey, p_retailprice) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n", "result_contract": {"capability": "json_array_object_aggregation", "row_identity": ["p_brand"], "columns": ["p_brand", {"name": "part_names", "type_class": "json"}, {"name": "part_prices", "type_class": "json"}, "part_count"]}, "variants": {"duckdb": "\n-- DuckDB uses JSON_GROUP_ARRAY and JSON_GROUP_OBJECT instead\nSELECT\n    p_brand,\n    JSON_GROUP_ARRAY(p_name) as part_names,\n    JSON_GROUP_OBJECT(p_partkey, p_retailprice) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n", "clickhouse": "\n-- ClickHouse has no JSON_ARRAYAGG/JSON_OBJECTAGG; build arrays/maps with\n-- groupArray + mapFromArrays then serialize via toJSONString.\nSELECT\n    p_brand,\n    toJSONString(groupArray(p_name)) as part_names,\n    toJSONString(mapFromArrays(groupArray(p_partkey), groupArray(p_retailprice))) as part_prices,\n    COUNT(*) as part_count\nFROM part\nWHERE p_type LIKE '%STEEL%'\nGROUP BY p_brand\nORDER BY p_brand\nLIMIT 100;\n"}, "skip_on": ["datafusion", "redshift"]}
+- {"id": "fulltext_simple_search", "category": "fulltext", "sql": "\n-- Basic full-text search capabilities on text columns\nSELECT\n    p_partkey,\n    p_name,\n    p_mfgr,\n    p_comment\nFROM part\nWHERE MATCH(p_name, p_comment) AGAINST ('STEEL COPPER' IN NATURAL LANGUAGE MODE)\nLIMIT 100;\n", "skip_on": ["bigquery", "clickhouse", "datafusion", "databricks", "duckdb", "redshift", "snowflake"]}
+- {"id": "fulltext_boolean_search", "category": "fulltext", "sql": "\n-- Boolean full-text search with operators\nSELECT\n    c_custkey,\n    c_name,\n    c_comment,\n    MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE) as relevance_score\nFROM customer\nWHERE MATCH(c_comment) AGAINST ('+BUILDING -FURNITURE' IN BOOLEAN MODE)\nORDER BY relevance_score DESC\nLIMIT 50;\n", "skip_on": ["bigquery", "clickhouse", "datafusion", "databricks", "duckdb", "redshift", "snowflake"]}
+- {"id": "fulltext_phrase_search", "category": "fulltext", "sql": "\n-- Phrase-based full-text search with ranking\nSELECT\n    s_suppkey,\n    s_name,\n    s_comment,\n    MATCH(s_comment) AGAINST ('\"Customer Complaints\"' IN BOOLEAN MODE) as phrase_match_score\nFROM supplier\nWHERE MATCH(s_comment) AGAINST ('\"Customer Complaints\"' IN BOOLEAN MODE)\nORDER BY phrase_match_score DESC;\n", "skip_on": ["bigquery", "clickhouse", "datafusion", "databricks", "duckdb", "redshift", "snowflake"]}
+- {"id": "statistical_percentiles", "category": "statistical", "sql": "\n-- Percentile calculation functions for distribution analysis\nSELECT\n    l_returnflag,\n    l_linestatus,\n    COUNT(*) as record_count,\n    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY l_quantity) as quantity_q1,\n    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l_quantity) as quantity_median,\n    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY l_quantity) as quantity_q3,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) as price_p95\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n", "result_contract": {"capability": "exact_continuous_percentiles", "row_identity": ["l_returnflag", "l_linestatus"], "columns": ["l_returnflag", "l_linestatus", "record_count", "quantity_q1", "quantity_median", "quantity_q3", "price_p95"]}, "variants": {"redshift": "\n-- Redshift supports PERCENTILE_CONT only as a window function, not aggregate\nSELECT DISTINCT\n    l_returnflag,\n    l_linestatus,\n    COUNT(*) OVER (PARTITION BY l_returnflag, l_linestatus) as record_count,\n    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_q1,\n    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_median,\n    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY l_quantity) OVER (PARTITION BY l_returnflag, l_linestatus) as quantity_q3,\n    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY l_extendedprice) OVER (PARTITION BY l_returnflag, l_linestatus) as price_p95\nFROM lineitem;\n"}, "skip_on": ["clickhouse"]}
+- {"id": "approx_quantiles_array", "category": "statistical", "sql": "\n-- Approximate quantiles returned as a single array per group\n-- Companion to statistical_percentiles, but exercises the\n-- vector-quantile path (one sketch evaluation per group instead of\n-- four PERCENTILE_CONT calls).\nSELECT\n    l_returnflag,\n    l_linestatus,\n    APPROX_QUANTILE(l_quantity, [0.25, 0.5, 0.75, 0.95]) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n", "result_contract": {"capability": "approximate_quantile_array", "row_identity": ["l_returnflag", "l_linestatus"], "columns": ["l_returnflag", "l_linestatus", {"name": "quantity_quantiles", "type_class": "array"}]}, "variants": {"bigquery": "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    [\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(25)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(50)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(75)],\n      APPROX_QUANTILES(l_quantity, 100)[OFFSET(95)]\n    ] as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n", "clickhouse": "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    quantilesTDigest(0.25, 0.5, 0.75, 0.95)(toFloat64(l_quantity)) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n", "snowflake": "\nSELECT\n    l_returnflag,\n    l_linestatus,\n    ARRAY_CONSTRUCT(\n      APPROX_PERCENTILE(l_quantity, 0.25),\n      APPROX_PERCENTILE(l_quantity, 0.5),\n      APPROX_PERCENTILE(l_quantity, 0.75),\n      APPROX_PERCENTILE(l_quantity, 0.95)\n    ) as quantity_quantiles\nFROM lineitem\nGROUP BY l_returnflag, l_linestatus;\n"}, "skip_on": ["redshift", "datafusion", "sqlite"]}
+- {"id": "statistical_variance_stddev", "category": "statistical", "sql": "\n-- Variance and standard deviation calculations\nSELECT\n    o_orderpriority,\n    COUNT(*) as order_count,\n    AVG(o_totalprice) as avg_price,\n    VARIANCE(o_totalprice) as price_variance,\n    STDDEV(o_totalprice) as price_stddev,\n    STDDEV_POP(o_totalprice) as price_stddev_pop,\n    STDDEV_SAMP(o_totalprice) as price_stddev_samp\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY o_orderpriority;\n"}
+- {"id": "statistical_correlation", "category": "statistical", "skip_on": ["redshift"], "sql": "\n-- Correlation analysis between numeric columns\nSELECT\n    CORR(l_quantity, l_extendedprice) as qty_price_correlation,\n    COVAR_POP(l_quantity, l_discount) as qty_discount_covariance,\n    COVAR_SAMP(l_tax, l_extendedprice) as tax_price_covariance,\n    REGR_SLOPE(l_extendedprice, l_quantity) as price_qty_slope,\n    REGR_INTERCEPT(l_extendedprice, l_quantity) as price_qty_intercept,\n    REGR_R2(l_extendedprice, l_quantity) as regression_r_squared\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01';\n", "result_contract": {"capability": "correlation_covariance_regression", "columns": ["qty_price_correlation", "qty_discount_covariance", "tax_price_covariance", "price_qty_slope", "price_qty_intercept", "regression_r_squared"]}, "variants": {"clickhouse": "\n-- ClickHouse's corr/covarPop/covarSamp reject Decimal arguments\n-- (ILLEGAL_TYPE_OF_ARGUMENT); cast columns to Float64 first.\n-- REGR_SLOPE/INTERCEPT/R2 are not available; compute manually from\n-- corr() and stddevSamp() over the cast columns.\nSELECT\n    corr(toFloat64(l_quantity), toFloat64(l_extendedprice)) as qty_price_correlation,\n    covarPop(toFloat64(l_quantity), toFloat64(l_discount)) as qty_discount_covariance,\n    covarSamp(toFloat64(l_tax), toFloat64(l_extendedprice)) as tax_price_covariance,\n    corr(toFloat64(l_extendedprice), toFloat64(l_quantity)) * stddevSamp(toFloat64(l_extendedprice)) / nullif(stddevSamp(toFloat64(l_quantity)), 0) as price_qty_slope,\n    avg(toFloat64(l_extendedprice)) - corr(toFloat64(l_extendedprice), toFloat64(l_quantity)) * stddevSamp(toFloat64(l_extendedprice)) / nullif(stddevSamp(toFloat64(l_quantity)), 0) * avg(toFloat64(l_quantity)) as price_qty_intercept,\n    pow(corr(toFloat64(l_extendedprice), toFloat64(l_quantity)), 2) as regression_r_squared\nFROM lineitem\nWHERE l_shipdate >= toDate('1995-01-01')\n  AND l_shipdate < toDate('1996-01-01');\n"}}
+- {"id": "olap_cube_analysis", "category": "olap", "sql": "\n-- CUBE operation for multidimensional analysis\nSELECT\n    n.n_name as nation,\n    r.r_name as region,\n    EXTRACT(YEAR FROM o.o_orderdate) as order_year,\n    EXTRACT(QUARTER FROM o.o_orderdate) as order_quarter,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue,\n    AVG(o.o_totalprice) as avg_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nWHERE o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1997-01-01'\nGROUP BY CUBE(n.n_name, r.r_name,\n              EXTRACT(YEAR FROM o.o_orderdate),\n              EXTRACT(QUARTER FROM o.o_orderdate));\n"}
+- {"id": "olap_rollup_analysis", "category": "olap", "sql": "\n-- ROLLUP operation for hierarchical aggregation\nSELECT\n    r.r_name as region,\n    n.n_name as nation,\n    c.c_mktsegment as market_segment,\n    COUNT(DISTINCT c.c_custkey) as customer_count,\n    COUNT(*) as order_count,\n    SUM(o.o_totalprice) as total_revenue,\n    AVG(o.o_totalprice) as avg_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nWHERE o.o_orderdate >= DATE '1995-01-01'\nGROUP BY ROLLUP(r.r_name, n.n_name, c.c_mktsegment)\nORDER BY r.r_name NULLS LAST, n.n_name NULLS LAST, c.c_mktsegment NULLS LAST;\n"}
+- {"id": "timeseries_trend_analysis", "category": "timeseries", "skip_on": ["redshift"], "sql": "\n-- Time series trend analysis with linear regression\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n", "result_contract": {"capability": "monthly_time_series_regression", "row_identity": ["order_month"], "columns": ["order_month", "order_count", "monthly_revenue", "avg_order_value", "revenue_trend_slope", "prev_month_revenue", "mom_growth_pct"]}, "variants": {"duckdb": "\n-- DuckDB doesn't allow nested aggregates, use CTE to pre-aggregate\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n", "clickhouse": "\n-- ClickHouse: use toStartOfMonth for DATE_TRUNC, toUnixTimestamp for EPOCH.\n-- REGR_SLOPE not available; compute slope manually from corr/stddev.\n-- Cast revenue/epoch to Float64 in the CTE because corr/stddev reject\n-- Decimal/UInt arguments (ILLEGAL_TYPE_OF_ARGUMENT).\nWITH monthly_totals AS (\n  SELECT\n    toStartOfMonth(o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    toFloat64(SUM(o_totalprice)) as monthly_revenue,\n    toFloat64(AVG(o_totalprice)) as avg_order_value,\n    toFloat64(toUnixTimestamp(toStartOfMonth(o_orderdate))) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= toDate('1995-01-01')\n    AND o_orderdate < toDate('1997-01-01')\n  GROUP BY toStartOfMonth(o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  corr(monthly_revenue, month_epoch) OVER () * stddevSamp(monthly_revenue) OVER () / nullif(stddevSamp(month_epoch) OVER (), 0) as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / nullif(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n", "datafusion": "\nWITH monthly_totals AS (\n  SELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue,\n    AVG(o_totalprice) as avg_order_value,\n    EXTRACT(EPOCH FROM DATE_TRUNC('month', o_orderdate)) as month_epoch\n  FROM orders\n  WHERE o_orderdate >= DATE '1995-01-01'\n    AND o_orderdate < DATE '1997-01-01'\n  GROUP BY DATE_TRUNC('month', o_orderdate)\n),\nmonthly_with_lag AS (\n  SELECT\n    order_month,\n    order_count,\n    monthly_revenue,\n    avg_order_value,\n    month_epoch,\n    LAG(monthly_revenue, 1) OVER (ORDER BY order_month) as prev_month_revenue\n  FROM monthly_totals\n)\nSELECT\n  order_month,\n  order_count,\n  monthly_revenue,\n  avg_order_value,\n  REGR_SLOPE(monthly_revenue, month_epoch) OVER () as revenue_trend_slope,\n  prev_month_revenue,\n  (monthly_revenue - prev_month_revenue) / NULLIF(prev_month_revenue, 0) * 100 as mom_growth_pct\nFROM monthly_with_lag\nORDER BY order_month;\n"}}
+- {"id": "max_by_simple", "category": "max", "sql": "\n-- Find the customer with the highest account balance in each nation\nSELECT\n    n_name,\n    MAX_BY(c_name, c_acctbal) as richest_customer,\n    MAX(c_acctbal) as max_balance\nFROM customer c\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nGROUP BY n_name\nORDER BY max_balance DESC, n_name;\n", "result_contract": {"capability": "arg_max_aggregate", "row_identity": ["n_name"], "columns": ["n_name", "richest_customer", "max_balance"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal DESC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as richest_customer,\n  c_acctbal as max_balance\nFROM ranked\nWHERE rn = 1\nORDER BY max_balance DESC, n_name;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal DESC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as richest_customer,\n  c_acctbal as max_balance\nFROM ranked\nWHERE rn = 1\nORDER BY max_balance DESC, n_name;\n"}}
+- {"id": "min_by_simple", "category": "min", "sql": "\n-- Find the customer with the lowest account balance in each nation\nSELECT\n    n_name,\n    MIN_BY(c_name, c_acctbal) as poorest_customer,\n    MIN(c_acctbal) as min_balance\nFROM customer c\nJOIN nation n ON c.c_nationkey = n.n_nationkey\nGROUP BY n_name\nORDER BY min_balance ASC, n_name;\n", "result_contract": {"capability": "arg_min_aggregate", "row_identity": ["n_name"], "columns": ["n_name", "poorest_customer", "min_balance"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal ASC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as poorest_customer,\n  c_acctbal as min_balance\nFROM ranked\nWHERE rn = 1\nORDER BY min_balance ASC, n_name;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    n.n_name,\n    c.c_name,\n    c.c_acctbal,\n    ROW_NUMBER() OVER (PARTITION BY n.n_name ORDER BY c.c_acctbal ASC, c.c_name) as rn\n  FROM customer c\n  JOIN nation n ON c.c_nationkey = n.n_nationkey\n)\nSELECT\n  n_name,\n  c_name as poorest_customer,\n  c_acctbal as min_balance\nFROM ranked\nWHERE rn = 1\nORDER BY min_balance ASC, n_name;\n"}}
+- {"id": "max_by_complex", "category": "max", "sql": "\n-- Find the most expensive order for each customer segment\nSELECT\n    c_mktsegment,\n    MAX_BY(o_orderkey, o_totalprice) as most_expensive_order_id,\n    MAX_BY(o_orderdate, o_totalprice) as most_expensive_order_date,\n    MAX(o_totalprice) as max_order_value\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nGROUP BY c_mktsegment\nORDER BY max_order_value DESC, c_mktsegment;\n", "result_contract": {"capability": "arg_max_aggregate", "row_identity": ["c_mktsegment"], "columns": ["c_mktsegment", "most_expensive_order_id", "most_expensive_order_date", "max_order_value"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    c.c_mktsegment,\n    o.o_orderkey,\n    o.o_orderdate,\n    o.o_totalprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY c.c_mktsegment\n      ORDER BY o.o_totalprice DESC, o.o_orderkey\n    ) as rn\n  FROM orders o\n  JOIN customer c ON o.o_custkey = c.c_custkey\n)\nSELECT\n  c_mktsegment,\n  o_orderkey as most_expensive_order_id,\n  o_orderdate as most_expensive_order_date,\n  o_totalprice as max_order_value\nFROM ranked\nWHERE rn = 1\nORDER BY max_order_value DESC, c_mktsegment;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    c.c_mktsegment,\n    o.o_orderkey,\n    o.o_orderdate,\n    o.o_totalprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY c.c_mktsegment\n      ORDER BY o.o_totalprice DESC, o.o_orderkey\n    ) as rn\n  FROM orders o\n  JOIN customer c ON o.o_custkey = c.c_custkey\n)\nSELECT\n  c_mktsegment,\n  o_orderkey as most_expensive_order_id,\n  o_orderdate as most_expensive_order_date,\n  o_totalprice as max_order_value\nFROM ranked\nWHERE rn = 1\nORDER BY max_order_value DESC, c_mktsegment;\n"}}
+- {"id": "min_by_complex", "category": "min", "sql": "\n-- Find the cheapest part for each brand\nSELECT\n    p_brand,\n    MIN_BY(p_name, p_retailprice) as cheapest_part_name,\n    MIN_BY(p_type, p_retailprice) as cheapest_part_type,\n    MIN(p_retailprice) as min_price\nFROM part\nGROUP BY p_brand\nORDER BY min_price ASC, p_brand;\n", "result_contract": {"capability": "arg_min_aggregate", "row_identity": ["p_brand"], "columns": ["p_brand", "cheapest_part_name", "cheapest_part_type", "min_price"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    p_brand,\n    p_name,\n    p_type,\n    p_retailprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY p_brand\n      ORDER BY p_retailprice ASC, p_name\n    ) as rn\n  FROM part\n)\nSELECT\n  p_brand,\n  p_name as cheapest_part_name,\n  p_type as cheapest_part_type,\n  p_retailprice as min_price\nFROM ranked\nWHERE rn = 1\nORDER BY min_price ASC, p_brand;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    p_brand,\n    p_name,\n    p_type,\n    p_retailprice,\n    ROW_NUMBER() OVER (\n      PARTITION BY p_brand\n      ORDER BY p_retailprice ASC, p_name\n    ) as rn\n  FROM part\n)\nSELECT\n  p_brand,\n  p_name as cheapest_part_name,\n  p_type as cheapest_part_type,\n  p_retailprice as min_price\nFROM ranked\nWHERE rn = 1\nORDER BY min_price ASC, p_brand;\n"}}
+- {"id": "max_by_with_ties", "category": "max", "sql": "\n-- Find the supplier with the highest supply cost for each part (handling ties)\nSELECT\n    p_partkey,\n    p_name,\n    MAX_BY(s_name, ps_supplycost) as supplier_name,\n    MAX(ps_supplycost) as max_supply_cost\nFROM partsupp ps\nJOIN part p ON ps.ps_partkey = p.p_partkey\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nGROUP BY p_partkey, p_name\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n", "result_contract": {"capability": "arg_max_aggregate", "row_identity": ["p_partkey", "p_name"], "columns": ["p_partkey", "p_name", "supplier_name", "max_supply_cost"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost DESC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as max_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost DESC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as max_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY max_supply_cost DESC, p_partkey, p_name\nLIMIT 100;\n"}}
+- {"id": "min_by_with_ties", "category": "min", "sql": "\n-- Find the supplier with the lowest supply cost for each part (handling ties)\nSELECT\n    p_partkey,\n    p_name,\n    MIN_BY(s_name, ps_supplycost) as supplier_name,\n    MIN(ps_supplycost) as min_supply_cost\nFROM partsupp ps\nJOIN part p ON ps.ps_partkey = p.p_partkey\nJOIN supplier s ON ps.ps_suppkey = s.s_suppkey\nGROUP BY p_partkey, p_name\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n", "result_contract": {"capability": "arg_min_aggregate", "row_identity": ["p_partkey", "p_name"], "columns": ["p_partkey", "p_name", "supplier_name", "min_supply_cost"]}, "variants": {"datafusion": "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost ASC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as min_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n", "redshift": "\nWITH ranked AS (\n  SELECT\n    p.p_partkey,\n    p.p_name,\n    s.s_name,\n    ps.ps_supplycost,\n    ROW_NUMBER() OVER (\n      PARTITION BY p.p_partkey, p.p_name\n      ORDER BY ps.ps_supplycost ASC, s.s_name\n    ) as rn\n  FROM partsupp ps\n  JOIN part p ON ps.ps_partkey = p.p_partkey\n  JOIN supplier s ON ps.ps_suppkey = s.s_suppkey\n)\nSELECT\n  p_partkey,\n  p_name,\n  s_name as supplier_name,\n  ps_supplycost as min_supply_cost\nFROM ranked\nWHERE rn = 1\nORDER BY min_supply_cost ASC, p_partkey, p_name\nLIMIT 100;\n"}}
+- {"id": "qualify_row_number", "category": "qualify", "sql": "\n-- Find the top 3 orders by total price for each customer using QUALIFY\nSELECT\n    c_custkey,\n    c_name,\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    ROW_NUMBER() OVER (PARTITION BY c_custkey ORDER BY o_totalprice DESC) as order_rank\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY ROW_NUMBER() OVER (PARTITION BY c_custkey ORDER BY o_totalprice DESC) <= 3\nORDER BY c_custkey, order_rank;\n"}
+- {"id": "qualify_dense_rank", "category": "qualify", "sql": "\n-- Find the top 2 most expensive parts in each category using QUALIFY\nSELECT\n    p_type,\n    p_name,\n    p_retailprice,\n    DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) as price_rank\nFROM part\nQUALIFY DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) <= 2\nORDER BY p_type, price_rank, p_name;\n", "result_contract": {"capability": "qualify_dense_rank_filter", "row_identity": ["p_type", "p_name", "p_retailprice"], "columns": ["p_type", "p_name", "p_retailprice", "price_rank"]}, "variants": {"redshift": "\n-- Redshift QUALIFY with DENSE_RANK requires subquery workaround\nSELECT p_type, p_name, p_retailprice, price_rank\nFROM (\n    SELECT\n        p_type,\n        p_name,\n        p_retailprice,\n        DENSE_RANK() OVER (PARTITION BY p_type ORDER BY p_retailprice DESC) as price_rank\n    FROM part\n) ranked\nWHERE price_rank <= 2\nORDER BY p_type, price_rank, p_name;\n"}}
+- {"id": "qualify_percentile", "category": "qualify", "sql": "\n-- Find orders in the top 10% by value for each order priority using QUALIFY\nSELECT\n    o_orderpriority,\n    o_orderkey,\n    o_totalprice,\n    PERCENT_RANK() OVER (PARTITION BY o_orderpriority ORDER BY o_totalprice) as price_percentile\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY PERCENT_RANK() OVER (PARTITION BY o_orderpriority ORDER BY o_totalprice) >= 0.9\nORDER BY o_orderpriority, o_totalprice DESC;\n"}
+- {"id": "qualify_ntile", "category": "qualify", "sql": "\n-- Find orders in the top quartile by value for each market segment using QUALIFY\nSELECT\n    c_mktsegment,\n    o_orderkey,\n    o_totalprice,\n    NTILE(4) OVER (PARTITION BY c_mktsegment ORDER BY o_totalprice) as quartile\nFROM orders o\nJOIN customer c ON o.o_custkey = c.c_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY NTILE(4) OVER (PARTITION BY c_mktsegment ORDER BY o_totalprice) = 4\nORDER BY c_mktsegment, o_totalprice DESC;\n"}
+- {"id": "qualify_cume_dist", "category": "qualify", "sql": "\n-- Find lineitems with quantity in the top 5% of their shipment date using QUALIFY\nSELECT\n    l_shipdate,\n    l_orderkey,\n    l_linenumber,\n    l_quantity,\n    CUME_DIST() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) as quantity_cumulative_dist\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\nQUALIFY CUME_DIST() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) >= 0.95\nORDER BY l_shipdate, l_quantity DESC, l_orderkey, l_linenumber;\n", "result_contract": {"capability": "qualify_cume_dist_filter", "row_identity": ["l_shipdate", "l_orderkey", "l_linenumber"], "columns": ["l_shipdate", "l_orderkey", "l_linenumber", "l_quantity", "quantity_cumulative_dist"]}, "variants": {"clickhouse": "\n-- ClickHouse does not support QUALIFY; rewrite using subquery WHERE filter.\n-- Window function names are case-sensitive (cume_dist, not CUME_DIST).\nSELECT l_shipdate, l_orderkey, l_linenumber, l_quantity, quantity_cumulative_dist\nFROM (\n  SELECT\n      l_shipdate,\n      l_orderkey,\n      l_linenumber,\n      l_quantity,\n      cume_dist() OVER (PARTITION BY l_shipdate ORDER BY l_quantity) as quantity_cumulative_dist\n  FROM lineitem\n  WHERE l_shipdate >= toDate('1995-01-01')\n    AND l_shipdate < toDate('1996-01-01')\n) t\nWHERE quantity_cumulative_dist >= 0.95\nORDER BY l_shipdate, l_quantity DESC, l_orderkey, l_linenumber;\n"}}
+- {"id": "qualify_lag_lead", "category": "qualify", "sql": "\n-- Find orders where the price increased from the previous order for each customer using QUALIFY\nSELECT\n    c_custkey,\n    c_name,\n    o_orderkey,\n    o_orderdate,\n    o_totalprice,\n    LAG(o_totalprice) OVER (PARTITION BY c_custkey ORDER BY o_orderdate) as prev_order_price\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE o_orderdate >= DATE '1995-01-01'\nQUALIFY o_totalprice > LAG(o_totalprice) OVER (PARTITION BY c_custkey ORDER BY o_orderdate)\nORDER BY c_custkey, o_orderdate;\n"}
+- {"id": "optimizer_exists_to_semijoin", "category": "optimizer", "sql": "\n-- Test EXISTS subquery decorrelation to semijoin optimization\n-- Good optimizers should convert the EXISTS to a semijoin for better performance\nSELECT\n    c_custkey,\n    c_name,\n    c_mktsegment,\n    c_nationkey\nFROM customer c\nWHERE EXISTS (\n    SELECT 1 \n    FROM orders o \n    WHERE o.o_custkey = c.c_custkey \n      AND o.o_orderdate >= DATE '1995-01-01'\n      AND o.o_orderdate < DATE '1996-01-01'\n      AND o.o_totalprice > 100000\n)\nORDER BY c_custkey\nLIMIT 1000;\n"}
+- {"id": "optimizer_distinct_elimination", "category": "optimizer", "sql": "\n-- Test DISTINCT elimination optimization\n-- Good optimizers should eliminate the DISTINCT when it's redundant due to primary key\nSELECT DISTINCT\n    o_orderkey,\n    o_custkey,\n    o_orderdate,\n    o_totalprice\nFROM orders o\nWHERE o_orderdate >= DATE '1995-01-01'\n  AND o_orderdate < DATE '1996-01-01'\n  AND o_totalprice > 50000\nORDER BY o_orderkey\nLIMIT 2000;\n"}
+- {"id": "optimizer_common_subexpression", "category": "optimizer", "sql": "\n-- Test Common Subexpression Elimination (CSE) optimization\n-- Good optimizers should compute the complex expression once and reuse it\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    l_linenumber,\n    l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) as revenue_with_tax,\n    CASE \n        WHEN l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 50000 THEN 'High Value'\n        WHEN l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 10000 THEN 'Medium Value'\n        ELSE 'Low Value'\n    END as value_category,\n    ROUND(l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax), 2) as rounded_revenue\nFROM lineitem\nWHERE l_shipdate >= DATE '1995-01-01'\n  AND l_shipdate < DATE '1996-01-01'\n  AND l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) > 1000\nORDER BY l_quantity * l_extendedprice * (1 - l_discount) * (1 + l_tax) DESC\nLIMIT 5000;\n"}
+- {"id": "optimizer_predicate_pushdown", "category": "optimizer", "sql": "\n-- Test predicate pushdown through joins optimization\n-- Good optimizers should push predicates down past joins to reduce intermediate results\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    o.o_orderdate,\n    o.o_totalprice\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_nationkey = 15  -- Should push down before join to reduce customer rows\n  AND o.o_orderdate >= DATE '1995-01-01'  -- Should push down before join to reduce order rows\n  AND o.o_orderdate < DATE '1996-01-01'\n  AND c.c_mktsegment = 'BUILDING'  -- Additional selectivity on customer\nORDER BY o.o_totalprice DESC\nLIMIT 1000;\n"}
+- {"id": "optimizer_join_reordering", "category": "optimizer", "sql": "\n-- Test join reordering optimization\n-- Good optimizers should reorder joins based on cardinality (nation smallest, then customer, then orders)\nSELECT\n    n.n_name,\n    c.c_name,\n    COUNT(o.o_orderkey) as order_count,\n    SUM(o.o_totalprice) as total_value\nFROM orders o  -- Largest table listed first (suboptimal order)\nJOIN customer c ON o.o_custkey = c.c_custkey  -- Medium table\nJOIN nation n ON c.c_nationkey = n.n_nationkey  -- Smallest table\nWHERE n.n_regionkey = 1  -- High selectivity on smallest table\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nGROUP BY n.n_name, c.c_name\nHAVING COUNT(o.o_orderkey) > 5\nORDER BY total_value DESC\nLIMIT 100;\n"}
+- {"id": "optimizer_limit_pushdown", "category": "optimizer", "sql": "\n-- Test limit pushdown through operations optimization\n-- Good optimizers should push partial limits down to reduce work in upstream operations\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    o.o_orderdate,\n    o.o_totalprice,\n    o.o_orderpriority\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_mktsegment = 'BUILDING'\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nORDER BY o.o_totalprice DESC\nLIMIT 100;  -- Should push partial limit down through join\n"}
+- {"id": "optimizer_aggregate_pushdown", "category": "optimizer", "sql": "\n-- Test aggregate pushdown through joins optimization\n-- Good optimizers should partially compute aggregates before joins when possible\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_nationkey,\n    COUNT(o.o_orderkey) as order_count,\n    SUM(o.o_totalprice) as total_spent,\n    AVG(o.o_totalprice) as avg_order_value\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey\nWHERE c.c_nationkey = 15\n  AND o.o_orderdate >= DATE '1995-01-01'\n  AND o.o_orderdate < DATE '1996-01-01'\nGROUP BY c.c_custkey, c.c_name, c.c_mktsegment, c.c_nationkey\nHAVING SUM(o.o_totalprice) > 500000  -- HAVING can influence pushdown strategy\nORDER BY total_spent DESC\nLIMIT 50;\n"}
+- {"id": "optimizer_scalar_subquery_flattening", "category": "optimizer", "sql": "\n-- Test scalar subquery flattening optimization\n-- Good optimizers should convert scalar subqueries to joins for better performance\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_acctbal,\n    (SELECT AVG(o.o_totalprice) \n     FROM orders o \n     WHERE o.o_custkey = c.c_custkey \n       AND o.o_orderdate >= DATE '1995-01-01') as avg_order_value,\n    (SELECT COUNT(o.o_orderkey)\n     FROM orders o \n     WHERE o.o_custkey = c.c_custkey \n       AND o.o_orderdate >= DATE '1995-01-01') as order_count\nFROM customer c\nWHERE c.c_nationkey = 15\n  AND c.c_acctbal > 5000\nORDER BY avg_order_value DESC, c.c_name\nLIMIT 100;\n", "skip_on": ["clickhouse", "datafusion"], "description": "ClickHouse and DataFusion do not support correlated subqueries (ClickHouse: NOT_IMPLEMENTED Code 48; DataFusion: planner rejects). The point of this query is to measure the optimizer's ability to auto-flatten correlated scalar subqueries into joins, so a pre-flattened LEFT JOIN rewrite would only measure plain join execution and defeat the test.", "result_contract": {"capability": "scalar_subquery_flattening", "row_identity": ["c_name", "c_mktsegment", "c_acctbal"], "columns": ["c_name", "c_mktsegment", "c_acctbal", "avg_order_value", "order_count"]}}
+- {"id": "optimizer_constant_folding", "category": "optimizer", "sql": "\n-- Test constant folding and expression simplification optimization\n-- Good optimizers should pre-compute constants and simplify expressions at compile time\nSELECT\n    l_orderkey,\n    l_partkey,\n    l_suppkey,\n    l_linenumber,\n    l_quantity * (1.0 + 0.0) as simplified_qty,  -- Should fold to l_quantity\n    l_extendedprice * (2 * 3 + 4) as constant_folded,  -- Should fold to l_extendedprice * 10\n    l_discount + 0.0 - 0.0 as zero_folded,  -- Should fold to l_discount\n    CASE WHEN 1 = 1 THEN l_tax ELSE 0 END as condition_folded,  -- Should fold to l_tax\n    l_quantity / 1.0 as division_folded,  -- Should fold to l_quantity\n    l_extendedprice + (5 - 5) as addition_folded  -- Should fold to l_extendedprice\nFROM lineitem\nWHERE l_quantity * 1 > 10  -- Should simplify to l_quantity > 10\n  AND l_shipdate >= DATE '1995-01-01'\n  AND l_discount + 0 < 0.1  -- Should simplify to l_discount < 0.1\nORDER BY l_quantity * (1 + 0) DESC  -- Should simplify to l_quantity DESC\nLIMIT 1000;\n"}
+- {"id": "optimizer_column_pruning", "category": "optimizer", "sql": "\n-- Test column pruning (projection pushdown) optimization\n-- Good optimizers should only read columns needed for the query result\nSELECT\n    c.c_name  -- Only need c_name from customer table\nFROM customer c\nJOIN orders o ON c.c_custkey = o.o_custkey  -- Only need c_custkey for join from customer\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey  -- Only need o_orderkey for join from orders\nWHERE o.o_orderdate >= DATE '1995-01-01'  -- Only need o_orderdate for filtering\n  AND o.o_orderdate < DATE '1996-01-01'\n  AND l.l_quantity > 40  -- Only need l_quantity for filtering\n  AND c.c_nationkey = 15  -- Only need c_nationkey for filtering\nORDER BY c.c_name\nLIMIT 500;\n"}
+- {"id": "optimizer_in_to_exists", "category": "optimizer", "sql": "\n-- Test IN-to-EXISTS transformation optimization\n-- Good optimizers should transform IN subqueries to EXISTS when beneficial\nSELECT\n    c.c_name,\n    c.c_mktsegment,\n    c.c_nationkey,\n    c.c_acctbal\nFROM customer c\nWHERE c.c_custkey IN (\n    SELECT o.o_custkey\n    FROM orders o\n    WHERE o.o_orderdate >= DATE '1995-01-01'\n      AND o.o_orderdate < DATE '1996-01-01'\n      AND o.o_totalprice > 100000\n)\n  AND c.c_nationkey IN (1, 2, 3, 4, 5)  -- Additional IN predicate\nORDER BY c.c_acctbal DESC\nLIMIT 200;\n"}
+- {"id": "optimizer_union_optimization", "category": "optimizer", "sql": "\n-- Test union/set operation optimization\n-- Good optimizers should optimize UNION ALL operations and eliminate redundant sorting\nSELECT c_name, c_mktsegment, 'high_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal > 8000\n  AND c_nationkey IN (1, 2, 3)\nUNION ALL\nSELECT c_name, c_mktsegment, 'medium_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal BETWEEN 4000 AND 8000\n  AND c_nationkey IN (1, 2, 3)\nUNION ALL\nSELECT c_name, c_mktsegment, 'low_value' as customer_type, c_acctbal\nFROM customer\nWHERE c_acctbal BETWEEN 1000 AND 4000\n  AND c_nationkey IN (1, 2, 3)\nORDER BY c_acctbal DESC\nLIMIT 300;\n"}
+- {"id": "optimizer_runtime_filter", "category": "optimizer", "sql": "\n-- Test runtime filter generation optimization\n-- Good optimizers should generate bloom filters or hash filters for selective joins\nSELECT\n    l.l_orderkey,\n    l.l_partkey,\n    l.l_suppkey,\n    l.l_quantity,\n    l.l_extendedprice,\n    p.p_name,\n    p.p_type\nFROM lineitem l\nJOIN part p ON l.l_partkey = p.p_partkey\nWHERE p.p_type LIKE '%STEEL%'  -- Selective filter should generate runtime filter\n  AND p.p_size BETWEEN 10 AND 20\n  AND l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1996-01-01'\n  AND l.l_quantity > 20\nORDER BY l.l_extendedprice DESC\nLIMIT 1000;\n"}
+- {"id": "optimizer_groupjoin", "category": "optimizer", "sql": "\n-- Test group-join (join+aggregate fusion) optimization\n-- Good optimizers fuse the JOIN and GROUP BY into a single grouped-join pass,\n-- avoiding full intermediate materialization of all lineitem rows per order\nSELECT\n    o.o_orderkey,\n    o.o_custkey,\n    o.o_orderdate,\n    COUNT(l.l_linenumber) AS line_count,\n    SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nGROUP BY o.o_orderkey, o.o_custkey, o.o_orderdate\nORDER BY revenue DESC\nLIMIT 100;\n"}
+- {"id": "any_value_simple", "category": "aggregation", "sql": "\n-- Select any customer name per market segment (faster than MIN/MAX)\nSELECT\n    c_mktsegment,\n    ANY_VALUE(c_name) as sample_customer,\n    COUNT(*) as customer_count\nFROM customer\nGROUP BY c_mktsegment;\n", "result_contract": {"capability": "arbitrary_value_aggregate", "row_identity": ["c_mktsegment"], "columns": ["c_mktsegment", "sample_customer", "customer_count"]}, "variants": {"clickhouse": "\nSELECT\n    c_mktsegment,\n    any(c_name) as sample_customer,\n    COUNT(*) as customer_count\nFROM customer\nGROUP BY c_mktsegment;\n"}, "skip_on": ["datafusion"]}
+- {"id": "any_value_with_filter", "category": "aggregation", "sql": "\n-- Any value with additional aggregates\nSELECT\n    n_regionkey,\n    ANY_VALUE(n_name) as sample_nation,\n    ANY_VALUE(n_comment) as sample_comment,\n    COUNT(*) as nation_count\nFROM nation\nGROUP BY n_regionkey;\n", "result_contract": {"capability": "arbitrary_value_aggregate", "row_identity": ["n_regionkey"], "columns": ["n_regionkey", "sample_nation", "sample_comment", "nation_count"]}, "variants": {"clickhouse": "\nSELECT\n    n_regionkey,\n    any(n_name) as sample_nation,\n    any(n_comment) as sample_comment,\n    COUNT(*) as nation_count\nFROM nation\nGROUP BY n_regionkey;\n"}, "skip_on": ["datafusion"]}
+- {"id": "groupby_all_simple", "category": "aggregation", "sql": "\n-- Automatic grouping by all non-aggregate columns\nSELECT\n    l_returnflag,\n    l_linestatus,\n    SUM(l_quantity) as total_qty,\n    AVG(l_extendedprice) as avg_price\nFROM lineitem\nGROUP BY ALL;\n"}
+- {"id": "groupby_all_complex", "category": "aggregation", "sql": "\n-- GROUP BY ALL with multiple non-aggregate expressions\nSELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    o_orderpriority,\n    COUNT(*) as order_count,\n    SUM(o_totalprice) as monthly_revenue\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY ALL\nORDER BY order_month, o_orderpriority;\n", "result_contract": {"capability": "group_by_all_expansion", "row_identity": ["order_month", "o_orderpriority"], "columns": ["order_month", "o_orderpriority", "order_count", "monthly_revenue"]}, "variants": {"datafusion": "\nSELECT\n    DATE_TRUNC('month', o_orderdate) as order_month,\n    o_orderpriority,\n    COUNT(o_orderkey) as order_count,\n    SUM(o_totalprice) as monthly_revenue\nFROM orders\nWHERE o_orderdate >= DATE '1995-01-01'\nGROUP BY DATE_TRUNC('month', o_orderdate), o_orderpriority\nORDER BY order_month, o_orderpriority;\n"}}
+- {"id": "orderby_all_simple", "category": "orderby", "sql": "\n-- Order by all columns in SELECT list\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY ALL;\n", "result_contract": {"capability": "order_by_all_expansion", "row_identity": ["r_name", "n_name"], "columns": ["r_name", "n_name", "supplier_count"]}, "variants": {"datafusion": "\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY r_name, n_name, supplier_count;\n", "redshift": "\nSELECT\n    r_name,\n    n_name,\n    COUNT(*) as supplier_count\nFROM supplier s\nJOIN nation n ON s.s_nationkey = n.n_nationkey\nJOIN region r ON n.n_regionkey = r.r_regionkey\nGROUP BY r_name, n_name\nORDER BY r_name, n_name, supplier_count;\n"}}
+- {"id": "orderby_all_desc", "category": "orderby", "sql": "\n-- ORDER BY ALL with direction\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY ALL DESC\nLIMIT 100;\n", "result_contract": {"capability": "order_by_all_desc_expansion", "row_identity": ["p_brand", "p_type"], "columns": ["p_brand", "p_type", "avg_price"]}, "variants": {"datafusion": "\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY p_brand DESC, p_type DESC, avg_price DESC\nLIMIT 100;\n", "redshift": "\nSELECT\n    p_brand,\n    p_type,\n    AVG(p_retailprice) as avg_price\nFROM part\nGROUP BY p_brand, p_type\nORDER BY p_brand DESC, p_type DESC, avg_price DESC\nLIMIT 100;\n"}}
+- {"id": "array_agg_simple", "category": "array", "sql": "\n-- Aggregate part keys into arrays per supplier\nSELECT\n    ps_suppkey,\n    ARRAY_AGG(ps_partkey ORDER BY ps_partkey) as supplied_parts,\n    COUNT(*) as part_count\nFROM partsupp\nGROUP BY ps_suppkey\nHAVING COUNT(*) <= 10\nORDER BY ps_suppkey\nLIMIT 100;\n", "result_contract": {"capability": "ordered_array_aggregation", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", {"name": "supplied_parts", "type_class": "array", "order_sensitive": true}, "part_count"]}, "variants": {"clickhouse": "\nSELECT\n    ps_suppkey,\n    arraySort(groupArray(ps_partkey)) as supplied_parts,\n    COUNT(*) as part_count\nFROM partsupp\nGROUP BY ps_suppkey\nHAVING COUNT(*) <= 10\nORDER BY ps_suppkey\nLIMIT 100;\n"}, "skip_on": ["redshift"]}
+- {"id": "array_agg_distinct", "category": "array", "sql": "\n-- Distinct array aggregation\nSELECT\n    c_mktsegment,\n    ARRAY_AGG(DISTINCT c_nationkey ORDER BY c_nationkey) as nation_keys\nFROM customer\nGROUP BY c_mktsegment\nORDER BY c_mktsegment;\n", "result_contract": {"capability": "ordered_distinct_array_aggregation", "row_identity": ["c_mktsegment"], "columns": ["c_mktsegment", {"name": "nation_keys", "type_class": "array", "order_sensitive": true}]}, "variants": {"clickhouse": "\nSELECT\n    c_mktsegment,\n    arraySort(groupUniqArray(c_nationkey)) as nation_keys\nFROM customer\nGROUP BY c_mktsegment\nORDER BY c_mktsegment;\n"}, "skip_on": ["redshift"]}
+- {"id": "array_unnest", "category": "array", "sql": "\n-- Unnest/explode array back to rows\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    UNNEST(parts) as part_key\nFROM supplier_parts;\n", "result_contract": {"capability": "array_unnest", "row_identity": ["ps_suppkey", "part_key"], "columns": ["ps_suppkey", "part_key"]}, "variants": {"bigquery": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_key\nFROM supplier_parts, UNNEST(parts) as part_key;\n", "clickhouse": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    arrayJoin(parts) as part_key\nFROM supplier_parts;\n"}, "skip_on": ["redshift"]}
+- {"id": "array_contains", "category": "array", "sql": "\n-- Check if array contains a value\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    ARRAY_CONTAINS(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n", "result_contract": {"capability": "array_membership_predicate", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", "has_part_100"]}, "variants": {"duckdb": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    list_contains(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n", "clickhouse": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    has(parts, 100) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n", "bigquery": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    100 IN UNNEST(parts) as has_part_100\nFROM supplier_parts\nORDER BY ps_suppkey\nLIMIT 100;\n"}, "skip_on": ["datafusion", "redshift"]}
+- {"id": "array_length", "category": "array", "sql": "\n-- Get array length/cardinality\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    CARDINALITY(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n", "result_contract": {"capability": "array_cardinality", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", "num_parts"]}, "variants": {"duckdb": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        ARRAY_AGG(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    len(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n", "clickhouse": "\nWITH supplier_parts AS (\n    SELECT\n        ps_suppkey,\n        groupArray(ps_partkey) as parts\n    FROM partsupp\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    length(parts) as num_parts\nFROM supplier_parts\nORDER BY num_parts DESC, ps_suppkey\nLIMIT 100;\n"}, "skip_on": ["datafusion", "redshift"]}
+- {"id": "array_slice", "category": "array", "sql": "\n-- Get array slice/subset\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice ORDER BY o_totalprice DESC) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    ARRAY_SLICE(prices, 1, 3) as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "result_contract": {"capability": "ordered_array_slice", "row_identity": ["o_custkey"], "columns": ["o_custkey", {"name": "top_3_orders", "type_class": "array", "order_sensitive": true}]}, "variants": {"duckdb": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice ORDER BY o_totalprice DESC) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    prices[1:3] as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "clickhouse": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        arrayReverseSort(groupArray(o_totalprice)) as prices\n    FROM orders\n    GROUP BY o_custkey\n    HAVING COUNT(*) >= 5\n)\nSELECT\n    o_custkey,\n    arraySlice(prices, 1, 3) as top_3_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"}, "skip_on": ["redshift"]}
+- {"id": "array_min_max", "category": "array", "sql": "\n-- Get min/max from array\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    ARRAY_MIN(prices) as min_order,\n    ARRAY_MAX(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "result_contract": {"capability": "array_min_max", "row_identity": ["o_custkey"], "columns": ["o_custkey", "min_order", "max_order"]}, "variants": {"duckdb": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    list_min(prices) as min_order,\n    list_max(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "clickhouse": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        groupArray(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    arrayMin(prices) as min_order,\n    arrayMax(prices) as max_order\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"}, "skip_on": ["bigquery", "datafusion", "redshift"]}
+- {"id": "array_sort", "category": "array", "sql": "\n-- Sort array elements\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    ARRAY_SORT(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n", "result_contract": {"capability": "array_sort", "row_identity": ["p_brand"], "columns": ["p_brand", {"name": "sorted_sizes", "type_class": "array", "order_sensitive": true}]}, "variants": {"duckdb": "\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    list_sort(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n", "clickhouse": "\nWITH part_sizes AS (\n    SELECT\n        p_brand,\n        groupArray(p_size) as sizes\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    arraySort(sizes) as sorted_sizes\nFROM part_sizes\nORDER BY p_brand\nLIMIT 50;\n"}, "skip_on": ["bigquery", "redshift"]}
+- {"id": "array_distinct", "category": "array", "sql": "\n-- Get distinct array elements\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    ARRAY_DISTINCT(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n", "result_contract": {"capability": "distinct_array_values", "row_identity": ["l_orderkey"], "columns": ["l_orderkey", {"name": "unique_modes", "type_class": "array"}]}, "variants": {"duckdb": "\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    list_distinct(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n", "clickhouse": "\nWITH ship_modes AS (\n    SELECT\n        l_orderkey,\n        groupArray(l_shipmode) as modes\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    arrayDistinct(modes) as unique_modes\nFROM ship_modes\nORDER BY l_orderkey\nLIMIT 100;\n"}, "skip_on": ["bigquery", "datafusion", "redshift"]}
+- {"id": "struct_construction", "category": "struct", "sql": "\n-- Construct struct/row from columns\nSELECT\n    c_custkey,\n    STRUCT(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n", "result_contract": {"capability": "positional_struct_construction", "row_identity": ["c_custkey"], "columns": ["c_custkey", {"name": "contact_info", "type_class": "struct"}, "c_acctbal"]}, "variants": {"clickhouse": "\nSELECT\n    c_custkey,\n    tuple(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n", "duckdb": "\nSELECT\n    c_custkey,\n    ROW(c_name, c_address, c_phone) as contact_info,\n    c_acctbal\nFROM customer\nWHERE c_nationkey = 1\nORDER BY c_custkey\nLIMIT 100;\n"}, "skip_on": ["redshift"]}
+- {"id": "struct_access", "category": "struct", "sql": "\n-- Access struct fields\nWITH customer_info AS (\n    SELECT\n        c_custkey,\n        STRUCT(c_name AS name, c_phone AS phone, c_acctbal AS balance) as info\n    FROM customer\n    WHERE c_nationkey = 1\n)\nSELECT\n    c_custkey,\n    info.name,\n    info.balance\nFROM customer_info\nWHERE info.balance > 5000\nORDER BY c_custkey\nLIMIT 100;\n", "result_contract": {"capability": "struct_field_access", "row_identity": ["c_custkey"], "columns": ["c_custkey", "name", "balance"]}, "variants": {"clickhouse": "\nWITH customer_info AS (\n    SELECT\n        c_custkey,\n        tuple(c_name, c_phone, c_acctbal) as info\n    FROM customer\n    WHERE c_nationkey = 1\n)\nSELECT\n    c_custkey,\n    info.1 as name,\n    info.3 as balance\nFROM customer_info\nWHERE info.3 > 5000\nORDER BY c_custkey\nLIMIT 100;\n"}, "skip_on": ["redshift"]}
+- {"id": "array_of_struct", "category": "struct", "sql": "\n-- Array of structs - orders with line items summary\nSELECT\n    o_orderkey,\n    ARRAY_AGG(\n        STRUCT(l_linenumber, l_partkey, l_quantity, l_extendedprice)\n        ORDER BY l_linenumber\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = DATE '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n", "result_contract": {"capability": "ordered_array_of_structs", "row_identity": ["o_orderkey"], "columns": ["o_orderkey", {"name": "line_items", "type_class": "array", "order_sensitive": true}]}, "variants": {"duckdb": "\nSELECT\n    o_orderkey,\n    ARRAY_AGG(\n        struct_pack(\n            l_linenumber := l_linenumber,\n            l_partkey := l_partkey,\n            l_quantity := l_quantity,\n            l_extendedprice := l_extendedprice\n        )\n        ORDER BY l_linenumber\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = DATE '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n", "clickhouse": "\nSELECT\n    o_orderkey,\n    arraySort(\n        x -> x.1,\n        groupArray(\n            CAST(\n                (l_linenumber, l_partkey, l_quantity, l_extendedprice),\n                'Tuple(l_linenumber Int32, l_partkey Int32, l_quantity Decimal(15,2), l_extendedprice Decimal(15,2))'\n            )\n        )\n    ) as line_items\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nWHERE o_orderdate = '1995-03-15'\nGROUP BY o_orderkey\nORDER BY o_orderkey\nLIMIT 50;\n"}, "skip_on": ["redshift"]}
+- {"id": "map_construction", "category": "map", "sql": "\n-- Construct map from key-value pairs\nSELECT\n    ps_suppkey,\n    MAP_FROM_ENTRIES(\n        ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n", "result_contract": {"capability": "map_construction", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", {"name": "part_costs", "type_class": "map"}]}, "variants": {"duckdb": "\nSELECT\n    ps_suppkey,\n    map_from_entries(\n        list(struct_pack(k := CAST(ps_partkey AS VARCHAR), v := ps_supplycost))\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n", "datafusion": "\nSELECT\n    ps_suppkey,\n    MAP(\n        ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n        ARRAY_AGG(ps_supplycost)\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n", "clickhouse": "\nSELECT\n    ps_suppkey,\n    CAST(\n        (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n        'Map(String, Decimal(15,2))'\n    ) as part_costs\nFROM partsupp\nWHERE ps_suppkey <= 10\nGROUP BY ps_suppkey\nORDER BY ps_suppkey;\n"}, "skip_on": ["bigquery", "redshift"]}
+- {"id": "map_access", "category": "map", "sql": "\n-- Access map values by key\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP_FROM_ENTRIES(\n            ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_costs['1'] as cost_for_part_1,\n    part_costs['5'] as cost_for_part_5\nFROM supplier_costs\nORDER BY ps_suppkey\nLIMIT 10;\n", "result_contract": {"capability": "map_key_access", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", "cost_for_part_1", "cost_for_part_5"]}, "variants": {"datafusion": "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP(\n            ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n            ARRAY_AGG(ps_supplycost)\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_EXTRACT(part_costs, '1')[1] as cost_for_part_1,\n    MAP_EXTRACT(part_costs, '5')[1] as cost_for_part_5\nFROM supplier_costs\nORDER BY ps_suppkey\nLIMIT 10;\n", "clickhouse": "\n-- ClickHouse builds Map via CAST((Array(K), Array(V)) AS Map(K, V));\n-- match the map_construction / map_keys_values convention.\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        CAST(\n            (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n            'Map(String, Decimal(15,2))'\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 10\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    part_costs['1'] as cost_for_part_1,\n    part_costs['5'] as cost_for_part_5\nFROM supplier_costs\nLIMIT 10;\n"}, "skip_on": ["bigquery", "redshift"]}
+- {"id": "map_keys_values", "category": "map", "sql": "\n-- Extract map keys and values\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP_FROM_ENTRIES(\n            ARRAY_AGG(STRUCT(CAST(ps_partkey AS VARCHAR), ps_supplycost))\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_KEYS(part_costs) as part_ids,\n    MAP_VALUES(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n", "result_contract": {"capability": "map_keys_values", "row_identity": ["ps_suppkey"], "columns": ["ps_suppkey", {"name": "part_ids", "type_class": "array"}, {"name": "costs", "type_class": "array"}]}, "variants": {"datafusion": "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        MAP(\n            ARRAY_AGG(CAST(ps_partkey AS VARCHAR)),\n            ARRAY_AGG(ps_supplycost)\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    MAP_KEYS(part_costs) as part_ids,\n    MAP_VALUES(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n", "clickhouse": "\nWITH supplier_costs AS (\n    SELECT\n        ps_suppkey,\n        CAST(\n            (groupArray(CAST(ps_partkey AS String)), groupArray(ps_supplycost)),\n            'Map(String, Decimal(15,2))'\n        ) as part_costs\n    FROM partsupp\n    WHERE ps_suppkey <= 5\n    GROUP BY ps_suppkey\n)\nSELECT\n    ps_suppkey,\n    mapKeys(part_costs) as part_ids,\n    mapValues(part_costs) as costs\nFROM supplier_costs\nORDER BY ps_suppkey;\n"}, "skip_on": ["bigquery", "redshift"]}
+- {"id": "list_transform", "category": "lambda", "sql": "\n-- Transform each array element\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    TRANSFORM(prices, x -> x * 1.1) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n", "result_contract": {"capability": "array_lambda_transform", "row_identity": ["p_brand"], "columns": ["p_brand", {"name": "prices_with_tax", "type_class": "array"}]}, "variants": {"duckdb": "\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        ARRAY_AGG(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    list_transform(prices, x -> x * 1.1) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n", "clickhouse": "\nWITH part_prices AS (\n    SELECT\n        p_brand,\n        groupArray(p_retailprice) as prices\n    FROM part\n    GROUP BY p_brand\n)\nSELECT\n    p_brand,\n    arrayMap(x -> x * 1.1, prices) as prices_with_tax\nFROM part_prices\nORDER BY p_brand\nLIMIT 50;\n"}, "skip_on": ["bigquery", "datafusion", "redshift"]}
+- {"id": "list_filter", "category": "lambda", "sql": "\n-- Filter array elements by condition\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    FILTER(prices, x -> x > 100000) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "result_contract": {"capability": "array_lambda_filter", "row_identity": ["o_custkey"], "columns": ["o_custkey", {"name": "large_orders", "type_class": "array"}]}, "variants": {"duckdb": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        ARRAY_AGG(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    list_filter(prices, x -> x > 100000) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n", "clickhouse": "\nWITH order_prices AS (\n    SELECT\n        o_custkey,\n        groupArray(o_totalprice) as prices\n    FROM orders\n    GROUP BY o_custkey\n)\nSELECT\n    o_custkey,\n    arrayFilter(x -> x > 100000, prices) as large_orders\nFROM order_prices\nORDER BY o_custkey\nLIMIT 100;\n"}, "skip_on": ["bigquery", "datafusion", "redshift"]}
+- {"id": "list_reduce", "category": "lambda", "sql": "\n-- Reduce array to single value\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    REDUCE(qtys, 0, (acc, x) -> acc + x) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n", "result_contract": {"capability": "array_lambda_reduce", "row_identity": ["l_orderkey"], "columns": ["l_orderkey", "total_qty"]}, "variants": {"duckdb": "\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        ARRAY_AGG(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    list_reduce(qtys, (acc, x) -> acc + x) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n", "clickhouse": "\nWITH quantities AS (\n    SELECT\n        l_orderkey,\n        groupArray(l_quantity) as qtys\n    FROM lineitem\n    GROUP BY l_orderkey\n)\nSELECT\n    l_orderkey,\n    arrayReduce('sum', qtys) as total_qty\nFROM quantities\nORDER BY l_orderkey\nLIMIT 100;\n"}, "skip_on": ["bigquery", "datafusion", "redshift"]}
+- {"id": "asof_join_basic", "category": "timeseries", "sql": "\n-- ASOF join: find closest prior order for each lineitem shipment\nSELECT\n    l.l_orderkey,\n    l.l_shipdate,\n    o.o_orderdate,\n    o.o_totalprice,\n    l.l_shipdate - o.o_orderdate as days_to_ship\nFROM lineitem l\nASOF JOIN orders o\n    ON l.l_orderkey = o.o_orderkey\n    AND l.l_shipdate >= o.o_orderdate\nWHERE l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1995-02-01'\nORDER BY l.l_orderkey, l.l_shipdate\nLIMIT 100;\n", "result_contract": {"capability": "asof_temporal_join", "columns": ["l_orderkey", "l_shipdate", "o_orderdate", "o_totalprice", "days_to_ship"]}, "variants": {"snowflake": "\nSELECT\n    l.l_orderkey,\n    l.l_shipdate,\n    o.o_orderdate,\n    o.o_totalprice,\n    l.l_shipdate - o.o_orderdate as days_to_ship\nFROM lineitem l\nASOF JOIN orders o\n    MATCH_CONDITION (l.l_shipdate >= o.o_orderdate)\n    ON l.l_orderkey = o.o_orderkey\nWHERE l.l_shipdate >= DATE '1995-01-01'\n  AND l.l_shipdate < DATE '1995-02-01'\nORDER BY l.l_orderkey, l.l_shipdate\nLIMIT 100;\n"}, "skip_on": ["bigquery", "datafusion", "databricks", "redshift"]}
+- {"id": "pivot_basic", "category": "pivot", "sql": "\n-- Pivot ship modes into columns\nSELECT *\nFROM (\n    SELECT\n        l_returnflag,\n        l_shipmode,\n        l_quantity\n    FROM lineitem\n    WHERE l_shipdate >= DATE '1995-01-01'\n      AND l_shipdate < DATE '1995-04-01'\n)\nPIVOT (\n    SUM(l_quantity)\n    FOR l_shipmode IN ('AIR', 'RAIL', 'SHIP', 'TRUCK')\n);\n", "skip_on": ["clickhouse"]}
+- {"id": "unpivot_basic", "category": "pivot", "sql": "\n-- Unpivot part dimensions into rows\nSELECT\n    p_partkey,\n    dimension_name,\n    dimension_value\nFROM (\n    SELECT\n        p_partkey,\n        CAST(p_size AS DECIMAL(15, 2)) as p_size,\n        p_retailprice\n    FROM part\n    WHERE p_partkey <= 100\n)\nUNPIVOT (\n    dimension_value\n    FOR dimension_name IN (p_size, p_retailprice)\n)\nORDER BY p_partkey, dimension_name;\n", "result_contract": {"capability": "unpivot_rows", "row_identity": ["p_partkey", "dimension_name"], "columns": ["p_partkey", "dimension_name", "dimension_value"]}, "variants": {"datafusion": "\nSELECT\n    p_partkey,\n    'p_size' as dimension_name,\n    CAST(p_size AS DECIMAL(15, 2)) as dimension_value\nFROM part\nWHERE p_partkey <= 100\nUNION ALL\nSELECT\n    p_partkey,\n    'p_retailprice' as dimension_name,\n    p_retailprice as dimension_value\nFROM part\nWHERE p_partkey <= 100\nORDER BY p_partkey, dimension_name;\n"}, "skip_on": ["clickhouse"]}
+- {"id": "filter_selective", "category": "filter", "sql": "\n-- Selective compound filter on lineitem\nSELECT l_orderkey, l_partkey, l_quantity, l_extendedprice\nFROM lineitem\nWHERE l_quantity > 45\n  AND l_extendedprice > 50000\n  AND l_discount < 0.05;\n"}
+- {"id": "filter_non_selective", "category": "filter", "sql": "\n-- Non-selective broad filter on lineitem\nSELECT l_orderkey, l_partkey, l_quantity, l_extendedprice\nFROM lineitem\nWHERE l_quantity > 1;\n"}
+- {"id": "orderby_simple", "category": "orderby", "sql": "\n-- Simple single-column sort with limit\nSELECT o_orderkey, o_orderdate, o_totalprice\nFROM orders\nORDER BY o_orderdate\nLIMIT 100;\n"}
+- {"id": "orderby_multi", "category": "orderby", "sql": "\n-- Multi-column sort with limit\nSELECT l_orderkey, l_linenumber, l_shipdate, l_quantity\nFROM lineitem\nORDER BY l_shipdate, l_orderkey, l_linenumber\nLIMIT 100;\n"}
+- {"id": "orderby_desc", "category": "orderby", "sql": "\n-- Descending sort with limit\nSELECT o_orderkey, o_totalprice, o_orderdate\nFROM orders\nORDER BY o_totalprice DESC\nLIMIT 100;\n"}
+- {"id": "string_like", "category": "string", "sql": "\n-- String contains (LIKE %pattern%)\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_name LIKE '%blue%';\n"}
+- {"id": "string_starts_with", "category": "string", "sql": "\n-- String prefix match\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_type LIKE 'STANDARD%';\n"}
+- {"id": "string_ends_with", "category": "string", "sql": "\n-- String suffix match\nSELECT p_partkey, p_name, p_type\nFROM part\nWHERE p_type LIKE '%BRASS';\n"}
+- {"id": "string_concat", "category": "string", "sql": "\n-- String concatenation\nSELECT c_custkey, c_name || ' - ' || c_mktsegment as customer_info\nFROM customer\nLIMIT 100;\n"}
+- {"id": "string_substring", "category": "string", "sql": "\n-- Substring extraction\nSELECT c_custkey, SUBSTRING(c_phone FROM 1 FOR 3) as country_code\nFROM customer\nLIMIT 100;\n"}
+- {"id": "shuffle_join", "category": "shuffle", "sql": "\n-- Inner join with aggregation\nSELECT o.o_orderkey, SUM(l.l_quantity) as total_qty\nFROM orders o\nJOIN lineitem l ON o.o_orderkey = l.l_orderkey\nGROUP BY o.o_orderkey;\n"}
+- {"id": "topn", "category": "topn", "sql": "\n-- Top-N by value (descending sort + limit)\nSELECT l_orderkey, l_partkey, l_extendedprice\nFROM lineitem\nORDER BY l_extendedprice DESC\nLIMIT 10;\n"}
+- {"id": "window_rank", "category": "window", "sql": "\n-- RANK window function with QUALIFY filter\nSELECT l_orderkey, l_returnflag, l_quantity,\n       RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\nFROM lineitem\nQUALIFY RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n", "result_contract": {"capability": "qualify_rank_filter", "columns": ["l_orderkey", "l_returnflag", "l_quantity", "qty_rank"]}, "variants": {"datafusion": "\nSELECT l_orderkey, l_returnflag, l_quantity, qty_rank\nFROM (\n    SELECT l_orderkey, l_returnflag, l_quantity,\n           RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\n    FROM lineitem\n) ranked\nWHERE qty_rank <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n", "redshift": "\n-- Redshift QUALIFY with RANK requires subquery workaround\nSELECT l_orderkey, l_returnflag, l_quantity, qty_rank\nFROM (\n    SELECT l_orderkey, l_returnflag, l_quantity,\n           RANK() OVER (PARTITION BY l_returnflag ORDER BY l_quantity DESC) as qty_rank\n    FROM lineitem\n) ranked\nWHERE qty_rank <= 5\nORDER BY l_returnflag, qty_rank, l_orderkey;\n"}}
+- {"id": "window_sum", "category": "window", "sql": "\n-- Partitioned window SUM\nSELECT l_orderkey, l_linenumber, l_extendedprice,\n       SUM(l_extendedprice) OVER (PARTITION BY l_orderkey) as order_total\nFROM lineitem;\n"}
+- {"id": "window_running_sum", "category": "window", "sql": "\n-- Cumulative running sum\nSELECT o_orderkey, o_orderdate, o_totalprice,\n       SUM(o_totalprice) OVER (ORDER BY o_orderdate) as cumulative_revenue\nFROM orders\nORDER BY o_orderdate\nLIMIT 100;\n", "skip_on": ["redshift"]}
+- {"id": "limit_ordered", "category": "limit", "sql": "\n-- LIMIT clause with ordering on large result set\nSELECT *\nFROM lineitem\nORDER BY l_orderkey, l_linenumber\nLIMIT 100;\n"}


### PR DESCRIPTION
## Shrink ledger

- Surface/module: Read Primitives query catalog
- Files changed: `benchbox/core/read_primitives/catalog/queries.yaml`
- Original code lines: 1,139 YAML (`cloc --by-file --csv`)
- New code lines: 159 YAML
- Lines removed: 980 code lines
- Reduction: 86.04% for this catalog
- Simplification type: compact YAML representation for generated-looking repeated catalog entries; no schema, key, SQL, variant, skip, or result-contract changes

## Behavior preserved

- `yaml.safe_load()` payload matches `HEAD` exactly: 157 queries
- Loaded `PrimitiveCatalog` dataclass output matches `HEAD` exactly
- Preserved 44 variant-bearing queries and 47 result contracts
- Public loader/API behavior remains unchanged; only catalog formatting changed

## Verification

- `uv run -- pre-commit run check-yaml --files benchbox/core/read_primitives/catalog/queries.yaml`
- `git diff --check`
- Exact raw YAML payload comparison against `HEAD`
- Exact loaded dataclass comparison against `HEAD`
- `uv run -- python -m pytest -n 0 tests/unit/read_primitives/test_query_catalog.py tests/unit/core/read_primitives/test_catalog_loader.py tests/unit/core/read_primitives/test_query_manager_variants.py tests/unit/core/read_primitives/test_read_primitives_variant_contracts.py tests/unit/core/read_primitives/test_benchmark_variants.py tests/unit/benchmarks/test_read_primitives_core.py tests/unit/benchmarks/test_read_primitives_dataframe_queries.py -q`
  - 149 passed
- `BENCHBOX_MAX_XDIST_WORKERS=1 make pr-preflight`
  - 22,710 passed, 5 skipped, 43 warnings, 4 subtests passed

## Residual risk

- Compact YAML is less hand-readable than block YAML. Runtime risk is low because parsed payload and loaded catalog objects are byte-for-byte semantically identical by structured comparison.

## Next recommended shrink target

Pivot to Python-heavy code. Highest-value candidates from current `cloc --by-file`: `benchbox/core/tpcds/dataframe_queries/queries.py` (9,116 Python code lines), followed by repeated DataFrame query modules and adapter families.