### PR TITLE
Propagate benchmark output roots before generators are built

### DIFF
--- a/benchbox/base.py
+++ b/benchbox/base.py
@@ -14,7 +14,7 @@ from benchbox.core.benchmark_result_validation import BenchmarkResultValidationM
 from benchbox.core.connection import DatabaseConnection
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.cloud_storage import create_path_handler
-from benchbox.utils.scale_factor import format_scale_factor
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 from benchbox.utils.verbosity import VerbosityMixin, compute_verbosity
 
 BENCHMARK_API_SURFACE = "beta-public"
@@ -29,6 +29,50 @@ else:
         import sqlglot
     except ImportError:
         sqlglot = None
+
+
+class GeneratorOutputDirMixin:
+    """Keep nested data-generator output paths in sync with ``output_dir``.
+
+    Several benchmarks construct a nested data/download generator in
+    ``__init__`` that captures ``output_dir`` at construction time. When the
+    runner or orchestrator later assigns a resolved output root to
+    ``benchmark.output_dir`` (for example from an explicit CLI ``--output`` or a
+    shared data source), those nested generators must follow so generated data
+    lands under the configured root instead of a stale ``cwd``-local default.
+
+    Classes opt in by mixing this in and listing the relevant attribute names in
+    :attr:`OUTPUT_DIR_GENERATOR_ATTRS`. The mixin must precede other bases so its
+    ``output_dir`` data descriptor governs assignment.
+    """
+
+    #: Instance attribute names holding nested generators to keep in sync.
+    OUTPUT_DIR_GENERATOR_ATTRS: tuple[str, ...] = ("data_generator",)
+
+    @property
+    def output_dir(self) -> Any:
+        """Return the resolved output directory handler."""
+        return getattr(self, "_output_dir", None)
+
+    @output_dir.setter
+    def output_dir(self, value: Union[str, Path]) -> None:
+        """Set the output directory and propagate it to nested generators."""
+        self._output_dir = create_path_handler(value)
+        self._sync_output_dir_to_generators(self._output_dir)
+
+    def _sync_output_dir_to_generators(self, path: Any) -> None:
+        """Point each opted-in nested generator at ``path`` when present."""
+        for attr in self.OUTPUT_DIR_GENERATOR_ATTRS:
+            # Only touch concrete instance attributes so lazily-constructed
+            # generator properties are not triggered prematurely.
+            generator = self.__dict__.get(attr)
+            if generator is None or not hasattr(generator, "output_dir"):
+                continue
+            generator.output_dir = path
+            # Benchmarks that reuse TPC-H data nest a second generator.
+            nested = getattr(generator, "tpch_generator", None)
+            if nested is not None and hasattr(nested, "output_dir"):
+                nested.output_dir = path
 
 
 class BaseBenchmark(BenchmarkResultValidationMixin, VerbosityMixin, ABC):
@@ -67,10 +111,13 @@ class BaseBenchmark(BenchmarkResultValidationMixin, VerbosityMixin, ABC):
         self.scale_factor = scale_factor
 
         if output_dir is None:
-            # Use CLI-compatible default path: benchmark_runs/datagen/{benchmark}_{sf}
+            # Resolve the datagen root through the shared helper so an explicit
+            # BENCHBOX_OUTPUT_DIR is honored at construction time, before nested
+            # data generators capture the path. When no env override is set this
+            # falls back to Path.cwd()/benchmark_runs/datagen, preserving the
+            # historical default for ordinary local runs.
             benchmark_name = self._get_benchmark_name().lower()
-            sf_str = format_scale_factor(scale_factor)
-            self.output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"{benchmark_name}_{sf_str}"
+            self.output_dir = get_benchmark_runs_datagen_path(benchmark_name, scale_factor)
         else:
             # Support both local and cloud storage paths
             self.output_dir = create_path_handler(output_dir)

