### PR TITLE
fix(uat): pin dask FAIL-and-advance on cluster death; document tpcds stability

### DIFF
--- a/_project/DONE/main/active/uat-dask-stability-under-sweep.yaml
+++ b/_project/DONE/main/active/uat-dask-stability-under-sweep.yaml
@@ -2,7 +2,8 @@ id: uat-dask-stability-under-sweep
 title: "Stabilize dask-df under UAT so cluster failures record FAIL and the sweep continues"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
+completed_date: "2026-05-29"
 category: Platform Expansion
 
 description: |
@@ -32,20 +33,54 @@ prior_art:
 work:
   - id: w0
     summary: "Reproduce dask tpcds 0.1 worker deaths locally and capture the scheduler/worker logs"
-    status: pending
-    notes: "Capture to an ignored local path; record memory profile / worker death cause in the PR body."
+    status: done
+    notes: |
+      REFRAME (evidence, 2026-05-29): the worker deaths NO LONGER REPRODUCE on
+      current develop. `benchbox run --platform dask-df --benchmark tpcds
+      --scale 0.1 --phases load,power` completed all 103 queries across 3
+      iterations with ZERO worker-death/OOM/exit-137 signals and no
+      truncation. The "4 workers died" failure mode was eliminated upstream by
+      the dask resource-envelope caps (2GB/worker, worker cap, spill) that
+      landed in the cross-engine dataframe work (#692). The 23 residual tpcds
+      failures are dataframe-TRANSLATION defects ('Series' has no attribute
+      'rank'/'iloc'/'notna', 'diff', unknown aggregate lambda, lazy-boolean
+      conversions), not resource instability; those belong to the
+      cross-engine/native-dataframe-compat track, not this stability item.
   - id: w1
     summary: "Add bounded memory/worker resource limits + timeouts to the dask client lifecycle under UAT"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      Already present on develop (#692): _DEFAULT_LOCAL_MEMORY_LIMIT=2GB,
+      _DEFAULT_LOCAL_WORKER_CAP, _cap_default_memory_limit, spill-to-disk with
+      target=0.6/pause=0.8. Confirmed effective by the w0 reproduction (tpcds
+      0.1 no longer kills workers). No further limits needed at swept scales.
   - id: w2
     summary: "Ensure a dask cluster failure records FAIL with the captured error and the sweep advances (no truncation/hang)"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      Mechanism existed (DaskResourceEnvelopeError -> build_failure_result_dict
+      via execute_query's except), but (a) was untested under tests/uat and (b)
+      the verified scheduler signature "4 workers died" (plural) was not matched
+      by the "worker died" (singular) substring pattern - only via the
+      KilledWorker exception type name. Added the plural "workers died" pattern
+      and a regression suite tests/uat/test_dask_cluster_failure.py proving each
+      death signature is classified and that a dying compute yields a FAILED
+      result dict (no hang/uncaught crash). Satisfies the verification's
+      `pytest tests/uat -m fast -k 'dask or cluster or worker'` (was 0 tests).
   - id: w3
     summary: "Decide and document whether dask tpcds@0.1/1.0 is supported locally under UAT constraints (support, prune, or scale-cap)"
     needs: [w1, w2]
-    status: pending
+    status: done
+    notes: |
+      DECISION: dask-df tpcds is SUPPORTED locally and is resource-stable at the
+      swept scales (0.01/0.1) - no prune or scale-cap needed for stability. tpcds
+      cells run to completion and any future cluster death records a clean FAIL
+      and advances. The remaining tpcds query failures are translation-coverage
+      gaps tracked under the dataframe-compat track, not a dask stability/UAT
+      gating concern. tpch cells continue to pass at 100% (Q10 skipped by the
+      existing local-envelope guard; see follow-up TODO on that guard's staleness).
 
 deps:
   needs:

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -79,6 +79,11 @@ _RESOURCE_ENVELOPE_PATTERNS = (
     "killedworker",
     "worker was killed",
     "worker died",
+    # Scheduler-side phrasing observed in UAT, e.g. "Task ... marked as failed
+    # because 4 workers died while trying to run it". The KilledWorker exception
+    # type name already matches above, but the plural message form can also
+    # surface wrapped in other exception types, so match it explicitly.
+    "workers died",
     "exceeded memory",
     "memory budget",
     "memoryerror",

--- a/tests/uat/test_dask_cluster_failure.py
+++ b/tests/uat/test_dask_cluster_failure.py
@@ -1,0 +1,133 @@
+"""UAT regression: a Dask cluster/worker death must record a clean FAIL.
+
+Motivated by uat-dask-stability-under-sweep. In the 2026-05-29 dataframe sweep,
+dask-df ran tpcds and the run was observed to stop with a scheduler error
+("Task ... marked as failed because 4 workers died while trying to run it")
+without cleanly recording a FAIL and advancing. The resource-envelope handling
+in the Dask adapter must classify such a death and surface it as a failed query
+result (so the orchestrator records FAIL and continues), never a hang or an
+uncaught crash that truncates the sweep.
+
+These tests pin that contract at the adapter boundary: a worker-death exception
+during ``compute`` is classified as a :class:`DaskResourceEnvelopeError`, and a
+query whose compute dies returns a failure result dict rather than propagating
+an uncaught exception.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+mod = importlib.import_module("benchbox.platforms.dataframe.dask_df")
+
+pytestmark = pytest.mark.fast
+
+
+def _make_local_envelope_adapter():
+    """Build a Dask adapter in the default constrained local envelope.
+
+    Mirrors the construction used in the unit coverage suite but avoids starting
+    a real cluster; only the resource-envelope classification paths are exercised.
+    """
+    adapter = object.__new__(mod.DaskDataFrameAdapter)
+    adapter._log_verbose = lambda *_a, **_k: None
+    adapter.n_workers = 1
+    adapter.threads_per_worker = 2
+    adapter.use_distributed = True
+    adapter.scheduler_address = None
+    adapter._client = None
+    adapter._cluster = None
+    adapter.verbose = False
+    adapter.working_dir = "."
+    adapter._memory_limit = "2GB"
+    adapter._spill_to_disk = True
+    adapter._configured_spill_directory = None
+    adapter._spill_directory = None
+    adapter._owns_spill_directory = False
+    adapter._n_workers_configured = False
+    adapter._threads_per_worker_configured = False
+    adapter._memory_limit_configured = False
+    return adapter
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        # KilledWorker exception type name (the real exception .compute() raises).
+        "KilledWorker: Attempt to run task has failed 4 times",
+        # Scheduler-side message form from the verified UAT evidence.
+        "Task ('_groupby_apply_funcs-abc', 0) marked as failed because 4 workers died while trying to run it",
+        # Single-worker phrasing and OS OOM kill.
+        "distributed.nanny - WARNING - worker died unexpectedly",
+        "Worker process exited with exit code 137",
+    ],
+)
+def test_worker_death_is_classified_as_resource_envelope_failure(error_text):
+    """Each known cluster-death signature must produce a resource-envelope diagnostic."""
+    adapter = _make_local_envelope_adapter()
+    diagnostic = adapter._resource_envelope_diagnostic("compute", RuntimeError(error_text))
+    assert diagnostic is not None, f"worker-death signature not classified: {error_text!r}"
+    assert "Dask resource-envelope failure during compute" in diagnostic
+
+
+def test_unrelated_error_is_not_classified_as_resource_envelope():
+    """A normal query error must NOT be misattributed to the resource envelope."""
+    adapter = _make_local_envelope_adapter()
+    assert adapter._resource_envelope_diagnostic("compute", RuntimeError("Column not found: foo")) is None
+
+
+def test_cluster_death_during_compute_raises_resource_envelope_error():
+    """A worker death during a wrapped Dask operation surfaces as DaskResourceEnvelopeError."""
+    adapter = _make_local_envelope_adapter()
+
+    def _dies():
+        raise RuntimeError("marked as failed because 4 workers died while trying to run it")
+
+    with pytest.raises(mod.DaskResourceEnvelopeError) as excinfo:
+        adapter._run_with_resource_diagnostics("compute", _dies)
+    assert "resource-envelope failure" in str(excinfo.value)
+
+
+def test_cluster_death_records_fail_result_and_does_not_hang():
+    """A query whose compute dies must yield a FAIL result dict, not an uncaught crash.
+
+    This is the FAIL-and-advance contract: the orchestrator records the failed
+    cell and continues the sweep. We drive the real adapter ``execute_query`` with
+    a compute that simulates a cluster death and assert a failure result is
+    returned (success is False) carrying the resource-envelope diagnostic.
+    """
+    adapter = _make_local_envelope_adapter()
+
+    # Stub the compute hook used by the base execute_query to simulate a worker death.
+    def _worker_death():
+        raise RuntimeError("marked as failed because 4 workers died while trying to run it")
+
+    def _dying_compute(_df):
+        return adapter._run_with_resource_diagnostics("compute", _worker_death)
+
+    adapter.compute = _dying_compute
+
+    class _LazyFrame:
+        def compute(self):  # pragma: no cover - routed through adapter.compute
+            raise AssertionError("adapter.compute should be used")
+
+    def _impl(_ctx):
+        return _LazyFrame()
+
+    query = SimpleNamespace(
+        query_id="query99",
+        query_name="cluster death simulation",
+        get_impl_for_family=lambda _family: _impl,
+    )
+
+    result = adapter.execute_query(ctx=SimpleNamespace(), query=query, query_id="query99")
+
+    # FAIL-and-advance: a failure result dict is returned (no uncaught crash / hang),
+    # carrying the resource-envelope diagnostic so the orchestrator records FAIL.
+    assert str(result.get("status")).upper() == "FAILED"
+    assert result.get("success") in (False, None)
+    error = result.get("error") or ""
+    assert "4 workers died" in error or "resource-envelope" in error


### PR DESCRIPTION
## Summary

Completes `uat-dask-stability-under-sweep`. The 2026-05-29 dataframe sweep stopped at dask-df tpcds with a scheduler "4 workers died" error and no `resume.json`.

## Key finding (reframe)

On current develop the worker deaths **no longer reproduce**. `benchbox run --platform dask-df --benchmark tpcds --scale 0.1 --phases load,power` completes all 103 queries across 3 iterations with **zero** worker-death/OOM/exit-137 signals and **no truncation**. The deaths were eliminated upstream by the dask resource-envelope caps (2GB/worker, worker cap, spill) from #692, and a cluster death is already converted to a FAIL via `DaskResourceEnvelopeError` → `build_failure_result_dict` so the sweep advances.

## Changes

- **`dask_df.py`:** add `"workers died"` (plural) to `_RESOURCE_ENVELOPE_PATTERNS`. The verified signature *"...marked as failed because 4 workers died..."* was not matched by the existing `"worker died"` (singular) substring — only via the `KilledWorker` exception type name. The plural form is now classified even when wrapped in other exception types.
- **`tests/uat/test_dask_cluster_failure.py` (new):** pins the FAIL-and-advance contract. The verification selector `pytest tests/uat -m fast -k 'dask or cluster or worker'` previously matched **0 tests**; now 7. Asserts each death signature (KilledWorker, "4 workers died", nanny worker death, exit 137) is classified, and that a dying `compute` yields a `FAILED` result dict (no hang / uncaught crash).

## Work-unit outcomes

| w | outcome |
|---|---|
| w0 reproduce | Cannot reproduce — resource caps (#692) eliminated it; documented |
| w1 bounded limits | Already present (#692); confirmed effective |
| w2 FAIL-and-advance | Mechanism existed; added plural pattern + regression test |
| w3 tpcds support | **Supported, resource-stable** at swept scales; 23 residual failures are translation gaps (dataframe-compat track), not stability |

## Verification

- `pytest tests/uat -m fast -k 'dask or cluster or worker'` → 7 passed (was 0)
- `pytest tests/unit/platforms/dataframe/test_dask_df_coverage.py` → 16 passed
- dask-df tpch@0.1 → 100% (Q10 skipped by existing local-envelope guard)
- dask-df tpcds@0.1 → 103 queries, all 3 iterations, no truncation
- `make pr-preflight` → 22,818 passed / 5 skipped

## Follow-up (no findings deferred in scope)

Spun out a separate TODO: the TPC-H Q10 dask skip guard appears **obsolete** — Dask 2026.3.0 makes the dask-expr optimizer mandatory, so Q10 now runs within the 2GB envelope at SF1 (verified via parquet + CSV). Tracked for its own PR (guard removal + projection-pushdown rework), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)