### PR TITLE
chore(agents): add agent-write-preflight guard and fix dead worktree-add reference

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -21,24 +21,30 @@ PR with one command and walk away - auto-merge handles the rest.
 
 Execute the following in order, stopping on the first failure:
 
-1. **Refuse if on `develop` or `main`.** If `git branch --show-current` returns
-   one of those, stop and tell the user to switch to a feature branch (offer
-   `make worktree-add BRANCH=<name>`).
+1. **Run `make agent-write-preflight`.** If it refuses because this is the
+   BenchBox primary clone, stop and tell the user to claim a pool worktree with
+   `make worktree-claim BRANCH=<name>`. Do not commit, push, or open a PR from
+   the primary clone unless the user explicitly set
+   `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1`.
 
-2. **If there are uncommitted changes**, create a single conventional commit
+2. **Refuse if on `develop` or `main`.** If `git branch --show-current` returns
+   one of those, stop and tell the user to switch to a feature branch (offer
+   `make worktree-claim BRANCH=<name>`).
+
+3. **If there are uncommitted changes**, create a single conventional commit
    (`feat:`/`fix:`/`docs:`/`test:`/`chore:`/`ci:`/`refactor:` prefix) summarizing
    them. Stage explicitly by path — never `git add -A`. Include the standard
    `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` trailer.
    If pre-commit hooks rewrite files, re-stage and commit again (do NOT use
    `--amend`; create a new commit).
 
-3. **Run `make pr-preflight`** to mirror the CI gate locally. If it fails, fix
-   the root cause and loop back to step 2. Do NOT bypass with `--no-verify`.
+4. **Run `make pr-preflight`** to mirror the CI gate locally. If it fails, fix
+   the root cause and loop back to step 3. Do NOT bypass with `--no-verify`.
 
-4. **Run `make pr-open`** — pushes the branch, opens a PR vs `develop` with
+5. **Run `make pr-open`** — pushes the branch, opens a PR vs `develop` with
    `gh pr create --fill`, and enables `gh pr merge --auto --squash`.
 
-5. **Print the PR URL** and a one-line summary of what auto-merge will do
+6. **Print the PR URL** and a one-line summary of what auto-merge will do
    ("will squash-merge once `ci-required-result` goes green").
    Do NOT poll for CI completion — auto-merge handles it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,32 @@ Use `rg`; read files in focused chunks. Prefer existing local helpers and
 patterns. For write work, research the affected path, change the narrowest
 surface that solves the problem, verify, then commit only authorized files.
 
+## Worktree Isolation
+
+BenchBox uses retained pool worktrees for routine write work. This is a
+BenchBox-local rule, not a global agent preference.
+
+Before any write action, first classify the task:
+
+- Read-only review, research, audit, or explanation: the primary clone is OK.
+- Any task that may edit files, switch branches, rebase, commit, push, or open
+  a PR: do not work in the primary clone. From `/Users/joe/Developer/BenchBox`,
+  claim a pool slot first:
+
+```bash
+make worktree-claim BRANCH=fix/descriptive-slug
+cd <WORKTREE_PATH>
+make agent-write-preflight
+```
+
+If `git rev-parse --show-toplevel` is `/Users/joe/Developer/BenchBox`, stop
+before editing and claim a worktree. Do not run `git switch`, `git checkout`,
+`git rebase`, `apply_patch`, commit, or `make pr-open` in the primary clone.
+
+Emergency release or hotfix work in the primary clone requires explicit user
+authorization in the prompt plus `BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1` on the
+guarded command. State the exception in the final response.
+
 ## Tooling
 
 `make` wrappers are preferred when present. Direct Python tools still run
@@ -128,6 +154,12 @@ Do not use `git add -A`; stage explicit paths only. Repo `origin` is
 `joeharris76/BenchBox`. Long-lived branches: `develop` for dev, `main` for
 release. Dev PRs target `develop`, squash-merge, linear history. `develop` is
 PR-gated; do not direct-push routine work.
+
+Run the local write guard before the first edit and before PR creation:
+
+```bash
+make agent-write-preflight
+```
 
 Push-to-PR gate (the implement-to-PR ritual is in "Default write-task
 close-out" below):

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -474,6 +474,7 @@ SKILL_SYNC ?= /Users/joe/Developer/skill-sync/dist/cli/index.js
 
 skill-sync:
 	@if [ -f "$(SKILL_SYNC)" ]; then \
+		$(MAKE) -s agent-write-preflight; \
 		node "$(SKILL_SYNC)" sync; \
 	else \
 		echo "skill-sync not installed at $(SKILL_SYNC); skipping (override with SKILL_SYNC=path/to/dist/cli/index.js)"; \
@@ -873,7 +874,10 @@ release-finalize:
 # branches stay live in parallel via worktrees.
 # =============================================================================
 
-.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
+.PHONY: pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-fanout pr-refresh pr-conflict-scan pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup audit-sha-check agent-write-preflight worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-release-locked worktree-pool-reset worktree-pool-reset-locked worktree-pool-sweep-stale worktree-pool-sweep-stale-locked worktree-pool-disk-clean worktree-list worktree-prune todo-reindex blind-spots-list blind-spots-report blind-spots-sweep
+
+agent-write-preflight:
+	@sh scripts/agent_write_preflight.sh
 
 # Lightweight local gate before pushing. Mirrors CI lint and fast marker
 # selection, but not CI's coverage fail-under; run ci-test for the exact
@@ -939,6 +943,7 @@ pr-content-guard:
 # (pure git, ~1s, no CI) and prints any textual conflicts so you can coordinate
 # before landing. Warn-only — does not block the push.
 pr-open:
+	@$(MAKE) -s agent-write-preflight
 	@CURRENT=$$(git branch --show-current); \
 	case "$$CURRENT" in \
 		develop|main) echo "Refusing to open PR from $$CURRENT — switch to a feature branch."; exit 1 ;; \
