### PR TITLE
chore: repair tpcds generated impl registry

### DIFF
--- a/_project/shrink-ledger/shrink-tpcds-generated-impl-registry.md
+++ b/_project/shrink-ledger/shrink-tpcds-generated-impl-registry.md
@@ -1,0 +1,94 @@
+---
+iteration: shrink-tpcds-generated-impl-registry
+date: 2026-05-25
+surface: TPC-DS DataFrame generated implementation registry
+branch: chore/shrink-tpcds-generated-impl-registry
+pr:
+raw_cloc_delta: -12
+credited_reduction: 0
+uncredited_relocation: 0
+repair_only_delta: -12
+generated_python_delta: 0
+moved_content: none
+decision_gate: conservative default
+verification:
+  - make shrink-rollup
+  - cloc --include-lang=Python --by-file benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
+  - TPC-DS registry/callable fingerprint diff
+  - uv run -- ruff check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
+  - uv run -- ruff format --check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
+  - uv run -- python -m compileall -q benchbox/core/tpcds/dataframe_queries
+  - uv run -- python -m pytest tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/core/test_dataframe_generated_impl_registry.py -q -n 0
+  - uv run -- python _project/scripts/reference_usage_audit.py --summary
+  - make pr-preflight
+---
+
+## Thesis
+
+Guardrail repair iteration. The TPC-DS DataFrame query module is a large future
+shrink surface at 7037 maintained-Python code lines, and the previous
+fingerprint repair established the callable identity contract required before
+changing generated implementations. The next blocker is that generated TPC-DS
+query implementations are still injected into module globals at import time.
+
+This slice replaces the dynamic `globals()[name] = impl` writes with an explicit
+generated-implementation registry plus PEP 562 `__getattr__` lookup. It keeps the
+current public behavior that named generated callables are resolvable from the
+module, keeps the registry/callable fingerprint stable, and makes the generated
+surface match the safer pattern already used by Read Primitives and JoinOrder.
+
+Expected credited reduction is 0. This is a repair-only slice that unlocks a
+later credited TPC-DS consolidation attempt without self-approving a
+generated-callable shrink gate.
+
+## Guardrail evidence
+
+- Iteration type: guardrail repair.
+- Campaign baseline: `make shrink-rollup` reports 2379 cumulative merged
+  credited reduction, 9621 remaining to the committed floor, and 16621 remaining
+  to stretch.
+- Open PR overlap: `gh pr list --base develop --state open --json ...` found
+  PR #626 touching JoinOrder/TODO files only; no overlap with this TPC-DS
+  generated-registry surface.
+- Target file baseline:
+  `cloc --include-lang=Python --by-file benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py`
+  reports 7061 total Python code lines, including 7037 in
+  `benchbox/core/tpcds/dataframe_queries/queries.py`.
+- Post-edit target files report 7082 total Python code lines, including 7049 in
+  `benchbox/core/tpcds/dataframe_queries/queries.py`. The maintained runtime
+  source delta is +12 code lines, ledgered as `raw_cloc_delta: -12`.
+- Post-edit raw maintained Python:
+  `cloc --include-lang=Python benchbox/` reports 931 files and 204628 code
+  lines.
+- Pre-edit fingerprint:
+  `/tmp/shrink-tpcds-generated-registry-fingerprint-pre.txt` captures 99
+  registered TPC-DS DataFrame queries with categories, expression/pandas
+  callable names, qualnames, and module attribute identity checks.
+- Post-edit fingerprint:
+  `/tmp/shrink-tpcds-generated-registry-fingerprint-post.txt` has the same 99
+  rows and `diff -u` against the pre-edit fingerprint is empty.
+- Moved-content classification: none. This slice does not move Python, SQL,
+  YAML, metadata, or benchmark data.
+- Decision-gate status: conservative default. This slice does not approve
+  deleting benchmarks/platforms, changing query semantics, changing the TPC-DS
+  spec-loading model, or consolidating generated query logic.
+
+## Verification
+
+- `uv run -- ruff check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py` passed.
+- `uv run -- ruff format --check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py` passed.
+- `uv run -- python -m compileall -q benchbox/core/tpcds/dataframe_queries` passed.
+- `uv run -- python -m pytest tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/core/test_dataframe_generated_impl_registry.py -q -n 0` passed, 39 tests.
+- `uv run -- python _project/scripts/reference_usage_audit.py --summary` passed
+  with 78 hits and 0 parse errors.
+- `git diff --check` passed.
+- Self-review finding fixed before preflight: `_impl_for` now returns the typed
+  `QueryImpl` protocol instead of `Any`.
+- `make pr-preflight` passed: `ci-lint` passed, and the fast suite reported
+  23025 passed, 5 skipped, 47 warnings, and 4 subtests passed.
+
+## Residual risk
+
+This repair does not reduce maintained Python lines. It only removes the
+dynamic module-global registration pattern that blocks safer future
+consolidation of the TPC-DS query surface.

