### PR TITLE
Add follow-up TODOs for benchmark output-root propagation

### DIFF
--- a/_project/TODO/main/planning/benchmark-output-root-explicit-override-propagation.yaml
+++ b/_project/TODO/main/planning/benchmark-output-root-explicit-override-propagation.yaml
@@ -1,0 +1,124 @@
+id: benchmark-output-root-explicit-override-propagation
+title: "Propagate explicit --output override to nested generators for tpcds and tpcdi"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: Core Functionality
+
+description: |
+  PR #759 made benchmark datagen roots honor BENCHBOX_OUTPUT_DIR at construction
+  and added GeneratorOutputDirMixin so a post-construction output_dir
+  reassignment propagates to nested generators. Several generator-backed
+  benchmarks (h2odb, ssb, tpch, nyctaxi, etc.) opted into the mixin; a few did
+  not because their generators are lazy or intentionally point elsewhere.
+
+  Two benchmarks build a generator (or derive directories) in __init__ but have
+  no synchronizing output_dir setter, so an explicit CLI --output root that
+  differs from the construction default does NOT reach them:
+
+  - tpcds: builds its data_generator in __init__ and has no output_dir setter, so
+    a post-construction reassignment (runner _resolve_output_dir_handler) leaves
+    the generator pointed at the construction-time path.
+  - tpcdi: derives source_dir/staging_dir/warehouse_dir and builds its
+    data_generator in __init__ from self.config.output_dir; a later output_dir
+    reassignment updates neither the ETL subdirs nor the generator.
+
+  This is a pre-existing residual gap, NOT a regression. The reported failure
+  mode (BENCHBOX_OUTPUT_DIR ignored) is already fixed for both: their
+  construction-time defaults resolve via the env-aware helper (tpcds via its
+  default path, tpcdi via TPCDIConfig.get_benchmark_runs_datagen_path), and in
+  the managed/env flow the runner's reassignment target equals the construction
+  default, so nothing diverges. Only an explicit `--output /custom` that differs
+  from the default exposes the gap.
+
+  Close it so an explicit override propagates correctly for these two
+  benchmarks, matching the contract the mixin already provides elsewhere. NOTE:
+  benchmark-output-root-resolve-at-construction-boundary proposes a deeper fix
+  (resolve the root before construction) that would subsume this item; this is
+  the tactical fix if that refactor is deferred.
+
+prior_art:
+  - "benchbox/base.py:GeneratorOutputDirMixin — reuse/extend; tpcds can adopt it directly (its data_generator is a plain instance attribute)"
+  - "benchbox/core/read_primitives/benchmark.py + benchbox/core/transactional/benchmark_base.py — reuse the existing output_dir setter pattern that re-derives nested state"
+  - "benchbox/core/tpcdi/config.py:TPCDIConfig (output_dir + create_directories) — reuse for re-deriving source/staging/warehouse on reassignment instead of duplicating path math"
+  - "benchbox/core/runner/runner.py:_resolve_output_dir_handler — the post-construction assignment site this fix must satisfy"
+
+work:
+  - id: w0
+    summary: "Confirm the override gap reproduces for tpcds and tpcdi on current develop"
+    status: pending
+    notes: |
+      Construct each, then assign a distinct explicit output_dir and assert the
+      nested generator / ETL subdirs do NOT follow today. Capture the probe to
+      /tmp/override-gap-w0.log (do not commit) and record results in the PR body.
+  - id: w1
+    summary: "Adopt GeneratorOutputDirMixin for tpcds so its data_generator tracks output_dir"
+    needs: [w0]
+    status: pending
+    notes: |
+      tpcds builds data_generator as a plain attribute in __init__, so the mixin
+      applies cleanly. Verify the tpcds_obt source-dir behavior is unaffected
+      (its generator is lazy and intentionally writes to a separate dir).
+  - id: w2
+    summary: "Add a tpcdi output_dir setter that re-derives ETL subdirs and syncs the generator"
+    needs: [w0]
+    status: pending
+    notes: |
+      On reassignment, update source_dir/staging_dir/warehouse_dir and
+      data_generator.output_dir, keeping self.config.output_dir consistent. Guard
+      against running before config exists during __init__.
+  - id: w3
+    summary: "Flip the tpcds/tpcdi xfail markers in the regression guard to passing"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      Coordinate with benchmark-output-root-regression-guard, which marks these
+      two xfail; this work removes the xfail once propagation is fixed.
+
+must_preserve:
+  - "Env/managed-flow behavior for tpcds and tpcdi remains unchanged (construction default already env-aware)."
+  - "tpcds_obt and datavault lazy generators that intentionally write to a separate source dir are NOT force-synced."
+  - "tpcdi data reuse: existing source/staging/warehouse layout names remain compatible."
+
+approach: |
+  Prefer reusing GeneratorOutputDirMixin where the generator is a plain instance
+  attribute (tpcds). For tpcdi, whose layout is config-driven and richer than a
+  single generator, add a focused property setter that re-derives the ETL
+  directories rather than shoehorning it into the mixin. Land tests first that
+  fail on the current tree.
+
+anti_patterns:
+  - "DO NOT blanket-sync every generator attribute - because tpcds_obt/datavault intentionally diverge - only sync generators that should follow the OBT/primary output root."
+  - "DO NOT duplicate ETL path math in the tpcdi setter - because TPCDIConfig already owns it - delegate to the config helpers."
+
+verification:
+  - description: "Explicit override now propagates for tpcds and tpcdi"
+    command: "uv run -- python -m pytest tests/unit/core/test_benchmark_output_root_propagation.py -q"
+    expected_output: "tpcds and tpcdi override cases pass (previously xfail)"
+  - description: "tpcds and tpcdi unit suites still pass"
+    command: "uv run -- python -m pytest tests/unit/core/tpcds tests/unit/core/tpcdi -q"
+    expected_output: "all tests pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpcds/"
+    - "benchbox/core/tpcdi/"
+    - "tests/unit/core/"
+  do_not_modify:
+    - "benchbox/core/tpcds_obt/benchmark.py"
+    - "benchbox/core/datavault/benchmark.py"
+    - "benchmark_runs/"
+
+success_metrics:
+  - "Constructing tpcds or tpcdi then assigning a distinct --output root leaves no nested generator or ETL subdir pointed at the construction-time default."
+  - "No change to env/managed-flow output locations for any benchmark."
+
+deps:
+  needs:
+    - benchmark-runs-output-root-propagation
+
+metadata:
+  tags: [output-paths, datagen, tpcds, tpcdi, benchmark-runs]
+  estimated_effort: "Medium"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"

