### PR TITLE
fix: strip trino primary key ddl metadata

### DIFF
--- a/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
+++ b/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
@@ -2,7 +2,7 @@ id: joinorder-trino-primary-key-ddl
 title: "Strip JoinOrder primary-key constraints from Trino CREATE TABLE DDL"
 worktree: main
 priority: Medium
-status: Not Started
+status: Under Review
 category: Platform Compatibility
 
 description: |
@@ -20,17 +20,23 @@ description: |
 work:
   - id: w1
     summary: "Confirm Trino connector behavior for PRIMARY KEY metadata"
-    status: pending
+    status: done
     notes: |
       Re-check Trino memory and Hive/Iceberg connector CREATE TABLE behavior
       with a minimal statement containing both inline and table-level PRIMARY
       KEY metadata. If current Trino accepts the metadata, document that and
       close this as no-op.
 
+      2026-05-26 evidence: Trino 481 CREATE TABLE syntax documents column
+      type/default/null/comment/properties and table WITH properties, not inline
+      or table-level PRIMARY KEY constraints. Memory, Hive, and Iceberg connector
+      docs document CREATE TABLE support and connector properties, with no
+      PRIMARY KEY acceptance path. No live Trino run was used.
+
   - id: w2
     summary: "Apply the shared primary-key stripping helper if Trino rejects the metadata"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       If Trino rejects PRIMARY KEY metadata, import `strip_primary_keys` from
       `benchbox.platforms.base.ddl_helpers` and call it before memory/Hive
@@ -39,7 +45,7 @@ work:
   - id: w3
     summary: "Add focused Trino optimizer regression coverage"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Cover inline `id INTEGER PRIMARY KEY` and table-level
       `PRIMARY KEY (id, coalesce(other_id, 0))` inputs. Keep the test focused

--- a/benchbox/platforms/trino.py
+++ b/benchbox/platforms/trino.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from benchbox.platforms.base.ddl_helpers import strip_with_properties
+from benchbox.platforms.base.ddl_helpers import strip_primary_keys, strip_with_properties
 
 from ..utils.dependencies import (
     check_platform_dependencies,
@@ -194,6 +194,11 @@ class TrinoAdapter(PrestoTrinoAdapterBase):
         """
         if not statement.upper().startswith("CREATE TABLE"):
             return statement
+
+        # Trino CREATE TABLE syntax does not include PRIMARY KEY constraints.
+        # BenchBox workloads load immutable benchmark data, so the constraint is
+        # metadata only and can be stripped for all Trino catalogs.
+        statement = strip_primary_keys(statement)
 
         # For memory catalog, remove any Trino-incompatible syntax
         # Memory catalog doesn't support WITH properties for the most part

--- a/tests/unit/platforms/test_trino_adapter.py
+++ b/tests/unit/platforms/test_trino_adapter.py
@@ -1408,6 +1408,46 @@ class TestTrinoTableDefinitionOptimization:
         result = adapter._optimize_table_definition(sql)
         assert "WITH (format = 'PARQUET')" in result
 
+    @pytest.mark.parametrize(
+        ("table_format", "adds_format"),
+        [("memory", False), ("hive", True), ("iceberg", True), ("delta", False)],
+    )
+    def test_strips_inline_primary_key_metadata(self, table_format, adds_format):
+        adapter = self._adapter(table_format=table_format)
+        sql = "CREATE TABLE kind_type (id INTEGER PRIMARY KEY, kind VARCHAR(15) NOT NULL)"
+        result = adapter._optimize_table_definition(sql)
+        result_upper = result.upper()
+
+        assert "PRIMARY KEY" not in result_upper
+        assert "id INTEGER" in result
+        if table_format == "memory":
+            assert "NOT NULL" not in result_upper
+        else:
+            assert "NOT NULL" in result_upper
+        if adds_format:
+            assert "WITH (format = 'PARQUET')" in result
+        else:
+            assert "WITH" not in result_upper
+
+    @pytest.mark.parametrize(
+        ("table_format", "adds_format"),
+        [("memory", False), ("hive", True), ("iceberg", True), ("delta", False)],
+    )
+    def test_strips_table_level_primary_key_metadata_with_nested_expression(self, table_format, adds_format):
+        adapter = self._adapter(table_format=table_format)
+        sql = "CREATE TABLE edge_case (id BIGINT, other_id BIGINT, PRIMARY KEY (id, coalesce(other_id, 0)))"
+        result = adapter._optimize_table_definition(sql)
+        result_upper = result.upper()
+
+        assert "PRIMARY KEY" not in result_upper
+        assert "coalesce" not in result
+        assert "id BIGINT" in result
+        assert "other_id BIGINT" in result
+        if adds_format:
+            assert "WITH (format = 'PARQUET')" in result
+        else:
+            assert "WITH" not in result_upper
+
 
 class TestTrinoConfigureForBenchmark:
     """Tests for configure_for_benchmark."""


### PR DESCRIPTION
Summary:
- Strip PRIMARY KEY metadata in Trino CREATE TABLE optimization before connector-specific rewrites.
- Add focused Trino adapter coverage for inline and table-level PRIMARY KEY stripping across memory, Hive, Iceberg, and Delta table formats.
- Mark joinorder-trino-primary-key-ddl work units done with compact Trino 481 documentation evidence.

Verification:
- uv run -- python -m pytest tests/unit/platforms/test_trino_adapter.py -q (107 passed)
- uv run -- python -m pytest tests/unit/platforms/base/test_ddl_helpers.py -q (22 passed)
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph (passed)
- uv run --project _project/scripts -- python _project/scripts/todo_cli.py validate _project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml (passed)
- make pr-preflight (22697 passed, 6 skipped, 42 warnings, 4 subtests passed)

CI note:
- GitHub Actions are currently blocked outside this diff: checkout/auto-merge jobs fail with 403 "Your account is suspended", and some action downloads fail from codeload.github.com during setup.