--- a/benchbox/core/tpcds/dataframe_queries/queries.py
+++ b/benchbox/core/tpcds/dataframe_queries/queries.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from csv import reader
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import yaml
 
@@ -38,6 +38,26 @@ from .registry import register_query
 # =============================================================================
 
 _FilterSpec = tuple[str, str | None, Any]
+
+
+class QueryImpl(Protocol):
+    """DataFrame query implementation callable."""
+
+    def __call__(self, ctx: DataFrameContext) -> Any: ...
+
+
+_GENERATED_IMPLS: dict[str, QueryImpl] = {}
+
+
+def _register_generated_impl(impl: QueryImpl) -> QueryImpl:
+    _GENERATED_IMPLS[impl.__name__] = impl
+    return impl
+
+
+def __getattr__(name: str) -> QueryImpl:
+    if name in _GENERATED_IMPLS:
+        return _GENERATED_IMPLS[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _tables(ctx: DataFrameContext, *names: str) -> tuple[Any, ...]:
@@ -1112,7 +1132,7 @@ def _load_helper_query_specs() -> list[dict[str, Any]]:
 _HELPER_QUERY_SPECS = _load_helper_query_specs()
 
 
-def _make_helper_impl(query_id: int, title: str, family: str, helper: Any, helper_args: tuple[Any, ...]) -> Any:
+def _make_helper_impl(query_id: int, title: str, family: str, helper: Any, helper_args: tuple[Any, ...]) -> QueryImpl:
     def impl(ctx: DataFrameContext) -> Any:
         return helper(ctx, query_id, *helper_args)
 
@@ -1125,11 +1145,11 @@ def _make_helper_impl(query_id: int, title: str, family: str, helper: Any, helpe
 for _spec in _HELPER_QUERY_SPECS:
     _qid = _spec["query_id"]
     _title = _spec["title"]
-    globals()[f"q{_qid}_expression_impl"] = _make_helper_impl(
-        _qid, _title, "expression", globals()[_spec["expression_helper"]], _spec["args"]
+    _register_generated_impl(
+        _make_helper_impl(_qid, _title, "expression", globals()[_spec["expression_helper"]], _spec["args"])
     )
-    globals()[f"q{_qid}_pandas_impl"] = _make_helper_impl(
-        _qid, _title, "pandas", globals()[_spec["pandas_helper"]], _spec["args"]
+    _register_generated_impl(
+        _make_helper_impl(_qid, _title, "pandas", globals()[_spec["pandas_helper"]], _spec["args"])
     )
 
 
@@ -1268,7 +1288,7 @@ def _joined_agg_pandas_impl(ctx: DataFrameContext, spec: dict[str, Any]) -> Any:
     return result if limit is None else result.head(limit)
 
 
-def _make_joined_agg_impl(query_id: int, title: str, family: str, spec: dict[str, Any]) -> Any:
+def _make_joined_agg_impl(query_id: int, title: str, family: str, spec: dict[str, Any]) -> QueryImpl:
     engine = _joined_agg_expression_impl if family == "expression" else _joined_agg_pandas_impl
 
     def impl(ctx: DataFrameContext) -> Any:
@@ -1347,7 +1367,7 @@ def _state_average_returns_pandas_impl(ctx: DataFrameContext, spec: dict[str, An
     return result[cols].sort_values(cols).head(100)
 
 
-def _make_state_average_returns_impl(query_id: int, title: str, family: str, spec: dict[str, Any]) -> Any:
+def _make_state_average_returns_impl(query_id: int, title: str, family: str, spec: dict[str, Any]) -> QueryImpl:
     engine = _state_average_returns_expression_impl if family == "expression" else _state_average_returns_pandas_impl
 
     def impl(ctx: DataFrameContext) -> Any:
@@ -1362,16 +1382,14 @@ def _make_state_average_returns_impl(query_id: int, title: str, family: str, spe
 for _spec in _QUERY_SPECS["joined_aggregate"]:
     _query_id = _spec["query_id"]
     _query_title = _spec["title"]
-    globals()[f"q{_query_id}_expression_impl"] = _make_joined_agg_impl(_query_id, _query_title, "expression", _spec)
-    globals()[f"q{_query_id}_pandas_impl"] = _make_joined_agg_impl(_query_id, _query_title, "pandas", _spec)
+    _register_generated_impl(_make_joined_agg_impl(_query_id, _query_title, "expression", _spec))
+    _register_generated_impl(_make_joined_agg_impl(_query_id, _query_title, "pandas", _spec))
 
 for _spec in _QUERY_SPECS["state_average_returns"]:
     _query_id = _spec["query_id"]
     _query_title = _spec["title"]
-    globals()[f"q{_query_id}_expression_impl"] = _make_state_average_returns_impl(
-        _query_id, _query_title, "expression", _spec
-    )
-    globals()[f"q{_query_id}_pandas_impl"] = _make_state_average_returns_impl(_query_id, _query_title, "pandas", _spec)
+    _register_generated_impl(_make_state_average_returns_impl(_query_id, _query_title, "expression", _spec))
+    _register_generated_impl(_make_state_average_returns_impl(_query_id, _query_title, "pandas", _spec))
 
 
 def q96_expression_impl(ctx: DataFrameContext) -> Any:
@@ -9770,8 +9788,12 @@ _CATEGORY_CODES = {
 _QUERY_METADATA = Path(__file__).with_name("query_metadata.csv").read_text(encoding="utf-8")
 
 
-def _impl_for(query_id: str, family: str) -> Any:
-    return globals()[f"q{query_id[1:].lower()}_{family}_impl"]
+def _impl_for(query_id: str, family: str) -> QueryImpl:
+    name = f"q{query_id[1:].lower()}_{family}_impl"
+    impl = globals().get(name)
+    if impl is not None:
+        return impl
+    return _GENERATED_IMPLS[name]
 
 
 def _register_all_queries() -> None:

--- a/tests/unit/core/test_dataframe_generated_impl_registry.py
+++ b/tests/unit/core/test_dataframe_generated_impl_registry.py
@@ -33,6 +33,15 @@ def test_joinorder_generated_impls_in_registry_not_globals() -> None:
     assert getattr(jo, sample) is jo._IMPLS[sample]
 
 
+def test_tpcds_generated_impls_in_registry_not_globals() -> None:
+    from benchbox.core.tpcds.dataframe_queries import queries as tpcds
+
+    for name in ("q3_expression_impl", "q19_pandas_impl"):
+        assert name in tpcds._GENERATED_IMPLS
+        assert name not in vars(tpcds)
+        assert getattr(tpcds, name) is tpcds._GENERATED_IMPLS[name]
+
+
 def test_dispatch_resolves_explicit_and_generated_from_registry() -> None:
     # _impl_for resolves both explicit module defs and generated impls via the
     # single typed registry.
@@ -45,3 +54,7 @@ def test_unknown_generated_name_raises_attribute_error() -> None:
         rp.totally_missing_query_impl  # noqa: B018
     with pytest.raises(AttributeError):
         jo.totally_missing_query_impl  # noqa: B018
+    from benchbox.core.tpcds.dataframe_queries import queries as tpcds
+
+    with pytest.raises(AttributeError):
+        tpcds.totally_missing_query_impl  # noqa: B018


### PR DESCRIPTION
---
iteration: shrink-tpcds-generated-impl-registry
date: 2026-05-25
surface: TPC-DS DataFrame generated implementation registry
branch: chore/shrink-tpcds-generated-impl-registry
pr:
raw_cloc_delta: -12
credited_reduction: 0
uncredited_relocation: 0
repair_only_delta: -12
generated_python_delta: 0
moved_content: none
decision_gate: conservative default
verification:
  - make shrink-rollup
  - cloc --include-lang=Python --by-file benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
  - TPC-DS registry/callable fingerprint diff
  - uv run -- ruff check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
  - uv run -- ruff format --check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py
  - uv run -- python -m compileall -q benchbox/core/tpcds/dataframe_queries
  - uv run -- python -m pytest tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/core/test_dataframe_generated_impl_registry.py -q -n 0
  - uv run -- python _project/scripts/reference_usage_audit.py --summary
  - make pr-preflight
---

## Thesis

Guardrail repair iteration. The TPC-DS DataFrame query module is a large future
shrink surface at 7037 maintained-Python code lines, and the previous
fingerprint repair established the callable identity contract required before
changing generated implementations. The next blocker is that generated TPC-DS
query implementations are still injected into module globals at import time.

This slice replaces the dynamic `globals()[name] = impl` writes with an explicit
generated-implementation registry plus PEP 562 `__getattr__` lookup. It keeps the
current public behavior that named generated callables are resolvable from the
module, keeps the registry/callable fingerprint stable, and makes the generated
surface match the safer pattern already used by Read Primitives and JoinOrder.

Expected credited reduction is 0. This is a repair-only slice that unlocks a
later credited TPC-DS consolidation attempt without self-approving a
generated-callable shrink gate.

## Guardrail evidence

- Iteration type: guardrail repair.
- Campaign baseline: `make shrink-rollup` reports 2379 cumulative merged
  credited reduction, 9621 remaining to the committed floor, and 16621 remaining
  to stretch.
- Open PR overlap: `gh pr list --base develop --state open --json ...` found
  PR #626 touching JoinOrder/TODO files only; no overlap with this TPC-DS
  generated-registry surface.
- Target file baseline:
  `cloc --include-lang=Python --by-file benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py`
  reports 7061 total Python code lines, including 7037 in
  `benchbox/core/tpcds/dataframe_queries/queries.py`.
- Post-edit target files report 7082 total Python code lines, including 7049 in
  `benchbox/core/tpcds/dataframe_queries/queries.py`. The maintained runtime
  source delta is +12 code lines, ledgered as `raw_cloc_delta: -12`.
- Post-edit raw maintained Python:
  `cloc --include-lang=Python benchbox/` reports 931 files and 204628 code
  lines.
- Pre-edit fingerprint:
  `/tmp/shrink-tpcds-generated-registry-fingerprint-pre.txt` captures 99
  registered TPC-DS DataFrame queries with categories, expression/pandas
  callable names, qualnames, and module attribute identity checks.
- Post-edit fingerprint:
  `/tmp/shrink-tpcds-generated-registry-fingerprint-post.txt` has the same 99
  rows and `diff -u` against the pre-edit fingerprint is empty.
- Moved-content classification: none. This slice does not move Python, SQL,
  YAML, metadata, or benchmark data.
- Decision-gate status: conservative default. This slice does not approve
  deleting benchmarks/platforms, changing query semantics, changing the TPC-DS
  spec-loading model, or consolidating generated query logic.

## Verification

- `uv run -- ruff check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py` passed.
- `uv run -- ruff format --check benchbox/core/tpcds/dataframe_queries/queries.py tests/unit/core/test_dataframe_generated_impl_registry.py` passed.
- `uv run -- python -m compileall -q benchbox/core/tpcds/dataframe_queries` passed.
- `uv run -- python -m pytest tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/core/test_dataframe_generated_impl_registry.py -q -n 0` passed, 39 tests.
- `uv run -- python _project/scripts/reference_usage_audit.py --summary` passed
  with 78 hits and 0 parse errors.
- `git diff --check` passed.
- Self-review finding fixed before preflight: `_impl_for` now returns the typed
  `QueryImpl` protocol instead of `Any`.
- `make pr-preflight` passed: `ci-lint` passed, and the fast suite reported
  23025 passed, 5 skipped, 47 warnings, and 4 subtests passed.

## Residual risk

This repair does not reduce maintained Python lines. It only removes the
dynamic module-global registration pattern that blocks safer future
consolidation of the TPC-DS query surface.
