### PR TITLE
fix(plan-capture): guard PostgreSQL DML against EXPLAIN ANALYZE double-execution

### DIFF
--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -697,12 +697,25 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         query: str,
         explain_options: dict[str, Any] | None = None,
     ) -> str | None:
-        """Get query execution plan using EXPLAIN (ANALYZE, FORMAT JSON)."""
+        """Get query execution plan using EXPLAIN (FORMAT JSON).
+
+        SELECT queries include ANALYZE and BUFFERS for actual timing and I/O.
+        DML statements (INSERT/UPDATE/DELETE/MERGE/COPY) use FORMAT JSON only:
+        EXPLAIN ANALYZE physically re-executes the statement, which would mutate
+        data a second time. The plan structure is still captured; execution
+        statistics are absent for DML.
+        """
+        from benchbox.platforms.base.result_capture import is_dml_query
+
         cursor = connection.cursor()
 
         # Use FORMAT JSON so PostgreSQLQueryPlanParser can parse the output.
-        # ANALYZE and BUFFERS give actual timing and I/O info.
-        options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]
+        # ANALYZE and BUFFERS give actual timing and I/O info for SELECT queries.
+        # DML queries are downgraded to FORMAT JSON only to prevent double-execution.
+        if is_dml_query(query):
+            options = ["FORMAT JSON"]
+        else:
+            options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]
         if explain_options:
             if explain_options.get("verbose"):
                 options.append("VERBOSE")

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -135,9 +135,7 @@ class TestPostgreSQLPlanCapture:
         adapter.get_query_plan(conn, dml_query)
 
         call_args = cursor.execute.call_args[0][0]
-        assert "ANALYZE" not in call_args.upper(), (
-            f"EXPLAIN ANALYZE must not be used for DML query: {dml_query!r}"
-        )
+        assert "ANALYZE" not in call_args.upper(), f"EXPLAIN ANALYZE must not be used for DML query: {dml_query!r}"
         assert "FORMAT JSON" in call_args.upper()
 
     def test_get_query_plan_select_uses_analyze(self, adapter):

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -114,6 +114,46 @@ class TestPostgreSQLPlanCapture:
         assert "FORMAT JSON" in call_args.upper()
         assert "FORMAT TEXT" not in call_args.upper()
 
+    @pytest.mark.parametrize(
+        "dml_query",
+        [
+            "INSERT INTO t VALUES (1)",
+            "UPDATE t SET a = 1 WHERE id = 2",
+            "DELETE FROM t WHERE id = 3",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a",
+            "COPY t FROM '/tmp/data.csv'",
+            "  insert into t values (1)",  # leading whitespace + lowercase
+        ],
+    )
+    def test_get_query_plan_dml_omits_analyze(self, adapter, dml_query):
+        """DML queries must not include ANALYZE to prevent double-execution."""
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('{"Plan":{}}',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, dml_query)
+
+        call_args = cursor.execute.call_args[0][0]
+        assert "ANALYZE" not in call_args.upper(), (
+            f"EXPLAIN ANALYZE must not be used for DML query: {dml_query!r}"
+        )
+        assert "FORMAT JSON" in call_args.upper()
+
+    def test_get_query_plan_select_uses_analyze(self, adapter):
+        """SELECT queries must still use EXPLAIN ANALYZE for actual timing data."""
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('{"Plan":{}}',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, "SELECT count(*) FROM orders")
+
+        call_args = cursor.execute.call_args[0][0]
+        assert "ANALYZE" in call_args.upper()
+        assert "BUFFERS" in call_args.upper()
+        assert "FORMAT JSON" in call_args.upper()
+
 
 class TestPostgreSQLSubclassInheritance:
     """Verify TimescaleDB, CedarDB, and pg_mooncake inherit the parser without overrides."""


### PR DESCRIPTION
## Summary

- `PostgreSQLAdapter.get_query_plan()` always issued `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)`. PostgreSQL's `EXPLAIN ANALYZE` physically re-executes the target statement, so INSERT/UPDATE/DELETE/MERGE/COPY queries were mutating data **twice** when `--capture-plans` was active.
- Apply the same DML guard already present in DuckDB (PR #767) and MotherDuck: detect DML via the shared `is_dml_query()` helper from `result_capture.py` and downgrade to `EXPLAIN (FORMAT JSON)` for those statements.
- SELECT queries continue to use `ANALYZE + BUFFERS` for actual timing and I/O data.
- TimescaleDB, CedarDB, and pg_mooncake subclass `PostgreSQLAdapter` and inherit the fix with zero code changes.

## What changed

**`benchbox/platforms/postgresql.py`** — `get_query_plan()`:
```python
# Before (always ANALYZE — re-executes DML)
options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]

# After (DML gets FORMAT JSON only)
if is_dml_query(query):
    options = ["FORMAT JSON"]
else:
    options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]
```

**`tests/unit/platforms/test_postgresql_plan_capture.py`** — new tests:
- `test_get_query_plan_dml_omits_analyze` — parametrized over INSERT/UPDATE/DELETE/MERGE/COPY + lowercase/whitespace variants
- `test_get_query_plan_select_uses_analyze` — confirms SELECT still gets ANALYZE + BUFFERS

## Test plan

- [x] `uv run -- python -m pytest tests/unit/platforms/test_postgresql_plan_capture.py -v` → 17 passed
- [x] `make pr-preflight` → green (lint + type + fast tests)

https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWmf6Zb9j85uUz5kaMzjda)_