### PR TITLE
fix(tpch-df): wire unseeded Q11 scale fraction into the production DataFrame path

### DIFF
--- a/benchbox/core/runner/dataframe_runner.py
+++ b/benchbox/core/runner/dataframe_runner.py
@@ -69,14 +69,6 @@ logger = logging.getLogger(__name__)
 
 console = quiet_console
 
-# Benchmark ids that share the TPC-H DataFrame parameter seam
-# (benchbox.core.tpch.dataframe_queries): canonical TPC-H plus the benchmarks
-# whose DataFrame queries reuse the same query impls and get_tpch_parameters().
-# TPC-H Skew re-registers the TPC-H DataFrame queries verbatim, and TPC-Havoc's
-# variants read the same parameter seam, so all three need the scale-dependent
-# Q11 default (0.0001/SF) set and cleared together.
-_TPCH_FAMILY_DATAFRAME_IDS = ("tpch", "tpch_skew", "tpchavoc")
-
 DATAFRAME_RUNNER_API_SURFACE = "deprecated"
 DATAFRAME_RUNNER_LIFECYCLE = "deprecated-internal-compatibility-runner"
 DATAFRAME_PRODUCTION_EXECUTION_PATH = "adapter.run_benchmark+BenchmarkExecutionMixin"
@@ -597,17 +589,16 @@ def _setup_scale_dependent_defaults(benchmark_id: str, scale_factor: float) -> N
 
     Canonical TPC-H Q11 renders its value threshold as ``0.0001 / SF``. Unseeded
     DataFrame runs would otherwise read the SF=1 default at every scale; setting
-    the scale factor here keeps them aligned with the SQL run path. TPC-H Skew
-    and TPC-Havoc reuse the same TPC-H DataFrame parameter seam, so they are
-    handled the same way (see :data:`_TPCH_FAMILY_DATAFRAME_IDS`).
+    the scale factor here keeps them aligned with the SQL run path. The shared
+    seam (:func:`set_scale_factor_for_benchmark`) is a no-op for benchmarks
+    outside the TPC-H family.
     """
-    if benchmark_id in _TPCH_FAMILY_DATAFRAME_IDS:
-        try:
-            from benchbox.core.tpch.dataframe_queries import set_scale_factor
+    try:
+        from benchbox.core.tpch.dataframe_queries import set_scale_factor_for_benchmark
 
-            set_scale_factor(scale_factor)
-        except Exception:  # pragma: no cover - defensive; never block execution
-            logger.debug("Failed to set TPC-H DataFrame scale factor", exc_info=True)
+        set_scale_factor_for_benchmark(benchmark_id, scale_factor)
+    except Exception:  # pragma: no cover - defensive; never block execution
+        logger.debug("Failed to set TPC-H DataFrame scale factor", exc_info=True)
 
 
 def _setup_parameter_overrides(
@@ -673,16 +664,21 @@ def _setup_parameter_overrides(
 
 def _clear_parameter_overrides(benchmark_id: str) -> None:
     """Clear parameter overrides after execution."""
-    if benchmark_id in _TPCH_FAMILY_DATAFRAME_IDS:
-        try:
-            from benchbox.core.tpch.dataframe_queries import set_parameter_overrides, set_scale_factor
+    try:
+        from benchbox.core.tpch.dataframe_queries import (
+            TPCH_FAMILY_DATAFRAME_IDS,
+            set_parameter_overrides,
+            set_scale_factor_for_benchmark,
+        )
 
+        if benchmark_id in TPCH_FAMILY_DATAFRAME_IDS:
             set_parameter_overrides(None)
             # Reset the scale-dependent defaults to the SF=1 rendering.
-            set_scale_factor(None)
-        except Exception:
-            pass
-    elif benchmark_id == "tpcds":
+            set_scale_factor_for_benchmark(benchmark_id, None)
+            return
+    except Exception:
+        pass
+    if benchmark_id == "tpcds":
         try:
             from benchbox.core.tpcds.dataframe_queries.parameters import set_parameter_overrides
 

--- a/benchbox/core/tpch/dataframe_queries.py
+++ b/benchbox/core/tpch/dataframe_queries.py
@@ -134,6 +134,32 @@ def set_scale_factor(scale_factor: float | None) -> None:
     _scale_factor = 1.0 if scale_factor is None else float(scale_factor)
 
 
+# Benchmark ids whose DataFrame queries reuse this module's parameter seam
+# (get_tpch_parameters / the scale-dependent Q11 default). TPC-H Skew
+# re-registers the TPC-H DataFrame queries verbatim and TPC-Havoc's variants
+# read the same seam, so all three derive Q11's 0.0001/SF threshold from the
+# run's scale factor the same way.
+TPCH_FAMILY_DATAFRAME_IDS = frozenset({"tpch", "tpch_skew", "tpchavoc"})
+
+
+def set_scale_factor_for_benchmark(benchmark_id: str, scale_factor: float | None) -> None:
+    """Apply :func:`set_scale_factor` for TPC-H-family DataFrame benchmarks.
+
+    A no-op for any benchmark whose DataFrame queries do not share this module's
+    parameter seam (see :data:`TPCH_FAMILY_DATAFRAME_IDS`). Pass
+    ``scale_factor=None`` to reset to the SF=1 rendering. Both the production
+    DataFrame execution path (``BenchmarkExecutionMixin``) and the compatibility
+    runner call this so unseeded runs derive Q11's 0.0001/SF threshold at every
+    scale.
+
+    Args:
+        benchmark_id: Normalized benchmark id (e.g. from normalize_benchmark_id).
+        scale_factor: The run's scale factor, or None to reset to 1.0.
+    """
+    if benchmark_id in TPCH_FAMILY_DATAFRAME_IDS:
+        set_scale_factor(scale_factor)
+
+
 def get_tpch_parameters(query_id: int) -> dict[str, Any]:
     """Get parameters for a TPC-H query.
 