--- a/_project/TODO/main/planning/benchmark-output-root-regression-guard.yaml
+++ b/_project/TODO/main/planning/benchmark-output-root-regression-guard.yaml
@@ -1,0 +1,138 @@
+id: benchmark-output-root-regression-guard
+title: "Registry-wide regression guard for benchmark output-root propagation"
+worktree: main
+priority: High
+status: "Not Started"
+category: Testing and Quality Assurance
+
+description: |
+  PR #759 fixed the lifecycle-ordering bug where generator-backed benchmarks
+  ignored BENCHBOX_OUTPUT_DIR and wrote datagen output under a worktree-local
+  benchmark_runs/. The fix made BaseBenchmark's default datagen root env-aware
+  and added an opt-in GeneratorOutputDirMixin that propagates a resolved root to
+  nested generators. The accompanying tests
+  (tests/unit/core/test_benchmark_output_root_propagation.py,
+  tests/unit/mcp/test_benchmark_output_root_propagation.py) only assert a
+  hand-picked subset of benchmark families.
+
+  The footgun is structural: a new generator-backed benchmark that builds its
+  generator in __init__ and forgets the mixin (or hardcodes
+  Path.cwd()/"benchmark_runs") silently reintroduces the original bug, and no
+  test or lint catches it. A one-off manual probe across all 24 registered
+  benchmarks confirmed the contract currently holds, but that evidence is not
+  durable.
+
+  Convert that probe into a registry-driven regression guard so the contract is
+  enforced for every current and future benchmark, and add a cheap static guard
+  that fails when a benchmark constructor hardcodes a cwd-local benchmark_runs
+  default instead of the shared resolver.
+
+prior_art:
+  - "tests/unit/core/test_benchmark_output_root_propagation.py — extend the per-family assertions into a registry-parametrized form rather than adding a parallel test file"
+  - "benchbox/core/benchmark_registry.py:get_all_benchmarks / get_public_benchmark_class — reuse to enumerate every benchmark under test"
+  - "benchbox/utils/path_utils.py:get_benchmark_runs_datagen_path / resolve_benchmark_runs_dir — reuse as the canonical env-aware root for assertions"
+  - "benchbox/base.py:GeneratorOutputDirMixin (OUTPUT_DIR_GENERATOR_ATTRS) — reuse to discover the nested-generator attributes to assert against"
+  - "_project/TODO/main/planning/benchmark-runs-local-artifact-guardrails.yaml — align with the runtime guardrail effort; this item is the test/lint counterpart"
+
+work:
+  - id: w0
+    summary: "Re-validate that every registered benchmark currently honors the env output root"
+    status: pending
+    notes: |
+      Construct each id from get_all_benchmarks() with BENCHBOX_OUTPUT_DIR set to
+      a tmp path and assert output_dir plus any OUTPUT_DIR_GENERATOR_ATTRS
+      generator resolves under it. Capture stdout to /tmp/output-root-guard-w0.log
+      (do not commit) and record the pass count and any exceptions in the PR body.
+  - id: w1
+    summary: "Add a registry-parametrized test asserting env-root honoring at construction for all benchmarks"
+    needs: [w0]
+    status: pending
+    notes: |
+      Parametrize over get_all_benchmarks(). For each, construct via the public
+      class (mirroring the MCP/library entry point) with BENCHBOX_OUTPUT_DIR set;
+      assert output_dir and each present nested generator/downloader resolve under
+      the root and that Path.cwd() is not a parent. Resolve nested generators via
+      _impl when the public wrapper delegates.
+  - id: w2
+    summary: "Add a test asserting post-construction output_dir reassignment propagates to nested generators"
+    needs: [w1]
+    status: pending
+    notes: |
+      For benchmarks that build a generator in __init__, assign a fresh explicit
+      root after construction and assert the nested generator follows. Mark the
+      known non-mixin benchmarks (tpcds, tpcdi) xfail and reference
+      benchmark-output-root-explicit-override-propagation so the gap is tracked,
+      not hidden.
+  - id: w3
+    summary: "Add a static guard that fails on hardcoded cwd-local benchmark_runs defaults in constructors"
+    needs: [w0]
+    status: pending
+    notes: |
+      A unit test (or ruff/grep-based check wired into ci-lint) that scans
+      benchbox/core/**/benchmark.py for Path.cwd()/"benchmark_runs" defaults and
+      fails with guidance to use get_benchmark_runs_datagen_path instead. Allow a
+      documented exception list only for intentional non-datagen paths.
+  - id: w4
+    summary: "Extend coverage to a cloud/dbfs output root through at least one generator-backed benchmark"
+    needs: [w1]
+    status: pending
+    notes: |
+      Assert that a CloudStagingPath/DatabricksPath assigned as the output root
+      propagates to the nested generator without being re-wrapped or losing cloud
+      semantics. Use a mocked/staging path so no live cloud access is required.
+
+deferred:
+  - summary: "Clean up orphaned non-canonical datagen dirs (e.g. nyctaxi_1.0) left by direct library users before PR #759 canonicalized the names"
+    reason: "Cleanup of existing on-disk artifacts belongs to benchmark-runs-duplicate-artifact-cleanup, not this regression-guard item."
+  - summary: "Runtime/UAT guardrail that fails a run when worktree-local benchmark_runs writes appear despite an external output root"
+    reason: "That filesystem-at-runtime assertion is owned by benchmark-runs-local-artifact-guardrails; this item is the unit-test + static-source counterpart (construction contract and hardcoded-default lint)."
+
+must_preserve:
+  - "The existing per-family assertions in test_benchmark_output_root_propagation.py keep passing (extend, do not delete)."
+  - "tests remain in the fast lane and write nothing under the active worktree."
+
+approach: |
+  Build the guard on top of the registry so it auto-covers new benchmarks. Reuse
+  the helper functions already in the propagation test for resolving nested
+  generators. Prefer xfail with an explicit reason over skipping for the known
+  tpcds/tpcdi override gap, so the tracker shows the residual work.
+
+anti_patterns:
+  - "DO NOT hand-list benchmark ids - because the point is to auto-cover future benchmarks - enumerate via get_all_benchmarks() instead."
+  - "DO NOT assert only benchmark.output_dir - because the original bug lived in nested generators - assert the nested generator/downloader paths too."
+
+verification:
+  - description: "New registry-wide propagation tests pass"
+    command: "uv run -- python -m pytest tests/unit/core/test_benchmark_output_root_propagation.py tests/unit/mcp/test_benchmark_output_root_propagation.py -q"
+    expected_output: "all tests pass; every registered benchmark is parametrized"
+  - description: "Static guard fails on a deliberately hardcoded cwd default"
+    command: "uv run -- python -m pytest tests/unit/core/test_benchmark_output_root_guard.py -q"
+    expected_output: "guard passes on current tree and fails when a benchmark hardcodes Path.cwd()/benchmark_runs"
+  - description: "Fast suite still passes"
+    command: "uv run -- python -m pytest -m fast -q"
+    expected_output: "no new failures attributable to this change"
+
+scope_limit:
+  only_modify:
+    - "tests/unit/core/"
+    - "tests/unit/mcp/"
+    - "Makefile"
+    - ".github/workflows/lint.yml"
+  do_not_modify:
+    - "benchbox/base.py"
+    - "benchmark_runs/"
+
+success_metrics:
+  - "Every id returned by get_all_benchmarks() is exercised by the env-root construction test."
+  - "A deliberately reintroduced cwd-local default fails the static guard."
+  - "The tpcds/tpcdi override gap is visible as an xfail referencing its tracking TODO, not a silent skip."
+
+deps:
+  needs:
+    - benchmark-runs-output-root-propagation
+
+metadata:
+  tags: [output-paths, datagen, testing, regression-guard, benchmark-runs]
+  estimated_effort: "Small-Medium"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"

