### PR TITLE
fix(uat): green DuckDB reference cells across tpchavoc + primitives

### DIFF
--- a/_project/DONE/main/active/uat-duckdb-reference-triage.yaml
+++ b/_project/DONE/main/active/uat-duckdb-reference-triage.yaml
@@ -2,7 +2,8 @@ id: uat-duckdb-reference-triage
 title: "Triage DuckDB reference-platform failures before any certification re-run"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
+completed_date: "2026-05-29"
 category: Testing and Quality Assurance
 
 description: |
@@ -35,7 +36,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-run the NO_JSON cells with stderr persistence enabled and capture exact root cause"
-    status: pending
+    status: done
     notes: |
       duckdb write_primitives (all scales) + ai_primitives (0.01, 1.0).
       Requires the failure-capture work to have landed. Capture to an
@@ -43,26 +44,40 @@ work:
   - id: w1
     summary: "Resolve tpchavoc window-definition parser error + l_partkey ambiguity, or prune as a query-authoring gap"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Decide: query rewrite (preferred if DuckDB-valid form exists) vs
       compatibility exclusion (if the construct is genuinely unsupported).
   - id: w2
     summary: "Fix or justify tpchavoc@1.0 1200s timeout (optimize, raise with justification, or prune if stress-only)"
     needs: [w1]
-    status: pending
+    status: done
+    notes: |
+      Root cause was query 10_v8 ("EXISTS pattern"), NOT a slow run: its
+      EXISTS subquery used unqualified columns (l2.l_orderkey = l_orderkey)
+      that silently bound to the inner alias l2, degenerating the correlated
+      semi-join into an uncorrelated full scan that DuckDB's planner blew up
+      at SF1 (>180s, uninterruptible in-engine; EXPLAIN showed a
+      self-equality filter l_orderkey=l_orderkey). Fixed by qualifying the
+      correlation to the outer table (l2.l_orderkey = lineitem.l_orderkey),
+      which DuckDB decorrelates into a RIGHT_SEMI hash join.
+      Evidence (2026-05-29, DuckDB 1.3.2 / tpchavoc_sf1):
+        - before: query 10_v8 hung >180s; tpchavoc@1.0 exit 124.
+        - after:  10_v8 EXPLAIN shows SEMI join, executes in 0.1s; full
+                  tpchavoc@1.0 load,power = 880/880 executions, 100%, PASSED.
+      Timeout was NOT raised (anti-pattern: cell was hung, not slow).
   - id: w3
     summary: "Fix transaction_primitives staging-table init + parser syntax failures"
     needs: [w0]
-    status: pending
+    status: done
   - id: w4
     summary: "Fix write_primitives / ai_primitives NO_JSON failures per w0 root cause"
     needs: [w0]
-    status: pending
+    status: done
   - id: w5
     summary: "Confirm DuckDB passes all required, non-pruned cells at 0.01/0.1/1.0"
     needs: [w1, w2, w3, w4]
-    status: pending
+    status: done
 
 deps:
   needs:

--- a/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+++ b/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
@@ -1,0 +1,91 @@
+id: tpchavoc-correlated-subquery-self-binding
+title: "Fix tpchavoc variants whose correlated subqueries silently self-bind to the inner alias"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  While fixing the DuckDB SF1 hang in tpchavoc 10_v8 (uat-duckdb-reference-triage),
+  the root cause was a correlated subquery whose unqualified columns
+  (`l2.l_orderkey = l_orderkey`) silently bound to the INNER alias (l2)
+  instead of the outer table, degenerating the intended correlated
+  semi-join into an uncorrelated full scan. 10_v8 was fixed by qualifying
+  the correlation to the outer table.
+
+  Two more variants carry the identical pattern but do NOT currently break
+  any platform (they execute in <0.1s at SF1 on DuckDB because the
+  degenerate subquery folds to a cheap one-time scalar), so they were left
+  out of the duckdb-reference-triage scope:
+
+  - q11 variant 1 ("Scalar subqueries"): subquery
+    `from partsupp ps2, ... where ps2.ps_partkey = ps_partkey` — unqualified
+    `ps_partkey` binds to ps2, so the threshold becomes an uncorrelated
+    avg over all German partsupp rows instead of per-part.
+  - q17 variant 8 ("EXISTS pattern"): EXISTS subquery
+    `from (...) avg_calc where avg_calc.l_partkey = l_partkey` — unqualified
+    `l_partkey` binds to avg_calc, dropping the per-part correlation.
+
+  These likely produce semantically-incorrect variant results on EVERY
+  platform (tpchavoc validates execution, not result equivalence, so the
+  defect is silent). This item is about correctness of the shared variant
+  SQL, not a DuckDB-specific failure.
+
+prior_art:
+  - "benchbox/core/tpchavoc/variant_sets/q10.yaml:8 — 10_v8 fix qualifies the EXISTS correlation to the outer table (lineitem.l_orderkey); reuse the same qualification approach"
+  - "benchbox/core/tpchavoc/variant_sets/q17.yaml:2 — q17_v2 already qualifies l_partkey -> lineitem.l_partkey for the same class of ambiguity"
+
+work:
+  - id: w0
+    summary: "Confirm intended semantics of q11_v1 and q17_v8 against the base TPC-H query they vary"
+    status: pending
+    notes: |
+      Establish the correct correlated form before editing. The fix is to
+      qualify the correlation column to the outer table, matching 10_v8.
+  - id: w1
+    summary: "Qualify the correlation in q11_v1 (ps2.ps_partkey = partsupp.ps_partkey) and verify it decorrelates"
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: "Qualify the correlation in q17_v8 (avg_calc.l_partkey = lineitem.l_partkey) and verify it decorrelates"
+    needs: [w0]
+    status: pending
+  - id: w3
+    summary: "Sweep all tpchavoc variant_sets for the same alias-self-binding pattern and fix any others"
+    needs: [w0]
+    status: pending
+
+must_preserve:
+  - "All tpchavoc variants must still parse, bind, and execute on every supported platform."
+  - "DuckDB tpchavoc must remain 100% green at 0.01/0.1/1.0 after the changes."
+
+approach: |
+  These are shared variant queries, so a change affects all platforms. Fix
+  by qualifying the correlation column to the outer table (the 10_v8 pattern),
+  not by restructuring the query. Add the affected variants to the DuckDB
+  regression EXPLAIN/decorrelation test in tests/integration/test_tpchavoc_duckdb.py.
+
+anti_patterns:
+  - "DO NOT restructure the variant into a different SQL shape - the variant's identity is its shape; only fix the correlation binding."
+
+verification:
+  - description: "DuckDB tpchavoc still 100% at 1.0"
+    command: "uv run -- benchbox run --platform duckdb --benchmark tpchavoc --scale 1.0 --non-interactive --phases load,power"
+    expected_output: "880/880 executions, 100%"
+  - description: "tpchavoc duckdb integration tests pass"
+    command: "uv run -- python -m pytest tests/integration/test_tpchavoc_duckdb.py -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/variant_sets/"
+    - "tests/integration/test_tpchavoc_duckdb.py"
+
+success_metrics:
+  - "q11_v1 and q17_v8 (and any others found) correlate to the outer table; tpchavoc stays green on all platforms."
+
+metadata:
+  tags: [tpchavoc, sql, correctness, dataframe, defect]
+  estimated_effort: "Small"
+  created_date: "2026-05-29"
+  last_updated: "2026-05-29T00:00:00"

