### PR TITLE
fix(plan-capture): stop swallowing strict-mode PlanCaptureError in SQLite, MotherDuck, and Redshift

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-strict-error-swallow
 title: "Fix strict-mode PlanCaptureError swallowing in SQLite and MotherDuck execute_query"
 worktree: platform-expansion
 priority: High
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -36,7 +36,7 @@ prior_art:
 work:
   - id: w1
     summary: "SQLite: move _merge_plan_capture_into_result outside the execute_query try"
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/sqlite.py execute_query(), stop calling the merge helper at
       line 569 inside the try. Build/return result on the success path, then call
@@ -45,7 +45,7 @@ work:
       still short-circuit before the post-try capture.
   - id: w2
     summary: "MotherDuck: move _merge_plan_capture_into_result outside the execute_query try"
-    status: pending
+    status: done
     notes: |
       Same change in benchbox/platforms/motherduck.py: relocate the merge call at line 314
       to after the try/except so result_dict is captured outside the broad except. result_dict
@@ -53,7 +53,7 @@ work:
   - id: w3
     summary: "Add strict-mode propagation tests for SQLite and MotherDuck"
     needs: [w1, w2]
-    status: pending
+    status: done
     notes: |
       In tests/unit/platforms/test_sqlite_plan_capture.py and test_motherduck_plan_capture.py,
       add a test that constructs the adapter with strict_plan_capture=True, monkeypatches
@@ -123,4 +123,4 @@ metadata:
   tags: [query-plan, sqlite, motherduck, correctness, strict-mode, error-handling]
   estimated_effort: "Small"
   created_date: "2026-06-11"
-  last_updated: "2026-06-11T00:00:00-04:00"
+  last_updated: "2026-06-12T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-strict-error-swallow.yaml
@@ -116,8 +116,10 @@ files_affected:
   modified:
     - "benchbox/platforms/sqlite.py"
     - "benchbox/platforms/motherduck.py"
+    - "benchbox/platforms/redshift.py"
     - "tests/unit/platforms/test_sqlite_plan_capture.py"
     - "tests/unit/platforms/test_motherduck_plan_capture.py"
+    - "tests/unit/platforms/test_redshift_plan_capture.py"
 
 metadata:
   tags: [query-plan, sqlite, motherduck, correctness, strict-mode, error-handling]

--- a/benchbox/platforms/motherduck.py
+++ b/benchbox/platforms/motherduck.py
@@ -302,18 +302,6 @@ class MotherDuckAdapter(PlatformAdapter):
                 "first_row": rows[0] if rows else None,
                 "error": None,
             }
-
-            # Display plan in console when --show-query-plans is active.
-            # Skip here when --capture-plans is also active: capture_query_plan below
-            # already calls get_query_plan (running EXPLAIN ANALYZE); calling
-            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
-            if not self.capture_plans:
-                self.display_query_plan_if_enabled(conn, query, query_id)
-
-            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
-            self._merge_plan_capture_into_result(result_dict, conn, query, query_id)
-
-            return result_dict
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             logger.error(f"Query {query_id} failed after {execution_time:.2f}s: {e}")
@@ -326,6 +314,21 @@ class MotherDuckAdapter(PlatformAdapter):
                 "error": str(e),
                 "error_type": type(e).__name__,
             }
+
+        # Display plan in console when --show-query-plans is active.
+        # Skip here when --capture-plans is also active: capture_query_plan below
+        # already calls get_query_plan (running EXPLAIN ANALYZE); calling
+        # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+        if not self.capture_plans:
+            self.display_query_plan_if_enabled(conn, query, query_id)
+
+        # Capture and merge structured query plan (SUCCESS-guarded in the helper).
+        # Deliberately outside the try: with strict_plan_capture=True a capture
+        # failure raises PlanCaptureError, which must propagate instead of being
+        # swallowed by the broad except and mislabeling the successful query FAILED.
+        self._merge_plan_capture_into_result(result_dict, conn, query, query_id)
+
+        return result_dict
 
     def get_platform_info(self, connection: Any = None) -> dict[str, Any]:
         """Get MotherDuck platform information for results traceability."""

--- a/benchbox/platforms/redshift.py
+++ b/benchbox/platforms/redshift.py
@@ -2114,18 +2114,6 @@ class RedshiftAdapter(PlatformAdapter):
             # Map query_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = query_stats
 
