### PR TITLE
todo: follow-ups from TPC-Havoc self-binding work (equivalence gate, q2_v10, cross-surface audit)

### DIFF
--- a/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
+++ b/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
@@ -1,0 +1,131 @@
+id: correlated-subquery-self-binding-cross-surface-audit
+title: "Audit DataFrame variants and other benchmarks for correlated-subquery self-binding, and add a durable detector"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  PR #756 fixed three TPC-Havoc SQL variants where a correlated subquery's
+  UNQUALIFIED correlation column silently bound to the INNER alias instead of
+  the outer table, degenerating the intended correlation into an uncorrelated
+  scan. That sweep covered the SQL variant_sets only, by hand. Two reachable
+  surfaces were never checked, and the manual sweep is not a durable guard.
+
+  Scope of this audit:
+
+  1. TPC-Havoc DataFrame variants (benchbox/core/tpchavoc/dataframe_queries/).
+     The DataFrame implementations of the correlated queries (Q2 min-cost,
+     Q11 threshold, Q17 per-part avg, Q20, Q21, Q22) must encode the SAME outer
+     correlation as the canonical query. DataFrame code does not "self-bind" the
+     same way, but the equivalent mistake - joining/filtering on the inner frame
+     instead of the outer row - is possible and equally silent.
+
+  2. Other SQL benchmarks with correlated subqueries: TPC-DS, SSB, join-order,
+     read-primitives (subquery category), and write-primitives
+     (update_with_subquery). Grep evidence already shows correlated patterns and
+     a "self-join pattern" comment in tpcds/dataframe_queries. Apply the same
+     qualify-the-outer-correlation audit.
+
+  3. A DURABLE detector so this class cannot silently reappear: a static check
+     (sqlglot-backed) that flags a correlated subquery whose correlation
+     predicate has an unqualified column also present in an inner aliased
+     relation. A binder-level check is hard to make exact, so a conservative
+     lint that surfaces candidates for human confirmation is acceptable.
+
+  Provenance question worth answering during the audit: how were these variants
+  authored? If LLM-generated or mechanically transformed, self-binding is likely
+  a SYSTEMATIC generation artifact, implying more instances and a generator that
+  needs a correctness contract rather than per-instance patches.
+
+prior_art:
+  - "_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - the SQL-variant fix this audit extends; reuse its qualify-the-outer-table pattern"
+  - "benchbox/core/tpchavoc/dataframe_queries/_delegating_variants.py - notes that Q16-Q22 delegate the core correlated/anti-join shape; verify those delegations are faithful"
+  - "benchbox/core/tpcds/dataframe_queries/queries.py:3801 - existing 'correlated subquery ... self-join pattern' comment; an explicit audit target"
+  - "benchbox/sql_compat/rules/ and benchbox/platforms/*_query_transformer.py - existing places SQL is rewritten; a static check could live near these"
+
+work:
+  - id: w0
+    summary: "Re-confirm the audit surfaces still exist and enumerate correlated-subquery sites"
+    status: pending
+    notes: |
+      Enumerate correlated subqueries across the DataFrame variants and the
+      other SQL benchmarks (grep + read). Record the candidate list before
+      editing. Capture stdout to /tmp and summarize counts in the TODO/PR.
+
+  - id: w1
+    summary: "Audit TPC-Havoc DataFrame variants for outer-correlation faithfulness and fix any drift"
+    needs: [w0]
+    status: pending
+    notes: |
+      For each correlated DataFrame query, confirm the join/filter references
+      the OUTER row, not the inner aggregate frame. Cross-check results against
+      canonical TPC-H at small SF.
+
+  - id: w2
+    summary: "Audit other SQL benchmarks (TPC-DS, SSB, join-order, read/write-primitives) for the self-binding pattern and fix any found"
+    needs: [w0]
+    status: pending
+
+  - id: w3
+    summary: "Prototype a durable static detector for unqualified self-binding correlations"
+    needs: [w0]
+    status: pending
+    notes: |
+      sqlglot-backed candidate flagger: parse each query, find correlated
+      subqueries, flag predicates whose unqualified column also exists in an
+      inner aliased relation. Conservative (candidates for human review) is
+      acceptable; wire into the equivalence/lint tooling, not as a hard blocker
+      until precision is validated.
+
+deferred:
+  - summary: "Author a correctness contract for the variant generator"
+    reason: "Depends on the provenance finding in w0/w1; only worth it if the pattern proves systematic across surfaces."
+
+must_preserve:
+  - "Existing DataFrame and SQL benchmark results that are already correct are unchanged."
+  - "Each variant keeps its declared structural identity; only the correlation binding is corrected."
+
+approach: |
+  Reuse the qualify-the-outer-table discipline from the merged self-binding fix.
+  For DataFrame variants, the analogous fix is correlating on the outer frame's
+  key, not the inner aggregate. Confirm every fix against canonical TPC-H/TPC-DS
+  at small SF. Build the static detector last, informed by the concrete cases
+  found, so its heuristics match real instances.
+
+anti_patterns:
+  - "DO NOT restructure variant/query shapes - because identity is the shape - only correct the correlation binding."
+  - "DO NOT ship a noisy static check as a hard CI blocker - because false positives will erode trust - start as an advisory candidate list."
+
+verification:
+  - description: "Audited correlated DataFrame/SQL queries match canonical results at small SF"
+    command: "compare each audited query to its canonical benchmark answer on DuckDB small SF"
+    expected_output: "set-equal results (modulo declared exceptions)"
+  - description: "Static detector flags the known historical self-binding cases when reverted"
+    command: "run the detector over variant_sets with a #756 fix reverted"
+    expected_output: "the reverted variant is flagged"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/dataframe_queries/"
+    - "benchbox/core/tpcds/"
+    - "benchbox/core/ssb/"
+    - "benchbox/core/joinorder/"
+    - "benchbox/core/read_primitives/"
+    - "benchbox/core/write_primitives/"
+    - "tests/"
+    - "_project/scripts/"
+
+open_questions:
+  - "Were the variants/queries authored by hand, LLM-generated, or mechanically transformed - i.e. is self-binding a systematic generation artifact?"
+  - "Can a sqlglot-based detector be made precise enough to gate, or does correct binding require a real catalog-aware binder?"
+
+success_metrics:
+  - "DataFrame variants and the surveyed SQL benchmarks are confirmed free of self-binding (or fixed)."
+  - "A documented, runnable detector flags the historical #756 cases when reintroduced."
+
+metadata:
+  tags: [tpchavoc, tpcds, dataframe, correctness, sql, audit, lint]
+  estimated_effort: "Medium"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"

