### PR TITLE
chore: shrink platform hook boilerplate

### DIFF
--- a/_project/shrink-ledger/shrink-platform-hook-boilerplate.md
+++ b/_project/shrink-ledger/shrink-platform-hook-boilerplate.md
@@ -1,0 +1,106 @@
+---
+iteration: shrink-platform-hook-boilerplate
+date: 2026-05-24
+surface: platform config/from_config/tuning hook boilerplate
+branch: chore/shrink-platform-hook-boilerplate
+pr:
+raw_cloc_delta: 538
+credited_reduction: 538
+uncredited_relocation: 0
+repair_only_delta: 0
+generated_python_delta: 0
+moved_content: logic
+decision_gate: conservative default
+verification:
+  - cloc --include-lang=Python benchbox/ (205013 -> 204475)
+  - uv run -- ruff check <touched source and tests>
+  - uv run -- python -m compileall -q benchbox/platforms
+  - uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/base/test_spark_execution_mixin.py -q
+  - uv run -- python -m pytest <targeted platform hook files> -q (1194 passed)
+  - uv run -- python _project/scripts/reference_usage_audit.py --summary
+  - make pr-preflight
+---
+
+## Thesis
+
+Shrink iteration across repeated platform hook plumbing by consolidating
+structurally identical `from_config` field-copy routines, cloud-Spark tuning
+application, hook dispatch, file/table discovery helpers, and explicit
+tuning-support predicates.
+
+Baseline evidence:
+
+- `make shrink-rollup`: 1,841 merged credited lines, 10,159 remaining to the
+  committed 12,000 floor, 17,159 remaining to stretch.
+- `cloc --include-lang=Python benchbox/`: 205,013 Python code lines.
+- Code-only structural duplicate scan: `from_config` assembly, repeated Spark
+  and SQL execution wrappers, constraint/unified tuning hooks, table-discovery
+  helpers, and tuning-support predicates form a coherent hook surface.
+- Open develop PRs #622, #623, and #624 do not touch platform hook/config files.
+
+Reduction path:
+
+- Add explicit helper functions for standard adapter config assembly,
+  tuning-support set checks, standard unified tuning dispatch, informational
+  constraint hooks, and cloud-Spark tuning application.
+- Replace repeated bodies with explicit public methods or grep-findable function
+  bindings; preserve public function names, signatures, `__name__`, and
+  `__qualname__`.
+- Do not delete platforms, change support status, move Python into data files,
+  add generated Python, or change live/cloud execution semantics.
+
+Actual credited reduction: 538 maintained-Python code lines. The post-edit
+`cloc --include-lang=Python benchbox/` delta cleared the 500-line shrink
+iteration floor.
+
+## Guardrail evidence
+
+Pre-edit public hook fingerprint:
+
+- `/tmp/shrink-platform-hooks-fingerprint-pre.txt`
+
+Planned guardrails:
+
+- Post-edit hook fingerprint must preserve public signatures and config builder
+  callable names/qualnames. Owner relocation to shared mixins/base hook is
+  expected and captured in `/tmp/shrink-platform-hooks-fingerprint.diff`.
+- Pure helper behavior is characterized by targeted unit tests for
+  `build_adapter_config`, `supports_named_tuning_type`, informational
+  constraint hooks, standard unified tuning dispatch, Spark execution wrapper
+  delegation, and shared `SHOW TABLES` table discovery.
+- Whole-tree references for touched hook names must remain valid.
+- No import-time I/O, no dynamic module-global mutation, no registry-key changes,
+  and no live/cloud tests without explicit approval.
+
+## Verification
+
+- `make shrink-rollup` before editing: 1,841 merged credited lines; 10,159
+  remaining to the committed 12,000 floor; 17,159 remaining to stretch.
+- `cloc --include-lang=Python benchbox/`: 205,013 before, 204,475 after; raw
+  maintained-Python delta 538.
+- Fingerprints:
+  - pre: `/tmp/shrink-platform-hooks-fingerprint-pre.txt`
+  - post: `/tmp/shrink-platform-hooks-fingerprint-post.txt`
+  - diff: `/tmp/shrink-platform-hooks-fingerprint.diff`
+- `uv run -- ruff check ...` for all touched source/test files: passed.
+- `uv run -- python -m compileall -q benchbox/platforms`: passed.
+- `uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/base/test_spark_execution_mixin.py -q`: 79 passed.
+- `uv run -- python -m pytest tests/unit/platforms/test_doris_adapter.py tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_lakesail_adapter.py tests/unit/platforms/test_redshift_adapter.py tests/unit/platforms/test_starrocks_adapter.py tests/unit/platforms/test_starrocks_tuning.py tests/unit/platforms/test_azure_synapse_adapter.py tests/unit/platforms/test_bigquery_adapter_coverage.py tests/unit/platforms/test_cedardb.py tests/unit/platforms/test_pg_duckdb_adapter.py tests/unit/platforms/test_databricks_adapter.py tests/unit/platforms/test_databricks_adapter_coverage.py tests/unit/platforms/test_firebolt_coverage.py tests/unit/platforms/test_presto_adapter.py tests/unit/platforms/test_velox_adapter.py -q`: 1,194 passed.
+- `uv run -- python _project/scripts/reference_usage_audit.py --summary`: passed
+  with 78 reference hits and 0 parse errors.
+- `make pr-preflight`: passed; the final fast-test gate reported 22,775
+  passed, 5 skipped, 47 warnings, and 4 subtests passed.
+
+## Residual risk
+
+The touched surface spans live/cloud adapters. The change is restricted to pure
+configuration and hook dispatch boilerplate, with behavior pinned by helper-level
+tests, existing platform tests, and callable fingerprints. The largest remaining
+risk is inherited-method ownership changing from adapter-local methods to shared
+mixins/base hooks; signatures, public names, and platform-specific messages are
+kept stable where behavior depends on them.
+
+## Next target
+
+If this slice lands, reassess smaller platform hook residues separately; do not
+stack unrelated adapter behavior into this PR.

--- a/benchbox/platforms/_spark_helpers.py
+++ b/benchbox/platforms/_spark_helpers.py
@@ -373,14 +373,9 @@ class SparkLikeAdapterMixin:
 
     def apply_unified_tuning(self, unified_config: Any, connection: Any) -> None:
         """Dispatch unified tuning to the constraint / platform / per-table hooks."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)  # type: ignore[attr-defined]
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: Any, connection: Any) -> None:
         """Forward ``platform_config.spark`` settings to ``spark.conf.set``."""

--- a/benchbox/platforms/athena.py
+++ b/benchbox/platforms/athena.py
@@ -44,6 +44,7 @@ from .base import DriverIsolationCapability, PlatformAdapter
 from .base.data_loading import DataSourceResolver, FileFormatRegistry
 from .base.ddl_helpers import strip_with_properties
 from .base.runtime_metadata import build_default_normalized_result_metadata
+from .presto_trino_utils import normalize_existing_files, show_tables_lower
 
 try:
     import boto3
@@ -278,47 +279,34 @@ class AthenaAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Athena adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="athena",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "region",
+                    "aws_region",
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "aws_profile",
+                    "workgroup",
+                    "catalog",
+                    "s3_output_location",
+                    "s3_staging_dir",
+                    "staging_root",
+                    "s3_bucket",
+                    "s3_prefix",
+                    "query_timeout",
+                    "encryption",
+                    "data_format",
+                    "default_format",
+                    "compression",
+                    "cleanup_staging",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # AWS configuration
-        for key in ["region", "aws_region", "aws_access_key_id", "aws_secret_access_key", "aws_profile"]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Athena-specific configuration
-        for key in [
-            "workgroup",
-            "catalog",
-            "s3_output_location",
-            "s3_staging_dir",
-            "staging_root",
-            "s3_bucket",
-            "s3_prefix",
-            "query_timeout",
-            "encryption",
-            "data_format",
-            "default_format",
-            "compression",
-            "cleanup_staging",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def _get_s3_client(self):
         """Get or create S3 client."""
@@ -1010,16 +998,7 @@ class AthenaAdapter(PlatformAdapter):
             raise ValueError("No data files found")
         return data_source.tables
 
-    @staticmethod
-    def _normalize_existing_files(file_paths: Any) -> list[Path]:
-        """Normalize file inputs to existing, non-empty local paths."""
-        normalized_paths = file_paths if isinstance(file_paths, list) else [file_paths]
-        valid_files: list[Path] = []
-        for file_path in normalized_paths:
-            path = Path(file_path)
-            if path.exists() and path.stat().st_size > 0:
-                valid_files.append(path)
-        return valid_files
+    _normalize_existing_files = staticmethod(normalize_existing_files)
 
     def _build_s3_table_path(self, table_name_lower: str, is_parquet_mode: bool) -> str:
         """Build the destination S3 prefix for a table load."""
@@ -1361,16 +1340,7 @@ class AthenaAdapter(PlatformAdapter):
             self.logger.debug(f"Connection test failed: {e}")
             return False
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Athena supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING",)
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Athena-specific tuning clauses."""
@@ -1425,16 +1395,7 @@ class AthenaAdapter(PlatformAdapter):
         if primary_key_config and primary_key_config.enabled:
             self.logger.info("Primary key constraints noted (Athena does not enforce constraints)")
 
