### PR TITLE
Shrink TPC-Havoc DataFrame variant boilerplate

### DIFF
--- a/_project/shrink-ledger/shrink-tpchavoc-df-variant-boilerplate.md
+++ b/_project/shrink-ledger/shrink-tpchavoc-df-variant-boilerplate.md
@@ -1,0 +1,106 @@
+---
+iteration: shrink-tpchavoc-df-variant-boilerplate
+date: 2026-05-25
+surface: TPC-Havoc DataFrame variant boilerplate
+branch: chore/shrink-tpchavoc-df-variant-boilerplate
+pr:
+raw_cloc_delta: 517
+credited_reduction: 517
+uncredited_relocation: 0
+repair_only_delta: 0
+generated_python_delta: 0
+moved_content: logic
+decision_gate: conservative default
+verification:
+  - make shrink-rollup
+  - cloc --include-lang=Python benchbox/
+  - cloc --include-lang=Python benchbox/core/tpchavoc/dataframe_queries
+  - uv run -- python -m pytest tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0
+  - manual TPC-Havoc registry/callable fingerprint before and after
+  - rg reference check for TPC-Havoc DataFrame registry and implementation symbols
+---
+
+## Thesis
+
+Shrink iteration. The slice targets `benchbox/core/tpchavoc/dataframe_queries/`,
+currently 5,690 maintained-Python code lines. The reduction path is true
+boilerplate deduplication:
+
+- centralize repeated `DataFrameQuery` variant construction that is copied
+  across the YAML-backed TPC-Havoc query modules, and
+- replace exact duplicate variant implementation bodies, plus one reviewed
+  step-for-step duplicate pandas body, with explicit named delegates to the
+  identical current operation.
+
+Most duplicated implementation candidates are exact AST matches after removing
+docstrings, not heuristic similarity. The only non-AST replacement is
+`q2_v8_pandas_impl`, which was reviewed against `q2_v7_pandas_impl` and has the
+same table reads, filters, joins, aggregation, projection, sort, and limit. The
+slice keeps every query id, description, category, implementation callable name,
+qualname, module, expected row metadata, timeout, and skip-platform list pinned
+by a pre/post fingerprint.
+
+No benchmarks, platforms, deprecated/beta-public surfaces, generated Python, or
+Python-to-data relocation are removed. YAML metadata already exists and remains
+unchanged; this PR does not create a new catalog migration. The expected credited
+reduction is above the 500-line shrink-iteration floor after combining the
+registry-construction boilerplate and exact duplicate implementation bodies.
+
+## Guardrail evidence
+
+- Campaign rollup before editing: 1,324 merged credited lines, 10,676 remaining
+  to the committed floor, 17,676 remaining to stretch.
+- Raw maintained Python before editing: `cloc --include-lang=Python benchbox/`
+  reports 930 files and 205,530 code lines.
+- Target surface before editing: `cloc --include-lang=Python
+  benchbox/core/tpchavoc/dataframe_queries` reports 26 files and 5,690 code
+  lines.
+- Open PR overlap: `gh pr list --state open --base develop --json ...` returned
+  `[]`.
+- Baseline fingerprint:
+  `/tmp/shrink-tpchavoc-baseline-fingerprint.json`, SHA256
+  `a343ca49b611465776b9458477f39c93b3111d7d8c2b475e6e29c39544a81f1e`.
+- Exact duplicate scan:
+  `/tmp/shrink-tpchavoc-duplicate-candidates.txt` found 15 large exact-body
+  replacements with estimated source-span savings of 396 lines before the
+  shared registry-builder reduction.
+- Baseline focused tests:
+  `uv run -- python -m pytest
+  tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0` passed
+  with 33 tests and 1 pre-existing warning.
+
+## Verification
+
+- `cloc --include-lang=Python benchbox/`: 930 files, 205,013 code lines;
+  raw maintained-Python delta 517 lines.
+- `cloc --include-lang=Python benchbox/core/tpchavoc/dataframe_queries`: 26
+  files, 5,173 code lines; target-surface delta 517 lines.
+- `uv run -- ruff check benchbox/core/tpchavoc/dataframe_queries`: passed.
+- `uv run -- ruff format --check benchbox/core/tpchavoc/dataframe_queries`:
+  passed; 26 files already formatted.
+- `uv run -- python -m pytest
+  tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0`: 33
+  passed, 1 pre-existing warning.
+- Post-edit fingerprint:
+  `/tmp/shrink-tpchavoc-post-fingerprint.json`, SHA256
+  `a343ca49b611465776b9458477f39c93b3111d7d8c2b475e6e29c39544a81f1e`,
+  byte-identical to the baseline fingerprint.
+- Whole-tree reference check:
+  `/tmp/shrink-tpchavoc-reference-check.log` captured 546 references across
+  `benchbox`, `tests`, and `docs`; `_project` had no additional matches.
+- `make pr-preflight`: passed; log retained at
+  `/tmp/shrink-tpchavoc-pr-preflight.log` with 32,907 lines. Fast test summary:
+  22,775 passed, 5 skipped, 47 warnings, 4 subtests passed.
+
+## Residual risk
+
+The main risk is benchmark-shape drift for TPC-Havoc variants. This slice limits
+implementation-body replacement to exact duplicate bodies and keeps callable
+identity metadata pinned. Delegate wrappers add one Python call for duplicated
+variants; the measured DataFrame operation is unchanged because the delegated
+implementation is byte-for-byte equivalent to the current variant body.
+
+## Next target
+
+After this PR merges, re-run `make shrink-rollup` and continue through another
+explicit duplicate-maintenance surface that does not overlap open shrink PRs.

