### PR TITLE
fix(tpch-df): make unseeded DataFrame Q11 fraction scale-aware

### DIFF
--- a/_project/TODO/main/active/tpch-dataframe-unseeded-q11-scale-fraction.yaml
+++ b/_project/TODO/main/active/tpch-dataframe-unseeded-q11-scale-fraction.yaml
@@ -2,7 +2,7 @@ id: tpch-dataframe-unseeded-q11-scale-fraction
 title: "Unseeded TPC-H DataFrame runs use the SF=1 Q11 fraction at every scale"
 worktree: main
 priority: Medium
-status: "Not Started"
+status: Under Review
 category: Bug Fixes
 
 description: |
@@ -40,7 +40,7 @@ prior_art:
 work:
   - id: w0
     summary: "Make the unseeded DataFrame Q11 fraction scale-aware at the runner seam"
-    status: pending
+    status: done
     notes: |
       When seed is None and benchmark_id is tpch (or a TPC-H-derived benchmark
       such as tpchavoc), inject {11: {"fraction": 0.0001 / scale_factor}} via
@@ -50,7 +50,7 @@ work:
   - id: w1
     summary: "Remove the gate-local Q11 override and re-verify the DataFrame gate"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Drop the set_parameter_overrides injection in
       find_dataframe_divergences; make tpchavoc-dataframe-equivalence-report
@@ -70,4 +70,4 @@ metadata:
   tags: [tpch, dataframe, correctness, parameters, q11]
   estimated_effort: "Small"
   created_date: "2026-06-12"
-  last_updated: "2026-06-12T12:00:00"
+  last_updated: "2026-06-14T14:16:31"

--- a/benchbox/core/runner/dataframe_runner.py
+++ b/benchbox/core/runner/dataframe_runner.py
@@ -69,6 +69,14 @@ logger = logging.getLogger(__name__)
 
 console = quiet_console
 
+# Benchmark ids that share the TPC-H DataFrame parameter seam
+# (benchbox.core.tpch.dataframe_queries): canonical TPC-H plus the benchmarks
+# whose DataFrame queries reuse the same query impls and get_tpch_parameters().
+# TPC-H Skew re-registers the TPC-H DataFrame queries verbatim, and TPC-Havoc's
+# variants read the same parameter seam, so all three need the scale-dependent
+# Q11 default (0.0001/SF) set and cleared together.
+_TPCH_FAMILY_DATAFRAME_IDS = ("tpch", "tpch_skew", "tpchavoc")
+
 DATAFRAME_RUNNER_API_SURFACE = "deprecated"
 DATAFRAME_RUNNER_LIFECYCLE = "deprecated-internal-compatibility-runner"
 DATAFRAME_PRODUCTION_EXECUTION_PATH = "adapter.run_benchmark+BenchmarkExecutionMixin"
@@ -560,6 +568,13 @@ def _setup_parameter_overrides_for_stream(
     applied_contexts: set[tuple[int, float, int | None]],
 ) -> None:
     """Apply parameter overrides once per unique seed/SF(/stream) context."""
+    # Scale-dependent parameter defaults (e.g. Q11's 0.0001/SF value threshold)
+    # apply with or without a seed, so set the scale factor on every call. This
+    # keeps the unseeded DataFrame run path scale-faithful, mirroring the SQL
+    # side's {q11_fraction} rendering. Seed-derived overrides below still take
+    # precedence over the scaled default.
+    _setup_scale_dependent_defaults(benchmark_id, scale_factor)
+
     if seed is None:
         return
 