-    def _get_existing_tables(self, connection: Any) -> list[str]:
-        """Get list of existing tables."""
-        cursor = connection.cursor()
-        try:
-            cursor.execute("SHOW TABLES")
-            return [row[0].lower() for row in cursor.fetchall()]
-        except Exception:
-            return []
-        finally:
-            cursor.close()
+    _get_existing_tables = staticmethod(show_tables_lower)
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Run ANALYZE on table (not needed for Athena - stats auto-collected)."""

--- a/benchbox/platforms/aws/athena_spark_adapter.py
+++ b/benchbox/platforms/aws/athena_spark_adapter.py
@@ -40,9 +40,7 @@ from typing import TYPE_CHECKING, Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import (
-        UnifiedTuningConfiguration,
-    )
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -744,34 +742,6 @@ result.show(100, truncate=False)
         return cls(**params)
 
     # configure_for_benchmark is inherited from CloudSparkConfigMixin
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     # apply_primary_keys, apply_foreign_keys, apply_platform_optimizations,
     # and apply_constraint_configuration are inherited from SparkTuningMixin

--- a/benchbox/platforms/aws/emr_serverless_adapter.py
+++ b/benchbox/platforms/aws/emr_serverless_adapter.py
@@ -42,9 +42,7 @@ from typing import TYPE_CHECKING, Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import (
-        UnifiedTuningConfiguration,
-    )
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -741,34 +739,6 @@ spark.stop()
         return cls(**params)
 
     # configure_for_benchmark is inherited from CloudSparkConfigMixin
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     # apply_primary_keys, apply_foreign_keys, apply_platform_optimizations,
     # and apply_constraint_configuration are inherited from SparkTuningMixin

--- a/benchbox/platforms/aws/glue_adapter.py
+++ b/benchbox/platforms/aws/glue_adapter.py
@@ -721,44 +721,31 @@ job.commit()
         Returns:
             Configured AWSGlueAdapter instance.
         """
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="glue",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "region",
+                    "aws_region",
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "aws_profile",
+                    "s3_staging_dir",
+                    "staging_root",
+                    "job_role",
+                    "iam_role",
+                    "worker_type",
+                    "number_of_workers",
+                    "glue_version",
+                    "job_timeout",
+                    "execution_mode",
+                    "spark_conf",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # AWS configuration
-        for key in ["region", "aws_region", "aws_access_key_id", "aws_secret_access_key", "aws_profile"]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Glue-specific configuration
-        for key in [
-            "s3_staging_dir",
-            "staging_root",
-            "job_role",
-            "iam_role",
-            "worker_type",
-            "number_of_workers",
-            "glue_version",
-            "job_timeout",
-            "execution_mode",
-            "spark_conf",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def configure_for_benchmark(self, connection: Any, benchmark_type: str) -> None:
         """Configure Glue for benchmark execution.

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -19,9 +19,7 @@ from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         TuningColumn,
         UnifiedTuningConfiguration,
     )
@@ -29,6 +27,8 @@ if TYPE_CHECKING:
 from ..utils.dependencies import check_platform_dependencies, get_dependency_error_message
 from .base import DriverIsolationCapability, PlatformAdapter
 from .base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
+from .base.tuning import make_informational_constraint_applier
+from .presto_trino_utils import normalize_existing_files
 
 # Azure Synapse uses T-SQL dialect (compatible with SQL Server)
 SYNAPSE_DIALECT = "tsql"
@@ -195,53 +195,40 @@ class AzureSynapseAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Azure Synapse adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate proper database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="synapse",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "server",
+                    "port",
+                    "username",
+                    "password",
+                    "schema",
+                    "auth_method",
+                    "tenant_id",
+                    "client_id",
+                    "client_secret",
+                    "driver",
+                    "connect_timeout",
+                    "query_timeout",
+                    "encrypt",
+                    "storage_account",
+                    "container",
+                    "storage_path",
+                    "staging_root",
+                    "storage_sas_token",
+                    "storage_account_key",
+                    "storage_credential",
+                    "resource_class",
+                    "distribution_default",
+                    "disable_result_cache",
+                    "strict_validation",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # Copy config keys
-        for key in [
-            "server",
-            "port",
-            "username",
-            "password",
-            "schema",
-            "auth_method",
-            "tenant_id",
-            "client_id",
-            "client_secret",
-            "driver",
-            "connect_timeout",
-            "query_timeout",
-            "encrypt",
-            "storage_account",
-            "container",
-            "storage_path",
-            "staging_root",
-            "storage_sas_token",
-            "storage_account_key",
-            "storage_credential",
-            "resource_class",
-            "distribution_default",
-            "disable_result_cache",
-            "strict_validation",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def _extract_storage_account(self, url: str) -> str | None:
         """Extract storage account name from Azure blob URL."""
@@ -719,16 +706,7 @@ class AzureSynapseAdapter(PlatformAdapter):
 
         return ", ".join(column_defs)
 
-    @staticmethod
-    def _normalize_existing_files(file_paths: Any) -> list[Path]:
-        """Normalize file inputs to existing, non-empty local paths."""
-        normalized_paths = file_paths if isinstance(file_paths, list) else [file_paths]
-        valid_files: list[Path] = []
-        for file_path in normalized_paths:
-            path = Path(file_path)
-            if path.exists() and path.stat().st_size > 0:
-                valid_files.append(path)
-        return valid_files
+    _normalize_existing_files = staticmethod(normalize_existing_files)
 
     def _resolve_data_files(self, benchmark: Any, data_dir: Path) -> DataSource:
         """Resolve benchmark data files via DataSourceResolver."""
@@ -1199,18 +1177,7 @@ class AzureSynapseAdapter(PlatformAdapter):
         except Exception:
             return False
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Azure Synapse supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.DISTRIBUTION,
-                TuningType.PARTITIONING,
-                TuningType.INDEXING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("DISTRIBUTION", "PARTITIONING", "INDEXING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Azure Synapse-specific tuning clauses for CREATE TABLE statements."""
@@ -1259,16 +1226,9 @@ class AzureSynapseAdapter(PlatformAdapter):
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
         """Apply unified tuning configuration to Azure Synapse."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Azure Synapse-specific platform optimizations."""
@@ -1277,22 +1237,10 @@ class AzureSynapseAdapter(PlatformAdapter):
 
         self.logger.info("Azure Synapse platform optimizations applied")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Azure Synapse.
-
-        Note: Azure Synapse supports PRIMARY KEY and FOREIGN KEY for query optimization,
-        but constraints are not enforced.
-        """
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled for Azure Synapse (informational only)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints enabled for Azure Synapse (informational only)")
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Azure Synapse (informational only)",
+        "Foreign key constraints enabled for Azure Synapse (informational only)",
+    )
 
 
 def _build_synapse_config(

--- a/benchbox/platforms/base/cloud_spark/mixins.py
+++ b/benchbox/platforms/base/cloud_spark/mixins.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         PlatformOptimizationConfiguration,
         PrimaryKeyConfiguration,
         TableTuning,
+        UnifiedTuningConfiguration,
     )
 
 from benchbox.platforms.base.cloud_spark.config import CloudPlatform, SparkConfigOptimizer
@@ -122,6 +123,22 @@ class SparkTuningMixin:
         """
         # Optimizations applied via Spark configuration, not DDL
         return []
+
+    def apply_tuning_configuration(
+        self,
+        config: UnifiedTuningConfiguration,
+    ) -> dict[str, Any]:
+        """Apply unified tuning configuration through the Spark tuning hooks."""
+        results: dict[str, Any] = {}
+        if config.scale_factor:
+            self._scale_factor = config.scale_factor
+        if config.primary_keys:
+            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
+        if config.foreign_keys:
+            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
+        if config.platform:
+            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
+        return results
 
     def apply_constraint_configuration(
         self,

--- a/benchbox/platforms/base/config_utils.py
+++ b/benchbox/platforms/base/config_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 POSTGRES_FAMILY_BASE_OPTIONS: dict[str, Any] = {
@@ -87,3 +88,32 @@ def build_platform_config(
         config_dict["database"] = overrides["database"]
 
     return DatabaseConfig(**config_dict)
+
+
+def build_adapter_config(
+    config: dict[str, Any],
+    *,
+    platform: str,
+    generated_key: str | None = "database",
+    fields: Iterable[str] = (),
+    include_none: bool = True,
+) -> dict[str, Any]:
+    """Build common adapter constructor kwargs from unified config."""
+    adapter_config: dict[str, Any] = {}
+    if generated_key:
+        if config.get(generated_key):
+            adapter_config[generated_key] = config[generated_key]
+        else:
+            from benchbox.utils.database_naming import generate_database_name
+
+            adapter_config[generated_key] = generate_database_name(
+                benchmark_name=config["benchmark"],
+                scale_factor=config["scale_factor"],
+                platform=platform,
+                tuning_config=config.get("tuning_config"),
+            )
+
+    for key in fields:
+        if key in config and (include_none or config[key] is not None):
+            adapter_config[key] = config[key]
+    return adapter_config

--- a/benchbox/platforms/base/mysql_wire.py
+++ b/benchbox/platforms/base/mysql_wire.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any, Callable
 
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -104,6 +105,34 @@ class MySqlWireLifecycleMixin:
     current_database_sql = "SELECT DATABASE()"
     empty_load_details: Any = None
     reset_table_rows_on_load_error = False
+
+    def execute_query(
+        self,
+        connection: Any,
+        query: str,
+        query_id: str,
+        benchmark_type: str | None = None,
+        scale_factor: float | None = None,
+        validate_row_count: bool = True,
+        stream_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute a single query through the shared SQL execution helper."""
+        from benchbox.platforms.base.sql_execution import execute_sql_query as default_execute_sql_query
+
+        module = sys.modules.get(type(self).__module__)
+        execute = getattr(module, "execute_sql_query", default_execute_sql_query)
+
+        return execute(
+            connection,
+            query,
+            query_id,
+            log_verbose=self.log_verbose,
+            build_query_result_with_validation=self._build_query_result_with_validation,
+            benchmark_type=benchmark_type,
+            scale_factor=scale_factor,
+            validate_row_count=validate_row_count,
+            stream_id=stream_id,
+        )
 
     def _validate_identifier(self, identifier: str) -> bool:
         return is_valid_sql_identifier(identifier, max_length=self.database_identifier_max_length)

--- a/benchbox/platforms/base/psycopg2_mixin.py
+++ b/benchbox/platforms/base/psycopg2_mixin.py
@@ -36,6 +36,31 @@ class PsycopgConnectionMixin:
 
     _max_identifier_length: int = 63
 
+    def execute_query(
+        self,
+        connection: Any,
+        query: str,
+        query_id: str,
+        benchmark_type: str | None = None,
+        scale_factor: float | None = None,
+        validate_row_count: bool = True,
+        stream_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute a single query through the shared SQL execution helper."""
+        from benchbox.platforms.base.sql_execution import execute_sql_query
+
+        return execute_sql_query(
+            connection,
+            query,
+            query_id,
+            log_verbose=self.log_verbose,
+            build_query_result_with_validation=self._build_query_result_with_validation,
+            benchmark_type=benchmark_type,
+            scale_factor=scale_factor,
+            validate_row_count=validate_row_count,
+            stream_id=stream_id,
+        )
+
     def _validate_identifier(self, identifier: str) -> bool:
         """Validate a SQL identifier to prevent injection.
 

--- a/benchbox/platforms/base/spark_execution_mixin.py
+++ b/benchbox/platforms/base/spark_execution_mixin.py
@@ -217,6 +217,12 @@ class SparkDataLoadMixin:
             return "hudi"
         return None
 
+    def load_data(
+        self, benchmark: Any, connection: Any, data_dir: Path
+    ) -> tuple[dict[str, int], float, dict[str, Any] | None]:
+        """Load data using the shared Spark DataFrame implementation."""
+        return self._load_data_spark(benchmark, data_dir, connection)
+
     def _load_data_spark(
         self,
         benchmark: Any,
@@ -460,6 +466,27 @@ class SparkQueryExecutionMixin:
     # Spark Connect backends like LakeSail do not implement ClearCache, so they
     # override this flag to False and rely on session-level cache suppression.
     _catalog_clear_cache_supported: bool = True
+
+    def execute_query(
+        self,
+        connection: Any,
+        query: str,
+        query_id: str,
+        benchmark_type: str | None = None,
+        scale_factor: float | None = None,
+        validate_row_count: bool = True,
+        stream_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute a SQL query with the shared Spark query implementation."""
+        return self._execute_query_spark(
+            connection=connection,
+            query=query,
+            query_id=query_id,
+            benchmark_type=benchmark_type,
+            scale_factor=scale_factor,
+            validate_row_count=validate_row_count,
+            stream_id=stream_id,
+        )
 
     def _execute_query_spark(
         self,

--- a/benchbox/platforms/base/tuning.py
+++ b/benchbox/platforms/base/tuning.py
@@ -13,15 +13,56 @@ surface is intentionally visible on the base class.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import TableTuning, TuningType as TuningTypeT
+    from benchbox.core.tuning.interface import (
+        ForeignKeyConfiguration,
+        PrimaryKeyConfiguration,
+        TableTuning,
+        TuningType as TuningTypeT,
+    )
 
 try:
     from benchbox.core.tuning.interface import TuningType
 except ImportError:
     TuningType = None
+
+
+def supports_named_tuning_type(tuning_type: Any, supported_names: Iterable[str]) -> bool:
+    """Return whether *tuning_type* matches one of the named TuningType members."""
+    try:
+        from benchbox.core.tuning.interface import TuningType as CurrentTuningType
+    except ImportError:
+        return False
+    for name in supported_names:
+        candidate = getattr(CurrentTuningType, name, None)
+        if candidate is not None and tuning_type == candidate:
+            return True
+    return False
+
+
+def make_informational_constraint_applier(
+    primary_message: str,
+    foreign_message: str,
+) -> Callable[[Any, Any, Any, Any], None]:
+    """Create a constraint hook that logs enabled informational constraints."""
+
+    def apply_constraint_configuration(
+        self,
+        primary_key_config: PrimaryKeyConfiguration,
+        foreign_key_config: ForeignKeyConfiguration,
+        connection: Any,
+    ) -> None:
+        if primary_key_config and primary_key_config.enabled:
+            self.logger.info(primary_message)
+        if foreign_key_config and foreign_key_config.enabled:
+            self.logger.info(foreign_message)
+
+    apply_constraint_configuration.__name__ = "apply_constraint_configuration"
+    apply_constraint_configuration.__qualname__ = "apply_constraint_configuration"
+    return apply_constraint_configuration
 
 
 class TuningHooksMixin:
@@ -32,6 +73,7 @@ class TuningHooksMixin:
     """
 
     platform_name: str
+    _supported_tuning_type_names: Iterable[str] | None = None
 
     def apply_table_tunings(self, table_tuning: TableTuning, connection: Any) -> None:
         """Apply tuning configurations to a database table.
@@ -59,6 +101,8 @@ class TuningHooksMixin:
         Returns:
             True if the tuning type is supported by this platform
         """
+        if self._supported_tuning_type_names is not None:
+            return supports_named_tuning_type(tuning_type, self._supported_tuning_type_names)
         if TuningType is None:
             return False
 

--- a/benchbox/platforms/base/tuning_config.py
+++ b/benchbox/platforms/base/tuning_config.py
@@ -18,6 +18,18 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
+def apply_standard_unified_tuning(adapter: Any, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
+    """Apply the standard constraint, platform, then table-tuning hook sequence."""
+    if not unified_config:
+        return
+
+    adapter.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
+    if unified_config.platform_optimizations:
+        adapter.apply_platform_optimizations(unified_config.platform_optimizations, connection)
+    for _table_name, table_tuning in unified_config.table_tunings.items():
+        adapter.apply_table_tunings(table_tuning, connection)
+
+
 class TuningConfigMixin:
     """Mixin providing unified-tuning configuration handling for `PlatformAdapter`.
 

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -16,13 +16,12 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         TuningColumn,
         UnifiedTuningConfiguration,
     )
@@ -1772,26 +1771,7 @@ class BigQueryAdapter(PlatformAdapter):
             # Silently ignore transport cleanup errors
             pass
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if BigQuery supports a specific tuning type.
-
-        BigQuery supports:
-        - PARTITIONING: Via PARTITION BY clause (date/timestamp/integer columns)
-        - CLUSTERING: Via CLUSTER BY clause (up to 4 columns)
-
-        Args:
-            tuning_type: The type of tuning to check support for
-
-        Returns:
-            True if the tuning type is supported by BigQuery
-        """
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {TuningType.PARTITIONING, TuningType.CLUSTERING}
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate BigQuery-specific tuning clauses for CREATE TABLE statements.
@@ -1952,25 +1932,10 @@ class BigQueryAdapter(PlatformAdapter):
             raise ValueError(f"Failed to apply tunings to BigQuery table {table_name}: {e}") from e
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
-        """Apply unified tuning configuration to BigQuery.
+        """Apply unified tuning configuration to BigQuery."""
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        Args:
-            unified_config: Unified tuning configuration to apply
-            connection: BigQuery connection
-        """
-        if not unified_config:
-            return
-
-        # Apply constraint configurations
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply BigQuery-specific platform optimizations.
@@ -1986,32 +1951,10 @@ class BigQueryAdapter(PlatformAdapter):
         # Store optimizations for use during query execution
         self.logger.info("BigQuery platform optimizations stored for query execution")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to BigQuery.
-
-        Note: BigQuery has limited constraint support. Constraints are mainly for metadata/optimization.
-
-        Args:
-            primary_key_config: Primary key constraint configuration
-            foreign_key_config: Foreign key constraint configuration
-            connection: BigQuery connection
-        """
-        # BigQuery constraints are applied at table creation time
-        # This method is called after tables are created, so log the configurations
-
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled for BigQuery (applied during table creation)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints enabled for BigQuery (applied during table creation)")
-
-        # BigQuery doesn't support ALTER TABLE to add constraints after creation
-        # So there's no additional work to do here
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for BigQuery (applied during table creation)",
+        "Foreign key constraints enabled for BigQuery (applied during table creation)",
+    )
 
 
 def _build_bigquery_config(

--- a/benchbox/platforms/cedardb.py
+++ b/benchbox/platforms/cedardb.py
@@ -225,26 +225,7 @@ class CedarDBAdapter(PostgreSQLAdapter):
             self.logger.warning(f"Failed to drop database {db_name}: {e}")
             raise
 
-    def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if CedarDB supports a specific tuning type.
-
-        CedarDB is a full relational database with ACID guarantees, so most
-        PostgreSQL tuning types apply. Distribution is not supported (single-node).
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: False,  # Not verified - needs live CedarDB testing
-                TuningType.SORTING: False,  # No native sort keys
-                TuningType.DISTRIBUTION: False,  # Single-node only
-                TuningType.CLUSTERING: False,  # Not verified - CLUSTER is PG-specific
-                TuningType.PRIMARY_KEYS: True,  # Full constraint support
-                TuningType.FOREIGN_KEYS: True,  # Full constraint support
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
 def _build_cedardb_config(

--- a/benchbox/platforms/clickhouse/tuning.py
+++ b/benchbox/platforms/clickhouse/tuning.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from benchbox.core.exceptions import ConfigurationError
+from benchbox.platforms.base.tuning import make_informational_constraint_applier, supports_named_tuning_type
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         UnifiedTuningConfiguration,
     )
 
@@ -284,33 +283,11 @@ class ClickHouseTuningMixin:
                 self.logger.warning(f"Failed to set {setting}: {e}")
             return False
 
+    _supported_tuning_type_names = ("PARTITIONING", "SORTING", "CLUSTERING", "DISTRIBUTION")
+
     def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if ClickHouse supports a specific tuning type.
-
-        ClickHouse supports:
-        - PARTITIONING: Via PARTITION BY clause in MergeTree engines
-        - SORTING: Via ORDER BY clause in MergeTree engines
-        - CLUSTERING: Via ORDER BY clause for data clustering
-        - DISTRIBUTION: Via distributed engine configurations
-
-        Args:
-            tuning_type: The type of tuning to check support for
-
-        Returns:
-            True if the tuning type is supported by ClickHouse
-        """
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.SORTING,
-                TuningType.CLUSTERING,
-                TuningType.DISTRIBUTION,
-            }
-        except ImportError:
-            return False
+        """Check if ClickHouse supports a specific tuning type."""
+        return supports_named_tuning_type(tuning_type, self._supported_tuning_type_names)
 
     def apply_table_tunings(self, table_tuning, connection: Any) -> None:
         """Apply ClickHouse-specific table tunings.
@@ -464,19 +441,9 @@ class ClickHouseTuningMixin:
             unified_config: Unified tuning configuration to apply
             connection: ClickHouse connection
         """
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        # Apply constraint configurations
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply ClickHouse-specific platform optimizations.
@@ -519,31 +486,10 @@ class ClickHouseTuningMixin:
         except Exception as e:
             self.logger.error(f"Failed to apply ClickHouse platform optimizations: {e}")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to ClickHouse.
-
-        Note: ClickHouse has limited constraint support compared to traditional RDBMS.
-        Primary keys and foreign keys are mainly for query optimization hints.
-
-        Args:
-            primary_key_config: Primary key constraint configuration
-            foreign_key_config: Foreign key constraint configuration
-            connection: ClickHouse connection
-        """
-        # ClickHouse constraints are applied at table creation time
-        # This method is called after tables are created, so log the configurations
-        # Actual constraint application happens in generate_tuning_clause during CREATE TABLE
-
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled for ClickHouse (applied during table creation)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints enabled for ClickHouse (applied during table creation)")
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for ClickHouse (applied during table creation)",
+        "Foreign key constraints enabled for ClickHouse (applied during table creation)",
+    )
 
 
 __all__ = ["ClickHouseTuningMixin"]

--- a/benchbox/platforms/databend/adapter.py
+++ b/benchbox/platforms/databend/adapter.py
@@ -34,15 +34,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         UnifiedTuningConfiguration,
     )
 
@@ -207,37 +206,16 @@ class DatabendAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Databend adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="databend",
-                tuning_config=config.get("tuning_config"),
+                fields=["host", "port", "username", "password", "dsn", "ssl", "warehouse", "disable_result_cache"],
+                include_none=False,
             )
-            adapter_config["database"] = database_name
-
-        # Map connection parameters
-        for key in [
-            "host",
-            "port",
-            "username",
-            "password",
-            "dsn",
-            "ssl",
-            "warehouse",
-            "disable_result_cache",
-        ]:
-            if key in config and config[key] is not None:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def get_target_dialect(self) -> str:
         """Return the target SQL dialect for Databend.
@@ -751,21 +729,7 @@ class DatabendAdapter(PlatformAdapter):
             if connection and hasattr(connection, "close"):
                 connection.close()
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Databend supports a specific tuning type.
-
-        Databend supports:
-        - CLUSTERING: Via CLUSTER BY clause (similar to Snowflake clustering keys)
-        - PARTITIONING: Not directly supported (uses automatic micro-partitioning)
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.CLUSTERING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("CLUSTERING",)
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Databend-specific tuning clauses.
@@ -820,19 +784,9 @@ class DatabendAdapter(PlatformAdapter):
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
         """Apply unified tuning configuration to Databend."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        # Apply constraint configurations (informational only in Databend)
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Databend-specific platform optimizations."""
@@ -841,21 +795,10 @@ class DatabendAdapter(PlatformAdapter):
 
         self.logger.info("Databend platform optimizations noted (engine pre-optimized for analytics)")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Databend.
-
-        Note: Databend does not enforce foreign key constraints.
-        """
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints noted for Databend (informational)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints noted for Databend (not enforced)")
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints noted for Databend (informational)",
+        "Foreign key constraints noted for Databend (not enforced)",
+    )
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Run ANALYZE on table for query optimization.

--- a/benchbox/platforms/databricks/adapter.py
+++ b/benchbox/platforms/databricks/adapter.py
@@ -23,9 +23,7 @@ from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         TuningColumn,
         UnifiedTuningConfiguration,
     )
