### PR TITLE
fix(docs): correct Transaction Primitives DataFrame coverage in roadmap

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -107,10 +107,15 @@ DataFrame benchmarking is supported for 21 benchmarks across two API families:
 - TPC-H, TPC-DS, TPC-DS OBT, TPC-DI, TPC-H Skew, TPC-Havoc, DataVault
 - SSB, ClickBench, AMPLab, CoffeeShop, H2ODB, TSBS DevOps
 - NYC Taxi, Flight Data, JoinOrder, JoinOrder Synthetic
-- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives, Transaction Primitives
+- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives
 
 **Pandas Family** (Pandas, Modin, cuDF, Dask):
 - Full coverage matching the Expression Family above
+
+**Transaction Primitives** — restricted to ACID-capable table-format adapters only:
+Delta Lake (`delta-lake`, `delta`), PySpark-Delta (`pyspark-delta`), and Iceberg
+(`iceberg`). Polars, DataFusion, and all Pandas-family adapters (`pandas-df`, Modin,
+cuDF, Dask) are rejected at runtime because they do not support ACID transactions.
 
 ### Remaining Expansion
 


### PR DESCRIPTION
## Summary

Addresses the unresolved P2 bot review comment on PR #753
(`chatgpt-codex-connector`, thread `PRRT_kwDOQ7J64c6Hkx-f`).

**Finding:** `docs/development/roadmap.md` listed Transaction Primitives alongside the other
20 benchmarks in both the Expression Family and the Pandas Family "full coverage" block,
but `benchbox/core/transaction_primitives/dataframe_operations.py` only permits ACID-capable
adapters (delta-lake, pyspark-delta, iceberg). Polars, DataFusion, pandas-df, Modin, cuDF,
and Dask all call `raises RuntimeError` at run time via `supports_transactions() → False`.
Users following the roadmap would attempt runs that immediately fail.

**Fix:** Remove Transaction Primitives from the shared family lists and add an explicit note
naming the three supported adapter paths so readers have accurate expectations.

## Test plan

- [ ] `make docs-validate` green (no broken example refs)
- [ ] Confirm roadmap no longer lists Transaction Primitives under the general Expression/Pandas family bullets
- [ ] Confirm the new note accurately reflects `benchbox/core/transaction_primitives/dataframe_operations.py` adapter support

https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV

---
_Generated by [Claude Code](https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV)_