### PR TITLE
todo: track clickhouse-server corpus follow-ups; close recovery w3

### DIFF
--- a/_project/TODO/main/planning/clickhouse-server-client-insert-type-coverage.yaml
+++ b/_project/TODO/main/planning/clickhouse-server-client-insert-type-coverage.yaml
@@ -1,0 +1,185 @@
+id: clickhouse-server-client-insert-type-coverage
+title: "Extend ClickHouse-server client-side insert type coverage (datetime, nullable-numeric, arrays, Arrow schemas)"
+worktree: main
+priority: High
+status: Identified
+category: Platform Expansion
+
+description: |
+  PR #738 (merged to develop as 4fe9124c1) gave clickhouse-server its own
+  client-side batch-insert load path because server-side `file()` is limited to
+  `/var/lib/clickhouse/user_files` and cannot read Docker-host data paths. The
+  new path lives in `benchbox/platforms/base/data_loading.py`
+  (`ClickHouseNativeHandler._load_delimited_via_client_insert`,
+  `_load_parquet_via_client_insert`, `_convert_field_for_clickhouse`) and is
+  gated to `deployment_mode == "server"` (`_uses_server_mode`). clickhouse-local
+  and cloud are unchanged and still use `file()`.
+
+  The conversion helper handles String / INT* / DECIMAL|NUMERIC / DOUBLE|FLOAT|REAL
+  / DATE only. The post-merge corpus rerun (57 cells, source 4fe9124c1, see
+  uat-clickhouse-server-rc1-recovery w3) proved the path is correct for clean
+  star-schemas (tpch, ssb, amplab, tpch_skew all pass) but has four type-coverage
+  gaps that cause hard LOAD failures (loud errors, not silent corruption) for
+  ~22 cells:
+
+    Bucket A - nullable numeric/date field into a non-Nullable column.
+      Empty fields map to None at data_loading.py:2119-2120; when the generated
+      ClickHouse DDL declares the column non-Nullable, clickhouse-driver rejects
+      None: `Code: 53 ... required argument is not an integer`.
+      Cells: tpcds (0.01/0.1/1.0 - ws_sold_date_sk, wr_returned_date_sk),
+      nyctaxi (0.01/0.1/1.0 - location_id, trip_id), flightdata (0.01/0.1; 1.0
+      times out at SF=1.0, same family). tpcds_obt 1.0 is downstream of tpcds
+      (`Table tpcds_sales_returns_obt is empty`, killed @631s).
+
+    Bucket B - datetime / timestamp columns are not converted at all.
+      `_convert_field_for_clickhouse` only handles `startswith("DATE")`; columns
+      typed TIMESTAMP/DATETIME fall through as raw strings and clickhouse-driver
+      raises `'str' object has no attribute 'tzinfo'`. (Latent: `startswith("DATE")`
+      also matches DATETIME and would mis-route to `date.fromisoformat`, dropping
+      time.) Cells: h2odb (3), tsbs_devops (3), clickbench (1.0).
+
+    Bucket C - array / vector columns.
+      Embedding/array columns serialized in delimited data are not parsed into
+      Python lists; `float(value)` is attempted on a non-scalar token:
+      `could not convert string to float:`. Cells: vector_search (3).
+
+    Bucket D - Arrow-backed benchmark schemas.
+      `_get_column_type_names` / `SchemaInspector.get_column_count` assume a dict
+      schema; datavault's `get_schema()` yields pyarrow Table values, so
+      `"columns" in table_schema` raises `argument of type 'Table' is not iterable`.
+      Cells: datavault (3).
+
+  This is BenchBox-side, fixable in data_loading.py - it is NOT a ClickHouse
+  compatibility limit. No silent corruption was found: empty strings into String
+  columns are preserved as "" (verified at data_loading.py:2119-2120), and every
+  gap fails loudly at load.
+
+prior_art:
+  - "benchbox/platforms/base/data_loading.py:_convert_field_for_clickhouse — extend: add DATETIME/TIMESTAMP and array handling, make nullability-aware"
+  - "benchbox/platforms/base/data_loading.py:DelimitedFileHandler.load_table — reuse: the generic per-row path uses the same RowBatchProcessor/SchemaInspector helpers"
+  - "benchbox/platforms/base/data_loading.py:_uses_server_mode (line 1935) — preserve: keeps local/cloud on the file() path"
+  - "benchbox/platforms/clickhouse/workload.py:DDL pipeline — reference: where column nullability/types are emitted; see track-upstream-platform-workarounds"
+
+work:
+  - id: w0
+    summary: "Re-derive each failure signature against current develop and pin the evidence"
+    status: pending
+    notes: |
+      Docker-free where possible: drive the conversion helper directly to
+      confirm the gaps still exist on HEAD, e.g.
+        uv run -- python -c "from benchbox.platforms.base.data_loading import ClickHouseNativeHandler as H; \
+          h=H.__new__(H); print(repr(h._convert_field_for_clickhouse('2016-01-01 12:00:00','TIMESTAMP'))); \
+          print(repr(h._convert_field_for_clickhouse('','INTEGER')))"
+      Expect the timestamp returned as a raw str (Bucket B) and '' -> None
+      (Bucket A). Capture to /tmp/clickhouse-server-insert-w0.log and record a
+      compact command/result summary here. Server-dependent signatures
+      (Code: 53, tzinfo) are pinned to corpus run
+      uat_clickhouse_server_rc1_corpus_20260601 @ source 4fe9124c1.
+
+  - id: w1
+    summary: "Bucket B: add DATETIME/TIMESTAMP conversion and fix the startswith('DATE') ordering"
+    needs: [w0]
+    status: pending
+    notes: |
+      Route DATETIME/DATETIME64/TIMESTAMP to datetime parsing and keep DATE on
+      date.fromisoformat; ensure DATETIME does not fall into the DATE branch.
+
+  - id: w2
+    summary: "Bucket A: make empty numeric/date handling column-nullability aware"
+    needs: [w0]
+    status: pending
+    notes: |
+      Resolve the open question first. Either emit Nullable(...) DDL where the
+      benchmark schema marks the column nullable, or coerce empty -> type
+      default for non-Nullable numeric/date columns to mirror the file()/
+      input_format_null_as_default behavior the local path relied on. Pick the
+      one that matches benchmark/data semantics; do not silently change values
+      for columns that genuinely allow NULL.
+
+  - id: w3
+    summary: "Bucket C: parse array/vector columns into Python lists before insert"
+    needs: [w0]
+    status: pending
+
+  - id: w4
+    summary: "Bucket D: harden schema introspection against non-dict (Arrow Table) schemas"
+    needs: [w0]
+    status: pending
+    notes: |
+      Guard `"columns" in table_schema` / `.get(...)` in
+      _get_column_type_names and SchemaInspector.get_column_count so a pyarrow
+      Table-valued schema does not raise; fall back to file-derived column count.
+
+  - id: w5
+    summary: "Regression-validate: clickhouse-local still uses file(); re-run affected server cells"
+    needs: [w1, w2, w3, w4]
+    status: pending
+    notes: |
+      Confirm the 15 currently-passing cells still pass and that affected cells
+      (tpcds, nyctaxi, h2odb, tsbs_devops, clickbench, vector_search, datavault)
+      now load. Do not re-run the whole 57-cell corpus; target the affected
+      benchmarks at SF=0.01/0.1.
+
+deferred:
+  - summary: "Parquet path materializes the whole table via to_pylist() (data_loading.py:2139-2145)"
+    reason: "Acceptable at UAT SF<=1; revisit only if large-SF server loads are needed (stream by row group)."
+  - summary: "Cloud mode still uses host file() (not gated by _uses_server_mode)"
+    reason: "Pre-existing; out of scope. Only relevant if ClickHouse Cloud is UAT'd against host-local data."
+
+must_preserve:
+  - "clickhouse-local and cloud retain the file() load path (data_loading.py:1989 gate on _uses_server_mode)."
+  - "Empty strings into String columns stay '' (no String -> None corruption)."
+  - "The 15 currently-passing corpus cells (tpch, ssb, amplab, tpch_skew, ai_primitives) keep passing."
+  - "load_table_bulk server override keeps delegating to the per-file base loop (data_loading.py:2156-2167)."
+
+approach: |
+  Centralize all type coercion in _convert_field_for_clickhouse and keep the
+  delimited and Parquet paths sharing it. Reuse RowBatchProcessor/SchemaInspector
+  rather than adding a parallel reader. Solve B and D first (pure conversion /
+  introspection fixes, no DDL change), then A (which may require a DDL or
+  nullability decision), then C. Validate against clickhouse-local after each
+  change to prove the file() path is untouched.
+
+anti_patterns:
+  - "DO NOT route DATETIME/TIMESTAMP through date.fromisoformat - it drops the time component or raises - parse to datetime."
+  - "DO NOT coerce empty -> default for columns that genuinely allow NULL - that silently fabricates data - decide per column nullability."
+  - "DO NOT add a second file reader for server mode - reuse the shared RowBatchProcessor/SchemaInspector helpers."
+
+verification:
+  - description: "Conversion helper handles datetime, nullable numeric, and arrays"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_clickhouse_adapter.py -q"
+    expected_output: "tests pass, including new datetime/array/nullable coverage"
+  - description: "clickhouse-local still uses file() (no regression)"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k clickhouse -q"
+    expected_output: "local file() path tests pass unchanged"
+  - description: "Affected server cells load after the fix"
+    command: "CLICKHOUSE_HOST_PORT=19000 CLICKHOUSE_HTTP_HOST_PORT=18123 make uat-cell PLATFORM=clickhouse-server BENCHMARK=tpcds SCALE=0.01"
+    expected_output: "load phase completes without Code: 53; cell passes or fails later than load"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/data_loading.py"
+    - "benchbox/platforms/clickhouse/workload.py"
+    - "benchbox/platforms/clickhouse/metadata.py"
+    - "tests/unit/platforms/test_clickhouse_adapter.py"
+    - "_project/TODO/main/planning/clickhouse-server-client-insert-type-coverage.yaml"
+
+deps:
+  needs: []
+
+success_metrics:
+  - "clickhouse-server loads tpcds, nyctaxi, h2odb, tsbs_devops, clickbench, vector_search, and datavault at SF=0.01 without a LOAD-phase failure."
+  - "No regression in the file() path for clickhouse-local or the 15 passing corpus cells."
+  - "Empty String fields remain '' and NULL-allowed numeric fields remain NULL (no fabricated values)."
+
+open_questions:
+  - question: "For Bucket A, is the correct fix Nullable(...) DDL or empty->type-default coercion?"
+    gating: true
+    affects: ["w2 success_metric: NULL-allowed numeric fields remain NULL"]
+    default: "Emit Nullable(...) where the benchmark schema marks the column nullable; only coerce empty->default for genuinely non-Nullable columns."
+
+metadata:
+  tags: [clickhouse-server, data-loading, uat, rc1, type-coverage]
+  estimated_effort: "Medium"
+  created_date: "2026-06-01"
+  last_updated: "2026-06-01T14:30:00-04:00"

--- a/_project/TODO/main/planning/clickhouse-server-ddl-type-and-engine-gaps.yaml
+++ b/_project/TODO/main/planning/clickhouse-server-ddl-type-and-engine-gaps.yaml
@@ -1,0 +1,120 @@
+id: clickhouse-server-ddl-type-and-engine-gaps
+title: "Fix ClickHouse-server DDL gaps: Time type and MergeTree ORDER BY/PRIMARY KEY"
+worktree: main
+priority: Medium-High
+status: Identified
+category: Platform Expansion
+
+description: |
+  After the PR #738 infrastructure fixes (merged to develop as 4fe9124c1), the
+  clickhouse-server corpus rerun (57 cells, source 4fe9124c1, see
+  uat-clickhouse-server-rc1-recovery w3) surfaced two genuine ClickHouse DDL
+  gaps that fail at schema-creation time - distinct from the client-insert
+  type-coverage work (see clickhouse-server-client-insert-type-coverage):
+
+    Bucket E - `Time` column type rejected by ClickHouse 25.8.
+      `Code: 44. DB::Exception: Cannot create column with type 'Time' because
+      Time type is not allowed. Set setting enable_time_time64_type = 1 in order
+      to allow it.` The benchmark schemas emit a `Time` type that the generated
+      ClickHouse DDL passes through verbatim.
+      Cells: tpcdi (0.01/0.1/1.0), coffeeshop (0.01/0.1/1.0). 6 cells.
+
+    Bucket F - MergeTree table created without ORDER BY / PRIMARY KEY.
+      `Code: 42. DB::Exception: ORDER BY or PRIMARY KEY clause is missing.`
+      The ENGINE/ORDER BY injection that works for clickhouse-local (documented
+      in track-upstream-platform-workarounds, workload.py) is not producing a
+      valid ORDER BY for these benchmark schemas in server mode.
+      Cells: write_primitives (0.01/0.1/1.0), transaction_primitives
+      (0.01/0.1/1.0). 6 cells.
+
+  These are ClickHouse-DDL issues, not the client-insert path. They are
+  out of scope for the recovery TODO, which was scoped to provisioning/
+  lifecycle only.
+
+prior_art:
+  - "benchbox/platforms/clickhouse/workload.py:DDL pipeline (ENGINE/ORDER BY injection) — extend: ensure server mode emits a valid ORDER BY/PK for write_primitives & transaction_primitives"
+  - "_project/TODO/main/planning/track-upstream-platform-workarounds.yaml — reference: documents the clickhouse-local ORDER BY/PK injection workaround; keep server-mode fix consistent with it"
+  - "benchbox/platforms/clickhouse/tuning.py:configure_for_benchmark — reuse: where a server-mode enable_time_time64_type session setting could be applied if Time support is chosen over type remapping"
+
+work:
+  - id: w0
+    summary: "Re-confirm the Code: 44 (Time) and Code: 42 (ORDER BY/PK) signatures on develop"
+    status: pending
+    notes: |
+      Pinned to corpus run uat_clickhouse_server_rc1_corpus_20260601 @ 4fe9124c1
+      (tpcdi/coffeeshop -> Code: 44; write_primitives/transaction_primitives ->
+      Code: 42). Re-derive cheaply by generating the clickhouse-server DDL for
+      one affected benchmark (e.g. coffeeshop, write_primitives) and inspecting
+      it for `Time` and a missing ORDER BY; capture to /tmp and summarize here.
+
+  - id: w1
+    summary: "Bucket E: handle the Time column type for ClickHouse server"
+    needs: [w0]
+    status: pending
+    notes: |
+      Decide between (a) remapping Time -> a supported ClickHouse type in the
+      clickhouse dialect/DDL, or (b) enabling enable_time_time64_type=1 for
+      server mode. (a) is more portable; (b) opts into an experimental type.
+
+  - id: w2
+    summary: "Bucket F: ensure server-mode MergeTree DDL always has a valid ORDER BY/PRIMARY KEY"
+    needs: [w0]
+    status: pending
+    notes: |
+      Mirror the clickhouse-local injection; for schemas with no natural key,
+      fall back to ORDER BY tuple(). Keep consistent with
+      track-upstream-platform-workarounds so a future dialect-native DDL swap
+      does not regress.
+
+  - id: w3
+    summary: "Validate tpcdi, coffeeshop, write_primitives, transaction_primitives load at SF=0.01"
+    needs: [w1, w2]
+    status: pending
+
+deferred:
+  - summary: "Replace the ENGINE/ORDER BY injection with native dialect='clickhouse' DDL"
+    reason: "Tracked separately in track-upstream-platform-workarounds; do not duplicate that effort here."
+
+must_preserve:
+  - "clickhouse-local ORDER BY/PRIMARY KEY injection behavior is unchanged (track-upstream-platform-workarounds)."
+  - "Benchmarks that already create valid MergeTree DDL keep their existing ORDER BY."
+
+approach: |
+  Treat E and F independently. For E prefer a dialect-level type remap so the
+  fix is portable and avoids opting into an experimental ClickHouse type; only
+  fall back to enable_time_time64_type if remapping loses semantics. For F,
+  extend the existing workload.py injection rather than adding new DDL code, and
+  verify the local path is byte-for-byte unchanged.
+
+anti_patterns:
+  - "DO NOT globally swap to dialect='clickhouse' DDL here - it can silently regress tables that derive ORDER BY today - that swap is its own tracked TODO."
+  - "DO NOT enable experimental settings server-wide if a portable type remap works - keep the surface minimal."
+
+verification:
+  - description: "Affected schemas create cleanly on ClickHouse server"
+    command: "CLICKHOUSE_HOST_PORT=19000 CLICKHOUSE_HTTP_HOST_PORT=18123 make uat-cell PLATFORM=clickhouse-server BENCHMARK=coffeeshop SCALE=0.01"
+    expected_output: "no Code: 44 / Code: 42; schema + load succeed"
+  - description: "clickhouse-local DDL unchanged"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'clickhouse and (ddl or workload)' -q"
+    expected_output: "local DDL/workload tests pass unchanged"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/clickhouse/workload.py"
+    - "benchbox/platforms/clickhouse/tuning.py"
+    - "tests/unit/platforms/test_clickhouse_adapter.py"
+    - "_project/TODO/main/planning/clickhouse-server-ddl-type-and-engine-gaps.yaml"
+
+deps:
+  needs: []
+
+success_metrics:
+  - "tpcdi and coffeeshop create their ClickHouse-server schema without Code: 44."
+  - "write_primitives and transaction_primitives create MergeTree tables without Code: 42."
+  - "No change to the clickhouse-local DDL/ORDER BY injection."
+
+metadata:
+  tags: [clickhouse-server, ddl, mergetree, uat, rc1]
+  estimated_effort: "Medium"
+  created_date: "2026-06-01"
+  last_updated: "2026-06-01T14:30:00-04:00"

