### PR TITLE
feat(plan-capture): add Spark plan parser and wire Spark and Databricks

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-spark-databricks.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-spark-databricks
 title: "Implement query plan parser and end-to-end capture for Spark and Databricks adapters"
 worktree: platform-expansion
 priority: Medium
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -51,7 +51,7 @@ prior_art:
 work:
   - id: w1
     summary: "Collect Spark EXPLAIN text samples and confirm format used by get_query_plan()"
-    status: pending
+    status: done
     notes: |
       Check what SQL string get_query_plan() in spark_execution_mixin.py currently
       issues (EXPLAIN? EXPLAIN EXTENDED? EXPLAIN FORMATTED?). Capture the output
@@ -67,7 +67,7 @@ work:
   - id: w2
     summary: "Implement SparkQueryPlanParser in benchbox/core/query_plans/parsers/spark.py"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Implement QueryPlanParser abstract interface:
         - parse(raw_plan: str) -> QueryPlanDAG
@@ -88,7 +88,7 @@ work:
   - id: w3
     summary: "Add unit tests for SparkQueryPlanParser using fixture samples"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Create tests/unit/query_plans/test_spark_parser.py. Cover:
         - Parse of fixture sample produces valid QueryPlanDAG
@@ -100,7 +100,7 @@ work:
   - id: w4
     summary: "Add get_query_plan_parser() override to SparkAdapter (or SparkQueryExecutionMixin)"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/spark.py or spark_execution_mixin.py (whichever is
       most appropriate for the mixin hierarchy):
@@ -113,7 +113,7 @@ work:
   - id: w5
     summary: "Integrate capture_query_plan() into _execute_query_spark()"
     needs: [w4]
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/base/spark_execution_mixin.py, inside
       _execute_query_spark() (line 491), after the timed SQL execution block:
@@ -128,7 +128,7 @@ work:
   - id: w6
     summary: "Assess Databricks adapter inheritance and wire or override as needed"
     needs: [w4, w5]
-    status: pending
+    status: done
     notes: |
       Inspect benchbox/platforms/databricks.py (if it exists). If Databricks
       inherits SparkAdapter or SparkQueryExecutionMixin, it will inherit plan
@@ -142,7 +142,7 @@ work:
   - id: w7
     summary: "Add wiring unit tests for SparkAdapter plan capture"
     needs: [w5, w6]
-    status: pending
+    status: done
     notes: |
       Create tests/unit/platforms/test_spark_plan_capture.py. Cover:
         - get_query_plan_parser() returns SparkQueryPlanParser
@@ -214,4 +214,4 @@ metadata:
   tags: [query-plan, spark, databricks, pyspark, new-parser]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-10T00:00:00-04:00"

--- a/benchbox/core/query_plans/parsers/registry.py
+++ b/benchbox/core/query_plans/parsers/registry.py
@@ -197,6 +197,7 @@ def _create_default_registry() -> ParserRegistry:
     from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
     from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
     from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+    from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
     from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
 
     registry = ParserRegistry()
@@ -224,6 +225,10 @@ def _create_default_registry() -> ParserRegistry:
     registry.register("trino", "0.0.0", PrestoTrinoQueryPlanParser)
     registry.register("starburst", "0.0.0", PrestoTrinoQueryPlanParser)
     registry.register("athena", "0.0.0", PrestoTrinoQueryPlanParser)
+
+    # Register Spark parser (shared by Spark and Databricks, which runs Spark SQL).
+    registry.register("spark", "0.0.0", SparkQueryPlanParser)
+    registry.register("databricks", "0.0.0", SparkQueryPlanParser)
 
     return registry
 

