### PR TITLE
chore(todo): add 5 follow-up TODO items from 2026-06-08 prioritization audit

### DIFF
--- a/_project/TODO/main/planning/todo-add-todo-validation-to-pr-preflight.yaml
+++ b/_project/TODO/main/planning/todo-add-todo-validation-to-pr-preflight.yaml
@@ -1,0 +1,84 @@
+id: todo-add-todo-validation-to-pr-preflight
+title: "Add a pre-commit hook for validate_todo.py to catch invalid TODO YAML at commit time"
+worktree: main
+priority: Medium
+status: Not Started
+category: Developer Tooling
+
+description: |
+  During the 2026-06-08 TODO prioritization pass, 6 priority fields were edited
+  and committed without running validate_todo.py first. The PR gate already
+  handles this: pr-content-guard runs validate_todo.py on each changed TODO path
+  when the diff routes to the content-only CI path. So PR merges are protected.
+
+  The gap is at commit time: an author can commit an invalid YAML locally (before
+  pushing or opening a PR) and only discover the error in CI. Adding a pre-commit
+  hook closes this gap by failing the commit immediately.
+
+  Separately, the current pr-content-guard validates only changed files. A mass
+  edit outside a PR (e.g. a direct push to a feature branch) could introduce
+  invalid YAML in unreviewed files. Belt-and-suspenders: add a validate --all
+  step to pr-preflight for the content-only code path as well.
+
+work:
+  - id: w1
+    summary: "Add validate_todo.py as a pre-commit hook for TODO/DONE YAML paths"
+    status: pending
+    notes: |
+      Check .pre-commit-config.yaml for the pattern used by other local hooks
+      (e.g. the existing check-yaml hook). Add an entry that runs:
+        uv run --project _project/scripts -- python _project/scripts/validate_todo.py {file}
+      scoped to files matching _project/TODO/**/*.yaml and _project/DONE/**/*.yaml.
+
+  - id: w2
+    summary: "Add validate_todo.py --all to pr-preflight content path as belt-and-suspenders"
+    needs: [w1]
+    status: pending
+    notes: |
+      pr-content-guard already validates changed files. Add --all to catch
+      any files outside the diff that may have been corrupted by a direct edit.
+      Insert after the existing todo.txt loop in pr-content-guard:
+        uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+
+  - id: w3
+    summary: "Verify: introduce a deliberate invalid priority value, confirm both gates fire"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      (a) Edit a TODO file locally, set priority to "Invalid", run git commit →
+          should fail at pre-commit hook.
+      (b) Skip the hook with --no-verify, push, open a PR → should fail in
+          pr-content-guard / pr-preflight.
+
+prior_art:
+  - ".pre-commit-config.yaml: existing local hooks pattern to follow"
+  - "Makefile:pr-content-guard — already validates changed TODO files; extend with --all"
+  - "_project/scripts/validate_todo.py: accepts single path or --all"
+
+must_preserve:
+  - "Existing pre-commit hooks continue to fire in the same order"
+  - "validate_todo.py --all exit code 0 when all current files are valid"
+  - "pr-content-guard continues to validate per-changed-file first (fail fast on the diff)"
+
+verification:
+  - description: "Commit with invalid priority value rejected by pre-commit hook"
+    command: "git commit -m 'test'"
+    expected_output: "pre-commit hook failure citing the invalid priority enum"
+  - description: "All current TODO files pass --all with no changes"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all"
+    expected_output: "0 errors"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - tooling
+    - ci
+    - pre-commit
+    - todo-system
+
+impact:
+  technical_debt: |
+    Without a pre-commit hook, schema violations are discovered in CI rather
+    than locally, adding a push-and-wait cycle to every TODO authoring mistake.
+    The PR gate already catches merges; this closes the earlier commit-time gap.

--- a/_project/TODO/main/planning/todo-backcompat-removal-matrix-formalize.yaml
+++ b/_project/TODO/main/planning/todo-backcompat-removal-matrix-formalize.yaml
@@ -1,0 +1,80 @@
+id: todo-backcompat-removal-matrix-formalize
+title: "Decide fate of remove-alpha-backward-compatibility-surface-removal-matrix.md in main/active/"
+worktree: main
+priority: Low
+status: Not Started
+category: Repository Maintenance
+
+description: |
+  `_project/TODO/main/active/remove-alpha-backward-compatibility-surface-removal-matrix.md`
+  is a Markdown file with 88 tracked backward-compatibility removal entries
+  across 35 modules. It lives in the `active/` lifecycle directory, implying
+  it is in-progress work, but it is not a YAML file and is therefore invisible
+  to todo_cli.py, validate_todo.py, and the index system.
+
+  As a result:
+  - It has no priority, owner, status, or work breakdown tracked by tooling
+  - Its 88 entries cannot be queried, filtered, or linked via deps.needs
+  - It won't appear in `make pr-preflight` validation sweeps after
+    todo-add-todo-validation-to-pr-preflight lands
+
+  One of three outcomes is needed:
+  1. Convert to a YAML TODO with work units for each module cluster
+  2. Keep as .md but add a YAML companion TODO that tracks the sweep work
+     and explicitly cites the .md as its scope document
+  3. Explicitly move it out of the TODO tree (e.g. into _project/docs/ or
+     a tracking issue) with a note that it is managed outside the TODO system
+
+work:
+  - id: w1
+    summary: "Read the .md file and assess how much work remains vs. is already done"
+    status: pending
+    notes: |
+      File: _project/TODO/main/active/remove-alpha-backward-compatibility-surface-removal-matrix.md
+      Count entries by 'active' vs 'deprecate' status. Estimate remaining effort.
+
+  - id: w2
+    summary: "Choose one of the three formalization options and document the decision"
+    needs: [w1]
+    status: pending
+    notes: |
+      Decision rule based on w1 counts:
+        - If >70% of entries are 'deprecate' or already-removed: choose option 3
+          (move .md to _project/docs/backward-compat/ and close). The work is
+          essentially done and doesn't need ongoing TODO tracking.
+        - If 30-70% remain 'active' and fit in 1-2 sessions: choose option 2
+          (add a YAML companion TODO citing the .md as scope doc; keep .md as-is).
+        - If <30% done and work spans multiple sessions: choose option 1
+          (convert .md to YAML with one work unit per module cluster).
+
+  - id: w3
+    summary: "Execute the chosen option"
+    needs: [w2]
+    status: pending
+
+prior_art:
+  - "_project/TODO/main/active/: examine other active/ YAML items for companion-TODO convention"
+  - "_project/TODO_ENTRY_TEMPLATE.yaml: use for any new YAML wrapper"
+
+must_preserve:
+  - "The 88 removal entries themselves are not lost — only their container changes"
+  - "If converted to YAML, the individual file paths and removal actions remain traceable"
+
+verification:
+  - description: "No .md files remain directly under any TODO lifecycle directory"
+    command: "find _project/TODO -name '*.md' -not -name 'README.md'"
+    expected_output: "Empty (or only README.md files)"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - housekeeping
+    - todo-system
+    - backward-compatibility
+
+impact:
+  technical_debt: |
+    An untracked .md in the active/ directory creates a hidden work item
+    that evades priority tracking, ownership, and CI validation. The longer
+    it stays invisible to tooling, the more likely it is to be forgotten.

--- a/_project/TODO/main/planning/todo-post-748-capture-status-audit.yaml
+++ b/_project/TODO/main/planning/todo-post-748-capture-status-audit.yaml
@@ -1,0 +1,99 @@
+id: todo-post-748-capture-status-audit
+title: "Audit and update TODO statuses staled by PRs #748-#759 (capture wiring, tpchavoc, output-root)"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  During the 2026-06-08 prioritization pass the develop branch tip was PR #748.
+  By the time the follow-up TODO files were authored, PRs #749-#759 had also
+  landed, including at least three that directly close or partially close open
+  TODO items:
+
+  - PR #748: wired query plan capture for PostgreSQL, Redshift, DataFusion,
+    SQLite, MotherDuck — likely completes query-plan-capture-datafusion-sqlite
+    (High) and query-plan-capture-postgresql-family (High), partially addresses
+    motherduck-cloud-features
+  - PR #756: fix(tpchavoc): qualify correlated-subquery self-binding —
+    likely completes tpchavoc-correlated-subquery-self-binding (Medium-High)
+  - PR #759: propagate benchmark output roots before generators are built —
+    likely completes benchmark-runs-output-root-propagation (Critical)
+
+  Audit each affected TODO against the actual PR diffs, update statuses, move
+  fully-completed items to the DONE tree, and adjust priorities for items where
+  the scope has changed. High/Critical items that are actually done inflate
+  perceived backlog urgency and distort prioritization.
+
+work:
+  - id: w0
+    summary: "Review PRs #748, #756, #759 diffs and commit messages for scope"
+    status: pending
+    notes: |
+      For each PR: gh pr view <N> --json body,files,commits
+      Identify which TODO items are fully vs. partially addressed.
+      PR #748: query plan capture adapters (PostgreSQL, Redshift, DataFusion, SQLite, MotherDuck)
+      PR #756: tpchavoc correlated-subquery self-binding fix
+      PR #759: benchmark output root propagation
+
+  - id: w1
+    summary: "Cross-reference affected TODOs against PR scopes"
+    needs: [w0]
+    status: pending
+    notes: |
+      Files to cross-reference:
+        TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+        TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+        TODO/platform-expansion/active/motherduck-cloud-features.yaml
+        TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
+        TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
+        TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
+        TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
+        TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+        TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+        TODO/main/planning/benchmark-runs-output-root-propagation.yaml
+      For each: status correct? scope still valid? work units still pending?
+
+  - id: w2
+    summary: "Update status and move Completed items to DONE tree"
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: "Update priority or description for items with changed scope"
+    needs: [w1]
+    status: pending
+
+  - id: w4
+    summary: "Run validate_todo.py --all and regenerate indexes"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+
+prior_art:
+  - "TODO/platform-expansion/planning/query-plan-capture-*.yaml: the cluster to audit"
+  - "TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml: check against PR #756"
+  - "TODO/main/planning/benchmark-runs-output-root-propagation.yaml: check against PR #759"
+
+must_preserve:
+  - "Items only partially addressed by these PRs remain open with updated description"
+  - "Cross-item deps that reference audited items remain consistent after moves to DONE"
+
+verification:
+  - description: "No affected items remain Not Started if they were fully resolved"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py list --status='Not Started'"
+    expected_output: "query-plan-capture-datafusion-sqlite, postgresql-family, tpchavoc-correlated-subquery-self-binding, and benchmark-runs-output-root-propagation absent if fully done"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - query-plan-capture
+    - housekeeping
+    - todo-system
+
+impact:
+  business_value: |
+    At least 4 open items (2 High, 1 Medium-High, 1 Critical) may already be done.
+    Leaving them open overstates urgency and misleads future prioritization passes.

