### PR TITLE
fix(plan-capture): treat CTAS/CMV/SELECT-INTO as writes in shared is_dml_query guard

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-ctas-write-ddl-guard.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-ctas-write-ddl-guard.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-ctas-write-ddl-guard
 title: "Close the CTAS/CMV write-DDL blind spot in is_dml_query so capture does not re-execute writes"
 worktree: platform-expansion
 priority: Medium-High
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -47,7 +47,7 @@ prior_art:
 work:
   - id: w1
     summary: "Extend the shared detector to recognize CTAS / CREATE MATERIALIZED VIEW AS / SELECT INTO as writes"
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/base/result_capture.py, add detection for:
         - ^CREATE (OR REPLACE )?(GLOBAL |LOCAL )?(TEMP(ORARY)? )?TABLE ... AS\b  (CTAS)
@@ -62,7 +62,7 @@ work:
   - id: w2
     summary: "Confirm DuckDB/MotherDuck get_query_plan now downgrade ANALYZE for CTAS/CMV"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       No adapter code change should be required if both call the shared helper, but
       verify that with the corrected helper, get_query_plan() uses FORMAT JSON
@@ -70,7 +70,7 @@ work:
   - id: w3
     summary: "Add unit tests for CTAS / CMV / SELECT INTO detection and the DuckDB/MotherDuck guard"
     needs: [w1, w2]
-    status: pending
+    status: done
     notes: |
       Extend tests/unit/platforms/test_duckdb_plan_capture.py and the is_dml_query
       contract test: assert CTAS, CREATE OR REPLACE TABLE AS, CREATE MATERIALIZED
@@ -122,4 +122,4 @@ metadata:
   tags: [query-plan, duckdb, motherduck, postgresql, dml, ctas, correctness]
   estimated_effort: "Small"
   created_date: "2026-06-11"
