### PR TITLE
fix: repair shrink campaign guardrails

### DIFF
--- a/_project/shrink-ledger/shrink-campaign-pr-audit-followups.md
+++ b/_project/shrink-ledger/shrink-campaign-pr-audit-followups.md
@@ -1,0 +1,99 @@
+---
+iteration: shrink-campaign-pr-audit-followups
+date: 2026-05-26
+surface: shrink campaign audit follow-up repairs
+branch: fix/shrink-campaign-pr-audit
+pr:
+raw_cloc_delta: -60
+credited_reduction: 0
+uncredited_relocation: 0
+repair_only_delta: -60
+generated_python_delta: 0
+moved_content: none
+decision_gate: conservative default
+verification:
+  - gh pr list --repo joeharris76/BenchBox --state merged --base develop --limit 200 --json number,title,mergedAt,headRefName,url
+  - make shrink-rollup
+  - cloc --include-lang=Python benchbox/
+  - uv run -- ruff check benchbox/core/dataframe/query.py benchbox/core/read_primitives/dataframe_queries.py benchbox/core/tpcds/dataframe_queries/__init__.py benchbox/core/tpcds/dataframe_queries/registry.py benchbox/core/tpcds/dataframe_queries/queries.py benchbox/core/tuning/coverage.py tests/unit/core/test_registry_lazy_load.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py tests/unit/cli/test_cli_package_exports.py
+  - uv run -- ty check benchbox/core/dataframe/query.py benchbox/core/read_primitives/dataframe_queries.py benchbox/core/tpcds/dataframe_queries/__init__.py benchbox/core/tpcds/dataframe_queries/registry.py benchbox/core/tpcds/dataframe_queries/queries.py benchbox/core/tuning/coverage.py tests/uat/test_tuning_coverage.py tests/unit/cli/test_cli_package_exports.py
+  - uv run -- python -m pytest tests/unit/cli/test_cli_package_exports.py tests/unit/core/test_registry_lazy_load.py tests/unit/core/test_dataframe_generated_impl_registry.py tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/benchmarks/test_read_primitives_dataframe_queries.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py -q -n 0
+  - uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_dataframe.py -q -n 0
+  - make catalog-schema-check
+  - make compat-docs-check
+  - make pr-preflight
+---
+
+## Thesis
+
+Audit follow-up for the merged shrink campaign PR set. This PR intentionally
+claims zero shrink credit: it fixes regressions and stale guardrail metadata
+found while reviewing the completed shrink PRs, and it records the 60-line
+repair cost explicitly instead of treating the work as a new shrink thesis.
+
+The audit regenerated the current merged shrink PR set from GitHub and reviewed
+102 merged shrink PRs in ascending PR-number order, including the seeded PR set
+and any shrink PRs merged since that seed. PR #581 exceeded the GitHub PR diff
+API limit, so its squash merge commit diff was used as the local review
+artifact.
+
+## Findings Fixed
+
+- PRs that deleted `benchbox/cli/execution.py` and
+  `benchbox/cli/validation.py` left those paths in the CLI-surface drift
+  allowlist. The stale allowlist entries are removed so the UAT guard now
+  reflects the current package surface.
+- The TPC-DI transformations deletion left stale references in Ruff per-file
+  ignores and coverage omit configuration. Those dead config paths are removed.
+- The shrink campaign left import-time metadata reads in DataFrame query
+  registries and tuning coverage. Read Primitives and TPC-DS DataFrame query
+  metadata now load through a lazy registry, and tuning coverage loads
+  `coverage.yaml` only when backlog data is needed.
+- The tuning import constants are now checked against the YAML source when the
+  YAML is explicitly loaded, preserving the no-import-I/O guardrail without
+  creating an untested duplicate source of truth.
+
+## Guardrail Evidence
+
+- Iteration type: guardrail repair.
+- Moved-content classification: none. No Python logic was relocated into data,
+  generated Python, SQL, YAML, or benchmark data.
+- Decision-gate status: conservative default. The lazy metadata changes follow
+  the existing runtime-load pattern ratified by the catalog-source ADR; this PR
+  does not approve a new catalog or code-generation pattern.
+- Ledger classification: zero credited reduction, `raw_cloc_delta: -60`, and
+  `repair_only_delta: -60`, based on `cloc --include-lang=Python benchbox/`
+  increasing from 195079 to 195139 maintained Python code lines.
+- Deleted-path sweep: exact references to shrink-deleted Python paths are gone
+  from current package code, tests, docs, and `pyproject.toml`. Archived
+  `_project/DONE` provenance and the 2026-04-30 path-filter evidence note still
+  mention historical paths and were left as historical records, not active
+  guardrails.
+- Import-time I/O sweep: an AST scan over shrink-touched `benchbox/**/*.py`
+  reports zero module-level `open`, `read_text`, `read_bytes`, or
+  `yaml.safe_load(Path(...).read_text(...))` candidates after the repair.
+
+## Verification
+
+- `make shrink-rollup`: 26 merged fragments before this PR body, 12090
+  cumulative merged credited reduction, 0 remaining to the committed floor.
+- `cloc --include-lang=Python benchbox/`: 913 Python files and 195139 code
+  lines after repairs.
+- `uv run -- ruff check ...`: pass for all touched runtime and test files.
+- `uv run -- ty check ...`: pass for touched runtime files and tuning tests.
+- `uv run -- python -m pytest tests/unit/cli/test_cli_package_exports.py tests/unit/core/test_registry_lazy_load.py tests/unit/core/test_dataframe_generated_impl_registry.py tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/benchmarks/test_read_primitives_dataframe_queries.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py -q -n 0`:
+  pass, 98 tests.
+- `uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_dataframe.py -q -n 0`:
+  pass, 383 tests.
+- `make catalog-schema-check`: pass.
+- `make compat-docs-check`: pass.
+- `make pr-preflight`: pass; CI lint passed and the fast lane reported 22692
+  passed, 5 skipped, 42 warnings, and 4 subtests passed.
+
+## Residual Risk
+
+The branch is deliberately repair-only and increases maintained Python by 60
+lines. The remaining risk is limited to lazy-load timing: first registry access
+now performs metadata file reads that previously happened at import time. The
+existing query registry and benchmark tests cover query IDs, callable identity,
+package data inclusion, and DataFrame behavior after first access.

