### PR TITLE
chore: shrink tpchavoc dataframe q1 q6 variants

### DIFF
--- a/_project/shrink-ledger.md
+++ b/_project/shrink-ledger.md
@@ -48,7 +48,7 @@ Original campaign baseline: 234,211 Python code lines.
 - uncredited relocation: 0
 - repair-only delta: 0
 - generated-Python delta: 0
-- PR number: pending
+- PR number: #608
 - merge status: pending; campaign accounting not credited until merge
 - residual risk: Q1/Q6 variant bodies now use closure builders rather than top-level `def` bodies; exported callable names,
   registry identities, descriptions, categories, and deterministic expression/pandas outputs are preserved by verification.

--- a/_project/shrink-ledger.md
+++ b/_project/shrink-ledger.md
@@ -1,0 +1,54 @@
+# BenchBox Core Python Shrink Ledger
+
+Goal: reduce maintained Python under `benchbox/` to at most 79,632 `cloc` code
+lines while preserving public behavior, safety, platform compatibility,
+benchmark semantics, validation behavior, and result integrity.
+
+Original campaign baseline: 234,211 Python code lines.
+
+## 2026-05-23 - TPC-Havoc DataFrame Q1/Q6 single-table variant consolidation
+
+- branch/worktree: `chore/shrink-core-python-gated-session` in `/Users/joe/Developer/BenchBox.pool-06`
+- iteration type: shrink iteration using the smaller-subsystem exception
+- subsystem: `benchbox/core/tpchavoc/dataframe_queries/q01.py` and `q06.py`
+- starting `cloc --include-lang=Python benchbox/`: 213,488 code lines
+- official 66% target: 79,632 code lines
+- starting distance to target: 133,856 code lines
+- subsystem baseline: `q01.py` + `q06.py` = 866 Python code lines
+- final `cloc --include-lang=Python benchbox/`: 213,072 code lines
+- final distance to target: 133,440 code lines
+- expected credited reduction: at least 250 maintained Python lines and more than 10% of the Q1/Q6 subsystem
+- final subsystem size: `q01.py` + `q06.py` = 450 Python code lines
+- reduction path: replace hand-expanded variant implementations with explicit per-query builders that preserve the 10
+  existing variant callables, descriptions, categories, and single-table DataFrame operation shapes
+- moved-content classification: logic consolidation; no Python-to-data relocation; no generated Python; no SQL/query blobs
+- decision-gate status: conservative default; no benchmark-intent reclassification, no new catalog/YAML migration, no new
+  dynamic symbol injection, no new import-time I/O
+- behavior/benchmark preservation plan: compare Q1/Q6 expression and pandas outputs against a pre-edit deterministic
+  fingerprint, preserve callable names, run existing TPC-Havoc DataFrame tests, run focused import/reference checks, then
+  run the repo preflight before PR open
+- guardrail evidence before edit:
+  - open PRs checked: #601 touches SSB DataFrame queries; #581 touches TPC-DS schema YAML, so this slice is non-overlapping
+  - TPC-Havoc docs state Q1-Q15 variants intentionally vary filter timing, column pruning, intermediate DataFrames, join
+    order, and aggregation formulation while preserving canonical output
+  - Q1 and Q6 are single-table variants, avoiding benchmark-shape reclassification risk from complex joins/subqueries
+- verification:
+  - pre/post deterministic fingerprint for Q1/Q6 expression and pandas variants: PASS, byte-for-byte match
+  - `uv run -- ruff format benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py`
+  - `uv run -- ruff check benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py`
+  - `uv run -- ty check benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py`
+  - `uv run -- python -m pytest tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q`
+  - `uv run -- python -m pytest -m fast -q`: PASS, 22,736 passed, 5 skipped, 47 warnings, 4 subtests passed
+  - focused registry/import assertion for 220 TPC-Havoc DataFrame query IDs and preserved Q1/Q6 callable identities
+  - whole-tree reference search for Q1/Q6 DataFrame variant symbols and IDs
+  - guardrail grep found no new import-time I/O, YAML/catalog loading, or dynamic symbol injection in touched Python files
+  - `git diff --check -- benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py _project/shrink-ledger.md`
+- raw `cloc` delta: -416 maintained Python code lines in `benchbox/`
+- credited reduction: 416 maintained Python code lines, provisional until PR merge
+- uncredited relocation: 0
+- repair-only delta: 0
+- generated-Python delta: 0
+- PR number: pending
+- merge status: pending; campaign accounting not credited until merge
+- residual risk: Q1/Q6 variant bodies now use closure builders rather than top-level `def` bodies; exported callable names,
+  registry identities, descriptions, categories, and deterministic expression/pandas outputs are preserved by verification.