@@ -33,6 +31,7 @@ if TYPE_CHECKING:
 from benchbox.core.upload_validation import UploadValidationEngine
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
 from benchbox.platforms.base.runtime_metadata import build_default_normalized_result_metadata
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.datagen_manifest import MANIFEST_FILENAME
 from benchbox.utils.dependencies import (
     check_platform_dependencies,
@@ -2166,31 +2165,7 @@ class DatabricksAdapter(PlatformAdapter):
         except Exception as e:
             self.logger.warning(f"Error closing connection: {e}")
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Databricks supports a specific tuning type.
-
-        Databricks supports:
-        - PARTITIONING: Via PARTITIONED BY clause in Delta Lake
-        - CLUSTERING: Via CLUSTER BY clause (Delta Lake 2.0+)
-        - DISTRIBUTION: Via Spark optimization hints and Z-ORDER clustering
-
-        Args:
-            tuning_type: The type of tuning to check support for
-
-        Returns:
-            True if the tuning type is supported by Databricks
-        """
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.CLUSTERING,
-                TuningType.DISTRIBUTION,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING", "DISTRIBUTION")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Databricks-specific tuning clauses for CREATE TABLE statements.
@@ -2410,25 +2385,10 @@ class DatabricksAdapter(PlatformAdapter):
             self.logger.warning(f"Failed to optimize Delta table {table_name}: {e}")
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
-        """Apply unified tuning configuration to Databricks.
+        """Apply unified tuning configuration to Databricks."""
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        Args:
-            unified_config: Unified tuning configuration to apply
-            connection: Databricks connection
-        """
-        if not unified_config:
-            return
-
-        # Apply constraint configurations
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Databricks-specific platform optimizations.
@@ -2450,35 +2410,7 @@ class DatabricksAdapter(PlatformAdapter):
         # Store optimizations for use during query execution and Delta Lake operations
         self.logger.info("Databricks platform optimizations stored for Spark session and Delta Lake management")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Databricks.
-
-        Note: Databricks (Spark SQL) supports PRIMARY KEY and FOREIGN KEY constraints
-        but they are informational only (not enforced). They are used for query optimization
-        in Catalyst optimizer and must be applied during table creation time.
-
-        Args:
-            primary_key_config: Primary key constraint configuration
-            foreign_key_config: Foreign key constraint configuration
-            connection: Databricks connection
-        """
-        # Databricks constraints are applied at table creation time for Catalyst optimization
-        # This method is called after tables are created, so log the configurations
-
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info(
-                "Primary key constraints enabled for Databricks (informational only, applied during table creation)"
-            )
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info(
-                "Foreign key constraints enabled for Databricks (informational only, applied during table creation)"
-            )
-
-        # Databricks constraints are informational and used by Catalyst optimizer
-        # No additional work to do here as they're applied during CREATE TABLE
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Databricks (informational only, applied during table creation)",
+        "Foreign key constraints enabled for Databricks (informational only, applied during table creation)",
+    )