--- a/_project/TODO/main/planning/benchmark-output-root-resolve-at-construction-boundary.yaml
+++ b/_project/TODO/main/planning/benchmark-output-root-resolve-at-construction-boundary.yaml
@@ -1,0 +1,143 @@
+id: benchmark-output-root-resolve-at-construction-boundary
+title: "Resolve benchmark datagen root at the construction boundary to remove post-construction mutation"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: Core Functionality
+
+description: |
+  PR #759 fixed the output-root propagation bug with two cooperating mechanisms:
+  an env-aware default in BaseBenchmark, and an opt-in GeneratorOutputDirMixin
+  whose setter re-syncs nested generators when output_dir is reassigned after
+  construction. This works, but it leaves the original architectural smell that
+  the TODO's w2 explicitly preferred to fix: the orchestrator still constructs
+  the benchmark BEFORE the final output root is resolved, then mutates
+  benchmark.output_dir afterward (orchestrator data-sharing redirect, runner
+  _resolve_output_dir_handler).
+
+  Consequences of keeping post-construction mutation as the contract:
+
+  - Footgun: any new generator-backed benchmark that builds its generator in
+    __init__ and forgets the mixin silently reintroduces the bug. The mixin is
+    opt-in, so correctness depends on author memory.
+  - Duplication: GeneratorOutputDirMixin now overlaps with the bespoke output_dir
+    setters in read_primitives/benchmark.py and transactional/benchmark_base.py.
+  - Residual gaps: benchmarks with lazy/derived layouts (tpcds, tpcdi) need the
+    separate explicit-override fix tracked in
+    benchmark-output-root-explicit-override-propagation.
+
+  Investigate resolving the benchmark-specific datagen directory once at the call
+  boundary and injecting it into the constructor, so generators capture the
+  correct root immediately and post-construction mutation (and the mixin) can be
+  retired or reduced to a thin compatibility shim. If adopted, this would subsume
+  the explicit-override item and let the duplicated setters collapse onto one
+  mechanism.
+
+prior_art:
+  - "benchbox/cli/orchestrator.py:_get_benchmark_instance / _resolve_output_root / _resolve_custom_output_root — the construction + resolution sites to reorder"
+  - "benchbox/core/benchmark_loader.py:instantiate_benchmark_class / constructor_accepts_argument — reuse to inject output_dir only where the constructor accepts it"
+  - "benchbox/core/runner/runner.py:_resolve_output_dir_handler — the post-construction mutation this item aims to retire or shrink"
+  - "benchbox/base.py:GeneratorOutputDirMixin and benchbox/core/read_primitives + transactional output_dir setters — candidates to dedupe once mutation is removed"
+  - "benchbox/utils/path_utils.py:get_benchmark_runs_datagen_path — reuse as the single resolver at the boundary"
+
+work:
+  - id: w0
+    summary: "Map every site that constructs a benchmark then mutates output_dir"
+    status: pending
+    notes: |
+      Enumerate orchestrator, runner, MCP, UAT runner, and direct test
+      constructors. For each, record whether the final root is knowable before
+      construction and what currently blocks passing it in (e.g. data-sharing
+      source resolution needing an instance).
+  - id: w1
+    summary: "Resolve the data-source root without a constructed instance"
+    needs: [w0]
+    status: pending
+    notes: |
+      get_data_source_benchmark() is currently an instance method, which forces
+      construct-then-redirect for read/write/transaction primitives. Evaluate a
+      class-level/registry lookup so the shared datagen dir is resolvable before
+      construction.
+  - id: w2
+    summary: "Inject the resolved datagen dir into constructors at the orchestrator/runner boundary"
+    needs: [w1]
+    status: pending
+    notes: |
+      Pass output_dir through instantiate_benchmark_class where accepted. Preserve
+      CLI --output precedence over BENCHBOX_OUTPUT_DIR and the cwd fallback when
+      neither is set.
+  - id: w3
+    summary: "Retire or shrink post-construction mutation and dedupe the output_dir setters"
+    needs: [w2]
+    status: pending
+    notes: |
+      Once construction receives the final root, reduce _resolve_output_dir_handler
+      to a no-op/compat shim and collapse GeneratorOutputDirMixin and the
+      read_primitives/transactional setters onto a single mechanism, keeping a
+      compatibility path for external callers that still assign output_dir.
+
+deferred:
+  - summary: "Cloud staging path (CloudStagingPath/DatabricksPath) construction-time injection edge cases"
+    reason: "Cloud roots resolve later via credentials in _apply_default_cloud_output_dir; needs its own analysis once the local-path boundary is settled."
+
+must_preserve:
+  - "CLI --output remains the highest-precedence output root."
+  - "BENCHBOX_OUTPUT_DIR remains the shared-root mechanism; cwd-local default preserved when neither is set."
+  - "External callers that still assign benchmark.output_dir after construction continue to work (compatibility shim)."
+  - "Data-sharing benchmarks (read/write/transaction primitives) keep reusing the source benchmark's datagen dir."
+
+approach: |
+  Treat this as an architecture-altitude change: prefer generalizing the
+  resolve-once-at-boundary mechanism over layering more per-class setters. Land
+  it behind the regression guard from benchmark-output-root-regression-guard so
+  any behavior drift is caught. Sequence: prove the data-source root is
+  resolvable pre-construction, inject at the boundary, then simplify the now-
+  redundant mutation/setters.
+
+anti_patterns:
+  - "DO NOT remove the output_dir setter compatibility path outright - because external/library callers assign it post-construction - keep a thin shim."
+  - "DO NOT add a third resolution helper - because get_benchmark_runs_datagen_path already exists - resolve through it at the boundary."
+
+verification:
+  - description: "Output-root regression guard passes after the refactor"
+    command: "uv run -- python -m pytest tests/unit/core/test_benchmark_output_root_propagation.py tests/unit/mcp/test_benchmark_output_root_propagation.py -q"
+    expected_output: "all propagation tests pass with no xfails remaining for generator-backed benchmarks"
+  - description: "Orchestrator/runner and data-sharing suites pass"
+    command: "uv run -- python -m pytest tests/unit/cli/test_orchestrator_data_sharing.py tests/unit/core/test_runner_helpers.py -q"
+    expected_output: "all tests pass"
+  - description: "Fast suite passes"
+    command: "uv run -- python -m pytest -m fast -q"
+    expected_output: "no new failures"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/orchestrator.py"
+    - "benchbox/core/benchmark_loader.py"
+    - "benchbox/core/runner/"
+    - "benchbox/base.py"
+    - "benchbox/core/read_primitives/benchmark.py"
+    - "tests/unit/"
+  do_not_modify:
+    - "benchmark_runs/"
+
+success_metrics:
+  - "Generator-backed benchmarks receive their final datagen root at construction; no nested generator depends on post-construction mutation for correctness."
+  - "GeneratorOutputDirMixin and the read_primitives/transactional setters are unified onto one mechanism (or the mixin becomes a thin shim)."
+  - "benchmark-output-root-explicit-override-propagation is rendered unnecessary (tpcds/tpcdi correct without a bespoke setter)."
+
+open_questions:
+  - question: "Can the data-source datagen root be resolved without constructing the benchmark (get_data_source_benchmark is currently an instance method)?"
+    gating: true
+    affects: ["w1", "w2"]
+    default: "Keep construct-then-redirect only for data-sharing benchmarks; inject at construction for all others."
+  - "Should the output_dir setter remain a supported public API for library users, or be deprecated with a migration window?"
+
+deps:
+  needs:
+    - "benchmark-output-root-regression-guard"
+
+metadata:
+  tags: [output-paths, datagen, architecture, orchestrator, benchmark-runs]
+  estimated_effort: "Large"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00"


