### PR TITLE
docs: make squash auto-merge the default for dev PRs in remote sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ elsewhere.** Conversely, write work on a worktree ends at `make pr-open`,
 not at `git push` — `make pr-open` is in the pre-approved set.
 Default write-task close-out: implement → `code review` (fix every finding,
 incl. nits) → `make pr-open` (see AGENTS.md).
+**Dev PRs land via squash auto-merge once CI passes** — `make pr-open`
+enables it automatically; in remote/cloud sessions (no `make`/`gh`,
+PRs created via GitHub MCP), enable squash auto-merge right after
+opening the PR instead of waiting for a manual merge instruction.
 TPC-DS SF<1 requires the patched dsdgen bundled with BenchBox.
 No `-o "addopts="` with pytest.
 **Efficiency**: long output → `/tmp/<slug>.log`, report summary + tail.


### PR DESCRIPTION
## Summary

CLAUDE.md pre-approves `gh pr merge --auto --squash` and AGENTS.md notes that `make pr-open` enables squash auto-merge, but nothing instructed remote/cloud sessions (where PRs are created via the GitHub MCP tools and `make`/`gh` are unavailable) to enable auto-merge after opening a PR. PR #780 sat green waiting for a manual merge instruction as a result.

Adds an explicit rule to the CLAUDE.md write-task close-out: dev PRs land via squash auto-merge once CI passes, and remote sessions must enable it right after opening the PR.

## Test plan

- [x] Docs-only change; no code paths affected

https://claude.ai/code/session_01TTL2Z9r1AsZYjhCrJ3J4bz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTL2Z9r1AsZYjhCrJ3J4bz)_