### PR TITLE
fix(pr-followups): address unresolved review comments from PRs #738–#749

### DIFF
--- a/_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml
@@ -140,6 +140,7 @@ scope_limit:
     - "tests/unit/platforms/test_clickhouse_adapter.py"
     - "tests/unit/sql_compat/"
     - "_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml"
+    - "_project/compat/inventory.jsonl"
 
 success_metrics:
   - "The affected cells no longer fail during CREATE TABLE."

--- a/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
@@ -2,7 +2,7 @@ id: uat-clickhouse-server-rc1-recovery
 title: "Recover ClickHouse-server UAT RC-1 after confirmed localhost:9000 refusal"
 worktree: main
 priority: High
-status: Identified
+status: Completed
 category: Platform Expansion
 
 description: |

--- a/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
+++ b/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
@@ -105,7 +105,6 @@ work:
 deps:
   needs:
     - uat-artifact-integrity-and-failure-capture
-    - uat-certification-rerun-ordering-and-gate
 
 must_preserve:
   - "UAT never runs docker system/volume/image prune or unqualified compose down; only project-scoped benchbox-uat-* teardown."

--- a/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
+++ b/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
@@ -105,6 +105,7 @@ work:
 deps:
   needs:
     - uat-artifact-integrity-and-failure-capture
+    - uat-certification-rerun-ordering-and-gate
 
 must_preserve:
   - "UAT never runs docker system/volume/image prune or unqualified compose down; only project-scoped benchbox-uat-* teardown."

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -6,6 +6,7 @@ and file formats, with support for compression and batch processing.
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import gzip
 import hashlib
@@ -2112,8 +2113,17 @@ class ClickHouseNativeHandler(FileFormatHandler):
 
         type_upper = type_name.upper()
 
-        # Array types embed scalar type names (e.g. "ARRAY(FLOAT64)"); skip scalar conversion.
+        # Array types: parse the CSV string representation into a Python list so
+        # clickhouse-driver receives a sequence rather than a raw string.
         if "ARRAY" in type_upper:
+            if not value or value.upper() in ("\\N", "NULL"):
+                return None
+            try:
+                parsed = ast.literal_eval(value)
+                if isinstance(parsed, (list, tuple)):
+                    return list(parsed)
+            except (ValueError, SyntaxError):
+                pass
             return value
 
         needs_non_string_value = (

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -2111,6 +2111,11 @@ class ClickHouseNativeHandler(FileFormatHandler):
             return value
 
         type_upper = type_name.upper()
+
+        # Array types embed scalar type names (e.g. "ARRAY(FLOAT64)"); skip scalar conversion.
+        if "ARRAY" in type_upper:
+            return value
+
         needs_non_string_value = (
             "INT" in type_upper
             or any(token in type_upper for token in ("DECIMAL", "NUMERIC", "DOUBLE", "FLOAT", "REAL"))

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -31,6 +31,7 @@ except ImportError:
     RuntimeEnv = None  # type: ignore[assignment, misc]  # ty: ignore[conflicting-declarations]
 
 from benchbox.core.dataframe.schema_utils import extract_schema_columns
+from benchbox.core.errors import PlanCaptureError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
 from benchbox.platforms.base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
 from benchbox.platforms.base.no_constraint_mixin import NoConstraintEnforcementMixin
@@ -1538,6 +1539,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
 
             return result
 
+        except PlanCaptureError:
+            raise
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             logger.error(

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -290,8 +290,12 @@ class MotherDuckAdapter(PlatformAdapter):
                 "error": None,
             }
 
-            # Display plan in console when --show-query-plans is active
-            self.display_query_plan_if_enabled(conn, query, query_id)
+            # Display plan in console when --show-query-plans is active.
+            # Skip here when --capture-plans is also active: capture_query_plan below
+            # already calls get_query_plan (running EXPLAIN ANALYZE); calling
+            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(conn, query, query_id)
 
             # Capture structured query plan if enabled
             if self.capture_plans:

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -12,6 +12,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -713,8 +714,14 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             cursor.execute(explain_query)
             plan_rows = cursor.fetchall()
             cursor.close()
-            # PostgreSQL returns the full JSON as the first column of the first row
-            return plan_rows[0][0] if plan_rows else None
+            # PostgreSQL returns the full JSON as the first column of the first row.
+            # psycopg decodes FORMAT JSON output as a Python object; re-serialize
+            # to a string so PostgreSQLQueryPlanParser.parse_explain_output() receives
+            # the string it expects.
+            raw = plan_rows[0][0] if plan_rows else None
+            if raw is not None and not isinstance(raw, str):
+                raw = json.dumps(raw)
+            return raw
 
         except Exception as e:
             cursor.close()


### PR DESCRIPTION
## Summary

Sweeps all unresolved (no-reply) review comment threads from PRs #738–#749 and implements the corrections identified.

### Code fixes (4 bugs)

- **`benchbox/platforms/base/data_loading.py`** — Guard Array types before scalar float/int conversion in `_convert_field_for_clickhouse`. ClickHouse `Array(Float64)` columns embed scalar type tokens (`"FLOAT"`) in the type string, causing `float("[0.1,0.2]")` to raise `ValueError` and record 0 loaded rows. (PR #738 comment)

- **`benchbox/platforms/postgresql.py`** — Serialize psycopg-decoded JSON plan objects back to a string in `get_query_plan()`. psycopg3 decodes `FORMAT JSON` output as a Python list/dict; `PostgreSQLQueryPlanParser.parse_explain_output()` expects a string and calls `.strip()`/`json.loads()` on it, raising `AttributeError`. (PR #748 comment 1)

- **`benchbox/platforms/datafusion.py`** — Re-raise `PlanCaptureError` before the broad `except Exception` in `execute_query()`. Previously, `strict_plan_capture=True` errors were swallowed and silently converted to FAILED query results. (PR #748 comment 2)

- **`benchbox/platforms/motherduck.py`** — Skip `display_query_plan_if_enabled` when `capture_plans` is also active. Both code paths independently call `get_query_plan()` which runs `EXPLAIN (ANALYZE, FORMAT JSON)`, re-executing the benchmark query twice when both `--show-query-plans` and `--capture-plans` are set. (PR #749 comment)

### TODO/doc fixes (3 files)

- **`uat-clickhouse-server-rc1-recovery.yaml`** — Update top-level `status: Identified` → `status: Completed`. All four work units (w0–w3) were done; the file was still showing as active/ready. Addressed review comments from PRs #740 and #741.

- **`uat-clickhouse-server-ddl-compatibility.yaml`** — Add `_project/compat/inventory.jsonl` to `scope_limit.only_modify`. This is the DDL governance inventory file validated by `--check-ddl-drift`; without it being in scope, implementers can't update it without violating the scope guardrail. (PR #741 comment 2)

- **`uat-docker-stack-recovery.yaml`** — Add `uat-certification-rerun-ordering-and-gate` to top-level `deps.needs`. w3/w4 are cert-rerun-owned and must not surface as standalone ready work when w0–w2 are done; the machine-readable dep gives tooling a check beyond the prose guard in the notes. (PR #739 comment)

### Moot comments (files no longer exist)
Replied to PR #719 (2 threads) and PR #721 confirming the referenced TODO files (`uat-explorer-smoke-release-hygiene.yaml`, `uat-charter-visibility-on-main.yaml`, `uat-single-connection-registry.yaml`) no longer exist on the current branch.

## Test plan

- [ ] `uv run -- python -m pytest tests/unit/platforms/ -q` — covers ClickHouse data-loading conversion and platform adapter contracts
- [ ] `uv run -- python -m pytest tests/unit/core/results/ -q` — covers query plan serialization
- [ ] `uv run -- python -m pytest tests/unit/platforms/test_local_platform_ctas_sort.py -q` — DataFusion adapter
- [ ] `uv run -- python -m benchbox.sql_compat.inventory --check-ddl-drift` — DDL governance check still passes

https://claude.ai/code/session_0191aNwauGDQqTUZu7VdPL82

---
_Generated by [Claude Code](https://claude.ai/code/session_0191aNwauGDQqTUZu7VdPL82)_