### PR TITLE
docs(todo): plan credential-gated live verification for cloud plan capture

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-redshift-motherduck.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-redshift-motherduck.yaml
@@ -1,0 +1,165 @@
+id: query-plan-capture-cloud-live-redshift-motherduck
+title: "Add CI secrets and nightly live plan capture verification for Redshift and MotherDuck"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Redshift and MotherDuck adapters already have query plan capture fully wired:
+    - RedshiftAdapter (benchbox/platforms/redshift.py)
+      - get_query_plan() at line 2414, get_query_plan_parser() at line 2427
+      - _merge_plan_capture_into_result() called in execute_query() at line 2125
+    - MotherDuckAdapter (benchbox/platforms/motherduck.py)
+      - get_query_plan() at line 227, get_query_plan_parser() at line 256
+      - _merge_plan_capture_into_result() called in execute_query() at line 314
+
+  But this wiring has never been verified against a live cluster/account —
+  unit tests use stubbed connections and fixture EXPLAIN text. This TODO adds
+  credential-gated live verification, following the decision to store cloud
+  credentials as GitHub Actions secrets (not UAT-only, not a credentials file).
+
+  The PostgreSQL service-container precedent (PR #777,
+  tests/integration/platforms/test_postgresql_live.py
+  TestLivePostgreSQLQueryPlanCapture) established the test shape:
+    - get_query_plan() returns parseable output
+    - capture_query_plan() returns a QueryPlanDAG with logical_root
+    - plan_fingerprint is a 64-char SHA256 hex string
+    - fingerprint is stable across repeated identical queries
+
+  This TODO replicates that test class for Redshift and MotherDuck in their
+  existing live test files, and adds a nightly CI job that runs them when
+  secrets are configured. Existing fixtures in
+  tests/integration/platforms/conftest.py already skip gracefully when
+  credentials are absent (get_env_or_skip / has_redshift_credentials), so the
+  job is safe to add before the secrets exist — tests skip, job stays green.
+
+prerequisites:
+  - "GitHub repository admin access to add Actions secrets (repo Settings → Secrets)"
+  - "AWS Redshift cluster reachable from GitHub-hosted runners (env: REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD, REDSHIFT_DATABASE, REDSHIFT_PORT)"
+  - "MotherDuck account + service token (env: MOTHERDUCK_TOKEN, MOTHERDUCK_DATABASE)"
+  - "Live tests skip (not fail) when secrets are absent — existing conftest fixtures already implement this"
+
+prior_art:
+  - "tests/integration/platforms/test_postgresql_live.py — TestLivePostgreSQLQueryPlanCapture test class shape (PR #777)"
+  - ".github/workflows/nightly.yml — postgres-integration job pattern (PR #777)"
+  - "tests/integration/platforms/conftest.py — redshift_credentials / motherduck_credentials fixtures with env-var skip"
+  - "tests/integration/platforms/test_redshift_live.py — existing live test file with live_redshift marker"
+  - "tests/integration/platforms/test_motherduck_live.py — existing live test file with live_motherduck marker"
+
+work:
+  - id: w1
+    summary: "Document and configure GitHub Actions secrets for Redshift and MotherDuck"
+    status: pending
+    notes: |
+      Secrets to add (names match the env vars the conftest fixtures read):
+        REDSHIFT_HOST, REDSHIFT_USER, REDSHIFT_PASSWORD,
+        REDSHIFT_DATABASE (default "dev"), REDSHIFT_PORT (default "5439"),
+        MOTHERDUCK_TOKEN, MOTHERDUCK_DATABASE (default "benchbox_test")
+      Adding the secrets themselves is a repo-admin action outside the PR;
+      the PR documents the expected names in the workflow file comments so
+      the mapping is discoverable. Do not echo secret values in any step.
+
+  - id: w2
+    summary: "Add TestLiveRedshiftQueryPlanCapture to test_redshift_live.py"
+    status: pending
+    notes: |
+      Mirror TestLivePostgreSQLQueryPlanCapture from test_postgresql_live.py:
+        - test_get_query_plan_returns_text: get_query_plan() returns non-empty
+          text (Redshift EXPLAIN is text format with XN-prefixed operators,
+          not JSON — assert non-empty string, not json.loads)
+        - test_capture_query_plan_returns_dag
+        - test_capture_query_plan_has_fingerprint (64-char SHA256 hex)
+        - test_capture_query_plan_fingerprint_stable
+      Use a fixture variant that passes capture_plans=True to RedshiftAdapter
+      (reuse _get_redshift_credentials() from conftest for connection params).
+      Keep existing pytestmark (live_redshift et al.) — module-level markers
+      apply to the new class automatically.
+
+  - id: w3
+    summary: "Add TestLiveMotherDuckQueryPlanCapture to test_motherduck_live.py"
+    status: pending
+    notes: |
+      Same four-test shape as w2. MotherDuck reuses the DuckDB parser, so
+      get_query_plan() output is DuckDB EXPLAIN JSON. A fixture variant with
+      capture_plans=True is needed; base it on motherduck_credentials from
+      conftest. Note: MotherDuck queries run against cloud compute — keep
+      test queries trivial (SELECT 1) to bound cost.
+
+  - id: w4
+    summary: "Add cloud-live-verification job to nightly.yml"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      Follow the postgres-integration job pattern in nightly.yml but without
+      a service container. Pass secrets as env vars at the job level:
+        env:
+          REDSHIFT_HOST: ${{ secrets.REDSHIFT_HOST }}
+          ... (all names from w1)
+      Run: uv run -- python -m pytest
+             tests/integration/platforms/test_redshift_live.py
+             tests/integration/platforms/test_motherduck_live.py
+             -m "live_redshift or live_motherduck" --tb=short -v
+      Job must NOT use continue-on-error: nightly is where persistent
+      failures surface (same posture as postgres-integration in nightly).
+      When secrets are unset the env vars are empty strings and the conftest
+      fixtures skip all tests, so the job passes green on forks and before
+      secrets are configured. Nightly-only — do NOT add to pr.yml: cloud
+      queries are billing-sensitive and PR-triggered runs from arbitrary
+      branches would leak spend.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Live tests must skip (not fail) when credentials are absent — forks and contributors without secrets must stay green."
+  - "Test queries must be trivial (SELECT 1) — Redshift and MotherDuck bill per compute; no benchmark-scale queries in CI."
+  - "No secret values may appear in workflow logs — do not echo env vars; pytest -v output must not print connection strings."
+  - "Existing tests in test_redshift_live.py and test_motherduck_live.py must be untouched."
+
+approach: |
+  w2 and w3 are independent and can be written immediately — the adapter
+  wiring already exists and the tests can be validated locally by anyone with
+  credentials. w4 lands last so the workflow change references test classes
+  that exist. w1 (adding actual secret values) is a repo-admin action that can
+  happen any time; the job degrades to all-skip until then.
+
+anti_patterns:
+  - "DO NOT add the cloud live job to pr.yml — PR-triggered cloud queries from arbitrary branches incur uncontrolled billing; nightly-only."
+  - "DO NOT gate the job on secret presence via job-level if — secrets are not available in job-level if context; rely on the conftest env-var skip instead."
+  - "DO NOT assert json.loads on Redshift EXPLAIN output — Redshift returns text-format plans with XN operators, unlike PostgreSQL FORMAT JSON."
+
+verification:
+  - description: "New live test classes collect under their markers"
+    command: "uv run -- python -m pytest tests/integration/platforms/test_redshift_live.py tests/integration/platforms/test_motherduck_live.py -m 'live_redshift or live_motherduck' --collect-only -q --override-ini='addopts='"
+    expected_output: "New plan capture tests listed for both files"
+  - description: "Tests skip cleanly without credentials"
+    command: "uv run -- python -m pytest tests/integration/platforms/test_redshift_live.py -m live_redshift --tb=short -q"
+    expected_output: "All tests skipped, 0 failures (when no credentials configured)"
+  - description: "Workflow YAML is valid"
+    command: "uv run -- pre-commit run check-yaml --files .github/workflows/nightly.yml"
+    expected_output: "check yaml...Passed"
+
+scope_limit:
+  only_modify:
+    - "tests/integration/platforms/test_redshift_live.py"
+    - "tests/integration/platforms/test_motherduck_live.py"
+    - ".github/workflows/nightly.yml"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-redshift-motherduck.yaml"
+
+success_metrics:
+  - "Nightly cloud-live-verification job exists and passes (skip-green without secrets, test-green with secrets)."
+  - "Redshift and MotherDuck plan capture verified against live services: DAG returned, 64-char fingerprint, stable across repeats."
+  - "Zero cloud spend on PR-triggered CI."
+
+open_questions:
+  - question: "Is a long-lived Redshift cluster available for nightly runs, or should the job target Redshift Serverless to avoid idle-cluster cost?"
+    gating: false
+    affects: ["w1", "w4"]
+    default: "Use whatever endpoint the secrets point at; the tests are endpoint-agnostic"
+
+metadata:
+  tags: [query-plan, redshift, motherduck, ci, live-integration, secrets]
+  estimated_effort: "Small"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-snowflake-bigquery.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-snowflake-bigquery.yaml
@@ -1,0 +1,158 @@
+id: query-plan-capture-cloud-live-snowflake-bigquery
+title: "Add CI secrets and nightly live plan capture verification for Snowflake and BigQuery"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Live verification of query plan capture for Snowflake and BigQuery, gated on
+  GitHub Actions secrets. This is the second half of the cloud live-verification
+  work: unlike Redshift and MotherDuck (covered by
+  query-plan-capture-cloud-live-redshift-motherduck), Snowflake and BigQuery do
+  NOT yet have plan capture wired — neither adapter overrides
+  get_query_plan_parser(), and no parser exists for either platform. That
+  implementation work is query-plan-capture-cloud-saas (w2 for Snowflake,
+  w3 for BigQuery); this TODO is hard-blocked on it.
+
+  Once the parsers land, this TODO adds:
+    - Live plan capture test classes to the existing live test files
+      (tests/integration/platforms/test_snowflake_live.py with live_snowflake
+      marker, test_bigquery_live.py with live_bigquery marker)
+    - Snowflake and BigQuery secret wiring to the nightly
+      cloud-live-verification job created by the Redshift/MotherDuck TODO
+
+  Test shape follows TestLivePostgreSQLQueryPlanCapture (PR #777): plan
+  returned, DAG with logical_root, 64-char SHA256 fingerprint, fingerprint
+  stable across repeated identical queries.
+
+  BigQuery caveat: plan capture uses the post-execution Job Statistics API
+  (job.query_plan), not EXPLAIN — see cloud-saas w3. The live test must
+  therefore exercise execute_query() with capture_plans=True and assert on
+  the merged result fields, rather than calling capture_query_plan() directly
+  with a query string the way the PostgreSQL tests do.
+
+prerequisites:
+  - "query-plan-capture-cloud-saas w2 (Snowflake parser + wiring) and w3 (BigQuery plan capture) merged"
+  - "GitHub repository admin access to add Actions secrets"
+  - "Snowflake account (env: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USERNAME, SNOWFLAKE_PASSWORD, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, SNOWFLAKE_SCHEMA)"
+  - "GCP project with BigQuery API + service account JSON key (env: GOOGLE_APPLICATION_CREDENTIALS, BIGQUERY_PROJECT, BIGQUERY_DATASET)"
+
+prior_art:
+  - "tests/integration/platforms/test_postgresql_live.py — TestLivePostgreSQLQueryPlanCapture test class shape (PR #777)"
+  - "tests/integration/platforms/conftest.py — snowflake_credentials / bigquery_credentials fixtures with env-var skip"
+  - "tests/integration/platforms/test_snowflake_live.py — existing live test file with live_snowflake marker"
+  - "tests/integration/platforms/test_bigquery_live.py — existing live test file with live_bigquery marker"
+  - "_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml — parser implementation this TODO verifies"
+
+work:
+  - id: w1
+    summary: "Document and configure GitHub Actions secrets for Snowflake and BigQuery"
+    status: pending
+    notes: |
+      Secrets to add (names match the env vars the conftest fixtures read):
+        SNOWFLAKE_ACCOUNT, SNOWFLAKE_USERNAME, SNOWFLAKE_PASSWORD,
+        SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, SNOWFLAKE_SCHEMA,
+        BIGQUERY_PROJECT, BIGQUERY_DATASET,
+        GCP_SERVICE_ACCOUNT_KEY (the JSON key content)
+      BigQuery needs a file-based credential: add a workflow step that writes
+      GCP_SERVICE_ACCOUNT_KEY to a temp file and exports
+      GOOGLE_APPLICATION_CREDENTIALS pointing at it. Write the file with
+      restrictive permissions and never cat/echo it.
+
+  - id: w2
+    summary: "Add TestLiveSnowflakeQueryPlanCapture to test_snowflake_live.py"
+    status: pending
+    notes: |
+      Four-test shape from the PostgreSQL precedent. Snowflake plans come from
+      `EXPLAIN USING JSON <query>` (per cloud-saas w2), so
+      test_get_query_plan_returns_json can assert json.loads succeeds.
+      Fixture variant passes capture_plans=True via snowflake_credentials.
+      Keep queries trivial (SELECT 1) — warehouse compute bills per second
+      and auto-resume on first query is expected; use an XS warehouse.
+
+  - id: w3
+    summary: "Add TestLiveBigQueryQueryPlanCapture to test_bigquery_live.py"
+    status: pending
+    notes: |
+      BigQuery cannot follow the capture_query_plan(connection, query, id)
+      direct-call shape — plans come from the completed QueryJob (cloud-saas
+      w3 implements _capture_bq_plan). Instead:
+        - test_execute_query_with_capture_returns_plan: run
+          execute_query(..., capture_plans=True) on SELECT 1 and assert the
+          result dict contains query_plan and a 64-char plan_fingerprint.
+        - test_plan_fingerprint_stable: run the same query twice, compare
+          fingerprints from the result dicts.
+      SELECT 1 processes 0 bytes in BigQuery (no table scan), so the test
+      is free; do not query real tables.
+
+  - id: w4
+    summary: "Extend the nightly cloud-live-verification job with Snowflake and BigQuery"
+    status: pending
+    needs: [w2, w3]
+    notes: |
+      Add the new secrets as job-level env vars, add the
+      GOOGLE_APPLICATION_CREDENTIALS file-write step from w1, and extend the
+      pytest invocation marker expression to
+        -m "live_redshift or live_motherduck or live_snowflake or live_bigquery"
+      with the two new test files in the path list. If the
+      Redshift/MotherDuck job does not exist yet (TODOs landed out of order),
+      create the job following the postgres-integration pattern in nightly.yml
+      with only the Snowflake/BigQuery pieces. Nightly-only; never pr.yml.
+
+deps:
+  needs: ["query-plan-capture-cloud-saas"]
+
+must_preserve:
+  - "Live tests must skip (not fail) when credentials are absent — forks and contributors without secrets must stay green."
+  - "BigQuery test queries must process 0 bytes (SELECT 1, no table references) — plan capture must not incur scan billing."
+  - "Snowflake tests must not require a dedicated warehouse size — XS with auto-suspend is the assumed floor."
+  - "No secret values may appear in workflow logs; the GCP key file must not be echoed or uploaded as an artifact."
+  - "Existing tests in test_snowflake_live.py and test_bigquery_live.py must be untouched."
+
+approach: |
+  Blocked until query-plan-capture-cloud-saas lands the Snowflake parser (w2)
+  and BigQuery job-statistics capture (w3). Once unblocked, w2 and w3 here are
+  independent; w4 lands last. Secret configuration (w1) is a repo-admin action
+  that can happen any time — the job degrades to all-skip until secrets exist.
+
+anti_patterns:
+  - "DO NOT add these tests to pr.yml — PR-triggered cloud queries from arbitrary branches incur uncontrolled billing; nightly-only."
+  - "DO NOT call capture_query_plan() directly for BigQuery — plans come from the completed QueryJob, not a pre-execution EXPLAIN; test through execute_query()."
+  - "DO NOT query real tables in BigQuery live tests — SELECT 1 is free; table scans bill per byte."
+  - "DO NOT store the GCP service account JSON in the repo or write it to a tracked path — write to a runner temp file only."
+
+verification:
+  - description: "New live test classes collect under their markers"
+    command: "uv run -- python -m pytest tests/integration/platforms/test_snowflake_live.py tests/integration/platforms/test_bigquery_live.py -m 'live_snowflake or live_bigquery' --collect-only -q --override-ini='addopts='"
+    expected_output: "New plan capture tests listed for both files"
+  - description: "Tests skip cleanly without credentials"
+    command: "uv run -- python -m pytest tests/integration/platforms/test_snowflake_live.py -m live_snowflake --tb=short -q"
+    expected_output: "All tests skipped, 0 failures (when no credentials configured)"
+  - description: "Workflow YAML is valid"
+    command: "uv run -- pre-commit run check-yaml --files .github/workflows/nightly.yml"
+    expected_output: "check yaml...Passed"
+
+scope_limit:
+  only_modify:
+    - "tests/integration/platforms/test_snowflake_live.py"
+    - "tests/integration/platforms/test_bigquery_live.py"
+    - ".github/workflows/nightly.yml"
+    - "_project/TODO/platform-expansion/planning/query-plan-capture-cloud-live-snowflake-bigquery.yaml"
+
+success_metrics:
+  - "Snowflake and BigQuery plan capture verified against live services: DAG returned, 64-char fingerprint, stable across repeats."
+  - "Nightly job covers all four cloud platforms (Redshift, MotherDuck, Snowflake, BigQuery) under one credential-gated job."
+  - "Zero cloud spend on PR-triggered CI; BigQuery live tests process 0 bytes."
+
+open_questions:
+  - question: "Should the GCP service account key be replaced with GitHub OIDC workload identity federation instead of a long-lived JSON key secret?"
+    gating: false
+    affects: ["w1", "w4"]
+    default: "Start with the JSON key secret (simpler, matches GOOGLE_APPLICATION_CREDENTIALS convention); revisit OIDC if key rotation becomes a burden"
+
+metadata:
+  tags: [query-plan, snowflake, bigquery, ci, live-integration, secrets]
+  estimated_effort: "Small"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"


### PR DESCRIPTION
## Summary

Implements the CI-secrets decision for cloud platform plan capture verification as two TODO items:

| TODO | Platforms | Status |
|------|-----------|--------|
| `query-plan-capture-cloud-live-redshift-motherduck` | Redshift, MotherDuck | Unblocked — adapter wiring already exists (parser overrides + `_merge_plan_capture_into_result` in `execute_query`) |
| `query-plan-capture-cloud-live-snowflake-bigquery` | Snowflake, BigQuery | Hard-blocked on `query-plan-capture-cloud-saas` via `deps.needs` (no parsers exist yet) |

Both TODOs specify:
- Live plan capture test classes mirroring the PostgreSQL precedent from PR #777 (DAG returned, 64-char SHA256 fingerprint, fingerprint stability)
- A nightly-only `cloud-live-verification` CI job — never `pr.yml`, to keep cloud spend off PR-triggered runs
- Secret-presence gating via the existing conftest `get_env_or_skip` fixtures, so the job is skip-green before secrets are configured and on forks
- Zero-cost test queries (`SELECT 1`; BigQuery processes 0 bytes without table references)
- The BigQuery caveat that plans come from the post-execution Job Statistics API, so live tests must go through `execute_query()` rather than calling `capture_query_plan()` directly

## Validation

- [x] `validate_todo.py` passes for both files
- [x] `todo_cli.py check-graph` — no dangling references (75 items checked)
- [x] `tests/unit/test_todo_executable_docs.py` — 5 passed
- [x] `pre-commit run check-yaml` — passed

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_