--- a/_project/TODO/main/planning/todo-priority-criteria-definition.yaml
+++ b/_project/TODO/main/planning/todo-priority-criteria-definition.yaml
@@ -1,0 +1,77 @@
+id: todo-priority-criteria-definition
+title: "Document concrete criteria for Critical vs High vs Medium-High priority levels"
+worktree: main
+priority: Low
+status: Not Started
+category: Process and Workflow
+
+description: |
+  The 2026-06-08 prioritization audit found no written criteria for the five
+  priority levels anywhere in the project docs. Without them, each author
+  applies the schema subjectively — items with similar impact land at different
+  tiers depending on who filed them, and automated agents cannot reason about
+  whether a given priority is correct.
+
+  Add a "Priority Definitions" section to TODO/README.md with a one-line
+  definition, a key distinguishing question, and 1-2 backlog examples for each
+  level (Critical / High / Medium-High / Medium / Low).
+
+work:
+  - id: w1
+    summary: "Survey the 2 Critical and top-5 High items to extract the implicit criteria"
+    status: pending
+    notes: |
+      Read: TODO/main/active/release-recovery-v0-3-1.yaml (Critical)
+            TODO/main/planning/benchmark-runs-output-root-propagation.yaml (Critical)
+      Read 5 representative High items. Identify what distinguishes Critical
+      from High (e.g., release-blocking? data-loss risk? production outage?).
+
+  - id: w2
+    summary: "Draft priority criteria table for README.md"
+    needs: [w1]
+    status: pending
+    notes: |
+      Proposed structure per level:
+        - One-line definition
+        - Key question to ask
+        - 1-2 examples from the actual backlog
+
+  - id: w3
+    summary: "Add an optional 'priority_rationale' comment to TODO_ENTRY_TEMPLATE.yaml"
+    needs: [w2]
+    status: pending
+    notes: |
+      A short inline comment above the priority field with a one-liner
+      reminder of what each level means, so authors see it at authoring time.
+
+  - id: w4
+    summary: "Update TODO/README.md with the Priority Definitions section"
+    needs: [w2]
+    status: pending
+
+prior_art:
+  - "_project/TODO/README.md: extend, do not replace"
+  - "_project/TODO_ENTRY_TEMPLATE.yaml: optional inline comment addition"
+
+must_preserve:
+  - "README.md existing sections remain intact"
+  - "TODO_ENTRY_TEMPLATE.yaml remains valid YAML after any inline comment additions"
+
+verification:
+  - description: "README.md contains a Priority Definitions section with criteria for all 5 levels"
+    command: "grep -A 30 'Priority Definitions' _project/TODO/README.md"
+    expected_output: "Definitions for Critical, High, Medium-High, Medium, Low each present"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - documentation
+    - process
+    - todo-system
+
+impact:
+  technical_debt: |
+    Undocumented priority criteria mean future prioritization passes (by
+    humans or agents) will be inconsistent and require repeated discussion.
+    A one-page definition eliminates the ambiguity permanently.

