### PR TITLE
fix(plan-capture): address adversarial review findings from PR #748

### DIFF
--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1408,7 +1408,7 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                 for i in range(batch.num_rows):
                     plan_type = batch.column(0)[i].as_py()
                     plan_text = batch.column(1)[i].as_py()
-                    if not plan_text:
+                    if not plan_type or not plan_text:
                         continue
                     lines = plan_text.split("\n")
                     prefix = " " * len(plan_type)

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -230,12 +230,11 @@ class MotherDuckAdapter(PlatformAdapter):
         MotherDuck uses DuckDB's SQL dialect; EXPLAIN format is identical.
         DuckDB EXPLAIN rows are (explain_key, explain_value) tuples; column 1 is the JSON payload.
         """
-        analyze = getattr(self, "analyze_plans", True)
-        explain_options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
+        explain_options = "ANALYZE, FORMAT JSON" if self.analyze_plans else "FORMAT JSON"
         try:
             rows = (connection or self.connection).execute(f"EXPLAIN ({explain_options}) {query}").fetchall()
             # column 0 is the key (e.g. "analyzed_plan"), column 1 is the JSON value
-            parts = [str(row[1]) for row in rows if len(row) > 1]
+            parts = [str(row[1]) for row in rows]
             return "\n".join(parts) if parts else None
         except Exception as e:
             logger.debug(f"Failed to get MotherDuck query plan: {e}")
@@ -290,6 +289,9 @@ class MotherDuckAdapter(PlatformAdapter):
                 "first_row": rows[0] if rows else None,
                 "error": None,
             }
+
+            # Display plan in console when --show-query-plans is active
+            self.display_query_plan_if_enabled(conn, query, query_id)
 
             # Capture structured query plan if enabled
             if self.capture_plans:

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2114,8 +2114,9 @@ class RedshiftAdapter(PlatformAdapter):
             # Map query_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = query_stats
 
-            # Capture structured query plan if enabled
-            if self.capture_plans:
+            # Capture structured query plan if enabled (only on SUCCESS to avoid
+            # wasteful EXPLAIN on validation-failed results)
+            if self.capture_plans and result_dict.get("status") == "SUCCESS":
                 query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
                 if query_plan:
                     result_dict["query_plan"] = query_plan

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -481,15 +481,16 @@ class SQLiteAdapter(PlatformAdapter):
         Reconstructs the tree-formatted text that SQLiteQueryPlanParser expects
         from the raw (id, parent, notused, detail) rows SQLite returns.
         """
+        cursor = connection.cursor()
         try:
-            cursor = connection.cursor()
             cursor.execute(f"EXPLAIN QUERY PLAN {query}")
             rows = cursor.fetchall()
-            cursor.close()
             return _format_sqlite_query_plan(rows) if rows else None
         except Exception as e:
             self.logger.debug(f"Failed to get SQLite query plan: {e}")
             return None
+        finally:
+            cursor.close()
 
     def get_query_plan_parser(self):
         """Get SQLite query plan parser."""

--- a/tests/unit/platforms/test_redshift_plan_capture.py
+++ b/tests/unit/platforms/test_redshift_plan_capture.py
@@ -73,6 +73,19 @@ class TestRedshiftPlanCapture:
         assert result["plan_fingerprint"] == "rs_fingerprint"
         assert result["plan_capture_time_ms"] == 3.0
 
+    def test_execute_query_failed_status_skips_capture(self, adapter, monkeypatch):
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+
+        capture_called = []
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: capture_called.append(True) or (None, 0.0))
+        monkeypatch.setattr(adapter, "_get_query_statistics", lambda *a, **k: {})
+        monkeypatch.setattr(adapter, "_build_query_result_with_validation", lambda **kw: {"status": "FAILED"})
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="rq_fail", validate_row_count=False)
+
+        assert not capture_called, "capture_query_plan must not be called on FAILED results"
+
     def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, monkeypatch):
         conn, cursor = _make_connection()
         cursor.fetchall.return_value = [(0, "col1")]


### PR DESCRIPTION
## Summary

Fixes 6 findings from an adversarial code review of PR #748 (query plan capture wiring):

- **Redshift status guard** (`redshift.py`): capture block now gates on `status == "SUCCESS"`, matching PostgreSQL's pattern — previously fired even when `_build_query_result_with_validation` returned `status="FAILED"` due to row-count validation failure
- **SQLite cursor leak** (`sqlite.py`): moved `cursor = connection.cursor()` outside the `try` block and added `finally: cursor.close()` — previously a cursor leak on any `execute()`/`fetchall()` exception
- **DataFusion null plan_type** (`datafusion.py`): added `not plan_type` to the existing `not plan_text` guard — previously `len(None)` would raise `TypeError` if the plan_type Arrow column contained a null value
- **MotherDuck display gap** (`motherduck.py`): added `display_query_plan_if_enabled()` call to match DuckDB's pattern — `--show-query-plans` previously produced no console output for MotherDuck
- **MotherDuck getattr drift** (`motherduck.py`): replaced `getattr(self, "analyze_plans", True)` with `self.analyze_plans` — the hardcoded fallback `True` would silently ignore any future change to the base-class default
- **MotherDuck dead guard** (`motherduck.py`): removed `len(row) > 1` filter on EXPLAIN rows — DuckDB always returns 2-column rows; the guard masked schema changes rather than surfacing them

## Test plan

- [ ] `uv run pytest tests/unit/platforms/test_redshift_plan_capture.py -v` — new `test_execute_query_failed_status_skips_capture` test confirms status guard
- [ ] `uv run pytest tests/unit/platforms/ -m "fast" -q` — full platform unit suite green
- [ ] `make pr-preflight` — lint + fast tests pass

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_