### PR TITLE
chore(contracts): gate public benchmark count claims against the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ Same benchmark, same scale factor, different execution paradigm.
 - Use `benchbox run` CLI for full benchmark execution
 
 **For Advanced Usage:**
-- Explore all 22 benchmark suites: TPC-H, TPC-DS, TPC-DI, ClickBench, H2ODB, NYC Taxi, Flight Data, Vector Search, and more
+- Explore the full benchmark suite: TPC-H, TPC-DS, TPC-DI, ClickBench, H2ODB, NYC Taxi, Flight Data, Vector Search, and more
 - Scale up with larger datasets (scale factors 1.0, 10.0, 100.0+)
 - Compare performance across different platforms
 - See [examples/INDEX.md](examples/INDEX.md) for complete examples navigation

--- a/_project/DONE/main/planning/public-benchmark-claim-drift-gate.yaml
+++ b/_project/DONE/main/planning/public-benchmark-claim-drift-gate.yaml
@@ -2,7 +2,8 @@ id: public-benchmark-claim-drift-gate
 title: "Add a drift gate for public benchmark count and support claims"
 worktree: main
 priority: Medium-High
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-05-25"
 category: Documentation and Contracts
 
 deps:
@@ -26,7 +27,7 @@ description: |
 work:
   - id: w0
     summary: "Inventory exact benchmark count, coverage, and support-claim text across public docs, landing pages, scripts, and generated docs sources"
-    status: pending
+    status: done
     notes: |
       Search for phrases such as "22 benchmarks", "23 benchmark", "registered
       benchmarks", "supported benchmarks", "benchmark variety", and benchmark
@@ -37,7 +38,7 @@ work:
   - id: w1
     summary: "Define allowed claim classes and source-of-truth rules"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Extend the public contract map or a nearby developer doc with concrete
       rules: exact public counts must be registry-derived or checked; editorial
@@ -47,7 +48,7 @@ work:
   - id: w2
     summary: "Implement a focused drift check for benchmark count and support-status claims"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Prefer extending an existing lightweight docs/contract test over adding a
       broad fragile scanner. The check should cover durable public surfaces such
@@ -58,7 +59,7 @@ work:
   - id: w3
     summary: "Repair stale public claims or reword them as editorial examples"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Update exact count claims to derive from the registry-backed marker where
       practical. Where exact counts are not important, reword copy to avoid a
@@ -68,12 +69,16 @@ work:
   - id: w4
     summary: "Wire the drift check into the narrowest existing verification lane"
     needs: [w2, w3]
-    status: pending
+    status: done
     notes: |
       Place the check where maintainers already expect public contract drift to
       fail, such as a unit contract test or the existing PR public-contract gate.
       Keep failure output concise and redirect any large inventory output to
       `/tmp` or a generated local artifact that is not committed.
+
+deferred:
+  - summary: "Fix stale 'eighteen benchmarks' claim in docs/usage/faq.md and add it to the drift gate"
+    reason: "docs/usage/ is outside this TODO's scope_limit. faq.md:32 says 'eighteen benchmarks' (stale; registry has 22 public). Repair it and extend test_public_benchmark_count_claims_are_registry_derived to cover faq.md in a follow-up that includes docs/usage/."
 
 metadata:
   tags:
@@ -83,7 +88,7 @@ metadata:
     - drift-gate
   estimated_effort: "1-2 days"
   created_date: "2026-05-21"
-  last_updated: "2026-05-21T00:00:00Z"
+  last_updated: "2026-05-25T00:00:00Z"
 
 impact:
   business_value: |

--- a/docs/reference/public-contracts.md
+++ b/docs/reference/public-contracts.md
@@ -136,6 +136,35 @@ Authoritative count statements should come from the relevant registry metadata.
 Editorial lists may remain in narrative docs, but they must not claim to be
 exhaustive unless a generated or tested check keeps them synchronized.
 
+### Benchmark Claim Classes
+
+Public benchmark breadth claims fall into four classes:
+
+| Claim class | Rule | Example |
+|---|---|---|
+| Registry-derived | Generated from or checked against `benchmark_registry`. The number must equal a registry count. | README `benchbox-registry-counts` marker; the Benchmark API snapshot above. |
+| Checked exact claim | A hand-written exact count that a drift gate pins to the registry. Allowed on durable public surfaces. | Landing "22 Benchmarks"; architecture "currently 22 benchmarks". |
+| Editorial example | Narrative that names representative benchmarks without an exhaustive total. Preferred when the exact number does not matter. | "TPC-H, TPC-DS, ClickBench, and more". |
+| Generated output | Produced by a named generator; hand edits are drift. | Generated compatibility docs. |
+
+Rules:
+
+- An exact public benchmark count must be registry-derived **or** covered by a
+  drift gate; otherwise reword it as an editorial example with no total.
+- Integrity-spec coverage claims (`N of M benchmarks`) are checked exact claims:
+  `N` is the spec count and `M` is the public benchmark count.
+- Generated outputs must state their generator; do not hand-edit them.
+- Internal `TODO`/`DONE`/ADR history is not public contract — historical count
+  evidence there is never treated as a stale public claim.
+
+The drift gate for the checked exact claims is
+`tests/unit/core/test_benchmark_api_contract.py::test_public_benchmark_count_claims_are_registry_derived`,
+which derives the expected counts from the registry and names any stale source
+file. The currently gated durable surfaces are `landing/index.html`,
+`docs/design/architecture.md`, `docs/development/result-integrity-validation.md`,
+and `docs/reference/cli/utilities.md`; the README marker is gated separately by
+the platform-registry marker tests.
+
 ## Drift Check Ownership
 
 Each public claim class has one owner and one preferred verification gate:

