### PR TITLE
ci(postgres): add PostgreSQL service container and plan capture tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -170,6 +170,43 @@ jobs:
         run: |
           uv run -- python -m pytest -q tests/integration/core/data_organization/test_presorted_generation.py -m "requires_table_formats" --tb=short
 
+  postgres-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: benchbox
+          POSTGRES_PASSWORD: benchbox
+          POSTGRES_DB: benchbox_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run PostgreSQL live integration tests
+        run: |
+          uv run -- python -m pytest tests/integration/platforms/test_postgresql_live.py \
+            -m "live_postgresql" --tb=short -v
+
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -389,6 +389,49 @@ jobs:
       - name: Run bounded real-result correctness gate
         run: make test-correctness-gate
 
+  postgres-integration:
+    name: postgres-integration
+    needs: ci-paths
+    if: ${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Non-blocking: service container startup can be flaky; failures surfaced as
+    # warnings rather than a gate block to avoid spurious PR failures.
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: benchbox
+          POSTGRES_PASSWORD: benchbox
+          POSTGRES_DB: benchbox_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run PostgreSQL live integration tests
+        run: |
+          uv run -- python -m pytest tests/integration/platforms/test_postgresql_live.py \
+            -m "live_postgresql" --tb=short -v
+
   explorer-tokens:
     name: explorer-tokens
     needs: ci-paths

--- a/tests/integration/platforms/test_postgresql_live.py
+++ b/tests/integration/platforms/test_postgresql_live.py
@@ -11,6 +11,8 @@ Setup:
 These tests require a running PostgreSQL instance accessible at localhost:5432.
 """
 
+import json
+
 import pytest
 
 from benchbox.platforms.postgresql import PostgreSQLAdapter
@@ -35,6 +37,22 @@ def postgresql_adapter():
         username="benchbox",
         password="benchbox",
         database="benchbox_test",
+    )
+    adapter.skip_database_management = True
+    yield adapter
+
+
+@pytest.fixture
+def postgresql_adapter_with_capture():
+    """Create a PostgreSQL adapter with query plan capture enabled."""
+    skip_unless_docker_service("localhost", 5432, platform="PostgreSQL")
+    adapter = PostgreSQLAdapter(
+        host="localhost",
+        port=5432,
+        username="benchbox",
+        password="benchbox",
+        database="benchbox_test",
+        capture_plans=True,
     )
     adapter.skip_database_management = True
     yield adapter
@@ -94,3 +112,58 @@ class TestLivePostgreSQLQueryExecution:
             assert result is not None
         finally:
             postgresql_adapter.close_connection(connection)
+
+
+class TestLivePostgreSQLQueryPlanCapture:
+    """Test query plan capture against a live PostgreSQL instance."""
+
+    def test_get_query_plan_returns_json(self, postgresql_adapter):
+        """get_query_plan should return a non-empty JSON string."""
+        connection = postgresql_adapter.create_connection()
+        try:
+            plan = postgresql_adapter.get_query_plan(connection, "SELECT 1")
+            assert plan is not None
+            assert len(plan) > 0
+            # PostgreSQL FORMAT JSON wraps the plan in a list
+            parsed = json.loads(plan)
+            assert isinstance(parsed, list)
+            assert len(parsed) > 0
+        finally:
+            postgresql_adapter.close_connection(connection)
+
+    def test_capture_query_plan_returns_dag(self, postgresql_adapter_with_capture):
+        """capture_query_plan should return a QueryPlanDAG for a simple SELECT."""
+        adapter = postgresql_adapter_with_capture
+        connection = adapter.create_connection()
+        try:
+            plan, capture_ms = adapter.capture_query_plan(connection, "SELECT 1", "q_test")
+            assert plan is not None, "Expected a QueryPlanDAG but got None"
+            assert capture_ms >= 0.0
+            assert plan.logical_root is not None
+        finally:
+            adapter.close_connection(connection)
+
+    def test_capture_query_plan_has_fingerprint(self, postgresql_adapter_with_capture):
+        """Captured plan must have a non-empty fingerprint."""
+        adapter = postgresql_adapter_with_capture
+        connection = adapter.create_connection()
+        try:
+            plan, _ = adapter.capture_query_plan(connection, "SELECT 1", "q_fp")
+            assert plan is not None
+            assert plan.plan_fingerprint
+            assert len(plan.plan_fingerprint) == 64  # SHA256 hex
+        finally:
+            adapter.close_connection(connection)
+
+    def test_capture_query_plan_fingerprint_stable(self, postgresql_adapter_with_capture):
+        """Same query executed twice must produce identical fingerprints."""
+        adapter = postgresql_adapter_with_capture
+        connection = adapter.create_connection()
+        try:
+            plan1, _ = adapter.capture_query_plan(connection, "SELECT 1", "q_fp_a")
+            plan2, _ = adapter.capture_query_plan(connection, "SELECT 1", "q_fp_b")
+            assert plan1 is not None
+            assert plan2 is not None
+            assert plan1.plan_fingerprint == plan2.plan_fingerprint
+        finally:
+            adapter.close_connection(connection)


### PR DESCRIPTION
## Summary

- Adds a `postgres-integration` job to `pr.yml` and `nightly.yml` that spins up a **PostgreSQL 17 service container** and runs `live_postgresql`-marked tests
- Adds `TestLivePostgreSQLQueryPlanCapture` to `test_postgresql_live.py` covering plan capture end-to-end: JSON format, DAG parsing, fingerprint presence, and fingerprint stability
- Fixes `import json` placement (was inside test method, now at module level)

## CI posture

| Workflow | Job | Gate |
|----------|-----|------|
| `pr.yml` | `postgres-integration` | Non-blocking (`continue-on-error: true`, excluded from `ci-required-result`) |
| `nightly.yml` | `postgres-integration` | Required (no override — persistent failures surface here) |

Non-blocking in PRs to avoid spurious gate failures from service container startup flakiness; blocking in nightly where infrastructure is more stable and persistent failures matter.

## Test plan

- [ ] pr.yml `postgres-integration` job appears as a visible (green) optional check on develop PRs
- [ ] nightly.yml `postgres-integration` job runs and passes
- [ ] All 8 `live_postgresql` tests collect correctly (`pytest --collect-only -m "live_postgresql"`)
- [ ] `test_capture_query_plan_returns_dag` passes against a live PostgreSQL 17 instance (verifies FORMAT JSON + parser wiring)
- [ ] `test_capture_query_plan_fingerprint_stable` produces identical fingerprints for `SELECT 1` across two calls

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_