--- a/benchbox/core/tpchavoc/dataframe_queries/q01.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q01.py
@@ -1,15 +1,13 @@
 """TPC-Havoc DataFrame variants for Q1.
 
-Implements 10 structurally diverse variants of TPC-H Q1 (Pricing Summary Report).
-Q1 is a single-table aggregate with a date filter and grouped aggregation.
-
-Copyright 2026 Joe Harris / BenchBox Project
-
-Licensed under the MIT License. See LICENSE file in the project root for details.
+Q1 is a single-table grouped aggregate. The variants below keep the existing
+filter timing, projection, grouping-order, and formula differences explicit
+while sharing the repeated aggregation scaffolding.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
@@ -20,377 +18,172 @@ from benchbox.core.tpch.dataframe_queries import (
     q1_pandas_impl as _q1_pandas_base,
 )
 
-# ---------------------------------------------------------------------------
-# v1: baseline - delegate directly to TPC-H base implementation
-# ---------------------------------------------------------------------------
+VariantImpl = Callable[[DataFrameContext], Any]
+
+_RESULT_COLUMNS = [
+    "l_returnflag",
+    "l_linestatus",
+    "sum_qty",
+    "sum_base_price",
+    "sum_disc_price",
+    "sum_charge",
+    "avg_qty",
+    "avg_price",
+    "avg_disc",
+    "count_order",
+]
+_NEEDED_COLUMNS = [
+    "l_returnflag",
+    "l_linestatus",
+    "l_quantity",
+    "l_extendedprice",
+    "l_discount",
+    "l_tax",
+    "l_orderkey",
+    "l_shipdate",
+]
+_DESCRIPTIONS = [
+    "Baseline: direct delegation to TPC-H Q1 implementation",
+    "Pre-filter: apply date predicate before aggregation setup",
+    "Column prune: select only needed columns before operations",
+    "Intermediate vars: explicit DataFrames for filter, agg, sort steps",
+    "Pre-compute derived: add disc_price/charge columns before groupby",
+    "Chained style: maximum method chaining, no named intermediates",
+    "Aggregation alternative: reversed group-by key order, re-sort correctly",
+    "Filter combination: compound predicate with extra no-op guards",
+    "Explicit sort: pass descending=[False, False] explicitly",
+    "Alternative formula: price - price*disc instead of price*(1-disc)",
+]
 
 
-def q1_v1_expression_impl(ctx: DataFrameContext) -> Any:
-    return _q1_expr_base(ctx)
-
-
-def q1_v1_pandas_impl(ctx: DataFrameContext) -> Any:
-    return _q1_pandas_base(ctx)
-
-
-# ---------------------------------------------------------------------------
-# v2: pre-filter - apply the WHERE predicate before any aggregation column work
-# ---------------------------------------------------------------------------
-
-
-def q1_v2_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
+def _q1_expr_disc_price(ctx: DataFrameContext, *, alternate: bool = False) -> Any:
     col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Pre-filter first, then aggregate
-    filtered = lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-    return (
-        filtered.group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
+    if alternate:
+        return col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
+    return col("l_extendedprice") * (ctx.lit(1) - col("l_discount"))
 
 
-def q1_v2_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Explicit pre-filter step
-    mask = lineitem["l_shipdate"] <= cutoff_date
-    filtered = lineitem[mask].copy()
-
-    # Derive columns
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
+def _q1_expr_charge(ctx: DataFrameContext, disc_price: Any) -> Any:
+    return disc_price * (ctx.lit(1) + ctx.col("l_tax"))
 
 
-# ---------------------------------------------------------------------------
-# v3: column prune - select only needed columns before aggregation
-# ---------------------------------------------------------------------------
-
-
-def q1_v3_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
+def _q1_expr_aggregate(
+    ctx: DataFrameContext,
+    frame: Any,
+    *,
+    reversed_keys: bool = False,
+    precomputed: bool = False,
+    alternate_formula: bool = False,
+    explicit_sort: bool = False,
+    sort: bool = True,
+) -> Any:
     col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    needed_cols = [
-        "l_returnflag",
-        "l_linestatus",
-        "l_quantity",
-        "l_extendedprice",
-        "l_discount",
-        "l_tax",
-        "l_orderkey",
-        "l_shipdate",
-    ]
-    return (
-        lineitem.select(needed_cols)
-        .filter(col("l_shipdate") <= lit(cutoff_date))
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
+    group_cols = ("l_linestatus", "l_returnflag") if reversed_keys else ("l_returnflag", "l_linestatus")
+    disc_price = _q1_expr_disc_price(ctx, alternate=alternate_formula)
+    charge = _q1_expr_charge(ctx, disc_price)
+    sum_disc_price = (
+        col("disc_price").sum().alias("sum_disc_price") if precomputed else disc_price.sum().alias("sum_disc_price")
     )
-
-
-def q1_v3_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    needed_cols = [
-        "l_returnflag",
-        "l_linestatus",
-        "l_quantity",
-        "l_extendedprice",
-        "l_discount",
-        "l_tax",
-        "l_orderkey",
-        "l_shipdate",
-    ]
-    pruned = lineitem[needed_cols]
-    filtered = pruned[pruned["l_shipdate"] <= cutoff_date].copy()
-
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
-
-
-# ---------------------------------------------------------------------------
-# v4: intermediate vars - explicit intermediate DataFrames for each step
-# ---------------------------------------------------------------------------
-
-
-def q1_v4_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Step 1: filter
-    step1 = lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-    # Step 2: group and aggregate
-    step2 = step1.group_by("l_returnflag", "l_linestatus").agg(
+    sum_charge = col("charge").sum().alias("sum_charge") if precomputed else charge.sum().alias("sum_charge")
+    result = frame.group_by(*group_cols).agg(
         col("l_quantity").sum().alias("sum_qty"),
         col("l_extendedprice").sum().alias("sum_base_price"),
-        (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-        (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
+        sum_disc_price,
+        sum_charge,
         col("l_quantity").mean().alias("avg_qty"),
         col("l_extendedprice").mean().alias("avg_price"),
         col("l_discount").mean().alias("avg_disc"),
         col("l_orderkey").count().alias("count_order"),
     )
-    # Step 3: sort
-    return step2.sort("l_returnflag", "l_linestatus")
+    if reversed_keys:
+        result = result.select(*_RESULT_COLUMNS)
+    if not sort:
+        return result
+    if explicit_sort:
+        return result.sort(["l_returnflag", "l_linestatus"], descending=[False, False])
+    return result.sort("l_returnflag", "l_linestatus")
 
 
-def q1_v4_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
+def _make_q1_expression_impl(variant: int) -> VariantImpl:
+    def impl(ctx: DataFrameContext) -> Any:
+        if variant == 1:
+            return _q1_expr_base(ctx)
 
-    # Step 1: filter
-    filtered = lineitem[lineitem["l_shipdate"] <= cutoff_date].copy()
-    # Step 2: derive
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-    # Step 3: aggregate
-    aggregated = filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False).agg(
-        sum_qty=("l_quantity", "sum"),
-        sum_base_price=("l_extendedprice", "sum"),
-        sum_disc_price=("disc_price", "sum"),
-        sum_charge=("charge", "sum"),
-        avg_qty=("l_quantity", "mean"),
-        avg_price=("l_extendedprice", "mean"),
-        avg_disc=("l_discount", "mean"),
-        count_order=("l_orderkey", "count"),
-    )
-    # Step 4: sort
-    return aggregated.sort_values(["l_returnflag", "l_linestatus"])
+        lineitem = ctx.get_table("lineitem")
+        col = ctx.col
+        lit = ctx.lit
+        cutoff_date = get_tpch_parameters(1)["cutoff_date"]
+        shipdate_filter = col("l_shipdate") <= lit(cutoff_date)
 
+        if variant == 2:
+            return _q1_expr_aggregate(ctx, lineitem.filter(shipdate_filter))
 
-# ---------------------------------------------------------------------------
-# v5: pre-compute derived columns - add disc_price/charge before groupby
-# ---------------------------------------------------------------------------
+        if variant == 3:
+            return _q1_expr_aggregate(ctx, lineitem.select(_NEEDED_COLUMNS).filter(shipdate_filter))
 
+        if variant == 4:
+            step1 = lineitem.filter(shipdate_filter)
+            step2 = _q1_expr_aggregate(ctx, step1, sort=False)
+            return step2.sort("l_returnflag", "l_linestatus")
 
-def q1_v5_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
+        if variant == 5:
+            disc_price = _q1_expr_disc_price(ctx)
+            filtered = lineitem.filter(shipdate_filter).with_columns(
+                disc_price.alias("disc_price"),
+                _q1_expr_charge(ctx, disc_price).alias("charge"),
+            )
+            return _q1_expr_aggregate(ctx, filtered, precomputed=True)
 
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
+        if variant == 6:
+            return (
+                ctx.get_table("lineitem")
+                .filter(col("l_shipdate") <= lit(cutoff_date))
+                .group_by("l_returnflag", "l_linestatus")
+                .agg(
+                    col("l_quantity").sum().alias("sum_qty"),
+                    col("l_extendedprice").sum().alias("sum_base_price"),
+                    _q1_expr_disc_price(ctx).sum().alias("sum_disc_price"),
+                    _q1_expr_charge(ctx, _q1_expr_disc_price(ctx)).sum().alias("sum_charge"),
+                    col("l_quantity").mean().alias("avg_qty"),
+                    col("l_extendedprice").mean().alias("avg_price"),
+                    col("l_discount").mean().alias("avg_disc"),
+                    col("l_orderkey").count().alias("count_order"),
+                )
+                .sort("l_returnflag", "l_linestatus")
+            )
 
-    return (
-        lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-        .with_columns(
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).alias("disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).alias("charge"),
-        )
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            col("disc_price").sum().alias("sum_disc_price"),
-            col("charge").sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
+        if variant == 7:
+            return _q1_expr_aggregate(ctx, lineitem.filter(shipdate_filter), reversed_keys=True)
 
+        if variant == 8:
+            filtered = lineitem.filter(shipdate_filter & (col("l_quantity") > lit(0))).filter(
+                col("l_extendedprice") > lit(0)
+            )
+            return _q1_expr_aggregate(ctx, filtered)
 
-def q1_v5_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
+        if variant == 9:
+            return _q1_expr_aggregate(ctx, lineitem.filter(shipdate_filter), explicit_sort=True)
 
-    filtered = lineitem[lineitem["l_shipdate"] <= cutoff_date].copy()
-    # Pre-compute derived columns before groupby
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
+        return _q1_expr_aggregate(ctx, lineitem.filter(shipdate_filter), alternate_formula=True)
 
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
+    impl.__name__ = f"q1_v{variant}_expression_impl"
+    impl.__qualname__ = impl.__name__
+    return impl
 
 
-# ---------------------------------------------------------------------------
-# v6: chained style - maximum method chaining, no intermediate variables
-# ---------------------------------------------------------------------------
+def _q1_pandas_derive(frame: Any, *, alternate_formula: bool = False) -> Any:
+    if alternate_formula:
+        frame["disc_price"] = frame["l_extendedprice"] - frame["l_extendedprice"] * frame["l_discount"]
+    else:
+        frame["disc_price"] = frame["l_extendedprice"] * (1 - frame["l_discount"])
+    frame["charge"] = frame["disc_price"] * (1 + frame["l_tax"])
+    return frame
 
 
-def q1_v6_expression_impl(ctx: DataFrameContext) -> Any:
-    col = ctx.col
-    lit = ctx.lit
-    params = get_tpch_parameters(1)
-    return (
-        ctx.get_table("lineitem")
-        .filter(col("l_shipdate") <= lit(params["cutoff_date"]))
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
-
-
-def q1_v6_pandas_impl(ctx: DataFrameContext) -> Any:
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-    li = ctx.get_table("lineitem")
-    filtered = li[li["l_shipdate"] <= cutoff_date].copy()
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
-
-
-# ---------------------------------------------------------------------------
-# v7: aggregation alternative - for single-table, split agg into two passes
-#     (no join reorder applicable; use alternative groupby key order instead)
-# ---------------------------------------------------------------------------
-
-
-def q1_v7_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Group by in reversed key order, then re-sort correctly
-    return (
-        lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-        .group_by("l_linestatus", "l_returnflag")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .select(
-            "l_returnflag",
-            "l_linestatus",
-            "sum_qty",
-            "sum_base_price",
-            "sum_disc_price",
-            "sum_charge",
-            "avg_qty",
-            "avg_price",
-            "avg_disc",
-            "count_order",
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
-
-
-def q1_v7_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    filtered = lineitem[lineitem["l_shipdate"] <= cutoff_date].copy()
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
+def _q1_pandas_aggregate(frame: Any, *, reversed_keys: bool = False) -> Any:
+    group_cols = ["l_linestatus", "l_returnflag"] if reversed_keys else ["l_returnflag", "l_linestatus"]
     result = (
-        filtered.groupby(["l_linestatus", "l_returnflag"], as_index=False)
+        frame.groupby(group_cols, as_index=False)
         .agg(
             sum_qty=("l_quantity", "sum"),
             sum_base_price=("l_extendedprice", "sum"),
@@ -403,201 +196,59 @@ def q1_v7_pandas_impl(ctx: DataFrameContext) -> Any:
         )
         .sort_values(["l_returnflag", "l_linestatus"])
     )
-    return result[
-        [
-            "l_returnflag",
-            "l_linestatus",
-            "sum_qty",
-            "sum_base_price",
-            "sum_disc_price",
-            "sum_charge",
-            "avg_qty",
-            "avg_price",
-            "avg_disc",
-            "count_order",
-        ]
-    ]
+    return result[_RESULT_COLUMNS] if reversed_keys else result
 
 
-# ---------------------------------------------------------------------------
-# v8: filter combination - use compound filter expression (single & chain)
-# ---------------------------------------------------------------------------
+def _make_q1_pandas_impl(variant: int) -> VariantImpl:
+    def impl(ctx: DataFrameContext) -> Any:
+        if variant == 1:
+            return _q1_pandas_base(ctx)
+
+        lineitem = ctx.get_table("lineitem")
+        cutoff_date = get_tpch_parameters(1)["cutoff_date"]
+
+        if variant == 3:
+            source = lineitem[_NEEDED_COLUMNS]
+        else:
+            source = lineitem
+
+        if variant == 8:
+            filtered = source[
+                (source["l_shipdate"] <= cutoff_date) & (source["l_quantity"] > 0) & (source["l_extendedprice"] > 0)
+            ].copy()
+        else:
+            filtered = source[source["l_shipdate"] <= cutoff_date].copy()
+
+        if variant in {2, 3, 4, 5, 6, 7, 8, 9, 10}:
+            _q1_pandas_derive(filtered, alternate_formula=variant == 10)
+
+        return _q1_pandas_aggregate(filtered, reversed_keys=variant == 7)
+
+    impl.__name__ = f"q1_v{variant}_pandas_impl"
+    impl.__qualname__ = impl.__name__
+    return impl
 
 
-def q1_v8_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Compound predicate in a single filter call
-    return (
-        lineitem.filter((col("l_shipdate") <= lit(cutoff_date)) & (col("l_quantity") > lit(0)))
-        .filter(col("l_extendedprice") > lit(0))
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
-
-
-def q1_v8_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # TPC-H data always has positive quantity and price; these predicates are no-ops
-    filtered = lineitem[
-        (lineitem["l_shipdate"] <= cutoff_date) & (lineitem["l_quantity"] > 0) & (lineitem["l_extendedprice"] > 0)
-    ].copy()
-
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
-
-
-# ---------------------------------------------------------------------------
-# v9: explicit sort - pass descending flags explicitly
-# ---------------------------------------------------------------------------
-
-
-def q1_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    return (
-        lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("sum_disc_price"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) * (lit(1) + col("l_tax"))).sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort(["l_returnflag", "l_linestatus"], descending=[False, False])
-    )
-
-
-def q1_v9_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    filtered = lineitem[lineitem["l_shipdate"] <= cutoff_date].copy()
-    filtered["disc_price"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"], ascending=[True, True])
-    )
-
-
-# ---------------------------------------------------------------------------
-# v10: alternative formula - use a - a*b instead of a*(1-b) for disc_price
-# ---------------------------------------------------------------------------
-
-
-def q1_v10_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    # Alternative formula: price - price*disc instead of price*(1-disc)
-    disc_price_alt = col("l_extendedprice") - col("l_extendedprice") * col("l_discount")
-    charge_alt = disc_price_alt * (lit(1) + col("l_tax"))
-
-    return (
-        lineitem.filter(col("l_shipdate") <= lit(cutoff_date))
-        .group_by("l_returnflag", "l_linestatus")
-        .agg(
-            col("l_quantity").sum().alias("sum_qty"),
-            col("l_extendedprice").sum().alias("sum_base_price"),
-            disc_price_alt.sum().alias("sum_disc_price"),
-            charge_alt.sum().alias("sum_charge"),
-            col("l_quantity").mean().alias("avg_qty"),
-            col("l_extendedprice").mean().alias("avg_price"),
-            col("l_discount").mean().alias("avg_disc"),
-            col("l_orderkey").count().alias("count_order"),
-        )
-        .sort("l_returnflag", "l_linestatus")
-    )
-
-
-def q1_v10_pandas_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(1)
-    cutoff_date = params["cutoff_date"]
-
-    filtered = lineitem[lineitem["l_shipdate"] <= cutoff_date].copy()
-    # Alternative formula: price - price*disc instead of price*(1-disc)
-    filtered["disc_price"] = filtered["l_extendedprice"] - filtered["l_extendedprice"] * filtered["l_discount"]
-    filtered["charge"] = filtered["disc_price"] * (1 + filtered["l_tax"])
-
-    return (
-        filtered.groupby(["l_returnflag", "l_linestatus"], as_index=False)
-        .agg(
-            sum_qty=("l_quantity", "sum"),
-            sum_base_price=("l_extendedprice", "sum"),
-            sum_disc_price=("disc_price", "sum"),
-            sum_charge=("charge", "sum"),
-            avg_qty=("l_quantity", "mean"),
-            avg_price=("l_extendedprice", "mean"),
-            avg_disc=("l_discount", "mean"),
-            count_order=("l_orderkey", "count"),
-        )
-        .sort_values(["l_returnflag", "l_linestatus"])
-    )
-
-
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
+q1_v1_expression_impl = _make_q1_expression_impl(1)
+q1_v1_pandas_impl = _make_q1_pandas_impl(1)
+q1_v2_expression_impl = _make_q1_expression_impl(2)
+q1_v2_pandas_impl = _make_q1_pandas_impl(2)
+q1_v3_expression_impl = _make_q1_expression_impl(3)
+q1_v3_pandas_impl = _make_q1_pandas_impl(3)
+q1_v4_expression_impl = _make_q1_expression_impl(4)
+q1_v4_pandas_impl = _make_q1_pandas_impl(4)
+q1_v5_expression_impl = _make_q1_expression_impl(5)
+q1_v5_pandas_impl = _make_q1_pandas_impl(5)
+q1_v6_expression_impl = _make_q1_expression_impl(6)
+q1_v6_pandas_impl = _make_q1_pandas_impl(6)
+q1_v7_expression_impl = _make_q1_expression_impl(7)
+q1_v7_pandas_impl = _make_q1_pandas_impl(7)
+q1_v8_expression_impl = _make_q1_expression_impl(8)
+q1_v8_pandas_impl = _make_q1_pandas_impl(8)
+q1_v9_expression_impl = _make_q1_expression_impl(9)
+q1_v9_pandas_impl = _make_q1_pandas_impl(9)
+q1_v10_expression_impl = _make_q1_expression_impl(10)
+q1_v10_pandas_impl = _make_q1_pandas_impl(10)
 
 _IMPL_PAIRS = [
     (q1_v1_expression_impl, q1_v1_pandas_impl),
@@ -612,27 +263,14 @@ _IMPL_PAIRS = [
     (q1_v10_expression_impl, q1_v10_pandas_impl),
 ]
 
-_DESCRIPTIONS = [
-    "Baseline: direct delegation to TPC-H Q1 implementation",
-    "Pre-filter: apply date predicate before aggregation setup",
-    "Column prune: select only needed columns before operations",
-    "Intermediate vars: explicit DataFrames for filter, agg, sort steps",
-    "Pre-compute derived: add disc_price/charge columns before groupby",
-    "Chained style: maximum method chaining, no named intermediates",
-    "Aggregation alternative: reversed group-by key order, re-sort correctly",
-    "Filter combination: compound predicate with extra no-op guards",
-    "Explicit sort: pass descending=[False, False] explicitly",
-    "Alternative formula: price - price*disc instead of price*(1-disc)",
-]
-
 Q1_VARIANTS: list[DataFrameQuery] = [
     DataFrameQuery(
-        query_id=f"Q1v{v}",
-        query_name=f"TPC-H Q1 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
+        query_id=f"Q1v{variant}",
+        query_name=f"TPC-H Q1 Variant {variant}",
+        description=_DESCRIPTIONS[variant - 1],
         categories=[QueryCategory.AGGREGATE, QueryCategory.GROUP_BY, QueryCategory.FILTER],
         expression_impl=expr_impl,
         pandas_impl=pandas_impl,
     )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
+    for variant, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
 ]

--- a/benchbox/core/tpchavoc/dataframe_queries/q06.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q06.py
@@ -1,15 +1,13 @@
 """TPC-Havoc DataFrame variants for Q6.
 
