### PR TITLE
fix(workflows): address open review comments from PR #752

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -64,8 +64,11 @@ jobs:
         id: drift
         run: |
           # Fail loudly on a missing remote ref — silent fetch failure must
-          # not be misread as "no drift".
-          git fetch origin published-results
+          # not be misread as "no drift". Use an explicit refspec so the
+          # remote-tracking ref origin/published-results is created/updated
+          # in this single-branch clone; a bare `git fetch origin published-results`
+          # only populates FETCH_HEAD and leaves origin/published-results missing.
+          git fetch origin published-results:refs/remotes/origin/published-results
 
           # Direct two-tree compare (no dots): `published-results` is an
           # orphan branch (W2 of the parent TODO force-pushed it to a fresh

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -41,6 +41,29 @@ jobs:
             | grep -v '\.manifest\.json$' \
             | grep -v 'submission-manifest\.json$' \
             || true)
+
+          # Detect changed manifest files separately. A manifest-only PR skips
+          # both validate_submission.py and the corpus inventory check because
+          # CHANGED stays empty — but manifests carry the bundle hash contract,
+          # so a bad manifest edit can merge without verifying the hash. For each
+          # changed manifest, derive its paired bundle path and add it to CHANGED
+          # so the existing validation step covers manifest-only PRs too.
+          CHANGED_MANIFESTS=$(git diff --name-only --diff-filter=ACMR \
+            ${{ github.event.pull_request.base.sha }}...HEAD -- \
+            'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
+            | grep '\.manifest\.json$' \
+            || true)
+          if [ -n "$CHANGED_MANIFESTS" ]; then
+            while IFS= read -r manifest; do
+              bundle="${manifest%.manifest.json}.json"
+              # Only add if the paired bundle exists and is not already in CHANGED.
+              if git cat-file -e "HEAD:${bundle}" 2>/dev/null \
+                  && ! printf '%s\n' "$CHANGED" | grep -qxF "$bundle"; then
+                CHANGED="${CHANGED:+${CHANGED}$'\n'}${bundle}"
+              fi
+            done <<< "$CHANGED_MANIFESTS"
+          fi
+
           if [ -z "$CHANGED" ]; then
             echo "No bundle files changed."
             echo "has_bundles=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Addresses both unresolved bot review threads on PR #752 (`chore/roadmap-accuracy-update`).

- **P1 — `sync-results-data-to-published.yml` (line 68):** Replace bare `git fetch origin published-results` with an explicit refspec `published-results:refs/remotes/origin/published-results`. Without the refspec, a single-branch checkout only populates `FETCH_HEAD`; `origin/published-results` is never created, so the `git diff --name-only origin/published-results …` call on the next line fails on the first run that lacks the ref.

- **P2 — `validate-submission.yml` (line 42):** Detect changed `*.manifest.json` files after filtering them from the main bundle list. For each changed manifest, derive the paired bundle path (`foo.manifest.json` → `foo.json`) and add it to `CHANGED` if the bundle exists and is not already present. This ensures manifest-only PRs still invoke `validate_submission.py` and the corpus inventory check rather than silently setting `has_bundles=false` and skipping all validation.

## Test plan

- [ ] Confirm the `sync-results-data-to-published.yml` diff step no longer fails on a fresh single-branch clone when `published-results` has not been fetched yet
- [ ] Confirm a PR to `published-results` that only changes a `*.manifest.json` file now triggers bundle validation for the paired `.json`
- [ ] Confirm PRs that change both a bundle and its manifest continue to validate correctly (no duplicate validation)
- [ ] CI lint / YAML check green on this branch

https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV

---
_Generated by [Claude Code](https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV)_