--- a/benchbox/platforms/doris.py
+++ b/benchbox/platforms/doris.py
@@ -56,7 +56,6 @@ from .base.mysql_wire import (
     NoOpTableTuningMixin,
     build_database_config,
 )
-from .base.sql_execution import execute_sql_query
 
 # Doris dialect for SQLGlot
 DORIS_DIALECT = "doris"
@@ -946,29 +945,6 @@ class DorisAdapter(NoOpTableTuningMixin, MySqlWireLifecycleMixin, PlatformAdapte
 
         cursor.close()
 
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute a single query and return detailed results."""
-        return execute_sql_query(
-            connection,
-            query,
-            query_id,
-            log_verbose=self.log_verbose,
-            build_query_result_with_validation=self._build_query_result_with_validation,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
-
     def _explain_query_prefix(self, explain_options: dict[str, Any] | None = None) -> str:
         verbose = explain_options.get("verbose", False) if explain_options else False
         return "EXPLAIN VERBOSE" if verbose else "EXPLAIN"
@@ -1451,22 +1427,7 @@ class DorisAdapter(NoOpTableTuningMixin, MySqlWireLifecycleMixin, PlatformAdapte
             validation_details["integrity_error"] = str(e)
             return "FAILED", validation_details
 
-    def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if Doris supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: True,  # PARTITION BY RANGE
-                TuningType.SORTING: True,  # Sort keys in Duplicate model
-                TuningType.DISTRIBUTION: True,  # DISTRIBUTED BY HASH
-                TuningType.CLUSTERING: False,  # No CLUSTER command
-                TuningType.PRIMARY_KEYS: True,  # Unique/Primary key models
-                TuningType.FOREIGN_KEYS: False,  # No FK enforcement
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "SORTING", "DISTRIBUTION", "PRIMARY_KEYS")
 
 
 def _build_doris_config(

--- a/benchbox/platforms/fabric_warehouse.py
+++ b/benchbox/platforms/fabric_warehouse.py
@@ -42,13 +42,12 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
     )
 
 from ..utils.dependencies import check_platform_dependencies, get_dependency_error_message, get_package_install_message
@@ -264,48 +263,37 @@ class FabricWarehouseAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Fabric Warehouse adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
+        adapter_source = config
+        if not config.get("database") and config.get("warehouse"):
+            adapter_source = {**config, "database": config["warehouse"]}
 
-        # Generate proper database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        elif "warehouse" in config and config["warehouse"]:
-            adapter_config["database"] = config["warehouse"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                adapter_source,
                 platform="fabric_dw",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "server",
+                    "workspace",
+                    "warehouse",
+                    "port",
+                    "schema",
+                    "auth_method",
+                    "tenant_id",
+                    "client_id",
+                    "client_secret",
+                    "driver",
+                    "connect_timeout",
+                    "query_timeout",
+                    "onelake_workspace",
+                    "staging_path",
+                    "disable_result_cache",
+                    "strict_validation",
+                    "item_type",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # Copy config keys
-        for key in [
-            "server",
-            "workspace",
-            "warehouse",
-            "port",
-            "schema",
-            "auth_method",
-            "tenant_id",
-            "client_id",
-            "client_secret",
-            "driver",
-            "connect_timeout",
-            "query_timeout",
-            "onelake_workspace",
-            "staging_path",
-            "disable_result_cache",
-            "strict_validation",
-            "item_type",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def _get_access_token(self) -> str:
         """Acquire Entra ID access token for SQL connection.
@@ -1148,48 +1136,12 @@ class FabricWarehouseAdapter(PlatformAdapter):
 
         self.logger.info("Fabric Warehouse platform optimizations applied")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Fabric Warehouse.
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Fabric Warehouse (informational only)",
+        "Foreign key constraints enabled for Fabric Warehouse (informational only)",
+    )
 
-        Note: Fabric Warehouse supports PRIMARY KEY and FOREIGN KEY for query
-        optimization, but constraints are not enforced (similar to Synapse).
-
-        Args:
-            primary_key_config: Primary key constraint configuration.
-            foreign_key_config: Foreign key constraint configuration.
-            connection: Active database connection.
-        """
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled for Fabric Warehouse (informational only)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints enabled for Fabric Warehouse (informational only)")
-
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Fabric Warehouse supports a specific tuning type.
-
-        Note: Fabric automatically manages distribution and partitioning,
-        so only clustering (columnstore index) is relevant.
-
-        Args:
-            tuning_type: TuningType enum value.
-
-        Returns:
-            True if supported, False otherwise.
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-        except ImportError:
-            return False
-
-        # Fabric automatically manages distribution and partitioning
-        # Only clustering (columnstore) is user-controllable
-        return tuning_type == TuningType.CLUSTERING
+    _supported_tuning_type_names = ("CLUSTERING",)
 
     def generate_tuning_clause(
         self,

--- a/benchbox/platforms/firebolt.py
+++ b/benchbox/platforms/firebolt.py
@@ -28,15 +28,15 @@ from urllib.parse import urlparse
 from benchbox.core.benchmark_mixins import CursorValidationQueryExecutionMixin
 from benchbox.core.sql_utils import normalize_table_name_in_sql
 from benchbox.platforms.base.runtime_metadata import build_default_normalized_result_metadata
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
+from benchbox.platforms.presto_trino_utils import normalize_existing_files, show_tables_lower
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         UnifiedTuningConfiguration,
     )
 
@@ -338,44 +338,32 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Firebolt adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
-                platform="firebolt",
-                tuning_config=config.get("tuning_config"),
-            )
-            adapter_config["database"] = database_name
-
-        # Mode and connection parameters
-        for key in [
-            "url",
-            "client_id",
-            "client_secret",
-            "account_name",
-            "engine_name",
-            "api_endpoint",
-            "region",
-            "cloud_region",
-            "cloud_provider",
-            "engine_type",
-            "engine_size",
-            "compute_size",
-            "deployment_mode",
-            "s3_staging_url",
-            "s3_region",
-            "disable_result_cache",
-            "strict_validation",
-        ]:
-            if key in config and config[key] is not None:
-                adapter_config[key] = config[key]
+        adapter_config = build_adapter_config(
+            config,
+            platform="firebolt",
+            fields=[
+                "url",
+                "client_id",
+                "client_secret",
+                "account_name",
+                "engine_name",
+                "api_endpoint",
+                "region",
+                "cloud_region",
+                "cloud_provider",
+                "engine_type",
+                "engine_size",
+                "compute_size",
+                "deployment_mode",
+                "s3_staging_url",
+                "s3_region",
+                "disable_result_cache",
+                "strict_validation",
+            ],
+            include_none=False,
+        )
 
         # Handle mode override
         if config.get("deployment_mode"):
@@ -899,16 +887,7 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
             return self._load_data_via_s3(benchmark, connection, data_dir)
         return self._load_data_via_insert(benchmark, connection, data_dir)
 
-    @staticmethod
-    def _normalize_existing_files(file_paths: Any) -> list[Path]:
-        """Normalize file inputs to existing, non-empty local paths."""
-        normalized_paths = file_paths if isinstance(file_paths, list) else [file_paths]
-        valid_files: list[Path] = []
-        for file_path in normalized_paths:
-            path = Path(file_path)
-            if path.exists() and path.stat().st_size > 0:
-                valid_files.append(path)
-        return valid_files
+    _normalize_existing_files = staticmethod(normalize_existing_files)
 
     def _resolve_data_files(self, benchmark, data_dir: Path) -> Any:
         """Resolve data files via DataSourceResolver.
@@ -1349,27 +1328,7 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
             self.logger.debug(f"Connection test failed: {e}")
             return False
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Firebolt supports a specific tuning type.
-
-        Firebolt supports:
-        - PARTITIONING: Via PARTITION BY clause
-        - DISTRIBUTION: Via PRIMARY INDEX clause (critical for Firebolt performance)
-        - Aggregating indexes (Firebolt-specific, not exposed via tuning interface)
-
-        Note: Primary/foreign key constraints are NOT enforced in Firebolt.
-        Firebolt's PRIMARY INDEX (mapped to DISTRIBUTION tuning type) controls
-        how data is distributed across nodes - this is different from PRIMARY KEY.
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.DISTRIBUTION,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "DISTRIBUTION")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Firebolt-specific tuning clauses.
@@ -1422,19 +1381,9 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
         """Apply unified tuning configuration to Firebolt."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        # Apply constraint configurations (informational only in Firebolt)
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Firebolt-specific platform optimizations.
@@ -1447,32 +1396,12 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
 
         self.logger.info("Firebolt platform optimizations noted (engine pre-optimized for analytics)")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Firebolt.
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Firebolt (informational only, not enforced)",
+        "Foreign key constraints enabled for Firebolt (informational only, not enforced)",
+    )
 
-        Note: Firebolt does not enforce constraints. They are informational only.
-        """
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled for Firebolt (informational only, not enforced)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints enabled for Firebolt (informational only, not enforced)")
-
-    def _get_existing_tables(self, connection: Any) -> list[str]:
-        """Get list of existing tables from Firebolt database."""
-        cursor = connection.cursor()
-        try:
-            cursor.execute("SHOW TABLES")
-            return [row[0].lower() for row in cursor.fetchall()]
-        except Exception:
-            return []
-        finally:
-            cursor.close()
+    _get_existing_tables = staticmethod(show_tables_lower)
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Run ANALYZE on table for query optimization.

--- a/benchbox/platforms/gcp/dataproc_adapter.py
+++ b/benchbox/platforms/gcp/dataproc_adapter.py
@@ -43,9 +43,7 @@ from typing import TYPE_CHECKING, Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import (
-        UnifiedTuningConfiguration,
-    )
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -722,34 +720,6 @@ spark.stop()
         return cls(**params)
 
     # configure_for_benchmark is inherited from CloudSparkConfigMixin
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     # apply_primary_keys, apply_foreign_keys, apply_platform_optimizations,
     # and apply_constraint_configuration are inherited from SparkTuningMixin

