### PR TITLE
docs(todo): plan query plan capture coverage for all platform families

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
@@ -1,0 +1,220 @@
+id: query-plan-capture-clickhouse-family
+title: "Implement query plan capture for ClickHouse local, server, and cloud adapters"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  None of the three ClickHouse adapters (clickhouse-local, clickhouse-server,
+  clickhouse-cloud) implement `get_query_plan()`, `get_query_plan_parser()`, or
+  call `capture_query_plan()`. They all inherit from `ClickHouseAdapter` which
+  itself does not add plan support. No ClickHouse parser exists in
+  `benchbox/core/query_plans/parsers/`.
+
+  ClickHouse supports several EXPLAIN variants:
+    - `EXPLAIN PLAN <query>` — logical plan tree (text, terse nodes)
+    - `EXPLAIN PIPELINE <query>` — physical execution pipeline (text)
+    - `EXPLAIN PIPELINE graph=1 <query>` — Graphviz DOT format
+    - `EXPLAIN ESTIMATE <query>` — row/part estimates only
+
+  The most useful for cross-platform comparison is `EXPLAIN PLAN` for logical
+  structure and `EXPLAIN PIPELINE` for physical operators. The plan is returned
+  as plain text with indentation-based tree structure, similar in format to
+  DuckDB's text output mode.
+
+  ClickHouse version note: EXPLAIN was added in ClickHouse 20.6. The three BenchBox
+  ClickHouse modes use different connections:
+    - clickhouse-local: in-process, no server needed
+    - clickhouse-server: self-hosted TCP/HTTP connection
+    - clickhouse-cloud: ClickHouse Cloud HTTP API
+
+  All three should share a common ClickHouseAdapter-level implementation of
+  get_query_plan() and a single ClickHouseQueryPlanParser.
+
+prerequisites:
+  - "ClickHouse ≥20.6 for EXPLAIN PLAN support"
+  - "clickhouse-local binary (bundled in _binaries/ or installed) for clickhouse-local integration"
+  - "Running clickhouse-server instance at localhost:9000 (or configured host) for server integration tests"
+  - "ClickHouse Cloud account + service endpoint + credentials for cloud integration tests (env: CLICKHOUSE_CLOUD_HOST, CLICKHOUSE_CLOUD_USER, CLICKHOUSE_CLOUD_PASSWORD)"
+  - "Unit tests (parser + wiring) can run without any live server using fixture text samples"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/duckdb.py — closest text-format parser; ClickHouse text plan is structurally similar"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface to implement"
+  - "benchbox/platforms/clickhouse_local.py:29 — ClickHouseLocalAdapter class"
+  - "benchbox/platforms/clickhouse_server.py:33 — ClickHouseServerAdapter class"
+  - "benchbox/platforms/duckdb.py:1038 — get_query_plan() implementation pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() pattern"
+
+work:
+  - id: w1
+    summary: "Collect EXPLAIN PLAN and EXPLAIN PIPELINE text samples from ClickHouse"
+    status: pending
+    notes: |
+      Against a live ClickHouse instance (local or server), run:
+        EXPLAIN PLAN SELECT l_orderkey, sum(l_quantity) FROM lineitem GROUP BY l_orderkey
+        EXPLAIN PIPELINE SELECT l_orderkey, sum(l_quantity) FROM lineitem GROUP BY l_orderkey
+      Capture both outputs and record the exact indentation and node-name format.
+      Note the ClickHouse version (SELECT version()). Store as:
+        tests/fixtures/query_plans/clickhouse_explain_plan_sample.txt
+        tests/fixtures/query_plans/clickhouse_explain_pipeline_sample.txt
+      Raw output to /tmp/clickhouse-explain-w1.log.
+
+  - id: w2
+    summary: "Implement ClickHouseQueryPlanParser in benchbox/core/query_plans/parsers/clickhouse.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement the QueryPlanParser abstract interface:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - Parse EXPLAIN PLAN text output (indentation-based tree)
+        - Map ClickHouse operator names to LogicalOperatorType:
+            ReadFromMergeTree / ReadFromMemoryStorage → SCAN
+            Filter → FILTER
+            Aggregating / PartialAggregating → AGGREGATE
+            Join → JOIN
+            Sorting → SORT
+            Expression → EXPRESSION
+            Limit / LimitBy → LIMIT
+            Union → UNION
+        - Use the DuckDB text parser as the structural template since both
+          use indented text trees
+        - Register in parsers/registry.py under dialect="clickhouse"
+
+  - id: w3
+    summary: "Add unit tests for ClickHouseQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_clickhouse_parser.py. Cover:
+        - EXPLAIN PLAN parse produces valid QueryPlanDAG with correct operator types
+        - EXPLAIN PIPELINE parse (if applicable to the same parser)
+        - Operator normalization maps ClickHouse node names to LogicalOperatorType
+        - Malformed input triggers graceful error recovery
+        - Parser registered in registry under "clickhouse" dialect
+
+  - id: w4
+    summary: "Add get_query_plan() to ClickHouseAdapter base class"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      IMPORTANT: The connection object type differs across the three ClickHouse modes
+      and must be confirmed during w1 before writing this implementation:
+        - clickhouse-local: uses chdb (in-process) — connection is likely a
+          chdb.session or similar in-process context, NOT a TCP socket.
+        - clickhouse-server: uses clickhouse-driver over TCP — connection.execute()
+          returns a list of tuples.
+        - clickhouse-cloud: uses clickhouse-connect over HTTP — different API.
+
+      After w1 confirms the actual connection type per mode, implement in the
+      shared ClickHouseAdapter base class (locate via grep for `class ClickHouseAdapter`).
+      If the connection API is uniform across modes (confirm first), use:
+        def get_query_plan(self, connection, query):
+            explain_query = f"EXPLAIN PLAN {query}"
+            # Execute via the mode-appropriate connection API confirmed in w1
+            return <extracted text from result>
+      If connection APIs differ per mode, override get_query_plan() separately
+      in ClickHouseLocalAdapter, ClickHouseServerAdapter, ClickHouseCloudAdapter
+      rather than using a base-class implementation that makes wrong assumptions.
+      Use EXPLAIN PLAN (not PIPELINE) as the default for cross-platform comparison.
+
+  - id: w5
+    summary: "Add get_query_plan_parser() override to ClickHouseAdapter base class"
+    needs: [w2]
+    status: pending
+    notes: |
+      In the same ClickHouseAdapter base used in w4:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.clickhouse import ClickHouseQueryPlanParser
+            return ClickHouseQueryPlanParser()
+      All three adapters (local, server, cloud) inherit this automatically.
+
+  - id: w6
+    summary: "Integrate capture_query_plan() into ClickHouse execute_query() path"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Locate each adapter's execute_query() — or the shared execute_query() if
+      ClickHouseAdapter has one. Add the capture guard after the timed SQL block:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      If clickhouse-local, clickhouse-server, and clickhouse-cloud have separate
+      execute_query() methods, patch each one. Prefer placing the call in the
+      shared base if execution flows through it.
+
+  - id: w7
+    summary: "Add unit tests for ClickHouse adapter plan capture wiring"
+    needs: [w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_clickhouse_plan_capture.py. Cover:
+        - get_query_plan_parser() returns ClickHouseQueryPlanParser for all three modes
+        - execute_query() with capture_plans=True triggers capture (mock connection)
+        - execute_query() with capture_plans=False does not trigger capture
+        - plan_fingerprint present in result dict when capture succeeds
+        - graceful degradation when EXPLAIN returns empty (old ClickHouse versions)
+
+deps:
+  needs: []
+
+must_preserve:
+  - "clickhouse-local, clickhouse-server, and clickhouse-cloud execute_query() result dict shape must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False."
+  - "EXPLAIN PLAN must not be issued when capture_plans=False — ClickHouse EXPLAIN can be expensive for complex queries."
+  - "Changes to the ClickHouseAdapter base class must not break the existing uat-clickhouse-server DDL fix work tracked separately."
+
+approach: |
+  Start with fixture collection (w1) to understand the exact text format.
+  Implement the parser (w2) modeled on the DuckDB text parser, then test it (w3).
+  Add get_query_plan() and get_query_plan_parser() to the shared ClickHouseAdapter
+  base (w4+w5) so all three modes inherit them. Wire capture into execute_query()
+  (w6) and add wiring tests (w7). Do not require a live server for unit tests —
+  use fixtures throughout.
+
+anti_patterns:
+  - "DO NOT use EXPLAIN PIPELINE as the default — pipeline output lacks logical operator names needed for cross-platform comparison."
+  - "DO NOT issue EXPLAIN PLAN during benchmarks when capture_plans=False — always guard with self.capture_plans check."
+  - "DO NOT assume the ClickHouse Python driver returns the same structure for local (chdb/in-process), server (clickhouse-driver/TCP), and cloud (clickhouse-connect/HTTP) connections — confirm each in w1 before writing the base-class implementation."
+  - "DO NOT add a single get_query_plan() to the base class if the connection API is different per mode — override per adapter instead."
+  - "DO NOT reuse or modify the existing DDL compatibility changes in clickhouse/setup.py as part of this TODO — keep plan capture and DDL fix orthogonal."
+
+verification:
+  - description: "ClickHouse parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_clickhouse_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "ClickHouse adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_clickhouse_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/clickhouse_local.py"
+    - "benchbox/platforms/clickhouse_server.py"
+    - "benchbox/platforms/clickhouse_cloud.py"
+    - "benchbox/core/query_plans/parsers/clickhouse.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_clickhouse_parser.py"
+    - "tests/unit/platforms/test_clickhouse_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/clickhouse/setup.py"
+    - "benchbox/sql_compat/rules/ddl_optimize/"
+
+success_metrics:
+  - "ClickHouseQueryPlanParser parses EXPLAIN PLAN text from fixture samples into valid QueryPlanDAG objects."
+  - "All three ClickHouse adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint in the result dict."
+  - "No regressions in existing ClickHouse UAT cells or DDL tests."
+
+metadata:
+  tags: [query-plan, clickhouse, clickhouse-local, clickhouse-server, clickhouse-cloud, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
@@ -1,0 +1,289 @@
+id: query-plan-capture-cloud-saas
+title: "Implement query plan capture for cloud SaaS platforms: Snowflake, BigQuery, Azure Synapse, Firebolt, Fabric Warehouse, and Lakesail"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Six cloud SaaS platforms need query plan capture work ranging from adding a new
+  parser to redesigning how the plan is fetched. Each has distinct EXPLAIN behavior
+  and all require cloud credentials for integration testing. The platforms are
+  grouped here because they share the pattern: need a new parser, need
+  execute_query() wiring, and each requires a cloud account.
+
+  Current state per platform:
+    1. SnowflakeAdapter (benchbox/platforms/snowflake.py)
+       - get_query_plan(): ❌ no override — Snowflake does not have a simple
+         EXPLAIN statement; instead it returns a query profile via
+         `EXPLAIN <query>` as JSON with LogicalPlanNode objects.
+       - No parser exists.
+       - Has execute_query() at line 1138.
+
+    2. BigQueryAdapter (benchbox/platforms/bigquery.py)
+       - get_query_plan(): ⚠️ exists at line 1714 but returns a dict with
+         `bytes_processed` and `job_id`, NOT a plan tree.
+         BigQuery's query plan is only available post-execution via the
+         Job Statistics API (`job.query_plan` on a completed QueryJob).
+       - No parser exists.
+       - Has execute_query() at line 1467.
+
+    3. AzureSynapseAdapter (benchbox/platforms/azure_synapse.py)
+       - get_query_plan(): ✅ line 1131 — EXPLAIN via cursor
+       - No parser exists.
+       - Has execute_query() at line 967.
+
+    4. FireboltAdapter (benchbox/platforms/firebolt.py)
+       - get_query_plan(): ✅ line 1296 — EXPLAIN via cursor
+       - No parser exists.
+
+    5. FabricWarehouseAdapter (benchbox/platforms/fabric_warehouse.py)
+       - get_query_plan(): ✅ line 1078
+       - No parser exists.
+       - Has execute_query() at line 638.
+
+    6. LakesailAdapter (benchbox/platforms/lakesail.py)
+       - get_query_plan(): ✅ line 552
+       - No parser exists.
+
+  BigQuery requires the most redesign: plans are not available from EXPLAIN but
+  from the post-execution Job statistics API. The `get_query_plan()` method must
+  be redesigned to accept a completed job reference rather than issuing a separate
+  EXPLAIN query.
+
+prerequisites:
+  - "Snowflake account + warehouse + database credentials (env: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE)"
+  - "Google Cloud project with BigQuery API enabled + service account JSON key (env: GOOGLE_APPLICATION_CREDENTIALS, BIGQUERY_PROJECT)"
+  - "Azure subscription with Synapse Analytics workspace (env: AZURE_SYNAPSE_SERVER, AZURE_SYNAPSE_DATABASE, AZURE_SYNAPSE_USER, AZURE_SYNAPSE_PASSWORD)"
+  - "Firebolt account + engine endpoint (env: FIREBOLT_ACCOUNT, FIREBOLT_USER, FIREBOLT_PASSWORD, FIREBOLT_ENGINE)"
+  - "Microsoft Fabric workspace with Warehouse (env: FABRIC_SERVER, FABRIC_DATABASE, FABRIC_USER, FABRIC_PASSWORD)"
+  - "Lakesail account credentials (env: LAKESAIL_HOST, LAKESAIL_USER, LAKESAIL_PASSWORD)"
+  - "Unit tests for parsers can run without credentials using fixture EXPLAIN text samples"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/datafusion.py — JSON tree parser pattern (for Snowflake)"
+  - "benchbox/core/query_plans/parsers/postgresql.py — text-tree parser pattern (for Azure Synapse, Firebolt, Fabric)"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface"
+  - "benchbox/platforms/duckdb.py:969 — execute_query() capture integration pattern"
+  - "benchbox/platforms/bigquery.py:1467 — BigQuery execute_query() with completed QueryJob in scope"
+
+work:
+  - id: w1
+    summary: "Collect EXPLAIN output samples for Snowflake, Azure Synapse, Firebolt, Fabric, and Lakesail"
+    status: pending
+    notes: |
+      For each available platform, run `EXPLAIN <simple_query>` and record:
+        - Full EXPLAIN output text (or JSON)
+        - Platform version / engine version
+        - Any differences in syntax (e.g., `EXPLAIN USING TEXT` for Snowflake)
+      Store as tests/fixtures/query_plans/{platform}_explain_sample.{txt|json}.
+      BigQuery: instead of EXPLAIN, run a small query, then call
+      `job.query_plan` on the completed QueryJob and record the JSON structure.
+
+  - id: w2
+    summary: "Implement SnowflakeQueryPlanParser and wire into SnowflakeAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Snowflake EXPLAIN returns JSON (when using `EXPLAIN USING JSON`):
+        {"GlobalStats": {...}, "Operations": [{"id": N, "operation": "...", ...}]}
+      Parser maps Snowflake operation names to LogicalOperatorType:
+        TableScan / JoinFilter → SCAN
+        Filter → FILTER
+        Aggregate → AGGREGATE
+        Join / InnerJoin / LeftOuterJoin → JOIN
+        Sort → SORT
+        Result / WithReference → PROJECT
+      Wire in SnowflakeAdapter:
+        - Override get_query_plan() to use `EXPLAIN USING JSON <query>`
+        - Override get_query_plan_parser() returning SnowflakeQueryPlanParser
+        - Add capture_query_plan() call to execute_query()
+
+  - id: w3
+    summary: "Implement BigQueryQueryPlanParser and override capture_query_plan() in BigQueryAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      BigQuery plans come from the Job Statistics API, not an EXPLAIN statement.
+      This is an architectural mismatch with the base class:
+        - Base class result_capture.py capture_query_plan() calls
+          self.get_query_plan(connection, query) BEFORE the query executes.
+        - BigQuery plans are only available AFTER execution via job.query_plan
+          on the completed google.cloud.bigquery.QueryJob object.
+
+      Required approach: override capture_query_plan() directly in BigQueryAdapter
+      to extract the plan from the already-completed QueryJob. Do NOT attempt
+      to use the get_query_plan() → parse() path for BigQuery; the QueryJob is
+      in scope inside execute_query() at line 1467 after job.result() returns.
+
+      Implementation:
+        1. Inside BigQueryAdapter.execute_query(), after job.result() completes,
+           call self._capture_bq_plan(job, query_id) instead of capture_query_plan().
+        2. Implement _capture_bq_plan(job, query_id) to:
+             a. Read job.query_plan — a list of QueryPlanEntry objects with
+                `name`, `substeps`, `records_read`, `records_written`, `status`.
+             b. Pass the JSON-serialized plan to BigQueryQueryPlanParser.parse().
+             c. Return (QueryPlanDAG, elapsed_ms).
+        3. Set plan_fingerprint from the returned DAG in the result dict.
+
+      Implement BigQueryQueryPlanParser:
+        - parse(raw_plan: str) -> QueryPlanDAG where raw_plan is JSON of
+          the job.query_plan structure.
+        - Each QueryPlanEntry.name maps to LogicalOperatorType:
+            INPUT → SCAN, FILTER → FILTER, AGGREGATE → AGGREGATE,
+            HASH_JOIN / BROADCAST_HASH_JOIN → JOIN, SORT → SORT,
+            OUTPUT → PROJECT (final projection/output step).
+        - entry.substeps provide operator detail strings.
+
+      Do NOT modify get_query_plan() in BigQueryAdapter for plan capture —
+      its current return (cost dict) may be used by other consumers; leave
+      it as-is and add the new _capture_bq_plan() method alongside it.
+
+  - id: w4
+    summary: "Implement AzureSynapseQueryPlanParser and wire into AzureSynapseAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Azure Synapse Dedicated Pool uses T-SQL-based EXPLAIN (XML format via
+      `SET SHOWPLAN_XML ON`; or text via `SET SHOWPLAN_TEXT ON`). Serverless
+      uses a different planner. Confirm which format get_query_plan() at
+      line 1131 currently retrieves. Implement a parser for that format.
+      Wire get_query_plan_parser() and the capture call in execute_query().
+
+  - id: w5
+    summary: "Implement FireboltQueryPlanParser and wire into FireboltAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Firebolt's EXPLAIN returns a JSON structure with a tree of nodes.
+      Implement FireboltQueryPlanParser mapping Firebolt operator names
+      (TableScan, Projection, Aggregation, Join, etc.) to LogicalOperatorType.
+      Wire get_query_plan_parser() and the capture call in FireboltAdapter.execute_query().
+
+  - id: w6
+    summary: "Wire FabricWarehouseAdapter plan capture; reuse AzureSynapseQueryPlanParser if format matches"
+    needs: [w1, w4]
+    status: pending
+    notes: |
+      Fabric Warehouse (Synapse Serverless + Delta Lake) EXPLAIN format may
+      differ from Synapse Dedicated. After collecting the Fabric fixture in w1
+      and implementing AzureSynapseQueryPlanParser in w4:
+
+      Decision gate (required before writing any Fabric parser code):
+        Compare the Fabric EXPLAIN fixture from w1 to the Azure Synapse fixture.
+        - If the T-SQL plan format is structurally identical:
+            Reuse AzureSynapseQueryPlanParser — do NOT implement a separate
+            FabricWarehouseQueryPlanParser. Wire FabricWarehouseAdapter to return
+            AzureSynapseQueryPlanParser from get_query_plan_parser().
+        - If the format differs (Synapse Serverless uses a different planner):
+            Implement a separate FabricWarehouseQueryPlanParser. Register under
+            dialect="fabric_warehouse" in the parser registry.
+
+      Wire get_query_plan_parser() and the capture call in execute_query()
+      regardless of which parser is chosen.
+
+  - id: w7
+    summary: "Implement LakesailQueryPlanParser and wire into LakesailAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Lakesail is a MySQL-wire-compatible engine. Collect EXPLAIN format in w1.
+      Implement LakesailQueryPlanParser. Wire get_query_plan_parser() and
+      the capture call in LakesailAdapter.execute_query().
+
+  - id: w8
+    summary: "Add unit tests for all new parsers and adapter wiring"
+    needs: [w2, w3, w4, w5, w6, w7]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/ tests for each new parser:
+        test_snowflake_parser.py, test_bigquery_parser.py,
+        test_azure_synapse_parser.py, test_firebolt_parser.py,
+        test_lakesail_parser.py
+        (FabricWarehouse parser test only if a new parser was required in w6;
+         skip if AzureSynapseQueryPlanParser is reused for Fabric)
+      For BigQuery, test _capture_bq_plan() directly with a mock QueryJob object
+      rather than testing get_query_plan_parser() — BigQuery bypasses that path.
+      Create tests/unit/platforms/test_cloud_saas_plan_capture.py with
+      parametrized cases for all six adapters:
+        - get_query_plan_parser() returns non-None
+        - execute_query() with capture_plans=True captures plan
+        - graceful degradation on capture failure
+
+deps:
+  needs: []
+
+must_preserve:
+  - "All six adapters' execute_query() result dict shape must not change for non-plan fields."
+  - "BigQuery execute_query() must not issue any additional API calls when capture_plans=False."
+  - "Plan capture failure must be silent when strict_plan_capture=False — cloud queries are expensive and billing-sensitive."
+  - "Do not issue extra EXPLAIN queries that incur billing in BigQuery — use the job statistics from the already-executed query."
+
+approach: |
+  Start with fixture collection (w1) since all parsers depend on knowing the
+  actual output format. Parse work can proceed in parallel per platform once
+  fixtures are available. BigQuery requires the most architectural thought (w3)
+  since its plan source is fundamentally different from EXPLAIN-based platforms.
+  Implement parsers and wiring in priority order: Snowflake (most popular),
+  Azure Synapse, Firebolt, Fabric Warehouse, Lakesail, BigQuery (architectural
+  redesign last or in parallel). Unit tests can all be written from fixtures
+  without cloud credentials.
+
+anti_patterns:
+  - "DO NOT issue a second EXPLAIN query for BigQuery — the query plan is already available from the completed job object at no extra cost."
+  - "DO NOT use synchronous EXPLAIN for BigQuery — there is no EXPLAIN statement; use the Job Statistics API."
+  - "DO NOT add plan capture to BigQuery's get_query_plan() method without addressing its current incorrect return type (returns cost dict, not plan text)."
+  - "DO NOT use SET SHOWPLAN_TEXT for Azure Synapse if SET SHOWPLAN_XML produces a richer parseable structure — prefer XML."
+
+verification:
+  - description: "All new parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_snowflake_parser.py tests/unit/query_plans/test_bigquery_parser.py tests/unit/query_plans/test_azure_synapse_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Cloud SaaS adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_cloud_saas_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/snowflake.py"
+    - "benchbox/platforms/bigquery.py"
+    - "benchbox/platforms/azure_synapse.py"
+    - "benchbox/platforms/firebolt.py"
+    - "benchbox/platforms/fabric_warehouse.py"
+    - "benchbox/platforms/lakesail.py"
+    - "benchbox/core/query_plans/parsers/snowflake.py"
+    - "benchbox/core/query_plans/parsers/bigquery.py"
+    - "benchbox/core/query_plans/parsers/azure_synapse.py"
+    - "benchbox/core/query_plans/parsers/firebolt.py"
+    - "benchbox/core/query_plans/parsers/fabric_warehouse.py"
+    - "benchbox/core/query_plans/parsers/lakesail.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/"
+    - "tests/unit/platforms/test_cloud_saas_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml"
+
+success_metrics:
+  - "All six adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for all six platforms."
+  - "BigQuery plan capture uses job statistics, not a separate EXPLAIN query."
+  - "All parser unit tests pass using fixture samples."
+
+open_questions:
+  - question: "Does Azure Synapse Serverless support EXPLAIN in the same format as Dedicated Pool?"
+    gating: true
+    affects: ["w4"]
+    default: "Implement separate parsers for Dedicated Pool (XML) and Serverless (text) if formats differ"
+  - question: "Does Fabric Warehouse share the Azure Synapse T-SQL plan format, or is it distinct?"
+    gating: true
+    affects: ["w6"]
+    default: "Collect fixture in w1 before implementing; reuse AzureSynapseParser if format matches"
+
+metadata:
+  tags: [query-plan, snowflake, bigquery, azure-synapse, firebolt, fabric-warehouse, lakesail, cloud-saas, new-parser]
+  estimated_effort: "Large"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
@@ -1,0 +1,197 @@
+id: query-plan-capture-datafusion-sqlite
+title: "Wire query plan capture for DataFusion and SQLite (parsers exist, no credentials needed)"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  DataFusion and SQLite each have fully-implemented parsers
+  (`benchbox/core/query_plans/parsers/datafusion.py` and
+  `benchbox/core/query_plans/parsers/sqlite.py`). Neither adapter currently
+  overrides `get_query_plan()` or `get_query_plan_parser()`, and neither
+  `execute_query()` calls `capture_query_plan()`. Both platforms run entirely
+  locally with no cloud credentials required — this is the lowest-friction
+  group to complete after the PostgreSQL family.
+
+  Gap summary per adapter:
+    - DataFusionAdapter (benchbox/platforms/datafusion.py)
+        • get_query_plan(): ❌ no override — base returns None
+        • get_query_plan_parser(): ❌ no override — base returns None
+        • execute_query(): ❌ never calls capture_query_plan()
+        • DataFusion EXPLAIN format: JSON — `EXPLAIN FORMAT JSON <query>`
+          or `EXPLAIN ANALYZE FORMAT JSON <query>` (includes execution stats)
+    - SQLiteAdapter (benchbox/platforms/sqlite.py — or embedded in another file)
+        • get_query_plan(): ❌ no override — base returns None
+        • get_query_plan_parser(): ❌ no override — base returns None
+        • execute_query(): ❌ never calls capture_query_plan()
+        • SQLite EXPLAIN format: `EXPLAIN QUERY PLAN <query>` returns rows of
+          (id, parent, notused, detail) — text-based tree representation
+
+  Both parsers already handle their respective formats and are covered by unit
+  tests. The only work is adding the three-point integration:
+  get_query_plan() → get_query_plan_parser() → execute_query() capture call.
+
+prerequisites:
+  - "No cloud credentials required — DataFusion and SQLite run in-process"
+  - "DataFusion Python package (`datafusion`) must be installed in the venv"
+  - "SQLite is part of Python stdlib — no external install needed"
+
+prior_art:
+  - "benchbox/platforms/duckdb.py:969 — canonical execute_query plan-capture integration pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/core/query_plans/parsers/datafusion.py — existing DataFusion JSON parser (20KB)"
+  - "benchbox/core/query_plans/parsers/sqlite.py — existing SQLite text-tree parser"
+  - "tests/unit/platforms/test_duckdb_plan_capture.py — unit test pattern to replicate"
+
+work:
+  - id: w1
+    summary: "Confirm DataFusion EXPLAIN JSON syntax via live query and document in TODO"
+    status: pending
+    notes: |
+      Run a trivial DataFusion query with EXPLAIN FORMAT JSON in the BenchBox
+      harness or a standalone script. Record the exact SQL syntax that works
+      with the installed datafusion version and confirm the output matches what
+      DataFusionQueryPlanParser expects. Capture to /tmp/datafusion-explain-w1.log.
+
+  - id: w2
+    summary: "Add get_query_plan() and get_query_plan_parser() to DataFusionAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      In benchbox/platforms/datafusion.py add:
+        def get_query_plan(self, connection, query):
+            ctx = connection  # DataFusion uses a SessionContext
+            result = ctx.sql(f"EXPLAIN FORMAT JSON {query}")
+            return result.collect()[0][0].as_py()  # adjust to actual API
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
+            return DataFusionQueryPlanParser()
+      Adjust the exact RecordBatch extraction to match the DataFusion Python API
+      as confirmed in w1.
+
+  - id: w3
+    summary: "Integrate capture_query_plan() into DataFusionAdapter.execute_query()"
+    needs: [w2]
+    status: pending
+    notes: |
+      Locate the result-assembly block in DataFusionAdapter.execute_query(). After
+      the timed execution block, add the same capture_plans guard as DuckDB:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate query_plan and plan_fingerprint into the return dict.
+
+  - id: w4
+    summary: "Add unit tests for DataFusion plan capture wiring"
+    needs: [w3]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_datafusion_plan_capture.py. Cover:
+        - get_query_plan_parser() returns DataFusionQueryPlanParser
+        - execute_query() with capture_plans=True triggers capture
+        - execute_query() with capture_plans=False does not trigger capture
+        - plan_fingerprint present in result dict when capture succeeds
+        - graceful degradation on parse failure
+      Mock the DataFusion SessionContext to avoid requiring datafusion package
+      in the base unit test run if it is not installed.
+
+  - id: w5
+    summary: "Confirm SQLite EXPLAIN QUERY PLAN syntax and parser compatibility"
+    status: pending
+    notes: |
+      Run `EXPLAIN QUERY PLAN <simple_query>` against an in-memory SQLite database
+      and compare the raw rows to what SQLiteQueryPlanParser expects.
+      SQLite returns (id, parent, notused, detail) tuples. Verify parser handles
+      them correctly. Capture to /tmp/sqlite-explain-w5.log.
+
+  - id: w6
+    summary: "Add get_query_plan() and get_query_plan_parser() to SQLiteAdapter"
+    needs: [w5]
+    status: pending
+    notes: |
+      In benchbox/platforms/sqlite.py (or wherever SQLiteAdapter lives) add:
+        def get_query_plan(self, connection, query):
+            cursor = connection.cursor()
+            cursor.execute(f"EXPLAIN QUERY PLAN {query}")
+            rows = cursor.fetchall()
+            cursor.close()
+            # Format as text tree for the parser
+            return "\n".join(f"{r[0]}|{r[1]}|{r[2]}|{r[3]}" for r in rows)
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+            return SQLiteQueryPlanParser()
+      Confirm the text format matches what SQLiteQueryPlanParser expects.
+
+  - id: w7
+    summary: "Integrate capture_query_plan() into SQLiteAdapter.execute_query()"
+    needs: [w6]
+    status: pending
+    notes: |
+      Same pattern as w3 but for SQLiteAdapter.
+
+  - id: w8
+    summary: "Add unit tests for SQLite plan capture wiring"
+    needs: [w7]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_sqlite_plan_capture.py. Same coverage as
+      w4 but using SQLiteQueryPlanParser and Python's stdlib sqlite3 connections.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "DataFusionAdapter.execute_query() and SQLiteAdapter.execute_query() must continue to return identical result dict keys to existing callers."
+  - "Plan capture failure must never fail the benchmark when strict_plan_capture=False."
+  - "DataFusion EXPLAIN queries must not be issued when capture_plans=False — avoid performance overhead on every query."
+
+approach: |
+  Start with DataFusion (w1-w4): confirm the exact EXPLAIN JSON API against the
+  installed datafusion version, then wire the three integration points. The
+  parser already exists, so this is plumbing work. Then replicate for SQLite
+  (w5-w8), which uses a text-tree format rather than JSON. Both platforms are
+  locally runnable so all unit tests can use real in-process connections rather
+  than mocks if desired.
+
+anti_patterns:
+  - "DO NOT use EXPLAIN ANALYZE for SQLite — SQLite's EXPLAIN QUERY PLAN does not support ANALYZE and will raise an error."
+  - "DO NOT import DataFusionQueryPlanParser at module level in datafusion.py — keep lazy to avoid import cost when DataFusion is not installed."
+  - "DO NOT use ctx.sql().to_pandas() for EXPLAIN output — use collect() and extract the scalar text to avoid an unnecessary pandas dependency."
+
+verification:
+  - description: "DataFusion plan capture unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_datafusion_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "SQLite plan capture unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit test suite still passes"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+    - "tests/unit/platforms/test_datafusion_plan_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml"
+  do_not_modify:
+    - "benchbox/core/query_plans/parsers/datafusion.py"
+    - "benchbox/core/query_plans/parsers/sqlite.py"
+
+success_metrics:
+  - "DataFusionAdapter.get_query_plan_parser() returns a non-None DataFusionQueryPlanParser instance."
+  - "SQLiteAdapter.get_query_plan_parser() returns a non-None SQLiteQueryPlanParser instance."
+  - "execute_query() with capture_plans=True stores a QueryPlanDAG and fingerprint in the result dict for both adapters."
+  - "All unit tests pass. No regressions."
+
+metadata:
+  tags: [query-plan, datafusion, sqlite, wiring, no-credentials]
+  estimated_effort: "Small"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -1,0 +1,268 @@
+id: query-plan-capture-misc-platforms
+title: "Implement or resolve query plan capture for QuestDB, Velox, Databend, MotherDuck, cuDF, Doris, and SingleStore"
+worktree: platform-expansion
+priority: Low
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Seven platforms each have distinct plan capture situations ranging from
+  trivial wiring to fundamental unsupportability. They are grouped here
+  because they are lower priority than the main platform families and each
+  requires individual assessment before implementation.
+
+  Current state:
+    1. QuestDB (benchbox/platforms/questdb.py:1219)
+       - get_query_plan(): ✅ implemented — but execute_query() delegates to
+         shared execute_sql_query() which does not call capture_query_plan().
+         QuestDB uses a non-standard HTTP REST API and its EXPLAIN format is
+         a JSON response specific to QuestDB's JITC compiler.
+       - No parser exists. No execute_query() override calls capture_query_plan().
+
+    2. VeloxAdapter (benchbox/platforms/velox.py:487)
+       - get_query_plan(): ✅ at line 487 — annotates VeloxColumnar vs JVM-fallback
+         nodes. Output is text with custom Velox operator names.
+       - No parser. No execute_query() capture call.
+       - Velox's EXPLAIN format (via Prestissimo) is JSON similar to Presto's format.
+         If PrestoTrinoQueryPlanParser is completed first (see presto-trino TODO),
+         Velox may be able to reuse it.
+
+    3. DatabendAdapter (benchbox/platforms/databend/adapter.py:579)
+       - get_query_plan(): ✅ at line 579. Databend uses `EXPLAIN <query>` returning
+         a text tree similar to DuckDB.
+       - execute_query() exists at line 502. No capture call.
+       - No parser exists.
+
+    4. MotherDuckAdapter (benchbox/platforms/motherduck.py:74)
+       - Inherits PlatformAdapter (not DuckDBAdapter). No plan support inherited.
+       - MotherDuck IS serverless DuckDB and uses the same DuckDB SQL dialect.
+       - Should override get_query_plan() and get_query_plan_parser() to reuse
+         DuckDBQueryPlanParser. The EXPLAIN output format is identical to DuckDB.
+
+    5. cuDFAdapter (benchbox/platforms/cudf.py:594)
+       - get_query_plan(): ✅ at line 594 — but always returns None.
+         cuDF does not currently support EXPLAIN for its DataFrame or SQL layer.
+       - Resolution: document the limitation; mark as unsupported until cuDF
+         adds EXPLAIN support. No parser needed yet.
+
+    6. DorisAdapter (benchbox/platforms/doris.py)
+       - No get_query_plan() override. Inherits base (returns None).
+       - Doris supports `EXPLAIN <query>` with a text tree similar to MySQL EXPLAIN.
+       - No parser exists.
+
+    7. SingleStoreAdapter (benchbox/platforms/singlestore.py)
+       - No get_query_plan() override. Inherits base (returns None).
+       - SingleStore supports `EXPLAIN <query>` (MySQL-compatible).
+       - May be able to reuse or extend a MySQL/text-tree parser if one is added.
+
+prerequisites:
+  - "QuestDB: running QuestDB 7.x+ instance (env: QUESTDB_HOST, QUESTDB_PORT)"
+  - "VeloxAdapter: Prestissimo/Velox cluster accessible (env per VeloxAdapter config)"
+  - "DatabendAdapter: running Databend server or Databend Cloud account (env: DATABEND_HOST, DATABEND_USER, DATABEND_PASSWORD)"
+  - "MotherDuck: MotherDuck account + service token (env: MOTHERDUCK_TOKEN) — but DuckDB parser reuse requires no new credentials for unit tests"
+  - "cuDF: NVIDIA GPU + cuDF ≥23.x — no EXPLAIN support currently; flag as blocked until cuDF upstream adds SQL EXPLAIN"
+  - "Doris: running Apache Doris cluster (env: DORIS_HOST, DORIS_USER, DORIS_PASSWORD)"
+  - "SingleStore: SingleStore Managed Service or Helios Cloud account (env: SINGLESTORE_HOST, SINGLESTORE_USER, SINGLESTORE_PASSWORD)"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/duckdb.py — reuse for MotherDuck (identical EXPLAIN format)"
+  - "benchbox/platforms/duckdb.py:1038 — get_query_plan() text-EXPLAIN pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() lazy import pattern"
+  - "benchbox/core/query_plans/parsers/presto_trino.py — reuse for Velox (Prestissimo uses Presto JSON format)"
+  - "benchbox/platforms/questdb.py:1219 — existing QuestDB get_query_plan() to confirm format before writing parser"
+
+work:
+  - id: w1
+    summary: "MotherDuck: add get_query_plan() and get_query_plan_parser() reusing DuckDB components"
+    status: pending
+    notes: |
+      MotherDuck uses DuckDB's SQL dialect. In benchbox/platforms/motherduck.py:
+        def get_query_plan(self, connection, query):
+            # Identical to DuckDBAdapter — EXPLAIN (ANALYZE, FORMAT JSON)
+            explain_query = f"EXPLAIN (ANALYZE, FORMAT JSON) {query}"
+            result = connection.execute(explain_query).fetchall()
+            return result[0][0] if result else None
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.duckdb import DuckDBQueryPlanParser
+            return DuckDBQueryPlanParser()
+      Then add the capture call to MotherDuckAdapter.execute_query() following
+      the DuckDB pattern. Verify EXPLAIN output is identical to DuckDB local.
+      Unit test: confirm get_query_plan_parser() returns DuckDBQueryPlanParser.
+
+  - id: w2
+    summary: "MotherDuck: integrate capture_query_plan() into execute_query()"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add the same capture guard as DuckDB to MotherDuckAdapter.execute_query().
+      MotherDuck connections are DuckDB connections; no format differences expected.
+
+  - id: w3
+    summary: "Databend: collect EXPLAIN sample, implement DatabendQueryPlanParser"
+    status: pending
+    notes: |
+      Run `EXPLAIN SELECT l_orderkey FROM lineitem LIMIT 10` against Databend.
+      Databend's EXPLAIN output uses an indented text tree similar to DuckDB's
+      text mode. Implement DatabendQueryPlanParser in
+      benchbox/core/query_plans/parsers/databend.py mapping operator names:
+        TableScan / ReadDataSource → SCAN
+        Filter → FILTER
+        AggregatorTransform / FinalAggregator → AGGREGATE
+        HashJoin → JOIN
+        SortingTransform → SORT
+      Register under dialect="databend". Wire get_query_plan_parser() and
+      capture call in DatabendAdapter.execute_query().
+
+  - id: w4
+    summary: "QuestDB: collect EXPLAIN JSON sample, implement QuestDBQueryPlanParser"
+    status: pending
+    notes: |
+      QuestDB EXPLAIN returns a JSON object with a `plan` array. Run
+      `EXPLAIN SELECT * FROM trades LIMIT 10` against a QuestDB instance.
+      Implement QuestDBQueryPlanParser for the JSON structure. Map QuestDB
+      operator names (SelectedRecord, Sort, GroupByRecord, etc.) to
+      LogicalOperatorType. Wire get_query_plan_parser() and fix the
+      execute_query() path to call capture_query_plan() — QuestDB's
+      execute_query() delegates to execute_sql_query(); may need an override.
+
+  - id: w5
+    summary: "Velox: assess Presto plan format reuse; wire parser after presto-trino TODO is complete"
+    status: pending
+    notes: |
+      BLOCKED on query-plan-capture-presto-trino-family.yaml being implemented first —
+      PrestoTrinoQueryPlanParser must exist before this work unit can proceed.
+      Velox (via Prestissimo) uses Presto's REST API and EXPLAIN FORMAT JSON.
+      Once PrestoTrinoQueryPlanParser is implemented, confirm Velox EXPLAIN output
+      matches the Presto fixture. If compatible, override get_query_plan_parser()
+      in VeloxAdapter to return PrestoTrinoQueryPlanParser. If Velox adds
+      Velox-native operator names, extend PrestoTrinoQueryPlanParser or subclass it.
+      Wire capture call in VeloxAdapter.execute_query().
+      NOTE: Only this work unit is blocked on Presto/Trino — w1 (MotherDuck),
+      w2 (MotherDuck), w3 (Databend), w4 (QuestDB), w6 (Doris), w7 (SingleStore)
+      can all proceed independently.
+
+  - id: w6
+    summary: "Doris + SingleStore: assess MySQL EXPLAIN format compatibility; implement shared or separate parsers"
+    status: pending
+    notes: |
+      Before writing any parser code, collect EXPLAIN output from both Doris and
+      SingleStore. Apache Doris EXPLAIN returns an indented text tree.
+      SingleStore EXPLAIN is MySQL-protocol-compatible and may use a similar format.
+
+      Pre-assessment step (required before parser implementation):
+        1. Run `EXPLAIN SELECT * FROM <table> LIMIT 1` against Doris and SingleStore.
+        2. If the indented-text format is identical or structurally equivalent,
+           implement ONE shared MySQLCompatibleQueryPlanParser that both adapters
+           can use via their get_query_plan_parser() override.
+        3. If the formats differ, implement DorisQueryPlanParser and
+           SingleStoreQueryPlanParser separately.
+
+      After parser decision is made:
+        - Wire get_query_plan() override for each adapter (if not present).
+        - Wire get_query_plan_parser() returning the chosen parser.
+        - Add capture_query_plan() call in each adapter's execute_query().
+
+  - id: w7
+    summary: "SingleStore: wire plan capture using parser chosen in w6"
+    needs: [w6]
+    status: pending
+    notes: |
+      After w6 determines whether DorisQueryPlanParser and SingleStoreQueryPlanParser
+      share a base or are separate, implement the SingleStore wiring:
+        - get_query_plan() returning `EXPLAIN <query>` output
+        - get_query_plan_parser() returning the chosen parser
+        - capture call in SingleStoreAdapter.execute_query()
+      If a shared MySQLCompatibleQueryPlanParser was created in w6, SingleStore
+      only needs the wiring; no new parser file required.
+
+  - id: w8
+    summary: "cuDF: document EXPLAIN limitation and add an explicit unsupported comment"
+    status: pending
+    notes: |
+      cuDF currently returns None from get_query_plan() (line 594). Add a
+      clear comment explaining why: cuDF's DataFrame/SQL layer does not expose
+      an EXPLAIN or plan inspection API as of the current cuDF version.
+      Track the upstream cuDF issue or GitHub discussion if one exists.
+      No parser or wiring needed until upstream support is added.
+
+  - id: w9
+    summary: "Add unit tests for all newly wired adapters"
+    needs: [w1, w2, w3, w4, w5, w6, w7]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_misc_plan_capture.py with parametrized
+      cases for MotherDuck, Databend, QuestDB, Velox, Doris, SingleStore:
+        - get_query_plan_parser() returns non-None
+        - execute_query() with capture_plans=True captures plan (mock connection)
+        - graceful degradation on capture failure
+
+deferred:
+  - summary: "cuDF EXPLAIN-based plan capture"
+    reason: "cuDF does not expose EXPLAIN or a plan inspection API. Defer until upstream cuDF adds support."
+
+deps:
+  needs: []
+  # Note: only w5 (Velox) is blocked on query-plan-capture-presto-trino-family.
+  # All other work units (MotherDuck, Databend, QuestDB, Doris, SingleStore)
+  # can proceed independently.
+
+must_preserve:
+  - "MotherDuckAdapter must continue to work without a MotherDuck account for unit tests."
+  - "cuDF adapter behavior must not change — get_query_plan() returning None is currently correct and expected."
+  - "All adapter execute_query() result dict shapes must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False for all seven platforms."
+
+approach: |
+  Start with MotherDuck (w1+w2) as the highest-confidence quick win — it reuses
+  DuckDBQueryPlanParser with no new parsing code required. Then Databend (w3)
+  because it runs locally. QuestDB (w4) is next since get_query_plan() already
+  exists. Velox (w5) depends on the Presto/Trino TODO being done first. Doris and
+  SingleStore (w6+w7) are lower priority since they require external cluster access.
+  cuDF (w8) is documentation only. Consolidate all wiring tests in w9.
+
+anti_patterns:
+  - "DO NOT implement a cuDF parser stub expecting it will be called — cuDF always returns None and should continue to do so until upstream support exists."
+  - "DO NOT add Velox-specific operator name handling to PrestoTrinoAdapterBase — Velox extensions should be in VeloxAdapter."
+  - "DO NOT require a GPU or cuDF install for any unit tests."
+
+verification:
+  - description: "MotherDuck plan capture wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_misc_plan_capture.py -k motherduck -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "All new misc-platform unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_misc_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/databend/adapter.py"
+    - "benchbox/platforms/questdb.py"
+    - "benchbox/platforms/velox.py"
+    - "benchbox/platforms/cudf.py"
+    - "benchbox/platforms/doris.py"
+    - "benchbox/platforms/singlestore.py"
+    - "benchbox/core/query_plans/parsers/databend.py"
+    - "benchbox/core/query_plans/parsers/questdb.py"
+    - "benchbox/core/query_plans/parsers/doris.py"
+    - "benchbox/core/query_plans/parsers/singlestore.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/platforms/test_misc_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml"
+
+success_metrics:
+  - "MotherDuck, Databend, QuestDB, Velox, Doris, and SingleStore adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for all six platforms."
+  - "cuDF adapter has a clear comment explaining EXPLAIN is unsupported; get_query_plan() behavior is unchanged."
+  - "All unit tests pass."
+
+metadata:
+  tags: [query-plan, questdb, velox, databend, motherduck, cudf, doris, singlestore, misc]
+  estimated_effort: "Large"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
@@ -1,0 +1,211 @@
+id: query-plan-capture-postgresql-family
+title: "Wire query plan capture end-to-end for PostgreSQL, Redshift, and derived adapters"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  PostgreSQL and Redshift both have fully-functional parsers in
+  `benchbox/core/query_plans/parsers/postgresql.py` and
+  `benchbox/core/query_plans/parsers/redshift.py`, and both adapters already
+  implement `get_query_plan()` that issues EXPLAIN ANALYZE. However, neither
+  adapter overrides `get_query_plan_parser()`, so the base class returns None
+  and `capture_query_plan()` is never reached. Three derived adapters —
+  TimescaleDB, CedarDB, and pg_mooncake — inherit `PostgreSQLAdapter` and will
+  receive plan capture for free once the parent is wired.
+
+  Gap summary per adapter:
+    - PostgreSQLAdapter (benchbox/platforms/postgresql.py:693)
+        • get_query_plan(): ✅ issues EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+        • get_query_plan_parser(): ❌ missing override → parser never instantiated
+        • execute_query(): ❌ never calls capture_query_plan()
+    - RedshiftAdapter (benchbox/platforms/redshift.py:2404)
+        • get_query_plan(): ✅ issues EXPLAIN
+        • get_query_plan_parser(): ❌ missing override
+        • execute_query(): ❌ never calls capture_query_plan()
+    - TimescaleDBAdapter, CedarDBAdapter, PgMooncakeAdapter
+        • All subclass PostgreSQLAdapter; will inherit fixed behavior once
+          PostgreSQLAdapter is patched.
+
+  The DuckDB adapter (benchbox/platforms/duckdb.py:969) is the reference
+  implementation. The pattern is: after the timed execute block, call
+  `capture_query_plan(connection, query, query_id)` guarded by
+  `self.capture_plans`, then set `plan_fingerprint` from the returned DAG.
+
+prerequisites:
+  - "Running PostgreSQL ≥12 instance accessible to the test harness for integration/UAT cells"
+  - "AWS Redshift credentials + cluster endpoint for Redshift integration tests (env: REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD, REDSHIFT_DB)"
+  - "Unit tests can run without credentials — mock the connection as PostgreSQL parser tests already do"
+
+prior_art:
+  - "benchbox/platforms/duckdb.py:969 — canonical execute_query plan-capture integration pattern to replicate"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/core/query_plans/parsers/postgresql.py — existing parser, not yet called by any adapter"
+  - "benchbox/core/query_plans/parsers/redshift.py — existing parser, not yet called by any adapter"
+  - "tests/unit/platforms/test_duckdb_plan_capture.py — test pattern to replicate for postgres family"
+  - "benchbox/platforms/base/result_capture.py:515 — base get_query_plan_parser() returns None"
+  - "benchbox/platforms/base/result_capture.py:561 — capture_query_plan() implementation"
+
+work:
+  - id: w1
+    summary: "Add get_query_plan_parser() override to PostgreSQLAdapter returning PostgreSQLQueryPlanParser"
+    status: pending
+    notes: |
+      Add to benchbox/platforms/postgresql.py:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
+            return PostgreSQLQueryPlanParser()
+      Keep the import lazy to match DuckDB's pattern and avoid heavy import cost at startup.
+
+  - id: w2
+    summary: "Integrate capture_query_plan() call into PostgreSQLAdapter.execute_query()"
+    needs: [w1]
+    status: pending
+    notes: |
+      Locate the return-result assembly block in PostgreSQLAdapter.execute_query().
+      After the timed SQL block, add the same capture_plans guard as DuckDB (line 968-971):
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate query_plan and plan_fingerprint into the result dict.
+
+  - id: w3
+    summary: "Add unit tests for PostgreSQL plan capture wiring"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_postgresql_plan_capture.py. Cover:
+        - get_query_plan_parser() returns PostgreSQLQueryPlanParser instance
+        - execute_query() with capture_plans=True calls capture_query_plan()
+        - execute_query() with capture_plans=False does not call capture_query_plan()
+        - plan_fingerprint is set in result dict when plan is captured
+        - capture failure is graceful (plan=None, benchmark still succeeds)
+      Mock the connection using the pattern in test_duckdb_plan_capture.py.
+
+  - id: w4
+    summary: "Add get_query_plan_parser() override to RedshiftAdapter returning RedshiftQueryPlanParser"
+    status: pending
+    notes: |
+      Same pattern as w1 but for benchbox/platforms/redshift.py:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+            return RedshiftQueryPlanParser()
+      Verify EXPLAIN format differences (Redshift uses text tree, not EXPLAIN ANALYZE BUFFERS).
+      Check whether RedshiftAdapter.get_query_plan() already strips the ANALYZE/BUFFERS
+      options for Redshift compatibility.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() call into RedshiftAdapter.execute_query()"
+    needs: [w4]
+    status: pending
+    notes: |
+      Same pattern as w2 but for benchbox/platforms/redshift.py execute_query().
+      Redshift EXPLAIN runs in the same connection context but cannot use ANALYZE
+      on live prod tables without advisory locks — confirm the existing
+      get_query_plan() already uses plain EXPLAIN (without ANALYZE) for Redshift.
+
+  - id: w6
+    summary: "Add unit tests for Redshift plan capture wiring"
+    needs: [w5]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_redshift_plan_capture.py. Same coverage
+      checklist as w3 but using RedshiftQueryPlanParser and mocking Redshift cursors.
+
+  - id: w7
+    summary: "Verify TimescaleDB, CedarDB, and pg_mooncake inherit plan capture without changes"
+    needs: [w3]
+    status: pending
+    notes: |
+      All three subclass PostgreSQLAdapter and do not override execute_query() or
+      get_query_plan_parser(). Run existing adapter unit tests to confirm no
+      regressions. Add a short parametrized test asserting that each subclass
+      instance returns a non-None parser from get_query_plan_parser().
+    coverage_checklist:
+      - id: ts-parser
+        description: "TimescaleDBAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+      - id: cedar-parser
+        description: "CedarDBAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+      - id: pgmc-parser
+        description: "PgMooncakeAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+
+  - id: w8
+    summary: "UAT cell smoke for PostgreSQL plan capture"
+    needs: [w3, w7]
+    status: pending
+    notes: |
+      Run a single TPC-H SF=0.01 cell against a live PostgreSQL instance with
+      --capture-plans enabled. Confirm query_plans_captured > 0 in the result
+      bundle. This step requires a live PostgreSQL instance (see prerequisites).
+
+deps:
+  needs: []
+
+must_preserve:
+  - "PostgreSQLAdapter.execute_query() continues to return the same result dict keys for callers that do not use plan capture."
+  - "TimescaleDB, CedarDB, and pg_mooncake adapters must not require any code changes — plan capture should be inherited automatically."
+  - "Redshift EXPLAIN must not use ANALYZE mode — Redshift does not support EXPLAIN ANALYZE syntax."
+  - "Plan capture failures must never raise an exception when strict_plan_capture is False (the default)."
+
+approach: |
+  Start with PostgreSQL (w1+w2+w3) since it is the reference SQL parser and
+  requires no cloud credentials for unit testing. Use DuckDB's execute_query()
+  as a line-by-line reference for the integration pattern. Then replicate for
+  Redshift (w4+w5+w6), noting that Redshift's EXPLAIN does not support ANALYZE.
+  After both parents are wired, run w7 to confirm the three derived adapters
+  inherit without change. Finish with a live PostgreSQL UAT cell (w8) if a
+  PostgreSQL instance is available; otherwise record as deferred.
+
+anti_patterns:
+  - "DO NOT add EXPLAIN ANALYZE to RedshiftAdapter.get_query_plan() — Redshift does not support EXPLAIN ANALYZE and will raise a syntax error."
+  - "DO NOT eagerly import PostgreSQLQueryPlanParser at module level — keep the import inside get_query_plan_parser() to match the lazy import pattern used by DuckDB."
+  - "DO NOT change TimescaleDBAdapter, CedarDBAdapter, or PgMooncakeAdapter — inheritance should carry the fix automatically; any explicit override is an anti-pattern here."
+  - "DO NOT add plan capture to the shared psycopg2 cursor helpers in benchbox/platforms/base/psycopg2_mixin.py — the capture call belongs in each adapter's own execute_query()."
+
+verification:
+  - description: "All new and existing PostgreSQL adapter unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_postgresql_plan_capture.py tests/unit/platforms/test_postgresql_adapter.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "All new Redshift adapter unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_redshift_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Subclass adapters inherit get_query_plan_parser() without overriding"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'timescale or cedardb or mooncake' -v"
+    expected_output: "Parametrized inheritance tests pass for all three adapters"
+  - description: "Full unit suite still green after changes"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/redshift.py"
+    - "tests/unit/platforms/test_postgresql_plan_capture.py"
+    - "tests/unit/platforms/test_redshift_plan_capture.py"
+    - "tests/unit/platforms/test_postgresql_adapter.py"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/timescaledb.py"
+    - "benchbox/platforms/cedardb.py"
+    - "benchbox/platforms/pg_mooncake.py"
+    - "benchbox/platforms/base/psycopg2_mixin.py"
+    - "benchbox/core/query_plans/parsers/postgresql.py"
+    - "benchbox/core/query_plans/parsers/redshift.py"
+
+success_metrics:
+  - "PostgreSQLAdapter.get_query_plan_parser() returns a non-None parser instance."
+  - "RedshiftAdapter.get_query_plan_parser() returns a non-None parser instance."
+  - "execute_query() with capture_plans=True captures and stores a QueryPlanDAG in the result dict."
+  - "TimescaleDB, CedarDB, and pg_mooncake adapters inherit plan capture with zero code changes."
+  - "All unit tests pass. No regressions in existing platform tests."
+
+metadata:
+  tags: [query-plan, postgresql, redshift, timescaledb, cedardb, pg-mooncake, wiring]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
@@ -1,0 +1,195 @@
+id: query-plan-capture-presto-trino-family
+title: "Implement query plan parser and end-to-end capture for Presto, Trino, Starburst, and Athena"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  The Presto/Trino family shares a common SQL dialect and EXPLAIN output format.
+  `presto_trino_adapter_base.py` already implements `get_query_plan()` at line 632
+  by delegating to `get_query_plan_from_cursor()`. PrestoAdapter and StarburstAdapter
+  inherit this without change. AthenaAdapter also implements `get_query_plan()` at
+  line 1294 the same way. None of these adapters override `get_query_plan_parser()`
+  (base returns None) and none call `capture_query_plan()` from `execute_query()`.
+
+  The primary work in this group is **writing a new PrestoTrinoQueryPlanParser**
+  since no parser exists today. Presto and Trino both output a JSON tree when
+  `EXPLAIN (FORMAT JSON)` is used, containing nodes with `id`, `name`,
+  `identifier`, `outputs`, `details`, and `children` fields. The parser
+  must produce a `QueryPlanDAG` from that structure.
+
+  Gap summary per adapter:
+    - PrestoAdapter / PrestoTrinoAdapterBase (benchbox/platforms/presto_trino_adapter_base.py)
+        • get_query_plan(): ✅ line 632 — EXPLAIN via cursor
+        • get_query_plan_parser(): ❌ no override
+        • execute_query(): ❌ no capture_query_plan() call
+    - StarburstAdapter (benchbox/platforms/starburst.py — inherits base)
+        • Same as PrestoAdapter via inheritance
+    - AthenaAdapter (benchbox/platforms/athena.py)
+        • get_query_plan(): ✅ line 1294 — EXPLAIN via cursor
+        • execute_query(): ✅ line 1179 — but no capture_query_plan() call
+        • get_query_plan_parser(): ❌ no override
+        • Athena uses the Presto engine; EXPLAIN output format is compatible
+
+  Note: Trino EXPLAIN FORMAT JSON and Presto EXPLAIN FORMAT JSON are structurally
+  similar but may differ in operator node names across major versions. The parser
+  should handle both dialects via version-aware node normalization.
+
+prerequisites:
+  - "Running Presto ≥0.280 or Trino ≥400 instance for integration tests and EXPLAIN format verification"
+  - "Starburst Galaxy or Enterprise instance for Starburst-specific EXPLAIN verification (optional — format should be identical to Trino)"
+  - "AWS credentials with AmazonAthenaFullAccess + S3 output bucket for Athena integration tests (env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, ATHENA_S3_OUTPUT, ATHENA_DATABASE)"
+  - "Unit tests (parser and wiring) can run without any credentials using recorded EXPLAIN fixtures"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/datafusion.py — closest existing JSON-tree parser to replicate structurally"
+  - "benchbox/core/query_plans/parsers/base.py — abstract QueryPlanParser interface to implement"
+  - "benchbox/core/query_plans/parsers/registry.py — version-aware parser registration to use"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/platforms/duckdb.py:969 — execute_query() capture integration pattern"
+  - "benchbox/platforms/presto_trino_adapter_base.py:632 — existing get_query_plan() implementation"
+
+work:
+  - id: w1
+    summary: "Collect representative EXPLAIN FORMAT JSON samples from Presto, Trino, and Athena"
+    status: pending
+    notes: |
+      Against live instances, run `EXPLAIN (FORMAT JSON) SELECT * FROM tpch.sf1.lineitem LIMIT 10`
+      (or equivalent small query) and capture the full JSON output. Record one sample
+      per engine+version combination. Store in tests/fixtures/query_plans/
+      as presto_explain_sample.json, trino_explain_sample.json,
+      athena_explain_sample.json. These fixtures drive parser unit tests.
+      Capture raw stdout to /tmp/presto-trino-explain-w1.log.
+
+  - id: w2
+    summary: "Implement PrestoTrinoQueryPlanParser in benchbox/core/query_plans/parsers/presto_trino.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement the abstract interface from base.py:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - Deserialize the JSON tree from EXPLAIN FORMAT JSON output
+        - Map Presto/Trino operator names to LogicalOperatorType enum
+          (TableScan→SCAN, Filter→FILTER, HashJoin/LookupJoin→JOIN, etc.)
+        - Normalize cross-version node naming differences (e.g., Trino renames
+          several operators across major versions — handle via operator name map)
+        - Register in parsers/registry.py under dialect="presto" and dialect="trino"
+          with version range 0.0.0+
+      Follow DataFusionQueryPlanParser as the closest structural template.
+
+  - id: w3
+    summary: "Add unit tests for PrestoTrinoQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_presto_trino_parser.py. Cover:
+        - Basic parse of each fixture sample produces a valid QueryPlanDAG
+        - Operator name normalization maps to expected LogicalOperatorType
+        - Cross-dialect (Presto vs Trino) produces equivalent DAG for same query
+        - Malformed JSON input triggers graceful error recovery (no exception)
+        - Parser registered correctly in registry for both dialects
+
+  - id: w4
+    summary: "Override get_query_plan_parser() in PrestoTrinoAdapterBase"
+    needs: [w2]
+    status: pending
+    notes: |
+      In benchbox/platforms/presto_trino_adapter_base.py add:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
+            return PrestoTrinoQueryPlanParser()
+      PrestoAdapter and StarburstAdapter inherit this automatically.
+      Note: confirm EXPLAIN FORMAT JSON is supported by the cursor
+      in get_query_plan_from_cursor() — if not, override get_query_plan()
+      to use `EXPLAIN (FORMAT JSON)` explicitly.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() into PrestoTrinoAdapterBase execute_query() path"
+    needs: [w4]
+    status: pending
+    notes: |
+      The base class may or may not have a shared execute_query(). If it does,
+      add the capture guard there. If each adapter has its own execute_query(),
+      patch PrestoAdapter and StarburstAdapter separately. Either way, the pattern
+      is identical to DuckDB's execute_query() (line 968-971).
+
+  - id: w6
+    summary: "Override get_query_plan_parser() in AthenaAdapter; integrate capture in execute_query()"
+    needs: [w4]
+    status: pending
+    notes: |
+      AthenaAdapter has its own execute_query() (line 1179). Add get_query_plan_parser()
+      returning PrestoTrinoQueryPlanParser and add the capture call in execute_query().
+      Confirm Athena's EXPLAIN output via the fixture from w1 — Athena may strip
+      the FORMAT JSON option and return a text plan. If so, create a separate
+      AthenaQueryPlanParser or extend PrestoTrinoQueryPlanParser to handle both.
+
+  - id: w7
+    summary: "Add wiring unit tests for Presto/Starburst/Athena adapters"
+    needs: [w5, w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_presto_trino_plan_capture.py. Cover
+      get_query_plan_parser() returns non-None for Presto, Starburst, and Athena.
+      Mock cursor to return the fixture JSON from w1 and assert the result dict
+      includes query_plan and plan_fingerprint when capture_plans=True.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "PrestoAdapter, StarburstAdapter, and AthenaAdapter execute_query() result dict shape must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False — Athena queries are expensive; never fail a benchmark run for a plan capture error."
+  - "The base EXPLAIN call in get_query_plan_from_cursor() must not be changed if other adapters depend on it."
+
+approach: |
+  Begin with fixture collection (w1) since the parser cannot be written without
+  knowing the exact JSON structure. Then implement the parser (w2) and its tests
+  (w3). Wire the parser into the adapter base (w4+w5), then handle Athena's
+  potentially different format separately (w6). Finish with wiring unit tests (w7).
+  Do not block on cloud credentials for the parser work — use fixtures for all
+  unit tests.
+
+anti_patterns:
+  - "DO NOT write the parser against assumed JSON structure — use the actual w1 fixture samples to drive the field mapping."
+  - "DO NOT use EXPLAIN ANALYZE for Athena — Athena does not run live queries during EXPLAIN; ANALYZE mode may not be supported."
+  - "DO NOT add Presto/Trino/Athena-specific logic to PrestoTrinoAdapterBase if only Athena needs it — Athena overrides should live in AthenaAdapter."
+
+verification:
+  - description: "Parser unit tests pass against fixture samples"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_presto_trino_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Adapter wiring unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_presto_trino_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/presto_trino_adapter_base.py"
+    - "benchbox/platforms/athena.py"
+    - "benchbox/core/query_plans/parsers/presto_trino.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_presto_trino_parser.py"
+    - "tests/unit/platforms/test_presto_trino_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/presto.py"
+    - "benchbox/platforms/starburst.py"
+
+success_metrics:
+  - "PrestoTrinoQueryPlanParser parses fixture JSON samples from Presto and Trino into valid QueryPlanDAG objects."
+  - "PrestoTrinoAdapterBase.get_query_plan_parser() returns a non-None parser."
+  - "AthenaAdapter.get_query_plan_parser() returns a non-None parser."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for Presto, Starburst, and Athena."
+  - "All unit tests pass."
+
+metadata:
+  tags: [query-plan, presto, trino, starburst, athena, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
@@ -1,0 +1,217 @@
+id: query-plan-capture-spark-databricks
+title: "Implement query plan parser and end-to-end capture for Spark and Databricks adapters"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  SparkAdapter has `get_query_plan()` implemented in
+  `benchbox/platforms/base/spark_execution_mixin.py` (line 688), but no parser
+  exists and `execute_query()` (line 470, via `_execute_query_spark`) never calls
+  `capture_query_plan()`. Databricks likely has a similar or inherited state.
+
+  Spark's EXPLAIN output has multiple modes:
+    - `df.explain()` / `EXPLAIN <query>` — text plan with three sections:
+        == Parsed Logical Plan ==
+        == Analyzed Logical Plan ==
+        == Optimized Logical Plan ==
+        == Physical Plan ==
+    - `df.explain(extended=True)` — all four sections
+    - `df.explain(mode='formatted')` — Spark 3.x formatted tree
+    - `df.explain(mode='cost')` — cost-annotated plan
+
+  The physical plan section uses indentation-based text similar to DuckDB/ClickHouse
+  text format. Operator names include: FileScan, Filter, Project, HashAggregate,
+  Exchange, Sort, BroadcastHashJoin, SortMergeJoin, etc.
+
+  A separate DataFrame profiling path exists at
+  `benchbox/core/dataframe/profiling.py` for DataFrame-based Spark plan capture —
+  this TODO covers only the SQL execution path (`execute_query()`), not DataFrame
+  profiling, which is a parallel system.
+
+  Note on SparkQueryExecutionMixin: execute_query() at line 470 delegates to
+  `_execute_query_spark()` (line 491). The capture call should go into
+  `_execute_query_spark()` after the timed SQL block.
+
+prerequisites:
+  - "Apache Spark ≥3.0 cluster or local Spark session (PySpark) for integration and EXPLAIN format verification"
+  - "Databricks workspace URL + personal access token for Databricks integration tests (env: DATABRICKS_HOST, DATABRICKS_TOKEN)"
+  - "Unit tests (parser + wiring) can run without a live cluster using recorded EXPLAIN fixture text"
+  - "pyspark Python package installed in the venv for unit test mocking"
+
+prior_art:
+  - "benchbox/platforms/base/spark_execution_mixin.py:688 — existing get_query_plan() implementation"
+  - "benchbox/platforms/base/spark_execution_mixin.py:491 — _execute_query_spark() to add capture to"
+  - "benchbox/core/query_plans/parsers/duckdb.py — closest text-format parser (DuckDB text mode)"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface to implement"
+  - "benchbox/core/dataframe/profiling.py — parallel DataFrame plan system; do not modify"
+  - "benchbox/platforms/duckdb.py:969 — canonical capture integration pattern"
+
+work:
+  - id: w1
+    summary: "Collect Spark EXPLAIN text samples and confirm format used by get_query_plan()"
+    status: pending
+    notes: |
+      Check what SQL string get_query_plan() in spark_execution_mixin.py currently
+      issues (EXPLAIN? EXPLAIN EXTENDED? EXPLAIN FORMATTED?). Capture the output
+      from a live Spark session against a simple TPC-H query. Record:
+        - Exact SQL issued
+        - Full text output (all plan sections)
+        - Spark version
+      Store as tests/fixtures/query_plans/spark_explain_sample.txt.
+      If get_query_plan() issues bare EXPLAIN, it returns only the physical plan.
+      If EXPLAIN EXTENDED, all four sections are returned. Decide which sections
+      to parse (physical plan is most useful for fingerprinting).
+
+  - id: w2
+    summary: "Implement SparkQueryPlanParser in benchbox/core/query_plans/parsers/spark.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement QueryPlanParser abstract interface:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - If EXPLAIN EXTENDED is used, extract the physical plan section
+          (text between '== Physical Plan ==' and end of output)
+        - Parse indentation-based physical plan tree
+        - Operator name normalization:
+            FileScan parquet / FileScan csv → SCAN
+            Filter → FILTER
+            Project → PROJECT
+            HashAggregate / ObjectHashAggregate → AGGREGATE
+            Exchange / ShuffleExchange → EXCHANGE (map to a suitable LogicalOperatorType)
+            BroadcastHashJoin / SortMergeJoin / BroadcastNestedLoopJoin → JOIN
+            Sort → SORT
+        - Register in parsers/registry.py under dialect="spark" with version 3.0.0+
+      Follow DuckDB text parser as the closest structural template.
+
+  - id: w3
+    summary: "Add unit tests for SparkQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_spark_parser.py. Cover:
+        - Parse of fixture sample produces valid QueryPlanDAG
+        - Physical plan section correctly extracted when EXPLAIN EXTENDED is used
+        - Operator normalization maps to expected LogicalOperatorType
+        - Malformed / empty input triggers graceful error recovery
+        - Parser registered in registry under "spark" dialect
+
+  - id: w4
+    summary: "Add get_query_plan_parser() override to SparkAdapter (or SparkQueryExecutionMixin)"
+    needs: [w2]
+    status: pending
+    notes: |
+      In benchbox/platforms/spark.py or spark_execution_mixin.py (whichever is
+      most appropriate for the mixin hierarchy):
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+            return SparkQueryPlanParser()
+      If get_query_plan_parser() is on SparkQueryExecutionMixin, SparkAdapter
+      inherits it automatically.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() into _execute_query_spark()"
+    needs: [w4]
+    status: pending
+    notes: |
+      In benchbox/platforms/base/spark_execution_mixin.py, inside
+      _execute_query_spark() (line 491), after the timed SQL execution block:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(
+                connection, query, query_id
+            )
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate into the return dict.
+
+  - id: w6
+    summary: "Assess Databricks adapter inheritance and wire or override as needed"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Inspect benchbox/platforms/databricks.py (if it exists). If Databricks
+      inherits SparkAdapter or SparkQueryExecutionMixin, it will inherit plan
+      capture automatically. If it has its own execute_query() or connection
+      model, add the capture call there. Databricks Connect uses the same
+      PySpark API but may return different EXPLAIN text for Unity Catalog queries.
+      Confirm with a w1-style EXPLAIN sample if a Databricks workspace is available.
+      If credentials are unavailable, defer Databricks live validation to a
+      follow-up UAT and note the deferred status here.
+
+  - id: w7
+    summary: "Add wiring unit tests for SparkAdapter plan capture"
+    needs: [w5, w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_spark_plan_capture.py. Cover:
+        - get_query_plan_parser() returns SparkQueryPlanParser
+        - _execute_query_spark() with capture_plans=True calls capture_query_plan()
+        - result dict includes query_plan and plan_fingerprint when capture succeeds
+        - graceful degradation on EXPLAIN failure
+      Mock SparkSession / DataFrame to avoid requiring a live cluster.
+
+deferred:
+  - summary: "Wire plan capture for DataFrame execution path in benchbox/core/dataframe/profiling.py"
+    reason: "The DataFrame profiling system is a parallel architecture to the SQL execution path. Merging the two systems is a larger refactor that should be a separate TODO. This TODO covers only execute_query() SQL path."
+
+deps:
+  needs: []
+
+must_preserve:
+  - "SparkAdapter.execute_query() result dict shape must not change for non-plan fields."
+  - "DataFrame profiling in benchbox/core/dataframe/profiling.py must not be modified — it is out of scope."
+  - "Plan capture failure must be silent when strict_plan_capture=False."
+  - "_execute_query_spark() must not issue EXPLAIN when capture_plans=False."
+
+approach: |
+  Start with fixture collection (w1) to confirm the exact SQL issued and output
+  format. Implement the parser (w2) targeting the physical plan section of EXPLAIN
+  EXTENDED or EXPLAIN (whichever get_query_plan() already uses). Test the parser (w3).
+  Wire get_query_plan_parser() into the mixin (w4) and add the capture call in
+  _execute_query_spark() (w5). Assess Databricks (w6) based on its inheritance chain.
+  Finish with wiring unit tests (w7).
+
+anti_patterns:
+  - "DO NOT modify benchbox/core/dataframe/profiling.py — that is a separate DataFrame plan system."
+  - "DO NOT issue EXPLAIN during execution when capture_plans=False."
+  - "DO NOT parse all four plan sections (Parsed, Analyzed, Optimized, Physical) — parse only the physical plan for fingerprinting to reduce noise across Spark versions."
+  - "DO NOT add Databricks-specific logic to SparkQueryExecutionMixin if it only applies to Databricks Connect."
+
+verification:
+  - description: "Spark parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_spark_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Spark adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_spark_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/spark.py"
+    - "benchbox/platforms/base/spark_execution_mixin.py"
+    - "benchbox/platforms/databricks.py"
+    - "benchbox/core/query_plans/parsers/spark.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_spark_parser.py"
+    - "tests/unit/platforms/test_spark_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml"
+  do_not_modify:
+    - "benchbox/core/dataframe/profiling.py"
+    - "benchbox/platforms/base/cloud_spark/"
+
+success_metrics:
+  - "SparkQueryPlanParser parses EXPLAIN text fixture samples into valid QueryPlanDAG objects."
+  - "SparkAdapter.get_query_plan_parser() returns a non-None parser."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint in result dict."
+  - "No regressions in existing Spark adapter tests."
+
+metadata:
+  tags: [query-plan, spark, databricks, pyspark, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"


### PR DESCRIPTION
## Summary

- Adds 7 TODO YAML files planning query plan capture implementation across all BenchBox platform families
- Each file identifies prerequisites (cloud credentials, running instances), contains a work unit DAG with `needs:` dependencies, scope limits, anti-patterns, verification commands, and success metrics

### Platform families covered

| File | Platforms | Priority | Key challenge |
|---|---|---|---|
| `query-plan-capture-postgresql-family` | PostgreSQL, Redshift, TimescaleDB, CedarDB, pg_mooncake | High | Parsers exist; need `get_query_plan_parser()` + `capture_query_plan()` wiring |
| `query-plan-capture-datafusion-sqlite` | DataFusion, SQLite | High | Parsers exist; need 3-point integration; no credentials required |
| `query-plan-capture-presto-trino-family` | Presto, Trino, Starburst, Athena | Medium-High | New `PrestoTrinoQueryPlanParser` from `EXPLAIN FORMAT JSON` |
| `query-plan-capture-clickhouse-family` | ClickHouse local/server/cloud | Medium-High | Three different connection APIs — must confirm before base-class impl |
| `query-plan-capture-spark-databricks` | Spark, Databricks | Medium | New `SparkQueryPlanParser`; capture in `_execute_query_spark()` |
| `query-plan-capture-cloud-saas` | Snowflake, BigQuery, Azure Synapse, Firebolt, Fabric Warehouse, Lakesail | Medium | BigQuery needs architectural redesign: plans from `job.query_plan` post-execution |
| `query-plan-capture-misc-platforms` | MotherDuck, Databend, QuestDB, Velox, Doris, SingleStore, cuDF | Low | MotherDuck reuses DuckDB parser; Velox blocked on Presto/Trino TODO |

### Review findings addressed before landing

1. **BigQuery architectural mismatch** — w3 mandates `_capture_bq_plan(job, query_id)` called after `job.result()`; existing `get_query_plan()` untouched
2. **ClickHouse connection type assumption** — w4 gated on w1 fixture collection; anti_pattern added against assuming uniform API
3. **Fabric Warehouse passive reuse** — w6 has `needs: [w1, w4]` with explicit decision gate (compare fixtures, then reuse or implement separately)
4. **Velox dependency scope** — `deps.needs: []`; only w5 carries the BLOCKED note; all other work units independent
5. **Doris/SingleStore duplicate parser risk** — merged into single w6 with required pre-assessment; w7 `needs: [w6]`

## Test plan

- [ ] CI path classifier should route this as `safe-content` (only `_project/TODO/**` files changed)
- [ ] No code changes; no unit tests to run

## Notes

Replaces PR #746, which was branched off a very old commit and showed 2000+ unrelated file changes in the diff.

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_