--- a/benchbox/core/amplab/benchmark.py
+++ b/benchbox/core/amplab/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.amplab.generator import AMPLabDataGenerator
 from benchbox.core.amplab.queries import AMPLabQueryManager
 from benchbox.core.amplab.schema import TABLES, get_all_create_table_sql
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class AMPLabBenchmark(TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class AMPLabBenchmark(
+    GeneratorOutputDirMixin, TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark
+):
     """AMPLab Big Data Benchmark implementation.
 
     Tests big data processing systems using web analytics workloads.

--- a/benchbox/core/clickbench/benchmark.py
+++ b/benchbox/core/clickbench/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.clickbench.generator import ClickBenchDataGenerator
 from benchbox.core.clickbench.queries import ClickBenchQueryManager
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class ClickBenchBenchmark(SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class ClickBenchBenchmark(GeneratorOutputDirMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
     """ClickBench (ClickHouse Analytics Benchmark) implementation.
 
     Tests analytical database performance using web analytics data.

--- a/benchbox/core/coffeeshop/benchmark.py
+++ b/benchbox/core/coffeeshop/benchmark.py
@@ -6,7 +6,7 @@ import csv
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.coffeeshop.generator import CoffeeShopDataGenerator
 from benchbox.core.coffeeshop.queries import CoffeeShopQueryManager
 from benchbox.core.coffeeshop.schema import TABLES, get_all_create_table_sql
@@ -54,7 +54,7 @@ GROUP BY dl.region, totals.grand_total
 ORDER BY revenue DESC;"""
 
 
-class CoffeeShopBenchmark(TranslatableQueryMixin, BaseBenchmark):
+class CoffeeShopBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, BaseBenchmark):
     """Expose data generation and query execution for the CoffeeShop benchmark."""
 
     def __init__(

--- a/benchbox/core/datavault/benchmark.py
+++ b/benchbox/core/datavault/benchmark.py
@@ -28,6 +28,7 @@ from benchbox.core.datavault.schema import (
     get_create_all_tables_sql,
     get_table_loading_order,
 )
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 from benchbox.utils.scale_factor import format_scale_factor
 
 logger = logging.getLogger(__name__)
@@ -118,8 +119,9 @@ class DataVaultBenchmark(BaseBenchmark):
         if output_dir is not None:
             self.output_dir = Path(output_dir) if isinstance(output_dir, str) else output_dir
         elif not hasattr(self, "output_dir") or self.output_dir is None:
-            sf_str = format_scale_factor(self.scale_factor)
-            self.output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"{self._get_benchmark_name()}_{sf_str}"
+            # Honor BENCHBOX_OUTPUT_DIR at construction; falls back to
+            # Path.cwd()/benchmark_runs/datagen when no override is set.
+            self.output_dir = get_benchmark_runs_datagen_path(self._get_benchmark_name(), self.scale_factor)
 
         # Lazy-loaded components
         self._tpch_generator: Optional[Any] = None

--- a/benchbox/core/flightdata/benchmark.py
+++ b/benchbox/core/flightdata/benchmark.py
@@ -20,18 +20,19 @@ from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.flightdata.downloader import LAST_AVAILABLE_YEAR, FlightDataDownloader
 from benchbox.core.flightdata.queries import FlightDataQueryManager
 from benchbox.core.flightdata.schema import FLIGHT_SCHEMA, get_create_tables_sql
 from benchbox.utils.compression_mixin import extract_compression_kwargs
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
     from benchbox.core.dataframe.query import QueryRegistry
 
 
-class FlightDataBenchmark(BaseBenchmark):
+class FlightDataBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """US Aviation On-Time Performance OLAP benchmark.
 
     Uses BTS On-Time Performance data for realistic aviation analytics:
@@ -56,6 +57,9 @@ class FlightDataBenchmark(BaseBenchmark):
         - carriers: Carrier comparison and ranking (3 queries)
     """
 
+    # Nested downloader that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("downloader",)
+
     def __init__(
         self,
         scale_factor: float = 1.0,
@@ -79,8 +83,11 @@ class FlightDataBenchmark(BaseBenchmark):
             force_regenerate: Force data regeneration
             **kwargs: Additional options
         """
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (canonical flightdata_sf<N> datagen name); falls back
+        # to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir) if output_dir else Path.cwd() / "benchmark_runs" / "datagen" / f"flightdata_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("flightdata", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/h2odb/benchmark.py
+++ b/benchbox/core/h2odb/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.h2odb.generator import H2ODataGenerator
 from benchbox.core.h2odb.queries import H2OQueryManager
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class H2OBenchmark(TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
+class H2OBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
     """H2O DB benchmark implementation.
 
     Tests analytical database performance using synthetic taxi trip data

--- a/benchbox/core/joinorder_synthetic/benchmark.py
+++ b/benchbox/core/joinorder_synthetic/benchmark.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.joinorder.schema import JoinOrderSchema
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning import UnifiedTuningConfiguration
 
 
-class JoinOrderSyntheticBenchmark(BaseBenchmark):
+class JoinOrderSyntheticBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """Synthetic Join Order Benchmark implementation.
 
     This internal surface is for fast schema and loader smoke tests only.
@@ -42,6 +42,9 @@ class JoinOrderSyntheticBenchmark(BaseBenchmark):
     # that produce lines like "1,Comedy Adventure,,4,1957,,,,,,,".
     csv_delimiter = ","
     csv_null_marker = ""
+
+    # Nested generator that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("_generator",)
 
     def __init__(
         self,
@@ -73,10 +76,11 @@ class JoinOrderSyntheticBenchmark(BaseBenchmark):
         quiet = kwargs.pop("quiet", False)
 
         if output_dir is None:
-            from benchbox.utils.scale_factor import format_scale_factor
+            # Honor BENCHBOX_OUTPUT_DIR at construction; falls back to
+            # Path.cwd()/benchmark_runs/datagen when no override is set.
+            from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
-            sf_str = format_scale_factor(scale_factor)
-            output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"joinorder_synthetic_{sf_str}"
+            output_dir = get_benchmark_runs_datagen_path("joinorder_synthetic", scale_factor)
 
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/nyctaxi/benchmark.py
+++ b/benchbox/core/nyctaxi/benchmark.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.nyctaxi.downloader import GreenTaxiDataDownloader, HVFHVDataDownloader, NYCTaxiDataDownloader
 from benchbox.core.nyctaxi.queries import NYCTaxiQueryManager
 from benchbox.core.nyctaxi.schema import (
@@ -30,12 +30,13 @@ from benchbox.core.nyctaxi.schema import (
 )
 from benchbox.utils.compression_mixin import extract_compression_kwargs
 from benchbox.utils.datagen_manifest import DataGenerationManifest, resolve_compression_metadata
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
 
 
-class NYCTaxiBenchmark(BaseBenchmark):
+class NYCTaxiBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """NYC Taxi OLAP benchmark implementation.
 
     Uses real NYC TLC trip data for OLAP analytics workloads. Supports three
@@ -88,6 +89,9 @@ class NYCTaxiBenchmark(BaseBenchmark):
     # Available years for validation
     AVAILABLE_YEARS = list(range(2019, 2026))
 
+    # Nested downloaders that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("downloader", "green_downloader", "hvfhv_downloader")
+
     def __init__(
         self,
         scale_factor: float = 1.0,
@@ -123,8 +127,11 @@ class NYCTaxiBenchmark(BaseBenchmark):
         if year not in self.AVAILABLE_YEARS:
             raise ValueError(f"year must be in {self.AVAILABLE_YEARS[0]}-{self.AVAILABLE_YEARS[-1]}, got {year}")
 
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (matching the canonical nyctaxi_sf<N> datagen name);
+        # falls back to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir) if output_dir else Path.cwd() / "benchmark_runs" / "datagen" / f"nyctaxi_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("nyctaxi", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/ssb/benchmark.py
+++ b/benchbox/core/ssb/benchmark.py
@@ -13,7 +13,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.query_catalog_base import TranslatableQueryMixin
 from benchbox.core.query_utils import get_queries_with_translation
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class SSBBenchmark(TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class SSBBenchmark(
+    GeneratorOutputDirMixin, TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark
+):
     """Star Schema Benchmark implementation.
 
     This class provides a complete implementation of the Star Schema Benchmark,

--- a/benchbox/core/tpcds_obt/benchmark.py
+++ b/benchbox/core/tpcds_obt/benchmark.py
@@ -12,7 +12,7 @@ from benchbox.core.base_benchmark import BaseBenchmark
 from benchbox.core.tpcds.generator import TPCDSDataGenerator
 from benchbox.core.tpcds_obt.etl.transformer import SUPPORTED_CHANNELS, TPCDSOBTTransformer
 from benchbox.core.tpcds_obt.queries import TPCDSOBTQueryManager
-from benchbox.utils.scale_factor import format_scale_factor
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 logger = logging.getLogger(__name__)
 
@@ -167,21 +167,19 @@ class TPCDSOBTBenchmark(BaseBenchmark):
             "TPC-DS benchmark adapted to a single wide One Big Table with sales + returns merged across channels."
         )
 
-        # Determine standard paths using scale factor formatting
-        sf_str = format_scale_factor(scale_factor)
-        default_base = Path.cwd() / "benchmark_runs" / "datagen"
-
+        # Determine standard paths via the shared helper so BENCHBOX_OUTPUT_DIR is
+        # honored; falls back to Path.cwd()/benchmark_runs/datagen when unset.
         # OBT output directory (for transformed OBT table)
         if output_dir:
             self.output_dir = Path(output_dir)
         else:
-            self.output_dir = default_base / f"tpcds_obt_{sf_str}"
+            self.output_dir = get_benchmark_runs_datagen_path("tpcds_obt", scale_factor)
 
         # TPC-DS source directory (for base TPC-DS data)
         if tpcds_source_dir:
             self.tpcds_source_dir = Path(tpcds_source_dir)
         else:
-            self.tpcds_source_dir = default_base / f"tpcds_{sf_str}"
+            self.tpcds_source_dir = get_benchmark_runs_datagen_path("tpcds", scale_factor)
 
         self.parallel = parallel
         self.force_regenerate = force_regenerate

--- a/benchbox/core/tpch/benchmark.py
+++ b/benchbox/core/tpch/benchmark.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Union
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.tpch.generator import TPCHDataGenerator
 from benchbox.core.tpch.maintenance_test import TPCHMaintenanceTest
 from benchbox.core.tpch.queries import TPCHQueries
@@ -152,7 +152,7 @@ def _expand_sqlite_named_column_aliases(query: str) -> str:
     )
 
 
-class TPCHBenchmark(BaseBenchmark):
+class TPCHBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """TPC-H benchmark implementation.
 
     This class provides a complete implementation of the TPC-H benchmark,

--- a/benchbox/core/tsbs_devops/benchmark.py
+++ b/benchbox/core/tsbs_devops/benchmark.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.tsbs_devops.generator import TSBSDevOpsDataGenerator
 from benchbox.core.tsbs_devops.queries import TSBSDevOpsQueryManager
 from benchbox.core.tsbs_devops.schema import (
@@ -26,12 +26,13 @@ from benchbox.core.tsbs_devops.schema import (
     get_create_tables_sql,
 )
 from benchbox.utils.compression_mixin import extract_compression_kwargs
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
 
 
-class TSBSDevOpsBenchmark(BaseBenchmark):
+class TSBSDevOpsBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """TSBS DevOps benchmark implementation.
 
     Implements Time Series Benchmark Suite for DevOps monitoring workloads:
@@ -101,10 +102,11 @@ class TSBSDevOpsBenchmark(BaseBenchmark):
             force_regenerate: Force data regeneration
             **kwargs: Additional options
         """
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (canonical tsbs_devops_sf<N> datagen name); falls
+        # back to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir)
-            if output_dir
-            else Path.cwd() / "benchmark_runs" / "datagen" / f"tsbs_devops_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("tsbs_devops", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/vector_search/benchmark.py
+++ b/benchbox/core/vector_search/benchmark.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.query_catalog_base import QuerySkippedError, TranslatableQueryMixin
 from benchbox.core.utils.tuning import extract_constraint_flags
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 DEFAULT_DIMENSIONS = 128
 
 
-class VectorSearchBenchmark(TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
+class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
     """Vector search benchmark implementation.
 
     Tests similarity-search performance across OLAP databases that support

--- a/tests/unit/core/test_benchmark_output_root_propagation.py
+++ b/tests/unit/core/test_benchmark_output_root_propagation.py
@@ -1,0 +1,143 @@
+"""Regression tests for benchmark output-root propagation.
+
+These tests guard the lifecycle-ordering fix described in the
+``benchmark-runs-output-root-propagation`` task: generator-backed benchmarks
+must honor an explicit ``BENCHBOX_OUTPUT_DIR`` (or post-construction output-root
+assignment) all the way down to their nested data generators, instead of
+leaving them pointed at a worktree-local ``cwd/benchmark_runs`` default.
+
+The assertions deliberately inspect the *nested generator* output paths (not
+just ``benchmark.output_dir``) so a benchmark that silently keeps a stale
+generator path fails here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.amplab.benchmark import AMPLabBenchmark
+from benchbox.core.clickbench.benchmark import ClickBenchBenchmark
+from benchbox.core.coffeeshop.benchmark import CoffeeShopBenchmark
+from benchbox.core.flightdata.benchmark import FlightDataBenchmark
+from benchbox.core.h2odb.benchmark import H2OBenchmark
+from benchbox.core.nyctaxi.benchmark import NYCTaxiBenchmark
+from benchbox.core.ssb.benchmark import SSBBenchmark
+from benchbox.core.tpch.benchmark import TPCHBenchmark
+from benchbox.core.tsbs_devops.benchmark import TSBSDevOpsBenchmark
+from benchbox.core.vector_search.benchmark import VectorSearchBenchmark
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _nested_generators(benchmark) -> list:
+    """Return the concrete nested generator/downloader objects on a benchmark."""
+    generators = []
+    for attr in getattr(benchmark, "OUTPUT_DIR_GENERATOR_ATTRS", ("data_generator",)):
+        gen = benchmark.__dict__.get(attr)
+        if gen is not None and hasattr(gen, "output_dir"):
+            generators.append(gen)
+    return generators
+
+
+# Representative generator-backed benchmark families. ``data_generator`` covers
+# the common case; nyctaxi/flightdata expose download-based generators instead.
+CONSTRUCTOR_CASES = [
+    (H2OBenchmark, {}),
+    (SSBBenchmark, {}),
+    (VectorSearchBenchmark, {}),
+    (TPCHBenchmark, {}),
+    (ClickBenchBenchmark, {}),
+    (AMPLabBenchmark, {}),
+    (CoffeeShopBenchmark, {}),
+    (TSBSDevOpsBenchmark, {}),
+    (NYCTaxiBenchmark, {}),
+    (FlightDataBenchmark, {}),
+]
+
+
+@pytest.mark.parametrize("benchmark_cls,kwargs", CONSTRUCTOR_CASES)
+def test_env_output_root_honored_at_construction(benchmark_cls, kwargs, tmp_path, monkeypatch):
+    """BENCHBOX_OUTPUT_DIR redirects datagen output before generators are built."""
+    root = tmp_path / "shared_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark = benchmark_cls(scale_factor=0.01, **kwargs)
+
+    output_dir = Path(str(benchmark.output_dir))
+    assert str(output_dir).startswith(str(root)), output_dir
+    # The stale-default failure mode lands under cwd/benchmark_runs.
+    assert Path.cwd() not in output_dir.parents, output_dir
+
+    generators = _nested_generators(benchmark)
+    assert generators, f"{benchmark_cls.__name__} exposed no nested generator to verify"
+    for gen in generators:
+        gen_dir = Path(str(gen.output_dir))
+        assert str(gen_dir).startswith(str(root)), (benchmark_cls.__name__, gen_dir)
+        assert Path.cwd() not in gen_dir.parents, (benchmark_cls.__name__, gen_dir)
+
+
+@pytest.mark.parametrize("benchmark_cls,kwargs", CONSTRUCTOR_CASES)
+def test_explicit_output_root_propagates_post_construction(benchmark_cls, kwargs, tmp_path, monkeypatch):
+    """An output-root assigned after construction reaches nested generators.
+
+    This mirrors the runner/orchestrator path that resolves an explicit CLI
+    ``--output`` root and assigns ``benchmark.output_dir`` after the benchmark
+    (and its generators) have already been constructed.
+    """
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+    benchmark = benchmark_cls(scale_factor=0.01, **kwargs)
+
+    explicit = tmp_path / "explicit_root" / "data"
+    benchmark.output_dir = str(explicit)
+
+    assert str(benchmark.output_dir) == str(explicit)
+    for gen in _nested_generators(benchmark):
+        assert str(gen.output_dir) == str(explicit), (benchmark_cls.__name__, gen.output_dir)
+
+
+def test_default_falls_back_to_cwd_when_unset(monkeypatch):
+    """With neither CLI --output nor BENCHBOX_OUTPUT_DIR set, the cwd default holds."""
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+    benchmark = H2OBenchmark(scale_factor=0.01)
+
+    expected = Path.cwd() / "benchmark_runs" / "datagen" / "h2odb_sf001"
+    assert Path(str(benchmark.output_dir)) == expected
+    assert Path(str(benchmark.data_generator.output_dir)) == expected
+
+
+def test_nyctaxi_optional_downloaders_all_track_output_dir(tmp_path, monkeypatch):
+    """Multi-type NYC Taxi keeps every optional downloader in sync."""
+    from benchbox.core.nyctaxi.schema import TaxiType
+
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+    benchmark = NYCTaxiBenchmark(
+        scale_factor=0.01,
+        taxi_types=[TaxiType.YELLOW, TaxiType.GREEN, TaxiType.HVFHV],
+    )
+
+    target = tmp_path / "nyc" / "data"
+    benchmark.output_dir = str(target)
+
+    assert str(benchmark.downloader.output_dir) == str(target)
+    assert str(benchmark.green_downloader.output_dir) == str(target)
+    assert str(benchmark.hvfhv_downloader.output_dir) == str(target)
+
+
+def test_tpch_variant_skew_inherits_propagation(tmp_path, monkeypatch):
+    """A TPC-H-family variant (skew) honors the env root for its own generator."""
+    from benchbox.core.tpch_skew.benchmark import TPCHSkewBenchmark
+
+    root = tmp_path / "runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark = TPCHSkewBenchmark(scale_factor=0.01)
+
+    assert str(benchmark.output_dir).startswith(str(root))
+    assert str(benchmark.data_generator.output_dir).startswith(str(root))
+    assert Path.cwd() not in Path(str(benchmark.data_generator.output_dir)).parents

--- a/tests/unit/mcp/test_benchmark_output_root_propagation.py
+++ b/tests/unit/mcp/test_benchmark_output_root_propagation.py
@@ -1,0 +1,73 @@
+"""Regression tests for output-root propagation on the MCP benchmark path.
+
+The MCP ``run_benchmark`` tool constructs benchmark instances directly via
+``get_public_benchmark_class(...)(scale_factor=...)`` and the data-only path
+resolves a datagen directory via ``get_benchmark_runs_datagen_path``. Both must
+honor ``BENCHBOX_OUTPUT_DIR`` so MCP-driven runs do not write generated data
+under a stale ``cwd/benchmark_runs`` default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.benchmark_registry import get_public_benchmark_class
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Generator-backed benchmarks reachable through the public MCP surface.
+MCP_BENCHMARKS = ["h2odb", "ssb", "vector_search", "tpch"]
+
+
+@pytest.mark.parametrize("benchmark_id", MCP_BENCHMARKS)
+def test_mcp_run_construction_honors_env_output_root(benchmark_id, tmp_path, monkeypatch):
+    """Mirror MCP ``_run_benchmark_impl`` construction under BENCHBOX_OUTPUT_DIR."""
+    root = tmp_path / "mcp_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark_class = get_public_benchmark_class(benchmark_id)
+    if benchmark_class is None:
+        pytest.skip(f"{benchmark_id} not available in this environment")
+
+    # Same call shape MCP uses: scale_factor only, no explicit output_dir.
+    benchmark = benchmark_class(scale_factor=0.01)
+
+    output_dir = Path(str(benchmark.output_dir))
+    assert str(output_dir).startswith(str(root)), output_dir
+    assert Path.cwd() not in output_dir.parents, output_dir
+
+    # Public benchmark wrappers delegate to a core ``_impl`` that owns the
+    # nested data generator.
+    core = getattr(benchmark, "_impl", benchmark)
+    generator = core.__dict__.get("data_generator")
+    assert generator is not None and hasattr(generator, "output_dir")
+    gen_dir = Path(str(generator.output_dir))
+    assert str(gen_dir).startswith(str(root)), gen_dir
+    assert Path.cwd() not in gen_dir.parents, gen_dir
+
+
+def test_mcp_data_only_datagen_path_honors_env_output_root(tmp_path, monkeypatch):
+    """The MCP data-only datagen directory resolves under the env output root."""
+    root = tmp_path / "mcp_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    data_dir = get_benchmark_runs_datagen_path("tpch", 0.01)
+
+    assert str(data_dir).startswith(str(root)), data_dir
+    assert data_dir.name == "tpch_sf001", data_dir
+    assert Path.cwd() not in data_dir.parents, data_dir
+
+
+def test_mcp_default_without_env_uses_cwd(monkeypatch):
+    """Without an output-root override the MCP datagen path stays cwd-local."""
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+    data_dir = get_benchmark_runs_datagen_path("tpch", 0.01)
+
+    assert data_dir == Path.cwd() / "benchmark_runs" / "datagen" / "tpch_sf001"


### PR DESCRIPTION
## Summary

Implements the `benchmark-runs-output-root-propagation` TODO. Fixes the lifecycle-ordering bug where generator-backed benchmarks wrote duplicate generated data under a worktree-local `benchmark_runs/` even when `BENCHBOX_OUTPUT_DIR` was set (the 2026-06-01 investigation found ~6.2G + ~4.2G of duplicated `datagen/` artifacts across worktrees).

### Root cause
`BaseBenchmark.__init__` defaulted `output_dir` to `Path.cwd() / "benchmark_runs" / "datagen" / ...` — ignoring `BENCHBOX_OUTPUT_DIR`. Nested `data_generator`/`downloader` instances built in `__init__` captured that stale cwd-local path, and post-construction `benchmark.output_dir = ...` reassignment (runner/orchestrator) did not reach them for benchmarks lacking a synchronizing setter.

### Changes
- **`benchbox/base.py`**
  - Default datagen root now resolves via `get_benchmark_runs_datagen_path(...)`, honoring `BENCHBOX_OUTPUT_DIR` at construction time. Falls back to `Path.cwd()/benchmark_runs/datagen` when neither CLI `--output` nor the env var is set (backward compatible).
  - New `GeneratorOutputDirMixin`: an opt-in `output_dir` property whose setter propagates the resolved root to nested generators named in `OUTPUT_DIR_GENERATOR_ATTRS` (and a nested `tpch_generator`, matching the existing read/write-primitives contract). Uses `self.__dict__.get(...)` so lazily-constructed generator properties are never triggered prematurely.
- **Applied the mixin** to generator-backed families that built generators in `__init__`: h2odb, ssb, vector_search, clickbench, tpch (covers the `tpch_skew` variant via inheritance), amplab, coffeeshop, tsbs_devops, nyctaxi (3 downloaders), flightdata, joinorder_synthetic.
- **Made constructor defaults env-aware** (previously hardcoded `Path.cwd()`): nyctaxi, flightdata, tsbs_devops, tpcds_obt (output + tpcds source), datavault, joinorder_synthetic. This also corrects non-canonical names like `nyctaxi_1.0` → canonical `nyctaxi_sf1`, aligning the constructor default with the runner's existing output root.
- **Regression tests** (`tests/unit/core/` and `tests/unit/mcp/`): assert nested generator/downloader paths (not just `benchmark.output_dir`) honor explicit and env output roots and never reference `cwd/benchmark_runs`; assert the cwd fallback still holds when unset; cover the MCP construction path.

### must_preserve / anti-patterns honored
- CLI `--output` precedence and `BENCHBOX_OUTPUT_DIR` as the shared-root mechanism preserved.
- cwd-local default retained when neither is set.
- No new env var; reuses `get_benchmark_runs_datagen_path` / `resolve_benchmark_runs_dir`.
- Tests assert nested generator paths and absence of `cwd/benchmark_runs`, not just `benchmark.output_dir`.
- No worktree `benchmark_runs/` deletion.

### w0 re-validation note
On a clean branch with `BENCHBOX_OUTPUT_DIR` set, generator-backed benchmarks (e.g. H2ODB, SSB, Vector Search, TPC-H, ClickBench, NYC Taxi, FlightData, TSBS, AMPLab, CoffeeShop) constructed with `output_dir=None` previously left both `benchmark.output_dir` and their nested generators at `Path.cwd()/benchmark_runs/datagen/...`; after the fix both resolve under the env root. Verified via the new regression tests.

### MCP path
The MCP `run_benchmark` tool constructs `benchmark_class(scale_factor=...)` with no explicit `output_dir`; the env-aware default now keeps that construction (and data-sharing benchmarks like read_primitives) under the configured root. `TPCDIConfig` already resolves through the same env-aware helper, so TPC-DI's reported failure mode does not occur.

### Verification
- New: `tests/unit/core/test_benchmark_output_root_propagation.py`, `tests/unit/mcp/test_benchmark_output_root_propagation.py` — pass.
- `tests/unit/core/test_runner_helpers.py tests/unit/cli/test_orchestrator_data_sharing.py tests/unit/utils/test_path_utils.py tests/unit/utils/test_output_path_normalization.py` — 67 passed.
- All modified-family unit suites — 1987 passed, 6 skipped.
- Fast suite — pre-existing failures only, all environment-related and unrelated to this change (root-container makes `/invalid` writable so "expects OSError on bad path" tests don't raise; git-worktree/changelog/path-filter tooling tests need history absent from a fresh clone; Delta Lake / zstd extension availability). Confirmed identical on `origin/develop`.
- `ruff check` / `ruff format --check` clean on changed files; `ty check` shows only two pre-existing diagnostics in untouched code regions (verified identical on `develop`).

### `/code review` (high effort)
Ran and verified all surfaced candidates. Bug candidates were refuted with runtime checks (lazy generators in datavault/tpcds_obt correctly track or intentionally diverge; `create_path_handler` is idempotent on already-wrapped paths; no `output_dir = None` assignments exist). Two items accepted as out-of-scope/pre-existing: TPC-DI's deeper ETL-subdir re-derivation on `--output` override (env case already correct), and the read/transactional-primitives setters that the mixin now generalizes (deduping would touch out-of-scope files).

https://claude.ai/code/session_01JA1u7r1PywnKmA8BaGU62u

---
_Generated by [Claude Code](https://claude.ai/code/session_01JA1u7r1PywnKmA8BaGU62u)_