### PR TITLE
docs(todo): add 5 follow-up TODOs for query-plan-capture review gaps

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cross-engine-conformance.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cross-engine-conformance.yaml
@@ -1,0 +1,100 @@
+id: query-plan-capture-cross-engine-conformance
+title: "Define a cross-engine plan-DAG conformance corpus and decide whether fingerprints are comparable across engines"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Operator-name harmonization was decided ad hoc in each parser with no shared conformance
+  target. Examples that may or may not be intended:
+    - ClickHouse maps every wrapper `Expression` node to PROJECT (inflating PROJECT count)
+    - Spark maps Exchange/codegen wrappers to OTHER
+    - Presto maps `Output` to PROJECT
+    - ClickHouse/Spark insert many transform/exchange nodes other engines do not emit
+
+  As a result there is no answer to the question "does the SAME logical query produce a
+  comparable harmonized DAG across engines?" — and therefore no basis for cross-engine
+  fingerprint or plan-shape comparison. This blocks one of the two plausible purposes of the
+  fingerprint (cross-engine comparison); the other purpose (per-engine within-version
+  regression detection) does not need it.
+
+  This TODO forces the decision and, if cross-engine comparison is in scope, builds the
+  missing artifact: a golden conformance corpus asserting invariants like "TPC-H Q3 yields a
+  DAG with exactly N JOINs and M base-table SCANs on every engine", independent of the
+  per-engine wrapper noise.
+
+prior_art:
+  - "benchbox/core/results/query_plan_models.py — LogicalOperatorType enum and get_structural_signature (the harmonization target)"
+  - "benchbox/core/query_plans/parsers/ — per-parser operator maps decided independently"
+  - "benchbox/core/query_plans/comparison.py — existing plan comparison entry point that would consume a conformance contract"
+
+work:
+  - id: w1
+    summary: "Decide the fingerprint's purpose: per-engine regression vs cross-engine comparison (or both)"
+    status: pending
+    notes: |
+      Document the intended use in query_plan_models.py. This gates everything: if cross-engine
+      comparison is out of scope, close w2/w3 as not-needed and instead document that fingerprints
+      are per-engine only. If in scope, proceed.
+  - id: w2
+    summary: "Build a cross-engine conformance corpus of canonical queries with expected DAG invariants"
+    needs: [w1]
+    status: pending
+    notes: |
+      For a small set of canonical queries (e.g. TPC-H Q1/Q3/Q5), record expected counts/shape of
+      the harmonized DAG (number of JOINs, base SCANs, AGGREGATEs) that every engine must satisfy.
+      Use recorded EXPLAIN fixtures per engine. Assert each parser's DAG meets the invariants,
+      ignoring engine-specific wrapper operators (Exchange/codegen/Expression).
+  - id: w3
+    summary: "Add a 'comparable subset' projection so wrapper noise does not break cross-engine equality"
+    needs: [w2]
+    status: pending
+    notes: |
+      If cross-engine comparison is wanted, add a normalization that drops OTHER/exchange/codegen
+      wrapper nodes before comparison, so the structural backbone (scans, joins, aggregates, sorts)
+      can be compared across engines. Keep it separate from the raw per-engine fingerprint.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "The existing per-engine raw fingerprint must remain available unchanged for within-engine regression detection."
+  - "No parser's operator mapping changes without a conformance test justifying it."
+
+approach: |
+  This is primarily a design-and-decision TODO (w1) that may close most of itself. Only build
+  the corpus and the comparable-subset projection if cross-engine comparison is an actual goal.
+  Reuse recorded EXPLAIN fixtures from the family TODOs rather than requiring live engines.
+
+anti_patterns:
+  - "DO NOT keep harmonizing operator names per parser without a shared target - because divergent maps make cross-engine comparison meaningless - define the conformance corpus first."
+  - "DO NOT force cross-engine equality on the raw fingerprint - because engines legitimately differ in physical wrappers - compare a wrapper-stripped subset instead if comparison is needed."
+
+verification:
+  - description: "Fingerprint purpose is documented and the corpus (if built) passes"
+    command: "uv run -- python -m pytest tests/unit/query_plans -k conformance -v"
+    expected_output: "Canonical queries meet the cross-engine DAG invariants, or the corpus is documented as out-of-scope"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/query_plan_models.py"
+    - "benchbox/core/query_plans/comparison.py"
+    - "tests/unit/query_plans/"
+    - "tests/fixtures/query_plans/"
+
+success_metrics:
+  - "The fingerprint's intended scope (per-engine vs cross-engine) is documented."
+  - "If cross-engine comparison is in scope, a conformance corpus asserts canonical-query DAG invariants across engines."
+
+open_questions:
+  - question: "Is cross-engine plan comparison an actual product goal, or are fingerprints purely per-engine regression keys?"
+    gating: true
+    affects: ["w2", "w3"]
+    default: "Treat fingerprints as per-engine within-version keys; build the cross-engine corpus only if a comparison feature is requested."
+
+metadata:
+  tags: [query-plan, fingerprint, harmonization, cross-engine, design]
+  estimated_effort: "Medium"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-fingerprint-estimate-leak.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-fingerprint-estimate-leak.yaml
@@ -1,0 +1,115 @@
+id: query-plan-capture-fingerprint-estimate-leak
+title: "Stop cost/cardinality estimates leaking into plan fingerprints; add a cross-parser signature-hygiene invariant"
+worktree: platform-expansion
+priority: Medium-High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  The plan fingerprint is documented (query_plan_models.py, added in #768) as a LOGICAL,
+  stats-INDEPENDENT structural hash: a VACUUM/ANALYZE or row-count change must NOT change it.
+  That contract is violated by at least one parser today.
+
+  The DuckDB parser (benchbox/core/query_plans/parsers/duckdb.py) folds an operator's raw
+  EXPLAIN `extra_info` — which includes an "Estimated Cardinality" — into signature-bearing
+  fields (join_conditions for JOIN, aggregation_functions for AGGREGATE, filter_expressions
+  for FILTER, sort_keys for SORT). Because get_structural_signature() hashes those fields,
+  a DuckDB JOIN/AGGREGATE/FILTER/SORT fingerprint CHANGES when the cardinality estimate
+  changes. This was confirmed empirically during #768: a GROUP BY fingerprint differed at
+  500 rows vs 5000 rows. The #768 contract was softened to "verify per engine" instead of
+  fixing the leak — this TODO fixes it and prevents regressions for the other six parsers.
+
+  Two-part fix:
+    1. Strip estimate/cost text (e.g. "Estimated Cardinality=...", "EC:", "rows=", "cost=")
+       from extra_info before storing it into signature-bearing fields, OR store the raw
+       extra_info only in physical_operator.platform_metadata (which is NOT hashed) and
+       extract only the structural predicate into the logical field.
+    2. Add a cross-parser invariant test asserting NO parser places cost/cardinality/estimate
+       text into any signature-bearing logical field, for every registered parser, driven by
+       fixtures that differ ONLY in row count / estimates.
+
+  This is distinct from query-plan-capture-fingerprint-literal-normalization: that TODO makes
+  FILTER LITERAL values opt-in-normalizable (a feature for cross-run seed differences); this
+  TODO removes ESTIMATE values that should never have been in the signature (a parser bug).
+
+prior_art:
+  - "benchbox/core/results/query_plan_models.py — get_structural_signature() and the stability contract docstring (#768)"
+  - "benchbox/core/query_plans/parsers/duckdb.py — folds extra_info incl. Estimated Cardinality into join_conditions/aggregation_functions/filter_expressions/sort_keys"
+  - "tests/unit/platforms/test_duckdb_plan_capture.py — index-stability tests added in #768 that the new invariant generalizes"
+
+work:
+  - id: w1
+    summary: "Quantify the leak: which parsers fold estimate/cost text into signature fields"
+    status: pending
+    notes: |
+      For each registered parser (duckdb, postgresql, redshift, datafusion, sqlite, presto,
+      trino, clickhouse, spark) capture two fixtures of the same query that differ only in
+      table size / estimates, and record which produce different fingerprints. DuckDB is the
+      known offender; confirm the full list before editing.
+  - id: w2
+    summary: "Strip estimate/cost tokens from signature-bearing fields in offending parsers"
+    needs: [w1]
+    status: pending
+    notes: |
+      In each offending parser, keep the raw EXPLAIN detail in physical_operator.platform_metadata
+      (not hashed) and place only the structural part (join keys, group keys, filter predicate
+      WITHOUT the cardinality) into the logical field. Prefer a shared helper, e.g.
+      strip_estimates(text), in the parsers base module so the rule lives in one place.
+  - id: w3
+    summary: "Add a cross-parser signature-hygiene invariant test"
+    needs: [w2]
+    status: pending
+    notes: |
+      Create tests/unit/query_plans/test_fingerprint_hygiene.py. For every parser in the
+      registry, parse two estimate-only-different fixtures and assert identical plan_fingerprint.
+      Also assert get_structural_signature() contains no digit-bearing 'cardinality'/'cost'/
+      'rows='/'EC:' token. This locks the contract for current and future parsers.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Genuine logical-shape changes (join order/type, added aggregation, different predicate columns) must still change the fingerprint."
+  - "physical_operator.platform_metadata may keep the raw EXPLAIN detail including estimates for display/debugging."
+  - "Existing parser unit tests must pass with at most fixture-value updates."
+
+approach: |
+  Confirm the offenders empirically (w1) rather than assuming only DuckDB. Move the raw
+  estimate text out of the hashed path (w2) using a single shared strip helper. Lock it with
+  a registry-wide invariant test (w3) so the stats-independence promise becomes enforceable
+  rather than aspirational, and update the query_plan_models.py contract docstring to drop the
+  "verify per engine" caveat once the invariant holds.
+
+anti_patterns:
+  - "DO NOT solve this by removing the fields from get_structural_signature entirely - because join keys / group keys / predicates ARE structural and must stay in the hash - only strip the estimate/cost tokens."
+  - "DO NOT special-case DuckDB - because the leak can recur in any parser that folds extra_info - enforce the rule with a registry-wide invariant test."
+  - "DO NOT conflate this with literal normalization - because estimates are an accidental bug while literals are an intentional design choice - keep the two TODOs separate."
+
+verification:
+  - description: "DuckDB fingerprint is stable across row-count change"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_duckdb_plan_capture.py -k fingerprint -v"
+    expected_output: "GROUP BY/JOIN fingerprint identical at small vs large row counts"
+  - description: "Cross-parser signature-hygiene invariant passes"
+    command: "uv run -- python -m pytest tests/unit/query_plans/test_fingerprint_hygiene.py -v"
+    expected_output: "No registered parser leaks estimate/cost text into the signature"
+  - description: "Full query_plans suite green"
+    command: "uv run -- python -m pytest tests/unit/core/query_plans/ tests/unit/query_plans/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/query_plans/parsers/"
+    - "benchbox/core/results/query_plan_models.py"
+    - "tests/unit/query_plans/test_fingerprint_hygiene.py"
+    - "tests/unit/platforms/test_duckdb_plan_capture.py"
+
+success_metrics:
+  - "DuckDB JOIN/AGGREGATE/FILTER/SORT fingerprints are invariant to cardinality-estimate changes."
+  - "A registry-wide invariant test forbids estimate/cost text in signature-bearing fields."
+  - "The query_plan_models.py stability contract no longer needs the per-engine stats-independence caveat."
+
+metadata:
+  tags: [query-plan, fingerprint, duckdb, parsers, correctness, invariant]
+  estimated_effort: "Medium"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-parser-live-validation.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-parser-live-validation.yaml
@@ -1,0 +1,114 @@
+id: query-plan-capture-parser-live-validation
+title: "Track and validate plan parsers that were only tested against synthetic fixtures"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Several plan parsers were implemented and their TODOs marked Completed without ever being
+  run against real EXPLAIN output, because no live instance was available:
+    - PrestoTrinoQueryPlanParser (#773): fixtures synthesized from documented FORMAT JSON
+    - ClickHouseQueryPlanParser (#775): fixtures synthesized from documented EXPLAIN PLAN
+    - SparkQueryPlanParser / Databricks (#778): fixture synthesized from documented EXPLAIN EXTENDED
+
+  Each parser and its test fixtures encode the SAME assumptions about output shape, so green
+  unit tests prove self-consistency, not correctness against a real engine. Two concrete risks:
+    1. Field-shape drift: the parser assumes, e.g., "Trino returns the JSON in one row",
+       "ClickHouse returns one row per plan line", "Spark EXPLAIN EXTENDED has a single
+       == Physical Plan == section". If a real driver chunks rows differently or a newer
+       engine version changes wording, get_query_plan's joined text is wrong, the parser
+       returns None, and capture silently degrades — with every unit test still green.
+    2. "Completed" overstates reality: the TODO state cannot distinguish code-merged from
+       validated-against-a-real-engine.
+
+  This TODO does NOT require provisioning clusters now. It makes the gap explicit and
+  trackable, and adds the validation hooks so it can be closed when credentials exist.
+
+prior_art:
+  - "benchbox/core/query_plans/parsers/presto_trino.py, clickhouse.py, spark.py — synthetic-fixture parsers"
+  - "tests/fixtures/query_plans/ — recorded (synthetic) EXPLAIN samples"
+  - "tests/integration/test_postgresql_plan_capture_integration.py (#768) — skipif(POSTGRESQL_HOST) live-integration pattern to replicate"
+
+work:
+  - id: w1
+    summary: "Add a fixture-provenance marker and a parser validation-status registry"
+    status: pending
+    notes: |
+      Annotate each tests/fixtures/query_plans/*.json|*.txt with provenance (synthetic vs
+      captured-from <engine> <version>), e.g. a sibling .meta.json or a header comment. Add a
+      small doc/table (docs or a module constant) listing each parser and whether it has been
+      validated against real output, so "Completed" can be read against ground truth.
+  - id: w2
+    summary: "Add CI-gated live integration tests for Presto/Trino, ClickHouse, and Spark"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror tests/integration/test_postgresql_plan_capture_integration.py: one file per engine,
+      module-level skipif on the relevant *_HOST/credentials env var. Each runs a real
+      EXPLAIN over a live instance and asserts the parser yields a non-None QueryPlanDAG with a
+      fingerprint. Skipped by default; runnable in a UAT/CI job that provisions the engine.
+  - id: w3
+    summary: "Harden get_query_plan row-shape handling against driver chunking differences"
+    needs: [w1]
+    status: pending
+    notes: |
+      Audit the get_query_plan implementations (Presto base, ClickHouse adapter, Databricks,
+      Spark helper) for the assumption about how many rows the driver returns. Make the text
+      join robust to both single-row-full-text and one-row-per-line shapes, and add a unit
+      test for each shape so a future driver change cannot silently zero out capture.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Live integration tests must skip gracefully (not fail) when credentials/instances are absent."
+  - "Existing synthetic-fixture unit tests remain as fast, no-credential coverage."
+
+approach: |
+  Treat this as the honest bookkeeping the family rollout skipped: mark what is synthetic
+  (w1), add the live hooks so it can be closed later (w2), and remove the most likely silent
+  failure mode — row-shape assumptions — with real unit coverage now (w3). w3 is the only part
+  that delivers value without credentials and should be prioritized.
+
+anti_patterns:
+  - "DO NOT mark this Completed until at least the row-shape hardening (w3) lands - because that is the part that does not need a live cluster and removes a real silent-failure path."
+  - "DO NOT hard-fail CI when an engine is unavailable - because these are opt-in live tests - gate every one on an explicit credential/host env var."
+  - "DO NOT delete the synthetic fixtures when live ones arrive - because they provide fast no-credential coverage - keep both and mark provenance."
+
+verification:
+  - description: "Live integration tests skip cleanly without credentials"
+    command: "uv run -- python -m pytest tests/integration -k plan_capture -v"
+    expected_output: "Tests skipped with a clear 'live <engine> not available' message"
+  - description: "get_query_plan row-shape unit tests pass for single-row and per-line shapes"
+    command: "uv run -- python -m pytest tests/unit/platforms -k 'plan and (row_shape or chunk)' -v"
+    expected_output: "Both driver row shapes parse to non-empty plan text"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/presto_trino_adapter_base.py"
+    - "benchbox/platforms/athena.py"
+    - "benchbox/platforms/clickhouse/adapter.py"
+    - "benchbox/platforms/databricks/adapter.py"
+    - "benchbox/platforms/_spark_helpers.py"
+    - "tests/fixtures/query_plans/"
+    - "tests/integration/"
+    - "tests/unit/platforms/"
+
+success_metrics:
+  - "Every synthetic fixture is marked as synthetic with the engine/version it models."
+  - "A parser-validation status list exists and is read against the 'Completed' TODO state."
+  - "get_query_plan tolerates both single-row and one-row-per-line driver outputs, with unit tests."
+  - "CI-gated live integration tests exist for Presto/Trino, ClickHouse, and Spark and skip cleanly by default."
+
+open_questions:
+  - question: "Should a parser be allowed to remain 'Completed' while validated only against synthetic fixtures, or should TODO status carry an explicit validation level (synthetic vs live)?"
+    gating: false
+    affects: ["w1"]
+    default: "Add a validation level to status reporting; keep code 'Completed' but surface 'synthetic-only' until a live run confirms it."
+
+metadata:
+  tags: [query-plan, presto, trino, clickhouse, spark, databricks, testing, validation, integration]
+  estimated_effort: "Medium"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-raw-output-retention.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-raw-output-retention.yaml
@@ -1,0 +1,83 @@
+id: query-plan-capture-raw-output-retention
+title: "Define a retention/size policy for raw_explain_output stored on every captured plan"
+worktree: platform-expansion
+priority: Low
+status: Not Started
+category: Platform Expansion
+
+description: |
+  Every captured QueryPlanDAG retains raw_explain_output (query_plan_models.py). For verbose
+  formats this is large per query per stream — Spark EXPLAIN EXTENDED stores all four plan
+  sections (Parsed/Analyzed/Optimized/Physical), and a throughput run multiplies that by query
+  count times stream count. capture_query_plan() already warns when a serialized plan exceeds
+  ~100KB, but there is no policy controlling how much raw text is retained in the results
+  bundle, so bundle size can grow unbounded with no operator control.
+
+  This TODO defines and implements a retention policy: e.g. a config flag to drop or truncate
+  raw_explain_output once the structured DAG and fingerprint are computed (the structural data
+  is what downstream comparison needs; the raw text is for debugging/display), plus a documented
+  default and a size cap.
+
+prior_art:
+  - "benchbox/core/results/query_plan_models.py — raw_explain_output field and estimate_serialized_size()"
+  - "benchbox/platforms/base/result_capture.py — the ~100KB large-plan warning (capture_query_plan)"
+
+work:
+  - id: w1
+    summary: "Measure raw_explain_output contribution to bundle size across formats"
+    status: pending
+    notes: |
+      Quantify raw text size per captured query for the verbose formats (Spark EXPLAIN EXTENDED,
+      DuckDB EXPLAIN ANALYZE FORMAT JSON) at a representative query count and stream count.
+  - id: w2
+    summary: "Add a retain/truncate/drop policy for raw_explain_output with a documented default"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a config option (e.g. plan_raw_output=full|truncated|none, default truncated with a
+      size cap) honored where the plan is serialized into the results bundle. Keep the structured
+      DAG and fingerprint regardless; only the raw text is governed.
+  - id: w3
+    summary: "Test the policy and document the default"
+    needs: [w2]
+    status: pending
+    notes: |
+      Unit-test that each policy value retains/truncates/drops raw_explain_output as specified and
+      that the structured DAG/fingerprint are unaffected. Document the default and trade-offs.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "plan_fingerprint and the structured QueryPlanDAG must be retained regardless of the raw-output policy."
+  - "Default behavior change (if any) must be documented; existing bundles must remain readable."
+
+approach: |
+  Measure first (w1) to pick a sane default, then add a single policy knob (w2) at the
+  serialization boundary, then test/document (w3). Low priority but cheap insurance against
+  unbounded bundle growth on large throughput runs.
+
+anti_patterns:
+  - "DO NOT drop the structured DAG or fingerprint to save space - because those are the comparison artifacts - only govern the raw_explain_output text."
+  - "DO NOT make 'none' the default - because raw text is valuable for debugging capture/parse issues - default to a truncated form with a size cap."
+
+verification:
+  - description: "Raw-output retention policy behaves per setting"
+    command: "uv run -- python -m pytest tests/unit -k 'plan and raw_output' -v"
+    expected_output: "full/truncated/none retain/truncate/drop raw text; DAG+fingerprint unaffected"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/query_plan_models.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "tests/unit/"
+
+success_metrics:
+  - "A documented raw_explain_output retention policy exists with a size-capped default."
+  - "Structured DAG and fingerprint are retained under every policy value."
+
+metadata:
+  tags: [query-plan, storage, results-bundle, retention]
+  estimated_effort: "Small"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
@@ -1,0 +1,126 @@
+id: query-plan-capture-strict-error-swallow
+title: "Fix strict-mode PlanCaptureError swallowing in SQLite and MotherDuck execute_query"
+worktree: platform-expansion
+priority: High
+status: Not Started
+category: Platform Expansion
+
+description: |
+  PR #769 factored plan capture into ResultCaptureMixin._merge_plan_capture_into_result()
+  and capture_query_plan() re-raises PlanCaptureError when strict_plan_capture=True
+  (benchbox/platforms/base/result_capture.py:682, 720). DuckDB and the adapters wired in
+  PRs #773/#775/#778 are safe: they either have `except PlanCaptureError: raise` before
+  the general handler, or call the helper OUTSIDE the execute_query try block.
+
+  SQLite and MotherDuck are NOT safe. They call _merge_plan_capture_into_result() INSIDE
+  the execute_query try whose tail is a broad `except Exception`, with no PlanCaptureError
+  re-raise:
+    - SQLite      benchbox/platforms/sqlite.py:569  (merge), :573 (except Exception)
+    - MotherDuck  benchbox/platforms/motherduck.py:314 (merge), :317 (except Exception)
+
+  Consequently, when strict_plan_capture=True and plan capture fails (parser error,
+  EXPLAIN failure, timeout), the PlanCaptureError is caught by the broad except and the
+  query is reported as status=FAILED even though the SQL executed successfully. This both
+  hides the real (capture) error behind a misleading query failure and corrupts benchmark
+  results by marking a successful query as failed.
+
+  The fix mirrors the canonical pattern: move the capture call OUTSIDE the try (after the
+  except/finally) so a strict PlanCaptureError propagates, matching PostgreSQL,
+  PrestoTrinoAdapterBase, Athena, ClickHouse, Spark, and Databricks.
+
+prior_art:
+  - "benchbox/platforms/duckdb.py — `except PlanCaptureError: raise` before the general except (safe pattern)"
+  - "benchbox/platforms/athena.py — capture placed after try/except/finally so strict errors propagate"
+  - "benchbox/platforms/base/result_capture.py:682 — capture_query_plan re-raises PlanCaptureError in strict mode"
+
+work:
+  - id: w1
+    summary: "SQLite: move _merge_plan_capture_into_result outside the execute_query try"
+    status: pending
+    notes: |
+      In benchbox/platforms/sqlite.py execute_query(), stop calling the merge helper at
+      line 569 inside the try. Build/return result on the success path, then call
+      self._merge_plan_capture_into_result(result, connection, query, query_id) after the
+      try/except, returning result. The validation-failed early-return path (if any) must
+      still short-circuit before the post-try capture.
+  - id: w2
+    summary: "MotherDuck: move _merge_plan_capture_into_result outside the execute_query try"
+    status: pending
+    notes: |
+      Same change in benchbox/platforms/motherduck.py: relocate the merge call at line 314
+      to after the try/except so result_dict is captured outside the broad except. result_dict
+      status is SUCCESS at that point on the success path.
+  - id: w3
+    summary: "Add strict-mode propagation tests for SQLite and MotherDuck"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      In tests/unit/platforms/test_sqlite_plan_capture.py and test_motherduck_plan_capture.py,
+      add a test that constructs the adapter with strict_plan_capture=True, monkeypatches
+      capture_query_plan to raise PlanCaptureError, and asserts the error PROPAGATES from
+      execute_query (pytest.raises) rather than being swallowed into a status=FAILED dict.
+      Also assert that with strict_plan_capture=False the same failure is silent (status=SUCCESS).
+
+deps:
+  needs: []
+
+must_preserve:
+  - "With strict_plan_capture=False, plan capture failure must remain silent and the query must report SUCCESS."
+  - "execute_query result dict shape must not change for non-plan fields."
+  - "A genuine query-execution failure must still be caught and returned as status=FAILED."
+
+approach: |
+  This is the same restructure already applied to Athena/ClickHouse/Spark/Databricks in
+  PRs #775/#778: pull the capture call out of the try so PlanCaptureError propagates in
+  strict mode. Each adapter change is a small relocation plus one test.
+
+  NOTE: query-plan-capture-isolation-phase-design proposes moving plan capture into a
+  separate post-measurement phase entirely. If that lands first, the capture call leaves
+  execute_query and this bug disappears at the source — coordinate so this fix is not done
+  twice. See open_questions.
+
+anti_patterns:
+  - "DO NOT add `except PlanCaptureError: raise` as a second except clause when the simpler fix is to move capture outside the try - because the project's other adapters standardized on the outside-the-try placement - relocate the call instead."
+  - "DO NOT change the non-strict behavior - because benchmarks rely on capture being a silent best-effort by default - only the strict-mode propagation path changes."
+
+verification:
+  - description: "SQLite strict-mode capture failure propagates"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -k strict -v"
+    expected_output: "PlanCaptureError propagates from execute_query; non-strict stays SUCCESS"
+  - description: "MotherDuck strict-mode capture failure propagates"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_motherduck_plan_capture.py -k strict -v"
+    expected_output: "PlanCaptureError propagates from execute_query; non-strict stays SUCCESS"
+  - description: "Full platform suite green"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/sqlite.py"
+    - "benchbox/platforms/motherduck.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_motherduck_plan_capture.py"
+
+success_metrics:
+  - "SQLite and MotherDuck propagate PlanCaptureError from execute_query when strict_plan_capture=True."
+  - "Non-strict capture failure remains silent with status=SUCCESS for both adapters."
+  - "No adapter in the fleet captures inside a broad-except try without PlanCaptureError propagation."
+
+open_questions:
+  - question: "Should this point fix land now, or be absorbed into query-plan-capture-isolation-phase-design which moves capture out of execute_query entirely?"
+    gating: false
+    affects: ["w1", "w2"]
+    default: "Land the point fix now (small, removes a live strict-mode correctness bug); the isolation-phase redesign supersedes the placement later."
+
+files_affected:
+  modified:
+    - "benchbox/platforms/sqlite.py"
+    - "benchbox/platforms/motherduck.py"
+    - "tests/unit/platforms/test_sqlite_plan_capture.py"
+    - "tests/unit/platforms/test_motherduck_plan_capture.py"
+
+metadata:
+  tags: [query-plan, sqlite, motherduck, correctness, strict-mode, error-handling]
+  estimated_effort: "Small"
+  created_date: "2026-06-11"
+  last_updated: "2026-06-11T00:00:00-04:00"


### PR DESCRIPTION
## Summary

A holistic review of the query-plan-capture effort (PRs #766–#778) surfaced findings **not covered** by the parallel session's 7 follow-up TODOs (`postgresql-dml-guard`, `isolation-phase-design`, `timeout-mechanism-fix`, `display-decouple`, `docs-overhead-correction`, `fingerprint-literal-normalization`, `e2e-pipeline-test`). This PR adds 5 TODOs for the gaps. Each was verified against the actual code on `develop`, and all pass `validate_todo.py`.

| TODO | Priority | Verified evidence |
|---|---|---|
| `strict-error-swallow` | High | `sqlite.py:569`/`:573`, `motherduck.py:314`/`:317` — capture inside broad `except`, no `PlanCaptureError` re-raise → strict-mode capture failure mislabels a successful query as `FAILED` |
| `fingerprint-estimate-leak` | Medium-High | DuckDB parser folds `Estimated Cardinality` into signature fields → fingerprint changes with row count (confirmed empirically in #768); adds a cross-parser hygiene invariant |
| `parser-live-validation` | Medium | Presto/Trino, ClickHouse, Spark parsers marked `Completed` while only tested against synthetic fixtures they co-define; adds provenance + CI-gated live tests + row-shape hardening |
| `cross-engine-conformance` | Medium | Operator harmonization decided ad hoc per parser; forces the per-engine-vs-cross-engine fingerprint decision |
| `raw-output-retention` | Low | `raw_explain_output` retained per plan with no size policy (Spark stores all 4 EXPLAIN sections × queries × streams) |

## Relationship to the parallel session's TODOs
- **Complementary, not duplicative** — none of these 5 overlap the other 7 by summary.
- `fingerprint-estimate-leak` is deliberately kept **distinct** from their `fingerprint-literal-normalization`: estimates in the hash are a parser **bug**; literal normalization is an intentional **feature**.
- `strict-error-swallow` notes an explicit interaction with their `isolation-phase-design` (if capture moves out of `execute_query`, the swallow is fixed at the source) via an `open_question`.

## Not filed here (escalated separately)
- Re-converging the inline capture blocks added in #773/#775/#778 onto the base helper — this **conflicts with** their `isolation-phase-design` and shouldn't be filed until that architecture decision is made.

## Test plan
- [x] `validate_todo.py` passes for all 5 files
- [x] `make todo-reindex` clean
- [ ] Content review of the 5 TODOs

https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX8debJJbKNYsSAAtjvKcr)_