--- a/benchbox/core/ai_primitives/benchmark.py
+++ b/benchbox/core/ai_primitives/benchmark.py
@@ -160,8 +160,8 @@ class AIPrimitivesBenchmark(BaseBenchmark):
         self.dry_run = dry_run
         self.cost_tracker = CostTracker(budget_usd=max_cost_usd)
 
-        # Data file mapping (reuses TPC-H)
-        self.tables: dict[str, str] = {}
+        # Data file mapping (reuses TPC-H). Values may be sharded file lists.
+        self.tables: dict[str, Any] = {}
 
     def get_data_source_benchmark(self) -> str | None:
         """AI Primitives benchmark shares TPC-H data."""
@@ -179,13 +179,19 @@ class AIPrimitivesBenchmark(BaseBenchmark):
         # AI Primitives uses TPC-H data - delegate to TPC-H generator
         from benchbox.core.tpch.benchmark import TPCHBenchmark
 
-        tpch = TPCHBenchmark(scale_factor=self.scale_factor)
-        data_files = tpch.generate_data()
+        tpch = TPCHBenchmark(scale_factor=self.scale_factor, output_dir=self.output_dir)
+        tpch.generate_data()
 
-        # Store table mappings
-        self.tables = {Path(f).stem: str(f) for f in data_files}
+        # Preserve TPC-H's table-name mapping so loaders can handle sharded files.
+        self.tables = dict(tpch.tables)
 
-        return data_files
+        flattened: list[Union[str, Path]] = []
+        for table_files in self.tables.values():
+            if isinstance(table_files, (list, tuple)):
+                flattened.extend(table_files)
+            else:
+                flattened.append(table_files)
+        return flattened
 
     def is_platform_supported(self, platform: str) -> bool:
         """Check if a platform supports AI functions.

--- a/benchbox/core/tpchavoc/variant_sets/q02.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q02.yaml
@@ -215,7 +215,7 @@ variants:
 
     with min_costs as (
         select
-            ps_partkey,
+            ps_partkey as min_ps_partkey,
             min(ps_supplycost) as min_cost
         from
             partsupp,
@@ -254,7 +254,7 @@ variants:
         and s_nationkey = n_nationkey
         and n_regionkey = r_regionkey
         and r_name = 'EUROPE'
-        and p_partkey = mc.ps_partkey
+        and p_partkey = mc.min_ps_partkey
         and ps_supplycost = mc.min_cost
     order by
         s_acctbal desc,

--- a/benchbox/core/tpchavoc/variant_sets/q05.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q05.yaml
@@ -275,27 +275,33 @@ variants:
   description: 'Window functions: Use window functions for regional analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with regional_revenue as (
+        select distinct
+            n_name,
+            sum(l_extendedprice * (1 - l_discount)) over (partition by n_name) as revenue
+        from
+            customer,
+            orders,
+            lineitem,
+            supplier,
+            nation,
+            region
+        where
+            c_custkey = o_custkey
+            and l_orderkey = o_orderkey
+            and l_suppkey = s_suppkey
+            and c_nationkey = s_nationkey
+            and s_nationkey = n_nationkey
+            and n_regionkey = r_regionkey
+            and r_name = 'ASIA'
+            and o_orderdate >= date '1994-01-01'
+            and o_orderdate < date '1994-01-01' + interval '1' year
+    )
+    select
         n_name,
-        sum(l_extendedprice * (1 - l_discount)) over (partition by n_name) as revenue,
-        rank() over (order by sum(l_extendedprice * (1 - l_discount)) over (partition by n_name) desc) as revenue_rank
-    from
-        customer,
-        orders,
-        lineitem,
-        supplier,
-        nation,
-        region
-    where
-        c_custkey = o_custkey
-        and l_orderkey = o_orderkey
-        and l_suppkey = s_suppkey
-        and c_nationkey = s_nationkey
-        and s_nationkey = n_nationkey
-        and n_regionkey = r_regionkey
-        and r_name = 'ASIA'
-        and o_orderdate >= date '1994-01-01'
-        and o_orderdate < date '1994-01-01' + interval '1' year
+        revenue,
+        rank() over (order by revenue desc) as revenue_rank
+    from regional_revenue
     order by
         revenue desc
 - id: 10

--- a/benchbox/core/tpchavoc/variant_sets/q07.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q07.yaml
@@ -348,30 +348,38 @@ variants:
   description: 'Window functions: Use window functions for revenue analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with shipping_revenue as (
+        select distinct
+            supp_nation,
+            cust_nation,
+            l_year,
+            sum(volume) over (partition by supp_nation, cust_nation, l_year) as revenue
+        from (
+            select
+                n1.n_name as supp_nation,
+                n2.n_name as cust_nation,
+                extract(year from l_shipdate) as l_year,
+                l_extendedprice * (1 - l_discount) as volume
+            from
+                supplier, lineitem, orders, customer, nation n1, nation n2
+            where
+                s_suppkey = l_suppkey
+                and o_orderkey = l_orderkey
+                and c_custkey = o_custkey
+                and s_nationkey = n1.n_nationkey
+                and c_nationkey = n2.n_nationkey
+                and ((n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+                     or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE'))
+                and l_shipdate between date '1995-01-01' and date '1996-12-31'
+        ) as shipping
+    )
+    select
         supp_nation,
         cust_nation,
         l_year,
-        sum(volume) over (partition by supp_nation, cust_nation, l_year) as revenue,
-        rank() over (partition by l_year order by sum(volume) over (partition by supp_nation, cust_nation, l_year) desc) as revenue_rank
-    from (
-        select
-            n1.n_name as supp_nation,
-            n2.n_name as cust_nation,
-            extract(year from l_shipdate) as l_year,
-            l_extendedprice * (1 - l_discount) as volume
-        from
-            supplier, lineitem, orders, customer, nation n1, nation n2
-        where
-            s_suppkey = l_suppkey
-            and o_orderkey = l_orderkey
-            and c_custkey = o_custkey
-            and s_nationkey = n1.n_nationkey
-            and c_nationkey = n2.n_nationkey
-            and ((n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
-                 or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE'))
-            and l_shipdate between date '1995-01-01' and date '1996-12-31'
-    ) as shipping
+        revenue,
+        rank() over (partition by l_year order by revenue desc) as revenue_rank
+    from shipping_revenue
     order by
         supp_nation,
         cust_nation,

--- a/benchbox/core/tpchavoc/variant_sets/q09.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q09.yaml
@@ -297,27 +297,34 @@ variants:
   description: 'Window functions: Use window functions for profit analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with yearly_profit as (
+        select distinct
+            nation,
+            o_year,
+            sum(amount) over (partition by nation, o_year) as sum_profit
+        from (
+            select
+                n_name as nation,
+                extract(year from o_orderdate) as o_year,
+                l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+            from
+                part, supplier, lineitem, partsupp, orders, nation
+            where
+                s_suppkey = l_suppkey
+                and ps_suppkey = l_suppkey
+                and ps_partkey = l_partkey
+                and p_partkey = l_partkey
+                and o_orderkey = l_orderkey
+                and s_nationkey = n_nationkey
+                and p_name like '%green%'
+        ) as profit
+    )
+    select
         nation,
         o_year,
-        sum(amount) over (partition by nation, o_year) as sum_profit,
-        rank() over (partition by o_year order by sum(amount) over (partition by nation, o_year) desc) as profit_rank
-    from (
-        select
-            n_name as nation,
-            extract(year from o_orderdate) as o_year,
-            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
-        from
-            part, supplier, lineitem, partsupp, orders, nation
-        where
-            s_suppkey = l_suppkey
-            and ps_suppkey = l_suppkey
-            and ps_partkey = l_partkey
-            and p_partkey = l_partkey
-            and o_orderkey = l_orderkey
-            and s_nationkey = n_nationkey
-            and p_name like '%green%'
-    ) as profit
+        sum_profit,
+        rank() over (partition by o_year order by sum_profit desc) as profit_rank
+    from yearly_profit
     order by
         nation,
         o_year desc

--- a/benchbox/core/tpchavoc/variant_sets/q10.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q10.yaml
@@ -340,8 +340,8 @@ variants:
         and exists (
             select 1
             from lineitem l2
-            where l2.l_orderkey = l_orderkey
-              and l2.l_linenumber = l_linenumber
+            where l2.l_orderkey = lineitem.l_orderkey
+              and l2.l_linenumber = lineitem.l_linenumber
               and l2.l_returnflag = 'R'
         )
     group by
@@ -358,28 +358,40 @@ variants:
   description: 'Window functions: Use window functions for customer analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with customer_revenue as (
+        select distinct
+            c_custkey,
+            c_name,
+            sum(l_extendedprice * (1 - l_discount)) over (partition by c_custkey) as revenue,
+            c_acctbal,
+            n_name,
+            c_address,
+            c_phone,
+            c_comment
+        from
+            customer,
+            orders,
+            lineitem,
+            nation
+        where
+            c_custkey = o_custkey
+            and l_orderkey = o_orderkey
+            and o_orderdate >= date '1993-10-01'
+            and o_orderdate < date '1993-10-01' + interval '3' month
+            and l_returnflag = 'R'
+            and c_nationkey = n_nationkey
+    )
+    select
         c_custkey,
         c_name,
-        sum(l_extendedprice * (1 - l_discount)) over (partition by c_custkey) as revenue,
+        revenue,
         c_acctbal,
         n_name,
         c_address,
         c_phone,
         c_comment,
-        rank() over (order by sum(l_extendedprice * (1 - l_discount)) over (partition by c_custkey) desc) as revenue_rank
-    from
-        customer,
-        orders,
-        lineitem,
-        nation
-    where
-        c_custkey = o_custkey
-        and l_orderkey = o_orderkey
-        and o_orderdate >= date '1993-10-01'
-        and o_orderdate < date '1993-10-01' + interval '3' month
-        and l_returnflag = 'R'
-        and c_nationkey = n_nationkey
+        rank() over (order by revenue desc) as revenue_rank
+    from customer_revenue
     order by
         revenue desc
 - id: 10

--- a/benchbox/core/tpchavoc/variant_sets/q11.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q11.yaml
@@ -253,25 +253,36 @@ variants:
   description: 'Window functions: Use window functions for inventory analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with inventory_values as (
+        select distinct
+            ps_partkey,
+            sum(ps_supplycost * ps_availqty) over (partition by ps_partkey) as value
+        from
+            partsupp,
+            supplier,
+            nation
+        where
+            ps_suppkey = s_suppkey
+            and s_nationkey = n_nationkey
+            and n_name = 'GERMANY'
+    ),
+    inventory_threshold as (
+        select
+            sum(ps_supplycost * ps_availqty) * 0.0001 as threshold
+        from partsupp, supplier, nation
+        where ps_suppkey = s_suppkey
+          and s_nationkey = n_nationkey
+          and n_name = 'GERMANY'
+    )
+    select
         ps_partkey,
-        sum(ps_supplycost * ps_availqty) over (partition by ps_partkey) as value,
-        rank() over (order by sum(ps_supplycost * ps_availqty) over (partition by ps_partkey) desc) as value_rank
+        value,
+        rank() over (order by value desc) as value_rank
     from
-        partsupp,
-        supplier,
-        nation
+        inventory_values,
+        inventory_threshold
     where
-        ps_suppkey = s_suppkey
-        and s_nationkey = n_nationkey
-        and n_name = 'GERMANY'
-        and sum(ps_supplycost * ps_availqty) over (partition by ps_partkey) > (
-            select sum(ps_supplycost * ps_availqty) * 0.0001
-            from partsupp, supplier, nation
-            where ps_suppkey = s_suppkey
-              and s_nationkey = n_nationkey
-              and n_name = 'GERMANY'
-        )
+        value > threshold
     order by
         value desc
 - id: 10

--- a/benchbox/core/tpchavoc/variant_sets/q13.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q13.yaml
@@ -206,21 +206,27 @@ variants:
   description: 'Window functions: Use window functions for distribution analysis (OLAP)'
   sql: |2
 
-    select distinct
+    with customer_distribution as (
+        select distinct
+            c_count,
+            count(*) over (partition by c_count) as custdist
+        from (
+            select
+                c_custkey,
+                count(o_orderkey) as c_count
+            from
+                customer left outer join orders on
+                    c_custkey = o_custkey
+                    and o_comment not like '%special%requests%'
+            group by
+                c_custkey
+        ) as c_orders
+    )
+    select
         c_count,
-        count(*) over (partition by c_count) as custdist,
-        rank() over (order by count(*) over (partition by c_count) desc, c_count desc) as dist_rank
-    from (
-        select
-            c_custkey,
-            count(o_orderkey) as c_count
-        from
-            customer left outer join orders on
-                c_custkey = o_custkey
-                and o_comment not like '%special%requests%'
-        group by
-            c_custkey
-    ) as c_orders
+        custdist,
+        rank() over (order by custdist desc, c_count desc) as dist_rank
+    from customer_distribution
     order by
         custdist desc,
         c_count desc

--- a/benchbox/core/tpchavoc/variant_sets/q17.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q17.yaml
@@ -6,7 +6,7 @@ variants:
 - id: 2
   description: 'HAVING clause: Use HAVING for post-aggregation filtering'
   sql: |
-    with avg_qty as (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part, avg_qty where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and avg_qty.l_partkey = l_partkey and l_quantity < avg_qty.threshold
+    with avg_qty as (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part, avg_qty where p_partkey = lineitem.l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and avg_qty.l_partkey = lineitem.l_partkey and l_quantity < avg_qty.threshold
 - id: 3
   description: 'Explicit JOINs: Replace comma-separated tables with explicit JOINs'
   sql: |
@@ -14,7 +14,7 @@ variants:
 - id: 4
   description: 'UNION ALL: Split query by conditions'
   sql: |
-    select sum(revenue) / 7.0 as avg_yearly from (select l_extendedprice as revenue from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < (select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey) union all select 0 as revenue from dual where false) combined
+    select sum(revenue) / 7.0 as avg_yearly from (select l_extendedprice as revenue from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and l_quantity < (select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey) union all select 0 as revenue from (select 1) as dual where false) combined
 - id: 5
   description: 'CTE: Use common table expressions for modular design'
   sql: |

--- a/benchbox/core/transaction_primitives/benchmark.py
+++ b/benchbox/core/transaction_primitives/benchmark.py
@@ -27,6 +27,9 @@ from benchbox.core.transaction_primitives.generator import TransactionPrimitives
 from benchbox.core.transaction_primitives.operations import TransactionOperationsManager
 from benchbox.core.transaction_primitives.schema import STAGING_TABLES, get_all_staging_tables_sql, get_create_table_sql
 from benchbox.core.transactional.benchmark_base import TransactionalBenchmarkBase
+from benchbox.sql_compat.rules.execution_filter.duckdb_transaction_primitives import (
+    DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS,
+)
 from benchbox.sql_compat.rules.execution_filter.pg_duckdb_transaction_primitives import (
     PG_DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS,
 )
@@ -668,6 +671,7 @@ class TransactionPrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult
 
         try:
             platform_operation_skips = {
+                "duckdb": DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS,
                 "pg_duckdb": PG_DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS,
                 "timescaledb": TIMESCALEDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS,
             }

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -36,6 +36,10 @@ from benchbox.core.write_primitives.schema import (
     get_all_staging_tables_sql,
     get_create_table_sql,
 )
+from benchbox.sql_compat.rules.execution_filter.duckdb_write_primitives import (
+    DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS,
+    DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS,
+)
 from benchbox.sql_compat.rules.execution_filter.postgres_write_primitives import (
     POSTGRES_WRITE_PRIMITIVES_CATEGORY_SKIPS,
     POSTGRES_WRITE_PRIMITIVES_OPERATION_SKIPS,
@@ -390,6 +394,19 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 return None, (
                     f"Operation '{operation.id}' is skipped on PostgreSQL-family platforms: "
                     f"{POSTGRES_WRITE_PRIMITIVES_OPERATION_SKIPS[operation.id]}"
+                )
+
+        if (platform_key or "").lower() == "duckdb":
+            category = getattr(operation, "category", "")
+            if category in DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS:
+                return None, (
+                    f"Operation '{operation.id}' is skipped on DuckDB: "
+                    f"{DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS[category]}"
+                )
+            if operation.id in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS:
+                return None, (
+                    f"Operation '{operation.id}' is skipped on DuckDB: "
+                    f"{DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS[operation.id]}"
                 )
 
         effective_sql = operation.write_sql
@@ -851,7 +868,25 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
         """
         normalized: dict[str, dict[str, Any]] = {}
 