--- a/_project/TODO/main/planning/clickhouse-server-query-dialect-partial-failures.yaml
+++ b/_project/TODO/main/planning/clickhouse-server-query-dialect-partial-failures.yaml
@@ -1,0 +1,105 @@
+id: clickhouse-server-query-dialect-partial-failures
+title: "Resolve ClickHouse-server query-dialect partial failures (case-sensitive window fns, timeouts)"
+worktree: main
+priority: Medium
+status: Identified
+category: Platform Expansion
+
+description: |
+  After the PR #738 infrastructure fixes (merged to develop as 4fe9124c1),
+  three benchmarks in the clickhouse-server corpus rerun (57 cells, source
+  4fe9124c1, see uat-clickhouse-server-rc1-recovery w3) LOAD successfully and
+  write a result JSON but exit non-zero because a minority of queries fail -
+  classified by UAT as `no_json_nonzero` with `validation: partial`. These are
+  SQL dialect-translation gaps, not load or infrastructure issues.
+
+    read_primitives (0.01/0.1): 438/447 queries pass, 9 fail. Representative:
+      `Code: 63. DB::Exception: Aggregate function with name 'LAG' does not
+      exist. Maybe you meant: ['lag']` - ClickHouse window function names are
+      lower-case; the emitted SQL uses upper-case LAG.
+    metadata_primitives (1.0): partial; result JSON written, exit 1.
+    tpchavoc (0.01/0.1): partial. tpchavoc 1.0 TIMES OUT at 1200s, and
+      flightdata 1.0 also times out - the SF=1.0 manifestations of the same
+      benchmarks; investigate whether the timeout is the same dialect/query
+      issue at scale or a genuine performance/query-plan problem.
+
+  Separately, joinorder 1.0 fails with `download failed after 3 attempts`
+  fetching the IMDB release asset - an infra/data-hosting issue unrelated to
+  ClickHouse; existing joinorder TODOs own that area.
+
+prior_art:
+  - "benchbox/platforms/clickhouse/ (SQL translation / dialect) — extend: lower-case window function emission (LAG/LEAD/etc.)"
+  - "tests/ dialect-translation tests — reference: where ClickHouse function-name casing is asserted"
+
+work:
+  - id: w0
+    summary: "Re-confirm the partial-failure query signatures on develop and enumerate the failing queries"
+    status: pending
+    notes: |
+      Pinned to corpus run uat_clickhouse_server_rc1_corpus_20260601 @ 4fe9124c1.
+      read_primitives result JSON shows summary.queries.failed=9 and an errors[]
+      entry for LAG. Re-derive by running read_primitives 0.01 against the
+      server and listing the failing query ids/messages; capture to /tmp and
+      summarize the distinct error classes here before fixing.
+
+  - id: w1
+    summary: "Fix case-sensitive window/aggregate function emission for ClickHouse (LAG/LEAD/etc.)"
+    needs: [w0]
+    status: pending
+
+  - id: w2
+    summary: "Triage the remaining read_primitives / metadata_primitives / tpchavoc failing queries"
+    needs: [w0]
+    status: pending
+    notes: "Bucket any beyond function-casing (unsupported functions, syntax) and fix or document as platform-unsupported."
+
+  - id: w3
+    summary: "Investigate tpchavoc 1.0 and flightdata 1.0 timeouts (same cause at scale vs perf)"
+    needs: [w0]
+    status: pending
+    notes: "flightdata 0.01/0.1 fail in the client-insert path (Code: 53); confirm whether the 1.0 timeout is the load path stalling or query execution."
+
+deferred:
+  - summary: "joinorder 1.0 IMDB release-asset download failure"
+    reason: "Infra/data-hosting, not ClickHouse; covered by existing joinorder TODOs (joinorder-scale-stress-decision-framework, joinorder-track2-groundwork)."
+
+must_preserve:
+  - "Query SQL for platforms other than ClickHouse is unaffected by any casing change."
+  - "The benchmarks that already pass all queries keep passing."
+
+approach: |
+  Start with the LAG/LEAD casing fix in the ClickHouse dialect, which likely
+  clears most of read_primitives' 9 failures, then re-run to see what remains.
+  Handle the timeouts last - they may resolve once the load-path (Code: 53) and
+  dialect fixes land, so coordinate with clickhouse-server-client-insert-type-coverage.
+
+anti_patterns:
+  - "DO NOT lower-case identifiers globally - only ClickHouse function names that are case-sensitive - other platforms and column names must be untouched."
+
+verification:
+  - description: "read_primitives passes all queries on ClickHouse server"
+    command: "CLICKHOUSE_HOST_PORT=19000 CLICKHOUSE_HTTP_HOST_PORT=18123 make uat-cell PLATFORM=clickhouse-server BENCHMARK=read_primitives SCALE=0.01"
+    expected_output: "validation full (no failed queries), cell passes"
+  - description: "Dialect translation tests cover ClickHouse function casing"
+    command: "uv run -- python -m pytest tests/ -k 'clickhouse and dialect' -q"
+    expected_output: "tests pass, including window-function casing"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/clickhouse/"
+    - "tests/"
+    - "_project/TODO/main/planning/clickhouse-server-query-dialect-partial-failures.yaml"
+
+deps:
+  needs: []
+
+success_metrics:
+  - "read_primitives clickhouse-server reaches validation: full (0 failed queries) at SF=0.01."
+  - "tpchavoc 1.0 and flightdata 1.0 either complete within the UAT timeout or have a documented root cause."
+  - "No SQL change affects non-ClickHouse platforms."
+
+metadata:
+  tags: [clickhouse-server, sql-dialect, uat, rc1]
+  estimated_effort: "Medium"
+  created_date: "2026-06-01"
+  last_updated: "2026-06-01T14:30:00-04:00"

