### PR TITLE
chore: shrink platform adapter boilerplate

### DIFF
--- a/_project/shrink-ledger/shrink-platform-config-builders.md
+++ b/_project/shrink-ledger/shrink-platform-config-builders.md
@@ -1,0 +1,113 @@
+---
+iteration: shrink-platform-config-builders
+date: 2026-05-25
+surface: platform hook config-builder and data-source resolver boilerplate
+branch: chore/shrink-platform-config-builders
+pr:
+raw_cloc_delta: 276
+credited_reduction: 276
+uncredited_relocation: 0
+repair_only_delta: 0
+generated_python_delta: 0
+moved_content: logic
+decision_gate: conservative default; explicit factory-bound config builders preserve static names and hook registration keys
+verification:
+  - make shrink-rollup
+  - cloc --include-lang=Python benchbox/
+  - cloc --include-lang=Python --by-file benchbox/platforms/base/config_utils.py <platform builder modules>
+  - make duplicate-check-json -> groups=278 duplicated_lines=6210
+  - uv run -- ruff check $(git diff --name-only -- '*.py')
+  - uv run -- python -m pytest <targeted platform/config/data-loading tests> -q -n 0 -> 1539 passed
+  - uv run -- python -m pytest <Presto/Trino/Starburst adapter tests> -q -n 0 -> 204 passed
+  - /tmp/shrink-platform-config-fingerprint-after.json matched 17 pre-existing builders
+  - /tmp/shrink-platform-config-pg-cedardb-after.json matched PostgreSQL/CedarDB pre-edit fingerprints
+  - make pr-preflight
+---
+
+## Thesis
+
+Shrink iteration under the smaller-subsystem exception. The platform adapter
+boilerplate subsystem is the repeated platform hook config-builder wrappers
+plus standard `DataSourceResolver` delegates. The initial config-builder target
+was 17 `_build_*_config` callables that already delegate to
+`benchbox.platforms.base.config_utils.build_platform_config`, measured at 643
+source lines before edits. The final slice also folds the adjacent
+PostgreSQL/CedarDB config builders and the standard resolver delegates used by
+cloud/Presto-family adapters, keeping the named subsystem under 1,000 source
+lines while removing 276 credited maintained-Python code lines.
+
+The reduction path is true boilerplate deduplication, not platform deletion or
+Python-to-data relocation: add a shared factory that creates a typed config
+builder callable and sets `__name__`, `__qualname__`, and `__module__`, then
+replace repeated function/import/return/register scaffolding with explicit
+module-level assignments. Platform-specific field lists, platform type,
+credential key, display name, driver package, base options, and the Athena and
+BigQuery post-processing steps remain local to their existing modules. The
+resolver reduction adds one shared `resolve_adapter_data_source()` helper and
+leaves each adapter's return shape intact.
+
+Credited reduction is 276 maintained-Python lines, above the 250-line and 10%
+smaller-subsystem floor.
+
+## Guardrail evidence
+
+- Baseline campaign rollup: 2,379 merged credited lines; 9,621 remaining to the
+  committed 12,000 floor; 16,621 remaining to stretch.
+- Baseline raw maintained Python: `cloc --include-lang=Python benchbox/` =
+  204,628 code lines.
+- Baseline touched-file raw Python for the initial config-builder target:
+  11,020 code lines.
+- Builder-body baseline: 17 functions, 643 source lines; expanded final
+  subsystem stayed under the smaller-subsystem 1,000-line ceiling.
+- Duplicate evidence: `make duplicate-check-json` reports a 7-copy,
+  180-duplicated-line group across cloud config builders plus additional
+  repeated Redshift/TimescaleDB/Postgres-family builders.
+- Open PR overlap: only PR #626 is open and it touches JoinOrder revert files,
+  not platform config builders.
+- Moved-content classification: logic consolidation only. No benchmark,
+  platform, deprecated/beta-public surface, generated Python, SQL/query surface,
+  catalog, or YAML migration changes.
+- Decision-gate status: conservative default. The factory binds explicit
+  module-level callable names and static registry keys; no dynamic symbol
+  injection or permissive open gate is used.
+- Behavior preservation: pre/post fingerprint each builder's callable name,
+  module, registry key, returned `DatabaseConfig` type/name/options/top-level
+  fields, saved-credential merge priority, explicit option priority, and runtime
+  override priority. PostgreSQL and CedarDB received separate before/after
+  fingerprints because their previous wrappers had different default-option and
+  override-consumption behavior.
+
+## Verification
+
+- `make shrink-rollup` at slice start: 2,379 merged credited lines; 9,621
+  remaining to the 12,000 floor.
+- `cloc --include-lang=Python benchbox/`: final raw maintained Python =
+  204,352 code lines, down 276 from the 204,628 pre-slice baseline.
+- `make duplicate-check-json`: groups=278, duplicate_instances=361,
+  duplicated_lines=6,210.
+- `uv run -- ruff check $(git diff --name-only -- '*.py')`: passed.
+- Targeted tests:
+  `uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/cli/test_platform_hooks.py tests/unit/platforms/test_data_loading.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/test_postgresql_adapter.py tests/unit/platforms/test_cedardb.py tests/unit/platforms/test_pg_duckdb_adapter.py tests/unit/platforms/test_pg_mooncake_adapter.py tests/unit/platforms/test_timescaledb_adapter.py tests/unit/platforms/test_clickhouse_cloud_coverage.py tests/unit/platforms/test_bigquery_adapter.py tests/unit/platforms/test_bigquery_adapter_coverage.py tests/unit/platforms/test_redshift_adapter.py tests/unit/platforms/test_redshift_adapter_coverage.py tests/unit/platforms/test_snowflake_adapter.py tests/unit/platforms/test_snowflake_adapter_coverage.py tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_databend_adapter.py tests/unit/platforms/test_azure_synapse_adapter.py tests/unit/platforms/test_firebolt_coverage.py tests/unit/platforms/test_firebolt_adapter.py -q -n 0`
+  -> 1,539 passed.
+- Presto/Trino/Starburst adapter follow-up:
+  `uv run -- python -m pytest tests/unit/platforms/test_presto_adapter.py tests/unit/platforms/test_trino_adapter.py tests/unit/platforms/test_starburst.py tests/unit/platforms/test_presto_trino_utils.py -q -n 0`
+  -> 204 passed.
+- `/tmp/shrink-platform-config-fingerprint-after.json`: matched all 17
+  pre-existing builder fingerprints.
+- `/tmp/shrink-platform-config-pg-cedardb-after.json`: matched PostgreSQL and
+  CedarDB pre-edit fingerprints.
+
+## Residual risk
+
+Residual risk is low but concentrated in introspection and test mocks: replacing
+direct `def` functions with factory-built callables could change callable
+metadata or hook registration, and centralizing resolver delegation moves the
+mock boundary. The factory pins callable metadata, fingerprints prove config
+values and builder identity, and the tests now pin the helper-level resolver
+contract.
+
+## Next target
+
+After merge, re-run `make shrink-rollup` and reassess the remaining low-risk
+reservoir. Do not move static query/catalog content for credit unless a human
+approves that credit class.

--- a/benchbox/platforms/athena.py
+++ b/benchbox/platforms/athena.py
@@ -41,6 +41,7 @@ from ..utils.dependencies import (
     get_dependency_error_message,
 )
 from .base import DriverIsolationCapability, PlatformAdapter
+from .base.config_utils import make_registered_platform_config_builder
 from .base.data_loading import DataSourceResolver, FileFormatRegistry
 from .base.ddl_helpers import strip_with_properties
 from .base.runtime_metadata import build_default_normalized_result_metadata
@@ -1402,51 +1403,33 @@ class AthenaAdapter(PlatformAdapter):
         self.logger.debug(f"ANALYZE not needed for Athena - statistics are auto-collected for {table_name}")
 
 
