### PR TITLE
docs(roadmap): update to reflect actual implementation status

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -21,170 +21,79 @@ BenchBox's expansion roadmap focuses on three strategic areas:
 
 | Category | Current | Planned |
 |----------|---------|---------|
-| SQL Platforms | 33 | +6 |
-| DataFrame Platforms | 8 | +0 |
-| Benchmarks | 12 | +6 |
-| DataFrame-enabled Benchmarks | 2 (TPC-H, TPC-DS) | +13 |
+| SQL Platforms | 39 | +0 |
+| DataFrame Platforms | 9 | +0 |
+| Benchmarks | 22 | +4 |
+| DataFrame-enabled Benchmarks | 21 | +1 (Geospatial) |
 
 ---
 
 ## Platform Additions
 
-### High Priority
+All previously planned platform additions through Phase 4 have shipped. The platform expansion roadmap is complete pending new sponsorship or community requests.
 
-#### LakeSail Sail (Rust-based Spark Replacement)
+### Completed Platforms
 
-**Status**: Not Started | **Effort**: Large | **Modes**: SQL + DataFrame
-
-LakeSail Sail is a Rust-based, drop-in replacement for Apache Spark built on DataFusion. It claims 4x faster execution with 94% lower hardware costs versus Apache Spark (TPC-H SF100 benchmarks).
-
-**Key Characteristics**:
-- Spark Connect protocol compatibility (existing PySpark code works unchanged)
-- Multi-threaded single-host or distributed cluster execution
-- DataFusion query optimizer with Rust workers
-
-**Why it matters**: Growing interest in Spark alternatives with improved cost efficiency. Direct comparison validates vendor performance claims with independent TPC-H/TPC-DS benchmarks.
-
-**Implementation**:
-- `benchbox/platforms/lakesail.py` - SQL adapter via Spark Connect
-- `benchbox/platforms/dataframe/lakesail_df.py` - DataFrame adapter
-
-**Reference**: [LakeSail Official Site](https://lakesail.com/) | [GitHub](https://github.com/lakehq/sail)
-
----
-
-### Medium-High Priority
-
-#### Apache Doris (MPP OLAP Engine)
-
-**Status**: Not Started | **Effort**: Medium
-
-Apache top-level project with 12,000+ GitHub stars, used by Xiaomi, ByteDance, Baidu, JD.com, and 4,000+ enterprises.
-
-**Key Characteristics**:
-- MySQL protocol (port 9030)
-- Stream Load for high-throughput data ingestion
-- Multiple table models (Duplicate, Aggregate, Unique, Primary Key)
-- Real-time analytics focus
-
-**Managed Options**: VeloDB Cloud, SelectDB Cloud, ApsaraDB for SelectDB
-
----
-
-#### StarRocks (Linux Foundation MPP OLAP)
-
-**Status**: Not Started | **Effort**: Medium
-
-Linux Foundation project with 11,000+ GitHub stars, used by Airbnb, Alibaba, Coinbase, Pinterest, Tencent.
-
-**Key Characteristics**:
-- MySQL protocol with Stream Load HTTP API
-- Native data lake support (Iceberg, Hudi, Delta Lake)
-- Competitive performance versus ClickHouse and Trino
-- Sub-second analytics on real-time data
-
----
-
-#### ClickHouse Cloud & Firebolt Cloud
-
-**Status**: Not Started | **Effort**: Small
-
-Cloud deployment modes for existing ClickHouse and Firebolt adapters.
-
-**Key Characteristics**:
-- Cloud-specific authentication and endpoint handling
-- Managed infrastructure configuration
-- Usage-based billing model support
-
----
-
-### Medium Priority
-
-#### QuestDB (Time-Series Database)
-
-**Status**: Not Started | **Effort**: Medium
-
-High-performance time-series database optimized for real-time analytics.
-
-**Key Characteristics**:
-- InfluxDB line protocol support
-- SQL interface with time-series extensions
-- Columnar storage with time-based partitioning
-
----
-
-#### Databend (Cloud-Native Data Warehouse)
-
-**Status**: Not Started | **Effort**: Medium | **Priority**: Low
-
-Rust-based cloud-native data warehouse with DataFrame and data lake focus.
-
----
-
-### Platform Infrastructure (In Progress)
-
-These foundational improvements enable cleaner platform expansion:
-
-| Item | Status | Purpose |
-|------|--------|---------|
-| Deployment Factory Integration | In Progress | Dynamic platform initialization with deployment modes |
-| Deployment Registry Extensions | In Progress | Enhanced registry for cloud variants |
-| Deployment CLI Integration | In Progress | CLI support for cloud credentials/endpoints |
-| Configuration Inheritance | In Progress | Base config inheritance for deployment variants |
+| Platform | Shipped | Modes |
+|----------|---------|-------|
+| LakeSail Sail | v0.2.1 | SQL + DataFrame |
+| Apache Doris | v0.2.1 | SQL |
+| StarRocks | v0.2.1 | SQL |
+| ClickHouse Cloud | v0.2.1 | SQL |
+| Firebolt Cloud | v0.2.1 | SQL |
+| QuestDB | v0.2.1 | SQL |
+| Databend | v0.2.1 | SQL |
+| Microsoft Fabric Spark | v0.2.x | SQL + DataFrame |
+| Starburst | v0.2.x | SQL |
+| TimescaleDB | v0.2.x | SQL |
 
 ---
 
 ## Benchmark Additions
 
-### Real-World Dataset Benchmarks
+### Completed Benchmarks
 
-#### Flight Data Benchmark (US Aviation On-Time Performance)
+| Benchmark | Shipped | Notes |
+|-----------|---------|-------|
+| Flight Data (US aviation on-time) | v0.3.0 | 20 queries, SQL + DataFrame |
+| NYC Taxi Expansion | v0.3.0 | Green, FHV, HVFHV vehicle types |
 
-**Status**: Not Started | **Effort**: Medium (2-3 weeks) | **Priority**: Medium
+### Planned Benchmarks
 
-BTS TranStats flight data (1987-present, ~200M flights, free public data).
+#### Geospatial Primitives
 
-**Key Characteristics**:
-- Scale factors from 0.01 (10MB, 1 week) to 100 (full dataset, 15-20GB)
-- Multi-dimensional analysis: temporal, geographic, carrier, aircraft
-- 20+ analytical queries across categories:
-  - On-time performance (5+ queries)
-  - Delay analysis (4+ queries)
-  - Route analytics (4+ queries)
-  - Temporal patterns (4+ queries)
-  - Carrier comparisons (3+ queries)
+**Status**: Not Started | **Effort**: Medium | **Priority**: Medium
 
-**Why it matters**: Realistic OLAP workload with intuitive domain, complements TPC-H synthetic data.
+Dedicated benchmark for spatial SQL operations (`ST_*` functions) across platforms. NYC Taxi already includes some spatial queries; this would be a standalone primitives suite covering the full spatial SQL surface.
 
----
-
-#### NYC Taxi Benchmark Expansion
-
-**Status**: Not Started | **Effort**: Medium (2-3 weeks) | **Priority**: Medium
-
-Expand existing Yellow Taxi benchmark to include all TLC vehicle types.
-
-**Current**: Yellow Taxi only
-**Planned Additions**:
-- Green Taxi (~500K trips/month, outer boroughs)
-- FHV (~1M trips/month, traditional car services)
-- HVFHV (Uber/Lyft, ~25M+ trips/month, since Feb 2019)
-
-**New Query Categories**:
-- Cross-type comparisons
-- Market share analysis
-- Price sensitivity across vehicle types
+**Scope**:
+- Point-in-polygon, distance, bounding box
+- Spatial indexing and predicate pushdown
+- Cross-platform dialect coverage (PostGIS, DuckDB spatial, ClickHouse, BigQuery)
 
 ---
 
-### Analytical Workload Benchmarks
+#### GitHub Archive
 
-| Benchmark | Status | Description |
-|-----------|--------|-------------|
-| Geospatial Primitives | Not Started | ST_* functions and spatial operations |
-| GitHub Archive | Not Started | Developer activity analytics |
-| Stack Overflow Dataset | Not Started | Q&A and engagement analytics |
-| Wikipedia Pageviews | Not Started | Web traffic time-series patterns |
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Developer activity analytics over the public GitHub event archive.
+
+---
+
+#### Stack Overflow Dataset
+
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Q&A and engagement analytics over the Stack Exchange data dump.
+
+---
+
+#### Wikipedia Pageviews
+
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Web traffic time-series patterns from Wikimedia pageview dumps.
 
 ---
 
@@ -192,63 +101,24 @@ Expand existing Yellow Taxi benchmark to include all TLC vehicle types.
 
 ### Current State
 
-DataFrame benchmarking is currently supported for:
-- TPC-H (22 queries)
-- TPC-DS (99 queries)
+DataFrame benchmarking is supported for 21 benchmarks across two API families:
 
-### Expansion Plan
+**Expression Family** (Polars, PySpark, DataFusion, LakeSail):
+- TPC-H, TPC-DS, TPC-DS OBT, TPC-DI, TPC-H Skew, TPC-Havoc, DataVault
+- SSB, ClickBench, AMPLab, CoffeeShop, H2ODB, TSBS DevOps
+- NYC Taxi, Flight Data, JoinOrder, JoinOrder Synthetic
+- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives, Transaction Primitives
 
-Extend DataFrame support to 15+ additional benchmarks (~700 new query implementations).
+**Pandas Family** (Pandas, Modin, cuDF, Dask):
+- Full coverage matching the Expression Family above
 
-#### Implementation Tiers
+### Remaining Expansion
 
-**Tier 1 - High Value (Recommended First)**
+The DataFrame initiative is substantially complete. The one remaining gap is:
 
-| Benchmark | Queries | Rationale |
-|-----------|---------|-----------|
-| SSB | 13 | Simple star-schema, good starter |
-| ClickBench | 43 | Popular industry benchmark |
-| NYC Taxi | 25 | Real-world, high user interest |
-| **Total** | **81** | |
-
-**Tier 2 - Strong DataFrame Fit**
-
-| Benchmark | Operations | Rationale |
-|-----------|------------|-----------|
-| TPC-DI | 38 | ETL transformations |
-| Write Primitives | 109 | INSERT/UPDATE/DELETE/MERGE |
-| TSBS DevOps | 18 | Time-series aggregations |
-| H2ODB | 10 | Data science workloads |
-| AMPLab | 8 | Established benchmark |
-| CoffeeShop | 11 | Analytics patterns |
-| **Total** | **194** | |
-
-**Tier 3 - Variants/Experimental**
-
-| Benchmark | Queries | Notes |
-|-----------|---------|-------|
-| TPC-H Skew | 22 | Skewed distributions |
-| TPC-DS-OBT | 17 | One Big Table variant |
-| TPC-Havoc | 220 | Query variants |
-| DataVault | 22 | Data Vault modeling |
-| **Total** | **281** | |
-
-**Tier 4 - Complex**
-
-| Benchmark | Queries | Notes |
-|-----------|---------|-------|
-| JoinOrder | 113 | High complexity joins |
-| Read Primitives | 136 | Foundation testing |
-| **Total** | **249** | |
-
-### Dual-Family Architecture
-
-Each DataFrame benchmark requires implementations for two API families:
-
-- **Expression Family**: Polars, PySpark, DataFusion (lazy evaluation, expression chains)
-- **Pandas Family**: Pandas, Modin, cuDF, Dask (eager evaluation, method chaining)
-
-**Estimated Effort**: 4-6 weeks for full coverage
+| Benchmark | Status | Notes |
+|-----------|--------|-------|
+| Geospatial Primitives | Not Started | Blocked on the benchmark itself existing |
 
 ---
 
@@ -262,32 +132,31 @@ Each DataFrame benchmark requires implementations for two API families:
 - ~~Onehouse Quanton adapter~~ ✓ (multi-format: Hudi, Iceberg, Delta)
 - ~~Apache Hudi maintenance operations~~ ✓
 
-### Phase 2: High-Impact Platforms
+### Phase 2: High-Impact Platforms (Completed)
 
-- LakeSail Sail (SQL + DataFrame)
-- Apache Doris
-- StarRocks
-- Cloud deployment modes (ClickHouse Cloud, Firebolt Cloud)
+- ~~LakeSail Sail (SQL + DataFrame)~~ ✓
+- ~~Apache Doris~~ ✓
+- ~~StarRocks~~ ✓
+- ~~Cloud deployment modes (ClickHouse Cloud, Firebolt Cloud)~~ ✓
 
-### Phase 3: Benchmark Diversity
+### Phase 3: Benchmark Diversity (Completed)
 
-- Flight Data Benchmark
-- NYC Taxi Expansion
-- DataFrame Tier 1 (SSB, ClickBench, NYC Taxi)
+- ~~Flight Data Benchmark~~ ✓
+- ~~NYC Taxi Expansion~~ ✓
+- ~~DataFrame Tier 1 (SSB, ClickBench, NYC Taxi)~~ ✓
 
-### Phase 4: Extended Coverage
+### Phase 4: Extended Coverage (Completed)
 
 - ~~Microsoft Fabric Spark~~ ✓
 - ~~Starburst~~ ✓
 - ~~TimescaleDB~~ ✓
-- Time-series platforms (QuestDB)
-- DataFrame Tier 2
+- ~~QuestDB~~ ✓
+- ~~DataFrame Tiers 2–4~~ ✓
 
 ### Phase 5: Specialized Workloads
 
-- Geospatial benchmarks
+- Geospatial Primitives benchmark
 - Real-world datasets (GitHub Archive, Stack Overflow, Wikipedia)
-- DataFrame Tier 3-4
 
 ---
 
@@ -318,4 +187,4 @@ See the [Platform Development Guide](platform-development.md) and [Adding New Pl
 
 ---
 
-*Last updated: 2026-01-20*
+*Last updated: 2026-06-05*


### PR DESCRIPTION
## Summary

- Roadmap was listing 7 platforms as "Not Started" that all shipped in v0.2.x (LakeSail, Doris, StarRocks, ClickHouse Cloud, Firebolt Cloud, QuestDB, Databend)
- DataFrame support was claimed as "2 benchmarks (TPC-H, TPC-DS)" — actual coverage is 21 benchmarks across both API families
- Flight Data and NYC Taxi Expansion were listed as "Not Started" — both shipped in v0.3.0
- Statistics table showed 33 SQL platforms +6 planned — reality is 39 shipped

Phases 2–4 and all DataFrame tiers are now marked complete. Phase 5 (Geospatial Primitives, GitHub Archive, Stack Overflow, Wikipedia) remains as the actual outstanding roadmap.

## Test plan

- [ ] Content-only change — `content-guard` validates YAML/markdown hygiene; no Python CI needed
- [ ] Verify no broken relative links introduced (preflight: no new broken links)

https://claude.ai/code/session_01XDWueaCYTNFeycm7v76P67

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDWueaCYTNFeycm7v76P67)_