### PR TITLE
feat(plan-capture): isolated capture-phase building block + thread-safe first-N counter

### DIFF
--- a/_project/TODO/main/planning/query-plan-capture-docs-overhead-correction.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-docs-overhead-correction.yaml
@@ -5,14 +5,15 @@ priority: Medium
 status: Completed
 category: Documentation
 
-# UPDATE (2026-06-14): Corrections applied to docs/features/query-plan-analysis.md.
-# Note: the PostgreSQL DML guard described as "pending" in this TODO has since
-# LANDED via #784 (PostgreSQL guard) and #786 (shared is_dml_query covering
-# CTAS/CMV/SELECT-INTO). The docs were therefore corrected to describe the guard
-# as present (not pending): PostgreSQL SELECT capture costs ~1x query time
-# (EXPLAIN ANALYZE, BUFFERS) and DML/write-DDL is downgraded to non-ANALYZE
-# EXPLAIN. The blanket "Other platforms: ~10-50ms" claim was replaced with a
-# per-platform overhead table distinguishing ANALYZE vs static-EXPLAIN paths.
+# UPDATE (2026-06-15): Already resolved on develop by PR #793
+# ("docs(plan-capture): correct overhead claims and PostgreSQL section"), which
+# landed concurrently with this branch. #793 replaced the blanket
+# "Other platforms: ~10-50ms" claim with a per-platform breakdown and corrected
+# the PostgreSQL section (SELECT ~1x via EXPLAIN ANALYZE/BUFFERS; DML downgraded
+# to non-ANALYZE EXPLAIN). The DML guard described as "pending" in this TODO had
+# itself already LANDED via #784 (PostgreSQL guard) + #786 (shared is_dml_query
+# covering CTAS/CMV/SELECT-INTO). This branch's duplicate doc edits were dropped
+# during rebase to defer to #793; closing this TODO as Completed (work done by #793).
 
 description: |
   docs/features/query-plan-analysis.md contains two inaccuracies added by PR #776:

--- a/_project/TODO/main/planning/query-plan-capture-docs-overhead-correction.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-docs-overhead-correction.yaml
@@ -2,8 +2,17 @@ id: query-plan-capture-docs-overhead-correction
 title: "Correct query-plan-analysis.md: PostgreSQL EXPLAIN ANALYZE overhead and DML note"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Documentation
+
+# UPDATE (2026-06-14): Corrections applied to docs/features/query-plan-analysis.md.
+# Note: the PostgreSQL DML guard described as "pending" in this TODO has since
+# LANDED via #784 (PostgreSQL guard) and #786 (shared is_dml_query covering
+# CTAS/CMV/SELECT-INTO). The docs were therefore corrected to describe the guard
+# as present (not pending): PostgreSQL SELECT capture costs ~1x query time
+# (EXPLAIN ANALYZE, BUFFERS) and DML/write-DDL is downgraded to non-ANALYZE
+# EXPLAIN. The blanket "Other platforms: ~10-50ms" claim was replaced with a
+# per-platform overhead table distinguishing ANALYZE vs static-EXPLAIN paths.
 
 description: |
   docs/features/query-plan-analysis.md contains two inaccuracies added by PR #776:
@@ -40,7 +49,7 @@ prior_art:
 work:
   - id: w1
     summary: "Correct the performance overhead table for PostgreSQL"
-    status: pending
+    status: done
     notes: |
       In the Performance Impact section, revise the "Other platforms" row to
       distinguish ANALYZE and non-ANALYZE paths:
@@ -59,7 +68,7 @@ work:
   - id: w2
     summary: "Correct the DML note in the PostgreSQL platform section"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       The DML note currently says: "DML statements use FORMAT JSON without ANALYZE
       to prevent double-execution side effects." Replace with:

--- a/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
@@ -2,8 +2,68 @@ id: query-plan-capture-isolation-phase-design
 title: "Design and implement plan capture as an explicit isolated benchmark phase"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Core Functionality
