### PR TITLE
fix(release): generate changelog from main delta

### DIFF
--- a/.github/RELEASE_PR_TEMPLATE.md
+++ b/.github/RELEASE_PR_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 This PR was opened by `make release-cut VERSION=X.Y.Z` from `develop`.
 It cuts the release branch, bumps the version sources, generates the
-CHANGELOG entry, drops maintainer paths (`_project/`, `_blog/`, agent
-configs, dev-tooling root files), and queues the change for a
+CHANGELOG entry from `origin/main..HEAD`, drops maintainer paths (`_project/`,
+`_blog/`, agent configs, dev-tooling root files), and queues the change for a
 squash-merge into `main`.
 
 ### Reviewer checklist

--- a/Makefile
+++ b/Makefile
@@ -777,7 +777,7 @@ RELEASE_REQUIRED_CONTEXTS := validate-base release-required-result
 # Cut a release branch from develop in one shot:
 #   1. Create v$(VERSION) branch off develop (develop is not modified).
 #   2. On v$(VERSION): bump version sources (scripts/update_version.py).
-#   3. On v$(VERSION): generate CHANGELOG.md entry.
+#   3. On v$(VERSION): generate CHANGELOG.md entry from origin/main..HEAD.
 #   4. $EDITOR opens CHANGELOG.md for hand-curation (skipped if EDITOR unset).
 #   5. Curate: git rm dev-only/deferred paths (per A3 in single-repo-migration.md).
 #   6. Commit "Release v$(VERSION)" (bump + changelog + curation in one squash-friendly commit).
@@ -792,7 +792,7 @@ release-cut:
 	git fetch origin
 	git checkout -b v$(VERSION) develop
 	uv run -- python scripts/update_version.py --version $(VERSION) --update-pyproject
-	uv run -- python scripts/generate_changelog_entry.py --version $(VERSION)
+	uv run -- python scripts/generate_changelog_entry.py --version $(VERSION) --since-ref origin/main
 	@if [ -n "$$EDITOR" ]; then \
 		echo "==> Opening CHANGELOG.md in $$EDITOR for hand-curation"; \
 		$$EDITOR CHANGELOG.md; \

