### PR TITLE
refactor(plan-capture): factor repeated capture block into base-class helper

### DIFF
--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -758,6 +758,39 @@ class ResultCaptureMixin:
         self.query_plans_captured += 1
         return plan, capture_time_ms
 
+    def _merge_plan_capture_into_result(
+        self,
+        result: dict[str, Any],
+        connection: Any,
+        query: str,
+        query_id: str,
+    ) -> None:
+        """Capture the query plan and merge the plan fields into ``result`` in place.
+
+        Encapsulates the per-adapter plan-capture block so it lives in exactly one
+        place. The SUCCESS guard is baked in universally: capture only runs when
+        ``capture_plans`` is enabled and the result succeeded, so a validation-
+        failed result never triggers a wasted EXPLAIN round-trip.
+
+        No-op when ``capture_plans`` is False or ``result["status"]`` is not
+        ``"SUCCESS"``. On success, sets ``query_plan`` and ``plan_fingerprint`` when
+        a plan was parsed, and always records ``plan_capture_time_ms`` when measured.
+
+        Args:
+            result: Result dict to mutate in place.
+            connection: Database connection.
+            query: SQL query text.
+            query_id: Query identifier.
+        """
+        if not self.capture_plans or result.get("status") != "SUCCESS":
+            return
+        query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+        if query_plan:
+            result["query_plan"] = query_plan
+            result["plan_fingerprint"] = query_plan.plan_fingerprint
+        if plan_capture_time_ms is not None:
+            result["plan_capture_time_ms"] = plan_capture_time_ms
+
     def validate_loaded_data(self, connection: Any, benchmark_type: str, scale_factor: float) -> ValidationResult:
         """Validate database state after data loading using platform-specific methods.
 

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -1535,15 +1535,8 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
             if not self.capture_plans:
                 self.display_query_plan_if_enabled(connection, query, query_id)
 
-            # Capture structured query plan if enabled (only on SUCCESS to avoid
-            # wasteful EXPLAIN on validation-failed results)
-            if self.capture_plans and result.get("status") == "SUCCESS":
-                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
-                if query_plan:
-                    result["query_plan"] = query_plan
-                    result["plan_fingerprint"] = query_plan.plan_fingerprint
-                if plan_capture_time_ms is not None:
-                    result["plan_capture_time_ms"] = plan_capture_time_ms
+            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
+            self._merge_plan_capture_into_result(result, connection, query, query_id)
 
             return result
 

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -961,15 +961,6 @@ class DuckDBAdapter(PlatformAdapter):
             # Display query plan if enabled
             self.display_query_plan_if_enabled(connection, query, query_id)
 
-            # Capture structured query plan if enabled
-            query_plan = None
-            plan_fingerprint = None
-            plan_capture_time_ms = None
-            if self.capture_plans:
-                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
-                if query_plan:
-                    plan_fingerprint = query_plan.plan_fingerprint
-
             # Validate row count if enabled and benchmark type is provided
             validation_result = None
             if validate_row_count and benchmark_type:
@@ -1004,12 +995,8 @@ class DuckDBAdapter(PlatformAdapter):
                 validation_result=validation_result,
             )
 
-            # Add query plan to result if captured
-            if query_plan:
-                result["query_plan"] = query_plan
-                result["plan_fingerprint"] = plan_fingerprint
-            if plan_capture_time_ms is not None:
-                result["plan_capture_time_ms"] = plan_capture_time_ms
+            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
+            self._merge_plan_capture_into_result(result, connection, query, query_id)
 
             return result
 

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -310,14 +310,8 @@ class MotherDuckAdapter(PlatformAdapter):
             if not self.capture_plans:
                 self.display_query_plan_if_enabled(conn, query, query_id)
 
-            # Capture structured query plan if enabled
-            if self.capture_plans:
-                query_plan, plan_capture_time_ms = self.capture_query_plan(conn, query, query_id)
-                if query_plan:
-                    result_dict["query_plan"] = query_plan
-                    result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
-                if plan_capture_time_ms is not None:
-                    result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
+            self._merge_plan_capture_into_result(result_dict, conn, query, query_id)
 
             return result_dict
         except Exception as e:

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -754,13 +754,7 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             validate_row_count=validate_row_count,
             stream_id=stream_id,
         )
-        if self.capture_plans and result.get("status") == "SUCCESS":
-            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
-            if query_plan:
-                result["query_plan"] = query_plan
-                result["plan_fingerprint"] = query_plan.plan_fingerprint
-            if plan_capture_time_ms is not None:
-                result["plan_capture_time_ms"] = plan_capture_time_ms
+        self._merge_plan_capture_into_result(result, connection, query, query_id)
         return result
 
     def analyze_table(self, connection: Any, table_name: str) -> None:

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2121,15 +2121,8 @@ class RedshiftAdapter(PlatformAdapter):
             if not self.capture_plans:
                 self.display_query_plan_if_enabled(connection, query, query_id)
 
-            # Capture structured query plan if enabled (only on SUCCESS to avoid
-            # wasteful EXPLAIN on validation-failed results)
-            if self.capture_plans and result_dict.get("status") == "SUCCESS":
-                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
-                if query_plan:
-                    result_dict["query_plan"] = query_plan
-                    result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
-                if plan_capture_time_ms is not None:
-                    result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
+            self._merge_plan_capture_into_result(result_dict, connection, query, query_id)
 
             return result_dict
 

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -565,15 +565,8 @@ class SQLiteAdapter(PlatformAdapter):
             if not self.capture_plans:
                 self.display_query_plan_if_enabled(connection, query, query_id)
 
-            # Capture structured query plan if enabled (only on SUCCESS to avoid
-            # wasteful EXPLAIN on validation-failed results)
-            if self.capture_plans and result.get("status") == "SUCCESS":
-                query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
-                if query_plan:
-                    result["query_plan"] = query_plan
-                    result["plan_fingerprint"] = query_plan.plan_fingerprint
-                if plan_capture_time_ms is not None:
-                    result["plan_capture_time_ms"] = plan_capture_time_ms
+            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
+            self._merge_plan_capture_into_result(result, connection, query, query_id)
 
             return result
 

--- a/tests/unit/platforms/base/test_result_capture.py
+++ b/tests/unit/platforms/base/test_result_capture.py
@@ -1,0 +1,91 @@
+"""Tests for ResultCaptureMixin._merge_plan_capture_into_result.
+
+The helper centralizes the plan-capture block that was previously copy-pasted
+into all six adapters, and bakes in the capture_plans + status=="SUCCESS" guard
+universally.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchbox.platforms.base.result_capture import ResultCaptureMixin
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+class _Host(ResultCaptureMixin):
+    """Minimal ResultCaptureMixin host that records capture_query_plan calls."""
+
+    def __init__(self, capture_plans=True, plan=None, capture_time_ms=1.5):
+        self.capture_plans = capture_plans
+        self._plan = plan
+        self._capture_time_ms = capture_time_ms
+        self.capture_calls = []
+
+    def capture_query_plan(self, connection, query, query_id):
+        self.capture_calls.append((connection, query, query_id))
+        return self._plan, self._capture_time_ms
+
+
+def _make_plan(fingerprint="fp123"):
+    plan = MagicMock()
+    plan.plan_fingerprint = fingerprint
+    return plan
+
+
+class TestMergePlanCaptureIntoResult:
+    def test_noop_when_capture_disabled(self):
+        host = _Host(capture_plans=False, plan=_make_plan())
+        result = {"status": "SUCCESS"}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert result == {"status": "SUCCESS"}
+        assert host.capture_calls == [], "capture_plans=False must not issue EXPLAIN"
+
+    def test_noop_when_status_failed(self):
+        host = _Host(capture_plans=True, plan=_make_plan())
+        result = {"status": "FAILED"}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert result == {"status": "FAILED"}
+        assert host.capture_calls == [], "FAILED status must not trigger capture"
+
+    def test_noop_when_status_missing(self):
+        host = _Host(capture_plans=True, plan=_make_plan())
+        result = {}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert result == {}
+        assert host.capture_calls == []
+
+    def test_merges_plan_fields_on_success(self):
+        plan = _make_plan("fpX")
+        host = _Host(capture_plans=True, plan=plan, capture_time_ms=2.0)
+        result = {"status": "SUCCESS"}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert result["query_plan"] is plan
+        assert result["plan_fingerprint"] == "fpX"
+        assert result["plan_capture_time_ms"] == 2.0
+        assert host.capture_calls == [("conn", "SELECT 1", "q1")]
+
+    def test_records_capture_time_even_when_no_plan(self):
+        host = _Host(capture_plans=True, plan=None, capture_time_ms=0.0)
+        result = {"status": "SUCCESS"}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert "query_plan" not in result
+        assert "plan_fingerprint" not in result
+        # 0.0 is not None, so the timing is still recorded for observability.
+        assert result["plan_capture_time_ms"] == 0.0
+
+    def test_no_plan_and_none_capture_time_leaves_result_unchanged(self):
+        host = _Host(capture_plans=True, plan=None, capture_time_ms=None)
+        result = {"status": "SUCCESS"}
+        host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert result == {"status": "SUCCESS"}
+
+    def test_mutates_in_place_and_returns_none(self):
+        host = _Host(capture_plans=True, plan=_make_plan())
+        result = {"status": "SUCCESS"}
+        ret = host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
+        assert ret is None, "helper mutates in place and must not return the dict"


