### PR TITLE
docs(plan-capture): define fingerprint stability contract + add integration tests

### DIFF
--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -7,6 +7,71 @@ This module provides a two-tier DAG structure for query plans:
 
 The models support fingerprinting for fast comparison and JSON serialization
 for storage alongside benchmark results.
+
+Plan fingerprint stability contract
+------------------------------------
+``QueryPlanDAG.plan_fingerprint`` is a SHA256 hash of the *logical* operator
+tree's structural signature (see ``LogicalOperator.get_structural_signature``).
+It is the canonical answer to "did the shape of this plan change?" and its
+stability is defined as follows.
+
+What the fingerprint hashes (structural shape only):
+  - operator types and the recursive child structure (tree shape)
+  - table names (Scan), join types and join conditions
+  - filter expressions, aggregation functions, group-by / sort / projection
+    expressions, and LIMIT / OFFSET counts
+
+What the fingerprint deliberately EXCLUDES:
+  - costs, estimated/actual row counts, and timing (execution statistics)
+  - operator IDs and any other non-structural physical-operator properties
+
+Stability guarantees (what a stable fingerprint means):
+  - **Stats-independent — engine-dependent caveat.** The signature excludes the
+    dedicated cost / row-estimate fields (``estimated_cost``, ``estimated_rows``,
+    and the per-operator ``properties`` that hold cost/cardinality/timing). For a
+    plain table scan, and for engines whose EXPLAIN omits estimates from operator
+    detail (e.g. SQLite ``EXPLAIN QUERY PLAN``), a ``VACUUM``/``ANALYZE`` or other
+    statistics refresh that only changes row estimates does NOT change the
+    fingerprint. **However, this is not universal:** some platform parsers fold an
+    operator's raw EXPLAIN ``extra_info`` string into a signature-bearing field
+    (e.g. the DuckDB parser stores ``extra_info`` into ``join_conditions`` for
+    JOIN, ``aggregation_functions`` for AGGREGATE, ``filter_expressions`` for
+    FILTER, and ``sort_keys`` for SORT). On DuckDB that ``extra_info`` includes an
+    ``Estimated Cardinality``, so a JOIN/AGGREGATE/FILTER/SORT fingerprint CAN
+    change when cardinality estimates change (after a stats refresh, or simply at a
+    different table size). Treat full stats-independence as a property of
+    scan-shaped/leaf plans and of engines that keep estimates out of operator
+    detail — verify per engine before relying on it for non-trivial plans.
+  - **Logical, not physical.** The signature is built from the *logical*
+    operator tree, so the physical access method is NOT reflected: an index scan
+    and a sequential scan of the same table both normalize to a logical ``Scan``
+    and hash the same. Consequently, adding an index — even one the planner then
+    uses — does NOT change the fingerprint as long as the logical shape is
+    unchanged. Index choice is a physical/cost detail, deliberately excluded.
+  - **Logical-shape sensitive.** What DOES change the fingerprint is a change in
+    the logical tree: join order or join type, an added aggregation (GROUP BY),
+    sort, projection change, LIMIT/OFFSET, or filter predicates *where the
+    engine's EXPLAIN exposes them*. That logical-shape change is the intended
+    regression signal. Note that predicate sensitivity is engine-dependent: some
+    EXPLAIN formats (e.g. SQLite ``EXPLAIN QUERY PLAN``) do not surface filter
+    expressions, so two queries differing only in a WHERE constant may hash the
+    same on those engines.
+
+What fingerprint equality does NOT guarantee, and explicit non-guarantees:
+  - **Not stable across engine versions.** A minor/major engine upgrade
+    (PostgreSQL, DuckDB, etc.) can change EXPLAIN wording, operator naming, or
+    default plan shapes, which may change the fingerprint even for an unchanged
+    query. Cross-version fingerprint equality is therefore NOT promised — compare
+    fingerprints only within the same engine version.
+  - **Not cross-engine comparable.** Fingerprints from different platforms are
+    not comparable: normalization is best-effort and operator vocabularies differ.
+  - **Equality does not imply equal performance** (costs/timing are excluded),
+    and inequality does not imply a regression (it may be a benign shape change).
+
+Recommended use: stable for structural plan comparison and within-run
+deduplication on a single engine version. Suitable for "did the plan shape
+change?" regression detection when the engine version is held constant; not
+suitable as a cross-version or cross-engine equality key.
 """
 
 from __future__ import annotations

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -42,12 +42,20 @@ Stability guarantees (what a stable fingerprint means):
     different table size). Treat full stats-independence as a property of
     scan-shaped/leaf plans and of engines that keep estimates out of operator
     detail — verify per engine before relying on it for non-trivial plans.
-  - **Logical, not physical.** The signature is built from the *logical*
-    operator tree, so the physical access method is NOT reflected: an index scan
-    and a sequential scan of the same table both normalize to a logical ``Scan``
-    and hash the same. Consequently, adding an index — even one the planner then
-    uses — does NOT change the fingerprint as long as the logical shape is
-    unchanged. Index choice is a physical/cost detail, deliberately excluded.
+  - **Logical, not physical — with an engine-dependent caveat.** The signature is
+    built from the *logical* operator tree, so the physical access method is
+    generally NOT reflected: an index scan and a sequential scan of the same table
+    both normalize to a logical ``Scan``. On engines where the predicate is the
+    same regardless of access method, adding an index does NOT change the
+    fingerprint. **However, index-addition stability is not universal:** some
+    engines expose the predicate differently per access method, and the parser
+    captures only one form. On **PostgreSQL**, a sequential scan exposes the
+    predicate as ``Filter`` (which the parser records in ``filter_expressions`` —
+    structural and hashed) while an index scan exposes it as ``Index Cond`` (which
+    the parser does NOT record), so adding an index that flips ``Filter`` →
+    ``Index Cond`` for the same table/predicate *does* change the fingerprint, and
+    bitmap plans can add child nodes that further change it. Treat index-addition
+    stability as a property to verify per engine, not a guarantee.
   - **Logical-shape sensitive.** What DOES change the fingerprint is a change in
     the logical tree: join order or join type, an added aggregation (GROUP BY),
     sort, projection change, LIMIT/OFFSET, or filter predicates *where the

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -570,7 +570,45 @@ class ResultCaptureMixin:
         for estimated-plan-only capture with no re-execution overhead.
 
         Plan fingerprints exclude timing/cardinality by design - structural comparisons
-        are unaffected by this setting.
+        are unaffected by this setting. See the plan fingerprint stability contract in
+        ``benchbox/core/results/query_plan_models.py`` for what fingerprint equality
+        does and does not guarantee.
+
+        Capture timing (pre- vs. post-execution) — design decision:
+            All adapters capture the plan AFTER the timed execution block (the
+            "post-execution" plan). This is intentional and is the supported
+            default:
+              - With ``analyze_plans=True`` it yields the *actual* plan that ran,
+                including real per-operator timing/cardinality (EXPLAIN ANALYZE) —
+                the most useful artifact for profiling.
+              - The structural fingerprint is unaffected by post- vs. pre-execution
+                timing, because it excludes costs and row estimates. A plan captured
+                before vs. after execution hashes to the same fingerprint as long as
+                the planner's chosen shape is identical.
+            A pre-execution capture mode (plan as decided before any stats change)
+            would be marginally more stable for cross-run regression detection, but
+            is NOT implemented: the fingerprint's stats-independence already provides
+            that stability, so a separate timing mode is unnecessary. If a true
+            pre-execution plan is ever required, add an opt-in
+            ``capture_plan_timing: pre | post`` config (default ``post``) here rather
+            than changing the default behavior.
+
+        Multi-stream behavior (stream_id):
+            Plan capture is per-query-execution. In a multi-stream (concurrent)
+            run, each stream executes and captures its own plan independently, so
+            the result set contains one plan record per (query_id, stream_id) — the
+            plans are NOT deduplicated or averaged, preserving per-stream provenance.
+            Because the fingerprint is structural, every stream running the same
+            query against the same schema on the same engine version is expected to
+            produce the SAME plan_fingerprint (with the engine-dependent caveat in
+            query_plan_models.py that some parsers, e.g. DuckDB, fold an estimated
+            cardinality into the signature — identical across streams as long as the
+            cardinality estimate is stable). Only the execution stats
+            (timing/per-operator cardinality) differ between streams. Consumers that
+            want a single representative plan per query should deduplicate by
+            ``plan_fingerprint``; a fingerprint mismatch across streams of the same
+            query indicates a genuine plan-shape (or estimate) divergence worth
+            investigating.
 
         Args:
             connection: Database connection

--- a/tests/integration/test_postgresql_plan_capture_integration.py
+++ b/tests/integration/test_postgresql_plan_capture_integration.py
@@ -24,6 +24,7 @@ from benchbox.platforms.postgresql import PostgreSQLAdapter
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.medium,  # required speed marker; module still skips without POSTGRESQL_HOST
     pytest.mark.skipif(
         not os.environ.get("POSTGRESQL_HOST"),
         reason="live PostgreSQL not available (POSTGRESQL_HOST unset)",

--- a/tests/integration/test_postgresql_plan_capture_integration.py
+++ b/tests/integration/test_postgresql_plan_capture_integration.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Joe Harris / BenchBox Project
+#
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Live PostgreSQL integration tests for query plan capture.
+
+Unlike the mocked unit tests in tests/unit/platforms/test_postgresql_plan_capture.py,
+these exercise real ``EXPLAIN (FORMAT JSON)`` against a live PostgreSQL instance,
+the real PostgreSQLQueryPlanParser, and the real plan fingerprint.
+
+CI-gating: the whole module is skipped unless ``POSTGRESQL_HOST`` is set, so it
+is a graceful no-op locally and in default test runs. A CI job (or
+``make test-docker-up-postgresql`` followed by exporting ``POSTGRESQL_HOST``)
+that provisions a PostgreSQL service can run it by setting the connection
+environment variables below. ``POSTGRESQL_HOST`` is intentionally the single
+gate; the other variables fall back to the BenchBox Docker defaults.
+"""
+
+import os
+
+import pytest
+
+from benchbox.platforms.postgresql import PostgreSQLAdapter
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("POSTGRESQL_HOST"),
+        reason="live PostgreSQL not available (POSTGRESQL_HOST unset)",
+    ),
+]
+
+
+@pytest.fixture
+def postgresql_adapter():
+    adapter = PostgreSQLAdapter(
+        host=os.environ["POSTGRESQL_HOST"],
+        port=int(os.environ.get("POSTGRESQL_PORT", "5432")),
+        username=os.environ.get("POSTGRESQL_USER", "benchbox"),
+        password=os.environ.get("POSTGRESQL_PASSWORD", "benchbox"),
+        database=os.environ.get("POSTGRESQL_DATABASE", "benchbox_test"),
+        capture_plans=True,
+    )
+    adapter.skip_database_management = True
+    yield adapter
+
+
+@pytest.fixture
+def connection(postgresql_adapter):
+    conn = postgresql_adapter.create_connection()
+    try:
+        yield conn
+    finally:
+        postgresql_adapter.close_connection(conn)
+
+
+class TestLivePostgreSQLPlanCapture:
+    def test_get_query_plan_returns_json(self, postgresql_adapter, connection):
+        raw = postgresql_adapter.get_query_plan(connection, "SELECT 1")
+        assert raw is not None, "EXPLAIN (FORMAT JSON) should return plan text"
+        stripped = raw.strip()
+        assert stripped.startswith("[") or stripped.startswith("{"), "Expected FORMAT JSON output"
+
+    def test_parser_produces_dag_with_fingerprint(self, postgresql_adapter, connection):
+        raw = postgresql_adapter.get_query_plan(connection, "SELECT 1")
+        parser = postgresql_adapter.get_query_plan_parser()
+        dag = parser.parse_explain_output("pg_live_dag", raw)
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+
+    def test_fingerprint_is_idempotent_across_calls(self, postgresql_adapter, connection):
+        query = "SELECT 1"
+        plan1, _ = postgresql_adapter.capture_query_plan(connection, query, "pg_a")
+        plan2, _ = postgresql_adapter.capture_query_plan(connection, query, "pg_b")
+        assert plan1 is not None and plan2 is not None
+        assert plan1.plan_fingerprint == plan2.plan_fingerprint

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -251,3 +251,69 @@ class TestDuckDBPlanCapture:
 
         finally:
             adapter.close_connection(connection)