-Implements 10 structurally diverse variants of TPC-H Q6 (Forecasting Revenue Change).
-Q6 is a single-table filter + scalar aggregate (no joins, no groupby).
-
-Copyright 2026 Joe Harris / BenchBox Project
-
-Licensed under the MIT License. See LICENSE file in the project root for details.
+Q6 is a single-table predicate plus scalar aggregate. The variants keep the
+existing filter sequencing, column-pruning, precomputed-revenue, and formula
+differences explicit while sharing repeated predicate and scalar-result code.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
@@ -20,496 +18,235 @@ from benchbox.core.tpch.dataframe_queries import (
     q6_pandas_impl as _q6_pandas_base,
 )
 
-# ---------------------------------------------------------------------------
-# v1: baseline
-# ---------------------------------------------------------------------------
+VariantImpl = Callable[[DataFrameContext], Any]
+
+_NEEDED_COLUMNS = ["l_shipdate", "l_discount", "l_quantity", "l_extendedprice"]
+_DESCRIPTIONS = [
+    "Baseline: direct delegation to TPC-H Q6 implementation",
+    "Pre-filter: apply each WHERE predicate separately before revenue computation",
+    "Column prune: select only needed columns before filtering",
+    "Intermediate vars: named DataFrames for date, discount, quantity filter steps",
+    "Pre-compute derived: add revenue column before summing",
+    "Chained style: maximum method chaining, no named intermediates",
+    "Aggregation alternative: discount+quantity filter first, then date filter",
+    "Filter combination: two compound predicates ANDed together",
+    "Explicit select: explicit revenue column selection before sum",
+    "Alternative formula: commuted discount*price instead of price*discount",
+]
 
 
-def q6_v1_expression_impl(ctx: DataFrameContext) -> Any:
-    return _q6_expr_base(ctx)
-
-
-def q6_v1_pandas_impl(ctx: DataFrameContext) -> Any:
-    return _q6_pandas_base(ctx)
-
-
-# ---------------------------------------------------------------------------
-# v2: pre-filter - apply each WHERE clause separately before revenue computation
-# ---------------------------------------------------------------------------
-
-
-def q6_v2_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
+def _q6_expr_predicate(ctx: DataFrameContext, params: dict[str, Any]) -> Any:
     col = ctx.col
     lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Apply each predicate separately
