### PR TITLE
docs(todo): add follow-up TODOs for query plan capture coverage gaps

### DIFF
--- a/.github/workflows/sync-results-data-to-published.yml
+++ b/.github/workflows/sync-results-data-to-published.yml
@@ -64,8 +64,11 @@ jobs:
         id: drift
         run: |
           # Fail loudly on a missing remote ref — silent fetch failure must
-          # not be misread as "no drift".
-          git fetch origin published-results
+          # not be misread as "no drift". Use an explicit refspec so the
+          # remote-tracking ref origin/published-results is created/updated
+          # in this single-branch clone; a bare `git fetch origin published-results`
+          # only populates FETCH_HEAD and leaves origin/published-results missing.
+          git fetch origin published-results:refs/remotes/origin/published-results
 
           # Direct two-tree compare (no dots): `published-results` is an
           # orphan branch (W2 of the parent TODO force-pushed it to a fresh

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -41,6 +41,29 @@ jobs:
             | grep -v '\.manifest\.json$' \
             | grep -v 'submission-manifest\.json$' \
             || true)
+
+          # Detect changed manifest files separately. A manifest-only PR skips
+          # both validate_submission.py and the corpus inventory check because
+          # CHANGED stays empty — but manifests carry the bundle hash contract,
+          # so a bad manifest edit can merge without verifying the hash. For each
+          # changed manifest, derive its paired bundle path and add it to CHANGED
+          # so the existing validation step covers manifest-only PRs too.
+          CHANGED_MANIFESTS=$(git diff --name-only --diff-filter=ACMR \
+            ${{ github.event.pull_request.base.sha }}...HEAD -- \
+            'results-data/bundles/*.json' 'results-data/bundles/**/*.json' \
+            | grep '\.manifest\.json$' \
+            || true)
+          if [ -n "$CHANGED_MANIFESTS" ]; then
+            while IFS= read -r manifest; do
+              bundle="${manifest%.manifest.json}.json"
+              # Only add if the paired bundle exists and is not already in CHANGED.
+              if git cat-file -e "HEAD:${bundle}" 2>/dev/null \
+                  && ! printf '%s\n' "$CHANGED" | grep -qxF "$bundle"; then
+                CHANGED="${CHANGED:+${CHANGED}$'\n'}${bundle}"
+              fi
+            done <<< "$CHANGED_MANIFESTS"
+          fi
+
           if [ -z "$CHANGED" ]; then
             echo "No bundle files changed."
             echo "has_bundles=false" >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -816,7 +816,7 @@ release-cut:
 	@# staged-for-add by a later git add.
 	@# Curation list: A3 of _project/decisions/single-repo-migration.md.
 	-git rm -rf _project _blog results-data results-explorer .claude .codex .gemini
-	-git rm -f .pre-commit-config.yaml _benchbox_pytest_xdist_safety.py todo.config.yaml skill-sync.yaml skill-sync.lock .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
+	-git rm -f .pre-commit-config.yaml todo.config.yaml skill-sync.yaml skill-sync.lock .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
 	-git rm -f .github/workflows/results-explorer-browser.yml .github/workflows/seed-corpus.yml .github/workflows/sync-results-data-to-published.yml .github/workflows/validate-submission.yml
 	@# Stage only the files update_version.py + generate_changelog_entry.py write.
 	@# Explicit list (not `git add -A`) to avoid staging build/cache artifacts.

--- a/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
+++ b/_project/TODO/benchmark-expansion/planning/approx-analytics-cloud-survey.yaml
@@ -2,7 +2,7 @@ id: approx-analytics-cloud-survey
 title: Approximate Analytics Cloud SQL Survey — read_primitives + SQL write_primitives at SF=0.1/1/10
 worktree: benchmark-expansion
 category: Benchmark Development
-priority: High
+priority: Medium-High
 status: Not Started
 description: |
   Survey approximate analytics support and performance across all major cloud SQL

--- a/_project/TODO/main/planning/data-fetch-concurrent-download-race.yaml
+++ b/_project/TODO/main/planning/data-fetch-concurrent-download-race.yaml
@@ -1,7 +1,7 @@
 id: data-fetch-concurrent-download-race
 title: "Make real-data archive downloads safe under concurrent fetch_data callers"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
+++ b/_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml
@@ -1,7 +1,7 @@
 id: joinorder-trino-primary-key-ddl
 title: "Strip JoinOrder primary-key constraints from Trino CREATE TABLE DDL"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Under Review
 category: Platform Compatibility
 

--- a/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+++ b/_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
@@ -1,7 +1,7 @@
 id: tpchavoc-correlated-subquery-self-binding
 title: "Fix tpchavoc variants whose correlated subqueries silently self-bind to the inner alias"
 worktree: main
-priority: Medium
+priority: Medium-High
 status: Not Started
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
+++ b/_project/TODO/main/planning/uat-certification-rerun-ordering-and-gate.yaml
@@ -1,7 +1,7 @@
 id: uat-certification-rerun-ordering-and-gate
 title: "UAT release-gate re-run: enforce ordering, fresh root, and an explicit approval gate"
 worktree: main
-priority: Medium-High
+priority: High
 status: In Progress
 category: Testing and Quality Assurance
 

--- a/_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml
@@ -140,6 +140,7 @@ scope_limit:
     - "tests/unit/platforms/test_clickhouse_adapter.py"
     - "tests/unit/sql_compat/"
     - "_project/TODO/main/planning/uat-clickhouse-server-ddl-compatibility.yaml"
+    - "_project/compat/inventory.jsonl"
 
 success_metrics:
   - "The affected cells no longer fail during CREATE TABLE."

--- a/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
+++ b/_project/TODO/main/planning/uat-clickhouse-server-rc1-recovery.yaml
@@ -2,7 +2,7 @@ id: uat-clickhouse-server-rc1-recovery
 title: "Recover ClickHouse-server UAT RC-1 after confirmed localhost:9000 refusal"
 worktree: main
 priority: High
-status: Identified
+status: Completed
 category: Platform Expansion
 
 description: |

--- a/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
+++ b/_project/TODO/main/planning/uat-docker-stack-recovery.yaml
@@ -1,7 +1,7 @@
 id: uat-docker-stack-recovery
 title: "Recover UAT Docker stacks: LakeSail startup timeout + empty Docker-OLTP run"
 worktree: main