-  last_updated: "2026-06-11T00:00:00-04:00"
+  last_updated: "2026-06-12T00:00:00-04:00"

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -75,33 +75,43 @@ _DML_LEADING_RE = re.compile(r"^(?:INSERT|UPDATE|DELETE|MERGE|COPY)\b", re.IGNOR
 # CTE-prefixed DML (``WITH cte AS (...) INSERT INTO ...``). COPY is excluded:
 # it cannot appear inside a CTE, and its leading form is already caught above.
 _DML_AFTER_CTE_RE = re.compile(r"\b(?:INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
-# Write-producing DDL: CREATE TABLE ... AS <query> (CTAS) and
+# Write-producing DDL prefixes: CREATE TABLE ... AS <query> (CTAS) and
 # CREATE MATERIALIZED VIEW ... AS <query>. Both materialize the query's rows,
-# so EXPLAIN ANALYZE would write them a second time. Requiring ``AS`` to be
-# followed by a query keyword (optionally parenthesized) keeps plain column
-# DDL out: a generated column's ``GENERATED ALWAYS AS (expr)`` is followed by
-# an expression, not SELECT/WITH/VALUES/TABLE/FROM, so it does not match.
-_CTAS_RE = re.compile(
-    r"^CREATE\s+(?:OR\s+REPLACE\s+)?(?:GLOBAL\s+|LOCAL\s+)?(?:TEMP(?:ORARY)?\s+|UNLOGGED\s+)?TABLE\b"
-    r".*?\bAS\s*\(*\s*(?:SELECT|WITH|VALUES|TABLE|FROM)\b",
-    re.IGNORECASE | re.DOTALL,
+# so EXPLAIN ANALYZE would write them a second time. The prefix alone is not
+# enough — _has_top_level_keyword() must also find a paren-depth-0 ``AS``
+# introducing a query, which keeps plain column DDL out: a generated column's
+# ``GENERATED ALWAYS AS (expr)`` and any literal text like ``DEFAULT 'AS
+# SELECT'`` sit inside the column-definition parentheses, so they never match.
+_CREATE_TABLE_PREFIX_RE = re.compile(
+    r"^CREATE\s+(?:OR\s+REPLACE\s+)?(?:GLOBAL\s+|LOCAL\s+)?(?:TEMP(?:ORARY)?\s+|UNLOGGED\s+)?TABLE\b",
+    re.IGNORECASE,
 )
-_CREATE_MATERIALIZED_VIEW_RE = re.compile(
-    r"^CREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\b.*?\bAS\s*\(*\s*(?:SELECT|WITH|VALUES|TABLE|FROM)\b",
-    re.IGNORECASE | re.DOTALL,
+_CREATE_MATERIALIZED_VIEW_PREFIX_RE = re.compile(
+    r"^CREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\b",
+    re.IGNORECASE,
 )
+# ``AS`` introducing a query body: optionally parenthesized SELECT/WITH/VALUES/
+# TABLE/FROM (DuckDB allows ``CREATE TABLE t AS FROM s``; PostgreSQL allows
+# ``CREATE TABLE t2 AS TABLE t1``).
+_AS_QUERY_RE = re.compile(r"AS\s*\(*\s*(?:SELECT|WITH|VALUES|TABLE|FROM)\b", re.IGNORECASE)
 _SELECT_LEADING_RE = re.compile(r"^SELECT\b", re.IGNORECASE)
+_WITH_LEADING_RE = re.compile(r"^WITH\b", re.IGNORECASE)
 _WORD_CHARS_RE = re.compile(r"\w")
 
 
-def _select_has_top_level_into(statement: str) -> bool:
-    """Return True when a SELECT statement contains a paren-depth-0 ``INTO``.
+def _has_top_level_keyword(statement: str, keyword: str, followed_by: re.Pattern[str] | None = None) -> bool:
+    """Return True when ``keyword`` appears at paren depth 0 outside quotes.
 
-    ``SELECT ... INTO <table>`` writes rows into a new table, so it must be
-    treated as a write. The scan skips single-quoted string literals and
-    double-quoted identifiers, and ignores ``INTO`` inside parentheses so a
-    subquery's text (or a literal like ``'INTO'``) does not trigger a match.
+    Used to find the statement-level ``INTO`` of ``SELECT ... INTO <table>``
+    and the statement-level ``AS`` of CTAS / CREATE MATERIALIZED VIEW. The
+    scan skips single-quoted string literals (including ``''`` escapes) and
+    double-quoted identifiers, and ignores anything inside parentheses, so a
+    subquery's text, a literal like ``'INTO'``, or a generated-column ``AS``
+    in a column list never triggers a match. When ``followed_by`` is given,
+    the keyword only counts if that pattern matches at the keyword's position.
     """
+    keyword = keyword.upper()
+    klen = len(keyword)
     depth = 0
     i = 0
     n = len(statement)
@@ -124,10 +134,10 @@ def _select_has_top_level_into(statement: str) -> bool:
             depth += 1
         elif ch == ")":
             depth -= 1
-        elif depth == 0 and ch in "iI" and statement[i : i + 4].upper() == "INTO":
+        elif depth == 0 and ch.upper() == keyword[0] and statement[i : i + klen].upper() == keyword:
             before_ok = i == 0 or not _WORD_CHARS_RE.match(statement[i - 1])
-            after_ok = i + 4 >= n or not _WORD_CHARS_RE.match(statement[i + 4])
-            if before_ok and after_ok:
+            after_ok = i + klen >= n or not _WORD_CHARS_RE.match(statement[i + klen])
+            if before_ok and after_ok and (followed_by is None or followed_by.match(statement, i)):
                 return True
         i += 1
     return False
@@ -183,15 +193,17 @@ def is_dml_query(query: str) -> bool:
     # leading-verb check alone misses it. Conservatively treat a WITH-prefixed
     # statement that contains a DML verb as DML — worst case a read-only CTE
     # query loses ANALYZE stats, which is far cheaper than a double mutation.
-    if re.match(r"^WITH\b", statement, re.IGNORECASE) and _DML_AFTER_CTE_RE.search(statement):
+    if _WITH_LEADING_RE.match(statement) and _DML_AFTER_CTE_RE.search(statement):
         return True
     # Write-producing DDL: CTAS and CREATE MATERIALIZED VIEW ... AS materialize
     # the query's result rows, so EXPLAIN ANALYZE would write the data twice
     # (or fail on "table already exists" for the non-REPLACE form).
-    if _CTAS_RE.match(statement) or _CREATE_MATERIALIZED_VIEW_RE.match(statement):
+    if (
+        _CREATE_TABLE_PREFIX_RE.match(statement) or _CREATE_MATERIALIZED_VIEW_PREFIX_RE.match(statement)
+    ) and _has_top_level_keyword(statement, "AS", followed_by=_AS_QUERY_RE):
         return True
     # SELECT ... INTO <table> writes its result rows into a new table.
-    if _SELECT_LEADING_RE.match(statement) and _select_has_top_level_into(statement):
+    if _SELECT_LEADING_RE.match(statement) and _has_top_level_keyword(statement, "INTO"):
         return True
     return False
 

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -75,6 +75,62 @@ _DML_LEADING_RE = re.compile(r"^(?:INSERT|UPDATE|DELETE|MERGE|COPY)\b", re.IGNOR
 # CTE-prefixed DML (``WITH cte AS (...) INSERT INTO ...``). COPY is excluded:
 # it cannot appear inside a CTE, and its leading form is already caught above.
 _DML_AFTER_CTE_RE = re.compile(r"\b(?:INSERT|UPDATE|DELETE|MERGE)\b", re.IGNORECASE)
+# Write-producing DDL: CREATE TABLE ... AS <query> (CTAS) and
+# CREATE MATERIALIZED VIEW ... AS <query>. Both materialize the query's rows,
+# so EXPLAIN ANALYZE would write them a second time. Requiring ``AS`` to be
+# followed by a query keyword (optionally parenthesized) keeps plain column
+# DDL out: a generated column's ``GENERATED ALWAYS AS (expr)`` is followed by
+# an expression, not SELECT/WITH/VALUES/TABLE/FROM, so it does not match.
+_CTAS_RE = re.compile(
+    r"^CREATE\s+(?:OR\s+REPLACE\s+)?(?:GLOBAL\s+|LOCAL\s+)?(?:TEMP(?:ORARY)?\s+|UNLOGGED\s+)?TABLE\b"
+    r".*?\bAS\s*\(*\s*(?:SELECT|WITH|VALUES|TABLE|FROM)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_CREATE_MATERIALIZED_VIEW_RE = re.compile(
+    r"^CREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\b.*?\bAS\s*\(*\s*(?:SELECT|WITH|VALUES|TABLE|FROM)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+_SELECT_LEADING_RE = re.compile(r"^SELECT\b", re.IGNORECASE)
+_WORD_CHARS_RE = re.compile(r"\w")
+
+
+def _select_has_top_level_into(statement: str) -> bool:
+    """Return True when a SELECT statement contains a paren-depth-0 ``INTO``.
+
+    ``SELECT ... INTO <table>`` writes rows into a new table, so it must be
+    treated as a write. The scan skips single-quoted string literals and
+    double-quoted identifiers, and ignores ``INTO`` inside parentheses so a
+    subquery's text (or a literal like ``'INTO'``) does not trigger a match.
+    """
+    depth = 0
+    i = 0
+    n = len(statement)
+    while i < n:
+        ch = statement[i]
+        if ch == "'":
+            i += 1
+            while i < n:
+                if statement[i] == "'":
+                    if i + 1 < n and statement[i + 1] == "'":  # escaped '' inside literal
+                        i += 2
+                        continue
+                    break
+                i += 1
+        elif ch == '"':
+            i += 1
+            while i < n and statement[i] != '"':
+                i += 1
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and ch in "iI" and statement[i : i + 4].upper() == "INTO":
+            before_ok = i == 0 or not _WORD_CHARS_RE.match(statement[i - 1])
+            after_ok = i + 4 >= n or not _WORD_CHARS_RE.match(statement[i + 4])
+            if before_ok and after_ok:
+                return True
+        i += 1
+    return False
 
 
 def _strip_leading_sql_comments(statement: str) -> str:
@@ -96,19 +152,27 @@ def _strip_leading_sql_comments(statement: str) -> str:
 
 
 def is_dml_query(query: str) -> bool:
-    """Return True for data-changing DML statements (INSERT/UPDATE/DELETE/MERGE/COPY).
+    """Return True for statements that write data when executed.
 
     Used to guard plan capture against double-execution: adapters that capture
-    plans via ``EXPLAIN ANALYZE`` (DuckDB, MotherDuck) physically re-run the
-    statement, so a DML query would mutate data twice. Callers downgrade to a
-    non-ANALYZE ``EXPLAIN`` for these statements.
+    plans via ``EXPLAIN ANALYZE`` (DuckDB, MotherDuck, PostgreSQL) physically
+    re-run the statement, so a data-writing query would mutate data twice.
+    Callers downgrade to a non-ANALYZE ``EXPLAIN`` for these statements.
 
-    Detection covers the data-modifying verbs INSERT/UPDATE/DELETE/MERGE/COPY,
-    including when they are preceded by a leading ``WITH`` CTE clause. DDL
-    (CREATE/DROP/ALTER/TRUNCATE) is intentionally excluded: DDL does not produce
-    duplicate data mutations, so it does not need the ANALYZE guard. Leading
-    line and block comments are stripped first so a commented preamble (e.g. a
-    ``/* query 12 */`` banner) does not mask the verb.
+    Detection covers the data-modifying verbs INSERT/UPDATE/DELETE/MERGE/COPY
+    (including when they are preceded by a leading ``WITH`` CTE clause) and the
+    write-producing DDL shapes that materialize a query's rows:
+
+    - ``CREATE [OR REPLACE] TABLE ... AS <query>`` (CTAS)
+    - ``CREATE [OR REPLACE] MATERIALIZED VIEW ... AS <query>``
+    - ``SELECT ... INTO <table>``
+
+    Non-writing DDL (plain ``CREATE TABLE`` with column definitions,
+    ``CREATE INDEX``, ``DROP``, ``ALTER``, ``TRUNCATE``) is intentionally
+    excluded: re-running its EXPLAIN writes no rows, so it keeps ANALYZE where
+    applicable. Leading line and block comments are stripped first so a
+    commented preamble (e.g. a ``/* query 12 */`` banner) does not mask the
+    verb.
     """
     statement = _strip_leading_sql_comments(query)
     if not statement:
@@ -120,6 +184,14 @@ def is_dml_query(query: str) -> bool:
     # statement that contains a DML verb as DML — worst case a read-only CTE
     # query loses ANALYZE stats, which is far cheaper than a double mutation.
     if re.match(r"^WITH\b", statement, re.IGNORECASE) and _DML_AFTER_CTE_RE.search(statement):
+        return True
+    # Write-producing DDL: CTAS and CREATE MATERIALIZED VIEW ... AS materialize
+    # the query's result rows, so EXPLAIN ANALYZE would write the data twice
+    # (or fail on "table already exists" for the non-REPLACE form).
+    if _CTAS_RE.match(statement) or _CREATE_MATERIALIZED_VIEW_RE.match(statement):
+        return True
+    # SELECT ... INTO <table> writes its result rows into a new table.
+    if _SELECT_LEADING_RE.match(statement) and _select_has_top_level_into(statement):
         return True
     return False
 

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -68,6 +68,7 @@ class TestIsDmlQueryHelper:
             "SELECT copy_total, merge_flag FROM t",  # identifiers, not verbs (word boundary)
             "CREATE TABLE t (id INT)",  # column DDL writes no rows
             "CREATE TABLE t (x INT GENERATED ALWAYS AS (x + 1) STORED)",  # generated column AS is not CTAS
+            "CREATE TABLE t (note TEXT DEFAULT 'AS SELECT')",  # literal inside column DDL is not CTAS
             "CREATE INDEX idx ON t (id)",
             "CREATE VIEW v AS SELECT 1",  # plain view stores no rows
             "DROP TABLE t",

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -40,10 +40,41 @@ class TestIsDmlQueryHelper:
     @pytest.mark.parametrize(
         "query",
         [
+            "CREATE TABLE t AS SELECT * FROM s",
+            "create or replace table t as select 1",
+            "CREATE TEMP TABLE t AS SELECT 1",
+            "CREATE TEMPORARY TABLE t AS (SELECT 1)",
+            "CREATE UNLOGGED TABLE t AS SELECT 1",
+            "CREATE TABLE t (a, b) AS SELECT x, y FROM s",  # CTAS with column alias list
+            "CREATE TABLE t AS\nWITH cte AS (SELECT 1) SELECT * FROM cte",
+            "CREATE TABLE t AS VALUES (1), (2)",
+            "/* banner */ CREATE TABLE t AS SELECT 1",
+            "CREATE MATERIALIZED VIEW v AS SELECT 1",
+            "CREATE OR REPLACE MATERIALIZED VIEW v AS (SELECT * FROM t)",
+            "SELECT * INTO new_t FROM t",
+            "select x into archive_t from t where x > 1",
+        ],
+    )
+    def test_write_producing_ddl_detected(self, query):
+        from benchbox.platforms.base.result_capture import is_dml_query
+
+        assert is_dml_query(query) is True
+
+    @pytest.mark.parametrize(
+        "query",
+        [
             "SELECT 1",
             "WITH cte AS (SELECT 1) SELECT * FROM cte",
             "SELECT copy_total, merge_flag FROM t",  # identifiers, not verbs (word boundary)
-            "CREATE TABLE t (id INT)",  # DDL is excluded
+            "CREATE TABLE t (id INT)",  # column DDL writes no rows
+            "CREATE TABLE t (x INT GENERATED ALWAYS AS (x + 1) STORED)",  # generated column AS is not CTAS
+            "CREATE INDEX idx ON t (id)",
+            "CREATE VIEW v AS SELECT 1",  # plain view stores no rows
+            "DROP TABLE t",
+            "ALTER TABLE t ADD COLUMN y INT",
+            "TRUNCATE TABLE t",
+            "SELECT * FROM t WHERE note = 'INTO the void'",  # INTO inside a string literal
+            "SELECT * FROM (SELECT 1 INTO_X) sub",  # parenthesized, not a top-level INTO
             "EXPLAIN SELECT 1",
             "",
             "-- only a comment",
@@ -100,11 +131,33 @@ class TestDuckDBDMLPlanGuard:
         assert "ANALYZE" not in conn.execute.call_args[0][0].upper(), f"DML must not run ANALYZE: {dml!r}"
 
     @pytest.mark.parametrize(
+        "write_ddl",
+        [
+            "CREATE TABLE t2 AS SELECT * FROM t",
+            "CREATE OR REPLACE TABLE t2 AS SELECT * FROM t",
+            "CREATE MATERIALIZED VIEW mv AS SELECT * FROM t",
+            "SELECT * INTO t2 FROM t",
+        ],
+    )
+    def test_ctas_query_does_not_use_analyze(self, write_ddl):
+        """CTAS/CMV/SELECT-INTO materialize rows; EXPLAIN ANALYZE would write them twice."""
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [("logical_plan", "{}")]
+
+        adapter.get_query_plan(conn, write_ddl)
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" not in called_sql, f"Write DDL must not run EXPLAIN ANALYZE: {called_sql}"
+        assert "FORMAT JSON" in called_sql
+
+    @pytest.mark.parametrize(
         "non_dml",
         [
             "SELECT * FROM t WHERE id = 1",
             "WITH cte AS (SELECT 1) SELECT * FROM cte",
             "SELECT copy_count, update_ts FROM t",  # column names starting with DML verbs
+            "CREATE TABLE t (id INT)",  # column DDL writes no rows
         ],
     )
     def test_non_dml_query_still_uses_analyze(self, non_dml):

--- a/tests/unit/platforms/test_motherduck_plan_capture.py
+++ b/tests/unit/platforms/test_motherduck_plan_capture.py
@@ -50,6 +50,33 @@ class TestMotherDuckDMLPlanGuard:
         assert "ANALYZE" not in called_sql, f"DML must not run EXPLAIN ANALYZE: {called_sql}"
         assert "FORMAT JSON" in called_sql
 
+    @pytest.mark.parametrize(
+        "write_ddl",
+        [
+            "CREATE TABLE t2 AS SELECT * FROM t",
+            "CREATE OR REPLACE TABLE t2 AS SELECT * FROM t",
+            "CREATE MATERIALIZED VIEW mv AS SELECT * FROM t",
+            "SELECT * INTO t2 FROM t",
+        ],
+    )
+    def test_ctas_query_does_not_use_analyze(self, adapter, write_ddl):
+        """CTAS/CMV/SELECT-INTO materialize rows; EXPLAIN ANALYZE would write them twice."""
+        conn = _mock_conn()
+
+        adapter.get_query_plan(conn, write_ddl)
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" not in called_sql, f"Write DDL must not run EXPLAIN ANALYZE: {called_sql}"
+        assert "FORMAT JSON" in called_sql
+
+    def test_plain_create_table_still_uses_analyze(self, adapter):
+        conn = _mock_conn()
+
+        adapter.get_query_plan(conn, "CREATE TABLE t (id INT)")
+
+        called_sql = conn.execute.call_args[0][0].upper()
+        assert "ANALYZE" in called_sql, "Column DDL writes no rows; ANALYZE must be kept"
+
     def test_select_query_still_uses_analyze(self, adapter):
         conn = _mock_conn()
 

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -138,6 +138,27 @@ class TestPostgreSQLPlanCapture:
         assert "ANALYZE" not in call_args.upper(), f"EXPLAIN ANALYZE must not be used for DML query: {dml_query!r}"
         assert "FORMAT JSON" in call_args.upper()
 
+    @pytest.mark.parametrize(
+        "write_ddl",
+        [
+            "CREATE TABLE t2 AS SELECT * FROM t",
+            "CREATE MATERIALIZED VIEW mv AS SELECT * FROM t",
+            "SELECT * INTO t2 FROM t",
+        ],
+    )
+    def test_get_query_plan_ctas_omits_analyze(self, adapter, write_ddl):
+        """CTAS/CMV/SELECT-INTO materialize rows; EXPLAIN ANALYZE would write them twice."""
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('{"Plan":{}}',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, write_ddl)
+
+        call_args = cursor.execute.call_args[0][0]
+        assert "ANALYZE" not in call_args.upper(), f"EXPLAIN ANALYZE must not be used for write DDL: {write_ddl!r}"
+        assert "FORMAT JSON" in call_args.upper()
+
     def test_get_query_plan_select_uses_analyze(self, adapter):
         """SELECT queries must still use EXPLAIN ANALYZE for actual timing data."""
         cursor = MagicMock()


### PR DESCRIPTION
## Summary

- **Close the CTAS double-execution gap** in the shared `is_dml_query()` write classifier (`benchbox/platforms/base/result_capture.py`): `CREATE [OR REPLACE] TABLE ... AS <query>`, `CREATE [OR REPLACE] MATERIALIZED VIEW ... AS <query>`, and `SELECT ... INTO <table>` are now classified as writes, so plan capture downgrades `EXPLAIN ANALYZE` to a plain `EXPLAIN` instead of physically re-running the write (silent double-write for `OR REPLACE`, "table already exists" failure otherwise).
- **Precise matching, not a CREATE sweep**: detection requires the statement-level `AS <query>` / top-level `INTO` shape via a paren-depth + quote-aware scanner, so plain column DDL (`CREATE TABLE t (id INT)`), generated columns (`GENERATED ALWAYS AS (expr)`), literals like `DEFAULT 'AS SELECT'`, `CREATE INDEX`, and plain `CREATE VIEW` stay non-write and keep ANALYZE.
- **Corrects the false docstring** claiming "DDL does not produce duplicate data mutations".
- Because PostgreSQL (#784), DuckDB, and MotherDuck (#767) all reuse this one helper, the single fix covers all three; adapter-level non-ANALYZE assertions added for each.
- Verified empirically that DuckDB executes `EXPLAIN (FORMAT JSON) CREATE TABLE ... AS` without materializing the table.

Closes TODO `query-plan-capture-ctas-write-ddl-guard` (marked Completed).

## Test plan

- [x] `uv run -- python -m pytest tests/unit/platforms/test_duckdb_plan_capture.py tests/unit/platforms/test_motherduck_plan_capture.py tests/unit/platforms/test_postgresql_plan_capture.py -q` — 101 passed
- [x] `uv run -- python -m pytest tests/unit/platforms/ -q` — 7548 passed, 2 skipped
- [x] `validate_todo.py` on the TODO YAML + `make todo-reindex`

https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg)_