-            # Display plan in console when --show-query-plans is active.
-            # Skip here when --capture-plans is also active: capture_query_plan below
-            # already calls get_query_plan (running EXPLAIN); calling
-            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
-            if not self.capture_plans:
-                self.display_query_plan_if_enabled(connection, query, query_id)
-
-            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
-            self._merge_plan_capture_into_result(result_dict, connection, query, query_id)
-
-            return result_dict
-
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             error_type = type(e).__name__
@@ -2143,6 +2131,21 @@ class RedshiftAdapter(PlatformAdapter):
             }
         finally:
             cursor.close()
+
+        # Display plan in console when --show-query-plans is active.
+        # Skip here when --capture-plans is also active: capture_query_plan below
+        # already calls get_query_plan (running EXPLAIN); calling
+        # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+        if not self.capture_plans:
+            self.display_query_plan_if_enabled(connection, query, query_id)
+
+        # Capture and merge structured query plan (SUCCESS-guarded in the helper).
+        # Deliberately outside the try: with strict_plan_capture=True a capture
+        # failure raises PlanCaptureError, which must propagate instead of being
+        # swallowed by the broad except and mislabeling the successful query FAILED.
+        self._merge_plan_capture_into_result(result_dict, connection, query, query_id)
+
+        return result_dict
 
     def _extract_table_name(self, statement: str) -> str | None:
         """Extract table name from CREATE TABLE statement."""

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -513,8 +513,8 @@ class SQLiteAdapter(PlatformAdapter):
         self.log_verbose(f"Executing query {query_id}")
         self.log_very_verbose(f"Query SQL (first 200 chars): {query[:200]}{'...' if len(query) > 200 else ''}")
 
+        cursor = connection.cursor()
         try:
-            cursor = connection.cursor()
             cursor.execute(query)
             results = cursor.fetchall()
 
@@ -567,6 +567,8 @@ class SQLiteAdapter(PlatformAdapter):
                 "rows_returned": 0,
                 "error": str(e),
             }
+        finally:
+            cursor.close()
 
         # Display plan in console when --show-query-plans is active.
         # Skip here when --capture-plans is also active: capture_query_plan below

--- a/benchbox/platforms/sqlite.py
+++ b/benchbox/platforms/sqlite.py
@@ -558,18 +558,6 @@ class SQLiteAdapter(PlatformAdapter):
             # Include full results for SQLite compatibility
             result["results"] = results
 
-            # Display plan in console when --show-query-plans is active.
-            # Skip here when --capture-plans is also active: capture_query_plan below
-            # already calls get_query_plan (running EXPLAIN); calling
-            # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
-            if not self.capture_plans:
-                self.display_query_plan_if_enabled(connection, query, query_id)
-
-            # Capture and merge structured query plan (SUCCESS-guarded in the helper)
-            self._merge_plan_capture_into_result(result, connection, query, query_id)
-
-            return result
-
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             return {
@@ -579,6 +567,21 @@ class SQLiteAdapter(PlatformAdapter):
                 "rows_returned": 0,
                 "error": str(e),
             }
+
+        # Display plan in console when --show-query-plans is active.
+        # Skip here when --capture-plans is also active: capture_query_plan below
+        # already calls get_query_plan (running EXPLAIN); calling
+        # display_query_plan_if_enabled separately would issue EXPLAIN a second time.
+        if not self.capture_plans:
+            self.display_query_plan_if_enabled(connection, query, query_id)
+
+        # Capture and merge structured query plan (SUCCESS-guarded in the helper).
+        # Deliberately outside the try: with strict_plan_capture=True a capture
+        # failure raises PlanCaptureError, which must propagate instead of being
+        # swallowed by the broad except and mislabeling the successful query FAILED.
+        self._merge_plan_capture_into_result(result, connection, query, query_id)
+
+        return result
 
     def run_power_test(self, benchmark, **kwargs) -> dict[str, Any]:
         """Run TPC power test (not implemented for SQLite)."""

--- a/tests/unit/platforms/test_motherduck_plan_capture.py
+++ b/tests/unit/platforms/test_motherduck_plan_capture.py
@@ -58,3 +58,50 @@ class TestMotherDuckDMLPlanGuard:
         called_sql = conn.execute.call_args[0][0].upper()
         assert "ANALYZE" in called_sql, "Non-DML SELECT must still use EXPLAIN ANALYZE"
         assert "FORMAT JSON" in called_sql