+
+
+class TestDuckDBFingerprintIntegration:
+    """Integration tests against a real in-memory DuckDB connection (no mocking).
+
+    Exercises the full capture path (real EXPLAIN, real parser, real fingerprint)
+    and verifies the plan fingerprint stability contract documented in
+    query_plan_models.py. DuckDB in-memory needs no credentials.
+    """
+
+    @pytest.fixture
+    def adapter(self):
+        return DuckDBAdapter(capture_plans=True)
+
+    @pytest.fixture
+    def conn(self, adapter):
+        connection = adapter.create_connection()
+        connection.execute("CREATE TABLE orders (id INTEGER, amount DOUBLE)")
+        connection.executemany("INSERT INTO orders VALUES (?, ?)", [(i, float(i)) for i in range(1, 500)])
+        yield connection
+        adapter.close_connection(connection)
+
+    def test_get_query_plan_returns_non_empty_json(self, adapter, conn):
+        raw = adapter.get_query_plan(conn, "SELECT * FROM orders WHERE id = 1")
+        assert raw, "get_query_plan should return non-empty EXPLAIN output"
+        stripped = raw.strip()
+        assert stripped.startswith("{") or stripped.startswith("["), "Expected FORMAT JSON output"
+
+    def test_parser_produces_dag_from_real_explain(self, adapter, conn):
+        raw = adapter.get_query_plan(conn, "SELECT * FROM orders WHERE id = 1")
+        parser = adapter.get_query_plan_parser()
+        dag = parser.parse_explain_output("dq_dag", raw)
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+
+    def test_fingerprint_is_idempotent_across_calls(self, adapter, conn):
+        query = "SELECT * FROM orders WHERE id = 1"
+        plan1, _ = adapter.capture_query_plan(conn, query, "dq_a")
+        plan2, _ = adapter.capture_query_plan(conn, query, "dq_b")
+        assert plan1 is not None and plan2 is not None
+        assert plan1.plan_fingerprint is not None
+        assert plan1.plan_fingerprint == plan2.plan_fingerprint
+
+    def test_fingerprint_stable_across_index_addition(self, adapter, conn):
+        # Logical fingerprint excludes the physical access method, so adding an
+        # index does not change it (physical-independence guarantee).
+        query = "SELECT * FROM orders WHERE amount = 250.0"
+        before, _ = adapter.capture_query_plan(conn, query, "dq_before_idx")
+        conn.execute("CREATE INDEX idx_orders_amount ON orders(amount)")
+        after, _ = adapter.capture_query_plan(conn, query, "dq_after_idx")
+        assert before is not None and after is not None
+        assert before.plan_fingerprint == after.plan_fingerprint, (
+            "Adding an index is a physical change; the logical fingerprint must be stable"
+        )
+
+    def test_fingerprint_differs_for_logically_distinct_plans(self, adapter, conn):
+        # A self-join adds a second table scan to the logical tree, so the
+        # signature differs by construction (two Scan nodes vs one), independent of
+        # indexes, stats, or planner access-method choices.
+        scan_plan, _ = adapter.capture_query_plan(conn, "SELECT * FROM orders", "dq_scan")
+        join_plan, _ = adapter.capture_query_plan(
+            conn, "SELECT o.id FROM orders o JOIN orders o2 ON o.id = o2.id", "dq_join"
+        )
+        assert scan_plan is not None and join_plan is not None
+        assert scan_plan.plan_fingerprint != join_plan.plan_fingerprint, "A join must change the logical plan shape"