--- a/_project/TODO/main/planning/todo-sweep-completed-items-from-open-tree.yaml
+++ b/_project/TODO/main/planning/todo-sweep-completed-items-from-open-tree.yaml
@@ -1,0 +1,74 @@
+id: todo-sweep-completed-items-from-open-tree
+title: "Sweep planning/ directories for items with status: Completed and move them to DONE"
+worktree: main
+priority: Low
+status: Not Started
+category: Repository Maintenance
+
+description: |
+  The 2026-06-08 TODO prioritization pass discovered that
+  `uat-clickhouse-server-rc1-recovery` has `status: Completed` but still
+  lives in `TODO/main/planning/`. Subsequent PRs #756 and #759 landed fixes
+  for `tpchavoc-correlated-subquery-self-binding` and
+  `benchmark-runs-output-root-propagation` respectively — both items may now
+  be Completed as well. The w0 re-validate step must be run first to get the
+  current count before moving anything.
+
+  Items left in planning/ or active/ after completion bloat the open count,
+  distort priority distributions, and can mislead automated or human triage.
+  Sweep all planning/ and active/ directories for Completed items and move
+  them to the appropriate DONE tree.
+
+work:
+  - id: w0
+    summary: "Re-validate: confirm which items have status: Completed in the open tree"
+    status: pending
+    notes: |
+      Run: uv run --project _project/scripts -- python _project/scripts/todo_cli.py list --status=completed
+      Capture output. As of 2026-06-08 at authoring time: uat-clickhouse-server-rc1-recovery
+      was the only confirmed case, but PRs #756 (tpchavoc self-binding fix) and
+      #759 (output-root propagation) have since landed and may have added more.
+      Also check: tpchavoc-correlated-subquery-self-binding and
+      benchmark-runs-output-root-propagation.
+
+  - id: w1
+    summary: "Move each confirmed-Completed item to the DONE tree"
+    needs: [w0]
+    status: pending
+    notes: |
+      Check _project/DONE/ structure for the destination convention.
+      Add a completed_date to each moved file matching status-change evidence
+      where available.
+
+  - id: w2
+    summary: "Run validate_todo.py --all; regenerate indexes"
+    needs: [w1]
+    status: pending
+    notes: |
+      uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+      Then: make todo-reindex
+
+prior_art:
+  - "_project/DONE/: examine existing entries for the move-to-DONE convention"
+  - "todo_cli.py list --status=completed — use this to find any additional cases"
+
+must_preserve:
+  - "Cross-item deps.needs references that point to moved items must still resolve"
+  - "Moved files retain their original id field (the slug)"
+
+verification:
+  - description: "No Completed items remain in TODO/ directories"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py list --status=completed"
+    expected_output: "0 items"
+
+metadata:
+  created_date: "2026-06-08"
+  estimated_effort: "Small"
+  tags:
+    - housekeeping
+    - todo-system
+
+impact:
+  technical_debt: |
+    Completed items left in open directories cause the priority distribution
+    and open-count metrics to be inflated, making backlog triage less reliable.


### PR DESCRIPTION
## Summary

Five actionable follow-up TODOs captured from the 2026-06-08 prioritization pass and blind-spot review. Each addresses a gap in the TODO system itself or stale backlog state caused by recently landed PRs.

- **`todo-add-todo-validation-to-pr-preflight`** (Medium) — Add a pre-commit hook for `validate_todo.py` so invalid TODO YAML is caught at commit time. `pr-content-guard` already validates changed files per-PR; this closes the earlier commit-time gap. Also adds `--all` sweep to `pr-preflight` as belt-and-suspenders.

- **`todo-sweep-completed-items-from-open-tree`** (Low) — Sweep `planning/` and `active/` for items with `status: Completed` and move them to the DONE tree. `uat-clickhouse-server-rc1-recovery` is confirmed; PRs #756 and #759 may have added `tpchavoc-correlated-subquery-self-binding` and `benchmark-runs-output-root-propagation`.

- **`todo-post-748-capture-status-audit`** (Medium-High) — Audit and update statuses for TODOs staled by PRs #748–#759: query-plan-capture cluster (2 High items), tpchavoc self-binding (Medium-High), output-root propagation (Critical) — all may now be Completed. Stale High/Critical open items distort future prioritization.

- **`todo-priority-criteria-definition`** (Low) — Document explicit criteria for all 5 priority levels in `TODO/README.md`. No written definition exists anywhere; authors apply the schema subjectively, causing inconsistent filing across the backlog.

- **`todo-backcompat-removal-matrix-formalize`** (Low) — Decide the fate of the untracked `.md` removal matrix in `active/` (88 entries, invisible to all TODO tooling). Includes a concrete >70%/>30% threshold rule for choosing between move-out, YAML companion, or full conversion.

## Test plan

- [x] All 5 files pass `validate_todo.py` schema validation
- [x] Pre-commit hooks passed on commit (codespell, check-yaml, fix-eol, trim-whitespace)
- [x] Content-only change — Python fast tests not required

https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX

---
_Generated by [Claude Code](https://claude.ai/code/session_013FzK1DZiUTQRgWWRgtbegX)_