### PR TITLE
feat(tpchavoc): variant-equivalence hard gate + fix all 24 variant divergences from canonical TPC-H

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -389,6 +389,9 @@ jobs:
       - name: Run bounded real-result correctness gate
         run: make test-correctness-gate
 
+      - name: Run TPC-Havoc variant-equivalence gate
+        run: make tpchavoc-equivalence-report
+
   postgres-integration:
     name: postgres-integration
     needs: ci-paths

--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,9 @@ test-smoke: test-quick
 test-correctness-gate:
 	BENCHBOX_STRICT_EXPECTED_RESULTS=1 BENCHBOX_CORRECTNESS_GATE_QUERY_IDS=1,2,3,4,5,6,7,8,9,10,12,13,14,15,17,19,21,22 uv run -- python -m pytest -m stress "tests/integration/test_local_platform_benchmark_matrix.py::test_local_platform_benchmark_matrix[tpch-duckdb]" -n 0 --tb=short --timeout=1200 -v
 
-# Diagnostic (non-gating): compare every TPC-Havoc SQL variant to canonical TPC-H
-# on real SF=0.1 DuckDB data and print a categorized divergence report. A hard
-# gate is deferred until the judgment-call divergence classes are triaged
-# (see _project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml).
+# Gate: compare every TPC-Havoc SQL variant to canonical TPC-H on real SF=0.1
+# DuckDB data; exits non-zero on any divergence beyond KNOWN_DIVERGENCES
+# (see benchbox/core/tpchavoc/equivalence.py).
 tpchavoc-equivalence-report:
 	uv run -- python -m benchbox.core.tpchavoc.equivalence
 
@@ -1829,7 +1828,7 @@ help:
 	@echo "  make test-dev        Fast development cycle testing"
 	@echo "  make test-smoke      Quick smoke testing"
 	@echo "  make test-correctness-gate Run bounded real-result correctness gate"
-	@echo "  make tpchavoc-equivalence-report Diagnostic: TPC-Havoc variant vs canonical TPC-H equivalence report"
+	@echo "  make tpchavoc-equivalence-report Gate: TPC-Havoc variant vs canonical TPC-H equivalence"
 	@echo "  make test-local-matrix Run real local benchmark matrix (stress)"
 	@echo "  make test-ci         Maintained broad local CI profile"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -111,6 +111,13 @@ test-smoke: test-quick
 # the stored row count vary with the generated data (see tests/README.md).
 test-correctness-gate:
 	BENCHBOX_STRICT_EXPECTED_RESULTS=1 BENCHBOX_CORRECTNESS_GATE_QUERY_IDS=1,2,3,4,5,6,7,8,9,10,12,13,14,15,17,19,21,22 uv run -- python -m pytest -m stress "tests/integration/test_local_platform_benchmark_matrix.py::test_local_platform_benchmark_matrix[tpch-duckdb]" -n 0 --tb=short --timeout=1200 -v
+
+# Diagnostic (non-gating): compare every TPC-Havoc SQL variant to canonical TPC-H
+# on real SF=0.1 DuckDB data and print a categorized divergence report. A hard
+# gate is deferred until the judgment-call divergence classes are triaged
+# (see _project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml).
+tpchavoc-equivalence-report:
+	uv run -- python -m benchbox.core.tpchavoc.equivalence
 
 # Real benchmark matrix across local SQL platforms x all benchmarks (heavy, opt-in)
 test-local-matrix:
@@ -1822,6 +1829,7 @@ help:
 	@echo "  make test-dev        Fast development cycle testing"
 	@echo "  make test-smoke      Quick smoke testing"
 	@echo "  make test-correctness-gate Run bounded real-result correctness gate"
+	@echo "  make tpchavoc-equivalence-report Diagnostic: TPC-Havoc variant vs canonical TPC-H equivalence report"
 	@echo "  make test-local-matrix Run real local benchmark matrix (stress)"
 	@echo "  make test-ci         Maintained broad local CI profile"
 	@echo ""

--- a/_project/TODO/main/active/tpchavoc-q2-v10-projection-faithfulness.yaml
+++ b/_project/TODO/main/active/tpchavoc-q2-v10-projection-faithfulness.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-q2-v10-projection-faithfulness
 title: "Fix q2_v10 projection that zeroes negative s_acctbal, and sweep variants for the same projection-faithfulness class"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: Under Review
 category: Testing and Quality Assurance
 
 description: |

--- a/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
+++ b/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-variant-equivalence-gate
 title: "Wire a bounded result-equivalence gate for TPC-Havoc variants and burn down the divergences it surfaces"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |

--- a/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
+++ b/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
@@ -98,9 +98,9 @@ work:
 
 deferred:
   - summary: "Extend the equivalence gate to the DataFrame variants"
-    reason: "DataFrame-surface correctness is owned by the cross-surface audit TODO; fold in only after the SQL gate is green."
+    reason: "PROMOTED to its own work item: tpchavoc-dataframe-variant-equivalence-gate (SQL gate is green; DataFrame variants are independent designs needing their own gate against canonical, not the SQL variants)."
   - summary: "Run the equivalence harness on a second engine (Postgres/ClickHouse/DataFusion)"
-    reason: "Cross-dialect equivalence of shared SQL is an open question; keep the routine gate DuckDB-bounded and sample a second engine separately if w1 evidence warrants."
+    reason: "PROMOTED to its own work item: tpchavoc-cross-dialect-equivalence-sampling. Routine gate stays DuckDB-bounded; a second engine is sampled separately."
 
 must_preserve:
   - "benchbox run --benchmark tpchavoc default (execution-only) behavior stays available; the gate is additive."

--- a/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
+++ b/_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-variant-equivalence-gate
 title: "Wire a bounded result-equivalence gate for TPC-Havoc variants and burn down the divergences it surfaces"
 worktree: main
 priority: High
-status: In Progress
+status: Under Review
 category: Testing and Quality Assurance
 
 description: |
@@ -50,7 +50,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-validate the evidence against current develop before building anything"
-    status: pending
+    status: done
     notes: |
       Confirm the gap and the known divergences are still true on the head SHA:
         - grep that `validate_variant_equivalence` has no non-test caller in a
@@ -66,7 +66,7 @@ work:
   - id: w1
     summary: "Build a parametrized equivalence harness (report mode) over all queries x 10 SQL variants"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Small SF on DuckDB. For each implemented query, execute the canonical
       TPC-H query once and every variant, then compare via
@@ -79,7 +79,7 @@ work:
   - id: w2
     summary: "Drive all real divergences to zero, leaving only declared exceptions"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       The known q2_v10 projection defect is owned by the companion burndown
       TODO `tpchavoc-q2-v10-projection-faithfulness`. Any further divergences
@@ -89,7 +89,7 @@ work:
   - id: w3
     summary: "Promote the harness to a bounded CI gate that fails on reintroduced divergences"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       One bounded small-SF DuckDB cell, marked per the existing correctness-gate
       marker policy (not a stress matrix). Prove the gate fails when a
@@ -161,4 +161,4 @@ metadata:
   tags: [tpchavoc, testing, correctness, oracle, ci, equivalence]
   estimated_effort: "Medium"
   created_date: "2026-06-08"
-  last_updated: "2026-06-08T00:00:00"
+  last_updated: "2026-06-11T00:00:00"

--- a/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
+++ b/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
@@ -21,6 +21,14 @@ description: |
      same way, but the equivalent mistake - joining/filtering on the inner frame
      instead of the outer row - is possible and equally silent.
 
