### PR TITLE
chore(todo): capture UAT remediation plan as 8 tracked TODOs

### DIFF
--- a/_project/TODO/main/planning/uat-artifact-integrity-and-failure-capture.yaml
+++ b/_project/TODO/main/planning/uat-artifact-integrity-and-failure-capture.yaml
@@ -1,0 +1,149 @@
+id: uat-artifact-integrity-and-failure-capture
+title: "UAT: make every sweep produce a traceable, abort-safe certification artifact"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The 2026-05-28/29 native + docker UAT runs could not be approved partly
+  because the *evidence* was incomplete, not only because cells failed. An
+  adversarial review of these run dirs found the process blockers below
+  (paths under ~/Developer/benchmark_runs/logs/):
+
+  - uat_complete_native_20260528_20260528: aborted on the /tmp disk floor
+    in the execute phase. Only resume.json survived; no matrix_summary.tsv,
+    no validator_rollup.tsv, no report footer. validate/package/
+    explorer_smoke/report never ran.
+  - uat_complete_native_remaining_non_oltp_20260528_20260529 (dataframe):
+    no manifests at all (no resume.json, cells.jsonl, uat_lifecycle.log,
+    matrix_summary.tsv). Pass/fail was only reconstructable from per-cell
+    result JSONs.
+  - NO_JSON failures (e.g. duckdb write_primitives/ai_primitives, all
+    modin-df cells) captured ZERO error text: the per-cell log held only
+    the command header (run with --quiet), and the tee log
+    /tmp/uat-logs/native_non_oltp_20260528.log was 0 bytes.
+  - No git commit SHA is recorded in any artifact; result JSONs carry only
+    driver versions (e.g. duckdb 1.3.2), so runs cannot be pinned to source.
+
+  This item makes the framework emit a complete, source-traceable artifact
+  for EVERY sweep, including aborted ones, so a reviewer can always prove
+  source SHA, command, phase status, terminal state, and failure cause.
+
+  Important correctness note from code reading (do not re-discover the
+  wrong way): per-cell stderr IS already captured into the CellResult
+  (tests/uat/phases/execute.py:708 builds `detail` from result.error /
+  result.stderr / result.stdout). The defect is that this captured text is
+  not persisted to the durable per-cell log file (only the command header
+  is written there) and is lost entirely when the run aborts before
+  cells.jsonl is written. report.py already models an `aborted` footer
+  state (tests/uat/phases/report.py:41) but the orchestrator's abort path
+  exits the execute phase before report/matrix_summary emission runs.
+
+  Evidence pin: the line references above (execute.py:708, report.py:41) and
+  "stderr only reaches `detail`, not the per-cell log" are confirmed against
+  commit da6a33c14. If they have drifted, re-confirm with
+  `grep -n 'result.stderr' tests/uat/phases/execute.py` and
+  `grep -n 'self.aborted' tests/uat/phases/report.py` before relying on them.
+
+prior_art:
+  - "tests/uat/orchestrator.py:resume.json writer — extend to also stamp run-level commit SHA + emit partial manifests on abort"
+  - "tests/uat/phases/report.py:REPORT_HEADER + aborted footer (line 41) — reuse for an always-emitted matrix_summary.partial + COMPLETED/ABORTED/BLOCKED footer"
+  - "tests/uat/phases/execute.py:708 detail = result.error or result.stderr ... — reuse the already-captured stderr/stdout; persist it, do not re-capture"
+  - "tests/uat/test_no_cli_surface_drift.py:155 _git('rev-parse', ...) — reuse the existing git rev-parse helper pattern for SHA capture"
+
+work:
+  - id: w1
+    summary: "Capture run commit SHA + dirty flag at sweep start; persist into resume.json, cells.jsonl, matrix_summary.tsv header, and report footer"
+    status: pending
+    notes: |
+      Read HEAD via the existing rev-parse pattern. Record short+full SHA
+      and a working-tree-dirty boolean once at sweep start, thread it
+      through the orchestrator into every manifest writer. A dirty tree
+      must be visibly flagged so a reviewer never mistakes an uncommitted
+      run for a pinned one.
+  - id: w2
+    summary: "Persist captured per-cell stderr/stdout tail to the durable per-cell log on nonzero exit / NO_JSON"
+    status: pending
+    notes: |
+      The CellResult already holds the text (execute.py:708). Write the
+      tail (bounded, e.g. last ~50 lines) into the per-cell .log after the
+      command header, and into the cells.jsonl row, regardless of --quiet.
+      Acceptance: a failed modin-df or duckdb cell carries its exact error
+      without relying on the tee log.
+  - id: w3
+    summary: "Add explicit NO_JSON / terminal-state classification to cell records"
+    needs: [w2]
+    status: pending
+    notes: |
+      Distinguish: exited 0 but no JSON; exited nonzero with no JSON;
+      timeout (124); killed (-9 / OOM); infra-terminated (e.g. sweep abort
+      before the cell finished). Surface the class in cells.jsonl and the
+      matrix_summary status column. Today these all collapse to "failed".
+  - id: w4
+    summary: "Guarantee abort-safe manifest + report emission"
+    needs: [w1, w3]
+    status: pending
+    notes: |
+      On disk-floor abort or any hard stop, still write cells.jsonl for
+      attempted cells, a matrix_summary.partial.tsv, compatibility_pruned.jsonl
+      for the enumerated complement, and a report footer with an explicit
+      COMPLETED | ABORTED | BLOCKED status. Ensure dataframe/native sweeps
+      always open a run-level uat_lifecycle.log (the dataframe run wrote
+      none). report.py already supports the aborted footer; wire the
+      orchestrator abort path to call it.
+
+must_preserve:
+  - "Successful (non-aborted) sweeps emit byte-identical artifacts to today apart from the new SHA fields and richer status column."
+  - "execute.parallel_platforms remains hard-rejected; sequential platform execution is unchanged."
+  - "No new always-on subprocess cost on the hot per-cell path beyond writing already-captured text."
+
+approach: |
+  Start in tests/uat/orchestrator.py: add a single run-context object holding
+  the commit SHA + dirty flag captured once at sweep start, and a finally/
+  except path around the execute phase that always invokes the manifest +
+  report writers (matrix_summary.partial, footer) before propagating an
+  abort. Thread the run-context into phases/report.py (header + footer),
+  phases/execute.py (per-cell log + cells.jsonl rows), and phases/enumerate.py
+  (compatibility_pruned on abort). Add the SHA column to REPORT_HEADER and the
+  matrix_summary header. Keep stderr persistence bounded (tail only).
+
+anti_patterns:
+  - "DO NOT shell out to git per cell - because it adds latency to the hot path - capture the SHA once at sweep start and pass it down."
+  - "DO NOT write full multi-MB stderr into per-cell logs - because some failures spew huge output - persist a bounded tail."
+  - "DO NOT treat the empty tee log as a fallback evidence source - it is operator redirection, not a framework artifact; the framework must self-contain its evidence."
+
+verification:
+  - description: "UAT framework unit suite passes"
+    command: "uv run -- python -m pytest tests/uat -m fast -q"
+    expected_output: "all pass, 0 failures"
+  - description: "Simulated abort still emits a complete artifact set"
+    command: "uv run -- python -m pytest tests/uat/test_orchestrator.py tests/uat/test_report.py -q"
+    expected_output: "abort-path tests assert cells.jsonl, matrix_summary.partial.tsv, and an ABORTED footer all exist"
+  - description: "A forced-failure cell carries its stderr tail in the per-cell log and cells.jsonl"
+    command: "uv run -- python -m pytest tests/uat/test_phases.py -k 'failure or stderr or classification' -q"
+    expected_output: "tests assert NO_JSON classification and persisted stderr"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/orchestrator.py"
+    - "tests/uat/phases/report.py"
+    - "tests/uat/phases/execute.py"
+    - "tests/uat/phases/enumerate.py"
+    - "tests/uat/phases/__init__.py"
+    - "tests/uat/test_orchestrator.py"
+    - "tests/uat/test_report.py"
+    - "tests/uat/test_phases.py"
+    - "docs/operations/uat-framework.md"
+  do_not_modify:
+    - "benchbox/"
+
+success_metrics:
+  - "Every run directory (including aborted) contains: commit SHA, per-cell command, phase status, terminal-state class, and a COMPLETED|ABORTED|BLOCKED footer."
+  - "A NO_JSON failure is debuggable from the run dir alone, with no tee log."
+
+metadata:
+  tags: [uat, traceability, observability, certification]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
+++ b/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
@@ -1,0 +1,122 @@
+id: uat-certification-rerun-ordering-and-gate
+title: "UAT certification re-run: enforce ordering, fresh root, and an explicit approval gate"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Once the framework and defect fixes land, a clean certification sweep must
+  be run — and its ordering and approval criteria must be explicit, because
+  the 2026-05-28/29 evidence had two structural problems beyond cell
+  failures:
+
+  - Ordering: the docker non-OLTP run started 2026-05-28 23:14, but a
+    native-execution dataframe sweep ran afterwards (2026-05-29 01:17-07:50).
+    A Docker stack began before all native/dataframe platforms had completed,
+    so cross-run certification value is compromised.
+  - Completeness: no run reached validate/package/explorer_smoke/report; no
+    matrix_summary.tsv or validator_rollup.tsv exists for any run.
+
+  Certification re-run contract:
+    1. native SQL platforms first
+    2. dataframe (native-execution) platforms second
+    3. Docker non-OLTP stacks third
+    4. Docker OLTP stacks last
+  Run sequentially, one platform at a time; lifecycle logs must prove native
+  completion before any Docker stack starts. Use a FRESH run root (not the
+  failed 2026-05-28 dirs), BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs,
+  a recorded seed, non-OLTP scales 0.01/0.1/1, OLTP scale 0.01.
+
+  APPROVAL GATE — APPROVE only if every non-blocked locally-testable platform
+  reaches the report phase and all required, non-pruned cells pass. HOLD if
+  ANY of: missing manifests, missing commit SHA, DuckDB reference failures,
+  a Docker zero-cell run, a hung platform, or a NO_JSON without error text.
+
+prior_art:
+  - "docs/operations/uat-framework.md 'Sequential platform execution' + 'Cross-scale coverage assertion (opt-in)' — reuse the report.cross_scale_coverage_min_pairs teeth; extend the doc with the ordering + approval-gate runbook"
+  - "tests/uat/configs/ historical + template configs — clone a template for the certification config rather than authoring from scratch"
+  - "tests/uat/phases/report.py REPORT_HEADER / footer — the report-phase artifact the approval gate reads"
+
+work:
+  - id: w1
+    summary: "Author/refresh the certification config(s) cloned from a template: scales 0.01/0.1/1 (non-OLTP), 0.01 (OLTP), recorded seed, fresh run root"
+    status: pending
+  - id: w2
+    summary: "Add an ordering assertion/lint: native completes before any Docker stack starts, provable from lifecycle logs"
+    status: pending
+    notes: |
+      Each sweep config is a separate invocation, so enforce via a documented
+      runbook ordering plus a lightweight check (e.g. a helper that verifies
+      no Docker action=up precedes the last native cell across the run set).
+  - id: w3
+    summary: "Encode the APPROVE/HOLD gate as a checklist + optional report teeth (cross_scale_coverage_min_pairs)"
+    needs: [w1]
+    status: pending
+  - id: w4
+    summary: "Write the certification runbook section in docs/operations/uat-framework.md"
+    needs: [w1, w2, w3]
+    status: pending
+  - id: w5
+    summary: "Execute the full certification re-run into a fresh root and confirm every config reaches the report phase"
+    needs: [w4]
+    status: pending
+    notes: |
+      Required terminal artifacts per run: cells.jsonl, compatibility_pruned.jsonl,
+      resume.json (if aborted), matrix_summary.tsv, validator_rollup.tsv,
+      uat_lifecycle.log, final report with COMPLETED footer + commit SHA.
+
+deps:
+  needs:
+    - uat-artifact-integrity-and-failure-capture
+    - uat-preflight-disk-headroom-gate
+    - uat-native-dataframe-compatibility-rules
+    - uat-cross-engine-dataframe-defects
+    - uat-duckdb-reference-triage
+    - uat-docker-stack-recovery
+
+must_preserve:
+  - "execute.parallel_platforms stays hard-rejected; one platform / one Docker stack at a time."
+  - "The 2026-05-28/29 run dirs are retained as failed-evidence reference, not reused as the certification root."
+  - "preserve_datagen:true; datagen reuse and reuse-aware pruning are unchanged."
+
+approach: |
+  This is the integration/sign-off item: it should be worked LAST, after the
+  five upstream fixes merge (see deps). Clone a config template, encode the
+  four-stage ordering and scales, add a lightweight ordering check and the
+  approval-gate checklist (reuse cross_scale_coverage_min_pairs for teeth),
+  document the runbook, then execute into a fresh root. The deliverable is a
+  COMPLETED report per config with a commit SHA — the artifact the original
+  review found missing.
+
+anti_patterns:
+  - "DO NOT start a Docker stack before native + dataframe platforms finish - that contaminated the 2026-05-28 evidence."
+  - "DO NOT resume into the failed 2026-05-28 dirs - treat them as non-evidentiary; use a fresh root."
+  - "DO NOT APPROVE on a partial run - the gate requires the report phase to complete with all required non-pruned cells green."
+
+verification:
+  - description: "Config validation + report-teeth tests pass"
+    command: "uv run -- python -m pytest tests/uat/test_config.py tests/uat/test_report.py -q"
+    expected_output: "all pass; cross_scale_coverage teeth exercised"
+  - description: "Certification re-run reaches report phase for every config"
+    command: "make uat-sweep CONFIG=<certification-config.yaml>"
+    expected_output: "each run dir has matrix_summary.tsv + validator_rollup.tsv + a COMPLETED report footer with commit SHA"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/configs/"
+    - "tests/uat/config.py"
+    - "tests/uat/test_config.py"
+    - "tests/uat/phases/report.py"
+    - "tests/uat/test_report.py"
+    - "docs/operations/uat-framework.md"
+
+success_metrics:
+  - "A full certification sweep runs in the required order from a fresh root, every config reaches the report phase, and the APPROVE/HOLD gate is evaluable from the artifacts alone."
+  - "Lifecycle logs prove native completion before any Docker stack starts."
+
+metadata:
+  tags: [uat, certification, ordering, approval-gate]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-cross-engine-dataframe-defects.yaml
+++ b/_project/TODO/main/planning/uat-cross-engine-dataframe-defects.yaml
@@ -1,0 +1,147 @@
+id: uat-cross-engine-dataframe-defects
+title: "Fix cross-engine DataFrame schema/loader defects surfaced by UAT"
+worktree: main
+priority: High
+status: Not Started
+category: Core Functionality
+
+description: |
+  The 2026-05-29 dataframe sweep
+  (uat_complete_native_remaining_non_oltp_20260528_20260529) exposed several
+  failures with IDENTICAL signatures across independent engines
+  (pandas-df, polars-df, pyspark-df, dask-df, and datafusion). Identical
+  failures across unrelated engines point to BenchBox defects in the shared
+  DataFrame loader/translation path, not to per-engine limitations. Evidence
+  (errors[] from the per-cell result JSONs):
+
+  1. datavault load_end_dts unresolvable on polars/pandas/pyspark (q66/66,
+     all scales). polars: 'unable to find column "load_end_dts"; valid
+     columns: ["92cec9d0fb7ef6a..."]'; pyspark suggests columns like
+     [``, `0.02`, `1996-02-12`] -> the datavault loader is binding header
+     rows / column names wrong.
+  2. pandas date-as-string typing: tpch q39/66, flightdata q60/60,
+     read_primitives q90/456 all fail with
+     "'<=' / '>=' not supported between instances of 'str' and
+     'datetime.date'" -> date columns load as strings in the pandas path.
+  3. write_primitives bulk_load_append_mode: pandas/polars/pyspark all fail
+     ~q195-204/399 with "Operation bulk_load_append_mode failed: IO Error:
+     No files found that..." -> shared write_primitives file-discovery bug.
+  4. datafusion positional column names: nyctaxi/flightdata/tsbs_devops fail
+     with "Schema error: No field named pickup_datetime. Valid fields are
+     trips.f0" -> table registration drops real column names, exposing
+     f0/f1/f2.
+  5. pandas tpcds every query fails (q309/309) with KeyError 'd_date_sk'.
+  6. UnifiedExpr clickbench: polars "cannot create expression literal for
+     value of type UnifiedExpr"; pyspark "'UnifiedExpr' object has no
+     attribute '_get_object_id'" -> literal/expression translation bug.
+
+  Note: polars|tpcdi correctly self-reports "TPC-DI DataFrame ETL requires
+  transactional maintenance capabilities" — that is a genuine limitation and
+  belongs in uat-native-dataframe-compatibility-rules, NOT here.
+
+prior_art:
+  - "benchbox/ DataFrame loader + UnifiedExpr translation layer (locate via the failing benchmark adapters: datavault, nyctaxi, flightdata, tsbs_devops, clickbench, write_primitives) — fix at the shared layer, not per engine"
+  - "PR #689 fix(spark): default warehouse_dir to benchmark_runs/databases — recently touched the spark df path; check for overlap with the pyspark datavault/flightdata failures"
+
+work:
+  - id: w0
+    summary: "Reproduce each signature at scale 0.01 and confirm it is shared-layer, not per-engine"
+    status: pending
+    notes: |
+      For each defect (1-6) run the smallest failing cell and capture the
+      exact error to an ignored local path (/tmp/<id>-w0.log). Confirm the
+      signature reproduces on >1 engine where the evidence claims so. Record
+      a compact summary (cell, engine, error head) in the PR body.
+  - id: w1
+    summary: "Fix datavault column-name/header binding so load_end_dts resolves consistently"
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: "Fix pandas date typing: load date columns as date/datetime, not str (tpch, flightdata, read_primitives)"
+    needs: [w0]
+    status: pending
+  - id: w3
+    summary: "Fix write_primitives bulk_load_append_mode file discovery (pandas/polars/pyspark)"
+    needs: [w0]
+    status: pending
+  - id: w4
+    summary: "Fix datafusion table registration to preserve real column names instead of f0/f1/f2"
+    needs: [w0]
+    status: pending
+  - id: w5
+    summary: "Fix pandas TPC-DS d_date_sk binding (q309/309)"
+    needs: [w0]
+    status: pending
+  - id: w6
+    summary: "Fix UnifiedExpr literal/expression translation for polars and pyspark clickbench"
+    needs: [w0]
+    status: pending
+  - id: w7
+    summary: "Re-run affected cells at 0.01 then full dataframe matrix; confirm green or genuinely-limited"
+    needs: [w1, w2, w3, w4, w5, w6]
+    status: pending
+
+deferred:
+  - summary: "Root-cause modin-df 51/51 NO_JSON (entire platform produced zero result JSONs in the 2026-05-29 run)"
+    reason: >-
+      No error text was captured (per-cell logs held only the command header;
+      tee log was 0 bytes). Cannot be triaged until stderr persistence lands
+      in uat-artifact-integrity-and-failure-capture (w2). Re-run one modin-df
+      cell after that to recover the cause, then decide whether the fix
+      belongs in this item or its own.
+
+must_preserve:
+  - "Engines that already pass these benchmarks (per the run: polars/pandas/pyspark passing cells) must not regress."
+  - "Genuine limitations (polars tpcdi transactional ETL) stay failures/prunes, not forced green."
+
+approach: |
+  Treat each numbered signature as a shared-layer bug first. Start from w0
+  reproduction at 0.01 to localize whether the fault is in datagen schema,
+  the DataFrame loader's column binding, type inference, or the UnifiedExpr
+  translation. Fix once at the shared layer; verify the fix clears the
+  signature on every engine the evidence named. Modin (51/51 NO_JSON) is
+  tracked separately — capture its root cause once stderr persistence lands
+  (see uat-artifact-integrity-and-failure-capture) before deciding if it
+  belongs here.
+
+anti_patterns:
+  - "DO NOT special-case per engine - because identical signatures across engines mean one shared cause - fix the shared loader/translation layer."
+  - "DO NOT mask a defect by adding a compatibility-prune rule - that hides a real bug - pruning is only for model-level gaps."
+
+verification:
+  - description: "Targeted dataframe cells pass at scale 0.01"
+    command: "for p in pandas-df polars-df pyspark-df; do uv run -- benchbox run --platform $p --benchmark datavault --scale 0.01 --non-interactive --phases load,power; done"
+    expected_output: "0 query failures for datavault load_end_dts across all three engines"
+  - description: "Datafusion nyctaxi resolves real column names"
+    command: "uv run -- benchbox run --platform datafusion --benchmark nyctaxi --scale 0.01 --non-interactive --phases load,power"
+    expected_output: "no 'Valid fields are trips.f0' schema errors"
+  - description: "Relevant adapter unit tests pass"
+    command: "uv run -- python -m pytest -m fast -q -k 'datavault or nyctaxi or flightdata or clickbench or write_primitives or tpcds'"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/dataframe/"
+    - "benchbox/core/dataframe/"
+    - "benchbox/core/datavault/dataframe_queries/"
+    - "benchbox/core/nyctaxi/dataframe_queries/"
+    - "benchbox/core/tpcds/dataframe_queries/"
+    - "benchbox/flightdata.py"
+    - "benchbox/read_primitives.py"
+    - "benchbox/write_primitives.py"
+    - "benchbox/clickbench.py"
+    - "tests/"
+  do_not_modify:
+    - "tests/uat/compatibility.py"
+  # NOTE: this allowlist is provisional. w0 localizes the true fault site;
+  # if a fix lands outside these paths, update only_modify in the same PR
+  # rather than silently widening scope.
+
+success_metrics:
+  - "All six cross-engine signatures cleared; affected cells pass at 0.01 and across the full dataframe matrix, or are explicitly genuine limitations."
+
+metadata:
+  tags: [dataframe, defect, schema, loader, uat]
+  estimated_effort: "Large"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-dask-stability-under-sweep.yaml
+++ b/_project/TODO/main/planning/uat-dask-stability-under-sweep.yaml
@@ -1,0 +1,98 @@
+id: uat-dask-stability-under-sweep
+title: "Stabilize dask-df under UAT so cluster failures record FAIL and the sweep continues"
+worktree: main
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  In the 2026-05-29 dataframe sweep, dask-df produced only 5 per-cell logs
+  (tpch 0.01/0.1/1.0, tpcds 0.01/0.1) before the run stopped — it was the
+  last platform by wall-clock and the sweep ended there with no resume.json
+  and no abort_reason. The dask tpcds 0.1 log ends with:
+  "distributed.scheduler - ERROR - Task ('_groupby_apply_funcs-...', 0)
+  marked as failed because 4 workers died while trying to run it".
+
+  Two problems: (a) tpcds on local Dask kills workers (likely memory
+  pressure during groupby/concat), and (b) a Dask cluster death did not
+  cleanly record FAIL and advance — it left the sweep truncated. A worker
+  death must terminate the cell as FAIL (with the captured scheduler error)
+  and the sweep must move on, never hang or silently stop.
+
+  NOTE: the plan draft cited "KeyError('ca_county')" for Dask; that is NOT
+  in the evidence. The verified Dask signature is the "4 workers died"
+  scheduler error on tpcds; "KeyError 'd_date_sk'" was the pandas-df tpcds
+  failure (tracked in uat-cross-engine-dataframe-defects). Use the verified
+  signatures.
+
+prior_art:
+  - "benchbox/ dask-df adapter + LocalCluster/Client setup (locate via the dask platform module) — reuse existing client lifecycle; add bounded resources"
+  - "tests/uat/timeouts.py — per-cell timeout mechanism; ensure a dask worker death trips a clean FAIL within the timeout, not a hang"
+
+work:
+  - id: w0
+    summary: "Reproduce dask tpcds 0.1 worker deaths locally and capture the scheduler/worker logs"
+    status: pending
+    notes: "Capture to an ignored local path; record memory profile / worker death cause in the PR body."
+  - id: w1
+    summary: "Add bounded memory/worker resource limits + timeouts to the dask client lifecycle under UAT"
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: "Ensure a dask cluster failure records FAIL with the captured error and the sweep advances (no truncation/hang)"
+    needs: [w0]
+    status: pending
+  - id: w3
+    summary: "Decide and document whether dask tpcds@0.1/1.0 is supported locally under UAT constraints (support, prune, or scale-cap)"
+    needs: [w1, w2]
+    status: pending
+
+deps:
+  needs:
+    - uat-artifact-integrity-and-failure-capture
+
+must_preserve:
+  - "dask-df cells that pass (tpch 0.01/0.1/1.0) must not regress."
+  - "Sequential platform execution and per-cell timeout semantics are unchanged."
+
+approach: |
+  Localize whether the worker deaths are OOM (most likely for groupby/concat
+  on tpcds) and cap worker memory / spill behaviour for the UAT Dask client.
+  Independently, harden the cell runner so a dead cluster surfaces as a FAIL
+  cell carrying the scheduler error (depends on failure-capture) rather than
+  ending the sweep. If tpcds cannot fit local Dask within UAT constraints,
+  prune it via a model-level rule (coordinate with
+  uat-native-dataframe-compatibility-rules) or cap its scale — do not leave
+  it as a silent hang.
+
+anti_patterns:
+  - "DO NOT chase the phantom 'ca_county' KeyError - it is not in the evidence - the real signal is '4 workers died' on tpcds."
+  - "DO NOT let a cluster death stop the whole sweep - one platform's failure must not truncate the matrix."
+
+verification:
+  - description: "dask tpch cells still pass"
+    command: "uv run -- benchbox run --platform dask-df --benchmark tpch --scale 0.1 --non-interactive --phases load,power"
+    expected_output: "0 query failures"
+  - description: "A simulated dask cluster failure records FAIL and the runner continues"
+    command: "uv run -- python -m pytest tests/uat -m fast -k 'dask or cluster or worker' -q"
+    expected_output: "test asserts FAIL recorded with captured error, no hang"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/dataframe/dask_df.py"
+    - "tests/"
+  do_not_modify:
+    # The clean-FAIL-and-advance behavior is owned upstream by
+    # uat-artifact-integrity-and-failure-capture; this item relies on it
+    # rather than editing the runner/orchestrator directly.
+    - "tests/uat/orchestrator.py"
+    - "tests/uat/phases/execute.py"
+
+success_metrics:
+  - "A dask worker death always yields a FAIL cell with the scheduler error and the sweep completes; tpcds support decision documented."
+
+metadata:
+  tags: [dask, dataframe, stability, uat]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
+++ b/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
@@ -1,0 +1,114 @@
+id: uat-docker-stack-recovery
+title: "Recover UAT Docker stacks: LakeSail startup timeout + empty Docker-OLTP run"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Neither Docker UAT run from 2026-05-28 produced usable certification
+  evidence:
+
+  - uat_complete_docker_non_oltp_20260528_20260528: cells.jsonl is EMPTY
+    (0 bytes) -> zero cells executed. uat_lifecycle.log shows only LakeSail:
+    "platform=lakesail action=up status=failed ... docker command timed out
+    after 300s", then "action=down status=ok". compatibility_pruned.jsonl
+    has 54 rows (lakesail, pg-duckdb, pg-mooncake, timescaledb, questdb) but
+    no non-pruned cell for any platform executed — the run ended after the
+    LakeSail compose-up timeout without attempting the remaining stacks.
+  - uat_complete_docker_oltp_20260528_20260528: the run directory is EMPTY
+    (0 files) — nothing ran; no manifests, no logs. No Docker-platform
+    result JSONs dated 2026-05-28/29 exist anywhere.
+
+  Two failures to fix: (1) LakeSail compose-up exceeds the 300s
+  docker_start_timeout_s (Spark Connect SparkSession startup); (2) the
+  Docker-OLTP sweep never started / produced nothing and must be re-run from
+  scratch with verified daemon + disk preconditions. Each Docker platform
+  must run individually (up -> run -> down) with lifecycle logs and a
+  non-empty run directory.
+
+prior_art:
+  - "docs/operations/uat-framework.md 'Docker storage cleanup' — docker_manage_platforms up/run/down lifecycle, docker_start_timeout_s, make uat-docker-cleanup; reuse the managed-lifecycle contract"
+  - "tests/uat/docker_assets.py + tests/uat/docker_cleanup.py — existing UAT-owned compose project handling; extend, do not replace"
+  - "uat_complete_docker_non_oltp_20260528 uat_lifecycle.log — reference for the docker action/status log line shape"
+
+work:
+  - id: w0
+    summary: "Confirm Docker daemon health + Docker data-root free space as a precondition before a Docker sweep"
+    status: pending
+    notes: "Ties to uat-preflight-disk-headroom-gate (Docker data root reporting)."
+  - id: w1
+    summary: "Measure LakeSail normal compose-up time; raise docker_start_timeout_s only to a justified value"
+    status: pending
+    notes: |
+      Do not raise blindly. Confirm the Spark Connect service actually
+      becomes healthy and how long it takes, then set the timeout above that.
+  - id: w2
+    summary: "Ensure a single platform's compose-up failure does not end the sweep; remaining stacks still attempt"
+    needs: [w0]
+    status: pending
+    notes: |
+      The non-oltp run stopped after LakeSail. A failed up should record the
+      platform's cells as BLOCKED/FAIL (infra) and advance to the next stack
+      (one stack at a time), per uat-artifact-integrity-and-failure-capture.
+  - id: w3
+    summary: "Re-run Docker-OLTP from scratch into a fresh run root with full lifecycle logs"
+    needs: [w0, w1, w2]
+    status: pending
+    notes: "Current oltp dir is empty and has no evidentiary value; discard it."
+  - id: w4
+    summary: "Re-run Docker-non-OLTP; verify per-platform up/run/down + non-empty cells.jsonl"
+    needs: [w0, w1, w2]
+    status: pending
+
+deps:
+  needs:
+    - uat-artifact-integrity-and-failure-capture
+
+must_preserve:
+  - "UAT never runs docker system/volume/image prune or unqualified compose down; only project-scoped benchbox-uat-* teardown."
+  - "Exactly one Docker stack runs at a time (sequential); PostgreSQL-family stacks sharing 5432 stay serialized."
+  - "Existing compatibility_pruned rules for docker platforms are unchanged."
+
+approach: |
+  Split infra hardening from re-runs. First confirm daemon + disk (w0) and
+  the real LakeSail startup time (w1). Then make a failed compose-up a
+  recorded, non-fatal event so the sweep advances (w2, depends on the
+  failure-capture/abort-safe work). Only after that, re-run both Docker
+  configs into a fresh run root (w3, w4) and verify every run dir is
+  non-empty with up/run/down lifecycle lines.
+
+anti_patterns:
+  - "DO NOT raise docker_start_timeout_s until you have measured a healthy startup - a longer timeout on a broken service just wastes 5+ minutes per attempt."
+  - "DO NOT reuse the empty 2026-05-28 oltp run dir as evidence - it has none; re-run into a fresh root."
+  - "DO NOT let one compose-up timeout abort the entire Docker sweep."
+
+verification:
+  - description: "Docker assets + cleanup tests pass"
+    command: "uv run -- python -m pytest tests/uat/test_docker_assets.py tests/uat/test_docker_cleanup.py tests/uat/test_cleanup.py -q"
+    expected_output: "all pass"
+  - description: "A managed Docker smoke produces a non-empty cells.jsonl with up/run/down lifecycle lines"
+    command: "make uat-sweep CONFIG=tests/uat/configs/stress-docker-managed.yaml"
+    expected_output: "run dir contains non-empty cells.jsonl and uat_lifecycle.log with action=up/down status lines per platform"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/docker_assets.py"
+    - "tests/uat/docker_cleanup.py"
+    - "tests/uat/cleanup.py"
+    - "tests/uat/config.py"
+    - "tests/uat/configs/"
+    - "tests/uat/test_docker_assets.py"
+    - "tests/uat/test_docker_cleanup.py"
+    - "tests/uat/test_cleanup.py"
+    - "docs/operations/uat-framework.md"
+
+success_metrics:
+  - "Both Docker stacks re-run into a fresh root with non-empty cells.jsonl, per-platform up/run/down lifecycle logs, and no empty run directories."
+  - "A single stack's compose-up failure no longer ends the sweep."
+
+metadata:
+  tags: [docker, lakesail, oltp, uat, certification]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-duckdb-reference-triage.yaml
+++ b/_project/TODO/main/planning/uat-duckdb-reference-triage.yaml
@@ -1,0 +1,107 @@
+id: uat-duckdb-reference-triage
+title: "Triage DuckDB reference-platform failures before any certification re-run"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  DuckDB is the reference/oracle platform; comparative UAT results are only
+  trustworthy if it is green or its unsupported cells are explicitly pruned.
+  In the 2026-05-28 native sweep (uat_complete_native_20260528_20260528)
+  DuckDB was NOT clean: 46 passed / 10 failed / 1 timed-out of 57 cells.
+  Evidence (from resume.json + per-cell result JSONs):
+
+  - tpchavoc 0.01/0.1: "Parser Error: window functions are not allowed in
+    window definitions"; also "Binder Error: Ambiguous reference to column
+    name l_partkey" (q27/660).
+  - tpchavoc 1.0: timed-out, exit 124, UAT_TIMEOUT timeout_s=1200.
+  - transaction_primitives 0.01: "Parser Error: syntax error" on
+    transaction_isolation_* ops; 0.1/1.0: "Failed to initialize staging
+    tables before executing 'transaction_create_temp_table' /
+    'transaction_long_running_mixed'" (q23/23 all fail).
+  - write_primitives 0.01/0.1/1.0 and ai_primitives 0.01/1.0: NO_JSON,
+    exit 1, with ZERO captured error text (per-cell log held only the
+    command header; tee log was 0 bytes).
+
+  The NO_JSON root causes are currently unrecoverable from the artifacts;
+  they become debuggable once stderr persistence lands. This item depends on
+  uat-artifact-integrity-and-failure-capture for that reason.
+
+prior_art:
+  - "benchbox/ duckdb adapter + transaction/write/ai primitive executors (locate via the failing benchmark families) — reuse existing duckdb adapter patterns"
+  - "tests/uat/timeouts.py — existing UAT_TIMEOUT mechanism; reuse for any justified timeout change on tpchavoc@1.0"
+
+work:
+  - id: w0
+    summary: "Re-run the NO_JSON cells with stderr persistence enabled and capture exact root cause"
+    status: pending
+    notes: |
+      duckdb write_primitives (all scales) + ai_primitives (0.01, 1.0).
+      Requires the failure-capture work to have landed. Capture to an
+      ignored local path; summarize cause in the PR body.
+  - id: w1
+    summary: "Resolve tpchavoc window-definition parser error + l_partkey ambiguity, or prune as a query-authoring gap"
+    needs: [w0]
+    status: pending
+    notes: |
+      Decide: query rewrite (preferred if DuckDB-valid form exists) vs
+      compatibility exclusion (if the construct is genuinely unsupported).
+  - id: w2
+    summary: "Fix or justify tpchavoc@1.0 1200s timeout (optimize, raise with justification, or prune if stress-only)"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Fix transaction_primitives staging-table init + parser syntax failures"
+    needs: [w0]
+    status: pending
+  - id: w4
+    summary: "Fix write_primitives / ai_primitives NO_JSON failures per w0 root cause"
+    needs: [w0]
+    status: pending
+  - id: w5
+    summary: "Confirm DuckDB passes all required, non-pruned cells at 0.01/0.1/1.0"
+    needs: [w1, w2, w3, w4]
+    status: pending
+
+deps:
+  needs:
+    - uat-artifact-integrity-and-failure-capture
+
+must_preserve:
+  - "DuckDB cells that already pass (46/57) must not regress."
+  - "Any timeout change is justified with measured runtime, not raised blindly."
+  - "DuckDB remains the reference for cross-platform validation/comparison."
+
+approach: |
+  Gate on w0: do not guess NO_JSON causes — recover them with the new stderr
+  persistence. For tpchavoc, prefer a DuckDB-valid query rewrite over pruning;
+  prune only if the construct is genuinely unsupported. For
+  transaction_primitives staging-table init, trace the setup path that fails
+  before the operations run. Each cell ends as PASS or an explicitly-pruned
+  model-level gap — never an unexplained FAIL.
+
+anti_patterns:
+  - "DO NOT prune a duckdb cell to make the reference look green - because that destroys the oracle's value - fix it or cite a real engine limit."
+  - "DO NOT raise the tpchavoc timeout without measuring actual runtime first - the 1.0 cell may be hung, not slow."
+
+verification:
+  - description: "DuckDB tpchavoc and transaction_primitives pass at 0.01"
+    command: "uv run -- benchbox run --platform duckdb --benchmark tpchavoc --scale 0.01 --non-interactive --phases load,power && uv run -- benchbox run --platform duckdb --benchmark transaction_primitives --scale 0.01 --non-interactive --phases load,power"
+    expected_output: "0 query failures"
+  - description: "DuckDB write_primitives / ai_primitives produce a result JSON (no NO_JSON)"
+    command: "uv run -- benchbox run --platform duckdb --benchmark write_primitives --scale 0.01 --non-interactive --phases load,power"
+    expected_output: "result JSON written; summary.queries.failed == 0 or explicit prune"
+
+scope_limit:
+  do_not_modify:
+    - "tests/uat/orchestrator.py"
+
+success_metrics:
+  - "DuckDB reference passes all required locally-testable cells at 0.01/0.1/1.0, with any exclusions documented as model-level prunes."
+
+metadata:
+  tags: [duckdb, reference, defect, uat, certification]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-native-dataframe-compatibility-rules.yaml
+++ b/_project/TODO/main/planning/uat-native-dataframe-compatibility-rules.yaml
@@ -1,0 +1,118 @@
+id: uat-native-dataframe-compatibility-rules
+title: "UAT: add compatibility-prune rules for read-only native + dataframe engine gaps"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  In the 2026-05-28 native SQL sweep, write/transaction/ai/vector-family
+  cells on read-only engines (datafusion, clickhouse-local) were ATTEMPTED
+  and FAILED rather than compatibility-pruned, inflating the failure count
+  with cells that policy should never have run. Examples from resume.json:
+  datafusion|write_primitives|*, datafusion|transaction_primitives|*,
+  datafusion|vector_search|*, clickhouse-local|write_primitives|*,
+  clickhouse-local|transaction_primitives|* — all "failed". The dataframe
+  sweep had the same shape (e.g. transaction_primitives NO_JSON across
+  pandas/polars/pyspark; polars tpcdi correctly self-reported "requires
+  transactional maintenance capabilities").
+
+  Correctness note from code reading: the pruning *machinery* already works
+  for every mode — tests/uat/phases/enumerate.py emits compatibility_pruned
+  rows from rules in tests/uat/compatibility.py. The reason native/dataframe
+  runs produced no native/dataframe prunes is that compatibility.py only
+  carries rules for docker platforms (pg-duckdb, pg-mooncake, timescaledb,
+  lakesail, questdb) plus one generic dataframe rule. The gap is MISSING
+  RULES, not missing emission. Do not rebuild emission.
+
+  Evidence pin: "compatibility.py carries rules only for docker platforms +
+  one generic dataframe rule" is confirmed against commit da6a33c14
+  (`grep -oE 'uat\.compat\.[a-z0-9-]+' tests/uat/compatibility.py | sort -u`).
+  Re-confirm before authoring rules in case coverage has since expanded.
+
+  Add rules so genuinely-unsupported engine x benchmark-family cells are
+  PRUNED (status compatibility-pruned, with rule_id + reason + evidence),
+  not counted as FAIL.
+
+  CRITICAL distinction (this is the adversarial trap): prune only what is
+  genuinely unsupported by the engine's model (e.g. row-level DML /
+  transactions on a read-only OLAP engine). DO NOT prune cells that failed
+  because of a BenchBox defect — those belong in the defect TODOs
+  (uat-cross-engine-dataframe-defects, uat-duckdb-reference-triage), where
+  they get fixed, not hidden. A prune rule must cite engine-model evidence,
+  not "it errored last run".
+
+prior_art:
+  - "tests/uat/compatibility.py — existing pg-duckdb/pg-mooncake/timescaledb/lakesail/questdb *.benchmark_gate rules; add datafusion/clickhouse-local/dataframe rules in the same shape"
+  - "tests/uat/phases/enumerate.py:_pruned_rows_for_rule — reuse as-is; it already emits compatibility_pruned.jsonl for any mode"
+  - "uat_complete_docker_non_oltp_20260528 compatibility_pruned.jsonl — reference for the rule_id / rule_status / reason / evidence schema"
+
+work:
+  - id: w1
+    summary: "Catalogue genuinely-unsupported engine x benchmark-family pairs with engine-model evidence"
+    status: pending
+    notes: |
+      For datafusion + clickhouse-local: write_primitives, transaction_primitives,
+      and any maintenance/DML-only families that the SQL operation executor
+      cannot run on a read-only engine. For dataframe engines: transaction/
+      write/maintenance families that are policy-incompatible (cf. polars
+      tpcdi self-report). Each entry needs a one-line model-level reason, not
+      a stack trace.
+  - id: w2
+    summary: "Add the rules to compatibility.py with rule_id, status=blocked, reason, evidence"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Assert in tests that these cells enumerate as compatibility-pruned, not as executable"
+    needs: [w2]
+    status: pending
+    notes: |
+      Extend tests/uat/test_phases.py and tests/uat/test_matrix.py candidate/
+      executed/pruned accounting so a regression that drops a rule (and lets
+      the cell fail instead) is caught.
+
+deps:
+  needs:
+    - uat-cross-engine-dataframe-defects
+
+must_preserve:
+  - "Early-stop pruning stays separate from compatibility pruning; neither is reported as a pass."
+  - "candidate_count == len(cells) + len(compatibility_pruned) invariant (test_phases.py) holds."
+  - "Existing docker prune rules are unchanged."
+
+approach: |
+  Enumerate the unsupported set from engine capability docs and the engine's
+  own errors that are model-level (e.g. clickhouse-local has no multi-statement
+  transaction semantics; datafusion has no row-level DML). Add benchmark_gate
+  rules mirroring the existing docker rules. Leave anything ambiguous OUT of
+  pruning and route it to the defect TODOs so it gets fixed.
+
+anti_patterns:
+  - "DO NOT prune a cell just because it failed last run - because that hides BenchBox defects (e.g. datafusion positional f0/f1 columns is a loader bug, not an engine limit) - prune only model-level gaps with cited evidence."
+  - "DO NOT add runtime SQL-rewrite logic here - because that lives in benchbox/sql_compat/ - UAT rules only explain why a cell is not attempted."
+
+verification:
+  - description: "Compatibility + enumeration + matrix tests pass"
+    command: "uv run -- python -m pytest tests/uat/test_phases.py tests/uat/test_matrix.py -q"
+    expected_output: "all pass, including pruned-accounting assertions"
+  - description: "A native sweep config enumerates datafusion/clickhouse write+transaction cells as pruned"
+    command: "uv run -- python -m pytest tests/uat/test_phases.py -k 'pruned and (datafusion or clickhouse or dataframe)' -q"
+    expected_output: "cells appear in compatibility_pruned with .benchmark_gate rule_id"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/compatibility.py"
+    - "tests/uat/test_phases.py"
+    - "tests/uat/test_matrix.py"
+  do_not_modify:
+    - "benchbox/sql_compat/"
+
+success_metrics:
+  - "datafusion/clickhouse-local write/transaction (and dataframe transaction/write) cells enumerate as compatibility-pruned with a model-level reason."
+  - "No cell that fails due to a BenchBox defect is pruned (verified against the defect TODOs)."
+
+metadata:
+  tags: [uat, compatibility, pruning, certification]
+  estimated_effort: "Medium"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"