--- a/benchbox/core/query_plans/parsers/spark.py
+++ b/benchbox/core/query_plans/parsers/spark.py
@@ -1,0 +1,199 @@
+"""Spark / Databricks query plan parser.
+
+Parses the ``== Physical Plan ==`` section of Spark's ``EXPLAIN EXTENDED`` output
+into the harmonized ``QueryPlanDAG``. ``EXPLAIN EXTENDED`` emits four sections
+(Parsed / Analyzed / Optimized Logical Plan and Physical Plan); only the physical
+plan is parsed, since it is the most stable across Spark versions for
+fingerprinting.
+
+The physical plan uses Spark's ``TreeNode.treeString`` drawing, where nesting is
+encoded by fixed 3-character prefix groups (``+- ``/``:- `` connectors and
+``:  ``/``   `` ancestor fillers) and operators may carry a ``*(n) `` whole-stage
+codegen marker, e.g.::
+
+    *(3) HashAggregate(keys=[...], functions=[...])
+    +- Exchange hashpartitioning(...)
+       +- *(2) BroadcastHashJoin [...], Inner, BuildRight
+          :- *(2) Filter isnotnull(...)
+          :  +- FileScan parquet default.lineitem[...]
+          +- BroadcastExchange ...
+             +- FileScan parquet default.orders[...]
+
+Operator depth is the number of leading 3-char prefix groups; the operator name
+is the first word after stripping the connector and codegen marker.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.results.query_plan_models import (
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SparkQueryPlanParser(QueryPlanParser):
+    """Parser for Spark / Databricks ``EXPLAIN EXTENDED`` physical-plan text."""
+
+    # Ordered (substring, type) pairs; first match in the lower-cased operator
+    # name wins, so specific names precede the generic ones they contain.
+    _OPERATOR_KEYWORDS: tuple[tuple[str, LogicalOperatorType], ...] = (
+        ("filescan", LogicalOperatorType.SCAN),
+        ("inmemorytablescan", LogicalOperatorType.SCAN),
+        ("hivetablescan", LogicalOperatorType.SCAN),
+        ("batchscan", LogicalOperatorType.SCAN),
+        ("rowdatasourcescan", LogicalOperatorType.SCAN),
+        ("datasourcescan", LogicalOperatorType.SCAN),
+        ("datasourcev2scan", LogicalOperatorType.SCAN),
+        ("scan", LogicalOperatorType.SCAN),
+        ("broadcasthashjoin", LogicalOperatorType.JOIN),
+        ("sortmergejoin", LogicalOperatorType.JOIN),
+        ("shuffledhashjoin", LogicalOperatorType.JOIN),
+        ("broadcastnestedloopjoin", LogicalOperatorType.JOIN),
+        ("cartesianproduct", LogicalOperatorType.JOIN),
+        ("join", LogicalOperatorType.JOIN),
+        ("hashaggregate", LogicalOperatorType.AGGREGATE),
+        ("objecthashaggregate", LogicalOperatorType.AGGREGATE),
+        ("sortaggregate", LogicalOperatorType.AGGREGATE),
+        ("aggregate", LogicalOperatorType.AGGREGATE),
+        ("takeorderedandproject", LogicalOperatorType.SORT),
+        ("sort", LogicalOperatorType.SORT),
+        ("globallimit", LogicalOperatorType.LIMIT),
+        ("locallimit", LogicalOperatorType.LIMIT),
+        ("collectlimit", LogicalOperatorType.LIMIT),
+        ("window", LogicalOperatorType.WINDOW),
+        ("union", LogicalOperatorType.UNION),
+        ("filter", LogicalOperatorType.FILTER),
+        ("project", LogicalOperatorType.PROJECT),
+        # Exchange / shuffle / codegen wrappers have no dedicated logical type.
+        ("broadcastexchange", LogicalOperatorType.OTHER),
+        ("shuffleexchange", LogicalOperatorType.OTHER),
+        ("exchange", LogicalOperatorType.OTHER),
+    )
+
+    _PHYSICAL_HEADER = "== Physical Plan =="
+    # One nesting level: a connector ("+- "/":- ") or an ancestor filler (":  "/"   ").
+    _PREFIX_RE = re.compile(r"^((?:\+- |:- |:  |   )*)(.*)$")
+    # Optional whole-stage codegen marker, e.g. "*(3) " or "* ".
+    _CODEGEN_RE = re.compile(r"^\*(?:\(\d+\))?\s*")
+
+    def __init__(self):
+        super().__init__("spark")
+
+    def _parse_impl(self, query_id: str, explain_output: str) -> QueryPlanDAG:
+        if not explain_output or not explain_output.strip():
+            raise ValueError("Empty EXPLAIN output")
+
+        physical_text = self._extract_physical_section(explain_output)
+        parsed_nodes = self._parse_lines(physical_text)
+        if not parsed_nodes:
+            raise ValueError("No operators found in Spark physical plan")
+
+        root = self._build_tree(parsed_nodes)
+        return QueryPlanDAG(
+            query_id=query_id,
+            platform=self.platform_name,
+            logical_root=root,
+            raw_explain_output=explain_output,
+        )
+
+    def _extract_physical_section(self, explain_output: str) -> str:
+        """Return the text after the last ``== Physical Plan ==`` header.
+
+        Bare ``EXPLAIN`` (no EXTENDED) returns only the physical plan with no
+        header, so when the header is absent the whole text is used.
+        """
+        idx = explain_output.rfind(self._PHYSICAL_HEADER)
+        if idx == -1:
+            return explain_output
+        return explain_output[idx + len(self._PHYSICAL_HEADER) :]
+
+    def _parse_lines(self, physical_text: str) -> list[dict[str, Any]]:
+        parsed: list[dict[str, Any]] = []
+        for raw_line in physical_text.splitlines():
+            if not raw_line.strip():
+                continue
+            prefix, rest = self._PREFIX_RE.match(raw_line).groups()
+            rest = rest.strip()
+            # Skip AQE sub-section headers like "== Initial Plan ==".
+            if rest.startswith("==") and rest.endswith("=="):
+                continue
+            depth = len(prefix) // 3
+            node_text = self._CODEGEN_RE.sub("", rest).strip()
+            name_match = re.match(r"([A-Za-z][\w]*)", node_text)
+            if not name_match:
+                continue
+            parsed.append({"depth": depth, "name": name_match.group(1), "details": node_text})
+        return parsed
+
+    def _build_tree(self, parsed_nodes: list[dict[str, Any]]) -> LogicalOperator:
+        stack: list[tuple[int, LogicalOperator]] = []
+        root: LogicalOperator | None = None
+
+        for node in parsed_nodes:
+            logical_op = self._convert_to_logical_operator(node)
+            while stack and stack[-1][0] >= node["depth"]:
+                stack.pop()
+            if not stack:
+                if root is None:
+                    root = logical_op
+                else:
+                    # A second depth-0 node (rare) becomes a child of the root so a
+                    # single connected DAG is always returned.
+                    root.children.append(logical_op)
+            else:
+                stack[-1][1].children.append(logical_op)
+            stack.append((node["depth"], logical_op))
+
+        if root is None:
+            raise ValueError("Could not determine root operator")
+        return root
+
+    def _convert_to_logical_operator(self, node: dict[str, Any]) -> LogicalOperator:
+        name = node["name"]
+        details = node["details"]
+        logical_type = self._map_operator_type(name)
+
+        kwargs: dict[str, Any] = {}
+        if logical_type == LogicalOperatorType.SCAN:
+            table = self._extract_table(details)
+            if table:
+                kwargs["table_name"] = table
+
+        physical_op = self._create_physical_operator(
+            name,
+            properties={},
+            platform_metadata={"details": details or None},
+        )
+        return self._create_logical_operator(
+            operator_type=logical_type,
+            children=[],
+            physical_operator=physical_op,
+            **kwargs,
+        )
+
+    @classmethod
+    def _map_operator_type(cls, name: str) -> LogicalOperatorType:
+        normalized = name.lower().replace(" ", "").replace("_", "")
+        for keyword, logical_type in cls._OPERATOR_KEYWORDS:
+            if keyword in normalized:
+                return logical_type
+        return LogicalOperatorType.OTHER
+
+    @staticmethod
+    def _extract_table(details: str) -> str | None:
+        """Extract the table from a FileScan/Scan detail, e.g. 'FileScan parquet default.lineitem[...]'."""
+        # FileScan <format> <db.table>[columns...]
+        match = re.search(r"(?:FileScan|Scan)\s+\w+\s+([A-Za-z_][\w.]*)", details)
+        if match:
+            return match.group(1)
+        # Fallback: a dotted identifier anywhere (e.g. "Scan hive default.orders").
+        dotted = re.search(r"\b([A-Za-z_]\w*\.[A-Za-z_][\w.]*)", details)
+        return dotted.group(1) if dotted else None

--- a/benchbox/platforms/base/spark_execution_mixin.py
+++ b/benchbox/platforms/base/spark_execution_mixin.py
@@ -569,10 +569,27 @@ class SparkQueryExecutionMixin:
             result_dict["query_statistics"] = query_stats
             result_dict["resource_usage"] = query_stats
 
-            return result_dict
-
         except Exception as e:
             return self._build_query_failure_result(query_id, start_time, e)
+
+        # Capture the query plan outside the try so a strict-mode PlanCaptureError
+        # propagates instead of being swallowed and mislabeled as a failed query.
+        # Guarded by capture_plans, so EXPLAIN is never issued when capture is off.
+        if getattr(self, "capture_plans", False) and result_dict.get("status") == "SUCCESS":
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                result_dict["query_plan"] = query_plan
+                result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
+            if plan_capture_time_ms is not None:
+                result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+
+        return result_dict
+
+    def get_query_plan_parser(self):
+        """Return the Spark plan parser (inherited by SparkAdapter)."""
+        from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+
+        return SparkQueryPlanParser()
 
     def _validate_data_integrity(
         self, benchmark: Any, connection: Any, table_stats: dict[str, int]

--- a/benchbox/platforms/databricks/adapter.py
+++ b/benchbox/platforms/databricks/adapter.py
@@ -2011,8 +2011,6 @@ class DatabricksAdapter(PlatformAdapter):
                 "execution_time_seconds": execution_time,
             }
 
-            return result_dict
-
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
 
@@ -2026,6 +2024,47 @@ class DatabricksAdapter(PlatformAdapter):
             }
         finally:
             cursor.close()
+
+        # Capture the query plan outside the try so a strict-mode PlanCaptureError
+        # propagates instead of being swallowed and mislabeled as a failed query.
+        # Guarded by capture_plans, so EXPLAIN is never issued when capture is off.
+        # capture_query_plan opens its own cursor (the query cursor is already closed).
+        if getattr(self, "capture_plans", False) and result_dict.get("status") == "SUCCESS":
+            query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
+            if query_plan:
+                result_dict["query_plan"] = query_plan
+                result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
+            if plan_capture_time_ms is not None:
+                result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+
+        return result_dict
+
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Get the Spark physical plan via ``EXPLAIN EXTENDED`` over the SQL cursor.
+
+        Databricks runs Spark SQL, so the plan text is parsed by
+        SparkQueryPlanParser. Returns ``None`` on any failure so capture degrades
+        gracefully.
+        """
+        cursor = connection.cursor()
+        try:
+            cursor.execute(f"EXPLAIN EXTENDED {query}")
+            plan_rows = cursor.fetchall()
+            if not plan_rows:
+                return None
+            text = "\n".join(str(row[0]) for row in plan_rows)
+            return text or None
+        except Exception as e:
+            self.logger.debug(f"Could not get Databricks query plan: {e}")
+            return None
+        finally:
+            cursor.close()
+
+    def get_query_plan_parser(self):
+        """Return the Spark plan parser (Databricks runs Spark SQL)."""
+        from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+
+        return SparkQueryPlanParser()
 
     def _fix_databricks_sql_syntax(self, sql: str) -> str:
         """Transform SQL syntax for Databricks compatibility.

--- a/tests/fixtures/query_plans/spark_explain_sample.txt
+++ b/tests/fixtures/query_plans/spark_explain_sample.txt
@@ -1,0 +1,35 @@
+== Parsed Logical Plan ==
+'Aggregate ['l_orderkey], ['l_orderkey, unresolvedalias('sum('l_quantity), None)]
++- 'Join Inner, ('l_orderkey = 'o_orderkey)
+   :- 'UnresolvedRelation [lineitem]
+   +- 'UnresolvedRelation [orders]
+
+== Analyzed Logical Plan ==
+l_orderkey: bigint, sum(l_quantity): double
+Aggregate [l_orderkey#0L], [l_orderkey#0L, sum(l_quantity#4) AS sum(l_quantity)#20]
++- Join Inner, (l_orderkey#0L = o_orderkey#10L)
+   :- SubqueryAlias lineitem
+   +- SubqueryAlias orders
+
+== Optimized Logical Plan ==
+Aggregate [l_orderkey#0L], [l_orderkey#0L, sum(l_quantity#4) AS sum(l_quantity)#20]
++- Project [l_orderkey#0L, l_quantity#4]
+   +- Join Inner, (l_orderkey#0L = o_orderkey#10L)
+      :- Filter isnotnull(l_orderkey#0L)
+      :  +- Relation default.lineitem[l_orderkey#0L,l_quantity#4] parquet
+      +- Filter isnotnull(o_orderkey#10L)
+         +- Relation default.orders[o_orderkey#10L] parquet
+
+== Physical Plan ==
+*(3) HashAggregate(keys=[l_orderkey#0L], functions=[sum(l_quantity#4)])
++- Exchange hashpartitioning(l_orderkey#0L, 200), ENSURE_REQUIREMENTS, [plan_id=42]
+   +- *(2) HashAggregate(keys=[l_orderkey#0L], functions=[partial_sum(l_quantity#4)])
+      +- *(2) Project [l_orderkey#0L, l_quantity#4]
+         +- *(2) BroadcastHashJoin [l_orderkey#0L], [o_orderkey#10L], Inner, BuildRight
+            :- *(2) Filter isnotnull(l_orderkey#0L)
+            :  +- *(2) ColumnarToRow
+            :     +- FileScan parquet default.lineitem[l_orderkey#0L,l_quantity#4] Batched: true
+            +- BroadcastExchange HashedRelationBroadcastMode(List(input[0, bigint, false])), [plan_id=37]
+               +- *(1) Filter isnotnull(o_orderkey#10L)
+                  +- *(1) ColumnarToRow
+                     +- FileScan parquet default.orders[o_orderkey#10L] Batched: true

--- a/tests/unit/platforms/test_spark_plan_capture.py
+++ b/tests/unit/platforms/test_spark_plan_capture.py
@@ -1,0 +1,137 @@
+"""Wiring tests for Spark and Databricks query plan capture.
+
+Uses fakes that return the recorded EXPLAIN EXTENDED fixture for EXPLAIN
+statements, so no live Spark/Databricks cluster is required.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+_PLAN_TEXT = (_FIXTURES / "spark_explain_sample.txt").read_text()
+
+
+# --- Spark (SparkSession-style) fakes ------------------------------------------------
+# PySpark Rows are tuple subclasses; use real tuples so tuple(row) terminates.
+class _DF:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def collect(self):
+        return self._rows
+
+
+class _FakeSpark:
+    def __init__(self):
+        self.queries = []
+
+    def sql(self, query):
+        self.queries.append(query)
+        if query.strip().upper().startswith("EXPLAIN"):
+            return _DF([(_PLAN_TEXT,)])
+        return _DF([(1,)])
+
+
+# --- Databricks (DBAPI cursor-style) fakes -------------------------------------------
+class _FakeCursor:
+    def __init__(self):
+        self.last = ""
+
+    def execute(self, sql, *a, **k):
+        self.last = sql
+
+    def fetchall(self):
+        return [(_PLAN_TEXT,)] if self.last.strip().upper().startswith("EXPLAIN") else [(1,)]
+
+    def close(self):
+        pass
+
+
+class _FakeDbxConn:
+    def __init__(self):
+        self.cursors = []
+
+    def cursor(self):
+        c = _FakeCursor()
+        self.cursors.append(c)
+        return c
+
+
+@pytest.fixture()
+def spark_adapter():
+    from benchbox.platforms.spark import SparkAdapter
+
+    adapter = SparkAdapter(capture_plans=True)
+    adapter.disable_cache = False  # avoid spark.catalog.clearCache() on the fake session
+    return adapter
+
+
+@pytest.fixture()
+def databricks_adapter(monkeypatch):
+    monkeypatch.setattr(
+        "benchbox.platforms.databricks.adapter.check_platform_dependencies",
+        lambda *a, **k: (True, []),
+    )
+    from benchbox.platforms.databricks.adapter import DatabricksAdapter
+
+    return DatabricksAdapter(capture_plans=True, server_hostname="h", http_path="/sql/1.0/x", access_token="t")
+
+
+class TestSparkPlanCapture:
+    def test_parser_is_spark(self, spark_adapter):
+        assert isinstance(spark_adapter.get_query_plan_parser(), SparkQueryPlanParser)
+
+    def test_execute_query_captures_plan(self, spark_adapter):
+        result = spark_adapter._execute_query_spark(
+            connection=_FakeSpark(), query="SELECT 1", query_id="sq1", validate_row_count=False
+        )
+        assert result["status"] == "SUCCESS"
+        assert result["query_plan"] is not None
+        assert result["plan_fingerprint"] is not None
+        assert result["query_plan"].plan_fingerprint == result["plan_fingerprint"]
+
+    def test_no_capture_when_disabled(self, spark_adapter):
+        spark_adapter.capture_plans = False
+        spark = _FakeSpark()
+        result = spark_adapter._execute_query_spark(
+            connection=spark, query="SELECT 1", query_id="sq2", validate_row_count=False
+        )
+        assert "query_plan" not in result or result.get("query_plan") is None
+        assert not any(q.strip().upper().startswith("EXPLAIN") for q in spark.queries)
+
+    def test_graceful_when_explain_fails(self, spark_adapter, monkeypatch):
+        # When no plan is available (get_query_plan returns None), capture yields no
+        # plan and the query still succeeds without plan fields.
+        monkeypatch.setattr(spark_adapter, "get_query_plan", lambda *a, **k: None)
+        result = spark_adapter._execute_query_spark(
+            connection=_FakeSpark(), query="SELECT 1", query_id="sq3", validate_row_count=False
+        )
+        assert result["status"] == "SUCCESS"
+        assert "query_plan" not in result or result.get("query_plan") is None
+
+
+class TestDatabricksPlanCapture:
+    def test_parser_is_spark(self, databricks_adapter):
+        assert isinstance(databricks_adapter.get_query_plan_parser(), SparkQueryPlanParser)
+
+    def test_get_query_plan_uses_explain_extended(self, databricks_adapter):
+        conn = _FakeDbxConn()
+        plan = databricks_adapter.get_query_plan(conn, "SELECT 1")
+        assert plan is not None
+        assert any("EXPLAIN EXTENDED" in c.last.upper() for c in conn.cursors)
+
+    def test_execute_query_captures_plan(self, databricks_adapter):
+        result = databricks_adapter.execute_query(
+            connection=_FakeDbxConn(), query="SELECT 1", query_id="dq1", validate_row_count=False
+        )
+        assert result["status"] == "SUCCESS"
+        assert result["query_plan"] is not None
+        assert result["plan_fingerprint"] is not None

