### PR TITLE
fix(todos): address open review comments from PRs #760, #762, #764

### DIFF
--- a/_project/DONE/main/benchmark-runs-output-root-propagation.yaml
+++ b/_project/DONE/main/benchmark-runs-output-root-propagation.yaml
@@ -72,6 +72,13 @@ work:
       Preserve CLI `--output` precedence over `BENCHBOX_OUTPUT_DIR`, and preserve
       the current cwd-local default only when neither explicit option nor env is
       set.
+
+      Residual gap: explicit CLI `--output` override does not yet propagate through
+      the post-construction setter for tpcds and tpcdi (lazy/derived layout
+      benchmarks). This gap is tracked and scoped in the follow-up TODO
+      `benchmark-output-root-explicit-override-propagation`; it does not block
+      closing this item because the env-root path (BENCHBOX_OUTPUT_DIR) is fully
+      correct and the explicit-override gap has a dedicated tracking item.
   - id: w3
     summary: "Add or standardize output_dir synchronization for benchmark classes with nested data_generator state"
     needs: [w1]

--- a/_project/TODO/main/planning/benchmark-output-root-regression-guard.yaml
+++ b/_project/TODO/main/planning/benchmark-output-root-regression-guard.yaml
@@ -69,9 +69,17 @@ work:
     status: pending
     notes: |
       A unit test (or ruff/grep-based check wired into ci-lint) that scans
-      benchbox/core/**/benchmark.py for Path.cwd()/"benchmark_runs" defaults and
-      fails with guidance to use get_benchmark_runs_datagen_path instead. Allow a
-      documented exception list only for intentional non-datagen paths.
+      registered benchmark class source files for Path.cwd()/"benchmark_runs"
+      defaults and fails with guidance to use get_benchmark_runs_datagen_path
+      instead. Allow a documented exception list only for intentional non-datagen
+      paths.
+
+      Scan target must cover ALL registered benchmark sources, not only files named
+      benchmark.py. For example, TPCDSBenchmark lives in
+      benchbox/core/tpcds/benchmark/runner.py, not benchmark.py. Derive scan
+      targets from the registered class __module__ paths (via get_all_benchmarks())
+      rather than a glob like benchbox/core/**/benchmark.py so future benchmarks
+      added in non-standard file names are automatically covered.
   - id: w4
     summary: "Extend coverage to a cloud/dbfs output root through at least one generator-backed benchmark"
     needs: [w1]

--- a/_project/TODO/main/planning/benchmark-output-root-resolve-at-construction-boundary.yaml
+++ b/_project/TODO/main/planning/benchmark-output-root-resolve-at-construction-boundary.yaml
@@ -116,6 +116,7 @@ scope_limit:
     - "benchbox/core/runner/"
     - "benchbox/base.py"
     - "benchbox/core/read_primitives/benchmark.py"
+    - "benchbox/core/transactional/benchmark_base.py"
     - "tests/unit/"
   do_not_modify:
     - "benchmark_runs/"

--- a/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
+++ b/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
@@ -39,9 +39,9 @@ description: |
   needs a correctness contract rather than per-instance patches.
 
 prior_art:
-  - "_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - the SQL-variant fix this audit extends; reuse its qualify-the-outer-table pattern"
+  - "_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - the SQL-variant fix this audit extends; reuse its qualify-the-outer-table pattern"
   - "benchbox/core/tpchavoc/dataframe_queries/_delegating_variants.py - notes that Q16-Q22 delegate the core correlated/anti-join shape; verify those delegations are faithful"
-  - "benchbox/core/tpcds/dataframe_queries/queries.py:3801 - existing 'correlated subquery ... self-join pattern' comment; an explicit audit target"
+  - "benchbox/core/tpcds/dataframe_queries/queries.py:2814 - existing 'self-join pattern' comment for correlated subquery implementation; an explicit audit target"
   - "benchbox/sql_compat/rules/ and benchbox/platforms/*_query_transformer.py - existing places SQL is rewritten; a static check could live near these"
 
 work:

--- a/_project/TODO/main/planning/tpchavoc-q2-v10-projection-faithfulness.yaml
+++ b/_project/TODO/main/planning/tpchavoc-q2-v10-projection-faithfulness.yaml
@@ -31,7 +31,7 @@ description: |
 prior_art:
   - "benchbox/core/tpchavoc/variant_sets/q02.yaml:455 q2_v10 - the CASE-wrapped s_acctbal/s_name/n_name/... projections are the locus"
   - "PR #756 / tests/integration/test_tpchavoc_duckdb.py - the canonical-vs-variant SF=1 comparison method that surfaced this; reuse it to confirm the fix"
-  - "_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - sibling defect class; same 'fix the SQL, preserve the shape' discipline"
+  - "_project/TODO/main/planning/tpchavoc-correlated-subquery-self-binding.yaml - sibling defect class; same 'fix the SQL, preserve the shape' discipline"
 
 work:
   - id: w0


### PR DESCRIPTION
## Summary

Addresses 4 unresolved P2 bot review threads across 3 merged PRs. All changes are TODO/DONE YAML corrections — no code changes.

### PR #764 — `benchmark-runs-output-root-propagation.yaml` (w2 notes)
`w2` was marked done while the explicit `--output` CLI override still doesn't propagate for tpcds/tpcdi. Added an explicit residual-gap note to w2's `notes` field documenting that this gap is tracked in `benchmark-output-root-explicit-override-propagation`, so the closure rationale is clear to future readers.

### PR #762 — `benchmark-output-root-regression-guard.yaml` (w3 scan target)
w3 proposed scanning `benchbox/core/**/benchmark.py` for hardcoded `Path.cwd()/"benchmark_runs"` defaults. `TPCDSBenchmark` lives in `runner.py`, not `benchmark.py`, so this glob would miss it. Updated w3 to derive scan targets from registered benchmark class `__module__` paths via `get_all_benchmarks()` instead of a filename glob.

### PR #762 — `benchmark-output-root-resolve-at-construction-boundary.yaml` (scope_limit)
w3 requires collapsing the `GeneratorOutputDirMixin` with both the read-primitives and transactional `output_dir` setters, but `benchbox/core/transactional/benchmark_base.py` was absent from `scope_limit.only_modify`. Added it.

### PR #760 — `correlated-subquery-self-binding-cross-surface-audit.yaml` + `tpchavoc-q2-v10-projection-faithfulness.yaml` (prior_art)
Both TODOs referenced `_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml` — a path that doesn't exist (item is still in `_project/TODO/`). Fixed to the correct path. Also corrected the TPC-DS self-join comment line reference from `:3801` to `:2814`.

## Test plan

- [ ] `uv run --project _project/scripts -- python _project/scripts/validate_todo.py` passes for all 5 changed files (already confirmed locally)
- [ ] `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` passes
- [ ] CI lint green

https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV

---
_Generated by [Claude Code](https://claude.ai/code/session_011g6yZeXafkxSWpMSheukaV)_