### PR DESCRIPTION
## Summary

Captures the follow-ups, blind spots, and architectural questions identified after PR #759 (*Propagate benchmark output roots before generators are built*) as three schema-valid TODO entries under `_project/TODO/main/planning/`.

This PR adds **planning artifacts only** — no runtime code changes.

### New TODOs

1. **`benchmark-output-root-regression-guard`** (High) — Convert the one-off manual probe into a registry-parametrized regression test so *every* current and future benchmark is asserted to honor the configured output root (env at construction + propagation on post-construction reassignment), plus a static-source guard that fails when a benchmark constructor hardcodes a `Path.cwd()/"benchmark_runs"` default. Marks the known `tpcds`/`tpcdi` `--output` override gap as `xfail` referencing TODO 2 (visible, not silently skipped).

2. **`benchmark-output-root-explicit-override-propagation`** (Medium) — Close the residual gap where an explicit `--output` root that differs from the construction default does not propagate to the nested generators of the non-mixin benchmarks: `tpcds` (adopt `GeneratorOutputDirMixin`) and `tpcdi` (add a setter that re-derives the ETL `source`/`staging`/`warehouse` dirs). The env/managed flow is already correct; this is the explicit-override case only.

3. **`benchmark-output-root-resolve-at-construction-boundary`** (Medium, Large effort) — Architectural item: resolve the datagen root at the orchestrator/runner boundary and inject it into constructors, retiring post-construction mutation. This removes the opt-in-mixin footgun (a new benchmark that forgets the mixin silently regresses), unifies `GeneratorOutputDirMixin` with the bespoke `read_primitives`/`transactional` setters, and would subsume TODO 2.

