### PR TITLE
chore(todo): capture drop-pandas-from-core for v0.3.1

### DIFF
--- a/_project/TODO/main/active/release-recovery-v0-3-1.yaml
+++ b/_project/TODO/main/active/release-recovery-v0-3-1.yaml
@@ -10,6 +10,7 @@ deps:
   - release-finalize-pretag-ci-wait
   - single-repo-migration-phase-6-delete-obsolete-tooling
   - single-repo-migration-phase-7-docs-cleanup
+  - drop-pandas-from-core-dependencies
 
 description: |
   The public `v0.3.0` tag, GitHub release, and PyPI files are immutable and

--- a/_project/TODO/main/planning/drop-pandas-from-core-dependencies.yaml
+++ b/_project/TODO/main/planning/drop-pandas-from-core-dependencies.yaml
@@ -1,0 +1,213 @@
+id: drop-pandas-from-core-dependencies
+title: "Drop pandas from core dependencies for v0.3.1 by fixing the eager import surface"
+worktree: main
+priority: Critical
+status: Not Started
+category: Dependency Management
+
+deps:
+  needs: []
+
+description: |
+  PR #681 fixed the v0.3.0 clean-install failure (`import benchbox` raised
+  ImportError without pandas) by adding `pandas>=2.0.0` to
+  `[project.dependencies]` (`pyproject.toml:50-52`). That treated the symptom,
+  not the cause.
+
+  Root cause: `import benchbox` eagerly pulls an engine-specific module that
+  imports pandas at module top level. The reachable chain is
+  `benchbox/__init__.py:28` -> `platforms/__init__.py:286` ->
+  `adapter_factory.py:17` -> `clickhouse/__init__.py:5` -> `adapter.py:13` ->
+  `setup.py:9` -> `client.py:11 import pandas as pd`. `platforms/__init__.py`
+  already lazy-loads `ClickHouseAdapter` via `__getattr__`, but
+  `adapter_factory.py:17` reaches through the package `__init__`, defeating that
+  lazy design. `client.py` uses pandas at exactly one runtime site
+  (`client.py:144`, an empty-result `pd.DataFrame()`), so it is trivially
+  lazy-able.
+
+  Consequences of the patch: every install — including a DuckDB-only SQL run —
+  now pays ~49 MB (pandas + pytz, tzdata, python-dateutil, six) for a library it
+  may never touch. pandas is simultaneously a hard core dep AND an optional
+  extra (`pandas`, `dataframe-pandas`, `tpcdi`, `modin`, `dask`, `all`), an
+  incoherent manifest. This contradicts the project's own documented thin-core
+  philosophy: `docs/development/dependency-inventory.md:159` classifies pandas
+  as "DF/BM" (DataFrame/Benchmark-specific, not core), and finding F1
+  (`:209-227`) recommends removing engine-specific libs from core for exactly
+  this reason.
+
+  v0.3.1 is UNRELEASED, so the correct fix lands NOW: make the import surface
+  minimal and drop pandas back to extras before the cut, rather than shipping
+  the heavy patch and deferring. Everyone who needs pandas still gets it via the
+  extras and transitively via `chdb` (which requires pandas).
+
+  This TODO is a gate on `release-recovery-v0-3-1` w3 (`make release-cut
+  VERSION=0.3.1`): the cut should carry the minimal-surface fix, not the patch.
+
+work:
+- id: w1
+  summary: "Lazy-ize the one reachable eager pandas import in the ClickHouse client"
+  status: pending
+  notes: |
+    Move `import pandas as pd` out of module scope in
+    `benchbox/platforms/clickhouse/client.py:11` into the function that uses it
+    (`client.py:144`). Mirror the in-function import pattern already used by
+    `benchbox/core/tpch/dataframe_queries.py:1064`. This single change removes
+    pandas from the entire `import benchbox` surface and is sufficient to make
+    a clean core install import without pandas present.
+
+- id: w2
+  summary: "Break the ClickHouse package-init eager re-export that defeats lazy loading"
+  needs: [w1]
+  status: pending
+  notes: |
+    Structural root cause. `adapter_factory.py:17` imports the pure helper
+    `clickhouse/deployment_mode.py` but executing `clickhouse/__init__.py:5-11`
+    eagerly re-exports the heavy `adapter`/`setup`/`client` modules. Either
+    (a) make `clickhouse/__init__.py` lazy via module `__getattr__`, or
+    (b) have `adapter_factory.py:17` import `deployment_mode` by full path
+    without triggering the package `__init__`. Without this, the next engine
+    module added to the chain re-introduces the #681 failure.
+
+- id: w3
+  summary: "Convert the latent top-level pandas imports to in-function imports"
+  needs: [w1]
+  status: pending
+  notes: |
+    BLIND SPOT: not reachable on the import surface today, but a future wiring
+    of these benchmarks recreates the exact #681 failure. Convert top-level
+    `import pandas` to in-function in:
+      - benchbox/core/joinorder/dataframe_queries.py:33
+      - benchbox/core/ssb/dataframe_queries/queries.py:8
+      - benchbox/core/joinorder_synthetic/dataframe_queries.py:17
+    Confirm none are reached from `import benchbox` before and after.
+
+- id: w4
+  summary: "Replace the wrong-contract pandas test with a minimal-deps import test"
+  needs: [w1]
+  status: pending
+  notes: |
+    BLIND SPOT: `tests/unit/test_release_infrastructure.py:99-107` asserts the
+    STRING `pandas>=` is present in pyproject — it locks in the #681 patch and
+    will fail once pandas leaves core (w6). Replace it with a test that imports
+    `benchbox` in a pandas-blocked / minimal-deps environment (e.g. a
+    `sys.modules['pandas'] = None` guard or subprocess with pandas absent) and
+    asserts success. Test the CONTRACT (import works on minimal deps), not the
+    manifest text.
+
+- id: w5
+  summary: "Make the core-only smoke gate prove a minimal import surface and gate the release"
+  needs: [w4]
+  status: pending
+  notes: |
+    BLIND SPOT: a core-only clean-install smoke test exists
+    (`.github/workflows/nightly.yml:235`, `test.yml:302`:
+    `uv run --isolated --no-project --with <wheel> -- python -c "import benchbox"`),
+    but it now PASSES because pandas is core — it no longer proves the surface
+    is minimal, which is why 0.3.0 shipped broken. Strengthen it to install the
+    CORE deps WITHOUT pandas (or block pandas) and assert `import benchbox`
+    succeeds. Confirm this gate runs on the release path (`release.yml:181,188`),
+    not only nightly/test, so a broken import surface blocks the tag.
+
+- id: w6
+  summary: "Remove pandas from core dependencies and reconcile the extras/pin"
+  needs: [w1, w2, w3, w4, w5]
+  status: pending
+  notes: |
+    Only after w1-w5 are green. Remove `pandas>=2.0.0` from
+    `[project.dependencies]` (`pyproject.toml:52`). It remains in the `tpcdi`,
+    `pandas`, `dataframe-pandas`, `modin`, `dask`, and `all` extras, and arrives
+    transitively via `chdb`. Verify with `uv` that a core-only resolve excludes
+    pandas and that each pandas-needing extra still resolves. Resolve the
+    core-dep/extra contradiction.
+    BLIND SPOT (pin): the `pandas>=2.0.0` floor was copied, not chosen (it
+    predates #681 across the extras). Decide deliberately: keep `>=2.0.0` or
+    tighten/loosen with a one-line rationale; do not leave it as cargo-culted.
+
+- id: w7
+  summary: "Audit remaining eager heavy imports on the import surface"
+  needs: [w1]
+  status: pending
+  notes: |
+    `pyarrow` and `numpy` are reached on `import benchbox` and are core. Verify
+    that is intentional (results/Arrow handling is plausibly genuinely core) and
+    record the decision. Cross-reference `dependency-inventory.md` F1
+    (`chdb-core` flagged for removal from core) and F2 (`jsonschema`) so this
+    work aligns with the documented thin-core direction rather than fixing only
+    pandas in isolation.
+
+verification:
+- description: "benchbox imports on a core install with pandas absent"
+  command: "uv run --isolated --no-project --with duckdb -- python -c 'import sys; sys.modules[\"pandas\"]=None; import benchbox; print(benchbox.__version__)'"
+  expected_output: "prints the version without ImportError"
+- description: "No top-level pandas import remains reachable from import benchbox"
+  command: "uv run -- python -c 'import benchbox, sys; assert \"pandas\" not in sys.modules, sorted(m for m in sys.modules if \"pandas\" in m)'"
+  expected_output: "exit 0 (pandas not imported)"
+- description: "pandas is not in the resolved core dependency set"
+  command: "uv export --no-dev --no-emit-project 2>/dev/null | grep -c '^pandas==' || true"
+  expected_output: "0"
+- description: "pandas-needing extras still resolve"
+  command: "uv pip install --dry-run '.[tpcdi]' >/dev/null && echo ok"
+  expected_output: "ok"
+- description: "TODO graph remains valid"
+  command: "uv run _project/scripts/todo_cli.py check-graph && uv run _project/scripts/validate_todo.py --all"
+  expected_output: "exit 0"
+
+must_preserve:
+- "`import benchbox` MUST succeed on a clean core install at every step; w1 satisfies this before pandas leaves core in w6."
+- "DataFrame mode, TPC-DI, and ClickHouse-local (chdb) runs must keep working — they receive pandas via their extras."
+- "Do not re-tag, force-push, or alter the immutable v0.3.0 tag/PyPI artifact."
+- "Do not weaken the release-required context or the core-only smoke gate to land this."
+
+approach: |
+  Land w1 first (lazy import) — it alone restores the minimal import surface and
+  de-risks everything downstream. Then w2-w5 (structural fix, latent imports,
+  real contract test, strengthened gate) so removing pandas in w6 is safe and
+  re-regression-proof. w7 is a documentation/decision pass aligning with
+  dependency-inventory F1/F2. The whole sequence must land on develop BEFORE
+  `make release-cut VERSION=0.3.1`, so v0.3.1 ships the minimal core, not the
+  pandas patch. Functional code fixes (w1-w3, w6) belong in a feature/fix PR;
+  test/gate changes (w4, w5) can ride along or in a sibling PR.
+
+anti_patterns:
+- "DO NOT keep pandas core and defer to v0.3.2 - because v0.3.1 is unreleased, so the correct minimal-core fix lands now at zero extra release cost."
+- "DO NOT remove pandas from core (w6) before the core-only-minus-pandas gate (w5) is green - because that gate is the only thing preventing a silent re-regression of the v0.3.0 failure."
+- "DO NOT keep the string-assert test (test_release_infrastructure.py:99-107) - because it tests the manifest text, not the import contract, and will both block w6 and fail to catch the real defect."
+- "DO NOT fix only client.py and leave the latent imports - because the user requires ALL blind spots addressed; w3 closes the next-failure vector."
+
+scope_limit:
+  only_modify:
+  - "pyproject.toml"
+  - "benchbox/platforms/clickhouse/client.py"
+  - "benchbox/platforms/clickhouse/__init__.py"
+  - "benchbox/platforms/adapter_factory.py"
+  - "benchbox/core/joinorder/dataframe_queries.py"
+  - "benchbox/core/ssb/dataframe_queries/queries.py"
+  - "benchbox/core/joinorder_synthetic/dataframe_queries.py"
+  - "tests/unit/test_release_infrastructure.py"
+  - ".github/workflows/nightly.yml"
+  - ".github/workflows/test.yml"
+  - ".github/workflows/release.yml"
+  - "docs/development/dependency-inventory.md"
+  notes: |
+    Touch only the import-surface modules, the dependency manifest, the
+    contract test, the smoke-gate workflows, and the dependency-inventory doc.
+    Do not refactor unrelated platform adapters.
+
+success_metrics:
+- "`import benchbox` succeeds on a core install with pandas not installed."
+- "`pandas` no longer appears in the resolved core dependency set; net install size drops ~49 MB for SQL-only users."
+- "A CI gate fails if any future change reintroduces a top-level heavy import on the `import benchbox` surface."
+- "pandas is declared in exactly one place per role (extras), with the version floor justified."
+- "v0.3.1 is cut from a develop that carries the minimal-core fix, not the #681 patch."
+
+metadata:
+  tags:
+  - dependencies
+  - packaging
+  - import-surface
+  - clean-install
+  - release-blocker
+  - v0.3.1
+  estimated_effort: "Medium"
+  created_date: "2026-05-30"
+  last_updated: "2026-05-30T00:00:00"


### PR DESCRIPTION
Add a Critical TODO to fix the eager import surface that PR #681 patched
by adding pandas to core deps. Lazy-ize clickhouse/client.py, break the
package-init re-export that defeats lazy loading, fix latent eager
imports, replace the manifest-string test with a real minimal-deps
import contract test, strengthen the core-only smoke gate, then remove
pandas from core. Captures all blind spots from the dependency
investigation. Gates release-recovery-v0-3-1 w3 so v0.3.1 ships the
minimal core, not the patch.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