-def _build_athena_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build Athena database configuration with credential loading."""
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    config = build_platform_config(
-        platform_type="athena",
-        credential_key="athena",
-        default_display_name="AWS Athena",
-        default_driver_package="pyathena",
-        platform_fields=[
-            "workgroup",
-            "database",
-            "catalog",
-            "s3_output_location",
-            "s3_staging_dir",
-            "staging_root",
-            "s3_bucket",
-            "s3_prefix",
-            "aws_profile",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "data_format",
-            "default_format",
-            "compression",
-            "cleanup_staging",
-            "query_timeout",
-            "encryption",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+def _apply_athena_config_fields(config: Any) -> None:
     config.region = config.options.get("region") or config.options.get("aws_region")
-    return config
 
 
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("athena", _build_athena_config)
-except ImportError:
-    pass
+_build_athena_config = make_registered_platform_config_builder(
+    "athena",
+    __name__,
+    "AWS Athena",
+    "pyathena",
+    [
+        "workgroup",
+        "database",
+        "catalog",
+        "s3_output_location",
+        "s3_staging_dir",
+        "staging_root",
+        "s3_bucket",
+        "s3_prefix",
+        "aws_profile",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "data_format",
+        "default_format",
+        "compression",
+        "cleanup_staging",
+        "query_timeout",
+        "encryption",
+    ],
+    postprocess=_apply_athena_config_fields,
+)

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -26,7 +26,8 @@ if TYPE_CHECKING:
 
 from ..utils.dependencies import check_platform_dependencies, get_dependency_error_message
 from .base import DriverIsolationCapability, PlatformAdapter
-from .base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
+from .base.config_utils import make_registered_platform_config_builder
+from .base.data_loading import NO_BENCHMARK, DataSource, resolve_adapter_data_source, resolve_csv_dialect
 from .base.tuning import make_informational_constraint_applier
 from .presto_trino_utils import normalize_existing_files
 
@@ -710,18 +711,7 @@ class AzureSynapseAdapter(PlatformAdapter):
 
     def _resolve_data_files(self, benchmark: Any, data_dir: Path) -> DataSource:
         """Resolve benchmark data files via DataSourceResolver."""
-        from benchbox.platforms.base.data_loading import DataSourceResolver
-
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-        return data_source
+        return resolve_adapter_data_source(self, benchmark, data_dir)
 
     def _upload_external_parquet_to_blob(self, table_name: str, files: list[Path]) -> str:
         """Upload Parquet files for external mode and return Synapse LOCATION path."""
@@ -1243,42 +1233,21 @@ class AzureSynapseAdapter(PlatformAdapter):
     )
 
 
-def _build_synapse_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build Azure Synapse database configuration with credential loading."""
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="synapse",
-        credential_key="synapse",
-        default_display_name="Azure Synapse",
-        default_driver_package="pyodbc",
-        platform_fields=[
-            "server",
-            "port",
-            "username",
-            "password",
-            "schema",
-            "auth_method",
-            "storage_account",
-            "container",
-            "staging_root",
-            "storage_sas_token",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("synapse", _build_synapse_config)
-except ImportError:
-    pass
+_build_synapse_config = make_registered_platform_config_builder(
+    "synapse",
+    __name__,
+    "Azure Synapse",
+    "pyodbc",
+    [
+        "server",
+        "port",
+        "username",
+        "password",
+        "schema",
+        "auth_method",
+        "storage_account",
+        "container",
+        "staging_root",
+        "storage_sas_token",
+    ],
+)

--- a/benchbox/platforms/base/config_utils.py
+++ b/benchbox/platforms/base/config_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 POSTGRES_FAMILY_BASE_OPTIONS: dict[str, Any] = {
@@ -18,6 +18,23 @@ POSTGRES_FAMILY_BASE_OPTIONS: dict[str, Any] = {
     "max_parallel_workers_per_gather": 2,
 }
 
+POSTGRES_CONNECTION_PLATFORM_FIELDS = (
+    "host",
+    "port",
+    "username",
+    "password",
+    "database",
+    "admin_database",
+    "sslmode",
+)
+POSTGRES_TUNING_PLATFORM_FIELDS = (
+    "work_mem",
+    "maintenance_work_mem",
+    "effective_cache_size",
+    "max_parallel_workers_per_gather",
+)
+POSTGRES_FAMILY_PLATFORM_FIELDS = POSTGRES_CONNECTION_PLATFORM_FIELDS + POSTGRES_TUNING_PLATFORM_FIELDS
+
 
 def build_platform_config(
     platform_type: str,
@@ -29,6 +46,8 @@ def build_platform_config(
     overrides: dict[str, Any],
     info: Any,
     base_options: dict[str, Any] | None = None,
+    field_defaults: dict[str, Any] | None = None,
+    consume_explicit_options: bool = False,
 ) -> Any:
     """Build a DatabaseConfig with credential loading and option merging.
 
@@ -47,6 +66,10 @@ def build_platform_config(
         base_options: Optional seed values applied before options (lowest priority).
             Used by platforms that need a fixed default (e.g. schema="public")
             that options/credentials/overrides should still be able to override.
+        field_defaults: Optional field-level defaults that are not inserted into
+            config.options.
+        consume_explicit_options: Preserve older builders that removed
+            _explicit_platform_options from overrides before merging.
 
     Returns:
         A DatabaseConfig instance.
@@ -57,7 +80,11 @@ def build_platform_config(
     cred_manager = CredentialManager()
     saved_creds = cred_manager.get_platform_credentials(credential_key) or {}
 
-    explicit_options = overrides.get("_explicit_platform_options", {})
+    explicit_options = (
+        overrides.pop("_explicit_platform_options", {})
+        if consume_explicit_options
+        else overrides.get("_explicit_platform_options", {})
+    )
 
     merged_options: dict[str, Any] = dict(base_options or {})
     merged_options.update(options)  # registered defaults (lowest priority)
@@ -77,8 +104,9 @@ def build_platform_config(
         "driver_auto_install": bool(overrides.get("driver_auto_install", options.get("driver_auto_install", False))),
     }
 
+    defaults = field_defaults or {}
     for field in platform_fields:
-        config_dict[field] = merged_options.get(field)
+        config_dict[field] = merged_options.get(field, defaults.get(field))
 
     config_dict["benchmark"] = overrides.get("benchmark")
     config_dict["scale_factor"] = overrides.get("scale_factor")
@@ -88,6 +116,80 @@ def build_platform_config(
         config_dict["database"] = overrides["database"]
 
     return DatabaseConfig(**config_dict)
+
+
+PlatformConfigPostprocess = Callable[[Any], None]
+PlatformConfigBuilder = Callable[[str, dict[str, Any], dict[str, Any], Any], Any]
+
+
+def make_platform_config_builder(
+    platform_type: str,
+    module_name: str,
+    default_display_name: str,
+    default_driver_package: str,
+    platform_fields: Iterable[str],
+    *,
+    function_name: str | None = None,
+    credential_key: str | None = None,
+    base_options: dict[str, Any] | None = None,
+    field_defaults: dict[str, Any] | None = None,
+    consume_explicit_options: bool = False,
+    postprocess: PlatformConfigPostprocess | None = None,
+) -> PlatformConfigBuilder:
+    """Create a named platform config builder around build_platform_config."""
+    fields = tuple(platform_fields)
+    name = function_name or f"_build_{platform_type.replace('-', '_')}_config"
+    platform_credential_key = credential_key or platform_type
+
+    def _builder(platform: str, options: dict[str, Any], overrides: dict[str, Any], info: Any) -> Any:
+        config = build_platform_config(
+            platform_type=platform_type,
+            credential_key=platform_credential_key,
+            default_display_name=default_display_name,
+            default_driver_package=default_driver_package,
+            platform_fields=list(fields),
+            options=options,
+            overrides=overrides,
+            info=info,
+            base_options=dict(base_options) if base_options is not None else None,
+            field_defaults=field_defaults,
+            consume_explicit_options=consume_explicit_options,
+        )
+        if postprocess is not None:
+            postprocess(config)
+        return config
+
+    _builder.__name__ = name
+    _builder.__qualname__ = name
+    _builder.__module__ = module_name
+    _builder.__doc__ = f"Build {default_display_name} database configuration with credential loading."
+    return _builder
+
+
+def make_registered_platform_config_builder(
+    registry_platform: str,
+    module_name: str,
+    default_display_name: str,
+    default_driver_package: str,
+    platform_fields: Iterable[str],
+    **kwargs: Any,
+) -> PlatformConfigBuilder:
+    """Create and register a platform config builder with PlatformHookRegistry."""
+    builder = make_platform_config_builder(
+        registry_platform,
+        module_name,
+        default_display_name,
+        default_driver_package,
+        platform_fields,
+        **kwargs,
+    )
+    try:
+        from benchbox.cli.platform_hooks import PlatformHookRegistry
+
+        PlatformHookRegistry.register_config_builder(registry_platform, builder)
+    except ImportError:
+        pass
+    return builder
 
 
 def build_adapter_config(

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -708,6 +708,20 @@ class DataSourceResolver:
         return source
 
 
+def resolve_adapter_data_source(adapter: Any, benchmark: Any, data_dir: Path) -> DataSource:
+    """Resolve data files for adapters that use standard DataSourceResolver state."""
+    resolver = DataSourceResolver(
+        platform_name=adapter.platform_name,
+        table_mode=adapter.table_mode,
+        platform_config=adapter.platform_config,
+        requested_format=adapter.requested_table_format,
+    )
+    data_source = resolver.resolve(benchmark, data_dir)
+    if not data_source or not data_source.tables:
+        raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
+    return data_source
+
+
 class CompressionHandler(ABC):
     """Abstract base class for compression handlers."""
 

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from benchbox.platforms.base.config_utils import make_registered_platform_config_builder
 from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
@@ -32,7 +33,7 @@ from benchbox.utils.printing import emit
 
 from ..utils.dependencies import check_platform_dependencies, get_dependency_error_message
 from .base import DriverIsolationCapability, PlatformAdapter
-from .base.data_loading import NO_BENCHMARK, DataSource, DataSourceResolver, resolve_csv_dialect
+from .base.data_loading import NO_BENCHMARK, DataSource, resolve_adapter_data_source, resolve_csv_dialect
 from .base.runtime_metadata import build_default_normalized_result_metadata
 
 try:
@@ -1125,16 +1126,7 @@ class BigQueryAdapter(PlatformAdapter):
 
     def _resolve_data_files(self, benchmark: Any, data_dir: Path) -> Any:
         """Resolve benchmark data files from benchmark tables or manifest."""
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-        return data_source
+        return resolve_adapter_data_source(self, benchmark, data_dir)
 
     @staticmethod
     def _ensure_file_list(file_paths: Any) -> list[Any]:
@@ -1957,44 +1949,7 @@ class BigQueryAdapter(PlatformAdapter):
     )
 
 
-def _build_bigquery_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build BigQuery database configuration with credential loading.
-
-    This function loads saved credentials from the CredentialManager and
-    merges them with CLI options and runtime overrides.
-
-    Args:
-        platform: Platform name (should be 'bigquery')
-        options: CLI platform options from --platform-option flags
-        overrides: Runtime overrides from orchestrator
-        info: Platform info from registry
-
-    Returns:
-        DatabaseConfig with credentials loaded and platform-specific fields at top-level
-    """
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    config = build_platform_config(
-        platform_type="bigquery",
-        credential_key="bigquery",
-        default_display_name="Google BigQuery",
-        default_driver_package="google-cloud-bigquery",
-        platform_fields=[
-            "project_id",
-            "dataset_id",
-            "location",
-            "credentials_path",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
+def _apply_bigquery_config_fields(config: Any) -> None:
     staging_root = config.options.get("staging_root")
     if not staging_root:
         default_output = config.options.get("default_output_location")
@@ -2015,15 +1970,18 @@ def _build_bigquery_config(
     config.staging_root = staging_root
     config.storage_bucket = storage_bucket
     config.storage_prefix = storage_prefix
-    return config
 
 
-# Register the config builder with the platform hook registry
-# This must happen when the module is imported
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("bigquery", _build_bigquery_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts (e.g., core-only usage)
-    pass
+_build_bigquery_config = make_registered_platform_config_builder(
+    "bigquery",
+    __name__,
+    "Google BigQuery",
+    "google-cloud-bigquery",
+    [
+        "project_id",
+        "dataset_id",
+        "location",
+        "credentials_path",
+    ],
+    postprocess=_apply_bigquery_config_fields,
+)

--- a/benchbox/platforms/cedardb.py
+++ b/benchbox/platforms/cedardb.py
@@ -20,18 +20,19 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from .base.config_utils import (
+    POSTGRES_CONNECTION_PLATFORM_FIELDS,
+    POSTGRES_FAMILY_BASE_OPTIONS,
+    make_platform_config_builder,
+)
 from .postgresql import (
     POSTGRES_DIALECT,
     PostgreSQLAdapter,
     _add_postgres_compatible_arguments,
     _build_postgres_connection_kwargs,
 )
-
-if TYPE_CHECKING:
-    from benchbox.core.platform_registry import PlatformInfo
-    from benchbox.core.schemas import DatabaseConfig
 
 # CedarDB default port - same as PostgreSQL; configurable via platform-option
 CEDARDB_DEFAULT_PORT = 5432
@@ -228,66 +229,13 @@ class CedarDBAdapter(PostgreSQLAdapter):
     _supported_tuning_type_names = ("PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
-def _build_cedardb_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: PlatformInfo | None,
-) -> DatabaseConfig:
-    """Build CedarDB database configuration with credential loading.
-
-    Args:
-        platform: Platform name (should be 'cedardb')
-        options: CLI platform options from --platform-option flags
-        overrides: Runtime overrides from orchestrator
-        info: Platform info from registry
-
-    Returns:
-        DatabaseConfig with credentials loaded
-    """
-    from benchbox.core.schemas import DatabaseConfig
-    from benchbox.security.credentials import CredentialManager
-
-    # Load saved credentials
-    cred_manager = CredentialManager()
-    saved_creds = cred_manager.get_platform_credentials("cedardb") or {}
-
-    # Priority: defaults < saved_creds < explicit_options < overrides
-    # `options` mixes registered defaults with explicit CLI values; explicit_options
-    # isolates only what the user actually typed so credentials win over defaults
-    # but lose to explicit --platform-option flags.
-    explicit_options = overrides.pop("_explicit_platform_options", {})
-    merged_options: dict[str, Any] = {"schema": "public"}
-    merged_options.update(options)
-    merged_options.update(saved_creds)
-    merged_options.update(explicit_options)
-    merged_options.update(overrides)
-
-    name = info.display_name if info else "CedarDB"
-    driver_package = info.driver_package if info else "psycopg"
-
-    config_dict = {
-        "type": "cedardb",
-        "name": name,
-        "options": merged_options,
-        "driver_package": driver_package,
-        "driver_version": overrides.get("driver_version") or options.get("driver_version"),
-        "driver_auto_install": bool(overrides.get("driver_auto_install", options.get("driver_auto_install", False))),
-        # Platform-specific fields
-        # Note: "schema" is not set at top-level because it conflicts with
-        # Pydantic BaseModel's deprecated schema() method. It is available
-        # via config.options["schema"] after build_database_config merges options.
-        "host": merged_options.get("host", "localhost"),
-        "port": merged_options.get("port", CEDARDB_DEFAULT_PORT),
-        "username": merged_options.get("username", "postgres"),
-        "password": merged_options.get("password"),
-        "database": merged_options.get("database"),
-        "admin_database": merged_options.get("admin_database", "postgres"),
-        "sslmode": merged_options.get("sslmode", "prefer"),
-        # Benchmark context
-        "benchmark": overrides.get("benchmark"),
-        "scale_factor": overrides.get("scale_factor"),
-        "tuning_config": overrides.get("tuning_config"),
-    }
-
-    return DatabaseConfig(**config_dict)
+_build_cedardb_config = make_platform_config_builder(
+    "cedardb",
+    __name__,
+    "CedarDB",
+    "psycopg",
+    POSTGRES_CONNECTION_PLATFORM_FIELDS,
+    base_options={"schema": "public"},
+    field_defaults={**POSTGRES_FAMILY_BASE_OPTIONS, "port": CEDARDB_DEFAULT_PORT},
+    consume_explicit_options=True,
+)

--- a/benchbox/platforms/clickhouse_cloud.py
+++ b/benchbox/platforms/clickhouse_cloud.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from benchbox.platforms.base.adapter import DriverIsolationCapability
+from benchbox.platforms.base.config_utils import make_registered_platform_config_builder
 from benchbox.platforms.base.runtime_metadata import build_default_normalized_result_metadata
 from benchbox.platforms.clickhouse import ClickHouseAdapter
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -736,17 +737,9 @@ class ClickHouseCloudAdapter(ClickHouseAdapter):
         Raises:
             ValueError: If no data files are found.
         """
-        from benchbox.platforms.base.data_loading import DataSourceResolver
+        from benchbox.platforms.base.data_loading import resolve_adapter_data_source
 
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
+        data_source = resolve_adapter_data_source(self, benchmark, data_dir)
         return {table: [Path(p) for p in paths] for table, paths in data_source.tables.items()}
 
     def _load_data_via_object_storage(
@@ -958,54 +951,33 @@ class ClickHouseCloudAdapter(ClickHouseAdapter):
         return parse_gcs_url(gcs_url)
 
 
-def _build_clickhouse_cloud_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="clickhouse-cloud",
-        credential_key="clickhouse-cloud",
-        default_display_name="ClickHouse Cloud",
-        default_driver_package="clickhouse-connect",
-        platform_fields=[
-            "host",
-            "password",
-            "username",
-            "database",
-            "oauth_token",
-            "region",
-            "cloud_region",
-            "cloud_provider",
-            "service_id",
-            "service_name",
-            "service_tier",
-            "compute_size",
-            "s3_staging_url",
-            "s3_region",
-            "gcs_staging_url",
-            "max_memory_usage",
-            "max_execution_time",
-            "disable_result_cache",
-            "compression",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("clickhouse-cloud", _build_clickhouse_cloud_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts (e.g., minimal installs, testing)
-    logger.debug("Platform hooks not available, skipping ClickHouse Cloud config builder registration")
+_build_clickhouse_cloud_config = make_registered_platform_config_builder(
+    "clickhouse-cloud",
+    __name__,
+    "ClickHouse Cloud",
+    "clickhouse-connect",
+    [
+        "host",
+        "password",
+        "username",
+        "database",
+        "oauth_token",
+        "region",
+        "cloud_region",
+        "cloud_provider",
+        "service_id",
+        "service_name",
+        "service_tier",
+        "compute_size",
+        "s3_staging_url",
+        "s3_region",
+        "gcs_staging_url",
+        "max_memory_usage",
+        "max_execution_time",
+        "disable_result_cache",
+        "compression",
+    ],
+)
 
 
 __all__ = ["ClickHouseCloudAdapter"]

--- a/benchbox/platforms/databend/__init__.py
+++ b/benchbox/platforms/databend/__init__.py
@@ -14,39 +14,26 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
+from benchbox.platforms.base.config_utils import make_platform_config_builder
 from benchbox.platforms.databend.adapter import DatabendAdapter
 
-
-def _build_databend_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Optional[Any],
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="databend",
-        credential_key="databend",
-        default_display_name="Databend",
-        default_driver_package="databend-driver",
-        platform_fields=[
-            "host",
-            "port",
-            "username",
-            "password",
-            "database",
-            "dsn",
-            "warehouse",
-            "ssl",
-            "disable_result_cache",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+_build_databend_config = make_platform_config_builder(
+    "databend",
+    __name__,
+    "Databend",
+    "databend-driver",
+    [
+        "host",
+        "port",
+        "username",
+        "password",
+        "database",
+        "dsn",
+        "warehouse",
+        "ssl",
+        "disable_result_cache",
+    ],
+)
 
 
 # NOTE: Registration of the config builder is done in benchbox/platforms/__init__.py

--- a/benchbox/platforms/databend/adapter.py
+++ b/benchbox/platforms/databend/adapter.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
 from benchbox.core.exceptions import ConfigurationError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
-from benchbox.platforms.base.data_loading import FileFormatRegistry
+from benchbox.platforms.base.data_loading import FileFormatRegistry, resolve_adapter_data_source
 from benchbox.platforms.base.ddl_helpers import strip_foreign_keys
 from benchbox.utils.dependencies import (
     check_platform_dependencies,
@@ -497,18 +497,7 @@ class DatabendAdapter(PlatformAdapter):
 
     def _resolve_data_files(self, benchmark, data_dir: Path) -> Any:
         """Resolve data files via DataSourceResolver."""
-        from benchbox.platforms.base.data_loading import DataSourceResolver
-
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-        return data_source
+        return resolve_adapter_data_source(self, benchmark, data_dir)
 
     def execute_query(
         self,

--- a/benchbox/platforms/databricks/__init__.py
+++ b/benchbox/platforms/databricks/__init__.py
@@ -8,14 +8,9 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, Optional
-
-if TYPE_CHECKING:
-    from benchbox.core.schemas import DatabaseConfig
-    from benchbox.platforms.base.models import PlatformInfo
-
 # Import and re-export the Databricks adapters
 # Import and re-export dependency checking utilities
+from benchbox.platforms.base.config_utils import make_platform_config_builder
 from benchbox.utils.dependencies import check_platform_dependencies, get_dependency_error_message
 
 from .adapter import DatabricksAdapter
@@ -30,44 +25,33 @@ __all__ = [
 ]
 
 
-def _build_databricks_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Optional["PlatformInfo"],
-) -> "DatabaseConfig":
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="databricks",
-        credential_key="databricks",
-        default_display_name="Databricks",
-        default_driver_package="databricks-sql-connector",
-        platform_fields=[
-            "server_hostname",
-            "http_path",
-            "access_token",
-            "catalog",
-            "schema",
-            "uc_catalog",
-            "uc_schema",
-            "uc_volume",
-            "staging_root",
-            "region",
-            "cloud_region",
-            "workspace_region",
-            "cluster_size",
-            "auto_terminate_minutes",
-            "enable_delta_optimization",
-            "delta_auto_optimize",
-            "delta_auto_compact",
-            "create_catalog",
-            "disable_result_cache",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+_build_databricks_config = make_platform_config_builder(
+    "databricks",
+    __name__,
+    "Databricks",
+    "databricks-sql-connector",
+    [
+        "server_hostname",
+        "http_path",
+        "access_token",
+        "catalog",
+        "schema",
+        "uc_catalog",
+        "uc_schema",
+        "uc_volume",
+        "staging_root",
+        "region",
+        "cloud_region",
+        "workspace_region",
+        "cluster_size",
+        "auto_terminate_minutes",
+        "enable_delta_optimization",
+        "delta_auto_optimize",
+        "delta_auto_compact",
+        "create_catalog",
+        "disable_result_cache",
+    ],
+)
 
 
 # NOTE: Registration of the config builder is done in benchbox/platforms/__init__.py

--- a/benchbox/platforms/firebolt.py
+++ b/benchbox/platforms/firebolt.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 
 from benchbox.core.benchmark_mixins import CursorValidationQueryExecutionMixin
 from benchbox.core.sql_utils import normalize_table_name_in_sql
+from benchbox.platforms.base.config_utils import make_registered_platform_config_builder
 from benchbox.platforms.base.runtime_metadata import build_default_normalized_result_metadata
 from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.platforms.presto_trino_utils import normalize_existing_files, show_tables_lower
@@ -1561,50 +1562,29 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
         return metadata
 
 
-def _build_firebolt_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="firebolt",
-        credential_key="firebolt",
-        default_display_name="Firebolt",
-        default_driver_package="firebolt-sdk",
-        platform_fields=[
-            "url",
-            "client_id",
-            "client_secret",
-            "account_name",
-            "engine_name",
-            "api_endpoint",
-            "database",
-            "region",
-            "cloud_region",
-            "cloud_provider",
-            "engine_type",
-            "engine_size",
-            "compute_size",
-            "deployment_mode",
-            "s3_staging_url",
-            "s3_region",
-            "disable_result_cache",
-            "strict_validation",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("firebolt", _build_firebolt_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts
-    pass
+_build_firebolt_config = make_registered_platform_config_builder(
+    "firebolt",
+    __name__,
+    "Firebolt",
+    "firebolt-sdk",
+    [
+        "url",
+        "client_id",
+        "client_secret",
+        "account_name",
+        "engine_name",
+        "api_endpoint",
+        "database",
+        "region",
+        "cloud_region",
+        "cloud_provider",
+        "engine_type",
+        "engine_size",
+        "compute_size",
+        "deployment_mode",
+        "s3_staging_url",
+        "s3_region",
+        "disable_result_cache",
+        "strict_validation",
+    ],
+)

--- a/benchbox/platforms/lakesail.py
+++ b/benchbox/platforms/lakesail.py
@@ -43,6 +43,7 @@ from ._spark_helpers import (
     validate_spark_identifier,
 )
 from .base import DriverIsolationCapability, PlatformAdapter
+from .base.config_utils import make_registered_platform_config_builder
 from .base.spark_execution_mixin import SparkDataLoadMixin, SparkQueryExecutionMixin
 
 try:
@@ -636,42 +637,21 @@ class LakeSailAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecu
         analyze_spark_table(connection, table_name, logger=self.logger)
 
 
-def _build_lakesail_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build LakeSail database configuration with credential loading."""
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="lakesail",
-        credential_key="lakesail",
-        default_display_name="LakeSail Sail",
-        default_driver_package="pyspark",
-        platform_fields=[
-            "endpoint",
-            "app_name",
-            "driver_memory",
-            "sail_mode",
-            "sail_workers",
-            "shuffle_partitions",
-            "adaptive_enabled",
-            "table_format",
-            "spark_config",
-            "disable_cache",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("lakesail", _build_lakesail_config)
-except ImportError:
-    pass
+_build_lakesail_config = make_registered_platform_config_builder(
+    "lakesail",
+    __name__,
+    "LakeSail Sail",
+    "pyspark",
+    [
+        "endpoint",
+        "app_name",
+        "driver_memory",
+        "sail_mode",
+        "sail_workers",
+        "shuffle_partitions",
+        "adaptive_enabled",
+        "table_format",
+        "spark_config",
+        "disable_cache",
+    ],
+)

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -39,6 +39,7 @@ except ImportError:
     duckdb = None
 
 from .base import DriverIsolationCapability, PlatformAdapter
+from .base.config_utils import make_platform_config_builder
 from .duckdb import _build_duckdb_ctas_sort_sql, _create_duckdb_external_views
 
 if TYPE_CHECKING:
@@ -55,38 +56,19 @@ def _redact_motherduck_token(message: str, token: str | None = None) -> str:
     return _MOTHERDUCK_TOKEN_RE.sub(r"\1****", redacted)
 
 
-def _build_motherduck_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build the MotherDuck DatabaseConfig.
-
-    The credential setup wizard (`benchbox/platforms/credentials/motherduck.py`)
-    saves a ``database`` field, but the default config builder did not call
-    CredentialManager, so runtime runs always fell back to the adapter's
-    internal default (``benchbox``) regardless of what the wizard captured.
-    Routing MotherDuck through the shared ``build_platform_config`` helper
-    pulls the saved database into ``options["database"]`` so the adapter's
-    ``config.get("database", "benchbox")`` resolves to the wizard value.
-    """
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="motherduck",
-        credential_key="motherduck",
-        default_display_name="MotherDuck",
-        default_driver_package="duckdb",
-        platform_fields=[
-            "database",
-            "memory_limit",
-            "token_env_var",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+# MotherDuck credentials include ``database``; route through the shared
+# credential-aware builder so saved setup values reach adapter config.
+_build_motherduck_config = make_platform_config_builder(
+    "motherduck",
+    __name__,
+    "MotherDuck",
+    "duckdb",
+    [
+        "database",
+        "memory_limit",
+        "token_env_var",
+    ],
+)
 
 
 class MotherDuckAdapter(PlatformAdapter):

--- a/benchbox/platforms/pg_duckdb.py
+++ b/benchbox/platforms/pg_duckdb.py
@@ -24,13 +24,14 @@ import logging
 import os
 import time
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from .base.config_utils import (
+    POSTGRES_FAMILY_BASE_OPTIONS,
+    POSTGRES_FAMILY_PLATFORM_FIELDS,
+    make_platform_config_builder,
+)
 from .postgresql import POSTGRES_DIALECT, PostgreSQLAdapter, _build_postgres_connection_kwargs
-
-if TYPE_CHECKING:
-    from benchbox.core.platform_registry import PlatformInfo
-    from benchbox.core.schemas import DatabaseConfig
 
 logger = logging.getLogger(__name__)
 
@@ -413,48 +414,22 @@ class PgDuckDBAdapter(PostgreSQLAdapter):
     _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING", "PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
-def _build_pg_duckdb_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: PlatformInfo | None,
-) -> DatabaseConfig:
-    """Build pg_duckdb database configuration with credential loading.
-
-    This function is registered with PlatformHookRegistry to provide
-    pg_duckdb-specific configuration handling.
-    """
-    from benchbox.platforms.base.config_utils import POSTGRES_FAMILY_BASE_OPTIONS, build_platform_config
-
-    return build_platform_config(
-        platform_type="pg-duckdb",
-        credential_key="pg-duckdb",
-        default_display_name="pg_duckdb",
-        default_driver_package="psycopg",
-        base_options={
-            **POSTGRES_FAMILY_BASE_OPTIONS,
-            "force_execution": True,
-            "postgres_scan_threads": 0,
-            "compare_native": False,
-        },
-        platform_fields=[
-            "host",
-            "port",
-            "username",
-            "password",
-            "database",
-            "admin_database",
-            "sslmode",
-            "work_mem",
-            "maintenance_work_mem",
-            "effective_cache_size",
-            "max_parallel_workers_per_gather",
-            "force_execution",
-            "postgres_scan_threads",
-            "compare_native",
-            "duckdb_db_path",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+_build_pg_duckdb_config = make_platform_config_builder(
+    "pg-duckdb",
+    __name__,
+    "pg_duckdb",
+    "psycopg",
+    POSTGRES_FAMILY_PLATFORM_FIELDS
+    + (
+        "force_execution",
+        "postgres_scan_threads",
+        "compare_native",
+        "duckdb_db_path",
+    ),
+    base_options={
+        **POSTGRES_FAMILY_BASE_OPTIONS,
+        "force_execution": True,
+        "postgres_scan_threads": 0,
+        "compare_native": False,
+    },
+)

--- a/benchbox/platforms/pg_mooncake.py
+++ b/benchbox/platforms/pg_mooncake.py
@@ -27,13 +27,14 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from .base.config_utils import (
+    POSTGRES_FAMILY_BASE_OPTIONS,
+    POSTGRES_FAMILY_PLATFORM_FIELDS,
+    make_platform_config_builder,
+)
 from .postgresql import POSTGRES_DIALECT, PostgreSQLAdapter
-
-if TYPE_CHECKING:
-    from benchbox.core.platform_registry import PlatformInfo
-    from benchbox.core.schemas import DatabaseConfig
 
 logger = logging.getLogger(__name__)
 
@@ -543,44 +544,14 @@ class PgMooncakeAdapter(PostgreSQLAdapter):
         return False
 
 
-def _build_pg_mooncake_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: PlatformInfo | None,
-) -> DatabaseConfig:
-    """Build pg_mooncake database configuration with credential loading.
-
-    This function is registered with PlatformHookRegistry to provide
-    pg_mooncake-specific configuration handling.
-    """
-    from benchbox.platforms.base.config_utils import POSTGRES_FAMILY_BASE_OPTIONS, build_platform_config
-
-    return build_platform_config(
-        platform_type="pg-mooncake",
-        credential_key="pg-mooncake",
-        default_display_name="pg_mooncake",
-        default_driver_package="psycopg",
-        base_options={
-            **POSTGRES_FAMILY_BASE_OPTIONS,
-            "storage_mode": "local",
-        },
-        platform_fields=[
-            "host",
-            "port",
-            "username",
-            "password",
-            "database",
-            "admin_database",
-            "sslmode",
-            "work_mem",
-            "maintenance_work_mem",
-            "effective_cache_size",
-            "max_parallel_workers_per_gather",
-            "storage_mode",
-            "mooncake_bucket",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+_build_pg_mooncake_config = make_platform_config_builder(
+    "pg-mooncake",
+    __name__,
+    "pg_mooncake",
+    "psycopg",
+    POSTGRES_FAMILY_PLATFORM_FIELDS + ("storage_mode", "mooncake_bucket"),
+    base_options={
+        **POSTGRES_FAMILY_BASE_OPTIONS,
+        "storage_mode": "local",
+    },
+)

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -35,6 +35,11 @@ from ..utils.dependencies import (
 )
 from ..utils.file_format import get_data_extension
 from .base import DriverIsolationCapability, PlatformAdapter, PsycopgConnectionMixin
+from .base.config_utils import (
+    POSTGRES_FAMILY_BASE_OPTIONS,
+    POSTGRES_FAMILY_PLATFORM_FIELDS,
+    make_platform_config_builder,
+)
 from .base.data_loading import (
     CsvDialect,
     DataSourceResolver,
@@ -1000,56 +1005,12 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
     _supported_tuning_type_names = ("PARTITIONING", "CLUSTERING", "PRIMARY_KEYS", "FOREIGN_KEYS")
 
 
-def _build_postgresql_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build PostgreSQL database configuration with credential loading.
-
-    This function is registered with PlatformHookRegistry to provide
-    PostgreSQL-specific configuration handling.
-    """
-    from benchbox.core.schemas import DatabaseConfig
-    from benchbox.security.credentials import CredentialManager
-
-    cred_manager = CredentialManager()
-    saved_creds = cred_manager.get_platform_credentials("postgresql") or {}
-
-    explicit_options = overrides.get("_explicit_platform_options", {})
-
-    merged_options: dict[str, Any] = {"schema": "public"}
-    merged_options.update(options)  # registered defaults (lowest priority)
-    merged_options.update(saved_creds)  # saved credentials win over defaults
-    merged_options.update(explicit_options)  # explicit CLI flags win over credentials
-    merged_options.update(overrides)  # runtime overrides (highest priority)
-
-    name = info.display_name if info else "PostgreSQL"
-    driver_package = info.driver_package if info else "psycopg"
-
-    config_dict = {
-        "type": "postgresql",
-        "name": name,
-        "options": merged_options or {},
-        "driver_package": driver_package,
-        "driver_version": overrides.get("driver_version") or options.get("driver_version"),
-        "driver_auto_install": bool(overrides.get("driver_auto_install", options.get("driver_auto_install", False))),
-        "host": merged_options.get("host", "localhost"),
-        "port": merged_options.get("port", 5432),
-        "username": merged_options.get("username", "postgres"),
-        "password": merged_options.get("password"),
-        "database": merged_options.get("database"),
-        "admin_database": merged_options.get("admin_database", "postgres"),
-        "sslmode": merged_options.get("sslmode", "prefer"),
-        "work_mem": merged_options.get("work_mem", "256MB"),
-        "maintenance_work_mem": merged_options.get("maintenance_work_mem", "512MB"),
-        "effective_cache_size": merged_options.get("effective_cache_size", "1GB"),
-        "max_parallel_workers_per_gather": merged_options.get("max_parallel_workers_per_gather", 2),
-        "enable_timescale": merged_options.get("enable_timescale", False),
-        "benchmark": overrides.get("benchmark"),
-        "scale_factor": overrides.get("scale_factor"),
-        "tuning_config": overrides.get("tuning_config"),
-    }
-
-    return DatabaseConfig(**config_dict)
+_build_postgresql_config = make_platform_config_builder(
+    "postgresql",
+    __name__,
+    "PostgreSQL",
+    "psycopg",
+    POSTGRES_FAMILY_PLATFORM_FIELDS + ("enable_timescale",),
+    base_options={"schema": "public"},
+    field_defaults={**POSTGRES_FAMILY_BASE_OPTIONS, "enable_timescale": False},
+)

--- a/benchbox/platforms/presto_trino_adapter_base.py
+++ b/benchbox/platforms/presto_trino_adapter_base.py
@@ -10,11 +10,11 @@ from typing import Any
 
 from benchbox.core.benchmark_mixins import CursorValidationQueryExecutionMixin
 from benchbox.core.sql_utils import normalize_table_name_in_sql
+from benchbox.platforms.base.data_loading import resolve_adapter_data_source
 from benchbox.platforms.base.external_table_mixin import HiveExternalTableMixin
 from benchbox.platforms.presto_trino_utils import (
     load_file_batches,
     normalize_existing_files,
-    resolve_data_files,
     show_tables_lower,
     validate_catalog_exists,
 )
@@ -472,14 +472,7 @@ class PrestoTrinoAdapterBase(CursorValidationQueryExecutionMixin, HiveExternalTa
 
     def _resolve_data_files(self, benchmark: Any, data_dir: Path) -> dict[str, Any]:
         """Resolve benchmark data files from benchmark tables or manifest."""
-        return resolve_data_files(
-            benchmark,
-            data_dir,
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
+        return resolve_adapter_data_source(self, benchmark, data_dir).tables
 
     def _load_table_data(
         self,

--- a/benchbox/platforms/presto_trino_utils.py
+++ b/benchbox/platforms/presto_trino_utils.py
@@ -36,34 +36,6 @@ def escape_insert_value(value: str) -> str:
         return "'" + str(value).replace("'", "''") + "'"
 
 
-def resolve_data_files(
-    benchmark: Any,
-    data_dir: Path,
-    *,
-    platform_name: str,
-    table_mode: str,
-    platform_config: Any,
-    requested_format: Any,
-) -> dict[str, Any]:
-    """Resolve benchmark data files via DataSourceResolver.
-
-    Raises ``ValueError`` when no data files are resolved - consistent
-    with the per-adapter message both Presto and Trino used.
-    """
-    from benchbox.platforms.base.data_loading import DataSourceResolver
-
-    resolver = DataSourceResolver(
-        platform_name=platform_name,
-        table_mode=table_mode,
-        platform_config=platform_config,
-        requested_format=requested_format,
-    )
-    data_source = resolver.resolve(benchmark, data_dir)
-    if not data_source or not data_source.tables:
-        raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-    return data_source.tables
-
-
 def load_file_batches(cursor: Any, file_path: Path, qualified_table: str) -> int:
     """Load one file into a Presto/Trino table using batched INSERT VALUES."""
     from benchbox.platforms.base.data_loading import FileFormatRegistry

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -34,7 +34,14 @@ from ..utils.dependencies import (
 )
 from ..utils.file_format import detect_compression, is_parquet_format
 from .base import DriverIsolationCapability, PlatformAdapter
-from .base.data_loading import NO_BENCHMARK, DataSource, DataSourceResolver, FileFormatRegistry, resolve_csv_dialect
+from .base.config_utils import make_registered_platform_config_builder
+from .base.data_loading import (
+    NO_BENCHMARK,
+    DataSource,
+    FileFormatRegistry,
+    resolve_adapter_data_source,
+    resolve_csv_dialect,
+)
 from .base.runtime_metadata import build_default_normalized_result_metadata
 
 try:
@@ -1319,16 +1326,7 @@ class RedshiftAdapter(PlatformAdapter):
 
     def _resolve_data_files(self, benchmark, data_dir: Path) -> Any:
         """Resolve data files from benchmark tables or manifest fallback."""
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-        return data_source
+        return resolve_adapter_data_source(self, benchmark, data_dir)
 
     def _create_s3_client(self):
         """Create S3 client with explicit error handling."""
@@ -2653,68 +2651,32 @@ class RedshiftAdapter(PlatformAdapter):
     )
 
 
-def _build_redshift_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build Redshift database configuration with credential loading.
-
-    This function loads saved credentials from the CredentialManager and
-    merges them with CLI options and runtime overrides.
-
-    Args:
-        platform: Platform name (should be 'redshift')
-        options: CLI platform options from --platform-option flags
-        overrides: Runtime overrides from orchestrator
-        info: Platform info from registry
-
-    Returns:
-        DatabaseConfig with credentials loaded
-    """
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="redshift",
-        credential_key="redshift",
-        default_display_name="Amazon Redshift",
-        default_driver_package="redshift-connector",
-        base_options={"admin_database": "dev"},
-        platform_fields=[
-            "host",
-            "port",
-            "username",
-            "password",
-            "schema",
-            "s3_bucket",
-            "s3_prefix",
-            "staging_root",
-            "iam_role",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
-            "aws_region",
-            "cluster_identifier",
-            "admin_database",
-            "connect_timeout",
-            "statement_timeout",
-            "sslmode",
-            "disable_result_cache",
-            "strict_validation",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-# This must happen when the module is imported
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("redshift", _build_redshift_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts (e.g., core-only usage)
-    pass
+_build_redshift_config = make_registered_platform_config_builder(
+    "redshift",
+    __name__,
+    "Amazon Redshift",
+    "redshift-connector",
+    [
+        "host",
+        "port",
+        "username",
+        "password",
+        "schema",
+        "s3_bucket",
+        "s3_prefix",
+        "staging_root",
+        "iam_role",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_region",
+        "cluster_identifier",
+        "admin_database",
+        "connect_timeout",
+        "statement_timeout",
+        "sslmode",
+        "disable_result_cache",
+        "strict_validation",
+    ],
+    base_options={"admin_database": "dev"},
+)

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -27,7 +27,8 @@ from ..core.exceptions import ConfigurationError
 from ..utils.cloud_storage import get_cloud_path_info
 from ..utils.dependencies import check_platform_dependencies, get_dependency_error_message
 from .base import DriverIsolationCapability, PlatformAdapter
-from .base.data_loading import NO_BENCHMARK, DataSource, DataSourceResolver, resolve_csv_dialect
+from .base.config_utils import make_registered_platform_config_builder
+from .base.data_loading import NO_BENCHMARK, DataSource, resolve_adapter_data_source, resolve_csv_dialect
 from .base.runtime_metadata import build_default_normalized_result_metadata
 from .base.tuning import make_informational_constraint_applier
 from .presto_trino_utils import normalize_existing_files
@@ -939,16 +940,7 @@ class SnowflakeAdapter(PlatformAdapter):
 
     def _resolve_data_files(self, benchmark: Any, data_dir: Path) -> DataSource:
         """Resolve benchmark data files from benchmark tables or manifest."""
-        resolver = DataSourceResolver(
-            platform_name=self.platform_name,
-            table_mode=self.table_mode,
-            platform_config=self.platform_config,
-            requested_format=self.requested_table_format,
-        )
-        data_source = resolver.resolve(benchmark, data_dir)
-        if not data_source or not data_source.tables:
-            raise ValueError("No data files found. Ensure benchmark.generate_data() was called first.")
-        return data_source
+        return resolve_adapter_data_source(self, benchmark, data_dir)
 
     _normalize_existing_files = staticmethod(normalize_existing_files)
 
@@ -1757,42 +1749,20 @@ class SnowflakeAdapter(PlatformAdapter):
     )
 
 
-def _build_snowflake_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="snowflake",
-        credential_key="snowflake",
-        default_display_name="Snowflake",
-        default_driver_package="snowflake-connector-python",
-        platform_fields=[
-            "account",
-            "warehouse",
-            "schema",
-            "username",
-            "password",
-            "role",
-            "authenticator",
-            "private_key_path",
-            "private_key_passphrase",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-# This must happen when the module is imported
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("snowflake", _build_snowflake_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts (e.g., core-only usage)
-    pass
+_build_snowflake_config = make_registered_platform_config_builder(
+    "snowflake",
+    __name__,
+    "Snowflake",
+    "snowflake-connector-python",
+    [
+        "account",
+        "warehouse",
+        "schema",
+        "username",
+        "password",
+        "role",
+        "authenticator",
+        "private_key_path",
+        "private_key_passphrase",
+    ],
+)

--- a/benchbox/platforms/spark.py
+++ b/benchbox/platforms/spark.py
@@ -37,6 +37,7 @@ from ._spark_helpers import (
     validate_spark_identifier,
 )
 from .base import DriverIsolationCapability, PlatformAdapter
+from .base.config_utils import make_registered_platform_config_builder
 from .base.spark_execution_mixin import SparkDataLoadMixin, SparkQueryExecutionMixin
 from .base.spark_logging import suppress_window_exec_warning
 
@@ -804,47 +805,26 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
         analyze_spark_table(connection, table_name, logger=self.logger)
 
 
-def _build_spark_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="spark",
-        credential_key="spark",
-        default_display_name="Apache Spark",
-        default_driver_package="pyspark",
-        platform_fields=[
-            "master",
-            "app_name",
-            "deploy_mode",
-            "driver_memory",
-            "executor_memory",
-            "executor_cores",
-            "num_executors",
-            "shuffle_partitions",
-            "broadcast_threshold",
-            "adaptive_enabled",
-            "table_format",
-            "enable_hive",
-            "spark_config",
-            "java_home",
-            "staging_root",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("spark", _build_spark_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts
-    pass
+_build_spark_config = make_registered_platform_config_builder(
+    "spark",
+    __name__,
+    "Apache Spark",
+    "pyspark",
+    [
+        "master",
+        "app_name",
+        "deploy_mode",
+        "driver_memory",
+        "executor_memory",
+        "executor_cores",
+        "num_executors",
+        "shuffle_partitions",
+        "broadcast_threshold",
+        "adaptive_enabled",
+        "table_format",
+        "enable_hive",
+        "spark_config",
+        "java_home",
+        "staging_root",
+    ],
+)

--- a/benchbox/platforms/starburst.py
+++ b/benchbox/platforms/starburst.py
@@ -21,6 +21,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from benchbox.platforms.base.adapter import DriverIsolationCapability
+from benchbox.platforms.base.config_utils import make_registered_platform_config_builder
 
 from .trino import TrinoAdapter
 
@@ -260,47 +261,26 @@ class StarburstAdapter(TrinoAdapter):
         )
 
 
-def _build_starburst_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="starburst",
-        credential_key="starburst",
-        default_display_name="Starburst",
-        default_driver_package="trino",
-        platform_fields=[
-            "host",
-            "port",
-            "catalog",
-            "username",
-            "password",
-            "role",
-            "http_scheme",
-            "verify_ssl",
-            "ssl_cert_path",
-            "session_properties",
-            "query_timeout",
-            "timezone",
-            "table_format",
-            "staging_root",
-            "schema",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-# Register the config builder with the platform hook registry
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("starburst", _build_starburst_config)
-except ImportError:
-    # Platform hooks may not be available in all contexts
-    pass
+_build_starburst_config = make_registered_platform_config_builder(
+    "starburst",
+    __name__,
+    "Starburst",
+    "trino",
+    [
+        "host",
+        "port",
+        "catalog",
+        "username",
+        "password",
+        "role",
+        "http_scheme",
+        "verify_ssl",
+        "ssl_cert_path",
+        "session_properties",
+        "query_timeout",
+        "timezone",
+        "table_format",
+        "staging_root",
+        "schema",
+    ],
+)

--- a/benchbox/platforms/timescaledb.py
+++ b/benchbox/platforms/timescaledb.py
@@ -30,6 +30,11 @@ from typing import Any
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 from .base import DriverIsolationCapability
+from .base.config_utils import (
+    POSTGRES_FAMILY_BASE_OPTIONS,
+    POSTGRES_FAMILY_PLATFORM_FIELDS,
+    make_platform_config_builder,
+)
 from .postgresql import (
     POSTGRES_DIALECT,
     PostgreSQLAdapter,
@@ -628,47 +633,16 @@ class TimescaleDBAdapter(PostgreSQLAdapter):
             return False
 
 
-def _build_timescaledb_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build TimescaleDB database configuration with credential loading.
-
-    This function is registered with PlatformHookRegistry to provide
-    TimescaleDB-specific configuration handling.
-    """
-    from benchbox.platforms.base.config_utils import POSTGRES_FAMILY_BASE_OPTIONS, build_platform_config
-
-    return build_platform_config(
-        platform_type="timescaledb",
-        credential_key="timescaledb",
-        default_display_name="TimescaleDB",
-        default_driver_package="psycopg",
-        base_options={
-            **POSTGRES_FAMILY_BASE_OPTIONS,
-            "chunk_interval": "1 day",
-            "compression_enabled": False,
-            "compression_after": "7 days",
-        },
-        platform_fields=[
-            "host",
-            "port",
-            "username",
-            "password",
-            "database",
-            "admin_database",
-            "sslmode",
-            "work_mem",
-            "maintenance_work_mem",
-            "effective_cache_size",
-            "max_parallel_workers_per_gather",
-            "chunk_interval",
-            "compression_enabled",
-            "compression_after",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
+_build_timescaledb_config = make_platform_config_builder(
+    "timescaledb",
+    __name__,
+    "TimescaleDB",
+    "psycopg",
+    POSTGRES_FAMILY_PLATFORM_FIELDS + ("chunk_interval", "compression_enabled", "compression_after"),
+    base_options={
+        **POSTGRES_FAMILY_BASE_OPTIONS,
+        "chunk_interval": "1 day",
+        "compression_enabled": False,
+        "compression_after": "7 days",
+    },
+)

--- a/benchbox/platforms/velox.py
+++ b/benchbox/platforms/velox.py
@@ -57,6 +57,7 @@ from ._spark_helpers import (
     validate_spark_identifier,
 )
 from .base import DriverIsolationCapability, PlatformAdapter
+from .base.config_utils import make_registered_platform_config_builder
 from .base.spark_execution_mixin import SparkDataLoadMixin, SparkQueryExecutionMixin
 
 try:
@@ -565,43 +566,23 @@ class VeloxAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
         analyze_spark_table(connection, table_name, logger=self.logger)
 
 
-def _build_velox_config(
-    platform: str,
-    options: dict[str, Any],
-    overrides: dict[str, Any],
-    info: Any,
-) -> Any:
-    """Build Velox configuration for the platform hook registry."""
-    from benchbox.platforms.base.config_utils import build_platform_config
-
-    return build_platform_config(
-        platform_type="velox",
-        credential_key="velox",
-        default_display_name="Apache Gluten + Velox",
-        default_driver_package="pyspark",
-        platform_fields=[
-            "deployment",
-            "endpoint",
-            "gluten_jar_path",
-            "gluten_version",
-            "offheap_size",
-            "app_name",
-            "driver_memory",
-            "shuffle_partitions",
-            "adaptive_enabled",
-            "table_format",
-            "spark_config",
-            "disable_cache",
-        ],
-        options=options,
-        overrides=overrides,
-        info=info,
-    )
-
-
-try:
-    from benchbox.cli.platform_hooks import PlatformHookRegistry
-
-    PlatformHookRegistry.register_config_builder("velox", _build_velox_config)
-except ImportError:
-    pass
+_build_velox_config = make_registered_platform_config_builder(
+    "velox",
+    __name__,
+    "Apache Gluten + Velox",
+    "pyspark",
+    [
+        "deployment",
+        "endpoint",
+        "gluten_jar_path",
+        "gluten_version",
+        "offheap_size",
+        "app_name",
+        "driver_memory",
+        "shuffle_partitions",
+        "adaptive_enabled",
+        "table_format",
+        "spark_config",
+        "disable_cache",
+    ],
+)

--- a/tests/unit/platforms/test_bigquery_adapter_coverage.py
+++ b/tests/unit/platforms/test_bigquery_adapter_coverage.py
@@ -2691,41 +2691,33 @@ class TestResolveDataFiles:
 
     def test_returns_tables_from_resolver(self):
         adapter = _make_adapter()
+        benchmark = Mock()
+        data_dir = Path("/tmp/data")
 
         mock_data_source = Mock()
         mock_data_source.tables = {"LINEITEM": [Path("/tmp/lineitem.parquet")]}
 
-        with patch("benchbox.platforms.bigquery.DataSourceResolver") as mock_resolver_cls:
-            mock_resolver = Mock()
-            mock_resolver.resolve.return_value = mock_data_source
-            mock_resolver_cls.return_value = mock_resolver
+        with patch("benchbox.platforms.bigquery.resolve_adapter_data_source", return_value=mock_data_source) as resolve:
+            result = adapter._resolve_data_files(benchmark, data_dir)
 
-            result = adapter._resolve_data_files(Mock(), Path("/tmp/data"))
-
+        resolve.assert_called_once_with(adapter, benchmark, data_dir)
         assert "LINEITEM" in result.tables
 
     def test_raises_when_no_data_files(self):
         adapter = _make_adapter()
 
-        with patch("benchbox.platforms.bigquery.DataSourceResolver") as mock_resolver_cls:
-            mock_resolver = Mock()
-            mock_resolver.resolve.return_value = None
-            mock_resolver_cls.return_value = mock_resolver
-
+        with patch(
+            "benchbox.platforms.bigquery.resolve_adapter_data_source", side_effect=ValueError("No data files found")
+        ):
             with pytest.raises(ValueError, match="No data files found"):
                 adapter._resolve_data_files(Mock(), Path("/tmp/data"))
 
     def test_raises_when_empty_tables(self):
         adapter = _make_adapter()
 
-        mock_data_source = Mock()
-        mock_data_source.tables = {}
-
-        with patch("benchbox.platforms.bigquery.DataSourceResolver") as mock_resolver_cls:
-            mock_resolver = Mock()
-            mock_resolver.resolve.return_value = mock_data_source
-            mock_resolver_cls.return_value = mock_resolver
-
+        with patch(
+            "benchbox.platforms.bigquery.resolve_adapter_data_source", side_effect=ValueError("No data files found")
+        ):
             with pytest.raises(ValueError, match="No data files found"):
                 adapter._resolve_data_files(Mock(), Path("/tmp/data"))
 

--- a/tests/unit/platforms/test_data_loading.py
+++ b/tests/unit/platforms/test_data_loading.py
@@ -13,7 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from benchbox.platforms.base.data_loading import ClickHouseNativeHandler, DataSource, DataSourceResolver
+from benchbox.platforms.base.data_loading import (
+    ClickHouseNativeHandler,
+    DataSource,
+    DataSourceResolver,
+    resolve_adapter_data_source,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
@@ -31,6 +36,16 @@ class _BenchmarkWithTables:
     """Benchmark stub that exposes tables (bypasses ManifestFileSource)."""
 
     tables: dict
+
+
+@dataclass
+class _AdapterStub:
+    """Adapter state consumed by resolve_adapter_data_source."""
+
+    platform_name: str = "Test Platform"
+    table_mode: str = "external"
+    platform_config: dict | None = None
+    requested_table_format: str | None = "parquet"
 
 
 def _write_manifest(directory: Path, tables_metadata: dict) -> None:
@@ -113,6 +128,35 @@ def test_datasource_table_metadata_defaults_to_empty_dict() -> None:
     """DataSource.table_metadata defaults to {} without requiring explicit arg."""
     ds = DataSource(source_type="benchmark_tables", tables={"t": [Path("/x")]})
     assert ds.table_metadata == {}
+
+
+def test_resolve_adapter_data_source_uses_standard_adapter_state(monkeypatch, tmp_path: Path) -> None:
+    """Shared adapter resolver delegates with the standard platform attributes."""
+    calls = {}
+    data_source = DataSource(source_type="benchmark_tables", tables={"t": [tmp_path / "t.tbl"]})
+
+    class FakeResolver:
+        def __init__(self, **kwargs):
+            calls["init"] = kwargs
+
+        def resolve(self, benchmark, data_dir):
+            calls["resolve"] = (benchmark, data_dir)
+            return data_source
+
+    monkeypatch.setattr("benchbox.platforms.base.data_loading.DataSourceResolver", FakeResolver)
+    adapter = _AdapterStub(platform_config={"storage": "external"})
+    benchmark = object()
+
+    result = resolve_adapter_data_source(adapter, benchmark, tmp_path)
+
+    assert result is data_source
+    assert calls["init"] == {
+        "platform_name": "Test Platform",
+        "table_mode": "external",
+        "platform_config": {"storage": "external"},
+        "requested_format": "parquet",
+    }
+    assert calls["resolve"] == (benchmark, tmp_path)
 
 
 def test_table_metadata_present_when_manifest_wins(tmp_path: Path) -> None:

--- a/tests/unit/platforms/test_presto_trino_utils.py
+++ b/tests/unit/platforms/test_presto_trino_utils.py
@@ -5,7 +5,7 @@ Pins the contract for the five helpers extracted by the dedup consolidation:
   * is_date_value: date pattern detection
   * normalize_existing_files: path list normalization and empty-file exclusion
   * load_file_batches: batched INSERT VALUES cursor delegation
-  * resolve_data_files: DataSourceResolver delegation and ValueError on empty result
+  * show_tables_lower: SHOW TABLES result normalization
 """
 
 from __future__ import annotations
@@ -20,7 +20,6 @@ from benchbox.platforms.presto_trino_utils import (
     is_date_value,
     load_file_batches,
     normalize_existing_files,
-    resolve_data_files,
     show_tables_lower,
 )
 
@@ -189,49 +188,3 @@ class TestLoadFileBatches:
             mock_reg.get_compression_handler.return_value.open.return_value = ctx
             rows = load_file_batches(cursor, f, "s.t")
         assert rows == 5
-
-
-class TestResolveDataFiles:
-    def test_raises_value_error_when_no_files(self) -> None:
-        empty_source = MagicMock()
-        empty_source.tables = {}
-        with patch("benchbox.platforms.base.data_loading.DataSourceResolver") as mock_cls:
-            mock_cls.return_value.resolve.return_value = empty_source
-            with pytest.raises(ValueError, match="No data files found"):
-                resolve_data_files(
-                    MagicMock(),
-                    Path("/data"),
-                    platform_name="presto",
-                    table_mode="native",
-                    platform_config=MagicMock(),
-                    requested_format=None,
-                )
-
-    def test_raises_value_error_when_resolver_returns_none(self) -> None:
-        with patch("benchbox.platforms.base.data_loading.DataSourceResolver") as mock_cls:
-            mock_cls.return_value.resolve.return_value = None
-            with pytest.raises(ValueError, match="No data files found"):
-                resolve_data_files(
-                    MagicMock(),
-                    Path("/data"),
-                    platform_name="presto",
-                    table_mode="native",
-                    platform_config=MagicMock(),
-                    requested_format=None,
-                )
-
-    def test_returns_tables_dict_on_success(self) -> None:
-        tables = {"lineitem": [Path("/data/lineitem.tbl")]}
-        source = MagicMock()
-        source.tables = tables
-        with patch("benchbox.platforms.base.data_loading.DataSourceResolver") as mock_cls:
-            mock_cls.return_value.resolve.return_value = source
-            result = resolve_data_files(
-                MagicMock(),
-                Path("/data"),
-                platform_name="trino",
-                table_mode="native",
-                platform_config=MagicMock(),
-                requested_format=None,
-            )
-        assert result is tables

--- a/tests/unit/platforms/test_redshift_adapter_coverage.py
+++ b/tests/unit/platforms/test_redshift_adapter_coverage.py
@@ -3640,27 +3640,18 @@ class TestResolveDataFiles:
         data_source = MagicMock()
         data_source.tables = {"lineitem": [tmp_path / "lineitem.tbl"]}
 
-        with patch("benchbox.platforms.redshift.DataSourceResolver") as mock_resolver_cls:
-            mock_resolver = mock_resolver_cls.return_value
-            mock_resolver.resolve.return_value = data_source
-
+        with patch("benchbox.platforms.redshift.resolve_adapter_data_source", return_value=data_source) as resolve:
             result = adapter._resolve_data_files(benchmark, tmp_path)
 
-        mock_resolver_cls.assert_called_once_with(
-            platform_name=adapter.platform_name,
-            table_mode=adapter.table_mode,
-            platform_config=adapter.platform_config,
-            requested_format=None,
-        )
-        mock_resolver.resolve.assert_called_once_with(benchmark, tmp_path)
+        resolve.assert_called_once_with(adapter, benchmark, tmp_path)
         assert result.tables == {"lineitem": [tmp_path / "lineitem.tbl"]}
 
     def test_resolve_data_files_raises_when_resolver_returns_empty(self, tmp_path):
         adapter = _make_adapter()
 
-        with patch("benchbox.platforms.redshift.DataSourceResolver") as mock_resolver_cls:
-            mock_resolver_cls.return_value.resolve.return_value = None
-
+        with patch(
+            "benchbox.platforms.redshift.resolve_adapter_data_source", side_effect=ValueError("No data files found")
+        ):
             with pytest.raises(ValueError, match="No data files found"):
                 adapter._resolve_data_files(MagicMock(), tmp_path)
 


### PR DESCRIPTION
---
iteration: shrink-platform-config-builders
date: 2026-05-25
surface: platform hook config-builder and data-source resolver boilerplate
branch: chore/shrink-platform-config-builders
pr:
raw_cloc_delta: 276
credited_reduction: 276
uncredited_relocation: 0
repair_only_delta: 0
generated_python_delta: 0
moved_content: logic
decision_gate: conservative default; explicit factory-bound config builders preserve static names and hook registration keys
verification:
  - make shrink-rollup
  - cloc --include-lang=Python benchbox/
  - cloc --include-lang=Python --by-file benchbox/platforms/base/config_utils.py <platform builder modules>
  - make duplicate-check-json -> groups=278 duplicated_lines=6210
  - uv run -- ruff check $(git diff --name-only -- '*.py')
  - uv run -- python -m pytest <targeted platform/config/data-loading tests> -q -n 0 -> 1539 passed
  - uv run -- python -m pytest <Presto/Trino/Starburst adapter tests> -q -n 0 -> 204 passed
  - /tmp/shrink-platform-config-fingerprint-after.json matched 17 pre-existing builders
  - /tmp/shrink-platform-config-pg-cedardb-after.json matched PostgreSQL/CedarDB pre-edit fingerprints
  - make pr-preflight
---

## Thesis

Shrink iteration under the smaller-subsystem exception. The platform adapter
boilerplate subsystem is the repeated platform hook config-builder wrappers
plus standard `DataSourceResolver` delegates. The initial config-builder target
was 17 `_build_*_config` callables that already delegate to
`benchbox.platforms.base.config_utils.build_platform_config`, measured at 643
source lines before edits. The final slice also folds the adjacent
PostgreSQL/CedarDB config builders and the standard resolver delegates used by
cloud/Presto-family adapters, keeping the named subsystem under 1,000 source
lines while removing 276 credited maintained-Python code lines.

The reduction path is true boilerplate deduplication, not platform deletion or
Python-to-data relocation: add a shared factory that creates a typed config
builder callable and sets `__name__`, `__qualname__`, and `__module__`, then
replace repeated function/import/return/register scaffolding with explicit
module-level assignments. Platform-specific field lists, platform type,
credential key, display name, driver package, base options, and the Athena and
BigQuery post-processing steps remain local to their existing modules. The
resolver reduction adds one shared `resolve_adapter_data_source()` helper and
leaves each adapter's return shape intact.

Credited reduction is 276 maintained-Python lines, above the 250-line and 10%
smaller-subsystem floor.

## Guardrail evidence

- Baseline campaign rollup: 2,379 merged credited lines; 9,621 remaining to the
  committed 12,000 floor; 16,621 remaining to stretch.
- Baseline raw maintained Python: `cloc --include-lang=Python benchbox/` =
  204,628 code lines.
- Baseline touched-file raw Python for the initial config-builder target:
  11,020 code lines.
- Builder-body baseline: 17 functions, 643 source lines; expanded final
  subsystem stayed under the smaller-subsystem 1,000-line ceiling.
- Duplicate evidence: `make duplicate-check-json` reports a 7-copy,
  180-duplicated-line group across cloud config builders plus additional
  repeated Redshift/TimescaleDB/Postgres-family builders.
- Open PR overlap: only PR #626 is open and it touches JoinOrder revert files,
  not platform config builders.
- Moved-content classification: logic consolidation only. No benchmark,
  platform, deprecated/beta-public surface, generated Python, SQL/query surface,
  catalog, or YAML migration changes.
- Decision-gate status: conservative default. The factory binds explicit
  module-level callable names and static registry keys; no dynamic symbol
  injection or permissive open gate is used.
- Behavior preservation: pre/post fingerprint each builder's callable name,
  module, registry key, returned `DatabaseConfig` type/name/options/top-level
  fields, saved-credential merge priority, explicit option priority, and runtime
  override priority. PostgreSQL and CedarDB received separate before/after
  fingerprints because their previous wrappers had different default-option and
  override-consumption behavior.

## Verification

- `make shrink-rollup` at slice start: 2,379 merged credited lines; 9,621
  remaining to the 12,000 floor.
- `cloc --include-lang=Python benchbox/`: final raw maintained Python =
  204,352 code lines, down 276 from the 204,628 pre-slice baseline.
- `make duplicate-check-json`: groups=278, duplicate_instances=361,
  duplicated_lines=6,210.
- `uv run -- ruff check $(git diff --name-only -- '*.py')`: passed.
- Targeted tests:
  `uv run -- python -m pytest tests/unit/platforms/base/test_platform_config_helpers.py tests/unit/cli/test_platform_hooks.py tests/unit/platforms/test_data_loading.py tests/unit/platforms/test_presto_trino_utils.py tests/unit/platforms/test_postgresql_adapter.py tests/unit/platforms/test_cedardb.py tests/unit/platforms/test_pg_duckdb_adapter.py tests/unit/platforms/test_pg_mooncake_adapter.py tests/unit/platforms/test_timescaledb_adapter.py tests/unit/platforms/test_clickhouse_cloud_coverage.py tests/unit/platforms/test_bigquery_adapter.py tests/unit/platforms/test_bigquery_adapter_coverage.py tests/unit/platforms/test_redshift_adapter.py tests/unit/platforms/test_redshift_adapter_coverage.py tests/unit/platforms/test_snowflake_adapter.py tests/unit/platforms/test_snowflake_adapter_coverage.py tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_databend_adapter.py tests/unit/platforms/test_azure_synapse_adapter.py tests/unit/platforms/test_firebolt_coverage.py tests/unit/platforms/test_firebolt_adapter.py -q -n 0`
  -> 1,539 passed.
- Presto/Trino/Starburst adapter follow-up:
  `uv run -- python -m pytest tests/unit/platforms/test_presto_adapter.py tests/unit/platforms/test_trino_adapter.py tests/unit/platforms/test_starburst.py tests/unit/platforms/test_presto_trino_utils.py -q -n 0`
  -> 204 passed.
- `/tmp/shrink-platform-config-fingerprint-after.json`: matched all 17
  pre-existing builder fingerprints.
- `/tmp/shrink-platform-config-pg-cedardb-after.json`: matched PostgreSQL and
  CedarDB pre-edit fingerprints.

## Residual risk

Residual risk is low but concentrated in introspection and test mocks: replacing
direct `def` functions with factory-built callables could change callable
metadata or hook registration, and centralizing resolver delegation moves the
mock boundary. The factory pins callable metadata, fingerprints prove config
values and builder identity, and the tests now pin the helper-level resolver
contract.

## Next target

After merge, re-run `make shrink-rollup` and reassess the remaining low-risk
reservoir. Do not move static query/catalog content for credit unless a human
approves that credit class.