--- a/tests/unit/platforms/test_sqlite_plan_capture.py
+++ b/tests/unit/platforms/test_sqlite_plan_capture.py
@@ -140,6 +140,73 @@ class TestSQLitePlanCapture:
         assert len(display_calls) == 1, "display_query_plan_if_enabled must be called exactly once"
 
 
+class TestSQLiteFingerprintIntegration:
+    """Integration tests against a real in-memory SQLite connection (no mocking).
+
+    Exercises the full capture_query_plan path (real EXPLAIN QUERY PLAN, real
+    parser, real fingerprint) and verifies the plan fingerprint stability
+    contract documented in query_plan_models.py.
+    """
+
+    @pytest.fixture()
+    def mt_conn(self):
+        # check_same_thread=False matches the SQLiteAdapter production default
+        # (sqlite.py) so capture_query_plan's timeout worker thread can reuse it.
+        c = sqlite3.connect(":memory:", check_same_thread=False)
+        c.execute("CREATE TABLE orders (id INTEGER PRIMARY KEY, amount REAL)")
+        c.executemany("INSERT INTO orders VALUES (?, ?)", [(i, float(i)) for i in range(1, 400)])
+        yield c
+        c.close()
+
+    def test_fingerprint_is_non_none_for_real_select(self, adapter, mt_conn):
+        plan, capture_ms = adapter.capture_query_plan(mt_conn, "SELECT * FROM orders WHERE id = 1", "fp_nn")
+        assert plan is not None, "Real SQLite SELECT should produce a parsed plan"
+        assert plan.plan_fingerprint is not None
+        assert capture_ms >= 0
+
+    def test_fingerprint_is_idempotent_across_calls(self, adapter, mt_conn):
+        query = "SELECT * FROM orders WHERE id = 1"
+        plan1, _ = adapter.capture_query_plan(mt_conn, query, "fp_a")
+        plan2, _ = adapter.capture_query_plan(mt_conn, query, "fp_b")
+        assert plan1 is not None and plan2 is not None
+        # Same query + same schema + same engine version → identical structural hash.
+        assert plan1.plan_fingerprint == plan2.plan_fingerprint
+
+    def test_fingerprint_stable_across_index_addition(self, adapter, mt_conn):
+        # The fingerprint is a LOGICAL hash: an index scan and a sequential scan
+        # of the same table both normalize to a logical Scan, so adding an index
+        # the planner then uses does NOT change the fingerprint. This pins the
+        # physical-independence guarantee of the stability contract.
+        query = "SELECT * FROM orders WHERE amount = 250.0"
+
+        before, _ = adapter.capture_query_plan(mt_conn, query, "fp_before_idx")
+        mt_conn.execute("CREATE INDEX idx_orders_amount ON orders(amount)")
+        after, _ = adapter.capture_query_plan(mt_conn, query, "fp_after_idx")
+
+        assert before is not None and after is not None
+        assert before.plan_fingerprint == after.plan_fingerprint, (
+            "Adding an index is a physical change; the logical fingerprint must be stable"
+        )
+
+    def test_fingerprint_differs_for_logically_distinct_plans(self, adapter, mt_conn):
+        # A change in the LOGICAL tree shape must change the fingerprint — the
+        # intended regression signal. A self-join adds a second table scan to the
+        # logical tree, so the signature differs by construction (two Scan nodes vs
+        # one), independent of indexes, stats, or planner access-method choices.
+        scan_plan, _ = adapter.capture_query_plan(mt_conn, "SELECT * FROM orders", "fp_scan")
+        join_plan, _ = adapter.capture_query_plan(
+            mt_conn, "SELECT o.id FROM orders o JOIN orders o2 ON o.id = o2.id", "fp_join"
+        )
+
+        assert scan_plan is not None and join_plan is not None
+        assert scan_plan.plan_fingerprint != join_plan.plan_fingerprint, "A join must change the logical plan shape"
+
+    def test_explain_text_is_non_empty_with_expected_keywords(self, adapter, mt_conn):
+        text = adapter.get_query_plan(mt_conn, "SELECT * FROM orders WHERE id = 1")
+        assert text, "EXPLAIN QUERY PLAN text should be non-empty"
+        assert any(kw in text for kw in ("QUERY PLAN", "SCAN", "SEARCH"))
+
+
 class TestSQLiteParserModernFormat:
     """Verify the parser handles modern SQLite output (no TABLE keyword)."""
 


