### PR TITLE
docs(benchmarks): add auditable support-status criteria matrix

### DIFF
--- a/_project/DONE/main/planning/benchmark-support-status-criteria-matrix.yaml
+++ b/_project/DONE/main/planning/benchmark-support-status-criteria-matrix.yaml
@@ -2,7 +2,8 @@ id: benchmark-support-status-criteria-matrix
 title: "Define auditable benchmark support-status promotion criteria"
 worktree: main
 priority: Medium-High
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-05-25"
 category: Benchmark Architecture
 
 deps:
@@ -28,7 +29,7 @@ description: |
 work:
   - id: w0
     summary: "Re-read the benchmark registry, public contract map, benchmark docs, and result-integrity spec list before proposing criteria"
-    status: pending
+    status: done
     notes: |
       Capture the checked SHA, current status counts, benchmark IDs, public IDs,
       and result-integrity spec coverage in the TODO or implementation PR body.
@@ -38,7 +39,7 @@ work:
   - id: w1
     summary: "Define status-specific acceptance criteria for benchmark families"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Write criteria for stable, beta, experimental, repo_only, deprecated, and
       document_only. Include benchmark-specific dimensions that platform status
@@ -49,7 +50,7 @@ work:
   - id: w2
     summary: "Score every registry benchmark against the criteria and record status rationale"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Produce one row per benchmark with the current registry status, rationale,
       evidence pointers, and any promotion/demotion blockers. The matrix may live
@@ -59,7 +60,7 @@ work:
   - id: w3
     summary: "Add tests or docs checks that keep the matrix synchronized with registry status values"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Add a focused test that fails when a benchmark status is added, removed, or
       changed without a corresponding criteria-matrix row or explicit rationale
@@ -69,12 +70,20 @@ work:
   - id: w4
     summary: "Record concrete promotion candidates and blockers as deferred work, not as silent comments"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       If the matrix shows that a beta benchmark is close to stable or that an
       experimental benchmark has unclear criteria, record follow-up TODOs or
       deferred entries with exact blockers. Do not change support_status values
       in this TODO unless the criteria evidence makes the change unambiguous.
+
+deferred:
+  - summary: "Promote vector_search beta -> stable once it has a BenchmarkSpec"
+    reason: "It is the only beta whose sole integrity-dimension gap is a missing result-integrity spec; adding one (plus a DataFrame routing decision) is the concrete blocker recorded in docs/benchmarks/support-status.md."
+  - summary: "Reassess tpcds_obt and datavault experimental status after the deprecated core base is removed"
+    reason: "Their status is partly coupled to the benchbox.core.base_benchmark.BaseBenchmark migration; revisit when that base is gone."
+  - summary: "Pin reproducible external-source contracts for nyctaxi and flightdata before any stable promotion"
+    reason: "External-dataset betas are gated on a pinned source contract, not on query coverage."
 
 metadata:
   tags:
@@ -84,7 +93,7 @@ metadata:
     - docs-drift
   estimated_effort: "1-2 days"
   created_date: "2026-05-21"
-  last_updated: "2026-05-21T00:00:00Z"
+  last_updated: "2026-05-25T00:00:00Z"
 
 impact:
   business_value: |

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -9,7 +9,9 @@ This section provides systematic documentation for each benchmark implementation
 
 Benchmark support status is sourced from `benchbox.core.benchmark_registry`, not
 from hand-maintained docs. Current status counts are documented and checked in
-the [public contract map](../reference/public-contracts.md). `support_status` is
+the [public contract map](../reference/public-contracts.md). The auditable
+per-benchmark rationale and promotion criteria live in
+[Benchmark Support Status Criteria](support-status.md). `support_status` is
 separate from public discovery visibility and from DataFrame capability.
 
 ## Contents
@@ -286,6 +288,7 @@ time-series-benchmarks
 benchbox-primitives
 ai-ml-benchmarks
 benchbox-experimental