--- a/tests/unit/core/test_benchmark_api_contract.py
+++ b/tests/unit/core/test_benchmark_api_contract.py
@@ -229,6 +229,42 @@ def test_benchmark_support_status_criteria_matrix_covers_every_benchmark() -> No
     assert mismatched == {}, f"criteria-matrix status differs from registry: {mismatched}"
 
 
+def test_public_benchmark_count_claims_are_registry_derived() -> None:
+    """Durable public surfaces must carry the registry-derived benchmark counts.
+
+    Drift gate: if the public benchmark count or integrity-spec coverage changes,
+    these hand-written exact-count claims go stale and this test names the files to
+    fix. The registry stays the source of truth; the docs are checked against it.
+    """
+    from benchbox.core.results.benchmark_specs import BENCHMARK_SPECS
+
+    public_ids = set(list_public_benchmark_ids())
+    public_count = len(public_ids)
+    spec_count = len(set(BENCHMARK_SPECS) & public_ids)
+
+    required_claims = {
+        "landing/index.html": [
+            f"{public_count} Benchmarks",
+            f"{public_count} benchmarks (TPC",
+            f"Explore {public_count} benchmarks",
+        ],
+        "docs/design/architecture.md": [f"currently {public_count} benchmarks"],
+        "docs/development/result-integrity-validation.md": [
+            f"Specs exist for {spec_count} of {public_count} registered benchmarks"
+        ],
+        "docs/reference/cli/utilities.md": [f"Specs cover {spec_count} of {public_count} benchmarks"],
+    }
+
+    stale: list[str] = []
+    for rel_path, fragments in required_claims.items():
+        text = (PROJECT_ROOT / rel_path).read_text(encoding="utf-8")
+        stale.extend(
+            f"{rel_path}: missing registry-derived claim {fragment!r}" for fragment in fragments if fragment not in text
+        )
+
+    assert stale == [], "Stale public benchmark count claims (update to match the registry):\n" + "\n".join(stale)
+
+
 def test_benchmark_data_source_metadata_matches_runtime_declarations() -> None:
     """Every registry entry has a static data_source key matching runtime declarations."""
 


### PR DESCRIPTION
## Summary

Implements `public-benchmark-claim-drift-gate`: stops stale "N benchmarks" public
claims from drifting from the registry.

- **Claim-class rules** in `docs/reference/public-contracts.md` (Count and Drift
  Policy): registry-derived vs checked-exact vs editorial vs generated, with rules
  for where exact public counts are allowed and how they're checked. Internal
  TODO/DONE history is explicitly not public contract.
- **Drift gate** `test_public_benchmark_count_claims_are_registry_derived` in
  `tests/unit/core/test_benchmark_api_contract.py` (fast lane): derives the public
  benchmark count (22) and integrity-spec coverage (20 of 22) from the registry and
  pins the exact claims on four durable surfaces — `landing/index.html`,
  `docs/design/architecture.md`, `docs/development/result-integrity-validation.md`,
  `docs/reference/cli/utilities.md`. A registry change that makes any go stale
  fails the test and names the file.
- **README** editorial bullet reworded from "all 22 benchmark suites" to "the full
  benchmark suite: …" — the `benchbox-registry-counts` marker stays the
  authoritative README count source (already gated by the platform-registry tests).

## w0 inventory

Exact/stale claims classified: landing (3×), architecture, result-integrity, and
cli-utilities carry currently-correct exact counts → kept and gated. README:480
editorial → reworded. `docs/usage/faq.md:32` says "eighteen benchmarks" (stale) but
`docs/usage/` is outside this TODO's `scope_limit` → recorded as a `deferred[]`
follow-up. `docs/_build` and `_project` history excluded by design.

## Verification

- `pytest tests/unit/core/test_benchmark_api_contract.py tests/unit/core/test_platform_registry.py` — 62 passed (incl. the new gate; non-vacuous).
- `make docs-validate` — passes.
- `ruff check` / `ruff format --check` / `ty check` — clean.

## Review notes

Five-axis self-review: no Critical/Required findings. Implemented the gate as a
**unit test** (the documented benchmark-api drift owner, runs on every PR) rather
than extending the path-gated `pr.yml` docs step, so a registry-only change that
makes docs stale is still caught. Anti-patterns avoided: targets 4 specific source
files (no global grep), keeps narrative prose (checks counts only), gates multiple
surfaces (not README-only), derives counts from the registry.

One **Consider**, not actioned: the gate pins minimal claim phrasings (e.g.
"currently 22 benchmarks"), so a legitimate reword that keeps the count would need
the fragment updated — intentional, to pin the claim location.

Closes `public-benchmark-claim-drift-gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
