### PR TITLE
fix(plan-capture): make the capture timeout actually return control to the caller

### DIFF
--- a/_project/TODO/main/planning/query-plan-capture-timeout-mechanism-fix.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-timeout-mechanism-fix.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-timeout-mechanism-fix
 title: "Fix plan capture timeout: ThreadPoolExecutor shutdown blocks despite TimeoutError"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Core Functionality
 
 description: |
@@ -56,7 +56,7 @@ prior_art:
 work:
   - id: w1
     summary: "Replace the with-block with explicit executor.shutdown(wait=False) on timeout"
-    status: pending
+    status: done
     notes: |
       Refactor result_capture.py:606-624:
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -79,7 +79,7 @@ work:
   - id: w2
     summary: "Add unit test asserting that a timed-out capture returns promptly"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Mock get_query_plan() to sleep for 10s. Set plan_capture_timeout_seconds=0.1.
       Assert capture_query_plan() returns (None, approx_0.1ms) in under 1 second
@@ -127,4 +127,4 @@ metadata:
   tags: [query-plan, timeout, concurrency, result_capture]
   estimated_effort: "Small"
   created_date: "2026-06-11"
-  last_updated: "2026-06-11T00:00:00-04:00"
+  last_updated: "2026-06-12T00:00:00-04:00"

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -780,27 +780,33 @@ class ResultCaptureMixin:
 
         start_time = time.perf_counter()
 
+        # Apply timeout protection for the EXPLAIN query. The executor is managed
+        # explicitly rather than via `with`: the context manager's __exit__ calls
+        # shutdown(wait=True), which blocks on the still-running EXPLAIN thread
+        # even after TimeoutError — making the timeout cosmetic. shutdown in the
+        # finally uses wait=False on every path, so a timed-out capture returns
+        # control promptly; the abandoned thread keeps running (holding the
+        # connection) until the database returns, which is acceptable because
+        # capture_query_plan does not reuse the connection afterwards.
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
-            # Apply timeout protection for EXPLAIN query
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(self.get_query_plan, connection, query)
-                try:
-                    explain_output = future.result(timeout=self.plan_capture_timeout_seconds)
-                except concurrent.futures.TimeoutError:
-                    capture_time_ms = (time.perf_counter() - start_time) * 1000
-                    self.logger.warning(
-                        "Query plan capture timed out for %s after %ds (%.2fms elapsed)",
-                        query_id,
-                        self.plan_capture_timeout_seconds,
-                        capture_time_ms,
-                    )
-                    self._record_plan_capture_failure(
-                        query_id,
-                        reason="timeout",
-                        message=f"EXPLAIN query timed out after {self.plan_capture_timeout_seconds}s",
-                        log_warning=False,
-                    )
-                    return None, capture_time_ms
+            future = executor.submit(self.get_query_plan, connection, query)
+            explain_output = future.result(timeout=self.plan_capture_timeout_seconds)
+        except concurrent.futures.TimeoutError:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self.logger.warning(
+                "Query plan capture timed out for %s after %ds (%.2fms elapsed)",
+                query_id,
+                self.plan_capture_timeout_seconds,
+                capture_time_ms,
+            )
+            self._record_plan_capture_failure(
+                query_id,
+                reason="timeout",
+                message=f"EXPLAIN query timed out after {self.plan_capture_timeout_seconds}s",
+                log_warning=False,
+            )
+            return None, capture_time_ms
         except PlanCaptureError:
             raise
         except Exception as exc:
@@ -811,6 +817,8 @@ class ResultCaptureMixin:
                 message=str(exc),
             )
             return None, capture_time_ms
+        finally:
+            executor.shutdown(wait=False)
 
         if not explain_output:
             capture_time_ms = (time.perf_counter() - start_time) * 1000

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -24,7 +24,6 @@ Instance attributes these methods read (initialized on the host adapter):
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 import math
 import os
@@ -55,6 +54,7 @@ from benchbox.platforms.base.runtime_metadata import build_default_normalized_re
 from benchbox.platforms.base.utils import is_non_interactive
 from benchbox.utils.clock import elapsed_seconds
 from benchbox.utils.printing import quiet_console
+from benchbox.utils.timeout_manager import run_with_timeout
 
 try:
     from benchbox.core.results.models import ExecutionPhases, QueryDefinition
@@ -780,22 +780,41 @@ class ResultCaptureMixin:
 
         start_time = time.perf_counter()
 