+support-status
 ```
 
 #### **Development and CI/CD**

--- a/docs/benchmarks/support-status.md
+++ b/docs/benchmarks/support-status.md
@@ -1,0 +1,96 @@
+<!-- Copyright 2026 Joe Harris / BenchBox Project. Licensed under the MIT License. -->
+
+# Benchmark Support Status Criteria
+
+```{tags} reference, contributor
+```
+
+Every benchmark in `benchbox.core.benchmark_registry` carries exactly one
+`support_status` from the public support taxonomy: `stable`, `beta`,
+`experimental`, `repo_only`, `deprecated`, or `document_only`. The registry is
+the runtime source of truth; this page is the **auditable rationale** for why
+each benchmark currently holds its status and what would have to change to
+promote or demote it.
+
+`support_status` is independent of two other registry fields:
+
+- **`surface`** (`public` or `internal`) controls discovery visibility. A
+  `repo_only` benchmark is `internal`; a `beta` benchmark is still `public`.
+- **`supports_dataframe`** is a capability flag for DataFrame routing, not a
+  support-level proxy. A `beta` benchmark may be DataFrame-capable; an
+  `experimental` one may not.
+
+The taxonomy meanings, packaging, and breakage policy live in the
+[public contract map](../reference/public-contracts.md#support-status-taxonomy).
+This page adds the benchmark-specific **acceptance criteria** and the
+per-benchmark scoring. Status counts are checked against the registry in the
+[Count and Drift Policy](../reference/public-contracts.md#count-and-drift-policy);
+the per-benchmark rows below are checked against the registry by
+`tests/unit/core/test_benchmark_api_contract.py`.
+
+## Acceptance Criteria by Status
+
+Promotion to (or demotion from) a status requires the evidence in this table.
+The dimensions are benchmark-specific: a platform can be `stable` without owning
+a dataset, but a `stable` benchmark must own a reproducible dataset contract,
+a canonical query set, and result-integrity coverage.
+
+| Status | User docs | Result-integrity spec | Query coverage | Dataset contract | Scale factors | DataFrame claim | Discovery & maintenance |
+|---|---|---|---|---|---|---|---|
+| `stable` | Full benchmark page with setup, tuning, and expected results. | `BenchmarkSpec` in `benchmark_specs.py` so result integrity is validated. | Complete canonical query set runs and validates. | Reproducible generator or pinned external source with a documented contract. | Official multi-scale range supported, not a single development scale. | DataFrame parity verified when `supports_dataframe` is true. | `surface: public`; known platform gaps documented; regressions fixed promptly. |
+| `beta` | Benchmark page present with a beta caveat. | Spec present, or the gap is documented as a promotion blocker. | Core query set runs; canonical completeness may still be in progress. | Dataset contract defined (generated, derived, or external). | Development scales work; full official range may be unverified. | Capability flag honored if set; parity not yet required. | `surface: public` with a beta label; changes ship with same-PR docs/tests. |
+| `experimental` | Experimental docs only; no support implication. | Optional; many experimental benchmarks have no spec. | Partial or research-shaped query set is acceptable. | Dataset may be derived or research-only. | Often a single or narrow scale range. | Capability flag is informational only. | `surface: public` but labeled experimental; may change or be removed without a compatibility promise. |
+| `repo_only` | Developer/project docs only. | Not required. | Whatever the contributor harness needs. | Synthetic or contributor-only data is acceptable. | Contributor-defined. | Capability flag may be set for internal runs. | `surface: internal`; hidden from public discovery; runnable by explicit ID; script/workflow checks only. |
+| `deprecated` | Migration path documented. | Retained until the removal window. | Frozen at the last supported set. | Frozen. | Frozen. | Frozen. | Listed with a deprecation label or hidden after the warning window; removal follows a registry target. |
+| `document_only` | Docs must state it is not executable. | None. | None (no runtime). | None. | None. | None. | Not listed as runnable; not exposed over MCP. |
+
+`deprecated` and `document_only` have **no current benchmark members**; the rows
+above define the bar a future entry would have to meet.
+
+## Benchmark Status Rationale
+
+One row per registry benchmark. The `Benchmark` and `Status` columns are checked
+against `benchbox.core.benchmark_registry` so a status change without an updated
+rationale fails the contract test. Evidence dimensions: docs page, integrity
+spec, query count, dataset/source, scales, and DataFrame capability.
+
+| Benchmark | Status | Rationale and evidence | Promotion / demotion blockers |
+|---|---|---|---|
+| `tpch` | `stable` | Canonical 22-query TPC-H; dbgen-generated; integrity spec; full docs; scales to SF100000; DataFrame-capable. | None — maintain. |
+| `tpcds` | `stable` | Canonical 99-query TPC-DS; dsdgen-generated (patched dsdgen for SF<1); integrity spec; full docs; scales to SF100; DataFrame-capable. | None — maintain. |
+| `ssb` | `stable` | 13-query Star Schema Benchmark; generated; integrity spec; full docs; scales to SF10; DataFrame-capable. | None — maintain. |
+| `clickbench` | `stable` | 43-query industry-standard analytics; external `hits` dataset; integrity spec; full docs; DataFrame-capable. | None — maintain. |
+| `joinorder` | `stable` | 113-query Join Order Benchmark; canonical IMDb 2013 JOB data; integrity spec; full docs; fixed `--scale 1`; DataFrame-capable. | None — maintain. |
+| `tpcdi` | `beta` | 38-query data-integration workload; generated; integrity spec; docs; scales to SF10; DataFrame-capable. | Confirm canonical transform/query completeness and a maintenance commitment before `stable`. |
+| `h2odb` | `beta` | 10-query data-science groupby/join; generated; integrity spec; docs; DataFrame-capable. | Broaden cross-platform coverage evidence before `stable`. |
+| `amplab` | `beta` | 8-query big-data subset; generated; integrity spec; docs; DataFrame-capable. | Small canonical subset; confirm dataset contract breadth before `stable`. |
+| `read_primitives` | `beta` | 136-query read-primitive matrix; derived from TPC-H data; integrity spec; docs; DataFrame-capable. | Pin the derived-from-`tpch` dataset contract and confirm DataFrame parity before `stable`. |
+| `write_primitives` | `beta` | 12-query non-transactional writes; derived from TPC-H; integrity spec; docs; DataFrame-capable. | Broad cross-platform write support still maturing. |
+| `metadata_primitives` | `beta` | 62-query catalog introspection; no data generation (`requires_tables_object=false`); integrity spec; docs; DataFrame-capable. | Cross-dialect catalog coverage still expanding. |
+| `transaction_primitives` | `beta` | 12-query ACID/isolation workload; derived from TPC-H; integrity spec (`high_failure_expected`); docs; DataFrame-capable. | ACID adapter coverage limited (PostgreSQL/MySQL/SQL Server adapters planned). |
+| `coffeeshop` | `beta` | 11-query point-of-sale workload; generated; integrity spec; docs; DataFrame-capable. | Confirm dataset/query stability before `stable`. |
+| `tsbs_devops` | `beta` | 18-query time-series DevOps workload; generated; integrity spec; docs; DataFrame-capable. | Time-series engine coverage breadth still expanding. |
+| `nyctaxi` | `beta` | 25-query real-world OLAP; external NYC TLC data; integrity spec; docs; DataFrame-capable. | External-dataset availability and a pinned source contract before `stable`. |
+| `flightdata` | `beta` | 20-query real-world aviation OLAP; external BTS data; integrity spec; docs; DataFrame-capable. | External-dataset availability and a pinned source contract before `stable`. |
+| `vector_search` | `beta` | 6-query vector similarity; synthetic embeddings; docs; not DataFrame-capable. | **No integrity spec** and ANN-recall validation still pending; capability is SQL-only. |
+| `tpcds_obt` | `experimental` | 17-query denormalized One-Big-Table; derived from `tpcds`; integrity spec; docs; SF1 only; DataFrame-capable. | Single-scale subset of TPC-DS; still on the deprecated core base. |
+| `ai_primitives` | `experimental` | 16-query SQL AI functions; derived from TPC-H text; docs; core-only ID; not DataFrame-capable. | Cloud-only AI functions, cost-gated, no integrity spec; intentionally research-only. |
+| `tpchavoc` | `experimental` | 220-variant optimizer stress (22 queries × 10 syntax variants); generated; integrity spec; docs; DataFrame-capable. | Optimizer-stress research tool, not a standard comparison workload. |
+| `tpch_skew` | `experimental` | 22-query TPC-H over skewed distributions; generated; integrity spec; docs; DataFrame-capable. | Non-canonical skew parameters; research workload. |
+| `datavault` | `experimental` | 22-query Data Vault 2.0 variant; generated from TPC-H source; integrity spec; docs; DataFrame-capable. | Modeling-variant research; still on the deprecated core base. |
+| `joinorder_synthetic` | `repo_only` | 13-query synthetic Join Order scaling harness; `surface: internal`; no integrity spec; DataFrame-capable; runnable by explicit ID only. | Public/beta promotion would need user docs, an integrity spec, and a separate `surface` decision — out of scope for this matrix. |
+
+## Promotion Candidates and Blockers
+
+Recorded as explicit follow-up work rather than reviewer memory. None of these
+are applied here: this matrix documents status, it does not change it.
+
+- **`vector_search` (beta → stable candidate, blocked):** the only missing piece
+  for the integrity dimension is a `BenchmarkSpec`. Adding one (and a DataFrame
+  routing decision) is the concrete blocker. Tracked as a deferred follow-up on
+  `benchmark-support-status-criteria-matrix`.
+- **External-dataset betas (`nyctaxi`, `flightdata`):** promotion is gated on a
+  pinned, reproducible external-source contract, not on query coverage.
+- **Deprecated-base experimentals (`tpcds_obt`, `datavault`):** their status is
+  partly coupled to the `benchbox.core.base_benchmark.BaseBenchmark` migration;
+  reassess after that base is removed.

--- a/docs/reference/public-contracts.md
+++ b/docs/reference/public-contracts.md
@@ -71,7 +71,11 @@ Allowed values:
 
 Platform and benchmark registry metadata now carry exactly one `support_status`
 for every runtime entry. Benchmark support status is distinct from benchmark
-`surface` visibility and from capability flags such as `supports_dataframe`.
+`surface` visibility and from capability flags such as `supports_dataframe`. The
+auditable per-benchmark rationale and promotion criteria are in
+[Benchmark Support Status Criteria](../benchmarks/support-status.md), whose
+per-benchmark status rows are drift-checked against the registry by
+`tests/unit/core/test_benchmark_api_contract.py`.
 
 ## Count and Drift Policy
 

--- a/tests/unit/core/test_benchmark_api_contract.py
+++ b/tests/unit/core/test_benchmark_api_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,9 @@ pytestmark = [
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 PUBLIC_CONTRACTS_DOC = PROJECT_ROOT / "docs/reference/public-contracts.md"
+SUPPORT_STATUS_CRITERIA_DOC = PROJECT_ROOT / "docs/benchmarks/support-status.md"
+# Matches a criteria-matrix table row whose first two cells are `id` and `status`.
+_CRITERIA_MATRIX_ROW = re.compile(r"^\|\s*`(?P<bid>[a-z0-9_]+)`\s*\|\s*`(?P<status>[a-z_]+)`\s*\|")
 CORE_ONLY_BENCHMARK_IDS = {"ai_primitives", "joinorder_synthetic"}
 BENCHMARK_API_COUNT_MARKER = (
     "Benchmark API snapshot: **23** registry entries; **23** loader-resolved core families; "
@@ -186,6 +190,43 @@ def test_benchmark_support_status_metadata_matches_contract_map() -> None:
     contract_doc = PUBLIC_CONTRACTS_DOC.read_text()
     assert "Benchmark support status: **5** stable, **12** beta, **5** experimental" in contract_doc
     assert "support status counts are stable=5, beta=12, experimental=5" in contract_doc
+
+
+def test_benchmark_support_status_criteria_matrix_covers_every_benchmark() -> None:
+    """The criteria matrix must carry one row per benchmark whose status matches the registry.
+
+    This is the drift guard: adding, removing, or re-classifying a benchmark in the
+    registry fails here until ``docs/benchmarks/support-status.md`` records the change.
+    """
+
+    registry_status = {bid: meta["support_status"] for bid, meta in BENCHMARK_METADATA.items()}
+    doc_text = SUPPORT_STATUS_CRITERIA_DOC.read_text()
+
+    matrix_status: dict[str, str] = {}
+    duplicates: list[str] = []
+    for line in doc_text.splitlines():
+        match = _CRITERIA_MATRIX_ROW.match(line)
+        if match is None:
+            continue
+        benchmark_id = match.group("bid")
+        if benchmark_id not in registry_status:
+            # Acceptance-criteria/legend rows whose first cell is not a benchmark id.
+            continue
+        if benchmark_id in matrix_status:
+            duplicates.append(benchmark_id)
+        matrix_status[benchmark_id] = match.group("status")
+
+    assert duplicates == [], f"benchmarks with more than one criteria-matrix row: {sorted(duplicates)}"
+
+    missing_rows = sorted(set(registry_status) - set(matrix_status))
+    assert missing_rows == [], f"benchmarks missing a criteria-matrix row: {missing_rows}"
+
+    mismatched = {
+        benchmark_id: {"matrix": matrix_status[benchmark_id], "registry": registry_status[benchmark_id]}
+        for benchmark_id in registry_status
+        if matrix_status[benchmark_id] != registry_status[benchmark_id]
+    }
+    assert mismatched == {}, f"criteria-matrix status differs from registry: {mismatched}"
 
 
 def test_benchmark_data_source_metadata_matches_runtime_declarations() -> None:


### PR DESCRIPTION
## Summary

Implements `benchmark-support-status-criteria-matrix`: turns the registry-owned
`support_status` metadata into an **auditable promotion-criteria matrix** with a
drift guard.

- **New doc** `docs/benchmarks/support-status.md` (benchmark analogue of
  `docs/platforms/support-status.md`):
  - **Acceptance criteria by status** — benchmark-specific dimensions (user docs,
    result-integrity spec, query coverage, dataset/source contract, scale
    factors, DataFrame claim, discovery & maintenance) for all six statuses.
  - **Per-benchmark rationale** — one row per registry benchmark with rationale,
    evidence, and promotion/demotion blockers.
  - **Promotion candidates** — explicit follow-up blockers (not silent comments).
- **Drift test** `test_benchmark_support_status_criteria_matrix_covers_every_benchmark`
  in `tests/unit/core/test_benchmark_api_contract.py`: fails when a benchmark
  status is added, removed, or re-classified in the registry without a matching
  matrix row. The registry stays the runtime source of truth — the doc rows are
  checked *against* it.
- Cross-links from `docs/benchmarks/index.md` and the public contract map; new
  doc registered in the benchmarks toctree.

## w0 evidence (current tree)

Checked at `2f135938`. Registry: **23** benchmarks (22 public, 1 internal).
Support status: **5 stable, 12 beta, 5 experimental, 1 repo_only, 0 deprecated,
0 document_only**. Result-integrity specs cover **20 of 22** public benchmarks
(`ai_primitives`, `vector_search` lack specs; `joinorder_synthetic` is internal).

## Verification

- `uv run -- python -m pytest tests/unit/core/test_benchmark_api_contract.py -q` — 12 passed
- `make docs-validate` — passes
- `todo_cli.py validate && check-graph` — 1056 valid, graph clean
- `make ci-lint` — passes (lint, fast-lane policy, compat-docs, DDL drift, dep audit)

## Review notes

Five-axis self-review: no Critical/Required/Nit findings. One **Consider**, not
actioned by design: the rationale prose embeds evidence numbers (e.g. query
counts) that are *not* gated — only `support_status` is drift-checked, matching
the TODO's w3 requirement and avoiding the brittle full-text scanner the sibling
drift-gate TODO explicitly warns against.

Promotion follow-ups recorded as `deferred[]` on the completed TODO
(`vector_search` spec gap; `tpcds_obt`/`datavault` deprecated-base coupling;
`nyctaxi`/`flightdata` external-source pinning).

Closes `benchmark-support-status-criteria-matrix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