@@ -575,6 +590,24 @@ def _setup_parameter_overrides_for_stream(
 
     _setup_parameter_overrides(benchmark_id, seed, scale_factor, stream_id=stream_id)
     applied_contexts.add(context_key)
+
+
+def _setup_scale_dependent_defaults(benchmark_id: str, scale_factor: float) -> None:
+    """Align scale-dependent parameter defaults with the run's scale factor.
+
+    Canonical TPC-H Q11 renders its value threshold as ``0.0001 / SF``. Unseeded
+    DataFrame runs would otherwise read the SF=1 default at every scale; setting
+    the scale factor here keeps them aligned with the SQL run path. TPC-H Skew
+    and TPC-Havoc reuse the same TPC-H DataFrame parameter seam, so they are
+    handled the same way (see :data:`_TPCH_FAMILY_DATAFRAME_IDS`).
+    """
+    if benchmark_id in _TPCH_FAMILY_DATAFRAME_IDS:
+        try:
+            from benchbox.core.tpch.dataframe_queries import set_scale_factor
+
+            set_scale_factor(scale_factor)
+        except Exception:  # pragma: no cover - defensive; never block execution
+            logger.debug("Failed to set TPC-H DataFrame scale factor", exc_info=True)
 
 
 def _setup_parameter_overrides(
@@ -640,11 +673,13 @@ def _setup_parameter_overrides(
 
 def _clear_parameter_overrides(benchmark_id: str) -> None:
     """Clear parameter overrides after execution."""
-    if benchmark_id == "tpch":
+    if benchmark_id in _TPCH_FAMILY_DATAFRAME_IDS:
         try:
-            from benchbox.core.tpch.dataframe_queries import set_parameter_overrides
+            from benchbox.core.tpch.dataframe_queries import set_parameter_overrides, set_scale_factor
 
             set_parameter_overrides(None)
+            # Reset the scale-dependent defaults to the SF=1 rendering.
+            set_scale_factor(None)
         except Exception:
             pass
     elif benchmark_id == "tpcds":

--- a/benchbox/core/tpch/dataframe_queries.py
+++ b/benchbox/core/tpch/dataframe_queries.py
@@ -92,6 +92,15 @@ TPCH_DEFAULT_PARAMS: dict[int, dict[str, Any]] = {
 # query execution, get_tpch_parameters() merges these into the defaults.
 _parameter_overrides: dict[int, dict[str, Any]] | None = None
 
+# Module-level scale factor for scale-dependent parameter defaults. Canonical
+# TPC-H Q11 renders its value threshold as 0.0001 / SF (qgen does this); the
+# value in TPCH_DEFAULT_PARAMS is the SF=1 rendering. get_tpch_parameters()
+# scales it by this factor so unseeded DataFrame runs stay scale-faithful at
+# every scale, mirroring the SQL run path's {q11_fraction} rendering. Set by the
+# dataframe_runner (and the TPC-Havoc equivalence gate) before execution;
+# defaults to 1.0 (the qgen SF=1 rendering).
+_scale_factor: float = 1.0
+
 
 def set_parameter_overrides(overrides: dict[int, dict[str, Any]] | None) -> None:
     """Set parameter overrides for the current benchmark run.
@@ -106,11 +115,36 @@ def set_parameter_overrides(overrides: dict[int, dict[str, Any]] | None) -> None
     _parameter_overrides = overrides
 
 
+def set_scale_factor(scale_factor: float | None) -> None:
+    """Set the scale factor used for scale-dependent parameter defaults.
+
+    Canonical TPC-H Q11 renders its value threshold as ``0.0001 / SF``. The
+    dataframe_runner calls this before query execution so unseeded runs derive
+    the scale-correct Q11 fraction (mirroring the SQL run path) instead of
+    always using the SF=1 default. Pass ``None`` (or ``1.0``) to reset to the
+    SF=1 rendering.
+
+    Seed-derived overrides (see :func:`set_parameter_overrides`) take precedence
+    over the scaled default, so seeded runs are unaffected.
+
+    Args:
+        scale_factor: The run's scale factor, or None to reset to 1.0.
+    """
+    global _scale_factor
+    _scale_factor = 1.0 if scale_factor is None else float(scale_factor)
+
+
 def get_tpch_parameters(query_id: int) -> dict[str, Any]:
     """Get parameters for a TPC-H query.
 
-    If parameter overrides are active (set via set_parameter_overrides),
-    override values are merged on top of the defaults for the given query.
+    Q11's value threshold is scale-dependent: canonical qgen renders it as
+    ``0.0001 / SF``. The default in TPCH_DEFAULT_PARAMS is the SF=1 value, so it
+    is scaled by the active scale factor (set via :func:`set_scale_factor`) to
+    keep unseeded DataFrame runs aligned with the SQL run path at every scale.
+
+    If parameter overrides are active (set via :func:`set_parameter_overrides`),
+    override values are merged on top, so seed-derived parameters win over the
+    scaled default.
 
     Args:
         query_id: Query number (1-22)
@@ -119,6 +153,12 @@ def get_tpch_parameters(query_id: int) -> dict[str, Any]:
         Dict of parameter values for this query.
     """
     params = dict(TPCH_DEFAULT_PARAMS.get(query_id, {}))
+    if query_id == 11 and "fraction" in params and _scale_factor > 0:
+        # Mirror canonical qgen's `0.0001 / SF` rendering exactly - including its
+        # 10-decimal literal - so the unseeded default matches both the SQL run
+        # path's {q11_fraction} token and the seeded extraction (which parses
+        # that same literal). TPCH_DEFAULT_PARAMS holds the SF=1 base value.
+        params["fraction"] = float(f"{params['fraction'] / _scale_factor:.10f}")
     if _parameter_overrides is not None and query_id in _parameter_overrides:
         params.update(_parameter_overrides[query_id])
     return params

--- a/benchbox/core/tpchavoc/dataframe_equivalence.py
+++ b/benchbox/core/tpchavoc/dataframe_equivalence.py
@@ -41,13 +41,12 @@ surface:
 
 Q11's value threshold is scale-dependent (canonical qgen renders
 ``0.0001 / SF``). The DataFrame implementations read the fraction from
-``get_tpch_parameters``, whose static default is the SF=1 value; production
-runs inject the scale-correct value via seeded parameter extraction. The gate
-mirrors that run path through the same public
-``set_parameter_overrides`` seam so the canonical SQL reference and the
-DataFrame variants agree on the threshold. Making the *unseeded* product run
-path scale-aware (and dropping this injection) is tracked in
-``_project/TODO/main/planning/tpch-dataframe-unseeded-q11-scale-fraction.yaml``.
+``get_tpch_parameters``, whose default is now scale-aware: it scales the SF=1
+value by the scale factor declared via ``set_scale_factor``, exactly like the
+qgen rendering and the unseeded production run path. The gate declares its
+scale (``EQUIVALENCE_SCALE``) through that same product seam so the canonical
+SQL reference and the DataFrame variants agree on the threshold without any
+gate-local parameter override.
 
 Copyright 2026 Joe Harris / BenchBox Project
 
@@ -202,17 +201,20 @@ def find_dataframe_divergences(
         :meth:`TPCHavocBenchmark.validate_variant_equivalence`.
     """
     from benchbox.core.tpch import dataframe_queries as tpch_dataframe_queries
-    from benchbox.core.tpch.dataframe_queries import TPCH_DEFAULT_PARAMS, set_parameter_overrides
+    from benchbox.core.tpch.dataframe_queries import set_parameter_overrides, set_scale_factor
 
     ids = query_ids if query_ids is not None else benchmark.get_implemented_queries()
     registry = benchmark.get_dataframe_queries()
     divergences: list[DataFrameDivergence] = []
-    # Align the DataFrame surface's Q11 threshold with canonical qgen's
-    # fraction/SF rendering, exactly as seeded production runs do; restore any
-    # ambient overrides afterwards rather than clearing them.
+    # Compare against the scale-aware defaults alone. The DataFrame Q11 default
+    # is now scale-aware (0.0001 / SF), exactly like canonical qgen and the
+    # unseeded production run path, so no gate-local fraction override is needed:
+    # clear any ambient parameter overrides and declare the gate's scale through
+    # the same product seam the run path uses. Restore both afterwards.
     previous_overrides = tpch_dataframe_queries._parameter_overrides
-    sf1_fraction = TPCH_DEFAULT_PARAMS[11]["fraction"]
-    set_parameter_overrides({11: {"fraction": sf1_fraction / benchmark.scale_factor}})
+    previous_scale_factor = tpch_dataframe_queries._scale_factor
+    set_parameter_overrides(None)
+    set_scale_factor(benchmark.scale_factor)
     try:
         for query_id in ids:
             try:
@@ -233,6 +235,7 @@ def find_dataframe_divergences(
                         divergences.append(DataFrameDivergence(query_id, variant_id, backend, f"error: {exc}"))
     finally:
         set_parameter_overrides(previous_overrides)
+        set_scale_factor(previous_scale_factor)
     return divergences
 
 

--- a/tests/unit/core/test_parameter_parity.py
+++ b/tests/unit/core/test_parameter_parity.py
@@ -22,6 +22,7 @@ from benchbox.core.runner.dataframe_runner import (
     _clear_parameter_overrides,
     _execute_dataframe_queries,
     _setup_parameter_overrides,
+    _setup_parameter_overrides_for_stream,
 )
 from benchbox.core.tpcds.dataframe_queries.parameters import (
     TPCDS_DEFAULT_PARAMS,
@@ -32,6 +33,7 @@ from benchbox.core.tpch.dataframe_queries import (
     TPCH_DEFAULT_PARAMS,
     get_tpch_parameters,
     set_parameter_overrides as tpch_set_overrides,
+    set_scale_factor as tpch_set_scale_factor,
 )
 from benchbox.core.tpch.parameter_extractor import (
     clear_cache as tpch_clear_cache,
@@ -549,3 +551,73 @@ class TestQueryFunctionsCentralized:
         tpcds_set_overrides(None)
         params = get_parameters(96)
         assert params.get("hours") == [(8, 9)]
+
+
+# =============================================================================
+# Unseeded Q11 Scale-Fraction Regression
+# =============================================================================
+
+
+class TestUnseededQ11ScaleFraction:
+    """Unseeded DataFrame runs must render Q11's fraction as 0.0001 / SF.
+
+    Canonical TPC-H qgen renders the Q11 value threshold as 0.0001 / SF, and the
+    SQL run path mirrors that via the {q11_fraction} token. Without a seed, the
+    DataFrame surface used to fall back to the static SF=1 value at every scale;
+    these tests pin the scale-aware default so the product run path stays
+    scale-faithful (regression for tpch-dataframe-unseeded-q11-scale-fraction).
+    """
+
+    def setup_method(self):
+        tpch_set_overrides(None)
+        tpch_set_scale_factor(None)
+
+    def teardown_method(self):
+        tpch_set_overrides(None)
+        tpch_set_scale_factor(None)
+
+    @pytest.mark.parametrize(
+        "scale_factor, expected_fraction",
+        [(0.1, 0.001), (1.0, 0.0001), (10.0, 0.00001)],
+    )
+    def test_unseeded_runner_setup_scales_q11_fraction(self, scale_factor, expected_fraction):
+        """The unseeded runner seam derives Q11's fraction from the scale factor."""
+        _setup_parameter_overrides_for_stream(
+            benchmark_id="tpch",
+            seed=None,
+            scale_factor=scale_factor,
+            stream_id=0,
+            applied_contexts=set(),
+        )
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(expected_fraction)
+
+    @pytest.mark.parametrize("benchmark_id", ["tpch", "tpch_skew", "tpchavoc"])
+    def test_tpch_family_unseeded_setup_scales_q11_fraction(self, benchmark_id):
+        """Every TPC-H-family benchmark shares the parameter seam and scales alike.
+
+        TPC-H Skew re-registers the canonical TPC-H DataFrame queries verbatim and
+        TPC-Havoc's variants read the same seam, so all three must derive Q11's
+        fraction from the run's scale factor on the unseeded path.
+        """
+        _setup_parameter_overrides_for_stream(
+            benchmark_id=benchmark_id,
+            seed=None,
+            scale_factor=0.1,
+            stream_id=0,
+            applied_contexts=set(),
+        )
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.001)
+
+    def test_seeded_override_takes_precedence_over_scaled_default(self):
+        """A seed-derived Q11 fraction override wins over the scaled default."""
+        tpch_set_scale_factor(0.1)  # scaled default would be 0.001
+        tpch_set_overrides({11: {"fraction": 0.00002}})
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.00002)
+
+    def test_clear_resets_scale_factor_to_sf1(self):
+        """Clearing overrides resets the Q11 fraction to the SF=1 rendering."""
+        tpch_set_scale_factor(0.1)
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.001)
+
+        _clear_parameter_overrides("tpch")
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.0001)


### PR DESCRIPTION
## Problem

Canonical TPC-H Q11 renders its value threshold as `0.0001 / SF`. The SQL run path is scale-faithful (PR #785's `{q11_fraction}` token), but the DataFrame surface was **not**, unless a qgen seed was given: `dataframe_runner._setup_parameter_overrides` returned early when `seed is None`, so every Q11 DataFrame impl (canonical TPC-H, **TPC-H Skew**, and all TPC-Havoc variants) fell back to `TPCH_DEFAULT_PARAMS[11]["fraction"] = 0.0001` (the SF=1 value) at **all** scales. At SF=0.1 the executed Q11 threshold was 10x too small; at SF=10, 10x too large — wrong row counts and timings on the product run path.

The TPC-Havoc DataFrame equivalence gate hid this by injecting `{11: {"fraction": 0.0001/SF}}` via `set_parameter_overrides`.

## Fix

Fixed at the parameter seam where scale is known:

- **`benchbox/core/tpch/dataframe_queries.py`** — added a module-level scale factor and `set_scale_factor()`. `get_tpch_parameters()` now derives Q11's fraction as `0.0001 / SF`, mirroring the SQL side's `{q11_fraction}` rendering **exactly** (same 10-decimal literal the seeded extraction parses). Seed-derived overrides still win, so seeded runs are unchanged.
- **`benchbox/core/runner/dataframe_runner.py`** — sets the scale factor on the unseeded path (and resets it on clear) for every TPC-H-family DataFrame benchmark (`tpch`, `tpch_skew`, `tpchavoc`) via a shared id set.
- **`benchbox/core/tpchavoc/dataframe_equivalence.py`** — dropped the gate-local Q11 fraction override; the gate now declares its scale through the same product seam and clears ambient overrides for isolation.

## Verification

- `make tpchavoc-dataframe-equivalence-report` → **0 divergent / 440 equivalent** at SF=0.1 with the override removed (proof the default is now scale-aware on its own).
- Verified Q11 equivalence vs canonical SQL at SF 0.1 and 1.0 via the gate machinery; SF=10's fraction (0.00001) covered by the new unit test.
- New focused regression tests: unseeded run path renders `0.0001/SF` for Q11 across the TPC-H family (`tpch`/`tpch_skew`/`tpchavoc`), seeded overrides take precedence, and clearing resets to the SF=1 rendering.
- `ruff check`/`format`, `ty check`, and the full unit suite for the touched areas all pass.

TODO `tpch-dataframe-unseeded-q11-scale-fraction` moved to `active/` and status-bumped.

https://claude.ai/code/session_01TBBm5e35fghYM4FNMgvtfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBm5e35fghYM4FNMgvtfZ)_