--- a/tests/unit/query_plans/test_spark_parser.py
+++ b/tests/unit/query_plans/test_spark_parser.py
@@ -1,0 +1,118 @@
+"""Unit tests for SparkQueryPlanParser.
+
+Driven by a recorded ``EXPLAIN EXTENDED`` fixture under tests/fixtures/query_plans/
+so they run with no live Spark/Databricks cluster.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _collect(op: LogicalOperator) -> list[LogicalOperator]:
+    nodes = [op]
+    for child in op.children:
+        nodes.extend(_collect(child))
+    return nodes
+
+
+@pytest.fixture()
+def parser():
+    return SparkQueryPlanParser()
+
+
+class TestSparkPhysicalPlan:
+    def test_parses_to_valid_dag(self, parser):
+        dag = parser.parse_explain_output("q1", _load("spark_explain_sample.txt"))
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+        assert dag.platform == "spark"
+
+    def test_only_physical_section_parsed(self, parser):
+        # The root must be the physical-plan HashAggregate, NOT the parsed logical
+        # 'Aggregate at the top of EXPLAIN EXTENDED output.
+        dag = parser.parse_explain_output("q2", _load("spark_explain_sample.txt"))
+        assert dag.logical_root.operator_type == LogicalOperatorType.AGGREGATE
+        assert dag.logical_root.physical_operator.operator_type == "HashAggregate"
+
+    def test_tree_has_join_over_two_scans(self, parser):
+        dag = parser.parse_explain_output("q3", _load("spark_explain_sample.txt"))
+        nodes = _collect(dag.logical_root)
+        types = [n.operator_type for n in nodes]
+        assert LogicalOperatorType.JOIN in types
+        assert types.count(LogicalOperatorType.SCAN) == 2
+        tables = {n.table_name for n in nodes if n.table_name}
+        assert tables == {"default.lineitem", "default.orders"}
+
+    def test_bare_physical_plan_without_header(self, parser):
+        # Bare EXPLAIN returns only the physical plan with no "== Physical Plan ==".
+        bare = "*(1) Filter isnotnull(x#1)\n+- FileScan parquet default.t[x#1]\n"
+        dag = parser.parse_explain_output("q4", bare)
+        assert dag is not None
+        types = [n.operator_type for n in _collect(dag.logical_root)]
+        assert types == [LogicalOperatorType.FILTER, LogicalOperatorType.SCAN]
+
+
+class TestSparkOperatorNormalization:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("FileScan", LogicalOperatorType.SCAN),
+            ("BatchScan", LogicalOperatorType.SCAN),
+            ("InMemoryTableScan", LogicalOperatorType.SCAN),
+            ("Filter", LogicalOperatorType.FILTER),
+            ("Project", LogicalOperatorType.PROJECT),
+            ("HashAggregate", LogicalOperatorType.AGGREGATE),
+            ("ObjectHashAggregate", LogicalOperatorType.AGGREGATE),
+            ("SortAggregate", LogicalOperatorType.AGGREGATE),
+            ("BroadcastHashJoin", LogicalOperatorType.JOIN),
+            ("SortMergeJoin", LogicalOperatorType.JOIN),
+            ("BroadcastNestedLoopJoin", LogicalOperatorType.JOIN),
+            ("ShuffledHashJoin", LogicalOperatorType.JOIN),
+            ("Sort", LogicalOperatorType.SORT),
+            ("TakeOrderedAndProject", LogicalOperatorType.SORT),
+            ("GlobalLimit", LogicalOperatorType.LIMIT),
+            ("CollectLimit", LogicalOperatorType.LIMIT),
+            ("Window", LogicalOperatorType.WINDOW),
+            ("Union", LogicalOperatorType.UNION),
+            ("Exchange", LogicalOperatorType.OTHER),
+            ("BroadcastExchange", LogicalOperatorType.OTHER),
+            ("ColumnarToRow", LogicalOperatorType.OTHER),
+        ],
+    )
+    def test_map_operator_type(self, name, expected):
+        assert SparkQueryPlanParser._map_operator_type(name) == expected
+
+
+class TestSparkErrorRecovery:
+    def test_empty_input_returns_none(self, parser):
+        assert parser.parse_explain_output("q", "") is None
+
+    def test_physical_header_with_no_ops_returns_none(self, parser):
+        assert parser.parse_explain_output("q", "== Physical Plan ==\n") is None
+
+    def test_garbage_input_does_not_raise(self, parser):
+        result = parser.parse_explain_output("q", "!@#$ %^&*")
+        assert result is None or result.logical_root is not None
+
+
+class TestSparkRegistration:
+    @pytest.mark.parametrize("dialect", ["spark", "databricks"])
+    def test_registered_for_dialect(self, dialect):
+        assert isinstance(get_parser_for_platform(dialect), SparkQueryPlanParser)


### PR DESCRIPTION
## Summary

Implements the **`query-plan-capture-spark-databricks`** TODO: a new `SparkQueryPlanParser` plus plan capture for Spark and Databricks (which runs Spark SQL).

## Parser (`benchbox/core/query_plans/parsers/spark.py`)

Extracts the `== Physical Plan ==` section of `EXPLAIN EXTENDED` (only the physical plan, per the TODO — most stable for fingerprinting) and parses Spark's `TreeNode` drawing:
- Depth = number of leading 3-char prefix groups (`+- `/`:- ` connectors, `:  `/`   ` ancestor fillers); strips `*(n) ` whole-stage-codegen markers.
- Maps operators to `LogicalOperatorType` (`FileScan`→`Scan`, `BroadcastHashJoin`/`SortMergeJoin`/`ShuffledHashJoin`→`Join`, `HashAggregate`→`Aggregate`, `Sort`/`TakeOrderedAndProject`→`Sort`, `Project`/`Filter`/`Limit`/`Union`/`Window`; `Exchange`/codegen wrappers→`Other`).
- Skips AQE `==…==` sub-headers; graceful `None` on empty/garbage input.
- Registered for the `spark` and `databricks` dialects.

## Wiring

- **`SparkQueryExecutionMixin`**: `get_query_plan_parser()` returns the parser; `_execute_query_spark()` captures the plan on `SUCCESS`, placed **after** the `try` so a strict-mode `PlanCaptureError` propagates; guarded by `capture_plans` so EXPLAIN is never issued when off.
- **`DatabricksAdapter`** (its own `execute_query`): adds `get_query_plan()` issuing `EXPLAIN EXTENDED` over the SQL cursor, `get_query_plan_parser()` returning the shared Spark parser, and the same post-`try` capture.

## Test plan
- [x] `pytest tests/unit/query_plans/test_spark_parser.py tests/unit/platforms/test_spark_plan_capture.py` — 37 passed
- [x] `pytest tests/unit/core/query_plans/ test_spark_adapter.py test_databricks_adapter.py tests/unit/query_plans/` — 580 passed
- [x] Spark-family regression (`-k "spark or lakesail or databricks"`, incl. fabric/cloud_spark) — **1366 passed**, no regressions from the shared-mixin change
- [x] `/code-review` (medium) — direct analysis (subagent hit session limit); no findings

## Notes / deviations
- **Databricks live validation deferred** per w6 (no workspace available); the parser/capture are unit-tested with mocked cursors. Databricks runs Spark SQL, so `SparkQueryPlanParser` is reused.
- The capture guard uses `getattr(capture_plans, False)` so partially-built adapter doubles (and Spark-family adapters at default settings) don't raise; capture is a graceful no-op when `capture_plans` is off or no plan is available.
- Fixture synthesized from documented `EXPLAIN EXTENDED` output (no live cluster).

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_