-        # Apply timeout protection for the EXPLAIN query. The executor is managed
-        # explicitly rather than via `with`: the context manager's __exit__ calls
-        # shutdown(wait=True), which blocks on the still-running EXPLAIN thread
-        # even after TimeoutError — making the timeout cosmetic. shutdown in the
-        # finally uses wait=False on every path, so a timed-out capture returns
-        # control promptly; the abandoned thread keeps running (holding the
-        # connection) until the database returns, which is acceptable because
-        # capture_query_plan does not reuse the connection afterwards.
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        # Apply timeout protection for the EXPLAIN query. run_with_timeout runs
+        # get_query_plan on a daemon thread and returns promptly when the timeout
+        # fires. (The previous `with ThreadPoolExecutor` implementation blocked in
+        # shutdown(wait=True) on exit even after TimeoutError, so the timeout was
+        # cosmetic: a runaway EXPLAIN still stalled the caller until the database
+        # returned.) Trade-off, accepted by design: after a timeout the abandoned
+        # EXPLAIN thread keeps running — holding the connection — until the
+        # database returns, so a subsequent query issued on the same connection
+        # may contend with it. The previous behavior (stalling the runner for the
+        # full EXPLAIN duration) was strictly worse; full isolation is tracked by
+        # query-plan-capture-isolation-phase-design.
         try:
-            future = executor.submit(self.get_query_plan, connection, query)
-            explain_output = future.result(timeout=self.plan_capture_timeout_seconds)
-        except concurrent.futures.TimeoutError:
+            explain_output, timed_out = run_with_timeout(
+                self.get_query_plan,
+                self.plan_capture_timeout_seconds,
+                f"plan capture EXPLAIN (query_id={query_id})",
+                connection,
+                query,
+            )
+        except PlanCaptureError:
+            raise
+        except Exception as exc:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self._record_plan_capture_failure(
+                query_id,
+                reason="explain_failed",
+                message=str(exc),
+            )
+            return None, capture_time_ms
+
+        if timed_out:
             capture_time_ms = (time.perf_counter() - start_time) * 1000
             self.logger.warning(
-                "Query plan capture timed out for %s after %ds (%.2fms elapsed)",
+                "Query plan capture timed out for %s after %ds (%.2fms elapsed); "
+                "the EXPLAIN may still be running on the connection until the database returns",
                 query_id,
                 self.plan_capture_timeout_seconds,
                 capture_time_ms,
@@ -807,18 +826,6 @@ class ResultCaptureMixin:
                 log_warning=False,
             )
             return None, capture_time_ms
-        except PlanCaptureError:
-            raise
-        except Exception as exc:
-            capture_time_ms = (time.perf_counter() - start_time) * 1000
-            self._record_plan_capture_failure(
-                query_id,
-                reason="explain_failed",
-                message=str(exc),
-            )
-            return None, capture_time_ms
-        finally:
-            executor.shutdown(wait=False)
 
         if not explain_output:
             capture_time_ms = (time.perf_counter() - start_time) * 1000

--- a/tests/unit/platforms/test_plan_capture_errors.py
+++ b/tests/unit/platforms/test_plan_capture_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Any
 
@@ -144,6 +145,68 @@ def test_plan_capture_timeout_records_failure(caplog: pytest.LogCaptureFixture) 
     assert adapter.plan_capture_errors[0]["reason"] == "timeout"
     assert "timed out" in adapter.plan_capture_errors[0]["message"]
     assert any("timed out" in record.message for record in caplog.records)
+
+
+def test_capture_timeout_returns_promptly() -> None:
+    """A timed-out capture must return control promptly, not block on the EXPLAIN thread.
+
+    The old implementation's `with ThreadPoolExecutor(...)` called
+    shutdown(wait=True) on exit, so even after TimeoutError the caller blocked
+    until the runaway EXPLAIN finished — the timeout was cosmetic. The EXPLAIN
+    here waits on an event that is only set AFTER capture_query_plan returns,
+    so the old code would block for the full 30s wait; the fixed code returns
+    in ~plan_capture_timeout_seconds.
+    """
+    release_explain = threading.Event()
+    adapter = DummyAdapter(capture_plans=True, plan_capture_timeout_seconds=1)
+
+    def hanging_explain(connection: Any, query: str) -> str:
+        release_explain.wait(timeout=30)
+        return "PLAN"
+
+    adapter.get_query_plan = hanging_explain  # type: ignore[method-assign]
+
+    start = time.monotonic()
+    try:
+        plan, capture_time_ms = adapter.capture_query_plan(None, "SELECT 1", "q_hang")
+        elapsed = time.monotonic() - start
+    finally:
+        # Unblock the abandoned EXPLAIN thread so it exits immediately and
+        # does not delay interpreter shutdown.
+        release_explain.set()
+
+    assert plan is None
+    assert elapsed < 10, f"capture_query_plan blocked for {elapsed:.1f}s after timeout - shutdown(wait=True) regression"
+    assert capture_time_ms >= 1000  # the timeout itself was still honored
+    assert adapter.plan_capture_failures == 1
+    assert adapter.plan_capture_errors[0]["reason"] == "timeout"
+
+
+def test_capture_timeout_strict_mode_raises_promptly() -> None:
+    """In strict mode the timeout's PlanCaptureError must also propagate promptly."""
+    release_explain = threading.Event()
+    adapter = DummyAdapter(
+        capture_plans=True,
+        plan_capture_timeout_seconds=1,
+        strict_plan_capture=True,
+    )
+
+    def hanging_explain(connection: Any, query: str) -> str:
+        release_explain.wait(timeout=30)
+        return "PLAN"
+
+    adapter.get_query_plan = hanging_explain  # type: ignore[method-assign]
+
+    start = time.monotonic()
+    try:
+        with pytest.raises(PlanCaptureError):
+            adapter.capture_query_plan(None, "SELECT 1", "q_hang_strict")
+        elapsed = time.monotonic() - start
+    finally:
+        release_explain.set()
+
+    assert elapsed < 10, f"strict-mode timeout blocked for {elapsed:.1f}s - shutdown(wait=True) regression"
+    assert adapter.plan_capture_errors[0]["reason"] == "timeout"
 
 
 def test_plan_capture_completes_within_timeout() -> None:

--- a/tests/unit/platforms/test_plan_capture_errors.py
+++ b/tests/unit/platforms/test_plan_capture_errors.py
@@ -176,7 +176,7 @@ def test_capture_timeout_returns_promptly() -> None:
         release_explain.set()
 
     assert plan is None
-    assert elapsed < 10, f"capture_query_plan blocked for {elapsed:.1f}s after timeout - shutdown(wait=True) regression"
+    assert elapsed < 5, f"capture_query_plan blocked for {elapsed:.1f}s after timeout - blocking-shutdown regression"
     assert capture_time_ms >= 1000  # the timeout itself was still honored
     assert adapter.plan_capture_failures == 1
     assert adapter.plan_capture_errors[0]["reason"] == "timeout"
@@ -205,7 +205,7 @@ def test_capture_timeout_strict_mode_raises_promptly() -> None:
     finally:
         release_explain.set()
 
-    assert elapsed < 10, f"strict-mode timeout blocked for {elapsed:.1f}s - shutdown(wait=True) regression"
+    assert elapsed < 5, f"strict-mode timeout blocked for {elapsed:.1f}s - blocking-shutdown regression"
     assert adapter.plan_capture_errors[0]["reason"] == "timeout"
 
 


### PR DESCRIPTION
## Summary

- `capture_query_plan()` wrapped `get_query_plan()` in `with ThreadPoolExecutor(...)` for timeout protection, but the context manager's `__exit__` calls `shutdown(wait=True)`, which blocked on the still-running EXPLAIN thread even after `TimeoutError` — a 60s EXPLAIN with a 5s timeout still stalled the benchmark runner for 60s. The timeout was cosmetic.
- The EXPLAIN now runs via the existing `benchbox.utils.timeout_manager.run_with_timeout` helper (daemon thread + `join(timeout)`), so a timed-out capture returns control in ~`plan_capture_timeout_seconds` on every path (non-strict return, strict-mode `PlanCaptureError` raise). Bonus correctness: a builtin `TimeoutError` raised by `get_query_plan` itself (e.g. socket timeout) is now recorded as `explain_failed` instead of being misclassified as a capture timeout, and abandoned daemon threads no longer delay interpreter exit.
- Accepted trade-off (per the spec's `must_preserve`): the abandoned EXPLAIN thread keeps running on the connection until the database returns; this is documented in code and in the timeout warning, with full isolation tracked by `query-plan-capture-isolation-phase-design`.
- Tests prove promptness with an Event-gated hanging EXPLAIN that only unblocks **after** `capture_query_plan` returns — the old code would block ~30s, the fixed code returns in ~1s — for both non-strict and strict modes, with `reason="timeout"` still recorded. The pre-existing timeout test now completes at the 1s timeout instead of the 2s EXPLAIN duration.

Closes TODO `query-plan-capture-timeout-mechanism-fix` (marked Completed).

## Test plan

- [x] `uv run -- python -m pytest tests/unit/platforms/ -k 'capture_timeout' -v` — 3 passed, call durations 1.00s (the timeout, not the hang)
- [x] `uv run -- python -m pytest tests/unit/platforms/ -k 'plan_capture' -q` — 176 passed
- [x] `uv run -- python -m pytest tests/unit/platforms/ -q` — 7550 passed, 2 skipped
- [x] `validate_todo.py` + `make todo-reindex`

https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg)_