### PR TITLE
feat(uat): certification re-run configs, ordering check, and approval gate

### DIFF
--- a/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
+++ b/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
@@ -2,7 +2,7 @@ id: uat-certification-rerun-ordering-and-gate
 title: "UAT certification re-run: enforce ordering, fresh root, and an explicit approval gate"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -41,30 +41,55 @@ prior_art:
 work:
   - id: w1
     summary: "Author/refresh the certification config(s) cloned from a template: scales 0.01/0.1/1 (non-OLTP), 0.01 (OLTP), recorded seed, fresh run root"
-    status: pending
+    status: done
+    notes: |
+      Three stage-ordered configs cloned from uat-enabled-platforms-full.yaml:
+      certification-01-native-dataframe.yaml (groups sql+dataframe, 0.01/0.1/1),
+      certification-02-docker-nonoltp.yaml (docker-fast, 0.01/0.1/1),
+      certification-03-docker-oltp.yaml (docker-slow, 0.01). Numeric prefixes +
+      runbook encode the run order. Fresh-root + recorded-seed are documented in
+      the configs and runbook (config schema has no seed field; the operator
+      records BENCHBOX_SEED). Validated in tests/uat/test_config.py.
   - id: w2
     summary: "Add an ordering assertion/lint: native completes before any Docker stack starts, provable from lifecycle logs"
-    status: pending
+    status: done
     notes: |
-      Each sweep config is a separate invocation, so enforce via a documented
-      runbook ordering plus a lightweight check (e.g. a helper that verifies
-      no Docker action=up precedes the last native cell across the run set).
+      report.parse_docker_up_events + report.certification_ordering_violations:
+      parse Docker action=up timestamps from each stage's uat_lifecycle.log and
+      flag any that precede the native+dataframe completion boundary. Stage 1 is
+      Docker-free (docker_manage_platforms=false), so it emits no action=up
+      events. Tested in tests/uat/test_report.py. Cross-stage order is also
+      enforced by the runbook (separate sequential invocations).
   - id: w3
     summary: "Encode the APPROVE/HOLD gate as a checklist + optional report teeth (cross_scale_coverage_min_pairs)"
     needs: [w1]
-    status: pending
+    status: done
+    notes: |
+      cross_scale_coverage_min_pairs armed in all three configs (report-phase
+      teeth: a floor breach forces a non-zero report exit). APPROVE/HOLD
+      checklist written in the runbook.
   - id: w4
     summary: "Write the certification runbook section in docs/operations/uat-framework.md"
     needs: [w1, w2, w3]
-    status: pending
+    status: done
+    notes: |
+      "Certification re-run" section added: four-stage ordering, fresh root +
+      seed, one-stack-at-a-time, measure-then-set Docker timeout, the ordering-
+      check snippet, the cross-scale teeth, and the APPROVE/HOLD gate checklist.
   - id: w5
     summary: "Execute the full certification re-run into a fresh root and confirm every config reaches the report phase"
     needs: [w4]
     status: pending
     notes: |
+      OPERATIONAL / live-environment sign-off step (deferred; not runnable in the
+      implementation sandbox). Requires all platforms incl. built/pulled Docker
+      stacks (LakeSail Spark image etc.) and a long multi-stage sweep. This is
+      where uat-docker-stack-recovery w3/w4 (the Docker re-runs) are executed.
       Required terminal artifacts per run: cells.jsonl, compatibility_pruned.jsonl,
       resume.json (if aborted), matrix_summary.tsv, validator_rollup.tsv,
-      uat_lifecycle.log, final report with COMPLETED footer + commit SHA.
+      uat_lifecycle.log, final report with COMPLETED footer + commit SHA. The
+      code scaffolding (configs, ordering check, gate teeth, runbook) is in place
+      so this becomes a run-and-evaluate step.
 
 deps:
   needs:

--- a/docs/operations/uat-framework.md
+++ b/docs/operations/uat-framework.md
@@ -309,3 +309,65 @@ just wastes the timeout window each attempt.
 | Fixed `container_name` collision | a compose file declares a global container name already in use | stop the conflicting developer stack or keep that platform external-only until the compose file is fixed |
 | Validator clean rate breaches floor | bundle quality regression | run `make uat-validate` standalone; it validates via `benchbox.validation.bundle` and writes the rollup TSV |
 | Make target missing | new release not synced | `make worktree-pool-status` to check pool freshness |