-priority: Medium-High
+priority: High
 status: In Progress
 category: Platform Expansion
 

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-base-class-refactor.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-base-class-refactor.yaml
@@ -1,0 +1,197 @@
+id: query-plan-capture-base-class-refactor
+title: "Factor repeated plan capture block into a base-class helper"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  The same 6-line plan capture block is copy-pasted verbatim into every adapter
+  that was wired in PRs #748 and #749. As of 2026-06-08, six adapters contain
+  near-identical code:
+
+    DuckDB      benchbox/platforms/duckdb.py:968
+    MotherDuck  benchbox/platforms/motherduck.py:297
+    PostgreSQL  benchbox/platforms/postgresql.py:751
+    Redshift    benchbox/platforms/redshift.py:2119
+    DataFusion  benchbox/platforms/datafusion.py:1531
+    SQLite      benchbox/platforms/sqlite.py:562
+
+  The block looks like:
+    if self.capture_plans [and result.get("status") == "SUCCESS"]:
+        query_plan, plan_capture_time_ms = self.capture_query_plan(conn, query, query_id)
+        if query_plan:
+            result["query_plan"] = query_plan
+            result["plan_fingerprint"] = query_plan.plan_fingerprint
+        if plan_capture_time_ms is not None:
+            result["plan_capture_time_ms"] = plan_capture_time_ms
+
+  Minor variations exist: DuckDB pre-declares variables before the block;
+  PostgreSQL and Redshift guard on status=="SUCCESS" while the other four do not
+  (a separate correctness bug tracked in query-plan-capture-missing-guards).
+
+  The correct fix is to add a helper method to ResultCaptureMixin in
+  benchbox/platforms/base/result_capture.py that encapsulates the pattern:
+
+    def _merge_plan_capture_into_result(
+        self,
+        result: dict,
+        connection: Any,
+        query: str,
+        query_id: str,
+    ) -> None:
+        """Capture query plan and merge fields into result in-place.
+
+        No-op when capture_plans is False or status is not SUCCESS.
+        """
+        if not self.capture_plans or result.get("status") != "SUCCESS":
+            return
+        query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+        if query_plan:
+            result["query_plan"] = query_plan
+            result["plan_fingerprint"] = query_plan.plan_fingerprint
+        if plan_capture_time_ms is not None:
+            result["plan_capture_time_ms"] = plan_capture_time_ms
+
+  This also bakes in the status guard universally, eliminating the inconsistency
+  that the missing-guards TODO addresses at the per-adapter level. If both TODOs
+  are worked in sequence, the missing-guards TODO can be skipped for DataFusion
+  and SQLite (the base helper fixes them implicitly).
+
+  DuckDB's execute_query() also pre-declares `query_plan = None` and
+  `plan_fingerprint = None` before `_build_query_result_with_validation()`.
+  These declarations become unnecessary once the helper moves the logic out.
+  The DuckDB path should be cleaned up as part of this TODO.
+
+prior_art:
+  - "benchbox/platforms/base/result_capture.py:561 — capture_query_plan() base implementation"
+  - "benchbox/platforms/base/result_capture.py:477 — display_query_plan_if_enabled() — existing helper method pattern to follow"
+  - "benchbox/platforms/duckdb.py:968 — canonical existing block; clean up pre-declarations when migrating"
+  - "benchbox/platforms/postgresql.py:750 — has status guard; use as correctness baseline for the new helper"
+
+work:
+  - id: w1
+    summary: "Add _merge_plan_capture_into_result() to ResultCaptureMixin in result_capture.py"
+    status: pending
+    notes: |
+      Add to benchbox/platforms/base/result_capture.py alongside capture_query_plan()
+      and display_query_plan_if_enabled(). The method signature:
+        def _merge_plan_capture_into_result(
+            self,
+            result: dict[str, Any],
+            connection: Any,
+            query: str,
+            query_id: str,
+        ) -> None:
+      The helper must include the status=="SUCCESS" guard so all callers benefit
+      automatically. It must be a no-op when capture_plans is False.
+
+  - id: w2
+    summary: "Replace inline capture blocks in all six adapters with calls to the new helper"
+    needs: [w1]
+    status: pending
+    notes: |
+      For each adapter, replace the inline block with:
+        self._merge_plan_capture_into_result(result_dict, conn, query, query_id)
+      Adapters: duckdb.py, motherduck.py, postgresql.py, redshift.py, datafusion.py, sqlite.py.
+
+      In DuckDB also remove the now-unused pre-declarations:
+        query_plan = None
+        plan_fingerprint = None
+        plan_capture_time_ms = None
+      and the existing `if self.capture_plans:` block that was building these.
+      The local `plan_fingerprint` variable is only used within the capture block
+      itself (line 971) — there is no separate result-dict assembly step that
+      references it. All three pre-declarations can be safely deleted once the
+      block is replaced by `_merge_plan_capture_into_result()`.
+
+  - id: w3
+    summary: "Update tests to cover the new helper and remove per-adapter duplication assertions"
+    needs: [w2]
+    status: pending
+    notes: |
+      The existing per-adapter tests (test_postgresql_plan_capture.py, etc.) already
+      cover the capture behavior via the adapters, so they remain valid. Add a
+      dedicated unit test for _merge_plan_capture_into_result() in
+      tests/unit/platforms/base/test_result_capture.py (or create the file if absent):
+        - Calling with capture_plans=False is a no-op
+        - Calling with status="FAILED" is a no-op (no capture)
+        - Calling with status="SUCCESS" and capture_plans=True merges fields
+        - When capture_query_plan() returns (None, 0.0), result is unchanged
+
+deferred:
+  - summary: "Consolidate display_query_plan_if_enabled + _merge_plan_capture_into_result into a single execute_query() template method"
+    reason: "More invasive refactor that requires changing the execute_query() base signature or adding a Template Method base implementation. Out of scope here; revisit when adding the next 3+ adapter families."
+
+must_preserve:
+  - "All six adapters must continue to populate query_plan, plan_fingerprint, and plan_capture_time_ms identically to today."
+  - "DuckDB execute_query() result dict must not drop any keys currently present."
+  - "capture_plans=False must remain a true no-op (no EXPLAIN issued)."
+  - "Existing plan capture unit tests must pass without modification."
+
+approach: |
+  Add the helper to the base class first (w1) and test it in isolation. Then
+  do a mechanical find-and-replace across the six adapters (w2) — each adapter
+  change is a deletion plus one line. Run the full unit suite after each adapter
+  to catch any variable-name mismatch (the connection variable is named `conn`
+  in some adapters and `connection` in others). Finally update tests (w3).
+
+anti_patterns:
+  - "DO NOT make _merge_plan_capture_into_result() return the result dict — in-place mutation matches the existing pattern and avoids callers having to reassign."
+  - "DO NOT remove the status guard from the helper to satisfy edge cases — every caller should benefit from the guard universally."
+  - "DO NOT land this refactor while some adapters still have un-guarded inline blocks — because that creates a partial state where guards are inconsistently applied — either complete missing-guards first or mark it superseded and land both in the same PR."
+
+verification:
+  - description: "All six adapter plan capture tests still pass after substitution"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_postgresql_plan_capture.py tests/unit/platforms/test_redshift_plan_capture.py tests/unit/platforms/test_datafusion_plan_capture.py tests/unit/platforms/test_sqlite_plan_capture.py tests/unit/platforms/test_duckdb_plan_capture.py -v"
+    expected_output: "All existing tests pass"
+  - description: "New base class helper tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/base/ -v"
+    expected_output: "New _merge_plan_capture_into_result tests pass"
+  - description: "Full unit suite green"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/redshift.py"
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+    - "tests/unit/platforms/base/test_result_capture.py"
+  do_not_modify:
+    - "benchbox/platforms/base/psycopg2_mixin.py"
+    - "benchbox/core/query_plans/"
+
+success_metrics:
+  - "The inline capture block exists in exactly ONE place (result_capture.py) instead of six."
+  - "All six adapters call _merge_plan_capture_into_result() instead of inlining the block."
+  - "status=='SUCCESS' guard is universally enforced for all adapters via the helper."
+  - "0 regressions in the full unit suite."
+
+files_affected:
+  modified:
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/redshift.py"
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+  added:
+    - "tests/unit/platforms/base/test_result_capture.py"
+
+open_questions:
+  - question: "Should query-plan-capture-missing-guards be completed before this refactor, or should this refactor land first and missing-guards be closed as superseded for DataFusion/SQLite?"
+    gating: true
+    affects: ["w2: if refactor lands first, the per-adapter guard additions in missing-guards w1/w2 are redundant; the test additions in missing-guards w6 should be redirected to the base-class helper tests"]
+    default: "Land missing-guards first for the per-adapter test coverage; then refactor supersedes the inline blocks"
+
+metadata:
+  tags: [query-plan, refactor, base-class, result-capture, code-quality]
+  estimated_effort: "Small"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
@@ -1,0 +1,220 @@
+id: query-plan-capture-clickhouse-family
+title: "Implement query plan capture for ClickHouse local, server, and cloud adapters"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  None of the three ClickHouse adapters (clickhouse-local, clickhouse-server,
+  clickhouse-cloud) implement `get_query_plan()`, `get_query_plan_parser()`, or
+  call `capture_query_plan()`. They all inherit from `ClickHouseAdapter` which
+  itself does not add plan support. No ClickHouse parser exists in
+  `benchbox/core/query_plans/parsers/`.
+
+  ClickHouse supports several EXPLAIN variants:
+    - `EXPLAIN PLAN <query>` — logical plan tree (text, terse nodes)
+    - `EXPLAIN PIPELINE <query>` — physical execution pipeline (text)
+    - `EXPLAIN PIPELINE graph=1 <query>` — Graphviz DOT format
+    - `EXPLAIN ESTIMATE <query>` — row/part estimates only
+
+  The most useful for cross-platform comparison is `EXPLAIN PLAN` for logical
+  structure and `EXPLAIN PIPELINE` for physical operators. The plan is returned
+  as plain text with indentation-based tree structure, similar in format to
+  DuckDB's text output mode.
+
+  ClickHouse version note: EXPLAIN was added in ClickHouse 20.6. The three BenchBox
+  ClickHouse modes use different connections:
+    - clickhouse-local: in-process, no server needed
+    - clickhouse-server: self-hosted TCP/HTTP connection
+    - clickhouse-cloud: ClickHouse Cloud HTTP API
+
+  All three should share a common ClickHouseAdapter-level implementation of
+  get_query_plan() and a single ClickHouseQueryPlanParser.
+
+prerequisites:
+  - "ClickHouse ≥20.6 for EXPLAIN PLAN support"
+  - "clickhouse-local binary (bundled in _binaries/ or installed) for clickhouse-local integration"
+  - "Running clickhouse-server instance at localhost:9000 (or configured host) for server integration tests"
+  - "ClickHouse Cloud account + service endpoint + credentials for cloud integration tests (env: CLICKHOUSE_CLOUD_HOST, CLICKHOUSE_CLOUD_USER, CLICKHOUSE_CLOUD_PASSWORD)"
+  - "Unit tests (parser + wiring) can run without any live server using fixture text samples"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/duckdb.py — closest text-format parser; ClickHouse text plan is structurally similar"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface to implement"
+  - "benchbox/platforms/clickhouse_local.py:29 — ClickHouseLocalAdapter class"
+  - "benchbox/platforms/clickhouse_server.py:33 — ClickHouseServerAdapter class"
+  - "benchbox/platforms/duckdb.py:1038 — get_query_plan() implementation pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() pattern"
+
+work:
+  - id: w1
+    summary: "Collect EXPLAIN PLAN and EXPLAIN PIPELINE text samples from ClickHouse"
+    status: pending
+    notes: |
+      Against a live ClickHouse instance (local or server), run:
+        EXPLAIN PLAN SELECT l_orderkey, sum(l_quantity) FROM lineitem GROUP BY l_orderkey
+        EXPLAIN PIPELINE SELECT l_orderkey, sum(l_quantity) FROM lineitem GROUP BY l_orderkey
+      Capture both outputs and record the exact indentation and node-name format.
+      Note the ClickHouse version (SELECT version()). Store as:
+        tests/fixtures/query_plans/clickhouse_explain_plan_sample.txt
+        tests/fixtures/query_plans/clickhouse_explain_pipeline_sample.txt
+      Raw output to /tmp/clickhouse-explain-w1.log.
+
+  - id: w2
+    summary: "Implement ClickHouseQueryPlanParser in benchbox/core/query_plans/parsers/clickhouse.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement the QueryPlanParser abstract interface:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - Parse EXPLAIN PLAN text output (indentation-based tree)
+        - Map ClickHouse operator names to LogicalOperatorType:
+            ReadFromMergeTree / ReadFromMemoryStorage → SCAN
+            Filter → FILTER
+            Aggregating / PartialAggregating → AGGREGATE
+            Join → JOIN
+            Sorting → SORT
+            Expression → EXPRESSION
+            Limit / LimitBy → LIMIT
+            Union → UNION
+        - Use the DuckDB text parser as the structural template since both
+          use indented text trees
+        - Register in parsers/registry.py under dialect="clickhouse"
+
+  - id: w3
+    summary: "Add unit tests for ClickHouseQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_clickhouse_parser.py. Cover:
+        - EXPLAIN PLAN parse produces valid QueryPlanDAG with correct operator types
+        - EXPLAIN PIPELINE parse (if applicable to the same parser)
+        - Operator normalization maps ClickHouse node names to LogicalOperatorType
+        - Malformed input triggers graceful error recovery
+        - Parser registered in registry under "clickhouse" dialect
+
+  - id: w4
+    summary: "Add get_query_plan() to ClickHouseAdapter base class"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      IMPORTANT: The connection object type differs across the three ClickHouse modes
+      and must be confirmed during w1 before writing this implementation:
+        - clickhouse-local: uses chdb (in-process) — connection is likely a
+          chdb.session or similar in-process context, NOT a TCP socket.
+        - clickhouse-server: uses clickhouse-driver over TCP — connection.execute()
+          returns a list of tuples.
+        - clickhouse-cloud: uses clickhouse-connect over HTTP — different API.
+
+      After w1 confirms the actual connection type per mode, implement in the
+      shared ClickHouseAdapter base class (locate via grep for `class ClickHouseAdapter`).
+      If the connection API is uniform across modes (confirm first), use:
+        def get_query_plan(self, connection, query):
+            explain_query = f"EXPLAIN PLAN {query}"
+            # Execute via the mode-appropriate connection API confirmed in w1
+            return <extracted text from result>
+      If connection APIs differ per mode, override get_query_plan() separately
+      in ClickHouseLocalAdapter, ClickHouseServerAdapter, ClickHouseCloudAdapter
+      rather than using a base-class implementation that makes wrong assumptions.
+      Use EXPLAIN PLAN (not PIPELINE) as the default for cross-platform comparison.
+
+  - id: w5
+    summary: "Add get_query_plan_parser() override to ClickHouseAdapter base class"
+    needs: [w2]
+    status: pending
+    notes: |
+      In the same ClickHouseAdapter base used in w4:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.clickhouse import ClickHouseQueryPlanParser
+            return ClickHouseQueryPlanParser()
+      All three adapters (local, server, cloud) inherit this automatically.
+
+  - id: w6
+    summary: "Integrate capture_query_plan() into ClickHouse execute_query() path"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Locate each adapter's execute_query() — or the shared execute_query() if
+      ClickHouseAdapter has one. Add the capture guard after the timed SQL block:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      If clickhouse-local, clickhouse-server, and clickhouse-cloud have separate
+      execute_query() methods, patch each one. Prefer placing the call in the
+      shared base if execution flows through it.
+
+  - id: w7
+    summary: "Add unit tests for ClickHouse adapter plan capture wiring"
+    needs: [w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_clickhouse_plan_capture.py. Cover:
+        - get_query_plan_parser() returns ClickHouseQueryPlanParser for all three modes
+        - execute_query() with capture_plans=True triggers capture (mock connection)
+        - execute_query() with capture_plans=False does not trigger capture
+        - plan_fingerprint present in result dict when capture succeeds
+        - graceful degradation when EXPLAIN returns empty (old ClickHouse versions)
+
+deps:
+  needs: []
+
+must_preserve:
+  - "clickhouse-local, clickhouse-server, and clickhouse-cloud execute_query() result dict shape must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False."
+  - "EXPLAIN PLAN must not be issued when capture_plans=False — ClickHouse EXPLAIN can be expensive for complex queries."
+  - "Changes to the ClickHouseAdapter base class must not break the existing uat-clickhouse-server DDL fix work tracked separately."
+
+approach: |
+  Start with fixture collection (w1) to understand the exact text format.
+  Implement the parser (w2) modeled on the DuckDB text parser, then test it (w3).
+  Add get_query_plan() and get_query_plan_parser() to the shared ClickHouseAdapter
+  base (w4+w5) so all three modes inherit them. Wire capture into execute_query()
+  (w6) and add wiring tests (w7). Do not require a live server for unit tests —
+  use fixtures throughout.
+
+anti_patterns:
+  - "DO NOT use EXPLAIN PIPELINE as the default — pipeline output lacks logical operator names needed for cross-platform comparison."
+  - "DO NOT issue EXPLAIN PLAN during benchmarks when capture_plans=False — always guard with self.capture_plans check."
+  - "DO NOT assume the ClickHouse Python driver returns the same structure for local (chdb/in-process), server (clickhouse-driver/TCP), and cloud (clickhouse-connect/HTTP) connections — confirm each in w1 before writing the base-class implementation."
+  - "DO NOT add a single get_query_plan() to the base class if the connection API is different per mode — override per adapter instead."
+  - "DO NOT reuse or modify the existing DDL compatibility changes in clickhouse/setup.py as part of this TODO — keep plan capture and DDL fix orthogonal."
+
+verification:
+  - description: "ClickHouse parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_clickhouse_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "ClickHouse adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_clickhouse_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/clickhouse_local.py"
+    - "benchbox/platforms/clickhouse_server.py"
+    - "benchbox/platforms/clickhouse_cloud.py"
+    - "benchbox/core/query_plans/parsers/clickhouse.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_clickhouse_parser.py"
+    - "tests/unit/platforms/test_clickhouse_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/clickhouse/setup.py"
+    - "benchbox/sql_compat/rules/ddl_optimize/"
+
+success_metrics:
+  - "ClickHouseQueryPlanParser parses EXPLAIN PLAN text from fixture samples into valid QueryPlanDAG objects."
+  - "All three ClickHouse adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint in the result dict."
+  - "No regressions in existing ClickHouse UAT cells or DDL tests."
+
+metadata:
+  tags: [query-plan, clickhouse, clickhouse-local, clickhouse-server, clickhouse-cloud, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-clickhouse-family.yaml
@@ -29,8 +29,10 @@ description: |
     - clickhouse-server: self-hosted TCP/HTTP connection
     - clickhouse-cloud: ClickHouse Cloud HTTP API
 
-  All three should share a common ClickHouseAdapter-level implementation of
-  get_query_plan() and a single ClickHouseQueryPlanParser.
+  The shared base class `ClickHouseAdapter` lives in
+  `benchbox/platforms/clickhouse/adapter.py`. All three modes should share a
+  base-level implementation of get_query_plan() and a single
+  ClickHouseQueryPlanParser.
 
 prerequisites:
   - "ClickHouse ≥20.6 for EXPLAIN PLAN support"
@@ -42,6 +44,7 @@ prerequisites:
 prior_art:
   - "benchbox/core/query_plans/parsers/duckdb.py — closest text-format parser; ClickHouse text plan is structurally similar"
   - "benchbox/core/query_plans/parsers/base.py — abstract interface to implement"
+  - "benchbox/platforms/clickhouse/adapter.py — ClickHouseAdapter base class (class ClickHouseAdapter)"
   - "benchbox/platforms/clickhouse_local.py:29 — ClickHouseLocalAdapter class"
   - "benchbox/platforms/clickhouse_server.py:33 — ClickHouseServerAdapter class"
   - "benchbox/platforms/duckdb.py:1038 — get_query_plan() implementation pattern"
@@ -107,9 +110,9 @@ work:
           returns a list of tuples.
         - clickhouse-cloud: uses clickhouse-connect over HTTP — different API.
 
-      After w1 confirms the actual connection type per mode, implement in the
-      shared ClickHouseAdapter base class (locate via grep for `class ClickHouseAdapter`).
-      If the connection API is uniform across modes (confirm first), use:
+      Implement in the shared ClickHouseAdapter base class at
+      benchbox/platforms/clickhouse/adapter.py (grep `class ClickHouseAdapter`).
+      If the connection API is uniform across modes (confirm in w1), use:
         def get_query_plan(self, connection, query):
             explain_query = f"EXPLAIN PLAN {query}"
             # Execute via the mode-appropriate connection API confirmed in w1
@@ -124,7 +127,8 @@ work:
     needs: [w2]
     status: pending
     notes: |
-      In the same ClickHouseAdapter base used in w4:
+      In benchbox/platforms/clickhouse/adapter.py (the same ClickHouseAdapter base
+      used in w4):
         def get_query_plan_parser(self):
             from benchbox.core.query_plans.parsers.clickhouse import ClickHouseQueryPlanParser
             return ClickHouseQueryPlanParser()
@@ -170,9 +174,9 @@ approach: |
   Start with fixture collection (w1) to understand the exact text format.
   Implement the parser (w2) modeled on the DuckDB text parser, then test it (w3).
   Add get_query_plan() and get_query_plan_parser() to the shared ClickHouseAdapter
-  base (w4+w5) so all three modes inherit them. Wire capture into execute_query()
-  (w6) and add wiring tests (w7). Do not require a live server for unit tests —
-  use fixtures throughout.
+  base at benchbox/platforms/clickhouse/adapter.py (w4+w5) so all three modes
+  inherit them. Wire capture into execute_query() (w6) and add wiring tests (w7).
+  Do not require a live server for unit tests — use fixtures throughout.
 
 anti_patterns:
   - "DO NOT use EXPLAIN PIPELINE as the default — pipeline output lacks logical operator names needed for cross-platform comparison."
@@ -194,6 +198,7 @@ verification:
 
 scope_limit:
   only_modify:
+    - "benchbox/platforms/clickhouse/adapter.py"
     - "benchbox/platforms/clickhouse_local.py"
     - "benchbox/platforms/clickhouse_server.py"
     - "benchbox/platforms/clickhouse_cloud.py"
@@ -217,4 +222,4 @@ metadata:
   tags: [query-plan, clickhouse, clickhouse-local, clickhouse-server, clickhouse-cloud, new-parser]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
@@ -1,0 +1,289 @@
+id: query-plan-capture-cloud-saas
+title: "Implement query plan capture for cloud SaaS platforms: Snowflake, BigQuery, Azure Synapse, Firebolt, Fabric Warehouse, and Lakesail"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Six cloud SaaS platforms need query plan capture work ranging from adding a new
+  parser to redesigning how the plan is fetched. Each has distinct EXPLAIN behavior
+  and all require cloud credentials for integration testing. The platforms are
+  grouped here because they share the pattern: need a new parser, need
+  execute_query() wiring, and each requires a cloud account.
+
+  Current state per platform:
+    1. SnowflakeAdapter (benchbox/platforms/snowflake.py)
+       - get_query_plan(): ❌ no override — Snowflake does not have a simple
+         EXPLAIN statement; instead it returns a query profile via
+         `EXPLAIN <query>` as JSON with LogicalPlanNode objects.
+       - No parser exists.
+       - Has execute_query() at line 1138.
+
+    2. BigQueryAdapter (benchbox/platforms/bigquery.py)
+       - get_query_plan(): ⚠️ exists at line 1714 but returns a dict with
+         `bytes_processed` and `job_id`, NOT a plan tree.
+         BigQuery's query plan is only available post-execution via the
+         Job Statistics API (`job.query_plan` on a completed QueryJob).
+       - No parser exists.
+       - Has execute_query() at line 1467.
+
+    3. AzureSynapseAdapter (benchbox/platforms/azure_synapse.py)
+       - get_query_plan(): ✅ line 1131 — EXPLAIN via cursor
+       - No parser exists.
+       - Has execute_query() at line 967.
+
+    4. FireboltAdapter (benchbox/platforms/firebolt.py)
+       - get_query_plan(): ✅ line 1296 — EXPLAIN via cursor
+       - No parser exists.
+
+    5. FabricWarehouseAdapter (benchbox/platforms/fabric_warehouse.py)
+       - get_query_plan(): ✅ line 1078
+       - No parser exists.
+       - Has execute_query() at line 638.
+
+    6. LakesailAdapter (benchbox/platforms/lakesail.py)
+       - get_query_plan(): ✅ line 552
+       - No parser exists.
+
+  BigQuery requires the most redesign: plans are not available from EXPLAIN but
+  from the post-execution Job statistics API. The `get_query_plan()` method must
+  be redesigned to accept a completed job reference rather than issuing a separate
+  EXPLAIN query.
+
+prerequisites:
+  - "Snowflake account + warehouse + database credentials (env: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE)"
+  - "Google Cloud project with BigQuery API enabled + service account JSON key (env: GOOGLE_APPLICATION_CREDENTIALS, BIGQUERY_PROJECT)"
+  - "Azure subscription with Synapse Analytics workspace (env: AZURE_SYNAPSE_SERVER, AZURE_SYNAPSE_DATABASE, AZURE_SYNAPSE_USER, AZURE_SYNAPSE_PASSWORD)"
+  - "Firebolt account + engine endpoint (env: FIREBOLT_ACCOUNT, FIREBOLT_USER, FIREBOLT_PASSWORD, FIREBOLT_ENGINE)"
+  - "Microsoft Fabric workspace with Warehouse (env: FABRIC_SERVER, FABRIC_DATABASE, FABRIC_USER, FABRIC_PASSWORD)"
+  - "Lakesail account credentials (env: LAKESAIL_HOST, LAKESAIL_USER, LAKESAIL_PASSWORD)"
+  - "Unit tests for parsers can run without credentials using fixture EXPLAIN text samples"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/datafusion.py — JSON tree parser pattern (for Snowflake)"
+  - "benchbox/core/query_plans/parsers/postgresql.py — text-tree parser pattern (for Azure Synapse, Firebolt, Fabric)"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface"
+  - "benchbox/platforms/duckdb.py:969 — execute_query() capture integration pattern"
+  - "benchbox/platforms/bigquery.py:1467 — BigQuery execute_query() with completed QueryJob in scope"
+
+work:
+  - id: w1
+    summary: "Collect EXPLAIN output samples for Snowflake, Azure Synapse, Firebolt, Fabric, and Lakesail"
+    status: pending
+    notes: |
+      For each available platform, run `EXPLAIN <simple_query>` and record:
+        - Full EXPLAIN output text (or JSON)
+        - Platform version / engine version
+        - Any differences in syntax (e.g., `EXPLAIN USING TEXT` for Snowflake)
+      Store as tests/fixtures/query_plans/{platform}_explain_sample.{txt|json}.
+      BigQuery: instead of EXPLAIN, run a small query, then call
+      `job.query_plan` on the completed QueryJob and record the JSON structure.
+
+  - id: w2
+    summary: "Implement SnowflakeQueryPlanParser and wire into SnowflakeAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Snowflake EXPLAIN returns JSON (when using `EXPLAIN USING JSON`):
+        {"GlobalStats": {...}, "Operations": [{"id": N, "operation": "...", ...}]}
+      Parser maps Snowflake operation names to LogicalOperatorType:
+        TableScan / JoinFilter → SCAN
+        Filter → FILTER
+        Aggregate → AGGREGATE
+        Join / InnerJoin / LeftOuterJoin → JOIN
+        Sort → SORT
+        Result / WithReference → PROJECT
+      Wire in SnowflakeAdapter:
+        - Override get_query_plan() to use `EXPLAIN USING JSON <query>`
+        - Override get_query_plan_parser() returning SnowflakeQueryPlanParser
+        - Add capture_query_plan() call to execute_query()
+
+  - id: w3
+    summary: "Implement BigQueryQueryPlanParser and override capture_query_plan() in BigQueryAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      BigQuery plans come from the Job Statistics API, not an EXPLAIN statement.
+      This is an architectural mismatch with the base class:
+        - Base class result_capture.py capture_query_plan() calls
+          self.get_query_plan(connection, query) BEFORE the query executes.
+        - BigQuery plans are only available AFTER execution via job.query_plan
+          on the completed google.cloud.bigquery.QueryJob object.
+
+      Required approach: override capture_query_plan() directly in BigQueryAdapter
+      to extract the plan from the already-completed QueryJob. Do NOT attempt
+      to use the get_query_plan() → parse() path for BigQuery; the QueryJob is
+      in scope inside execute_query() at line 1467 after job.result() returns.
+
+      Implementation:
+        1. Inside BigQueryAdapter.execute_query(), after job.result() completes,
+           call self._capture_bq_plan(job, query_id) instead of capture_query_plan().
+        2. Implement _capture_bq_plan(job, query_id) to:
+             a. Read job.query_plan — a list of QueryPlanEntry objects with
+                `name`, `substeps`, `records_read`, `records_written`, `status`.
+             b. Pass the JSON-serialized plan to BigQueryQueryPlanParser.parse().
+             c. Return (QueryPlanDAG, elapsed_ms).
+        3. Set plan_fingerprint from the returned DAG in the result dict.
+
+      Implement BigQueryQueryPlanParser:
+        - parse(raw_plan: str) -> QueryPlanDAG where raw_plan is JSON of
+          the job.query_plan structure.
+        - Each QueryPlanEntry.name maps to LogicalOperatorType:
+            INPUT → SCAN, FILTER → FILTER, AGGREGATE → AGGREGATE,
+            HASH_JOIN / BROADCAST_HASH_JOIN → JOIN, SORT → SORT,
+            OUTPUT → PROJECT (final projection/output step).
+        - entry.substeps provide operator detail strings.
+
+      Do NOT modify get_query_plan() in BigQueryAdapter for plan capture —
+      its current return (cost dict) may be used by other consumers; leave
+      it as-is and add the new _capture_bq_plan() method alongside it.
+
+  - id: w4
+    summary: "Implement AzureSynapseQueryPlanParser and wire into AzureSynapseAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Azure Synapse Dedicated Pool uses T-SQL-based EXPLAIN (XML format via
+      `SET SHOWPLAN_XML ON`; or text via `SET SHOWPLAN_TEXT ON`). Serverless
+      uses a different planner. Confirm which format get_query_plan() at
+      line 1131 currently retrieves. Implement a parser for that format.
+      Wire get_query_plan_parser() and the capture call in execute_query().
+
+  - id: w5
+    summary: "Implement FireboltQueryPlanParser and wire into FireboltAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Firebolt's EXPLAIN returns a JSON structure with a tree of nodes.
+      Implement FireboltQueryPlanParser mapping Firebolt operator names
+      (TableScan, Projection, Aggregation, Join, etc.) to LogicalOperatorType.
+      Wire get_query_plan_parser() and the capture call in FireboltAdapter.execute_query().
+
+  - id: w6
+    summary: "Wire FabricWarehouseAdapter plan capture; reuse AzureSynapseQueryPlanParser if format matches"
+    needs: [w1, w4]
+    status: pending
+    notes: |
+      Fabric Warehouse (Synapse Serverless + Delta Lake) EXPLAIN format may
+      differ from Synapse Dedicated. After collecting the Fabric fixture in w1
+      and implementing AzureSynapseQueryPlanParser in w4:
+
+      Decision gate (required before writing any Fabric parser code):
+        Compare the Fabric EXPLAIN fixture from w1 to the Azure Synapse fixture.
+        - If the T-SQL plan format is structurally identical:
+            Reuse AzureSynapseQueryPlanParser — do NOT implement a separate
+            FabricWarehouseQueryPlanParser. Wire FabricWarehouseAdapter to return
+            AzureSynapseQueryPlanParser from get_query_plan_parser().
+        - If the format differs (Synapse Serverless uses a different planner):
+            Implement a separate FabricWarehouseQueryPlanParser. Register under
+            dialect="fabric_warehouse" in the parser registry.
+
+      Wire get_query_plan_parser() and the capture call in execute_query()
+      regardless of which parser is chosen.
+
+  - id: w7
+    summary: "Implement LakesailQueryPlanParser and wire into LakesailAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      Lakesail is a MySQL-wire-compatible engine. Collect EXPLAIN format in w1.
+      Implement LakesailQueryPlanParser. Wire get_query_plan_parser() and
+      the capture call in LakesailAdapter.execute_query().
+
+  - id: w8
+    summary: "Add unit tests for all new parsers and adapter wiring"
+    needs: [w2, w3, w4, w5, w6, w7]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/ tests for each new parser:
+        test_snowflake_parser.py, test_bigquery_parser.py,
+        test_azure_synapse_parser.py, test_firebolt_parser.py,
+        test_lakesail_parser.py
+        (FabricWarehouse parser test only if a new parser was required in w6;
+         skip if AzureSynapseQueryPlanParser is reused for Fabric)
+      For BigQuery, test _capture_bq_plan() directly with a mock QueryJob object
+      rather than testing get_query_plan_parser() — BigQuery bypasses that path.
+      Create tests/unit/platforms/test_cloud_saas_plan_capture.py with
+      parametrized cases for all six adapters:
+        - get_query_plan_parser() returns non-None
+        - execute_query() with capture_plans=True captures plan
+        - graceful degradation on capture failure
+
+deps:
+  needs: []
+
+must_preserve:
+  - "All six adapters' execute_query() result dict shape must not change for non-plan fields."
+  - "BigQuery execute_query() must not issue any additional API calls when capture_plans=False."
+  - "Plan capture failure must be silent when strict_plan_capture=False — cloud queries are expensive and billing-sensitive."
+  - "Do not issue extra EXPLAIN queries that incur billing in BigQuery — use the job statistics from the already-executed query."
+
+approach: |
+  Start with fixture collection (w1) since all parsers depend on knowing the
+  actual output format. Parse work can proceed in parallel per platform once
+  fixtures are available. BigQuery requires the most architectural thought (w3)
+  since its plan source is fundamentally different from EXPLAIN-based platforms.
+  Implement parsers and wiring in priority order: Snowflake (most popular),
+  Azure Synapse, Firebolt, Fabric Warehouse, Lakesail, BigQuery (architectural
+  redesign last or in parallel). Unit tests can all be written from fixtures
+  without cloud credentials.
+
+anti_patterns:
+  - "DO NOT issue a second EXPLAIN query for BigQuery — the query plan is already available from the completed job object at no extra cost."
+  - "DO NOT use synchronous EXPLAIN for BigQuery — there is no EXPLAIN statement; use the Job Statistics API."
+  - "DO NOT add plan capture to BigQuery's get_query_plan() method without addressing its current incorrect return type (returns cost dict, not plan text)."
+  - "DO NOT use SET SHOWPLAN_TEXT for Azure Synapse if SET SHOWPLAN_XML produces a richer parseable structure — prefer XML."
+
+verification:
+  - description: "All new parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_snowflake_parser.py tests/unit/query_plans/test_bigquery_parser.py tests/unit/query_plans/test_azure_synapse_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Cloud SaaS adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_cloud_saas_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/snowflake.py"
+    - "benchbox/platforms/bigquery.py"
+    - "benchbox/platforms/azure_synapse.py"
+    - "benchbox/platforms/firebolt.py"
+    - "benchbox/platforms/fabric_warehouse.py"
+    - "benchbox/platforms/lakesail.py"
+    - "benchbox/core/query_plans/parsers/snowflake.py"
+    - "benchbox/core/query_plans/parsers/bigquery.py"
+    - "benchbox/core/query_plans/parsers/azure_synapse.py"
+    - "benchbox/core/query_plans/parsers/firebolt.py"
+    - "benchbox/core/query_plans/parsers/fabric_warehouse.py"
+    - "benchbox/core/query_plans/parsers/lakesail.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/"
+    - "tests/unit/platforms/test_cloud_saas_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml"
+
+success_metrics:
+  - "All six adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for all six platforms."
+  - "BigQuery plan capture uses job statistics, not a separate EXPLAIN query."
+  - "All parser unit tests pass using fixture samples."
+
+open_questions:
+  - question: "Does Azure Synapse Serverless support EXPLAIN in the same format as Dedicated Pool?"
+    gating: true
+    affects: ["w4"]
+    default: "Implement separate parsers for Dedicated Pool (XML) and Serverless (text) if formats differ"
+  - question: "Does Fabric Warehouse share the Azure Synapse T-SQL plan format, or is it distinct?"
+    gating: true
+    affects: ["w6"]
+    default: "Collect fixture in w1 before implementing; reuse AzureSynapseParser if format matches"
+
+metadata:
+  tags: [query-plan, snowflake, bigquery, azure-synapse, firebolt, fabric-warehouse, lakesail, cloud-saas, new-parser]
+  estimated_effort: "Large"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
@@ -69,22 +69,31 @@ prior_art:
 
 work:
   - id: w1
-    summary: "Collect EXPLAIN output samples for Snowflake, Azure Synapse, Firebolt, Fabric, and Lakesail"
+    summary: "Collect EXPLAIN output samples for each platform independently"
     status: pending
     notes: |
+      Each platform's fixture can be collected independently — as soon as a
+      single platform's fixture is available, that platform's parser work (w2-w7)
+      can begin without waiting for all other platforms. Collect in priority order:
+      Snowflake, Azure Synapse, Firebolt, Fabric Warehouse, Lakesail, BigQuery.
+
       For each available platform, run `EXPLAIN <simple_query>` and record:
         - Full EXPLAIN output text (or JSON)
         - Platform version / engine version
         - Any differences in syntax (e.g., `EXPLAIN USING TEXT` for Snowflake)
       Store as tests/fixtures/query_plans/{platform}_explain_sample.{txt|json}.
+
       BigQuery: instead of EXPLAIN, run a small query, then call
       `job.query_plan` on the completed QueryJob and record the JSON structure.
+      This requires a live BigQuery project — no EXPLAIN statement is available.
 
   - id: w2
     summary: "Implement SnowflakeQueryPlanParser and wire into SnowflakeAdapter"
     needs: [w1]
     status: pending
     notes: |
+      Requires: Snowflake fixture from w1.
+
       Snowflake EXPLAIN returns JSON (when using `EXPLAIN USING JSON`):
         {"GlobalStats": {...}, "Operations": [{"id": N, "operation": "...", ...}]}
       Parser maps Snowflake operation names to LogicalOperatorType:
@@ -104,6 +113,8 @@ work:
     needs: [w1]
     status: pending
     notes: |
+      Requires: BigQuery job.query_plan fixture from w1.
+
       BigQuery plans come from the Job Statistics API, not an EXPLAIN statement.
       This is an architectural mismatch with the base class:
         - Base class result_capture.py capture_query_plan() calls
@@ -144,6 +155,8 @@ work:
     needs: [w1]
     status: pending
     notes: |
+      Requires: Azure Synapse fixture from w1.
+
       Azure Synapse Dedicated Pool uses T-SQL-based EXPLAIN (XML format via
       `SET SHOWPLAN_XML ON`; or text via `SET SHOWPLAN_TEXT ON`). Serverless
       uses a different planner. Confirm which format get_query_plan() at
@@ -155,6 +168,8 @@ work:
     needs: [w1]
     status: pending
     notes: |
+      Requires: Firebolt fixture from w1.
+
       Firebolt's EXPLAIN returns a JSON structure with a tree of nodes.
       Implement FireboltQueryPlanParser mapping Firebolt operator names
       (TableScan, Projection, Aggregation, Join, etc.) to LogicalOperatorType.
@@ -165,6 +180,8 @@ work:
     needs: [w1, w4]
     status: pending
     notes: |
+      Requires: Fabric Warehouse fixture from w1 and AzureSynapseQueryPlanParser from w4.
+
       Fabric Warehouse (Synapse Serverless + Delta Lake) EXPLAIN format may
       differ from Synapse Dedicated. After collecting the Fabric fixture in w1
       and implementing AzureSynapseQueryPlanParser in w4:
@@ -187,6 +204,8 @@ work:
     needs: [w1]
     status: pending
     notes: |
+      Requires: Lakesail fixture from w1.
+
       Lakesail is a MySQL-wire-compatible engine. Collect EXPLAIN format in w1.
       Implement LakesailQueryPlanParser. Wire get_query_plan_parser() and
       the capture call in LakesailAdapter.execute_query().
@@ -220,20 +239,21 @@ must_preserve:
   - "Do not issue extra EXPLAIN queries that incur billing in BigQuery — use the job statistics from the already-executed query."
 
 approach: |
-  Start with fixture collection (w1) since all parsers depend on knowing the
-  actual output format. Parse work can proceed in parallel per platform once
-  fixtures are available. BigQuery requires the most architectural thought (w3)
-  since its plan source is fundamentally different from EXPLAIN-based platforms.
-  Implement parsers and wiring in priority order: Snowflake (most popular),
-  Azure Synapse, Firebolt, Fabric Warehouse, Lakesail, BigQuery (architectural
-  redesign last or in parallel). Unit tests can all be written from fixtures
-  without cloud credentials.
+  Fixture collection (w1) is per-platform and unblocks each platform's parser
+  work independently — do not wait for all six fixtures before starting. Collect
+  in priority order: Snowflake (most popular), Azure Synapse, Firebolt, Fabric
+  Warehouse, Lakesail, BigQuery (architectural redesign). As each fixture lands,
+  implement that platform's parser and wiring in parallel. BigQuery requires the
+  most architectural thought (w3) since its plan source is fundamentally different
+  from EXPLAIN-based platforms. Unit tests can all be written from fixtures
+  without cloud credentials once fixtures are collected.
 
 anti_patterns:
   - "DO NOT issue a second EXPLAIN query for BigQuery — the query plan is already available from the completed job object at no extra cost."
   - "DO NOT use synchronous EXPLAIN for BigQuery — there is no EXPLAIN statement; use the Job Statistics API."
   - "DO NOT add plan capture to BigQuery's get_query_plan() method without addressing its current incorrect return type (returns cost dict, not plan text)."
   - "DO NOT use SET SHOWPLAN_TEXT for Azure Synapse if SET SHOWPLAN_XML produces a richer parseable structure — prefer XML."
+  - "DO NOT block all platform work on complete fixture collection — each platform's fixture independently unblocks that platform's w2-w7 work."
 
 verification:
   - description: "All new parser unit tests pass"
@@ -286,4 +306,4 @@ metadata:
   tags: [query-plan, snowflake, bigquery, azure-synapse, firebolt, fabric-warehouse, lakesail, cloud-saas, new-parser]
   estimated_effort: "Large"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
@@ -19,18 +19,24 @@ description: |
         • get_query_plan(): ❌ no override — base returns None
         • get_query_plan_parser(): ❌ no override — base returns None
         • execute_query(): ❌ never calls capture_query_plan()
-        • DataFusion EXPLAIN format: JSON — `EXPLAIN FORMAT JSON <query>`
-          or `EXPLAIN ANALYZE FORMAT JSON <query>` (includes execution stats)
+        • DataFusion EXPLAIN format: text — `EXPLAIN <query>` or
+          `EXPLAIN ANALYZE <query>` (includes execution stats).
+          DataFusionQueryPlanParser is a text/indent parser that reads
+          logical_plan/physical_plan section headers; do NOT use FORMAT JSON.
     - SQLiteAdapter (benchbox/platforms/sqlite.py — or embedded in another file)
         • get_query_plan(): ❌ no override — base returns None
         • get_query_plan_parser(): ❌ no override — base returns None
         • execute_query(): ❌ never calls capture_query_plan()
         • SQLite EXPLAIN format: `EXPLAIN QUERY PLAN <query>` returns rows of
-          (id, parent, notused, detail) — text-based tree representation
+          (id, parent, notused, detail) — text-based tree representation.
+          Note: modern SQLite outputs `SCAN orders` / `SEARCH orders USING INDEX`
+          rather than `SCAN TABLE orders`; the parser may need _infer_operator_type()
+          fixes to classify these correctly.
 
   Both parsers already handle their respective formats and are covered by unit
   tests. The only work is adding the three-point integration:
-  get_query_plan() → get_query_plan_parser() → execute_query() capture call.
+  get_query_plan() → get_query_plan_parser() → execute_query() capture call,
+  plus any parser fixes required for modern SQLite output patterns.
 
 prerequisites:
   - "No cloud credentials required — DataFusion and SQLite run in-process"
@@ -40,19 +46,21 @@ prerequisites:
 prior_art:
   - "benchbox/platforms/duckdb.py:969 — canonical execute_query plan-capture integration pattern"
   - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
-  - "benchbox/core/query_plans/parsers/datafusion.py — existing DataFusion JSON parser (20KB)"
+  - "benchbox/core/query_plans/parsers/datafusion.py — existing DataFusion text/indent parser"
   - "benchbox/core/query_plans/parsers/sqlite.py — existing SQLite text-tree parser"
   - "tests/unit/platforms/test_duckdb_plan_capture.py — unit test pattern to replicate"
 
 work:
   - id: w1
-    summary: "Confirm DataFusion EXPLAIN JSON syntax via live query and document in TODO"
+    summary: "Confirm DataFusion EXPLAIN text syntax via live query and document in TODO"
     status: pending
     notes: |
-      Run a trivial DataFusion query with EXPLAIN FORMAT JSON in the BenchBox
-      harness or a standalone script. Record the exact SQL syntax that works
-      with the installed datafusion version and confirm the output matches what
-      DataFusionQueryPlanParser expects. Capture to /tmp/datafusion-explain-w1.log.
+      Run a trivial DataFusion query with EXPLAIN (text format — not FORMAT JSON) in
+      the BenchBox harness or a standalone script. DataFusionQueryPlanParser is a
+      text/indent parser that reads logical_plan/physical_plan section headers, so
+      text output is required. Record the exact SQL syntax that works with the
+      installed datafusion version and confirm the section headers in the output match
+      what DataFusionQueryPlanParser expects. Capture to /tmp/datafusion-explain-w1.log.
 
   - id: w2
     summary: "Add get_query_plan() and get_query_plan_parser() to DataFusionAdapter"
@@ -62,14 +70,21 @@ work:
       In benchbox/platforms/datafusion.py add:
         def get_query_plan(self, connection, query):
             ctx = connection  # DataFusion uses a SessionContext
-            result = ctx.sql(f"EXPLAIN FORMAT JSON {query}")
-            return result.collect()[0][0].as_py()  # adjust to actual API
+            result = ctx.sql(f"EXPLAIN {query}")
+            # EXPLAIN returns a DataFrame with columns (type, plan);
+            # column 1 contains the plan text. Exact API confirmed in w1.
+            batches = result.collect()
+            lines = []
+            for batch in batches:
+                for i in range(batch.num_rows):
+                    lines.append(batch.column(1)[i].as_py())
+            return "\n".join(lines) if lines else None
 
         def get_query_plan_parser(self):
             from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
             return DataFusionQueryPlanParser()
-      Adjust the exact RecordBatch extraction to match the DataFusion Python API
-      as confirmed in w1.
+      Adjust the exact RecordBatch column index/API to match the DataFusion Python
+      version as confirmed in w1.
 
   - id: w3
     summary: "Integrate capture_query_plan() into DataFusionAdapter.execute_query()"
@@ -107,8 +122,15 @@ work:
       SQLite returns (id, parent, notused, detail) tuples. Verify parser handles
       them correctly. Capture to /tmp/sqlite-explain-w5.log.
 
+      Also check whether `SQLiteQueryPlanParser._infer_operator_type()` handles
+      modern SQLite output. Recent SQLite versions (≥3.36) output `SCAN orders`
+      and `SEARCH orders USING INDEX` rather than `SCAN TABLE orders`. If
+      operator type inference is stale it will classify these as OTHER, producing
+      poor fingerprints. Fix `_infer_operator_type()` in w6 if needed —
+      `benchbox/core/query_plans/parsers/sqlite.py` is in scope.
+
   - id: w6
-    summary: "Add get_query_plan() and get_query_plan_parser() to SQLiteAdapter"
+    summary: "Add get_query_plan() and get_query_plan_parser() to SQLiteAdapter; fix parser if needed"
     needs: [w5]
     status: pending
     notes: |
@@ -116,15 +138,21 @@ work:
         def get_query_plan(self, connection, query):
             cursor = connection.cursor()
             cursor.execute(f"EXPLAIN QUERY PLAN {query}")
-            rows = cursor.fetchall()
+            rows = cursor.fetchall()  # returns (id, parent, notused, detail) tuples
             cursor.close()
-            # Format as text tree for the parser
-            return "\n".join(f"{r[0]}|{r[1]}|{r[2]}|{r[3]}" for r in rows)
+            # SQLiteQueryPlanParser expects indented text with |-- / `-- tree chars.
+            # The exact transformation from tuples to tree text must be confirmed in
+            # w5 against the actual parser input format. Do not assume the pipe-
+            # delimited raw tuple format works — verify first.
+            return <tree-formatted text confirmed in w5>
 
         def get_query_plan_parser(self):
             from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
             return SQLiteQueryPlanParser()
-      Confirm the text format matches what SQLiteQueryPlanParser expects.
+
+      If w5 found that `_infer_operator_type()` misclassifies modern SQLite output
+      (`SCAN orders`, `SEARCH orders USING INDEX`, etc.), fix the method in
+      benchbox/core/query_plans/parsers/sqlite.py before wiring the adapter.
 
   - id: w7
     summary: "Integrate capture_query_plan() into SQLiteAdapter.execute_query()"
@@ -150,17 +178,18 @@ must_preserve:
   - "DataFusion EXPLAIN queries must not be issued when capture_plans=False — avoid performance overhead on every query."
 
 approach: |
-  Start with DataFusion (w1-w4): confirm the exact EXPLAIN JSON API against the
-  installed datafusion version, then wire the three integration points. The
-  parser already exists, so this is plumbing work. Then replicate for SQLite
-  (w5-w8), which uses a text-tree format rather than JSON. Both platforms are
-  locally runnable so all unit tests can use real in-process connections rather
-  than mocks if desired.
+  Start with DataFusion (w1-w4): confirm the exact EXPLAIN text API against the
+  installed datafusion version (text format, not FORMAT JSON), then wire the three
+  integration points. The parser already exists. Then replicate for SQLite (w5-w8),
+  verifying both the tuple-to-text format conversion and whether
+  _infer_operator_type() needs updating for modern SQLite output patterns.
 
 anti_patterns:
+  - "DO NOT use EXPLAIN FORMAT JSON for DataFusion — DataFusionQueryPlanParser is a text/indent parser that reads logical_plan/physical_plan section headers and cannot consume JSON output."
   - "DO NOT use EXPLAIN ANALYZE for SQLite — SQLite's EXPLAIN QUERY PLAN does not support ANALYZE and will raise an error."
   - "DO NOT import DataFusionQueryPlanParser at module level in datafusion.py — keep lazy to avoid import cost when DataFusion is not installed."
   - "DO NOT use ctx.sql().to_pandas() for EXPLAIN output — use collect() and extract the scalar text to avoid an unnecessary pandas dependency."
+  - "DO NOT assume the raw (id, parent, notused, detail) SQLite tuple format matches SQLiteQueryPlanParser input — confirm the expected text format in w5 before writing the get_query_plan() formatter."
 
 verification:
   - description: "DataFusion plan capture unit tests pass"
@@ -177,12 +206,12 @@ scope_limit:
   only_modify:
     - "benchbox/platforms/datafusion.py"
     - "benchbox/platforms/sqlite.py"
+    - "benchbox/core/query_plans/parsers/sqlite.py"
     - "tests/unit/platforms/test_datafusion_plan_capture.py"
     - "tests/unit/platforms/test_sqlite_plan_capture.py"
     - "_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml"
   do_not_modify:
     - "benchbox/core/query_plans/parsers/datafusion.py"
-    - "benchbox/core/query_plans/parsers/sqlite.py"
 
 success_metrics:
   - "DataFusionAdapter.get_query_plan_parser() returns a non-None DataFusionQueryPlanParser instance."
@@ -194,4 +223,4 @@ metadata:
   tags: [query-plan, datafusion, sqlite, wiring, no-credentials]
   estimated_effort: "Small"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-datafusion-sqlite
 title: "Wire query plan capture for DataFusion and SQLite (parsers exist, no credentials needed)"
 worktree: platform-expansion
 priority: High
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -223,4 +223,6 @@ metadata:
   tags: [query-plan, datafusion, sqlite, wiring, no-credentials]
   estimated_effort: "Small"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T12:00:00-04:00"
+  last_updated: "2026-06-08T00:00:00-04:00"
+  completed_date: "2026-06-04"
+  completed_in_prs: ["#748", "#749"]

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
@@ -1,0 +1,197 @@
+id: query-plan-capture-datafusion-sqlite
+title: "Wire query plan capture for DataFusion and SQLite (parsers exist, no credentials needed)"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  DataFusion and SQLite each have fully-implemented parsers
+  (`benchbox/core/query_plans/parsers/datafusion.py` and
+  `benchbox/core/query_plans/parsers/sqlite.py`). Neither adapter currently
+  overrides `get_query_plan()` or `get_query_plan_parser()`, and neither
+  `execute_query()` calls `capture_query_plan()`. Both platforms run entirely
+  locally with no cloud credentials required — this is the lowest-friction
+  group to complete after the PostgreSQL family.
+
+  Gap summary per adapter:
+    - DataFusionAdapter (benchbox/platforms/datafusion.py)
+        • get_query_plan(): ❌ no override — base returns None
+        • get_query_plan_parser(): ❌ no override — base returns None
+        • execute_query(): ❌ never calls capture_query_plan()
+        • DataFusion EXPLAIN format: JSON — `EXPLAIN FORMAT JSON <query>`
+          or `EXPLAIN ANALYZE FORMAT JSON <query>` (includes execution stats)
+    - SQLiteAdapter (benchbox/platforms/sqlite.py — or embedded in another file)
+        • get_query_plan(): ❌ no override — base returns None
+        • get_query_plan_parser(): ❌ no override — base returns None
+        • execute_query(): ❌ never calls capture_query_plan()
+        • SQLite EXPLAIN format: `EXPLAIN QUERY PLAN <query>` returns rows of
+          (id, parent, notused, detail) — text-based tree representation
+
+  Both parsers already handle their respective formats and are covered by unit
+  tests. The only work is adding the three-point integration:
+  get_query_plan() → get_query_plan_parser() → execute_query() capture call.
+
+prerequisites:
+  - "No cloud credentials required — DataFusion and SQLite run in-process"
+  - "DataFusion Python package (`datafusion`) must be installed in the venv"
+  - "SQLite is part of Python stdlib — no external install needed"
+
+prior_art:
+  - "benchbox/platforms/duckdb.py:969 — canonical execute_query plan-capture integration pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/core/query_plans/parsers/datafusion.py — existing DataFusion JSON parser (20KB)"
+  - "benchbox/core/query_plans/parsers/sqlite.py — existing SQLite text-tree parser"
+  - "tests/unit/platforms/test_duckdb_plan_capture.py — unit test pattern to replicate"
+
+work:
+  - id: w1
+    summary: "Confirm DataFusion EXPLAIN JSON syntax via live query and document in TODO"
+    status: pending
+    notes: |
+      Run a trivial DataFusion query with EXPLAIN FORMAT JSON in the BenchBox
+      harness or a standalone script. Record the exact SQL syntax that works
+      with the installed datafusion version and confirm the output matches what
+      DataFusionQueryPlanParser expects. Capture to /tmp/datafusion-explain-w1.log.
+
+  - id: w2
+    summary: "Add get_query_plan() and get_query_plan_parser() to DataFusionAdapter"
+    needs: [w1]
+    status: pending
+    notes: |
+      In benchbox/platforms/datafusion.py add:
+        def get_query_plan(self, connection, query):
+            ctx = connection  # DataFusion uses a SessionContext
+            result = ctx.sql(f"EXPLAIN FORMAT JSON {query}")
+            return result.collect()[0][0].as_py()  # adjust to actual API
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
+            return DataFusionQueryPlanParser()
+      Adjust the exact RecordBatch extraction to match the DataFusion Python API
+      as confirmed in w1.
+
+  - id: w3
+    summary: "Integrate capture_query_plan() into DataFusionAdapter.execute_query()"
+    needs: [w2]
+    status: pending
+    notes: |
+      Locate the result-assembly block in DataFusionAdapter.execute_query(). After
+      the timed execution block, add the same capture_plans guard as DuckDB:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate query_plan and plan_fingerprint into the return dict.
+
+  - id: w4
+    summary: "Add unit tests for DataFusion plan capture wiring"
+    needs: [w3]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_datafusion_plan_capture.py. Cover:
+        - get_query_plan_parser() returns DataFusionQueryPlanParser
+        - execute_query() with capture_plans=True triggers capture
+        - execute_query() with capture_plans=False does not trigger capture
+        - plan_fingerprint present in result dict when capture succeeds
+        - graceful degradation on parse failure
+      Mock the DataFusion SessionContext to avoid requiring datafusion package
+      in the base unit test run if it is not installed.
+
+  - id: w5
+    summary: "Confirm SQLite EXPLAIN QUERY PLAN syntax and parser compatibility"
+    status: pending
+    notes: |
+      Run `EXPLAIN QUERY PLAN <simple_query>` against an in-memory SQLite database
+      and compare the raw rows to what SQLiteQueryPlanParser expects.
+      SQLite returns (id, parent, notused, detail) tuples. Verify parser handles
+      them correctly. Capture to /tmp/sqlite-explain-w5.log.
+
+  - id: w6
+    summary: "Add get_query_plan() and get_query_plan_parser() to SQLiteAdapter"
+    needs: [w5]
+    status: pending
+    notes: |
+      In benchbox/platforms/sqlite.py (or wherever SQLiteAdapter lives) add:
+        def get_query_plan(self, connection, query):
+            cursor = connection.cursor()
+            cursor.execute(f"EXPLAIN QUERY PLAN {query}")
+            rows = cursor.fetchall()
+            cursor.close()
+            # Format as text tree for the parser
+            return "\n".join(f"{r[0]}|{r[1]}|{r[2]}|{r[3]}" for r in rows)
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+            return SQLiteQueryPlanParser()
+      Confirm the text format matches what SQLiteQueryPlanParser expects.
+
+  - id: w7
+    summary: "Integrate capture_query_plan() into SQLiteAdapter.execute_query()"
+    needs: [w6]
+    status: pending
+    notes: |
+      Same pattern as w3 but for SQLiteAdapter.
+
+  - id: w8
+    summary: "Add unit tests for SQLite plan capture wiring"
+    needs: [w7]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_sqlite_plan_capture.py. Same coverage as
+      w4 but using SQLiteQueryPlanParser and Python's stdlib sqlite3 connections.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "DataFusionAdapter.execute_query() and SQLiteAdapter.execute_query() must continue to return identical result dict keys to existing callers."
+  - "Plan capture failure must never fail the benchmark when strict_plan_capture=False."
+  - "DataFusion EXPLAIN queries must not be issued when capture_plans=False — avoid performance overhead on every query."
+
+approach: |
+  Start with DataFusion (w1-w4): confirm the exact EXPLAIN JSON API against the
+  installed datafusion version, then wire the three integration points. The
+  parser already exists, so this is plumbing work. Then replicate for SQLite
+  (w5-w8), which uses a text-tree format rather than JSON. Both platforms are
+  locally runnable so all unit tests can use real in-process connections rather
+  than mocks if desired.
+
+anti_patterns:
+  - "DO NOT use EXPLAIN ANALYZE for SQLite — SQLite's EXPLAIN QUERY PLAN does not support ANALYZE and will raise an error."
+  - "DO NOT import DataFusionQueryPlanParser at module level in datafusion.py — keep lazy to avoid import cost when DataFusion is not installed."
+  - "DO NOT use ctx.sql().to_pandas() for EXPLAIN output — use collect() and extract the scalar text to avoid an unnecessary pandas dependency."
+
+verification:
+  - description: "DataFusion plan capture unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_datafusion_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "SQLite plan capture unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit test suite still passes"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+    - "tests/unit/platforms/test_datafusion_plan_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml"
+  do_not_modify:
+    - "benchbox/core/query_plans/parsers/datafusion.py"
+    - "benchbox/core/query_plans/parsers/sqlite.py"
+
+success_metrics:
+  - "DataFusionAdapter.get_query_plan_parser() returns a non-None DataFusionQueryPlanParser instance."
+  - "SQLiteAdapter.get_query_plan_parser() returns a non-None SQLiteQueryPlanParser instance."
+  - "execute_query() with capture_plans=True stores a QueryPlanDAG and fingerprint in the result dict for both adapters."
+  - "All unit tests pass. No regressions."
+
+metadata:
+  tags: [query-plan, datafusion, sqlite, wiring, no-credentials]
+  estimated_effort: "Small"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-dml-double-execution.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-dml-double-execution.yaml
@@ -1,0 +1,205 @@
+id: query-plan-capture-dml-double-execution
+title: "Guard plan capture against DML double-execution in DuckDB and MotherDuck"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  DuckDB and MotherDuck both use `EXPLAIN (ANALYZE, FORMAT JSON) <query>` to
+  capture query plans. Unlike PostgreSQL where `EXPLAIN ANALYZE` is a
+  read-only introspection that re-runs the query in a separate executor context,
+  DuckDB's `EXPLAIN ANALYZE` physically executes the statement. For DML queries
+  (INSERT, UPDATE, DELETE, MERGE), this means any benchmark query that mutates
+  data will be executed TWICE when `capture_plans=True` is active:
+
+    1. Once by `conn.execute(query)` in `execute_query()`
+    2. Once by `EXPLAIN (ANALYZE, FORMAT JSON) {query}` inside `get_query_plan()`
+
+  This is a data integrity risk. TPC-DS maintenance streams, TPC-DI load phases,
+  and any custom write workloads would silently insert/update/delete rows twice
+  per captured query.
+
+  `capture_plans` defaults to `False`, so this is not triggered in normal usage.
+  But the risk is non-obvious to users who enable `capture_plans=True` for DML
+  benchmarks. There is no warning, no guard, and no documentation.
+
+  Scope: DuckDBAdapter and MotherDuckAdapter are the only adapters affected.
+  PostgreSQL's `EXPLAIN ANALYZE` also physically re-executes DML statements —
+  it is NOT rollback-safe for DML. However, BenchBox's PostgreSQL adapter uses
+  `EXPLAIN (FORMAT JSON)` without ANALYZE, so it does not re-execute queries
+  and is not affected by this issue. Redshift does not use EXPLAIN ANALYZE at
+  all. SQLite and DataFusion use plain EXPLAIN (no ANALYZE), so they do not
+  re-execute.
+
+  The fix has three options (ordered by preference):
+    A. **Detect DML prefix and skip ANALYZE** — check if query starts with
+       INSERT/UPDATE/DELETE/MERGE/COPY and switch `explain_options` to
+       `FORMAT JSON` (without ANALYZE). Safest: no re-execution, but loses
+       execution stats for DML plans.
+    B. **Skip capture entirely for DML queries** — if query is DML, return
+       `None` from `get_query_plan()` immediately. Zero risk, but no plan
+       for DML at all.
+    C. **Log a warning and document the behavior** — add a warning log when
+       `analyze_plans=True` and the query looks like DML, leave behavior
+       unchanged. Least invasive, highest documentation burden.
+
+  Option A is preferred: DML plan structure (table scans, indexes used) is
+  still captured without execution stats, which is the most useful outcome.
+
+prerequisites:
+  - "No credentials required — DuckDB is fully local."
+  - "MotherDuck requires MOTHERDUCK_TOKEN for live testing, but unit tests can mock the connection."
+
+prior_art:
+  - "benchbox/platforms/duckdb.py:1038 — get_query_plan() to add DML detection to"
+  - "benchbox/platforms/motherduck.py:227 — get_query_plan() to add DML detection to"
+  - "benchbox/platforms/datafusion.py:89 — DataFusionConnectionCompat._requires_eager_execution() — existing DML prefix detection pattern to reuse"
+  - "benchbox/platforms/base/result_capture.py:561 — capture_query_plan() — entry point that calls get_query_plan()"
+
+work:
+  - id: w1
+    summary: "Extract DML-detection helper into benchbox/platforms/base/result_capture.py or a shared utils module"
+    status: pending
+    notes: |
+      benchbox/platforms/datafusion.py already has DataFusionConnectionCompat._requires_eager_execution()
+      which checks for INSERT/UPDATE/DELETE/MERGE/CREATE/DROP/ALTER/TRUNCATE/COPY prefixes.
+      Extract a version of this as a module-level function — e.g.
+      `_is_dml_query(query: str) -> bool` — in a shared location so DuckDB and
+      MotherDuck can both call it. Suggested home: benchbox/platforms/base/result_capture.py
+      or benchbox/utils/sql_utils.py.
+
+      Implementation reference (from DataFusion):
+        def _is_dml_query(query: str) -> bool:
+            stmt = query.lstrip()
+            # skip leading comments
+            while stmt.startswith("--"):
+                nl = stmt.find("\n")
+                if nl == -1:
+                    return False
+                stmt = stmt[nl + 1:].lstrip()
+            upper = stmt.upper()
+            # Intentionally excludes CREATE/DROP/ALTER/TRUNCATE — DDL statements
+            # do not produce duplicate data mutations; only data-changing DML
+            # needs the ANALYZE guard. Do not expand to DDL when extracting
+            # from _requires_eager_execution().
+            return upper.startswith(("INSERT", "UPDATE", "DELETE", "MERGE", "COPY"))
+
+  - id: w2
+    summary: "DuckDB: skip ANALYZE for DML queries in get_query_plan()"
+    needs: [w1]
+    status: pending
+    notes: |
+      In benchbox/platforms/duckdb.py get_query_plan(), after the existing
+      `analyze = self.analyze_plans` check, add:
+        if analyze and _is_dml_query(query):
+            analyze = False  # EXPLAIN ANALYZE re-executes DML; use FORMAT JSON only
+      The rest of the method uses `analyze` to build explain_options, so the
+      change propagates automatically. The DML plan structure is still captured;
+      only execution statistics (rows affected, timing) are absent.
+
+  - id: w3
+    summary: "MotherDuck: same DML ANALYZE guard in get_query_plan()"
+    needs: [w1]
+    status: pending
+    notes: |
+      Same change as w2 but for benchbox/platforms/motherduck.py get_query_plan().
+      MotherDuck's get_query_plan() already uses self.analyze_plans; add the
+      same `if analyze and _is_dml_query(query): analyze = False` guard.
+
+  - id: w4
+    summary: "Add unit tests verifying DML queries use FORMAT JSON (not ANALYZE) for DuckDB and MotherDuck"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      In tests/unit/platforms/test_duckdb_plan_capture.py (if it exists) or
+      tests/unit/platforms/test_duckdb_adapter.py, add a parametrized test:
+        @pytest.mark.parametrize("dml", ["INSERT INTO t VALUES (1)", "UPDATE t SET x=1", "DELETE FROM t"])
+        def test_dml_query_does_not_use_analyze(adapter, dml):
+            ...
+            called_sql = conn.execute.call_args[0][0]
+            assert "ANALYZE" not in called_sql.upper()
+            assert "FORMAT JSON" in called_sql.upper()
+
+      Same test for MotherDuck in tests/unit/platforms/ (create
+      test_motherduck_plan_capture.py if it doesn't exist).
+
+  - id: w5
+    summary: "Document the behavior in the adapter docstrings and --help"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Add a note to DuckDBAdapter.get_query_plan() docstring:
+        "DML queries (INSERT/UPDATE/DELETE/MERGE/COPY) are explained without
+         ANALYZE to prevent double-execution, even when analyze_plans=True."
+      Same for MotherDuckAdapter.get_query_plan().
+
+deferred:
+  - summary: "Extend DML guard to PostgreSQL EXPLAIN ANALYZE"
+    reason: "BenchBox's PostgreSQL adapter already uses EXPLAIN (FORMAT JSON) without ANALYZE, so it is not currently affected. If PostgreSQL ANALYZE is ever added to the PostgreSQL adapter, a DML guard will be needed — PostgreSQL EXPLAIN ANALYZE also physically re-executes DML."
+
+must_preserve:
+  - "DuckDB SELECT/WITH/EXPLAIN queries must continue to use EXPLAIN (ANALYZE, FORMAT JSON) when analyze_plans=True."
+  - "Plan fingerprint must be populated for DML queries (FORMAT JSON without ANALYZE still produces a plan structure)."
+  - "capture_plans=False behavior must be unchanged — DML guard only applies when plan capture is active."
+
+approach: |
+  The DataFusion adapter already has exactly the DML prefix detection logic needed.
+  Extract it into a shared helper (w1) to avoid duplicating the regex. Then add the
+  guard in DuckDB (w2) and MotherDuck (w3) — each is a 3-line change. Write
+  parametrized tests (w4) to prevent regression. Update docstrings (w5).
+
+anti_patterns:
+  - "DO NOT add a new DML detection regex when DataFusion already has one — reuse _requires_eager_execution logic via a shared helper."
+  - "DO NOT skip capture entirely for DML (Option B from description) — FORMAT JSON without ANALYZE still produces useful plan structure."
+  - "DO NOT add the guard to the capture_query_plan() base class — the decision belongs in get_query_plan() where EXPLAIN options are built."
+
+verification:
+  - description: "DML INSERT query uses FORMAT JSON (no ANALYZE) in DuckDB get_query_plan()"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'duckdb and dml' -v"
+    expected_output: "Parametrized DML tests pass; ANALYZE absent from EXPLAIN SQL"
+  - description: "SELECT query still uses EXPLAIN (ANALYZE, FORMAT JSON) when analyze_plans=True"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'duckdb and plan' -v"
+    expected_output: "Existing plan capture tests pass unchanged"
+  - description: "Full unit suite green"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/utils/sql_utils.py"
+    - "tests/unit/platforms/test_duckdb_plan_capture.py"
+    - "tests/unit/platforms/test_motherduck_plan_capture.py"
+  do_not_modify:
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/redshift.py"
+    - "benchbox/platforms/base/psycopg2_mixin.py"
+
+success_metrics:
+  - "DML queries never trigger EXPLAIN ANALYZE for DuckDB or MotherDuck regardless of analyze_plans setting."
+  - "SELECT query plan capture behavior is unchanged."
+  - "Plan fingerprint is still populated for DML queries (FORMAT JSON plan is captured)."
+  - "Unit tests verify the guard for INSERT, UPDATE, DELETE, and MERGE."
+
+files_affected:
+  modified:
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/base/result_capture.py"  # or benchbox/utils/sql_utils.py — chosen during w1
+    - "tests/unit/platforms/test_duckdb_plan_capture.py"
+  added:
+    - "tests/unit/platforms/test_motherduck_plan_capture.py"
+
+open_questions:
+  - "Should COPY statements also be guarded? DuckDB COPY loads data and would double-load if EXPLAIN ANALYZE re-executes it."
+  - "Should the DML guard be opt-out (dml_safe_capture=True by default) rather than opt-in? This would change default behavior for existing users of capture_plans=True."
+
+metadata:
+  tags: [query-plan, duckdb, motherduck, dml, correctness, analyze]
+  estimated_effort: "Small"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-fingerprint-contract.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-fingerprint-contract.yaml
@@ -1,0 +1,248 @@
+id: query-plan-capture-fingerprint-contract
+title: "Define plan fingerprint stability contract, integration tests, and capture design decisions"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  PRs #748 and #749 wired plan capture for five adapters and produced 46 unit
+  tests. However, all tests mock the database connection; no test exercises
+  plan capture against a real engine. Several design questions were also deferred
+  that need answers before plan fingerprints can be used reliably in regression
+  detection.
+
+  **1. Plan fingerprint stability contract (undefined)**
+
+  `query_plan.plan_fingerprint` is written to the result dict for every captured
+  query. No documentation defines what "stability" means for this field:
+    - Does the fingerprint survive a PostgreSQL minor version upgrade?
+    - Does it survive a VACUUM ANALYZE / stats refresh that changes row estimates?
+    - Does it survive adding a new index that wasn't used?
+    - Does it survive a DuckDB version bump?
+
+  Without a stability contract, callers cannot rely on fingerprint equality for
+  regression detection. The fingerprint may be meaningful for within-run
+  deduplication but unreliable for cross-run comparison.
+
+  **2. EXPLAIN timing: pre-execution vs. post-execution (unresolved)**
+
+  All adapters currently capture the plan AFTER the timed execution block.
+  This gives the "warm" post-execution plan (stats are current, caches are warm).
+  An alternative is to capture BEFORE execution:
+    - Pre-execution: gives the planner's decision before any stats changes.
+      More useful for regression detection ("did the plan change?").
+    - Post-execution (current): gives the actual plan used, with execution
+      stats (when ANALYZE is used). More useful for profiling.
+
+  The choice has implications for fingerprint stability. Pre-execution
+  fingerprints are more stable (stats-independent). Post-execution fingerprints
+  capture real behavior but may differ between runs due to stats changes.
+
+  **3. Multi-stream plan deduplication (undefined)**
+
+  When `stream_id` is set (concurrent benchmark streams), each stream captures
+  the same plan independently. Result bundles will contain N copies of
+  essentially the same fingerprint. Whether these should be deduplicated,
+  stored separately, or averaged is not defined.
+
+  **4. No integration tests (gap)**
+
+  All 46 plan capture tests use mocked connections. Bugs in the EXPLAIN format
+  parsing (wrong column index, format mismatch, encoding issue) would pass
+  all mocked tests and fail silently in production.
+
+  This TODO addresses all four concerns: define the fingerprint contract,
+  answer the timing question, decide on multi-stream handling, and add real
+  integration tests where possible (SQLite is already local; DuckDB is local;
+  PostgreSQL requires an instance but CI can provide one).
+
+prior_art:
+  - "benchbox/core/query_plans/plan_fingerprint.py — fingerprint implementation to document"
+  - "benchbox/platforms/base/result_capture.py:561 — capture_query_plan() — timing insertion point"
+  - "benchbox/platforms/duckdb.py:962 — display_query_plan_if_enabled() before capture — note pre/post ordering"
+  - "tests/unit/platforms/test_sqlite_plan_capture.py — real SQLite connection tests, use as template for integration tests"
+  - "tests/integration/ — existing integration test directory and patterns"
+
+work:
+  - id: w1
+    summary: "Document plan_fingerprint stability contract in plan_fingerprint.py"
+    status: pending
+    notes: |
+      Read benchbox/core/query_plans/plan_fingerprint.py to understand what the
+      fingerprint hashes. Document in the module docstring:
+        - Which plan fields are included in the hash (operator types, join order,
+          index names, table names, estimated rows — or just structural shape?)
+        - What changes are expected to produce a new fingerprint vs. the same one
+        - Recommended use: "stable for structural plan comparison within the same
+          engine version; may change across minor versions"
+        - What fingerprint equality does NOT guarantee
+
+      If the fingerprint implementation hashes fields that change with stats
+      (e.g., estimated rows), document that fingerprint equality is
+      "structural, not cost-based" or propose separating structural hash from
+      cost hash.
+
+  - id: w2
+    summary: "Decide and document pre- vs. post-execution capture timing"
+    status: pending
+    notes: |
+      Analyze the tradeoffs and pick a default. The current behavior (post-execution)
+      is fine for profiling. For regression detection, pre-execution is preferable.
+
+      Proposed resolution: capture post-execution (current behavior) but add a
+      `capture_plan_timing: pre | post` config option (default: post) that adapters
+      can respect in get_query_plan(). This is a config change, not a behavior change.
+
+      If no change is made, document the current behavior in ResultCaptureMixin
+      and result_capture.py.
+
+  - id: w3
+    summary: "Define multi-stream plan deduplication policy"
+    status: pending
+    notes: |
+      For `stream_id` != None cases, answer:
+        1. Are per-stream plans stored as separate records or collapsed?
+        2. Does the result bundle include one plan per (query_id, stream_id) or
+           one plan per query_id?
+        3. For fingerprint comparison, should all streams for the same query
+           have the same fingerprint (assertion) or may they differ (documented)?
+
+      Check existing result bundle schema in benchbox/core/result_bundle.py or
+      equivalent to understand where plan data lands. Document the policy in
+      result_capture.py.
+
+  - id: w4
+    summary: "Add SQLite integration tests using real in-memory connections"
+    status: pending
+    notes: |
+      tests/unit/platforms/test_sqlite_plan_capture.py already uses a real
+      sqlite3 in-memory connection. Extend it with integration-style assertions:
+        - Verify plan_fingerprint is non-None for a real SELECT query
+        - Verify plan_fingerprint is consistent across two calls with the same query
+          and same schema (idempotent fingerprint)
+        - Verify plan_fingerprint differs when adding an index (structural change)
+        - Verify EXPLAIN QUERY PLAN text is non-empty and contains expected keywords
+
+      These tests require no mocking — use the existing `conn` fixture.
+      Mark with @pytest.mark.integration or @pytest.mark.unit (SQLite is in-memory
+      so it qualifies as unit).
+
+  - id: w5
+    summary: "Add DuckDB integration tests using real DuckDB in-memory connection"
+    status: pending
+    notes: |
+      DuckDB has no credentials requirement for in-memory operation. Add tests in
+      tests/unit/platforms/test_duckdb_plan_capture.py (or create it):
+        - Verify DuckDBAdapter.get_query_plan() returns non-empty JSON for a
+          real SELECT on an in-memory table
+        - Verify DuckDBQueryPlanParser.parse_explain_output() produces a
+          non-None QueryPlanDAG from the real EXPLAIN output
+        - Verify plan_fingerprint is populated and consistent across two calls
+        - Verify plan_fingerprint changes after CREATE INDEX
+
+      Use duckdb.connect(":memory:") — no fixtures or credentials needed.
+
+  - id: w6
+    summary: "Add PostgreSQL integration test fixture (CI-gated, skipped locally without instance)"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Add tests/integration/test_postgresql_plan_capture_integration.py with:
+        - A pytest.mark.live_integration marker
+        - Skip condition: pytest.skip() when POSTGRESQL_HOST env is absent
+        - Test: real EXPLAIN (FORMAT JSON) against a live PostgreSQL instance
+        - Assertions: plan JSON is non-None, parser produces QueryPlanDAG,
+          fingerprint is populated
+
+      This test can run in CI if a PostgreSQL service is available (GitHub Actions
+      has postgres service containers). It is skipped locally by default.
+
+      Note: this is the only work unit that requires a live PostgreSQL instance.
+      w4 (SQLite) and w5 (DuckDB) are fully local and can run in fast tests.
+
+      CI configuration: if a PostgreSQL service container needs to be added to
+      a GitHub Actions workflow (e.g., .github/workflows/ci.yml), that workflow
+      file modification is in scope for this work unit. If CI config is not
+      modified here, document in a follow-up infra TODO instead.
+
+deferred:
+  - summary: "Integration tests for Redshift, DataFusion, and MotherDuck plan capture"
+    reason: "Require live cloud instances (Redshift cluster, MotherDuck token). Defer until CI has those credentials or a dedicated UAT workflow is in place."
+
+must_preserve:
+  - "All existing plan capture unit tests must pass without modification."
+  - "plan_fingerprint field must continue to appear in result dicts when capture is enabled."
+  - "capture_plans=False must remain a true no-op — no EXPLAIN issued, no fingerprint in result."
+
+approach: |
+  Start with documentation (w1 + w2 + w3) — no code changes, just decisions.
+  Then add local integration tests (w4 + w5) since they need no infrastructure.
+  Finally add the PostgreSQL CI fixture (w6) which may require a GitHub Actions
+  service block in the CI config.
+
+  The fingerprint contract (w1) should be resolved before writing integration
+  tests that assert fingerprint values, so w4/w5 depend on w1 conceptually
+  (but can be written in parallel if the fingerprint implementation is clear
+  from reading the source).
+
+verification:
+  - description: "SQLite integration tests pass without any mocking"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -v"
+    expected_output: "All tests pass including new fingerprint consistency tests"
+  - description: "DuckDB integration tests pass against real in-memory DuckDB"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_duckdb_plan_capture.py -v"
+    expected_output: "All tests pass including fingerprint consistency tests"
+  - description: "PostgreSQL integration tests skip gracefully when POSTGRESQL_HOST is absent"
+    command: "uv run -- python -m pytest tests/integration/test_postgresql_plan_capture_integration.py -v"
+    expected_output: "Tests skipped with 'live PostgreSQL not available' message"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/query_plans/plan_fingerprint.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_duckdb_plan_capture.py"
+  added:
+    - "tests/integration/test_postgresql_plan_capture_integration.py"
+  do_not_modify:
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/core/query_plans/parsers/"
+
+success_metrics:
+  - "plan_fingerprint stability contract is documented in plan_fingerprint.py module docstring."
+  - "Pre- vs. post-execution timing decision is documented in result_capture.py."
+  - "Multi-stream deduplication policy is documented."
+  - "SQLite fingerprint consistency is verified by at least 2 real-connection tests."
+  - "DuckDB fingerprint consistency is verified by at least 2 real-connection tests."
+  - "PostgreSQL integration test exists and skips gracefully when instance is unavailable."
+
+open_questions:
+  - question: "Should plan_fingerprint hash estimated row counts or only structural plan shape?"
+    gating: true
+    affects: ["w1: determines what the stability contract can promise"]
+    default: "Exclude row estimates; hash only structural shape (operator types, join order, index names)"
+  - question: "Should capture_plan_timing be a per-adapter config or a global benchbox config?"
+    gating: false
+    affects: ["w2"]
+    default: "Global config, default post-execution (current behavior)"
+  - question: "Are concurrent stream plans expected to have identical fingerprints? If yes, should a mismatch be logged as a warning?"
+    gating: false
+    affects: ["w3: determines deduplication policy and whether mismatch logging is added"]
+    default: "TBD — resolve during w3 by checking result bundle schema"
+
+files_affected:
+  modified:
+    - "benchbox/core/query_plans/plan_fingerprint.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_duckdb_plan_capture.py"
+  added:
+    - "tests/integration/test_postgresql_plan_capture_integration.py"
+
+metadata:
+  tags: [query-plan, fingerprint, integration-tests, design, stability]
+  estimated_effort: "Medium"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -81,7 +81,8 @@ work:
             # Identical to DuckDBAdapter — EXPLAIN (ANALYZE, FORMAT JSON)
             explain_query = f"EXPLAIN (ANALYZE, FORMAT JSON) {query}"
             result = connection.execute(explain_query).fetchall()
-            return result[0][0] if result else None
+            # DuckDB EXPLAIN rows are (key, value) tuples; column 1 is the JSON value.
+            return result[0][1] if result else None
 
         def get_query_plan_parser(self):
             from benchbox.core.query_plans.parsers.duckdb import DuckDBQueryPlanParser
@@ -188,14 +189,17 @@ work:
 
   - id: w9
     summary: "Add unit tests for all newly wired adapters"
-    needs: [w1, w2, w3, w4, w5, w6, w7]
+    needs: [w1, w2, w3, w4, w6, w7]
     status: pending
     notes: |
       Create tests/unit/platforms/test_misc_plan_capture.py with parametrized
-      cases for MotherDuck, Databend, QuestDB, Velox, Doris, SingleStore:
+      cases for MotherDuck, Databend, QuestDB, Doris, SingleStore:
         - get_query_plan_parser() returns non-None
         - execute_query() with capture_plans=True captures plan (mock connection)
         - graceful degradation on capture failure
+      Velox (w5) is excluded from this test unit's needs because w5 is blocked
+      on the Presto/Trino TODO. Add Velox wiring tests to this file as a
+      follow-on once w5 completes.
 
 deferred:
   - summary: "cuDF EXPLAIN-based plan capture"
@@ -219,12 +223,14 @@ approach: |
   because it runs locally. QuestDB (w4) is next since get_query_plan() already
   exists. Velox (w5) depends on the Presto/Trino TODO being done first. Doris and
   SingleStore (w6+w7) are lower priority since they require external cluster access.
-  cuDF (w8) is documentation only. Consolidate all wiring tests in w9.
+  cuDF (w8) is documentation only. Consolidate most wiring tests in w9; add Velox
+  test separately after w5 unblocks.
 
 anti_patterns:
   - "DO NOT implement a cuDF parser stub expecting it will be called — cuDF always returns None and should continue to do so until upstream support exists."
   - "DO NOT add Velox-specific operator name handling to PrestoTrinoAdapterBase — Velox extensions should be in VeloxAdapter."
   - "DO NOT require a GPU or cuDF install for any unit tests."
+  - "DO NOT return result[0][0] from MotherDuck EXPLAIN — DuckDB EXPLAIN (ANALYZE, FORMAT JSON) rows are (key, value) tuples; column 0 is the key string (e.g., 'analyzed_plan'), column 1 is the JSON value. Use result[0][1]."
 
 verification:
   - description: "MotherDuck plan capture wiring tests pass"
@@ -265,4 +271,4 @@ metadata:
   tags: [query-plan, questdb, velox, databend, motherduck, cudf, doris, singlestore, misc]
   estimated_effort: "Large"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -74,7 +74,7 @@ prior_art:
 work:
   - id: w1
     summary: "MotherDuck: add get_query_plan() and get_query_plan_parser() reusing DuckDB components"
-    status: pending
+    status: done
     notes: |
       MotherDuck uses DuckDB's SQL dialect. In benchbox/platforms/motherduck.py:
         def get_query_plan(self, connection, query):
@@ -94,7 +94,7 @@ work:
   - id: w2
     summary: "MotherDuck: integrate capture_query_plan() into execute_query()"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Add the same capture guard as DuckDB to MotherDuckAdapter.execute_query().
       MotherDuck connections are DuckDB connections; no format differences expected.
@@ -271,4 +271,4 @@ metadata:
   tags: [query-plan, questdb, velox, databend, motherduck, cudf, doris, singlestore, misc]
   estimated_effort: "Large"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T12:00:00-04:00"
+  last_updated: "2026-06-08T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -1,0 +1,268 @@
+id: query-plan-capture-misc-platforms
+title: "Implement or resolve query plan capture for QuestDB, Velox, Databend, MotherDuck, cuDF, Doris, and SingleStore"
+worktree: platform-expansion
+priority: Low
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Seven platforms each have distinct plan capture situations ranging from
+  trivial wiring to fundamental unsupportability. They are grouped here
+  because they are lower priority than the main platform families and each
+  requires individual assessment before implementation.
+
+  Current state:
+    1. QuestDB (benchbox/platforms/questdb.py:1219)
+       - get_query_plan(): ✅ implemented — but execute_query() delegates to
+         shared execute_sql_query() which does not call capture_query_plan().
+         QuestDB uses a non-standard HTTP REST API and its EXPLAIN format is
+         a JSON response specific to QuestDB's JITC compiler.
+       - No parser exists. No execute_query() override calls capture_query_plan().
+
+    2. VeloxAdapter (benchbox/platforms/velox.py:487)
+       - get_query_plan(): ✅ at line 487 — annotates VeloxColumnar vs JVM-fallback
+         nodes. Output is text with custom Velox operator names.
+       - No parser. No execute_query() capture call.
+       - Velox's EXPLAIN format (via Prestissimo) is JSON similar to Presto's format.
+         If PrestoTrinoQueryPlanParser is completed first (see presto-trino TODO),
+         Velox may be able to reuse it.
+
+    3. DatabendAdapter (benchbox/platforms/databend/adapter.py:579)
+       - get_query_plan(): ✅ at line 579. Databend uses `EXPLAIN <query>` returning
+         a text tree similar to DuckDB.
+       - execute_query() exists at line 502. No capture call.
+       - No parser exists.
+
+    4. MotherDuckAdapter (benchbox/platforms/motherduck.py:74)
+       - Inherits PlatformAdapter (not DuckDBAdapter). No plan support inherited.
+       - MotherDuck IS serverless DuckDB and uses the same DuckDB SQL dialect.
+       - Should override get_query_plan() and get_query_plan_parser() to reuse
+         DuckDBQueryPlanParser. The EXPLAIN output format is identical to DuckDB.
+
+    5. cuDFAdapter (benchbox/platforms/cudf.py:594)
+       - get_query_plan(): ✅ at line 594 — but always returns None.
+         cuDF does not currently support EXPLAIN for its DataFrame or SQL layer.
+       - Resolution: document the limitation; mark as unsupported until cuDF
+         adds EXPLAIN support. No parser needed yet.
+
+    6. DorisAdapter (benchbox/platforms/doris.py)
+       - No get_query_plan() override. Inherits base (returns None).
+       - Doris supports `EXPLAIN <query>` with a text tree similar to MySQL EXPLAIN.
+       - No parser exists.
+
+    7. SingleStoreAdapter (benchbox/platforms/singlestore.py)
+       - No get_query_plan() override. Inherits base (returns None).
+       - SingleStore supports `EXPLAIN <query>` (MySQL-compatible).
+       - May be able to reuse or extend a MySQL/text-tree parser if one is added.
+
+prerequisites:
+  - "QuestDB: running QuestDB 7.x+ instance (env: QUESTDB_HOST, QUESTDB_PORT)"
+  - "VeloxAdapter: Prestissimo/Velox cluster accessible (env per VeloxAdapter config)"
+  - "DatabendAdapter: running Databend server or Databend Cloud account (env: DATABEND_HOST, DATABEND_USER, DATABEND_PASSWORD)"
+  - "MotherDuck: MotherDuck account + service token (env: MOTHERDUCK_TOKEN) — but DuckDB parser reuse requires no new credentials for unit tests"
+  - "cuDF: NVIDIA GPU + cuDF ≥23.x — no EXPLAIN support currently; flag as blocked until cuDF upstream adds SQL EXPLAIN"
+  - "Doris: running Apache Doris cluster (env: DORIS_HOST, DORIS_USER, DORIS_PASSWORD)"
+  - "SingleStore: SingleStore Managed Service or Helios Cloud account (env: SINGLESTORE_HOST, SINGLESTORE_USER, SINGLESTORE_PASSWORD)"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/duckdb.py — reuse for MotherDuck (identical EXPLAIN format)"
+  - "benchbox/platforms/duckdb.py:1038 — get_query_plan() text-EXPLAIN pattern"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() lazy import pattern"
+  - "benchbox/core/query_plans/parsers/presto_trino.py — reuse for Velox (Prestissimo uses Presto JSON format)"
+  - "benchbox/platforms/questdb.py:1219 — existing QuestDB get_query_plan() to confirm format before writing parser"
+
+work:
+  - id: w1
+    summary: "MotherDuck: add get_query_plan() and get_query_plan_parser() reusing DuckDB components"
+    status: pending
+    notes: |
+      MotherDuck uses DuckDB's SQL dialect. In benchbox/platforms/motherduck.py:
+        def get_query_plan(self, connection, query):
+            # Identical to DuckDBAdapter — EXPLAIN (ANALYZE, FORMAT JSON)
+            explain_query = f"EXPLAIN (ANALYZE, FORMAT JSON) {query}"
+            result = connection.execute(explain_query).fetchall()
+            return result[0][0] if result else None
+
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.duckdb import DuckDBQueryPlanParser
+            return DuckDBQueryPlanParser()
+      Then add the capture call to MotherDuckAdapter.execute_query() following
+      the DuckDB pattern. Verify EXPLAIN output is identical to DuckDB local.
+      Unit test: confirm get_query_plan_parser() returns DuckDBQueryPlanParser.
+
+  - id: w2
+    summary: "MotherDuck: integrate capture_query_plan() into execute_query()"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add the same capture guard as DuckDB to MotherDuckAdapter.execute_query().
+      MotherDuck connections are DuckDB connections; no format differences expected.
+
+  - id: w3
+    summary: "Databend: collect EXPLAIN sample, implement DatabendQueryPlanParser"
+    status: pending
+    notes: |
+      Run `EXPLAIN SELECT l_orderkey FROM lineitem LIMIT 10` against Databend.
+      Databend's EXPLAIN output uses an indented text tree similar to DuckDB's
+      text mode. Implement DatabendQueryPlanParser in
+      benchbox/core/query_plans/parsers/databend.py mapping operator names:
+        TableScan / ReadDataSource → SCAN
+        Filter → FILTER
+        AggregatorTransform / FinalAggregator → AGGREGATE
+        HashJoin → JOIN
+        SortingTransform → SORT
+      Register under dialect="databend". Wire get_query_plan_parser() and
+      capture call in DatabendAdapter.execute_query().
+
+  - id: w4
+    summary: "QuestDB: collect EXPLAIN JSON sample, implement QuestDBQueryPlanParser"
+    status: pending
+    notes: |
+      QuestDB EXPLAIN returns a JSON object with a `plan` array. Run
+      `EXPLAIN SELECT * FROM trades LIMIT 10` against a QuestDB instance.
+      Implement QuestDBQueryPlanParser for the JSON structure. Map QuestDB
+      operator names (SelectedRecord, Sort, GroupByRecord, etc.) to
+      LogicalOperatorType. Wire get_query_plan_parser() and fix the
+      execute_query() path to call capture_query_plan() — QuestDB's
+      execute_query() delegates to execute_sql_query(); may need an override.
+
+  - id: w5
+    summary: "Velox: assess Presto plan format reuse; wire parser after presto-trino TODO is complete"
+    status: pending
+    notes: |
+      BLOCKED on query-plan-capture-presto-trino-family.yaml being implemented first —
+      PrestoTrinoQueryPlanParser must exist before this work unit can proceed.
+      Velox (via Prestissimo) uses Presto's REST API and EXPLAIN FORMAT JSON.
+      Once PrestoTrinoQueryPlanParser is implemented, confirm Velox EXPLAIN output
+      matches the Presto fixture. If compatible, override get_query_plan_parser()
+      in VeloxAdapter to return PrestoTrinoQueryPlanParser. If Velox adds
+      Velox-native operator names, extend PrestoTrinoQueryPlanParser or subclass it.
+      Wire capture call in VeloxAdapter.execute_query().
+      NOTE: Only this work unit is blocked on Presto/Trino — w1 (MotherDuck),
+      w2 (MotherDuck), w3 (Databend), w4 (QuestDB), w6 (Doris), w7 (SingleStore)
+      can all proceed independently.
+
+  - id: w6
+    summary: "Doris + SingleStore: assess MySQL EXPLAIN format compatibility; implement shared or separate parsers"
+    status: pending
+    notes: |
+      Before writing any parser code, collect EXPLAIN output from both Doris and
+      SingleStore. Apache Doris EXPLAIN returns an indented text tree.
+      SingleStore EXPLAIN is MySQL-protocol-compatible and may use a similar format.
+
+      Pre-assessment step (required before parser implementation):
+        1. Run `EXPLAIN SELECT * FROM <table> LIMIT 1` against Doris and SingleStore.
+        2. If the indented-text format is identical or structurally equivalent,
+           implement ONE shared MySQLCompatibleQueryPlanParser that both adapters
+           can use via their get_query_plan_parser() override.
+        3. If the formats differ, implement DorisQueryPlanParser and
+           SingleStoreQueryPlanParser separately.
+
+      After parser decision is made:
+        - Wire get_query_plan() override for each adapter (if not present).
+        - Wire get_query_plan_parser() returning the chosen parser.
+        - Add capture_query_plan() call in each adapter's execute_query().
+
+  - id: w7
+    summary: "SingleStore: wire plan capture using parser chosen in w6"
+    needs: [w6]
+    status: pending
+    notes: |
+      After w6 determines whether DorisQueryPlanParser and SingleStoreQueryPlanParser
+      share a base or are separate, implement the SingleStore wiring:
+        - get_query_plan() returning `EXPLAIN <query>` output
+        - get_query_plan_parser() returning the chosen parser
+        - capture call in SingleStoreAdapter.execute_query()
+      If a shared MySQLCompatibleQueryPlanParser was created in w6, SingleStore
+      only needs the wiring; no new parser file required.
+
+  - id: w8
+    summary: "cuDF: document EXPLAIN limitation and add an explicit unsupported comment"
+    status: pending
+    notes: |
+      cuDF currently returns None from get_query_plan() (line 594). Add a
+      clear comment explaining why: cuDF's DataFrame/SQL layer does not expose
+      an EXPLAIN or plan inspection API as of the current cuDF version.
+      Track the upstream cuDF issue or GitHub discussion if one exists.
+      No parser or wiring needed until upstream support is added.
+
+  - id: w9
+    summary: "Add unit tests for all newly wired adapters"
+    needs: [w1, w2, w3, w4, w5, w6, w7]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_misc_plan_capture.py with parametrized
+      cases for MotherDuck, Databend, QuestDB, Velox, Doris, SingleStore:
+        - get_query_plan_parser() returns non-None
+        - execute_query() with capture_plans=True captures plan (mock connection)
+        - graceful degradation on capture failure
+
+deferred:
+  - summary: "cuDF EXPLAIN-based plan capture"
+    reason: "cuDF does not expose EXPLAIN or a plan inspection API. Defer until upstream cuDF adds support."
+
+deps:
+  needs: []
+  # Note: only w5 (Velox) is blocked on query-plan-capture-presto-trino-family.
+  # All other work units (MotherDuck, Databend, QuestDB, Doris, SingleStore)
+  # can proceed independently.
+
+must_preserve:
+  - "MotherDuckAdapter must continue to work without a MotherDuck account for unit tests."
+  - "cuDF adapter behavior must not change — get_query_plan() returning None is currently correct and expected."
+  - "All adapter execute_query() result dict shapes must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False for all seven platforms."
+
+approach: |
+  Start with MotherDuck (w1+w2) as the highest-confidence quick win — it reuses
+  DuckDBQueryPlanParser with no new parsing code required. Then Databend (w3)
+  because it runs locally. QuestDB (w4) is next since get_query_plan() already
+  exists. Velox (w5) depends on the Presto/Trino TODO being done first. Doris and
+  SingleStore (w6+w7) are lower priority since they require external cluster access.
+  cuDF (w8) is documentation only. Consolidate all wiring tests in w9.
+
+anti_patterns:
+  - "DO NOT implement a cuDF parser stub expecting it will be called — cuDF always returns None and should continue to do so until upstream support exists."
+  - "DO NOT add Velox-specific operator name handling to PrestoTrinoAdapterBase — Velox extensions should be in VeloxAdapter."
+  - "DO NOT require a GPU or cuDF install for any unit tests."
+
+verification:
+  - description: "MotherDuck plan capture wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_misc_plan_capture.py -k motherduck -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "All new misc-platform unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_misc_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/databend/adapter.py"
+    - "benchbox/platforms/questdb.py"
+    - "benchbox/platforms/velox.py"
+    - "benchbox/platforms/cudf.py"
+    - "benchbox/platforms/doris.py"
+    - "benchbox/platforms/singlestore.py"
+    - "benchbox/core/query_plans/parsers/databend.py"
+    - "benchbox/core/query_plans/parsers/questdb.py"
+    - "benchbox/core/query_plans/parsers/doris.py"
+    - "benchbox/core/query_plans/parsers/singlestore.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/platforms/test_misc_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml"
+
+success_metrics:
+  - "MotherDuck, Databend, QuestDB, Velox, Doris, and SingleStore adapters return a non-None parser from get_query_plan_parser()."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for all six platforms."
+  - "cuDF adapter has a clear comment explaining EXPLAIN is unsupported; get_query_plan() behavior is unchanged."
+  - "All unit tests pass."
+
+metadata:
+  tags: [query-plan, questdb, velox, databend, motherduck, cudf, doris, singlestore, misc]
+  estimated_effort: "Large"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-missing-guards.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-missing-guards.yaml
@@ -1,0 +1,185 @@
+id: query-plan-capture-missing-guards
+title: "Fix plan capture: missing SUCCESS guard and display_query_plan_if_enabled in DataFusion, SQLite, Redshift"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  PR #748 wired plan capture for DataFusion, SQLite, Redshift, PostgreSQL, and
+  MotherDuck. A follow-up adversarial review (PR #749) fixed two issues in Redshift
+  but left the same defects in DataFusion and SQLite, and a third defect in all
+  three non-DuckDB adapters.
+
+  **Defect 1 — Missing status guard in DataFusion and SQLite**
+
+  DataFusion (`benchbox/platforms/datafusion.py:1531`) and SQLite
+  (`benchbox/platforms/sqlite.py:562`) both have:
+
+    if self.capture_plans:
+        query_plan, plan_capture_time_ms = self.capture_query_plan(...)
+
+  with no `result.get("status") == "SUCCESS"` guard. When
+  `_build_query_result_with_validation()` returns `status="FAILED"` (row-count
+  validation failure), plan capture still fires — wasting an EXPLAIN round-trip
+  and attaching plan metadata to a FAILED result. PostgreSQL and Redshift both
+  have the correct guard (added in #749). DataFusion and SQLite do not.
+
+  **Defect 2 — display_query_plan_if_enabled not called in SQLite, DataFusion, Redshift**
+
+  `--show-query-plans` (CLI flag) is implemented via
+  `ResultCaptureMixin.display_query_plan_if_enabled()` in
+  `benchbox/platforms/base/result_capture.py:477`. DuckDB calls it at line 962
+  of `duckdb.py` unconditionally. MotherDuck calls it conditionally at line 298
+  (`if not self.capture_plans:`) to avoid issuing EXPLAIN twice when both
+  `--show-query-plans` and `--capture-plans` are active. SQLite, DataFusion,
+  and Redshift do not call it at all, so `--show-query-plans` silently produces
+  no console output for those three platforms.
+
+  **Pattern decision for w3/w4/w5**: Use the MotherDuck conditional pattern
+  (`if not self.capture_plans: self.display_query_plan_if_enabled(...)`) rather
+  than the DuckDB unconditional pattern. The conditional avoids double EXPLAIN
+  when capture is active, which is the correct tradeoff for display-only use.
+
+prior_art:
+  - "benchbox/platforms/postgresql.py:750 — correct pattern: if self.capture_plans and result.get('status') == 'SUCCESS'"
+  - "benchbox/platforms/redshift.py:2119 — correct pattern added in PR #749"
+  - "benchbox/platforms/duckdb.py:962 — display_query_plan_if_enabled() unconditional call (fires even when capture_plans=True, causing double EXPLAIN)"
+  - "benchbox/platforms/motherduck.py:298 — display_query_plan_if_enabled() conditional call: if not self.capture_plans — preferred pattern; avoids double EXPLAIN"
+  - "benchbox/platforms/base/result_capture.py:477 — display_query_plan_if_enabled() implementation"
+  - "tests/unit/platforms/test_redshift_plan_capture.py:76 — test_execute_query_failed_status_skips_capture pattern to replicate"
+
+work:
+  - id: w1
+    summary: "DataFusion: add status=='SUCCESS' guard to capture block"
+    status: pending
+    notes: |
+      In benchbox/platforms/datafusion.py around line 1531, change:
+        if self.capture_plans:
+      to:
+        if self.capture_plans and result.get("status") == "SUCCESS":
+      The variable holding the result of _build_query_result_with_validation()
+      at that point is named `result`.
+
+  - id: w2
+    summary: "SQLite: add status=='SUCCESS' guard to capture block"
+    status: pending
+    notes: |
+      In benchbox/platforms/sqlite.py around line 562, change:
+        if self.capture_plans:
+      to:
+        if self.capture_plans and result.get("status") == "SUCCESS":
+      The variable holding the result of _build_query_result_with_validation()
+      at that point is named `result`.
+
+  - id: w3
+    summary: "DataFusion: add display_query_plan_if_enabled() call before capture block"
+    needs: [w1]
+    status: pending
+    notes: |
+      In DataFusionAdapter.execute_query(), after the timed execution block
+      completes and before the capture_plans guard, add the conditional pattern
+      (matches motherduck.py:298 — avoids double EXPLAIN when both flags are active):
+        if not self.capture_plans:
+            self.display_query_plan_if_enabled(connection, query, query_id)
+      Place it immediately before `if self.capture_plans and ...`.
+
+  - id: w4
+    summary: "SQLite: add display_query_plan_if_enabled() call before capture block"
+    needs: [w2]
+    status: pending
+    notes: |
+      Same as w3 but for SQLiteAdapter.execute_query() in benchbox/platforms/sqlite.py.
+      Use the conditional pattern (`if not self.capture_plans: ...`).
+
+  - id: w5
+    summary: "Redshift: add display_query_plan_if_enabled() call before capture block"
+    status: pending
+    notes: |
+      RedshiftAdapter.execute_query() (benchbox/platforms/redshift.py) already has
+      the correct status guard (added in PR #749) but is missing the display call.
+      Use the conditional pattern before the capture guard at line ~2119:
+        if not self.capture_plans:
+            self.display_query_plan_if_enabled(connection, query, query_id)
+      Note: Redshift's result variable is named `result_dict` (not `result` as in
+      DataFusion/SQLite) — do not confuse variable names when adding the guard.
+
+  - id: w6
+    summary: "Add tests: DataFusion FAILED-status skips capture; DataFusion/SQLite/Redshift display call"
+    needs: [w1, w2, w3, w4, w5]
+    status: pending
+    notes: |
+      In tests/unit/platforms/test_datafusion_plan_capture.py, add
+      test_execute_query_failed_status_skips_capture mirroring the Redshift test
+      in test_redshift_plan_capture.py:76.
+
+      In tests/unit/platforms/test_sqlite_plan_capture.py, add the same.
+
+      For display_query_plan_if_enabled: add a test that monkeypatches
+      display_query_plan_if_enabled and confirms it is called exactly once
+      per execute_query() call for DataFusion, SQLite, and Redshift. One
+      test per adapter is sufficient; can be in the existing plan-capture test files.
+
+must_preserve:
+  - "DataFusionAdapter.execute_query() result dict shape must not change for non-plan fields."
+  - "SQLiteAdapter.execute_query() result dict shape must not change for non-plan fields."
+  - "RedshiftAdapter.execute_query() result dict shape must not change for non-plan fields."
+  - "Plan capture failures must not raise exceptions when strict_plan_capture=False."
+
+approach: |
+  These are all small, surgical edits — single-line guard additions and one
+  method call per adapter. Start with the status guard fixes (w1+w2) since they
+  are correctness bugs. Then add display calls (w3+w4+w5). Finally add the
+  tests (w6) to lock in the invariants. Each change is 1-3 lines; the tests
+  are the bulk of the work.
+
+  Variable naming note: DataFusion and SQLite use `result` as the local result
+  variable; Redshift uses `result_dict`. The connection variable is named
+  `connection` in DataFusion and `conn` in SQLite and Redshift. Verify the
+  actual names in each file before editing to avoid NameError.
+
+anti_patterns:
+  - "DO NOT add the display call after the return statement — because --show-query-plans must work independently of capture_plans — place it immediately before the `if self.capture_plans` guard instead."
+  - "DO NOT use the DuckDB unconditional display pattern (duckdb.py:962) — because it causes double EXPLAIN when both --show-query-plans and --capture-plans are active — use the MotherDuck conditional pattern (`if not self.capture_plans:`) instead."
+  - "DO NOT change result dict key names or touch existing fields — because downstream consumers depend on stable dict shape — only add the guard condition and display call."
+
+verification:
+  - description: "DataFusion FAILED-status skips capture test passes"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_datafusion_plan_capture.py -v"
+    expected_output: "All tests pass including new test_execute_query_failed_status_skips_capture"
+  - description: "SQLite FAILED-status skips capture test passes"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -v"
+    expected_output: "All tests pass including new test_execute_query_failed_status_skips_capture"
+  - description: "Full platform unit suite still green"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+    - "benchbox/platforms/redshift.py"
+    - "tests/unit/platforms/test_datafusion_plan_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_redshift_plan_capture.py"
+
+success_metrics:
+  - "DataFusion and SQLite capture blocks guard on status=='SUCCESS', matching PostgreSQL and Redshift."
+  - "--show-query-plans produces console output for DataFusion, SQLite, and Redshift."
+  - "New FAILED-status skip tests exist for DataFusion and SQLite."
+  - "0 regressions in the full unit suite."
+
+files_affected:
+  modified:
+    - "benchbox/platforms/datafusion.py"
+    - "benchbox/platforms/sqlite.py"
+    - "benchbox/platforms/redshift.py"
+    - "tests/unit/platforms/test_datafusion_plan_capture.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_redshift_plan_capture.py"
+
+metadata:
+  tags: [query-plan, datafusion, sqlite, redshift, correctness, display]
+  estimated_effort: "Small"
+  created_date: "2026-06-08"
+  last_updated: "2026-06-08T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-postgresql-family
 title: "Wire query plan capture end-to-end for PostgreSQL, Redshift, and derived adapters"
 worktree: platform-expansion
 priority: High
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -208,4 +208,6 @@ metadata:
   tags: [query-plan, postgresql, redshift, timescaledb, cedardb, pg-mooncake, wiring]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-08T00:00:00-04:00"
+  completed_date: "2026-06-04"
+  completed_in_prs: ["#748", "#749"]

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
@@ -1,0 +1,211 @@
+id: query-plan-capture-postgresql-family
+title: "Wire query plan capture end-to-end for PostgreSQL, Redshift, and derived adapters"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  PostgreSQL and Redshift both have fully-functional parsers in
+  `benchbox/core/query_plans/parsers/postgresql.py` and
+  `benchbox/core/query_plans/parsers/redshift.py`, and both adapters already
+  implement `get_query_plan()` that issues EXPLAIN ANALYZE. However, neither
+  adapter overrides `get_query_plan_parser()`, so the base class returns None
+  and `capture_query_plan()` is never reached. Three derived adapters —
+  TimescaleDB, CedarDB, and pg_mooncake — inherit `PostgreSQLAdapter` and will
+  receive plan capture for free once the parent is wired.
+
+  Gap summary per adapter:
+    - PostgreSQLAdapter (benchbox/platforms/postgresql.py:693)
+        • get_query_plan(): ✅ issues EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+        • get_query_plan_parser(): ❌ missing override → parser never instantiated
+        • execute_query(): ❌ never calls capture_query_plan()
+    - RedshiftAdapter (benchbox/platforms/redshift.py:2404)
+        • get_query_plan(): ✅ issues EXPLAIN
+        • get_query_plan_parser(): ❌ missing override
+        • execute_query(): ❌ never calls capture_query_plan()
+    - TimescaleDBAdapter, CedarDBAdapter, PgMooncakeAdapter
+        • All subclass PostgreSQLAdapter; will inherit fixed behavior once
+          PostgreSQLAdapter is patched.
+
+  The DuckDB adapter (benchbox/platforms/duckdb.py:969) is the reference
+  implementation. The pattern is: after the timed execute block, call
+  `capture_query_plan(connection, query, query_id)` guarded by
+  `self.capture_plans`, then set `plan_fingerprint` from the returned DAG.
+
+prerequisites:
+  - "Running PostgreSQL ≥12 instance accessible to the test harness for integration/UAT cells"
+  - "AWS Redshift credentials + cluster endpoint for Redshift integration tests (env: REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD, REDSHIFT_DB)"
+  - "Unit tests can run without credentials — mock the connection as PostgreSQL parser tests already do"
+
+prior_art:
+  - "benchbox/platforms/duckdb.py:969 — canonical execute_query plan-capture integration pattern to replicate"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/core/query_plans/parsers/postgresql.py — existing parser, not yet called by any adapter"
+  - "benchbox/core/query_plans/parsers/redshift.py — existing parser, not yet called by any adapter"
+  - "tests/unit/platforms/test_duckdb_plan_capture.py — test pattern to replicate for postgres family"
+  - "benchbox/platforms/base/result_capture.py:515 — base get_query_plan_parser() returns None"
+  - "benchbox/platforms/base/result_capture.py:561 — capture_query_plan() implementation"
+
+work:
+  - id: w1
+    summary: "Add get_query_plan_parser() override to PostgreSQLAdapter returning PostgreSQLQueryPlanParser"
+    status: pending
+    notes: |
+      Add to benchbox/platforms/postgresql.py:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
+            return PostgreSQLQueryPlanParser()
+      Keep the import lazy to match DuckDB's pattern and avoid heavy import cost at startup.
+
+  - id: w2
+    summary: "Integrate capture_query_plan() call into PostgreSQLAdapter.execute_query()"
+    needs: [w1]
+    status: pending
+    notes: |
+      Locate the return-result assembly block in PostgreSQLAdapter.execute_query().
+      After the timed SQL block, add the same capture_plans guard as DuckDB (line 968-971):
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate query_plan and plan_fingerprint into the result dict.
+
+  - id: w3
+    summary: "Add unit tests for PostgreSQL plan capture wiring"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_postgresql_plan_capture.py. Cover:
+        - get_query_plan_parser() returns PostgreSQLQueryPlanParser instance
+        - execute_query() with capture_plans=True calls capture_query_plan()
+        - execute_query() with capture_plans=False does not call capture_query_plan()
+        - plan_fingerprint is set in result dict when plan is captured
+        - capture failure is graceful (plan=None, benchmark still succeeds)
+      Mock the connection using the pattern in test_duckdb_plan_capture.py.
+
+  - id: w4
+    summary: "Add get_query_plan_parser() override to RedshiftAdapter returning RedshiftQueryPlanParser"
+    status: pending
+    notes: |
+      Same pattern as w1 but for benchbox/platforms/redshift.py:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+            return RedshiftQueryPlanParser()
+      Verify EXPLAIN format differences (Redshift uses text tree, not EXPLAIN ANALYZE BUFFERS).
+      Check whether RedshiftAdapter.get_query_plan() already strips the ANALYZE/BUFFERS
+      options for Redshift compatibility.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() call into RedshiftAdapter.execute_query()"
+    needs: [w4]
+    status: pending
+    notes: |
+      Same pattern as w2 but for benchbox/platforms/redshift.py execute_query().
+      Redshift EXPLAIN runs in the same connection context but cannot use ANALYZE
+      on live prod tables without advisory locks — confirm the existing
+      get_query_plan() already uses plain EXPLAIN (without ANALYZE) for Redshift.
+
+  - id: w6
+    summary: "Add unit tests for Redshift plan capture wiring"
+    needs: [w5]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_redshift_plan_capture.py. Same coverage
+      checklist as w3 but using RedshiftQueryPlanParser and mocking Redshift cursors.
+
+  - id: w7
+    summary: "Verify TimescaleDB, CedarDB, and pg_mooncake inherit plan capture without changes"
+    needs: [w3]
+    status: pending
+    notes: |
+      All three subclass PostgreSQLAdapter and do not override execute_query() or
+      get_query_plan_parser(). Run existing adapter unit tests to confirm no
+      regressions. Add a short parametrized test asserting that each subclass
+      instance returns a non-None parser from get_query_plan_parser().
+    coverage_checklist:
+      - id: ts-parser
+        description: "TimescaleDBAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+      - id: cedar-parser
+        description: "CedarDBAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+      - id: pgmc-parser
+        description: "PgMooncakeAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
+        evidence_required: "Assertion passes in parametrized unit test"
+
+  - id: w8
+    summary: "UAT cell smoke for PostgreSQL plan capture"
+    needs: [w3, w7]
+    status: pending
+    notes: |
+      Run a single TPC-H SF=0.01 cell against a live PostgreSQL instance with
+      --capture-plans enabled. Confirm query_plans_captured > 0 in the result
+      bundle. This step requires a live PostgreSQL instance (see prerequisites).
+
+deps:
+  needs: []
+
+must_preserve:
+  - "PostgreSQLAdapter.execute_query() continues to return the same result dict keys for callers that do not use plan capture."
+  - "TimescaleDB, CedarDB, and pg_mooncake adapters must not require any code changes — plan capture should be inherited automatically."
+  - "Redshift EXPLAIN must not use ANALYZE mode — Redshift does not support EXPLAIN ANALYZE syntax."
+  - "Plan capture failures must never raise an exception when strict_plan_capture is False (the default)."
+
+approach: |
+  Start with PostgreSQL (w1+w2+w3) since it is the reference SQL parser and
+  requires no cloud credentials for unit testing. Use DuckDB's execute_query()
+  as a line-by-line reference for the integration pattern. Then replicate for
+  Redshift (w4+w5+w6), noting that Redshift's EXPLAIN does not support ANALYZE.
+  After both parents are wired, run w7 to confirm the three derived adapters
+  inherit without change. Finish with a live PostgreSQL UAT cell (w8) if a
+  PostgreSQL instance is available; otherwise record as deferred.
+
+anti_patterns:
+  - "DO NOT add EXPLAIN ANALYZE to RedshiftAdapter.get_query_plan() — Redshift does not support EXPLAIN ANALYZE and will raise a syntax error."
+  - "DO NOT eagerly import PostgreSQLQueryPlanParser at module level — keep the import inside get_query_plan_parser() to match the lazy import pattern used by DuckDB."
+  - "DO NOT change TimescaleDBAdapter, CedarDBAdapter, or PgMooncakeAdapter — inheritance should carry the fix automatically; any explicit override is an anti-pattern here."
+  - "DO NOT add plan capture to the shared psycopg2 cursor helpers in benchbox/platforms/base/psycopg2_mixin.py — the capture call belongs in each adapter's own execute_query()."
+
+verification:
+  - description: "All new and existing PostgreSQL adapter unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_postgresql_plan_capture.py tests/unit/platforms/test_postgresql_adapter.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "All new Redshift adapter unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_redshift_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Subclass adapters inherit get_query_plan_parser() without overriding"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'timescale or cedardb or mooncake' -v"
+    expected_output: "Parametrized inheritance tests pass for all three adapters"
+  - description: "Full unit suite still green after changes"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/redshift.py"
+    - "tests/unit/platforms/test_postgresql_plan_capture.py"
+    - "tests/unit/platforms/test_redshift_plan_capture.py"
+    - "tests/unit/platforms/test_postgresql_adapter.py"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/timescaledb.py"
+    - "benchbox/platforms/cedardb.py"
+    - "benchbox/platforms/pg_mooncake.py"
+    - "benchbox/platforms/base/psycopg2_mixin.py"
+    - "benchbox/core/query_plans/parsers/postgresql.py"
+    - "benchbox/core/query_plans/parsers/redshift.py"
+
+success_metrics:
+  - "PostgreSQLAdapter.get_query_plan_parser() returns a non-None parser instance."
+  - "RedshiftAdapter.get_query_plan_parser() returns a non-None parser instance."
+  - "execute_query() with capture_plans=True captures and stores a QueryPlanDAG in the result dict."
+  - "TimescaleDB, CedarDB, and pg_mooncake adapters inherit plan capture with zero code changes."
+  - "All unit tests pass. No regressions in existing platform tests."
+
+metadata:
+  tags: [query-plan, postgresql, redshift, timescaledb, cedardb, pg-mooncake, wiring]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
@@ -1,0 +1,195 @@
+id: query-plan-capture-presto-trino-family
+title: "Implement query plan parser and end-to-end capture for Presto, Trino, Starburst, and Athena"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  The Presto/Trino family shares a common SQL dialect and EXPLAIN output format.
+  `presto_trino_adapter_base.py` already implements `get_query_plan()` at line 632
+  by delegating to `get_query_plan_from_cursor()`. PrestoAdapter and StarburstAdapter
+  inherit this without change. AthenaAdapter also implements `get_query_plan()` at
+  line 1294 the same way. None of these adapters override `get_query_plan_parser()`
+  (base returns None) and none call `capture_query_plan()` from `execute_query()`.
+
+  The primary work in this group is **writing a new PrestoTrinoQueryPlanParser**
+  since no parser exists today. Presto and Trino both output a JSON tree when
+  `EXPLAIN (FORMAT JSON)` is used, containing nodes with `id`, `name`,
+  `identifier`, `outputs`, `details`, and `children` fields. The parser
+  must produce a `QueryPlanDAG` from that structure.
+
+  Gap summary per adapter:
+    - PrestoAdapter / PrestoTrinoAdapterBase (benchbox/platforms/presto_trino_adapter_base.py)
+        • get_query_plan(): ✅ line 632 — EXPLAIN via cursor
+        • get_query_plan_parser(): ❌ no override
+        • execute_query(): ❌ no capture_query_plan() call
+    - StarburstAdapter (benchbox/platforms/starburst.py — inherits base)
+        • Same as PrestoAdapter via inheritance
+    - AthenaAdapter (benchbox/platforms/athena.py)
+        • get_query_plan(): ✅ line 1294 — EXPLAIN via cursor
+        • execute_query(): ✅ line 1179 — but no capture_query_plan() call
+        • get_query_plan_parser(): ❌ no override
+        • Athena uses the Presto engine; EXPLAIN output format is compatible
+
+  Note: Trino EXPLAIN FORMAT JSON and Presto EXPLAIN FORMAT JSON are structurally
+  similar but may differ in operator node names across major versions. The parser
+  should handle both dialects via version-aware node normalization.
+
+prerequisites:
+  - "Running Presto ≥0.280 or Trino ≥400 instance for integration tests and EXPLAIN format verification"
+  - "Starburst Galaxy or Enterprise instance for Starburst-specific EXPLAIN verification (optional — format should be identical to Trino)"
+  - "AWS credentials with AmazonAthenaFullAccess + S3 output bucket for Athena integration tests (env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, ATHENA_S3_OUTPUT, ATHENA_DATABASE)"
+  - "Unit tests (parser and wiring) can run without any credentials using recorded EXPLAIN fixtures"
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/datafusion.py — closest existing JSON-tree parser to replicate structurally"
+  - "benchbox/core/query_plans/parsers/base.py — abstract QueryPlanParser interface to implement"
+  - "benchbox/core/query_plans/parsers/registry.py — version-aware parser registration to use"
+  - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
+  - "benchbox/platforms/duckdb.py:969 — execute_query() capture integration pattern"
+  - "benchbox/platforms/presto_trino_adapter_base.py:632 — existing get_query_plan() implementation"
+
+work:
+  - id: w1
+    summary: "Collect representative EXPLAIN FORMAT JSON samples from Presto, Trino, and Athena"
+    status: pending
+    notes: |
+      Against live instances, run `EXPLAIN (FORMAT JSON) SELECT * FROM tpch.sf1.lineitem LIMIT 10`
+      (or equivalent small query) and capture the full JSON output. Record one sample
+      per engine+version combination. Store in tests/fixtures/query_plans/
+      as presto_explain_sample.json, trino_explain_sample.json,
+      athena_explain_sample.json. These fixtures drive parser unit tests.
+      Capture raw stdout to /tmp/presto-trino-explain-w1.log.
+
+  - id: w2
+    summary: "Implement PrestoTrinoQueryPlanParser in benchbox/core/query_plans/parsers/presto_trino.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement the abstract interface from base.py:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - Deserialize the JSON tree from EXPLAIN FORMAT JSON output
+        - Map Presto/Trino operator names to LogicalOperatorType enum
+          (TableScan→SCAN, Filter→FILTER, HashJoin/LookupJoin→JOIN, etc.)
+        - Normalize cross-version node naming differences (e.g., Trino renames
+          several operators across major versions — handle via operator name map)
+        - Register in parsers/registry.py under dialect="presto" and dialect="trino"
+          with version range 0.0.0+
+      Follow DataFusionQueryPlanParser as the closest structural template.
+
+  - id: w3
+    summary: "Add unit tests for PrestoTrinoQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_presto_trino_parser.py. Cover:
+        - Basic parse of each fixture sample produces a valid QueryPlanDAG
+        - Operator name normalization maps to expected LogicalOperatorType
+        - Cross-dialect (Presto vs Trino) produces equivalent DAG for same query
+        - Malformed JSON input triggers graceful error recovery (no exception)
+        - Parser registered correctly in registry for both dialects
+
+  - id: w4
+    summary: "Override get_query_plan_parser() in PrestoTrinoAdapterBase"
+    needs: [w2]
+    status: pending
+    notes: |
+      In benchbox/platforms/presto_trino_adapter_base.py add:
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
+            return PrestoTrinoQueryPlanParser()
+      PrestoAdapter and StarburstAdapter inherit this automatically.
+      Note: confirm EXPLAIN FORMAT JSON is supported by the cursor
+      in get_query_plan_from_cursor() — if not, override get_query_plan()
+      to use `EXPLAIN (FORMAT JSON)` explicitly.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() into PrestoTrinoAdapterBase execute_query() path"
+    needs: [w4]
+    status: pending
+    notes: |
+      The base class may or may not have a shared execute_query(). If it does,
+      add the capture guard there. If each adapter has its own execute_query(),
+      patch PrestoAdapter and StarburstAdapter separately. Either way, the pattern
+      is identical to DuckDB's execute_query() (line 968-971).
+
+  - id: w6
+    summary: "Override get_query_plan_parser() in AthenaAdapter; integrate capture in execute_query()"
+    needs: [w4]
+    status: pending
+    notes: |
+      AthenaAdapter has its own execute_query() (line 1179). Add get_query_plan_parser()
+      returning PrestoTrinoQueryPlanParser and add the capture call in execute_query().
+      Confirm Athena's EXPLAIN output via the fixture from w1 — Athena may strip
+      the FORMAT JSON option and return a text plan. If so, create a separate
+      AthenaQueryPlanParser or extend PrestoTrinoQueryPlanParser to handle both.
+
+  - id: w7
+    summary: "Add wiring unit tests for Presto/Starburst/Athena adapters"
+    needs: [w5, w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_presto_trino_plan_capture.py. Cover
+      get_query_plan_parser() returns non-None for Presto, Starburst, and Athena.
+      Mock cursor to return the fixture JSON from w1 and assert the result dict
+      includes query_plan and plan_fingerprint when capture_plans=True.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "PrestoAdapter, StarburstAdapter, and AthenaAdapter execute_query() result dict shape must not change for non-plan fields."
+  - "Plan capture failure must be silent when strict_plan_capture=False — Athena queries are expensive; never fail a benchmark run for a plan capture error."
+  - "The base EXPLAIN call in get_query_plan_from_cursor() must not be changed if other adapters depend on it."
+
+approach: |
+  Begin with fixture collection (w1) since the parser cannot be written without
+  knowing the exact JSON structure. Then implement the parser (w2) and its tests
+  (w3). Wire the parser into the adapter base (w4+w5), then handle Athena's
+  potentially different format separately (w6). Finish with wiring unit tests (w7).
+  Do not block on cloud credentials for the parser work — use fixtures for all
+  unit tests.
+
+anti_patterns:
+  - "DO NOT write the parser against assumed JSON structure — use the actual w1 fixture samples to drive the field mapping."
+  - "DO NOT use EXPLAIN ANALYZE for Athena — Athena does not run live queries during EXPLAIN; ANALYZE mode may not be supported."
+  - "DO NOT add Presto/Trino/Athena-specific logic to PrestoTrinoAdapterBase if only Athena needs it — Athena overrides should live in AthenaAdapter."
+
+verification:
+  - description: "Parser unit tests pass against fixture samples"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_presto_trino_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Adapter wiring unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_presto_trino_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/presto_trino_adapter_base.py"
+    - "benchbox/platforms/athena.py"
+    - "benchbox/core/query_plans/parsers/presto_trino.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_presto_trino_parser.py"
+    - "tests/unit/platforms/test_presto_trino_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml"
+  do_not_modify:
+    - "benchbox/platforms/presto.py"
+    - "benchbox/platforms/starburst.py"
+
+success_metrics:
+  - "PrestoTrinoQueryPlanParser parses fixture JSON samples from Presto and Trino into valid QueryPlanDAG objects."
+  - "PrestoTrinoAdapterBase.get_query_plan_parser() returns a non-None parser."
+  - "AthenaAdapter.get_query_plan_parser() returns a non-None parser."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint for Presto, Starburst, and Athena."
+  - "All unit tests pass."
+
+metadata:
+  tags: [query-plan, presto, trino, starburst, athena, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-presto-trino-family.yaml
@@ -19,15 +19,20 @@ description: |
   `identifier`, `outputs`, `details`, and `children` fields. The parser
   must produce a `QueryPlanDAG` from that structure.
 
+  IMPORTANT: The current `get_query_plan_from_cursor()` implementation issues bare
+  `EXPLAIN {query}` — it does NOT include FORMAT JSON. Overriding `get_query_plan()`
+  to issue `EXPLAIN (FORMAT JSON)` is required; this override is definitive, not
+  conditional.
+
   Gap summary per adapter:
     - PrestoAdapter / PrestoTrinoAdapterBase (benchbox/platforms/presto_trino_adapter_base.py)
-        • get_query_plan(): ✅ line 632 — EXPLAIN via cursor
+        • get_query_plan(): ⚠️ line 632 — issues bare EXPLAIN (FORMAT JSON override required)
         • get_query_plan_parser(): ❌ no override
         • execute_query(): ❌ no capture_query_plan() call
     - StarburstAdapter (benchbox/platforms/starburst.py — inherits base)
         • Same as PrestoAdapter via inheritance
     - AthenaAdapter (benchbox/platforms/athena.py)
-        • get_query_plan(): ✅ line 1294 — EXPLAIN via cursor
+        • get_query_plan(): ⚠️ line 1294 — bare EXPLAIN (FORMAT JSON override required)
         • execute_query(): ✅ line 1179 — but no capture_query_plan() call
         • get_query_plan_parser(): ❌ no override
         • Athena uses the Presto engine; EXPLAIN output format is compatible
@@ -40,7 +45,7 @@ prerequisites:
   - "Running Presto ≥0.280 or Trino ≥400 instance for integration tests and EXPLAIN format verification"
   - "Starburst Galaxy or Enterprise instance for Starburst-specific EXPLAIN verification (optional — format should be identical to Trino)"
   - "AWS credentials with AmazonAthenaFullAccess + S3 output bucket for Athena integration tests (env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, ATHENA_S3_OUTPUT, ATHENA_DATABASE)"
-  - "Unit tests (parser and wiring) can run without any credentials using recorded EXPLAIN fixtures"
+  - "Unit tests (parser and wiring) can run without any credentials using recorded EXPLAIN fixtures or synthetic fixtures based on the documented JSON schema"
 
 prior_art:
   - "benchbox/core/query_plans/parsers/datafusion.py — closest existing JSON-tree parser to replicate structurally"
@@ -48,7 +53,7 @@ prior_art:
   - "benchbox/core/query_plans/parsers/registry.py — version-aware parser registration to use"
   - "benchbox/platforms/duckdb.py:1069 — get_query_plan_parser() override pattern"
   - "benchbox/platforms/duckdb.py:969 — execute_query() capture integration pattern"
-  - "benchbox/platforms/presto_trino_adapter_base.py:632 — existing get_query_plan() implementation"
+  - "benchbox/platforms/presto_trino_adapter_base.py:632 — existing get_query_plan() (issues bare EXPLAIN; must be overridden)"
 
 work:
   - id: w1
@@ -61,6 +66,10 @@ work:
       as presto_explain_sample.json, trino_explain_sample.json,
       athena_explain_sample.json. These fixtures drive parser unit tests.
       Capture raw stdout to /tmp/presto-trino-explain-w1.log.
+
+      If live instances are not available, w2 and w3 can proceed with a synthetic
+      fixture based on the public Presto/Trino EXPLAIN FORMAT JSON schema —
+      document any assumptions in the fixture file header.
 
   - id: w2
     summary: "Implement PrestoTrinoQueryPlanParser in benchbox/core/query_plans/parsers/presto_trino.py"
@@ -91,18 +100,30 @@ work:
         - Parser registered correctly in registry for both dialects
 
   - id: w4
-    summary: "Override get_query_plan_parser() in PrestoTrinoAdapterBase"
+    summary: "Override get_query_plan() and get_query_plan_parser() in PrestoTrinoAdapterBase"
     needs: [w2]
     status: pending
     notes: |
-      In benchbox/platforms/presto_trino_adapter_base.py add:
-        def get_query_plan_parser(self):
-            from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
-            return PrestoTrinoQueryPlanParser()
-      PrestoAdapter and StarburstAdapter inherit this automatically.
-      Note: confirm EXPLAIN FORMAT JSON is supported by the cursor
-      in get_query_plan_from_cursor() — if not, override get_query_plan()
-      to use `EXPLAIN (FORMAT JSON)` explicitly.
+      In benchbox/platforms/presto_trino_adapter_base.py, BOTH overrides are required:
+
+      1. Override get_query_plan() to issue FORMAT JSON explicitly:
+           def get_query_plan(self, connection, query):
+               # The inherited get_query_plan_from_cursor() issues bare EXPLAIN;
+               # override here to get JSON for PrestoTrinoQueryPlanParser.
+               cursor = connection.cursor()
+               cursor.execute(f"EXPLAIN (FORMAT JSON) {query}")
+               rows = cursor.fetchall()
+               cursor.close()
+               return rows[0][0] if rows else None
+
+      2. Override get_query_plan_parser():
+           def get_query_plan_parser(self):
+               from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
+               return PrestoTrinoQueryPlanParser()
+
+      PrestoAdapter and StarburstAdapter inherit both automatically.
+      Verify the cursor API against w1 fixture collection — adjust row extraction
+      if needed.
 
   - id: w5
     summary: "Integrate capture_query_plan() into PrestoTrinoAdapterBase execute_query() path"
@@ -115,12 +136,13 @@ work:
       is identical to DuckDB's execute_query() (line 968-971).
 
   - id: w6
-    summary: "Override get_query_plan_parser() in AthenaAdapter; integrate capture in execute_query()"
+    summary: "Override get_query_plan() and get_query_plan_parser() in AthenaAdapter; integrate capture"
     needs: [w4]
     status: pending
     notes: |
-      AthenaAdapter has its own execute_query() (line 1179). Add get_query_plan_parser()
-      returning PrestoTrinoQueryPlanParser and add the capture call in execute_query().
+      AthenaAdapter has its own execute_query() (line 1179). Add get_query_plan()
+      returning `EXPLAIN (FORMAT JSON) {query}` output and get_query_plan_parser()
+      returning PrestoTrinoQueryPlanParser. Add the capture call in execute_query().
       Confirm Athena's EXPLAIN output via the fixture from w1 — Athena may strip
       the FORMAT JSON option and return a text plan. If so, create a separate
       AthenaQueryPlanParser or extend PrestoTrinoQueryPlanParser to handle both.
@@ -141,18 +163,21 @@ deps:
 must_preserve:
   - "PrestoAdapter, StarburstAdapter, and AthenaAdapter execute_query() result dict shape must not change for non-plan fields."
   - "Plan capture failure must be silent when strict_plan_capture=False — Athena queries are expensive; never fail a benchmark run for a plan capture error."
-  - "The base EXPLAIN call in get_query_plan_from_cursor() must not be changed if other adapters depend on it."
+  - "get_query_plan_from_cursor() in the base class must not be changed if other non-plan consumers depend on it — override get_query_plan() at the adapter level instead."
 
 approach: |
-  Begin with fixture collection (w1) since the parser cannot be written without
-  knowing the exact JSON structure. Then implement the parser (w2) and its tests
-  (w3). Wire the parser into the adapter base (w4+w5), then handle Athena's
-  potentially different format separately (w6). Finish with wiring unit tests (w7).
-  Do not block on cloud credentials for the parser work — use fixtures for all
-  unit tests.
+  Fixture collection (w1) is ideal but not blocking for parser work — the
+  Presto/Trino EXPLAIN FORMAT JSON schema is publicly documented and synthetic
+  fixtures can be written to unblock w2 and w3 without live instances. Then
+  wire the adapter base (w4+w5), noting that the get_query_plan() override is
+  required (not optional) because the inherited implementation issues bare EXPLAIN.
+  Handle Athena's potentially different format separately (w6). Finish with
+  wiring unit tests (w7). Do not block on cloud credentials for the parser
+  work — use fixtures for all unit tests.
 
 anti_patterns:
-  - "DO NOT write the parser against assumed JSON structure — use the actual w1 fixture samples to drive the field mapping."
+  - "DO NOT skip the get_query_plan() override in PrestoTrinoAdapterBase — the inherited get_query_plan_from_cursor() issues bare EXPLAIN, not FORMAT JSON, and PrestoTrinoQueryPlanParser cannot parse text output."
+  - "DO NOT write the parser against assumed JSON structure — use actual or synthetic w1 fixture samples to drive the field mapping."
   - "DO NOT use EXPLAIN ANALYZE for Athena — Athena does not run live queries during EXPLAIN; ANALYZE mode may not be supported."
   - "DO NOT add Presto/Trino/Athena-specific logic to PrestoTrinoAdapterBase if only Athena needs it — Athena overrides should live in AthenaAdapter."
 
@@ -192,4 +217,4 @@ metadata:
   tags: [query-plan, presto, trino, starburst, athena, new-parser]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
@@ -9,7 +9,10 @@ description: |
   SparkAdapter has `get_query_plan()` implemented in
   `benchbox/platforms/base/spark_execution_mixin.py` (line 688), but no parser
   exists and `execute_query()` (line 470, via `_execute_query_spark`) never calls
-  `capture_query_plan()`. Databricks likely has a similar or inherited state.
+  `capture_query_plan()`. Databricks has a dedicated adapter at
+  `benchbox/platforms/databricks/adapter.py` that inherits `PlatformAdapter`
+  directly (NOT SparkAdapter or SparkQueryExecutionMixin), so it will not inherit
+  plan capture automatically — explicit wiring is always required.
 
   Spark's EXPLAIN output has multiple modes:
     - `df.explain()` / `EXPLAIN <query>` — text plan with three sections:
@@ -35,7 +38,7 @@ description: |
   `_execute_query_spark()` after the timed SQL block.
 
 prerequisites:
-  - "Apache Spark ≥3.0 cluster or local Spark session (PySpark) for integration and EXPLAIN format verification"
+  - "Apache Spark ≥3.0 cluster or local Spark session (PySpark local[*] mode) for integration and EXPLAIN format verification — no cluster required for w1 with local mode"
   - "Databricks workspace URL + personal access token for Databricks integration tests (env: DATABRICKS_HOST, DATABRICKS_TOKEN)"
   - "Unit tests (parser + wiring) can run without a live cluster using recorded EXPLAIN fixture text"
   - "pyspark Python package installed in the venv for unit test mocking"
@@ -55,7 +58,8 @@ work:
     notes: |
       Check what SQL string get_query_plan() in spark_execution_mixin.py currently
       issues (EXPLAIN? EXPLAIN EXTENDED? EXPLAIN FORMATTED?). Capture the output
-      from a live Spark session against a simple TPC-H query. Record:
+      from a live Spark session (PySpark local[*] mode works without a cluster)
+      against a simple TPC-H query. Record:
         - Exact SQL issued
         - Full text output (all plan sections)
         - Spark version
@@ -126,18 +130,27 @@ work:
       Propagate into the return dict.
 
   - id: w6
-    summary: "Assess Databricks adapter inheritance and wire or override as needed"
+    summary: "Wire Databricks adapter plan capture explicitly"
     needs: [w4, w5]
     status: pending
     notes: |
-      Inspect benchbox/platforms/databricks.py (if it exists). If Databricks
-      inherits SparkAdapter or SparkQueryExecutionMixin, it will inherit plan
-      capture automatically. If it has its own execute_query() or connection
-      model, add the capture call there. Databricks Connect uses the same
-      PySpark API but may return different EXPLAIN text for Unity Catalog queries.
-      Confirm with a w1-style EXPLAIN sample if a Databricks workspace is available.
-      If credentials are unavailable, defer Databricks live validation to a
-      follow-up UAT and note the deferred status here.
+      IMPORTANT: DatabricksAdapter (benchbox/platforms/databricks/adapter.py)
+      inherits PlatformAdapter directly — NOT SparkAdapter or SparkQueryExecutionMixin.
+      Plan capture is never inherited automatically; wiring is always required
+      regardless of the Spark mixin implementation.
+
+      Steps:
+        1. Inspect benchbox/platforms/databricks/adapter.py to locate execute_query()
+           and understand the connection model.
+        2. Override get_query_plan_parser() to return SparkQueryPlanParser (Databricks
+           uses the same PySpark EXPLAIN format).
+        3. Override get_query_plan() if needed for the Databricks connection model.
+        4. Add the capture_query_plan() call in execute_query() after the timed block.
+
+      Databricks Connect uses the same PySpark API but may return different EXPLAIN
+      text for Unity Catalog queries. Confirm with a w1-style EXPLAIN sample if a
+      Databricks workspace is available. If credentials are unavailable, defer
+      Databricks live validation to a follow-up UAT and note the deferred status.
 
   - id: w7
     summary: "Add wiring unit tests for SparkAdapter plan capture"
@@ -166,17 +179,19 @@ must_preserve:
 
 approach: |
   Start with fixture collection (w1) to confirm the exact SQL issued and output
-  format. Implement the parser (w2) targeting the physical plan section of EXPLAIN
-  EXTENDED or EXPLAIN (whichever get_query_plan() already uses). Test the parser (w3).
+  format — PySpark local[*] mode avoids needing a real cluster for this step.
+  Implement the parser (w2) targeting the physical plan section. Test the parser (w3).
   Wire get_query_plan_parser() into the mixin (w4) and add the capture call in
-  _execute_query_spark() (w5). Assess Databricks (w6) based on its inheritance chain.
+  _execute_query_spark() (w5). Then wire Databricks explicitly (w6) — it does not
+  inherit from SparkAdapter so the mixin work does not flow through automatically.
   Finish with wiring unit tests (w7).
 
 anti_patterns:
   - "DO NOT modify benchbox/core/dataframe/profiling.py — that is a separate DataFrame plan system."
   - "DO NOT issue EXPLAIN during execution when capture_plans=False."
   - "DO NOT parse all four plan sections (Parsed, Analyzed, Optimized, Physical) — parse only the physical plan for fingerprinting to reduce noise across Spark versions."
-  - "DO NOT add Databricks-specific logic to SparkQueryExecutionMixin if it only applies to Databricks Connect."
+  - "DO NOT assume Databricks inherits plan capture from SparkQueryExecutionMixin — DatabricksAdapter inherits PlatformAdapter directly and requires explicit wiring in benchbox/platforms/databricks/adapter.py."
+  - "DO NOT edit benchbox/platforms/databricks.py — that path does not exist; the adapter is at benchbox/platforms/databricks/adapter.py."
 
 verification:
   - description: "Spark parser unit tests pass"
@@ -193,7 +208,7 @@ scope_limit:
   only_modify:
     - "benchbox/platforms/spark.py"
     - "benchbox/platforms/base/spark_execution_mixin.py"
-    - "benchbox/platforms/databricks.py"
+    - "benchbox/platforms/databricks/adapter.py"
     - "benchbox/core/query_plans/parsers/spark.py"
     - "benchbox/core/query_plans/parsers/registry.py"
     - "tests/unit/query_plans/test_spark_parser.py"
@@ -214,4 +229,4 @@ metadata:
   tags: [query-plan, spark, databricks, pyspark, new-parser]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-02T12:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
@@ -1,0 +1,217 @@
+id: query-plan-capture-spark-databricks
+title: "Implement query plan parser and end-to-end capture for Spark and Databricks adapters"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  SparkAdapter has `get_query_plan()` implemented in
+  `benchbox/platforms/base/spark_execution_mixin.py` (line 688), but no parser
+  exists and `execute_query()` (line 470, via `_execute_query_spark`) never calls
+  `capture_query_plan()`. Databricks likely has a similar or inherited state.
+
+  Spark's EXPLAIN output has multiple modes:
+    - `df.explain()` / `EXPLAIN <query>` — text plan with three sections:
+        == Parsed Logical Plan ==
+        == Analyzed Logical Plan ==
+        == Optimized Logical Plan ==
+        == Physical Plan ==
+    - `df.explain(extended=True)` — all four sections
+    - `df.explain(mode='formatted')` — Spark 3.x formatted tree
+    - `df.explain(mode='cost')` — cost-annotated plan
+
+  The physical plan section uses indentation-based text similar to DuckDB/ClickHouse
+  text format. Operator names include: FileScan, Filter, Project, HashAggregate,
+  Exchange, Sort, BroadcastHashJoin, SortMergeJoin, etc.
+
+  A separate DataFrame profiling path exists at
+  `benchbox/core/dataframe/profiling.py` for DataFrame-based Spark plan capture —
+  this TODO covers only the SQL execution path (`execute_query()`), not DataFrame
+  profiling, which is a parallel system.
+
+  Note on SparkQueryExecutionMixin: execute_query() at line 470 delegates to
+  `_execute_query_spark()` (line 491). The capture call should go into
+  `_execute_query_spark()` after the timed SQL block.
+
+prerequisites:
+  - "Apache Spark ≥3.0 cluster or local Spark session (PySpark) for integration and EXPLAIN format verification"
+  - "Databricks workspace URL + personal access token for Databricks integration tests (env: DATABRICKS_HOST, DATABRICKS_TOKEN)"
+  - "Unit tests (parser + wiring) can run without a live cluster using recorded EXPLAIN fixture text"
+  - "pyspark Python package installed in the venv for unit test mocking"
+
+prior_art:
+  - "benchbox/platforms/base/spark_execution_mixin.py:688 — existing get_query_plan() implementation"
+  - "benchbox/platforms/base/spark_execution_mixin.py:491 — _execute_query_spark() to add capture to"
+  - "benchbox/core/query_plans/parsers/duckdb.py — closest text-format parser (DuckDB text mode)"
+  - "benchbox/core/query_plans/parsers/base.py — abstract interface to implement"
+  - "benchbox/core/dataframe/profiling.py — parallel DataFrame plan system; do not modify"
+  - "benchbox/platforms/duckdb.py:969 — canonical capture integration pattern"
+
+work:
+  - id: w1
+    summary: "Collect Spark EXPLAIN text samples and confirm format used by get_query_plan()"
+    status: pending
+    notes: |
+      Check what SQL string get_query_plan() in spark_execution_mixin.py currently
+      issues (EXPLAIN? EXPLAIN EXTENDED? EXPLAIN FORMATTED?). Capture the output
+      from a live Spark session against a simple TPC-H query. Record:
+        - Exact SQL issued
+        - Full text output (all plan sections)
+        - Spark version
+      Store as tests/fixtures/query_plans/spark_explain_sample.txt.
+      If get_query_plan() issues bare EXPLAIN, it returns only the physical plan.
+      If EXPLAIN EXTENDED, all four sections are returned. Decide which sections
+      to parse (physical plan is most useful for fingerprinting).
+
+  - id: w2
+    summary: "Implement SparkQueryPlanParser in benchbox/core/query_plans/parsers/spark.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Implement QueryPlanParser abstract interface:
+        - parse(raw_plan: str) -> QueryPlanDAG
+        - If EXPLAIN EXTENDED is used, extract the physical plan section
+          (text between '== Physical Plan ==' and end of output)
+        - Parse indentation-based physical plan tree
+        - Operator name normalization:
+            FileScan parquet / FileScan csv → SCAN
+            Filter → FILTER
+            Project → PROJECT
+            HashAggregate / ObjectHashAggregate → AGGREGATE
+            Exchange / ShuffleExchange → EXCHANGE (map to a suitable LogicalOperatorType)
+            BroadcastHashJoin / SortMergeJoin / BroadcastNestedLoopJoin → JOIN
+            Sort → SORT
+        - Register in parsers/registry.py under dialect="spark" with version 3.0.0+
+      Follow DuckDB text parser as the closest structural template.
+
+  - id: w3
+    summary: "Add unit tests for SparkQueryPlanParser using fixture samples"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_spark_parser.py. Cover:
+        - Parse of fixture sample produces valid QueryPlanDAG
+        - Physical plan section correctly extracted when EXPLAIN EXTENDED is used
+        - Operator normalization maps to expected LogicalOperatorType
+        - Malformed / empty input triggers graceful error recovery
+        - Parser registered in registry under "spark" dialect
+
+  - id: w4
+    summary: "Add get_query_plan_parser() override to SparkAdapter (or SparkQueryExecutionMixin)"
+    needs: [w2]
+    status: pending
+    notes: |
+      In benchbox/platforms/spark.py or spark_execution_mixin.py (whichever is
+      most appropriate for the mixin hierarchy):
+        def get_query_plan_parser(self):
+            from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+            return SparkQueryPlanParser()
+      If get_query_plan_parser() is on SparkQueryExecutionMixin, SparkAdapter
+      inherits it automatically.
+
+  - id: w5
+    summary: "Integrate capture_query_plan() into _execute_query_spark()"
+    needs: [w4]
+    status: pending
+    notes: |
+      In benchbox/platforms/base/spark_execution_mixin.py, inside
+      _execute_query_spark() (line 491), after the timed SQL execution block:
+        if self.capture_plans:
+            query_plan, plan_capture_time_ms = self.capture_query_plan(
+                connection, query, query_id
+            )
+            if query_plan:
+                plan_fingerprint = query_plan.plan_fingerprint
+      Propagate into the return dict.
+
+  - id: w6
+    summary: "Assess Databricks adapter inheritance and wire or override as needed"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Inspect benchbox/platforms/databricks.py (if it exists). If Databricks
+      inherits SparkAdapter or SparkQueryExecutionMixin, it will inherit plan
+      capture automatically. If it has its own execute_query() or connection
+      model, add the capture call there. Databricks Connect uses the same
+      PySpark API but may return different EXPLAIN text for Unity Catalog queries.
+      Confirm with a w1-style EXPLAIN sample if a Databricks workspace is available.
+      If credentials are unavailable, defer Databricks live validation to a
+      follow-up UAT and note the deferred status here.
+
+  - id: w7
+    summary: "Add wiring unit tests for SparkAdapter plan capture"
+    needs: [w5, w6]
+    status: pending
+    notes: |
+      Create tests/unit/platforms/test_spark_plan_capture.py. Cover:
+        - get_query_plan_parser() returns SparkQueryPlanParser
+        - _execute_query_spark() with capture_plans=True calls capture_query_plan()
+        - result dict includes query_plan and plan_fingerprint when capture succeeds
+        - graceful degradation on EXPLAIN failure
+      Mock SparkSession / DataFrame to avoid requiring a live cluster.
+
+deferred:
+  - summary: "Wire plan capture for DataFrame execution path in benchbox/core/dataframe/profiling.py"
+    reason: "The DataFrame profiling system is a parallel architecture to the SQL execution path. Merging the two systems is a larger refactor that should be a separate TODO. This TODO covers only execute_query() SQL path."
+
+deps:
+  needs: []
+
+must_preserve:
+  - "SparkAdapter.execute_query() result dict shape must not change for non-plan fields."
+  - "DataFrame profiling in benchbox/core/dataframe/profiling.py must not be modified — it is out of scope."
+  - "Plan capture failure must be silent when strict_plan_capture=False."
+  - "_execute_query_spark() must not issue EXPLAIN when capture_plans=False."
+
+approach: |
+  Start with fixture collection (w1) to confirm the exact SQL issued and output
+  format. Implement the parser (w2) targeting the physical plan section of EXPLAIN
+  EXTENDED or EXPLAIN (whichever get_query_plan() already uses). Test the parser (w3).
+  Wire get_query_plan_parser() into the mixin (w4) and add the capture call in
+  _execute_query_spark() (w5). Assess Databricks (w6) based on its inheritance chain.
+  Finish with wiring unit tests (w7).
+
+anti_patterns:
+  - "DO NOT modify benchbox/core/dataframe/profiling.py — that is a separate DataFrame plan system."
+  - "DO NOT issue EXPLAIN during execution when capture_plans=False."
+  - "DO NOT parse all four plan sections (Parsed, Analyzed, Optimized, Physical) — parse only the physical plan for fingerprinting to reduce noise across Spark versions."
+  - "DO NOT add Databricks-specific logic to SparkQueryExecutionMixin if it only applies to Databricks Connect."
+
+verification:
+  - description: "Spark parser unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_spark_parser.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Spark adapter wiring tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_spark_plan_capture.py -v"
+    expected_output: "All tests pass, 0 failures"
+  - description: "Full unit suite passes"
+    command: "uv run -- python -m pytest tests/unit/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/spark.py"
+    - "benchbox/platforms/base/spark_execution_mixin.py"
+    - "benchbox/platforms/databricks.py"
+    - "benchbox/core/query_plans/parsers/spark.py"
+    - "benchbox/core/query_plans/parsers/registry.py"
+    - "tests/unit/query_plans/test_spark_parser.py"
+    - "tests/unit/platforms/test_spark_plan_capture.py"
+    - "tests/fixtures/query_plans/"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml"
+  do_not_modify:
+    - "benchbox/core/dataframe/profiling.py"
+    - "benchbox/platforms/base/cloud_spark/"
+
+success_metrics:
+  - "SparkQueryPlanParser parses EXPLAIN text fixture samples into valid QueryPlanDAG objects."
+  - "SparkAdapter.get_query_plan_parser() returns a non-None parser."
+  - "execute_query() with capture_plans=True stores QueryPlanDAG and plan_fingerprint in result dict."
+  - "No regressions in existing Spark adapter tests."
+
+metadata:
+  tags: [query-plan, spark, databricks, pyspark, new-parser]
+  estimated_effort: "Medium"
+  created_date: "2026-06-02"
+  last_updated: "2026-06-02T00:00:00-04:00"

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -41,8 +41,8 @@ branch-to-branch use; it is no longer a two-repo bridge but a `develop` →
 - **A1 — Branch name**: long-lived dev branch is `develop`.
 - **A2 — Default branch on GitHub**: stays `main`, so the canonical URL shows the release tree.
 - **A3 — Tree split**:
-  - **`main` only**: `benchbox/`, `tests/`, `docs/`, `examples/`, `_binaries/`, `_sources/`, `_chart_data/`, release-related contents of `scripts/`, `pyproject.toml`, `MANIFEST.in`, `Makefile`, `README.md`, `CHANGELOG.md`, `LICENSE`, `COPYRIGHT.md`, `DISCLAIMER.md`, `CONTRIBUTING.md`, `pytest.ini`, `pytest-ci.ini`, `uv.lock`, `.gitignore`, `.codespell-ignore.txt`, `landing/`, `.github/` (workflows + templates).
-  - **`develop` only** (in addition to everything on `main`): `_project/`, `_blog/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.gemini/`, `.pre-commit-config.yaml`, `_benchbox_pytest_xdist_safety.py`, `todo.config.yaml`, `skill-sync.yaml`, `skill-sync.lock`, `.coveragerc_core`, `.dockerignore`, `.env.example`, `.mcp.json`, dev-only scripts.
+  - **`main` only**: `benchbox/`, `tests/`, `docs/`, `examples/`, `_binaries/`, `_sources/`, `_chart_data/`, release-related contents of `scripts/`, `pyproject.toml`, `MANIFEST.in`, `Makefile`, `README.md`, `CHANGELOG.md`, `LICENSE`, `COPYRIGHT.md`, `DISCLAIMER.md`, `CONTRIBUTING.md`, `pytest.ini`, `pytest-ci.ini`, `_benchbox_pytest_xdist_safety.py`, `uv.lock`, `.gitignore`, `.codespell-ignore.txt`, `landing/`, `.github/` (workflows + templates).
+  - **`develop` only** (in addition to everything on `main`): `_project/`, `_blog/`, `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.claude/`, `.codex/`, `.gemini/`, `.pre-commit-config.yaml`, `todo.config.yaml`, `skill-sync.yaml`, `skill-sync.lock`, `.coveragerc_core`, `.dockerignore`, `.env.example`, `.mcp.json`, dev-only scripts.
 - **A4 — Release flow** (post-migration, repeated each release):
 
   ```

--- a/benchbox/base.py
+++ b/benchbox/base.py
@@ -14,7 +14,7 @@ from benchbox.core.benchmark_result_validation import BenchmarkResultValidationM
 from benchbox.core.connection import DatabaseConnection
 from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.cloud_storage import create_path_handler
-from benchbox.utils.scale_factor import format_scale_factor
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 from benchbox.utils.verbosity import VerbosityMixin, compute_verbosity
 
 BENCHMARK_API_SURFACE = "beta-public"
@@ -29,6 +29,50 @@ else:
         import sqlglot
     except ImportError:
         sqlglot = None
+
+
+class GeneratorOutputDirMixin:
+    """Keep nested data-generator output paths in sync with ``output_dir``.
+
+    Several benchmarks construct a nested data/download generator in
+    ``__init__`` that captures ``output_dir`` at construction time. When the
+    runner or orchestrator later assigns a resolved output root to
+    ``benchmark.output_dir`` (for example from an explicit CLI ``--output`` or a
+    shared data source), those nested generators must follow so generated data
+    lands under the configured root instead of a stale ``cwd``-local default.
+
+    Classes opt in by mixing this in and listing the relevant attribute names in
+    :attr:`OUTPUT_DIR_GENERATOR_ATTRS`. The mixin must precede other bases so its
+    ``output_dir`` data descriptor governs assignment.
+    """
+
+    #: Instance attribute names holding nested generators to keep in sync.
+    OUTPUT_DIR_GENERATOR_ATTRS: tuple[str, ...] = ("data_generator",)
+
+    @property
+    def output_dir(self) -> Any:
+        """Return the resolved output directory handler."""
+        return getattr(self, "_output_dir", None)
+
+    @output_dir.setter
+    def output_dir(self, value: Union[str, Path]) -> None:
+        """Set the output directory and propagate it to nested generators."""
+        self._output_dir = create_path_handler(value)
+        self._sync_output_dir_to_generators(self._output_dir)
+
+    def _sync_output_dir_to_generators(self, path: Any) -> None:
+        """Point each opted-in nested generator at ``path`` when present."""
+        for attr in self.OUTPUT_DIR_GENERATOR_ATTRS:
+            # Only touch concrete instance attributes so lazily-constructed
+            # generator properties are not triggered prematurely.
+            generator = self.__dict__.get(attr)
+            if generator is None or not hasattr(generator, "output_dir"):
+                continue
+            generator.output_dir = path
+            # Benchmarks that reuse TPC-H data nest a second generator.
+            nested = getattr(generator, "tpch_generator", None)
+            if nested is not None and hasattr(nested, "output_dir"):
+                nested.output_dir = path
 
 
 class BaseBenchmark(BenchmarkResultValidationMixin, VerbosityMixin, ABC):
@@ -67,10 +111,13 @@ class BaseBenchmark(BenchmarkResultValidationMixin, VerbosityMixin, ABC):
         self.scale_factor = scale_factor
 
         if output_dir is None:
-            # Use CLI-compatible default path: benchmark_runs/datagen/{benchmark}_{sf}
+            # Resolve the datagen root through the shared helper so an explicit
+            # BENCHBOX_OUTPUT_DIR is honored at construction time, before nested
+            # data generators capture the path. When no env override is set this
+            # falls back to Path.cwd()/benchmark_runs/datagen, preserving the
+            # historical default for ordinary local runs.
             benchmark_name = self._get_benchmark_name().lower()
-            sf_str = format_scale_factor(scale_factor)
-            self.output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"{benchmark_name}_{sf_str}"
+            self.output_dir = get_benchmark_runs_datagen_path(benchmark_name, scale_factor)
         else:
             # Support both local and cloud storage paths
             self.output_dir = create_path_handler(output_dir)

--- a/benchbox/core/amplab/benchmark.py
+++ b/benchbox/core/amplab/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.amplab.generator import AMPLabDataGenerator
 from benchbox.core.amplab.queries import AMPLabQueryManager
 from benchbox.core.amplab.schema import TABLES, get_all_create_table_sql
@@ -24,7 +24,9 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class AMPLabBenchmark(TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class AMPLabBenchmark(
+    GeneratorOutputDirMixin, TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark
+):
     """AMPLab Big Data Benchmark implementation.
 
     Tests big data processing systems using web analytics workloads.

--- a/benchbox/core/clickbench/benchmark.py
+++ b/benchbox/core/clickbench/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.clickbench.generator import ClickBenchDataGenerator
 from benchbox.core.clickbench.queries import ClickBenchQueryManager
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class ClickBenchBenchmark(SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class ClickBenchBenchmark(GeneratorOutputDirMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
     """ClickBench (ClickHouse Analytics Benchmark) implementation.
 
     Tests analytical database performance using web analytics data.

--- a/benchbox/core/coffeeshop/benchmark.py
+++ b/benchbox/core/coffeeshop/benchmark.py
@@ -6,7 +6,7 @@ import csv
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.coffeeshop.generator import CoffeeShopDataGenerator
 from benchbox.core.coffeeshop.queries import CoffeeShopQueryManager
 from benchbox.core.coffeeshop.schema import TABLES, get_all_create_table_sql
@@ -54,7 +54,7 @@ GROUP BY dl.region, totals.grand_total
 ORDER BY revenue DESC;"""
 
 
-class CoffeeShopBenchmark(TranslatableQueryMixin, BaseBenchmark):
+class CoffeeShopBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, BaseBenchmark):
     """Expose data generation and query execution for the CoffeeShop benchmark."""
 
     def __init__(

--- a/benchbox/core/datavault/benchmark.py
+++ b/benchbox/core/datavault/benchmark.py
@@ -28,6 +28,7 @@ from benchbox.core.datavault.schema import (
     get_create_all_tables_sql,
     get_table_loading_order,
 )
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 from benchbox.utils.scale_factor import format_scale_factor
 
 logger = logging.getLogger(__name__)
@@ -118,8 +119,9 @@ class DataVaultBenchmark(BaseBenchmark):
         if output_dir is not None:
             self.output_dir = Path(output_dir) if isinstance(output_dir, str) else output_dir
         elif not hasattr(self, "output_dir") or self.output_dir is None:
-            sf_str = format_scale_factor(self.scale_factor)
-            self.output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"{self._get_benchmark_name()}_{sf_str}"
+            # Honor BENCHBOX_OUTPUT_DIR at construction; falls back to
+            # Path.cwd()/benchmark_runs/datagen when no override is set.
+            self.output_dir = get_benchmark_runs_datagen_path(self._get_benchmark_name(), self.scale_factor)
 
         # Lazy-loaded components
         self._tpch_generator: Optional[Any] = None

--- a/benchbox/core/flightdata/benchmark.py
+++ b/benchbox/core/flightdata/benchmark.py
@@ -20,18 +20,19 @@ from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.flightdata.downloader import LAST_AVAILABLE_YEAR, FlightDataDownloader
 from benchbox.core.flightdata.queries import FlightDataQueryManager
 from benchbox.core.flightdata.schema import FLIGHT_SCHEMA, get_create_tables_sql
 from benchbox.utils.compression_mixin import extract_compression_kwargs
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
     from benchbox.core.dataframe.query import QueryRegistry
 
 
-class FlightDataBenchmark(BaseBenchmark):
+class FlightDataBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """US Aviation On-Time Performance OLAP benchmark.
 
     Uses BTS On-Time Performance data for realistic aviation analytics:
@@ -56,6 +57,9 @@ class FlightDataBenchmark(BaseBenchmark):
         - carriers: Carrier comparison and ranking (3 queries)
     """
 
+    # Nested downloader that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("downloader",)
+
     def __init__(
         self,
         scale_factor: float = 1.0,
@@ -79,8 +83,11 @@ class FlightDataBenchmark(BaseBenchmark):
             force_regenerate: Force data regeneration
             **kwargs: Additional options
         """
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (canonical flightdata_sf<N> datagen name); falls back
+        # to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir) if output_dir else Path.cwd() / "benchmark_runs" / "datagen" / f"flightdata_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("flightdata", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/h2odb/benchmark.py
+++ b/benchbox/core/h2odb/benchmark.py
@@ -10,7 +10,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.h2odb.generator import H2ODataGenerator
 from benchbox.core.h2odb.queries import H2OQueryManager
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class H2OBenchmark(TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
+class H2OBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
     """H2O DB benchmark implementation.
 
     Tests analytical database performance using synthetic taxi trip data

--- a/benchbox/core/joinorder_synthetic/benchmark.py
+++ b/benchbox/core/joinorder_synthetic/benchmark.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.joinorder.schema import JoinOrderSchema
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from benchbox.core.tuning import UnifiedTuningConfiguration
 
 
-class JoinOrderSyntheticBenchmark(BaseBenchmark):
+class JoinOrderSyntheticBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """Synthetic Join Order Benchmark implementation.
 
     This internal surface is for fast schema and loader smoke tests only.
@@ -42,6 +42,9 @@ class JoinOrderSyntheticBenchmark(BaseBenchmark):
     # that produce lines like "1,Comedy Adventure,,4,1957,,,,,,,".
     csv_delimiter = ","
     csv_null_marker = ""
+
+    # Nested generator that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("_generator",)
 
     def __init__(
         self,
@@ -73,10 +76,11 @@ class JoinOrderSyntheticBenchmark(BaseBenchmark):
         quiet = kwargs.pop("quiet", False)
 
         if output_dir is None:
-            from benchbox.utils.scale_factor import format_scale_factor
+            # Honor BENCHBOX_OUTPUT_DIR at construction; falls back to
+            # Path.cwd()/benchmark_runs/datagen when no override is set.
+            from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
-            sf_str = format_scale_factor(scale_factor)
-            output_dir = Path.cwd() / "benchmark_runs" / "datagen" / f"joinorder_synthetic_{sf_str}"
+            output_dir = get_benchmark_runs_datagen_path("joinorder_synthetic", scale_factor)
 
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/nyctaxi/benchmark.py
+++ b/benchbox/core/nyctaxi/benchmark.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.nyctaxi.downloader import GreenTaxiDataDownloader, HVFHVDataDownloader, NYCTaxiDataDownloader
 from benchbox.core.nyctaxi.queries import NYCTaxiQueryManager
 from benchbox.core.nyctaxi.schema import (
@@ -30,12 +30,13 @@ from benchbox.core.nyctaxi.schema import (
 )
 from benchbox.utils.compression_mixin import extract_compression_kwargs
 from benchbox.utils.datagen_manifest import DataGenerationManifest, resolve_compression_metadata
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
 
 
-class NYCTaxiBenchmark(BaseBenchmark):
+class NYCTaxiBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """NYC Taxi OLAP benchmark implementation.
 
     Uses real NYC TLC trip data for OLAP analytics workloads. Supports three
@@ -88,6 +89,9 @@ class NYCTaxiBenchmark(BaseBenchmark):
     # Available years for validation
     AVAILABLE_YEARS = list(range(2019, 2026))
 
+    # Nested downloaders that must track output_dir reassignment.
+    OUTPUT_DIR_GENERATOR_ATTRS = ("downloader", "green_downloader", "hvfhv_downloader")
+
     def __init__(
         self,
         scale_factor: float = 1.0,
@@ -123,8 +127,11 @@ class NYCTaxiBenchmark(BaseBenchmark):
         if year not in self.AVAILABLE_YEARS:
             raise ValueError(f"year must be in {self.AVAILABLE_YEARS[0]}-{self.AVAILABLE_YEARS[-1]}, got {year}")
 
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (matching the canonical nyctaxi_sf<N> datagen name);
+        # falls back to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir) if output_dir else Path.cwd() / "benchmark_runs" / "datagen" / f"nyctaxi_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("nyctaxi", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/query_plans/parsers/sqlite.py
+++ b/benchbox/core/query_plans/parsers/sqlite.py
@@ -147,9 +147,10 @@ class SQLiteQueryPlanParser(QueryPlanParser):
         """Infer operator type from line text."""
         upper = line.upper()
 
-        if "SCAN TABLE" in upper or "SCAN SUBQUERY" in upper:
+        # Handle both old ("SCAN TABLE name") and modern ("SCAN name") SQLite formats
+        if "SCAN TABLE" in upper or "SCAN SUBQUERY" in upper or upper.startswith("SCAN "):
             return "SCAN"
-        elif "SEARCH TABLE" in upper:
+        elif "SEARCH TABLE" in upper or upper.startswith("SEARCH "):
             return "INDEX_SCAN"
         elif "ORDER BY" in upper:
             return "SORT"
@@ -175,7 +176,8 @@ class SQLiteQueryPlanParser(QueryPlanParser):
         details: dict[str, Any] = {}
 
         # Extract table name from SCAN/SEARCH patterns
-        match = re.search(r"(?:SCAN|SEARCH) (?:TABLE|SUBQUERY) (\w+)", line, re.IGNORECASE)
+        # Handles both old ("SCAN TABLE name") and modern ("SCAN name") SQLite formats
+        match = re.search(r"(?:SCAN|SEARCH) (?:TABLE |SUBQUERY )?(\w+)", line, re.IGNORECASE)
         if match:
             details["table_name"] = match.group(1)
 

--- a/benchbox/core/ssb/benchmark.py
+++ b/benchbox/core/ssb/benchmark.py
@@ -13,7 +13,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.query_catalog_base import TranslatableQueryMixin
 from benchbox.core.query_utils import get_queries_with_translation
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
 
-class SSBBenchmark(TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark):
+class SSBBenchmark(
+    GeneratorOutputDirMixin, TranslatableQueryMixin, SimpleBenchmarkMixin, DataGenerationMixin, BaseBenchmark
+):
     """Star Schema Benchmark implementation.
 
     This class provides a complete implementation of the Star Schema Benchmark,

--- a/benchbox/core/tpcds_obt/benchmark.py
+++ b/benchbox/core/tpcds_obt/benchmark.py
@@ -12,7 +12,7 @@ from benchbox.core.base_benchmark import BaseBenchmark
 from benchbox.core.tpcds.generator import TPCDSDataGenerator
 from benchbox.core.tpcds_obt.etl.transformer import SUPPORTED_CHANNELS, TPCDSOBTTransformer
 from benchbox.core.tpcds_obt.queries import TPCDSOBTQueryManager
-from benchbox.utils.scale_factor import format_scale_factor
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 logger = logging.getLogger(__name__)
 
@@ -167,21 +167,19 @@ class TPCDSOBTBenchmark(BaseBenchmark):
             "TPC-DS benchmark adapted to a single wide One Big Table with sales + returns merged across channels."
         )
 
-        # Determine standard paths using scale factor formatting
-        sf_str = format_scale_factor(scale_factor)
-        default_base = Path.cwd() / "benchmark_runs" / "datagen"
-
+        # Determine standard paths via the shared helper so BENCHBOX_OUTPUT_DIR is
+        # honored; falls back to Path.cwd()/benchmark_runs/datagen when unset.
         # OBT output directory (for transformed OBT table)
         if output_dir:
             self.output_dir = Path(output_dir)
         else:
-            self.output_dir = default_base / f"tpcds_obt_{sf_str}"
+            self.output_dir = get_benchmark_runs_datagen_path("tpcds_obt", scale_factor)
 
         # TPC-DS source directory (for base TPC-DS data)
         if tpcds_source_dir:
             self.tpcds_source_dir = Path(tpcds_source_dir)
         else:
-            self.tpcds_source_dir = default_base / f"tpcds_{sf_str}"
+            self.tpcds_source_dir = get_benchmark_runs_datagen_path("tpcds", scale_factor)
 
         self.parallel = parallel
         self.force_regenerate = force_regenerate

--- a/benchbox/core/tpch/benchmark.py
+++ b/benchbox/core/tpch/benchmark.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Union
 if TYPE_CHECKING:
     from benchbox.core.tuning.interface import UnifiedTuningConfiguration
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.tpch.generator import TPCHDataGenerator
 from benchbox.core.tpch.maintenance_test import TPCHMaintenanceTest
 from benchbox.core.tpch.queries import TPCHQueries
@@ -152,7 +152,7 @@ def _expand_sqlite_named_column_aliases(query: str) -> str:
     )
 
 
-class TPCHBenchmark(BaseBenchmark):
+class TPCHBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """TPC-H benchmark implementation.
 
     This class provides a complete implementation of the TPC-H benchmark,

--- a/benchbox/core/tpchavoc/variant_sets/q02.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q02.yaml
@@ -397,7 +397,7 @@ variants:
               and s2.s_nationkey = n2.n_nationkey
               and n2.n_regionkey = r2.r_regionkey
               and r2.r_name = 'EUROPE'
-              and ps2.ps_supplycost < ps_supplycost
+              and ps2.ps_supplycost < partsupp.ps_supplycost
         )
     order by
         s_acctbal desc,

--- a/benchbox/core/tpchavoc/variant_sets/q11.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q11.yaml
@@ -20,7 +20,7 @@ variants:
             where ps2.ps_suppkey = s2.s_suppkey
               and s2.s_nationkey = n2.n_nationkey
               and n2.n_name = 'GERMANY'
-              and ps2.ps_partkey = ps_partkey
+              and ps2.ps_partkey = partsupp.ps_partkey
         )
     group by
         ps_partkey

--- a/benchbox/core/tpchavoc/variant_sets/q17.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q17.yaml
@@ -30,7 +30,7 @@ variants:
 - id: 8
   description: 'EXISTS pattern: Use EXISTS for membership testing'
   sql: |
-    select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and exists (select 1 from (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) avg_calc where avg_calc.l_partkey = l_partkey and l_quantity < avg_calc.threshold)
+    select sum(l_extendedprice) / 7.0 as avg_yearly from lineitem, part where p_partkey = l_partkey and p_brand = 'Brand#23' and p_container = 'MED BOX' and exists (select 1 from (select l_partkey, 0.2 * avg(l_quantity) as threshold from lineitem group by l_partkey) avg_calc where avg_calc.l_partkey = lineitem.l_partkey and lineitem.l_quantity < avg_calc.threshold)
 - id: 9
   description: 'Window functions (OLAP): Use window functions for ranking'
   sql: |

--- a/benchbox/core/tsbs_devops/benchmark.py
+++ b/benchbox/core/tsbs_devops/benchmark.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.tsbs_devops.generator import TSBSDevOpsDataGenerator
 from benchbox.core.tsbs_devops.queries import TSBSDevOpsQueryManager
 from benchbox.core.tsbs_devops.schema import (
@@ -26,12 +26,13 @@ from benchbox.core.tsbs_devops.schema import (
     get_create_tables_sql,
 )
 from benchbox.utils.compression_mixin import extract_compression_kwargs
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
 
 if TYPE_CHECKING:
     from benchbox.core.connection import DatabaseConnection
 
 
-class TSBSDevOpsBenchmark(BaseBenchmark):
+class TSBSDevOpsBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
     """TSBS DevOps benchmark implementation.
 
     Implements Time Series Benchmark Suite for DevOps monitoring workloads:
@@ -101,10 +102,11 @@ class TSBSDevOpsBenchmark(BaseBenchmark):
             force_regenerate: Force data regeneration
             **kwargs: Additional options
         """
+        # Resolve through the shared helper so BENCHBOX_OUTPUT_DIR is honored at
+        # construction time (canonical tsbs_devops_sf<N> datagen name); falls
+        # back to Path.cwd()/benchmark_runs/datagen when no override is set.
         resolved_output_dir = (
-            Path(output_dir)
-            if output_dir
-            else Path.cwd() / "benchmark_runs" / "datagen" / f"tsbs_devops_{scale_factor}"
+            Path(output_dir) if output_dir else get_benchmark_runs_datagen_path("tsbs_devops", scale_factor)
         )
         super().__init__(
             scale_factor=scale_factor,

--- a/benchbox/core/vector_search/benchmark.py
+++ b/benchbox/core/vector_search/benchmark.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from benchbox.base import BaseBenchmark
+from benchbox.base import BaseBenchmark, GeneratorOutputDirMixin
 from benchbox.core.benchmark_mixins import DataGenerationMixin
 from benchbox.core.query_catalog_base import QuerySkippedError, TranslatableQueryMixin
 from benchbox.core.utils.tuning import extract_constraint_flags
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 DEFAULT_DIMENSIONS = 128
 
 
-class VectorSearchBenchmark(TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
+class VectorSearchBenchmark(GeneratorOutputDirMixin, TranslatableQueryMixin, DataGenerationMixin, BaseBenchmark):
     """Vector search benchmark implementation.
 
     Tests similarity-search performance across OLAP databases that support

--- a/benchbox/platforms/base/data_loading.py
+++ b/benchbox/platforms/base/data_loading.py
@@ -6,6 +6,7 @@ and file formats, with support for compression and batch processing.
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import gzip
 import hashlib
@@ -2111,6 +2112,20 @@ class ClickHouseNativeHandler(FileFormatHandler):
             return value
 
         type_upper = type_name.upper()
+
+        # Array types: parse the CSV string representation into a Python list so
+        # clickhouse-driver receives a sequence rather than a raw string.
+        if "ARRAY" in type_upper:
+            if not value or value.upper() in ("\\N", "NULL"):
+                return None
+            try:
+                parsed = ast.literal_eval(value)
+                if isinstance(parsed, (list, tuple)):
+                    return list(parsed)
+            except (ValueError, SyntaxError):
+                pass
+            return value
+
         needs_non_string_value = (
             "INT" in type_upper
             or any(token in type_upper for token in ("DECIMAL", "NUMERIC", "DOUBLE", "FLOAT", "REAL"))

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -31,6 +31,7 @@ except ImportError:
     RuntimeEnv = None  # type: ignore[assignment, misc]  # ty: ignore[conflicting-declarations]
 
 from benchbox.core.dataframe.schema_utils import extract_schema_columns
+from benchbox.core.errors import PlanCaptureError
 from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
 from benchbox.platforms.base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
 from benchbox.platforms.base.no_constraint_mixin import NoConstraintEnforcementMixin
@@ -1538,6 +1539,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
 
             return result
 
+        except PlanCaptureError:
+            raise
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             logger.error(

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1408,7 +1408,7 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                 for i in range(batch.num_rows):
                     plan_type = batch.column(0)[i].as_py()
                     plan_text = batch.column(1)[i].as_py()
-                    if not plan_text:
+                    if not plan_type or not plan_text:
                         continue
                     lines = plan_text.split("\n")
                     prefix = " " * len(plan_type)

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1393,6 +1393,39 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         # Additional benchmark-specific settings can be added here
         self.log_verbose(f"DataFusion configured for {benchmark_type} benchmark")
 
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Get DataFusion query execution plan using EXPLAIN.
+
+        DataFusion's EXPLAIN returns a DataFrame with columns (plan_type, plan).
+        We reconstruct the pipe-delimited text format expected by DataFusionQueryPlanParser.
+        """
+        try:
+            batches = connection.sql(f"EXPLAIN {query}").collect()
+            if not batches:
+                return None
+            parts = []
+            for batch in batches:
+                for i in range(batch.num_rows):
+                    plan_type = batch.column(0)[i].as_py()
+                    plan_text = batch.column(1)[i].as_py()
+                    if not plan_text:
+                        continue
+                    lines = plan_text.split("\n")
+                    prefix = " " * len(plan_type)
+                    parts.append(f"{plan_type} | {lines[0]}")
+                    for line in lines[1:]:
+                        parts.append(f"{prefix} | {line}")
+            return "\n".join(parts) if parts else None
+        except Exception as e:
+            self.logger.debug(f"Failed to get DataFusion query plan: {e}")
+            return None
+
+    def get_query_plan_parser(self):
+        """Get DataFusion query plan parser."""
+        from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
+
+        return DataFusionQueryPlanParser()
+
     def execute_query(
         self,
         connection: Any,
@@ -1486,13 +1519,24 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                     )
 
             # Use centralized helper to build result with validation
-            return self._build_query_result_with_validation(
+            result = self._build_query_result_with_validation(
                 query_id=query_id,
                 execution_time=execution_time,
                 actual_row_count=actual_row_count,
                 first_row=first_row,
                 validation_result=validation_result,
             )
+
+            # Capture structured query plan if enabled
+            if self.capture_plans:
+                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+                if query_plan:
+                    result["query_plan"] = query_plan
+                    result["plan_fingerprint"] = query_plan.plan_fingerprint
+                if plan_capture_time_ms is not None:
+                    result["plan_capture_time_ms"] = plan_capture_time_ms
+
+            return result
 
         except Exception as e:
             execution_time = elapsed_seconds(start_time)

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -224,6 +224,29 @@ class MotherDuckAdapter(PlatformAdapter):
         if connection is None:
             self.connection = None
 
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Get MotherDuck query execution plan using EXPLAIN (ANALYZE, FORMAT JSON).
+
+        MotherDuck uses DuckDB's SQL dialect; EXPLAIN format is identical.
+        DuckDB EXPLAIN rows are (explain_key, explain_value) tuples; column 1 is the JSON payload.
+        """
+        analyze = getattr(self, "analyze_plans", True)
+        explain_options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
+        try:
+            rows = (connection or self.connection).execute(f"EXPLAIN ({explain_options}) {query}").fetchall()
+            # column 0 is the key (e.g. "analyzed_plan"), column 1 is the JSON value
+            parts = [str(row[1]) for row in rows if len(row) > 1]
+            return "\n".join(parts) if parts else None
+        except Exception as e:
+            logger.debug(f"Failed to get MotherDuck query plan: {e}")
+            return None
+
+    def get_query_plan_parser(self):
+        """Get MotherDuck query plan parser (reuses DuckDB parser)."""
+        from benchbox.core.query_plans.parsers.duckdb import DuckDBQueryPlanParser
+
+        return DuckDBQueryPlanParser()
+
     def execute_query(
         self,
         connection: Any,
@@ -258,7 +281,7 @@ class MotherDuckAdapter(PlatformAdapter):
             rows = result.fetchall()
             execution_time = elapsed_seconds(start_time)
             logger.debug(f"Query {query_id} completed in {execution_time:.3f}s, returned {len(rows)} rows")
-            return {
+            result_dict = {
                 "query_id": query_id,
                 "stream_id": stream_id,
                 "status": "SUCCESS",
@@ -267,6 +290,17 @@ class MotherDuckAdapter(PlatformAdapter):
                 "first_row": rows[0] if rows else None,
                 "error": None,
             }
+
+            # Capture structured query plan if enabled
+            if self.capture_plans:
+                query_plan, plan_capture_time_ms = self.capture_query_plan(conn, query, query_id)
+                if query_plan:
+                    result_dict["query_plan"] = query_plan
+                    result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
+                if plan_capture_time_ms is not None:
+                    result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+
+            return result_dict
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             logger.error(f"Query {query_id} failed after {execution_time:.2f}s: {e}")

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -290,8 +290,12 @@ class MotherDuckAdapter(PlatformAdapter):
                 "error": None,
             }
 
-            # Display plan in console when --show-query-plans is active
-            self.display_query_plan_if_enabled(conn, query, query_id)
+            # Display plan in console when --show-query-plans is active.
+            # Skip here when --capture-plans is also active: capture_query_plan below
+            # already calls get_query_plan (running EXPLAIN ANALYZE); calling
+            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(conn, query, query_id)
 
             # Capture structured query plan if enabled
             if self.capture_plans:

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -230,12 +230,11 @@ class MotherDuckAdapter(PlatformAdapter):
         MotherDuck uses DuckDB's SQL dialect; EXPLAIN format is identical.
         DuckDB EXPLAIN rows are (explain_key, explain_value) tuples; column 1 is the JSON payload.
         """
-        analyze = getattr(self, "analyze_plans", True)
-        explain_options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
+        explain_options = "ANALYZE, FORMAT JSON" if self.analyze_plans else "FORMAT JSON"
         try:
             rows = (connection or self.connection).execute(f"EXPLAIN ({explain_options}) {query}").fetchall()
             # column 0 is the key (e.g. "analyzed_plan"), column 1 is the JSON value
-            parts = [str(row[1]) for row in rows if len(row) > 1]
+            parts = [str(row[1]) for row in rows]
             return "\n".join(parts) if parts else None
         except Exception as e:
             logger.debug(f"Failed to get MotherDuck query plan: {e}")
@@ -290,6 +289,9 @@ class MotherDuckAdapter(PlatformAdapter):
                 "first_row": rows[0] if rows else None,
                 "error": None,
             }
+
+            # Display plan in console when --show-query-plans is active
+            self.display_query_plan_if_enabled(conn, query, query_id)
 
             # Capture structured query plan if enabled
             if self.capture_plans:

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -12,6 +12,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -713,8 +714,14 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             cursor.execute(explain_query)
             plan_rows = cursor.fetchall()
             cursor.close()
-            # PostgreSQL returns the full JSON as the first column of the first row
-            return plan_rows[0][0] if plan_rows else None
+            # PostgreSQL returns the full JSON as the first column of the first row.
+            # psycopg decodes FORMAT JSON output as a Python object; re-serialize
+            # to a string so PostgreSQLQueryPlanParser.parse_explain_output() receives
+            # the string it expects.
+            raw = plan_rows[0][0] if plan_rows else None
+            if raw is not None and not isinstance(raw, str):
+                raw = json.dumps(raw)
+            return raw
 
         except Exception as e:
             cursor.close()

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -695,17 +695,16 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         connection: Any,
         query: str,
         explain_options: dict[str, Any] | None = None,
-    ) -> str:
-        """Get query execution plan using EXPLAIN ANALYZE."""
+    ) -> str | None:
+        """Get query execution plan using EXPLAIN (ANALYZE, FORMAT JSON)."""
         cursor = connection.cursor()
 
-        # Build EXPLAIN options
-        options = ["ANALYZE", "BUFFERS", "FORMAT TEXT"]
+        # Use FORMAT JSON so PostgreSQLQueryPlanParser can parse the output.
+        # ANALYZE and BUFFERS give actual timing and I/O info.
+        options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]
         if explain_options:
             if explain_options.get("verbose"):
                 options.append("VERBOSE")
-            if explain_options.get("costs", True):
-                options.append("COSTS")
 
         options_str = ", ".join(options)
         explain_query = f"EXPLAIN ({options_str}) {query}"
@@ -714,12 +713,48 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             cursor.execute(explain_query)
             plan_rows = cursor.fetchall()
             cursor.close()
-
-            return "\n".join(row[0] for row in plan_rows)
+            # PostgreSQL returns the full JSON as the first column of the first row
+            return plan_rows[0][0] if plan_rows else None
 
         except Exception as e:
             cursor.close()
-            return f"Failed to get query plan: {e}"
+            self.logger.debug(f"Failed to get query plan: {e}")
+            return None
+
+    def get_query_plan_parser(self):
+        """Get PostgreSQL query plan parser."""
+        from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
+
+        return PostgreSQLQueryPlanParser()
+
+    def execute_query(
+        self,
+        connection: Any,
+        query: str,
+        query_id: str,
+        benchmark_type: str | None = None,
+        scale_factor: float | None = None,
+        validate_row_count: bool = True,
+        stream_id: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute a query and optionally capture the structured query plan."""
+        result = super().execute_query(
+            connection=connection,
+            query=query,
+            query_id=query_id,
+            benchmark_type=benchmark_type,
+            scale_factor=scale_factor,
+            validate_row_count=validate_row_count,
+            stream_id=stream_id,
+        )
+        if self.capture_plans and result.get("status") == "SUCCESS":
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                result["query_plan"] = query_plan
+                result["plan_fingerprint"] = query_plan.plan_fingerprint
+            if plan_capture_time_ms is not None:
+                result["plan_capture_time_ms"] = plan_capture_time_ms
+        return result
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Run ANALYZE on a table to update statistics."""

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2114,8 +2114,9 @@ class RedshiftAdapter(PlatformAdapter):
             # Map query_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = query_stats
 
-            # Capture structured query plan if enabled
-            if self.capture_plans:
+            # Capture structured query plan if enabled (only on SUCCESS to avoid
+            # wasteful EXPLAIN on validation-failed results)
+            if self.capture_plans and result_dict.get("status") == "SUCCESS":
                 query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
                 if query_plan:
                     result_dict["query_plan"] = query_plan

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         UnifiedTuningConfiguration,
     )
 
+from ..core.errors import PlanCaptureError
 from ..core.exceptions import ConfigurationError
 from ..utils.dependencies import (
     check_platform_dependencies,
@@ -2126,6 +2127,8 @@ class RedshiftAdapter(PlatformAdapter):
 
             return result_dict
 
+        except PlanCaptureError:
+            raise
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             error_type = type(e).__name__

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2114,6 +2114,15 @@ class RedshiftAdapter(PlatformAdapter):
             # Map query_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = query_stats
 
+            # Capture structured query plan if enabled
+            if self.capture_plans:
+                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+                if query_plan:
+                    result_dict["query_plan"] = query_plan
+                    result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
+                if plan_capture_time_ms is not None:
+                    result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+
             return result_dict
 
         except Exception as e:
@@ -2401,18 +2410,24 @@ class RedshiftAdapter(PlatformAdapter):
         finally:
             cursor.close()
 
-    def get_query_plan(self, connection: Any, query: str) -> str:
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
         """Get query execution plan for analysis."""
         cursor = connection.cursor()
         try:
-            # Note: Query dialect translation is now handled automatically by the base adapter
             cursor.execute(f"EXPLAIN {query}")
             plan_rows = cursor.fetchall()
-            return "\n".join([row[0] for row in plan_rows])
+            return "\n".join([row[0] for row in plan_rows]) if plan_rows else None
         except Exception as e:
-            return f"Could not get query plan: {e}"
+            self.logger.debug(f"Could not get query plan: {e}")
+            return None
         finally:
             cursor.close()
+
+    def get_query_plan_parser(self):
+        """Get Redshift query plan parser."""
+        from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+
+        return RedshiftQueryPlanParser()
 
     def close_connection(self, connection: Any) -> None:
         """Close Redshift connection."""

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from benchbox.core.errors import PlanCaptureError
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 if TYPE_CHECKING:
@@ -569,6 +570,8 @@ class SQLiteAdapter(PlatformAdapter):
 
             return result
 
+        except PlanCaptureError:
+            raise
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             return {

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -475,6 +475,28 @@ class SQLiteAdapter(PlatformAdapter):
             # OLTP optimizations
             connection.execute("PRAGMA synchronous = FULL")
 
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Get SQLite query execution plan using EXPLAIN QUERY PLAN.
+
+        Reconstructs the tree-formatted text that SQLiteQueryPlanParser expects
+        from the raw (id, parent, notused, detail) rows SQLite returns.
+        """
+        try:
+            cursor = connection.cursor()
+            cursor.execute(f"EXPLAIN QUERY PLAN {query}")
+            rows = cursor.fetchall()
+            cursor.close()
+            return _format_sqlite_query_plan(rows) if rows else None
+        except Exception as e:
+            self.logger.debug(f"Failed to get SQLite query plan: {e}")
+            return None
+
+    def get_query_plan_parser(self):
+        """Get SQLite query plan parser."""
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        return SQLiteQueryPlanParser()
+
     def execute_query(
         self,
         connection: Any,
@@ -534,6 +556,16 @@ class SQLiteAdapter(PlatformAdapter):
             )
             # Include full results for SQLite compatibility
             result["results"] = results
+
+            # Capture structured query plan if enabled
+            if self.capture_plans:
+                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+                if query_plan:
+                    result["query_plan"] = query_plan
+                    result["plan_fingerprint"] = query_plan.plan_fingerprint
+                if plan_capture_time_ms is not None:
+                    result["plan_capture_time_ms"] = plan_capture_time_ms
+
             return result
 
         except Exception as e:
@@ -557,6 +589,41 @@ class SQLiteAdapter(PlatformAdapter):
     def run_maintenance_test(self, benchmark, **kwargs) -> dict[str, Any]:
         """Run TPC maintenance test (not implemented for SQLite)."""
         raise NotImplementedError("Maintenance test not implemented for SQLite adapter")
+
+
+def _format_sqlite_query_plan(rows: list) -> str | None:
+    """Format SQLite EXPLAIN QUERY PLAN rows into tree text for SQLiteQueryPlanParser.
+
+    SQLite returns rows of (id, parent, notused, detail). Reconstructs the
+    indented "|--" / "`--" tree format that SQLiteQueryPlanParser expects.
+    """
+    if not rows:
+        return None
+    node_text: dict[int, str] = {}
+    children: dict[int, list[int]] = {}
+    for row in rows:
+        node_id, parent_id, _unused, detail = int(row[0]), int(row[1]), row[2], str(row[3])
+        node_text[node_id] = detail
+        children.setdefault(parent_id, []).append(node_id)
+
+    roots = children.get(0, [])
+    if not roots:
+        return None
+
+    lines = ["QUERY PLAN"]
+
+    def _emit(node_id: int, prefix: str, is_last: bool) -> None:
+        marker = "`--" if is_last else "|--"
+        lines.append(f"{prefix}{marker}{node_text[node_id]}")
+        child_ids = children.get(node_id, [])
+        ext = "   " if is_last else "|  "
+        for i, cid in enumerate(child_ids):
+            _emit(cid, prefix + ext, i == len(child_ids) - 1)
+
+    for i, rid in enumerate(roots):
+        _emit(rid, "", i == len(roots) - 1)
+
+    return "\n".join(lines)
 
 
 def _is_tpch_benchmark(benchmark: Any) -> bool:

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -481,15 +481,16 @@ class SQLiteAdapter(PlatformAdapter):
         Reconstructs the tree-formatted text that SQLiteQueryPlanParser expects
         from the raw (id, parent, notused, detail) rows SQLite returns.
         """
+        cursor = connection.cursor()
         try:
-            cursor = connection.cursor()
             cursor.execute(f"EXPLAIN QUERY PLAN {query}")
             rows = cursor.fetchall()
-            cursor.close()
             return _format_sqlite_query_plan(rows) if rows else None
         except Exception as e:
             self.logger.debug(f"Failed to get SQLite query plan: {e}")
             return None
+        finally:
+            cursor.close()
 
     def get_query_plan_parser(self):
         """Get SQLite query plan parser."""

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -21,170 +21,79 @@ BenchBox's expansion roadmap focuses on three strategic areas:
 
 | Category | Current | Planned |
 |----------|---------|---------|
-| SQL Platforms | 33 | +6 |
-| DataFrame Platforms | 8 | +0 |
-| Benchmarks | 12 | +6 |
-| DataFrame-enabled Benchmarks | 2 (TPC-H, TPC-DS) | +13 |
+| SQL Platforms | 39 | +0 |
+| DataFrame Platforms | 9 | +0 |
+| Benchmarks | 22 | +4 |
+| DataFrame-enabled Benchmarks | 21 | +1 (Geospatial) |
 
 ---
 
 ## Platform Additions
 
-### High Priority
+All previously planned platform additions through Phase 4 have shipped. The platform expansion roadmap is complete pending new sponsorship or community requests.
 
-#### LakeSail Sail (Rust-based Spark Replacement)
+### Completed Platforms
 
-**Status**: Not Started | **Effort**: Large | **Modes**: SQL + DataFrame
-
-LakeSail Sail is a Rust-based, drop-in replacement for Apache Spark built on DataFusion. It claims 4x faster execution with 94% lower hardware costs versus Apache Spark (TPC-H SF100 benchmarks).
-
-**Key Characteristics**:
-- Spark Connect protocol compatibility (existing PySpark code works unchanged)
-- Multi-threaded single-host or distributed cluster execution
-- DataFusion query optimizer with Rust workers
-
-**Why it matters**: Growing interest in Spark alternatives with improved cost efficiency. Direct comparison validates vendor performance claims with independent TPC-H/TPC-DS benchmarks.
-
-**Implementation**:
-- `benchbox/platforms/lakesail.py` - SQL adapter via Spark Connect
-- `benchbox/platforms/dataframe/lakesail_df.py` - DataFrame adapter
-
-**Reference**: [LakeSail Official Site](https://lakesail.com/) | [GitHub](https://github.com/lakehq/sail)
-
----
-
-### Medium-High Priority
-
-#### Apache Doris (MPP OLAP Engine)
-
-**Status**: Not Started | **Effort**: Medium
-
-Apache top-level project with 12,000+ GitHub stars, used by Xiaomi, ByteDance, Baidu, JD.com, and 4,000+ enterprises.
-
-**Key Characteristics**:
-- MySQL protocol (port 9030)
-- Stream Load for high-throughput data ingestion
-- Multiple table models (Duplicate, Aggregate, Unique, Primary Key)
-- Real-time analytics focus
-
-**Managed Options**: VeloDB Cloud, SelectDB Cloud, ApsaraDB for SelectDB
-
----
-
-#### StarRocks (Linux Foundation MPP OLAP)
-
-**Status**: Not Started | **Effort**: Medium
-
-Linux Foundation project with 11,000+ GitHub stars, used by Airbnb, Alibaba, Coinbase, Pinterest, Tencent.
-
-**Key Characteristics**:
-- MySQL protocol with Stream Load HTTP API
-- Native data lake support (Iceberg, Hudi, Delta Lake)
-- Competitive performance versus ClickHouse and Trino
-- Sub-second analytics on real-time data
-
----
-
-#### ClickHouse Cloud & Firebolt Cloud
-
-**Status**: Not Started | **Effort**: Small
-
-Cloud deployment modes for existing ClickHouse and Firebolt adapters.
-
-**Key Characteristics**:
-- Cloud-specific authentication and endpoint handling
-- Managed infrastructure configuration
-- Usage-based billing model support
-
----
-
-### Medium Priority
-
-#### QuestDB (Time-Series Database)
-
-**Status**: Not Started | **Effort**: Medium
-
-High-performance time-series database optimized for real-time analytics.
-
-**Key Characteristics**:
-- InfluxDB line protocol support
-- SQL interface with time-series extensions
-- Columnar storage with time-based partitioning
-
----
-
-#### Databend (Cloud-Native Data Warehouse)
-
-**Status**: Not Started | **Effort**: Medium | **Priority**: Low
-
-Rust-based cloud-native data warehouse with DataFrame and data lake focus.
-
----
-
-### Platform Infrastructure (In Progress)
-
-These foundational improvements enable cleaner platform expansion:
-
-| Item | Status | Purpose |
-|------|--------|---------|
-| Deployment Factory Integration | In Progress | Dynamic platform initialization with deployment modes |
-| Deployment Registry Extensions | In Progress | Enhanced registry for cloud variants |
-| Deployment CLI Integration | In Progress | CLI support for cloud credentials/endpoints |
-| Configuration Inheritance | In Progress | Base config inheritance for deployment variants |
+| Platform | Shipped | Modes |
+|----------|---------|-------|
+| LakeSail Sail | v0.2.1 | SQL + DataFrame |
+| Apache Doris | v0.2.1 | SQL |
+| StarRocks | v0.2.1 | SQL |
+| ClickHouse Cloud | v0.2.1 | SQL |
+| Firebolt Cloud | v0.2.1 | SQL |
+| QuestDB | v0.2.1 | SQL |
+| Databend | v0.2.1 | SQL |
+| Microsoft Fabric Spark | v0.2.x | SQL + DataFrame |
+| Starburst | v0.2.x | SQL |
+| TimescaleDB | v0.2.x | SQL |
 
 ---
 
 ## Benchmark Additions
 
-### Real-World Dataset Benchmarks
+### Completed Benchmarks
 
-#### Flight Data Benchmark (US Aviation On-Time Performance)
+| Benchmark | Shipped | Notes |
+|-----------|---------|-------|
+| Flight Data (US aviation on-time) | v0.3.0 | 20 queries, SQL + DataFrame |
+| NYC Taxi Expansion | v0.3.0 | Green, FHV, HVFHV vehicle types |
 
-**Status**: Not Started | **Effort**: Medium (2-3 weeks) | **Priority**: Medium
+### Planned Benchmarks
 
-BTS TranStats flight data (1987-present, ~200M flights, free public data).
+#### Geospatial Primitives
 
-**Key Characteristics**:
-- Scale factors from 0.01 (10MB, 1 week) to 100 (full dataset, 15-20GB)
-- Multi-dimensional analysis: temporal, geographic, carrier, aircraft
-- 20+ analytical queries across categories:
-  - On-time performance (5+ queries)
-  - Delay analysis (4+ queries)
-  - Route analytics (4+ queries)
-  - Temporal patterns (4+ queries)
-  - Carrier comparisons (3+ queries)
+**Status**: Not Started | **Effort**: Medium | **Priority**: Medium
 
-**Why it matters**: Realistic OLAP workload with intuitive domain, complements TPC-H synthetic data.
+Dedicated benchmark for spatial SQL operations (`ST_*` functions) across platforms. NYC Taxi already includes some spatial queries; this would be a standalone primitives suite covering the full spatial SQL surface.
 
----
-
-#### NYC Taxi Benchmark Expansion
-
-**Status**: Not Started | **Effort**: Medium (2-3 weeks) | **Priority**: Medium
-
-Expand existing Yellow Taxi benchmark to include all TLC vehicle types.
-
-**Current**: Yellow Taxi only
-**Planned Additions**:
-- Green Taxi (~500K trips/month, outer boroughs)
-- FHV (~1M trips/month, traditional car services)
-- HVFHV (Uber/Lyft, ~25M+ trips/month, since Feb 2019)
-
-**New Query Categories**:
-- Cross-type comparisons
-- Market share analysis
-- Price sensitivity across vehicle types
+**Scope**:
+- Point-in-polygon, distance, bounding box
+- Spatial indexing and predicate pushdown
+- Cross-platform dialect coverage (PostGIS, DuckDB spatial, ClickHouse, BigQuery)
 
 ---
 
-### Analytical Workload Benchmarks
+#### GitHub Archive
 
-| Benchmark | Status | Description |
-|-----------|--------|-------------|
-| Geospatial Primitives | Not Started | ST_* functions and spatial operations |
-| GitHub Archive | Not Started | Developer activity analytics |
-| Stack Overflow Dataset | Not Started | Q&A and engagement analytics |
-| Wikipedia Pageviews | Not Started | Web traffic time-series patterns |
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Developer activity analytics over the public GitHub event archive.
+
+---
+
+#### Stack Overflow Dataset
+
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Q&A and engagement analytics over the Stack Exchange data dump.
+
+---
+
+#### Wikipedia Pageviews
+
+**Status**: Not Started | **Effort**: Medium | **Priority**: Low
+
+Web traffic time-series patterns from Wikimedia pageview dumps.
 
 ---
 
@@ -192,63 +101,24 @@ Expand existing Yellow Taxi benchmark to include all TLC vehicle types.
 
 ### Current State
 
-DataFrame benchmarking is currently supported for:
-- TPC-H (22 queries)
-- TPC-DS (99 queries)
+DataFrame benchmarking is supported for 21 benchmarks across two API families:
 
-### Expansion Plan
+**Expression Family** (Polars, PySpark, DataFusion, LakeSail):
+- TPC-H, TPC-DS, TPC-DS OBT, TPC-DI, TPC-H Skew, TPC-Havoc, DataVault
+- SSB, ClickBench, AMPLab, CoffeeShop, H2ODB, TSBS DevOps
+- NYC Taxi, Flight Data, JoinOrder, JoinOrder Synthetic
+- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives, Transaction Primitives
 
-Extend DataFrame support to 15+ additional benchmarks (~700 new query implementations).
+**Pandas Family** (Pandas, Modin, cuDF, Dask):
+- Full coverage matching the Expression Family above
 
-#### Implementation Tiers
+### Remaining Expansion
 
-**Tier 1 - High Value (Recommended First)**
+The DataFrame initiative is substantially complete. The one remaining gap is:
 
-| Benchmark | Queries | Rationale |
-|-----------|---------|-----------|
-| SSB | 13 | Simple star-schema, good starter |
-| ClickBench | 43 | Popular industry benchmark |
-| NYC Taxi | 25 | Real-world, high user interest |
-| **Total** | **81** | |
-
-**Tier 2 - Strong DataFrame Fit**
-
-| Benchmark | Operations | Rationale |
-|-----------|------------|-----------|
-| TPC-DI | 38 | ETL transformations |
-| Write Primitives | 109 | INSERT/UPDATE/DELETE/MERGE |
-| TSBS DevOps | 18 | Time-series aggregations |
-| H2ODB | 10 | Data science workloads |
-| AMPLab | 8 | Established benchmark |
-| CoffeeShop | 11 | Analytics patterns |
-| **Total** | **194** | |
-
-**Tier 3 - Variants/Experimental**
-
-| Benchmark | Queries | Notes |
-|-----------|---------|-------|
-| TPC-H Skew | 22 | Skewed distributions |
-| TPC-DS-OBT | 17 | One Big Table variant |
-| TPC-Havoc | 220 | Query variants |
-| DataVault | 22 | Data Vault modeling |
-| **Total** | **281** | |
-
-**Tier 4 - Complex**
-
-| Benchmark | Queries | Notes |
-|-----------|---------|-------|
-| JoinOrder | 113 | High complexity joins |
-| Read Primitives | 136 | Foundation testing |
-| **Total** | **249** | |
-
-### Dual-Family Architecture
-
-Each DataFrame benchmark requires implementations for two API families:
-
-- **Expression Family**: Polars, PySpark, DataFusion (lazy evaluation, expression chains)
-- **Pandas Family**: Pandas, Modin, cuDF, Dask (eager evaluation, method chaining)
-
-**Estimated Effort**: 4-6 weeks for full coverage
+| Benchmark | Status | Notes |
+|-----------|--------|-------|
+| Geospatial Primitives | Not Started | Blocked on the benchmark itself existing |
 
 ---
 
@@ -262,32 +132,31 @@ Each DataFrame benchmark requires implementations for two API families:
 - ~~Onehouse Quanton adapter~~ ✓ (multi-format: Hudi, Iceberg, Delta)
 - ~~Apache Hudi maintenance operations~~ ✓
 
-### Phase 2: High-Impact Platforms
+### Phase 2: High-Impact Platforms (Completed)
 
-- LakeSail Sail (SQL + DataFrame)
-- Apache Doris
-- StarRocks
-- Cloud deployment modes (ClickHouse Cloud, Firebolt Cloud)
+- ~~LakeSail Sail (SQL + DataFrame)~~ ✓
+- ~~Apache Doris~~ ✓
+- ~~StarRocks~~ ✓
+- ~~Cloud deployment modes (ClickHouse Cloud, Firebolt Cloud)~~ ✓
 
-### Phase 3: Benchmark Diversity
+### Phase 3: Benchmark Diversity (Completed)
 
-- Flight Data Benchmark
-- NYC Taxi Expansion
-- DataFrame Tier 1 (SSB, ClickBench, NYC Taxi)
+- ~~Flight Data Benchmark~~ ✓
+- ~~NYC Taxi Expansion~~ ✓
+- ~~DataFrame Tier 1 (SSB, ClickBench, NYC Taxi)~~ ✓
 
-### Phase 4: Extended Coverage
+### Phase 4: Extended Coverage (Completed)
 
 - ~~Microsoft Fabric Spark~~ ✓
 - ~~Starburst~~ ✓
 - ~~TimescaleDB~~ ✓
-- Time-series platforms (QuestDB)
-- DataFrame Tier 2
+- ~~QuestDB~~ ✓
+- ~~DataFrame Tiers 2–4~~ ✓
 
 ### Phase 5: Specialized Workloads
 
-- Geospatial benchmarks
+- Geospatial Primitives benchmark
 - Real-world datasets (GitHub Archive, Stack Overflow, Wikipedia)
-- DataFrame Tier 3-4
 
 ---
 
@@ -318,4 +187,4 @@ See the [Platform Development Guide](platform-development.md) and [Adding New Pl
 
 ---
 
-*Last updated: 2026-01-20*
+*Last updated: 2026-06-05*

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -107,10 +107,15 @@ DataFrame benchmarking is supported for 21 benchmarks across two API families:
 - TPC-H, TPC-DS, TPC-DS OBT, TPC-DI, TPC-H Skew, TPC-Havoc, DataVault
 - SSB, ClickBench, AMPLab, CoffeeShop, H2ODB, TSBS DevOps
 - NYC Taxi, Flight Data, JoinOrder, JoinOrder Synthetic
-- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives, Transaction Primitives
+- Read Primitives, Write Primitives, AI Primitives, Metadata Primitives
 
 **Pandas Family** (Pandas, Modin, cuDF, Dask):
 - Full coverage matching the Expression Family above
+
+**Transaction Primitives** — restricted to ACID-capable table-format adapters only:
+Delta Lake (`delta-lake`, `delta`), PySpark-Delta (`pyspark-delta`), and Iceberg
+(`iceberg`). Polars, DataFusion, and all Pandas-family adapters (`pandas-df`, Modin,
+cuDF, Dask) are rejected at runtime because they do not support ACID transactions.
 
 ### Remaining Expansion
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -23,7 +23,7 @@ BenchBox's expansion roadmap focuses on three strategic areas:
 |----------|---------|---------|
 | SQL Platforms | 39 | +0 |
 | DataFrame Platforms | 9 | +0 |
-| Benchmarks | 22 | +4 |
+| Benchmarks | 23 | +4 |
 | DataFrame-enabled Benchmarks | 21 | +1 (Geospatial) |
 
 ---

--- a/tests/integration/test_tpchavoc_duckdb.py
+++ b/tests/integration/test_tpchavoc_duckdb.py
@@ -45,6 +45,13 @@ class TestTPCHavocDuckDBIntegration:
         yield conn
         conn.close()
 
+    @staticmethod
+    def _create_duckdb_schema(tpchavoc, conn):
+        """Create the TPC-H schema (DuckDB dialect) on the given connection."""
+        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+            if statement.strip():
+                conn.execute(statement.strip())
+
     def test_variant_query_generation(self, tpchavoc):
         """Test that TPC-Havoc can generate query variants."""
         # Get implemented queries
@@ -200,21 +207,22 @@ class TestTPCHavocDuckDBIntegration:
 
     def test_duckdb_regression_variants_explain(self, tpchavoc, duckdb_conn):
         """Previously failing DuckDB TPC-Havoc variants should parse and bind."""
-        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
-            if statement.strip():
-                duckdb_conn.execute(statement.strip())
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
 
         regression_variants = [
             "2_v5",
+            "2_v8",
             "5_v9",
             "7_v9",
             "9_v9",
             "10_v8",
             "10_v9",
+            "11_v1",
             "11_v9",
             "13_v9",
             "17_v2",
             "17_v4",
+            "17_v8",
         ]
         for query_id in regression_variants:
             duckdb_conn.execute(f"EXPLAIN {tpchavoc.get_query(query_id)}")
@@ -226,12 +234,52 @@ class TestTPCHavocDuckDBIntegration:
         inner alias, turning a semi-join into an uncorrelated full scan that hung
         DuckDB at SF1. The qualified form must decorrelate into a semi-join.
         """
-        for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
-            if statement.strip():
-                duckdb_conn.execute(statement.strip())
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
 
         sql = tpchavoc.get_query("10_v8")
         assert "l2.l_orderkey = lineitem.l_orderkey" in sql, "EXISTS must correlate to the outer lineitem"
 
         plan = duckdb_conn.execute(f"EXPLAIN {sql}").fetchall()[0][1]
         assert "SEMI" in plan.upper(), "EXISTS should decorrelate into a semi-join, not a self-referential scan"
+
+    def test_correlated_subquery_variants_bind_to_outer_table(self, tpchavoc, duckdb_conn):
+        """Variants with correlated subqueries must qualify the correlation to the outer table.
+
+        Each of these variants carried an unqualified correlation column that silently
+        bound to the INNER alias (the same class of defect as 10_v8), degenerating the
+        intended correlated subquery into an uncorrelated scan. The fix qualifies the
+        correlation to the outer table so the per-row correlation is preserved.
+        """
+        self._create_duckdb_schema(tpchavoc, duckdb_conn)
+
+        # (variant, required qualified correlation that must reference the outer table)
+        expected_correlations = {
+            # q11_v1 scalar threshold: per-part avg, not an uncorrelated avg over all German rows.
+            "11_v1": "ps2.ps_partkey = partsupp.ps_partkey",
+            # q17_v8 EXISTS: per-part threshold, not the inner derived table's own partkey.
+            "17_v8": "avg_calc.l_partkey = lineitem.l_partkey",
+            # q2_v8 NOT EXISTS min-cost: compare against the outer row's supplycost, not ps2's own.
+            "2_v8": "ps2.ps_supplycost < partsupp.ps_supplycost",
+        }
+        plans = {}
+        for query_id, correlation in expected_correlations.items():
+            sql = tpchavoc.get_query(query_id)
+            assert correlation in sql, (
+                f"{query_id} must qualify the correlation to the outer table ({correlation}); "
+                "an unqualified column silently self-binds to the inner alias"
+            )
+            # Must still parse, bind, and plan on DuckDB; keep the plan for the check below.
+            plans[query_id] = duckdb_conn.execute(f"EXPLAIN {sql}").fetchall()[0][1]
+
+        # q11_v1's scalar subquery only becomes correlated once the partkey is qualified to the
+        # outer table; DuckDB then decorrelates it via a delimiter join. The unqualified (buggy)
+        # form folds to a single uncorrelated aggregate with no delimiter join, so DELIM presence
+        # is a faithful regression signal here.
+        #
+        # 17_v8 and 2_v8 are guarded by the substring assertion only, not a plan check: each
+        # carries a *second*, already-qualified correlation (17_v8 via lineitem.l_quantity, 2_v8
+        # via p_partkey = ps2.ps_partkey), so their plans still show a decorrelated semi-/anti-join
+        # even in the buggy form. The plan therefore cannot distinguish fixed from broken for them.
+        assert "DELIM" in plans["11_v1"].upper(), (
+            "11_v1's correlated scalar subquery should decorrelate into a delimiter join"
+        )

--- a/tests/unit/core/test_benchmark_output_root_propagation.py
+++ b/tests/unit/core/test_benchmark_output_root_propagation.py
@@ -1,0 +1,143 @@
+"""Regression tests for benchmark output-root propagation.
+
+These tests guard the lifecycle-ordering fix described in the
+``benchmark-runs-output-root-propagation`` task: generator-backed benchmarks
+must honor an explicit ``BENCHBOX_OUTPUT_DIR`` (or post-construction output-root
+assignment) all the way down to their nested data generators, instead of
+leaving them pointed at a worktree-local ``cwd/benchmark_runs`` default.
+
+The assertions deliberately inspect the *nested generator* output paths (not
+just ``benchmark.output_dir``) so a benchmark that silently keeps a stale
+generator path fails here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.amplab.benchmark import AMPLabBenchmark
+from benchbox.core.clickbench.benchmark import ClickBenchBenchmark
+from benchbox.core.coffeeshop.benchmark import CoffeeShopBenchmark
+from benchbox.core.flightdata.benchmark import FlightDataBenchmark
+from benchbox.core.h2odb.benchmark import H2OBenchmark
+from benchbox.core.nyctaxi.benchmark import NYCTaxiBenchmark
+from benchbox.core.ssb.benchmark import SSBBenchmark
+from benchbox.core.tpch.benchmark import TPCHBenchmark
+from benchbox.core.tsbs_devops.benchmark import TSBSDevOpsBenchmark
+from benchbox.core.vector_search.benchmark import VectorSearchBenchmark
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _nested_generators(benchmark) -> list:
+    """Return the concrete nested generator/downloader objects on a benchmark."""
+    generators = []
+    for attr in getattr(benchmark, "OUTPUT_DIR_GENERATOR_ATTRS", ("data_generator",)):
+        gen = benchmark.__dict__.get(attr)
+        if gen is not None and hasattr(gen, "output_dir"):
+            generators.append(gen)
+    return generators
+
+
+# Representative generator-backed benchmark families. ``data_generator`` covers
+# the common case; nyctaxi/flightdata expose download-based generators instead.
+CONSTRUCTOR_CASES = [
+    (H2OBenchmark, {}),
+    (SSBBenchmark, {}),
+    (VectorSearchBenchmark, {}),
+    (TPCHBenchmark, {}),
+    (ClickBenchBenchmark, {}),
+    (AMPLabBenchmark, {}),
+    (CoffeeShopBenchmark, {}),
+    (TSBSDevOpsBenchmark, {}),
+    (NYCTaxiBenchmark, {}),
+    (FlightDataBenchmark, {}),
+]
+
+
+@pytest.mark.parametrize("benchmark_cls,kwargs", CONSTRUCTOR_CASES)
+def test_env_output_root_honored_at_construction(benchmark_cls, kwargs, tmp_path, monkeypatch):
+    """BENCHBOX_OUTPUT_DIR redirects datagen output before generators are built."""
+    root = tmp_path / "shared_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark = benchmark_cls(scale_factor=0.01, **kwargs)
+
+    output_dir = Path(str(benchmark.output_dir))
+    assert str(output_dir).startswith(str(root)), output_dir
+    # The stale-default failure mode lands under cwd/benchmark_runs.
+    assert Path.cwd() not in output_dir.parents, output_dir
+
+    generators = _nested_generators(benchmark)
+    assert generators, f"{benchmark_cls.__name__} exposed no nested generator to verify"
+    for gen in generators:
+        gen_dir = Path(str(gen.output_dir))
+        assert str(gen_dir).startswith(str(root)), (benchmark_cls.__name__, gen_dir)
+        assert Path.cwd() not in gen_dir.parents, (benchmark_cls.__name__, gen_dir)
+
+
+@pytest.mark.parametrize("benchmark_cls,kwargs", CONSTRUCTOR_CASES)
+def test_explicit_output_root_propagates_post_construction(benchmark_cls, kwargs, tmp_path, monkeypatch):
+    """An output-root assigned after construction reaches nested generators.
+
+    This mirrors the runner/orchestrator path that resolves an explicit CLI
+    ``--output`` root and assigns ``benchmark.output_dir`` after the benchmark
+    (and its generators) have already been constructed.
+    """
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+    benchmark = benchmark_cls(scale_factor=0.01, **kwargs)
+
+    explicit = tmp_path / "explicit_root" / "data"
+    benchmark.output_dir = str(explicit)
+
+    assert str(benchmark.output_dir) == str(explicit)
+    for gen in _nested_generators(benchmark):
+        assert str(gen.output_dir) == str(explicit), (benchmark_cls.__name__, gen.output_dir)
+
+
+def test_default_falls_back_to_cwd_when_unset(monkeypatch):
+    """With neither CLI --output nor BENCHBOX_OUTPUT_DIR set, the cwd default holds."""
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+    benchmark = H2OBenchmark(scale_factor=0.01)
+
+    expected = Path.cwd() / "benchmark_runs" / "datagen" / "h2odb_sf001"
+    assert Path(str(benchmark.output_dir)) == expected
+    assert Path(str(benchmark.data_generator.output_dir)) == expected
+
+
+def test_nyctaxi_optional_downloaders_all_track_output_dir(tmp_path, monkeypatch):
+    """Multi-type NYC Taxi keeps every optional downloader in sync."""
+    from benchbox.core.nyctaxi.schema import TaxiType
+
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+    benchmark = NYCTaxiBenchmark(
+        scale_factor=0.01,
+        taxi_types=[TaxiType.YELLOW, TaxiType.GREEN, TaxiType.HVFHV],
+    )
+
+    target = tmp_path / "nyc" / "data"
+    benchmark.output_dir = str(target)
+
+    assert str(benchmark.downloader.output_dir) == str(target)
+    assert str(benchmark.green_downloader.output_dir) == str(target)
+    assert str(benchmark.hvfhv_downloader.output_dir) == str(target)
+
+
+def test_tpch_variant_skew_inherits_propagation(tmp_path, monkeypatch):
+    """A TPC-H-family variant (skew) honors the env root for its own generator."""
+    from benchbox.core.tpch_skew.benchmark import TPCHSkewBenchmark
+
+    root = tmp_path / "runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark = TPCHSkewBenchmark(scale_factor=0.01)
+
+    assert str(benchmark.output_dir).startswith(str(root))
+    assert str(benchmark.data_generator.output_dir).startswith(str(root))
+    assert Path.cwd() not in Path(str(benchmark.data_generator.output_dir)).parents

--- a/tests/unit/mcp/test_benchmark_output_root_propagation.py
+++ b/tests/unit/mcp/test_benchmark_output_root_propagation.py
@@ -1,0 +1,73 @@
+"""Regression tests for output-root propagation on the MCP benchmark path.
+
+The MCP ``run_benchmark`` tool constructs benchmark instances directly via
+``get_public_benchmark_class(...)(scale_factor=...)`` and the data-only path
+resolves a datagen directory via ``get_benchmark_runs_datagen_path``. Both must
+honor ``BENCHBOX_OUTPUT_DIR`` so MCP-driven runs do not write generated data
+under a stale ``cwd/benchmark_runs`` default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.benchmark_registry import get_public_benchmark_class
+from benchbox.utils.path_utils import get_benchmark_runs_datagen_path
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Generator-backed benchmarks reachable through the public MCP surface.
+MCP_BENCHMARKS = ["h2odb", "ssb", "vector_search", "tpch"]
+
+
+@pytest.mark.parametrize("benchmark_id", MCP_BENCHMARKS)
+def test_mcp_run_construction_honors_env_output_root(benchmark_id, tmp_path, monkeypatch):
+    """Mirror MCP ``_run_benchmark_impl`` construction under BENCHBOX_OUTPUT_DIR."""
+    root = tmp_path / "mcp_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    benchmark_class = get_public_benchmark_class(benchmark_id)
+    if benchmark_class is None:
+        pytest.skip(f"{benchmark_id} not available in this environment")
+
+    # Same call shape MCP uses: scale_factor only, no explicit output_dir.
+    benchmark = benchmark_class(scale_factor=0.01)
+
+    output_dir = Path(str(benchmark.output_dir))
+    assert str(output_dir).startswith(str(root)), output_dir
+    assert Path.cwd() not in output_dir.parents, output_dir
+
+    # Public benchmark wrappers delegate to a core ``_impl`` that owns the
+    # nested data generator.
+    core = getattr(benchmark, "_impl", benchmark)
+    generator = core.__dict__.get("data_generator")
+    assert generator is not None and hasattr(generator, "output_dir")
+    gen_dir = Path(str(generator.output_dir))
+    assert str(gen_dir).startswith(str(root)), gen_dir
+    assert Path.cwd() not in gen_dir.parents, gen_dir
+
+
+def test_mcp_data_only_datagen_path_honors_env_output_root(tmp_path, monkeypatch):
+    """The MCP data-only datagen directory resolves under the env output root."""
+    root = tmp_path / "mcp_runs"
+    monkeypatch.setenv("BENCHBOX_OUTPUT_DIR", str(root))
+
+    data_dir = get_benchmark_runs_datagen_path("tpch", 0.01)
+
+    assert str(data_dir).startswith(str(root)), data_dir
+    assert data_dir.name == "tpch_sf001", data_dir
+    assert Path.cwd() not in data_dir.parents, data_dir
+
+
+def test_mcp_default_without_env_uses_cwd(monkeypatch):
+    """Without an output-root override the MCP datagen path stays cwd-local."""
+    monkeypatch.delenv("BENCHBOX_OUTPUT_DIR", raising=False)
+
+    data_dir = get_benchmark_runs_datagen_path("tpch", 0.01)
+
+    assert data_dir == Path.cwd() / "benchmark_runs" / "datagen" / "tpch_sf001"

--- a/tests/unit/platforms/test_datafusion_plan_capture.py
+++ b/tests/unit/platforms/test_datafusion_plan_capture.py
@@ -1,0 +1,126 @@
+"""Tests for DataFusion query plan capture wiring."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchbox.platforms.datafusion import DataFusionAdapter
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Minimal DataFusion EXPLAIN text output as the parser expects
+_EXPLAIN_TEXT = (
+    "logical_plan | TableScan: t1 projection=[id, val]\nphysical_plan | DataSourceExec: file_groups={1 group}"
+)
+
+
+def _make_explain_batch(plan_type_val, plan_text_val):
+    """Return a minimal mock RecordBatch for EXPLAIN output."""
+    col0 = MagicMock()
+    col0.__getitem__ = lambda self, i: MagicMock(as_py=lambda: plan_type_val)
+    col1 = MagicMock()
+    col1.__getitem__ = lambda self, i: MagicMock(as_py=lambda: plan_text_val)
+    batch = MagicMock()
+    batch.num_rows = 1
+    batch.column = lambda i: col0 if i == 0 else col1
+    return batch
+
+
+@pytest.fixture()
+def adapter(monkeypatch):
+    monkeypatch.setattr("benchbox.platforms.datafusion.datafusion", MagicMock(), raising=False)
+    return DataFusionAdapter(capture_plans=True)
+
+
+@pytest.fixture()
+def adapter_no_capture(monkeypatch):
+    monkeypatch.setattr("benchbox.platforms.datafusion.datafusion", MagicMock(), raising=False)
+    return DataFusionAdapter(capture_plans=False)
+
+
+class TestDataFusionPlanCapture:
+    def test_get_query_plan_parser_returns_instance(self, adapter):
+        from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
+
+        parser = adapter.get_query_plan_parser()
+        assert parser is not None
+        assert isinstance(parser, DataFusionQueryPlanParser)
+
+    def test_get_query_plan_returns_formatted_text(self, adapter):
+        batch = _make_explain_batch("logical_plan", "TableScan: t1")
+        conn = MagicMock()
+        conn.sql.return_value.collect.return_value = [batch]
+
+        result = adapter.get_query_plan(conn, "SELECT 1")
+        assert result is not None
+        assert "logical_plan" in result
+        assert "TableScan" in result
+
+    def test_get_query_plan_returns_none_on_empty(self, adapter):
+        conn = MagicMock()
+        conn.sql.return_value.collect.return_value = []
+        assert adapter.get_query_plan(conn, "SELECT 1") is None
+
+    def test_get_query_plan_returns_none_on_error(self, adapter):
+        conn = MagicMock()
+        conn.sql.side_effect = Exception("datafusion error")
+        assert adapter.get_query_plan(conn, "SELECT 1") is None
+
+    def test_get_query_plan_does_not_use_format_json(self, adapter):
+        batch = _make_explain_batch("physical_plan", "DataSourceExec: ...")
+        conn = MagicMock()
+        conn.sql.return_value.collect.return_value = [batch]
+
+        adapter.get_query_plan(conn, "SELECT 1")
+
+        called_sql = conn.sql.call_args[0][0]
+        assert "FORMAT JSON" not in called_sql.upper(), "DataFusionQueryPlanParser expects text/indent format, not JSON"
+
+    def test_execute_query_with_capture_adds_plan_fields(self, adapter, monkeypatch):
+        conn = MagicMock()
+        conn.sql.return_value.collect.return_value = MagicMock()
+        conn.sql.return_value.collect.return_value.__iter__ = lambda s: iter([])
+
+        mock_plan = MagicMock()
+        mock_plan.plan_fingerprint = "df_fp"
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: (mock_plan, 2.5))
+
+        # Patch the underlying sql execution to return a success result
+        from unittest.mock import patch as _patch
+
+        fake_result = MagicMock()
+        fake_result.collect.return_value = []
+        conn.sql.return_value = fake_result
+
+        with _patch.object(
+            adapter,
+            "_build_query_result_with_validation",
+            return_value={"query_id": "df_q1", "status": "SUCCESS", "rows_returned": 0},
+        ):
+            result = adapter.execute_query(
+                connection=conn, query="SELECT 1", query_id="df_q1", validate_row_count=False
+            )
+
+        assert result["query_plan"] is mock_plan
+        assert result["plan_fingerprint"] == "df_fp"
+        assert result["plan_capture_time_ms"] == 2.5
+
+    def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, monkeypatch):
+        conn = MagicMock()
+        fake_result = MagicMock()
+        fake_result.collect.return_value = []
+        conn.sql.return_value = fake_result
+
+        with patch.object(
+            adapter_no_capture,
+            "_build_query_result_with_validation",
+            return_value={"query_id": "df_q2", "status": "SUCCESS", "rows_returned": 0},
+        ):
+            result = adapter_no_capture.execute_query(
+                connection=conn, query="SELECT 1", query_id="df_q2", validate_row_count=False
+            )
+
+        assert "query_plan" not in result or result.get("query_plan") is None

--- a/tests/unit/platforms/test_postgresql_adapter.py
+++ b/tests/unit/platforms/test_postgresql_adapter.py
@@ -325,12 +325,12 @@ class TestPostgreSQLAdapter:
         assert result["error_type"] == "Exception"
 
     def test_get_query_plan(self, postgres_stubs):
-        """Query plan should use EXPLAIN ANALYZE."""
+        """Query plan should use EXPLAIN (ANALYZE, FORMAT JSON) and return JSON."""
         mock_conn = Mock()
         mock_cursor = Mock()
+        # PostgreSQL returns the full JSON in the first column of the first row with FORMAT JSON
         mock_cursor.fetchall.return_value = [
-            ("Seq Scan on test  (cost=0.00..10.00 rows=100 width=36)",),
-            ("  Filter: (id > 5)",),
+            ('[{"Plan": {"Node Type": "Seq Scan", "Filter": "(id > 5)"}}]',),
         ]
         mock_conn.cursor.return_value = mock_cursor
 
@@ -338,8 +338,12 @@ class TestPostgreSQLAdapter:
 
         plan = adapter.get_query_plan(mock_conn, "SELECT * FROM test WHERE id > 5")
 
+        assert plan is not None
         assert "Seq Scan" in plan
-        assert "Filter" in plan
+        # Confirm FORMAT JSON is used (parser requires JSON, not text)
+        explain_sql = mock_cursor.execute.call_args[0][0]
+        assert "FORMAT JSON" in explain_sql.upper()
+        assert "FORMAT TEXT" not in explain_sql.upper()
 
     def test_configure_for_benchmark_olap(self, postgres_stubs):
         """OLAP configuration should set appropriate settings."""

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -1,0 +1,150 @@
+"""Tests for PostgreSQL query plan capture wiring."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchbox.platforms.postgresql import PostgreSQLAdapter
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+@pytest.fixture()
+def adapter(monkeypatch):
+    """PostgreSQLAdapter with psycopg stubbed out."""
+    monkeypatch.setattr("benchbox.platforms.postgresql.psycopg", MagicMock())
+    return PostgreSQLAdapter(capture_plans=True)
+
+
+@pytest.fixture()
+def adapter_no_capture(monkeypatch):
+    monkeypatch.setattr("benchbox.platforms.postgresql.psycopg", MagicMock())
+    return PostgreSQLAdapter(capture_plans=False)
+
+
+def _make_connection(plan_json='[{"Plan": {"Node Type": "Result"}}]'):
+    """Build a mock psycopg connection that returns a fixed EXPLAIN JSON."""
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [(plan_json,)]
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+class TestPostgreSQLPlanCapture:
+    def test_get_query_plan_parser_returns_instance(self, adapter):
+        from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
+
+        parser = adapter.get_query_plan_parser()
+        assert parser is not None
+        assert isinstance(parser, PostgreSQLQueryPlanParser)
+
+    def test_get_query_plan_returns_json(self, adapter):
+        conn = _make_connection('[{"Plan": {"Node Type": "Seq Scan"}}]')
+        result = adapter.get_query_plan(conn, "SELECT 1")
+        assert result is not None
+        assert "Plan" in result or "Seq Scan" in result
+
+    def test_get_query_plan_returns_none_on_error(self, adapter):
+        conn = MagicMock()
+        conn.cursor.return_value.execute.side_effect = Exception("db error")
+        result = adapter.get_query_plan(conn, "SELECT 1")
+        assert result is None
+
+    def test_execute_query_with_capture_adds_plan_fields(self, adapter, monkeypatch):
+        conn = _make_connection()
+
+        # Patch capture_query_plan on the adapter instance
+        mock_plan = MagicMock()
+        mock_plan.plan_fingerprint = "abc123"
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: (mock_plan, 5.0))
+
+        # Patch the mixin execute_query to return a SUCCESS result
+        monkeypatch.setattr(
+            "benchbox.platforms.base.psycopg2_mixin.PsycopgConnectionMixin.execute_query",
+            lambda self, **kw: {"query_id": kw["query_id"], "status": "SUCCESS", "rows_returned": 1},
+        )
+
+        result = adapter.execute_query(connection=conn, query="SELECT 1", query_id="q1")
+
+        assert result["status"] == "SUCCESS"
+        assert result["query_plan"] is mock_plan
+        assert result["plan_fingerprint"] == "abc123"
+        assert result["plan_capture_time_ms"] == 5.0
+
+    def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, monkeypatch):
+        conn = _make_connection()
+
+        monkeypatch.setattr(
+            "benchbox.platforms.base.psycopg2_mixin.PsycopgConnectionMixin.execute_query",
+            lambda self, **kw: {"query_id": kw["query_id"], "status": "SUCCESS", "rows_returned": 1},
+        )
+
+        result = adapter_no_capture.execute_query(connection=conn, query="SELECT 1", query_id="q1")
+
+        assert "query_plan" not in result or result.get("query_plan") is None
+
+    def test_execute_query_failed_status_skips_capture(self, adapter, monkeypatch):
+        conn = _make_connection()
+
+        capture_called = []
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: capture_called.append(True) or (None, 0.0))
+
+        monkeypatch.setattr(
+            "benchbox.platforms.base.psycopg2_mixin.PsycopgConnectionMixin.execute_query",
+            lambda self, **kw: {"query_id": kw["query_id"], "status": "FAILED", "rows_returned": 0},
+        )
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="q1")
+
+        assert not capture_called, "capture_query_plan must not be called on FAILED queries"
+
+    def test_get_query_plan_uses_format_json(self, adapter):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('{"Plan":{}}',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, "SELECT 1")
+
+        call_args = cursor.execute.call_args[0][0]
+        assert "FORMAT JSON" in call_args.upper()
+        assert "FORMAT TEXT" not in call_args.upper()
+
+
+class TestPostgreSQLSubclassInheritance:
+    """Verify TimescaleDB, CedarDB, and pg_mooncake inherit the parser without overrides."""
+
+    @pytest.mark.parametrize(
+        "adapter_class_path,module_path",
+        [
+            ("benchbox.platforms.timescaledb.TimescaleDBAdapter", "benchbox.platforms.timescaledb"),
+            ("benchbox.platforms.cedardb.CedarDBAdapter", "benchbox.platforms.cedardb"),
+            ("benchbox.platforms.pg_mooncake.PgMooncakeAdapter", "benchbox.platforms.pg_mooncake"),
+        ],
+    )
+    def test_subclass_returns_postgresql_parser(self, adapter_class_path, module_path, monkeypatch):
+        from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
+
+        module_name, class_name = adapter_class_path.rsplit(".", 1)
+        monkeypatch.setattr("benchbox.platforms.postgresql.psycopg", MagicMock())
+
+        try:
+            import importlib
+
+            module = importlib.import_module(module_name)
+            # Stub out any extra dependencies the subclass may import
+            cls = getattr(module, class_name)
+            adapter = cls.__new__(cls)
+            # Inject capture_plans via the base class dict
+            adapter.__dict__["capture_plans"] = True
+
+            parser = PostgreSQLAdapter.get_query_plan_parser(adapter)
+            assert isinstance(parser, PostgreSQLQueryPlanParser), (
+                f"{class_name} should inherit PostgreSQLQueryPlanParser via PostgreSQLAdapter"
+            )
+        except (ImportError, AttributeError):
+            pytest.skip(f"Could not import {adapter_class_path}")

--- a/tests/unit/platforms/test_redshift_adapter.py
+++ b/tests/unit/platforms/test_redshift_adapter.py
@@ -2970,7 +2970,7 @@ class TestQueryPlanGeneration:
         assert "Output: o_orderkey, o_custkey" in plan
         mock_cursor.close.assert_called_once()
 
-    def test_explain_failure_returns_error_message(self):
+    def test_explain_failure_returns_none(self):
         adapter = _make_adapter()
         mock_conn = Mock()
         mock_cursor = Mock()
@@ -2978,8 +2978,7 @@ class TestQueryPlanGeneration:
         mock_cursor.execute.side_effect = Exception("permission denied")
 
         plan = adapter.get_query_plan(mock_conn, "SELECT 1")
-        assert "Could not get query plan" in plan
-        assert "permission denied" in plan
+        assert plan is None
         mock_cursor.close.assert_called_once()
 
 

--- a/tests/unit/platforms/test_redshift_adapter_coverage.py
+++ b/tests/unit/platforms/test_redshift_adapter_coverage.py
@@ -1889,7 +1889,7 @@ class TestGetQueryPlan:
         plan = adapter.get_query_plan(mock_conn, "SELECT * FROM lineitem")
         assert "XN Seq Scan" in plan
 
-    def test_returns_error_message_on_exception(self):
+    def test_returns_none_on_exception(self):
         adapter = _make_adapter()
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
@@ -1897,7 +1897,7 @@ class TestGetQueryPlan:
         mock_cursor.execute.side_effect = Exception("permission denied")
 
         plan = adapter.get_query_plan(mock_conn, "SELECT * FROM forbidden_table")
-        assert "Could not get query plan" in plan
+        assert plan is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/platforms/test_redshift_plan_capture.py
+++ b/tests/unit/platforms/test_redshift_plan_capture.py
@@ -73,6 +73,19 @@ class TestRedshiftPlanCapture:
         assert result["plan_fingerprint"] == "rs_fingerprint"
         assert result["plan_capture_time_ms"] == 3.0
 
+    def test_execute_query_failed_status_skips_capture(self, adapter, monkeypatch):
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+
+        capture_called = []
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: capture_called.append(True) or (None, 0.0))
+        monkeypatch.setattr(adapter, "_get_query_statistics", lambda *a, **k: {})
+        monkeypatch.setattr(adapter, "_build_query_result_with_validation", lambda **kw: {"status": "FAILED"})
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="rq_fail", validate_row_count=False)
+
+        assert not capture_called, "capture_query_plan must not be called on FAILED results"
+
     def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, monkeypatch):
         conn, cursor = _make_connection()
         cursor.fetchall.return_value = [(0, "col1")]

--- a/tests/unit/platforms/test_redshift_plan_capture.py
+++ b/tests/unit/platforms/test_redshift_plan_capture.py
@@ -1,0 +1,96 @@
+"""Tests for Redshift query plan capture wiring."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchbox.platforms.redshift import RedshiftAdapter
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+_STUB_CREDS = {"host": "localhost", "username": "test", "password": "test"}
+
+
+@pytest.fixture()
+def adapter(monkeypatch):
+    monkeypatch.setattr("benchbox.platforms.redshift.redshift_connector", MagicMock(), raising=False)
+    return RedshiftAdapter(**_STUB_CREDS, capture_plans=True)
+
+
+@pytest.fixture()
+def adapter_no_capture(monkeypatch):
+    monkeypatch.setattr("benchbox.platforms.redshift.redshift_connector", MagicMock(), raising=False)
+    return RedshiftAdapter(**_STUB_CREDS, capture_plans=False)
+
+
+def _make_connection(plan_text="XN Seq Scan on orders\n  (cost=0.00..10.00 rows=1 width=4)"):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [(line,) for line in plan_text.split("\n")]
+    cursor.__enter__ = lambda s: s
+    cursor.__exit__ = MagicMock(return_value=False)
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestRedshiftPlanCapture:
+    def test_get_query_plan_parser_returns_instance(self, adapter):
+        from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+
+        parser = adapter.get_query_plan_parser()
+        assert parser is not None
+        assert isinstance(parser, RedshiftQueryPlanParser)
+
+    def test_get_query_plan_returns_text(self, adapter):
+        conn, _ = _make_connection("XN Seq Scan on orders")
+        result = adapter.get_query_plan(conn, "SELECT 1")
+        assert result is not None
+        assert "XN Seq Scan" in result
+
+    def test_get_query_plan_returns_none_on_error(self, adapter):
+        conn = MagicMock()
+        conn.cursor.return_value.execute.side_effect = Exception("network error")
+        result = adapter.get_query_plan(conn, "SELECT 1")
+        assert result is None
+
+    def test_execute_query_with_capture_adds_plan_fields(self, adapter, monkeypatch):
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]  # query result rows
+
+        mock_plan = MagicMock()
+        mock_plan.plan_fingerprint = "rs_fingerprint"
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: (mock_plan, 3.0))
+        monkeypatch.setattr(adapter, "_get_query_statistics", lambda *a, **k: {})
+
+        result = adapter.execute_query(connection=conn, query="SELECT 1", query_id="rq1", validate_row_count=False)
+
+        assert result["status"] == "SUCCESS"
+        assert result["query_plan"] is mock_plan
+        assert result["plan_fingerprint"] == "rs_fingerprint"
+        assert result["plan_capture_time_ms"] == 3.0
+
+    def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, monkeypatch):
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+        monkeypatch.setattr(adapter_no_capture, "_get_query_statistics", lambda *a, **k: {})
+
+        result = adapter_no_capture.execute_query(
+            connection=conn, query="SELECT 1", query_id="rq2", validate_row_count=False
+        )
+
+        assert "query_plan" not in result or result.get("query_plan") is None
+
+    def test_get_query_plan_does_not_use_analyze(self, adapter):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [("XN Seq Scan",)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, "SELECT 1")
+
+        call_args = cursor.execute.call_args[0][0].upper()
+        assert "EXPLAIN ANALYZE" not in call_args, "Redshift does not support EXPLAIN ANALYZE"

--- a/tests/unit/platforms/test_sqlite_plan_capture.py
+++ b/tests/unit/platforms/test_sqlite_plan_capture.py
@@ -1,0 +1,155 @@
+"""Tests for SQLite query plan capture wiring."""
+
+import sqlite3
+
+import pytest
+
+from benchbox.platforms.sqlite import SQLiteAdapter, _format_sqlite_query_plan
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+@pytest.fixture()
+def adapter():
+    return SQLiteAdapter(capture_plans=True)
+
+
+@pytest.fixture()
+def adapter_no_capture():
+    return SQLiteAdapter(capture_plans=False)
+
+
+@pytest.fixture()
+def conn():
+    """In-memory SQLite connection."""
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL)")
+    c.execute("INSERT INTO orders VALUES (1, 99.9), (2, 49.9)")
+    c.execute("CREATE TABLE lineitem (order_id INTEGER, qty INTEGER)")
+    c.execute("INSERT INTO lineitem VALUES (1, 3), (2, 1)")
+    yield c
+    c.close()
+
+
+class TestFormatSQLiteQueryPlan:
+    def test_single_root_node(self):
+        rows = [(2, 0, 0, "SCAN orders")]
+        text = _format_sqlite_query_plan(rows)
+        assert text is not None
+        assert "QUERY PLAN" in text
+        assert "`--SCAN orders" in text
+
+    def test_multiple_root_nodes(self):
+        rows = [(2, 0, 0, "SCAN orders"), (4, 0, 0, "SCAN lineitem")]
+        text = _format_sqlite_query_plan(rows)
+        assert "|--SCAN orders" in text
+        assert "`--SCAN lineitem" in text
+
+    def test_parent_child_nesting(self):
+        rows = [(2, 0, 0, "SCAN customer"), (4, 2, 0, "SEARCH lineitem USING INDEX")]
+        text = _format_sqlite_query_plan(rows)
+        assert "SCAN customer" in text
+        assert "SEARCH lineitem" in text
+
+    def test_empty_rows_returns_none(self):
+        assert _format_sqlite_query_plan([]) is None
+
+
+class TestSQLitePlanCapture:
+    def test_get_query_plan_parser_returns_instance(self, adapter):
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        parser = adapter.get_query_plan_parser()
+        assert parser is not None
+        assert isinstance(parser, SQLiteQueryPlanParser)
+
+    def test_get_query_plan_returns_text(self, adapter, conn):
+        result = adapter.get_query_plan(conn, "SELECT * FROM orders")
+        assert result is not None
+        assert "QUERY PLAN" in result or "SCAN" in result
+
+    def test_get_query_plan_returns_none_on_error(self, adapter):
+        from unittest.mock import MagicMock
+
+        bad_conn = MagicMock()
+        bad_conn.cursor.return_value.execute.side_effect = Exception("error")
+        assert adapter.get_query_plan(bad_conn, "SELECT 1") is None
+
+    def test_execute_query_with_capture_adds_plan_fields(self, adapter, conn):
+        result = adapter.execute_query(
+            connection=conn,
+            query="SELECT * FROM orders",
+            query_id="sq1",
+            validate_row_count=False,
+        )
+        assert result["status"] == "SUCCESS"
+        # Plan capture runs against real in-memory SQLite
+        if "query_plan" in result and result["query_plan"] is not None:
+            assert result["plan_fingerprint"] is not None
+            assert result["plan_capture_time_ms"] >= 0
+
+    def test_execute_query_without_capture_has_no_plan(self, adapter_no_capture, conn):
+        result = adapter_no_capture.execute_query(
+            connection=conn,
+            query="SELECT * FROM orders",
+            query_id="sq2",
+            validate_row_count=False,
+        )
+        assert "query_plan" not in result or result.get("query_plan") is None
+
+    def test_execute_query_capture_does_not_affect_row_count(self, adapter, conn):
+        result = adapter.execute_query(
+            connection=conn,
+            query="SELECT * FROM orders",
+            query_id="sq3",
+            validate_row_count=False,
+        )
+        assert result["status"] == "SUCCESS"
+        assert result["rows_returned"] == 2
+
+
+class TestSQLiteParserModernFormat:
+    """Verify the parser handles modern SQLite output (no TABLE keyword)."""
+
+    def test_infer_scan_without_table_keyword(self):
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        parser = SQLiteQueryPlanParser()
+        op_type = parser._infer_operator_type("SCAN orders")
+        assert op_type == "SCAN"
+
+    def test_infer_search_without_table_keyword(self):
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        parser = SQLiteQueryPlanParser()
+        op_type = parser._infer_operator_type("SEARCH orders USING INDEX idx_customer (c_custkey=?)")
+        assert op_type == "INDEX_SCAN"
+
+    def test_extract_details_without_table_keyword(self):
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        parser = SQLiteQueryPlanParser()
+        details = parser._extract_details("SCAN orders")
+        assert details.get("table_name") == "orders"
+
+    def test_parse_modern_explain_output(self, conn):
+        """End-to-end: parse actual SQLite 3.36+ EXPLAIN QUERY PLAN output."""
+        from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
+
+        cursor = conn.cursor()
+        cursor.execute("EXPLAIN QUERY PLAN SELECT * FROM orders WHERE id = 1")
+        rows = cursor.fetchall()
+        cursor.close()
+
+        from benchbox.platforms.sqlite import _format_sqlite_query_plan
+
+        plan_text = _format_sqlite_query_plan(rows)
+
+        if plan_text:
+            parser = SQLiteQueryPlanParser()
+            dag = parser.parse_explain_output("test_q", plan_text)
+            assert dag is not None
+            assert dag.logical_root is not None


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

After PRs #748 and #749 wired query plan capture for five adapters, this PR adds four follow-up TODOs that address remaining correctness, design, and test gaps, plus marks completed TODOs and MotherDuck work units as done.

**New TODOs:**

- **`query-plan-capture-missing-guards` (High)**: DataFusion and SQLite are missing the `status=="SUCCESS"` guard on their capture blocks (will run EXPLAIN on FAILED results). All three non-DuckDB adapters (DataFusion, SQLite, Redshift) also don't call `display_query_plan_if_enabled()`, so `--show-query-plans` silently produces no output for them. Includes guidance on the correct conditional display pattern to avoid double EXPLAIN.

- **`query-plan-capture-dml-double-execution` (Medium-High)**: DuckDB and MotherDuck use `EXPLAIN ANALYZE` which physically re-executes the query — DML statements (INSERT/UPDATE/DELETE/MERGE) would be executed twice when `capture_plans=True`. Fix: detect DML prefix and downgrade to `FORMAT JSON` (no ANALYZE) for those queries, reusing the detection pattern already in DataFusion.

- **`query-plan-capture-base-class-refactor` (Medium)**: The 6-line capture block is copy-pasted verbatim into all six adapters. Factor it into `_merge_plan_capture_into_result()` on `ResultCaptureMixin`, which bakes in the SUCCESS guard universally.

- **`query-plan-capture-fingerprint-contract` (Medium)**: No documentation defines what "stability" means for `plan_fingerprint` across version upgrades or stats refreshes. Also adds SQLite and DuckDB in-memory integration tests (no mocking), and a CI-gated PostgreSQL integration test.

**Updated existing TODOs:**
- `query-plan-capture-postgresql-family` and `query-plan-capture-datafusion-sqlite`: marked `Completed` (delivered in #748/#749)
- `query-plan-capture-misc-platforms`: MotherDuck w1/w2 marked `done`

## Test plan

- [ ] All four new TODO files pass `validate_todo.py` schema validation
- [ ] Content audit findings (7 REQUIRED, 5 SHOULD) applied: incorrect PostgreSQL EXPLAIN ANALYZE claim corrected, line numbers verified, `files_affected` complete, `anti_patterns` in required format, hard `deps.needs` replaced with `open_questions`

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_