--- a/benchbox/core/dataframe/query.py
+++ b/benchbox/core/dataframe/query.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable
+from threading import Lock
+from typing import TYPE_CHECKING, Any, Callable, Iterable, NamedTuple
 
 if TYPE_CHECKING:
     from benchbox.core.dataframe.context import DataFrameContext
@@ -275,7 +276,7 @@ class QueryRegistry:
         ```
     """
 
-    def __init__(self, benchmark: str) -> None:
+    def __init__(self, benchmark: str, loader: Callable[[], Iterable[DataFrameQuery]] | None = None) -> None:
         """Initialize a new QueryRegistry.
 
         Args:
@@ -283,6 +284,38 @@ class QueryRegistry:
         """
         self.benchmark = benchmark
         self._queries: dict[str, DataFrameQuery] = {}
+        self._loader = loader
+        self._load_lock = Lock()
+        self._loaded = False
+        self._load_hits = 0
+        self._load_misses = 0
+
+    def set_loader(self, loader: Callable[[], Iterable[DataFrameQuery]]) -> None:
+        """Set the lazy loader before the registry has been populated."""
+        with self._load_lock:
+            if self._loaded or self._queries:
+                raise RuntimeError(f"{self.benchmark} registry loader cannot be changed after loading")
+            self._loader = loader
+
+    def _register_query(self, query: DataFrameQuery) -> None:
+        if query.query_id in self._queries:
+            raise ValueError(f"Query '{query.query_id}' already registered in {self.benchmark} registry")
+        self._queries[query.query_id] = query
+
+    def _ensure_loaded(self) -> None:
+        if self._loader is None:
+            return
+        with self._load_lock:
+            if self._loaded:
+                self._load_hits += 1
+                return
+            if self._loader is None:
+                return
+
+            self._load_misses += 1
+            for query in self._loader():
+                self._register_query(query)
+            self._loaded = True
 
     def register(self, query: DataFrameQuery) -> None:
         """Register a query in the registry.
@@ -293,9 +326,8 @@ class QueryRegistry:
         Raises:
             ValueError: If a query with the same ID already exists
         """
-        if query.query_id in self._queries:
-            raise ValueError(f"Query '{query.query_id}' already registered in {self.benchmark} registry")
-        self._queries[query.query_id] = query
+        self._ensure_loaded()
+        self._register_query(query)
 
     def register_many(self, queries: list[DataFrameQuery]) -> None:
         """Register multiple queries at once.
@@ -303,8 +335,9 @@ class QueryRegistry:
         Args:
             queries: List of queries to register
         """
+        self._ensure_loaded()
         for query in queries:
-            self.register(query)
+            self._register_query(query)
 
     def get(self, query_id: str) -> DataFrameQuery | None:
         """Get a query by ID.
@@ -315,6 +348,7 @@ class QueryRegistry:
         Returns:
             The query, or None if not found
         """
+        self._ensure_loaded()
         return self._queries.get(query_id)
 
     def get_or_raise(self, query_id: str) -> DataFrameQuery:
@@ -340,6 +374,7 @@ class QueryRegistry:
         Returns:
             List of all queries, sorted by query_id
         """
+        self._ensure_loaded()
         return sorted(self._queries.values(), key=lambda q: q.query_id)
 
     def get_query_ids(self) -> list[str]:
@@ -348,6 +383,7 @@ class QueryRegistry:
         Returns:
             Sorted list of query IDs
         """
+        self._ensure_loaded()
         return sorted(self._queries.keys())
 
     def get_queries_by_category(self, category: QueryCategory) -> list[DataFrameQuery]:
@@ -409,12 +445,34 @@ class QueryRegistry:
 
     def __len__(self) -> int:
         """Return the number of registered queries."""
+        self._ensure_loaded()
         return len(self._queries)
 
     def __contains__(self, query_id: str) -> bool:
         """Check if a query ID is registered."""
+        self._ensure_loaded()
         return query_id in self._queries
 
     def __iter__(self):
         """Iterate over query IDs."""
+        self._ensure_loaded()
         return iter(sorted(self._queries.keys()))
+
+    def load_info(self) -> QueryRegistryLoadInfo:
+        """Return lazy-load statistics."""
+        with self._load_lock:
+            return QueryRegistryLoadInfo(
+                hits=self._load_hits,
+                misses=self._load_misses,
+                maxsize=1,
+                currsize=1 if self._loaded else 0,
+            )
+
+
+class QueryRegistryLoadInfo(NamedTuple):
+    """Lazy query-registry load statistics for import-path tests."""
+
+    hits: int
+    misses: int
+    maxsize: int
+    currsize: int

--- a/benchbox/core/read_primitives/dataframe_queries.py
+++ b/benchbox/core/read_primitives/dataframe_queries.py
@@ -3669,8 +3669,6 @@ _CATEGORY_CODES = {
     "W": QueryCategory.WINDOW,
 }
 
-_QUERY_METADATA = Path(__file__).with_name("dataframe_query_metadata.csv").read_text(encoding="utf-8")
-
 # Index the explicit module-level `def *_impl` functions into the same registry
 # the factories populate, so the dispatch resolves both kinds with one typed
 # lookup. Runs after every def and factory loop above; globals() is only read,
@@ -3702,11 +3700,12 @@ def _make_query(row: list[str]) -> DataFrameQuery:
     )
 
 
-_QUERIES = [_make_query(row) for row in reader(_QUERY_METADATA.splitlines(), delimiter="|")]
+def _load_queries() -> list[DataFrameQuery]:
+    metadata = Path(__file__).with_name("dataframe_query_metadata.csv").read_text(encoding="utf-8")
+    return [_make_query(row) for row in reader(metadata.splitlines(), delimiter="|")]
 
-# Register all queries
-for query in _QUERIES:
-    REGISTRY.register(query)
+
+REGISTRY.set_loader(_load_queries)
 
 
 def get_dataframe_queries() -> QueryRegistry:

--- a/benchbox/core/tpcds/dataframe_queries/__init__.py
+++ b/benchbox/core/tpcds/dataframe_queries/__init__.py
@@ -13,7 +13,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
-# Import queries module to trigger registration
+# Import queries module to configure the lazy registry loader.
 from benchbox.core.tpcds.dataframe_queries import queries as _queries  # noqa: F401
 from benchbox.core.tpcds.dataframe_queries.registry import (
     TPCDS_DATAFRAME_QUERIES,

--- a/benchbox/core/tpcds/dataframe_queries/queries.py
+++ b/benchbox/core/tpcds/dataframe_queries/queries.py
@@ -31,7 +31,7 @@ from benchbox.core.dataframe.context import DataFrameContext
 from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 
 from .parameters import get_parameters
-from .registry import register_query
+from .registry import configure_query_loader
 
 # =============================================================================
 # Simple Queries - 3-table joins with straightforward aggregation
@@ -9785,8 +9785,6 @@ _CATEGORY_CODES = {
     "W": QueryCategory.WINDOW,
 }
 
-_QUERY_METADATA = Path(__file__).with_name("query_metadata.csv").read_text(encoding="utf-8")
-
 
 def _impl_for(query_id: str, family: str) -> QueryImpl:
     name = f"q{query_id[1:].lower()}_{family}_impl"
@@ -9796,20 +9794,20 @@ def _impl_for(query_id: str, family: str) -> QueryImpl:
     return _GENERATED_IMPLS[name]
 
 
-def _register_all_queries() -> None:
-    """Register all TPC-DS DataFrame queries."""
-    for query_id, query_name, description, category_codes in reader(_QUERY_METADATA.splitlines(), delimiter="|"):
-        register_query(
-            DataFrameQuery(
-                query_id=query_id,
-                query_name=query_name,
-                description=description,
-                categories=[_CATEGORY_CODES[code] for code in category_codes.split(",")],
-                expression_impl=_impl_for(query_id, "expression"),
-                pandas_impl=_impl_for(query_id, "pandas"),
-            )
+def _load_queries() -> list[DataFrameQuery]:
+    """Load all TPC-DS DataFrame query metadata."""
+    metadata = Path(__file__).with_name("query_metadata.csv").read_text(encoding="utf-8")
+    return [
+        DataFrameQuery(
+            query_id=query_id,
+            query_name=query_name,
+            description=description,
+            categories=[_CATEGORY_CODES[code] for code in category_codes.split(",")],
+            expression_impl=_impl_for(query_id, "expression"),
+            pandas_impl=_impl_for(query_id, "pandas"),
         )
+        for query_id, query_name, description, category_codes in reader(metadata.splitlines(), delimiter="|")
+    ]
 
 
-# Register all queries when module is imported
-_register_all_queries()
+configure_query_loader(_load_queries)

--- a/benchbox/core/tpcds/dataframe_queries/registry.py
+++ b/benchbox/core/tpcds/dataframe_queries/registry.py
@@ -12,10 +12,18 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import Callable
+
 from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory, QueryRegistry
 
 # TPC-DS DataFrame Query Registry
 TPCDS_DATAFRAME_QUERIES = QueryRegistry("tpcds")
+
+
+def configure_query_loader(loader: Callable[[], Iterable[DataFrameQuery]]) -> None:
+    """Configure the lazy loader for generated TPC-DS query metadata."""
+    TPCDS_DATAFRAME_QUERIES.set_loader(loader)
 
 
 def get_tpcds_query(query_id: str) -> DataFrameQuery | None:

--- a/benchbox/core/tuning/coverage.py
+++ b/benchbox/core/tuning/coverage.py
@@ -10,38 +10,50 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Iterable, Mapping
 
 import yaml
 
-_SPEC = yaml.safe_load((Path(__file__).with_suffix(".yaml")).read_text(encoding="utf-8"))
-_STATUS_BY_KEY = {status["key"]: status for status in _SPEC["statuses"]}
-_DECISION_BY_KEY = {decision["key"]: decision for decision in _SPEC["decisions"]}
+TUNED_TEMPLATE = "tuned_template"
+BASIC_CONSTRAINTS = "basic_constraints"
+UNTUNED = "untuned"
+VALID_STATUSES = frozenset({TUNED_TEMPLATE, BASIC_CONSTRAINTS, UNTUNED})
 
-TUNED_TEMPLATE = _STATUS_BY_KEY["tuned_template"]["value"]
-BASIC_CONSTRAINTS = _STATUS_BY_KEY["basic_constraints"]["value"]
-UNTUNED = _STATUS_BY_KEY["untuned"]["value"]
-VALID_STATUSES = frozenset(status["value"] for status in _SPEC["statuses"])
+DECISION_AUTHOR = "author"
+DECISION_WAIVED = "waived"
+DECISION_DONE = "done"
+VALID_DECISIONS = frozenset({DECISION_AUTHOR, DECISION_WAIVED, DECISION_DONE})
 
-DECISION_AUTHOR = _DECISION_BY_KEY["author"]["value"]
-DECISION_WAIVED = _DECISION_BY_KEY["waived"]["value"]
-DECISION_DONE = _DECISION_BY_KEY["done"]["value"]
-VALID_DECISIONS = frozenset(decision["value"] for decision in _SPEC["decisions"])
-
-STATUS_RANK = {status["value"]: status["rank"] for status in _SPEC["statuses"]}
+STATUS_RANK = {
+    TUNED_TEMPLATE: 2,
+    BASIC_CONSTRAINTS: 1,
+    UNTUNED: 0,
+}
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TUNING_TEMPLATE_ROOT = REPO_ROOT / "examples" / "tunings"
-MATRIX_COLUMNS = tuple(_SPEC["matrix_columns"])
+MATRIX_COLUMNS = ("platform", "benchmark", "status", "decision", "reason", "template_path")
 
-# The 2026-05-05 handoff called these out as high-priority tuned-template gaps.
-HIGH_PRIORITY_AUTHOR_BACKLOG = frozenset(
-    (entry["platform"], entry["benchmark"]) for entry in _SPEC["high_priority_author_backlog"]
+_RUNTIME_STATUS_MARKERS: tuple[tuple[str, str], ...] = (
+    ("Tuning: auto-discovered template", TUNED_TEMPLATE),
+    ("Tuning: using basic constraints", BASIC_CONSTRAINTS),
+    ("Tuning disabled:", UNTUNED),
 )
-_RUNTIME_STATUS_MARKERS: tuple[tuple[str, str], ...] = tuple(
-    (status["runtime_marker"], status["value"]) for status in _SPEC["statuses"]
-)
+
+
+@cache
+def _coverage_spec() -> dict:
+    return yaml.safe_load((Path(__file__).with_suffix(".yaml")).read_text(encoding="utf-8"))
+
+
+@cache
+def _high_priority_author_backlog() -> frozenset[tuple[str, str]]:
+    # The 2026-05-05 handoff called these out as high-priority tuned-template gaps.
+    return frozenset(
+        (entry["platform"], entry["benchmark"]) for entry in _coverage_spec()["high_priority_author_backlog"]
+    )
 
 
 @dataclass(frozen=True)
@@ -122,7 +134,7 @@ def default_decision(platform: str, benchmark: str, status: str) -> tuple[str, s
     """Return the matrix disposition for one platform/benchmark status."""
     if status == TUNED_TEMPLATE:
         return DECISION_DONE, "benchmark-specific tuned template exists"
-    if (platform, benchmark) in HIGH_PRIORITY_AUTHOR_BACKLOG:
+    if (platform, benchmark) in _high_priority_author_backlog():
         return DECISION_AUTHOR, "high-priority backlog from 2026-05-05 fallback evidence"
     if status == BASIC_CONSTRAINTS:
         return DECISION_WAIVED, "basic constraints are acceptable until measured benefit justifies a template"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -631,7 +631,6 @@ max-complexity = 18
 # preview mode for names defined in TYPE_CHECKING blocks or deferred imports.
 "**/__init__.py" = ["F401", "F811", "F822"]
 # Pre-existing violations surfaced by preview mode; out of scope for windows-ci-hardening.
-"benchbox/core/tpcdi/etl/transformations.py" = ["C419"]  # unnecessary list comprehension in max()
 "benchbox/utils/runtime_env.py" = ["F401"]               # unused importlib.machinery import
 # PLW1514 (unspecified-encoding): all benchbox/ sites now have explicit encoding=
 # (fixed under quality-bulk-fix-encoding-lint-and-ratchet). Per-file-ignores removed.
@@ -700,7 +699,6 @@ omit = [
     "benchbox/core/nyctaxi/dataframe_queries/queries.py",
     # TPC-DI ETL: requires full CDC/SCD pipeline infrastructure with staged
     # incremental loads. Cannot be meaningfully unit-tested at unit granularity.
-    "benchbox/core/tpcdi/etl/transformations.py",
     "benchbox/core/tpcdi/etl/scd_processor.py",
     # Experimental concurrency: changes frequently, pool tester requires real
     # concurrent database connections (~284 miss stmts).

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -26,8 +26,6 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/commands/visualize.py",
     "benchbox/cli/config.py",
     "benchbox/cli/display.py",
-    "benchbox/cli/execution.py",
-    "benchbox/cli/validation.py",
     "benchbox/cli/help.py",
     "benchbox/cli/orchestrator.py",
 }

--- a/tests/uat/test_tuning_coverage.py
+++ b/tests/uat/test_tuning_coverage.py
@@ -11,9 +11,14 @@ from benchbox.core.tuning.coverage import (
     DECISION_AUTHOR,
     DECISION_DONE,
     DECISION_WAIVED,
+    MATRIX_COLUMNS,
+    STATUS_RANK,
     TUNED_TEMPLATE,
+    UNTUNED,
     VALID_DECISIONS,
+    VALID_STATUSES,
     TuningCoverageRow,
+    _coverage_spec,
     build_tuning_coverage_rows,
     parse_runtime_tuning_logs,
     read_tuning_coverage_tsv,
@@ -26,6 +31,23 @@ from tests.uat.matrix import PLATFORM_GROUPS, load_benchmarks, resolve_benchmark
 pytestmark = pytest.mark.fast
 
 MATRIX_PATH = Path(__file__).resolve().parent / "data" / "tuning_coverage.tsv"
+
+
+def test_tuning_coverage_import_constants_match_yaml_spec():
+    spec = _coverage_spec()
+    statuses = {status["key"]: status for status in spec["statuses"]}
+    decisions = {decision["key"]: decision for decision in spec["decisions"]}
+
+    assert statuses["tuned_template"]["value"] == TUNED_TEMPLATE
+    assert statuses["basic_constraints"]["value"] == BASIC_CONSTRAINTS
+    assert statuses["untuned"]["value"] == UNTUNED
+    assert {status["value"] for status in spec["statuses"]} == VALID_STATUSES
+    assert {status["value"]: status["rank"] for status in spec["statuses"]} == STATUS_RANK
+    assert decisions["author"]["value"] == DECISION_AUTHOR
+    assert decisions["waived"]["value"] == DECISION_WAIVED
+    assert decisions["done"]["value"] == DECISION_DONE
+    assert {decision["value"] for decision in spec["decisions"]} == VALID_DECISIONS
+    assert tuple(spec["matrix_columns"]) == MATRIX_COLUMNS
 
 
 def test_tuning_coverage_matrix_is_checked_in_and_has_decisions():

--- a/tests/unit/core/test_registry_lazy_load.py
+++ b/tests/unit/core/test_registry_lazy_load.py
@@ -39,6 +39,18 @@ def test_catalogs_load_lazily_not_at_import() -> None:
     assert lines == ["0 0", "1 1"]
 
 
+def test_dataframe_query_metadata_loads_lazily_not_at_import() -> None:
+    lines = _run(
+        "import benchbox.core.read_primitives.dataframe_queries as rp;"
+        "import benchbox.core.tpcds.dataframe_queries as tpcds;"
+        "print(rp.REGISTRY.load_info().misses, tpcds.TPCDS_DATAFRAME_QUERIES.load_info().misses);"
+        "len(rp.REGISTRY);"
+        "len(tpcds.TPCDS_DATAFRAME_QUERIES);"
+        "print(rp.REGISTRY.load_info().misses, tpcds.TPCDS_DATAFRAME_QUERIES.load_info().misses)"
+    )
+    assert lines == ["0 0", "1 1"]
+
+
 def test_lazy_registry_first_access_is_single_flight(monkeypatch: pytest.MonkeyPatch) -> None:
     import benchbox.core.benchmark_registry as r
 


### PR DESCRIPTION
---
iteration: shrink-campaign-pr-audit-followups
date: 2026-05-26
surface: shrink campaign audit follow-up repairs
branch: fix/shrink-campaign-pr-audit
pr:
raw_cloc_delta: -60
credited_reduction: 0
uncredited_relocation: 0
repair_only_delta: -60
generated_python_delta: 0
moved_content: none
decision_gate: conservative default
verification:
  - gh pr list --repo joeharris76/BenchBox --state merged --base develop --limit 200 --json number,title,mergedAt,headRefName,url
  - make shrink-rollup
  - cloc --include-lang=Python benchbox/
  - uv run -- ruff check benchbox/core/dataframe/query.py benchbox/core/read_primitives/dataframe_queries.py benchbox/core/tpcds/dataframe_queries/__init__.py benchbox/core/tpcds/dataframe_queries/registry.py benchbox/core/tpcds/dataframe_queries/queries.py benchbox/core/tuning/coverage.py tests/unit/core/test_registry_lazy_load.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py tests/unit/cli/test_cli_package_exports.py
  - uv run -- ty check benchbox/core/dataframe/query.py benchbox/core/read_primitives/dataframe_queries.py benchbox/core/tpcds/dataframe_queries/__init__.py benchbox/core/tpcds/dataframe_queries/registry.py benchbox/core/tpcds/dataframe_queries/queries.py benchbox/core/tuning/coverage.py tests/uat/test_tuning_coverage.py tests/unit/cli/test_cli_package_exports.py
  - uv run -- python -m pytest tests/unit/cli/test_cli_package_exports.py tests/unit/core/test_registry_lazy_load.py tests/unit/core/test_dataframe_generated_impl_registry.py tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/benchmarks/test_read_primitives_dataframe_queries.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py -q -n 0
  - uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_dataframe.py -q -n 0
  - make catalog-schema-check
  - make compat-docs-check
  - make pr-preflight
---

## Thesis

Audit follow-up for the merged shrink campaign PR set. This PR intentionally
claims zero shrink credit: it fixes regressions and stale guardrail metadata
found while reviewing the completed shrink PRs, and it records the 60-line
repair cost explicitly instead of treating the work as a new shrink thesis.

The audit regenerated the current merged shrink PR set from GitHub and reviewed
102 merged shrink PRs in ascending PR-number order, including the seeded PR set
and any shrink PRs merged since that seed. PR #581 exceeded the GitHub PR diff
API limit, so its squash merge commit diff was used as the local review
artifact.

## Findings Fixed

- PRs that deleted `benchbox/cli/execution.py` and
  `benchbox/cli/validation.py` left those paths in the CLI-surface drift
  allowlist. The stale allowlist entries are removed so the UAT guard now
  reflects the current package surface.
- The TPC-DI transformations deletion left stale references in Ruff per-file
  ignores and coverage omit configuration. Those dead config paths are removed.
- The shrink campaign left import-time metadata reads in DataFrame query
  registries and tuning coverage. Read Primitives and TPC-DS DataFrame query
  metadata now load through a lazy registry, and tuning coverage loads
  `coverage.yaml` only when backlog data is needed.
- The tuning import constants are now checked against the YAML source when the
  YAML is explicitly loaded, preserving the no-import-I/O guardrail without
  creating an untested duplicate source of truth.

## Guardrail Evidence

- Iteration type: guardrail repair.
- Moved-content classification: none. No Python logic was relocated into data,
  generated Python, SQL, YAML, or benchmark data.
- Decision-gate status: conservative default. The lazy metadata changes follow
  the existing runtime-load pattern ratified by the catalog-source ADR; this PR
  does not approve a new catalog or code-generation pattern.
- Ledger classification: zero credited reduction, `raw_cloc_delta: -60`, and
  `repair_only_delta: -60`, based on `cloc --include-lang=Python benchbox/`
  increasing from 195079 to 195139 maintained Python code lines.
- Deleted-path sweep: exact references to shrink-deleted Python paths are gone
  from current package code, tests, docs, and `pyproject.toml`. Archived
  `_project/DONE` provenance and the 2026-04-30 path-filter evidence note still
  mention historical paths and were left as historical records, not active
  guardrails.
- Import-time I/O sweep: an AST scan over shrink-touched `benchbox/**/*.py`
  reports zero module-level `open`, `read_text`, `read_bytes`, or
  `yaml.safe_load(Path(...).read_text(...))` candidates after the repair.

## Verification

- `make shrink-rollup`: 26 merged fragments before this PR body, 12090
  cumulative merged credited reduction, 0 remaining to the committed floor.
- `cloc --include-lang=Python benchbox/`: 913 Python files and 195139 code
  lines after repairs.
- `uv run -- ruff check ...`: pass for all touched runtime and test files.
- `uv run -- ty check ...`: pass for touched runtime files and tuning tests.
- `uv run -- python -m pytest tests/unit/cli/test_cli_package_exports.py tests/unit/core/test_registry_lazy_load.py tests/unit/core/test_dataframe_generated_impl_registry.py tests/unit/core/tpcds/test_tpcds_dataframe_queries.py tests/unit/benchmarks/test_read_primitives_dataframe_queries.py tests/uat/test_tuning_coverage.py tests/uat/test_no_cli_surface_drift.py -q -n 0`:
  pass, 98 tests.
- `uv run -- python -m pytest tests/unit/core/read_primitives/test_read_primitives_dataframe.py -q -n 0`:
  pass, 383 tests.
- `make catalog-schema-check`: pass.
- `make compat-docs-check`: pass.
- `make pr-preflight`: pass; CI lint passed and the fast lane reported 22692
  passed, 5 skipped, 42 warnings, and 4 subtests passed.

## Residual Risk

The branch is deliberately repair-only and increases maintained Python by 60
lines. The remaining risk is limited to lazy-load timing: first registry access
now performs metadata file reads that previously happened at import time. The
existing query registry and benchmark tests cover query IDs, callable identity,
package data inclusion, and DataFrame behavior after first access.