+     Review evidence (PR #770): the DataFrame variants are INDEPENDENT designs,
+     not mirrors of the SQL variants - e.g. DataFrame q9_v10 is an algebraic
+     reformulation while SQL q9_v10 had nation-bucketing/clamping defects. None
+     of the 24 SQL-side divergences PR #770 fixed has a mirrored DataFrame
+     analog, but the same variant ID means a DIFFERENT transformation per
+     surface, so the SQL equivalence gate proves nothing about this surface;
+     it needs its own result-equivalence check against canonical.
+
   2. Other SQL benchmarks with correlated subqueries: TPC-DS, SSB, join-order,
      read-primitives (subquery category), and write-primitives
      (update_with_subquery). Grep evidence already shows correlated patterns and

--- a/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
+++ b/_project/TODO/main/planning/correlated-subquery-self-binding-cross-surface-audit.yaml
@@ -26,8 +26,14 @@ description: |
      reformulation while SQL q9_v10 had nation-bucketing/clamping defects. None
      of the 24 SQL-side divergences PR #770 fixed has a mirrored DataFrame
      analog, but the same variant ID means a DIFFERENT transformation per
-     surface, so the SQL equivalence gate proves nothing about this surface;
-     it needs its own result-equivalence check against canonical.
+     surface, so the SQL equivalence gate proves nothing about this surface.
+
+     NOTE: broad DataFrame result-equivalence vs canonical TPC-H is now owned by
+     its own work item, tpchavoc-dataframe-variant-equivalence-gate. THIS audit's
+     DataFrame scope is the narrower, targeted self-binding / inner-frame-
+     correlation check on the correlated queries (Q2, Q11, Q17, Q20, Q21, Q22);
+     run it alongside, or fold it into, that gate rather than duplicating the
+     harness.
 
   2. Other SQL benchmarks with correlated subqueries: TPC-DS, SSB, join-order,
      read-primitives (subquery category), and write-primitives

--- a/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
@@ -1,0 +1,146 @@
+id: tpchavoc-cross-dialect-equivalence-sampling
+title: "Sample TPC-Havoc variant equivalence on a second SQL engine beyond DuckDB"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The TPC-Havoc SQL equivalence gate landed in PR #770 proves every variant is
+  result-equivalent to canonical TPC-H on ONE engine: DuckDB at SF=0.1. But the
+  variants are written once and run, after dialect translation, on ~20 platforms
+  (Postgres-family, ClickHouse, DataFusion, Spark, Snowflake, BigQuery, Trino,
+  etc.). "Equivalent on DuckDB" does not imply "equivalent everywhere":
+
+    - Dialect translation can change semantics (NULL ordering, integer vs float
+      division, DISTINCT/window edge cases, implicit casts, date arithmetic).
+    - Engines differ in window-function, QUALIFY, and aggregate-filter support;
+      the variant families lean on exactly these (the gate's burndown touched
+      QUALIFY, window rank columns, and FILTER variants).
+    - The existing PostgreSQL execution-filter skip-list
+      (benchbox/sql_compat/rules/execution_filter/postgres_tpchavoc.py) already
+      encodes ~17 variants Postgres can't even execute - evidence that
+      cross-engine behavior diverges structurally, not just numerically.
+
+  So a variant can be execution-green AND wrong on engine X while the DuckDB gate
+  stays green - the precise silent-divergence failure mode the SQL gate exists to
+  kill, just one engine over. This TODO does NOT try to gate all 20 engines in
+  routine CI (too slow, too flaky). It adds a SECOND, bounded engine sample to
+  catch the largest class of translation-induced divergence, and decides from the
+  evidence whether a broader matrix is warranted.
+
+  PostgreSQL is the natural first second-engine: a Postgres service container
+  already exists in the PR CI (the postgres-integration job added on develop),
+  and its skip-list gives a ready-made expected-exception set.
+
+prior_art:
+  - "benchbox/core/tpchavoc/equivalence.py - the DuckDB gate; parameterize the engine/connection and reuse find_divergences + validate_variant_equivalence rather than forking"
+  - "benchbox/sql_compat/rules/execution_filter/postgres_tpchavoc.py POSTGRES_TPCHAVOC_SKIPS - the per-variant Postgres execution skips; these are NOT equivalence exceptions but they bound which variants are even checkable on Postgres"
+  - ".github/workflows/pr.yml postgres-integration job - an existing Postgres 17 service container in CI; reuse it rather than standing up a new one"
+  - "benchbox/core/tpch/benchmark.py translate_query_text + the dialect translation layer - the seam whose correctness this sampling actually exercises"
+  - "_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml - the DuckDB gate this extends; its 'second engine' item was explicitly deferred to here"
+
+work:
+  - id: w0
+    summary: "Make the equivalence oracle engine-agnostic"
+    status: pending
+    notes: |
+      Factor find_divergences so the connection/engine and the dialect used to
+      render both canonical and variants are injected, not hardcoded to DuckDB.
+      Canonical TPC-H and the variants must be translated to the SAME target
+      dialect before comparison. Keep DuckDB as the default; add the engine as a
+      parameter. No behavior change to the existing DuckDB gate.
+
+  - id: w1
+    summary: "Run the oracle on PostgreSQL in report mode and classify divergences"
+    needs: [w0]
+    status: pending
+    notes: |
+      Use the existing Postgres service container. Exclude variants in
+      POSTGRES_TPCHAVOC_SKIPS (un-executable, not a divergence). For the rest,
+      report every result divergence from canonical TPC-H run on the same Postgres
+      instance. Classify each: dialect-translation bug (fixable in the translation
+      layer or the variant), genuine engine semantic difference (declared
+      exception with justification), or a real variant defect the DuckDB gate
+      missed.
+
+  - id: w2
+    summary: "Fix translation/variant bugs; declare true engine exceptions"
+    needs: [w1]
+    status: pending
+    notes: |
+      Drive w1's divergences down. Prefer fixing the translation layer over
+      per-variant hacks (a translation bug likely affects many variants/engines).
+      Record irreducible engine-semantic differences as classified, justified
+      exceptions keyed by (engine, variant).
+
+  - id: w3
+    summary: "Decide the routine-CI posture for the second engine and wire it"
+    needs: [w2]
+    status: pending
+    notes: |
+      Based on w1-w2 evidence, choose: (a) a bounded Postgres equivalence gate in
+      the existing non-blocking postgres-integration job, or (b) a periodic/opt-in
+      check if the divergence surface is dominated by declared engine differences.
+      Whichever, the DuckDB gate stays the hard blocker; the second engine is a
+      sample, not a 20-engine matrix. Record the decision and the rationale.
+
+deferred:
+  - summary: "Extend cross-engine equivalence sampling to a third engine (ClickHouse/DataFusion/Spark)"
+    reason: "Sequence after the Postgres sample yields evidence on whether translation divergence is engine-specific or systematic; don't fan out before the two-engine signal is in."
+
+must_preserve:
+  - "The DuckDB SQL equivalence gate stays the hard, blocking gate with empty KNOWN_DIVERGENCES."
+  - "POSTGRES_TPCHAVOC_SKIPS semantics are unchanged; un-executable variants are excluded, not silently passed."
+  - "Reuse validate_variant_equivalence and the oracle; do not fork the comparator per engine."
+
+approach: |
+  Parameterize the existing oracle by engine + target dialect (w0), run it on the
+  already-present Postgres container in report mode (w1), burn down translation
+  bugs and declare true engine exceptions (w2), then pick a bounded routine-CI
+  posture from the evidence (w3). Keep DuckDB the hard gate; treat the second
+  engine as a sample that catches translation-induced divergence, explicitly NOT
+  a full platform matrix.
+
+anti_patterns:
+  - "DO NOT gate all ~20 platforms in routine CI - too slow and flaky; sample ONE second engine and decide from evidence."
+  - "DO NOT treat a POSTGRES_TPCHAVOC_SKIPS entry as an equivalence pass - those variants don't execute; exclude them, never mark them equivalent."
+  - "DO NOT patch individual variants for what is a translation-layer bug - fix the translation seam so the fix generalizes across variants and engines."
+  - "DO NOT compare a Postgres variant result to a DuckDB canonical result - run canonical on the SAME engine, same dialect, to isolate translation effects."
+
+verification:
+  - description: "Postgres report-mode oracle enumerates divergences excluding un-executable variants"
+    command: "python -m benchbox.core.tpchavoc.equivalence --engine postgres  # report mode"
+    expected_output: "categorized divergence list over POSTGRES-executable variants; skip-list variants excluded"
+  - description: "A translation-induced divergence is caught and attributed to the translation layer, not the variant"
+    command: "inspect a w1 divergence; confirm canonical-vs-variant differ on Postgres but agree on DuckDB"
+    expected_output: "divergence reproduces on Postgres only, pointing at translation"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/"
+    - "benchbox/sql_compat/"
+    - "tests/integration/"
+    - ".github/workflows/"
+    - "Makefile"
+
+open_questions:
+  - question: "Second engine: PostgreSQL (container already in CI, skip-list ready) vs an engine with richer window/QUALIFY support closer to DuckDB (ClickHouse/DataFusion)?"
+    gating: true
+    affects: ["w1 engine choice"]
+    default: "PostgreSQL first - lowest setup cost (existing container) and its skip-list already maps un-executable variants; it stresses the translation layer hardest precisely because it lacks DuckDB conveniences."
+  - question: "Is canonical TPC-H itself trustworthy as the cross-engine reference, given its own queries are dialect-translated per engine?"
+    gating: false
+    affects: ["w1 reference choice"]
+    default: "Run canonical on the same engine/dialect as the variants; equivalence is variant-vs-canonical on ONE engine, so shared translation of the reference cancels out engine-isolated differences."
+
+success_metrics:
+  - "The equivalence oracle runs on a second SQL engine (PostgreSQL) and reports variant divergences from canonical TPC-H."
+  - "Translation-induced divergences are fixed in the translation layer; irreducible engine differences are classified and justified."
+  - "A documented decision exists on the routine-CI posture for cross-engine equivalence (bounded gate vs opt-in), with the DuckDB gate remaining the hard blocker."
+
+metadata:
+  tags: [tpchavoc, cross-dialect, equivalence, correctness, postgres, ci]
+  estimated_effort: "Medium"
+  created_date: "2026-06-12"
+  last_updated: "2026-06-12T00:00:00"

--- a/_project/TODO/main/planning/tpchavoc-dataframe-variant-equivalence-gate.yaml
+++ b/_project/TODO/main/planning/tpchavoc-dataframe-variant-equivalence-gate.yaml
@@ -1,0 +1,149 @@
+id: tpchavoc-dataframe-variant-equivalence-gate
+title: "Extend the TPC-Havoc result-equivalence gate to the DataFrame variants"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  PR #770 landed a hard result-equivalence gate for the TPC-Havoc *SQL*
+  variants: it executes canonical TPC-H plus every SQL variant on a bounded
+  SF=0.1 DuckDB cell, compares with float tolerance, and fails CI on any
+  divergence (KNOWN_DIVERGENCES is empty). That gate found and drove out 24
+  silent correctness defects (value clamping, join fan-out, schema leakage,
+  scale-threshold, QUALIFY-vs-WHERE filtering).
+
+  The DataFrame variants (benchbox/core/tpchavoc/dataframe_queries/) get NO such
+  guard. TPC-Havoc claims the 10 DataFrame variants of each query are
+  semantically equivalent to canonical TPC-H exactly as the SQL variants do, and
+  `TPCHavocBenchmark.supports_dataframe_mode()` returns True, so the DataFrame
+  surface is a shipped, runnable benchmark whose core invariant is unchecked.
+
+  Crucially, the SQL gate proves NOTHING about this surface. Review evidence
+  from PR #770: the DataFrame variants are INDEPENDENT designs, not mirrors of
+  the SQL variants. The same variant id encodes a DIFFERENT transformation per
+  surface (e.g. SQL q9_v10 had nation-bucketing + negative-profit clamping
+  defects; DataFrame q9_v10 is a benign algebraic reformulation of the profit
+  term). None of the 24 SQL-side divergences had a DataFrame analog when spot-
+  checked, but "spot-checked, no analog found" is not "gated, proven equivalent"
+  - the same defect CLASSES (clamping a value via a conditional, dropping/adding
+  an output column, filtering the inner frame instead of the outer row) are all
+  expressible in DataFrame code and would be equally silent.
+
+  This TODO builds the DataFrame analog of the SQL gate: execute every DataFrame
+  variant against the same small-SF data, compare each to canonical TPC-H with
+  the SAME validator/tolerance, drive any divergence to zero (fix or declared
+  exception), and wire it into the same bounded CI job. It is the natural
+  completion of tpchavoc-variant-equivalence-gate across both execution
+  surfaces.
+
+prior_art:
+  - "benchbox/core/tpchavoc/equivalence.py - the SQL gate: build_duckdb_with_tpch, find_divergences, strip_top_n, KNOWN_DIVERGENCES, main(); mirror its shape and REUSE build_duckdb_with_tpch and the validator rather than starting fresh"
+  - "benchbox/core/tpchavoc/benchmark.py validate_variant_equivalence - the comparator; reuse it, the DataFrame results just need to be materialized to row tuples in the same column order as canonical"
+  - "benchbox/core/tpchavoc/dataframe_queries/ - the variant registry (get_dataframe_queries) plus per-query expression_impl/pandas_impl pairs; q01.py..q22.py and matching .yaml"
+  - "tests/unit/core/tpchavoc/test_tpchavoc_dataframe_queries.py:212 test_q14v8_parity_with_q14v1 - existing ad-hoc per-variant DataFrame parity test; generalize/replace with the gate rather than adding more one-offs"
+  - "tests/integration/test_tpchavoc_variant_equivalence.py - the fast-lane regression companion to the SQL gate; add the DataFrame analog beside it"
+  - "_project/TODO/main/active/tpchavoc-variant-equivalence-gate.yaml - the SQL gate's design (bounded single-SF DuckDB cell, empty KNOWN_DIVERGENCES, fail-on-divergence); mirror it exactly"
+
+work:
+  - id: w0
+    summary: "Pin down how DataFrame variants execute and materialize to comparable rows"
+    status: pending
+    notes: |
+      Determine the execution entrypoint for a DataFrame variant on DuckDB-backed
+      data (expression_impl vs pandas_impl; what context/engine get_dataframe_queries
+      hands them) and how to materialize each result to an ordered list of row
+      tuples matching canonical TPC-H's column order. Both DataFrame backends
+      (expression and pandas) must be reachable; decide whether the gate runs one
+      or both. Capture a single worked example (e.g. q1_v1) end to end before
+      generalizing.
+
+  - id: w1
+    summary: "Build the DataFrame equivalence oracle in report mode over all queries x 10 variants"
+    needs: [w0]
+    status: pending
+    notes: |
+      Reuse build_duckdb_with_tpch for the data, the canonical TPC-H SQL answer as
+      the reference, and validate_variant_equivalence as the comparator. Emit the
+      full divergence set (query, variant, backend, kind, row/column delta) without
+      asserting. Apply the same top-N / trailing-LIMIT normalization the SQL gate
+      uses where the DataFrame variant mirrors canonical's presentational cut.
+
+  - id: w2
+    summary: "Drive every DataFrame divergence to zero (fix or declared exception)"
+    needs: [w1]
+    status: pending
+    notes: |
+      For each divergence decide bug vs intentional structural difference, mirroring
+      the SQL burndown taxonomy. Fix the bugs in the variant impls; record any
+      genuinely-intentional difference as a classified, justified entry. Verify each
+      fix against canonical TPC-H (not a sibling DataFrame variant), exactly as the
+      SQL burndown did - sibling-only checks are how the original degenerate forms
+      hid.
+
+  - id: w3
+    summary: "Promote to a bounded CI gate and add the fast-lane regression"
+    needs: [w2]
+    status: pending
+    notes: |
+      Fail-non-zero on any unclassified DataFrame divergence, wired into the same
+      correctness-gate CI job as the SQL gate (keep the cell bounded; do not add a
+      stress matrix). Prove it fails when a value-clamp or dropped-column defect is
+      deliberately introduced into a DataFrame variant. Add a default-lane pytest
+      mirroring tests/integration/test_tpchavoc_variant_equivalence.py.
+
+must_preserve:
+  - "The SQL equivalence gate and its empty KNOWN_DIVERGENCES stay green and unchanged."
+  - "benchbox run --benchmark tpchavoc DataFrame mode default (execution-only) behavior stays available; the gate is additive."
+  - "ResultValidator tolerance and checksum semantics are unchanged; reuse, do not fork, the comparator."
+
+approach: |
+  Mirror benchbox/core/tpchavoc/equivalence.py one-to-one for the DataFrame
+  surface: same data builder, same canonical reference, same validator, same
+  bounded SF=0.1 DuckDB cell, same empty-baseline fail-on-divergence policy, same
+  CI wiring. The only new logic is executing a DataFrame variant and materializing
+  its result to ordered row tuples. Land report-mode first (w1), burn down (w2),
+  then flip the gate (w3). Do not duplicate the comparator or the data builder.
+
+anti_patterns:
+  - "DO NOT assume a DataFrame variant matches its SQL namesake - they are independent designs; gate the DataFrame result against CANONICAL TPC-H, not against the SQL variant."
+  - "DO NOT write a second comparator or data builder - reuse validate_variant_equivalence and build_duckdb_with_tpch."
+  - "DO NOT verify a fix against a sibling DataFrame variant - check against canonical TPC-H, because sibling-only agreement is exactly how the SQL degenerate forms stayed hidden."
+  - "DO NOT expand to a stress matrix - keep one bounded small-SF DuckDB cell like the SQL gate."
+
+verification:
+  - description: "Report-mode oracle enumerates every DataFrame variant divergence from canonical TPC-H"
+    command: "python -m benchbox.core.tpchavoc.dataframe_equivalence  # report mode"
+    expected_output: "full categorized divergence list; 220 variant-backend cells checked"
+  - description: "Flipped gate fails on a deliberately introduced DataFrame value-clamp"
+    command: "clamp a negative value in one DataFrame variant, then run the gate"
+    expected_output: "gate FAILS (non-zero), naming the divergent query/variant/backend"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/"
+    - "tests/integration/test_tpchavoc_variant_equivalence.py"
+    - "tests/unit/core/tpchavoc/"
+    - ".github/workflows/"
+    - "Makefile"
+
+open_questions:
+  - question: "Gate one DataFrame backend or both (expression_impl and pandas_impl)? Both ship and could diverge independently."
+    gating: true
+    affects: ["w1 success_metric: every DataFrame variant equivalence-checked"]
+    default: "Gate both backends; report backend in the divergence key. If runtime is prohibitive, gate the default backend in CI and run the other in the slower lane."
+  - question: "Do DataFrame variants reproduce canonical's presentational ORDER BY ... LIMIT, or omit it like the SQL families?"
+    gating: false
+    affects: ["w1 normalization"]
+    default: "Apply the same trailing-LIMIT/top-N normalization the SQL gate uses; treat a computational LIMIT as a divergence to fix, not normalize."
+
+success_metrics:
+  - "Every implemented TPC-Havoc DataFrame variant is result-equivalence-checked against canonical TPC-H in a bounded CI gate."
+  - "All DataFrame divergences are fixed or explicitly declared; the gate is green on develop."
+  - "Reintroducing a value-clamp or dropped/added-column divergence in a DataFrame variant fails CI."
+
+metadata:
+  tags: [tpchavoc, dataframe, testing, correctness, equivalence, ci]
+  estimated_effort: "Medium"
+  created_date: "2026-06-12"
+  last_updated: "2026-06-12T00:00:00"

--- a/benchbox/core/tpch/benchmark.py
+++ b/benchbox/core/tpch/benchmark.py
@@ -260,7 +260,10 @@ class TPCHBenchmark(GeneratorOutputDirMixin, BaseBenchmark):
         """
         src = (base_dialect or "netezza").lower()
         tgt = (dialect or src).lower()
-        int_queries = self.query_manager.get_all_queries()
+        # Render scale-dependent parameters (e.g. Q11's 0.0001/SF value threshold)
+        # at the benchmark's actual scale factor, not the SF=1 default, so the
+        # run path stays scale-faithful for both TPC-H and TPC-Havoc variants.
+        int_queries = self.query_manager.get_all_queries(scale_factor=self.scale_factor)
         base_queries = {str(k): v for k, v in int_queries.items()}
         translated_queries = {}
         for query_id, query in base_queries.items():

--- a/benchbox/core/tpchavoc/benchmark.py
+++ b/benchbox/core/tpchavoc/benchmark.py
@@ -172,7 +172,7 @@ class TPCHavocBenchmark(TPCHBenchmark):
         Raises:
             ValueError: If the query_id or variant_id is invalid
         """
-        return self.query_manager.get_query_variant(query_id, variant_id, params)
+        return self.query_manager.get_query_variant(query_id, variant_id, params, scale_factor=self.scale_factor)
 
     def get_all_variants(self, query_id: int) -> dict[int, str]:
         """Get all variants for a specific query.
@@ -186,7 +186,7 @@ class TPCHavocBenchmark(TPCHBenchmark):
         Raises:
             ValueError: If the query_id is invalid or not implemented
         """
-        return self.query_manager.get_all_variants(query_id)
+        return self.query_manager.get_all_variants(query_id, scale_factor=self.scale_factor)
 
     def get_variant_description(self, query_id: int, variant_id: int) -> str:
         """Get description of a specific variant.

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -21,7 +21,7 @@ LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
 relies on ``LIMIT`` for computation rather than presentation (``14_v9``) is
 recorded as a known divergence.
 
-Known divergences observed at SF=0.1 on DuckDB fall into four classes:
+Known divergences observed at SF=0.1 on DuckDB fall into three classes:
 
 * ``scale-threshold`` - the Q11 variants hardcode the ``0.0001`` value
   threshold while canonical TPC-H scales it by ``1 / SF``; they are equivalent
@@ -30,8 +30,14 @@ Known divergences observed at SF=0.1 on DuckDB fall into four classes:
   column, changing the output schema (an intended structural difference).
 * ``limit-semantics`` - ``14_v9`` uses ``LIMIT 1`` to collapse a window result
   to a single row; the top-N normalization here removes it.
-* ``suspected-defect`` - value/ordering mismatches that need triage and may be
-  genuine variant bugs (``1_v8``, ``7_v5``, ``9_v10``).
+
+A fourth ``suspected-defect`` class (``1_v8``, ``7_v5``, ``9_v10``) was triaged
+and fixed: each was a genuine correctness bug that silently distorted results -
+``1_v8`` aggregated over unfiltered ``lineitem`` (the shipdate predicate lived in
+``QUALIFY``, which filters output rows, not aggregation input); ``7_v5`` fanned a
+date-filtered-orders CTE back against the full ``lineitem`` table, inflating
+revenue ~4.5x; ``9_v10`` bucketed 22 nations into ``OTHER AMERICAS`` and clamped
+negative profit to ``0``.
 
 Copyright 2026 Joe Harris / BenchBox Project
 
@@ -64,13 +70,10 @@ EQUIVALENCE_SCALE = 0.1
 # reason class. This is the burndown input for the deferred hard gate, not an
 # allow-list the diagnostic enforces. Keyed by "<query>_v<variant>".
 KNOWN_DIVERGENCES: dict[str, str] = {
-    "1_v8": "suspected-defect",
     "5_v9": "extra-column",
-    "7_v5": "suspected-defect",
     "7_v9": "extra-column",
     "8_v9": "extra-column",
     "9_v9": "extra-column",
-    "9_v10": "suspected-defect",
     "10_v9": "extra-column",
     **{f"11_v{variant}": "scale-threshold" for variant in range(1, 11)},
     "12_v9": "extra-column",

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -1,0 +1,232 @@
+"""Result-equivalence oracle for TPC-Havoc SQL variants.
+
+TPC-Havoc's premise is that the ten SQL variants of each TPC-H query are
+structurally diverse but *semantically equivalent* to the canonical TPC-H
+query. benchbox ships :meth:`TPCHavocBenchmark.validate_variant_equivalence`,
+but nothing in the default run or in CI ever calls it for a real variant, so
+divergences are silent (see ``_project/TODO/main/planning/
+tpchavoc-variant-equivalence-gate.yaml``).
+
+This module wires that existing validator over a real, small-scale DuckDB
+dataset and reports every variant that diverges from canonical TPC-H. It is a
+**diagnostic**: ``python -m benchbox.core.tpchavoc.equivalence`` (or
+``make tpchavoc-equivalence-report``) prints a categorized report and always
+exits ``0``. A hard CI gate is deliberately deferred until the judgment-call
+divergence classes recorded in :data:`KNOWN_DIVERGENCES` are triaged.
+
+Comparison is order-insensitive with float tolerance (the validator sorts both
+sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
+LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
+``LIMIT`` is stripped from both sides before comparison; the one variant that
+relies on ``LIMIT`` for computation rather than presentation (``14_v9``) is
+recorded as a known divergence.
+
+Known divergences observed at SF=0.1 on DuckDB fall into four classes:
+
+* ``scale-threshold`` - the Q11 variants hardcode the ``0.0001`` value
+  threshold while canonical TPC-H scales it by ``1 / SF``; they are equivalent
+  only at SF=1.
+* ``extra-column`` - the "window function" variants add a ranking/helper
+  column, changing the output schema (an intended structural difference).
+* ``limit-semantics`` - ``14_v9`` uses ``LIMIT 1`` to collapse a window result
+  to a single row; the top-N normalization here removes it.
+* ``suspected-defect`` - value/ordering mismatches that need triage and may be
+  genuine variant bugs (``1_v8``, ``7_v5``, ``9_v10``).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
+
+from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
+from benchbox.core.tpchavoc.validation import ValidationError
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from benchbox import TPCH
+
+# Smallest scale that is discriminating for the known defect classes: at SF=0.01
+# the Q2/Q10 projection bugs do not surface (no negative balances in the result)
+# and Q17 is NULL, so a gate there would be vacuous. SF=0.1 catches them while
+# staying ~10x cheaper than SF=1.
+EQUIVALENCE_SCALE = 0.1
+
+# Variants known to diverge from canonical TPC-H at EQUIVALENCE_SCALE, with the
+# reason class. This is the burndown input for the deferred hard gate, not an
+# allow-list the diagnostic enforces. Keyed by "<query>_v<variant>".
+KNOWN_DIVERGENCES: dict[str, str] = {
+    "1_v8": "suspected-defect",
+    "5_v9": "extra-column",
+    "7_v5": "suspected-defect",
+    "7_v9": "extra-column",
+    "8_v9": "extra-column",
+    "9_v9": "extra-column",
+    "9_v10": "suspected-defect",
+    "10_v9": "extra-column",
+    **{f"11_v{variant}": "scale-threshold" for variant in range(1, 11)},
+    "12_v9": "extra-column",
+    "13_v9": "extra-column",
+    "14_v9": "limit-semantics",
+    "15_v4": "extra-column",
+}
+
+_TRAILING_LIMIT = re.compile(r"(?is)\s+limit\s+\d+\s*;?\s*$")
+
+
+@dataclass(frozen=True)
+class Divergence:
+    """A single variant whose result differs from the canonical TPC-H query."""
+
+    query_id: int
+    variant_id: int
+    detail: str
+
+    @property
+    def key(self) -> str:
+        """Stable ``<query>_v<variant>`` identifier."""
+        return f"{self.query_id}_v{self.variant_id}"
+
+
+def strip_top_n(sql: str) -> str:
+    """Remove a trailing line comment, statement terminator, and ``LIMIT n``.
+
+    Canonical TPC-H queries truncate to a top-N for display; the TPC-Havoc
+    variant families do not do this consistently, and some variant files end the
+    statement with a ``-- Variant N`` comment. The trailing comment, terminator,
+    and ``LIMIT`` are normalized away on both sides before comparing the
+    underlying result sets, so a variant that keeps ``LIMIT`` (e.g. ``21_v*``,
+    which end ``limit 100 -- Variant N``) is compared on the same footing as one
+    that drops it.
+    """
+    normalized = re.sub(r"\s*--[^\n]*$", "", sql.strip())
+    normalized = normalized.rstrip().rstrip(";")
+    return _TRAILING_LIMIT.sub("", normalized)
+
+
+def find_divergences(
+    connection: Any,
+    benchmark: TPCHavocBenchmark,
+    canonical_query: Callable[[int], str],
+    *,
+    query_ids: list[int] | None = None,
+) -> list[Divergence]:
+    """Compare every variant of each query to canonical TPC-H on ``connection``.
+
+    Args:
+        connection: A DBAPI/DuckDB connection already populated with TPC-H data.
+        benchmark: The TPC-Havoc benchmark providing variants and the validator.
+        canonical_query: Callable returning the canonical TPC-H SQL for a query id.
+        query_ids: Subset of query ids to check; defaults to all implemented.
+
+    Returns:
+        One :class:`Divergence` per variant whose result is not equivalent to
+        canonical TPC-H. Reuses :meth:`TPCHavocBenchmark.validate_variant_equivalence`.
+    """
+    ids = query_ids if query_ids is not None else benchmark.get_implemented_queries()
+    divergences: list[Divergence] = []
+    for query_id in ids:
+        try:
+            original = connection.execute(strip_top_n(canonical_query(query_id))).fetchall()
+        except Exception as exc:  # noqa: BLE001 - a diagnostic must report, not crash, on a bad query
+            divergences.append(Divergence(query_id, 0, f"canonical query failed: {exc}"))
+            continue
+        for variant_id in range(1, 11):
+            try:
+                variant_sql = strip_top_n(benchmark.get_query(f"{query_id}_v{variant_id}"))
+                variant_rows = connection.execute(variant_sql).fetchall()
+                benchmark.validate_variant_equivalence(query_id, variant_id, original, variant_rows)
+            except ValidationError as exc:
+                divergences.append(Divergence(query_id, variant_id, str(exc)))
+            except Exception as exc:  # noqa: BLE001 - surface execution/sort errors as divergences
+                divergences.append(Divergence(query_id, variant_id, f"error: {exc}"))
+    return divergences
+
+
+def build_duckdb_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple[Any, TPCHavocBenchmark, TPCH]:
+    """Generate TPC-H data and return a populated in-memory DuckDB connection.
+
+    Platform/generator imports are deferred so importing this module does not
+    pull DuckDB or the data generator into the core import graph.
+
+    Returns:
+        ``(connection, tpchavoc_benchmark, tpch_benchmark)``.
+    """
+    import duckdb
+
+    from benchbox import TPCH
+    from benchbox.core.tpch.generator import TPCHDataGenerator
+    from benchbox.platforms.duckdb import DuckDBAdapter
+
+    output_dir = Path(output_dir)
+    generated = TPCHDataGenerator(scale_factor=scale_factor, output_dir=output_dir).generate()
+    data_dir = next(Path(paths[0] if isinstance(paths, list) else paths).parent for paths in generated.values())
+
+    tpchavoc = TPCHavocBenchmark(scale_factor=scale_factor, output_dir=output_dir)
+    tpch = TPCH(scale_factor=scale_factor, output_dir=output_dir)
+
+    connection = duckdb.connect(":memory:")
+    for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+        if statement.strip():
+            connection.execute(statement.strip())
+    DuckDBAdapter(database=":memory:").load_data(tpchavoc, connection, data_dir)
+    return connection, tpchavoc, tpch
+
+
+def main() -> int:
+    """Generate data, run the oracle, and print a categorized report.
+
+    Always returns ``0`` - this is a diagnostic, not a gate.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        connection, tpchavoc, tpch = build_duckdb_with_tpch(EQUIVALENCE_SCALE, tmp)
+        try:
+            divergences = find_divergences(connection, tpchavoc, lambda q: tpch.get_query(q))
+        finally:
+            connection.close()
+
+    total = len(tpchavoc.get_implemented_queries()) * 10
+    found = {d.key for d in divergences}
+    new = sorted(found - set(KNOWN_DIVERGENCES), key=_sort_key)
+    resolved = sorted(set(KNOWN_DIVERGENCES) - found, key=_sort_key)
+
+    print(f"TPC-Havoc variant equivalence vs canonical TPC-H @ SF={EQUIVALENCE_SCALE} (DuckDB)")
+    print(f"  checked {total} variants - {len(divergences)} divergent, {total - len(divergences)} equivalent\n")
+
+    by_class: dict[str, list[Divergence]] = {}
+    for divergence in sorted(divergences, key=lambda d: _sort_key(d.key)):
+        klass = KNOWN_DIVERGENCES.get(divergence.key, "UNCLASSIFIED")
+        by_class.setdefault(klass, []).append(divergence)
+    for klass in sorted(by_class):
+        print(f"  [{klass}]")
+        for divergence in by_class[klass]:
+            print(f"    {divergence.key}: {divergence.detail}")
+        print()
+
+    if new:
+        print(f"NEW (unclassified) divergences - triage needed: {new}")
+    if resolved:
+        print(f"Previously-known divergences now equivalent - update KNOWN_DIVERGENCES: {resolved}")
+    if not new and not resolved:
+        print("Divergence set matches KNOWN_DIVERGENCES.")
+    return 0
+
+
+def _sort_key(key: str) -> tuple[int, int]:
+    """Sort ``<query>_v<variant>`` keys numerically."""
+    query, variant = key.split("_v")
+    return int(query), int(variant)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -1,43 +1,40 @@
-"""Result-equivalence oracle for TPC-Havoc SQL variants.
+"""Result-equivalence gate for TPC-Havoc SQL variants.
 
 TPC-Havoc's premise is that the ten SQL variants of each TPC-H query are
 structurally diverse but *semantically equivalent* to the canonical TPC-H
 query. benchbox ships :meth:`TPCHavocBenchmark.validate_variant_equivalence`,
-but nothing in the default run or in CI ever calls it for a real variant, so
-divergences are silent (see ``_project/TODO/main/planning/
+but nothing in the default run or in CI ever called it for a real variant, so
+divergences were silent (see ``_project/TODO/main/active/
 tpchavoc-variant-equivalence-gate.yaml``).
 
 This module wires that existing validator over a real, small-scale DuckDB
-dataset and reports every variant that diverges from canonical TPC-H. It is a
-**diagnostic**: ``python -m benchbox.core.tpchavoc.equivalence`` (or
-``make tpchavoc-equivalence-report``) prints a categorized report and always
-exits ``0``. A hard CI gate is deliberately deferred until the judgment-call
-divergence classes recorded in :data:`KNOWN_DIVERGENCES` are triaged.
+dataset: ``python -m benchbox.core.tpchavoc.equivalence`` (or
+``make tpchavoc-equivalence-report``) compares every variant of every
+implemented query to canonical TPC-H, prints a report, and **exits non-zero**
+if any variant diverges beyond the classified baseline in
+:data:`KNOWN_DIVERGENCES` (currently empty - every variant must match).
 
 Comparison is order-insensitive with float tolerance (the validator sorts both
 sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
 LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
-``LIMIT`` is stripped from both sides before comparison; the one variant that
-relies on ``LIMIT`` for computation rather than presentation (``14_v9``) is
-recorded as a known divergence.
+``LIMIT`` is stripped from both sides before comparison.
 
-Known divergences observed at SF=0.1 on DuckDB fall into three classes:
+The gate's burndown (24 divergences at the first report) resolved every
+divergence class as a variant defect:
 
-* ``scale-threshold`` - the Q11 variants hardcode the ``0.0001`` value
-  threshold while canonical TPC-H scales it by ``1 / SF``; they are equivalent
-  only at SF=1.
-* ``extra-column`` - the "window function" variants add a ranking/helper
-  column, changing the output schema (an intended structural difference).
-* ``limit-semantics`` - ``14_v9`` uses ``LIMIT 1`` to collapse a window result
-  to a single row; the top-N normalization here removes it.
-
-A fourth ``suspected-defect`` class (``1_v8``, ``7_v5``, ``9_v10``) was triaged
-and fixed: each was a genuine correctness bug that silently distorted results -
-``1_v8`` aggregated over unfiltered ``lineitem`` (the shipdate predicate lived in
-``QUALIFY``, which filters output rows, not aggregation input); ``7_v5`` fanned a
-date-filtered-orders CTE back against the full ``lineitem`` table, inflating
-revenue ~4.5x; ``9_v10`` bucketed 22 nations into ``OTHER AMERICAS`` and clamped
-negative profit to ``0``.
+* value-distorting bugs: ``q2_v10``/``q10_v10`` clamped negative balances,
+  ``q1_v8`` filtered in ``QUALIFY`` instead of ``WHERE``, ``q7_v5`` fanned a
+  date-filtered-orders CTE against the full ``lineitem`` table (~4.5x revenue),
+  ``q9_v10`` bucketed nations and clamped negative profit.
+* ``scale-threshold``: the Q11 variants hardcoded the SF=1 ``0.0001`` value
+  threshold; they now carry a ``{q11_fraction}`` token rendered with
+  ``0.0001 / scale_factor`` exactly like canonical qgen.
+* ``extra-column``: eight "window function" variants projected a helper
+  ``rank()``/discriminator column; the window structure stays, the column no
+  longer leaks into the output schema.
+* ``limit-semantics``: ``14_v9`` needed ``LIMIT 1`` only because its helper
+  rank column defeated ``DISTINCT``; with the column gone, ``DISTINCT``
+  collapses to the canonical single row.
 
 Copyright 2026 Joe Harris / BenchBox Project
 
@@ -66,21 +63,12 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # staying ~10x cheaper than SF=1.
 EQUIVALENCE_SCALE = 0.1
 
-# Variants known to diverge from canonical TPC-H at EQUIVALENCE_SCALE, with the
-# reason class. This is the burndown input for the deferred hard gate, not an
-# allow-list the diagnostic enforces. Keyed by "<query>_v<variant>".
-KNOWN_DIVERGENCES: dict[str, str] = {
-    "5_v9": "extra-column",
-    "7_v9": "extra-column",
-    "8_v9": "extra-column",
-    "9_v9": "extra-column",
-    "10_v9": "extra-column",
-    **{f"11_v{variant}": "scale-threshold" for variant in range(1, 11)},
-    "12_v9": "extra-column",
-    "13_v9": "extra-column",
-    "14_v9": "limit-semantics",
-    "15_v4": "extra-column",
-}
+# Variants tolerated to diverge from canonical TPC-H at EQUIVALENCE_SCALE, with
+# the reason class. Empty: the original 24-divergence burndown is complete and
+# every variant must match canonical. Add an entry (with a class and a tracking
+# TODO) only for a divergence that is deliberate, never to mute a regression.
+# Keyed by "<query>_v<variant>".
+KNOWN_DIVERGENCES: dict[str, str] = {}
 
 _TRAILING_LIMIT = re.compile(r"(?is)\s+limit\s+\d+\s*;?\s*$")
 
@@ -187,7 +175,8 @@ def build_duckdb_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple
 def main() -> int:
     """Generate data, run the oracle, and print a categorized report.
 
-    Always returns ``0`` - this is a diagnostic, not a gate.
+    Returns non-zero if any variant diverges beyond :data:`KNOWN_DIVERGENCES` -
+    this is the TPC-Havoc semantic-equivalence gate.
     """
     import tempfile
 
@@ -217,12 +206,12 @@ def main() -> int:
         print()
 
     if new:
-        print(f"NEW (unclassified) divergences - triage needed: {new}")
+        print(f"GATE FAILURE - unclassified divergences from canonical TPC-H: {new}")
     if resolved:
         print(f"Previously-known divergences now equivalent - update KNOWN_DIVERGENCES: {resolved}")
     if not new and not resolved:
-        print("Divergence set matches KNOWN_DIVERGENCES.")
-    return 0
+        print("All variants equivalent to canonical TPC-H (modulo KNOWN_DIVERGENCES).")
+    return 1 if new else 0
 
 
 def _sort_key(key: str) -> tuple[int, int]:

--- a/benchbox/core/tpchavoc/queries.py
+++ b/benchbox/core/tpchavoc/queries.py
@@ -79,13 +79,22 @@ class TPCHavocQueryManager(TPCHQueries):
             22: Q22_VARIANTS,
         }
 
-    def get_query_variant(self, query_id: int, variant_id: int, params: Optional[dict[str, Any]] = None) -> str:
+    def get_query_variant(
+        self,
+        query_id: int,
+        variant_id: int,
+        params: Optional[dict[str, Any]] = None,
+        *,
+        scale_factor: float = 1.0,
+    ) -> str:
         """Get a specific query variant.
 
         Args:
             query_id: The query ID (1-22)
             variant_id: The variant ID (1-10)
             params: Optional parameter values to use
+            scale_factor: Scale factor for scale-dependent substitution values
+                (used when ``params`` is not given)
 
         Returns:
             The variant query string
@@ -101,13 +110,28 @@ class TPCHavocQueryManager(TPCHQueries):
 
         variant_generator = self.variant_generators[query_id][variant_id]
         base_query = self.get_query(query_id)
+        if params is None:
+            params = self._variant_scale_params(query_id, scale_factor)
         return variant_generator.generate(base_query, params)
 
-    def get_all_variants(self, query_id: int) -> dict[int, str]:
+    @staticmethod
+    def _variant_scale_params(query_id: int, scale_factor: float) -> Optional[dict[str, Any]]:
+        """Scale-dependent substitution values for variant SQL templates.
+
+        Canonical TPC-H Q11 divides the 0.0001 value-fraction threshold by the
+        scale factor (qgen renders it as a 10-decimal literal); the Q11 variants
+        carry a ``{q11_fraction}`` token so they scale the same way.
+        """
+        if query_id == 11:
+            return {"q11_fraction": f"{0.0001 / scale_factor:.10f}"}
+        return None
+
+    def get_all_variants(self, query_id: int, *, scale_factor: float = 1.0) -> dict[int, str]:
         """Get all variants for a specific query.
 
         Args:
             query_id: The query ID (1-22)
+            scale_factor: Scale factor for scale-dependent substitution values
 
         Returns:
             Dictionary mapping variant IDs to query strings
@@ -119,7 +143,8 @@ class TPCHavocQueryManager(TPCHQueries):
             raise ValueError(f"Query variants not implemented for query {query_id}")
 
         return {
-            variant_id: self.get_query_variant(query_id, variant_id) for variant_id in self.variant_generators[query_id]
+            variant_id: self.get_query_variant(query_id, variant_id, scale_factor=scale_factor)
+            for variant_id in self.variant_generators[query_id]
         }
 
     def get_variant_description(self, query_id: int, variant_id: int) -> str:
@@ -213,18 +238,20 @@ class TPCHavocQueryManager(TPCHQueries):
 
         Args:
             **kwargs: Additional arguments passed to query generation
+                (``scale_factor`` is used for scale-dependent substitution values)
 
         Returns:
             Dictionary mapping query IDs to query strings for all variants
         """
         all_queries = {}
+        scale_factor = kwargs.get("scale_factor", 1.0)
 
         # Add all variants as regular queries
         for query_id in self.variant_generators:
             for variant_id in self.variant_generators[query_id]:
                 query_key = f"{query_id}_v{variant_id}"
                 try:
-                    all_queries[query_key] = self.get_query_variant(query_id, variant_id)
+                    all_queries[query_key] = self.get_query_variant(query_id, variant_id, scale_factor=scale_factor)
                 except Exception:
                     # Skip variants that fail to generate
                     continue
@@ -268,7 +295,7 @@ class TPCHavocQueryManager(TPCHQueries):
 
                 # Generate parameters if needed
                 params = kwargs.get("params") or self._generate_random_params(base_query_id, seed, scale_factor)
-                return self.get_query_variant(base_query_id, variant_id, params)
+                return self.get_query_variant(base_query_id, variant_id, params, scale_factor=scale_factor)
             except (ValueError, IndexError) as e:
                 raise ValueError(f"Invalid variant query ID format: {query_id}") from e
 

--- a/benchbox/core/tpchavoc/queries.py
+++ b/benchbox/core/tpchavoc/queries.py
@@ -94,7 +94,6 @@ class TPCHavocQueryManager(TPCHQueries):
             variant_id: The variant ID (1-10)
             params: Optional parameter values to use
             scale_factor: Scale factor for scale-dependent substitution values
-                (used when ``params`` is not given)
 
         Returns:
             The variant query string
@@ -110,9 +109,10 @@ class TPCHavocQueryManager(TPCHQueries):
 
         variant_generator = self.variant_generators[query_id][variant_id]
         base_query = self.get_query(query_id)
-        if params is None:
-            params = self._variant_scale_params(query_id, scale_factor)
-        return variant_generator.generate(base_query, params)
+        # Scale-dependent substitutions are defaults, so explicit caller params
+        # can never suppress them and leak a raw {token} into the SQL.
+        merged = {**(self._variant_scale_params(query_id, scale_factor) or {}), **(params or {})}
+        return variant_generator.generate(base_query, merged or None)
 
     @staticmethod
     def _variant_scale_params(query_id: int, scale_factor: float) -> Optional[dict[str, Any]]:

--- a/benchbox/core/tpchavoc/queries.py
+++ b/benchbox/core/tpchavoc/queries.py
@@ -177,7 +177,7 @@ class TPCHavocQueryManager(TPCHQueries):
         return list(self.variant_generators.keys())
 
     def get_parameterized_query_variant(
-        self, query_id: int, variant_id: int, params: Optional[dict[str, Any]] = None
+        self, query_id: int, variant_id: int, params: Optional[dict[str, Any]] = None, *, scale_factor: float = 1.0
     ) -> str:
         """Get a parameterized TPC-Havoc query variant.
 
@@ -186,6 +186,7 @@ class TPCHavocQueryManager(TPCHQueries):
             variant_id: The variant ID (1-10)
             params: Optional parameter values to use
                    If None, random parameters will be generated
+            scale_factor: Scale factor for scale-dependent substitution values
 
         Returns:
             The parameterized variant query string
@@ -203,9 +204,13 @@ class TPCHavocQueryManager(TPCHQueries):
         if params is None:
             params = self._generate_random_params(query_id)
 
+        # Scale-dependent substitutions are defaults under caller/random params, so
+        # a Q11 {token} can never leak unrendered (mirrors get_query_variant).
+        merged = {**(self._variant_scale_params(query_id, scale_factor) or {}), **(params or {})}
+
         variant_generator = self.variant_generators[query_id][variant_id]
         base_query = self.get_query(query_id)
-        return variant_generator.generate(base_query, params)
+        return variant_generator.generate(base_query, merged or None)
 
     def get_all_variants_info(self, query_id: int) -> dict[int, dict[str, str | int]]:
         """Get information about all variants for a specific query.

--- a/benchbox/core/tpchavoc/variant_base.py
+++ b/benchbox/core/tpchavoc/variant_base.py
@@ -23,14 +23,22 @@ class VariantGenerator(ABC):
 
 
 class StaticSQLVariant(VariantGenerator):
-    """Simple variant generator that returns a static SQL string."""
+    """Variant generator that returns a static SQL string with token substitution.
+
+    Occurrences of ``{key}`` in the SQL are replaced by ``params[key]``. The only
+    token currently in use is ``{q11_fraction}`` (the Q11 value threshold, which
+    canonical TPC-H scales by ``1 / scale_factor``).
+    """
 
     def __init__(self, variant_id: int, description: str, sql: str) -> None:
         super().__init__(variant_id, description)
         self._sql = sql
 
     def generate(self, base_query: str, params: dict[str, Any] | None = None) -> str:  # noqa: ARG002
-        return self._sql
+        sql = self._sql
+        for key, value in (params or {}).items():
+            sql = sql.replace("{" + key + "}", str(value))
+        return sql
 
 
 __all__ = ["VariantGenerator", "StaticSQLVariant"]

--- a/benchbox/core/tpchavoc/variant_sets/q01.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q01.yaml
@@ -249,9 +249,10 @@ variants:
         count(*) over w as count_order
     from
         lineitem
+    where
+        l_shipdate <= date '1998-12-01' - interval '90' day
     window w as (partition by l_returnflag, l_linestatus)
     qualify count(*) over w > 0
-        and l_shipdate <= date '1998-12-01' - interval '90' day
     order by
         l_returnflag,
         l_linestatus

--- a/benchbox/core/tpchavoc/variant_sets/q02.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q02.yaml
@@ -456,7 +456,7 @@ variants:
   sql: |2
 
     select
-        case when s_acctbal > 0 then s_acctbal else 0 end as s_acctbal,
+        s_acctbal,
         case when s_name is not null then s_name else 'UNKNOWN' end as s_name,
         case when n_name is not null then n_name else 'UNKNOWN' end as n_name,
         p_partkey,
@@ -488,7 +488,7 @@ variants:
               and r_name = 'EUROPE'
         )
     order by
-        case when s_acctbal > 0 then s_acctbal else 0 end desc,
+        s_acctbal desc,
         case when n_name is not null then n_name else 'ZZZZZ' end,
         case when s_name is not null then s_name else 'ZZZZZ' end,
         p_partkey

--- a/benchbox/core/tpchavoc/variant_sets/q05.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q05.yaml
@@ -299,8 +299,7 @@ variants:
     )
     select
         n_name,
