### PR TITLE
fix(tpchavoc): qualify correlated-subquery self-binding in variants

### DIFF
--- a/benchbox/core/tpchavoc/variant_sets/q02.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q02.yaml
@@ -397,7 +397,7 @@ variants:
               and s2.s_nationkey = n2.n_nationkey
               and n2.n_regionkey = r2.r_regionkey
               and r2.r_name = 'EUROPE'
-              and ps2.ps_supplycost < ps_supplycost
+              and ps2.ps_supplycost < partsupp.ps_supplycost
         )
     order by
         s_acctbal desc,

--- a/benchbox/core/tpchavoc/variant_sets/q11.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q11.yaml
@@ -20,7 +20,7 @@ variants:
             where ps2.ps_suppkey = s2.s_suppkey
               and s2.s_nationkey = n2.n_nationkey
               and n2.n_name = 'GERMANY'
-              and ps2.ps_partkey = ps_partkey
+              and ps2.ps_partkey = partsupp.ps_partkey
         )
     group by
         ps_partkey

--- a/benchbox/core/tpchavoc/variant_sets/q17.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q17.yaml
@@ -30,7 +30,7 @@ variants:
 - id: 8
   description: 'EXISTS pattern: Use EXISTS for membership testing'
   sql: |
-    select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and exists (select 1 from (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) avg_calc where avg_calc.l_partkey = l_partkey and l_quantity < avg_calc.threshold)
+    select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and exists (select 1 from (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) avg_calc where avg_calc.l_partkey = lineitem.l_partkey and lineitem.l_quantity < avg_calc.threshold)
 - id: 9
   description: 'Window functions (OLAP): Use window functions for ranking'
   sql: |

--- a/tests/integration/test_tpchavoc_duckdb.py
+++ b/tests/integration/test_tpchavoc_duckdb.py
@@ -45,6 +45,13 @@ class TestTPCHavocDuckDBIntegration:
         yield conn
         conn.close()
 
+    @staticmethod
+    def _create_duckdb_schema(tpchavoc, conn):
+        """Create the TPC-H schema (DuckDB dialect) on the given connection."""
+        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+            if statement.strip():
+                conn.execute(statement.strip())
+
     def test_variant_query_generation(self, tpchavoc):
         """Test that TPC-Havoc can generate query variants."""
         # Get implemented queries
@@ -200,21 +207,22 @@ class TestTPCHavocDuckDBIntegration:
 
     def test_duckdb_regression_variants_explain(self, tpchavoc, duckdb_conn):
         """Previously failing DuckDB TPC-Havoc variants should parse and bind."""
-        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
-            if statement.strip():
-                duckdb_conn.execute(statement.strip())
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
 
         regression_variants = [
             "2_v5",
+            "2_v8",
             "5_v9",
             "7_v9",
             "9_v9",
             "10_v8",
             "10_v9",
+            "11_v1",
             "11_v9",
             "13_v9",
             "17_v2",
             "17_v4",
+            "17_v8",
         ]
         for query_id in regression_variants:
             duckdb_conn.execute(f"EXPLAIN {tpchavoc.get_query(query_id)}")