@@ -1889,6 +1894,7 @@ help:
 	@echo "  make docs-check      Run all documentation checks (validate, linkcheck, build)"
 	@echo ""
 	@echo "PR Workflow & Worktrees:"
+	@echo "  make agent-write-preflight  Refuse write work from the BenchBox primary clone unless explicitly overridden"
 	@echo "  make pr-preflight    Run lint + fast marker tests locally (coverage remains CI-only)"
 	@echo "  make pr-open [PR_BODY_FILE=path] Push branch + open PR vs develop + enable auto-merge"
 	@echo "  make pr-fanout       Run pr-open across worktrees with bounded parallelism (PR_FANOUT_JOBS=$(PR_FANOUT_JOBS))"

--- a/scripts/agent_write_preflight.sh
+++ b/scripts/agent_write_preflight.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+# BenchBox-local guard for agent write sessions. It intentionally does not
+# encode a global preference: it only protects this repository's primary clone.
+
+top=$(git rev-parse --show-toplevel)
+common_dir=$(git rev-parse --git-common-dir)
+
+case "$common_dir" in
+  /*) common_abs=$(realpath "$common_dir") ;;
+  *) common_abs=$(cd "$top" && realpath "$common_dir") ;;
+esac
+
+primary_clone=${BENCHBOX_AGENT_PRIMARY_CLONE:-$(dirname "$common_abs")}
+top_abs=$(realpath "$top")
+primary_abs=$(realpath "$primary_clone")
+
+allow_main=${BENCHBOX_ALLOW_MAIN_CLONE_WRITE:-${ALLOW_MAIN_CLONE_WRITE:-}}
+
+if [ "$top_abs" = "$primary_abs" ] && [ "$allow_main" != "1" ]; then
+  cat >&2 <<EOF
+Refusing BenchBox write preflight in the primary clone:
+  $top_abs
+
+Claim a pool worktree before write work:
+  make worktree-claim BRANCH=fix/descriptive-slug
+  cd <WORKTREE_PATH>
+
+Read-only review/research may stay in the primary clone. Emergency main-clone
+hotfix work requires explicit user authorization and:
+  BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1 make agent-write-preflight
+EOF
+  exit 1
+fi
+
+printf 'BenchBox write preflight OK: %s\n' "$top_abs"

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -54,7 +54,7 @@ def test_preflight_allows_explicit_primary_clone_override() -> None:
 
 
 def test_preflight_allows_non_primary_worktree() -> None:
-    result = _run_preflight(primary_clone=Path.cwd().parent / "BenchBox")
+    result = _run_preflight(primary_clone=Path.cwd().parent)
 
     assert result.returncode == 0
     assert "BenchBox write preflight OK" in result.stdout

--- a/tests/unit/test_agent_write_preflight.py
+++ b/tests/unit/test_agent_write_preflight.py
@@ -1,0 +1,75 @@
+"""Tests for the BenchBox-local agent write preflight guard."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+SCRIPT = Path("scripts/agent_write_preflight.sh")
+
+
+def _run_preflight(*, primary_clone: Path, allow: bool = False) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "BENCHBOX_AGENT_PRIMARY_CLONE": str(primary_clone),
+    }
+    if allow:
+        env["BENCHBOX_ALLOW_MAIN_CLONE_WRITE"] = "1"
+    else:
+        env.pop("BENCHBOX_ALLOW_MAIN_CLONE_WRITE", None)
+        env.pop("ALLOW_MAIN_CLONE_WRITE", None)
+
+    return subprocess.run(
+        ["sh", str(SCRIPT)],
+        cwd=Path.cwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_preflight_rejects_primary_clone_without_override() -> None:
+    result = _run_preflight(primary_clone=Path.cwd())
+
+    assert result.returncode == 1
+    assert "Refusing BenchBox write preflight in the primary clone" in result.stderr
+    assert "make worktree-claim BRANCH=fix/descriptive-slug" in result.stderr
+
+
+def test_preflight_allows_explicit_primary_clone_override() -> None:
+    result = _run_preflight(primary_clone=Path.cwd(), allow=True)
+
+    assert result.returncode == 0
+    assert "BenchBox write preflight OK" in result.stdout
+
+
+def test_preflight_allows_non_primary_worktree() -> None:
+    result = _run_preflight(primary_clone=Path.cwd().parent / "BenchBox")
+
+    assert result.returncode == 0
+    assert "BenchBox write preflight OK" in result.stdout
+
+
+def test_claude_pr_command_runs_write_preflight_before_pr_workflow() -> None:
+    command = Path(".claude/commands/pr.md").read_text(encoding="utf-8")
+
+    assert "make agent-write-preflight" in command
+    assert "make worktree-claim BRANCH=<name>" in command
+    assert "make worktree-add" not in command
+
+
+def test_skill_sync_write_target_runs_preflight() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    target = makefile.split("\nskill-sync:", maxsplit=1)[1].split("\nskill-sync-check:", maxsplit=1)[0]
+
+    assert "$(MAKE) -s agent-write-preflight" in target


### PR DESCRIPTION
- New scripts/agent_write_preflight.sh refuses write work from the BenchBox
  primary clone; allow-list via BENCHBOX_ALLOW_MAIN_CLONE_WRITE=1
- Wired into pr-open and skill-sync Makefile targets
- pr.md step 1 now runs agent-write-preflight; fixes dead worktree-add →
  worktree-claim reference in the refusal message (worktree-add was removed)
- AGENTS.md gains Worktree Isolation section and pre-edit guard callout
- 5 unit tests covering reject/override/non-primary/command-wiring scenarios

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