--- a/benchbox/platforms/gcp/dataproc_serverless_adapter.py
+++ b/benchbox/platforms/gcp/dataproc_serverless_adapter.py
@@ -41,9 +41,7 @@ from typing import TYPE_CHECKING, Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import (
-        UnifiedTuningConfiguration,
-    )
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -594,34 +592,6 @@ spark.stop()
         return cls(**params)
 
     # configure_for_benchmark is inherited from CloudSparkConfigMixin
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     # apply_primary_keys, apply_foreign_keys, apply_platform_optimizations,
     # and apply_constraint_configuration are inherited from SparkTuningMixin

--- a/benchbox/platforms/lakesail.py
+++ b/benchbox/platforms/lakesail.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import argparse
 import subprocess
-from pathlib import Path
 from typing import Any
 
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -212,45 +211,26 @@ class LakeSailAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecu
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create LakeSail adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate proper database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="lakesail",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "endpoint",
+                    "app_name",
+                    "driver_memory",
+                    "sail_mode",
+                    "sail_workers",
+                    "shuffle_partitions",
+                    "adaptive_enabled",
+                    "table_format",
+                    "spark_config",
+                    "disable_cache",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # Core configuration parameters
-        for key in [
-            "endpoint",
-            "app_name",
-            "driver_memory",
-            "sail_mode",
-            "sail_workers",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Optional configuration parameters
-        for key in [
-            "shuffle_partitions",
-            "adaptive_enabled",
-            "table_format",
-            "spark_config",
-            "disable_cache",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get LakeSail platform information."""
@@ -539,16 +519,6 @@ class LakeSailAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecu
 
         return elapsed_seconds(start_time)
 
-    def load_data(
-        self, benchmark, connection: Any, data_dir: Path
-    ) -> tuple[dict[str, int], float, dict[str, Any] | None]:
-        """Load data into Sail server via Spark Connect.
-
-        Delegates to SparkDataLoadMixin._load_data_spark for the shared
-        DataFrame-based loading implementation.
-        """
-        return self._load_data_spark(benchmark, data_dir, connection)
-
     def configure_for_benchmark(self, connection: Any, benchmark_type: str) -> None:
         """Apply Sail-specific optimizations based on benchmark type."""
         spark = connection
@@ -565,31 +535,6 @@ class LakeSailAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecu
 
         except Exception as e:
             self.logger.warning(f"Failed to apply benchmark configuration: {e}")
-
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute query via Spark Connect to Sail server with timing.
-
-        Delegates to SparkQueryExecutionMixin._execute_query_spark for the
-        shared execution implementation.
-        """
-        return self._execute_query_spark(
-            connection=connection,
-            query=query,
-            query_id=query_id,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
 
     def _get_dialect_queries(self, benchmark: Any, benchmark_slug: str, connection: Any | None = None) -> dict:
         """Use LakeSail-specific query rules where Spark syntax compatibility diverges."""
@@ -648,17 +593,7 @@ class LakeSailAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecu
             self.logger.debug(f"Connection test failed: {e}")
             return False
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if LakeSail supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.SORTING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "SORTING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Spark-compatible tuning clauses for CREATE TABLE statements."""

--- a/benchbox/platforms/onehouse/quanton_adapter.py
+++ b/benchbox/platforms/onehouse/quanton_adapter.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import UnifiedTuningConfiguration
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -631,34 +631,6 @@ class QuantonAdapter(
                 params[key] = config[key]
 
         return cls(**params)
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     def get_target_dialect(self) -> str:
         """Return the target SQL dialect for Quanton.

--- a/benchbox/platforms/pg_duckdb.py
+++ b/benchbox/platforms/pg_duckdb.py
@@ -410,28 +410,7 @@ class PgDuckDBAdapter(PostgreSQLAdapter):
             entries=entries,
         )
 
-    def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if pg_duckdb supports a specific tuning type.
-
-        pg_duckdb operates on standard PostgreSQL heap tables, so tuning
-        capabilities match PostgreSQL. The main optimization is the DuckDB
-        execution engine itself, which benefits less from B-tree indexes
-        for analytical queries.
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: True,  # PostgreSQL declarative partitioning
-                TuningType.SORTING: False,  # No native sort keys
-                TuningType.DISTRIBUTION: False,  # Not distributed
-                TuningType.CLUSTERING: True,  # CLUSTER command available
-                TuningType.PRIMARY_KEYS: True,  # Full constraint support
-                TuningType.FOREIGN_KEYS: True,  # Full constraint support
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING", "PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
 def _build_pg_duckdb_config(

--- a/benchbox/platforms/pg_mooncake.py
+++ b/benchbox/platforms/pg_mooncake.py
@@ -539,28 +539,8 @@ class PgMooncakeAdapter(PostgreSQLAdapter):
             cursor.close()
 
     def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if pg_mooncake supports a specific tuning type.
-
-        pg_mooncake columnstore tables have different tuning characteristics
-        than PostgreSQL heap tables:
-        - No B-tree indexes on columnstore tables
-        - No CLUSTER support (Parquet-based storage)
-        - Partitioning handled at the Iceberg/Parquet level
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: False,  # Columnstore handles its own partitioning
-                TuningType.SORTING: False,  # No native sort keys on columnstore
-                TuningType.DISTRIBUTION: False,  # Not distributed
-                TuningType.CLUSTERING: False,  # No CLUSTER on columnstore tables
-                TuningType.PRIMARY_KEYS: False,  # Columnstore tables don't support constraints
-                TuningType.FOREIGN_KEYS: False,  # Columnstore tables don't support constraints
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+        """Check if pg_mooncake supports a specific tuning type."""
+        return False
 
 
 def _build_pg_mooncake_config(

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -42,7 +42,6 @@ from .base.data_loading import (
     prepare_local_load_file,
     resolve_csv_dialect,
 )
-from .base.sql_execution import execute_sql_query
 
 # PostgreSQL dialect for SQLGlot
 POSTGRES_DIALECT = "postgres"
@@ -686,29 +685,6 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         connection.commit()
         cursor.close()
 
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute a single query and return detailed results."""
-        return execute_sql_query(
-            connection,
-            query,
-            query_id,
-            log_verbose=self.log_verbose,
-            build_query_result_with_validation=self._build_query_result_with_validation,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
-
     def get_query_plan(
         self,
         connection: Any,
@@ -1021,23 +997,7 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             # Fallback if validation module not available
             return None
 
-    def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if PostgreSQL supports a specific tuning type."""
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: True,  # PostgreSQL supports declarative partitioning
-                TuningType.SORTING: False,  # No native sort keys like columnar stores
-                TuningType.DISTRIBUTION: False,  # No distribution keys (not distributed)
-                TuningType.CLUSTERING: True,  # CLUSTER command available
-                TuningType.PRIMARY_KEYS: True,  # Full constraint support
-                TuningType.FOREIGN_KEYS: True,  # Full constraint support
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING", "PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
 def _build_postgresql_config(

--- a/benchbox/platforms/presto_trino_adapter_base.py
+++ b/benchbox/platforms/presto_trino_adapter_base.py
@@ -15,6 +15,7 @@ from benchbox.platforms.presto_trino_utils import (
     load_file_batches,
     normalize_existing_files,
     resolve_data_files,
+    show_tables_lower,
     validate_catalog_exists,
 )
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -115,24 +116,16 @@ class PrestoTrinoAdapterBase(CursorValidationQueryExecutionMixin, HiveExternalTa
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create a Presto-family adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-        if config.get("schema"):
-            adapter_config["schema"] = config["schema"]
-        else:
-            adapter_config["schema"] = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform=cls.platform_key,
-                tuning_config=config.get("tuning_config"),
+                generated_key="schema",
+                fields=("host", "port", "catalog", "username", "password", *cls.from_config_optional_fields),
             )
-
-        for key in ("host", "port", "catalog", "username", "password", *cls.from_config_optional_fields):
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def get_target_dialect(self) -> str:
         """Return the target SQL dialect."""
@@ -677,14 +670,9 @@ class PrestoTrinoAdapterBase(CursorValidationQueryExecutionMixin, HiveExternalTa
 
     def apply_unified_tuning(self, unified_config: Any, connection: Any) -> None:
         """Apply unified tuning configuration."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: Any, connection: Any) -> None:
         """Apply platform optimizations."""
@@ -703,13 +691,4 @@ class PrestoTrinoAdapterBase(CursorValidationQueryExecutionMixin, HiveExternalTa
                 f"Foreign key constraints enabled for {self.platform_log_name} (informational only, not enforced)"
             )
 
-    def _get_existing_tables(self, connection: Any) -> list[str]:
-        """Get list of existing tables from schema."""
-        cursor = connection.cursor()
-        try:
-            cursor.execute("SHOW TABLES")
-            return [row[0].lower() for row in cursor.fetchall()]
-        except Exception:
-            return []
-        finally:
-            cursor.close()
+    _get_existing_tables = staticmethod(show_tables_lower)

--- a/benchbox/platforms/presto_trino_utils.py
+++ b/benchbox/platforms/presto_trino_utils.py
@@ -110,6 +110,18 @@ def normalize_existing_files(file_paths: Any) -> list[Path]:
     return valid_files
 
 
+def show_tables_lower(connection: Any) -> list[str]:
+    """Return lower-cased table names from a cursor-based SHOW TABLES result."""
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SHOW TABLES")
+        return [row[0].lower() for row in cursor.fetchall()]
+    except Exception:
+        return []
+    finally:
+        cursor.close()
+
+
 def validate_catalog_exists(
     catalog: str | None,
     *,

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -16,13 +16,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from benchbox.core.sql_utils import normalize_table_name_in_sql
+from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         TuningColumn,
         UnifiedTuningConfiguration,
     )
@@ -234,61 +233,45 @@ class RedshiftAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Redshift adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate proper database name using benchmark characteristics
-        # (unless explicitly overridden in config)
-        if "database" in config and config["database"]:
-            # User explicitly provided database name - use it
-            adapter_config["database"] = config["database"]
-        else:
-            # Generate configuration-aware database name
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="redshift",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "host",
+                    "port",
+                    "username",
+                    "password",
+                    "schema",
+                    "iam_role",
+                    "s3_bucket",
+                    "s3_prefix",
+                    "staging_root",
+                    "aws_access_key_id",
+                    "aws_secret_access_key",
+                    "aws_session_token",
+                    "aws_region",
+                    "cluster_identifier",
+                    "admin_database",
+                    "connect_timeout",
+                    "statement_timeout",
+                    "sslmode",
+                    "ssl_enabled",
+                    "ssl_insecure",
+                    "sslrootcert",
+                    "wlm_query_slot_count",
+                    "wlm_query_queue_name",
+                    "wlm_config",
+                    "compupdate",
+                    "auto_vacuum",
+                    "auto_analyze",
+                    "disable_result_cache",
+                    "strict_validation",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # Core connection parameters (database handled above)
-        for key in ["host", "port", "username", "password", "schema"]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Optional staging/optimization parameters
-        for key in [
-            "iam_role",
-            "s3_bucket",
-            "s3_prefix",
-            "staging_root",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
-            "aws_region",
-            "cluster_identifier",
-            "admin_database",
-            "connect_timeout",
-            "statement_timeout",
-            "sslmode",
-            "ssl_enabled",
-            "ssl_insecure",
-            "sslrootcert",
-            "wlm_query_slot_count",
-            "wlm_query_queue_name",
-            "wlm_config",
-            "compupdate",
-            "auto_vacuum",
-            "auto_analyze",
-            "disable_result_cache",
-            "strict_validation",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def _detect_client_library_version(self) -> str | None:
         if redshift_connector:
@@ -2441,31 +2424,7 @@ class RedshiftAdapter(PlatformAdapter):
         except Exception as e:
             self.logger.warning(f"Error closing connection: {e}")
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Redshift supports a specific tuning type.
-
-        Redshift supports:
-        - DISTRIBUTION: Via DISTSTYLE and DISTKEY clauses
-        - SORTING: Via SORTKEY clause (compound and interleaved)
-        - PARTITIONING: Through table design patterns and date partitioning
-
-        Args:
-            tuning_type: The type of tuning to check support for
-
-        Returns:
-            True if the tuning type is supported by Redshift
-        """
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.DISTRIBUTION,
-                TuningType.SORTING,
-                TuningType.PARTITIONING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("DISTRIBUTION", "SORTING", "PARTITIONING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Redshift-specific tuning clauses for CREATE TABLE statements.
@@ -2664,19 +2623,9 @@ class RedshiftAdapter(PlatformAdapter):
             unified_config: Unified tuning configuration to apply
             connection: Redshift connection
         """
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        # Apply constraint configurations
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Redshift-specific platform optimizations.
@@ -2698,38 +2647,10 @@ class RedshiftAdapter(PlatformAdapter):
         # Store optimizations for use during query execution and maintenance operations
         self.logger.info("Redshift platform optimizations stored for session and workload management")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Redshift.
-
-        Note: Redshift supports PRIMARY KEY and FOREIGN KEY constraints for query optimization,
-        but they are informational only (not enforced). Constraints must be applied during
-        table creation time.
-
-        Args:
-            primary_key_config: Primary key constraint configuration
-            foreign_key_config: Foreign key constraint configuration
-            connection: Redshift connection
-        """
-        # Redshift constraints are applied at table creation time for query optimization
-        # This method is called after tables are created, so log the configurations
-
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info(
-                "Primary key constraints enabled for Redshift (informational only, applied during table creation)"
-            )
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info(
-                "Foreign key constraints enabled for Redshift (informational only, applied during table creation)"
-            )
-
-        # Redshift constraints are informational and used for query optimization
-        # No additional work to do here as they're applied during CREATE TABLE
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Redshift (informational only, applied during table creation)",
+        "Foreign key constraints enabled for Redshift (informational only, applied during table creation)",
+    )
 
 
 def _build_redshift_config(

--- a/benchbox/platforms/singlestore.py
+++ b/benchbox/platforms/singlestore.py
@@ -40,7 +40,7 @@ from .base.data_loading import (
     resolve_csv_dialect,
 )
 from .base.mysql_wire import MySqlWireLifecycleMixin, NoOpTableTuningMixin, build_database_config
-from .base.sql_execution import execute_sql_query
+from .base.sql_execution import execute_sql_query  # noqa: F401 - tests patch this module-local execution hook.
 
 # SQLGlot dialect - SingleStore is MySQL-compatible
 SINGLESTORE_DIALECT = "mysql"
@@ -371,29 +371,6 @@ class SingleStoreAdapter(NoOpTableTuningMixin, MySqlWireLifecycleMixin, BaseDdlO
         finally:
             cursor.close()
 
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute a single query and return detailed results."""
-        return execute_sql_query(
-            connection,
-            query,
-            query_id,
-            log_verbose=self.log_verbose,
-            build_query_result_with_validation=self._build_query_result_with_validation,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
-
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get SingleStore platform information."""
         platform_info: dict[str, Any] = {
@@ -641,22 +618,7 @@ class SingleStoreAdapter(NoOpTableTuningMixin, MySqlWireLifecycleMixin, BaseDdlO
         except Exception:
             warnings.append("Could not query SingleStore version")
 
-    def supports_tuning_type(self, tuning_type: Any) -> bool:
-        """Check if SingleStore supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            supported = {
-                TuningType.PARTITIONING: False,  # Not used in standard benchmarks
-                TuningType.SORTING: True,  # SORT KEY
-                TuningType.DISTRIBUTION: True,  # SHARD KEY
-                TuningType.CLUSTERING: False,  # No CLUSTER command
-                TuningType.PRIMARY_KEYS: False,  # No enforced PKs
-                TuningType.FOREIGN_KEYS: False,  # No FK enforcement
-            }
-            return supported.get(tuning_type, False)
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("SORTING", "DISTRIBUTION")
 
 
 def _build_singlestore_config(

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -18,9 +18,7 @@ from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         TuningColumn,
         UnifiedTuningConfiguration,
     )
@@ -31,6 +29,8 @@ from ..utils.dependencies import check_platform_dependencies, get_dependency_err
 from .base import DriverIsolationCapability, PlatformAdapter
 from .base.data_loading import NO_BENCHMARK, DataSource, DataSourceResolver, resolve_csv_dialect
 from .base.runtime_metadata import build_default_normalized_result_metadata
+from .base.tuning import make_informational_constraint_applier
+from .presto_trino_utils import normalize_existing_files
 
 try:
     import snowflake.connector
@@ -200,59 +200,41 @@ class SnowflakeAdapter(PlatformAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Snowflake adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate proper database name using benchmark characteristics
-        # (unless explicitly overridden in config)
-        if "database" in config and config["database"]:
-            # User explicitly provided database name - use it
-            adapter_config["database"] = config["database"]
-        else:
-            # Generate configuration-aware database name
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="snowflake",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "account",
+                    "warehouse",
+                    "schema",
+                    "username",
+                    "password",
+                    "role",
+                    "authenticator",
+                    "private_key_path",
+                    "private_key_passphrase",
+                    "warehouse_size",
+                    "auto_suspend",
+                    "auto_resume",
+                    "multi_cluster_warehouse",
+                    "query_tag",
+                    "timezone",
+                    "file_format",
+                    "compression",
+                    "staging_root",
+                    "iceberg_external_volume",
+                    "iceberg_catalog",
+                    "delta_table_format",
+                    "disable_result_cache",
+                    "strict_validation",
+                    "suppress_nondeterministic_errors",
+                    "modify_warehouse_settings",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        # Copy other config keys
-        for key in [
-            "account",
-            "warehouse",
-            # "database" - handled above with generation logic
-            "schema",
-            "username",
-            "password",
-            "role",
-            "authenticator",
-            "private_key_path",
-            "private_key_passphrase",
-            "warehouse_size",
-            "auto_suspend",
-            "auto_resume",
-            "multi_cluster_warehouse",
-            "query_tag",
-            "timezone",
-            "file_format",
-            "compression",
-            "staging_root",
-            "iceberg_external_volume",
-            "iceberg_catalog",
-            "delta_table_format",
-            # Behavior control options
-            "disable_result_cache",
-            "strict_validation",
-            "suppress_nondeterministic_errors",
-            "modify_warehouse_settings",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get Snowflake platform information.
@@ -968,16 +950,7 @@ class SnowflakeAdapter(PlatformAdapter):
             raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
         return data_source
 
-    @staticmethod
-    def _normalize_existing_files(file_paths: Any) -> list[Path]:
-        """Normalize file inputs to existing, non-empty local paths."""
-        normalized_paths = file_paths if isinstance(file_paths, list) else [file_paths]
-        valid_files: list[Path] = []
-        for file_path in normalized_paths:
-            path = Path(file_path)
-            if path.exists() and path.stat().st_size > 0:
-                valid_files.append(path)
-        return valid_files
+    _normalize_existing_files = staticmethod(normalize_existing_files)
 
     def _get_file_format_for_table(
         self,
@@ -1599,26 +1572,7 @@ class SnowflakeAdapter(PlatformAdapter):
         except Exception as e:
             self.logger.warning(f"Error closing connection: {e}")
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Snowflake supports a specific tuning type.
-
-        Snowflake supports:
-        - CLUSTERING: Via CLUSTER BY clause and automatic clustering
-        - PARTITIONING: Via micro-partitions (automatic) and manual clustering keys
-
-        Args:
-            tuning_type: The type of tuning to check support for
-
-        Returns:
-            True if the tuning type is supported by Snowflake
-        """
-        # Import here to avoid circular imports
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {TuningType.CLUSTERING, TuningType.PARTITIONING}
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("CLUSTERING", "PARTITIONING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Snowflake-specific tuning clauses for CREATE TABLE statements.
@@ -1773,19 +1727,9 @@ class SnowflakeAdapter(PlatformAdapter):
             unified_config: Unified tuning configuration to apply
             connection: Snowflake connection
         """
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        # Apply constraint configurations
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        # Apply platform optimizations
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        # Apply table-level tunings
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
     def apply_platform_optimizations(self, platform_config: PlatformOptimizationConfiguration, connection: Any) -> None:
         """Apply Snowflake-specific platform optimizations.
@@ -1807,38 +1751,10 @@ class SnowflakeAdapter(PlatformAdapter):
         # Store optimizations for use during query execution
         self.logger.info("Snowflake platform optimizations stored for warehouse and session management")
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to Snowflake.
-
-        Note: Snowflake supports PRIMARY KEY and FOREIGN KEY constraints but they are
-        not enforced (informational only). They are used for query optimization and
-        must be applied during table creation time.
-
-        Args:
-            primary_key_config: Primary key constraint configuration
-            foreign_key_config: Foreign key constraint configuration
-            connection: Snowflake connection
-        """
-        # Snowflake constraints are applied at table creation time for query optimization
-        # This method is called after tables are created, so log the configurations
-
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info(
-                "Primary key constraints enabled for Snowflake (informational only, applied during table creation)"
-            )
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info(
-                "Foreign key constraints enabled for Snowflake (informational only, applied during table creation)"
-            )
-
-        # Snowflake constraints are informational and used for query optimization
-        # No additional work to do here as they're applied during CREATE TABLE
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled for Snowflake (informational only, applied during table creation)",
+        "Foreign key constraints enabled for Snowflake (informational only, applied during table creation)",
+    )
 
 
 def _build_snowflake_config(

--- a/benchbox/platforms/snowpark_connect.py
+++ b/benchbox/platforms/snowpark_connect.py
@@ -48,9 +48,7 @@ from typing import TYPE_CHECKING, Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
-    from benchbox.core.tuning.interface import (
-        UnifiedTuningConfiguration,
-    )
+    pass
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
@@ -646,34 +644,6 @@ class SnowparkConnectAdapter(SparkTuningMixin, PlatformAdapter):
         if self._session:
             self._session.sql("ALTER SESSION SET USE_CACHED_RESULT = FALSE").collect()
             logger.debug("Disabled result cache for benchmarking")
-
-    def apply_tuning_configuration(
-        self,
-        config: UnifiedTuningConfiguration,
-    ) -> dict[str, Any]:
-        """Apply unified tuning configuration.
-
-        Args:
-            config: Unified tuning configuration.
-
-        Returns:
-            Dict with results of applied configurations.
-        """
-        results: dict[str, Any] = {}
-
-        if config.scale_factor:
-            self._scale_factor = config.scale_factor
-
-        if config.primary_keys:
-            results["primary_keys"] = self.apply_primary_keys(config.primary_keys)
-
-        if config.foreign_keys:
-            results["foreign_keys"] = self.apply_foreign_keys(config.foreign_keys)
-
-        if config.platform:
-            results["platform_optimizations"] = self.apply_platform_optimizations(config.platform)
-
-        return results
 
     # apply_primary_keys, apply_foreign_keys, apply_platform_optimizations,
     # and apply_constraint_configuration are inherited from SparkTuningMixin

--- a/benchbox/platforms/spark.py
+++ b/benchbox/platforms/spark.py
@@ -300,50 +300,31 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Spark adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
         benchmark_name = str(config["benchmark"]).lower()
-
-        # Generate proper database name using benchmark characteristics
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
-                platform="spark",
-                tuning_config=config.get("tuning_config"),
-            )
-            adapter_config["database"] = database_name
-
-        # Core configuration parameters
-        for key in [
-            "master",
-            "app_name",
-            "deploy_mode",
-            "driver_memory",
-            "executor_memory",
-            "executor_cores",
-            "num_executors",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Optional configuration parameters
-        for key in [
-            "warehouse_dir",
-            "shuffle_partitions",
-            "broadcast_threshold",
-            "adaptive_enabled",
-            "table_format",
-            "enable_hive",
-            "spark_config",
-            "staging_root",
-            "disable_cache",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
+        adapter_config = build_adapter_config(
+            config,
+            platform="spark",
+            fields=[
+                "master",
+                "app_name",
+                "deploy_mode",
+                "driver_memory",
+                "executor_memory",
+                "executor_cores",
+                "num_executors",
+                "warehouse_dir",
+                "shuffle_partitions",
+                "broadcast_threshold",
+                "adaptive_enabled",
+                "table_format",
+                "enable_hive",
+                "spark_config",
+                "staging_root",
+                "disable_cache",
+            ],
+        )
 
         spark_config = adapter_config.get("spark_config") or {}
         broadcast_threshold = adapter_config.get("broadcast_threshold")
@@ -640,16 +621,6 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
 
         return elapsed_seconds(start_time)
 
-    def load_data(
-        self, benchmark, connection: Any, data_dir: Path
-    ) -> tuple[dict[str, int], float, dict[str, Any] | None]:
-        """Load data using Spark DataFrame/SQL with DataSourceResolver.
-
-        Delegates to SparkDataLoadMixin._load_data_spark for the shared
-        DataFrame-based loading implementation.
-        """
-        return self._load_data_spark(benchmark, data_dir, connection)
-
     def configure_for_benchmark(self, connection: Any, benchmark_type: str) -> None:
         """Apply Spark-specific optimizations based on benchmark type."""
 
@@ -670,31 +641,6 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
 
         except Exception as e:
             self.logger.warning(f"Failed to apply benchmark configuration: {e}")
-
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute query with detailed timing and performance tracking.
-
-        Delegates to SparkQueryExecutionMixin._execute_query_spark for the
-        shared execution implementation.
-        """
-        return self._execute_query_spark(
-            connection=connection,
-            query=query,
-            query_id=query_id,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
 
     def _remove_orphaned_table_location(self, spark: Any, table_name: str) -> None:
         """Remove orphaned managed-table directory when catalog entry is gone.
@@ -764,24 +710,7 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
             self.logger.debug(f"Connection test failed: {e}")
             return False
 
-    def supports_tuning_type(self, tuning_type) -> bool:
-        """Check if Spark supports a specific tuning type.
-
-        Spark supports:
-        - PARTITIONING: Via partitionBy in DataFrame write
-        - BUCKETING: Via bucketBy in DataFrame write
-        - SORTING: Via sortBy in DataFrame write
-        - CLUSTERING: Via Z-ordering in Delta Lake
-        """
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.SORTING,
-            }
-        except ImportError:
-            return False
+    _supported_tuning_type_names = ("PARTITIONING", "SORTING")
 
     def generate_tuning_clause(self, table_tuning) -> str:
         """Generate Spark-specific tuning clauses for CREATE TABLE statements.

--- a/benchbox/platforms/starburst.py
+++ b/benchbox/platforms/starburst.py
@@ -230,45 +230,34 @@ class StarburstAdapter(TrinoAdapter):
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create Starburst adapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        # Generate proper schema name using benchmark characteristics
-        if "schema" in config and config["schema"]:
-            adapter_config["schema"] = config["schema"]
-        else:
-            schema_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="starburst",
-                tuning_config=config.get("tuning_config"),
+                generated_key="schema",
+                fields=[
+                    "host",
+                    "port",
+                    "catalog",
+                    "username",
+                    "password",
+                    "role",
+                    "http_scheme",
+                    "verify_ssl",
+                    "ssl_cert_path",
+                    "session_properties",
+                    "query_timeout",
+                    "timezone",
+                    "encoding",
+                    "disable_result_cache",
+                    "table_format",
+                    "staging_root",
+                    "source_catalog",
+                ],
             )
-            adapter_config["schema"] = schema_name
-
-        # Core connection parameters
-        for key in ["host", "port", "catalog", "username", "password", "role"]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        # Optional configuration parameters
-        for key in [
-            "http_scheme",
-            "verify_ssl",
-            "ssl_cert_path",
-            "session_properties",
-            "query_timeout",
-            "timezone",
-            "encoding",
-            "disable_result_cache",
-            "table_format",
-            "staging_root",
-            "source_catalog",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
 
 def _build_starburst_config(

--- a/benchbox/platforms/starrocks/tuning.py
+++ b/benchbox/platforms/starrocks/tuning.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from benchbox.platforms.base.tuning import make_informational_constraint_applier, supports_named_tuning_type
+
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import (
-        ForeignKeyConfiguration,
         PlatformOptimizationConfiguration,
-        PrimaryKeyConfiguration,
         UnifiedTuningConfiguration,
     )
 
@@ -83,36 +83,16 @@ class StarRocksTuningMixin:
         finally:
             cursor.close()
 
-    def apply_constraint_configuration(
-        self,
-        primary_key_config: PrimaryKeyConfiguration,
-        foreign_key_config: ForeignKeyConfiguration,
-        connection: Any,
-    ) -> None:
-        """Apply constraint configurations to StarRocks.
+    apply_constraint_configuration = make_informational_constraint_applier(
+        "Primary key constraints enabled (applied during table creation)",
+        "Foreign key constraints noted (StarRocks does not enforce foreign keys)",
+    )
 
-        StarRocks uses data model keys (DUPLICATE/AGGREGATE/UNIQUE/PRIMARY)
-        defined at table creation time. This method logs the configuration
-        since constraints are applied during CREATE TABLE.
-        """
-        if primary_key_config and primary_key_config.enabled:
-            self.logger.info("Primary key constraints enabled (applied during table creation)")
-
-        if foreign_key_config and foreign_key_config.enabled:
-            self.logger.info("Foreign key constraints noted (StarRocks does not enforce foreign keys)")
+    _supported_tuning_type_names = ("PARTITIONING", "SORTING", "DISTRIBUTION")
 
     def supports_tuning_type(self, tuning_type) -> bool:
         """Check if StarRocks supports a specific tuning type."""
-        try:
-            from benchbox.core.tuning.interface import TuningType
-
-            return tuning_type in {
-                TuningType.PARTITIONING,
-                TuningType.SORTING,
-                TuningType.DISTRIBUTION,
-            }
-        except ImportError:
-            return False
+        return supports_named_tuning_type(tuning_type, self._supported_tuning_type_names)
 
     def apply_table_tunings(self, table_tuning, connection: Any) -> None:
         """Apply StarRocks-specific table tunings.
@@ -157,16 +137,9 @@ class StarRocksTuningMixin:
 
     def apply_unified_tuning(self, unified_config: UnifiedTuningConfiguration, connection: Any) -> None:
         """Apply unified tuning configuration to StarRocks."""
-        if not unified_config:
-            return
+        from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
 
-        self.apply_constraint_configuration(unified_config.primary_keys, unified_config.foreign_keys, connection)
-
-        if unified_config.platform_optimizations:
-            self.apply_platform_optimizations(unified_config.platform_optimizations, connection)
-
-        for _table_name, table_tuning in unified_config.table_tunings.items():
-            self.apply_table_tunings(table_tuning, connection)
+        apply_standard_unified_tuning(self, unified_config, connection)
 
 
 __all__ = ["StarRocksTuningMixin"]

--- a/benchbox/platforms/velox.py
+++ b/benchbox/platforms/velox.py
@@ -161,45 +161,29 @@ class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
     @classmethod
     def from_config(cls, config: dict[str, Any]):
         """Create VeloxAdapter from unified configuration."""
-        from benchbox.utils.database_naming import generate_database_name
+        from benchbox.platforms.base.config_utils import build_adapter_config
 
-        adapter_config: dict[str, Any] = {}
-
-        if "database" in config and config["database"]:
-            adapter_config["database"] = config["database"]
-        else:
-            database_name = generate_database_name(
-                benchmark_name=config["benchmark"],
-                scale_factor=config["scale_factor"],
+        return cls(
+            **build_adapter_config(
+                config,
                 platform="velox",
-                tuning_config=config.get("tuning_config"),
+                fields=[
+                    "deployment",
+                    "deployment_mode",
+                    "endpoint",
+                    "gluten_jar_path",
+                    "gluten_version",
+                    "offheap_size",
+                    "app_name",
+                    "driver_memory",
+                    "shuffle_partitions",
+                    "adaptive_enabled",
+                    "table_format",
+                    "spark_config",
+                    "disable_cache",
+                ],
             )
-            adapter_config["database"] = database_name
-
-        for key in [
-            "deployment",
-            "deployment_mode",
-            "endpoint",
-            "gluten_jar_path",
-            "gluten_version",
-            "offheap_size",
-            "app_name",
-            "driver_memory",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        for key in [
-            "shuffle_partitions",
-            "adaptive_enabled",
-            "table_format",
-            "spark_config",
-            "disable_cache",
-        ]:
-            if key in config:
-                adapter_config[key] = config[key]
-
-        return cls(**adapter_config)
+        )
 
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get Velox platform information including velox_active probe."""
@@ -494,33 +478,6 @@ class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
             raise
 
         return elapsed_seconds(start_time)
-
-    def load_data(
-        self, benchmark, connection: Any, data_dir: Path
-    ) -> tuple[dict[str, int], float, dict[str, Any] | None]:
-        """Load benchmark data via SparkDataLoadMixin."""
-        return self._load_data_spark(benchmark, data_dir, connection)
-
-    def execute_query(
-        self,
-        connection: Any,
-        query: str,
-        query_id: str,
-        benchmark_type: str | None = None,
-        scale_factor: float | None = None,
-        validate_row_count: bool = True,
-        stream_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Execute query via SparkQueryExecutionMixin."""
-        return self._execute_query_spark(
-            connection=connection,
-            query=query,
-            query_id=query_id,
-            benchmark_type=benchmark_type,
-            scale_factor=scale_factor,
-            validate_row_count=validate_row_count,
-            stream_id=stream_id,
-        )
 
     # ------------------------------------------------------------------
     # Query plans

--- a/tests/unit/platforms/base/test_platform_config_helpers.py
+++ b/tests/unit/platforms/base/test_platform_config_helpers.py
@@ -1,0 +1,101 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchbox.core.tuning.interface import TuningType
+from benchbox.platforms.base.config_utils import build_adapter_config
+from benchbox.platforms.base.tuning import TuningHooksMixin, make_informational_constraint_applier
+from benchbox.platforms.base.tuning_config import apply_standard_unified_tuning
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def test_build_adapter_config_generates_name_and_skips_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def fake_generate_database_name(**kwargs):
+        calls.append(kwargs)
+        return "tpch_sf001_platform"
+
+    monkeypatch.setattr("benchbox.utils.database_naming.generate_database_name", fake_generate_database_name)
+
+    result = build_adapter_config(
+        {"benchmark": "tpch", "scale_factor": 0.01, "host": "localhost", "port": None},
+        platform="platform",
+        fields=("host", "port"),
+        include_none=False,
+    )
+
+    assert result == {"database": "tpch_sf001_platform", "host": "localhost"}
+    assert calls == [{"benchmark_name": "tpch", "scale_factor": 0.01, "platform": "platform", "tuning_config": None}]
+
+
+def test_build_adapter_config_honors_explicit_generated_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    generate = MagicMock(return_value="generated")
+    monkeypatch.setattr("benchbox.utils.database_naming.generate_database_name", generate)
+
+    result = build_adapter_config(
+        {"benchmark": "tpch", "scale_factor": 1, "schema": "explicit", "catalog": "memory"},
+        platform="trino",
+        generated_key="schema",
+        fields=("catalog",),
+    )
+
+    assert result == {"schema": "explicit", "catalog": "memory"}
+    generate.assert_not_called()
+
+
+def test_supported_tuning_type_names_override_base_compatibility() -> None:
+    class FixedSupportAdapter(TuningHooksMixin):
+        platform_name = "not-used"
+        _supported_tuning_type_names = ("PARTITIONING",)
+
+    adapter = FixedSupportAdapter()
+
+    assert adapter.supports_tuning_type(TuningType.PARTITIONING) is True
+    assert adapter.supports_tuning_type(TuningType.SORTING) is False
+
+
+def test_informational_constraint_applier_logs_enabled_constraints() -> None:
+    class Adapter:
+        logger = MagicMock()
+        apply_constraint_configuration = make_informational_constraint_applier("primary enabled", "foreign enabled")
+
+    adapter = Adapter()
+    adapter.apply_constraint_configuration(SimpleNamespace(enabled=True), SimpleNamespace(enabled=False), object())
+
+    adapter.logger.info.assert_called_once_with("primary enabled")
+
+
+def test_apply_standard_unified_tuning_preserves_dispatch_order() -> None:
+    class Adapter:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def apply_constraint_configuration(self, primary_keys, foreign_keys, connection) -> None:
+            self.calls.append(("constraints", primary_keys, foreign_keys, connection))
+
+        def apply_platform_optimizations(self, platform_optimizations, connection) -> None:
+            self.calls.append(("platform", platform_optimizations, connection))
+
+        def apply_table_tunings(self, table_tuning, connection) -> None:
+            self.calls.append(("table", table_tuning, connection))
+
+    adapter = Adapter()
+    connection = object()
+    config = SimpleNamespace(
+        primary_keys="pk",
+        foreign_keys="fk",
+        platform_optimizations="platform",
+        table_tunings={"orders": "orders_tuning", "lineitem": "lineitem_tuning"},
+    )
+
+    apply_standard_unified_tuning(adapter, config, connection)
+
+    assert adapter.calls == [
+        ("constraints", "pk", "fk", connection),
+        ("platform", "platform", connection),
+        ("table", "orders_tuning", connection),
+        ("table", "lineitem_tuning", connection),
+    ]

--- a/tests/unit/platforms/base/test_spark_execution_mixin.py
+++ b/tests/unit/platforms/base/test_spark_execution_mixin.py
@@ -44,6 +44,16 @@ def _run_load(adapter: _DummySparkAdapter, spark: MagicMock, table_path: Path) -
     assert stats["orders"] == 5
 
 
+def test_load_data_delegates_to_shared_spark_loader(tmp_path: Path) -> None:
+    adapter = _DummySparkAdapter()
+    adapter._load_data_spark = MagicMock(return_value=({"orders": 1}, 0.1, None))
+    benchmark = MagicMock()
+    connection = MagicMock()
+
+    assert adapter.load_data(benchmark, connection, tmp_path) == ({"orders": 1}, 0.1, None)
+    adapter._load_data_spark.assert_called_once_with(benchmark, tmp_path, connection)
+
+
 def test_load_data_spark_uses_delta_reader_for_delta_directory(tmp_path: Path) -> None:
     adapter = _DummySparkAdapter()
     spark = MagicMock()
@@ -590,6 +600,25 @@ class _DummyQueryAdapter(SparkQueryExecutionMixin):
 
     def log_verbose(self, msg: str) -> None:
         pass
+
+
+def test_execute_query_delegates_to_shared_spark_executor() -> None:
+    adapter = _DummyQueryAdapter()
+    adapter._execute_query_spark = MagicMock(return_value={"status": "ok"})
+    connection = MagicMock()
+
+    assert adapter.execute_query(connection, "select 1", "Q1", benchmark_type="tpch", scale_factor=0.01) == {
+        "status": "ok"
+    }
+    adapter._execute_query_spark.assert_called_once_with(
+        connection=connection,
+        query="select 1",
+        query_id="Q1",
+        benchmark_type="tpch",
+        scale_factor=0.01,
+        validate_row_count=True,
+        stream_id=None,
+    )
 
 
 def _make_spark(table_rows: dict[str, list] | None = None) -> MagicMock:

--- a/tests/unit/platforms/test_presto_trino_utils.py
+++ b/tests/unit/platforms/test_presto_trino_utils.py
@@ -21,6 +21,7 @@ from benchbox.platforms.presto_trino_utils import (
     load_file_batches,
     normalize_existing_files,
     resolve_data_files,
+    show_tables_lower,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
@@ -128,6 +129,27 @@ class TestNormalizeExistingFiles:
         f.write_text("x\n")
         result = normalize_existing_files([str(f)])
         assert all(isinstance(p, Path) for p in result)
+
+
+class TestShowTablesLower:
+    def test_returns_lowercase_table_names_and_closes_cursor(self) -> None:
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [("ORDERS",), ("LineItem",)]
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+
+        assert show_tables_lower(connection) == ["orders", "lineitem"]
+        cursor.execute.assert_called_once_with("SHOW TABLES")
+        cursor.close.assert_called_once_with()
+
+    def test_returns_empty_list_and_closes_cursor_on_error(self) -> None:
+        cursor = MagicMock()
+        cursor.execute.side_effect = RuntimeError("boom")
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+
+        assert show_tables_lower(connection) == []
+        cursor.close.assert_called_once_with()
 
 
 class TestLoadFileBatches:


### PR DESCRIPTION
---
iteration: shrink-platform-hook-boilerplate
date: 2026-05-24
surface: platform config/from_config/tuning hook boilerplate
branch: chore/shrink-platform-hook-boilerplate
pr:
raw_cloc_delta: 538
credited_reduction: 538
uncredited_relocation: 0
repair_only_delta: 0
generated_python_delta: 0
moved_content: logic
decision_gate: conservative default
verification:
  - cloc --include-lang=Python benchbox/ (205013 -> 204475)
  - uv run -- ruff check <touched source and tests>
  - uv run -- python -m compileall -q benchbox/platforms
  - uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/base/test_spark_execution_mixin.py -q
  - uv run -- python -m pytest <targeted platform hook files> -q (1194 passed)
  - uv run -- python _project/scripts/reference_usage_audit.py --summary
  - make pr-preflight
---

## Thesis

Shrink iteration across repeated platform hook plumbing by consolidating
structurally identical `from_config` field-copy routines, cloud-Spark tuning
application, hook dispatch, file/table discovery helpers, and explicit
tuning-support predicates.

Baseline evidence:

- `make shrink-rollup`: 1,841 merged credited lines, 10,159 remaining to the
  committed 12,000 floor, 17,159 remaining to stretch.
- `cloc --include-lang=Python benchbox/`: 205,013 Python code lines.
- Code-only structural duplicate scan: `from_config` assembly, repeated Spark
  and SQL execution wrappers, constraint/unified tuning hooks, table-discovery
  helpers, and tuning-support predicates form a coherent hook surface.
- Open develop PRs #622, #623, and #624 do not touch platform hook/config files.

Reduction path:

- Add explicit helper functions for standard adapter config assembly,
  tuning-support set checks, standard unified tuning dispatch, informational
  constraint hooks, and cloud-Spark tuning application.
- Replace repeated bodies with explicit public methods or grep-findable function
  bindings; preserve public function names, signatures, `__name__`, and
  `__qualname__`.
- Do not delete platforms, change support status, move Python into data files,
  add generated Python, or change live/cloud execution semantics.

Actual credited reduction: 538 maintained-Python code lines. The post-edit
`cloc --include-lang=Python benchbox/` delta cleared the 500-line shrink
iteration floor.

## Guardrail evidence

Pre-edit public hook fingerprint:

- `/tmp/shrink-platform-hooks-fingerprint-pre.txt`

Planned guardrails:

- Post-edit hook fingerprint must preserve public signatures and config builder
  callable names/qualnames. Owner relocation to shared mixins/base hook is
  expected and captured in `/tmp/shrink-platform-hooks-fingerprint.diff`.
- Pure helper behavior is characterized by targeted unit tests for
  `build_adapter_config`, `supports_named_tuning_type`, informational
  constraint hooks, standard unified tuning dispatch, Spark execution wrapper
  delegation, and shared `SHOW TABLES` table discovery.
- Whole-tree references for touched hook names must remain valid.
- No import-time I/O, no dynamic module-global mutation, no registry-key changes,
  and no live/cloud tests without explicit approval.

## Verification

- `make shrink-rollup` before editing: 1,841 merged credited lines; 10,159
  remaining to the committed 12,000 floor; 17,159 remaining to stretch.
- `cloc --include-lang=Python benchbox/`: 205,013 before, 204,475 after; raw
  maintained-Python delta 538.
- Fingerprints:
  - pre: `/tmp/shrink-platform-hooks-fingerprint-pre.txt`
  - post: `/tmp/shrink-platform-hooks-fingerprint-post.txt`
  - diff: `/tmp/shrink-platform-hooks-fingerprint.diff`
- `uv run -- ruff check ...` for all touched source/test files: passed.
- `uv run -- python -m compileall -q benchbox/platforms`: passed.
- `uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/base/test_spark_execution_mixin.py -q`: 79 passed.
- `uv run -- python -m pytest tests/unit/platforms/test_doris_adapter.py tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_lakesail_adapter.py tests/unit/platforms/test_redshift_adapter.py tests/unit/platforms/test_starrocks_adapter.py tests/unit/platforms/test_starrocks_tuning.py tests/unit/platforms/test_azure_synapse_adapter.py tests/unit/platforms/test_bigquery_adapter_coverage.py tests/unit/platforms/test_cedardb.py tests/unit/platforms/test_pg_duckdb_adapter.py tests/unit/platforms/test_databricks_adapter.py tests/unit/platforms/test_databricks_adapter_coverage.py tests/unit/platforms/test_firebolt_coverage.py tests/unit/platforms/test_presto_adapter.py tests/unit/platforms/test_velox_adapter.py -q`: 1,194 passed.
- `uv run -- python _project/scripts/reference_usage_audit.py --summary`: passed
  with 78 reference hits and 0 parse errors.
- `make pr-preflight`: passed; the final fast-test gate reported 22,775
  passed, 5 skipped, 47 warnings, and 4 subtests passed.

## Residual risk

The touched surface spans live/cloud adapters. The change is restricted to pure
configuration and hook dispatch boilerplate, with behavior pinned by helper-level
tests, existing platform tests, and callable fingerprints. The largest remaining
risk is inherited-method ownership changing from adapter-local methods to shared
mixins/base hooks; signatures, public names, and platform-specific messages are
kept stable where behavior depends on them.

## Next target

If this slice lands, reassess smaller platform hook residues separately; do not
stack unrelated adapter behavior into this PR.