--- a/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
@@ -91,7 +91,7 @@ work:
   - id: w3
     summary: "If the smallest cell passes, rerun the clickhouse-server fast Docker corpus into a fresh run root"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Use the repo's managed Docker lifecycle rather than an ad hoc server:
       a config with `cleanup.docker_manage_platforms=true`,
@@ -100,6 +100,29 @@ work:
       cells.jsonl is non-empty, lifecycle logs contain up/run/down for
       clickhouse-server, and matrix_summary.tsv no longer shows a total
       platform wipeout.
+
+      DONE 2026-06-01. UAT-managed corpus, 57 executable cells, source
+      4fe9124c1 (source_dirty=false). Config
+      /tmp/uat-clickhouse-server-rc1-corpus-20260601.yaml; artifacts under
+      ~/Developer/benchmark_runs/logs/uat_clickhouse_server_rc1_corpus_20260601
+      (matrix_summary.tsv, cells.jsonl). Docker lifecycle clean: action=up
+      status=ok, action=down status=ok, UAT-owned project removed (only the
+      pre-existing uat-clickhouse-debug container remained).
+
+      Result: rows=57 candidates=57 executed=57 compatibility_pruned=0
+      early_stop_pruned=0 passed=15 failed=40 timed_out=2, run_status=COMPLETED.
+      The 57/57 wipeout is resolved - auth/port/database-bootstrap/host-path-load/
+      session-settings are all fixed. The 15 passing cells (tpch, ssb, amplab,
+      tpch_skew, ai_primitives x3 scales) are submittable.
+
+      Remaining 40 failures + 2 timeouts are NOT this recovery's lifecycle
+      scope; they are split into follow-up TODOs:
+        - clickhouse-server-client-insert-type-coverage (Bucket A/B/C/D/J, ~22
+          cells - the new client-insert path's type coverage; BenchBox-side)
+        - clickhouse-server-ddl-type-and-engine-gaps (Bucket E/F, 12 cells -
+          Time type, MergeTree ORDER BY/PK)
+        - clickhouse-server-query-dialect-partial-failures (Bucket G + timeouts,
+          ~7 cells - case-sensitive window fns; joinorder download deferred)
 
 deps:
   needs: []
@@ -161,4 +184,4 @@ metadata:
   tags: [clickhouse-server, docker, uat, rc1]
   estimated_effort: "Medium"
   created_date: "2026-06-01"
-  last_updated: "2026-06-01T11:42:00-04:00"
+  last_updated: "2026-06-01T14:30:00-04:00"


### PR DESCRIPTION
Mark uat-clickhouse-server-rc1-recovery w3 done with corpus-proof
evidence (57 cells @ 4fe9124c1: 15 passed / 40 failed / 2 timed out,
run_status=COMPLETED, clean Docker lifecycle).

Split the remaining 42 non-passing cells into three follow-up TODOs,
classified by root cause from the corpus matrix:

- clickhouse-server-client-insert-type-coverage (High): ~22 cells in
  PR #738's new client-side insert path - datetime/timestamp, nullable
  numeric/date into non-Nullable columns, arrays/vectors, Arrow-backed
  schemas. BenchBox-side, not a ClickHouse limit; no silent corruption.
- clickhouse-server-ddl-type-and-engine-gaps (Medium-High): 12 cells -
  Time type rejected by CH 25.8, MergeTree ORDER BY/PRIMARY KEY missing.
- clickhouse-server-query-dialect-partial-failures (Medium): ~7 cells -
  case-sensitive window fns (LAG vs lag) and the two SF=1.0 timeouts;
  joinorder release-asset download deferred to existing joinorder TODOs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