+        # The 8 base TPC-H tables (fixed by the spec) plus the write-primitives
+        # staging tables. Anything else in TABLES (e.g. operation-created sketch
+        # tables) is created at execution time, not loaded, so it is excluded.
+        loadable_table_names = {
+            "region",
+            "nation",
+            "customer",
+            "supplier",
+            "part",
+            "partsupp",
+            "orders",
+            "lineitem",
+            *STAGING_TABLES.keys(),
+        }
+
         for table_name, table_def in TABLES.items():
+            if table_name not in loadable_table_names:
+                continue
+
             # Write Primitives staging tables are already dict-shaped.
             if isinstance(table_def, dict) and "columns" in table_def:
                 normalized[table_name] = table_def

--- a/benchbox/sql_compat/rules/execution_filter/duckdb_transaction_primitives.py
+++ b/benchbox/sql_compat/rules/execution_filter/duckdb_transaction_primitives.py
@@ -1,0 +1,35 @@
+"""DuckDB execution-filter rules for transaction_primitives operation gaps."""
+
+from __future__ import annotations
+
+from benchbox.sql_compat.actions import CompatAction
+from benchbox.sql_compat.context import Phase
+from benchbox.sql_compat.decision import CompatibilityDecision, FailureMode, SkipQueryPayload, SupportLevel
+from benchbox.sql_compat.registry import REGISTRY
+
+DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS = {
+    "transaction_savepoint_nested": "DuckDB rejects SAVEPOINT syntax in transaction_primitives operations.",
+    "transaction_savepoint_deep_nesting": "DuckDB rejects SAVEPOINT syntax in transaction_primitives operations.",
+    "transaction_isolation_read_committed": "DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax.",
+    "transaction_isolation_repeatable_read": "DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax.",
+    "transaction_isolation_serializable": "DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax.",
+}
+
+for _query_id, _reason in DUCKDB_TRANSACTION_PRIMITIVES_OPERATION_SKIPS.items():
+    REGISTRY.register(
+        CompatibilityDecision(
+            rule_id=f"execution_filter.duckdb.transaction_primitives.{_query_id}",
+            action=CompatAction.SKIP_QUERY,
+            support_level=SupportLevel.SKIPPED_QUERY,
+            failure_mode=FailureMode.UNSUPPORTED_FEATURE,
+            payload=SkipQueryPayload(
+                reason=f"{_reason} Evidence: DuckDB 1.3.2 local parser verification on 2026-05-29.",
+                query_id=_query_id,
+            ),
+            reason=_reason,
+        ),
+        Phase.EXECUTION_FILTER,
+        "duckdb",
+        benchmark="transaction_primitives",
+        query_id=_query_id,
+    )

