### PR TITLE
chore: shrink nyctaxi downloader lifecycle

### DIFF
--- a/_project/shrink-ledger/shrink-nyctaxi-downloader-lifecycle.md
+++ b/_project/shrink-ledger/shrink-nyctaxi-downloader-lifecycle.md
@@ -1,0 +1,120 @@
+---
+iteration: shrink-nyctaxi-downloader-lifecycle
+date: 2026-05-24
+surface: NYC Taxi downloader lifecycle
+branch: chore/shrink-nyctaxi-downloader-lifecycle
+pr:
+raw_cloc_delta: 250
+credited_reduction: 250
+uncredited_relocation: 0
+repair_only_delta: 0
+generated_python_delta: 0
+moved_content: logic
+decision_gate: conservative default
+verification:
+  - make shrink-rollup
+  - cloc --include-lang=Python benchbox/
+  - cloc --by-file --include-lang=Python benchbox/core/nyctaxi/downloader.py
+  - make duplicate-check-json
+  - uv run -- python scripts/check_complexity.py --source-root benchbox/core/nyctaxi --no-fail --top 20
+  - uv run -- ruff check benchbox/core/nyctaxi/downloader.py tests/unit/core/nyctaxi/test_downloader.py tests/unit/core/nyctaxi/test_multi_type.py tests/unit/generators/test_scale_factor_harmonization.py
+  - uv run -- python -m pytest tests/unit/core/nyctaxi/test_downloader.py tests/unit/core/nyctaxi/test_multi_type.py tests/unit/generators/test_scale_factor_harmonization.py -q -n 0
+  - uv run -- python - <<'PY' ... # manual NYC Taxi downloader fingerprint
+  - make pr-preflight
+---
+
+## Thesis
+
+Shrink iteration under the smaller-subsystem exception. The NYC Taxi downloader
+lifecycle subsystem is `benchbox/core/nyctaxi/downloader.py`, measured at 632
+Python code lines before edits. The final file is 382 Python code lines, for a
+250-line credited maintained-Python reduction. This meets the smaller-subsystem
+floor: at least 250 credited lines and at least 10% of the subsystem.
+
+The three public downloader classes stay explicit and grep-findable:
+`NYCTaxiDataDownloader`, `GreenTaxiDataDownloader`, and `HVFHVDataDownloader`.
+The repeated lifecycle around initialization, sample-rate saturation warnings,
+trip-file output, monthly parquet download, sampling, row writing, malformed-row
+logging, and stats construction moved into a private shared base. The
+taxi-type-specific behavior remains on the concrete classes: public return
+types, table names, filenames, URL prefixes, logger names, warning labels,
+column providers, row-mapping aliases/defaults, synthetic generation
+parameters/row writers, and HVFHV February 2019 default-month behavior.
+
+Credited reduction is the net maintained-Python cloc reduction after adding the
+private helper/base code. There is no Python-to-data relocation, generated
+Python, SQL/query movement, benchmark deletion, platform deletion, or
+deprecated/beta-public surface removal.
+
+## Guardrail Evidence
+
+- Iteration type: shrink iteration, smaller-subsystem exception.
+- Subsystem: `benchbox/core/nyctaxi/downloader.py`; baseline 632 Python cloc,
+  below the 1,000-line smaller-subsystem cap.
+- Minimum gate: remove at least 250 credited Python lines and at least 10% of
+  the subsystem. Final measurement is 250 lines, 39.6% of the subsystem.
+- Moved-content classification: logic consolidation only.
+- Decision-gate status: conservative default. No open policy gate is used to
+  approve relocation, generated implementation, or dynamic symbol injection.
+- Public/exported surface: all three downloader class names, constructor
+  signatures, and module imports remain explicit.
+- Open PR overlap: after PR #617 merged, `gh pr list --state open --base
+  develop --json number,title,headRefName,baseRefName,state,mergeStateStatus
+  --limit 30` returned `[]`.
+- Baseline duplicate evidence: `make duplicate-check-json` reports duplicated
+  NYC Taxi downloader blocks in `_process_parquet_file` (3 x 54),
+  `_download_and_process_trips` (3 x 38), `__init__` (2 x 52), and
+  `get_download_stats` (3 x 14).
+- Baseline complexity evidence: `uv run -- python scripts/check_complexity.py
+  --source-root benchbox/core/nyctaxi --no-fail --top 20` passed with
+  downloader lifecycle functions at CC 7 and 4.
+- Baseline behavior evidence: `uv run -- python -m pytest
+  tests/unit/core/nyctaxi/test_downloader.py
+  tests/unit/core/nyctaxi/test_multi_type.py
+  tests/unit/generators/test_scale_factor_harmonization.py -q -n 0` reported
+  91 passed before edits.
+
+## Verification
+
+- `make shrink-rollup` before edits: cumulative merged credited reduction 252;
+  remaining floor 11,748, stretch 18,748.
+- `cloc --include-lang=Python benchbox/`: 206,352 Python code lines after the
+  slice, down from the 206,602 pre-edit sanity measurement on this branch.
+- `cloc --by-file --include-lang=Python benchbox/core/nyctaxi/downloader.py`:
+  382 code lines after the slice, down from 632 before the slice.
+- `make duplicate-check-json`: no duplicate groups remain for
+  `benchbox/core/nyctaxi/downloader.py`; repo duplicate summary moved from 306
+  groups / 414 instances / 7,730 duplicated lines to 301 groups / 406
+  instances / 7,435 duplicated lines.
+- `uv run -- python scripts/check_complexity.py --source-root
+  benchbox/core/nyctaxi --no-fail --top 20`: passed; downloader lifecycle
+  worst CC remains 7, with `_write_metered_synthetic_row` at 5 and
+  `_download_and_process_trips` at 4.
+- `uv run -- ruff check benchbox/core/nyctaxi/downloader.py
+  tests/unit/core/nyctaxi/test_downloader.py
+  tests/unit/core/nyctaxi/test_multi_type.py
+  tests/unit/generators/test_scale_factor_harmonization.py`: passed.
+- `uv run -- python -m pytest tests/unit/core/nyctaxi/test_downloader.py
+  tests/unit/core/nyctaxi/test_multi_type.py
+  tests/unit/generators/test_scale_factor_harmonization.py -q -n 0`: 91
+  passed.
+- Manual pre/post fingerprint against `origin/develop` matched exactly for all
+  three public downloader classes: constructor signature, logger name, explicit
+  months, sample rate, stats shape, deterministic synthetic row count, first
+  rows, synthetic SHA-256, and HVFHV default months for 2019 and 2020.
+- `make pr-preflight`: passed; broad fast suite reported 22,775 passed, 5
+  skipped, 47 warnings, and 4 subtests passed.
+
+## Residual Risk
+
+The main risk is collapsing superficially identical download lifecycle code
+that still carries type-specific behavior. Those differences are kept in
+explicit class attributes or methods, and verification fingerprints public
+constructor defaults, logger names, table/file names, URL patterns, stats
+shape, and deterministic synthetic output for all three downloaders.
+
+## Next Target
+
+If this slice lands with credit, continue through another duplicate-maintenance
+surface with no benchmark/platform deletion. If it misses the smaller-subsystem
+threshold, reject it and move to a larger true-dedup target.

--- a/benchbox/core/nyctaxi/downloader.py
+++ b/benchbox/core/nyctaxi/downloader.py
@@ -37,13 +37,7 @@ def _load_downloader_specs() -> dict[str, Any]:
 
 _DOWNLOADER_SPECS = _load_downloader_specs()
 
-# TLC data URLs
 TLC_BASE_URL = _DOWNLOADER_SPECS["tlc_base_url"]
-TAXI_ZONES_URL = _DOWNLOADER_SPECS["taxi_zones_url"]
-
-# Available data ranges
-AVAILABLE_YEARS = list(_DOWNLOADER_SPECS["available_years"])
-AVAILABLE_MONTHS = list(_DOWNLOADER_SPECS["available_months"])
 SCALE_FACTOR_SAMPLE_DIVISOR = float(_DOWNLOADER_SPECS["scale_factor_sample_divisor"])
 
 # Complete NYC TLC Taxi Zone data (all 265 zones)
@@ -51,12 +45,10 @@ SCALE_FACTOR_SAMPLE_DIVISOR = float(_DOWNLOADER_SPECS["scale_factor_sample_divis
 TAXI_ZONES_DATA = [tuple(row) for row in _DOWNLOADER_SPECS["taxi_zones"]]
 
 
-class NYCTaxiDataDownloader(CompressionMixin, VerbosityMixin):
-    """Downloads and processes NYC TLC trip data.
-
-    Supports resumable downloads and deterministic sampling for
-    reproducible scale factors.
-    """
+class _TripDataDownloader(CompressionMixin, VerbosityMixin):
+    _COLUMN_ALIASES: dict[str, tuple[str, ...]] = {}
+    _COLUMN_DEFAULTS: dict[str, Any] = {}
+    _STATS_TAXI_TYPE: str | None = None
 
     def __init__(
         self,
@@ -70,46 +62,243 @@ class NYCTaxiDataDownloader(CompressionMixin, VerbosityMixin):
         force_redownload: bool = False,
         **kwargs,
     ) -> None:
-        """Initialize data downloader.
-
-        Args:
-            scale_factor: Scale factor for sampling (0.01 to 100.0)
-            output_dir: Directory for output files
-            year: Year of data to download
-            months: List of months (1-12) to download, None for all
-            seed: Random seed for reproducible sampling
-            verbose: Verbosity level
-            quiet: Suppress output
-            force_redownload: Force re-download even if files exist
-            **kwargs: Additional options
-        """
         super().__init__(**kwargs)
 
         self.scale_factor = scale_factor
         self.output_dir = Path(output_dir) if output_dir else Path.cwd() / "nyctaxi_data"
         self.year = year
-        self.months = months or list(range(1, 13))
+        self.months = months or self._default_months(year)
         self.seed = seed
         self.rng = np.random.default_rng(seed)
         self.force_redownload = force_redownload
 
-        # Initialize verbosity
-        verbosity_settings = compute_verbosity(verbose, quiet)
-        self.apply_verbosity(verbosity_settings)
-        self.logger = logging.getLogger("benchbox.core.nyctaxi.downloader")
+        self.apply_verbosity(compute_verbosity(verbose, quiet))
+        self.logger = logging.getLogger(self._LOGGER_NAME)
 
-        # Calculate sample rate based on scale factor
-        # SF=1.0 corresponds to ~10% of Yellow Taxi data, which is close to
-        # BenchBox's ~1GB uncompressed baseline once CSV overhead is included.
         self.sample_rate = min(1.0, scale_factor / SCALE_FACTOR_SAMPLE_DIVISOR)
         if self.sample_rate >= 1.0 and scale_factor >= SCALE_FACTOR_SAMPLE_DIVISOR:
             self.logger.warning(
-                "NYC Taxi (Yellow): sample_rate saturated at 1.0 (SF=%.1f). "
+                "NYC Taxi (%s): sample_rate saturated at 1.0 (SF=%.1f). "
                 "Full dataset is in use; no additional scaling beyond SF=%.0f.",
+                self._TAXI_LABEL,
                 scale_factor,
                 SCALE_FACTOR_SAMPLE_DIVISOR,
             )
         self._table_row_counts: dict[str, int] = {}
+
+    def _default_months(self, year: int) -> list[int]:
+        return list(range(1, 13))
+
+    def download(self) -> Path:
+        """Download and process one NYC Taxi trip table."""
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        return self._download_and_process_trips()
+
+    def _download_and_process_trips(self) -> Path:
+        """Download and process trip data with sampling."""
+        output_path = self.output_dir / self.get_compressed_filename(self._OUTPUT_FILENAME)
+
+        if output_path.exists() and not self.force_redownload:
+            self.log_verbose(self._SKIP_EXISTING_MESSAGE)
+            return output_path
+
+        self.log_verbose(f"Downloading {self._DOWNLOAD_LOG_LABEL} data for {self.year}")
+        self.log_verbose(f"  Months: {self.months}")
+        self.log_verbose(f"  Sample rate: {self.sample_rate:.4f}")
+
+        output_columns = type(self)._COLUMN_PROVIDER()
+        trip_id = 0
+        total_rows = 0
+
+        with self.open_output_file(output_path, "wt") as outf:
+            writer = csv.writer(outf)
+            writer.writerow(["trip_id"] + output_columns)
+
+            for month in self.months:
+                url = f"{TLC_BASE_URL}/{self._URL_PREFIX}_{self.year}-{month:02d}.parquet"
+                self.log_verbose(f"  Processing {self.year}-{month:02d}...")
+
+                try:
+                    month_rows = self._process_parquet_file(url, writer, trip_id)
+                    trip_id += month_rows
+                    total_rows += month_rows
+                except Exception as e:
+                    self.logger.warning(f"Failed to process {url}: {e}")
+                    continue
+
+        self._table_row_counts[self._TABLE_NAME] = total_rows
+        self.log_verbose(f"  {self._TABLE_NAME}: {total_rows} rows total")
+        return output_path
+
+    def _process_parquet_file(self, url: str, writer: csv.writer, start_trip_id: int) -> int:
+        """Download and process a single parquet file."""
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:
+            self.logger.warning("pyarrow not installed, using synthetic data")
+            return self._generate_synthetic_month(writer, start_trip_id)
+
+        fd, tmp_name = tempfile.mkstemp(suffix=".parquet")
+        os.close(fd)
+        try:
+            urllib.request.urlretrieve(url, tmp_name)
+            table = pq.read_table(tmp_name)
+            df = table.to_pandas()
+        except Exception as e:
+            self.logger.warning(f"Download failed: {e}, using synthetic data")
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_name)
+            return self._generate_synthetic_month(writer, start_trip_id)
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+
+        if self.sample_rate < 1.0:
+            sample_size = max(1, int(len(df) * self.sample_rate))
+            df = df.sample(n=sample_size, random_state=self.seed)
+
+        rows_written = 0
+        rows_skipped = 0
+        for _idx, row in df.iterrows():
+            try:
+                writer.writerow(self._map_row_to_schema(row, start_trip_id + rows_written))
+                rows_written += 1
+            except Exception:
+                rows_skipped += 1
+                continue
+
+        if rows_skipped:
+            label = self._TAXI_LABEL if self._TAXI_LABEL == "HVFHV" else f"{self._TAXI_LABEL} Taxi"
+            self.logger.debug("Skipped %d malformed rows during %s processing", rows_skipped, label)
+        return rows_written
+
+    @staticmethod
+    def _get_col(row: Any, names: tuple[str, ...], default: Any = None) -> Any:
+        for name in names:
+            if name in row and row[name] is not None:
+                return row[name]
+        return default
+
+    def _map_row_to_schema(self, row, trip_id: int) -> list:
+        columns = type(self)._COLUMN_PROVIDER()
+        return [
+            trip_id,
+            *[
+                self._get_col(row, self._COLUMN_ALIASES.get(column, (column,)), self._COLUMN_DEFAULTS.get(column, 0))
+                for column in columns
+            ],
+        ]
+
+    def _generate_synthetic_month(self, writer: csv.writer, start_trip_id: int) -> int:
+        num_trips = max(self._SYNTHETIC_MIN_TRIPS, int(self._SYNTHETIC_MONTHLY_TRIPS * self.sample_rate * 100))
+        for i in range(num_trips):
+            trip_id = start_trip_id + i
+            hour = int(self.rng.choice(self._SYNTHETIC_HOURS))
+            minute = int(self.rng.integers(0, 60))
+            day = int(self.rng.integers(1, 29))
+            month = int(self.rng.choice(self.months))
+            pickup_time = datetime(self.year, month, day, hour, minute)
+            duration_min = int(self._SYNTHETIC_DURATION_OFFSET + self.rng.exponential(self._SYNTHETIC_DURATION_SCALE))
+            dropoff_time = pickup_time + timedelta(minutes=duration_min)
+            distance = max(0.1, self.rng.exponential(self._SYNTHETIC_DISTANCE_SCALE))
+            fare = 2.50 + distance * 2.50 + duration_min * 0.35
+            self._write_metered_synthetic_row(writer, trip_id, pickup_time, dropoff_time, distance, fare)
+        return num_trips
+
+    def _write_metered_synthetic_row(
+        self,
+        writer: csv.writer,
+        trip_id: int,
+        pickup_time: datetime,
+        dropoff_time: datetime,
+        distance: float,
+        fare: float,
+    ) -> None:
+        is_yellow = self._TAXI_LABEL == "Yellow"
+        zones = self._POPULAR_ZONES if is_yellow else self._OUTER_BOROUGH_ZONES
+        values = {
+            "vendor_id": int(self.rng.choice([1, 2])),
+            "pickup_datetime": pickup_time.strftime("%Y-%m-%d %H:%M:%S"),
+            "dropoff_datetime": dropoff_time.strftime("%Y-%m-%d %H:%M:%S"),
+            "trip_distance": f"{distance:.2f}",
+            "fare_amount": f"{fare:.2f}",
+            "mta_tax": "0.50",
+            "improvement_surcharge": "0.30",
+        }
+        if is_yellow:
+            values["passenger_count"] = int(self.rng.choice([1, 1, 1, 2, 2, 3]))
+        values["pickup_location_id"] = int(self.rng.choice(zones))
+        values["dropoff_location_id"] = int(self.rng.choice(zones))
+        if not is_yellow:
+            values["passenger_count"] = int(self.rng.choice([1, 1, 1, 2, 2]))
+        values["rate_code_id"] = 1
+        values["store_and_fwd_flag"] = "N"
+        if is_yellow:
+            values["payment_type"] = int(self.rng.choice([1, 1, 1, 2]))
+        values["extra"] = f"{self.rng.random() * (2 if is_yellow else 1):.2f}"
+        values["tip_amount"] = f"{fare * 0.15:.2f}" if self.rng.random() > (0.3 if is_yellow else 0.35) else "0.00"
+        values["tolls_amount"] = (
+            f"{self.rng.random() * (5 if is_yellow else 4):.2f}" if self.rng.random() > 0.9 else "0.00"
+        )
+        values["total_amount"] = f"{fare * (1.2 if is_yellow else 1.18):.2f}"
+        if not is_yellow:
+            values["ehail_fee"] = "0.00"
+            values["payment_type"] = int(self.rng.choice([1, 1, 1, 2]))
+            values["trip_type"] = int(self.rng.choice([1, 1, 2]))
+        values["congestion_surcharge"] = "2.50" if self.rng.random() > 0.5 else "0.00"
+        writer.writerow([trip_id, *[values.get(column, "0.00") for column in type(self)._COLUMN_PROVIDER()]])
+
+    def get_download_stats(self) -> dict:
+        stats = {
+            "scale_factor": self.scale_factor,
+            "sample_rate": self.sample_rate,
+            "year": self.year,
+            "months": self.months,
+            "seed": self.seed,
+            "row_counts": dict(self._table_row_counts),
+        }
+        return {"taxi_type": self._STATS_TAXI_TYPE, **stats} if self._STATS_TAXI_TYPE is not None else stats
+
+
+class NYCTaxiDataDownloader(_TripDataDownloader):
+    """Downloads and processes NYC TLC trip data.
+
+    Supports resumable downloads and deterministic sampling for
+    reproducible scale factors.
+    """
+
+    _TABLE_NAME = "trips"
+    _OUTPUT_FILENAME = "trips.csv"
+    _URL_PREFIX = "yellow_tripdata"
+    _LOGGER_NAME = "benchbox.core.nyctaxi.downloader"
+    _TAXI_LABEL = "Yellow"
+    _DOWNLOAD_LOG_LABEL = "NYC Taxi"
+    _SKIP_EXISTING_MESSAGE = "Trips data already exists, skipping"
+    _COLUMN_PROVIDER = get_trips_columns
+    _COLUMN_ALIASES = {
+        "vendor_id": ("VendorID", "vendorid"),
+        "pickup_datetime": ("tpep_pickup_datetime", "pickup_datetime"),
+        "dropoff_datetime": ("tpep_dropoff_datetime", "dropoff_datetime"),
+        "pickup_location_id": ("PULocationID", "pulocationid"),
+        "dropoff_location_id": ("DOLocationID", "dolocationid"),
+        "rate_code_id": ("RatecodeID", "ratecodeid"),
+        "airport_fee": ("airport_fee", "Airport_fee"),
+    }
+    _COLUMN_DEFAULTS = {
+        "vendor_id": 1,
+        "pickup_datetime": "",
+        "dropoff_datetime": "",
+        "passenger_count": 1,
+        "rate_code_id": 1,
+        "store_and_fwd_flag": "N",
+        "payment_type": 1,
+    }
+    _SYNTHETIC_MONTHLY_TRIPS = 10000
+    _SYNTHETIC_MIN_TRIPS = 100
+    _SYNTHETIC_HOURS = (8, 9, 17, 18, 12, 13, 14, 15, 16, 19, 20, 21, 22)
+    _SYNTHETIC_DURATION_OFFSET = 10
+    _SYNTHETIC_DURATION_SCALE = 15.0
+    _SYNTHETIC_DISTANCE_SCALE = 3.0
+    _POPULAR_ZONES = (132, 138, 161, 162, 163, 164, 186, 230, 234, 236, 237, 239)
 
     def download(self) -> dict[str, Path]:
         """Download and process NYC Taxi data.
@@ -121,16 +310,7 @@ class NYCTaxiDataDownloader(CompressionMixin, VerbosityMixin):
             RuntimeError: If download fails
         """
         self.output_dir.mkdir(parents=True, exist_ok=True)
-
-        table_files = {}
-
-        # Generate taxi zones dimension table
-        table_files["taxi_zones"] = self._generate_taxi_zones()
-
-        # Download and process trip data
-        table_files["trips"] = self._download_and_process_trips()
-
-        return table_files
+        return {"taxi_zones": self._generate_taxi_zones(), "trips": self._download_and_process_trips()}
 
     def _generate_taxi_zones(self) -> Path:
         """Generate taxi zones dimension table."""
@@ -145,211 +325,14 @@ class NYCTaxiDataDownloader(CompressionMixin, VerbosityMixin):
         with self.open_output_file(output_path, "wt") as f:
             writer = csv.writer(f)
             writer.writerow(["location_id", "borough", "zone", "service_zone"])
-            for zone in TAXI_ZONES_DATA:
-                writer.writerow(zone)
+            writer.writerows(TAXI_ZONES_DATA)
 
         self._table_row_counts["taxi_zones"] = len(TAXI_ZONES_DATA)
         self.log_verbose(f"  taxi_zones: {len(TAXI_ZONES_DATA)} rows")
         return output_path
 
-    def _download_and_process_trips(self) -> Path:
-        """Download and process trip data with sampling."""
-        output_path = self.output_dir / self.get_compressed_filename("trips.csv")
 
-        if output_path.exists() and not self.force_redownload:
-            self.log_verbose("Trips data already exists, skipping")
-            return output_path
-
-        self.log_verbose(f"Downloading NYC Taxi data for {self.year}")
-        self.log_verbose(f"  Months: {self.months}")
-        self.log_verbose(f"  Sample rate: {self.sample_rate:.4f}")
-
-        # Get column mapping
-        output_columns = get_trips_columns()
-        trip_id = 0
-        total_rows = 0
-
-        with self.open_output_file(output_path, "wt") as outf:
-            writer = csv.writer(outf)
-            # Write header with trip_id
-            writer.writerow(["trip_id"] + output_columns)
-
-            for month in self.months:
-                # Download parquet file for this month
-                url = f"{TLC_BASE_URL}/yellow_tripdata_{self.year}-{month:02d}.parquet"
-                self.log_verbose(f"  Processing {self.year}-{month:02d}...")
-
-                try:
-                    month_rows = self._process_parquet_file(url, writer, trip_id)
-                    trip_id += month_rows
-                    total_rows += month_rows
-                except Exception as e:
-                    self.logger.warning(f"Failed to process {url}: {e}")
-                    continue
-
-        self._table_row_counts["trips"] = total_rows
-        self.log_verbose(f"  trips: {total_rows} rows total")
-        return output_path
-
-    def _process_parquet_file(self, url: str, writer: csv.writer, start_trip_id: int) -> int:
-        """Download and process a single parquet file.
-
-        Args:
-            url: URL to download
-            writer: CSV writer
-            start_trip_id: Starting trip ID
-
-        Returns:
-            Number of rows written
-        """
-        try:
-            import pyarrow.parquet as pq
-        except ImportError:
-            self.logger.warning("pyarrow not installed, using synthetic data")
-            return self._generate_synthetic_month(writer, start_trip_id)
-
-        # Download to temp file.  Use mkstemp so the fd is closed before any
-        # unlink attempt — NamedTemporaryFile keeps the handle open on Windows,
-        # making os.unlink raise WinError 32 from inside the finally block.
-        fd, tmp_name = tempfile.mkstemp(suffix=".parquet")
-        os.close(fd)
-        try:
-            urllib.request.urlretrieve(url, tmp_name)
-            table = pq.read_table(tmp_name)
-            df = table.to_pandas()
-        except Exception as e:
-            self.logger.warning(f"Download failed: {e}, using synthetic data")
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            return self._generate_synthetic_month(writer, start_trip_id)
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_name)
-
-        # Sample data
-        if self.sample_rate < 1.0:
-            sample_size = max(1, int(len(df) * self.sample_rate))
-            df = df.sample(n=sample_size, random_state=self.seed)
-
-        # Map columns to our schema
-        rows_written = 0
-        rows_skipped = 0
-        for idx, row in df.iterrows():
-            try:
-                trip_row = self._map_row_to_schema(row, start_trip_id + rows_written)
-                writer.writerow(trip_row)
-                rows_written += 1
-            except Exception:
-                rows_skipped += 1
-                continue
-
-        if rows_skipped:
-            self.logger.debug("Skipped %d malformed rows during Yellow Taxi processing", rows_skipped)
-        return rows_written
-
-    def _map_row_to_schema(self, row, trip_id: int) -> list:
-        """Map a TLC row to our schema."""
-
-        # Handle different column naming conventions across years
-        def get_col(names: list, default=None):
-            for name in names:
-                if name in row and row[name] is not None:
-                    return row[name]
-            return default
-
-        return [
-            trip_id,
-            get_col(["VendorID", "vendorid"], 1),
-            get_col(["tpep_pickup_datetime", "pickup_datetime"], ""),
-            get_col(["tpep_dropoff_datetime", "dropoff_datetime"], ""),
-            get_col(["passenger_count"], 1),
-            get_col(["trip_distance"], 0),
-            get_col(["PULocationID", "pulocationid"], 0),
-            get_col(["DOLocationID", "dolocationid"], 0),
-            get_col(["RatecodeID", "ratecodeid"], 1),
-            get_col(["store_and_fwd_flag"], "N"),
-            get_col(["payment_type"], 1),
-            get_col(["fare_amount"], 0),
-            get_col(["extra"], 0),
-            get_col(["mta_tax"], 0),
-            get_col(["tip_amount"], 0),
-            get_col(["tolls_amount"], 0),
-            get_col(["improvement_surcharge"], 0),
-            get_col(["congestion_surcharge"], 0),
-            get_col(["airport_fee", "Airport_fee"], 0),
-            get_col(["total_amount"], 0),
-        ]
-
-    def _generate_synthetic_month(self, writer: csv.writer, start_trip_id: int) -> int:
-        """Generate synthetic trip data for one month.
-
-        Used as fallback when real data is unavailable or for testing.
-        """
-        # Generate ~10K trips per month at SF=1
-        num_trips = int(10000 * self.sample_rate * 100)
-        num_trips = max(100, num_trips)
-
-        popular_zones = [132, 138, 161, 162, 163, 164, 186, 230, 234, 236, 237, 239]
-
-        for i in range(num_trips):
-            trip_id = start_trip_id + i
-
-            # Generate realistic trip data
-            hour = int(self.rng.choice([8, 9, 17, 18, 12, 13, 14, 15, 16, 19, 20, 21, 22]))
-            minute = int(self.rng.integers(0, 60))
-            day = int(self.rng.integers(1, 29))
-
-            month = int(self.rng.choice(self.months))
-            pickup_time = datetime(self.year, month, day, hour, minute)
-            duration_min = int(10 + self.rng.exponential(15))
-            dropoff_time = pickup_time + timedelta(minutes=duration_min)
-
-            distance = max(0.1, self.rng.exponential(3.0))
-            fare = 2.50 + distance * 2.50 + duration_min * 0.35
-
-            writer.writerow(
-                [
-                    trip_id,
-                    int(self.rng.choice([1, 2])),  # vendor_id
-                    pickup_time.strftime("%Y-%m-%d %H:%M:%S"),
-                    dropoff_time.strftime("%Y-%m-%d %H:%M:%S"),
-                    int(self.rng.choice([1, 1, 1, 2, 2, 3])),  # passenger_count
-                    f"{distance:.2f}",
-                    int(self.rng.choice(popular_zones)),  # pickup_location
-                    int(self.rng.choice(popular_zones)),  # dropoff_location
-                    1,  # rate_code
-                    "N",  # store_and_fwd
-                    int(self.rng.choice([1, 1, 1, 2])),  # payment_type
-                    f"{fare:.2f}",
-                    f"{self.rng.random() * 2:.2f}",  # extra
-                    "0.50",  # mta_tax
-                    f"{fare * 0.15:.2f}" if self.rng.random() > 0.3 else "0.00",  # tip
-                    f"{self.rng.random() * 5:.2f}" if self.rng.random() > 0.9 else "0.00",  # tolls
-                    "0.30",  # improvement_surcharge
-                    "2.50" if self.rng.random() > 0.5 else "0.00",  # congestion
-                    "0.00",  # airport_fee
-                    f"{fare * 1.2:.2f}",  # total
-                ]
-            )
-
-        return num_trips
-
-    def get_download_stats(self) -> dict:
-        """Get statistics about the download configuration.
-
-        Returns:
-            Statistics dictionary
-        """
-        return {
-            "scale_factor": self.scale_factor,
-            "sample_rate": self.sample_rate,
-            "year": self.year,
-            "months": self.months,
-            "seed": self.seed,
-            "row_counts": dict(self._table_row_counts),
-        }
-
-
-class GreenTaxiDataDownloader(CompressionMixin, VerbosityMixin):
+class GreenTaxiDataDownloader(_TripDataDownloader):
     """Downloads and processes NYC TLC Green Taxi (LPEP) trip data.
 
     Green Taxi operates in outer boroughs and above 96th St in Manhattan.
@@ -357,257 +340,48 @@ class GreenTaxiDataDownloader(CompressionMixin, VerbosityMixin):
     Coverage: 2014-present, ~500K trips/month
     """
 
-    def __init__(
-        self,
-        scale_factor: float = 1.0,
-        output_dir: Union[str, Path] | None = None,
-        year: int = 2019,
-        months: list[int] | None = None,
-        seed: int | None = None,
-        verbose: int | bool = 0,
-        quiet: bool = False,
-        force_redownload: bool = False,
-        **kwargs,
-    ) -> None:
-        super().__init__(**kwargs)
-
-        self.scale_factor = scale_factor
-        self.output_dir = Path(output_dir) if output_dir else Path.cwd() / "nyctaxi_data"
-        self.year = year
-        self.months = months or list(range(1, 13))
-        self.seed = seed
-        self.rng = np.random.default_rng(seed)
-        self.force_redownload = force_redownload
-
-        verbosity_settings = compute_verbosity(verbose, quiet)
-        self.apply_verbosity(verbosity_settings)
-        self.logger = logging.getLogger("benchbox.core.nyctaxi.downloader.green")
-
-        self.sample_rate = min(1.0, scale_factor / SCALE_FACTOR_SAMPLE_DIVISOR)
-        if self.sample_rate >= 1.0 and scale_factor >= SCALE_FACTOR_SAMPLE_DIVISOR:
-            self.logger.warning(
-                "NYC Taxi (Green): sample_rate saturated at 1.0 (SF=%.1f). "
-                "Full dataset is in use; no additional scaling beyond SF=%.0f.",
-                scale_factor,
-                SCALE_FACTOR_SAMPLE_DIVISOR,
-            )
-        self._table_row_counts: dict[str, int] = {}
-
-    def download(self) -> Path:
-        """Download and process Green Taxi data.
-
-        Returns:
-            Path to the generated green_trips CSV file
-        """
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        return self._download_and_process_trips()
-
-    def _download_and_process_trips(self) -> Path:
-        """Download and process Green Taxi trip data with sampling."""
-        output_path = self.output_dir / self.get_compressed_filename("green_trips.csv")
-
-        if output_path.exists() and not self.force_redownload:
-            self.log_verbose("Green trips data already exists, skipping")
-            return output_path
-
-        self.log_verbose(f"Downloading Green Taxi data for {self.year}")
-        self.log_verbose(f"  Months: {self.months}")
-        self.log_verbose(f"  Sample rate: {self.sample_rate:.4f}")
-
-        output_columns = get_green_trips_columns()
-        trip_id = 0
-        total_rows = 0
-
-        with self.open_output_file(output_path, "wt") as outf:
-            writer = csv.writer(outf)
-            writer.writerow(["trip_id"] + output_columns)
-
-            for month in self.months:
-                url = f"{TLC_BASE_URL}/green_tripdata_{self.year}-{month:02d}.parquet"
-                self.log_verbose(f"  Processing {self.year}-{month:02d}...")
-
-                try:
-                    month_rows = self._process_parquet_file(url, writer, trip_id)
-                    trip_id += month_rows
-                    total_rows += month_rows
-                except Exception as e:
-                    self.logger.warning(f"Failed to process {url}: {e}")
-                    continue
-
-        self._table_row_counts["green_trips"] = total_rows
-        self.log_verbose(f"  green_trips: {total_rows} rows total")
-        return output_path
-
-    def _process_parquet_file(self, url: str, writer: csv.writer, start_trip_id: int) -> int:
-        """Download and process a single Green Taxi parquet file."""
-        try:
-            import pyarrow.parquet as pq
-        except ImportError:
-            self.logger.warning("pyarrow not installed, using synthetic data")
-            return self._generate_synthetic_month(writer, start_trip_id)
-
-        fd, tmp_name = tempfile.mkstemp(suffix=".parquet")
-        os.close(fd)
-        try:
-            urllib.request.urlretrieve(url, tmp_name)
-            table = pq.read_table(tmp_name)
-            df = table.to_pandas()
-        except Exception as e:
-            self.logger.warning(f"Download failed: {e}, using synthetic data")
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            return self._generate_synthetic_month(writer, start_trip_id)
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_name)
-
-        if self.sample_rate < 1.0:
-            sample_size = max(1, int(len(df) * self.sample_rate))
-            df = df.sample(n=sample_size, random_state=self.seed)
-
-        rows_written = 0
-        rows_skipped = 0
-        for idx, row in df.iterrows():
-            try:
-                trip_row = self._map_row_to_schema(row, start_trip_id + rows_written)
-                writer.writerow(trip_row)
-                rows_written += 1
-            except Exception:
-                rows_skipped += 1
-                continue
-
-        if rows_skipped:
-            self.logger.debug("Skipped %d malformed rows during Green Taxi processing", rows_skipped)
-        return rows_written
-
-    def _map_row_to_schema(self, row, trip_id: int) -> list:
-        """Map a Green Taxi (LPEP) TLC row to our schema."""
-
-        def get_col(names: list, default=None):
-            for name in names:
-                if name in row and row[name] is not None:
-                    return row[name]
-            return default
-
-        return [
-            trip_id,
-            get_col(["VendorID", "vendorid"], 1),
-            get_col(["lpep_pickup_datetime", "pickup_datetime"], ""),
-            get_col(["lpep_dropoff_datetime", "dropoff_datetime"], ""),
-            get_col(["store_and_fwd_flag"], "N"),
-            get_col(["RatecodeID", "ratecodeid"], 1),
-            get_col(["PULocationID", "pulocationid"], 0),
-            get_col(["DOLocationID", "dolocationid"], 0),
-            get_col(["passenger_count"], 1),
-            get_col(["trip_distance"], 0),
-            get_col(["fare_amount"], 0),
-            get_col(["extra"], 0),
-            get_col(["mta_tax"], 0),
-            get_col(["tip_amount"], 0),
-            get_col(["tolls_amount"], 0),
-            get_col(["ehail_fee"], 0),
-            get_col(["improvement_surcharge"], 0),
-            get_col(["total_amount"], 0),
-            get_col(["payment_type"], 1),
-            get_col(["trip_type"], 1),
-            get_col(["congestion_surcharge"], 0),
-        ]
-
-    def _generate_synthetic_month(self, writer: csv.writer, start_trip_id: int) -> int:
-        """Generate synthetic Green Taxi trip data (outer-borough patterns)."""
-        # Green Taxi volume is ~5x lower than Yellow (~2K/month at SF=1)
-        num_trips = int(2000 * self.sample_rate * 100)
-        num_trips = max(50, num_trips)
-
-        # Outer-borough zones (Brooklyn, Queens, Bronx focus)
-        outer_borough_zones = [
-            7,
-            8,
-            17,
-            21,
-            22,
-            25,
-            26,
-            33,
-            35,
-            36,
-            37,
-            39,
-            40,
-            49,
-            61,
-            62,
-            65,
-            69,
-            74,
-            76,
-            85,
-            103,
-            109,
-            128,
-            129,
-            133,
-            143,
-            181,
-            189,
-            197,
-        ]
-
-        for i in range(num_trips):
-            trip_id = start_trip_id + i
-
-            hour = int(self.rng.choice([7, 8, 9, 17, 18, 19, 12, 13, 14, 15, 16]))
-            minute = int(self.rng.integers(0, 60))
-            day = int(self.rng.integers(1, 29))
-
-            month = int(self.rng.choice(self.months))
-            pickup_time = datetime(self.year, month, day, hour, minute)
-            duration_min = int(8 + self.rng.exponential(12))
-            dropoff_time = pickup_time + timedelta(minutes=duration_min)
-
-            distance = max(0.1, self.rng.exponential(2.5))
-            fare = 2.50 + distance * 2.50 + duration_min * 0.35
-
-            writer.writerow(
-                [
-                    trip_id,
-                    int(self.rng.choice([1, 2])),  # vendor_id
-                    pickup_time.strftime("%Y-%m-%d %H:%M:%S"),
-                    dropoff_time.strftime("%Y-%m-%d %H:%M:%S"),
-                    "N",  # store_and_fwd_flag
-                    1,  # rate_code_id
-                    int(self.rng.choice(outer_borough_zones)),  # pickup_location_id
-                    int(self.rng.choice(outer_borough_zones)),  # dropoff_location_id
-                    int(self.rng.choice([1, 1, 1, 2, 2])),  # passenger_count
-                    f"{distance:.2f}",
-                    f"{fare:.2f}",
-                    f"{self.rng.random() * 1:.2f}",  # extra
-                    "0.50",  # mta_tax
-                    f"{fare * 0.15:.2f}" if self.rng.random() > 0.35 else "0.00",  # tip
-                    f"{self.rng.random() * 4:.2f}" if self.rng.random() > 0.9 else "0.00",  # tolls
-                    "0.00",  # ehail_fee
-                    "0.30",  # improvement_surcharge
-                    f"{fare * 1.18:.2f}",  # total_amount
-                    int(self.rng.choice([1, 1, 1, 2])),  # payment_type
-                    int(self.rng.choice([1, 1, 2])),  # trip_type (1=street-hail, 2=dispatch)
-                    "2.50" if self.rng.random() > 0.5 else "0.00",  # congestion_surcharge
-                ]
-            )
-
-        return num_trips
-
-    def get_download_stats(self) -> dict:
-        return {
-            "taxi_type": "green",
-            "scale_factor": self.scale_factor,
-            "sample_rate": self.sample_rate,
-            "year": self.year,
-            "months": self.months,
-            "seed": self.seed,
-            "row_counts": dict(self._table_row_counts),
-        }
+    _TABLE_NAME = "green_trips"
+    _OUTPUT_FILENAME = "green_trips.csv"
+    _URL_PREFIX = "green_tripdata"
+    _LOGGER_NAME = "benchbox.core.nyctaxi.downloader.green"
+    _TAXI_LABEL = "Green"
+    _DOWNLOAD_LOG_LABEL = "Green Taxi"
+    _SKIP_EXISTING_MESSAGE = "Green trips data already exists, skipping"
+    _COLUMN_PROVIDER = get_green_trips_columns
+    _STATS_TAXI_TYPE = "green"
+    _COLUMN_ALIASES = {
+        "vendor_id": ("VendorID", "vendorid"),
+        "pickup_datetime": ("lpep_pickup_datetime", "pickup_datetime"),
+        "dropoff_datetime": ("lpep_dropoff_datetime", "dropoff_datetime"),
+        "rate_code_id": ("RatecodeID", "ratecodeid"),
+        "pickup_location_id": ("PULocationID", "pulocationid"),
+        "dropoff_location_id": ("DOLocationID", "dolocationid"),
+    }
+    _COLUMN_DEFAULTS = {
+        "vendor_id": 1,
+        "pickup_datetime": "",
+        "dropoff_datetime": "",
+        "store_and_fwd_flag": "N",
+        "rate_code_id": 1,
+        "passenger_count": 1,
+        "payment_type": 1,
+        "trip_type": 1,
+    }
+    _SYNTHETIC_MONTHLY_TRIPS = 2000
+    _SYNTHETIC_MIN_TRIPS = 50
+    _SYNTHETIC_HOURS = (7, 8, 9, 17, 18, 19, 12, 13, 14, 15, 16)
+    _SYNTHETIC_DURATION_OFFSET = 8
+    _SYNTHETIC_DURATION_SCALE = 12.0
+    _SYNTHETIC_DISTANCE_SCALE = 2.5
+    _OUTER_BOROUGH_ZONES = (
+        tuple(range(7, 9))
+        + (17, 21, 22, 25, 26, 33)
+        + tuple(range(35, 38))
+        + (39, 40, 49, 61, 62, 65, 69, 74, 76, 85, 103, 109, 128, 129, 133, 143, 181, 189, 197)
+    )
 
 
-class HVFHVDataDownloader(CompressionMixin, VerbosityMixin):
+class HVFHVDataDownloader(_TripDataDownloader):
     """Downloads and processes NYC TLC High Volume For-Hire Vehicle (HVFHV) trip data.
 
     HVFHV covers Uber, Lyft, Via, and Juno - the app-based rideshare companies.
@@ -617,179 +391,39 @@ class HVFHVDataDownloader(CompressionMixin, VerbosityMixin):
     """
 
     # HVFHV data only available from Feb 2019
-    HVFHV_START_YEAR = 2019
-    HVFHV_START_MONTH = 2
+    HVFHV_START_YEAR, HVFHV_START_MONTH = 2019, 2
+    HVFHV_LICENSE_NUMS = {"HV0002": "Juno", "HV0003": "Uber", "HV0004": "Via", "HV0005": "Lyft"}
 
-    # TLC license numbers for major HVFHV bases
-    HVFHV_LICENSE_NUMS = {
-        "HV0002": "Juno",
-        "HV0003": "Uber",
-        "HV0004": "Via",
-        "HV0005": "Lyft",
+    _TABLE_NAME = "hvfhv_trips"
+    _OUTPUT_FILENAME = "hvfhv_trips.csv"
+    _URL_PREFIX = "fhvhv_tripdata"
+    _LOGGER_NAME = "benchbox.core.nyctaxi.downloader.hvfhv"
+    _TAXI_LABEL = "HVFHV"
+    _DOWNLOAD_LOG_LABEL = "HVFHV"
+    _SKIP_EXISTING_MESSAGE = "HVFHV trips data already exists, skipping"
+    _COLUMN_PROVIDER = get_hvfhv_trips_columns
+    _STATS_TAXI_TYPE = "hvfhv"
+    _COLUMN_ALIASES = {
+        "pickup_location_id": ("PULocationID", "pulocationid"),
+        "dropoff_location_id": ("DOLocationID", "dolocationid"),
+    }
+    _COLUMN_DEFAULTS = {
+        "hvfhs_license_num": "HV0003",
+        "dispatching_base_num": "",
+        "originating_base_num": "",
+        "request_datetime": "",
+        "on_scene_datetime": "",
+        "pickup_datetime": "",
+        "dropoff_datetime": "",
+        "shared_request_flag": "N",
+        "shared_match_flag": "N",
+        "access_a_ride_flag": "N",
+        "wav_request_flag": "N",
+        "wav_match_flag": "N",
     }
 
-    def __init__(
-        self,
-        scale_factor: float = 1.0,
-        output_dir: Union[str, Path] | None = None,
-        year: int = 2019,
-        months: list[int] | None = None,
-        seed: int | None = None,
-        verbose: int | bool = 0,
-        quiet: bool = False,
-        force_redownload: bool = False,
-        **kwargs,
-    ) -> None:
-        super().__init__(**kwargs)
-
-        self.scale_factor = scale_factor
-        self.output_dir = Path(output_dir) if output_dir else Path.cwd() / "nyctaxi_data"
-        self.year = year
-        # HVFHV starts Feb 2019 - skip Jan 2019 if year==2019
-        default_months = list(range(1, 13))
-        if year == self.HVFHV_START_YEAR:
-            default_months = list(range(self.HVFHV_START_MONTH, 13))
-        self.months = months or default_months
-        self.seed = seed
-        self.rng = np.random.default_rng(seed)
-        self.force_redownload = force_redownload
-
-        verbosity_settings = compute_verbosity(verbose, quiet)
-        self.apply_verbosity(verbosity_settings)
-        self.logger = logging.getLogger("benchbox.core.nyctaxi.downloader.hvfhv")
-
-        self.sample_rate = min(1.0, scale_factor / SCALE_FACTOR_SAMPLE_DIVISOR)
-        if self.sample_rate >= 1.0 and scale_factor >= SCALE_FACTOR_SAMPLE_DIVISOR:
-            self.logger.warning(
-                "NYC Taxi (HVFHV): sample_rate saturated at 1.0 (SF=%.1f). "
-                "Full dataset is in use; no additional scaling beyond SF=%.0f.",
-                scale_factor,
-                SCALE_FACTOR_SAMPLE_DIVISOR,
-            )
-        self._table_row_counts: dict[str, int] = {}
-
-    def download(self) -> Path:
-        """Download and process HVFHV data.
-
-        Returns:
-            Path to the generated hvfhv_trips CSV file
-        """
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        return self._download_and_process_trips()
-
-    def _download_and_process_trips(self) -> Path:
-        """Download and process HVFHV trip data with sampling."""
-        output_path = self.output_dir / self.get_compressed_filename("hvfhv_trips.csv")
-
-        if output_path.exists() and not self.force_redownload:
-            self.log_verbose("HVFHV trips data already exists, skipping")
-            return output_path
-
-        self.log_verbose(f"Downloading HVFHV data for {self.year}")
-        self.log_verbose(f"  Months: {self.months}")
-        self.log_verbose(f"  Sample rate: {self.sample_rate:.4f}")
-
-        output_columns = get_hvfhv_trips_columns()
-        trip_id = 0
-        total_rows = 0
-
-        with self.open_output_file(output_path, "wt") as outf:
-            writer = csv.writer(outf)
-            writer.writerow(["trip_id"] + output_columns)
-
-            for month in self.months:
-                url = f"{TLC_BASE_URL}/fhvhv_tripdata_{self.year}-{month:02d}.parquet"
-                self.log_verbose(f"  Processing {self.year}-{month:02d}...")
-
-                try:
-                    month_rows = self._process_parquet_file(url, writer, trip_id)
-                    trip_id += month_rows
-                    total_rows += month_rows
-                except Exception as e:
-                    self.logger.warning(f"Failed to process {url}: {e}")
-                    continue
-
-        self._table_row_counts["hvfhv_trips"] = total_rows
-        self.log_verbose(f"  hvfhv_trips: {total_rows} rows total")
-        return output_path
-
-    def _process_parquet_file(self, url: str, writer: csv.writer, start_trip_id: int) -> int:
-        """Download and process a single HVFHV parquet file."""
-        try:
-            import pyarrow.parquet as pq
-        except ImportError:
-            self.logger.warning("pyarrow not installed, using synthetic data")
-            return self._generate_synthetic_month(writer, start_trip_id)
-
-        fd, tmp_name = tempfile.mkstemp(suffix=".parquet")
-        os.close(fd)
-        try:
-            urllib.request.urlretrieve(url, tmp_name)
-            table = pq.read_table(tmp_name)
-            df = table.to_pandas()
-        except Exception as e:
-            self.logger.warning(f"Download failed: {e}, using synthetic data")
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            return self._generate_synthetic_month(writer, start_trip_id)
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_name)
-
-        if self.sample_rate < 1.0:
-            sample_size = max(1, int(len(df) * self.sample_rate))
-            df = df.sample(n=sample_size, random_state=self.seed)
-
-        rows_written = 0
-        rows_skipped = 0
-        for idx, row in df.iterrows():
-            try:
-                trip_row = self._map_row_to_schema(row, start_trip_id + rows_written)
-                writer.writerow(trip_row)
-                rows_written += 1
-            except Exception:
-                rows_skipped += 1
-                continue
-
-        if rows_skipped:
-            self.logger.debug("Skipped %d malformed rows during HVFHV processing", rows_skipped)
-        return rows_written
-
-    def _map_row_to_schema(self, row, trip_id: int) -> list:
-        """Map an HVFHV TLC row to our schema."""
-
-        def get_col(names: list, default=None):
-            for name in names:
-                if name in row and row[name] is not None:
-                    return row[name]
-            return default
-
-        return [
-            trip_id,
-            get_col(["hvfhs_license_num"], "HV0003"),
-            get_col(["dispatching_base_num"], ""),
-            get_col(["originating_base_num"], ""),
-            get_col(["request_datetime"], ""),
-            get_col(["on_scene_datetime"], ""),
-            get_col(["pickup_datetime"], ""),
-            get_col(["dropoff_datetime"], ""),
-            get_col(["PULocationID", "pulocationid"], 0),
-            get_col(["DOLocationID", "dolocationid"], 0),
-            get_col(["trip_miles"], 0),
-            get_col(["trip_time"], 0),
-            get_col(["base_passenger_fare"], 0),
-            get_col(["tolls"], 0),
-            get_col(["bcf"], 0),
-            get_col(["sales_tax"], 0),
-            get_col(["congestion_surcharge"], 0),
-            get_col(["airport_fee"], 0),
-            get_col(["tips"], 0),
-            get_col(["driver_pay"], 0),
-            get_col(["shared_request_flag"], "N"),
-            get_col(["shared_match_flag"], "N"),
-            get_col(["access_a_ride_flag"], "N"),
-            get_col(["wav_request_flag"], "N"),
-            get_col(["wav_match_flag"], "N"),
-        ]
+    def _default_months(self, year: int) -> list[int]:
+        return list(range(self.HVFHV_START_MONTH if year == self.HVFHV_START_YEAR else 1, 13))
 
     def _generate_synthetic_month(self, writer: csv.writer, start_trip_id: int) -> int:
         """Generate synthetic HVFHV trip data (app-based rideshare patterns).
@@ -797,8 +431,7 @@ class HVFHVDataDownloader(CompressionMixin, VerbosityMixin):
         HVFHV is citywide with high volume (~25M/month real data).
         At SF=1.0 we generate ~25K synthetic trips/month.
         """
-        num_trips = int(25000 * self.sample_rate * 100)
-        num_trips = max(100, num_trips)
+        num_trips = max(100, int(25000 * self.sample_rate * 100))
 
         # All NYC zones - HVFHV is truly citywide
         all_zones = list(range(1, 263))
@@ -835,41 +468,30 @@ class HVFHVDataDownloader(CompressionMixin, VerbosityMixin):
                 [
                     trip_id,
                     license_num,
-                    base_num,  # dispatching_base_num
-                    base_num,  # originating_base_num
+                    base_num,
+                    base_num,
                     request_time.strftime("%Y-%m-%d %H:%M:%S"),
                     on_scene_time.strftime("%Y-%m-%d %H:%M:%S"),
                     pickup_time.strftime("%Y-%m-%d %H:%M:%S"),
                     dropoff_time.strftime("%Y-%m-%d %H:%M:%S"),
                     int(self.rng.choice(all_zones)),  # pickup_location_id
                     int(self.rng.choice(all_zones)),  # dropoff_location_id
-                    f"{distance:.2f}",  # trip_miles
-                    int(duration_min * 60),  # trip_time (seconds)
-                    f"{base_fare:.2f}",  # base_passenger_fare
+                    f"{distance:.2f}",
+                    int(duration_min * 60),
+                    f"{base_fare:.2f}",
                     f"{self.rng.random() * 4:.2f}" if self.rng.random() > 0.9 else "0.00",  # tolls
-                    f"{base_fare * 0.025:.2f}",  # bcf (2.5% Black Car Fund)
-                    f"{base_fare * 0.089:.2f}",  # sales_tax (8.875%)
+                    f"{base_fare * 0.025:.2f}",
+                    f"{base_fare * 0.089:.2f}",
                     "2.75" if self.rng.random() > 0.5 else "0.00",  # congestion_surcharge
-                    "0.00",  # airport_fee
+                    "0.00",
                     f"{base_fare * 0.20:.2f}" if self.rng.random() > 0.55 else "0.00",  # tips
-                    f"{base_fare * 0.60:.2f}",  # driver_pay
-                    "Y" if is_shared else "N",  # shared_request_flag
+                    f"{base_fare * 0.60:.2f}",
+                    "Y" if is_shared else "N",
                     "Y" if (is_shared and self.rng.random() > 0.5) else "N",  # shared_match_flag
-                    "N",  # access_a_ride_flag
+                    "N",
                     "Y" if self.rng.random() > 0.95 else "N",  # wav_request_flag
                     "Y" if self.rng.random() > 0.97 else "N",  # wav_match_flag
                 ]
             )
 
         return num_trips
-
-    def get_download_stats(self) -> dict:
-        return {
-            "taxi_type": "hvfhv",
-            "scale_factor": self.scale_factor,
-            "sample_rate": self.sample_rate,
-            "year": self.year,
-            "months": self.months,
-            "seed": self.seed,
-            "row_counts": dict(self._table_row_counts),
-        }


### PR DESCRIPTION
---
iteration: shrink-nyctaxi-downloader-lifecycle
date: 2026-05-24
surface: NYC Taxi downloader lifecycle
branch: chore/shrink-nyctaxi-downloader-lifecycle
pr:
raw_cloc_delta: 250
credited_reduction: 250
uncredited_relocation: 0
repair_only_delta: 0
generated_python_delta: 0
moved_content: logic
decision_gate: conservative default
verification:
  - make shrink-rollup
  - cloc --include-lang=Python benchbox/
  - cloc --by-file --include-lang=Python benchbox/core/nyctaxi/downloader.py
  - make duplicate-check-json
  - uv run -- python scripts/check_complexity.py --source-root benchbox/core/nyctaxi --no-fail --top 20
  - uv run -- ruff check benchbox/core/nyctaxi/downloader.py tests/unit/core/nyctaxi/test_downloader.py tests/unit/core/nyctaxi/test_multi_type.py tests/unit/generators/test_scale_factor_harmonization.py
  - uv run -- python -m pytest tests/unit/core/nyctaxi/test_downloader.py tests/unit/core/nyctaxi/test_multi_type.py tests/unit/generators/test_scale_factor_harmonization.py -q -n 0
  - uv run -- python - <<'PY' ... # manual NYC Taxi downloader fingerprint
  - make pr-preflight
---

## Thesis

Shrink iteration under the smaller-subsystem exception. The NYC Taxi downloader
lifecycle subsystem is `benchbox/core/nyctaxi/downloader.py`, measured at 632
Python code lines before edits. The final file is 382 Python code lines, for a
250-line credited maintained-Python reduction. This meets the smaller-subsystem
floor: at least 250 credited lines and at least 10% of the subsystem.

The three public downloader classes stay explicit and grep-findable:
`NYCTaxiDataDownloader`, `GreenTaxiDataDownloader`, and `HVFHVDataDownloader`.
The repeated lifecycle around initialization, sample-rate saturation warnings,
trip-file output, monthly parquet download, sampling, row writing, malformed-row
logging, and stats construction moved into a private shared base. The
taxi-type-specific behavior remains on the concrete classes: public return
types, table names, filenames, URL prefixes, logger names, warning labels,
column providers, row-mapping aliases/defaults, synthetic generation
parameters/row writers, and HVFHV February 2019 default-month behavior.

Credited reduction is the net maintained-Python cloc reduction after adding the
private helper/base code. There is no Python-to-data relocation, generated
Python, SQL/query movement, benchmark deletion, platform deletion, or
deprecated/beta-public surface removal.

## Guardrail Evidence

- Iteration type: shrink iteration, smaller-subsystem exception.
- Subsystem: `benchbox/core/nyctaxi/downloader.py`; baseline 632 Python cloc,
  below the 1,000-line smaller-subsystem cap.
- Minimum gate: remove at least 250 credited Python lines and at least 10% of
  the subsystem. Final measurement is 250 lines, 39.6% of the subsystem.
- Moved-content classification: logic consolidation only.
- Decision-gate status: conservative default. No open policy gate is used to
  approve relocation, generated implementation, or dynamic symbol injection.
- Public/exported surface: all three downloader class names, constructor
  signatures, and module imports remain explicit.
- Open PR overlap: after PR #617 merged, `gh pr list --state open --base
  develop --json number,title,headRefName,baseRefName,state,mergeStateStatus
  --limit 30` returned `[]`.
- Baseline duplicate evidence: `make duplicate-check-json` reports duplicated
  NYC Taxi downloader blocks in `_process_parquet_file` (3 x 54),
  `_download_and_process_trips` (3 x 38), `__init__` (2 x 52), and
  `get_download_stats` (3 x 14).
- Baseline complexity evidence: `uv run -- python scripts/check_complexity.py
  --source-root benchbox/core/nyctaxi --no-fail --top 20` passed with
  downloader lifecycle functions at CC 7 and 4.
- Baseline behavior evidence: `uv run -- python -m pytest
  tests/unit/core/nyctaxi/test_downloader.py
  tests/unit/core/nyctaxi/test_multi_type.py
  tests/unit/generators/test_scale_factor_harmonization.py -q -n 0` reported
  91 passed before edits.

## Verification

- `make shrink-rollup` before edits: cumulative merged credited reduction 252;
  remaining floor 11,748, stretch 18,748.
- `cloc --include-lang=Python benchbox/`: 206,352 Python code lines after the
  slice, down from the 206,602 pre-edit sanity measurement on this branch.
- `cloc --by-file --include-lang=Python benchbox/core/nyctaxi/downloader.py`:
  382 code lines after the slice, down from 632 before the slice.
- `make duplicate-check-json`: no duplicate groups remain for
  `benchbox/core/nyctaxi/downloader.py`; repo duplicate summary moved from 306
  groups / 414 instances / 7,730 duplicated lines to 301 groups / 406
  instances / 7,435 duplicated lines.
- `uv run -- python scripts/check_complexity.py --source-root
  benchbox/core/nyctaxi --no-fail --top 20`: passed; downloader lifecycle
  worst CC remains 7, with `_write_metered_synthetic_row` at 5 and
  `_download_and_process_trips` at 4.
- `uv run -- ruff check benchbox/core/nyctaxi/downloader.py
  tests/unit/core/nyctaxi/test_downloader.py
  tests/unit/core/nyctaxi/test_multi_type.py
  tests/unit/generators/test_scale_factor_harmonization.py`: passed.
- `uv run -- python -m pytest tests/unit/core/nyctaxi/test_downloader.py
  tests/unit/core/nyctaxi/test_multi_type.py
  tests/unit/generators/test_scale_factor_harmonization.py -q -n 0`: 91
  passed.
- Manual pre/post fingerprint against `origin/develop` matched exactly for all
  three public downloader classes: constructor signature, logger name, explicit
  months, sample rate, stats shape, deterministic synthetic row count, first
  rows, synthetic SHA-256, and HVFHV default months for 2019 and 2020.
- `make pr-preflight`: passed; broad fast suite reported 22,775 passed, 5
  skipped, 47 warnings, and 4 subtests passed.

## Residual Risk

The main risk is collapsing superficially identical download lifecycle code
that still carries type-specific behavior. Those differences are kept in
explicit class attributes or methods, and verification fingerprints public
constructor defaults, logger names, table/file names, URL patterns, stats
shape, and deterministic synthetic output for all three downloaders.

## Next Target

If this slice lands with credit, continue through another duplicate-maintenance
surface with no benchmark/platform deletion. If it misses the smaller-subsystem
threshold, reject it and move to a larger true-dedup target.