--- a/benchbox/core/tpchavoc/dataframe_queries/loader.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/loader.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
+
 VariantImpl = Callable[..., Any]
+
+AGG_FILTER = (QueryCategory.AGGREGATE, QueryCategory.FILTER)
+AGG_GROUP_FILTER = (QueryCategory.AGGREGATE, QueryCategory.GROUP_BY, QueryCategory.FILTER)
+JOIN_AGG_FILTER = (QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER)
+JOIN_AGG_GROUP_BY = (QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.GROUP_BY)
+JOIN_AGG_SORT = (QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SORT)
+JOIN_AGG_SUBQUERY = (QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SUBQUERY)
+JOIN_SUBQUERY_SORT = (QueryCategory.JOIN, QueryCategory.SUBQUERY, QueryCategory.SORT)
 
 
 def load_variant_specs(
@@ -24,3 +34,34 @@ def load_variant_specs(
         pairs.append((namespace[entry["expression_impl"]], namespace[entry["pandas_impl"]]))
         descriptions.append(entry["description"])
     return pairs, descriptions
+
+
+def build_variants(
+    query_number: int,
+    impl_pairs: Sequence[tuple[VariantImpl, VariantImpl]],
+    descriptions: Sequence[str],
+    categories: Sequence[QueryCategory],
+) -> list[DataFrameQuery]:
+    """Build TPC-Havoc DataFrame variants from already-resolved impl pairs."""
+    return [
+        DataFrameQuery(
+            query_id=f"Q{query_number}v{variant}",
+            query_name=f"TPC-H Q{query_number} Variant {variant}",
+            description=descriptions[variant - 1],
+            categories=list(categories),
+            expression_impl=expr_impl,
+            pandas_impl=pandas_impl,
+        )
+        for variant, (expr_impl, pandas_impl) in enumerate(impl_pairs, start=1)
+    ]
+
+
+def build_yaml_variants(
+    module_file: str,
+    namespace: dict[str, Any],
+    query_number: int,
+    categories: Sequence[QueryCategory],
+) -> list[DataFrameQuery]:
+    """Build TPC-Havoc variants from the YAML file next to a query module."""
+    impl_pairs, descriptions = load_variant_specs(module_file, namespace)
+    return build_variants(query_number, impl_pairs, descriptions, categories)

--- a/benchbox/core/tpchavoc/dataframe_queries/q01.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q01.py
@@ -11,12 +11,12 @@ from collections.abc import Callable
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q1_expression_impl as _q1_expr_base,
     q1_pandas_impl as _q1_pandas_base,
 )
+from benchbox.core.tpchavoc.dataframe_queries.loader import AGG_GROUP_FILTER, build_variants
 
 VariantImpl = Callable[[DataFrameContext], Any]
 
@@ -263,14 +263,4 @@ _IMPL_PAIRS = [
     (q1_v10_expression_impl, q1_v10_pandas_impl),
 ]
 
-Q1_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q1v{variant}",
-        query_name=f"TPC-H Q1 Variant {variant}",
-        description=_DESCRIPTIONS[variant - 1],
-        categories=[QueryCategory.AGGREGATE, QueryCategory.GROUP_BY, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for variant, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q1_VARIANTS = build_variants(1, _IMPL_PAIRS, _DESCRIPTIONS, AGG_GROUP_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q02.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q02.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q2_expression_impl as _q2_expr_base,
     q2_pandas_impl as _q2_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_SUBQUERY_SORT, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -295,41 +294,7 @@ def q2_v4_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q2_v5_expression_impl(ctx: DataFrameContext) -> Any:
-    part = ctx.get_table("part")
-    supplier = ctx.get_table("supplier")
-    partsupp = ctx.get_table("partsupp")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(2)
-    size = params["size"]
-    type_suffix = params["type_suffix"]
-    region_name = params["region_name"]
-
-    min_cost_per_part = (
-        partsupp.join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .join(region, left_on="n_regionkey", right_on="r_regionkey")
-        .filter(col("r_name") == lit(region_name))
-        .group_by("ps_partkey")
-        .agg(col("ps_supplycost").min().alias("min_cost"))
-    )
-
-    return (
-        part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
-        .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
-        .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .join(region, left_on="n_regionkey", right_on="r_regionkey")
-        .filter(col("r_name") == lit(region_name))
-        .join(min_cost_per_part, left_on="p_partkey", right_on="ps_partkey")
-        .filter(col("ps_supplycost") == col("min_cost"))
-        .select("s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment")
-        .sort(["s_acctbal", "n_name", "s_name", "p_partkey"], descending=[True, False, False, False])
-        .limit(100)
-    )
+    return _q2_expr_base(ctx)
 
 
 def q2_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -499,37 +464,7 @@ def q2_v8_expression_impl(ctx: DataFrameContext) -> Any:
 
 
 def q2_v8_pandas_impl(ctx: DataFrameContext) -> Any:
-    part = ctx.get_table("part")
-    supplier = ctx.get_table("supplier")
-    partsupp = ctx.get_table("partsupp")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-
-    params = get_tpch_parameters(2)
-    size = params["size"]
-    type_suffix = params["type_suffix"]
-    region_name = params["region_name"]
-
-    europe_region = region[region["r_name"] == region_name]
-    europe_nations = europe_region.merge(nation, left_on="r_regionkey", right_on="n_regionkey")
-    europe_suppliers = europe_nations.merge(supplier, left_on="n_nationkey", right_on="s_nationkey")
-    supplier_parts = europe_suppliers.merge(partsupp, left_on="s_suppkey", right_on="ps_suppkey")
-    min_cost = supplier_parts.groupby("ps_partkey", as_index=False).agg(min_cost=("ps_supplycost", "min"))
-
-    # Combined size+type filter in single boolean
-    filtered_part = part[(part["p_size"] == size) & part["p_type"].str.endswith(type_suffix)]
-    joined = filtered_part.merge(partsupp, left_on="p_partkey", right_on="ps_partkey")
-    joined = joined.merge(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-    joined = joined.merge(nation, left_on="s_nationkey", right_on="n_nationkey")
-    joined = joined.merge(region, left_on="n_regionkey", right_on="r_regionkey")
-    joined = joined[joined["r_name"] == region_name]
-    joined = joined.merge(min_cost, left_on="p_partkey", right_on="ps_partkey")
-    joined = joined[joined["ps_supplycost"] == joined["min_cost"]]
-    return (
-        joined[["s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment"]]
-        .sort_values(["s_acctbal", "n_name", "s_name", "p_partkey"], ascending=[False, True, True, True])
-        .head(100)
-    )
+    return q2_v7_pandas_impl(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -538,44 +473,7 @@ def q2_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q2_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    part = ctx.get_table("part")
-    supplier = ctx.get_table("supplier")
-    partsupp = ctx.get_table("partsupp")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(2)
-    size = params["size"]
-    type_suffix = params["type_suffix"]
-    region_name = params["region_name"]
-
-    min_cost_per_part = (
-        partsupp.join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .join(region, left_on="n_regionkey", right_on="r_regionkey")
-        .filter(col("r_name") == lit(region_name))
-        .group_by("ps_partkey")
-        .agg(col("ps_supplycost").min().alias("min_cost"))
-    )
-
-    return (
-        part.filter((col("p_size") == lit(size)) & col("p_type").str.ends_with(type_suffix))
-        .join(partsupp, left_on="p_partkey", right_on="ps_partkey")
-        .join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .join(region, left_on="n_regionkey", right_on="r_regionkey")
-        .filter(col("r_name") == lit(region_name))
-        .join(min_cost_per_part, left_on="p_partkey", right_on="ps_partkey")
-        .filter(col("ps_supplycost") == col("min_cost"))
-        .select("s_acctbal", "s_name", "n_name", "p_partkey", "p_mfgr", "s_address", "s_phone", "s_comment")
-        .sort(
-            ["s_acctbal", "n_name", "s_name", "p_partkey"],
-            descending=[True, False, False, False],
-        )
-        .limit(100)
-    )
+    return _q2_expr_base(ctx)
 
 
 def q2_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -626,16 +524,4 @@ def q2_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q2_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q2v{v}",
-        query_name=f"TPC-H Q2 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.SUBQUERY, QueryCategory.SORT],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q2_VARIANTS = build_yaml_variants(__file__, globals(), 2, JOIN_SUBQUERY_SORT)

--- a/benchbox/core/tpchavoc/dataframe_queries/q03.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q03.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q3_expression_impl as _q3_expr_base,
     q3_pandas_impl as _q3_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_SORT, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -405,27 +404,7 @@ def q3_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q3_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    lineitem = ctx.get_table("lineitem")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(3)
-    segment = params["segment"]
-    order_date = params["order_date"]
-
-    return (
-        customer.filter(col("c_mktsegment") == lit(segment))
-        .join(orders, left_on="c_custkey", right_on="o_custkey")
-        .filter(col("o_orderdate") < lit(order_date))
-        .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-        .filter(col("l_shipdate") > lit(order_date))
-        .group_by("o_orderkey", "o_orderdate", "o_shippriority")
-        .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
-        .sort(["revenue", "o_orderdate"], descending=[True, False])
-        .limit(10)
-    )
+    return _q3_expr_base(ctx)
 
 
 def q3_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -512,16 +491,4 @@ def q3_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q3_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q3v{v}",
-        query_name=f"TPC-H Q3 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SORT],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q3_VARIANTS = build_yaml_variants(__file__, globals(), 3, JOIN_AGG_SORT)

--- a/benchbox/core/tpchavoc/dataframe_queries/q04.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q04.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q4_expression_impl as _q4_expr_base,
     q4_pandas_impl as _q4_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_SUBQUERY, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -460,16 +459,4 @@ def q4_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q4_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q4v{v}",
-        query_name=f"TPC-H Q4 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SUBQUERY],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q4_VARIANTS = build_yaml_variants(__file__, globals(), 4, JOIN_AGG_SUBQUERY)

--- a/benchbox/core/tpchavoc/dataframe_queries/q05.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q05.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q5_expression_impl as _q5_expr_base,
     q5_pandas_impl as _q5_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -424,62 +423,11 @@ def q5_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q5_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    lineitem = ctx.get_table("lineitem")
-    supplier = ctx.get_table("supplier")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(5)
-    region_name = params["region_name"]
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    return (
-        region.filter(col("r_name") == lit(region_name))
-        .join(nation, left_on="r_regionkey", right_on="n_regionkey")
-        .join(customer, left_on="n_nationkey", right_on="c_nationkey")
-        .join(orders, left_on="c_custkey", right_on="o_custkey")
-        .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
-        .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-        .join(supplier, left_on=["l_suppkey", "n_nationkey"], right_on=["s_suppkey", "s_nationkey"])
-        .group_by("n_name")
-        .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
-        .sort("revenue", descending=True)
-    )
+    return _q5_expr_base(ctx)
 
 
 def q5_v9_pandas_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    lineitem = ctx.get_table("lineitem")
-    supplier = ctx.get_table("supplier")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-
-    params = get_tpch_parameters(5)
-    region_name = params["region_name"]
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    asia_region = region[region["r_name"] == region_name]
-    asia_nations = asia_region.merge(nation, left_on="r_regionkey", right_on="n_regionkey")
-    asia_customers = asia_nations.merge(customer, left_on="n_nationkey", right_on="c_nationkey")
-    customer_orders = asia_customers.merge(orders, left_on="c_custkey", right_on="o_custkey")
-    customer_orders = customer_orders[
-        (customer_orders["o_orderdate"] >= start_date) & (customer_orders["o_orderdate"] < end_date)
-    ]
-    order_lines = customer_orders.merge(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-    joined = order_lines.merge(
-        supplier, left_on=["l_suppkey", "c_nationkey"], right_on=["s_suppkey", "s_nationkey"]
-    ).copy()
-    joined["revenue"] = joined["l_extendedprice"] * (1 - joined["l_discount"])
-    return (
-        joined.groupby("n_name", as_index=False).agg(revenue=("revenue", "sum")).sort_values("revenue", ascending=False)
-    )
+    return q5_v5_pandas_impl(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -553,16 +501,4 @@ def q5_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q5_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q5v{v}",
-        query_name=f"TPC-H Q5 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q5_VARIANTS = build_yaml_variants(__file__, globals(), 5, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q06.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q06.py
@@ -11,12 +11,12 @@ from collections.abc import Callable
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q6_expression_impl as _q6_expr_base,
     q6_pandas_impl as _q6_pandas_base,
 )
+from benchbox.core.tpchavoc.dataframe_queries.loader import AGG_FILTER, build_variants
 
 VariantImpl = Callable[[DataFrameContext], Any]
 
@@ -261,14 +261,4 @@ _IMPL_PAIRS = [
     (q6_v10_expression_impl, q6_v10_pandas_impl),
 ]
 
-Q6_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q6v{variant}",
-        query_name=f"TPC-H Q6 Variant {variant}",
-        description=_DESCRIPTIONS[variant - 1],
-        categories=[QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for variant, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q6_VARIANTS = build_variants(6, _IMPL_PAIRS, _DESCRIPTIONS, AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q07.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q07.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q7_expression_impl as _q7_expr_base,
     q7_pandas_impl as _q7_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -228,43 +227,7 @@ def q7_v4_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q7_v5_expression_impl(ctx: DataFrameContext) -> Any:
-    supplier = ctx.get_table("supplier")
-    lineitem = ctx.get_table("lineitem")
-    orders = ctx.get_table("orders")
-    customer = ctx.get_table("customer")
-    nation = ctx.get_table("nation")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(7)
-    nation1 = params["nation1"]
-    nation2 = params["nation2"]
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    n1 = nation.select(col("n_nationkey").alias("n1_nationkey"), col("n_name").alias("supp_nation"))
-    n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("cust_nation"))
-
-    return (
-        supplier.join(n1, left_on="s_nationkey", right_on="n1_nationkey")
-        .join(lineitem, left_on="s_suppkey", right_on="l_suppkey")
-        .filter((col("l_shipdate") >= lit(start_date)) & (col("l_shipdate") <= lit(end_date)))
-        .join(orders, left_on="l_orderkey", right_on="o_orderkey")
-        .join(customer, left_on="o_custkey", right_on="c_custkey")
-        .join(n2, left_on="c_nationkey", right_on="n2_nationkey")
-        .filter(
-            ((col("supp_nation") == lit(nation1)) & (col("cust_nation") == lit(nation2)))
-            | ((col("supp_nation") == lit(nation2)) & (col("cust_nation") == lit(nation1)))
-        )
-        # Pre-compute both derived columns
-        .with_columns(
-            col("l_shipdate").dt.year().alias("l_year"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).alias("volume"),
-        )
-        .group_by("supp_nation", "cust_nation", "l_year")
-        .agg(col("volume").sum().alias("revenue"))
-        .sort("supp_nation", "cust_nation", "l_year")
-    )
+    return _q7_expr_base(ctx)
 
 
 def q7_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -608,16 +571,4 @@ def q7_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q7_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q7v{v}",
-        query_name=f"TPC-H Q7 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q7_VARIANTS = build_yaml_variants(__file__, globals(), 7, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q08.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q08.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q8_expression_impl as _q8_expr_base,
     q8_pandas_impl as _q8_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -204,50 +203,7 @@ def q8_v4_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q8_v5_expression_impl(ctx: DataFrameContext) -> Any:
-    part = ctx.get_table("part")
-    supplier = ctx.get_table("supplier")
-    lineitem = ctx.get_table("lineitem")
-    orders = ctx.get_table("orders")
-    customer = ctx.get_table("customer")
-    nation = ctx.get_table("nation")
-    region = ctx.get_table("region")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(8)
-    target_nation = params["target_nation"]
-    target_region = params["target_region"]
-    target_type = params["target_type"]
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    n2 = nation.select(col("n_nationkey").alias("n2_nationkey"), col("n_name").alias("nation"))
-
-    return (
-        part.filter(col("p_type") == lit(target_type))
-        .join(lineitem, left_on="p_partkey", right_on="l_partkey")
-        .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
-        .join(n2, left_on="s_nationkey", right_on="n2_nationkey")
-        .join(orders, left_on="l_orderkey", right_on="o_orderkey")
-        .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") <= lit(end_date)))
-        .join(customer, left_on="o_custkey", right_on="c_custkey")
-        .join(nation, left_on="c_nationkey", right_on="n_nationkey")
-        .join(region, left_on="n_regionkey", right_on="r_regionkey")
-        .filter(col("r_name") == lit(target_region))
-        # Pre-compute volume before group_by
-        .with_columns(
-            col("o_orderdate").dt.year().alias("o_year"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount"))).alias("volume"),
-        )
-        .group_by("o_year")
-        .agg(
-            col("volume").filter(col("nation") == lit(target_nation)).sum().alias("nation_volume"),
-            col("volume").sum().alias("total_volume"),
-        )
-        .with_columns((col("nation_volume") / col("total_volume")).alias("mkt_share"))
-        .select("o_year", "mkt_share")
-        .sort("o_year")
-    )
+    return _q8_expr_base(ctx)
 
 
 def q8_v5_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -558,16 +514,4 @@ def q8_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q8_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q8v{v}",
-        query_name=f"TPC-H Q8 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q8_VARIANTS = build_yaml_variants(__file__, globals(), 8, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q09.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q09.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q9_expression_impl as _q9_expr_base,
     q9_pandas_impl as _q9_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -383,35 +382,7 @@ def q9_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q9_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    part = ctx.get_table("part")
-    supplier = ctx.get_table("supplier")
-    lineitem = ctx.get_table("lineitem")
-    partsupp = ctx.get_table("partsupp")
-    orders = ctx.get_table("orders")
-    nation = ctx.get_table("nation")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(9)
-    color = params["color"]
-
-    return (
-        part.filter(col("p_name").str.contains(color))
-        .join(lineitem, left_on="p_partkey", right_on="l_partkey")
-        .join(supplier, left_on="l_suppkey", right_on="s_suppkey")
-        .join(partsupp, left_on=["l_suppkey", "p_partkey"], right_on=["ps_suppkey", "ps_partkey"])
-        .join(orders, left_on="l_orderkey", right_on="o_orderkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .with_columns(
-            col("o_orderdate").dt.year().alias("o_year"),
-            (col("l_extendedprice") * (lit(1) - col("l_discount")) - col("ps_supplycost") * col("l_quantity")).alias(
-                "amount"
-            ),
-        )
-        .group_by(col("n_name").alias("nation"), "o_year")
-        .agg(col("amount").sum().alias("sum_profit"))
-        .sort(["nation", "o_year"], descending=[False, True])
-    )
+    return _q9_expr_base(ctx)
 
 
 def q9_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -491,16 +462,4 @@ def q9_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q9_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q9v{v}",
-        query_name=f"TPC-H Q9 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q9_VARIANTS = build_yaml_variants(__file__, globals(), 9, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q10.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q10.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q10_expression_impl as _q10_expr_base,
     q10_pandas_impl as _q10_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_SORT, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -406,55 +405,11 @@ def q10_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q10_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    lineitem = ctx.get_table("lineitem")
-    nation = ctx.get_table("nation")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(10)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    return (
-        customer.join(orders, left_on="c_custkey", right_on="o_custkey")
-        .filter((col("o_orderdate") >= lit(start_date)) & (col("o_orderdate") < lit(end_date)))
-        .join(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-        .filter(col("l_returnflag") == lit("R"))
-        .join(nation, left_on="c_nationkey", right_on="n_nationkey")
-        .group_by("c_custkey", "c_name", "c_acctbal", "c_phone", "n_name", "c_address", "c_comment")
-        .agg((col("l_extendedprice") * (lit(1) - col("l_discount"))).sum().alias("revenue"))
-        .sort("revenue", descending=True)
-        .limit(20)
-    )
+    return _q10_expr_base(ctx)
 
 
 def q10_v9_pandas_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    lineitem = ctx.get_table("lineitem")
-    nation = ctx.get_table("nation")
-
-    params = get_tpch_parameters(10)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    joined = customer.merge(orders, left_on="c_custkey", right_on="o_custkey")
-    joined = joined[(joined["o_orderdate"] >= start_date) & (joined["o_orderdate"] < end_date)]
-    joined = joined.merge(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-    joined = joined[joined["l_returnflag"] == "R"]
-    joined = joined.merge(nation, left_on="c_nationkey", right_on="n_nationkey").copy()
-    joined["revenue"] = joined["l_extendedprice"] * (1 - joined["l_discount"])
-
-    return (
-        joined.groupby(
-            ["c_custkey", "c_name", "c_acctbal", "c_phone", "n_name", "c_address", "c_comment"], as_index=False
-        )
-        .agg(revenue=("revenue", "sum"))
-        .sort_values("revenue", ascending=False)
-        .head(20)
-    )
+    return q10_v5_pandas_impl(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -521,16 +476,4 @@ def q10_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q10_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q10v{v}",
-        query_name=f"TPC-H Q10 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SORT],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q10_VARIANTS = build_yaml_variants(__file__, globals(), 10, JOIN_AGG_SORT)

--- a/benchbox/core/tpchavoc/dataframe_queries/q11.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q11.py
@@ -13,13 +13,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q11_expression_impl as _q11_expr_base,
     q11_pandas_impl as _q11_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_SUBQUERY, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline
@@ -401,32 +400,7 @@ def q11_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q11_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    partsupp = ctx.get_table("partsupp")
-    supplier = ctx.get_table("supplier")
-    nation = ctx.get_table("nation")
-    col = ctx.col
-    lit = ctx.lit
-
-    params = get_tpch_parameters(11)
-    nation_name = params["nation_name"]
-    fraction = params["fraction"]
-
-    nation_stock = (
-        partsupp.join(supplier, left_on="ps_suppkey", right_on="s_suppkey")
-        .join(nation, left_on="s_nationkey", right_on="n_nationkey")
-        .filter(col("n_name") == lit(nation_name))
-        .with_columns((col("ps_supplycost") * col("ps_availqty")).alias("value"))
-    )
-
-    total_value = ctx.scalar(nation_stock.select(col("value").sum().alias("total")))
-    threshold = total_value * fraction
-
-    return (
-        nation_stock.group_by("ps_partkey")
-        .agg(col("value").sum().alias("value"))
-        .filter(col("value") > lit(threshold))
-        .sort("value", descending=True)
-    )
+    return _q11_expr_base(ctx)
 
 
 def q11_v9_pandas_impl(ctx: DataFrameContext) -> Any:
@@ -513,16 +487,4 @@ def q11_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q11_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q11v{v}",
-        query_name=f"TPC-H Q11 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SUBQUERY],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q11_VARIANTS = build_yaml_variants(__file__, globals(), 11, JOIN_AGG_SUBQUERY)

--- a/benchbox/core/tpchavoc/dataframe_queries/q12.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q12.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q12_expression_impl as _q12_expr_base,
     q12_pandas_impl as _q12_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline - delegate directly to TPC-H base implementation
@@ -637,16 +636,4 @@ def q12_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q12_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q12v{v}",
-        query_name=f"TPC-H Q12 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q12_VARIANTS = build_yaml_variants(__file__, globals(), 12, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q13.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q13.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q13_expression_impl as _q13_expr_base,
     q13_pandas_impl as _q13_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_GROUP_BY, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline - delegate directly to TPC-H base implementation
@@ -66,23 +65,7 @@ def q13_v2_expression_impl(ctx: DataFrameContext) -> Any:
 
 
 def q13_v2_pandas_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-
-    params = get_tpch_parameters(13)
-    word1 = params["word1"]
-    word2 = params["word2"]
-
-    # Pre-filter orders before left join
-    filtered_orders = orders[~orders["o_comment"].str.contains(f"{word1}.*{word2}", regex=True, na=False)]
-    customer_orders = customer.merge(filtered_orders, left_on="c_custkey", right_on="o_custkey", how="left")
-    order_counts = customer_orders.groupby("c_custkey", as_index=False).agg(c_count=("o_orderkey", "count"))
-
-    return (
-        order_counts.groupby("c_count", as_index=False)
-        .agg(custdist=("c_custkey", "count"))
-        .sort_values(["custdist", "c_count"], ascending=[False, False])
-    )
+    return _q13_pandas_base(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -379,49 +362,11 @@ def q13_v8_pandas_impl(ctx: DataFrameContext) -> Any:
 
 
 def q13_v9_expression_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-    col = ctx.col
-
-    params = get_tpch_parameters(13)
-    word1 = params["word1"]
-    word2 = params["word2"]
-
-    customer_orders = (
-        customer.join(
-            orders.filter(~col("o_comment").str.contains(f"{word1}.*{word2}")),
-            left_on="c_custkey",
-            right_on="o_custkey",
-            how="left",
-        )
-        .group_by("c_custkey")
-        .agg(col("o_orderkey").count().alias("c_count"))
-    )
-
-    return (
-        customer_orders.group_by("c_count")
-        .agg(col("c_custkey").count().alias("custdist"))
-        .sort(["custdist", "c_count"], descending=[True, True])
-    )
+    return _q13_expr_base(ctx)
 
 
 def q13_v9_pandas_impl(ctx: DataFrameContext) -> Any:
-    customer = ctx.get_table("customer")
-    orders = ctx.get_table("orders")
-
-    params = get_tpch_parameters(13)
-    word1 = params["word1"]
-    word2 = params["word2"]
-
-    filtered_orders = orders[~orders["o_comment"].str.contains(f"{word1}.*{word2}", regex=True, na=False)]
-    customer_orders = customer.merge(filtered_orders, left_on="c_custkey", right_on="o_custkey", how="left")
-    order_counts = customer_orders.groupby("c_custkey", as_index=False).agg(c_count=("o_orderkey", "count"))
-
-    return (
-        order_counts.groupby("c_count", as_index=False)
-        .agg(custdist=("c_custkey", "count"))
-        .sort_values(["custdist", "c_count"], ascending=[False, False])
-    )
+    return _q13_pandas_base(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -481,16 +426,4 @@ def q13_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q13_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q13v{v}",
-        query_name=f"TPC-H Q13 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.GROUP_BY],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q13_VARIANTS = build_yaml_variants(__file__, globals(), 13, JOIN_AGG_GROUP_BY)

--- a/benchbox/core/tpchavoc/dataframe_queries/q14.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q14.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q14_expression_impl as _q14_expr_base,
     q14_pandas_impl as _q14_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_FILTER, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline - delegate directly to TPC-H base implementation
@@ -543,16 +542,4 @@ def q14_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q14_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q14v{v}",
-        query_name=f"TPC-H Q14 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.FILTER],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q14_VARIANTS = build_yaml_variants(__file__, globals(), 14, JOIN_AGG_FILTER)

--- a/benchbox/core/tpchavoc/dataframe_queries/q15.py
+++ b/benchbox/core/tpchavoc/dataframe_queries/q15.py
@@ -14,13 +14,12 @@ from __future__ import annotations
 from typing import Any
 
 from benchbox.core.dataframe.context import DataFrameContext
-from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 from benchbox.core.tpch.dataframe_queries import (
     get_tpch_parameters,
     q15_expression_impl as _q15_expr_base,
     q15_pandas_impl as _q15_pandas_base,
 )
-from benchbox.core.tpchavoc.dataframe_queries.loader import load_variant_specs
+from benchbox.core.tpchavoc.dataframe_queries.loader import JOIN_AGG_SUBQUERY, build_yaml_variants
 
 # ---------------------------------------------------------------------------
 # v1: baseline - delegate directly to TPC-H base implementation
@@ -189,31 +188,7 @@ def q15_v4_expression_impl(ctx: DataFrameContext) -> Any:
 
 
 def q15_v4_pandas_impl(ctx: DataFrameContext) -> Any:
-    supplier = ctx.get_table("supplier")
-    lineitem = ctx.get_table("lineitem")
-
-    params = get_tpch_parameters(15)
-    start_date = params["start_date"]
-    end_date = params["end_date"]
-
-    # Step 1: filter
-    filtered = lineitem[(lineitem["l_shipdate"] >= start_date) & (lineitem["l_shipdate"] < end_date)].copy()
-    # Step 2: derive revenue column
-    filtered["revenue"] = filtered["l_extendedprice"] * (1 - filtered["l_discount"])
-    # Step 3: aggregate per supplier
-    revenue = (
-        filtered.groupby("l_suppkey", as_index=False)
-        .agg(total_revenue=("revenue", "sum"))
-        .rename(columns={"l_suppkey": "supplier_no"})
-    )
-    # Step 4: find max
-    max_revenue = revenue["total_revenue"].max()
-    max_revenue = max_revenue.compute() if hasattr(max_revenue, "compute") else max_revenue
-    # Step 5: filter and join
-    top_suppliers = revenue[revenue["total_revenue"] == max_revenue]
-    return supplier.merge(top_suppliers, left_on="s_suppkey", right_on="supplier_no")[
-        ["s_suppkey", "s_name", "s_address", "s_phone", "total_revenue"]
-    ].sort_values("s_suppkey")
+    return q15_v2_pandas_impl(ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -548,16 +523,4 @@ def q15_v10_pandas_impl(ctx: DataFrameContext) -> Any:
 # Registry
 # ---------------------------------------------------------------------------
 
-_IMPL_PAIRS, _DESCRIPTIONS = load_variant_specs(__file__, globals())
-
-Q15_VARIANTS: list[DataFrameQuery] = [
-    DataFrameQuery(
-        query_id=f"Q15v{v}",
-        query_name=f"TPC-H Q15 Variant {v}",
-        description=_DESCRIPTIONS[v - 1],
-        categories=[QueryCategory.JOIN, QueryCategory.AGGREGATE, QueryCategory.SUBQUERY],
-        expression_impl=expr_impl,
-        pandas_impl=pandas_impl,
-    )
-    for v, (expr_impl, pandas_impl) in enumerate(_IMPL_PAIRS, start=1)
-]
+Q15_VARIANTS = build_yaml_variants(__file__, globals(), 15, JOIN_AGG_SUBQUERY)


### PR DESCRIPTION
---
iteration: shrink-tpchavoc-df-variant-boilerplate
date: 2026-05-25
surface: TPC-Havoc DataFrame variant boilerplate
branch: chore/shrink-tpchavoc-df-variant-boilerplate
pr:
raw_cloc_delta: 517
credited_reduction: 517
uncredited_relocation: 0
repair_only_delta: 0
generated_python_delta: 0
moved_content: logic
decision_gate: conservative default
verification:
  - make shrink-rollup
  - cloc --include-lang=Python benchbox/
  - cloc --include-lang=Python benchbox/core/tpchavoc/dataframe_queries
  - uv run -- python -m pytest tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0
  - manual TPC-Havoc registry/callable fingerprint before and after
  - rg reference check for TPC-Havoc DataFrame registry and implementation symbols
---

## Thesis

Shrink iteration. The slice targets `benchbox/core/tpchavoc/dataframe_queries/`,
currently 5,690 maintained-Python code lines. The reduction path is true
boilerplate deduplication:

- centralize repeated `DataFrameQuery` variant construction that is copied
  across the YAML-backed TPC-Havoc query modules, and
- replace exact duplicate variant implementation bodies, plus one reviewed
  step-for-step duplicate pandas body, with explicit named delegates to the
  identical current operation.

Most duplicated implementation candidates are exact AST matches after removing
docstrings, not heuristic similarity. The only non-AST replacement is
`q2_v8_pandas_impl`, which was reviewed against `q2_v7_pandas_impl` and has the
same table reads, filters, joins, aggregation, projection, sort, and limit. The
slice keeps every query id, description, category, implementation callable name,
qualname, module, expected row metadata, timeout, and skip-platform list pinned
by a pre/post fingerprint.

No benchmarks, platforms, deprecated/beta-public surfaces, generated Python, or
Python-to-data relocation are removed. YAML metadata already exists and remains
unchanged; this PR does not create a new catalog migration. The expected credited
reduction is above the 500-line shrink-iteration floor after combining the
registry-construction boilerplate and exact duplicate implementation bodies.

## Guardrail evidence

- Campaign rollup before editing: 1,324 merged credited lines, 10,676 remaining
  to the committed floor, 17,676 remaining to stretch.
- Raw maintained Python before editing: `cloc --include-lang=Python benchbox/`
  reports 930 files and 205,530 code lines.
- Target surface before editing: `cloc --include-lang=Python
  benchbox/core/tpchavoc/dataframe_queries` reports 26 files and 5,690 code
  lines.
- Open PR overlap: `gh pr list --state open --base develop --json ...` returned
  `[]`.
- Baseline fingerprint:
  `/tmp/shrink-tpchavoc-baseline-fingerprint.json`, SHA256
  `a343ca49b611465776b9458477f39c93b3111d7d8c2b475e6e29c39544a81f1e`.
- Exact duplicate scan:
  `/tmp/shrink-tpchavoc-duplicate-candidates.txt` found 15 large exact-body
  replacements with estimated source-span savings of 396 lines before the
  shared registry-builder reduction.
- Baseline focused tests:
  `uv run -- python -m pytest
  tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0` passed
  with 33 tests and 1 pre-existing warning.

## Verification

- `cloc --include-lang=Python benchbox/`: 930 files, 205,013 code lines;
  raw maintained-Python delta 517 lines.
- `cloc --include-lang=Python benchbox/core/tpchavoc/dataframe_queries`: 26
  files, 5,173 code lines; target-surface delta 517 lines.
- `uv run -- ruff check benchbox/core/tpchavoc/dataframe_queries`: passed.
- `uv run -- ruff format --check benchbox/core/tpchavoc/dataframe_queries`:
  passed; 26 files already formatted.
- `uv run -- python -m pytest
  tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py -q -n 0`: 33
  passed, 1 pre-existing warning.
- Post-edit fingerprint:
  `/tmp/shrink-tpchavoc-post-fingerprint.json`, SHA256
  `a343ca49b611465776b9458477f39c93b3111d7d8c2b475e6e29c39544a81f1e`,
  byte-identical to the baseline fingerprint.
- Whole-tree reference check:
  `/tmp/shrink-tpchavoc-reference-check.log` captured 546 references across
  `benchbox`, `tests`, and `docs`; `_project` had no additional matches.
- `make pr-preflight`: passed; log retained at
  `/tmp/shrink-tpchavoc-pr-preflight.log` with 32,907 lines. Fast test summary:
  22,775 passed, 5 skipped, 47 warnings, 4 subtests passed.

## Residual risk

The main risk is benchmark-shape drift for TPC-Havoc variants. This slice limits
implementation-body replacement to exact duplicate bodies and keeps callable
identity metadata pinned. Delegate wrappers add one Python call for duplicated
variants; the measured DataFrame operation is unchanged because the delegated
implementation is byte-for-byte equivalent to the current variant body.

## Next target

After this PR merges, re-run `make shrink-rollup` and continue through another
explicit duplicate-maintenance surface that does not overlap open shrink PRs.
