### PR TITLE
fix(release): keep _benchbox_pytest_xdist_safety.py in release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -816,7 +816,7 @@ release-cut:
 	@# staged-for-add by a later git add.
 	@# Curation list: A3 of _project/decisions/single-repo-migration.md.
 	-git rm -rf _project _blog results-data results-explorer .claude .codex .gemini
-	-git rm -f .pre-commit-config.yaml _benchbox_pytest_xdist_safety.py todo.config.yaml skill-sync.yaml skill-sync.lock .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
+	-git rm -f .pre-commit-config.yaml todo.config.yaml skill-sync.yaml skill-sync.lock .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
 	-git rm -f .github/workflows/results-explorer-browser.yml .github/workflows/seed-corpus.yml .github/workflows/sync-results-data-to-published.yml .github/workflows/validate-submission.yml
 	@# Stage only the files update_version.py + generate_changelog_entry.py write.
 	@# Explicit list (not `git add -A`) to avoid staging build/cache artifacts.

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -41,8 +41,8 @@ branch-to-branch use; it is no longer a two-repo bridge but a `develop` →
 - **A1 — Branch name**: long-lived dev branch is `develop`.
 - **A2 — Default branch on GitHub**: stays `main`, so the canonical URL shows the release tree.
 - **A3 — Tree split**:
-  - **`main` only**: `benchbox/`, `tests/`, `docs/`, `examples/`, `_binaries/`, `_sources/`, `_chart_data/`, release-related contents of `scripts/`, `pyproject.toml`, `MANIFEST.in`, `Makefile`, `README.md`, `CHANGELOG.md`, `LICENSE`, `COPYRIGHT.md`, `DISCLAIMER.md`, `CONTRIBUTING.md`, `pytest.ini`, `pytest-ci.ini`, `uv.lock`, `.gitignore`, `.codespell-ignore.txt`, `landing/`, `.github/` (workflows + templates).
-  - **`develop` only** (in addition to everything on `main`): `_project/`, `_blog/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.gemini/`, `.pre-commit-config.yaml`, `_benchbox_pytest_xdist_safety.py`, `todo.config.yaml`, `skill-sync.yaml`, `skill-sync.lock`, `.coveragerc_core`, `.dockerignore`, `.env.example`, `.mcp.json`, dev-only scripts.
+  - **`main` only**: `benchbox/`, `tests/`, `docs/`, `examples/`, `_binaries/`, `_sources/`, `_chart_data/`, release-related contents of `scripts/`, `pyproject.toml`, `MANIFEST.in`, `Makefile`, `README.md`, `CHANGELOG.md`, `LICENSE`, `COPYRIGHT.md`, `DISCLAIMER.md`, `CONTRIBUTING.md`, `pytest.ini`, `pytest-ci.ini`, `_benchbox_pytest_xdist_safety.py`, `uv.lock`, `.gitignore`, `.codespell-ignore.txt`, `landing/`, `.github/` (workflows + templates).
+  - **`develop` only** (in addition to everything on `main`): `_project/`, `_blog/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.gemini/`, `.pre-commit-config.yaml`, `todo.config.yaml`, `skill-sync.yaml`, `skill-sync.lock`, `.coveragerc_core`, `.dockerignore`, `.env.example`, `.mcp.json`, dev-only scripts.
 - **A4 — Release flow** (post-migration, repeated each release):
 
   ```


### PR DESCRIPTION
## Summary

- Removes `_benchbox_pytest_xdist_safety.py` from the `release-cut` Makefile curation list so future release branches retain the plugin
- Updates the A3 tree-split doc in `_project/decisions/single-repo-migration.md` to classify the plugin under `main`/release rather than `develop`-only

## Problem

The `release-cut` Makefile target removed `_benchbox_pytest_xdist_safety.py` as part of dev-tooling curation. However, `pytest.ini` and `pytest-ci.ini` (which **are** kept in the release tree) both load the plugin with `-p _benchbox_pytest_xdist_safety`. This caused an `ImportError` that aborted test collection on release branches before any tests ran.

This was surfaced as a P1 review comment on PR #712 (v0.3.1 release).

## Fix

The plugin caps unsafe xdist worker counts and has no dev-only content — it belongs alongside `pytest.ini`/`pytest-ci.ini` in the release tree. Removing it from the curation list is the minimal, correct fix.

## Test plan

- [ ] Confirm `_benchbox_pytest_xdist_safety.py` is no longer in the `git rm -f` line in `Makefile` (line 819)
- [ ] Confirm `_project/decisions/single-repo-migration.md` A3 lists `_benchbox_pytest_xdist_safety.py` under `main only`
- [ ] Next `make release-cut` run should retain the plugin and pass `pytest --collect-only` without ImportError

https://claude.ai/code/session_01QooVqLTXzUJj529YMh7uJb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QooVqLTXzUJj529YMh7uJb)_