--- a/benchbox/platforms/dataframe/benchmark_mixin.py
+++ b/benchbox/platforms/dataframe/benchmark_mixin.py
@@ -713,6 +713,38 @@ class BenchmarkExecutionMixin:
         monitor: Any | None,
         run_options: DataFrameRunOptions | None = None,
     ) -> list[dict[str, Any]]:
+        """Execute DataFrame queries, scoping scale-dependent parameter defaults.
+
+        Canonical TPC-H Q11 renders its value threshold as ``0.0001 / SF``.
+        Unseeded DataFrame runs read the SF=1 default unless the scale factor is
+        declared, so set it for TPC-H-family benchmarks for the duration of query
+        execution (mirroring the SQL run path's ``{q11_fraction}`` rendering) and
+        reset it afterwards on every path.
+        """
+        from benchbox.core.tpch.dataframe_queries import set_scale_factor_for_benchmark
+
+        benchmark_id = normalize_benchmark_id(benchmark_config.name)
+        scale_factor = getattr(benchmark_config, "scale_factor", 1.0)
+        set_scale_factor_for_benchmark(benchmark_id, scale_factor)
+        try:
+            return self._run_query_iterations(
+                ctx=ctx,
+                benchmark_config=benchmark_config,
+                benchmark_instance=benchmark_instance,
+                monitor=monitor,
+                run_options=run_options,
+            )
+        finally:
+            set_scale_factor_for_benchmark(benchmark_id, None)
+
+    def _run_query_iterations(
+        self,
+        ctx: Any,
+        benchmark_config: BenchmarkConfig,
+        benchmark_instance: Any | None,
+        monitor: Any | None,
+        run_options: DataFrameRunOptions | None = None,
+    ) -> list[dict[str, Any]]:
         """Execute DataFrame queries with warmup and measurement iterations.
 
         Follows TPC power test methodology:

--- a/tests/unit/core/test_parameter_parity.py
+++ b/tests/unit/core/test_parameter_parity.py
@@ -621,3 +621,109 @@ class TestUnseededQ11ScaleFraction:
 
         _clear_parameter_overrides("tpch")
         assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.0001)
+
+
+# =============================================================================
+# Production DataFrame Path (BenchmarkExecutionMixin) Q11 Scale-Fraction
+# =============================================================================
+
+
+class TestMixinUnseededQ11ScaleFraction:
+    """The production DataFrame execution path must scope Q11's scaled fraction.
+
+    Real polars-df/pandas-df runs execute via BenchmarkExecutionMixin (not the
+    deprecated compatibility runner), so the mixin must set the scale factor for
+    the duration of query execution and reset it afterwards. Regression for the
+    follow-up to tpch-dataframe-unseeded-q11-scale-fraction.
+    """
+
+    def setup_method(self):
+        tpch_set_overrides(None)
+        tpch_set_scale_factor(None)
+
+    def teardown_method(self):
+        tpch_set_overrides(None)
+        tpch_set_scale_factor(None)
+
+    @staticmethod
+    def _make_probe_adapter():
+        """A minimal mixin subclass that records the active Q11 fraction."""
+        from benchbox.platforms.dataframe.benchmark_mixin import BenchmarkExecutionMixin
+
+        class _ScaleProbeAdapter(BenchmarkExecutionMixin):
+            def __init__(self):
+                self.observed_fraction = None
+
+            def _run_query_iterations(self, *, ctx, benchmark_config, benchmark_instance, monitor, run_options=None):
+                self.observed_fraction = get_tpch_parameters(11)["fraction"]
+                return []
+
+        return _ScaleProbeAdapter()
+
+    @pytest.mark.parametrize("benchmark_name", ["tpch", "tpch_skew", "tpchavoc"])
+    def test_mixin_scopes_q11_scale_for_tpch_family(self, benchmark_name):
+        """The mixin scales Q11 during execution and resets afterwards."""
+        adapter = self._make_probe_adapter()
+        config = MagicMock()
+        config.name = benchmark_name
+        config.scale_factor = 0.1
+
+        adapter._execute_queries_phase(ctx=MagicMock(), benchmark_config=config, benchmark_instance=None, monitor=None)
+
+        # Scale was active during execution ...
+        assert adapter.observed_fraction == pytest.approx(0.001)
+        # ... and reset to the SF=1 rendering once execution finished.
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.0001)
+
+    def test_mixin_is_noop_for_non_tpch_family(self):
+        """A non-TPC-H-family benchmark leaves the Q11 default untouched."""
+        adapter = self._make_probe_adapter()
+        config = MagicMock()
+        config.name = "tpcds"
+        config.scale_factor = 0.1
+
+        adapter._execute_queries_phase(ctx=MagicMock(), benchmark_config=config, benchmark_instance=None, monitor=None)
+
+        assert adapter.observed_fraction == pytest.approx(0.0001)
+
+    def test_mixin_resets_scale_on_exception(self):
+        """The scale factor is reset even when execution raises."""
+        from benchbox.platforms.dataframe.benchmark_mixin import BenchmarkExecutionMixin
+
+        class _BoomAdapter(BenchmarkExecutionMixin):
+            def _run_query_iterations(self, **kwargs):
+                raise RuntimeError("boom")
+
+        config = MagicMock()
+        config.name = "tpch"
+        config.scale_factor = 0.1
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _BoomAdapter()._execute_queries_phase(
+                ctx=MagicMock(), benchmark_config=config, benchmark_instance=None, monitor=None
+            )
+
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.0001)
+
+
+class TestSetScaleFactorForBenchmark:
+    """Direct coverage for the shared scale-seam helper."""
+
+    def setup_method(self):
+        tpch_set_scale_factor(None)
+
+    def teardown_method(self):
+        tpch_set_scale_factor(None)
+
+    @pytest.mark.parametrize("benchmark_id", ["tpch", "tpch_skew", "tpchavoc"])
+    def test_applies_for_tpch_family(self, benchmark_id):
+        from benchbox.core.tpch.dataframe_queries import set_scale_factor_for_benchmark
+
+        set_scale_factor_for_benchmark(benchmark_id, 0.1)
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.001)
+
+    def test_noop_for_other_benchmarks(self):
+        from benchbox.core.tpch.dataframe_queries import set_scale_factor_for_benchmark
+
+        set_scale_factor_for_benchmark("tpcds", 0.1)
+        assert get_tpch_parameters(11)["fraction"] == pytest.approx(0.0001)


### PR DESCRIPTION
## Problem (follow-up to #795)

#795 made `get_tpch_parameters()`'s Q11 fraction scale-aware (`0.0001 / SF`) and wired `set_scale_factor` into the **compatibility runner** (`run_dataframe_benchmark`) and the TPC-Havoc DataFrame equivalence gate. But as flagged by a P1 review comment on that PR, the **production** `polars-df` / `pandas-df` execution path runs through `BenchmarkExecutionMixin.run_benchmark()` → `_execute_queries_phase()`, which never declared the scale factor. `run_dataframe_benchmark` is marked deprecated and is only used by `metadata_primitives` + tests.

Net: real unseeded TPC-H-family DataFrame runs still used the SF=1 Q11 fraction (`0.0001`) at every scale. The gate passed because it sets the scale directly, masking the production gap.

## Fix

- **`benchbox/core/tpch/dataframe_queries.py`** — add the shared `TPCH_FAMILY_DATAFRAME_IDS` set and `set_scale_factor_for_benchmark(benchmark_id, scale_factor)` helper, so every caller declares scale through one seam (single source of truth for which benchmarks share the TPC-H DataFrame parameter seam: `tpch`, `tpch_skew`, `tpchavoc`).
- **`benchbox/platforms/dataframe/benchmark_mixin.py`** — `_execute_queries_phase` now sets the scale factor for TPC-H-family benchmarks for the duration of query execution and resets it on every path (via try/finally; the body moved to `_run_query_iterations`).
- **`benchbox/core/runner/dataframe_runner.py`** — delegate to the shared helper/set instead of a duplicated local id tuple.

## Verification

- New regression tests: the production mixin path scopes Q11's `0.0001/SF` fraction **during** execution for `tpch`/`tpch_skew`/`tpchavoc`, resets it afterwards (including on exceptions), is a no-op for non-TPC-H benchmarks, plus direct coverage of the shared helper.
- `ruff check`/`format` clean; `ty check` adds no new diagnostics (the one pre-existing `load_table`/`delimiter` info is present on `develop`).
- 4740 unit tests across the touched areas (dataframe / mixin / parameter / tpch_skew / tpchavoc) pass.

Addresses the P1 from #795 (https://github.com/joeharris76/BenchBox/pull/795#discussion_r3409708876).

https://claude.ai/code/session_01TBBm5e35fghYM4FNMgvtfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBBm5e35fghYM4FNMgvtfZ)_