### PR TITLE
fix(plan-capture): guard DuckDB/MotherDuck DML against double-execution

### DIFF
--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -30,6 +30,7 @@ import math
 import os
 import platform
 import random
+import re
 import statistics
 import time
 from collections.abc import Mapping
@@ -65,6 +66,62 @@ try:
     from benchbox.core.validation import ValidationResult
 except ImportError:  # pragma: no cover - validation always present in real install
     ValidationResult = None  # type: ignore[assignment, misc]
+
+
+# A data-changing verb at the very start of the statement (word-bounded so an
+# identifier like ``COPYRIGHTS`` or ``MERGEABLE`` is not misread as DML).
+_DML_LEADING_RE = re.compile(r"^(?:INSERT|UPDATE|DELETE|MERGE|COPY)\b", re.IGNORECASE)
+# A data-modifying verb anywhere — used only after a leading WITH to catch
+# CTE-prefixed DML (``WITH cte AS (...) INSERT INTO ...``). COPY is excluded:
+# it cannot appear inside a CTE, and its leading form is already caught above.
+_DML_AFTER_CTE_RE = re.compile(r"\b(?:INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
+
+
+def _strip_leading_sql_comments(statement: str) -> str:
+    """Drop leading ``--`` line comments and ``/* */`` block comments + whitespace."""
+    statement = statement.lstrip()
+    while True:
+        if statement.startswith("--"):
+            newline_pos = statement.find("\n")
+            if newline_pos == -1:
+                return ""
+            statement = statement[newline_pos + 1 :].lstrip()
+        elif statement.startswith("/*"):
+            end = statement.find("*/")
+            if end == -1:
+                return ""
+            statement = statement[end + 2 :].lstrip()
+        else:
+            return statement
+
+
+def is_dml_query(query: str) -> bool:
+    """Return True for data-changing DML statements (INSERT/UPDATE/DELETE/MERGE/COPY).
+
+    Used to guard plan capture against double-execution: adapters that capture
+    plans via ``EXPLAIN ANALYZE`` (DuckDB, MotherDuck) physically re-run the
+    statement, so a DML query would mutate data twice. Callers downgrade to a
+    non-ANALYZE ``EXPLAIN`` for these statements.
+
+    Detection covers the data-modifying verbs INSERT/UPDATE/DELETE/MERGE/COPY,
+    including when they are preceded by a leading ``WITH`` CTE clause. DDL
+    (CREATE/DROP/ALTER/TRUNCATE) is intentionally excluded: DDL does not produce
+    duplicate data mutations, so it does not need the ANALYZE guard. Leading
+    line and block comments are stripped first so a commented preamble (e.g. a
+    ``/* query 12 */`` banner) does not mask the verb.
+    """
+    statement = _strip_leading_sql_comments(query)
+    if not statement:
+        return False
+    if _DML_LEADING_RE.match(statement):
+        return True
+    # CTE-prefixed DML: the data-modifying verb follows the CTE definitions, so a
+    # leading-verb check alone misses it. Conservatively treat a WITH-prefixed
+    # statement that contains a DML verb as DML — worst case a read-only CTE
+    # query loses ANALYZE stats, which is far cheaper than a double mutation.
+    if re.match(r"^WITH\b", statement, re.IGNORECASE) and _DML_AFTER_CTE_RE.search(statement):
+        return True
+    return False
 
 
 def _extract_result_field(result: Any, attr: str, default: Any = None) -> Any:

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -1051,8 +1051,20 @@ class DuckDBAdapter(PlatformAdapter):
         Note: EXPLAIN (ANALYZE, ...) re-executes the query, adding ~1× query cost to the
         capture step. Plan fingerprints are unaffected - compute_plan_fingerprint()
         excludes timing/cardinality by design.
+
+        DML queries (INSERT/UPDATE/DELETE/MERGE/COPY) are explained without ANALYZE
+        to prevent double-execution, even when analyze_plans=True: DuckDB's
+        EXPLAIN ANALYZE physically runs the statement, which would mutate data a
+        second time. The plan structure is still captured (FORMAT JSON only);
+        execution statistics are absent for these statements.
         """
+        from benchbox.platforms.base.result_capture import is_dml_query
+
         analyze = self.analyze_plans
+        # EXPLAIN ANALYZE re-executes the statement; for DML that would double-mutate
+        # data, so downgrade to FORMAT JSON (estimated plan, no execution stats).
+        if analyze and is_dml_query(query):
+            analyze = False
         # EXPLAIN (ANALYZE, FORMAT JSON) is the PostgreSQL-style combined syntax supported by DuckDB.
         # Plain EXPLAIN (FORMAT JSON) produces estimated plans only (no timing/cardinality data).
         explain_options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -229,8 +229,21 @@ class MotherDuckAdapter(PlatformAdapter):
 
         MotherDuck uses DuckDB's SQL dialect; EXPLAIN format is identical.
         DuckDB EXPLAIN rows are (explain_key, explain_value) tuples; column 1 is the JSON payload.
+
+        DML queries (INSERT/UPDATE/DELETE/MERGE/COPY) are explained without ANALYZE
+        to prevent double-execution, even when analyze_plans=True: EXPLAIN ANALYZE
+        physically runs the statement, which would mutate data a second time. The
+        plan structure is still captured (FORMAT JSON only); execution statistics
+        are absent for these statements.
         """
-        explain_options = "ANALYZE, FORMAT JSON" if self.analyze_plans else "FORMAT JSON"
+        from benchbox.platforms.base.result_capture import is_dml_query
+
+        analyze = self.analyze_plans
+        # EXPLAIN ANALYZE re-executes the statement; for DML that would double-mutate
+        # data, so downgrade to FORMAT JSON (estimated plan, no execution stats).
+        if analyze and is_dml_query(query):
+            analyze = False
+        explain_options = "ANALYZE, FORMAT JSON" if analyze else "FORMAT JSON"
         try:
             rows = (connection or self.connection).execute(f"EXPLAIN ({explain_options}) {query}").fetchall()
             # column 0 is the key (e.g. "analyzed_plan"), column 1 is the JSON value

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -4,6 +4,8 @@ Tests for DuckDB query plan capture integration.
 Verifies that query plans are captured and parsed during query execution.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from benchbox.platforms.duckdb import DuckDBAdapter
@@ -12,6 +14,109 @@ pytestmark = [
     pytest.mark.unit,
     pytest.mark.fast,
 ]
+
+
+class TestIsDmlQueryHelper:
+    """Direct contract tests for the shared is_dml_query classifier."""
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "INSERT INTO t VALUES (1)",
+            "update t set x = 1",
+            "  DELETE FROM t",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET x = 1",
+            "COPY t FROM 'f.csv'",
+            "/* banner */ INSERT INTO t VALUES (1)",
+            "-- c\nUPDATE t SET x = 1",
+            "WITH s AS (SELECT 1) INSERT INTO t SELECT * FROM s",
+        ],
+    )
+    def test_dml_detected(self, query):
+        from benchbox.platforms.base.result_capture import is_dml_query
+
+        assert is_dml_query(query) is True
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT 1",
+            "WITH cte AS (SELECT 1) SELECT * FROM cte",
+            "SELECT copy_total, merge_flag FROM t",  # identifiers, not verbs (word boundary)
+            "CREATE TABLE t (id INT)",  # DDL is excluded
+            "EXPLAIN SELECT 1",
+            "",
+            "-- only a comment",
+        ],
+    )
+    def test_non_dml_not_detected(self, query):
+        from benchbox.platforms.base.result_capture import is_dml_query
+
+        assert is_dml_query(query) is False
+
+
+class TestDuckDBDMLPlanGuard:
+    """EXPLAIN ANALYZE re-executes statements; DML must downgrade to FORMAT JSON."""
+
+    @pytest.mark.parametrize(
+        "dml",
+        [
+            "INSERT INTO t VALUES (1)",
+            "UPDATE t SET x = 1",
+            "DELETE FROM t WHERE id = 1",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET x = 1",
+            "COPY t FROM 'data.csv'",
+        ],
+    )
+    def test_dml_query_does_not_use_analyze(self, dml):
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [("logical_plan", "{}")]
+
+        adapter.get_query_plan(conn, dml)
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" not in called_sql, f"DML must not run EXPLAIN ANALYZE: {called_sql}"
+        assert "FORMAT JSON" in called_sql
+
+    @pytest.mark.parametrize(
+        "dml",
+        [
+            "-- leading comment\nINSERT INTO t VALUES (1)",
+            "  insert into t values (1)",
+            "/* query 12 */ INSERT INTO t VALUES (1)",
+            "/* a */ -- b\n  DELETE FROM t",
+            "WITH src AS (SELECT * FROM staging) INSERT INTO t SELECT * FROM src",
+            "WITH d AS (SELECT id FROM t) DELETE FROM t WHERE id IN (SELECT id FROM d)",
+        ],
+    )
+    def test_dml_guard_handles_comments_cte_and_whitespace(self, dml):
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [("logical_plan", "{}")]
+
+        adapter.get_query_plan(conn, dml)
+
+        assert "ANALYZE" not in conn.execute.call_args[0][0].upper(), f"DML must not run ANALYZE: {dml!r}"
+
+    @pytest.mark.parametrize(
+        "non_dml",
+        [
+            "SELECT * FROM t WHERE id = 1",
+            "WITH cte AS (SELECT 1) SELECT * FROM cte",
+            "SELECT copy_count, update_ts FROM t",  # column names starting with DML verbs
+        ],
+    )
+    def test_non_dml_query_still_uses_analyze(self, non_dml):
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [("analyzed_plan", "{}")]
+
+        adapter.get_query_plan(conn, non_dml)
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" in called_sql, f"Non-DML must still use EXPLAIN ANALYZE: {non_dml!r}"
+        assert "FORMAT JSON" in called_sql
 
 
 class TestDuckDBPlanCapture:

--- a/tests/unit/platforms/test_motherduck_plan_capture.py
+++ b/tests/unit/platforms/test_motherduck_plan_capture.py
@@ -1,0 +1,60 @@
+"""Tests for MotherDuck query plan capture DML double-execution guard.
+
+MotherDuck captures plans via EXPLAIN (ANALYZE, FORMAT JSON), which physically
+re-executes the statement. For DML (INSERT/UPDATE/DELETE/MERGE/COPY) this would
+mutate data twice, so get_query_plan() must downgrade to FORMAT JSON without
+ANALYZE. These tests pass a mock connection, so no MotherDuck network access is
+required.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchbox.platforms.motherduck import MotherDuckAdapter
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+@pytest.fixture()
+def adapter():
+    return MotherDuckAdapter(token="test-token", capture_plans=True, analyze_plans=True)
+
+
+def _mock_conn():
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [("analyzed_plan", "{}")]
+    return conn
+
+
+class TestMotherDuckDMLPlanGuard:
+    @pytest.mark.parametrize(
+        "dml",
+        [
+            "INSERT INTO t VALUES (1)",
+            "UPDATE t SET x = 1",
+            "DELETE FROM t WHERE id = 1",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET x = 1",
+            "COPY t FROM 'data.csv'",
+        ],
+    )
+    def test_dml_query_does_not_use_analyze(self, adapter, dml):
+        conn = _mock_conn()
+
+        adapter.get_query_plan(conn, dml)
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" not in called_sql, f"DML must not run EXPLAIN ANALYZE: {called_sql}"
+        assert "FORMAT JSON" in called_sql
+
+    def test_select_query_still_uses_analyze(self, adapter):
+        conn = _mock_conn()
+
+        adapter.get_query_plan(conn, "SELECT * FROM t WHERE id = 1")
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" in called_sql, "Non-DML SELECT must still use EXPLAIN ANALYZE"
+        assert "FORMAT JSON" in called_sql


### PR DESCRIPTION
## Summary

Implements the **`query-plan-capture-dml-double-execution`** TODO.

DuckDB and MotherDuck capture plans via `EXPLAIN (ANALYZE, FORMAT JSON)`, which **physically re-executes** the statement. For DML (`INSERT`/`UPDATE`/`DELETE`/`MERGE`/`COPY`), any benchmark query that mutates data was executed **twice** when `capture_plans=True` — a data-integrity risk for TPC-DS maintenance streams, TPC-DI load phases, and custom write workloads.

## Fix (Option A from the TODO — preferred)

- Adds module-level `is_dml_query()` to `benchbox/platforms/base/result_capture.py` (the existing plan-capture home).
- Both adapters' `get_query_plan()` now downgrade to `EXPLAIN (FORMAT JSON)` (no `ANALYZE`) for DML: `if analyze and is_dml_query(query): analyze = False`. Plan structure is still captured; only execution stats are absent for DML. SELECT/WITH read-only capture is unchanged.

The classifier is hardened beyond a bare prefix check (per `/code-review` findings) so the success metric — *"DML queries never trigger EXPLAIN ANALYZE regardless of analyze_plans"* — holds for real-world SQL:
- strips leading `--` line **and** `/* */` block comments (e.g. `/* query 12 */ INSERT …`),
- word-boundary verb matching (so identifiers like `copy_total` are not misread),
- conservatively treats CTE-prefixed DML (`WITH cte AS (…) INSERT/UPDATE/DELETE/MERGE …`) as DML.

DDL (CREATE/DROP/ALTER/TRUNCATE) is intentionally excluded — it does not double-mutate data.

## Changes
- `benchbox/platforms/base/result_capture.py` — `is_dml_query()` + comment-stripping helper
- `benchbox/platforms/duckdb.py`, `benchbox/platforms/motherduck.py` — DML guard + docstring notes
- `tests/unit/platforms/test_duckdb_plan_capture.py` — parametrized DML/non-DML guard tests + direct `is_dml_query` contract test
- `tests/unit/platforms/test_motherduck_plan_capture.py` — new file mirroring the guard tests

## Test plan
- [x] `pytest tests/unit/platforms/test_duckdb_plan_capture.py tests/unit/platforms/test_motherduck_plan_capture.py` — 44 passed
- [x] `pytest tests/unit/platforms/` — 7458 passed, 2 skipped, 0 failures
- [x] `/code-review` (medium) — 3 classification-gap findings surfaced and all corrected

## Scope
Limited to the TODO `scope_limit`; `datafusion.py`/`postgresql.py`/`redshift.py` untouched (`do_not_modify`).

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_