### PR TITLE
fix(plan-capture): add SUCCESS guard and display call to DataFusion, SQLite, Redshift

### DIFF
--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1528,8 +1528,16 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
                 validation_result=validation_result,
             )
 
-            # Capture structured query plan if enabled
-            if self.capture_plans:
+            # Display plan in console when --show-query-plans is active.
+            # Skip here when --capture-plans is also active: capture_query_plan below
+            # already calls get_query_plan (running EXPLAIN); calling
+            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(connection, query, query_id)
+
+            # Capture structured query plan if enabled (only on SUCCESS to avoid
+            # wasteful EXPLAIN on validation-failed results)
+            if self.capture_plans and result.get("status") == "SUCCESS":
                 query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
                 if query_plan:
                     result["query_plan"] = query_plan

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2114,6 +2114,13 @@ class RedshiftAdapter(PlatformAdapter):
             # Map query_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = query_stats
 
+            # Display plan in console when --show-query-plans is active.
+            # Skip here when --capture-plans is also active: capture_query_plan below
+            # already calls get_query_plan (running EXPLAIN); calling
+            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(connection, query, query_id)
+
             # Capture structured query plan if enabled (only on SUCCESS to avoid
             # wasteful EXPLAIN on validation-failed results)
             if self.capture_plans and result_dict.get("status") == "SUCCESS":

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -558,8 +558,16 @@ class SQLiteAdapter(PlatformAdapter):
             # Include full results for SQLite compatibility
             result["results"] = results
 
-            # Capture structured query plan if enabled
-            if self.capture_plans:
+            # Display plan in console when --show-query-plans is active.
+            # Skip here when --capture-plans is also active: capture_query_plan below
+            # already calls get_query_plan (running EXPLAIN); calling
+            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(connection, query, query_id)
+
+            # Capture structured query plan if enabled (only on SUCCESS to avoid
+            # wasteful EXPLAIN on validation-failed results)
+            if self.capture_plans and result.get("status") == "SUCCESS":
                 query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
                 if query_plan:
                     result["query_plan"] = query_plan

--- a/tests/unit/platforms/test_datafusion_plan_capture.py
+++ b/tests/unit/platforms/test_datafusion_plan_capture.py
@@ -124,3 +124,45 @@ class TestDataFusionPlanCapture:
             )
 
         assert "query_plan" not in result or result.get("query_plan") is None
+
+    def test_execute_query_failed_status_skips_capture(self, adapter, monkeypatch):
+        conn = MagicMock()
+        fake_result = MagicMock()
+        fake_result.collect.return_value = []
+        conn.sql.return_value = fake_result
+
+        capture_called = []
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: capture_called.append(True) or (None, 0.0))
+        monkeypatch.setattr(
+            adapter,
+            "_build_query_result_with_validation",
+            lambda **kw: {"query_id": "df_fail", "status": "FAILED", "rows_returned": 0},
+        )
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="df_fail", validate_row_count=False)
+
+        assert not capture_called, "capture_query_plan must not be called on FAILED results"
+
+    def test_execute_query_calls_display_when_not_capturing(self, adapter_no_capture, monkeypatch):
+        conn = MagicMock()
+        fake_result = MagicMock()
+        fake_result.collect.return_value = []
+        conn.sql.return_value = fake_result
+
+        display_calls = []
+        monkeypatch.setattr(
+            adapter_no_capture,
+            "display_query_plan_if_enabled",
+            lambda *a, **k: display_calls.append(True),
+        )
+        monkeypatch.setattr(
+            adapter_no_capture,
+            "_build_query_result_with_validation",
+            lambda **kw: {"query_id": "df_disp", "status": "SUCCESS", "rows_returned": 0},
+        )
+
+        adapter_no_capture.execute_query(
+            connection=conn, query="SELECT 1", query_id="df_disp", validate_row_count=False
+        )
+
+        assert len(display_calls) == 1, "display_query_plan_if_enabled must be called exactly once"

--- a/tests/unit/platforms/test_redshift_plan_capture.py
+++ b/tests/unit/platforms/test_redshift_plan_capture.py
@@ -97,6 +97,24 @@ class TestRedshiftPlanCapture:
 
         assert "query_plan" not in result or result.get("query_plan") is None
 