### Why these three

- **Blind spot closed:** a registry-wide probe confirmed all 24 benchmarks currently honor the env root, but that evidence wasn't durable — TODO 1 makes it a permanent, auto-extending gate.
- **Residual correctness gap:** the `--output` override path for `tpcds`/`tpcdi` (pre-existing, not a #759 regression) is tracked in TODO 2.
- **Deeper question:** #759 chose "env-aware default + post-construction setter" over the originally-preferred "resolve at the boundary"; TODO 3 charters that architectural change.

Cleanup of already-written duplicate artifacts and the runtime/UAT filesystem guardrail are deliberately **not** duplicated here — they remain owned by the existing `benchmark-runs-duplicate-artifact-cleanup` and `benchmark-runs-local-artifact-guardrails` TODOs, which the new entries cross-reference.

### Validation (the `/todo review` equivalent)

`/todo create` and `/todo review` aren't registered commands in this environment, so the equivalent native machinery was used:

- `validate_todo.py --all` → **1102/1102 valid** (schema + work-unit DAG + cross-item `deps.needs` resolution; per-file validation matches the CI gate in `pr.yml`).
- `todo_cli.py check-graph` → **passed** (no inter-item cycles, no work-unit cycles, no dangling references).
- Semantic review applied the documented axes (`todo-review-semantic-guardrails`): `prior_art` present and verified against real symbols; `w0` re-validate units lead the evidence-citing TODOs; no branch-selection/mutually-exclusive work units; verification commands are single-line and runnable.
- Review corrections applied: clarified TODO 1 vs the existing runtime guardrail TODO (unit/static-source vs runtime/UAT), and added `deps.needs: [benchmark-runs-output-root-propagation]` for provenance, matching the sibling TODOs.

All technical claims were verified against the code on `develop`: `TPCDSBenchmark` builds `data_generator` as a plain attribute with no `output_dir` setter; `TPCDIConfig` resolves via `get_benchmark_runs_datagen_path`; `tpcds_obt`/`datavault` generators are lazy/intentionally separate; `read_primitives`/`transactional` have bespoke setters; `GeneratorOutputDirMixin` exists in `benchbox/base.py`.

https://claude.ai/code/session_01JA1u7r1PywnKmA8BaGU62u

---
_Generated by [Claude Code](https://claude.ai/code/session_01JA1u7r1PywnKmA8BaGU62u)_