--- a/_project/notes/v0.3.1-changelog-draft.md
+++ b/_project/notes/v0.3.1-changelog-draft.md
@@ -1,0 +1,77 @@
+# v0.3.1 Changelog Draft
+
+Prepared for the broad `v0.3.1` release cut from current `develop`.
+
+Use this as the starting point when `make release-cut VERSION=0.3.1` opens
+`CHANGELOG.md` for hand-curation. The release-cut generator now uses
+`origin/main..HEAD`; this draft applies editorial grouping on top of that
+range and intentionally omits TODO-only, review-followup-only, and internal
+shrink-campaign bookkeeping commits.
+
+```markdown
+## [0.3.1] - 2026-05-26
+
+### Added
+
+- **Release gate hardening** - Added stable main-release validation contexts,
+  pre-tag release-finalize checks, release canary freshness, ruleset drift
+  checks, dependency-bound reporting, and isolated package smoke gates so
+  release PRs have explicit pre-publish evidence before a public tag is pushed.
+- **Benchmark support diagnostics** - Added support-status metadata,
+  diagnostics, and auditable criteria so benchmark and platform support claims
+  can be checked against registry-backed surfaces instead of hand-maintained
+  prose.
+- **SQL compatibility governance** - Added DDL rewrite inventory and governance
+  checks that make adapter CREATE TABLE rewrites visible, registered, and
+  drift-checked.
+- **Result schema policy** - Added centralized result schema policy and driver
+  metadata propagation so result bundles carry more consistent execution and
+  platform metadata.
+- **Catalog validation infrastructure** - Added YAML-backed schema/catalog specs
+  and validation paths for migrated benchmark catalogs, pricing data, result
+  specs, and query catalogs.
+- **Prompt safety guidance** - Expanded the prompt composer with provenance,
+  paid-platform safety, MCP parity, platform footgun, and CLI hygiene guidance
+  for agent-generated benchmark runs.
+
+### Fixed
+
+- **Clean install import recovery** - Fixed the `benchbox` clean-install import
+  path by declaring the pandas runtime dependency needed by the current
+  ClickHouse/TPC-DI/DataFrame import surface.
+- **Release publication workflow** - Fixed the release path so publication
+  relies on stable pre-merge release contexts instead of post-merge signals that
+  can fail after an immutable tag has started publishing.
+- **Trino primary-key DDL translation** - Stripped unsupported primary-key DDL
+  metadata from Trino output to avoid invalid table definitions.
+- **Benchmark registry and support-status drift** - Hardened registry-derived
+  benchmark counts, support-status visibility, and benchmark class loading so
+  public claims stay aligned with runtime registry behavior.
+- **SQL/catalog loading reliability** - Fixed migrated SQL catalogs by storing
+  SQL as YAML block scalars and lazy-caching registry/spec loads off the import
+  path.
+- **DataFrame query registration** - Fixed generated DataFrame query typing and
+  registration, including TPC-DS generated implementation coverage and
+  fingerprint tests.
+- **JoinOrder platform followups** - Fixed JoinOrder followups for SQLite,
+  Spark, Presto, labels, and corpus-aware UI/platform surfaces.
+- **Landing and prompt pages** - Fixed prompt and landing surfaces so platform
+  lists and command examples are registry-derived, safer for paid runs, and
+  more readable in light/dark themes.
+
+### Changed
+
+- **Large internal simplification pass** - Removed or consolidated unused
+  helpers, legacy TPC reporting surfaces, deprecated CLI shims, static catalogs,
+  platform boilerplate, and duplicate DataFrame query wrappers while preserving
+  runtime behavior through focused tests.
+- **Benchmark catalog storage** - Migrated many benchmark schemas, query
+  catalogs, cost/pricing specs, and result specs toward structured YAML-backed
+  sources.
+- **Release documentation** - Updated release operations docs, release PR
+  templates, and repo-admin settings around the new required contexts, release
+  canary, ruleset drift, and recovery process.
+- **Test lane policy** - Split fast, resource-heavy, stress, live-integration,
+  and release-canary responsibilities more explicitly so release checks are
+  strict without accidentally absorbing long-running advisory suites.
+```

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -77,7 +77,11 @@ must not be bypassed with an undocumented local change.
 
 1. Cuts a `vX.Y.Z` branch off `develop` (`develop` itself is never modified).
 2. Bumps the 6 version sources via `scripts/update_version.py` and generates
-   the CHANGELOG entry via `scripts/generate_changelog_entry.py`.
+   the CHANGELOG entry via `scripts/generate_changelog_entry.py --since-ref
+   origin/main`. The release note boundary is the current release branch diff
+   against `main`, not the latest tag reachable from `develop`, because
+   `release-finalize` intentionally does not replay release commits onto
+   `develop`.
 3. Opens `$EDITOR` on `CHANGELOG.md` for hand-curation. (Headless mode:
    refuses to skip the curation step rather than silently committing
    raw output.)

--- a/scripts/generate_changelog_entry.py
+++ b/scripts/generate_changelog_entry.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate a CHANGELOG.md entry from conventional commits since the last tag.
+"""Generate a CHANGELOG.md entry from conventional commits since a release boundary.
 
 Standalone CLI extracted from scripts/automate_release.py for the version-branch
 release flow. Run on the develop branch to draft a `## [VERSION] - DATE` section
@@ -7,7 +7,8 @@ ahead of cutting the release branch with `make release-prepare`.
 
 Behaviour mirrors the legacy automate_release.py:_build_raw_changelog,
 _summarize_changelog_with_claude, and generate_changelog_entry helpers:
-- Parses commits since the most recent v* tag (or all commits if no tag exists).
+- Parses commits since an explicit lower-bound ref, or since the most recent
+  v* tag when no lower-bound ref is supplied.
 - Categorises conventional commits into Added (feat), Fixed (fix), and
   Changed (perf). Skips test/docs/chore/ci/build/refactor/style and
   non-conventional commits.
@@ -21,6 +22,8 @@ Usage:
     uv run python scripts/generate_changelog_entry.py --version 0.3.0
     uv run python scripts/generate_changelog_entry.py --version 0.3.0 \
         --release-date 2026-04-30 --since-tag v0.2.1
+    uv run python scripts/generate_changelog_entry.py --version 0.3.1 \
+        --since-ref origin/main
 """
 
 from __future__ import annotations
