### PR TITLE
fix(plan-capture): suppress DuckDB display PRAGMA and EXPLAIN when capture_plans is active

### DIFF
--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -539,7 +539,7 @@ class ResultCaptureMixin:
             query: SQL query text
             query_id: Query identifier
         """
-        if not self.show_query_plans or self.capture_plans:
+        if not self.show_query_plans:
             return
 
         try:

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -539,7 +539,7 @@ class ResultCaptureMixin:
             query: SQL query text
             query_id: Query identifier
         """
-        if not self.show_query_plans:
+        if not self.show_query_plans or self.capture_plans:
             return
 
         try:

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -945,8 +945,8 @@ class DuckDBAdapter(PlatformAdapter):
         start_time = mono_time()
 
         try:
-            # Enable profiling only if query plans are requested
-            if self.show_query_plans:
+            # Enable profiling only if display is active (not when capture suppresses display)
+            if self.show_query_plans and not self.capture_plans:
                 connection.execute("PRAGMA enable_profiling = 'query_tree'")
                 logger.debug("DuckDB query profiling enabled for this query")
 
@@ -958,8 +958,10 @@ class DuckDBAdapter(PlatformAdapter):
             actual_row_count = len(rows)
             logger.debug(f"Query {query_id} completed in {execution_time:.3f}s, returned {actual_row_count} rows")
 
-            # Display query plan if enabled
-            self.display_query_plan_if_enabled(connection, query, query_id)
+            # Display query plan if enabled; skip when capture_plans is also active
+            # to avoid issuing EXPLAIN twice (display + capture would both call get_query_plan).
+            if not self.capture_plans:
+                self.display_query_plan_if_enabled(connection, query, query_id)
 
             # Validate row count if enabled and benchmark type is provided
             validation_result = None
@@ -1018,8 +1020,8 @@ class DuckDBAdapter(PlatformAdapter):
                 "error_type": type(e).__name__,
             }
         finally:
-            # Disable profiling if it was enabled
-            if self.show_query_plans:
+            # Disable profiling if it was enabled (mirrors the enable condition)
+            if self.show_query_plans and not self.capture_plans:
                 connection.execute("PRAGMA disable_profiling")
 
     def get_query_plan(self, connection: Any, query: str) -> str | None:

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -757,8 +757,9 @@ class DuckDBAdapter(PlatformAdapter):
         self.log_very_verbose("DuckDB OLAP optimizations applied")
         # Note: enable_optimizer setting not available in current DuckDB versions
 
-        # Enable profiling only if requested
-        if self.show_query_plans:
+        # Enable profiling only when displaying plans; skip when capture_plans is active
+        # (EXPLAIN ANALYZE handles plan capture separately without requiring profiling).
+        if self.show_query_plans and not self.capture_plans:
             conn.execute("SET enable_profiling = 'query_tree_optimizer'")
             config_applied.append("query profiling")
             self.log_very_verbose("DuckDB query profiling enabled")
@@ -908,8 +909,8 @@ class DuckDBAdapter(PlatformAdapter):
 
     def configure_for_benchmark(self, connection: Any, benchmark_type: str) -> None:
         """Apply DuckDB-specific optimizations based on benchmark type."""
-        # Only apply profiling when explicitly requested
-        if self.show_query_plans:
+        # Enable profiling only when displaying plans; skip when capture_plans is active.
+        if self.show_query_plans and not self.capture_plans:
             connection.execute("SET enable_profiling = 'query_tree'")
 
     def execute_query(

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -154,7 +154,9 @@ class TestDuckDBDisplayQueryPlan:
 
         adapter.execute_query(connection=conn, query="SELECT 1", query_id="q", validate_row_count=False)
 
-        assert len(display_calls) == 0, "display_query_plan_if_enabled must not fire when capture_plans=True (avoids double EXPLAIN)"
+        assert len(display_calls) == 0, (
+            "display_query_plan_if_enabled must not fire when capture_plans=True (avoids double EXPLAIN)"
+        )
 
 
 class TestDuckDBPlanCapture:

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -119,6 +119,44 @@ class TestDuckDBDMLPlanGuard:
         assert "FORMAT JSON" in called_sql
 
 
+class TestDuckDBDisplayQueryPlan:
+    """display_query_plan_if_enabled must not be called when capture_plans is active."""
+
+    def _make_adapter(self, capture_plans: bool):
+        return DuckDBAdapter(capture_plans=capture_plans)
+
+    def _mock_execute(self, monkeypatch, adapter):
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = []
+        monkeypatch.setattr(
+            adapter,
+            "_build_query_result_with_validation",
+            lambda **kw: {"query_id": kw.get("query_id", "q"), "status": "SUCCESS", "rows_returned": 0},
+        )
+        monkeypatch.setattr(adapter, "_merge_plan_capture_into_result", lambda *a, **k: None)
+        return conn
+
+    def test_display_called_when_not_capturing(self, monkeypatch):
+        adapter = self._make_adapter(capture_plans=False)
+        conn = self._mock_execute(monkeypatch, adapter)
+        display_calls = []
+        monkeypatch.setattr(adapter, "display_query_plan_if_enabled", lambda *a, **k: display_calls.append(True))
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="q", validate_row_count=False)
+
+        assert len(display_calls) == 1, "display_query_plan_if_enabled should fire once when capture_plans=False"
+
+    def test_display_suppressed_when_capturing(self, monkeypatch):
+        adapter = self._make_adapter(capture_plans=True)
+        conn = self._mock_execute(monkeypatch, adapter)
+        display_calls = []
+        monkeypatch.setattr(adapter, "display_query_plan_if_enabled", lambda *a, **k: display_calls.append(True))
+
+        adapter.execute_query(connection=conn, query="SELECT 1", query_id="q", validate_row_count=False)
+
+        assert len(display_calls) == 0, "display_query_plan_if_enabled must not fire when capture_plans=True (avoids double EXPLAIN)"
+
+
 class TestDuckDBPlanCapture:
     """Test query plan capture in DuckDB adapter."""
 


### PR DESCRIPTION
## Summary

- `DuckDBAdapter.execute_query()` called `display_query_plan_if_enabled()` unconditionally, causing a second `EXPLAIN (ANALYZE, FORMAT JSON)` when both `--show-query-plans` and `--capture-plans` were active
- `PRAGMA enable/disable_profiling` was also firing unconditionally on `show_query_plans=True`, wasting per-query profiling overhead even when display was suppressed by `capture_plans`
- `display_query_plan_if_enabled()` in the base class had no `capture_plans` guard, so future adapters that call it without the outer wrapper would silently double-EXPLAIN

**Changes:**
- Guard `PRAGMA enable_profiling` / `PRAGMA disable_profiling` in `duckdb.py` on `show_query_plans and not capture_plans`
- Guard the `display_query_plan_if_enabled()` call in `duckdb.py` on `not capture_plans` — consistent with the pattern already used in DataFusion, SQLite, Redshift, and MotherDuck
- Add `or self.capture_plans` to the early-return in `display_query_plan_if_enabled()` in `result_capture.py`, making the method self-protecting for future adapters

## Test plan

- [ ] New `TestDuckDBDisplayQueryPlan` tests verify display is called when `capture_plans=False` and suppressed when `capture_plans=True`
- [ ] Existing 40 DuckDB plan capture tests pass unchanged
- [ ] `test_base_adapter_database_management.py` display tests pass

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_