--- a/_project/TODO/main/planning/tpchavoc-q2-v10-projection-faithfulness.yaml
+++ b/_project/TODO/main/planning/tpchavoc-q2-v10-projection-faithfulness.yaml
@@ -1,0 +1,102 @@
+id: tpchavoc-q2-v10-projection-faithfulness
+title: "Fix q2_v10 projection that zeroes negative s_acctbal, and sweep variants for the same projection-faithfulness class"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  While verifying PR #756 (correlated-subquery self-binding fixes), a SECOND,
+  different class of equivalence defect surfaced in the TPC-Havoc variant set.
+  `q2_v10` (the "CASE expressions" variant) returns the correct 460-row key set
+  at SF=1 but reformulates its output projection as
+  `case when s_acctbal > 0 then s_acctbal else 0 end as s_acctbal`. The 38
+  suppliers in the result whose `s_acctbal` is negative are therefore reported
+  as `0.00` instead of their real (negative) balance, so q2_v10 diverges from
+  canonical TPC-H Q2 and from its nine sibling variants on those rows.
+
+  This is NOT the self-binding pattern PR #756 addressed; it is
+  projection-faithfulness drift - an output reformulation (CASE / COALESCE /
+  NULL-handling wrappers) that changes projected VALUES while leaving the
+  filtered row set correct. Like self-binding, it is silent today because
+  TPC-Havoc validates execution, not result equivalence (see the companion
+  `tpchavoc-variant-equivalence-gate` TODO).
+
+  Fix q2_v10 to project the true `s_acctbal`, then sweep every variant set for
+  the same class: projection expressions that can alter a value relative to the
+  canonical query (CASE wrappers that substitute defaults, COALESCE-to-0 on
+  nullable measures, casts that round/truncate). Fix any found WITHOUT changing
+  a variant's structural identity.
+
+prior_art:
+  - "benchbox/core/tpchavoc/variant_sets/q02.yaml:455 q2_v10 - the CASE-wrapped s_acctbal/s_name/n_name/... projections are the locus"
+  - "PR #756 / tests/integration/test_tpchavoc_duckdb.py - the canonical-vs-variant SF=1 comparison method that surfaced this; reuse it to confirm the fix"
+  - "_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - sibling defect class; same 'fix the SQL, preserve the shape' discipline"
+
+work:
+  - id: w0
+    summary: "Reproduce the q2_v10 divergence and quantify it against canonical Q2 at SF=1"
+    status: pending
+    notes: |
+      On a populated DuckDB SF=1 cell, confirm q2_v10 differs from canonical Q2
+      (without its LIMIT 100) on exactly the negative-acctbal rows (38 at SF=1),
+      and that all nine other q2 variants agree with canonical. Capture stdout
+      to /tmp and record the count + sample rows.
+
+  - id: w1
+    summary: "Fix q2_v10 projections to be value-faithful to canonical Q2"
+    needs: [w0]
+    status: pending
+    notes: |
+      Project the real s_acctbal (and any other CASE/COALESCE-wrapped output
+      columns that substitute values) without altering the variant's
+      CASE-expressions identity in its predicates/structure. Confirm q2_v10 then
+      set-matches canonical Q2 minus LIMIT.
+
+  - id: w2
+    summary: "Sweep all variant_sets for projection-faithfulness drift and fix any others"
+    needs: [w0]
+    status: pending
+    notes: |
+      Audit every variant's SELECT list for value-altering wrappers (CASE
+      default substitution, COALESCE-to-0 on nullable measures, rounding casts)
+      and verify each against canonical at a scale where the affected values are
+      non-trivial. Fix in place; preserve shape.
+
+must_preserve:
+  - "Each touched variant keeps its declared structural identity (q2_v10 stays the 'CASE expressions' variant)."
+  - "DuckDB tpchavoc remains 100% execution-green at SF 0.01 / 0.1 / 1.0."
+  - "Row/key sets already correct are not changed - only value-faithfulness of projected columns."
+
+approach: |
+  Targeted, low-risk SQL edits to projection expressions only. Use the PR #756
+  verification recipe (populate a DuckDB SF=1 cell, compare each variant to the
+  canonical TPC-H query for that id with set-equality after rounding, modulo the
+  q2 family's intentional LIMIT omission). Start with the known q2_v10 case,
+  then generalize the check across all variants.
+
+anti_patterns:
+  - "DO NOT restructure q2_v10 away from CASE expressions - because its identity IS the CASE shape - only fix the value-altering output substitution."
+  - "DO NOT widen scope into filtering/correlation logic - because that is the self-binding class handled elsewhere - stay on projection faithfulness."
+
+verification:
+  - description: "q2_v10 set-matches canonical Q2 (minus LIMIT) at SF=1, including negative-acctbal rows"
+    command: "populate DuckDB SF=1; compare norm(q2_v10) to norm(canonical Q2 without LIMIT)"
+    expected_output: "identical 460-row sets; no zeroed negative balances"
+  - description: "tpchavoc duckdb tests pass"
+    command: "uv run -- python -m pytest tests/integration/test_tpchavoc_duckdb.py -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/variant_sets/"
+    - "tests/integration/test_tpchavoc_duckdb.py"
+
+success_metrics:
+  - "q2_v10 is value-faithful to canonical Q2; no variant substitutes projected values vs canonical (modulo declared exceptions)."
+
+metadata:
+  tags: [tpchavoc, sql, correctness, projection, defect]
+  estimated_effort: "Small"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"

--- a/_project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml
+++ b/_project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml
@@ -1,0 +1,164 @@
+id: tpchavoc-variant-equivalence-gate
+title: "Wire a bounded result-equivalence gate for TPC-Havoc variants and burn down the divergences it surfaces"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  TPC-Havoc's premise is that the 10 SQL (and DataFrame) variants of each
+  TPC-H query are structurally diverse but SEMANTICALLY EQUIVALENT to the
+  canonical TPC-H query. Nothing in the default run or in CI enforces that
+  equivalence: `benchbox run --benchmark tpchavoc` reports execution success
+  ("Success rate: 100%") while never comparing any variant to the canonical
+  answer, and the develop correctness gate validates TPC-H, not TPC-Havoc
+  variants. A fast-but-wrong variant therefore makes a platform look good for
+  executing the WRONG query, silently corrupting the performance comparison the
+  benchmark exists to produce.
+
+  benchbox already ships the comparison primitive:
+  `TPCHavocBenchmark.validate_variant_equivalence(...)`
+  (benchbox/core/tpchavoc/benchmark.py:242) delegates to
+  `ResultValidator.validate_results_exact` / `validate_results_checksum` /
+  `validate_query1_results`. But it is invoked only from unit tests with
+  synthetic inputs - no run path executes the canonical TPC-H query and feeds
+  `original_results` for a real variant. `--validate-results` is an opt-in flag
+  (default off) that routes through `ValidationConfig` without driving
+  per-variant equivalence for tpchavoc.
+
+  The cost of this gap is concrete and already realized. PR #756 fixed three
+  correlated-subquery self-binding defects (q2_v8, q11_v1, q17_v8) that were
+  silent for exactly this reason, and the same PR's verification surfaced a
+  fourth, different-class divergence: q2_v10 zeroes negative `s_acctbal` via a
+  CASE-wrapped projection (38 of 460 rows differ from canonical Q2 at SF=1). A
+  result-equivalence gate would have caught all four.
+
+  This TODO wires the EXISTING validator into a bounded, CI-affordable gate,
+  enumerates every current divergence, and (via the companion burndown TODO)
+  drives them to zero so the gate lands green. It is complementary to
+  `testing-approach-correctness-gates` (that gate checks TPC-H answers; this
+  one checks TPC-Havoc cross-variant equivalence) and should mirror its
+  bounded single-cell shape.
+
+prior_art:
+  - "benchbox/core/tpchavoc/benchmark.py:242 validate_variant_equivalence - REUSE as the comparator; do not write a new one"
+  - "benchbox/core/expected_results/loader.py - reuse stored canonical TPC-H answers where present instead of re-executing the base query"
+  - "tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py:212 test_q14v8_parity_with_q14v1 - existing ad-hoc per-variant parity test; generalize it rather than adding more one-offs"
+  - "_project/TODO/main/planning/testing-approach-correctness-gates.yaml - the bounded-gate design (single small-SF DuckDB cell, marker policy); mirror the shape, keep it complementary"
+  - "tests/integration/test_tpchavoc_duckdb.py - already creates the DuckDB schema and runs variants; extend here rather than starting a new harness"
+
+work:
+  - id: w0
+    summary: "Re-validate the evidence against current develop before building anything"
+    status: pending
+    notes: |
+      Confirm the gap and the known divergences are still true on the head SHA:
+        - grep that `validate_variant_equivalence` has no non-test caller in a
+          run/execute path;
+        - confirm `benchbox run --benchmark tpchavoc` default does not validate
+          equivalence (no canonical query executed);
+        - reproduce the four known divergences on a populated DuckDB SF=1 cell:
+          q2_v8/q11_v1/q17_v8 match canonical only post-#756, and q2_v10 still
+          differs from canonical Q2 by the 38 negative-acctbal rows.
+      Capture raw stdout to `/tmp/tpchavoc-equiv-w0.log` or CI artifacts and
+      record the command, checked SHA, PASS/FAIL, and row counts in the PR/TODO.
+
+  - id: w1
+    summary: "Build a parametrized equivalence harness (report mode) over all queries x 10 SQL variants"
+    needs: [w0]
+    status: pending
+    notes: |
+      Small SF on DuckDB. For each implemented query, execute the canonical
+      TPC-H query once and every variant, then compare via
+      validate_variant_equivalence. Run in REPORT mode first: emit the full set
+      of divergences (query, variant, kind, row-count delta) rather than
+      asserting. Encode INTENTIONAL non-equivalences (e.g. the q2 variant
+      family omits canonical Q2's `LIMIT 100`) as reviewable DATA, not inline
+      per-query special cases.
+
+  - id: w2
+    summary: "Drive all real divergences to zero, leaving only declared exceptions"
+    needs: [w1]
+    status: pending
+    notes: |
+      The known q2_v10 projection defect is owned by the companion burndown
+      TODO `tpchavoc-q2-v10-projection-faithfulness`. Any further divergences
+      w1 surfaces get fixed or, if genuinely intentional, added to the declared-
+      exception list with a one-line justification.
+
+  - id: w3
+    summary: "Promote the harness to a bounded CI gate that fails on reintroduced divergences"
+    needs: [w2]
+    status: pending
+    notes: |
+      One bounded small-SF DuckDB cell, marked per the existing correctness-gate
+      marker policy (not a stress matrix). Prove the gate fails when a
+      self-binding or projection divergence is deliberately reintroduced, and is
+      not silently disarmable by scale/benchmark drift.
+
+deferred:
+  - summary: "Extend the equivalence gate to the DataFrame variants"
+    reason: "DataFrame-surface correctness is owned by the cross-surface audit TODO; fold in only after the SQL gate is green."
+  - summary: "Run the equivalence harness on a second engine (Postgres/ClickHouse/DataFusion)"
+    reason: "Cross-dialect equivalence of shared SQL is an open question; keep the routine gate DuckDB-bounded and sample a second engine separately if w1 evidence warrants."
+
+must_preserve:
+  - "benchbox run --benchmark tpchavoc default (execution-only) behavior stays available; the gate is additive."
+  - "DuckDB tpchavoc stays 100% execution-green at SF 0.01 / 0.1 / 1.0."
+  - "ResultValidator tolerance and checksum semantics are unchanged."
+
+approach: |
+  Reuse validate_variant_equivalence and the expected_results loader; do not
+  add a new comparator or a second source of canonical answers. Build the
+  harness as a parametrized pytest over get_implemented_queries() x
+  get_all_variants(q), extending tests/integration/test_tpchavoc_duckdb.py's
+  existing schema/exec scaffolding. Land it in REPORT mode, fix everything it
+  finds (delegating the q2_v10 projection class to the burndown TODO), then
+  flip to a gating assertion and wire the bounded cell into CI mirroring
+  testing-approach-correctness-gates. Keep declared intentional differences
+  (Q2 LIMIT) in one reviewable structure.
+
+anti_patterns:
+  - "DO NOT write a new result comparator - because validate_variant_equivalence already exists - reuse it."
+  - "DO NOT turn the gate into a full stress matrix - because routine develop PRs must stay cheap - keep one bounded small-SF DuckDB cell like testing-approach-correctness-gates."
+  - "DO NOT hardcode per-query exceptions inline in the assert - because they rot invisibly - declare intentional non-equivalences (Q2 LIMIT) as reviewable data."
+  - "DO NOT assert exact equality where the variant family intentionally differs (Q2 LIMIT) - because the gate would be permanently red - model the exception explicitly."
+
+verification:
+  - description: "Report-mode harness flags q2_v10 and would flag the #756 variants if reverted"
+    command: "uv run -- python -m pytest tests/integration/test_tpchavoc_duckdb.py -k equivalence -q"
+    expected_output: "q2_v10 reported as divergent; reverting any #756 fix reproduces a divergence"
+  - description: "Bounded gate fails on a deliberately reintroduced self-binding"
+    command: "temporarily revert ps2.ps_partkey=partsupp.ps_partkey then run the gate"
+    expected_output: "gate FAILS (non-zero), naming the divergent query/variant"
+
+scope_limit:
+  only_modify:
+    - "tests/integration/test_tpchavoc_duckdb.py"
+    - "tests/unit/core/tpchavoc/"
+    - "benchbox/core/tpchavoc/"
+    - ".github/workflows/"
+    - "Makefile"
+
+open_questions:
+  - question: "How are intentional non-equivalences (e.g. the q2 family omitting canonical Q2's LIMIT 100) declared so the gate stays meaningful without per-query inline hacks?"
+    gating: true
+    affects: ["w1 success_metric: every variant equivalence-checked"]
+    default: "A single reviewable mapping of {query: exception-kind} consulted by the harness; LIMIT differences compared as set-equality against canonical-without-LIMIT."
+  - "Is the routine gate DuckDB-only sufficient, or must a second engine sample shared-SQL equivalence given variants run on all platforms?"
+  - "Should the gate also run the canonical query, or load stored expected results from expected_results/ to avoid double execution cost?"
+  - question: "Landing order vs the q2_v10 fix: w0/w1 (report harness) are independent and should run first to enumerate the full divergence set, but the w3 gate-flip will turn CI red unless tpchavoc-q2-v10-projection-faithfulness (and any other w1 finding) has landed. Sequence so the assertion flips only after the burndown."
+    gating: true
+    affects: ["w3 success_metric: gate green on develop"]
+    default: "Build/report (w0-w1) first; land the q2_v10 fix; only then flip w3 to a hard assertion. No hard inter-item dep, to avoid blocking discovery."
+
+success_metrics:
+  - "Every implemented TPC-Havoc SQL variant is result-equivalence-checked against canonical TPC-H in a bounded gate."
+  - "All current divergences are fixed or explicitly declared; the gate is green on develop."
+  - "Reintroducing a self-binding or projection-faithfulness divergence fails CI."
+
+metadata:
+  tags: [tpchavoc, testing, correctness, oracle, ci, equivalence]
+  estimated_effort: "Medium"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"


### PR DESCRIPTION
## Summary

Three new planning TODOs capturing the systemic issues and open questions surfaced while implementing `tpchavoc-correlated-subquery-self-binding` (merged in #756). Authored to the repo TODO schema and the documented `/todo review` rubric.

The unifying root cause: **benchbox already ships `validate_variant_equivalence` (`benchbox/core/tpchavoc/benchmark.py:242`), but nothing in the default run or CI ever calls it for a real variant** — it's exercised only by unit tests with synthetic inputs, and `--validate-results` is opt-in. So TPC-Havoc's structurally-diverse variants execute "100% green" while their *semantic equivalence* — the entire point of the benchmark — is never checked. That's why four defects stayed silent (the three self-binding fixes in #756, plus a fourth, different-class divergence found during its verification).

## TODOs added

| File | Priority | Addresses |
|---|---|---|
| `tpchavoc-variant-equivalence-gate.yaml` | High | The systemic blind spot — wire the existing validator into a bounded, CI-affordable equivalence gate; enumerate divergences (report → burndown → gate). Also captures the cross-platform and execution-only-design questions. |
| `tpchavoc-q2-v10-projection-faithfulness.yaml` | Medium-High | The concrete second-class defect found verifying #756: `q2_v10` zeroes negative `s_acctbal` via a CASE-wrapped projection (38/460 rows differ from canonical Q2 at SF1), plus a sweep for the projection-faithfulness defect *class* (distinct from self-binding). |
| `correlated-subquery-self-binding-cross-surface-audit.yaml` | Medium | Extend the self-binding audit to the **DataFrame** variants and **other SQL benchmarks** (TPC-DS, SSB, join-order, read/write-primitives), plus a durable sqlglot-based detector and the variant-provenance question. |

These are **complementary to** the existing `testing-approach-correctness-gates` / `testing-approach-oracle-hardening` TODOs (those validate TPC-H *answers*; these validate TPC-Havoc *cross-variant equivalence*) — cross-referenced in `prior_art`, and they reuse the existing validator and `expected_results` loader rather than building new machinery.

## Review performed

- `validate_todo.py` (the actual CI gate, non-strict) — **all three valid**.
- `todo_cli.py check-graph` — **passed** (no cycles, no dangling references across 66 items).
- Applied the documented review rubric. One finding self-corrected: TODO 1 originally declared an item-level `deps.needs` on the q2_v10 fix, which over-blocked — the report-mode harness (w1) should run *first* to enumerate the full divergence set. Replaced the hard dep with a gating `open_question` documenting the landing order (build/report → fix → flip the gate assertion).

_Note: `--strict` validation flags the `prior_art`/`approach`/`scope_limit` guardrail fields, but those are documented house style (used by 43 existing planning TODOs) and the enforced gate runs non-strict._

No code changes — planning artifacts only.

https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk)_