--- a/_project/TODO/main/planning/uat-preflight-disk-headroom-gate.yaml
+++ b/_project/TODO/main/planning/uat-preflight-disk-headroom-gate.yaml
@@ -1,0 +1,89 @@
+id: uat-preflight-disk-headroom-gate
+title: "UAT: preflight disk report + headroom gate sized to the largest configured scale"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The native SQL sweep (uat_complete_native_20260528_20260528) aborted
+  mid-execute when /tmp fell below the 4.0 GiB floor:
+  resume.json abort_reason = "free space 3.6 GiB < cutoff 4.0 GiB at /tmp".
+  uat_lifecycle.log shows free space drifting down (18.63 -> 11.01 -> 7.36
+  -> 4.86 GiB) across platforms with docker_cleanup_status=not-run until the
+  floor tripped. The existing preflight.free_space_min_gib cutoff is a single
+  static floor; it does not relate available headroom to the workload the
+  config actually demands, and it watches a limited set of paths.
+
+  Make preflight (a) report free space at every relevant root and (b) gate
+  the sweep against the largest configured scale's expected peak from the
+  disk-budget table, so a sweep does not start only to abort halfway.
+
+prior_art:
+  - "tests/uat/preflight_budget.py — existing disk-budget estimate from tests/uat/data/disk_budget_table.tsv; extend it from advisory-only into a gate input"
+  - "tests/uat/phases/* free_space_min_gib cutoff (docs/operations/uat-framework.md 'Disk-budget estimate and resume manifests') — reuse the cutoff mechanism, add per-root reporting"
+
+work:
+  - id: w1
+    summary: "Emit a preflight free-space report for /tmp, output root, benchmark data root, and (managed mode) Docker data root"
+    status: pending
+    notes: |
+      One compact table line per root, printed before workload cells run.
+      The native abort was on /tmp specifically while the output root still
+      had headroom, so per-root visibility is the point.
+  - id: w2
+    summary: "Relate the disk-budget peak estimate to the largest configured scale and gate on it"
+    needs: [w1]
+    status: pending
+    notes: |
+      Use preflight_budget.py's peak estimate. If estimated peak for the
+      largest configured scale exceeds free headroom on any required root,
+      fail preflight with an actionable message (free space, shrink matrix,
+      or override). Keep unknown-cell handling explicit (count + warn), per
+      the existing advisory contract; do not silently pass unknowns.
+  - id: w3
+    summary: "Document the disk gate and override in docs/operations/uat-framework.md"
+    needs: [w2]
+    status: pending
+
+must_preserve:
+  - "free_space_min_gib remains a valid explicit override; the new gate must be overridable for operators who know the run fits."
+  - "preserve_datagen:false stays rejected by the config validator."
+  - "Unknown disk-budget cells are still reported, not treated as zero."
+
+approach: |
+  Extend preflight_budget.py to expose both the steady and peak estimate per
+  scale, and a helper that compares peak against shutil.disk_usage on each
+  configured root. Wire it into the preflight phase before the existing
+  free_space_min_gib check; emit the per-root table either way. Largest scale
+  = max(scale) across the config matrix.
+
+anti_patterns:
+  - "DO NOT make the gate a hard non-overridable block - because budget table coverage is incomplete (unknown cells exist) - keep an explicit override and surface unknowns."
+  - "DO NOT only watch the output root - because the 2026-05-28 abort was on /tmp - report every root the run writes to."
+
+verification:
+  - description: "Preflight budget + disk tests pass"
+    command: "uv run -- python -m pytest tests/uat/test_preflight.py tests/uat/test_preflight_budget.py -q"
+    expected_output: "all pass"
+  - description: "A configured matrix whose peak exceeds free space fails preflight with an actionable message"
+    command: "uv run -- python -m pytest tests/uat/test_preflight_budget.py -k 'gate or headroom' -q"
+    expected_output: "gate test asserts non-zero preflight + message naming the short root"
+
+scope_limit:
+  only_modify:
+    - "tests/uat/preflight_budget.py"
+    - "tests/uat/test_preflight_budget.py"
+    - "tests/uat/test_preflight.py"
+    - "tests/uat/data/disk_budget_table.tsv"
+    - "docs/operations/uat-framework.md"
+
+success_metrics:
+  - "No sweep starts unless estimated peak for the largest configured scale fits free headroom on every required root, or the operator overrides explicitly."
+  - "Preflight output shows free space at /tmp, output root, benchmark data root, and Docker data root (managed mode)."
+
+metadata:
+  tags: [uat, preflight, disk, certification]
+  estimated_effort: "Small"
+  created_date: "2026-05-28"
+  last_updated: "2026-05-28T00:00:00"


### PR DESCRIPTION
Convert the 2026-05-28/29 native+docker UAT adversarial-review HOLD into
tracked work. The runs failed to produce a complete, traceable certification
artifact: native SQL aborted on the /tmp disk floor, the dataframe sweep wrote
no manifests, docker non-OLTP executed zero cells, and docker OLTP never ran.
No run reached validate/package/explorer-smoke/report; no commit SHA was
recorded anywhere.

Process-blocker TODOs (highest priority):
- uat-artifact-integrity-and-failure-capture: SHA provenance, abort-safe
  manifest/report emission, persist already-captured stderr to per-cell logs,
  NO_JSON terminal-state classification.
- uat-preflight-disk-headroom-gate: per-root free-space report + gate sized
  to the largest configured scale.
- uat-native-dataframe-compatibility-rules: add prune rules for read-only
  native (datafusion, clickhouse-local) + dataframe engine gaps so model-level
  gaps are PRUNED, not counted as FAIL.

Defect TODOs:
- uat-cross-engine-dataframe-defects: identical-signature shared-layer bugs
  (datavault load_end_dts, pandas date-as-string, write_primitives bulk_load,
  datafusion positional f0/f1 columns, tpcds d_date_sk, UnifiedExpr clickbench).
- uat-duckdb-reference-triage: reference platform must be green or pruned
  (tpchavoc parser/timeout, transaction staging-table init, write/ai NO_JSON).
- uat-dask-stability-under-sweep: "4 workers died" tpcds crash; clean FAIL +
  advance (drops the plan's phantom 'ca_county' signature for the verified one).
- uat-docker-stack-recovery: LakeSail compose-up timeout + empty docker-OLTP.

Integration:
- uat-certification-rerun-ordering-and-gate: native -> dataframe -> docker
  non-OLTP -> docker OLTP ordering, fresh run root, explicit APPROVE/HOLD gate
  (depends on the six above).

Corrections vs the draft plan: stderr is already captured into CellResult
(execute.py:708) so the fix is persistence not capture; compat-prune emission
already exists for all modes (enumerate.py) so the gap is missing rules not
missing machinery; the Dask signature is "4 workers died", not KeyError
'ca_county' (that was pandas tpcds d_date_sk). Code-state claims pinned to
da6a33c14.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