+
+
+class TestMotherDuckStrictPlanCapture:
+    """strict_plan_capture must propagate PlanCaptureError from execute_query.
+
+    The capture call sits OUTSIDE execute_query's broad except: a capture
+    failure on a successful query must surface as PlanCaptureError in strict
+    mode, not mislabel the query status=FAILED.
+    """
+
+    @staticmethod
+    def _break_plan_capture(adapter, monkeypatch):
+        def boom(connection, query):
+            raise RuntimeError("EXPLAIN blew up")
+
+        monkeypatch.setattr(adapter, "get_query_plan", boom)
+
+    def test_strict_capture_failure_propagates(self, monkeypatch):
+        from benchbox.core.errors import PlanCaptureError
+
+        adapter = MotherDuckAdapter(token="test-token", capture_plans=True, strict_plan_capture=True)
+        self._break_plan_capture(adapter, monkeypatch)
+        conn = _mock_conn()
+
+        with pytest.raises(PlanCaptureError):
+            adapter.execute_query(conn, "SELECT * FROM t", "q_strict")
+
+    def test_non_strict_capture_failure_is_silent(self, monkeypatch):
+        adapter = MotherDuckAdapter(token="test-token", capture_plans=True, strict_plan_capture=False)
+        self._break_plan_capture(adapter, monkeypatch)
+        conn = _mock_conn()
+
+        result = adapter.execute_query(conn, "SELECT * FROM t", "q_nonstrict")
+
+        assert result["status"] == "SUCCESS"
+        assert "query_plan" not in result
+
+    def test_strict_mode_does_not_mask_real_query_failure(self):
+        """A genuine SQL error must still return status=FAILED, not raise."""
+        adapter = MotherDuckAdapter(token="test-token", capture_plans=True, strict_plan_capture=True)
+        conn = MagicMock()
+        conn.execute.side_effect = RuntimeError("no such table: t")
+
+        result = adapter.execute_query(conn, "SELECT * FROM t", "q_bad")
+
+        assert result["status"] == "FAILED"
+        assert "no such table" in result["error"]

--- a/tests/unit/platforms/test_redshift_plan_capture.py
+++ b/tests/unit/platforms/test_redshift_plan_capture.py
@@ -125,3 +125,57 @@ class TestRedshiftPlanCapture:
 
         call_args = cursor.execute.call_args[0][0].upper()
         assert "EXPLAIN ANALYZE" not in call_args, "Redshift does not support EXPLAIN ANALYZE"
+
+
+class TestRedshiftStrictPlanCapture:
+    """strict_plan_capture must propagate PlanCaptureError from execute_query.
+
+    The capture call sits OUTSIDE execute_query's broad except: a capture
+    failure on a successful query must surface as PlanCaptureError in strict
+    mode, not mislabel the query status=FAILED.
+    """
+
+    @staticmethod
+    def _make_adapter(monkeypatch, strict):
+        monkeypatch.setattr("benchbox.platforms.redshift.redshift_connector", MagicMock(), raising=False)
+        adapter = RedshiftAdapter(**_STUB_CREDS, capture_plans=True, strict_plan_capture=strict)
+        monkeypatch.setattr(adapter, "_get_query_statistics", lambda *a, **k: {})
+
+        def boom(connection, query, explain_options=None):
+            raise RuntimeError("EXPLAIN blew up")
+
+        monkeypatch.setattr(adapter, "get_query_plan", boom)
+        return adapter
+
+    def test_strict_capture_failure_propagates(self, monkeypatch):
+        from benchbox.core.errors import PlanCaptureError
+
+        adapter = self._make_adapter(monkeypatch, strict=True)
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+
+        with pytest.raises(PlanCaptureError):
+            adapter.execute_query(connection=conn, query="SELECT 1", query_id="rq_strict", validate_row_count=False)
+
+    def test_non_strict_capture_failure_is_silent(self, monkeypatch):
+        adapter = self._make_adapter(monkeypatch, strict=False)
+        conn, cursor = _make_connection()
+        cursor.fetchall.return_value = [(0, "col1")]
+
+        result = adapter.execute_query(
+            connection=conn, query="SELECT 1", query_id="rq_nonstrict", validate_row_count=False
+        )
+
+        assert result["status"] == "SUCCESS"
+        assert "query_plan" not in result
+
+    def test_strict_mode_does_not_mask_real_query_failure(self, monkeypatch):
+        """A genuine SQL error must still return status=FAILED, not raise."""
+        adapter = self._make_adapter(monkeypatch, strict=True)
+        conn = MagicMock()
+        conn.cursor.return_value.execute.side_effect = RuntimeError("no such table: t")
+
+        result = adapter.execute_query(connection=conn, query="SELECT 1", query_id="rq_bad", validate_row_count=False)
+
+        assert result["status"] == "FAILED"
+        assert "no such table" in result["error"]

