### PR TITLE
docs: decide catalog runtime parse pattern

### DIFF
--- a/_project/DONE/main/shrink-followup-codegen-vs-runtime-parse-adr.yaml
+++ b/_project/DONE/main/shrink-followup-codegen-vs-runtime-parse-adr.yaml
@@ -2,8 +2,17 @@ id: shrink-followup-codegen-vs-runtime-parse-adr
 title: "ADR: choose runtime-parse-YAML vs build-time-codegen as the canonical catalog pattern"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
+completed_date: "2026-05-25"
 category: Documentation
+
+# Resolution (2026-05-25): accepted the existing runtime-parse direction as the
+# canonical catalog pattern, with lazy accessors by default and cached access for
+# hot paths / compatibility exports. Build-time generated Python is rejected as
+# the default because the measured import regression was solved by lazy cached
+# loading, while codegen would add build complexity, generated churn, and
+# separate accounting. Decision recorded in
+# _project/decisions/catalog-runtime-parse-vs-codegen.md.
 
 description: |
   The shrink campaign moved large amounts of data (metadata, specs, query
@@ -27,7 +36,7 @@ description: |
 work:
   - id: w1
     summary: "Document both options with measured/representative tradeoffs"
-    status: pending
+    status: done
     notes: |
       Cover: runtime-parse (current) vs build-time codegen. Dimensions: import
       time / runtime cost, static findability + ty coverage, build complexity,
@@ -38,7 +47,7 @@ work:
   - id: w2
     summary: "Recommend one as the canonical catalog pattern and record the ADR"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Write the ADR with decision, rationale, and rejected alternatives. If
       codegen is chosen, note that it supersedes the runtime lazy-load fix in
@@ -94,7 +103,7 @@ metadata:
     - catalog
   estimated_effort: "Small"
   created_date: "2026-05-23"
-  last_updated: "2026-05-23T16:00:00"
+  last_updated: "2026-05-25T00:00:00"
 
 impact:
   technical_debt: |
@@ -108,4 +117,4 @@ success_metrics:
 
 files_affected:
   added:
-    - "docs/ (or _project/) ADR file"
+    - "_project/decisions/catalog-runtime-parse-vs-codegen.md"

--- a/_project/decisions/catalog-runtime-parse-vs-codegen.md
+++ b/_project/decisions/catalog-runtime-parse-vs-codegen.md
@@ -1,0 +1,139 @@
+# ADR: Catalog Runtime Parse vs. Build-Time Codegen
+
+**Status:** Accepted - 2026-05-25
+**Decision owner:** BenchBox shrink campaign
+**Operative docs:** `_project/goal-shrink-core-code.md`,
+`_project/DONE/main/shrink-followup-codegen-vs-runtime-parse-adr.yaml`
+**Related decisions:** `_project/decisions/shrink-objective.md`
+
+## Context
+
+The shrink campaign moved benchmark metadata, specs, and query catalog content
+out of maintained Python into structured files. That work followed an implicit
+runtime-parse pattern:
+
+- Six pre-existing catalog loaders already read YAML through explicit loader
+  functions: `ai_primitives`, `metadata_primitives`, `primitives`,
+  `read_primitives`, `transaction_primitives`, and `write_primitives`.
+- Commit #579 moved TPC-DS specs to YAML using the same general pattern.
+- Later registry/spec migrations initially preserved module-level constants by
+  eagerly parsing YAML during import. The follow-up
+  `_project/DONE/main/shrink-followup-registry-lazy-cached-load.yaml` measured
+  that eager import cost and converted it to lazy cached access.
+
+The credible alternative is build-time codegen: treat YAML as canonical but
+generate Python modules from it so runtime imports do not parse YAML and static
+tools can see generated symbols directly. That is a legitimate architecture,
+but it adds a build step, generated-file churn, and separate generated-Python
+accounting. The shrink control document needed one canonical catalog pattern so
+future reductions do not decide case by case.
+
+## Decision
+
+BenchBox's canonical catalog pattern is **human-authored structured source
+loaded through lazy runtime accessors**.
+
+Use YAML, CSV, SQL files, TOML, or another reviewable structured format when
+the content is data, metadata, or declared query surface. Load it from package
+resources only inside explicit accessors or lazy module attributes, not at
+module import time. Cache the parsed result when the accessor preserves
+module-level compatibility names, sits on a hot path, or is expected to be
+called repeatedly in one process.
+
+Build-time generated Python is **not** the default catalog pattern and earns no
+official shrink credit unless a future explicit ADR supersedes this decision.
+Generated Python may still be used for a separately justified product or tooling
+reason, but it must be tracked as generated surface and cannot silently reduce
+the maintained-Python distance.
+
+When legacy imports require old constants or callables, preserve them with
+explicit registries, typed mappings, or PEP 562 `__getattr__` wrappers. Do not
+reintroduce dynamic `globals()` mutation or generated-name synthesis as a way to
+hide maintenance surface.
+
+## Evidence
+
+| Implementation | Source Shape | Loading Shape | Notes |
+| --- | --- | --- | --- |
+| `benchbox/core/write_primitives/catalog/loader.py:111` | YAML operation catalog | Runtime loader function | Reads package resource only inside `_load_catalog_payload()`; `load_write_primitives_catalog()` calls it explicitly. |
+| `benchbox/core/primitives/catalog/loader.py:408` | YAML operation/query catalogs | Runtime loader helper | Shared `_load_yaml()` centralizes resource reads and validation for two catalog families. |
+| `benchbox/core/ai_primitives/catalog/loader.py:59` | YAML query catalog | Runtime loader function | Same lazy-by-call convention as write primitives. |
+| `benchbox/core/metadata_primitives/catalog/loader.py:55` | YAML query catalog | Runtime loader function | Small direct loader; no import-time parse. |
+| `benchbox/core/benchmark_registry.py:70` | YAML benchmark metadata | Lazy cached module data | `@functools.lru_cache(maxsize=1)` builds derived structures on first access; `__getattr__` preserves public names. |
+| `benchbox/core/results/benchmark_specs.py:87` | YAML benchmark specs | Lazy cached module data | Same cache plus `__getattr__` pattern for compatibility exports. |
+
+The registry lazy-load follow-up measured the import regression from eager YAML
+loads before repairing it:
+
+| Surface | Eager module self-time | Isolated parse cost | Lazy cached self-time after repair |
+| --- | ---: | ---: | ---: |
+| `benchmark_registry` | ~10.2 ms | 8.98 ms | ~0.40 ms |
+| `benchmark_specs` | ~12.6 ms | 10.70 ms | ~0.57 ms |
+
+Those numbers show the real hazard is module-scope parsing, not the existence
+of structured catalog files. Lazy cached access removes the import-time
+regression without adding a generated-Python build pipeline.
+
+## Decision Matrix
+
+| Option | Import/runtime cost | Static findability and typing | Build/review cost | Consistency | Shrink accounting |
+| --- | --- | --- | --- | --- | --- |
+| Lazy runtime parse, cache hot accessors | No import-time parse; first-use parse only; repeat calls cached where needed | Good when paired with typed containers, explicit registries, schema validation, and fingerprints | Low; source files stay human-authored and diffable | Matches existing loader direction and lazy registry/spec repair | Eligible only for genuine maintained-Python reduction; relocation remains uncredited unless approved |
+| Build-time Python codegen from YAML | No runtime parse for generated modules | Strong for generated symbols, but source of truth moves behind a build step | High; generated churn, tooling, packaging, and review rules required | Breaks the current runtime-loader convention | Generated lines tracked separately; no official shrink credit by default |
+| Eager runtime YAML parse | First import pays I/O and parse cost | Same as runtime parse after import | Low | Conflicts with import-loading guardrail | Rejected; measured import-time regression |
+| No canonical pattern | Depends on local choice | Depends on local choice | Low initially, high over time | Drift across catalogs | Rejected; reopens the same gate for every shrink slice |
+
+## Required Pattern For Future Catalog Shrink
+
+Future Python-to-catalog/query reductions must satisfy all of these technical
+gates before credit can even be considered. These gates are necessary, not
+sufficient: the shrink objective's ledger formula still decides whether the
+change is genuine maintained-Python reduction or uncredited relocation.
+
+1. The structured file is the human-authored canonical source, or the PR cites
+   a newer ADR that says otherwise.
+2. Loading is lazy. Hot-path, compatibility-export, or repeated-load surfaces
+   are cached.
+3. The catalog has schema or typed validation exercised by tests or a project
+   gate.
+4. Query surface remains reviewable. SQL in YAML uses block scalars, not escaped
+   newline blobs; external `.sql` files are preferred when they improve review.
+5. Public import names, callable names, registry keys, categories, and benchmark
+   semantics are fingerprinted when they can change.
+6. Generated Python, if any, is marked generated, ledgered separately, and
+   uncredited unless a future ADR changes the accounting rule.
+
+## Alternatives Rejected
+
+### Build-Time Generated Python From Catalog Source
+
+This gives direct grep and type-check visibility for generated symbols and can
+avoid first-use YAML parsing. It loses on current evidence because BenchBox
+already has a runtime-loader convention, the measured import problem was solved
+by lazy cached access, and codegen would add a new generated-artifact lifecycle
+with no demonstrated maintenance win large enough to justify it.
+
+### Eager Runtime Parse At Module Import
+
+Rejected. The registry/spec repair measured a material import-time cost from
+eager YAML parse. Future migrations should not recreate that shape without a
+linked exception, measurement, and budget.
+
+### Case-By-Case Local Decisions
+
+Rejected. Shrink work is especially prone to metric pressure. Without a
+canonical pattern, future slices would repeatedly trade reviewability,
+performance, generated churn, and credit accounting differently.
+
+## Consequences
+
+- The codegen/runtime-source gate in the shrink control document is resolved
+  conservatively.
+- TPC-DS generated DataFrame query shrink can proceed only if it preserves
+  static findability, schema/typed validation, query reviewability, and lazy
+  runtime access. It cannot use generated Python to claim official credit.
+- Existing runtime catalogs do not need churn merely to conform. The decision
+  governs new migrations and touched surfaces.
+- A future codegen proposal is still possible, but it must be a separate ADR
+  with measured benefits, build/publishing rules, generated-file accounting,
+  and review guidance.

--- a/_project/goal-shrink-core-code.md
+++ b/_project/goal-shrink-core-code.md
@@ -41,10 +41,10 @@ Unresolved TODOs, ADRs, and user decisions default to the conservative path. Aut
 
 - Objective-function TODO ratified (2026-05-24; see `_project/analysis/shrink-objective-backfill.md`): the logic-vs-data discriminator in "Ledger and Credit" plus the Guardrails *are* the objective function, validated against #587-604 (credits genuine logic reductions, refuses gamed relocations). The provisional credit formula and the conservative default below stand — `approved_credit_for_valid_data_extraction` remains 0 until a human approves that credit class; executor agents may not (see the executor-only boundary above).
 - JoinOrder/benchmark-semantics TODO unresolved: prove benchmark-shape preservation or stop; agents may not reclassify benchmark intent.
-- Import-loading TODO unresolved: default to lazy/memoized loading. Eager import-time loading needs linked approval, import-delta measurement, and budget.
-- Generated-implementation findability TODO unresolved: default to explicit registries or typed mappings. Dynamic symbol injection needs linked approval and grep/type-check evidence.
-- Codegen/runtime-source ADR unresolved: generated Python is tracked separately and earns no maintained-code shrink credit unless the ADR says otherwise.
-- New catalog/YAML migrations need a canonical-source decision; extending an existing catalog with newly relocated Python counts as a new migration.
+- Import-loading TODO resolved (2026-05-24; see `_project/DONE/main/shrink-followup-registry-lazy-cached-load.yaml`): default to lazy/memoized loading. Eager import-time loading needs linked approval, import-delta measurement, and budget.
+- Generated-implementation findability TODO resolved (2026-05-24; see `_project/DONE/main/shrink-followup-generated-impl-findability.yaml`): default to explicit registries or typed mappings. Dynamic symbol injection needs linked approval and grep/type-check evidence.
+- Codegen/runtime-source ADR resolved (2026-05-25; see `_project/decisions/catalog-runtime-parse-vs-codegen.md`): the canonical catalog pattern is human-authored structured source loaded through lazy runtime accessors, cached when the surface is hot or preserves compatibility exports. Build-time generated Python is not the default and earns no maintained-code shrink credit unless a future explicit ADR supersedes that decision.
+- New catalog/YAML migrations must name the canonical source, preserve reviewability, use lazy loading, include schema or typed validation, and fingerprint public symbols/queries when relevant. Extending an existing catalog with newly relocated Python counts as a new migration.
 
 ## Ledger and Credit
 

--- a/_project/shrink-ledger/shrink-codegen-runtime-adr.md
+++ b/_project/shrink-ledger/shrink-codegen-runtime-adr.md
@@ -1,0 +1,79 @@
+---
+iteration: guardrail-repair
+date: 2026-05-25
+surface: catalog-source-pattern-decision
+branch: chore/shrink-codegen-runtime-adr
+pr: 638
+raw_cloc_delta: 0
+credited_reduction: 0
+uncredited_relocation: 0
+repair_only_delta: 0
+generated_python_delta: 0
+moved_content: none
+decision_gate: conservative-default
+verification:
+  - grep -rniE 'codegen|runtime.parse|canonical catalog' docs/ _project/ 2>/dev/null | grep -i adr
+  - uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate
+  - git diff --check
+  - make pr-preflight
+---
+
+## Thesis
+
+Guardrail repair iteration for the open codegen/runtime-source decision gate.
+Current `origin/develop` has 5,111 merged credited shrink lines, 6,889 lines
+remaining to the 12,000 floor, and 201,896 raw maintained-Python `cloc` lines
+under `benchbox/`. The next large non-overlapping reservoir is catalog/query
+surface, especially generated TPC-DS DataFrame query implementation structure.
+At slice start, the control document blocked new catalog/YAML migrations while
+the canonical runtime-parse-vs-codegen pattern was unresolved.
+
+This slice records the decision without changing runtime code. The expected
+credited reduction is zero; the expected future payoff is that subsequent
+catalog/query shrink can use one conservative pattern instead of re-litigating
+whether YAML/data catalogs should be parsed lazily at runtime or converted into
+generated Python.
+
+## Guardrail evidence
+
+- Iteration type: guardrail repair, because it directly removes an open
+  decision blocker to future credited catalog/query shrink.
+- Moved-content classification: none. This PR does not move Python logic,
+  metadata, data, query surface, or generated code.
+- Decision gate status: conservative default. The prior lazy registry/spec
+  repair measured eager YAML import overhead and converted it to lazy cached
+  runtime loading; this ADR ratifies that pattern unless future explicit
+  evidence and approval supersede it.
+- Goal gate alignment: the control document now cites the already-completed
+  import-loading and generated-findability repairs, plus this ADR, without
+  loosening the ledger credit formula.
+- Behavior preservation: documentation/TODO-only change; no runtime imports,
+  registry entries, query callables, platform adapters, benchmark semantics,
+  or public APIs are touched.
+
+## Verification
+
+Passed:
+
+- `grep -rniE 'codegen|runtime.parse|canonical catalog' docs/ _project/ 2>/dev/null | grep -i adr`
+  found the ADR and completed TODO references.
+- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
+  reported 1,052 valid files and 0 invalid files.
+- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
+  reported no inter-item dependency cycles, no work-unit cycles, and no
+  dangling references across 49 active items.
+- `git diff --check` passed.
+- `make pr-preflight` passed: 22,828 passed, 5 skipped, 47 warnings, and
+  4 subtests passed in 154.49s.
+
+## Residual risk
+
+The repair does not by itself reduce maintained Python. The next iteration
+must either attempt the unlocked catalog/query shrink or re-justify why another
+guardrail repair is still required for the same surface.
+
+## Next target
+
+After this decision lands, reassess the TPC-DS generated DataFrame query
+surface and the smaller TPC-DI helper-export surface once PR #637 is merged or
+its overlap is gone.


### PR DESCRIPTION
---
iteration: guardrail-repair
date: 2026-05-25
surface: catalog-source-pattern-decision
branch: chore/shrink-codegen-runtime-adr
pr: 638
raw_cloc_delta: 0
credited_reduction: 0
uncredited_relocation: 0
repair_only_delta: 0
generated_python_delta: 0
moved_content: none
decision_gate: conservative-default
verification:
  - grep -rniE 'codegen|runtime.parse|canonical catalog' docs/ _project/ 2>/dev/null | grep -i adr
  - uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate
  - git diff --check
  - make pr-preflight
---

## Thesis

Guardrail repair iteration for the open codegen/runtime-source decision gate.
Current `origin/develop` has 5,111 merged credited shrink lines, 6,889 lines
remaining to the 12,000 floor, and 201,896 raw maintained-Python `cloc` lines
under `benchbox/`. The next large non-overlapping reservoir is catalog/query
surface, especially generated TPC-DS DataFrame query implementation structure.
At slice start, the control document blocked new catalog/YAML migrations while
the canonical runtime-parse-vs-codegen pattern was unresolved.

This slice records the decision without changing runtime code. The expected
credited reduction is zero; the expected future payoff is that subsequent
catalog/query shrink can use one conservative pattern instead of re-litigating
whether YAML/data catalogs should be parsed lazily at runtime or converted into
generated Python.

## Guardrail evidence

- Iteration type: guardrail repair, because it directly removes an open
  decision blocker to future credited catalog/query shrink.
- Moved-content classification: none. This PR does not move Python logic,
  metadata, data, query surface, or generated code.
- Decision gate status: conservative default. The prior lazy registry/spec
  repair measured eager YAML import overhead and converted it to lazy cached
  runtime loading; this ADR ratifies that pattern unless future explicit
  evidence and approval supersede it.
- Goal gate alignment: the control document now cites the already-completed
  import-loading and generated-findability repairs, plus this ADR, without
  loosening the ledger credit formula.
- Behavior preservation: documentation/TODO-only change; no runtime imports,
  registry entries, query callables, platform adapters, benchmark semantics,
  or public APIs are touched.

## Verification

Passed:

- `grep -rniE 'codegen|runtime.parse|canonical catalog' docs/ _project/ 2>/dev/null | grep -i adr`
  found the ADR and completed TODO references.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate`
  reported 1,052 valid files and 0 invalid files.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
  reported no inter-item dependency cycles, no work-unit cycles, and no
  dangling references across 49 active items.
- `git diff --check` passed.
- `make pr-preflight` passed: 22,828 passed, 5 skipped, 47 warnings, and
  4 subtests passed in 154.49s.

## Residual risk

The repair does not by itself reduce maintained Python. The next iteration
must either attempt the unlocked catalog/query shrink or re-justify why another
guardrail repair is still required for the same surface.

## Next target

After this decision lands, reassess the TPC-DS generated DataFrame query
surface and the smaller TPC-DI helper-export surface once PR #637 is merged or
its overlap is gone.
