### PR TITLE
chore(todo): re-prioritize 6 open TODO items

### DIFF
--- a/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
+++ b/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
@@ -2,7 +2,7 @@ id: approx-analytics-cloud-survey
 title: Approximate Analytics Cloud SQL Survey — read_primitives + SQL write_primitives at SF=0.1/1/10
 worktree: benchmark-expansion
 category: Benchmark Development
-priority: High
+priority: Medium-High
 status: Not Started
 description: |
   Survey approximate analytics support and performance across all major cloud SQL

--- a/_project/TODO/main/planning/data-fetch-concurrent-download-race.yaml
+++ b/_project/TODO/main/planning/data-fetch-concurrent-download-race.yaml
@@ -1,7 +1,7 @@
 id: data-fetch-concurrent-download-race
 title: "Make real-data archive downloads safe under concurrent fetch_data callers"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
+++ b/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
@@ -1,7 +1,7 @@
 id: joinorder-trino-primary-key-ddl
 title: "Strip JoinOrder primary-key constraints from Trino CREATE TABLE DDL"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Under Review
 category: Platform Compatibility
 

--- a/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+++ b/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
@@ -1,7 +1,7 @@
 id: tpchavoc-correlated-subquery-self-binding
 title: "Fix tpchavoc variants whose correlated subqueries silently self-bind to the inner alias"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
+++ b/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
@@ -1,7 +1,7 @@
 id: uat-certification-rerun-ordering-and-gate
 title: "UAT release-gate re-run: enforce ordering, fresh root, and an explicit approval gate"
 worktree: main
-priority: Medium-High
+priority: High
 status: In Progress
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
+++ b/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
@@ -1,7 +1,7 @@
 id: uat-docker-stack-recovery
 title: "Recover UAT Docker stacks: LakeSail startup timeout + empty Docker-OLTP run"
 worktree: main
-priority: Medium-High
+priority: High
 status: In Progress
 category: Platform Expansion
 


### PR DESCRIPTION
## Summary

- Raise `uat-docker-stack-recovery` and `uat-certification-rerun-ordering-and-gate` from Medium-High → **High**: both are In Progress and gate the release certification sweep
- Raise `data-fetch-concurrent-download-race` from Medium → **Medium-High**: data-safety bug under concurrent `fetch_data` callers
- Raise `tpchavoc-correlated-subquery-self-binding` from Medium → **Medium-High**: silent correctness bug in benchmark corpus (correlated subquery self-binds to inner alias)
- Raise `joinorder-trino-primary-key-ddl` from Medium → **Medium-High**: Under Review status; DDL incompatibility directly breaks Trino CREATE TABLE
- Lower `approx-analytics-cloud-survey` from High → **Medium-High**: benchmark expansion research, not core/release; consistent with all other `benchmark-expansion/` items being Low–Medium-High

## Test plan

- [ ] Content-only change (YAML priority field edits); Python fast tests not required
- [ ] Verify each changed file has exactly one `priority:` line updated

https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX

---
_Generated by [Claude Code](https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX)_