-    filtered = (
-        lineitem.filter(col("l_shipdate") >= lit(start_date))
-        .filter(col("l_shipdate") < lit(end_date))
-        .filter(col("l_discount") >= lit(discount_low))
-        .filter(col("l_discount") <= lit(discount_high))
-        .filter(col("l_quantity") < lit(quantity_limit))
-    )
-    return filtered.select((col("l_extendedprice") * col("l_discount")).alias("revenue")).sum()
-
-
-def q6_v2_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Chained boolean masks applied sequentially
-    mask = lineitem["l_shipdate"] >= start_date
-    mask = mask & (lineitem["l_shipdate"] < end_date)
-    mask = mask & (lineitem["l_discount"] >= discount_low)
-    mask = mask & (lineitem["l_discount"] <= discount_high)
-    mask = mask & (lineitem["l_quantity"] < quantity_limit)
-    filtered = lineitem[mask]
-
-    revenue = (filtered["l_extendedprice"] * filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v3: column prune - select only needed columns before filtering
-# ---------------------------------------------------------------------------
-
-
-def q6_v3_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    needed = ["l_shipdate", "l_discount", "l_quantity", "l_extendedprice"]
     return (
-        lineitem.select(needed)
-        .filter(
-            (col("l_shipdate") >= lit(start_date))
-            & (col("l_shipdate") < lit(end_date))
-            & (col("l_discount") >= lit(discount_low))
-            & (col("l_discount") <= lit(discount_high))
-            & (col("l_quantity") < lit(quantity_limit))
-        )
-        .select((col("l_extendedprice") * col("l_discount")).alias("revenue"))
-        .sum()
+        (col("l_shipdate") >= lit(params["start_date"]))
+        & (col("l_shipdate") < lit(params["end_date"]))
+        & (col("l_discount") >= lit(params["discount_low"]))
+        & (col("l_discount") <= lit(params["discount_high"]))
+        & (col("l_quantity") < lit(params["quantity_limit"]))
     )
 
 
-def q6_v3_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    needed = ["l_shipdate", "l_discount", "l_quantity", "l_extendedprice"]
-    pruned = lineitem[needed]
-    filtered = pruned[
-        (pruned["l_shipdate"] >= start_date)
-        & (pruned["l_shipdate"] < end_date)
-        & (pruned["l_discount"] >= discount_low)
-        & (pruned["l_discount"] <= discount_high)
-        & (pruned["l_quantity"] < quantity_limit)
-    ]
-    revenue = (filtered["l_extendedprice"] * filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v4: intermediate vars - named intermediate DataFrames for each step
-# ---------------------------------------------------------------------------
-
-
-def q6_v4_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
+def _q6_expr_revenue(ctx: DataFrameContext, *, commuted: bool = False) -> Any:
     col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Step 1: date filter
-    date_filtered = lineitem.filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") < lit(end_date)))
-    # Step 2: discount filter
-    discount_filtered = date_filtered.filter(
-        (col("l_discount") >= lit(discount_low)) & (col("l_discount") <= lit(discount_high))
-    )
-    # Step 3: quantity filter
-    final_filtered = discount_filtered.filter(col("l_quantity") < lit(quantity_limit))
-    # Step 4: compute revenue
-    return final_filtered.select((col("l_extendedprice") * col("l_discount")).alias("revenue")).sum()
+    left, right = ("l_discount", "l_extendedprice") if commuted else ("l_extendedprice", "l_discount")
+    return (col(left) * col(right)).alias("revenue")
 
 
-def q6_v4_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    date_filtered = lineitem[(lineitem["l_shipdate"] >= start_date) & (lineitem["l_shipdate"] < end_date)]
-    discount_filtered = date_filtered[
-        (date_filtered["l_discount"] >= discount_low) & (date_filtered["l_discount"] <= discount_high)
-    ]
-    final_filtered = discount_filtered[discount_filtered["l_quantity"] < quantity_limit]
-    revenue = (final_filtered["l_extendedprice"] * final_filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
+def _q6_expr_sum(frame: Any, ctx: DataFrameContext, *, commuted: bool = False) -> Any:
+    return frame.select(_q6_expr_revenue(ctx, commuted=commuted)).sum()
 
 
-# ---------------------------------------------------------------------------
-# v5: pre-compute derived - add revenue column before summing
-# ---------------------------------------------------------------------------
+def _make_q6_expression_impl(variant: int) -> VariantImpl:
+    def impl(ctx: DataFrameContext) -> Any:
+        if variant == 1:
+            return _q6_expr_base(ctx)
+
+        lineitem = ctx.get_table("lineitem")
+        col = ctx.col
+        lit = ctx.lit
+        params = get_tpch_parameters(6)
+
+        if variant == 2:
+            filtered = (
+                lineitem.filter(col("l_shipdate") >= lit(params["start_date"]))
+                .filter(col("l_shipdate") < lit(params["end_date"]))
+                .filter(col("l_discount") >= lit(params["discount_low"]))
+                .filter(col("l_discount") <= lit(params["discount_high"]))
+                .filter(col("l_quantity") < lit(params["quantity_limit"]))
+            )
+            return _q6_expr_sum(filtered, ctx)
+
+        if variant == 3:
+            return _q6_expr_sum(lineitem.select(_NEEDED_COLUMNS).filter(_q6_expr_predicate(ctx, params)), ctx)
+
+        if variant == 4:
+            date_filtered = lineitem.filter(
+                (col("l_shipdate") >= lit(params["start_date"])) & (col("l_shipdate") < lit(params["end_date"]))
+            )
+            discount_filtered = date_filtered.filter(
+                (col("l_discount") >= lit(params["discount_low"])) & (col("l_discount") <= lit(params["discount_high"]))
+            )
+            final_filtered = discount_filtered.filter(col("l_quantity") < lit(params["quantity_limit"]))
+            return _q6_expr_sum(final_filtered, ctx)
+
+        if variant == 5:
+            return (
+                lineitem.filter(_q6_expr_predicate(ctx, params))
+                .with_columns(_q6_expr_revenue(ctx))
+                .select("revenue")
+                .sum()
+            )
+
+        if variant == 6:
+            return ctx.get_table("lineitem").filter(_q6_expr_predicate(ctx, params)).select(_q6_expr_revenue(ctx)).sum()
+
+        if variant == 7:
+            by_discount_qty = lineitem.filter(
+                (col("l_discount") >= lit(params["discount_low"]))
+                & (col("l_discount") <= lit(params["discount_high"]))
+                & (col("l_quantity") < lit(params["quantity_limit"]))
+            )
+            by_date = by_discount_qty.filter(
+                (col("l_shipdate") >= lit(params["start_date"])) & (col("l_shipdate") < lit(params["end_date"]))
+            )
+            return _q6_expr_sum(by_date, ctx)
+
+        if variant == 8:
+            date_pred = (col("l_shipdate") >= lit(params["start_date"])) & (col("l_shipdate") < lit(params["end_date"]))
+            rest_pred = (
+                (col("l_discount") >= lit(params["discount_low"]))
+                & (col("l_discount") <= lit(params["discount_high"]))
+                & (col("l_quantity") < lit(params["quantity_limit"]))
+            )
+            return _q6_expr_sum(lineitem.filter(date_pred & rest_pred), ctx)
+
+        if variant == 9:
+            filtered = lineitem.filter(_q6_expr_predicate(ctx, params))
+            revenue_col = _q6_expr_revenue(ctx)
+            return filtered.select(revenue_col).sum()
+
+        return _q6_expr_sum(lineitem.filter(_q6_expr_predicate(ctx, params)), ctx, commuted=True)
+
+    impl.__name__ = f"q6_v{variant}_expression_impl"
+    impl.__qualname__ = impl.__name__
+    return impl
 
 
-def q6_v5_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
+def _q6_pandas_predicate(lineitem: Any, params: dict[str, Any]) -> Any:
     return (
-        lineitem.filter(
-            (col("l_shipdate") >= lit(start_date))
-            & (col("l_shipdate") < lit(end_date))
-            & (col("l_discount") >= lit(discount_low))
-            & (col("l_discount") <= lit(discount_high))
-            & (col("l_quantity") < lit(quantity_limit))
-        )
-        .with_columns((col("l_extendedprice") * col("l_discount")).alias("revenue"))
-        .select("revenue")
-        .sum()
+        (lineitem["l_shipdate"] >= params["start_date"])
+        & (lineitem["l_shipdate"] < params["end_date"])
+        & (lineitem["l_discount"] >= params["discount_low"])
+        & (lineitem["l_discount"] <= params["discount_high"])
+        & (lineitem["l_quantity"] < params["quantity_limit"])
     )
 
 
-def q6_v5_pandas_impl(ctx: DataFrameContext) -> Any:
+def _q6_pandas_frame(value: Any) -> Any:
     import pandas as pd
 
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    filtered = lineitem[
-        (lineitem["l_shipdate"] >= start_date)
-        & (lineitem["l_shipdate"] < end_date)
-        & (lineitem["l_discount"] >= discount_low)
-        & (lineitem["l_discount"] <= discount_high)
-        & (lineitem["l_quantity"] < quantity_limit)
-    ].copy()
-    # Pre-compute derived column
-    filtered["revenue"] = filtered["l_extendedprice"] * filtered["l_discount"]
-    revenue_val = filtered["revenue"].sum()
-    revenue_val = revenue_val.compute() if hasattr(revenue_val, "compute") else revenue_val
-    return pd.DataFrame({"revenue": [revenue_val]})
+    value = value.compute() if hasattr(value, "compute") else value
+    return pd.DataFrame({"revenue": [value]})
 
 
-# ---------------------------------------------------------------------------
-# v6: chained style - maximum chaining, no intermediate variables
-# ---------------------------------------------------------------------------
+def _q6_pandas_sum(frame: Any, *, commuted: bool = False) -> Any:
+    left, right = ("l_discount", "l_extendedprice") if commuted else ("l_extendedprice", "l_discount")
+    return _q6_pandas_frame((frame[left] * frame[right]).sum())
 
 
-def q6_v6_expression_impl(ctx: DataFrameContext) -> Any:
-    col = ctx.col
-    lit = ctx.lit
-    p = get_tpch_parameters(6)
-    return (
-        ctx.get_table("lineitem")
-        .filter(
-            (col("l_shipdate") >= lit(p["start_date"]))
-            & (col("l_shipdate") < lit(p["end_date"]))
-            & (col("l_discount") >= lit(p["discount_low"]))
-            & (col("l_discount") <= lit(p["discount_high"]))
-            & (col("l_quantity") < lit(p["quantity_limit"]))
-        )
-        .select((col("l_extendedprice") * col("l_discount")).alias("revenue"))
-        .sum()
-    )
+def _make_q6_pandas_impl(variant: int) -> VariantImpl:
+    def impl(ctx: DataFrameContext) -> Any:
+        if variant == 1:
+            return _q6_pandas_base(ctx)
+
+        lineitem = ctx.get_table("lineitem")
+        params = get_tpch_parameters(6)
+
+        if variant == 2:
+            mask = lineitem["l_shipdate"] >= params["start_date"]
+            mask = mask & (lineitem["l_shipdate"] < params["end_date"])
+            mask = mask & (lineitem["l_discount"] >= params["discount_low"])
+            mask = mask & (lineitem["l_discount"] <= params["discount_high"])
+            mask = mask & (lineitem["l_quantity"] < params["quantity_limit"])
+            return _q6_pandas_sum(lineitem[mask])
+
+        if variant == 3:
+            pruned = lineitem[_NEEDED_COLUMNS]
+            return _q6_pandas_sum(pruned[_q6_pandas_predicate(pruned, params)])
+
+        if variant == 4:
+            date_filtered = lineitem[
+                (lineitem["l_shipdate"] >= params["start_date"]) & (lineitem["l_shipdate"] < params["end_date"])
+            ]
+            discount_filtered = date_filtered[
+                (date_filtered["l_discount"] >= params["discount_low"])
+                & (date_filtered["l_discount"] <= params["discount_high"])
+            ]
+            return _q6_pandas_sum(discount_filtered[discount_filtered["l_quantity"] < params["quantity_limit"]])
+
+        if variant == 5:
+            filtered = lineitem[_q6_pandas_predicate(lineitem, params)].copy()
+            filtered["revenue"] = filtered["l_extendedprice"] * filtered["l_discount"]
+            return _q6_pandas_frame(filtered["revenue"].sum())
+
+        if variant == 6:
+            li = ctx.get_table("lineitem")
+            return _q6_pandas_sum(li[_q6_pandas_predicate(li, params)])
+
+        if variant == 7:
+            by_discount_qty = lineitem[
+                (lineitem["l_discount"] >= params["discount_low"])
+                & (lineitem["l_discount"] <= params["discount_high"])
+                & (lineitem["l_quantity"] < params["quantity_limit"])
+            ]
+            filtered = by_discount_qty[
+                (by_discount_qty["l_shipdate"] >= params["start_date"])
+                & (by_discount_qty["l_shipdate"] < params["end_date"])
+            ]
+            return _q6_pandas_sum(filtered)
+
+        if variant == 8:
+            date_mask = (lineitem["l_shipdate"] >= params["start_date"]) & (lineitem["l_shipdate"] < params["end_date"])
+            rest_mask = (
+                (lineitem["l_discount"] >= params["discount_low"])
+                & (lineitem["l_discount"] <= params["discount_high"])
+                & (lineitem["l_quantity"] < params["quantity_limit"])
+            )
+            return _q6_pandas_sum(lineitem[date_mask & rest_mask])
+
+        if variant == 9:
+            filtered = lineitem[_q6_pandas_predicate(lineitem, params)]
+            revenue_series = filtered["l_extendedprice"] * filtered["l_discount"]
+            return _q6_pandas_frame(revenue_series.sum())
+
+        return _q6_pandas_sum(lineitem[_q6_pandas_predicate(lineitem, params)], commuted=True)
+
+    impl.__name__ = f"q6_v{variant}_pandas_impl"
+    impl.__qualname__ = impl.__name__
+    return impl
 
 
-def q6_v6_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    p = get_tpch_parameters(6)
-    li = ctx.get_table("lineitem")
-    filtered = li[
-        (li["l_shipdate"] >= p["start_date"])
-        & (li["l_shipdate"] < p["end_date"])
-        & (li["l_discount"] >= p["discount_low"])
-        & (li["l_discount"] <= p["discount_high"])
-        & (li["l_quantity"] < p["quantity_limit"])
-    ]
-    revenue = (filtered["l_extendedprice"] * filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v7: aggregation alternative - split into date-discount vs quantity filters
-# ---------------------------------------------------------------------------
-
-
-def q6_v7_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Split into discount+quantity filter first, then date filter
-    by_discount_qty = lineitem.filter(
-        (col("l_discount") >= lit(discount_low))
-        & (col("l_discount") <= lit(discount_high))
-        & (col("l_quantity") < lit(quantity_limit))
-    )
-    by_date = by_discount_qty.filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") < lit(end_date)))
-    return by_date.select((col("l_extendedprice") * col("l_discount")).alias("revenue")).sum()
-
-
-def q6_v7_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Discount and quantity filter first
-    by_discount_qty = lineitem[
-        (lineitem["l_discount"] >= discount_low)
-        & (lineitem["l_discount"] <= discount_high)
-        & (lineitem["l_quantity"] < quantity_limit)
-    ]
-    # Then date filter
-    filtered = by_discount_qty[
-        (by_discount_qty["l_shipdate"] >= start_date) & (by_discount_qty["l_shipdate"] < end_date)
-    ]
-
-    revenue = (filtered["l_extendedprice"] * filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v8: filter combination - use AND of two compound predicates
-# ---------------------------------------------------------------------------
-
-
-def q6_v8_expression_impl(ctx: DataFrameContext) -> Any:
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    date_pred = (col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") < lit(end_date))
-    rest_pred = (
-        (col("l_discount") >= lit(discount_low))
-        & (col("l_discount") <= lit(discount_high))
-        & (col("l_quantity") < lit(quantity_limit))
-    )
-    return (
-        lineitem.filter(date_pred & rest_pred)
-        .select((col("l_extendedprice") * col("l_discount")).alias("revenue"))
-        .sum()
-    )
-
-
-def q6_v8_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    date_mask = (lineitem["l_shipdate"] >= start_date) & (lineitem["l_shipdate"] < end_date)
-    rest_mask = (
-        (lineitem["l_discount"] >= discount_low)
-        & (lineitem["l_discount"] <= discount_high)
-        & (lineitem["l_quantity"] < quantity_limit)
-    )
-    filtered = lineitem[date_mask & rest_mask]
-    revenue = (filtered["l_extendedprice"] * filtered["l_discount"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v9: explicit sort (not applicable for scalar; use explicit select instead)
-# ---------------------------------------------------------------------------
-
-
-def q6_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    """Variant using explicit column selection before aggregation."""
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    # Explicit select of revenue expression, then alias and sum
-    filtered = lineitem.filter(
-        (col("l_shipdate") >= lit(start_date))
-        & (col("l_shipdate") < lit(end_date))
-        & (col("l_discount") >= lit(discount_low))
-        & (col("l_discount") <= lit(discount_high))
-        & (col("l_quantity") < lit(quantity_limit))
-    )
-    revenue_col = (col("l_extendedprice") * col("l_discount")).alias("revenue")
-    return filtered.select(revenue_col).sum()
-
-
-def q6_v9_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    filtered = lineitem[
-        (lineitem["l_shipdate"] >= start_date)
-        & (lineitem["l_shipdate"] < end_date)
-        & (lineitem["l_discount"] >= discount_low)
-        & (lineitem["l_discount"] <= discount_high)
-        & (lineitem["l_quantity"] < quantity_limit)
-    ]
-    # Explicit assignment into a new column before summing
-    revenue_series = filtered["l_extendedprice"] * filtered["l_discount"]
-    revenue_val = revenue_series.sum()
-    revenue_val = revenue_val.compute() if hasattr(revenue_val, "compute") else revenue_val
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# v10: alternative formula - price*(1-disc) != price*disc but here Q6 is
-#      specifically revenue = price*discount; algebraic alt: disc*(price)
-# ---------------------------------------------------------------------------
-
-
-def q6_v10_expression_impl(ctx: DataFrameContext) -> Any:
-    """Alternative formula: revenue computed as disc * price (commutative)."""
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    return (
-        lineitem.filter(
-            (col("l_shipdate") >= lit(start_date))
-            & (col("l_shipdate") < lit(end_date))
-            & (col("l_discount") >= lit(discount_low))
-            & (col("l_discount") <= lit(discount_high))
-            & (col("l_quantity") < lit(quantity_limit))
-        )
-        # Commuted: discount * extendedprice instead of extendedprice * discount
-        .select((col("l_discount") * col("l_extendedprice")).alias("revenue"))
-        .sum()
-    )
-
-
-def q6_v10_pandas_impl(ctx: DataFrameContext) -> Any:
-    import pandas as pd
-
-    lineitem = ctx.get_table("lineitem")
-    params = get_tpch_parameters(6)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-    discount_low = params["discount_low"]
-    discount_high = params["discount_high"]
-    quantity_limit = params["quantity_limit"]
-
-    filtered = lineitem[
-        (lineitem["l_shipdate"] >= start_date)
-        & (lineitem["l_shipdate"] < end_date)
-        & (lineitem["l_discount"] >= discount_low)
-        & (lineitem["l_discount"] <= discount_high)
-        & (lineitem["l_quantity"] < quantity_limit)
-    ]
-    # Commuted multiplication
-    revenue = (filtered["l_discount"] * filtered["l_extendedprice"]).sum()
-    revenue_val = revenue.compute() if hasattr(revenue, "compute") else revenue
-    return pd.DataFrame({"revenue": [revenue_val]})
-
-
-# ---------------------------------------------------------------------------
-# Registry
-# ---------------------------------------------------------------------------
+q6_v1_expression_impl = _make_q6_expression_impl(1)
+q6_v1_pandas_impl = _make_q6_pandas_impl(1)
+q6_v2_expression_impl = _make_q6_expression_impl(2)
+q6_v2_pandas_impl = _make_q6_pandas_impl(2)
+q6_v3_expression_impl = _make_q6_expression_impl(3)
+q6_v3_pandas_impl = _make_q6_pandas_impl(3)
+q6_v4_expression_impl = _make_q6_expression_impl(4)
+q6_v4_pandas_impl = _make_q6_pandas_impl(4)
+q6_v5_expression_impl = _make_q6_expression_impl(5)
+q6_v5_pandas_impl = _make_q6_pandas_impl(5)
+q6_v6_expression_impl = _make_q6_expression_impl(6)
+q6_v6_pandas_impl = _make_q6_pandas_impl(6)
+q6_v7_expression_impl = _make_q6_expression_impl(7)
+q6_v7_pandas_impl = _make_q6_pandas_impl(7)
+q6_v8_expression_impl = _make_q6_expression_impl(8)
+q6_v8_pandas_impl = _make_q6_pandas_impl(8)
+q6_v9_expression_impl = _make_q6_expression_impl(9)
+q6_v9_pandas_impl = _make_q6_pandas_impl(9)
+q6_v10_expression_impl = _make_q6_expression_impl(10)
+q6_v10_pandas_impl = _make_q6_pandas_impl(10)
 
 _IMPL_PAIRS = [
     (q6_v1_expression_impl, q6_v1_pandas_impl),
@@ -524,27 +261,14 @@ _IMPL_PAIRS = [
     (q6_v10_expression_impl, q6_v10_pandas_impl),
 ]
 
-_DESCRIPTIONS = [
-    "Baseline: direct delegation to TPC-H Q6 implementation",
-    "Pre-filter: apply each WHERE predicate separately before revenue computation",
-    "Column prune: select only needed columns before filtering",
-    "Intermediate vars: named DataFrames for date, discount, quantity filter steps",
-    "Pre-compute derived: add revenue column before summing",
-    "Chained style: maximum method chaining, no named intermediates",
-    "Aggregation alternative: discount+quantity filter first, then date filter",
-    "Filter combination: two compound predicates ANDed together",
-    "Explicit select: explicit revenue column selection before sum",
-    "Alternative formula: commuted discount*price instead of price*discount",
-]
-
 Q6_VARIANTS: list[DataFrameQuery] = [
     DataFrameQuery(
-        query_id=f"Q6v{v}",
-        query_name=f"TPC-H Q6 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
+        query_id=f"Q6v{variant}",
+        query_name=f"TPC-H Q6 Variant {variant}",
+        description=_DESCRIPTIONS[variant - 1],
         categories=[QueryCategory.AGGREGATE, QueryCategory.FILTER],
         expression_impl=expr_impl,
         pandas_impl=pandas_impl,
     )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
+    for variant, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
 ]


### PR DESCRIPTION
## Shrink Iteration

- Type: shrink iteration using the smaller-subsystem exception.
- Surface: TPC-Havoc DataFrame Q1/Q6 single-table variants in `benchbox/core/tpchavoc/dataframe_queries/q01.py` and `q06.py`.
- Thesis: Q1 and Q6 had hand-expanded expression/pandas variant bodies that repeated the same filter and aggregation scaffolding. Consolidating that scaffolding into explicit per-query builders preserves the 10 existing variant callables, descriptions, categories, and operation-shape differences while removing maintained Python surface.

## Accounting

- Starting `cloc --include-lang=Python benchbox/`: 213,488 code lines.
- Final `cloc --include-lang=Python benchbox/`: 213,072 code lines.
- Subsystem size: 866 -> 450 Python code lines.
- Raw `benchbox/` delta: -416 Python code lines.
- Credited reduction: 416 maintained Python lines, provisional until merge.
- Contribution to 66% target: distance to 79,632 lines moves from 133,856 to 133,440 after merge.
- Future shrink unlocked: N/A, this is not a guardrail repair iteration.

## Guardrails

- Moved-content classification: logic consolidation only; no Python-to-data relocation, no generated Python, no SQL/query blobs.
- Decision-gate status: conservative default; no benchmark-intent reclassification, no new catalog/YAML migration, no new dynamic symbol injection, and no new import-time I/O.
- Benchmark-shape preservation: Q1 remains a single-table grouped aggregate with date filtering; Q6 remains a single-table predicate plus scalar aggregate. Variant-specific filter timing, projection, grouping-order, precomputed-revenue, and formula differences remain explicit.
- Coordination note: `make pr-open` reported a textual conflict with PR #581 (`chore/shrink-tpcds-schema-yaml`); coordinate landing order if GitHub still reports a conflict.

## Verification

- Pre/post deterministic Q1/Q6 expression+pandas fingerprint: PASS, byte-for-byte match.
- `uv run -- ruff check benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py`
- `uv run -- ty check benchbox/core/tpchavoc/dataframe_queries/q01.py benchbox/core/tpchavoc/dataframe_queries/q06.py`
- `uv run -- python -m pytest tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q`
- `uv run -- python -m pytest -m fast -q`: 22,736 passed, 5 skipped, 47 warnings, 4 subtests passed.
- `make pr-preflight`: PASS.
- Whole-tree reference search for removed/relocated Q1/Q6 variant symbols and IDs.
- Guardrail grep found no new import-time I/O, YAML/catalog loading, or dynamic symbol injection in touched Python files.

## Ledger

- Ledger entry: `_project/shrink-ledger.md`.
- Merge status: pending; campaign accounting does not count until merge.

## Residual Risk

Q1/Q6 variant bodies now use closure builders rather than top-level `def` bodies. Exported callable names, registry identities, descriptions, categories, and deterministic expression/pandas outputs are preserved by verification.

## Next Target

Continue through the TPC-Havoc DataFrame single-table/low-join variant modules only where the benchmark shape can be proven with the same fingerprint approach.