-        revenue,
-        rank() over (order by revenue desc) as revenue_rank
+        revenue
     from regional_revenue
     order by
         revenue desc

--- a/benchbox/core/tpchavoc/variant_sets/q07.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q07.yaml
@@ -376,8 +376,7 @@ variants:
         supp_nation,
         cust_nation,
         l_year,
-        revenue,
-        rank() over (partition by l_year order by revenue desc) as revenue_rank
+        revenue
     from shipping_revenue
     order by
         supp_nation,

--- a/benchbox/core/tpchavoc/variant_sets/q07.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q07.yaml
@@ -184,16 +184,14 @@ variants:
           and n_name in ('FRANCE', 'GERMANY')
     ),
     qualified_orders as (
-        select o_orderkey, o_custkey, extract(year from l_shipdate) as l_year
-        from orders, lineitem
-        where o_orderkey = l_orderkey
-          and l_shipdate between date '1995-01-01' and date '1996-12-31'
+        select o_orderkey, o_custkey
+        from orders
     ),
     shipping_base as (
         select
             qs.supp_nation,
             qc.cust_nation,
-            qo.l_year,
+            extract(year from l.l_shipdate) as l_year,
             l.l_extendedprice * (1 - l.l_discount) as volume
         from
             qualified_suppliers qs
@@ -201,8 +199,9 @@ variants:
             join qualified_orders qo on l.l_orderkey = qo.o_orderkey
             join qualified_customers qc on qo.o_custkey = qc.c_custkey
         where
-            ((qs.supp_nation = 'FRANCE' and qc.cust_nation = 'GERMANY')
-             or (qs.supp_nation = 'GERMANY' and qc.cust_nation = 'FRANCE'))
+            l.l_shipdate between date '1995-01-01' and date '1996-12-31'
+            and ((qs.supp_nation = 'FRANCE' and qc.cust_nation = 'GERMANY')
+                 or (qs.supp_nation = 'GERMANY' and qc.cust_nation = 'FRANCE'))
     )
     select
         supp_nation,