+
+# PROGRESS (2026-06-14):
+#   - w1 (design note): DONE — see design_note below.
+#   - w2 (thread safety): DONE — _plan_capture_iteration_counts read-increment-write
+#     is now guarded by self._plan_capture_lock (threading.Lock created in
+#     PlatformAdapter.__init__). Concurrent-stream tests added in
+#     tests/unit/platforms/test_plan_capture_iteration_count.py.
+#   - w3 (phase hook): PARTIAL — the additive phase function lives in the new
+#     benchbox/core/plan_capture_phase.py (run_plan_capture_phase). It opens a
+#     fresh connection by default, forces analyze_plans=False (structural only),
+#     bypasses the measurement-phase sampling filters, and returns plans +
+#     fingerprints + per-query timing. NOT YET wired into benchbox/cli/commands/run.py
+#     as a --capture-plans phase toggle — the inline path remains the default
+#     (deliberately additive; see anti_patterns). CLI cutover is the remaining work.
+#   - w4 (user-facing CLI/phase docs): DEFERRED until the CLI wiring lands, so the
+#     docs do not claim a phase that --capture-plans does not yet trigger. The
+#     overhead/DML doc corrections (separate TODO) are complete.
+#   - w5 (phase isolation tests): PARTIAL — module-level isolation tests added in
+#     tests/integration/test_plan_capture_phase.py (DML single-execution, fingerprint
+#     population, config restoration, supplied-connection reuse). A full end-to-end
+#     CLI run assertion follows the w3 CLI cutover.
+
+design_note: |
+  Plan capture phase contract (w1)
+  --------------------------------
+  Lifecycle position: the capture phase runs AFTER all power/throughput
+  iterations complete, when measurement is already stable. It never executes
+  while a timed query is in flight, so EXPLAIN can no longer delay a measured
+  query or contend on the measurement connection (the accepted trade-off in the
+  timeout PR, #789).
+
+  Connection model (resolves the gating open_question): SEPARATE connection by
+  default. run_plan_capture_phase() opens a fresh connection via
+  adapter.create_connection() and closes it when done, so the phase cannot
+  contaminate measurement transaction state. Callers may pass connection=<conn>
+  to reuse an existing one (e.g. embedded :memory: engines where a second
+  connection would not see loaded data); in that case the caller owns closing it.
+
+  EXPLAIN mode: structural-only. The phase forces analyze_plans=False, so:
+    - DML/write-DDL is never re-executed (the shared is_dml_query guard already
+      downgrades these, and analyze_plans=False makes SELECT capture cheap too).
+    - SELECT capture pays planning cost only, not ~1x execution time.
+  Fingerprints are unaffected (they exclude timing/cardinality), so structural
+  regression detection is unchanged. ANALYZE remains opt-in via the analyze_plans
+  argument for callers that explicitly want actual-plan stats.
+
+  Filter semantics: the phase receives an explicit query list, which IS the
+  selection. It bypasses the measurement-phase sampling filters (plan_first_n,
+  plan_sampling_rate) so each requested query is captured exactly once, and
+  restores all overridden adapter attributes in a finally block.
+
+  Result contract: PlanCapturePhaseResult carries plans (query_id -> DAG),
+  fingerprints (query_id -> str), per_query_capture_ms, total_capture_ms, and
+  captured/failed counts — ready to merge into run metadata (plan_fingerprints).
+
+  Backward compatibility: this is ADDITIVE. The inline execute_query() capture
+  path is untouched, so platforms that surface plans as an execution side effect
+  (BigQuery job stats, Spark event logs) keep working. The CLI cutover that makes
+  --capture-plans drive the phase for EXPLAIN-based platforms is the remaining
+  incremental step.
 
 description: |
   Plan capture is intended to run as a separate, isolated phase of the benchmark
@@ -60,7 +120,7 @@ prior_art:
 work:
   - id: w1
     summary: "Design the plan capture phase contract: inputs, outputs, timing, connection model"
-    status: pending
+    status: done
     notes: |
       Write a design note (inline in this TODO or as a brief ADR) covering:
         - Where in the run lifecycle the capture phase fires (after last power/throughput iteration)
@@ -73,7 +133,7 @@ work:
   - id: w2
     summary: "Fix _plan_capture_iteration_counts thread safety"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Replace the bare dict mutation at result_capture.py:591-595 with a
       threading.Lock-protected increment. Options:
@@ -87,7 +147,7 @@ work:
   - id: w3
     summary: "Add a run_plan_capture_phase() hook to the run orchestrator"
     needs: [w1]
-    status: pending
+    status: partial  # phase function in benchbox/core/plan_capture_phase.py; CLI cutover pending
     notes: |
       Add a function to benchbox/cli/commands/run.py (or a new
       benchbox/core/plan_capture_phase.py) that:
@@ -104,7 +164,7 @@ work:
   - id: w4
     summary: "Update docs and --help to describe capture as a post-measurement phase"
     needs: [w3]
-    status: pending
+    status: deferred  # gated on w3 CLI cutover; docs must not claim a phase --capture-plans does not yet trigger
     notes: |
       Update docs/features/query-plan-analysis.md and docs/reference/cli/run.md:
         - Describe that --capture-plans triggers a separate post-measurement phase
@@ -115,7 +175,7 @@ work:
   - id: w5
     summary: "Add integration test verifying phase isolation"
     needs: [w3, w4]
-    status: pending
+    status: partial  # tests/integration/test_plan_capture_phase.py covers phase isolation; full CLI-run assertion follows w3 cutover
     notes: |
       Add a test that:
         - Runs a mock benchmark with capture_plans=True

--- a/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
@@ -147,7 +147,7 @@ work:
   - id: w3
     summary: "Add a run_plan_capture_phase() hook to the run orchestrator"
     needs: [w1]
-    status: partial  # phase function in benchbox/core/plan_capture_phase.py; CLI cutover pending
+    status: in_progress  # phase function in benchbox/core/plan_capture_phase.py; CLI cutover pending
     notes: |
       Add a function to benchbox/cli/commands/run.py (or a new
       benchbox/core/plan_capture_phase.py) that:
@@ -164,7 +164,7 @@ work:
   - id: w4
     summary: "Update docs and --help to describe capture as a post-measurement phase"
     needs: [w3]
-    status: deferred  # gated on w3 CLI cutover; docs must not claim a phase --capture-plans does not yet trigger
+    status: pending  # gated on w3 CLI cutover; docs must not claim a phase --capture-plans does not yet trigger
     notes: |
       Update docs/features/query-plan-analysis.md and docs/reference/cli/run.md:
         - Describe that --capture-plans triggers a separate post-measurement phase
@@ -175,7 +175,7 @@ work:
   - id: w5
     summary: "Add integration test verifying phase isolation"
     needs: [w3, w4]
-    status: partial  # tests/integration/test_plan_capture_phase.py covers phase isolation; full CLI-run assertion follows w3 cutover
+    status: in_progress  # tests/integration/test_plan_capture_phase.py covers phase isolation; full CLI-run assertion follows w3 cutover
     notes: |
       Add a test that:
         - Runs a mock benchmark with capture_plans=True

--- a/benchbox/core/plan_capture_phase.py
+++ b/benchbox/core/plan_capture_phase.py
@@ -24,7 +24,10 @@ Key isolation properties:
 - **Structural-only**: ``analyze_plans`` is forced to ``False`` for the phase,
   so DML/CTAS queries are never re-executed and SELECT queries pay only the
   planning cost rather than ~1x execution time. The structural fingerprint is
-  unaffected (it excludes timing/cardinality by design).
+  unaffected (it excludes timing/cardinality by design). Adapters must honour
+  ``analyze_plans`` in ``get_query_plan()`` for this to hold — DuckDB/MotherDuck
+  and PostgreSQL do; an adapter that always issues EXPLAIN ANALYZE would still
+  re-execute SELECTs in this phase.
 - **Filter-independent**: the measurement-phase sampling filters
   (``plan_first_n``, ``plan_sampling_rate``) are bypassed so each requested
   query is captured exactly once; the explicit query list is the selection.

--- a/benchbox/core/plan_capture_phase.py
+++ b/benchbox/core/plan_capture_phase.py
@@ -1,0 +1,153 @@
+"""Isolated, post-measurement query-plan capture phase.
+
+Plan capture is intended to be a *separate* phase of a benchmark run, decoupled
+from the timed power/throughput measurement. The legacy path captures plans
+inline inside each adapter's ``execute_query()`` (guarded by ``capture_plans``),
+which interleaves EXPLAIN with the timed query and — for ANALYZE-based adapters
+(DuckDB, MotherDuck, PostgreSQL) — contends on the same connection.
+
+This module provides the additive building block for the phased model:
+``run_plan_capture_phase()`` captures plans *after* measurement is complete,
+using a fresh connection and structural-only EXPLAIN (no ANALYZE re-execution).
+It is intentionally additive — the inline path stays in place so platforms that
+surface plans as an execution side effect (BigQuery job stats, Spark event logs)
+keep working. See ``_project/TODO/main/planning/
+query-plan-capture-isolation-phase-design.yaml`` for the full design note.
+
+Key isolation properties:
+
+- **Post-measurement**: the caller runs this after all power/throughput
+  iterations, so EXPLAIN never delays a timed query.
+- **Separate connection** (default): a fresh connection is opened via
+  ``adapter.create_connection()`` so the phase cannot contaminate measurement
+  transaction state. Callers may pass an existing ``connection`` to opt out.
+- **Structural-only**: ``analyze_plans`` is forced to ``False`` for the phase,
+  so DML/CTAS queries are never re-executed and SELECT queries pay only the
+  planning cost rather than ~1x execution time. The structural fingerprint is
+  unaffected (it excludes timing/cardinality by design).
+- **Filter-independent**: the measurement-phase sampling filters
+  (``plan_first_n``, ``plan_sampling_rate``) are bypassed so each requested
+  query is captured exactly once; the explicit query list is the selection.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class PlanCapturePhaseResult:
+    """Outcome of an isolated plan-capture phase.
+
+    Attributes:
+        plans: query_id -> parsed ``QueryPlanDAG`` for queries captured.
+        fingerprints: query_id -> structural ``plan_fingerprint``.
+        per_query_capture_ms: query_id -> wall-clock ms spent on that capture.
+        total_capture_ms: wall-clock ms for the whole phase (incl. connection).
+        captured: number of queries with a parsed plan.
+        failed: number of queries whose capture failed (no plan parsed).
+    """
+
+    plans: dict[str, Any] = field(default_factory=dict)
+    fingerprints: dict[str, str] = field(default_factory=dict)
+    per_query_capture_ms: dict[str, float] = field(default_factory=dict)
+    total_capture_ms: float = 0.0
+    captured: int = 0
+    failed: int = 0
+
+
+def _normalize_queries(queries: Mapping[str, str] | Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Coerce the queries argument into an ordered list of ``(query_id, sql)``."""
+    if isinstance(queries, Mapping):
+        return list(queries.items())
+    return [(str(qid), sql) for qid, sql in queries]
+
+
+def run_plan_capture_phase(
+    adapter: Any,
+    queries: Mapping[str, str] | Iterable[tuple[str, str]],
+    *,
+    connection: Any | None = None,
+    connection_config: Mapping[str, Any] | None = None,
+    analyze_plans: bool = False,
+    close_connection: bool | None = None,
+) -> PlanCapturePhaseResult:
+    """Capture query plans in an isolated phase, decoupled from measurement.
+
+    Intended to run *after* all power/throughput iterations complete. For each
+    ``(query_id, sql)`` it calls ``adapter.capture_query_plan()`` and collects
+    the parsed plan, fingerprint, and per-query capture time.
+
+    Args:
+        adapter: A platform adapter exposing ``capture_query_plan()`` and (when
+            opening its own connection) ``create_connection()``.
+        queries: Mapping of ``query_id -> sql`` or an iterable of
+            ``(query_id, sql)`` pairs. Order is preserved.
+        connection: An existing connection to capture against. When ``None``
+            (default), a fresh connection is opened via
+            ``adapter.create_connection(**connection_config)`` — the isolation
+            default that avoids contaminating measurement state.
+        connection_config: kwargs forwarded to ``create_connection()`` when a
+            fresh connection is opened. Ignored if ``connection`` is provided.
+        analyze_plans: Whether the phase should run ANALYZE-based EXPLAIN.
+            Defaults to ``False`` (structural plan only, no re-execution cost);
+            ANALYZE belongs to the measurement phase, not the capture phase.
+        close_connection: Whether to close the connection when done. Defaults to
+            ``True`` when this function opened the connection and ``False`` when
+            the caller supplied one.
+
+    Returns:
+        A :class:`PlanCapturePhaseResult` with plans, fingerprints, and timing.
+    """
+    items = _normalize_queries(queries)
+    result = PlanCapturePhaseResult()
+
+    owns_connection = connection is None
+    if close_connection is None:
+        close_connection = owns_connection
+
+    # Save the measurement-phase configuration so the phase can run structural,
+    # filter-free capture without leaking that override back into the adapter.
+    saved = {
+        "analyze_plans": getattr(adapter, "analyze_plans", True),
+        "capture_plans": getattr(adapter, "capture_plans", False),
+        "plan_first_n": getattr(adapter, "plan_first_n", None),
+        "plan_sampling_rate": getattr(adapter, "plan_sampling_rate", None),
+    }
+
+    phase_start = time.perf_counter()
+    try:
+        if owns_connection:
+            connection = adapter.create_connection(**(dict(connection_config) if connection_config else {}))
+
+        adapter.analyze_plans = analyze_plans
+        adapter.capture_plans = True
+        # The explicit query list is the selection for this phase; bypass the
+        # measurement-phase sampling filters so each query is captured once.
+        adapter.plan_first_n = None
+        adapter.plan_sampling_rate = None
+
+        for query_id, sql in items:
+            plan, capture_ms = adapter.capture_query_plan(connection, sql, query_id)
+            result.per_query_capture_ms[query_id] = capture_ms
+            if plan is not None:
+                result.plans[query_id] = plan
+                result.fingerprints[query_id] = plan.plan_fingerprint
+                result.captured += 1
+            else:
+                result.failed += 1
+    finally:
+        adapter.analyze_plans = saved["analyze_plans"]
+        adapter.capture_plans = saved["capture_plans"]
+        adapter.plan_first_n = saved["plan_first_n"]
+        adapter.plan_sampling_rate = saved["plan_sampling_rate"]
+        if close_connection and connection is not None:
+            with contextlib.suppress(Exception):
+                connection.close()
+
+    result.total_capture_ms = (time.perf_counter() - phase_start) * 1000
+    return result

--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -135,8 +136,12 @@ class PlatformAdapter(
         self.plan_query_filter: set[str] | None = (
             {q.strip() for q in plan_queries_str.split(",") if q.strip()} if plan_queries_str else None
         )
-        # Track iteration counts for plan_first_n
+        # Track iteration counts for plan_first_n. Under concurrent stream
+        # execution (--streams > 1) multiple threads call capture_query_plan()
+        # and run a read-increment-write against this dict, so the increment is
+        # guarded by a lock to keep plan_first_n a correct per-query-id counter.
         self._plan_capture_iteration_counts: dict[str, int] = {}
+        self._plan_capture_lock = threading.Lock()
         self.tuning_enabled = config.get("tuning_enabled", False)
         # Driver runtime contract metadata (set by adapter factory / runtime resolution).
         self.driver_package = config.get("driver_package")

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -31,6 +31,7 @@ import platform
 import random
 import re
 import statistics
+import threading
 import time
 from collections.abc import Mapping
 from datetime import datetime
@@ -462,6 +463,12 @@ class ResultCaptureMixin:
         self.plan_capture_failures = 0
         self.plan_capture_errors: list[dict[str, Any]] = []
         self._plan_capture_iteration_counts: dict[str, int] = {}
+        # The lock is created in PlatformAdapter.__init__; create it defensively
+        # for hosts that reset stats without going through __init__ (e.g. tests
+        # that mix in this class directly). Reset runs before any worker threads
+        # spawn, so installing the lock here is safe.
+        if not hasattr(self, "_plan_capture_lock"):
+            self._plan_capture_lock = threading.Lock()
 
     def get_normalized_result_metadata(
         self,
@@ -766,10 +773,13 @@ class ResultCaptureMixin:
         if self.plan_query_filter and query_id not in self.plan_query_filter:
             return None, 0.0
 
-        # Apply first-N iterations filter if specified
+        # Apply first-N iterations filter if specified. The read-increment-write
+        # is guarded so concurrent streams (--streams > 1) cannot interleave and
+        # capture more (or fewer) than plan_first_n plans per query_id.
         if self.plan_first_n is not None:
-            iteration = self._plan_capture_iteration_counts.get(query_id, 0)
-            self._plan_capture_iteration_counts[query_id] = iteration + 1
+            with self._plan_capture_lock:
+                iteration = self._plan_capture_iteration_counts.get(query_id, 0)
+                self._plan_capture_iteration_counts[query_id] = iteration + 1
             if iteration >= self.plan_first_n:
                 return None, 0.0
 

--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -704,18 +704,24 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         EXPLAIN ANALYZE physically re-executes the statement, which would mutate
         data a second time. The plan structure is still captured; execution
         statistics are absent for DML.
+
+        ANALYZE is also suppressed when ``self.analyze_plans`` is False (e.g. the
+        isolated capture phase or ``--platform-option analyze_plans=false``):
+        plain EXPLAIN (FORMAT JSON) captures the estimated plan structure without
+        re-executing the query, so a SELECT is not run a second time.
         """
         from benchbox.platforms.base.result_capture import is_dml_query
 
         cursor = connection.cursor()
 
         # Use FORMAT JSON so PostgreSQLQueryPlanParser can parse the output.
-        # ANALYZE and BUFFERS give actual timing and I/O info for SELECT queries.
-        # DML queries are downgraded to FORMAT JSON only to prevent double-execution.
-        if is_dml_query(query):
-            options = ["FORMAT JSON"]
-        else:
+        # ANALYZE and BUFFERS give actual timing and I/O info for SELECT queries,
+        # but they re-execute the statement. Skip them for DML (double-mutation
+        # guard) and whenever analyze_plans is disabled (estimated-plan-only).
+        if self.analyze_plans and not is_dml_query(query):
             options = ["ANALYZE", "BUFFERS", "FORMAT JSON"]
+        else:
+            options = ["FORMAT JSON"]
         if explain_options:
             if explain_options.get("verbose"):
                 options.append("VERBOSE")

--- a/tests/integration/test_plan_capture_phase.py
+++ b/tests/integration/test_plan_capture_phase.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Joe Harris / BenchBox Project
+#
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Integration tests for the isolated, post-measurement plan-capture phase.
+
+These exercise ``run_plan_capture_phase`` end-to-end against a real (file-based)
+DuckDB database, the real DuckDB EXPLAIN, and the real DuckDBQueryPlanParser —
+no external credentials required. They verify the two isolation guarantees that
+motivated query-plan-capture-isolation-phase-design:
+
+- the phase runs *after* measurement and does not re-execute DML
+  (``dml_single_execution``), and
+- the phase populates plan fingerprints in its result
+  (``capture_phase`` fires post-measurement).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.plan_capture_phase import run_plan_capture_phase
+from benchbox.platforms.duckdb import DuckDBAdapter
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+@pytest.fixture
+def file_adapter(tmp_path):
+    """A file-based DuckDB adapter so a fresh phase connection sees loaded data."""
+    db_path = str(tmp_path / "phase.duckdb")
+    return DuckDBAdapter(database_path=db_path, capture_plans=True)
+
+
+def _seed_table(adapter: DuckDBAdapter) -> None:
+    conn = adapter.create_connection()
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER, val INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)")
+    finally:
+        conn.close()
+
+
+def _row_count(adapter: DuckDBAdapter) -> int:
+    conn = adapter.create_connection()
+    try:
+        return conn.execute("SELECT COUNT(*) FROM t").fetchall()[0][0]
+    finally:
+        conn.close()
+
+
+def test_capture_phase_populates_fingerprints_post_measurement(file_adapter):
+    """The capture phase opens its own connection and fills plans + fingerprints."""
+    _seed_table(file_adapter)
+
+    queries = {
+        "q_select": "SELECT id, SUM(val) FROM t GROUP BY id",
+        "q_filter": "SELECT * FROM t WHERE val > 15",
+    }
+    result = run_plan_capture_phase(file_adapter, queries)
+
+    assert result.captured == 2
+    assert result.failed == 0
+    assert set(result.plans) == {"q_select", "q_filter"}
+    # Structural fingerprints are populated for every captured query.
+    for query_id in queries:
+        assert result.fingerprints[query_id]
+        assert result.per_query_capture_ms[query_id] >= 0.0
+    assert result.total_capture_ms >= 0.0
+
+
+def test_capture_phase_dml_single_execution(file_adapter):
+    """A DML query is captured structurally without re-executing the write."""
+    _seed_table(file_adapter)
+    before = _row_count(file_adapter)
+    assert before == 3
+
+    # The capture phase forces analyze_plans=False, and the shared DML guard
+    # downgrades writes to EXPLAIN (FORMAT JSON) — so EXPLAIN must not insert.
+    result = run_plan_capture_phase(
+        file_adapter,
+        {"q_insert": "INSERT INTO t VALUES (4, 40)"},
+    )
+
+    after = _row_count(file_adapter)
+    assert after == before, "capture phase must not execute the INSERT"
+    # The structural plan is still captured for the DML statement.
+    assert result.captured == 1
+    assert result.fingerprints["q_insert"]
+
+
+def test_capture_phase_restores_adapter_config(file_adapter):
+    """The phase must not leak its structural-only overrides back to the adapter."""
+    _seed_table(file_adapter)
+    file_adapter.analyze_plans = True
+    file_adapter.plan_first_n = 7
+    file_adapter.plan_sampling_rate = 0.5
+
+    run_plan_capture_phase(file_adapter, {"q": "SELECT 1"})
+
+    assert file_adapter.analyze_plans is True
+    assert file_adapter.plan_first_n == 7
+    assert file_adapter.plan_sampling_rate == 0.5
+    assert file_adapter.capture_plans is True
+
+
+def test_capture_phase_reuses_supplied_connection(file_adapter):
+    """When a connection is supplied, the phase captures against it and leaves it open."""
+    _seed_table(file_adapter)
+    conn = file_adapter.create_connection()
+    try:
+        result = run_plan_capture_phase(
+            file_adapter,
+            {"q": "SELECT * FROM t"},
+            connection=conn,
+        )
+        assert result.captured == 1
+        # Connection is still usable: phase must not close a caller-owned connection.
+        assert conn.execute("SELECT COUNT(*) FROM t").fetchall()[0][0] == 3
+    finally:
+        conn.close()

--- a/tests/integration/test_plan_capture_phase.py
+++ b/tests/integration/test_plan_capture_phase.py
@@ -24,6 +24,7 @@ from benchbox.platforms.duckdb import DuckDBAdapter
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.medium,  # required speed marker: real (file-based) DuckDB I/O
 ]
 
 

--- a/tests/unit/platforms/test_plan_capture_iteration_count.py
+++ b/tests/unit/platforms/test_plan_capture_iteration_count.py
@@ -81,9 +81,7 @@ def test_plan_first_n_counts_are_per_query_id(monkeypatch):
         barrier.wait()
         adapter.capture_query_plan(connection=object(), query="SELECT 1", query_id=query_id)
 
-    threads = [
-        threading.Thread(target=worker, args=(qid,)) for qid in query_ids for _ in range(per_query_threads)
-    ]
+    threads = [threading.Thread(target=worker, args=(qid,)) for qid in query_ids for _ in range(per_query_threads)]
     for thread in threads:
         thread.start()
     for thread in threads:

--- a/tests/unit/platforms/test_plan_capture_iteration_count.py
+++ b/tests/unit/platforms/test_plan_capture_iteration_count.py
@@ -1,0 +1,95 @@
+"""Thread-safety tests for the plan_first_n iteration counter.
+
+Under concurrent stream execution (``--streams > 1``) multiple threads call
+``capture_query_plan()`` for the same query_id and run a read-increment-write
+against ``_plan_capture_iteration_counts``. Without a lock that sequence can
+interleave and capture more than ``plan_first_n`` plans. These tests hammer the
+counter from many threads and assert ``plan_first_n`` is honoured exactly.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from benchbox.platforms.duckdb import DuckDBAdapter
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+class _StubPlan:
+    """Minimal QueryPlanDAG stand-in for capture_query_plan()."""
+
+    plan_fingerprint = "stub-fingerprint"
+
+    def estimate_serialized_size(self) -> int:
+        return 16
+
+
+class _StubParser:
+    def parse_explain_output(self, query_id: str, explain_output: str) -> _StubPlan:
+        return _StubPlan()
+
+
+def _make_stubbed_adapter(monkeypatch, **config) -> DuckDBAdapter:
+    """DuckDBAdapter whose EXPLAIN + parser are stubbed (no real database)."""
+    adapter = DuckDBAdapter(capture_plans=True, **config)
+    monkeypatch.setattr(adapter, "get_query_plan", lambda connection, query: "EXPLAIN OUTPUT")
+    monkeypatch.setattr(adapter, "get_query_plan_parser", lambda: _StubParser())
+    return adapter
+
+
+def test_plan_first_n_honoured_under_concurrent_capture(monkeypatch):
+    """N threads capturing the same query_id must yield exactly plan_first_n plans."""
+    first_n = 5
+    thread_count = 64
+    adapter = _make_stubbed_adapter(monkeypatch, plan_first_n=first_n)
+
+    barrier = threading.Barrier(thread_count)
+
+    def worker() -> None:
+        barrier.wait()  # maximise contention on the read-increment-write
+        adapter.capture_query_plan(connection=object(), query="SELECT 1", query_id="Q1")
+
+    threads = [threading.Thread(target=worker) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # The counter is a global per-query-id count, not per-thread: every call
+    # increments it, so it equals the number of invocations.
+    assert adapter._plan_capture_iteration_counts["Q1"] == thread_count
+    # Exactly plan_first_n captures should have produced a plan.
+    assert adapter.query_plans_captured == first_n
+
+
+def test_plan_first_n_counts_are_per_query_id(monkeypatch):
+    """Distinct query_ids keep independent first-N budgets under concurrency."""
+    first_n = 3
+    per_query_threads = 20
+    query_ids = ["Q1", "Q2", "Q3"]
+    adapter = _make_stubbed_adapter(monkeypatch, plan_first_n=first_n)
+
+    barrier = threading.Barrier(len(query_ids) * per_query_threads)
+
+    def worker(query_id: str) -> None:
+        barrier.wait()
+        adapter.capture_query_plan(connection=object(), query="SELECT 1", query_id=query_id)
+
+    threads = [
+        threading.Thread(target=worker, args=(qid,)) for qid in query_ids for _ in range(per_query_threads)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for qid in query_ids:
+        assert adapter._plan_capture_iteration_counts[qid] == per_query_threads
+    # first_n per query_id across three query_ids.
+    assert adapter.query_plans_captured == first_n * len(query_ids)

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -173,6 +173,21 @@ class TestPostgreSQLPlanCapture:
         assert "BUFFERS" in call_args.upper()
         assert "FORMAT JSON" in call_args.upper()
 
+    def test_get_query_plan_select_omits_analyze_when_disabled(self, monkeypatch):
+        """analyze_plans=False makes SELECT capture structural-only (no re-execution)."""
+        monkeypatch.setattr("benchbox.platforms.postgresql.psycopg", MagicMock())
+        adapter = PostgreSQLAdapter(capture_plans=True, analyze_plans=False)
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [('{"Plan":{}}',)]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        adapter.get_query_plan(conn, "SELECT count(*) FROM orders")
+
+        call_args = cursor.execute.call_args[0][0]
+        assert "ANALYZE" not in call_args.upper(), "analyze_plans=False must not re-execute the SELECT"
+        assert "FORMAT JSON" in call_args.upper()
+
 
 class TestPostgreSQLSubclassInheritance:
     """Verify TimescaleDB, CedarDB, and pg_mooncake inherit the parser without overrides."""


### PR DESCRIPTION
Picks up the two follow-up TODOs filed by #781 that most directly extend the recent plan-capture work.

## `query-plan-capture-isolation-phase-design` (High)

- **Thread-safety fix (w2, done):** the `_plan_capture_iteration_counts` read-increment-write is now guarded by a per-adapter `threading.Lock` (created in `PlatformAdapter.__init__`, defensively in `_reset_plan_capture_stats`). `plan_first_n` is now honoured exactly under concurrent streams.
- **Phase building block (w3, partial):** new `benchbox/core/plan_capture_phase.py` with `run_plan_capture_phase()` — an additive, post-measurement capture path. It opens a **fresh connection by default** (separate from measurement, resolving the gating open question), forces `analyze_plans=False` for structural-only EXPLAIN (no ANALYZE re-execution / no DML double-run), bypasses the measurement-phase sampling filters, restores all overridden adapter config in a `finally` block, and returns plans + fingerprints + per-query/total timing.
- **PostgreSQL now honours `analyze_plans`** (`benchbox/platforms/postgresql.py`): ANALYZE/BUFFERS are suppressed when `analyze_plans=False`, so the isolated phase no longer re-executes PostgreSQL SELECTs (fixes the review finding). Default behavior (`analyze_plans=True`) is unchanged.
- The inline `execute_query()` capture path is **left untouched** so BigQuery/Spark side-effect capture keeps working — per the TODO's anti-patterns, CLI cutover is intentionally a separate incremental step (remaining w3/w4/w5).
- Design note (w1) recorded in the TODO; work-item statuses updated.

## `query-plan-capture-docs-overhead-correction` (Medium)

⚠️ **Already resolved on `develop` by #793** ("docs(plan-capture): correct overhead claims and PostgreSQL section"), which landed concurrently with this branch. The duplicate `docs/features/query-plan-analysis.md` edits originally in this PR were **dropped during rebase** to defer to #793. This PR now only closes out the TODO (marks it Completed, attributing the doc fix to #793).

## Tests

- `tests/unit/platforms/test_plan_capture_iteration_count.py` — concurrent-stream first-N counter (64-thread contention, per-query-id budgets).
- `tests/integration/test_plan_capture_phase.py` — phase isolation: DML single-execution, fingerprint population, config restoration, supplied-connection reuse.
- `tests/unit/platforms/test_postgresql_plan_capture.py` — PostgreSQL `analyze_plans=False` structural-only path.

Rebased onto latest `develop` (b58b7463); merge conflict in the docs file resolved in favor of #793.

https://claude.ai/code/session_017QzkP7Z4himacTdL1sDreX