--- a/benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py
+++ b/benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py
@@ -1,0 +1,35 @@
+"""DuckDB execution-filter rules for write_primitives operation gaps."""
+
+from __future__ import annotations
+
+from benchbox.sql_compat.actions import CompatAction
+from benchbox.sql_compat.context import Phase
+from benchbox.sql_compat.decision import CompatibilityDecision, FailureMode, SkipQueryPayload, SupportLevel
+from benchbox.sql_compat.registry import REGISTRY
+
+DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS = {
+    "merge": "DuckDB 1.3.2 rejects the catalog's MERGE statements; keep them explicit skips until the bundled driver supports MERGE.",
+}
+
+DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS = {
+    "bulk_load_upsert_mode": DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS["merge"],
+}
+
+for _query_id, _reason in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS.items():
+    REGISTRY.register(
+        CompatibilityDecision(
+            rule_id=f"execution_filter.duckdb.write_primitives.{_query_id}",
+            action=CompatAction.SKIP_QUERY,
+            support_level=SupportLevel.SKIPPED_QUERY,
+            failure_mode=FailureMode.UNSUPPORTED_FEATURE,
+            payload=SkipQueryPayload(
+                reason=f"{_reason} Evidence: DuckDB 1.3.2 local parser verification on 2026-05-29.",
+                query_id=_query_id,
+            ),
+            reason=_reason,
+        ),
+        Phase.EXECUTION_FILTER,
+        "duckdb",
+        benchmark="write_primitives",
+        query_id=_query_id,
+    )

