### PR TITLE
ci: harden canary exit-code propagation and fix main-release-only ruleset

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -60,16 +60,15 @@ jobs:
         id: run-tests
         shell: bash
         run: |
-          set +e
+          rc=0
           uv run -- python -m pytest \
             -m "(slow or resource_heavy) and not (stress or live_integration)" \
             -n 0 \
             --tb=short \
             --maxfail=5 \
-            2>&1 | tee release-canary-artifacts/non-fast-pytest.log
-          rc=${PIPESTATUS[0]}
+            2>&1 | tee release-canary-artifacts/non-fast-pytest.log \
+            || rc=${PIPESTATUS[0]}
           echo "pytest_exit_code=$rc" >> "$GITHUB_OUTPUT"
-          exit 0
 
       - name: Write non-fast canary summary
         if: always()
@@ -140,14 +139,13 @@ jobs:
           RELEASE_READINESS_OVERRIDE_SHA: ${{ vars.RELEASE_READINESS_OVERRIDE_SHA }}
           RELEASE_READINESS_OVERRIDE_REASON: ${{ vars.RELEASE_READINESS_OVERRIDE_REASON }}
         run: |
-          set +e
           mkdir -p release-canary-artifacts
+          rc=0
           uv run -- python scripts/ruleset_drift_check.py \
             --output release-canary-artifacts/ruleset-drift.json \
-            2>&1 | tee release-canary-artifacts/ruleset-drift.txt
-          rc=${PIPESTATUS[0]}
+            2>&1 | tee release-canary-artifacts/ruleset-drift.txt \
+            || rc=${PIPESTATUS[0]}
           echo "drift_exit_code=$rc" >> "$GITHUB_OUTPUT"
-          exit 0
 
       - name: Upload ruleset drift artifacts
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,7 +253,10 @@ jobs:
         run: |
           uv run -- python -m pytest tests/integration -m "integration and not slow and not stress" --tb=short --maxfail=5 --timeout=300
 
-  # Package build and install test
+  # Package build and install test — builds a fresh wheel from this branch to verify
+  # the package is importable and the CLI entry point resolves. This is an independent
+  # build from the wheel published by release.yml; it validates pre-merge correctness,
+  # not artifact identity.
   test-package:
     if: ${{ github.event_name != 'pull_request' || github.base_ref != 'develop' }}
     runs-on: ${{ matrix.os }}

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -274,10 +274,15 @@ class TestReleaseInfrastructure:
         assert "--collect-only" in non_fast_text
         assert "release-canary-artifacts/non-fast-summary.json" in non_fast_text
         assert "raw" not in non_fast_text.lower()
+        # Exit code must propagate via rc= variable, not be swallowed by set+e/exit 0.
+        assert "set +e" not in non_fast_text
+        assert "exit 0" not in non_fast_text
 
         ruleset_text = _workflow_job_run_text("release-canary.yml", "ruleset-drift")
         assert "scripts/ruleset_drift_check.py" in ruleset_text
         assert "release-canary-artifacts/ruleset-drift.json" in ruleset_text
+        assert "set +e" not in ruleset_text
+        assert "exit 0" not in ruleset_text
 
         result_job = jobs["release-canary-result"]
         assert result_job["name"] == "release-canary-result"
@@ -285,6 +290,18 @@ class TestReleaseInfrastructure:
         result_text = _workflow_job_run_text("release-canary.yml", "release-canary-result")
         assert '"freshness_contract_hours": 48' in result_text
         assert "Release canary passed." in result_text
+
+    def test_canary_collect_count_regex_matches_pytest_deselect_format(self):
+        """The canary collect-step grep regex must match the actual pytest --collect-only output format."""
+        collect_text = _workflow_job_run_text("release-canary.yml", "credential-free-non-fast")
+        assert "'^[0-9]+/[0-9]+ tests collected'" in collect_text
+
+        # Verify the regex semantics using Python re (same logic as the grep ERE pattern).
+        pattern = re.compile(r"^\d+/\d+ tests collected")
+        assert pattern.match("92/24795 tests collected (24703 deselected) in 16.98s")
+        assert pattern.match("1/100 tests collected")
+        assert not pattern.match("24795 tests collected in 16.98s")
+        assert not pattern.match("0 tests collected")
 
     def test_validate_main_pr_checks_release_canary_freshness(self):
         """The required validate-base context must include release canary freshness."""


### PR DESCRIPTION
- Replace set+e/exit-0 swallow pattern in release-canary.yml with
  rc=0 || rc=${PIPESTATUS[0]} for both non-fast and ruleset-drift
  steps so pytest/script failures propagate correctly.
- Add clarifying comment to test-package job distinguishing the
  pre-merge build from the published release.yml artifact.
- Add regression guards asserting set+e and exit-0 are absent from
  canary run steps; add unit test pinning the collect-count grep
  regex against the actual pytest --collect-only deselect output
  format.
- Applied live GitHub ruleset fix to main-release-only (id 15611783):
  swapped required contexts from lint+test(ubuntu-latest,3.12)+
  validate-base to validate-base+release-required-result, and
  corrected strict_required_status_checks_policy from true to false.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