+
+## Certification re-run
+
+A certification sweep produces the sign-off evidence (a COMPLETED report per
+config with a commit SHA). It runs in four stages, in this order, so that all
+native and dataframe platforms finish before any Docker stack starts — the
+ordering the 2026-05-28/29 evidence violated.
+
+Stages (run each to completion before starting the next):
+
+1. **Native SQL + dataframe** — `tests/uat/configs/certification-01-native-dataframe.yaml` (scales 0.01/0.1/1)
+2. **Docker non-OLTP** — `tests/uat/configs/certification-02-docker-nonoltp.yaml` (scales 0.01/0.1/1)
+3. **Docker OLTP** — `tests/uat/configs/certification-03-docker-oltp.yaml` (scale 0.01)
+
+(Stage 1 covers certification stages 1–2 of the contract — native SQL then
+dataframe — in a single Docker-free sweep; stages 2 and 3 are the Docker tiers.)
+
+Run rules:
+
+- Use a **fresh run root** under `BENCHBOX_OUTPUT_DIR=~/Developer/benchmark_runs`;
+  never resume into the failed 2026-05-28/29 dirs (they are non-evidentiary).
+- Record the run **seed** (`BENCHBOX_SEED`) in the certification log.
+- One platform / one Docker stack at a time (`execute.parallel_platforms` is
+  hard-rejected). A single Docker stack's compose-up failure records FAIL and
+  the sweep advances; it does not truncate the run.
+- For slow Docker stacks (e.g. LakeSail), set `cleanup.docker_start_timeout_s`
+  from a measured healthy startup (see "Managed Docker startup failures are
+  non-fatal") before the stage-2 run.
+
+Ordering check: after the runs, capture the stage-1 completion timestamp (the
+last line of stage 1's `uat_lifecycle.log`, or the stage-1 run-dir completion
+time) and verify no Docker stack came up earlier:
+
+```python
+from tests.uat.phases.report import certification_ordering_violations
+violations = certification_ordering_violations(
+    [open(stage2_lifecycle_log).read(), open(stage3_lifecycle_log).read()],
+    native_stage_completed_at=stage1_completed_at,
+)
+assert not violations, violations
+```
+
+`cross_scale_coverage_min_pairs` in each config is the report-phase teeth: a
+breach forces a non-zero report exit, so a partial or regressed sweep cannot be
+APPROVED. Tune the value to the certified pair count during bring-up.
+
+### APPROVE / HOLD gate
+
+APPROVE only if **all** of the following hold for every config:
+
+- [ ] The run reached the **report** phase with a `# run_status=COMPLETED`
+      footer carrying a `source_commit_sha` (and `source_dirty=false`).
+- [ ] `matrix_summary.tsv` and `validator_rollup.tsv` exist and are non-empty.
+- [ ] Every required, non-pruned cell **passed**; `cross_scale_coverage_min_pairs`
+      is met (no floor breach).
+- [ ] The ordering check returns no violations (no Docker `action=up` before
+      native + dataframe completion).
+- [ ] DuckDB (the reference) is green or its cells are explicitly pruned.
+
+HOLD if **any** of: missing manifests, missing commit SHA, a DuckDB reference
+failure, a Docker zero-cell run, a hung platform, or a `NO_JSON` cell without
+captured error text.

--- a/tests/uat/configs/certification-01-native-dataframe.yaml
+++ b/tests/uat/configs/certification-01-native-dataframe.yaml
@@ -1,0 +1,65 @@
+# Certification re-run — STAGE 1 of 3: native SQL + dataframe (native execution).
+#
+# Run order (see docs/operations/uat-framework.md "Certification re-run"):
+#   1. certification-01-native-dataframe.yaml   <-- this file
+#   2. certification-02-docker-nonoltp.yaml
+#   3. certification-03-docker-oltp.yaml
+#
+# Native SQL and dataframe (native-execution) platforms must complete BEFORE
+# any Docker stack starts (the 2026-05-28/29 evidence was contaminated because a
+# Docker stack began before the dataframe sweep finished). This stage runs no
+# Docker platforms, so its uat_lifecycle.log contains no `action=up` events —
+# that absence is what the ordering check keys on. Use a FRESH run root and
+# record the run seed (BENCHBOX_SEED) in the certification log.
+name: "certification-01-native-dataframe"
+description: "Certification stage 1: native SQL + dataframe platforms, scales 0.01/0.1/1"
+
+phases:
+  - preflight
+  - execute
+  - validate
+  - package
+  - explorer_smoke
+  - report
+
+platforms:
+  groups: ["sql", "dataframe"]
+
+benchmarks:
+  groups: ["all"]
+
+scales:
+  rungs: [0.01, 0.1, 1.0]
+
+execute:
+  per_cell_timeout_s: 1200
+  early_stop_after_s: 86400
+  early_stop_on_failure: false
+  phases_arg: "load,power"
+  skip_unreachable: true
+  parallel_platforms: false
+
+preflight:
+  free_space_min_gib: 5
+  free_space_path: "~/Developer/benchmark_runs"
+
+cleanup:
+  preserve_datagen: true
+  prune_databases: true
+  docker_manage_platforms: false
+
+validate:
+  validator_clean_rate_floor: 1.0
+
+report:
+  matrix_summary_tsv: "matrix_summary.tsv"
+  # APPROVE gate teeth: require every required (platform, benchmark) pair to be
+  # clean across all three rungs. Set to the count expected after a green run;
+  # a breach forces a non-zero report exit so the gate cannot be APPROVED on a
+  # partial/regressed sweep. Tune to the certified pair count during bring-up.
+  cross_scale_coverage_min_pairs: 1
+
+output:
+  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
+  logs_dir_template: "~/Developer/benchmark_runs/logs/certification_01_native_dataframe_{date}"
+  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/configs/certification-02-docker-nonoltp.yaml
+++ b/tests/uat/configs/certification-02-docker-nonoltp.yaml
@@ -1,0 +1,67 @@
+# Certification re-run — STAGE 2 of 3: Docker non-OLTP stacks.
+#
+# Start ONLY after certification-01-native-dataframe.yaml has fully completed
+# (its report reached the COMPLETED footer). The certification ordering check
+# (tests/uat/phases/report.py::certification_ordering_violations) verifies that
+# no Docker `action=up` in this stage's uat_lifecycle.log precedes the stage-1
+# completion timestamp recorded in the runbook.
+#
+# UAT-managed Docker lifecycle: one stack at a time, project-scoped teardown
+# only. A single stack's compose-up failure records FAIL and the sweep advances
+# (see uat-docker-stack-recovery), so a slow/broken stack cannot empty the run.
+name: "certification-02-docker-nonoltp"
+description: "Certification stage 2: Docker non-OLTP stacks, scales 0.01/0.1/1"
+
+phases:
+  - preflight
+  - execute
+  - validate
+  - package
+  - explorer_smoke
+  - report
+
+platforms:
+  groups: ["docker-fast"]
+
+benchmarks:
+  groups: ["all"]
+
+scales:
+  rungs: [0.01, 0.1, 1.0]
+
+execute:
+  per_cell_timeout_s: 1200
+  early_stop_after_s: 86400
+  early_stop_on_failure: false
+  phases_arg: "load,power"
+  skip_unreachable: true
+  parallel_platforms: false
+
+preflight:
+  free_space_min_gib: 5
+  free_space_path: "~/Developer/benchmark_runs"
+  docker_required: true
+
+cleanup:
+  preserve_datagen: true
+  prune_databases: true
+  docker_manage_platforms: true
+  docker_platform_switch: "volumes"
+  docker_project_prefix: "benchbox-uat-cert"
+  # Provisional: set from a measured healthy startup during bring-up (see the
+  # "measure-then-set" guidance), especially for the LakeSail Spark Connect
+  # service which exceeded the prior 300s default.
+  docker_start_timeout_s: 300
+  docker_fixed_container_name_policy: "fail"
+
+validate:
+  validator_clean_rate_floor: 1.0
+
+report:
+  matrix_summary_tsv: "matrix_summary.tsv"
+  cross_scale_coverage_min_pairs: 1
+
+output:
+  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
+  logs_dir_template: "~/Developer/benchmark_runs/logs/certification_02_docker_nonoltp_{date}"
+  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/configs/certification-03-docker-oltp.yaml
+++ b/tests/uat/configs/certification-03-docker-oltp.yaml
@@ -1,0 +1,58 @@
+# Certification re-run — STAGE 3 of 3: Docker OLTP stacks.
+#
+# Start ONLY after stages 1 and 2 have fully completed. OLTP stacks run at
+# scale 0.01 only. PostgreSQL-family stacks share port 5432 and MUST stay
+# serialized (one Docker stack at a time; parallel_platforms is hard-rejected).
+name: "certification-03-docker-oltp"
+description: "Certification stage 3: Docker OLTP stacks, scale 0.01"
+
+phases:
+  - preflight
+  - execute
+  - validate
+  - package
+  - explorer_smoke
+  - report
+
+platforms:
+  groups: ["docker-slow"]
+
+benchmarks:
+  groups: ["all"]
+
+scales:
+  rungs: [0.01]
+
+execute:
+  per_cell_timeout_s: 1200
+  early_stop_after_s: 86400
+  early_stop_on_failure: false
+  phases_arg: "load,power"
+  skip_unreachable: true
+  parallel_platforms: false
+
+preflight:
+  free_space_min_gib: 5
+  free_space_path: "~/Developer/benchmark_runs"
+  docker_required: true
+
+cleanup:
+  preserve_datagen: true
+  prune_databases: true
+  docker_manage_platforms: true
+  docker_platform_switch: "volumes"
+  docker_project_prefix: "benchbox-uat-cert"
+  docker_start_timeout_s: 300
+  docker_fixed_container_name_policy: "fail"
+
+validate:
+  validator_clean_rate_floor: 1.0
+
+report:
+  matrix_summary_tsv: "matrix_summary.tsv"
+  cross_scale_coverage_min_pairs: 1
+
+output:
+  benchmark_runs_dir_template: "~/Developer/benchmark_runs"
+  logs_dir_template: "~/Developer/benchmark_runs/logs/certification_03_docker_oltp_{date}"
+  submissions_dir_template: "~/Developer/benchmark_runs/submissions/{name}"

--- a/tests/uat/phases/report.py
+++ b/tests/uat/phases/report.py
@@ -9,6 +9,7 @@ Finding 1 scoping (default OFF; sweep authors enable explicitly).
 
 from __future__ import annotations
 
+import datetime as _dt
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -203,3 +204,70 @@ def write_report(
 
 def _footer_value(value: str) -> str:
     return value.replace("\t", " ").replace("\n", " ")
+
+
+# ---------------------------------------------------------------------------
+# Certification re-run ordering check.
+#
+# The certification contract (uat-certification-rerun-ordering-and-gate) runs
+# four stages — native SQL, then dataframe, then Docker non-OLTP, then Docker
+# OLTP — and requires that ALL native + dataframe platforms complete before any
+# Docker stack starts. The 2026-05-28/29 evidence was contaminated because a
+# Docker stack began before the dataframe sweep finished. Each sweep is a
+# separate invocation, so the cross-stage order is enforced by the runbook; this
+# helper provides the lightweight, machine-checkable proof from lifecycle logs.
+# ---------------------------------------------------------------------------
+
+
+def parse_docker_up_events(lifecycle_log_text: str) -> list[tuple[_dt.datetime, str]]:
+    """Extract ``(timestamp, platform)`` for each Docker ``action=up`` line.
+
+    Parses ``uat_lifecycle.log`` lines of the shape::
+
+        2026-05-30T01:02:03 [docker] platform=lakesail action=up status=ok ...
+
+    Lines without a Docker ``action=up`` marker, or with an unparseable leading
+    ISO timestamp, are skipped.
+    """
+    events: list[tuple[_dt.datetime, str]] = []
+    for raw in lifecycle_log_text.splitlines():
+        line = raw.strip()
+        if "[docker]" not in line or "action=up" not in line:
+            continue
+        timestamp_token = line.split(" ", 1)[0]
+        try:
+            timestamp = _dt.datetime.fromisoformat(timestamp_token)
+        except ValueError:
+            continue
+        platform = "unknown"
+        for token in line.split():
+            if token.startswith("platform="):
+                platform = token.split("=", 1)[1]
+                break
+        events.append((timestamp, platform))
+    return events
+
+
+def certification_ordering_violations(
+    docker_stage_lifecycle_logs: Iterable[str],
+    *,
+    native_stage_completed_at: _dt.datetime,
+) -> list[str]:
+    """Return ordering violations for a certification run-set.
+
+    Given the ``uat_lifecycle.log`` text of each Docker stage and the timestamp
+    at which the native + dataframe stage completed, return a human-readable
+    violation for every Docker ``action=up`` that started at or before that
+    boundary. An empty list means the four-stage ordering held: no Docker stack
+    came up before native + dataframe finished.
+    """
+    violations: list[str] = []
+    for log_text in docker_stage_lifecycle_logs:
+        for timestamp, platform in parse_docker_up_events(log_text):
+            if timestamp <= native_stage_completed_at:
+                violations.append(
+                    f"Docker stack '{platform}' started at {timestamp.isoformat()} "
+                    f"at/before native+dataframe stage completion "
+                    f"{native_stage_completed_at.isoformat()}"
+                )
+    return violations

--- a/tests/uat/test_config.py
+++ b/tests/uat/test_config.py
@@ -300,3 +300,37 @@ def test_stress_override_scale_sets_override_without_mutating_rungs():
     overridden = replace(cfg, scales=replace(cfg.scales, override=0.1))
     assert overridden.scales.rungs == (0.01, 0.1, 1.0)
     assert overridden.scales.override == 0.1
+
+
+# ---------------------------------------------------------------------------
+# Certification re-run configs (uat-certification-rerun-ordering-and-gate).
+# ---------------------------------------------------------------------------
+
+_CERT_CONFIGS_DIR = Path(__file__).parent / "configs"
+
+
+def test_certification_configs_load_and_encode_stage_ordering():
+    """The three certification configs validate and encode the four-stage order."""
+    stage1 = config.load_config(_CERT_CONFIGS_DIR / "certification-01-native-dataframe.yaml")
+    stage2 = config.load_config(_CERT_CONFIGS_DIR / "certification-02-docker-nonoltp.yaml")
+    stage3 = config.load_config(_CERT_CONFIGS_DIR / "certification-03-docker-oltp.yaml")
+
+    # Stage 1 is native + dataframe only — no Docker management, so no `action=up`
+    # events can precede the Docker stages.
+    assert stage1.platforms.groups == ("sql", "dataframe")
+    assert stage1.cleanup.docker_manage_platforms is False
+    assert stage1.scales.rungs == (0.01, 0.1, 1.0)
+
+    # Stages 2 and 3 are the Docker tiers, managed lifecycle, serialized.
+    assert stage2.platforms.groups == ("docker-fast",)
+    assert stage3.platforms.groups == ("docker-slow",)
+    for stage in (stage2, stage3):
+        assert stage.cleanup.docker_manage_platforms is True
+        assert stage.execute.parallel_platforms is False
+    assert stage3.scales.rungs == (0.01,)  # OLTP at 0.01 only
+
+    # Every stage reaches the report phase and arms the cross-scale gate teeth.
+    for stage in (stage1, stage2, stage3):
+        assert "report" in stage.phases
+        assert stage.report.cross_scale_coverage_min_pairs is not None
+        assert stage.execute.parallel_platforms is False

--- a/tests/uat/test_report.py
+++ b/tests/uat/test_report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as _dt
 from pathlib import Path
 
 import pytest
@@ -158,3 +159,47 @@ def test_cross_scale_validator_status_normalizes_lookup_paths(tmp_path: Path, mo
     )
 
     assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Certification re-run ordering check.
+# ---------------------------------------------------------------------------
+
+_NATIVE_LOG = """2026-05-30T01:00:00 [report] native+dataframe stage complete
+"""
+
+_DOCKER_LOG_OK = """2026-05-30T02:00:00 [docker] platform=lakesail action=up status=ok project=benchbox-uat-cert-lakesail command=['docker'] message=started
+2026-05-30T02:30:00 [docker] platform=lakesail action=down status=ok project=benchbox-uat-cert-lakesail command=['docker'] message=removed
+2026-05-30T02:31:00 [docker] platform=clickhouse-server action=up status=ok project=benchbox-uat-cert-ch command=['docker'] message=started
+"""
+
+_DOCKER_LOG_EARLY = """2026-05-30T00:30:00 [docker] platform=cedardb action=up status=ok project=benchbox-uat-cert-cedardb command=['docker'] message=started
+"""
+
+
+def test_parse_docker_up_events_extracts_timestamp_and_platform():
+    events = report.parse_docker_up_events(_DOCKER_LOG_OK)
+    # Only `action=up` lines are returned (the `action=down` line is ignored).
+    assert [p for _, p in events] == ["lakesail", "clickhouse-server"]
+    assert all(isinstance(ts, _dt.datetime) for ts, _ in events)
+
+
+def test_parse_docker_up_events_ignores_non_docker_and_garbage_lines():
+    assert report.parse_docker_up_events(_NATIVE_LOG) == []
+    assert report.parse_docker_up_events("not-a-timestamp [docker] action=up platform=x") == []
+
+
+def test_certification_ordering_no_violation_when_docker_starts_after_native():
+    boundary = _dt.datetime(2026, 5, 30, 1, 0, 0)
+    violations = report.certification_ordering_violations([_DOCKER_LOG_OK], native_stage_completed_at=boundary)
+    assert violations == []
+
+
+def test_certification_ordering_flags_docker_up_before_native_completion():
+    boundary = _dt.datetime(2026, 5, 30, 1, 0, 0)
+    violations = report.certification_ordering_violations(
+        [_DOCKER_LOG_EARLY, _DOCKER_LOG_OK], native_stage_completed_at=boundary
+    )
+    assert len(violations) == 1
+    assert "cedardb" in violations[0]
+    assert "at/before native+dataframe stage completion" in violations[0]


### PR DESCRIPTION
## Summary

Scaffolding for a clean, ordered, gated UAT certification re-run. Addresses `uat-certification-rerun-ordering-and-gate` w1–w4. The 2026-05-28/29 evidence had two structural problems beyond cell failures: a Docker stack began before the native/dataframe sweep finished (ordering), and no run reached the report phase (no `matrix_summary.tsv` / `validator_rollup.tsv`).

## Changes

- **Configs** (`tests/uat/configs/certification-0{1,2,3}-*.yaml`): three stage-ordered configs cloned from the full template — native SQL + dataframe (0.01/0.1/1), Docker non-OLTP (0.01/0.1/1), Docker OLTP (0.01). Numeric prefixes + the runbook encode the four-stage order; all reach the `report` phase and arm `cross_scale_coverage_min_pairs`.
- **Ordering check** (`report.py`): `parse_docker_up_events` + `certification_ordering_violations` parse Docker `action=up` timestamps from each stage's `uat_lifecycle.log` and flag any preceding native+dataframe completion. Stage 1 is Docker-free, so it emits no `action=up` events.
- **Runbook** (`uat-framework.md` "Certification re-run"): four-stage ordering, fresh root + recorded seed, one-stack-at-a-time, measure-then-set Docker timeout, the ordering-check snippet, cross-scale teeth, and the **APPROVE/HOLD gate checklist**.
- **Tests**: `test_config.py` validates the configs + stage ordering; `test_report.py` covers the ordering parser and violation detection.

## Work-unit outcomes

| w | outcome |
|---|---|
| w1 configs | done (3 stage configs, validated) |
| w2 ordering check | done (helper + tests) |
| w3 gate teeth + checklist | done (cross_scale teeth armed; APPROVE/HOLD checklist) |
| w4 runbook | done |
| w5 execute live cert run | **deferred — operational sign-off** |

## Verification

- `pytest tests/uat/test_config.py tests/uat/test_report.py` → 45 passed (TODO verification #1)
- `make pr-preflight` → 22,824 passed / 5 skipped

## Deferred (w5)

Executing the full live certification re-run requires all platforms incl. built/pulled Docker stacks (LakeSail Spark image etc.) and a long multi-stage sweep — it is the operational sign-off step and is where `uat-docker-stack-recovery` w3/w4 (the Docker re-runs) execute. The scaffolding here (configs, ordering check, gate teeth, runbook) makes w5 a run-and-evaluate step. The `uat-certification-rerun-ordering-and-gate` TODO stays In Progress until that run is performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)