--- a/docs/compat/capability-matrix.md
+++ b/docs/compat/capability-matrix.md
@@ -4,9 +4,9 @@
 
 Every rule registered in `benchbox.sql_compat` is listed below. The registry is the authoritative source of compatibility policy; this document is regenerated from it. See [adr-sql-compat-phase-aware-pipeline.md](../development/adr/adr-sql-compat-phase-aware-pipeline.md) for the design.
 
-**Total registered rules:** 333
+**Total registered rules:** 339
 
-**Platforms covered:** 29
+**Platforms covered:** 30
 
 ## Phase coverage by platform
 
@@ -19,6 +19,7 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | databricks | - | - | - | 2 | 1 | - | 3 |
 | datafusion | - | - | 4 | 2 | - | - | 6 |
 | doris | - | 7 | - | 2 | 1 | - | 10 |
+| duckdb | - | - | - | - | - | 6 | 6 |
 | fabric_dw | - | - | - | - | 1 | - | 1 |
 | firebolt | - | - | - | - | 1 | - | 1 |
 | lakesail | 5 | 6 | - | - | 1 | 69 | 81 |
@@ -123,6 +124,17 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | schema_emit | benchmark=transaction_primitives | rewrite_ddl | INFORMATIONAL | SILENT_CORRUPTION | `schema_emit.doris.transaction_primitives.pk_lock_table_unsupported` |
 | schema_emit | benchmark=write_primitives | rewrite_ddl | INFORMATIONAL | SILENT_CORRUPTION | `schema_emit.doris.write_primitives.pk_lock_table_unsupported` |
 | ddl_optimize | platform-wide | rewrite_ddl | REWRITTEN | SYNTAX_ERROR | `ddl_optimize.doris.all.inject_ddl_clauses` |
+
+### duckdb
+
+| phase | scope | action | support | failure mode | rule_id |
+|---|---|---|---|---|---|
+| execution_filter | benchmark=transaction_primitives, query=transaction_isolation_read_committed | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.transaction_primitives.transaction_isolation_read_committed` |
+| execution_filter | benchmark=transaction_primitives, query=transaction_isolation_repeatable_read | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.transaction_primitives.transaction_isolation_repeatable_read` |
+| execution_filter | benchmark=transaction_primitives, query=transaction_isolation_serializable | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.transaction_primitives.transaction_isolation_serializable` |
+| execution_filter | benchmark=transaction_primitives, query=transaction_savepoint_deep_nesting | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_deep_nesting` |
+| execution_filter | benchmark=transaction_primitives, query=transaction_savepoint_nested | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_nested` |
+| execution_filter | benchmark=write_primitives, query=bulk_load_upsert_mode | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.duckdb.write_primitives.bulk_load_upsert_mode` |
 
 ### fabric_dw
 

--- a/docs/compat/skip-reference.md
+++ b/docs/compat/skip-reference.md
@@ -4,13 +4,24 @@
 
 Rules the registry applies to queries, benchmarks, and DDL statements. Split into two sections based on whether the outcome is user-visible in result counts. Each entry names the platform, the scope the rule applies to, the registered reason, and the rule_id you can grep for in `benchbox/sql_compat/rules/`.
 
-**Total rules:** 240
+**Total rules:** 246
 
-**Platforms with rules:** 17
+**Platforms with rules:** 18
 
 ## Will not run
 
 Queries or benchmarks that are **omitted from the result set** - either because the benchmark is refused at preflight (BLOCKED) or a specific query is excluded from execution (SKIPPED_QUERY). Users see these as missing entries in result counts.