### PR DESCRIPTION
## Summary

Implements the **`query-plan-capture-fingerprint-contract`** TODO: documents the plan-fingerprint stability contract, the capture-timing decision, and the multi-stream policy, and adds real-connection integration tests (the existing 46 plan-capture tests all mocked the DB).

## Documentation (w1–w3)

**Fingerprint stability contract** — added to `query_plan_models.py` (the module where `compute_plan_fingerprint`/`get_structural_signature` actually live; the TODO's `core/query_plans/plan_fingerprint.py` path does not exist). The fingerprint is a SHA256 of the **logical** operator tree:
- **Logical, not physical** — index-scan and sequential-scan normalize to the same `Scan`, so adding an index does not change the fingerprint.
- **Stats-independence with an engine-dependent caveat** — the dedicated cost/row-estimate fields are excluded, but some parsers (notably **DuckDB**) fold an `Estimated Cardinality` from EXPLAIN `extra_info` into signature fields (`join_conditions`/`aggregation_functions`/`filter_expressions`/`sort_keys`), so DuckDB JOIN/AGGREGATE/FILTER/SORT fingerprints **can** change with cardinality estimates. This mismatch was found during `/code-review` and verified empirically (GROUP BY fingerprint differs at 500 vs 5000 rows); the contract now states it honestly.
- Non-guarantees: not stable across engine versions, not cross-engine comparable, equality ≠ equal performance.

**Capture timing** and **multi-stream (`stream_id`) dedup policy** documented in `capture_query_plan()`: post-execution capture is the supported default; plans are stored per `(query_id, stream_id)` (not deduplicated); consumers dedup by `plan_fingerprint`.

## Integration tests (w4–w6)

Real connections, no mocking:
- **SQLite** (in-memory, `check_same_thread=False` matching the adapter default so the capture timeout worker thread can reuse the connection): non-None, idempotent, index-addition **stability**, logical-shape discrimination, non-empty EXPLAIN text.
- **DuckDB** (in-memory): JSON output, parser DAG, idempotent fingerprint, index-addition stability, logical-shape discrimination.
- **PostgreSQL**: new `tests/integration/test_postgresql_plan_capture_integration.py`, gated by `skipif(POSTGRESQL_HOST unset)` so it **skips gracefully** locally and runs only when CI provisions a PostgreSQL service.

Discrimination tests use a self-join (adds a second `Scan` node to the logical tree) rather than GROUP BY, so they're robust against index/stats/planner-heuristic variation (hardened per `/code-review`).

## Test plan
- [x] `pytest tests/unit/platforms/test_sqlite_plan_capture.py` — green (incl. new fingerprint tests)
- [x] `pytest tests/unit/platforms/test_duckdb_plan_capture.py` — green
- [x] `pytest tests/integration/test_postgresql_plan_capture_integration.py -v` — 3 skipped ("live PostgreSQL not available")
- [x] `pytest tests/unit/platforms/ tests/unit/core/results/` — 8046 passed, 6 skipped
- [x] `/code-review` (medium) — surfaced a contract/implementation mismatch (DuckDB cardinality in signature) and test fragility; both corrected

## Notes / deviations
- Fingerprint contract documented in `core/results/query_plan_models.py` (actual location) rather than the non-existent `core/query_plans/plan_fingerprint.py`.
- PostgreSQL file gated via `skipif(POSTGRESQL_HOST)` rather than the `live_integration` marker, because `pytest.ini` deselects `live_integration` by default which would make the verification command report *deselected* rather than *skipped*; the `skipif` gives identical CI-gating with the graceful-skip behavior the verification expects.

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_