### PR TITLE
fix(dataframe): remove obsolete dask Q10 skip guard; projection-push Q10

### DIFF
--- a/_project/DONE/main/active/dask-q10-guard-staleness-and-projection-rework.yaml
+++ b/_project/DONE/main/active/dask-q10-guard-staleness-and-projection-rework.yaml
@@ -1,0 +1,98 @@
+id: dask-q10-guard-staleness-and-projection-rework
+title: "Remove the obsolete dask TPC-H Q10 skip guard and apply a projection-pushdown rework"
+worktree: main
+priority: Medium
+status: Completed
+completed_date: "2026-05-30"
+category: Platform Expansion
+
+description: |
+  dask-df pre-emptively SKIPPED TPC-H Q10 in the default local envelope via a
+  resource guard (benchbox/platforms/dataframe/dask_df.py:
+  _RESOURCE_ENVELOPE_SKIP_QUERY_IDS = {"Q10"}, _guarded_resource_query_diagnostic,
+  _collect_skip_query_ids override). The guard's premise was that Q10's
+  Pandas-family Dask graph terminates the parent process with exit 137 (OOM) on
+  local runs.
+
+  Investigation on 2026-05-29/30 (during uat-dask-stability-under-sweep) showed
+  the guard was OBSOLETE:
+
+  - Dask 2026.3.0 makes the dask-expr query optimizer MANDATORY. Disabling it
+    raises NotImplementedError ("The legacy implementation is no longer
+    supported"). The optimizer auto-applies projection + filter pushdown, so the
+    naive Q10 graph that OOMed on legacy Dask no longer materializes.
+  - The unmodified q10_pandas_impl ran within the 2GB/1-worker/spill local
+    envelope at SF1 in 2.6s (parquet) and 13.9s (CSV, the real benchbox IO),
+    producing 37,967 groups — no OOM, no exit 137.
+  - A projection-pushdown rework (select needed columns, push the
+    l_returnflag='R' filter before the lineitem join, group by the narrow
+    integer keys c_custkey/c_nationkey then rejoin detail columns) is byte-
+    identical to the current result (same all_hash, same top-20) and also fits.
+
+prior_art:
+  - "benchbox/platforms/dataframe/dask_df.py: removed _RESOURCE_ENVELOPE_SKIP_QUERY_IDS / _guarded_resource_query_diagnostic / _collect_skip_query_ids override / _is_local_envelope / _tpch_q10_resource_envelope_diagnostic"
+  - "benchbox/core/tpch/dataframe_queries.py:q10_pandas_impl — reworked with projection pushdown; q10_expression_impl unchanged"
+  - "tests/unit/platforms/dataframe/test_dask_df_coverage.py — replaced the Q10-guard tests with test_q10_not_preemptively_skipped_on_dask_local_envelope"
+
+work:
+  - id: w0
+    summary: "Re-validate: confirm unmodified Q10 runs within the default local envelope at 0.01/0.1/1 with the guard bypassed"
+    status: done
+    notes: |
+      SF1 (= scale 1.0) validated via the real adapter IO paths: parquet 2.6s,
+      CSV 13.9s, 37,967 groups, no exit 137. Live dask-df Q10 @0.1 after guard
+      removal: Q10 executed (not skipped), 1.3s, 100% success. 0.01 is trivially
+      within envelope.
+  - id: w1
+    summary: "Apply the projection-pushdown rework to q10_pandas_impl"
+    status: done
+    notes: |
+      Byte-identical to the prior output (verified: same all_hash, same top-20,
+      37,967 groups). 178 tests/unit/core/tpch dataframe/pandas tests pass.
+  - id: w2
+    summary: "Remove/relax the dask Q10 skip guard so Q10 runs in the default local envelope"
+    status: done
+    notes: |
+      Removed the pre-emptive guard: execute_query/execute_query_profiled
+      overrides, _guarded_resource_query_diagnostic, _collect_skip_query_ids /
+      _build_skipped_results overrides, _is_local_envelope,
+      _has_explicit_local_resource_settings, _is_tpch_benchmark,
+      _tpch_q10_resource_envelope_diagnostic, and the guard constants. KEPT the
+      generic worker-death safety net (_run_with_resource_diagnostics,
+      _resource_envelope_diagnostic, _RESOURCE_ENVELOPE_PATTERNS,
+      DaskResourceEnvelopeError) and the memory/worker caps.
+  - id: w3
+    summary: "Update tests: drop the Q10-guard tests, add coverage that Q10 is no longer skipped"
+    status: done
+
+must_preserve:
+  - "All other dask-df TPC-H cells that pass must not regress."
+  - "Q10 result is identical (same rows) before and after the rework."
+  - "The generic worker-death -> DaskResourceEnvelopeError -> FAIL safety net stays (only the Q10 pre-emptive skip is removed)."
+
+anti_patterns:
+  - "DO NOT remove the generic _run_with_resource_diagnostics worker-death catch - only the Q10 pre-emptive skip is obsolete."
+  - "DO NOT change Q10 semantics - the rework returns the identical result set."
+
+verification:
+  - description: "dask-df Q10 runs and returns rows (no pre-emptive skip)"
+    command: "uv run -- benchbox run --platform dask-df --benchmark tpch --scale 0.1 --queries Q10 --non-interactive --phases load,power"
+    expected_output: "Q10 executes (not SKIPPED) and returns rows; no exit 137"
+  - description: "dask coverage tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/dataframe/test_dask_df_coverage.py -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/dataframe/dask_df.py"
+    - "benchbox/core/tpch/dataframe_queries.py"
+    - "tests/"
+
+success_metrics:
+  - "dask-df runs TPC-H Q10 in the default local envelope with the identical result set; the obsolete pre-emptive skip is gone; the generic worker-death safety net remains."
+
+metadata:
+  tags: [dask, dataframe, tpch, q10, performance, defect]
+  estimated_effort: "Small"
+  created_date: "2026-05-30"
+  last_updated: "2026-05-30T00:00:00"

--- a/benchbox/core/tpch/dataframe_queries.py
+++ b/benchbox/core/tpch/dataframe_queries.py
@@ -1188,29 +1188,43 @@ def q10_pandas_impl(ctx: DataFrameContext) -> Any:
     start_date = params["start_date"]
     end_date = params["end_date"]
 
-    # Join customer -> orders, filter by date
-    customer_orders = customer.merge(orders, left_on="c_custkey", right_on="o_custkey")
-    customer_orders = customer_orders[
-        (customer_orders["o_orderdate"] >= start_date) & (customer_orders["o_orderdate"] < end_date)
+    # Projection pushdown: carry only the columns each stage needs so the wide
+    # string columns (c_comment, l_comment, o_comment, ...) never ride through
+    # the large lineitem join. Push the l_returnflag='R' filter below the join,
+    # and group by the narrow integer keys (c_custkey is the customer PK so it
+    # functionally determines the other customer attributes; c_nationkey -> n_name),
+    # then rejoin the small detail columns onto the aggregated result. This keeps
+    # the groupby off wide string keys and is what lets the graph fit a
+    # constrained local Dask envelope; the result is identical to grouping by all
+    # seven output columns.
+    customer_keys = customer[["c_custkey", "c_nationkey"]]
+    customer_detail = customer[["c_custkey", "c_name", "c_acctbal", "c_phone", "c_address", "c_comment"]]
+
+    orders_window = orders[["o_orderkey", "o_custkey", "o_orderdate"]]
+    orders_window = orders_window[
+        (orders_window["o_orderdate"] >= start_date) & (orders_window["o_orderdate"] < end_date)
     ]
 
-    # Join with lineitem, filter for returns
-    order_lines = customer_orders.merge(lineitem, left_on="o_orderkey", right_on="l_orderkey")
-    order_lines = order_lines[order_lines["l_returnflag"] == "R"]
+    returned_lines = lineitem[["l_orderkey", "l_extendedprice", "l_discount", "l_returnflag"]]
+    returned_lines = returned_lines[returned_lines["l_returnflag"] == "R"]
+    returned_lines = returned_lines.assign(
+        revenue=returned_lines["l_extendedprice"] * (1 - returned_lines["l_discount"])
+    )[["l_orderkey", "revenue"]]
 
-    # Join with nation
-    joined = order_lines.merge(nation, left_on="c_nationkey", right_on="n_nationkey")
+    customer_orders = customer_keys.merge(orders_window, left_on="c_custkey", right_on="o_custkey")
+    order_lines = customer_orders.merge(returned_lines, left_on="o_orderkey", right_on="l_orderkey")
 
-    # Calculate revenue
-    joined = joined.copy()
-    joined["revenue"] = joined["l_extendedprice"] * (1 - joined["l_discount"])
+    revenue_by_customer = order_lines.groupby(["c_custkey", "c_nationkey"], as_index=False).agg(
+        revenue=("revenue", "sum")
+    )
 
-    # Aggregate
+    with_nation = revenue_by_customer.merge(
+        nation[["n_nationkey", "n_name"]], left_on="c_nationkey", right_on="n_nationkey"
+    )
+    with_detail = with_nation.merge(customer_detail, on="c_custkey")
+
     return (
-        joined.groupby(
-            ["c_custkey", "c_name", "c_acctbal", "c_phone", "n_name", "c_address", "c_comment"], as_index=False
-        )
-        .agg(revenue=("revenue", "sum"))
+        with_detail[["c_custkey", "c_name", "c_acctbal", "c_phone", "n_name", "c_address", "c_comment", "revenue"]]
         .sort_values("revenue", ascending=False)
         .head(20)
     )

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -56,9 +56,7 @@ except ImportError:
     pd = None  # type: ignore[assignment]
     PANDAS_AVAILABLE = False
 
-from benchbox.core.dataframe.profiling import QueryExecutionProfile
 from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration
-from benchbox.platforms.dataframe._result_helpers import build_failure_result_dict
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
@@ -91,8 +89,6 @@ _RESOURCE_ENVELOPE_PATTERNS = (
 _DEFAULT_LOCAL_MEMORY_LIMIT = "2GB"
 _DEFAULT_LOCAL_WORKER_CAP = 2
 _DEFAULT_LOCAL_THREADS_PER_WORKER_CAP = 2
-_GUARDED_TPCH_Q10_NAME = "returned item reporting"
-_RESOURCE_ENVELOPE_SKIP_QUERY_IDS = frozenset({"Q10"})
 
 
 class DaskResourceEnvelopeError(RuntimeError):
@@ -391,148 +387,6 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
     def platform_name(self) -> str:
         """Return the platform name."""
         return "Dask"
-
-    def execute_query(self, ctx: Any, query: Any, query_id: str | None = None) -> dict[str, Any]:
-        """Execute a query, guarding known parent-killing Dask graphs."""
-        qid = str(query_id or getattr(query, "query_id", "unknown"))
-        diagnostic = self._guarded_resource_query_diagnostic(query, qid)
-        if diagnostic is not None:
-            logger.error("Query %s failed: %s", qid, diagnostic)
-            return build_failure_result_dict(
-                query_id=qid,
-                execution_time_seconds=0.0,
-                error_message=diagnostic,
-            )
-
-        return super().execute_query(ctx, query, query_id=query_id)
-
-    def execute_query_profiled(
-        self,
-        ctx: Any,
-        query: Any,
-        query_id: str | None = None,
-        **kwargs: Any,
-    ) -> tuple[dict[str, Any], QueryExecutionProfile]:
-        """Execute a profiled query, guarding known parent-killing Dask graphs."""
-        qid = str(query_id or getattr(query, "query_id", "unknown"))
-        diagnostic = self._guarded_resource_query_diagnostic(query, qid)
-        if diagnostic is not None:
-            logger.error("Query %s failed: %s", qid, diagnostic)
-            return (
-                build_failure_result_dict(
-                    query_id=qid,
-                    execution_time_seconds=0.0,
-                    error_message=diagnostic,
-                ),
-                QueryExecutionProfile(
-                    query_id=qid,
-                    execution_time_ms=0.0,
-                    platform=self.platform_name,
-                    lazy_evaluation=True,
-                    metrics={"resource_envelope_guarded": True},
-                ),
-            )
-
-        return super().execute_query_profiled(ctx, query, query_id=query_id, **kwargs)
-
-    def _guarded_resource_query_diagnostic(self, query: Any, query_id: str) -> str | None:
-        """Return a diagnostic when a known Dask graph can kill the parent process."""
-        query_name = str(getattr(query, "query_name", "")).strip().lower()
-        if query_id.strip().upper() != "Q10" or query_name != _GUARDED_TPCH_Q10_NAME:
-            return None
-        if not self._is_local_envelope():
-            return None
-
-        return (
-            "Dask resource-envelope failure before query execution: TPC-H Q10 Returned Item Reporting "
-            "is guarded because this Pandas-family Dask graph has been observed to terminate the parent "
-            f"benchmark process with exit 137 on local runs. Envelope: {self._resource_envelope_settings()}. "
-            "The query was not executed to preserve process stability; use a query subset excluding Q10, "
-            "an external scheduler, explicit local Dask resource settings, or another DataFrame platform "
-            "when Q10 coverage is required."
-        )
-
-    def _collect_skip_query_ids(self, benchmark_instance: Any | None) -> set[str]:
-        """Add Dask resource-envelope skips to benchmark-provided skip lists.
-
-        The TPC-H Q10 OOM that motivated this guard is specific to the default
-        local single-machine distributed envelope. When the user provides an
-        external ``scheduler_address`` or explicit local resource settings, Q10
-        should run normally; skipping it for those runs would lose legitimate
-        full-suite coverage.
-        """
-        skip_query_ids = super()._collect_skip_query_ids(benchmark_instance)
-        self._resource_envelope_skip_query_ids: set[str] = set()
-        if self._is_tpch_benchmark(benchmark_instance) and self._is_local_envelope():
-            self._resource_envelope_skip_query_ids = set(_RESOURCE_ENVELOPE_SKIP_QUERY_IDS)
-            skip_query_ids |= self._resource_envelope_skip_query_ids
-            logger.warning(
-                "Skipping TPC-H Q10 for dask-df local envelope: %s. "
-                "Pass --platform-option scheduler_address=tcp://... or explicit local resource options "
-                "to run Q10 with provisioned resources.",
-                self._tpch_q10_resource_envelope_diagnostic(),
-            )
-        return skip_query_ids
-
-    def _is_local_envelope(self) -> bool:
-        """Return True only for the default constrained local distributed envelope.
-
-        External schedulers and explicitly provisioned local resources are
-        out-of-envelope: those runs have taken ownership of the resource budget
-        and must not lose Q10 coverage to the default local-OOM guard.
-        """
-        if getattr(self, "scheduler_address", None):
-            return False
-        if not getattr(self, "use_distributed", False):
-            return False
-        return not self._has_explicit_local_resource_settings()
-
-    def _has_explicit_local_resource_settings(self) -> bool:
-        """Return whether local Dask resource sizing came from user configuration."""
-        return any(
-            getattr(self, flag_name, False)
-            for flag_name in (
-                "_n_workers_configured",
-                "_threads_per_worker_configured",
-                "_memory_limit_configured",
-            )
-        )
-
-    def _build_skipped_results(self, filtered_skip_query_ids: set[str]) -> list[dict[str, Any]]:
-        """Build skipped results, preserving Dask resource-envelope skip reasons."""
-        results = super()._build_skipped_results(filtered_skip_query_ids)
-        resource_skip_query_ids = getattr(self, "_resource_envelope_skip_query_ids", set())
-        for result in results:
-            query_id = str(result.get("query_id", "")).strip().upper()
-            if query_id in resource_skip_query_ids:
-                result["error"] = self._tpch_q10_resource_envelope_diagnostic()
-                result["dask_resource_envelope_guarded"] = True
-        return results
-
-    @staticmethod
-    def _is_tpch_benchmark(benchmark_instance: Any | None) -> bool:
-        """Return whether a benchmark instance is the TPC-H benchmark."""
-        if benchmark_instance is None:
-            return False
-        benchmark_type = type(benchmark_instance)
-        benchmark_name = str(
-            getattr(benchmark_instance, "name", "") or getattr(benchmark_instance, "_name", "")
-        ).lower()
-        return (
-            benchmark_type.__name__ == "TPCHBenchmark"
-            or benchmark_type.__module__.startswith("benchbox.core.tpch")
-            or "tpc-h" in benchmark_name
-        )
-
-    def _tpch_q10_resource_envelope_diagnostic(self) -> str:
-        """Return the stable diagnostic for the guarded TPC-H Q10 path."""
-        return (
-            "Dask resource-envelope guard: TPC-H Q10 Returned Item Reporting is skipped because this "
-            "Pandas-family Dask graph has been observed to terminate the parent benchmark process with "
-            f"exit 137 on default local-envelope runs. Envelope: {self._resource_envelope_settings()}. "
-            "Use an external scheduler, explicitly provision local Dask resources, or another DataFrame "
-            "platform when Q10 coverage is required."
-        )
 
     # =========================================================================
     # Data Loading Methods

--- a/tests/unit/platforms/dataframe/test_dask_df_coverage.py
+++ b/tests/unit/platforms/dataframe/test_dask_df_coverage.py
@@ -260,85 +260,27 @@ def test_resource_envelope_diagnostic_ignores_unrelated_errors():
     assert adapter._resource_envelope_diagnostic("compute", RuntimeError("bad column")) is None
 
 
-def test_tpch_q10_guard_and_skip_result_classification():
-    adapter = _make_adapter()
-    adapter.use_distributed = True
-    query = SimpleNamespace(query_id="Q10", query_name="Returned Item Reporting")
+def test_q10_not_preemptively_skipped_on_dask_local_envelope():
+    """The TPC-H Q10 dask skip guard was removed (dask-q10-guard-staleness).
 
-    result = adapter.execute_query(SimpleNamespace(), query)
-    assert result["status"] == "FAILED"
-    assert "Dask resource-envelope failure before query execution" in result["error"]
-    assert "exit 137" in result["error"]
-
-    benchmark = SimpleNamespace(name="TPC-H Benchmark")
-    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
-    skipped = adapter._build_skipped_results(skip_query_ids)
-
-    q10_skip = next(item for item in skipped if item["query_id"] == "Q10")
-    assert q10_skip["status"] == "SKIPPED"
-    assert q10_skip["dask_resource_envelope_guarded"] is True
-    assert "Dask resource-envelope guard" in q10_skip["error"]
-
-
-def test_profiled_tpch_q10_guard_returns_failure_profile():
-    adapter = _make_adapter()
-    adapter.use_distributed = True
-    query = SimpleNamespace(query_id="Q10", query_name="Returned Item Reporting")
-
-    result, profile = adapter.execute_query_profiled(SimpleNamespace(), query)
-
-    assert result["status"] == "FAILED"
-    assert profile.query_id == "Q10"
-    assert profile.metrics["resource_envelope_guarded"] is True
-
-
-def test_q10_skip_dropped_when_external_scheduler_address_set():
-    """w8 regression: an external scheduler means the run is no longer in the
-    constrained local envelope that motivated the OOM guard. Q10 must run."""
-    adapter = _make_adapter()
-    adapter.use_distributed = True
-    adapter.scheduler_address = "tcp://scheduler.example:8786"
-    benchmark = SimpleNamespace(name="TPC-H Benchmark")
-    query = SimpleNamespace(query_id="Q10", query_name="Returned Item Reporting")
-
-    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
-
-    assert "Q10" not in skip_query_ids
-    assert adapter._resource_envelope_skip_query_ids == set()
-    assert adapter._guarded_resource_query_diagnostic(query, "Q10") is None
-
-
-def test_q10_skip_dropped_when_local_resources_explicitly_configured():
-    """w8 regression: an explicitly provisioned local Dask run must not lose Q10 coverage."""
+    Dask 2026.3.0 makes the dask-expr optimizer mandatory, so Q10's projection-
+    pushed graph fits the default local envelope (validated at SF1 via parquet +
+    CSV: 37,967 groups, no OOM). Q10 must no longer be pre-emptively skipped, and
+    the guard machinery must be gone — while the generic worker-death catch stays.
+    """
     adapter = _make_adapter()
     adapter.use_distributed = True
     adapter.scheduler_address = None
-    adapter.n_workers = 8
-    adapter.threads_per_worker = 4
-    adapter._memory_limit = "16GB"
-    adapter._n_workers_configured = True
-    adapter._threads_per_worker_configured = True
-    adapter._memory_limit_configured = True
     benchmark = SimpleNamespace(name="TPC-H Benchmark")
-    query = SimpleNamespace(query_id="Q10", query_name="Returned Item Reporting")
 
     skip_query_ids = adapter._collect_skip_query_ids(benchmark)
-
     assert "Q10" not in skip_query_ids
-    assert adapter._resource_envelope_skip_query_ids == set()
-    assert adapter._guarded_resource_query_diagnostic(query, "Q10") is None
 
-
-def test_q10_skip_kept_for_default_local_distributed_envelope():
-    """w8 regression: default local LocalCluster runs remain inside the Q10 guard."""
-    adapter = _make_adapter()
-    adapter.scheduler_address = None
-    adapter.use_distributed = True
-    benchmark = SimpleNamespace(name="TPC-H Benchmark")
-
-    skip_query_ids = adapter._collect_skip_query_ids(benchmark)
-
-    assert "Q10" in skip_query_ids
+    # The pre-emptive Q10 guard machinery is removed...
+    assert not hasattr(adapter, "_guarded_resource_query_diagnostic")
+    assert not hasattr(adapter, "_tpch_q10_resource_envelope_diagnostic")
+    # ...but the generic resource-envelope worker-death safety net remains.
+    assert adapter._resource_envelope_diagnostic("compute", RuntimeError("exit code 137")) is not None
 
 
 def test_close_and_del_cleanup():


### PR DESCRIPTION
dask-df pre-emptively SKIPPED TPC-H Q10 in the default local envelope, on the
premise that its Pandas-family graph OOM-kills the parent process (exit 137).
That premise is obsolete: Dask 2026.3.0 makes the dask-expr query optimizer
mandatory (the legacy engine "is no longer supported"), so projection/filter
pushdown is always applied and the graph that OOMed no longer materializes.

Evidence (local 2GB/1-worker/spill envelope, SF1): the unmodified Q10 ran in
2.6s (parquet) and 13.9s (CSV, the real benchbox IO), 37,967 groups, no exit
137. After this change, live dask-df Q10 @0.1 executes (not skipped) in 1.3s at
100% success.

Changes:
- q10_pandas_impl: projection-pushdown rework — project only needed columns so
  wide strings (c_comment, l_comment, ...) don't ride through the lineitem join,
  push the l_returnflag='R' filter below the join, group by the narrow integer
  keys c_custkey/c_nationkey (c_custkey is the PK, so it determines the other
  customer attributes), then rejoin detail columns onto the small aggregate.
  Byte-identical result (same top-20, 37,967 groups); benefits all pandas-family
  platforms.
- dask_df.py: remove the pre-emptive Q10 guard (execute_query/profiled
  overrides, _guarded_resource_query_diagnostic, _collect_skip_query_ids /
  _build_skipped_results overrides, _is_local_envelope,
  _has_explicit_local_resource_settings, _is_tpch_benchmark,
  _tpch_q10_resource_envelope_diagnostic, and the guard constants). KEEP the
  generic worker-death safety net (_run_with_resource_diagnostics,
  _resource_envelope_diagnostic, DaskResourceEnvelopeError) and the memory caps.
- tests: replace the five Q10-guard tests with one asserting Q10 is no longer
  pre-emptively skipped and the guard machinery is gone while the generic catch
  remains.

Verification: test_dask_df_coverage.py 12 passed; tests/unit/core/tpch
dataframe/pandas tests 178 passed; live dask-df Q10 @0.1 executes at 100%.

Completes dask-q10-guard-staleness-and-projection-rework (follow-up from
uat-dask-stability-under-sweep).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
