### PR TITLE
fix(docs): correct total benchmark count to 23 in roadmap

### DIFF
--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -23,7 +23,7 @@ BenchBox's expansion roadmap focuses on three strategic areas:
 |----------|---------|---------|
 | SQL Platforms | 39 | +0 |
 | DataFrame Platforms | 9 | +0 |
-| Benchmarks | 22 | +4 |
+| Benchmarks | 23 | +4 |
 | DataFrame-enabled Benchmarks | 21 | +1 (Geospatial) |
 
 ---


### PR DESCRIPTION
## Summary

- `docs/development/roadmap.md` summary table had `Benchmarks | 22` — the authoritative single source of truth (`benchbox/core/benchmark_registry.py`) lists **23** metadata entries.
- One-line fix, no other changes.

## Context

The stale `22` predates `vector_search` being added to the registry. The DataFrame-enabled count (`21`) is intentionally correct per #757: Transaction Primitives is restricted to ACID-capable adapters and is excluded from the full Expression/Pandas family coverage figure.

Note: PR #752 is closed — it accumulated a bad branch lineage and couldn't be cleanly targeted at `develop`. This PR carries only the one outstanding correction.

## Test plan

- [ ] Content-only change — `content-guard` validates YAML/markdown hygiene

https://claude.ai/code/session_01PxTyetsyLimUhvKYbh4hvA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxTyetsyLimUhvKYbh4hvA)_