### PR TITLE
chore/local status closeout

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,19 @@ How did you verify the change? Include the commands you ran (e.g.
 - [ ] Any platform/benchmark count claim in docs is generated/checked from
       registry metadata, or explicitly marked editorial/non-authoritative.
 
+## Documentation
+
+- [ ] I updated the relevant user-facing docs.
+- [ ] I added regression notes for behavior changes.
+- [ ] I confirmed API contract wording remains accurate.
+
+## Code Quality
+
+- [ ] I ran formatting and lint/type checks.
+- [ ] I reviewed impacted modules for backwards compatibility and migration impact.
+- [ ] I added/updated tests for behavior changes and error paths.
+- [ ] I confirmed public contracts and release checklists are still valid.
+
 ## Artifact Hygiene
 
 - [ ] I did not commit raw screenshots, browser reports, generated logs,

--- a/_project/blind-spots/2026-05-23-223538-todo-review-misses-spec-the-todo-edits.md
+++ b/_project/blind-spots/2026-05-23-223538-todo-review-misses-spec-the-todo-edits.md
@@ -1,0 +1,43 @@
+---
+id: 2026-05-23-223538-todo-review-misses-spec-the-todo-edits
+date: 2026-05-23
+status: open
+finding_kind: framework-gap
+review_context: "/todo review — chore/shrink-review-followup-todos (shrink-campaign follow-ups)"
+related_paths:
+  - _project/TODO/main/planning/shrink-objective-function-and-guardrail.yaml
+  - _project/goal-shrink-core-code.md
+suggested_sweep: "grep active TODO descriptions for 'goal line N' / spec line-number citations; promote a rubric-extension TODO if it recurs"
+todo_id: null
+---
+
+# TODO-review freshness axis misses spec/goal docs the TODO itself edits
+
+## Finding
+A TODO that proposes to edit a living policy/spec document (here
+`_project/goal-shrink-core-code.md`) cited that document's current state as
+fixed evidence ("goal line 12", "goal line 19", "still driven by a single
+naive `cloc` metric"). The goal file had since been rewritten to encode the
+very objective function the TODO's w1 was going to author, and the cited line
+numbers no longer held. The TODO scored 3 on clarity, guardrails, prior_art,
+and work breakdown and would have passed a mechanical review; only manually
+reading the goal file revealed w1 was already done and the premise falsified.
+The review rubric's evidence-durability sub-axis enumerates dependency
+versions, harness PASS, and observed external behavior — but not "the
+spec/goal file this TODO proposes to modify may have already moved."
+
+## Why this matters
+TODOs authored from a campaign review often target the campaign's governing
+spec, and that spec is itself a living document. Quoting its line numbers as
+fixed evidence makes the whole TODO go stale the moment the spec is edited —
+silently, because every other axis still scores well. The freshness axis
+should treat a TODO's own edit target as a durability hazard, not just its
+external dependencies.
+
+## Suggested next steps
+- [ ] Extend the todo `review` evidence-durability rule: when a TODO's
+      `scope_limit.only_modify` includes a policy/spec/goal doc AND its
+      `description` quotes that doc, require a `w0` that re-reads current state
+      and diffs against the quoted text (score 0 if absent).
+- [ ] Spot-check other active TODOs for spec line-number citations that can
+      drift (sql-catalog already corrected to a stable phrase reference here).

--- a/benchbox/core/config_utils.py
+++ b/benchbox/core/config_utils.py
@@ -264,6 +264,7 @@ def build_platform_adapter_config(
                 }
             )
         cfg["data_path"] = get_value("data_path", "/tmp/benchbox_ch_local")
+        cfg.setdefault("mode", cfg["deployment_mode"])
 
         if cfg["deployment_mode"] == "server":
             cfg.update(

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -400,7 +400,46 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 return None, f"Operation '{operation.id}' is unsupported on platform '{platform_key}'."
             effective_sql = override
 
+        if (missing_file := self._check_bulk_load_file_dependencies(operation)) is not None:
+            return None, (
+                f"Operation '{operation.id}' is skipped because required bulk-load files are missing: {missing_file}"
+            )
+
         return effective_sql, None
+
+    def _check_bulk_load_file_dependencies(self, operation: Any) -> str | None:
+        """Return a comma-separated list of missing file-dependency paths, if any.
+
+        Only operations that declare `file_dependencies` are checked. Missing files
+        are treated as a non-fatal skip reason to keep benchmark runs stable when
+        auxiliary data has not been generated yet.
+        """
+        dependencies = list(getattr(operation, "file_dependencies", []))
+        if not dependencies:
+            return None
+
+        files_dir = getattr(self.data_generator, "files_dir", None)
+        if files_dir is None:
+            return ", ".join(dependencies)
+
+        missing: list[str] = []
+        for filename in dependencies:
+            try:
+                if "*" in filename:
+                    matches = list(files_dir.glob(filename))
+                    if not matches:
+                        missing.append(filename)
+                else:
+                    dependency_path = files_dir / filename
+                    if not dependency_path.exists():
+                        missing.append(filename)
+            except Exception:
+                missing.append(filename)
+
+        if not missing:
+            return None
+
+        return ", ".join(missing)
 
     def _table_exists(self, connection: DatabaseConnection, table_name: str) -> bool:
         """Check if a table exists in the database.
@@ -866,16 +905,63 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             raise ValueError(f"Operation '{operation.id}' is DataFrame aggregate-state only and is not exposed as SQL")
         return operation.write_sql
 
+    def get_all_operations(self) -> dict[str, Any]:
+        """Return SQL-operable operations.
+
+        Aggregate-state operations are routed through the DataFrame execution
+        path and intentionally excluded here so SQL-only counts and defaults
+        match legacy write-primitives behavior.
+        """
+        return {
+            op_id: operation
+            for op_id, operation in self.operations_manager.get_all_operations().items()
+            if operation.aggregate_state is None and operation.category.lower() != "sketch"
+        }
+
+    def get_operation_categories(self) -> list[str]:
+        """Get categories for SQL-operable operations."""
+        return sorted({operation.category for operation in self.get_all_operations().values()})
+
+    def get_operations_by_category(self, category: str) -> dict[str, Any]:
+        """Get SQL-operable operations filtered by category."""
+        normalized = category.lower()
+        return {
+            op_id: operation
+            for op_id, operation in self.get_all_operations().items()
+            if operation.category.lower() == normalized
+        }
+
+    def get_benchmark_info(self) -> dict[str, Any]:
+        """Return benchmark metadata using SQL operation count/category."""
+        return {
+            "name": self._name,
+            "version": self._version,
+            "description": self._description,
+            "scale_factor": self.scale_factor,
+            "total_operations": len(self.get_all_operations()),
+            "categories": self.get_operation_categories(),
+            "tables": list(self._staging_tables.keys()),
+            "data_source": "tpch",
+        }
+
     def get_queries(self, dialect: Optional[str] = None) -> dict[str, str]:
         """Get SQL-runnable write operations, excluding DataFrame-only aggregate-state ops."""
         _ = dialect
         operations = self.operations_manager.get_all_operations()
-        return {op_id: op.write_sql for op_id, op in operations.items() if op.aggregate_state is None}
+        return {
+            op_id: op.write_sql
+            for op_id, op in operations.items()
+            if op.aggregate_state is None and op.category.lower() != "sketch"
+        }
 
     def get_queries_by_category(self, category: str) -> dict[str, str]:
         """Get SQL-runnable write operations for a category."""
         operations = self.operations_manager.get_operations_by_category(category)
-        return {op_id: op.write_sql for op_id, op in operations.items() if op.aggregate_state is None}
+        return {
+            op_id: op.write_sql
+            for op_id, op in operations.items()
+            if op.aggregate_state is None and op.category.lower() != "sketch"
+        }
 
     def execute_operation(
         self,

--- a/tests/unit/core/test_config_utils.py
+++ b/tests/unit/core/test_config_utils.py
@@ -307,6 +307,7 @@ class TestBuildPlatformAdapterConfig:
 
         expected = {
             "deployment_mode": "server",
+            "mode": "server",
             "data_path": "/tmp/ch_data",
             "host": "clickhouse.example.com",
             "port": 9000,
@@ -317,7 +318,7 @@ class TestBuildPlatformAdapterConfig:
         assert result == expected
 
     def test_build_clickhouse_config_normalizes_legacy_mode_alias(self):
-        """Legacy `mode` input should emit canonical deployment_mode."""
+        """Legacy `mode` input should emit matching canonical and compatibility keys."""
         args = SimpleNamespace(
             deployment_mode=None,
             mode="embedded",
@@ -332,7 +333,7 @@ class TestBuildPlatformAdapterConfig:
         result = build_platform_adapter_config("clickhouse", args)
 
         assert result["deployment_mode"] == "local"
-        assert "mode" not in result
+        assert result["mode"] == "local"
 
     def test_build_clickhouse_config_rejects_cloud_mode(self):
         """Passing cloud deployment through config helpers must raise."""

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -1376,6 +1376,20 @@ def test_get_queries_returns_all(fast_bench):
     assert len(queries) > 0
 
 
+def test_default_sql_operations_exclude_sketch_category(fast_bench):
+    operations = fast_bench.get_all_operations()
+
+    assert "sketch_query_theta_union_merge" not in operations
+    assert all(operation.category != "sketch" for operation in operations.values())
+
+
+def test_get_query_allows_explicit_sql_sketch_operation(fast_bench):
+    result = fast_bench.get_query("sketch_query_theta_union_merge")
+
+    assert isinstance(result, str)
+    assert "sketch_ops_daily_users" in result
+
+
 def test_get_queries_by_category_returns_subset(fast_bench):
     queries = fast_bench.get_queries_by_category("insert")
     assert isinstance(queries, dict)
@@ -1526,6 +1540,25 @@ def test_get_effective_write_sql_no_overrides(fast_bench):
     sql, skip = fast_bench._get_effective_write_sql(operation)
     assert sql == "INSERT INTO t VALUES (1)"
     assert skip is None
+
+
+def test_get_effective_write_sql_skips_when_file_dependencies_missing(fast_bench, tmp_path):
+    """Bulk-load operations should be skipped when required files are unavailable."""
+    fast_bench.data_generator.files_dir = tmp_path
+    operation = SimpleNamespace(
+        id="bulk_load_csv_small_uncompressed",
+        write_sql="COPY bulk_load_ops_target FROM 'unused';",
+        platform_overrides={},
+        category="bulk_load",
+        file_dependencies=["csv_small_1k.csv", "csv_missing.csv"],
+    )
+
+    sql, skip = fast_bench._get_effective_write_sql(operation)
+
+    assert sql is None
+    assert skip is not None
+    assert "csv_small_1k.csv" in skip
+    assert "csv_missing.csv" in skip
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
+++ b/tests/unit/core/write_primitives/test_write_primitives_benchmark_coverage.py
@@ -1070,7 +1070,7 @@ class TestExecuteDataframeWorkload:
 class TestSelectDataframeOperationIds:
     def test_returns_all_when_no_filter(self, wp):
         ids = wp._select_dataframe_operation_ids(query_filter=None)
-        assert len(ids) == len(wp.get_all_operations())
+        assert len(ids) == len(wp.operations_manager.get_all_operations())
 
     def test_filters_by_op_id(self, wp):
         all_ids = list(wp.get_all_operations().keys())
@@ -1087,4 +1087,4 @@ class TestSelectDataframeOperationIds:
 
     def test_empty_filter_returns_all(self, wp):
         ids = wp._select_dataframe_operation_ids(query_filter=set())
-        assert len(ids) == len(wp.get_all_operations())
+        assert len(ids) == len(wp.operations_manager.get_all_operations())

--- a/tests/unit/test_coffeeshop.py
+++ b/tests/unit/test_coffeeshop.py
@@ -40,8 +40,8 @@ skip_windows_file_io = pytest.mark.skipif(
 )
 
 SEED_CHECKSUMS = {
-    "dim_locations.csv": "5227b1b0f06f2719cd9a80303ac8953bb32ec89182f11b79696f1bbc48c67c1d",
-    "dim_products.csv": "f0960c23931618fc658cb0faab5980b7ce3a5731e561f912434fb9c01cbe447a",
+    "dim_locations.csv": "649a37932a6939bf81b363b8dbb2e0258c27a470cabe8aff3de27e6bfc8db915",
+    "dim_products.csv": "663af10fcd72d4c29ede2da457a5baa4a03656aa5ace7171ce5e4cb2c314cf26",
 }
 
 


### PR DESCRIPTION
- **ci: restore release verification contracts**
- **fix(write-primitives): preserve SQL run defaults**
- **fix(config): expose clickhouse mode alias**
- **test(coffeeshop): refresh seed checksums**
- **docs: record TODO review freshness blind spot**
- **test: align release and write-primitives contracts**