+
+### duckdb
+
+| support | scope | phase | reason | rule_id |
+|---|---|---|---|---|
+| SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_isolation_read_committed | execution_filter | DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax. | `execution_filter.duckdb.transaction_primitives.transaction_isolation_read_committed` |
+| SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_isolation_repeatable_read | execution_filter | DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax. | `execution_filter.duckdb.transaction_primitives.transaction_isolation_repeatable_read` |
+| SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_isolation_serializable | execution_filter | DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax. | `execution_filter.duckdb.transaction_primitives.transaction_isolation_serializable` |
+| SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_savepoint_deep_nesting | execution_filter | DuckDB rejects SAVEPOINT syntax in transaction_primitives operations. | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_deep_nesting` |
+| SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_savepoint_nested | execution_filter | DuckDB rejects SAVEPOINT syntax in transaction_primitives operations. | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_nested` |
+| SKIPPED_QUERY | benchmark=write_primitives, query=bulk_load_upsert_mode | execution_filter | DuckDB 1.3.2 rejects the catalog's MERGE statements; keep them explicit skips until the bundled driver supports MERGE. | `execution_filter.duckdb.write_primitives.bulk_load_upsert_mode` |
 
 ### lakesail
 

--- a/tests/integration/test_tpchavoc_duckdb.py
+++ b/tests/integration/test_tpchavoc_duckdb.py
@@ -197,3 +197,41 @@ class TestTPCHavocDuckDBIntegration:
                 assert query_text.count("(") == query_text.count(")"), (
                     f"Q{query_id}.{variant_id} should have balanced parentheses"
                 )
+
+    def test_duckdb_regression_variants_explain(self, tpchavoc, duckdb_conn):
+        """Previously failing DuckDB TPC-Havoc variants should parse and bind."""
+        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+            if statement.strip():
+                duckdb_conn.execute(statement.strip())
+
+        regression_variants = [
+            "2_v5",
+            "5_v9",
+            "7_v9",
+            "9_v9",
+            "10_v8",
+            "10_v9",
+            "11_v9",
+            "13_v9",
+            "17_v2",
+            "17_v4",
+        ]
+        for query_id in regression_variants:
+            duckdb_conn.execute(f"EXPLAIN {tpchavoc.get_query(query_id)}")
+
+    def test_q10_v8_exists_correlates_to_outer_lineitem(self, tpchavoc, duckdb_conn):
+        """10_v8's EXISTS must correlate to the outer lineitem, not self-bind to l2.
+
+        The unqualified form (`l2.l_orderkey = l_orderkey`) silently bound to the
+        inner alias, turning a semi-join into an uncorrelated full scan that hung
+        DuckDB at SF1. The qualified form must decorrelate into a semi-join.
+        """
+        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+            if statement.strip():
+                duckdb_conn.execute(statement.strip())
+
+        sql = tpchavoc.get_query("10_v8")
+        assert "l2.l_orderkey = lineitem.l_orderkey" in sql, "EXISTS must correlate to the outer lineitem"
+
+        plan = duckdb_conn.execute(f"EXPLAIN {sql}").fetchall()[0][1]
+        assert "SEMI" in plan.upper(), "EXISTS should decorrelate into a semi-join, not a self-referential scan"

--- a/tests/unit/core/ai_primitives/test_benchmark.py
+++ b/tests/unit/core/ai_primitives/test_benchmark.py
@@ -55,6 +55,37 @@ class TestAIPrimitivesBenchmark:
         """Test data source is TPC-H."""
         assert ai_benchmark.get_data_source_benchmark() == "tpch"
 
+    def test_generate_data_preserves_sharded_tpch_table_mapping(self, monkeypatch, tmp_path):
+        """AI primitives must keep TPC-H table names when TPC-H returns sharded files."""
+
+        class FakeTPCHBenchmark:
+            def __init__(self, scale_factor, output_dir):
+                assert scale_factor == 0.01
+                assert output_dir == tmp_path
+                self.tables = {}
+
+            def generate_data(self):
+                self.tables = {
+                    "lineitem": [tmp_path / "lineitem.tbl.1", tmp_path / "lineitem.tbl.2"],
+                    "orders": tmp_path / "orders.tbl",
+                }
+                return list(self.tables.values())
+
+        monkeypatch.setattr("benchbox.core.tpch.benchmark.TPCHBenchmark", FakeTPCHBenchmark)
+        benchmark = AIPrimitivesBenchmark(scale_factor=0.01, output_dir=tmp_path)
+
+        files = benchmark.generate_data()
+
+        assert benchmark.tables == {
+            "lineitem": [tmp_path / "lineitem.tbl.1", tmp_path / "lineitem.tbl.2"],
+            "orders": tmp_path / "orders.tbl",
+        }
+        assert files == [
+            tmp_path / "lineitem.tbl.1",
+            tmp_path / "lineitem.tbl.2",
+            tmp_path / "orders.tbl",
+        ]
+
     def test_is_platform_supported_true(self, ai_benchmark):
         """Test supported platforms are recognized."""
         for platform in SUPPORTED_PLATFORMS:

--- a/tests/unit/core/transaction_primitives/test_execute_operation.py
+++ b/tests/unit/core/transaction_primitives/test_execute_operation.py
@@ -292,6 +292,27 @@ class TestSkippedStatus:
         assert "SAVEPOINT is not supported" in (result.skip_reason or "")
         conn.execute.assert_not_called()
 
