### PR TITLE
chore(todo): audit and close capture/tpchavoc items landed by PRs #748/#756

### DIFF
--- a/_project/DONE/main/planning/todo-post-748-capture-status-audit.yaml
+++ b/_project/DONE/main/planning/todo-post-748-capture-status-audit.yaml
@@ -2,7 +2,7 @@ id: todo-post-748-capture-status-audit
 title: "Audit and update TODO statuses staled by PRs #748-#759 (capture wiring, tpchavoc, output-root)"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: "Completed"
 category: Testing and Quality Assurance
 
 description: |
@@ -28,20 +28,52 @@ description: |
 work:
   - id: w0
     summary: "Review PRs #748, #756, #759 diffs and commit messages for scope"
-    status: pending
+    status: done
     notes: |
-      For each PR: gh pr view <N> --json body,files,commits
-      Identify which TODO items are fully vs. partially addressed.
-      PR #748: query plan capture adapters (PostgreSQL, Redshift, DataFusion, SQLite, MotherDuck)
-      PR #756: tpchavoc correlated-subquery self-binding fix
-      PR #759: benchmark output root propagation
+      Reviewed via GitHub MCP pull_request_read (get_files) on the actual merged
+      diffs rather than titles.
+      PR #748 (e9999563): wired get_query_plan()/get_query_plan_parser() + capture
+        into DataFusion, SQLite, PostgreSQL, Redshift, MotherDuck; added
+        DataFusion/SQLite/PostgreSQL/Redshift plan-capture unit tests incl. a
+        PostgreSQL subclass-inheritance test. Fully completes
+        query-plan-capture-datafusion-sqlite and the wiring (w1-w7) of
+        query-plan-capture-postgresql-family; supplies the MotherDuck portion
+        (w1/w2) of query-plan-capture-misc-platforms. Did NOT touch the
+        motherduck-cloud-features credential-wizard/upload/cache work.
+      PR #756 (82ff4aa5): qualified q11_v1, q17_v8, and (via sweep) q2_v8 to the
+        outer table; added a DuckDB regression test. Fully completes
+        tpchavoc-correlated-subquery-self-binding.
+      PR #759 (fa0f7898): benchmark output-root propagation — the item was already
+        moved to _project/DONE/main/benchmark-runs-output-root-propagation.yaml.
+      Supplementary: PR #777 (7b06b7db) added a live PostgreSQL CI container +
+        plan-capture integration tests, completing postgresql-family w8.
 
   - id: w1
     summary: "Cross-reference affected TODOs against PR scopes"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Files to cross-reference:
+      Audit outcome per cross-referenced file:
+        - query-plan-capture-datafusion-sqlite: Not Started -> Completed (PR #748).
+        - query-plan-capture-postgresql-family: In Progress -> Completed
+          (PR #748 wiring + #777 live UAT; w7/w8 confirmed done).
+        - motherduck-cloud-features: unchanged (Blocked). PR #748 added plan
+          capture, NOT the credential-wizard/cloud-upload/cache-control features
+          this item tracks — confirmed via diff, contradicting the title-level guess.
+        - query-plan-capture-clickhouse-family: already status Completed
+          (landed via PR #775, outside #748-759); left for the dedicated
+          todo-sweep-completed-items-from-open-tree task.
+        - query-plan-capture-presto-trino-family: already status Completed; same
+          handling as clickhouse (not touched by #748-759).
+        - query-plan-capture-spark-databricks: already status Completed (PR #778);
+          same handling.
+        - query-plan-capture-misc-platforms: stays In Progress. MotherDuck (w1/w2)
+          done by #748; Databend/QuestDB/Velox/Doris/SingleStore/cuDF + tests (w9)
+          remain pending. Notes refreshed to cite PR #748.
+        - tpchavoc-correlated-subquery-self-binding: Not Started -> Completed (#756).
+        - benchmark-runs-output-root-propagation: already in _project/DONE
+          (PR #759 / #780). No action.
+      Files originally listed:
         TODO/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
         TODO/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
         TODO/platform-expansion/active/motherduck-cloud-features.yaml
@@ -57,19 +89,33 @@ work:
   - id: w2
     summary: "Update status and move Completed items to DONE tree"
     needs: [w1]
-    status: pending
+    status: done
+    notes: |
+      Moved to _project/DONE preserving directory structure:
+        - DONE/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+        - DONE/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+        - DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+      Each gained completed_date, commits, and an Implementation Summary section.
+      No deps.needs reference these ids (only prior_art free-text mentions), so
+      dependency resolution stays consistent after the moves.
 
   - id: w3
     summary: "Update priority or description for items with changed scope"
     needs: [w1]
-    status: pending
+    status: done
+    notes: |
+      query-plan-capture-misc-platforms remains In Progress; its MotherDuck work
+      units (w1/w2) were refreshed to cite PR #748 as the landing PR while the
+      remaining platforms stay open. No priority changes were warranted — the
+      partially-addressed items keep their existing priorities.
 
   - id: w4
     summary: "Run validate_todo.py --all and regenerate indexes"
     needs: [w2, w3]
-    status: pending
+    status: done
     notes: |
       uv run --project _project/scripts -- python _project/scripts/validate_todo.py --all
+      uv run _project/scripts/generate_indexes.py
 
 prior_art:
   - "TODO/platform-expansion/planning/query-plan-capture-*.yaml: the cluster to audit"
@@ -92,6 +138,8 @@ metadata:
     - query-plan-capture
     - housekeeping
     - todo-system
+
+completed_date: "2026-06-14"
 
 impact:
   business_value: |

--- a/_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
+++ b/_project/DONE/main/planning/tpchavoc-correlated-subquery-self-binding.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-correlated-subquery-self-binding
 title: "Fix tpchavoc variants whose correlated subqueries silently self-bind to the inner alias"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: "Completed"
 category: Testing and Quality Assurance
 
 description: |
@@ -38,22 +38,40 @@ prior_art:
 work:
   - id: w0
     summary: "Confirm intended semantics of q11_v1 and q17_v8 against the base TPC-H query they vary"
-    status: pending
+    status: done
     notes: |
       Establish the correct correlated form before editing. The fix is to
       qualify the correlation column to the outer table, matching 10_v8.
+      COMPLETED in PR #756: the intended per-part/per-row correlation was
+      confirmed against canonical TPC-H before qualifying.
   - id: w1
     summary: "Qualify the correlation in q11_v1 (ps2.ps_partkey = partsupp.ps_partkey) and verify it decorrelates"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      COMPLETED in PR #756. q11.yaml variant 1 now reads
+      `ps2.ps_partkey = partsupp.ps_partkey`. A DuckDB EXPLAIN regression assertion
+      in tests/integration/test_tpchavoc_duckdb.py confirms it decorrelates into a
+      delimiter join (DELIM present), which the unqualified form did not produce.
   - id: w2
     summary: "Qualify the correlation in q17_v8 (avg_calc.l_partkey = lineitem.l_partkey) and verify it decorrelates"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      COMPLETED in PR #756. q17.yaml variant 8 EXISTS subquery now reads
+      `avg_calc.l_partkey = lineitem.l_partkey and lineitem.l_quantity < avg_calc.threshold`.
+      Guarded by the substring assertion in the new regression test (its second,
+      already-qualified correlation makes the plan check non-discriminating).
   - id: w3
     summary: "Sweep all tpchavoc variant_sets for the same alias-self-binding pattern and fix any others"
     needs: [w0]
-    status: pending
+    status: done
+    notes: |
+      COMPLETED in PR #756. The sweep found one additional occurrence,
+      q2 variant 8 (NOT EXISTS min-cost), now qualified to
+      `ps2.ps_supplycost < partsupp.ps_supplycost`. q2_v8, q11_v1, and q17_v8 were
+      added to the DuckDB regression EXPLAIN list in
+      tests/integration/test_tpchavoc_duckdb.py.
 
 must_preserve:
   - "All tpchavoc variants must still parse, bind, and execute on every supported platform."
@@ -88,4 +106,31 @@ metadata:
   tags: [tpchavoc, sql, correctness, dataframe, defect]
   estimated_effort: "Small"
   created_date: "2026-05-29"
-  last_updated: "2026-05-29T00:00:00"
+  last_updated: "2026-06-14T00:00:00"
+
+completed_date: "2026-06-06"
+
+commits:
+  - "82ff4aa5"
+
+sections:
+  "Implementation Summary": |
+    Landed in PR #756 (squash-merged to develop as 82ff4aa5), confirmed during the
+    post-748 TODO status audit by reading the merged diff.
+
+    The fix qualified each correlated subquery's correlation column to the outer
+    table (the 10_v8 pattern), preserving the variant shape:
+    - q11.yaml v1 ("Scalar subqueries"): ps2.ps_partkey = partsupp.ps_partkey
+    - q17.yaml v8 ("EXISTS pattern"): avg_calc.l_partkey = lineitem.l_partkey
+    - q2.yaml v8 ("NOT EXISTS min-cost"), found by the w3 sweep:
+      ps2.ps_supplycost < partsupp.ps_supplycost
+
+    tests/integration/test_tpchavoc_duckdb.py added
+    test_correlated_subquery_variants_bind_to_outer_table (substring + DuckDB
+    EXPLAIN/DELIM assertions) and added 2_v8, 11_v1, 17_v8 to the regression
+    EXPLAIN variant list.
+
+    Follow-up cross-surface work (other benchmarks/dialects carrying the same
+    class of defect) is tracked separately in
+    correlated-subquery-self-binding-cross-surface-audit; this item covers only
+    the tpchavoc shared-variant SQL fix and is complete.

--- a/_project/DONE/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
+++ b/_project/DONE/platform-expansion/planning/query-plan-capture-datafusion-sqlite.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-datafusion-sqlite
 title: "Wire query plan capture for DataFusion and SQLite (parsers exist, no credentials needed)"
 worktree: platform-expansion
 priority: High
-status: Not Started
+status: "Completed"
 category: Platform Expansion
 
 description: |
@@ -47,7 +47,7 @@ prior_art:
 work:
   - id: w1
     summary: "Confirm DataFusion EXPLAIN JSON syntax via live query and document in TODO"
-    status: pending
+    status: done
     notes: |
       Run a trivial DataFusion query with EXPLAIN FORMAT JSON in the BenchBox
       harness or a standalone script. Record the exact SQL syntax that works
@@ -57,7 +57,7 @@ work:
   - id: w2
     summary: "Add get_query_plan() and get_query_plan_parser() to DataFusionAdapter"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/datafusion.py add:
         def get_query_plan(self, connection, query):
@@ -74,7 +74,7 @@ work:
   - id: w3
     summary: "Integrate capture_query_plan() into DataFusionAdapter.execute_query()"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Locate the result-assembly block in DataFusionAdapter.execute_query(). After
       the timed execution block, add the same capture_plans guard as DuckDB:
@@ -87,7 +87,7 @@ work:
   - id: w4
     summary: "Add unit tests for DataFusion plan capture wiring"
     needs: [w3]
-    status: pending
+    status: done
     notes: |
       Create tests/unit/platforms/test_datafusion_plan_capture.py. Cover:
         - get_query_plan_parser() returns DataFusionQueryPlanParser
@@ -100,7 +100,7 @@ work:
 
   - id: w5
     summary: "Confirm SQLite EXPLAIN QUERY PLAN syntax and parser compatibility"
-    status: pending
+    status: done
     notes: |
       Run `EXPLAIN QUERY PLAN <simple_query>` against an in-memory SQLite database
       and compare the raw rows to what SQLiteQueryPlanParser expects.
@@ -110,7 +110,7 @@ work:
   - id: w6
     summary: "Add get_query_plan() and get_query_plan_parser() to SQLiteAdapter"
     needs: [w5]
-    status: pending
+    status: done
     notes: |
       In benchbox/platforms/sqlite.py (or wherever SQLiteAdapter lives) add:
         def get_query_plan(self, connection, query):
@@ -129,14 +129,14 @@ work:
   - id: w7
     summary: "Integrate capture_query_plan() into SQLiteAdapter.execute_query()"
     needs: [w6]
-    status: pending
+    status: done
     notes: |
       Same pattern as w3 but for SQLiteAdapter.
 
   - id: w8
     summary: "Add unit tests for SQLite plan capture wiring"
     needs: [w7]
-    status: pending
+    status: done
     notes: |
       Create tests/unit/platforms/test_sqlite_plan_capture.py. Same coverage as
       w4 but using SQLiteQueryPlanParser and Python's stdlib sqlite3 connections.
@@ -194,4 +194,35 @@ metadata:
   tags: [query-plan, datafusion, sqlite, wiring, no-credentials]
   estimated_effort: "Small"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-14T00:00:00-04:00"
+
+completed_date: "2026-06-03"
+
+commits:
+  - "e9999563"
+
+sections:
+  "Implementation Summary": |
+    Landed in PR #748 (squash-merged to develop as e9999563), confirmed during the
+    post-748 TODO status audit by reading the merged diff.
+
+    DataFusion (benchbox/platforms/datafusion.py):
+    - get_query_plan() issues plain `EXPLAIN {query}` and reconstructs the
+      pipe-delimited "plan_type | line" text that DataFusionQueryPlanParser expects.
+      NOTE: the original w1/w2 hypothesis of `EXPLAIN FORMAT JSON` was not used —
+      the parser consumes DataFusion's text/indent format, and a wiring test asserts
+      FORMAT JSON is never issued.
+    - get_query_plan_parser() returns DataFusionQueryPlanParser (lazy import).
+    - execute_query() captures the plan and sets query_plan / plan_fingerprint /
+      plan_capture_time_ms when capture_plans is enabled.
+    - tests/unit/platforms/test_datafusion_plan_capture.py added.
+
+    SQLite (benchbox/platforms/sqlite.py):
+    - get_query_plan() issues `EXPLAIN QUERY PLAN`; a new _format_sqlite_query_plan()
+      helper rebuilds the indented "|--"/"`--" tree text for SQLiteQueryPlanParser.
+    - get_query_plan_parser() returns SQLiteQueryPlanParser (lazy import); capture
+      wired into execute_query().
+    - benchbox/core/query_plans/parsers/sqlite.py updated to also accept modern
+      ("SCAN name" / "SEARCH name") SQLite EXPLAIN output, not just legacy
+      ("SCAN TABLE name").
+    - tests/unit/platforms/test_sqlite_plan_capture.py added.

--- a/_project/DONE/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
+++ b/_project/DONE/platform-expansion/planning/query-plan-capture-postgresql-family.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-postgresql-family
 title: "Wire query plan capture end-to-end for PostgreSQL, Redshift, and derived adapters"
 worktree: platform-expansion
 priority: High
-status: In Progress
+status: "Completed"
 category: Platform Expansion
 
 description: |
@@ -102,12 +102,13 @@ work:
   - id: w7
     summary: "Verify TimescaleDB, CedarDB, and pg_mooncake inherit plan capture without changes"
     needs: [w3]
-    status: pending
+    status: done
     notes: |
-      All three subclass PostgreSQLAdapter and do not override execute_query() or
-      get_query_plan_parser(). Run existing adapter unit tests to confirm no
-      regressions. Add a short parametrized test asserting that each subclass
-      instance returns a non-None parser from get_query_plan_parser().
+      COMPLETED in PR #748. tests/unit/platforms/test_postgresql_plan_capture.py
+      added TestPostgreSQLSubclassInheritance, a parametrized test asserting that
+      TimescaleDBAdapter, CedarDBAdapter, and PgMooncakeAdapter all return a
+      PostgreSQLQueryPlanParser via the inherited get_query_plan_parser() with no
+      per-subclass override.
     coverage_checklist:
       - id: ts-parser
         description: "TimescaleDBAdapter().get_query_plan_parser() returns PostgreSQLQueryPlanParser"
@@ -122,11 +123,16 @@ work:
   - id: w8
     summary: "UAT cell smoke for PostgreSQL plan capture"
     needs: [w3, w7]
-    status: pending
+    status: done
     notes: |
-      Run a single TPC-H SF=0.01 cell against a live PostgreSQL instance with
-      --capture-plans enabled. Confirm query_plans_captured > 0 in the result
-      bundle. This step requires a live PostgreSQL instance (see prerequisites).
+      COMPLETED in PR #777. Live PostgreSQL plan capture is now exercised in CI via
+      a postgres:17 service container (postgres-integration jobs in
+      .github/workflows/pr.yml and nightly.yml). tests/integration/platforms/
+      test_postgresql_live.py added TestLivePostgreSQLQueryPlanCapture, which
+      asserts get_query_plan() returns parseable JSON and capture_query_plan()
+      yields a QueryPlanDAG with a stable 64-char SHA256 fingerprint against a live
+      instance. The DML guard gap noted in w2 is intentionally out of scope here and
+      remains tracked in query-plan-capture-postgresql-dml-guard.
 
 deps:
   needs: []
@@ -193,4 +199,37 @@ metadata:
   tags: [query-plan, postgresql, redshift, timescaledb, cedardb, pg-mooncake, wiring]
   estimated_effort: "Medium"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-14T00:00:00-04:00"
+
+completed_date: "2026-06-11"
+
+commits:
+  - "e9999563"
+  - "7b06b7db"
+
+sections:
+  "Implementation Summary": |
+    Confirmed complete during the post-748 TODO status audit by reading the merged
+    diffs of PR #748 and PR #777.
+
+    PR #748 (e9999563) wired the family (w1-w7):
+    - PostgreSQLAdapter: get_query_plan() switched to EXPLAIN (ANALYZE, BUFFERS,
+      FORMAT JSON) so PostgreSQLQueryPlanParser can parse it; get_query_plan_parser()
+      override added; execute_query() captures the plan on SUCCESS when
+      capture_plans is set.
+    - RedshiftAdapter: get_query_plan_parser() returns RedshiftQueryPlanParser;
+      capture wired into execute_query(); plain EXPLAIN (no ANALYZE) preserved.
+    - get_query_plan() error paths now return None instead of an error string so
+      capture degrades gracefully.
+    - tests/unit/platforms/test_postgresql_plan_capture.py (incl. the
+      TimescaleDB/CedarDB/pg_mooncake inheritance test for w7),
+      test_redshift_plan_capture.py, and updated adapter tests added.
+
+    PR #777 (7b06b7db) closed w8 (live UAT smoke):
+    - Added a postgres:17 service-container CI job (pr.yml + nightly.yml) and
+      TestLivePostgreSQLQueryPlanCapture in tests/integration/platforms/
+      test_postgresql_live.py, verifying live JSON plans, a QueryPlanDAG, and a
+      stable SHA256 fingerprint.
+
+    Out of scope / tracked separately: the EXPLAIN ANALYZE DML double-execution
+    guard (query-plan-capture-postgresql-dml-guard).

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -75,17 +75,20 @@ work:
     summary: "MotherDuck: add get_query_plan() and get_query_plan_parser() reusing DuckDB components"
     status: done
     notes: |
-      COMPLETED in commit d06fe3e3. MotherDuckAdapter.get_query_plan() issues
+      COMPLETED in PR #748 (develop commit e9999563; originally d06fe3e3 on the
+      feature branch). MotherDuckAdapter.get_query_plan() issues
       EXPLAIN (ANALYZE, FORMAT JSON) and get_query_plan_parser() returns
-      DuckDBQueryPlanParser. Wiring is live on the branch.
+      DuckDBQueryPlanParser. Confirmed against the merged diff during the post-748
+      audit. Dedicated MotherDuck wiring unit tests remain part of w9 (pending).
 
   - id: w2
     summary: "MotherDuck: integrate capture_query_plan() into execute_query()"
     needs: [w1]
     status: done
     notes: |
-      COMPLETED in commit d06fe3e3. MotherDuckAdapter.execute_query() now calls
-      capture_query_plan() with the capture_plans guard.
+      COMPLETED in PR #748 (develop commit e9999563). MotherDuckAdapter.execute_query()
+      now calls capture_query_plan() with the capture_plans guard and propagates
+      query_plan / plan_fingerprint / plan_capture_time_ms into the result dict.
 
   - id: w3
     summary: "Databend: collect EXPLAIN sample, implement DatabendQueryPlanParser"


### PR DESCRIPTION
## Summary

Post-748 TODO status audit (`todo-post-748-capture-status-audit`). Pure housekeeping — only `_project/TODO/` and `_project/DONE/` files; no production code changes. Scope of each PR was verified against the **actual merged diffs** via the GitHub MCP tools, not titles.

## Items moved to `_project/DONE` (fully completed by in-scope PRs)

- **query-plan-capture-datafusion-sqlite** → Completed (PR #748). DataFusion + SQLite `get_query_plan()`/`get_query_plan_parser()`/capture wiring plus unit tests all landed. (DataFusion uses plain `EXPLAIN` text, not the `EXPLAIN FORMAT JSON` the TODO hypothesized — noted in the summary.)
- **query-plan-capture-postgresql-family** → Completed. PR #748 wired PostgreSQL/Redshift incl. the TimescaleDB/CedarDB/pg_mooncake subclass-inheritance test (w7); PR #777 added a live PostgreSQL CI service container + plan-capture integration tests (w8). DML guard remains tracked separately.
- **tpchavoc-correlated-subquery-self-binding** → Completed (PR #756). Qualified `q11_v1`, `q17_v8`, and swept-up `q2_v8` to the outer table, with a DuckDB EXPLAIN regression test.

Each moved file gained `completed_date`, commit refs, and an Implementation Summary. No `deps.needs` reference the moved ids (only `prior_art` free-text), so dependency resolution stays consistent.

## Items intentionally left open

- **query-plan-capture-misc-platforms** stays In Progress — MotherDuck (w1/w2) landed in PR #748 (notes refreshed); Databend/QuestDB/Velox/Doris/SingleStore/cuDF + tests remain pending.
- **motherduck-cloud-features** unchanged — PR #748 added plan capture, **not** the credential-wizard/cloud-upload/cache-control features this item tracks (confirmed via diff, contradicting the title-level guess).
- Items already `Completed` from out-of-scope PRs (clickhouse/presto-trino/spark, etc.) are left to the dedicated `todo-sweep-completed-items-from-open-tree` task.

The audit item itself was moved to `_project/DONE/main/planning/`.

## Validation

- `validate_todo.py --all`: **1128/1128 valid**
- Indexes regenerated (`generate_indexes.py`)
- `make agent-write-preflight`: OK

https://claude.ai/code/session_01WT3x2bq4EfDjftszWbygaM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT3x2bq4EfDjftszWbygaM)_