### PR TITLE
fix(uat): capture diagnostics when --quiet hides cell failures

### DIFF
--- a/tests/uat/matrix.py
+++ b/tests/uat/matrix.py
@@ -393,11 +393,16 @@ def benchbox_run_argv(
     compression: str | None = None,
     extra_args: Iterable[str] = (),
     local_managed_platform: bool = False,
+    quiet: bool = True,
 ) -> list[str]:
     """Build the full `uv run -- benchbox run ...` argv for a single cell.
 
     Combines uv extras, platform `--platform-option` blocks, platform CLI
     flags, and any caller-provided extra argv.
+
+    ``quiet`` defaults to ``True`` so the final stdout line is the result-JSON
+    path (parsed by the runner). Pass ``quiet=False`` to capture a full
+    diagnostic transcript when a cell exits non-zero with no captured output.
     """
     argv = uv_run_argv(platform)
     argv += [
@@ -410,7 +415,10 @@ def benchbox_run_argv(
         "--scale",
         str(scale),
         "--non-interactive",
-        "--quiet",
+    ]
+    if quiet:
+        argv += ["--quiet"]
+    argv += [
         "--phases",
         phases,
     ]

--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -106,6 +106,38 @@ def _default_log_path(log_dir: Path, platform: str, benchmark: str, scale: float
     return log_dir / f"{platform}_{benchmark}_{scale}_{timestamp}.log"
 
 
+# Upper bound for the verbose diagnostic re-run triggered when a `--quiet`
+# cell exits non-zero without emitting any output. Failures surface fast, so a
+# tight cap keeps the re-run cheap while still capturing the real error.
+DIAGNOSTIC_RERUN_TIMEOUT_S = 180
+
+
+def _append_diagnostic_rerun(log_fh, argv: list[str], *, timeout_s: int, env: dict[str, str]) -> None:
+    """Re-run a failed cell verbosely and append its output to the log.
+
+    Invoked only when the original ``--quiet`` invocation exited non-zero
+    without emitting any output (``--quiet`` suppresses benchbox's own error
+    reporting). Output is written as plain lines so ``_cell_log_tail`` captures
+    it into ``failure_tail``. Best-effort: never raises into the caller.
+    """
+    log_fh.write("[uat] verbose diagnostic re-run (--quiet suppressed the original error):\n")
+    log_fh.flush()
+    try:
+        rerun = run_with_timeout(
+            argv,
+            timeout_s=timeout_s,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+        text = _decode_process_output(rerun.stdout)
+        if text:
+            log_fh.write(text if text.endswith("\n") else text + "\n")
+        log_fh.write(f"[uat] diagnostic re-run exit_code={rerun.exit_code} timed_out={rerun.timed_out}\n")
+    except Exception as exc:  # noqa: BLE001 - diagnostics must never mask the original failure
+        log_fh.write(f"[uat] diagnostic re-run error {type(exc).__name__}: {exc}\n")
+
+
 def run_cell(
     platform: str,
     benchmark: str,
@@ -154,6 +186,22 @@ def run_cell(
             log_fh.write(stdout_text)
         if timeout_result.timed_out:
             log_fh.write(f"# UAT_TIMEOUT timeout_s={timeout_s} exit_code={timeout_result.exit_code}\n")
+        elif timeout_result.exit_code != 0 and not stdout_text.strip():
+            _append_diagnostic_rerun(
+                log_fh,
+                benchbox_run_argv(
+                    platform,
+                    benchmark,
+                    scale,
+                    phases=phases,
+                    compression=compression,
+                    extra_args=("--output", str(runs_dir / "datagen"), *extra_args),
+                    local_managed_platform=local_managed_platform,
+                    quiet=False,
+                ),
+                timeout_s=min(timeout_s, DIAGNOSTIC_RERUN_TIMEOUT_S),
+                env=env,
+            )
 
     result_path_str = last_nonempty_output_line(stdout_text) if timeout_result.exit_code == 0 else None
     result_path = _resolve_result_path(result_path_str, runs_dir) if result_path_str else None


### PR DESCRIPTION
## Summary

Fast-platform UAT sweeps produced a wall of identical, opaque failures —
`status=failed terminal_state=no_json_nonzero submit_terminal_state=missing_manifest`
with an **empty `failure_tail`** — across clickhouse-server (57/57 and 22/22) and
scattered duckdb / datafusion / lakesail cells. That single signature was hiding
**several unrelated root causes**, made indistinguishable by one diagnostic gap.

**Root cause of the opacity (fixed here):** UAT cells run `benchbox run --quiet`
so the final stdout line is the result-JSON path the runner parses. But `--quiet`
*also* suppresses benchbox's own error output, so a non-zero exit left the
per-cell log empty (`(no subprocess output captured)`) — every distinct failure
collapsed to the same signature.

`no_json_nonzero` + `missing_manifest` does **not** mean "ran but wrote no
manifest". It means **benchbox itself exited non-zero**: `runner.py` nulls
`result_path` whenever `exit_code != 0` and forces `submit_state =
missing_manifest`. The classifier is faithful; it just had nothing to report.

## Change

- `tests/uat/matrix.py`: add `quiet: bool = True` to `benchbox_run_argv` to build
  a verbose argv on demand. Default stays `True`, preserving result-path parsing;
  `--quiet` now appended conditionally (ordering preserved relative to `--phases`).
- `tests/uat/runner.py`: when a cell exits non-zero with **no captured output**
  (and did not time out), re-run it once **verbosely** (`quiet=False`, stderr
  merged into stdout, capped at `DIAGNOSTIC_RERUN_TIMEOUT_S=180s`) via
  `_append_diagnostic_rerun`, appending the transcript as plain lines so
  `_cell_log_tail` surfaces it into `failure_tail`. Best-effort `try/except` so
  diagnostics never mask the original failure.

This makes the next sweep **self-describing** — real per-cell errors land in
`failure_tail` / `cells.jsonl` instead of being swallowed.

## Verification

- `pytest tests/uat/test_runner.py` → 24 passed; `tests/uat/test_matrix.py` → 185 passed
- `ruff format` / `ruff check` / `ty check` clean on both files; `py_compile` clean
- `make pr-preflight-fast-tests` passed at first push (matrix.py); **re-run after
  the runner.py commit** to validate the full change end-to-end.

## Root-cause analysis & follow-ups (diagnosis-gated)

This PR fixes the diagnostic keystone. The remaining root causes need a live
docker-backed repro loop (now far easier with verbose tails). Each should be its
own follow-up:

| # | Platform / scope | Likely cause | Next step |
|---|---|---|---|
| RC-1 | clickhouse-server (100%, ~7–8s, `docker up=ok`) | Pre-load failure swallowed by `--quiet`; suspect uv-extra wiring or connection contract (cells pass no host/port, unlike starrocks/cedardb) | Re-run one cell with this fix → read real error → fix wiring in `PLATFORM_UV_EXTRA` / `PLATFORM_EXTRA_OPTS` |
| RC-2 | cedardb | (a) `Bind 0.0.0.0:5435 already allocated` (stale container); (b) sweep **hung** mid-run on `tpcds_obt 1.0` — per-cell JSONs were clean | Per-cell hard wall-clock kill; `docker compose down` in `finally`; pre-`up` port preflight |
| RC-3 | starrocks | Same sweep-hang pattern; per-bench JSONs exist, no `cells.jsonl`/`matrix_summary` | Same as RC-2 |
| RC-4 | duckdb / datafusion / lakesail (scattered) | **Genuine** benchmark failures, correctly reported. e.g. duckdb `write_primitives` load: *"No files found that match pattern path_…"*; `flightdata`/`datavault` sf=1.0 **timeouts** | Fix `write_primitives` datagen path-glob; raise `timeout_s` (or mark slow) for sf=1.0 outliers |

## Notes

- No functional change to the benchmark execution path; harness diagnostics only.
- The diagnostic re-run fires **only on failure with empty output** (rare) and is
  time-capped, so it adds no cost to passing or already-diagnosed cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