--- a/tests/unit/platforms/test_sqlite_plan_capture.py
+++ b/tests/unit/platforms/test_sqlite_plan_capture.py
@@ -249,3 +249,47 @@ class TestSQLiteParserModernFormat:
             dag = parser.parse_explain_output("test_q", plan_text)
             assert dag is not None
             assert dag.logical_root is not None
+
+
+class TestSQLiteStrictPlanCapture:
+    """strict_plan_capture must propagate PlanCaptureError from execute_query.
+
+    The capture call sits OUTSIDE execute_query's broad except: a capture
+    failure on a successful query must surface as PlanCaptureError in strict
+    mode, not mislabel the query status=FAILED.
+    """
+
+    @staticmethod
+    def _break_plan_capture(adapter, monkeypatch):
+        def boom(connection, query, explain_options=None):
+            raise RuntimeError("EXPLAIN blew up")
+
+        monkeypatch.setattr(adapter, "get_query_plan", boom)
+
+    def test_strict_capture_failure_propagates(self, conn, monkeypatch):
+        from benchbox.core.errors import PlanCaptureError
+
+        adapter = SQLiteAdapter(capture_plans=True, strict_plan_capture=True)
+        self._break_plan_capture(adapter, monkeypatch)
+
+        with pytest.raises(PlanCaptureError):
+            adapter.execute_query(conn, "SELECT * FROM orders", "q_strict", validate_row_count=False)
+
+    def test_non_strict_capture_failure_is_silent(self, conn, monkeypatch):
+        adapter = SQLiteAdapter(capture_plans=True, strict_plan_capture=False)
+        self._break_plan_capture(adapter, monkeypatch)
+
+        result = adapter.execute_query(conn, "SELECT * FROM orders", "q_nonstrict", validate_row_count=False)
+
+        assert result["status"] == "SUCCESS"
+        assert "query_plan" not in result
+        assert result["rows_returned"] == 2
+
+    def test_strict_mode_does_not_mask_real_query_failure(self, conn):
+        """A genuine SQL error must still return status=FAILED, not raise."""
+        adapter = SQLiteAdapter(capture_plans=True, strict_plan_capture=True)
+
+        result = adapter.execute_query(conn, "SELECT * FROM no_such_table", "q_bad", validate_row_count=False)
+
+        assert result["status"] == "FAILED"
+        assert result["error"]


### PR DESCRIPTION
## Summary

- **SQLite and MotherDuck** called `_merge_plan_capture_into_result()` inside `execute_query`'s broad `except Exception` with no `PlanCaptureError` re-raise, so with `strict_plan_capture=True` a capture failure (parser error, EXPLAIN failure, timeout) mislabeled a **successful** query as `status=FAILED` — hiding the real capture error and corrupting benchmark results. The capture call (and the internally-guarded plan display) now sits **outside** the try, mirroring the canonical PostgreSQL/Athena/ClickHouse/Spark placement.
- **Redshift** (found during code review) had the identical defect at `redshift.py:2125`; the same relocation is applied, so the TODO's success metric — *no adapter in the fleet captures inside a broad-except try without PlanCaptureError propagation* — now holds (DuckDB/DataFusion re-raise explicitly; everyone else captures outside the try).
- Non-strict behavior is unchanged: capture failure stays a silent no-op with `status=SUCCESS`, and a genuine SQL failure still returns `status=FAILED`.
- Also closes a pre-existing SQLite cursor leak in `execute_query` via `try/finally`.
- Tests per adapter: strict propagation (`pytest.raises(PlanCaptureError)`), non-strict silence, and real-query-failure-still-FAILED.

Closes TODO `query-plan-capture-strict-error-swallow` (marked Completed).

## Test plan

- [x] `uv run -- python -m pytest tests/unit/platforms/test_sqlite_plan_capture.py -k strict -v` — 3 passed
- [x] `uv run -- python -m pytest tests/unit/platforms/test_motherduck_plan_capture.py -k strict -v` — 3 passed
- [x] `uv run -- python -m pytest tests/unit/platforms/test_redshift_plan_capture.py -k strict -v` — 3 passed
- [x] `uv run -- python -m pytest tests/unit/platforms/ -q` — 7522 passed, 2 skipped
- [x] `validate_todo.py` + `make todo-reindex`

https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg)_