### PR TITLE
fix(tpchavoc): use fetch_arrow_table() for version-stable Arrow export

### DIFF
--- a/benchbox/core/tpchavoc/dataframe_equivalence.py
+++ b/benchbox/core/tpchavoc/dataframe_equivalence.py
@@ -136,7 +136,10 @@ def build_dataframe_contexts(connection: Any) -> dict[str, Any]:
             else column.name
             for column in table.columns
         ]
-        arrow = connection.execute(f"SELECT {', '.join(projections)} FROM {table.name.lower()}").arrow()
+        # fetch_arrow_table() (not .arrow()) so the result is a materialized
+        # pyarrow.Table on every DuckDB version, including >=1.4 where
+        # .arrow() returns a RecordBatchReader.
+        arrow = connection.execute(f"SELECT {', '.join(projections)} FROM {table.name.lower()}").fetch_arrow_table()
         expression_ctx.register_table(table.name, pl.from_arrow(arrow).lazy())
         pandas_ctx.register_table(table.name, arrow.to_pandas(types_mapper=pd.ArrowDtype))
     return {"expression": expression_ctx, "pandas": pandas_ctx}


### PR DESCRIPTION
## Summary

Follow-up to #785 (merged). The DataFrame variant-equivalence gate's table
materializer used `connection.execute(...).arrow()`, which returns a
materialized `pyarrow.Table` on the currently-pinned `duckdb<1.4` but becomes a
`RecordBatchReader` (no `.to_pandas()`) on `duckdb>=1.4`. Since the `<1.4` cap
is temporary (held only until duckdb-wasm can attach newer native DB files),
this switches to the explicit `fetch_arrow_table()` API so the gate keeps
working when the cap lifts.

This is pure future-proofing — the gate is correct and green on the pinned
version today. The fix was raised as a P1 review comment on #785 but landed
~80s after that PR auto-merged, so it never made it onto `develop`; this PR
carries it over (cherry-pick of the original commit).

## Verification

- `ruff check` clean.
- `tests/integration/test_tpchavoc_dataframe_variant_equivalence.py` passes on
  the new `develop` base (~39s).

https://claude.ai/code/session_01PdaR6AzhwDXFZ4XYhLsFUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdaR6AzhwDXFZ4XYhLsFUB)_