### PR DESCRIPTION
## Summary

Implements the **`query-plan-capture-base-class-refactor`** TODO (depends on #766, merged). The same 6-line plan-capture block was copy-pasted into all six adapters; this factors it into a single base-class helper.

## Changes

- **`ResultCaptureMixin._merge_plan_capture_into_result(result, connection, query, query_id)`** (new) — captures the plan and merges `query_plan`/`plan_fingerprint`/`plan_capture_time_ms` into the result dict in place, with the `capture_plans` + `status == "SUCCESS"` guard **baked in universally**.
- All six adapters (DuckDB, MotherDuck, PostgreSQL, Redshift, DataFusion, SQLite) now call the helper instead of inlining the block.
- **DuckDB** additionally drops its now-unused pre-declared `query_plan`/`plan_fingerprint`/`plan_capture_time_ms` locals and its separate pre-validation capture step. Its capture now runs after the result is built and **gains the SUCCESS guard** like every other adapter.
- New `tests/unit/platforms/base/test_result_capture.py` covering the helper.

## Behavior

- **SUCCESS path: identical** for all six adapters (same keys, same values).
- **DuckDB & MotherDuck gain the universal SUCCESS guard.** The only semantic change is that a row-count-FAILED DuckDB result no longer triggers a wasted EXPLAIN / plan fields — exactly the guard goal of this TODO and consistent with the merged missing-guards work. MotherDuck's success-path `result_dict["status"]` is `"SUCCESS"` at the call site, so its behavior is unchanged.

## Test plan
- [x] `pytest tests/unit/platforms/base/test_result_capture.py` — 7 passed
- [x] six adapter plan-capture test files — 87 passed
- [x] `pytest tests/unit/platforms/` — 7470 passed, 2 skipped, 0 failures
- [x] `/code-review` (medium) — no findings

## Scope
Limited to the TODO `scope_limit` (the six adapters + `result_capture.py` + the new base test). The inline capture block now exists in exactly one place.

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_