+    def test_execute_query_calls_display_when_not_capturing(self, adapter_no_capture, monkeypatch):
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+        monkeypatch.setattr(adapter_no_capture, "_get_query_statistics", lambda *a, **k: {})
+
+        display_calls = []
+        monkeypatch.setattr(
+            adapter_no_capture,
+            "display_query_plan_if_enabled",
+            lambda *a, **k: display_calls.append(True),
+        )
+
+        adapter_no_capture.execute_query(
+            connection=conn, query="SELECT 1", query_id="rq_disp", validate_row_count=False
+        )
+
+        assert len(display_calls) == 1, "display_query_plan_if_enabled must be called exactly once"
+
     def test_get_query_plan_does_not_use_analyze(self, adapter):
         cursor = MagicMock()
         cursor.fetchall.return_value = [("XN Seq Scan",)]

--- a/tests/unit/platforms/test_sqlite_plan_capture.py
+++ b/tests/unit/platforms/test_sqlite_plan_capture.py
@@ -110,6 +110,35 @@ class TestSQLitePlanCapture:
         assert result["status"] == "SUCCESS"
         assert result["rows_returned"] == 2
 
+    def test_execute_query_failed_status_skips_capture(self, adapter, conn, monkeypatch):
+        capture_called = []
+        monkeypatch.setattr(adapter, "capture_query_plan", lambda *a, **k: capture_called.append(True) or (None, 0.0))
+        monkeypatch.setattr(
+            adapter,
+            "_build_query_result_with_validation",
+            lambda **kw: {"query_id": "sq_fail", "status": "FAILED", "rows_returned": 0},
+        )
+
+        adapter.execute_query(
+            connection=conn, query="SELECT * FROM orders", query_id="sq_fail", validate_row_count=False
+        )
+
+        assert not capture_called, "capture_query_plan must not be called on FAILED results"
+
+    def test_execute_query_calls_display_when_not_capturing(self, adapter_no_capture, conn, monkeypatch):
+        display_calls = []
+        monkeypatch.setattr(
+            adapter_no_capture,
+            "display_query_plan_if_enabled",
+            lambda *a, **k: display_calls.append(True),
+        )
+
+        adapter_no_capture.execute_query(
+            connection=conn, query="SELECT * FROM orders", query_id="sq_disp", validate_row_count=False
+        )
+
+        assert len(display_calls) == 1, "display_query_plan_if_enabled must be called exactly once"
+
 
 class TestSQLiteParserModernFormat:
     """Verify the parser handles modern SQLite output (no TABLE keyword)."""


### PR DESCRIPTION
## Summary

Implements the **`query-plan-capture-missing-guards`** TODO. PR #748 wired plan capture for five adapters; a follow-up review (#749) fixed Redshift but left the same defects in DataFusion/SQLite plus a third defect in all three non-DuckDB adapters.

**Defect 1 — missing `status == "SUCCESS"` guard (DataFusion, SQLite)**
Both adapters ran `capture_query_plan()` even when `_build_query_result_with_validation()` returned `status="FAILED"`, wasting an EXPLAIN round-trip and attaching plan metadata to a failed result. Now guarded on `result.get("status") == "SUCCESS"`, matching PostgreSQL and Redshift.

**Defect 2 — `display_query_plan_if_enabled()` never called (DataFusion, SQLite, Redshift)**
`--show-query-plans` silently produced no output for these three platforms. All three now call it using the MotherDuck **conditional** pattern (`if not self.capture_plans:`) so display works standalone but does not issue a second EXPLAIN when `--capture-plans` is also active.

## Changes
- `benchbox/platforms/datafusion.py` — SUCCESS guard + conditional display call
- `benchbox/platforms/sqlite.py` — SUCCESS guard + conditional display call
- `benchbox/platforms/redshift.py` — conditional display call (guard already present from #749)
- Tests: FAILED-status skip tests for DataFusion & SQLite; display-call test for all three adapters

## Test plan
- [x] `pytest tests/unit/platforms/test_{datafusion,sqlite,redshift}_plan_capture.py` — 33 passed (5 new)
- [x] `pytest tests/unit/platforms/` — 7428 passed, 2 skipped, 0 failures
- [x] `/code-review` (medium) — no findings

## Scope
Limited to the six files in the TODO `scope_limit`. Result dict shapes for non-plan fields are unchanged.

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_