@@ -145,20 +148,11 @@ Now summarize the following raw commits:
     return f"## [{version}] - {release_date}\n\n{summary}\n"
 
 
-def generate_changelog_entry(source: Path, version: str, release_date: str, since_tag: str | None = None) -> bool:
-    """Generate a changelog entry from conventional commits since the last tag.
-
-    Args:
-        source: Source repository path.
-        version: New version string (without leading 'v').
-        release_date: Release date in YYYY-MM-DD format.
-        since_tag: Tag to use as the lower bound (e.g. 'v0.2.1'). If None,
-            the latest matching v* tag is auto-detected.
-
-    Returns:
-        True if changelog was updated, False otherwise.
-    """
-    print(f"\n  Auto-generating changelog entry for v{version}...")
+def _resolve_log_range(source: Path, since_ref: str | None, since_tag: str | None) -> str | None:
+    """Return the git log range for changelog generation."""
+    if since_ref is not None:
+        print(f"  Since ref: {since_ref}")
+        return f"{since_ref}..HEAD"
 
     if since_tag is None:
         result = subprocess.run(
@@ -169,14 +163,40 @@ def generate_changelog_entry(source: Path, version: str, release_date: str, sinc
         )
         if result.returncode != 0:
             print("  Warning: No previous version tag found, using all commits")
-            since_tag = None
-        else:
-            since_tag = result.stdout.strip()
-            print(f"  Previous tag: {since_tag}")
+            return None
+        since_tag = result.stdout.strip()
+        print(f"  Previous tag: {since_tag}")
     else:
         print(f"  Since tag: {since_tag}")
 
-    log_range = f"{since_tag}..HEAD" if since_tag else "HEAD"
+    return f"{since_tag}..HEAD"
+
+
+def generate_changelog_entry(
+    source: Path,
+    version: str,
+    release_date: str,
+    since_tag: str | None = None,
+    since_ref: str | None = None,
+) -> bool:
+    """Generate a changelog entry from conventional commits.
+
+    Args:
+        source: Source repository path.
+        version: New version string (without leading 'v').
+        release_date: Release date in YYYY-MM-DD format.
+        since_tag: Tag to use as the lower bound (e.g. 'v0.2.1'). Ignored
+            when since_ref is set. If neither is set, the latest matching v*
+            tag is auto-detected.
+        since_ref: Ref to use as the lower bound (e.g. 'origin/main'). This is
+            the release-branch flow default because `develop` is intentionally
+            not tagged after releases.
+
+    Returns:
+        True if changelog was updated, False otherwise.
+    """
+    print(f"\n  Auto-generating changelog entry for v{version}...")
+    log_range = _resolve_log_range(source, since_ref=since_ref, since_tag=since_tag) or "HEAD"
     result = subprocess.run(
         ["git", "log", "--format=%s", log_range],
         cwd=source,
@@ -248,7 +268,7 @@ def generate_changelog_entry(source: Path, version: str, release_date: str, sinc
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Generate a CHANGELOG.md entry from conventional commits since the last v* tag."
+        description="Generate a CHANGELOG.md entry from conventional commits since a release boundary."
     )
     parser.add_argument(
         "--version",
@@ -263,7 +283,12 @@ def main() -> int:
     parser.add_argument(
         "--since-tag",
         default=None,
-        help="Lower-bound tag for commit range (default: auto-detect latest v* tag)",
+        help="Lower-bound tag for commit range (default: auto-detect latest v* tag unless --since-ref is set)",
+    )
+    parser.add_argument(
+        "--since-ref",
+        default=None,
+        help="Lower-bound ref for commit range, e.g. origin/main. Overrides --since-tag.",
     )
     parser.add_argument(
         "--source",
@@ -282,6 +307,7 @@ def main() -> int:
         version=args.version,
         release_date=args.release_date,
         since_tag=args.since_tag,
+        since_ref=args.since_ref,
     )
     return 0 if success else 1
 

--- a/tests/unit/scripts/test_generate_changelog_entry.py
+++ b/tests/unit/scripts/test_generate_changelog_entry.py
@@ -1,0 +1,71 @@
+"""Tests for release changelog generation."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_changelog_entry.py"
+
+spec = importlib.util.spec_from_file_location("generate_changelog_entry", SCRIPT_PATH)
+assert spec is not None
+generate_changelog_entry = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(generate_changelog_entry)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str, filename: str, content: str) -> None:
+    path = repo / filename
+    path.write_text(content, encoding="utf-8")
+    _git(repo, "add", filename)
+    _git(repo, "commit", "-m", message)
+
+
+def test_since_ref_limits_release_changelog_to_main_delta(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Release branches should summarize changes absent from main, not all reachable commits."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n\n", encoding="utf-8")
+    _git(repo, "add", "CHANGELOG.md")
+    _git(repo, "commit", "-m", "chore: initial")
+    initial_commit = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "branch", "-M", "main")
+    _commit(repo, "fix: main-only release hardening", "main.txt", "main\n")
+
+    _git(repo, "checkout", "-b", "develop", initial_commit)
+    _commit(repo, "feat: add broad release feature", "feature.txt", "feature\n")
+    _commit(repo, "fix: repair clean install", "fix.txt", "fix\n")
+
+    monkeypatch.setattr(generate_changelog_entry, "_summarize_changelog_with_claude", lambda *args: None)
+
+    assert generate_changelog_entry.generate_changelog_entry(
+        repo,
+        version="0.3.1",
+        release_date="2026-05-26",
+        since_ref="main",
+    )
+
+    changelog = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [0.3.1] - 2026-05-26" in changelog
+    assert "- add broad release feature" in changelog
+    assert "- repair clean install" in changelog
+    assert "main-only release hardening" not in changelog

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -443,6 +443,17 @@ class TestReleaseInfrastructure:
             assert "pre-merge" in normalized
             assert "patch release or incident" in content
 
+    def test_release_cut_generates_changelog_from_main_delta(self):
+        """The release branch changelog boundary is main..HEAD, not develop tag ancestry."""
+        recipe = _make_target_recipe("release-cut")
+        release_guide = (REPO_ROOT / "docs" / "operations" / "release-guide.md").read_text(encoding="utf-8")
+        release_template = (REPO_ROOT / ".github" / "RELEASE_PR_TEMPLATE.md").read_text(encoding="utf-8")
+
+        assert "scripts/generate_changelog_entry.py --version $(VERSION) --since-ref origin/main" in recipe
+        assert "origin/main..HEAD" in release_template
+        assert "origin/main" in release_guide
+        assert "release-finalize` intentionally does not replay release commits onto" in release_guide
+
     def test_issue_templates_exist(self):
         """Test that GitHub issue templates exist."""
         templates_dir = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"


### PR DESCRIPTION
## Summary

- Generate the v0.3.1 release-cut changelog from the current release branch delta (`origin/main..HEAD`) instead of the latest release tag reachable from `develop`.
- Add `--since-ref` support to `scripts/generate_changelog_entry.py`, with tests covering the broad-release boundary.
- Update release docs and PR template language for the main-delta release model.
- Add `_project/notes/v0.3.1-changelog-draft.md` as a curated starting point for the broad v0.3.1 changelog.

## Testing

- `uv run -- python -m pytest tests/unit/test_release_infrastructure.py::TestReleaseInfrastructure::test_release_cut_generates_changelog_from_main_delta -q`
- `uv run -- python -m pytest tests/unit/scripts/test_generate_changelog_entry.py -q -n 0`
- `uv run -- python -m pytest tests/unit/test_release_infrastructure.py tests/unit/scripts/test_generate_changelog_entry.py -q -n 0`
- `uv run -- ruff check scripts/generate_changelog_entry.py tests/unit/scripts/test_generate_changelog_entry.py tests/unit/test_release_infrastructure.py`
- `uv run -- ruff format --check scripts/generate_changelog_entry.py tests/unit/scripts/test_generate_changelog_entry.py tests/unit/test_release_infrastructure.py`
- `uv run -- pre-commit run markdownlint --files docs/operations/release-guide.md .github/RELEASE_PR_TEMPLATE.md _project/notes/v0.3.1-changelog-draft.md`
- `make pr-preflight` (`22784 passed, 5 skipped`; full log at `/tmp/release-changelog-main-range-pr-preflight.log`)

## Notes

This prepares the release mechanics and changelog assets only. It does not cut, tag, publish, or finalize v0.3.1.