@@ -226,12 +234,52 @@ class TestTPCHavocDuckDBIntegration:
         inner alias, turning a semi-join into an uncorrelated full scan that hung
         DuckDB at SF1. The qualified form must decorrelate into a semi-join.
         """
-        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
-            if statement.strip():
-                duckdb_conn.execute(statement.strip())
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
 
         sql = tpchavoc.get_query("10_v8")
         assert "l2.l_orderkey = lineitem.l_orderkey" in sql, "EXISTS must correlate to the outer lineitem"
 
         plan = duckdb_conn.execute(f"EXPLAIN {sql}").fetchall()[0][1]
         assert "SEMI" in plan.upper(), "EXISTS should decorrelate into a semi-join, not a self-referential scan"
+
+    def test_correlated_subquery_variants_bind_to_outer_table(self, tpchavoc, duckdb_conn):
+        """Variants with correlated subqueries must qualify the correlation to the outer table.
+
+        Each of these variants carried an unqualified correlation column that silently
+        bound to the INNER alias (the same class of defect as 10_v8), degenerating the
+        intended correlated subquery into an uncorrelated scan. The fix qualifies the
+        correlation to the outer table so the per-row correlation is preserved.
+        """
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
+
+        # (variant, required qualified correlation that must reference the outer table)
+        expected_correlations = {
+            # q11_v1 scalar threshold: per-part avg, not an uncorrelated avg over all German rows.
+            "11_v1": "ps2.ps_partkey = partsupp.ps_partkey",
+            # q17_v8 EXISTS: per-part threshold, not the inner derived table's own partkey.
+            "17_v8": "avg_calc.l_partkey = lineitem.l_partkey",
+            # q2_v8 NOT EXISTS min-cost: compare against the outer row's supplycost, not ps2's own.
+            "2_v8": "ps2.ps_supplycost < partsupp.ps_supplycost",
+        }
+        plans = {}
+        for query_id, correlation in expected_correlations.items():
+            sql = tpchavoc.get_query(query_id)
+            assert correlation in sql, (
+                f"{query_id} must qualify the correlation to the outer table ({correlation}); "
+                "an unqualified column silently self-binds to the inner alias"
+            )
+            # Must still parse, bind, and plan on DuckDB; keep the plan for the check below.
+            plans[query_id] = duckdb_conn.execute(f"EXPLAIN {sql}").fetchall()[0][1]
+
+        # q11_v1's scalar subquery only becomes correlated once the partkey is qualified to the
+        # outer table; DuckDB then decorrelates it via a delimiter join. The unqualified (buggy)
+        # form folds to a single uncorrelated aggregate with no delimiter join, so DELIM presence
+        # is a faithful regression signal here.
+        #
+        # 17_v8 and 2_v8 are guarded by the substring assertion only, not a plan check: each
+        # carries a *second*, already-qualified correlation (17_v8 via lineitem.l_quantity, 2_v8
+        # via p_partkey = ps2.ps_partkey), so their plans still show a decorrelated semi-/anti-join
+        # even in the buggy form. The plan therefore cannot distinguish fixed from broken for them.
+        assert "DELIM" in plans["11_v1"].upper(), (
+            "11_v1's correlated scalar subquery should decorrelate into a delimiter join"
+        )


### PR DESCRIPTION
## Summary

Implements the `tpchavoc-correlated-subquery-self-binding` TODO.

Three TPC-Havoc variant queries carried a correlated subquery whose **unqualified** correlation column silently bound to the **inner** alias instead of the outer table, degenerating the intended per-row correlation into an uncorrelated scan — the same defect class fixed in `10_v8` (uat-duckdb-reference-triage). Because TPC-Havoc validates execution rather than result equivalence, the defect was silent.

The fix qualifies each correlation to the outer (unaliased) table, matching the `10_v8` approach, **without altering the variant's SQL shape** (per the TODO's anti-pattern guidance).

## Fixes

| Variant | Subquery | Before | After |
|---|---|---|---|
| `q11_v1` | scalar threshold | `ps2.ps_partkey = ps_partkey` | `ps2.ps_partkey = partsupp.ps_partkey` |
| `q17_v8` | `EXISTS` | `avg_calc.l_partkey = l_partkey` | `avg_calc.l_partkey = lineitem.l_partkey` |
| `q2_v8` | `NOT EXISTS` (min-cost) | `ps2.ps_supplycost < ps_supplycost` | `ps2.ps_supplycost < partsupp.ps_supplycost` |

`q11_v1` and `q17_v8` are the two cases named in the TODO. The required **sweep of all variant sets** (work item `w3`) turned up a third: `q2_v8`, a `NOT EXISTS` rewrite of Q2's "minimum cost supplier" whose `ps_supplycost` self-bound to `ps2`, making the predicate always false and the `NOT EXISTS` always true.

In `q17_v8` the sibling `l_quantity` reference is also qualified to `lineitem.l_quantity`: it is currently bound correctly only because `avg_calc` happens not to expose `l_quantity`, so qualifying it hardens the variant against the exact same self-binding class.

## Verification

Against real TPC-H SF=0.01 data (DuckDB):

- **`q2_v8`**: buggy form returned **5 rows**; fixed form returns **4 rows**, matching the canonical `q2_v1`/`q2_v3` — i.e. this variant was returning semantically wrong results, now corrected.
- **`q11_v1`** / **`q17_v8`**: fixed forms match their canonical siblings; at small scale the degenerate form coincidentally produced the same result (the "silent" defect the TODO describes). Correctness lives in the correlation binding, covered by the new assertions.
- Full DuckDB `tpchavoc` run (`load,power`, SF 0.01): **220/220** queries execute, no failures.
- `pytest tests/integration/test_tpchavoc_duckdb.py` and the `tpchavoc` unit suites pass; `ruff check`/`format` clean.

## Tests

`tests/integration/test_tpchavoc_duckdb.py`:
- The three variants join the regression `EXPLAIN` parse/bind list.
- New `test_correlated_subquery_variants_bind_to_outer_table` asserts each correlation is qualified to the outer table and that `q11_v1` decorrelates into a DuckDB delimiter (`DELIM`) join. `q17_v8`/`q2_v8` are guarded by the substring assertion only — each retains a *second* qualified correlation, so their plans look decorrelated even in the buggy form and cannot distinguish fixed from broken (documented inline).
- Extracted the repeated DuckDB schema-setup into a shared `_create_duckdb_schema` helper.

Changes are confined to the TODO's `scope_limit.only_modify` paths: `benchbox/core/tpchavoc/variant_sets/` and `tests/integration/test_tpchavoc_duckdb.py`.

https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk)_