--- a/benchbox/core/tpchavoc/variant_sets/q08.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q08.yaml
@@ -328,8 +328,7 @@ variants:
     select distinct
         o_year,
         sum(case when nation = 'BRAZIL' then volume else 0 end) over (partition by o_year) /
-        sum(volume) over (partition by o_year) as mkt_share,
-        rank() over (order by o_year) as year_rank
+        sum(volume) over (partition by o_year) as mkt_share
     from (
         select
             extract(year from o_orderdate) as o_year,

--- a/benchbox/core/tpchavoc/variant_sets/q09.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q09.yaml
@@ -333,18 +333,9 @@ variants:
   sql: |2
 
     select
-        case
-            when nation in ('UNITED STATES', 'CANADA', 'BRAZIL') then nation
-            else 'OTHER AMERICAS'
-        end as nation,
+        nation,
         o_year,
-        sum(
-            case
-                when amount > 0 then amount
-                when amount < 0 then 0
-                else amount
-            end
-        ) as sum_profit
+        sum(amount) as sum_profit
     from (
         select
             case

--- a/benchbox/core/tpchavoc/variant_sets/q09.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q09.yaml
@@ -322,8 +322,7 @@ variants:
     select
         nation,
         o_year,
-        sum_profit,
-        rank() over (partition by o_year order by sum_profit desc) as profit_rank
+        sum_profit
     from yearly_profit
     order by
         nation,

--- a/benchbox/core/tpchavoc/variant_sets/q10.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q10.yaml
@@ -389,8 +389,7 @@ variants:
         n_name,
         c_address,
         c_phone,
-        c_comment,
-        rank() over (order by revenue desc) as revenue_rank
+        c_comment
     from customer_revenue
     order by
         revenue desc

--- a/benchbox/core/tpchavoc/variant_sets/q10.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q10.yaml
@@ -416,10 +416,7 @@ variants:
                 else 0
             end
         ) as revenue,
-        case
-            when c_acctbal > 0 then c_acctbal
-            else 0
-        end as c_acctbal,
+        c_acctbal,
         case
             when n_name is not null then n_name
             else 'UNKNOWN NATION'

--- a/benchbox/core/tpchavoc/variant_sets/q11.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q11.yaml
@@ -15,7 +15,7 @@ variants:
         and s_nationkey = n_nationkey
         and n_name = 'GERMANY'
         and (ps_supplycost * ps_availqty) > (
-            select avg(ps2.ps_supplycost * ps2.ps_availqty) * 0.0001
+            select avg(ps2.ps_supplycost * ps2.ps_availqty) * {q11_fraction}
             from partsupp ps2, supplier s2, nation n2
             where ps2.ps_suppkey = s2.s_suppkey
               and s2.s_nationkey = n2.n_nationkey
@@ -26,7 +26,7 @@ variants:
         ps_partkey
     having
         sum(ps_supplycost * ps_availqty) > (
-            select sum(ps3.ps_supplycost * ps3.ps_availqty) * 0.0001
+            select sum(ps3.ps_supplycost * ps3.ps_availqty) * {q11_fraction}
             from partsupp ps3, supplier s3, nation n3
             where ps3.ps_suppkey = s3.s_suppkey
               and s3.s_nationkey = n3.n_nationkey
@@ -53,7 +53,7 @@ variants:
         ps_partkey
     having
         sum(ps_supplycost * ps_availqty) > (
-            select sum(ps_supplycost * ps_availqty) * 0.0001
+            select sum(ps_supplycost * ps_availqty) * {q11_fraction}
             from partsupp, supplier, nation
             where ps_suppkey = s_suppkey
               and s_nationkey = n_nationkey
@@ -80,7 +80,7 @@ variants:
         ps.ps_partkey
     having
         sum(ps.ps_supplycost * ps.ps_availqty) > (
-            select sum(ps2.ps_supplycost * ps2.ps_availqty) * 0.0001
+            select sum(ps2.ps_supplycost * ps2.ps_availqty) * {q11_fraction}
             from partsupp ps2
             inner join supplier s2 on ps2.ps_suppkey = s2.s_suppkey
             inner join nation n2 on s2.s_nationkey = n2.n_nationkey
@@ -121,7 +121,7 @@ variants:
     group by ps_partkey
     having
         sum(value) > (
-            select sum(ps_supplycost * ps_availqty) * 0.0001
+            select sum(ps_supplycost * ps_availqty) * {q11_fraction}
             from partsupp, supplier, nation
             where ps_suppkey = s_suppkey
               and s_nationkey = n_nationkey
@@ -145,7 +145,7 @@ variants:
         where ps_suppkey = s_suppkey
     ),
     total_threshold as (
-        select sum(part_value) * 0.0001 as threshold
+        select sum(part_value) * {q11_fraction} as threshold
         from inventory_values
     ),
     part_totals as (
@@ -182,7 +182,7 @@ variants:
             ps_partkey
         having
             sum(ps_supplycost * ps_availqty) > (
-                select sum(ps_supplycost * ps_availqty) * 0.0001
+                select sum(ps_supplycost * ps_availqty) * {q11_fraction}
                 from partsupp, supplier, nation
                 where ps_suppkey = s_suppkey
                   and s_nationkey = n_nationkey
@@ -210,7 +210,7 @@ variants:
         ps_partkey
     having
         sum(ps_supplycost * ps_availqty) filter (where n_name = 'GERMANY') > (
-            select sum(ps_supplycost * ps_availqty) * 0.0001
+            select sum(ps_supplycost * ps_availqty) * {q11_fraction}
             from partsupp, supplier, nation
             where ps_suppkey = s_suppkey
               and s_nationkey = n_nationkey
@@ -241,7 +241,7 @@ variants:
         ps_partkey
     having
         sum(ps_supplycost * ps_availqty) > (
-            select sum(ps_supplycost * ps_availqty) * 0.0001
+            select sum(ps_supplycost * ps_availqty) * {q11_fraction}
             from partsupp, supplier, nation
             where ps_suppkey = s_suppkey
               and s_nationkey = n_nationkey
@@ -268,7 +268,7 @@ variants:
     ),
     inventory_threshold as (
         select
-            sum(ps_supplycost * ps_availqty) * 0.0001 as threshold
+            sum(ps_supplycost * ps_availqty) * {q11_fraction} as threshold
         from partsupp, supplier, nation
         where ps_suppkey = s_suppkey
           and s_nationkey = n_nationkey
@@ -276,8 +276,7 @@ variants:
     )
     select
         ps_partkey,
-        value,
-        rank() over (order by value desc) as value_rank
+        value
     from
         inventory_values,
         inventory_threshold
@@ -321,7 +320,7 @@ variants:
         ) > (
             select
                 case
-                    when sum(ps_supplycost * ps_availqty) > 0 then sum(ps_supplycost * ps_availqty) * 0.0001
+                    when sum(ps_supplycost * ps_availqty) > 0 then sum(ps_supplycost * ps_availqty) * {q11_fraction}
                     else 0
                 end
             from partsupp, supplier, nation

--- a/benchbox/core/tpchavoc/variant_sets/q12.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q12.yaml
@@ -256,8 +256,7 @@ variants:
         sum(case when o_orderpriority = '1-URGENT' or o_orderpriority = '2-HIGH' then 1 else 0 end)
             over (partition by l_shipmode) as high_line_count,
         sum(case when o_orderpriority <> '1-URGENT' and o_orderpriority <> '2-HIGH' then 1 else 0 end)
-            over (partition by l_shipmode) as low_line_count,
-        rank() over (order by l_shipmode) as shipmode_rank
+            over (partition by l_shipmode) as low_line_count
     from
         orders,
         lineitem

--- a/benchbox/core/tpchavoc/variant_sets/q13.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q13.yaml
@@ -224,8 +224,7 @@ variants:
     )
     select
         c_count,
-        custdist,
-        rank() over (order by custdist desc, c_count desc) as dist_rank
+        custdist
     from customer_distribution
     order by
         custdist desc,

--- a/benchbox/core/tpchavoc/variant_sets/q14.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q14.yaml
@@ -174,8 +174,7 @@ variants:
     select distinct
         100.00 *
         sum(case when p_type like 'PROMO%' then l_extendedprice * (1 - l_discount) else 0 end) over () /
-        sum(l_extendedprice * (1 - l_discount)) over () as promo_revenue,
-        rank() over (order by l_partkey) as part_rank
+        sum(l_extendedprice * (1 - l_discount)) over () as promo_revenue
     from
         lineitem,
         part
@@ -183,7 +182,6 @@ variants:
         l_partkey = p_partkey
         and l_shipdate >= date '1995-09-01'
         and l_shipdate < date '1995-09-01' + interval '1' month
-    limit 1
 - id: 10
   description: 'CASE expressions: Add extensive CASE logic for promotion classification'
   sql: |2

--- a/benchbox/core/tpchavoc/variant_sets/q15.yaml
+++ b/benchbox/core/tpchavoc/variant_sets/q15.yaml
@@ -97,7 +97,13 @@ variants:
   description: 'UNION ALL: Split query into parts and union'
   sql: |2
 
-    select * from (
+    select
+        s_suppkey,
+        s_name,
+        s_address,
+        s_phone,
+        total_revenue
+    from (
         select
             s_suppkey,
             s_name,

--- a/tests/integration/test_tpchavoc_variant_equivalence.py
+++ b/tests/integration/test_tpchavoc_variant_equivalence.py
@@ -1,0 +1,77 @@
+"""Result-equivalence regression test for the fixed TPC-Havoc variants.
+
+This is the narrow, gating companion to the non-gating diagnostic in
+``benchbox/core/tpchavoc/equivalence.py`` (run via
+``make tpchavoc-equivalence-report``). The diagnostic enumerates every variant
+that diverges from canonical TPC-H; this test locks in the two value-zeroing
+projection defects that were fixed (``q2_v10`` and ``q10_v10`` clamped negative
+account balances to ``0`` via CASE projections) by asserting the whole Q2 and
+Q10 variant families are now equivalent to canonical TPC-H.
+
+A broader hard gate over all queries is deliberately deferred until the
+remaining divergence classes recorded in
+``benchbox.core.tpchavoc.equivalence.KNOWN_DIVERGENCES`` are triaged (see
+``_project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml``).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.equivalence import (
+    EQUIVALENCE_SCALE,
+    KNOWN_DIVERGENCES,
+    build_duckdb_with_tpch,
+    find_divergences,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.stress,
+    pytest.mark.duckdb,
+    pytest.mark.tpchavoc,
+]
+
+
+@pytest.fixture(scope="module")
+def populated_duckdb(tmp_path_factory):
+    """Generate SF=0.1 TPC-H data once and yield a populated DuckDB connection."""
+    output_dir = tmp_path_factory.mktemp("tpchavoc_equivalence")
+    connection, tpchavoc, tpch = build_duckdb_with_tpch(EQUIVALENCE_SCALE, output_dir)
+    try:
+        yield connection, tpchavoc, tpch
+    finally:
+        connection.close()
+
+
+def test_fixed_projection_variants_equivalent_to_canonical(populated_duckdb):
+    """``q2_v10`` and ``q10_v10`` must match canonical TPC-H after the projection fix.
+
+    Pre-fix, both reported negative ``s_acctbal``/``c_acctbal`` as ``0`` via a
+    CASE-wrapped projection, diverging from canonical on the negative-balance
+    rows. This asserts the fix holds and that no other Q2/Q10 variant regressed
+    beyond the documented, deferred divergences (e.g. the ``10_v9`` extra-column
+    window variant).
+    """
+    connection, tpchavoc, tpch = populated_duckdb
+
+    divergences = find_divergences(connection, tpchavoc, lambda query_id: tpch.get_query(query_id), query_ids=[2, 10])
+    divergent = {d.key for d in divergences}
+
+    assert {"2_v10", "10_v10"}.isdisjoint(divergent), (
+        "Fixed value-zeroing variants diverge from canonical TPC-H: "
+        + ", ".join(f"{d.key} ({d.detail})" for d in divergences if d.key in {"2_v10", "10_v10"})
+    )
+
+    # Guard against a NEW Q2/Q10 regression without coupling to the whole global
+    # baseline: only the Q2/Q10 entries of KNOWN_DIVERGENCES are tolerated here.
+    known_q2_q10 = {key for key in KNOWN_DIVERGENCES if int(key.split("_v")[0]) in {2, 10}}
+    unexpected = divergent - known_q2_q10
+    assert not unexpected, f"New, unclassified Q2/Q10 divergence(s) from canonical TPC-H: {sorted(unexpected)}"

--- a/tests/integration/test_tpchavoc_variant_equivalence.py
+++ b/tests/integration/test_tpchavoc_variant_equivalence.py
@@ -34,7 +34,7 @@ from benchbox.core.tpchavoc.equivalence import (
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.stress,
+    pytest.mark.medium,
     pytest.mark.duckdb,
     pytest.mark.tpchavoc,
 ]

--- a/tests/integration/test_tpchavoc_variant_equivalence.py
+++ b/tests/integration/test_tpchavoc_variant_equivalence.py
@@ -3,10 +3,17 @@
 This is the narrow, gating companion to the non-gating diagnostic in
 ``benchbox/core/tpchavoc/equivalence.py`` (run via
 ``make tpchavoc-equivalence-report``). The diagnostic enumerates every variant
-that diverges from canonical TPC-H; this test locks in the two value-zeroing
-projection defects that were fixed (``q2_v10`` and ``q10_v10`` clamped negative
-account balances to ``0`` via CASE projections) by asserting the whole Q2 and
-Q10 variant families are now equivalent to canonical TPC-H.
+that diverges from canonical TPC-H; this test locks in the variant correctness
+defects that have been fixed so far:
+
+* ``q2_v10`` / ``q10_v10`` - clamped negative account balances to ``0`` via CASE
+  projections.
+* ``q1_v8`` - aggregated over unfiltered ``lineitem`` (the shipdate predicate was
+  in ``QUALIFY``, which filters output rows, not aggregation input).
+* ``q7_v5`` - fanned a date-filtered-orders CTE back against the full
+  ``lineitem`` table, inflating revenue ~4.5x.
+* ``q9_v10`` - bucketed 22 nations into ``OTHER AMERICAS`` and clamped negative
+  profit to ``0``.
 
 A broader hard gate over all queries is deliberately deferred until the
 remaining divergence classes recorded in
@@ -51,27 +58,34 @@ def populated_duckdb(tmp_path_factory):
         connection.close()
 
 
-def test_fixed_projection_variants_equivalent_to_canonical(populated_duckdb):
-    """``q2_v10`` and ``q10_v10`` must match canonical TPC-H after the projection fix.
+# Variants whose correctness defects have been fixed and must stay equivalent to
+# canonical TPC-H. Their parent queries are also swept for new, unclassified
+# regressions (tolerating only that query's documented KNOWN_DIVERGENCES).
+FIXED_VARIANTS = frozenset({"1_v8", "2_v10", "7_v5", "9_v10", "10_v10"})
 
-    Pre-fix, both reported negative ``s_acctbal``/``c_acctbal`` as ``0`` via a
-    CASE-wrapped projection, diverging from canonical on the negative-balance
-    rows. This asserts the fix holds and that no other Q2/Q10 variant regressed
-    beyond the documented, deferred divergences (e.g. the ``10_v9`` extra-column
-    window variant).
+
+def test_fixed_variants_equivalent_to_canonical(populated_duckdb):
+    """Every fixed variant must match canonical TPC-H, with no new regressions.
+
+    Covers the value-zeroing projection fixes (``q2_v10``, ``q10_v10``) and the
+    three triaged correctness defects (``q1_v8`` filtered in ``QUALIFY`` instead
+    of ``WHERE``; ``q7_v5`` fanned out revenue ~4.5x; ``q9_v10`` bucketed nations
+    and clamped negative profit). Also guards the affected query families against
+    a *new* unclassified divergence without coupling to the global baseline.
     """
     connection, tpchavoc, tpch = populated_duckdb
 
-    divergences = find_divergences(connection, tpchavoc, lambda query_id: tpch.get_query(query_id), query_ids=[2, 10])
+    query_ids = sorted({int(key.split("_v")[0]) for key in FIXED_VARIANTS})
+    divergences = find_divergences(connection, tpchavoc, lambda query_id: tpch.get_query(query_id), query_ids=query_ids)
     divergent = {d.key for d in divergences}
 
-    assert {"2_v10", "10_v10"}.isdisjoint(divergent), (
-        "Fixed value-zeroing variants diverge from canonical TPC-H: "
-        + ", ".join(f"{d.key} ({d.detail})" for d in divergences if d.key in {"2_v10", "10_v10"})
+    regressed = FIXED_VARIANTS & divergent
+    assert not regressed, "Fixed variants diverge from canonical TPC-H: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in divergences if d.key in regressed
     )
 
-    # Guard against a NEW Q2/Q10 regression without coupling to the whole global
-    # baseline: only the Q2/Q10 entries of KNOWN_DIVERGENCES are tolerated here.
-    known_q2_q10 = {key for key in KNOWN_DIVERGENCES if int(key.split("_v")[0]) in {2, 10}}
-    unexpected = divergent - known_q2_q10
-    assert not unexpected, f"New, unclassified Q2/Q10 divergence(s) from canonical TPC-H: {sorted(unexpected)}"
+    # Only the tested queries' entries of KNOWN_DIVERGENCES are tolerated here, so
+    # a new Q2/Q10 entry to the global baseline can't silently excuse a regression.
+    known_for_queries = {key for key in KNOWN_DIVERGENCES if int(key.split("_v")[0]) in query_ids}
+    unexpected = divergent - known_for_queries
+    assert not unexpected, f"New, unclassified divergence(s) from canonical TPC-H: {sorted(unexpected)}"

--- a/tests/integration/test_tpchavoc_variant_equivalence.py
+++ b/tests/integration/test_tpchavoc_variant_equivalence.py
@@ -1,10 +1,10 @@
 """Result-equivalence regression test for the fixed TPC-Havoc variants.
 
-This is the narrow, gating companion to the non-gating diagnostic in
-``benchbox/core/tpchavoc/equivalence.py`` (run via
-``make tpchavoc-equivalence-report``). The diagnostic enumerates every variant
-that diverges from canonical TPC-H; this test locks in the variant correctness
-defects that have been fixed so far:
+This is the fast, default-lane companion to the full semantic-equivalence gate
+in ``benchbox/core/tpchavoc/equivalence.py`` (run via
+``make tpchavoc-equivalence-report``, wired into the ``correctness-gate`` CI
+job). The full gate sweeps all 220 variants; this test re-checks the query
+families where variant correctness defects were found and fixed:
 
 * ``q2_v10`` / ``q10_v10`` - clamped negative account balances to ``0`` via CASE
   projections.
@@ -14,11 +14,8 @@ defects that have been fixed so far:
   ``lineitem`` table, inflating revenue ~4.5x.
 * ``q9_v10`` - bucketed 22 nations into ``OTHER AMERICAS`` and clamped negative
   profit to ``0``.
-
-A broader hard gate over all queries is deliberately deferred until the
-remaining divergence classes recorded in
-``benchbox.core.tpchavoc.equivalence.KNOWN_DIVERGENCES`` are triaged (see
-``_project/TODO/main/planning/tpchavoc-variant-equivalence-gate.yaml``).
+* ``q7_v9`` / ``q9_v9`` / ``q10_v9`` - projected a helper ``rank()`` column,
+  changing the output schema.
 
 Copyright 2026 Joe Harris / BenchBox Project
 
@@ -58,34 +55,31 @@ def populated_duckdb(tmp_path_factory):
         connection.close()
 
 
-# Variants whose correctness defects have been fixed and must stay equivalent to
-# canonical TPC-H. Their parent queries are also swept for new, unclassified
-# regressions (tolerating only that query's documented KNOWN_DIVERGENCES).
-FIXED_VARIANTS = frozenset({"1_v8", "2_v10", "7_v5", "9_v10", "10_v10"})
+# Queries whose variants had correctness defects (value distortion or schema
+# leakage); every variant of these queries must now match canonical TPC-H.
+FIXED_DEFECT_QUERIES = (1, 2, 7, 9, 10)
 
 
-def test_fixed_variants_equivalent_to_canonical(populated_duckdb):
-    """Every fixed variant must match canonical TPC-H, with no new regressions.
+def test_fixed_variant_families_equivalent_to_canonical(populated_duckdb):
+    """Every variant of the previously-defective queries must match canonical.
 
-    Covers the value-zeroing projection fixes (``q2_v10``, ``q10_v10``) and the
-    three triaged correctness defects (``q1_v8`` filtered in ``QUALIFY`` instead
-    of ``WHERE``; ``q7_v5`` fanned out revenue ~4.5x; ``q9_v10`` bucketed nations
-    and clamped negative profit). Also guards the affected query families against
-    a *new* unclassified divergence without coupling to the global baseline.
+    Covers the value-distorting fixes (``q1_v8``, ``q2_v10``, ``q7_v5``,
+    ``q9_v10``, ``q10_v10``) and the schema fixes (``q7_v9``, ``q9_v9``,
+    ``q10_v9``). The full 220-variant gate runs in the ``correctness-gate`` CI
+    job; this is the fast default-lane regression for the riskiest families.
     """
     connection, tpchavoc, tpch = populated_duckdb
 
-    query_ids = sorted({int(key.split("_v")[0]) for key in FIXED_VARIANTS})
-    divergences = find_divergences(connection, tpchavoc, lambda query_id: tpch.get_query(query_id), query_ids=query_ids)
-    divergent = {d.key for d in divergences}
-
-    regressed = FIXED_VARIANTS & divergent
-    assert not regressed, "Fixed variants diverge from canonical TPC-H: " + ", ".join(
-        f"{d.key} ({d.detail})" for d in divergences if d.key in regressed
+    divergences = find_divergences(
+        connection,
+        tpchavoc,
+        lambda query_id: tpch.get_query(query_id),
+        query_ids=list(FIXED_DEFECT_QUERIES),
     )
 
-    # Only the tested queries' entries of KNOWN_DIVERGENCES are tolerated here, so
-    # a new Q2/Q10 entry to the global baseline can't silently excuse a regression.
-    known_for_queries = {key for key in KNOWN_DIVERGENCES if int(key.split("_v")[0]) in query_ids}
-    unexpected = divergent - known_for_queries
-    assert not unexpected, f"New, unclassified divergence(s) from canonical TPC-H: {sorted(unexpected)}"
+    # KNOWN_DIVERGENCES is empty after the burndown; tolerate only entries that
+    # are explicitly classified there, never an unclassified regression.
+    unexpected = {d.key for d in divergences} - set(KNOWN_DIVERGENCES)
+    assert not unexpected, "Variant(s) diverge from canonical TPC-H: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in divergences if d.key in unexpected
+    )

--- a/tests/unit/core/test_tpch_benchmark_fakes.py
+++ b/tests/unit/core/test_tpch_benchmark_fakes.py
@@ -34,7 +34,7 @@ def fake_tpch_components(monkeypatch, tmp_path):
             return tables
 
     class FakeTPCHQueryManager:
-        def get_all_queries(self):
+        def get_all_queries(self, **_):
             return {1: "SELECT 1", 2: "SELECT 2"}
 
         def get_query(self, query_id, **_):

--- a/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
+++ b/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
@@ -164,7 +164,7 @@ def test_get_query_variant_delegates(tmp_path, monkeypatch) -> None:
 
     result = bench.get_query_variant(2, 3)
 
-    mock_qm.get_query_variant.assert_called_once_with(2, 3, None)
+    mock_qm.get_query_variant.assert_called_once_with(2, 3, None, scale_factor=bench.scale_factor)
     assert result == "SELECT variant"
 
 
@@ -175,7 +175,7 @@ def test_get_all_variants_delegates(tmp_path, monkeypatch) -> None:
     result = bench.get_all_variants(1)
 
     assert result == {1: "SELECT a", 2: "SELECT b"}
-    mock_qm.get_all_variants.assert_called_once_with(1)
+    mock_qm.get_all_variants.assert_called_once_with(1, scale_factor=bench.scale_factor)
 
 
 def test_get_variant_description_delegates(tmp_path, monkeypatch) -> None:

--- a/tests/unit/tpchavoc/test_query_manager.py
+++ b/tests/unit/tpchavoc/test_query_manager.py
@@ -40,3 +40,26 @@ def test_invalid_variant_errors(manager: TPCHavocQueryManager):
 
     with pytest.raises(ValueError):
         manager.get_query_variant(99, 1)
+
+
+def test_q11_fraction_scales_with_scale_factor(manager: TPCHavocQueryManager):
+    """Q11 variants must render the value threshold as 0.0001/SF like canonical qgen."""
+    for scale_factor, literal in [(1.0, "0.0001000000"), (0.1, "0.0010000000"), (10.0, "0.0000100000")]:
+        for variant_id in range(1, 11):
+            sql = manager.get_query_variant(11, variant_id, scale_factor=scale_factor)
+            assert literal in sql, f"11_v{variant_id} at SF={scale_factor} missing threshold {literal}"
+
+
+def test_explicit_params_do_not_suppress_scale_substitution(manager: TPCHavocQueryManager):
+    """Scale tokens are defaults: caller-supplied params must never leak a raw token."""
+    sql = manager.get_query_variant(11, 1, params={"unrelated": "value"}, scale_factor=0.1)
+    assert "{q11_fraction}" not in sql
+    assert "0.0010000000" in sql
+
+
+def test_no_unsubstituted_tokens_in_any_variant(manager: TPCHavocQueryManager):
+    """Every rendered variant must be free of unrendered {token} placeholders."""
+    for query_id in manager.get_implemented_queries():
+        for variant_id in range(1, 11):
+            sql = manager.get_query_variant(query_id, variant_id, scale_factor=0.1)
+            assert "{" not in sql and "}" not in sql, f"unsubstituted token in {query_id}_v{variant_id}"

--- a/tests/unit/tpchavoc/test_query_manager.py
+++ b/tests/unit/tpchavoc/test_query_manager.py
@@ -58,8 +58,22 @@ def test_explicit_params_do_not_suppress_scale_substitution(manager: TPCHavocQue
 
 
 def test_no_unsubstituted_tokens_in_any_variant(manager: TPCHavocQueryManager):
-    """Every rendered variant must be free of unrendered {token} placeholders."""
+    """Every rendered variant must be free of unrendered {token} placeholders.
+
+    Covers both entry points - get_query_variant and the parameterized variant
+    path - since each merges the scale substitution independently.
+    """
     for query_id in manager.get_implemented_queries():
         for variant_id in range(1, 11):
-            sql = manager.get_query_variant(query_id, variant_id, scale_factor=0.1)
-            assert "{" not in sql and "}" not in sql, f"unsubstituted token in {query_id}_v{variant_id}"
+            for sql in (
+                manager.get_query_variant(query_id, variant_id, scale_factor=0.1),
+                manager.get_parameterized_query_variant(query_id, variant_id, scale_factor=0.1),
+            ):
+                assert "{" not in sql and "}" not in sql, f"unsubstituted token in {query_id}_v{variant_id}"
+
+
+def test_parameterized_variant_renders_scale_threshold(manager: TPCHavocQueryManager):
+    """get_parameterized_query_variant must also fill the Q11 scale token."""
+    sql = manager.get_parameterized_query_variant(11, 1, scale_factor=0.1)
+    assert "{q11_fraction}" not in sql
+    assert "0.0010000000" in sql


### PR DESCRIPTION
## Summary

Completes `tpchavoc-variant-equivalence-gate` end-to-end (and resolves `tpchavoc-q2-v10-projection-faithfulness`): wires the existing-but-never-called `validate_variant_equivalence` over real SF=0.1 DuckDB data, burns down **all 24 divergences** it surfaced, and flips the oracle to a **hard CI gate**.

**Root cause it closes:** TPC-Havoc's variants executed "100% green" while their *semantic equivalence* to canonical TPC-H (the benchmark's core invariant) went unchecked. The gate now enforces it: **220/220 variants equivalent**, and any regression fails CI.

## The burndown — every divergence class resolved as a variant defect

**Value-distorting bugs (5):**
- `q2_v10` / `q10_v10` — clamped negative `s_acctbal`/`c_acctbal` to `0` via CASE projections.
- `q1_v8` — shipdate predicate lived in `QUALIFY`, which filters output rows *after* window aggregates are computed; sums/avgs/counts spanned the whole `lineitem` table. Moved to `WHERE`.
- `q7_v5` — a date-filtered-orders CTE was rejoined against the full `lineitem` table, fanning revenue out ~4.5×.
- `q9_v10` — bucketed 22 nations into `OTHER AMERICAS` and clamped negative profit to `0`.

**`scale-threshold` (10):** all `11_v*` hardcoded the SF=1 `0.0001` threshold while canonical qgen renders `0.0001/SF`. The variants now carry a `{q11_fraction}` token; `StaticSQLVariant` gained minimal token substitution. Substitution defaults merge UNDER caller params on **both** entry points (`get_query_variant` and `get_parameterized_query_variant`), so explicit/random params can never suppress them and leak a raw token (the second path was caught in review). Unit tests pin the rendering at SF 1.0/0.1/10 for all ten variants and sweep every variant for unsubstituted `{tokens}` via both entry points.

**`extra-column` (9):** `5/7/8/9/10/12/13_v9`, `11_v9` (previously masked by the threshold mismatch), and `15_v4` projected a helper `rank()`/`result_group` column, leaking it into the output schema. The window/UNION structure that defines each variant is unchanged; descriptions verified still accurate; PostgreSQL skip-list reasons still hold.

**`limit-semantics` (1):** `14_v9`'s helper rank column defeated `DISTINCT`, forcing a `LIMIT 1`; with the column gone, `DISTINCT` collapses the constant `over ()` windows to the canonical single row.

## Run-path scale faithfulness (bonus correctness fix)

The bulk renderer `TPCHBenchmark.get_queries` → `get_all_queries` passed no scale factor, so Q11's `0.0001/SF` threshold always rendered at the SF=1 default regardless of the benchmark's actual scale — for **both** canonical TPC-H and (via inheritance) every TPC-Havoc variant on the run path. At SF≠1 the executed Q11 was not the spec-scaled query (wrong row count and timing). Fixed at the one shared seam so both stay scale-faithful and mutually consistent (verified at SF 0.1/1/10). Q11 is excluded from the bounded correctness gate, which still passes.

## The gate

- `KNOWN_DIVERGENCES` is **empty**; `make tpchavoc-equivalence-report` **exits non-zero** on any unclassified divergence.
- Wired into the **`correctness-gate` CI job**; CI run confirmed green ("checked 220 variants - 0 divergent", ~15s on the runner).
- **Fail-proof verified:** deliberately reintroducing the `q10_v10` clamp makes the gate exit 1 naming `10_v10`.
- Fast default lane: `tests/integration/test_tpchavoc_variant_equivalence.py` + substitution unit tests in `tests/unit/tpchavoc/test_query_manager.py`.

## Scope boundaries → promoted to their own TODOs

- **Cross-dialect equivalence**: the gate proves equivalence on DuckDB only; variants run translated on ~20 engines. Promoted to `tpchavoc-cross-dialect-equivalence-sampling` (bounded second-engine/Postgres sample, not a 20-engine matrix).
- **DataFrame surface**: the SQL gate proves nothing about the DataFrame variants, which are *independent designs* (verified: same variant id ≠ same transformation; none of the 24 fixed divergences had a DataFrame analog). Promoted to `tpchavoc-dataframe-variant-equivalence-gate` (its own gate against canonical TPC-H).

## Verification

- Full sweep: **220 checked, 0 divergent** at SF=0.1; Q11 also clean at SF=0.05.
- Each fix verified against canonical TPC-H (not sibling variants): e.g. `q7_v5` 21.2M → 4.64M revenue; `q9_v10` BRAZIL 1992 clamped 5043961.91 → real 5035200.05; `q1_v8` N/O group 300716 → 292000 rows.
- SF discrimination: SF=0.1 chosen because at SF=0.01 the projection bugs don't surface and Q17 is NULL.
- tpchavoc unit/integration tests + 946 TPC-H unit tests + bounded TPC-H correctness gate: pass. `ruff check`/`format` clean. Gate TODO: all four work items done, status Under Review.

https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk)_