### PR TITLE
docs(todo): add approximate analytics cloud survey plan

### DIFF
--- a/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
+++ b/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
@@ -1,0 +1,535 @@
+id: approx-analytics-cloud-survey
+title: Approximate Analytics Cloud SQL Survey — read_primitives + SQL write_primitives at SF=0.1/1/10
+worktree: benchmark-expansion
+category: Benchmark Development
+priority: High
+status: Not Started
+description: |
+  Survey approximate analytics support and performance across all major cloud SQL
+  platforms by running the read_primitives (one-shot approx aggregates) and
+  write_primitives SQL sketch category (persist + merge + requery) benchmarks at three
+  scale factors (SF=0.1, SF=1, SF=10).
+
+  The goal is a complete support matrix — which platform supports which sketch family,
+  at what latency, and how latency scales with data volume — plus identification of
+  any gaps or regressions not yet captured in the cross-engine docs.
+
+  Target platforms (SQL mode):
+  - Databricks SQL (enabled, credentials available)
+  - ClickHouse Cloud (enabled)
+  - Firebolt Cloud (enabled)
+  - Starburst/Trino Cloud (enabled)
+  - MotherDuck (enabled)
+  - Snowflake (driver install required)
+  - Amazon Redshift (driver install required)
+  - Google BigQuery (driver install required)
+
+  read_primitives queries in scope (5):
+    approx_count_distinct_simple, approx_count_distinct_groupby,
+    approx_quantile_groupby, approx_quantiles_array, approx_top_k_lineitem
+
+  SQL write_primitives sketch ops in scope (22 sketch_* operations):
+    sketch_ddl_create_persistent_table through sketch_query_topk_combine_lgmm10.
+    Exclude sketch_df_hll_persist_merge and sketch_df_topk_persist_merge because
+    those are DataFrame aggregate-state operations, not SQL cloud-platform operations.
+
+  Known platform limitations (from docs — verify, don't assume still current):
+  - Redshift: HLL substitution only; KLL and Top-K skipped (no native equivalent)
+  - BigQuery: Theta substituted with HLL; Top-K skipped (no native accumulator)
+  - DataFusion: sketches skipped entirely
+  - DuckDB (not in scope here): 4 theta/topk ops blocked by extension `2e38607`
+
+context_sections:
+  - name: Query IDs — read_primitives
+    summary: |
+      | Query ID                        | Capability                    | Category    | Notes                                    |
+      |---------------------------------|-------------------------------|-------------|------------------------------------------|
+      | approx_count_distinct_simple    | HLL distinct count, scalar    | aggregation | All platforms via sqlglot rewrite         |
+      | approx_count_distinct_groupby   | HLL distinct count, per group | aggregation | All platforms via sqlglot rewrite         |
+      | approx_quantile_groupby         | T-Digest / KLL single quantile| statistical | Redshift uses APPROXIMATE PERCENTILE_DISC |
+      | approx_quantiles_array          | Vector quantiles per group    | statistical | Redshift, DataFusion: skipped             |
+      | approx_top_k_lineitem           | Approximate top-K             | topn        | Redshift, DataFusion: skipped             |
+
+      Approximate CLI flag: --queries approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby,approx_quantiles_array,approx_top_k_lineitem
+
+  - name: Sketch Op IDs — write_primitives
+    summary: |
+      Theta family: sketch_ddl_create_persistent_table, sketch_insert_theta_per_partition,
+        sketch_query_theta_union_merge, sketch_query_theta_union_merge_lgk10,
+        sketch_query_theta_union_merge_lgk14, sketch_drop_persistent_table
+      KLL family: sketch_insert_kll_per_partition, sketch_query_kll_quantiles_merge,
+        sketch_query_kll_quantiles_merge_k100, sketch_query_kll_quantiles_merge_k1000
+      Top-K family: sketch_insert_topk_per_shard, sketch_query_topk_combine,
+        sketch_query_topk_combine_lgmm8, sketch_query_topk_combine_lgmm10
+      CPC family: sketch_cpc_create_persistent_table, sketch_cpc_insert_per_partition,
+        sketch_cpc_query_union_merge, sketch_cpc_drop_persistent_table
+      REQ family: sketch_req_create_persistent_table, sketch_req_insert_per_partition,
+        sketch_req_query_quantile_merge, sketch_req_drop_persistent_table
+      Excluded from this SQL-mode survey:
+        sketch_df_hll_persist_merge, sketch_df_topk_persist_merge
+        (DataFrame aggregate-state operations; handled by the deferred DataFrame survey)
+
+      Approximate CLI flag:
+        --queries sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table,sketch_cpc_create_persistent_table,sketch_cpc_insert_per_partition,sketch_cpc_query_union_merge,sketch_cpc_drop_persistent_table,sketch_req_create_persistent_table,sketch_req_insert_per_partition,sketch_req_query_quantile_merge,sketch_req_drop_persistent_table,sketch_query_theta_union_merge_lgk10,sketch_query_theta_union_merge_lgk14,sketch_query_kll_quantiles_merge_k100,sketch_query_kll_quantiles_merge_k1000,sketch_query_topk_combine_lgmm8,sketch_query_topk_combine_lgmm10
+
+  - name: Sketch family × platform support matrix
+    summary: |
+      From docs/benchmarks/write-primitives-sketch-functions.md (verify at run time):
+
+      | Sketch family   | Full DataSketches binary support        | Native-but-distinct          | No support          |
+      |-----------------|------------------------------------------|------------------------------|---------------------|
+      | Theta (distinct)| Databricks, Snowflake, DuckDB ext       | BigQuery (HLL), Redshift (HLL), ClickHouse (uniqState) | DataFusion |
+      | KLL (quantile)  | Databricks, Snowflake, BigQuery, DuckDB | ClickHouse (quantileTDigestState) | Redshift, DataFusion |
+      | Top-K (frequent)| Databricks, Snowflake, DuckDB ext       | ClickHouse (topKState)       | BigQuery, Redshift, DataFusion |
+      | CPC             | Databricks, Snowflake, DuckDB ext       | —                            | BigQuery, Redshift, ClickHouse, DataFusion |
+      | REQ             | Databricks, Snowflake, DuckDB ext       | —                            | BigQuery, Redshift, ClickHouse, DataFusion |
+
+      Firebolt and Starburst not yet in this matrix — verifying coverage is a
+      primary deliverable of this survey.
+
+  - name: Scale factor rationale
+    summary: |
+      SF=0.1 (~600K lineitem rows): Validates support and catches dialect translation
+        failures cheaply; comparable to SF=0.01 existing data but large enough for
+        meaningful sketch-merge workload.
+      SF=1 (~6M lineitem rows): Standard benchmark reference point; aligns with
+        existing platform result bundles for non-approx queries.
+      SF=10 (~60M lineitem rows): Tests scaling behavior — sketch merge cost should
+        be roughly constant (O(k)), while exact-fallback platforms pay O(n). Key
+        differentiator between sketch-backed and exact engines.
+
+  - name: Prerequisites and cloud storage
+    summary: |
+      Each cloud platform needs an --output cloud URI for data staging:
+      - Databricks: dbfs:/Volumes/<catalog>/<schema>/<volume>/benchbox
+      - Snowflake: must use --table-mode native (Snowflake stages via internal)
+      - BigQuery: gs://<bucket>/benchbox or use BQ native load
+      - Redshift: s3://<bucket>/benchbox (needs IAM COPY permissions)
+      - ClickHouse Cloud: s3://<bucket> or ClickHouse native load
+      - Firebolt: s3://<bucket>/benchbox
+      - Starburst: depends on cluster storage config
+      - MotherDuck: md: path (local duck file)
+
+      Confirm credentials and BENCHBOX_<PLATFORM>_* env vars are set before each
+      platform run. Use --dry-run first to verify config.
+
+prior_art:
+  - "docs/benchmarks/read-primitives-approximate-functions.md — cross-engine function reference; reuse as ground truth for expected dialect rewrites"
+  - "docs/benchmarks/write-primitives-sketch-functions.md — sketch family × engine support matrix; reuse and extend with Firebolt + Starburst findings"
+  - "benchmark_runs/datagen/tpch_sf001/ — SF=0.01 datagen exists; extend, don't regenerate"
+  - "benchbox/core/read_primitives/catalog/queries.yaml — 5 approx query IDs already defined; no new catalog work needed"
+  - "benchbox/core/write_primitives/catalog/operations.yaml — 22 SQL sketch op IDs plus 2 DataFrame sketch ops already defined; reuse only SQL ops here"
+  - "benchbox/cli/commands/run.py — canonical cloud platform keys include clickhouse-cloud and firebolt:cloud; reuse exact keys"
+
+work:
+  - id: w0
+    summary: "Verify platform keys, driver availability, credentials, and evidence freshness"
+    needs: []
+    status: pending
+    notes: |
+      Use exact platform keys for this survey:
+        databricks, clickhouse-cloud, firebolt:cloud, starburst, motherduck,
+        snowflake, bigquery, redshift
+      Dependency-check keys differ for deployment aliases:
+        firebolt:cloud -> firebolt
+        motherduck -> verify via platforms list/status (no dedicated check-deps key)
+
+      Run:
+        uv run -- benchbox platforms list
+        uv run -- benchbox check-deps --platform <dependency-check-key>
+
+      For each target platform, record a compact evidence summary for the final
+      docs update:
+        - checked BenchBox SHA
+        - command(s) run
+        - platform status (enabled / missing driver / missing credentials / blocked)
+        - driver package and version when available
+        - credential signal checked, with secrets redacted
+
+      Keep raw stdout under /tmp or $BENCHBOX_OUTPUT_DIR/logs/approx-survey-*/
+      only. Do not commit raw logs.
+
+  - id: w1
+    summary: "Install or activate missing optional cloud drivers without widening project scope"
+    needs: [w0]
+    status: pending
+    notes: |
+      For each missing platform identified in w0, prefer existing optional extras:
+        uv sync --extra snowflake
+        uv sync --extra bigquery
+        uv sync --extra redshift
+
+      If the local environment still needs one-off tooling, use uv-managed
+      commands only; never pip install. Do not commit pyproject.toml or uv.lock
+      changes for driver activation in this survey. If an optional extra is
+      missing or incorrect, file a separate follow-up TODO instead of fixing
+      packaging here.
+
+      Re-run:
+        uv run -- benchbox platforms list
+        uv run -- benchbox check-deps --platform <dependency-check-key>
+
+  - id: w2
+    summary: "Get explicit live-run approval and define the run envelope"
+    needs: [w0]
+    status: pending
+    notes: |
+      Before any live cloud benchmark, cloud upload, or SF=10 generation, present
+      the operator with:
+        - target platforms and exact commands
+        - estimated data volume and cloud services touched
+        - max runtime per platform and overall stop condition
+        - cost/budget ceiling, if one applies
+        - output root and log root
+        - disk-free threshold; minimum 25 GiB because SF=10 TPC-H data is large
+
+      Require an explicit approval reply in the implementation thread before
+      continuing. Use:
+        export BENCHBOX_OUTPUT_DIR="${BENCHBOX_OUTPUT_DIR:-$HOME/Developer/benchmark_runs}"
+        export APPROX_SURVEY_LOG_DIR="$BENCHBOX_OUTPUT_DIR/logs/approx-survey-<YYYYMMDD-HHMMSS>"
+
+      Live runs are sequential by platform. Stop new work if disk space drops
+      below the approved threshold, if cloud credentials are invalid, or if a
+      command exceeds the approved runtime cap.
+
+  - id: w3
+    summary: "Dry-run all 8 platforms x 2 SQL benchmarks before data generation or live runs"
+    needs: [w0, w1]
+    status: pending
+    notes: |
+      Use dry-run to catch query selection, dialect, and config errors before
+      generating SF=10 data or touching live warehouses.
+
+      Read query set:
+        approx_count_distinct_simple,approx_count_distinct_groupby,approx_quantile_groupby,approx_quantiles_array,approx_top_k_lineitem
+
+      SQL sketch query set (22 operations; intentionally excludes sketch_df_*):
+        sketch_ddl_create_persistent_table,sketch_insert_theta_per_partition,sketch_insert_kll_per_partition,sketch_insert_topk_per_shard,sketch_query_theta_union_merge,sketch_query_kll_quantiles_merge,sketch_query_topk_combine,sketch_drop_persistent_table,sketch_cpc_create_persistent_table,sketch_cpc_insert_per_partition,sketch_cpc_query_union_merge,sketch_cpc_drop_persistent_table,sketch_req_create_persistent_table,sketch_req_insert_per_partition,sketch_req_query_quantile_merge,sketch_req_drop_persistent_table,sketch_query_theta_union_merge_lgk10,sketch_query_theta_union_merge_lgk14,sketch_query_kll_quantiles_merge_k100,sketch_query_kll_quantiles_merge_k1000,sketch_query_topk_combine_lgmm8,sketch_query_topk_combine_lgmm10
+
+      For each platform:
+        uv run -- benchbox run --platform <platform-key> --benchmark read_primitives --scale 0.1 \
+          --phases load,power \
+          --queries <read-query-set> \
+          --non-interactive \
+          --dry-run /tmp/approx-survey-dryrun/<platform>-read
+        uv run -- benchbox run --platform <platform-key> --benchmark write_primitives --scale 0.1 \
+          --phases load,power \
+          --queries <sql-sketch-query-set> \
+          --non-interactive \
+          --dry-run /tmp/approx-survey-dryrun/<platform>-write
+
+      Fix no code here. If dry-run exposes a translation or adapter defect,
+      file a separate TODO and mark that platform blocked for this survey.
+
+  - id: w4
+    summary: "Generate TPC-H data at SF=0.1, SF=1, SF=10 in the shared UAT output root"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Use the approved BENCHBOX_OUTPUT_DIR from w2. Run sequentially:
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark read_primitives --scale 0.1
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark write_primitives --scale 0.1
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark read_primitives --scale 1
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark write_primitives --scale 1
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark read_primitives --scale 10
+        BENCHBOX_OUTPUT_DIR="$BENCHBOX_OUTPUT_DIR" uv run -- benchbox datagen --benchmark write_primitives --scale 10
+
+      Verify manifests under:
+        $BENCHBOX_OUTPUT_DIR/datagen/tpch_sf01/_datagen_manifest.json
+        $BENCHBOX_OUTPUT_DIR/datagen/tpch_sf1/_datagen_manifest.json
+        $BENCHBOX_OUTPUT_DIR/datagen/tpch_sf10/_datagen_manifest.json
+
+      Estimated disk: ~200MB (SF=0.1), ~2GB (SF=1), ~20GB (SF=10)
+      uncompressed TBL. Announce the SF=10 command, max runtime, log path, and
+      stop condition immediately before launch.
+
+  - id: w5
+    summary: "Live run: Databricks SQL at SF=0.1, SF=1, SF=10"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: databricks. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Output/staging: dbfs:/Volumes/<catalog>/<schema>/<volume>/benchbox
+      Record result bundle paths and query status counts for w13.
+
+  - id: w6
+    summary: "Live run: ClickHouse Cloud at SF=0.1, SF=1, SF=10"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: clickhouse-cloud. Use phases load,power, --non-interactive, the
+      read query set, and the 22-op SQL sketch query set from w3.
+      ClickHouse uses native -State/-Merge combinators for sketches, not
+      DataSketches binary portability. Record result bundle paths and query
+      status counts for w13.
+
+  - id: w7
+    summary: "Live run: Firebolt Cloud at SF=0.1, SF=1, SF=10"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: firebolt:cloud. Use phases load,power, --non-interactive, the
+      read query set, and the 22-op SQL sketch query set from w3.
+      Firebolt approximate-analytics coverage is not yet in the cross-engine
+      reference docs. Record which sketch ops succeed, fail, or skip and which
+      dialect rewrites Firebolt applies.
+
+  - id: w8
+    summary: "Live run: Starburst/Trino Cloud at SF=0.1, SF=1, SF=10"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: starburst. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Trino's one-shot approx functions include approx_distinct, approx_percentile,
+      and approx_most_frequent. Record whether persisted sketch operations have a
+      native, substituted, skipped, or failed path.
+
+  - id: w9
+    summary: "Live run: MotherDuck at SF=0.1, SF=1, SF=10"
+    needs: [w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: motherduck. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Verify the DuckDB extension version MotherDuck exposes before assuming the
+      local DuckDB extension limitation at `2e38607` still applies.
+
+  - id: w10
+    summary: "Live run: Snowflake at SF=0.1, SF=1, SF=10"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: snowflake. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Use --table-mode native unless the approved run envelope chooses a different
+      mode. Full DataSketches binary support is expected; verify actual behavior
+      from query statuses and platform errors.
+
+  - id: w11
+    summary: "Live run: Google BigQuery at SF=0.1, SF=1, SF=10"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: bigquery. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Cloud storage URI: gs://<bucket>/benchbox or approved BigQuery native load.
+      Expected substitutions: Theta to HLL_COUNT.INIT/MERGE; KLL through
+      KLL_QUANTILES; Top-K skipped. Verify instead of assuming.
+
+  - id: w12
+    summary: "Live run: Amazon Redshift at SF=0.1, SF=1, SF=10"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Platform: redshift. Use phases load,power, --non-interactive, the read
+      query set, and the 22-op SQL sketch query set from w3.
+      Cloud storage URI: s3://<bucket>/benchbox with IAM COPY permissions.
+      Expected substitutions: Theta to HLLSKETCH/HLL_CREATE_SKETCH; KLL and
+      Top-K skipped. Verify instead of assuming.
+
+  - id: w13
+    summary: "Compile cross-platform support matrix and performance comparison"
+    needs: [w5, w6, w7, w8, w9, w10, w11, w12]
+    status: pending
+    notes: |
+      For each platform x benchmark x query x scale factor, extract from result bundles:
+        - Pass / Fail / Skipped status
+        - execution_time_seconds, converted to ms only for display
+        - Sketch family mapping actually used (native / substitution / skipped / failed)
+        - Result bundle path and checked BenchBox SHA
+
+      Produce a compact summary, not raw stdout:
+        1. Support matrix table: platforms x sketch families
+        2. Performance comparison: SF=1 latency across platforms per sketch op
+        3. Scale analysis: SF=0.1/1/10 per platform, highlighting O(1) sketch
+           merge behavior versus O(n) exact/substituted fallback
+
+      Use:
+        uv run -- benchbox compare <bundle1> <bundle2> ...
+        uv run -- benchbox visualize <bundle> --chart-type performance_bar
+
+      Save generated charts/raw analysis under $BENCHBOX_OUTPUT_DIR or /tmp.
+      Commit only durable markdown summaries.
+
+  - id: w14
+    summary: "Document findings and file focused platform-gap TODOs"
+    needs: [w13]
+    status: pending
+    notes: |
+      Update docs/benchmarks/write-primitives-sketch-functions.md with:
+        - Firebolt and Starburst rows in the sketch family x engine support matrix
+        - MotherDuck extension version observation
+        - Current compact evidence summary: commands, checked SHA, driver versions,
+          PASS/FAIL/SKIPPED counts, and result-bundle identifiers
+        - Any changed platform behavior versus the pre-survey docs
+
+      Update docs/benchmarks/read-primitives-approximate-functions.md with:
+        - Firebolt and Starburst rows in the function reference tables
+        - Current compact evidence summary for read_primitives query support
+
+      For each unsupported or broken sketch family that requires code or adapter
+      work, file a separate follow-up TODO under platform-expansion/planning/.
+      This survey commit may edit docs and follow-up TODO YAML only; no runtime
+      code or catalog changes.
+
+deferred:
+  - summary: "DataFrame mode survey (Polars, PySpark, DataFusion) for approx queries"
+    reason: "SQL mode establishes the baseline; DataFrame mode includes the sketch_df_* aggregate-state operations and has known exact-fallback caveats on Polars/Dask that make cross-engine comparison less clean. Separate survey."
+  - summary: "Throughput phase benchmarking (concurrent sessions)"
+    reason: "Power phase (single session) is sufficient for capability verification and latency measurement. Throughput adds cloud cost and complexity; defer to a dedicated concurrency study."
+  - summary: "Error-rate analysis (actual approximation accuracy vs exact)"
+    reason: "BenchBox measures latency, not approximation error. Accuracy belongs in a separate accuracy study with known-answer datasets."
+  - summary: "Amazon Athena SQL, Azure Synapse, Fabric Warehouse"
+    reason: "pyathen/pyodbc drivers and IAM setup are significant additional overhead. Start with the 8 primary platforms; add these if they surface unique sketch behavior."
+
+approach: |
+  Run this as a two-stage survey: cheap platform/driver/dry-run validation
+  first, then approved live cloud execution. Use only SQL-mode query IDs in
+  the cloud SQL survey; keep DataFrame aggregate-state operations for the
+  deferred DataFrame survey. Use BENCHBOX_OUTPUT_DIR=$HOME/Developer/benchmark_runs
+  for generated data, result bundles, analysis artifacts, and long-run logs.
+  Commit durable markdown summaries and follow-up TODOs only; keep raw logs,
+  charts, and result JSONs outside git.
+
+anti_patterns:
+  - "DO NOT run live cloud benchmarks, upload cloud data, or generate SF=10 data until w2 records explicit approval, max runtime, log path, output root, disk threshold, and stop conditions."
+  - "DO NOT include sketch_df_hll_persist_merge or sketch_df_topk_persist_merge in SQL-mode cloud runs; they are DataFrame aggregate-state operations."
+  - "DO NOT commit raw stdout logs, benchmark_runs result bundles, generated TBL/Parquet data, or screenshot/chart batches; summarize durable facts in docs instead."
+  - "DO NOT fix SQL translation, platform adapters, catalog operations, or packaging defects in this survey; file separate TODOs for those implementation gaps."
+
+verification:
+  - description: "TODO query scope stays SQL-only and excludes DataFrame aggregate-state sketch ops"
+    command: |
+      uv run -- python - <<'PY'
+      from pathlib import Path
+      import yaml
+
+      item = yaml.safe_load(Path("_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml").read_text())
+      work_notes = "\n".join(str(unit.get("notes", "")) for unit in item["work"])
+      assert "sketch_df_hll_persist_merge" not in work_notes
+      assert "sketch_df_topk_persist_merge" not in work_notes
+      print("sql-only sketch scope verified")
+      PY
+    expected_output: "sql-only sketch scope verified"
+  - description: "SF=0.1, SF=1, SF=10 datagen manifests exist under BENCHBOX_OUTPUT_DIR with correct scale_factor"
+    command: |
+      BENCHBOX_OUTPUT_DIR="${BENCHBOX_OUTPUT_DIR:-$HOME/Developer/benchmark_runs}" uv run -- python - <<'PY'
+      import json
+      import os
+      from pathlib import Path
+
+      root = Path(os.environ["BENCHBOX_OUTPUT_DIR"]) / "datagen"
+      expected = {"sf01": 0.1, "sf1": 1.0, "sf10": 10.0}
+      for sf, value in expected.items():
+          path = root / f"tpch_{sf}" / "_datagen_manifest.json"
+          manifest = json.loads(path.read_text())
+          actual = float(manifest["scale_factor"])
+          assert actual == value, f"{path}: expected {value}, got {actual}"
+          print(f"tpch_{sf}: scale_factor={actual}")
+      PY
+    expected_output: |
+      tpch_sf01: scale_factor=0.1
+      tpch_sf1: scale_factor=1.0
+      tpch_sf10: scale_factor=10.0
+  - description: "SF=1 result bundles have structured query statuses for each target platform and both SQL benchmarks"
+    command: |
+      BENCHBOX_OUTPUT_DIR="${BENCHBOX_OUTPUT_DIR:-$HOME/Developer/benchmark_runs}" uv run -- python - <<'PY'
+      import json
+      import os
+      from pathlib import Path
+
+      root = Path(os.environ["BENCHBOX_OUTPUT_DIR"]) / "results"
+      platforms = {"databricks", "clickhouse-cloud", "firebolt", "starburst", "motherduck", "snowflake", "bigquery", "redshift"}
+      benchmarks = {"read_primitives", "write_primitives"}
+      aliases = {
+          "amazon-redshift": "redshift",
+          "clickhouse-cloud": "clickhouse-cloud",
+          "databricks-sql": "databricks",
+          "google-bigquery": "bigquery",
+      }
+      found: set[tuple[str, str]] = set()
+      for path in root.glob("*.json"):
+          data = json.loads(path.read_text())
+          benchmark = data.get("benchmark", {})
+          benchmark_id = str(benchmark.get("id", ""))
+          if benchmark_id not in benchmarks or float(benchmark.get("scale_factor", -1)) != 1.0:
+              continue
+          platform_name = str(data.get("platform", {}).get("name", "")).lower().replace(" ", "-")
+          platform_key = aliases.get(platform_name, platform_name)
+          filename = path.name.replace("_", "-").lower()
+          for expected in platforms:
+              if platform_key == expected or expected in filename:
+                  queries = data.get("queries", [])
+                  assert queries, f"{path}: missing query statuses"
+                  assert all("status" in query for query in queries), f"{path}: query without status"
+                  found.add((expected, benchmark_id))
+      missing = sorted((platform, benchmark) for platform in platforms for benchmark in benchmarks if (platform, benchmark) not in found)
+      assert not missing, f"missing result bundles: {missing}"
+      print(f"verified {len(found)} platform/benchmark SF=1 result bundles")
+      PY
+    expected_output: "verified 16 platform/benchmark SF=1 result bundles"
+  - description: "Reference docs contain explicit Firebolt and Starburst rows after the survey"
+    command: |
+      uv run -- python - <<'PY'
+      from pathlib import Path
+
+      docs = [
+          Path("docs/benchmarks/write-primitives-sketch-functions.md"),
+          Path("docs/benchmarks/read-primitives-approximate-functions.md"),
+      ]
+      for path in docs:
+          text = path.read_text()
+          for platform in ("Firebolt", "Starburst"):
+              assert f"| {platform}" in text or f"| `{platform}`" in text, f"{path}: missing {platform} table row"
+      print("Firebolt and Starburst rows present in approximate analytics docs")
+      PY
+    expected_output: "Firebolt and Starburst rows present in approximate analytics docs"
+
+must_preserve:
+  - "Existing result bundles in benchmark_runs/results/ and $BENCHBOX_OUTPUT_DIR/results/ — never overwrite or delete"
+  - "benchmark_runs/datagen/tpch_sf001/ and $BENCHBOX_OUTPUT_DIR/datagen/tpch_sf001/ — existing SF=0.01 data; do not force-regenerate"
+  - "docs/benchmarks/read-primitives-approximate-functions.md and write-primitives-sketch-functions.md — update only, never truncate"
+
+scope_limit:
+  only_modify:
+    - "docs/benchmarks/read-primitives-approximate-functions.md"
+    - "docs/benchmarks/write-primitives-sketch-functions.md"
+    - "_project/TODO/platform-expansion/planning/"
+  local_artifacts:
+    - "$BENCHBOX_OUTPUT_DIR/datagen/"
+    - "$BENCHBOX_OUTPUT_DIR/results/"
+    - "$BENCHBOX_OUTPUT_DIR/logs/approx-survey-*/"
+    - "/tmp/approx-survey-dryrun/"
+    - "/tmp/approx-survey-results/"
+  no_new_code: true
+  rationale: "This is a benchmarking execution and documentation survey. No catalog changes, no new query IDs, no platform adapter changes, and no package/dependency changes. If a platform gap requires code or packaging fixes, file a separate TODO."
+
+metadata:
+  owners:
+    - joeharris76
+  tags:
+    - approximate-analytics
+    - cross-platform
+    - read-primitives
+    - write-primitives
+    - sketches
+    - survey
+  estimated_effort: "3-5 days (data gen + 8 platform runs + analysis)"
+  created_date: "2026-05-25"
+  last_updated: "2026-05-25T00:00:00"
+
+impact:
+  business_value: |
+    Establishes the definitive cross-platform approximate analytics benchmark for BenchBox.
+    Gives users a data-driven answer to "which cloud platform best supports HLL / KLL /
+    Top-K sketches at scale?" — currently only documented for DuckDB and a few engines
+    in the cross-engine reference docs, not measured against a live workload.
+  user_impact: |
+    Users choosing a cloud data warehouse for approximate analytics workloads get
+    concrete latency numbers across platforms and scale factors, plus a clear support
+    matrix showing which sketch families work natively vs via substitution vs not at all.
+  technical_debt: |
+    Firebolt and Starburst are absent from both cross-engine reference docs despite
+    being enabled platforms. This survey closes that documentation gap.


### PR DESCRIPTION
## Summary
- add a corrected planning TODO for the approximate analytics cloud SQL survey
- constrain the survey to SQL sketch operations and defer DataFrame aggregate-state sketch ops
- add explicit live-cloud approval, shared BENCHBOX_OUTPUT_DIR/log guardrails, split platform work units, and structured verification

## Verification
- uv run --project ~/.claude/tools/todo todo-validate _project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph
- uv run -- python - <<PY ... SQL-only sketch scope verified
- make pr-preflight
