### PR TITLE
docs: add shrink-campaign review follow-up TODOs

### DIFF
--- a/_project/TODO/main/planning/shrink-followup-catalog-schema-validation.yaml
+++ b/_project/TODO/main/planning/shrink-followup-catalog-schema-validation.yaml
@@ -1,0 +1,99 @@
+id: shrink-followup-catalog-schema-validation
+title: "Add CI-callable schema validation for migrated YAML catalogs"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The shrink campaign migrated benchmark metadata, dependency metadata, and
+  query catalogs from Python literals (PRs #590-#593, #604) into YAML. The
+  existing catalog loaders already guard structurally (raise on non-mapping,
+  parse into typed dataclass containers, and a cross-loader parity test exists
+  at tests/unit/core/primitives/test_loader_parity.py), so this is NOT the
+  "silent KeyError" free-for-all the original review implied.
+
+  The residual gap: there is no per-FIELD schema (JSON Schema / Pydantic
+  model) validating the migrated catalogs as a CI gate. A typo in a category
+  name, a missing required field, or a wrong type currently surfaces as a
+  runtime error at first use rather than a CI failure. With data now in YAML
+  (no Python parser type-checking it), a single shared validation step closes
+  the gap across all catalogs.
+
+work:
+  - id: w1
+    summary: "Inventory migrated catalogs and identify which lack per-field validation"
+    status: pending
+    notes: |
+      Cover #590-593 + #604 catalogs and the six existing catalog/loader.py
+      modules. Note where dataclass containers already provide field-level
+      safety vs where validation is only structural (is-a-mapping).
+
+  - id: w2
+    summary: "Add a shared schema/typed-model validation + a test that validates every catalog"
+    needs: [w1]
+    status: pending
+    notes: |
+      Prefer one shared validator (Pydantic models, or jsonschema documents)
+      reused across catalogs over per-loader ad-hoc checks. The test loads
+      every catalog YAML and asserts it validates; add a deliberately-broken
+      fixture proving the validator rejects it.
+
+  - id: w3
+    summary: "Wire the validation test into CI / preflight"
+    needs: [w2]
+    status: pending
+
+must_preserve:
+  - "Existing loader guards and typed dataclass containers keep working"
+  - "tests/unit/core/primitives/test_loader_parity.py behavior is preserved"
+  - "Loader public APIs unchanged"
+
+approach: |
+  Centralize: one validation module exercised by one test over all catalogs,
+  not N copies. jsonschema is already a dependency; reuse it (or Pydantic,
+  also present). The broken-fixture assertion is what proves the gate has
+  teeth.
+
+anti_patterns:
+  - "DO NOT add a separate ad-hoc validator to each of the 6+ loaders -- because that duplicates logic and drifts -- define one shared schema/model and reuse it"
+  - "DO NOT validate only that the file is a mapping -- because that is the gap we already have -- validate required fields and types"
+
+verification:
+  - description: "Validator rejects a broken catalog fixture and accepts real catalogs"
+    command: "uv run -- python -m pytest -k 'catalog_schema or catalog_validation' -q"
+    expected_output: "passing tests including a negative (broken-fixture) case"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/"
+    - "tests/"
+
+prior_art:
+  - "benchbox/core/write_primitives/catalog/loader.py — existing structural guards + typed container; extend with field-level schema"
+  - "tests/unit/core/primitives/test_loader_parity.py — existing cross-loader test; extend with schema validation"
+  - "jsonschema / pydantic (already in the dependency set) — reuse rather than adding a validation library"
+
+metadata:
+  tags:
+    - shrink
+    - validation
+    - yaml-catalog
+    - ci
+  estimated_effort: "Medium"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Converts catalog typos from first-use runtime errors into CI failures,
+    recovering the implicit type safety the Python literals used to provide.
+
+success_metrics:
+  - "One shared schema/model validates all migrated catalogs"
+  - "A CI-callable test fails on a broken fixture and passes on real catalogs"
+
+files_affected:
+  added:
+    - "benchbox/core/ (shared catalog schema module)"
+    - "tests/ (catalog schema validation test + broken fixture)"

--- a/_project/TODO/main/planning/shrink-followup-codegen-vs-runtime-parse-adr.yaml
+++ b/_project/TODO/main/planning/shrink-followup-codegen-vs-runtime-parse-adr.yaml
@@ -1,0 +1,103 @@
+id: shrink-followup-codegen-vs-runtime-parse-adr
+title: "ADR: choose runtime-parse-YAML vs build-time-codegen as the canonical catalog pattern"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  The shrink campaign moved large amounts of data (metadata, specs, query
+  catalogs) from Python into YAML loaded at runtime (PRs #590-#604), extending
+  the repo's existing six runtime catalog loaders and commit #579's
+  "tpcds specs to yaml" precedent. The campaign chose runtime-parse
+  implicitly, without an ADR.
+
+  The shrink-campaign review surfaced a credible alternative: treat YAML as
+  the canonical source and GENERATE Python from it at build time, rather than
+  parse YAML at runtime. This would address both the perf concern (no runtime
+  YAML parse / module-level I/O) and the findability concern (generated .py is
+  grep-able and ty-visible) -- but adds build complexity and generated-file
+  churn, and breaks consistency with the six existing runtime loaders.
+
+  This item produces the decision, not an implementation. It exists so the
+  catalog-loading architecture is chosen deliberately and recorded, and so the
+  corrected goal statement ([[shrink-objective-function-and-guardrail]]) can
+  name one official pattern.
+
+work:
+  - id: w1
+    summary: "Document both options with measured/representative tradeoffs"
+    status: pending
+    notes: |
+      Cover: runtime-parse (current) vs build-time codegen. Dimensions: import
+      time / runtime cost, static findability + ty coverage, build complexity,
+      generated-file churn and review noise, consistency with the six existing
+      loaders, and how each interacts with the catalog schema validation
+      ([[shrink-followup-catalog-schema-validation]]).
+
+  - id: w2
+    summary: "Recommend one as the canonical catalog pattern and record the ADR"
+    needs: [w1]
+    status: pending
+    notes: |
+      Write the ADR with decision, rationale, and rejected alternatives. If
+      codegen is chosen, note that it supersedes the runtime lazy-load fix in
+      [[shrink-followup-registry-lazy-cached-load]] (which remains a safe
+      interim improvement) and file implementation follow-up TODOs.
+
+open_questions:
+  - question: "Does the perf+findability benefit of codegen outweigh build complexity and breaking consistency with 6 runtime loaders?"
+    gating: true
+    affects: ["w2 success_metric: canonical pattern decision"]
+    default: "Lean runtime-parse + lazy-load + caching (consistency with existing loaders, no build step), unless w1 shows a material, measured runtime/findability win for codegen."
+
+must_preserve:
+  - "No code behavior change in this item -- it is a decision artifact only"
+
+approach: |
+  Decision-only. Gather the import-time evidence already measured in
+  [[shrink-followup-registry-lazy-cached-load]] w0 rather than re-measuring.
+  Bias toward the pattern that minimizes new machinery unless the evidence is
+  decisive.
+
+anti_patterns:
+  - "DO NOT implement codegen as part of this TODO -- because it is a decision artifact -- if codegen wins, file separate implementation TODOs"
+  - "DO NOT decide in a vacuum -- because the choice interacts with schema validation and the registry-load fix -- reference both before recommending"
+
+verification:
+  - description: "ADR exists with decision, rationale, and rejected alternatives"
+    command: "grep -rniE 'codegen|runtime.parse|canonical catalog' docs/ _project/ 2>/dev/null | grep -i adr"
+    expected_output: "ADR file present recording the decision"
+
+scope_limit:
+  only_modify:
+    - "docs/"
+    - "_project/"
+
+prior_art:
+  - "benchbox/core/*/catalog/loader.py (six loaders) — the current runtime-parse convention; the ADR either ratifies or supersedes it"
+  - "commit #579 (move tpcds specs to yaml) — the precedent that established runtime parse"
+
+metadata:
+  tags:
+    - shrink
+    - adr
+    - architecture
+    - catalog
+  estimated_effort: "Small"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Prevents the catalog-loading architecture from drifting case-by-case.
+    A recorded decision lets the goal statement name one pattern and stops
+    future shrink slices from re-litigating runtime-vs-codegen ad hoc.
+
+success_metrics:
+  - "ADR recorded with a clear canonical-pattern decision and rejected alternatives"
+  - "Goal statement can reference the chosen pattern"
+
+files_affected:
+  added:
+    - "docs/ (or _project/) ADR file"

--- a/_project/TODO/main/planning/shrink-followup-generated-impl-findability.yaml
+++ b/_project/TODO/main/planning/shrink-followup-generated-impl-findability.yaml
@@ -1,0 +1,119 @@
+id: shrink-followup-generated-impl-findability
+title: "Give globals()-generated dataframe query impls static findability and ty visibility"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Technical Debt
+
+description: |
+  The dataframe-query shrink (notably PR #603) replaced families of
+  near-identical query functions with generators that inject impls into the
+  module namespace:
+
+    benchbox/core/read_primitives/dataframe_queries.py:307,393,456,578  (writes)
+    benchbox/core/read_primitives/dataframe_queries.py:1385,4329         (dynamic dispatch reads)
+    benchbox/core/joinorder/dataframe_queries.py:446-447                  (same pattern)
+
+  This is the correct mechanism for collapsing repeated implementation
+  families (it is exactly what the goal endorses) and the generated impls set
+  real __name__/__doc__, so stack traces are fine. The legitimate residual
+  cost: the impls are not grep-able as `def <name>`, and the dispatch sites
+  (`globals()[f"{impl_base}_{family}_impl"]`) are Any-typed and invisible to
+  `ty`. The fix must restore findability/typing WITHOUT reverting to explicit
+  per-query defs (which would re-inflate the surface the factory removed).
+
+work:
+  - id: w1
+    summary: "Assess ty coverage of the dispatch sites and enumerate the generated-name families"
+    status: pending
+    notes: |
+      Confirm the dispatch returns Any (run `make typecheck` and inspect the
+      reveal at the dispatch lines). List every generated-name family and the
+      factory that produces it, in both read_primitives and joinorder.
+
+  - id: w2
+    summary: "Decide: explicit typed registry, vs globals()+Protocol+generated-name index"
+    needs: [w1]
+    status: pending
+    notes: |
+      GATING. Options:
+      (a) Populate an explicit `dict[str, QueryImpl]` registry (typed via a
+          Protocol) instead of injecting into globals(); dispatch reads the
+          dict and is fully typed.
+      (b) Keep globals() injection but add: a typed Protocol for the impl
+          signature, a generated-name index (module docstring or a tuple of
+          produced names), and a typed accessor wrapping the globals() read.
+      Prefer (a) if it does not complicate the call sites.
+
+  - id: w3
+    summary: "Implement the chosen path; ty sees typed dispatch, names discoverable"
+    needs: [w2]
+    status: pending
+
+open_questions:
+  - question: "Can a typed registry replace globals() injection without re-introducing per-query boilerplate?"
+    gating: true
+    affects: ["w2 success_metric: registry vs globals+Protocol"]
+    default: "Prefer an explicit typed registry dict; fall back to globals()+Protocol+index only if the registry materially complicates the dispatch call sites."
+
+must_preserve:
+  - "Generated impls keep explicit __name__/__doc__"
+  - "All dataframe query tests pass (read_primitives and joinorder)"
+  - "No re-inflation: line count does not return toward the pre-factory baseline"
+
+approach: |
+  Reuse the existing QueryRegistry abstraction (joinorder already constructs
+  one) rather than inventing a new container. The Protocol for the impl
+  signature is the typing anchor that makes the dispatch ty-visible. Start in
+  read_primitives (the densest globals() user), then apply the same shape to
+  joinorder.
+
+anti_patterns:
+  - "DO NOT revert to one explicit `def` per query -- because that undoes the shrink the factory achieved -- use a typed registry/Protocol instead"
+  - "DO NOT silence the dispatch with `# type: ignore` -- because that hides the problem rather than fixing findability -- make the dispatch actually typed"
+
+verification:
+  - description: "Type check is clean and the dispatch is no longer Any"
+    command: "make typecheck"
+    expected_output: "0 errors; dispatch site resolves to the Protocol type"
+  - description: "Generated impl names are statically discoverable"
+    command: "grep -rnE 'QueryImpl|registry\\[|GENERATED_IMPL_NAMES|Protocol' benchbox/core/read_primitives/dataframe_queries.py"
+    expected_output: "typed registry/index present"
+  - description: "Dataframe query tests pass"
+    command: "uv run -- python -m pytest tests/unit/core/read_primitives/ tests/unit/core/joinorder/ -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/read_primitives/dataframe_queries.py"
+    - "benchbox/core/joinorder/dataframe_queries.py"
+    - "tests/"
+
+prior_art:
+  - "benchbox/core/joinorder/dataframe_queries.py:QueryRegistry — reuse this container for an explicit typed registry"
+  - "benchbox/core/joinorder/dataframe_queries.py:427-447 — the factory already sets __name__/__doc__; extend with Protocol typing"
+
+metadata:
+  tags:
+    - shrink
+    - typing
+    - findability
+    - dataframe-queries
+  estimated_effort: "Medium"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Restores IDE/grep navigation and static type coverage over the generated
+    query families without sacrificing the line reduction the factory bought.
+
+success_metrics:
+  - "Dispatch sites are statically typed (no Any) and ty-clean"
+  - "Generated impl names discoverable via a typed registry or explicit index"
+  - "Line count does not regress toward the pre-factory baseline"
+
+files_affected:
+  modified:
+    - "benchbox/core/read_primitives/dataframe_queries.py"
+    - "benchbox/core/joinorder/dataframe_queries.py"

--- a/_project/TODO/main/planning/shrink-followup-joinorder-benchmark-semantics.yaml
+++ b/_project/TODO/main/planning/shrink-followup-joinorder-benchmark-semantics.yaml
@@ -1,0 +1,131 @@
+id: shrink-followup-joinorder-benchmark-semantics
+title: "Prove JoinOrder DataFrame translations preserve benchmark-measured operation, not just rows"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Highest-severity finding from the shrink-campaign review. PRs #587 (113-query
+  JOB) and #588 (13-query synthetic) removed the hand-written DataFrame
+  translations and set `_HAND_TRANSLATED_DATAFRAME_QUERY_IDS = set()`
+  (benchbox/core/joinorder/dataframe_queries.py:39), promoting the generated
+  translation factory (lines 427-447) to sole authority.
+
+  The standing oracle tests
+  (tests/unit/core/joinorder/test_dataframe_query_capabilities.py:93-157)
+  assert *result-equivalence*: each generated pandas and expression impl
+  returns the same rows as a DuckDB oracle executing the canonical SQL, and
+  `get_untranslated_dataframe_query_ids() == []`. That is genuine and
+  sufficient to refute the "untested" charge from the original review.
+
+  But result-equivalence is NOT benchmark-equivalence. The Join Order
+  Benchmark exists to stress the optimizer's ability to reorder joins across
+  113 query shapes. A generator that emits a deterministic, topology-fixed
+  join sequence passes every row-equality test while measuring a different
+  thing: multi-join *execution* with a fixed plan, not optimizer join-ordering
+  quality. This is "right results, wrong thing measured" -- unfalsifiable by
+  any row assertion -- and it touches the goal's "preserve benchmark
+  semantics" non-negotiable. Neither the campaign nor the original review
+  caught it.
+
+work:
+  - id: w1
+    summary: "Characterize what JoinOrder DataFrame mode actually measures today"
+    status: pending
+    notes: |
+      Read the generated factories (`_make_generated_expression_impl`,
+      `_make_generated_pandas_impl`, joinorder/dataframe_queries.py:427-447)
+      and `_execute_joinorder_expression_query` / `_execute_joinorder_pandas_query`.
+      Determine whether join order is fixed by the query topology in the
+      generator, or deferred to the engine (polars/pandas) -- and whether the
+      engine even exposes optimizer join-reordering the way the SQL backend
+      does. Record the finding; it decides w2.
+
+  - id: w2
+    summary: "Decide: document semantic reclassification, or add a structural plan-shape test"
+    needs: [w1]
+    status: pending
+    notes: |
+      GATING. Two mitigations:
+      (a) If DataFrame JoinOrder is inherently execution-focused (likely --
+          DataFrame engines plan differently than a SQL optimizer), document
+          the reclassification: "JoinOrder DataFrame mode measures multi-join
+          execution, not optimizer ordering." Restore that distinction to the
+          module docstring (this is the PR #588 note the review flagged).
+      (b) If it is meant to preserve optimizer-stress, add a structural test
+          asserting the generated plan is NOT deterministically sequenced
+          (e.g. logical-plan cardinality/shape snapshot per query).
+      Pick based on w1; (a) is cheaper and likely correct.
+
+  - id: w3
+    summary: "Implement the chosen mitigation"
+    needs: [w2]
+    status: pending
+
+open_questions:
+  - question: "Does DataFrame JoinOrder even attempt optimizer-stress, or is it inherently execution-focused?"
+    gating: true
+    affects: ["w2 success_metric: reclassify vs structural-test"]
+    default: "Assume execution-focused (DataFrame engines plan differently than a SQL optimizer); reclassify and document (path a), which is cheaper and most likely accurate."
+
+must_preserve:
+  - "The oracle tests at tests/unit/core/joinorder/test_dataframe_query_capabilities.py:93-157 keep passing"
+  - "get_untranslated_dataframe_query_ids() == [] (113/113 JOB coverage) remains true"
+  - "Generated impls keep their explicit __name__/__doc__"
+
+approach: |
+  This is primarily an analysis + documentation/test task, not a translator
+  rewrite. Lead with w1 -- the empirical question of whether join order is
+  fixed -- because it determines whether there is a real regression or just a
+  missing semantic label. Do NOT reintroduce hand-translations as a reflex.
+
+anti_patterns:
+  - "DO NOT treat the row-equality oracle tests as evidence of benchmark equivalence -- because they prove same rows, not same measured operation -- assert plan shape or document the reclassification instead"
+  - "DO NOT reintroduce the 13/113 hand-translations to 'fix' this without measuring -- because the generator may be perfectly correct once the benchmark intent is reclassified -- decide via w1/w2 first"
+
+verification:
+  - description: "JoinOrder DataFrame test module passes"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder/ -q"
+    expected_output: "all pass"
+  - description: "Chosen mitigation present (semantic note or structural test)"
+    command: "grep -rnE 'multi-join execution|optimizer ordering|plan.shape|not deterministically' benchbox/core/joinorder/ tests/unit/core/joinorder/"
+    expected_output: "matching reclassification doc or structural assertion found"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/joinorder/"
+    - "tests/unit/core/joinorder/"
+
+prior_art:
+  - "tests/unit/core/joinorder/test_dataframe_query_capabilities.py:93-157 — extend the oracle suite with a plan-shape assertion (path b) rather than a new test harness"
+  - "benchbox/core/joinorder/dataframe_queries.py:427-447 — the generator factory under scrutiny; reclassification doc attaches here"
+
+metadata:
+  tags:
+    - shrink
+    - joinorder
+    - benchmark-semantics
+    - correctness
+  estimated_effort: "Small"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    A benchmarking tool that silently measures the wrong operation is worse
+    than one that errors. Either the semantic label is corrected (cheap, high
+    clarity) or a structural guard is added (catches future generator drift).
+  user_impact: |
+    Users comparing DataFrame vs SQL JoinOrder results must know whether they
+    are comparing optimizer quality or execution throughput. Today the answer
+    is undocumented.
+
+success_metrics:
+  - "Documented answer to whether JoinOrder DataFrame mode measures optimizer ordering or multi-join execution"
+  - "Either a restored semantic note in the module docstring, or a structural plan-shape test guarding against deterministic-sequencing drift"
+
+files_affected:
+  modified:
+    - "benchbox/core/joinorder/dataframe_queries.py"
+    - "tests/unit/core/joinorder/test_dataframe_query_capabilities.py"

--- a/_project/TODO/main/planning/shrink-followup-registry-lazy-cached-load.yaml
+++ b/_project/TODO/main/planning/shrink-followup-registry-lazy-cached-load.yaml
@@ -1,0 +1,129 @@
+id: shrink-followup-registry-lazy-cached-load
+title: "Make benchmark registry/specs YAML loads lazy+cached to match the repo's loader pattern"
+worktree: main
+priority: High
+status: Not Started
+category: Performance
+
+description: |
+  PR #590 moved benchmark metadata from Python literals to YAML, then loaded
+  it eagerly at module scope:
+
+    benchbox/core/benchmark_registry.py:51   _REGISTRY_PAYLOAD = _load_registry_payload()
+    benchbox/core/results/benchmark_specs.py:74  _SPECS_PAYLOAD = _load_benchmark_specs_payload()
+
+  This executes file I/O + pure-Python YAML parse at import. `benchmark_registry`
+  is on the import-critical path (imported by benchmark_loader). The defect is
+  also self-inconsistent: the repo's six other catalog loaders load LAZILY
+  inside a function -- e.g. benchbox/core/write_primitives/catalog/loader.py:111
+  (`_load_catalog_payload`) is only called from inside
+  `load_write_primitives_catalog()` at line 315, not at module scope.
+
+  This is a direct product of the original Python having module-level
+  constants (CATEGORY_ORDER, BENCHMARK_ORDER, ...); the cheapest
+  metric-preserving translation kept them module-level but sourced from YAML.
+  The fix restores lazy+cached loading while preserving those public symbols.
+
+work:
+  - id: w0
+    summary: "Measure the import-time cost of the eager YAML loads (baseline evidence)"
+    status: pending
+    notes: |
+      Evidence gate. Measure import time of benchbox.core.benchmark_registry
+      and benchbox.core.results.benchmark_specs with the eager loads, e.g.
+      `uv run -- python -X importtime -c 'import benchbox.core.benchmark_registry'`
+      isolating the YAML parse cost. Capture raw stdout to
+      `/tmp/shrink-followup-registry-lazy-cached-load-w0.log`; record a compact
+      summary (command, measured ms, key lines) in this TODO / PR body. This
+      decides whether w1 is a perf fix or purely a consistency fix.
+
+  - id: w1
+    summary: "Decide: convert to lazy+cached accessor, or document accepted eager tradeoff"
+    needs: [w0]
+    status: pending
+    notes: |
+      GATING. If the import delta is material, convert both modules to a
+      lazy `@functools.lru_cache` loader + module `__getattr__` (or accessor
+      functions) so the public symbols still resolve, matching
+      write_primitives/catalog/loader.py. If the delta is negligible AND the
+      module-level-constant contract genuinely requires eager values,
+      document the accepted tradeoff in a comment instead.
+
+  - id: w2
+    summary: "Implement the chosen path, preserving every public symbol"
+    needs: [w1]
+    status: pending
+    notes: |
+      CATEGORY_ORDER, BENCHMARK_ORDER, BENCHMARK_CLASS_NAMES,
+      BENCHMARK_DATA_SOURCE_PROBE_IDS, TPC_OFFICIAL_SCALE_OPTIONS and the
+      benchmark_specs public names must remain importable with identical
+      values. Use module __getattr__ (PEP 562) if needed to keep names while
+      deferring I/O.
+
+open_questions:
+  - question: "Does the codegen-vs-runtime-parse ADR supersede this runtime-parse fix?"
+    gating: false
+    affects: ["w1 success_metric: lazy-load approach"]
+    default: "Proceed -- lazy+cached runtime parse is strictly better than eager regardless of the codegen decision in [[shrink-followup-codegen-vs-runtime-parse-adr]]; if codegen is later chosen it replaces the loader entirely, making this a safe interim improvement."
+
+must_preserve:
+  - "benchbox.core.benchmark_registry public symbols (CATEGORY_ORDER, BENCHMARK_ORDER, BENCHMARK_CLASS_NAMES, etc.) remain importable with identical values"
+  - "benchbox.core.results.benchmark_specs public API unchanged"
+  - "The circular-imports test (tests/unit/test_circular_imports.py) still passes"
+
+approach: |
+  w0 first -- measure before deciding. Reuse the lazy loader shape already
+  proven in write_primitives/catalog/loader.py rather than inventing a new
+  caching scheme. PEP 562 module __getattr__ lets the public constant names
+  survive while the actual I/O is deferred to first access and cached.
+
+anti_patterns:
+  - "DO NOT rename the public constants into accessor calls that break importers -- because benchmark_loader and others import these names -- use module __getattr__ or cached module-level accessors that keep the names"
+  - "DO NOT leave uncached file I/O on a hot import path -- because repeated process starts pay it every time -- cache with lru_cache or a module-level sentinel"
+
+verification:
+  - description: "Public symbols still resolve to identical values"
+    command: "uv run -- python -c 'import benchbox.core.benchmark_registry as r; print(len(r.CATEGORY_ORDER), len(r.BENCHMARK_CLASS_NAMES))'"
+    expected_output: "same counts as before the change"
+  - description: "No module-level YAML load remains (lazy path chosen)"
+    command: "grep -nE '^_REGISTRY_PAYLOAD = |^_SPECS_PAYLOAD = ' benchbox/core/benchmark_registry.py benchbox/core/results/benchmark_specs.py"
+    expected_output: "no module-scope eager load (or a documented justification comment if eager retained)"
+  - description: "Circular imports test passes"
+    command: "uv run -- python -m pytest tests/unit/test_circular_imports.py -q"
+    expected_output: "pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/benchmark_registry.py"
+    - "benchbox/core/results/benchmark_specs.py"
+    - "tests/"
+
+prior_art:
+  - "benchbox/core/write_primitives/catalog/loader.py:111,315 — reuse the lazy load-inside-function pattern (the repo's own convention)"
+  - "PEP 562 module __getattr__ — extend to keep public constant names while deferring I/O"
+
+metadata:
+  tags:
+    - shrink
+    - performance
+    - import-time
+    - registry
+  estimated_effort: "Small"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Restores consistency with the six existing lazy catalog loaders and
+    removes uncached I/O from the import-critical path. Aligns with the
+    "zero regression on critical paths" performance bar.
+
+success_metrics:
+  - "Import-time delta for benchmark_registry/specs measured and recorded (w0)"
+  - "Either lazy+cached loading matching the repo pattern, or a documented justification for retaining eager load"
+  - "All public symbols preserved; circular-imports test green"
+
+files_affected:
+  modified:
+    - "benchbox/core/benchmark_registry.py"
+    - "benchbox/core/results/benchmark_specs.py"

--- a/_project/TODO/main/planning/shrink-followup-restore-dataframe-orientation-docs.yaml
+++ b/_project/TODO/main/planning/shrink-followup-restore-dataframe-orientation-docs.yaml
@@ -1,0 +1,98 @@
+id: shrink-followup-restore-dataframe-orientation-docs
+title: "Restore orientation docstrings dropped by the dataframe-query body removals"
+worktree: main
+priority: Low
+status: Not Started
+category: Documentation
+
+description: |
+  The dataframe-query body-removal PRs (#599-#602) deleted query
+  implementations and, per the shrink-campaign review, some orientation
+  context with them -- e.g. PR #599 was said to remove the ClickBench category
+  groupings ("Basic aggregation Q1-Q7", "Text/pattern Q21-Q27", etc.) that
+  help a reader navigate the query set.
+
+  IMPORTANT -- verify before acting. A quick check found the ClickBench
+  category grouping still present at benchbox/core/clickbench/queries.py:6
+  ("Basic aggregations and counting"). The original review used a diff-only
+  methodology that already produced two retracted findings, so the grouping
+  may survive and this Nit may be partly moot. Confirm what #599 actually
+  removed (likely from the dataframe_queries package docstring specifically,
+  not queries.py) before restoring anything.
+
+  The JoinOrder optimizer-vs-execution semantic note (PR #588) is intentionally
+  NOT handled here -- it is the documentation deliverable of
+  [[shrink-followup-joinorder-benchmark-semantics]] w2 (path a). This item
+  covers ClickBench and any other genuinely-lost orientation context in
+  #599-#602, to avoid double-touching the joinorder surface.
+
+work:
+  - id: w1
+    summary: "Verify what orientation context #599-#602 actually removed (vs what survives)"
+    status: pending
+    notes: |
+      For ClickBench, compare the pre-#599 module docstring against the
+      current benchbox/core/clickbench/dataframe_queries/ modules. Confirm the
+      category grouping is genuinely gone from where a reader of the dataframe
+      queries would look (not merely surviving in queries.py:6). Repeat the
+      check for flightdata/nyctaxi/taxi/tsbs/ssb dataframe-query modules
+      touched by #600-#602.
+
+  - id: w2
+    summary: "Restore only the orientation docstrings that are genuinely lost and aid navigation"
+    needs: [w1]
+    status: pending
+    notes: |
+      Re-add category groupings / orientation comments where they no longer
+      exist and help navigation. Do not restore anything that already survives
+      elsewhere.
+
+must_preserve:
+  - "Do not re-add any removed CODE -- this is docstrings/comments only"
+  - "The Python-line reductions from #599-#602 are not undone"
+
+approach: |
+  Verification-first. w1 is the real work -- confirm the loss is real before
+  restoring. Keep additions to concise orientation context (category maps,
+  query-group labels), not prose.
+
+anti_patterns:
+  - "DO NOT restore docs that already survive elsewhere -- because that is redundant noise -- grep first (the ClickBench grouping survives at clickbench/queries.py:6)"
+  - "DO NOT reintroduce removed query bodies -- because that reverses the shrink -- comments and docstrings only"
+
+verification:
+  - description: "Restored orientation context is present where it was genuinely lost"
+    command: "grep -rnE 'aggregation|Text/pattern|category|Q1-Q7|Q21-Q27' benchbox/core/clickbench/dataframe_queries/"
+    expected_output: "category grouping present in the dataframe_queries package docstring (only if w1 confirmed it was lost there)"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/clickbench/"
+    - "benchbox/core/flightdata/"
+    - "benchbox/core/nyctaxi/"
+
+prior_art:
+  - "benchbox/core/clickbench/queries.py:6 — the surviving category grouping; mirror its wording if restoring to the dataframe_queries docstring"
+
+metadata:
+  tags:
+    - shrink
+    - documentation
+    - orientation
+    - nit
+  estimated_effort: "Small"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Cheap orientation context that helps future readers navigate large query
+    sets. Low priority and contingent on w1 confirming the loss is real.
+
+success_metrics:
+  - "Verified record of what #599-#602 removed vs what survives"
+  - "Genuinely-lost orientation docstrings restored; nothing redundant re-added"
+
+files_affected:
+  modified:
+    - "benchbox/core/clickbench/dataframe_queries/"

--- a/_project/TODO/main/planning/shrink-followup-sql-catalog-yaml-block-scalars.yaml
+++ b/_project/TODO/main/planning/shrink-followup-sql-catalog-yaml-block-scalars.yaml
@@ -1,0 +1,118 @@
+id: shrink-followup-sql-catalog-yaml-block-scalars
+title: "Re-serialize migrated SQL catalogs as YAML block scalars instead of escaped quoted strings"
+worktree: main
+priority: High
+status: Not Started
+category: Technical Debt
+
+description: |
+  PR #604 moved SQL out of Python triple-quoted strings into YAML catalogs --
+  a legitimate, on-pattern reduction (-1840 Python lines). But the SQL was
+  machine-dumped as escaped-newline DOUBLE-QUOTED scalars, e.g.:
+
+    sql: "\n            SELECT\n                f.reporting_airline,\n ..."
+
+  rather than literal block scalars (`sql: |`). A grep across PR 604 found
+  ZERO block-scalar SQL keys. The consequence: the SQL is un-greppable with
+  any tool expecting normal whitespace, un-lintable, and effectively
+  unreadable in the file. This is the navigability defect the goal's line 19
+  is meant to forbid ("move code without reducing conceptual surface area").
+
+  The fix is a pure serialization change -- re-dump the same SQL text as
+  literal block scalars -- with no semantic change to the queries.
+
+  Affected catalogs (PR 604):
+    - benchbox/core/flightdata/query_catalog.yaml
+    - benchbox/core/nyctaxi/query_catalog.yaml
+    - benchbox/core/tsbs_devops/query_catalog.yaml
+    - (loader: benchbox/core/static_query_catalog.py)
+
+work:
+  - id: w1
+    summary: "Confirm current serialization and enumerate every affected SQL key"
+    status: pending
+    notes: |
+      Verify the escaped-scalar form and list all catalogs/keys holding SQL.
+      Confirm whether any placeholders (e.g. {start_date}, {end_date}) live
+      inside the SQL -- they must survive byte-identical.
+
+  - id: w2
+    summary: "Re-dump each catalog's SQL as YAML literal block scalars (|), programmatically"
+    needs: [w1]
+    status: pending
+    notes: |
+      Use a yaml dumper configured to emit block style for the `sql` field
+      (e.g. a str subclass with a registered representer, or post-process).
+      Do NOT hand-edit SQL text -- generate the new YAML so the SQL string
+      content is provably unchanged.
+
+  - id: w3
+    summary: "Add a round-trip test: loaded SQL string == pre-migration SQL string"
+    needs: [w2]
+    status: pending
+    notes: |
+      Assert load_static_query_catalog(...)["QUERIES"][id]["sql"] is
+      byte-identical before and after reformatting (or parses to the same
+      DuckDB AST). This guards against whitespace-sensitive breakage and
+      placeholder loss.
+
+must_preserve:
+  - "Exact SQL semantics and any {placeholder} tokens inside the SQL strings"
+  - "load_static_query_catalog() API and the QUERIES dict shape are unchanged"
+  - "The Python-line reduction from #604 is not undone (SQL stays in YAML)"
+
+approach: |
+  Treat this as a mechanical re-serialization guarded by an equality test.
+  w3 (the round-trip equality test) is the safety net -- write it first if
+  convenient so w2 is provably non-semantic. Reuse the existing loader; only
+  the on-disk YAML representation changes.
+
+anti_patterns:
+  - "DO NOT hand-edit the SQL while reformatting -- because a single stray character changes query semantics -- re-dump programmatically and diff the loaded strings"
+  - "DO NOT move the SQL back into Python -- because that re-inflates the Python surface #604 correctly reduced -- the catalog pattern is right; only the scalar style is wrong"
+
+verification:
+  - description: "SQL is now stored as block scalars"
+    command: "grep -cE '^\\s*sql: \\|' benchbox/core/flightdata/query_catalog.yaml"
+    expected_output: "non-zero (one block scalar per query)"
+  - description: "Round-trip SQL equality test passes"
+    command: "uv run -- python -m pytest -k 'static_query_catalog or query_catalog' -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/flightdata/query_catalog.yaml"
+    - "benchbox/core/nyctaxi/query_catalog.yaml"
+    - "benchbox/core/tsbs_devops/query_catalog.yaml"
+    - "benchbox/core/static_query_catalog.py"
+    - "tests/"
+
+prior_art:
+  - "benchbox/core/read_primitives/catalog/queries.yaml — existing catalog; check whether it already uses block scalars and match that convention"
+  - "benchbox/core/static_query_catalog.py:load_static_query_catalog — reuse the loader unchanged; only the dumper/representation changes"
+
+metadata:
+  tags:
+    - shrink
+    - yaml
+    - sql-catalog
+    - navigability
+  estimated_effort: "Small"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    Block scalars restore grep/lint/diff over the SQL with no cost to the
+    Python reduction. Leaving escaped scalars in place is a standing
+    readability tax on every future query edit.
+
+success_metrics:
+  - "All migrated SQL stored as literal block scalars (`sql: |`)"
+  - "A round-trip test proves the loaded SQL is byte-identical to the pre-reformat text"
+
+files_affected:
+  modified:
+    - "benchbox/core/flightdata/query_catalog.yaml"
+    - "benchbox/core/nyctaxi/query_catalog.yaml"
+    - "benchbox/core/tsbs_devops/query_catalog.yaml"

--- a/_project/TODO/main/planning/shrink-objective-function-and-guardrail.yaml
+++ b/_project/TODO/main/planning/shrink-objective-function-and-guardrail.yaml
@@ -1,0 +1,164 @@
+id: shrink-objective-function-and-guardrail
+title: "Correct the shrink goal's objective function and add countervailing guardrails"
+worktree: main
+priority: Critical
+status: Not Started
+category: Technical Debt
+
+description: |
+  CAMPAIGN GATE. This item gates new YAML-migration shrink PRs. Defect-fix
+  follow-ups (joinorder-benchmark-semantics, sql-catalog-yaml-block-scalars,
+  registry-lazy-cached-load, etc.) proceed in parallel; net-new Python->YAML
+  relocation PRs hold until w1 lands.
+
+  The shrink campaign (#587-#604, 18 PRs merged in ~6h) was driven by a single
+  metric: `cloc --include-lang=Python benchbox/`, with the explicit rule that
+  reductions outside `benchbox/**/*.py` "do not count" (goal line 12). A
+  three-round review of that campaign concluded the metric is a gameable proxy
+  that directly induced two confirmed defects:
+
+    1. Module-level eager YAML I/O (benchmark_registry.py:51,
+       results/benchmark_specs.py:74) -- the cheapest metric-preserving
+       translation of module-level constants, self-inconsistent with the
+       repo's six lazy catalog loaders.
+    2. SQL relocated into escaped-newline quoted YAML scalars (PR 604,
+       flightdata/nyctaxi/tsbs_devops query_catalog.yaml) -- un-greppable,
+       un-lintable; a metric win that violates goal line 19 ("do not move
+       code without reducing conceptual surface area") undetected.
+
+  Root cause: `cloc`-Python is a proxy for conceptual/maintenance surface with
+  two exploitable weaknesses -- (a) it scores data-as-code identically to
+  logic-as-code, and (b) it is relocation-gameable (YAML "doesn't count", so
+  any Python->YAML move is a free win). Line 19 gropes toward the fix but is
+  unoperationalized, so the violations went uncaught.
+
+  The genuine wins of the campaign are real (dead-code removal #587-589,
+  adapter DRY #594-595, ~-15,400 Python diff lines total). The objective
+  function must keep crediting those while refusing to credit gamed
+  relocations and while gating runtime cost, navigability, and benchmark
+  semantics.
+
+work:
+  - id: w1
+    summary: "Decide and write the corrected objective function into the goal statement"
+    status: pending
+    notes: |
+      GATING. Amend `_project/goal-shrink-core-code.md` to:
+        - Distinguish *logic surface* from *relocated data*. Credit
+          Python->data-file moves only when the moved content is genuinely
+          data (no control flow). SQL is a grey zone -- state the rule
+          explicitly (proposed: SQL relocation is neutral unless it improves
+          navigability, e.g. block scalars not escaped scalars).
+        - Add countervailing gates the metric currently lacks:
+          (a) runtime-cost: no net-new module-level I/O on the import path;
+          (b) benchmark-semantics: translator-replacement PRs prove preserved
+              measured-operation, not just result-equivalence (see
+              [[shrink-followup-joinorder-benchmark-semantics]]);
+          (c) navigability: no globals() injection or escaped-scalar
+              serialization that defeats grep/ty.
+        - Operationalize line 19 with a measurable definition of "conceptual
+          surface area" (proposed: symbol count + import-time cost + type
+          coverage, not raw line count).
+      Until this lands, net-new Python->YAML relocation shrink PRs hold.
+
+  - id: w2
+    summary: "Implement per-PR guardrail measurement (logic-LOC, import-time, type-coverage deltas)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Extend the dev-loop metrics tooling to emit, per shrink PR: Python
+      logic-LOC delta (excluding pure-data relocation), import-time delta for
+      touched modules, and `ty` coverage delta. Output a compact summary the
+      PR body must include.
+
+  - id: w3
+    summary: "Wire the guardrail into preflight / a Makefile target"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add `make shrink-guardrail` (or fold into pr-preflight) so a shrink PR
+      cannot be opened without surfacing the countervailing metrics.
+
+  - id: w4
+    summary: "Backfill-classify #587-604 against the corrected objective function"
+    needs: [w1]
+    status: pending
+    notes: |
+      Confirm the corrected metric still credits the genuine wins (#587-589
+      dead code, #594-595 DRY) and flags the gamed relocations (#604 SQL,
+      #590 eager load). If it doesn't separate them cleanly, the objective
+      function in w1 is wrong -- iterate. This is the validation that the new
+      metric is not just another unmeasured proxy.
+
+open_questions:
+  - question: "Is cloc-Python salvageable as the headline metric with countervailing gates, or must the objective function be replaced outright?"
+    gating: true
+    affects: ["w1 success_metric: corrected objective function"]
+    default: "Keep cloc-Python as the headline number but make it advisory; gate merges on the countervailing metrics (runtime, navigability, benchmark-semantics) rather than on line count alone."
+  - question: "Where exactly is the line between legitimate data->catalog extraction (good) and metric-gaming relocation (bad)?"
+    gating: true
+    affects: ["w1 success_metric: logic-vs-data discriminator"]
+    default: "Data with no control flow is creditable; SQL/logic relocation is neutral unless it measurably improves navigability."
+
+must_preserve:
+  - "The 66% reduction intent and the genuine wins already merged (#587-589, #594-595) are not penalized or reverted retroactively"
+  - "`benchbox/**/*.py` remains the primary surface of concern -- the correction adds gates, it does not abandon the Python-reduction goal"
+
+approach: |
+  Start with w1 (the decision) -- it is the gate and everything else depends
+  on it. w4 validates w1 against real history before w2/w3 build tooling, so
+  run w4 immediately after w1 to catch a bad objective function early. Reuse
+  the existing dev-loop-metrics machinery rather than building a new metrics
+  subsystem.
+
+anti_patterns:
+  - "DO NOT retroactively revert merged PRs -- because the genuine reductions are valuable and reverting churns develop -- fix the metric going forward and file targeted defect-fix TODOs for the specific regressions"
+  - "DO NOT replace one gameable proxy (line count) with another unmeasured proxy -- because that repeats the original mistake -- w4 must demonstrate the new metric separates good from gamed reductions on real history"
+
+verification:
+  - description: "Goal statement encodes the logic-vs-data rule and the three countervailing gates"
+    command: "grep -nE 'logic|relocat|runtime-cost|navigab|benchmark-semantic|conceptual surface' _project/goal-shrink-core-code.md"
+    expected_output: "matches showing the corrected objective function and gates"
+  - description: "Guardrail target exists and emits the deltas"
+    command: "grep -nE 'shrink-guardrail|import-time|type-coverage' Makefile"
+    expected_output: "target present"
+
+scope_limit:
+  only_modify:
+    - "_project/goal-shrink-core-code.md"
+    - "Makefile"
+    - "_project/scripts/"
+
+prior_art:
+  - "Makefile:dev-loop-metrics — extend with shrink-specific logic-LOC/import-time/type-coverage deltas rather than a new metrics subsystem"
+  - "_project/goal-shrink-core-code.md:19 — operationalize the existing anti-gaming clause instead of adding a parallel rule"
+  - "cloc --include-lang=Python usage in the goal statement — supersede as the sole gate; keep as an advisory headline number"
+
+metadata:
+  tags:
+    - shrink
+    - goal-statement
+    - metric
+    - goodhart
+    - campaign-gate
+  estimated_effort: "Medium"
+  created_date: "2026-05-23"
+  last_updated: "2026-05-23T12:00:00"
+
+impact:
+  technical_debt: |
+    The metric choice is the upstream cause of the campaign's defects. Fixing
+    it once prevents the same class of regression across every remaining
+    shrink slice, and converts line 19 from aspiration into an enforced gate.
+
+success_metrics:
+  - "Corrected objective function documented in the goal statement with a logic-vs-data rule and runtime/navigability/benchmark-semantics gates"
+  - "Per-PR guardrail surfaces import-time and type-coverage deltas, callable from preflight"
+  - "Backfill classification (w4) credits #587-589/#594-595 and flags #590/#604 -- proving the metric separates genuine from gamed reductions"
+
+files_affected:
+  modified:
+    - "_project/goal-shrink-core-code.md"
+    - "Makefile"
+  added:
+    - "_project/scripts/ (guardrail metric helper)"


### PR DESCRIPTION
Capture the action plan from the three-round review of the shrink
campaign (#587-604) as 8 validated TODOs with decision gates and
guardrails.

- shrink-objective-function-and-guardrail (Critical, campaign gate):
  correct the cloc-Python metric (logic-vs-data discriminator +
  runtime/navigability/benchmark-semantics gates); operationalize the
  goal's anti-gaming clause. Holds net-new Python->YAML relocation PRs.
- shrink-followup-joinorder-benchmark-semantics (High): result-equivalence
  != benchmark-equivalence for JOB; document reclassification or add a
  plan-shape test.
- shrink-followup-sql-catalog-yaml-block-scalars (High): re-dump #604 SQL
  as block scalars (currently escaped quoted scalars).
- shrink-followup-registry-lazy-cached-load (High): module-level eager YAML
  load deviates from the repo's 6 lazy loaders; measure + lazy-cache.
- shrink-followup-generated-impl-findability (Medium-High): typed registry
  for globals()-injected impls.
- shrink-followup-catalog-schema-validation (Medium): CI-callable per-field
  catalog validation.
- shrink-followup-codegen-vs-runtime-parse-adr (Medium): decide canonical
  catalog pattern.
- shrink-followup-restore-dataframe-orientation-docs (Low): verify+restore
  orientation docstrings dropped by #599-602.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