+    def test_returns_skipped_for_duckdb_explicit_isolation_gap(self, tmp_path: Path):
+        bench = _make_benchmark(tmp_path)
+        bench.operations_manager.get_operation.return_value = _make_operation(
+            id="transaction_isolation_read_committed",
+            write_sql="SET TRANSACTION ISOLATION LEVEL READ COMMITTED; BEGIN TRANSACTION; COMMIT;",
+        )
+        conn = _make_connection()
+
+        result = bench.execute_operation(
+            "transaction_isolation_read_committed",
+            conn,
+            platform_key="duckdb",
+            platform_name="DuckDB",
+        )
+
+        assert result.status == "SKIPPED"
+        assert result.success is True
+        assert result.error is None
+        assert "SET TRANSACTION ISOLATION LEVEL" in (result.skip_reason or "")
+        conn.execute.assert_not_called()
+
     def test_returns_skipped_for_timescaledb_non_default_isolation_gap(self, tmp_path: Path):
         bench = _make_benchmark(tmp_path)
         bench.operations_manager.get_operation.return_value = _make_operation(

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -403,6 +403,20 @@ class TestExecuteOperation:
         assert "MERGE" in (result.skip_reason or "")
         mock_conn.execute.assert_not_called()
 
+    def test_execute_operation_skips_duckdb_merge_gap(self, wp_benchmark, monkeypatch):
+        """DuckDB 1.3.2 does not accept the write-primitives MERGE catalog."""
+        mock_conn = Mock()
+        mock_conn.execute = Mock()
+        monkeypatch.setattr(wp_benchmark, "is_setup", lambda conn: True)
+
+        result = wp_benchmark.execute_operation("merge_simple_upsert_small", mock_conn, platform_key="duckdb")
+
+        assert result.status == "SKIPPED"
+        assert result.success is True
+        assert result.error is None
+        assert "MERGE" in (result.skip_reason or "")
+        mock_conn.execute.assert_not_called()
+
     def test_execute_operation_uses_platform_override_when_available(self, wp_benchmark, monkeypatch):
         """Platform override SQL should be used instead of base write_sql."""
         operation = wp_benchmark.get_operation("insert_on_conflict_ignore")
@@ -1346,6 +1360,13 @@ def test_get_schema_returns_normalized_dict(fast_bench):
     # Staging tables should be present
     for table_name, table_def in schema.items():
         assert "columns" in table_def or isinstance(table_def, dict)
+
+
+def test_get_schema_excludes_operation_created_sketch_tables(fast_bench):
+    schema = fast_bench.get_schema()
+
+    assert "sketch_ops_daily_users" not in schema
+    assert "sketch_ops_topk" not in schema
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Triage and fix the DuckDB reference-platform failures from the 2026-05-28 native sweep so the oracle is clean before any certification re-run. Completes `uat-duckdb-reference-triage`.

DuckDB was 46 passed / 10 failed / 1 timed-out of 57 cells. This PR drives every required, locally-testable DuckDB cell to PASS or an explicitly-documented model-level prune.

## Changes

**tpchavoc (w1, w2)**
- Rewrite window-in-window-definition variants (`q05/07/09/10/11/13_v9`) into CTEs — DuckDB rejects an aggregate window nested inside another window's definition.
- Qualify ambiguous columns in `q02` and `q17_v2/v4` to fix binder "Ambiguous reference" errors.
- **SF1 timeout (exit 124) root cause:** `q10_v8`'s EXISTS used unqualified columns (`l2.l_orderkey = l_orderkey`) that silently bound to the inner alias `l2`, degenerating the correlated semi-join into an uncorrelated full scan DuckDB blew up at scale 1.0 (>180s, uninterruptible in-engine; EXPLAIN showed a `l_orderkey = l_orderkey` self-filter). Qualified the correlation to the outer table (`lineitem.l_orderkey`) → DuckDB decorrelates into a RIGHT_SEMI hash join (0.1s). **Timeout was NOT raised** — the cell was hung, not slow (per the TODO anti-pattern).

**primitives (w3, w4)**
- `transaction_primitives`: DuckDB execution-filter skips for SAVEPOINT + explicit SET TRANSACTION ISOLATION LEVEL ops (genuine DuckDB 1.3.2 syntax gaps), mirroring the `pg_duckdb` pattern.
- `write_primitives`: DuckDB MERGE-category skip; exclude operation-created sketch tables from the loadable-table set.
- `ai_primitives`: fix `generate_data` to pass `output_dir` and preserve TPC-H's sharded table mapping → resolves the NO_JSON crash; cell now exports a valid result JSON.

## Verification (DuckDB 1.3.2)

| Cell | Result |
|---|---|
| tpchavoc @0.01 | 880/880 (100%) PASSED |
| tpchavoc @1.0 | 880/880 (100%) PASSED — was exit 124 |
| transaction_primitives @0.01 | 18 passed / 5 skipped, PASSED |
| write_primitives @0.01 | 88 passed / 21 skipped, PASSED |
| ai_primitives @0.01 | PASSED, result JSON exported (no NO_JSON) |
| `make pr-preflight` | 22,812 passed / 4 skipped |

All skips are documented model-level gaps, never unexplained FAILs. New `test_q10_v8_exists_correlates_to_outer_lineitem` guards the decorrelation regression.

## Review findings

- **Consider (deferred, out of scope):** `q11_v1` and `q17_v8` share the same silent self-binding pattern as the fixed `10_v8`, but do **not** break DuckDB (verified <0.1s at SF1) — they fold to a cheap one-time scalar. They likely produce semantically-incorrect *variant* results across all platforms (tpchavoc validates execution, not equivalence). Tracked in new TODO `tpchavoc-correlated-subquery-self-binding` rather than expanding this PR's scope.
- No Critical/Required findings. One in-scope Nit applied (clarifying comment on `loadable_table_names`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)