### PR TITLE
feat(query-plans): cloud SaaS plan capture (Snowflake, BigQuery, Azure Synapse, Fabric, LakeSail)

### DIFF
--- a/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-cloud-saas.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-cloud-saas
 title: "Implement query plan capture for cloud SaaS platforms: Snowflake, BigQuery, Azure Synapse, Firebolt, Fabric Warehouse, and Lakesail"
 worktree: platform-expansion
 priority: Medium
-status: Not Started
+status: In Progress
 category: Platform Expansion
 
 description: |
@@ -51,6 +51,28 @@ description: |
   be redesigned to accept a completed job reference rather than issuing a separate
   EXPLAIN query.
 
+  Progress (2026-06-15):
+    Parsers + execute_query() wiring + fixture-driven unit tests landed for five
+    of the six platforms (Snowflake, BigQuery, Azure Synapse Dedicated Pool,
+    Fabric Warehouse, LakeSail). LakeSail already executes via the Spark Connect
+    mixin and emits Spark EXPLAIN plans, so it reuses SparkQueryPlanParser
+    (registry alias added) rather than a bespoke parser — the w7 "MySQL-wire"
+    premise was incorrect against the actual adapter. BigQuery captures the plan
+    from the already-completed QueryJob via BigQueryAdapter._capture_bq_plan()
+    (no second query / no extra billing); its get_query_plan() cost-dict return
+    is untouched. Fabric Warehouse retrieves SET SHOWPLAN_TEXT (SQL Server text
+    showplan), which is a different format from Synapse's distributed dsql XML,
+    so per the w6 decision gate it gets its own FabricWarehouseQueryPlanParser.
+
+    Firebolt (w5) is deferred / blocked-on-fixture: its EXPLAIN output format
+    could not be confirmed from docs or existing code without guessing, so no
+    parser was written for it (firebolt.py is intentionally unmodified). All
+    parsers were written from EXPLAIN samples documented by the vendors and
+    recorded under tests/fixtures/query_plans/; this environment has no cloud
+    credentials, so live sample collection (w1) and per-platform smoke runs are
+    deferred. The item therefore stays In Progress pending live verification and
+    the Firebolt parser. See the `deferred` section.
+
 prerequisites:
   - "Snowflake account + warehouse + database credentials (env: SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE)"
   - "Google Cloud project with BigQuery API enabled + service account JSON key (env: GOOGLE_APPLICATION_CREDENTIALS, BIGQUERY_PROJECT)"
@@ -70,7 +92,7 @@ prior_art:
 work:
   - id: w1
     summary: "Collect EXPLAIN output samples for Snowflake, Azure Synapse, Firebolt, Fabric, and Lakesail"
-    status: pending
+    status: in_progress
     notes: |
       For each available platform, run `EXPLAIN <simple_query>` and record:
         - Full EXPLAIN output text (or JSON)
@@ -80,11 +102,35 @@ work:
       BigQuery: instead of EXPLAIN, run a small query, then call
       `job.query_plan` on the completed QueryJob and record the JSON structure.
 
+      Done (from vendor docs, not live accounts — no credentials in this env):
+        - tests/fixtures/query_plans/snowflake_explain_sample.json
+          (EXPLAIN USING JSON: GlobalStats + Operations)
+        - tests/fixtures/query_plans/bigquery_query_plan_sample.json
+          (serialized job.query_plan stage list)
+        - tests/fixtures/query_plans/azure_synapse_explain_sample.xml
+          (Dedicated Pool EXPLAIN -> distributed dsql XML)
+        - tests/fixtures/query_plans/fabric_warehouse_showplan_sample.txt
+          (SET SHOWPLAN_TEXT -> SQL Server text showplan)
+        - LakeSail reuses the existing spark_explain_sample.txt (Spark EXPLAIN).
+      DEFERRED: live sample collection against real accounts (to confirm the
+      recorded shapes match running engines and capture version strings), and a
+      Firebolt EXPLAIN sample (format unconfirmed — see w5).
+
   - id: w2
     summary: "Implement SnowflakeQueryPlanParser and wire into SnowflakeAdapter"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
+      DONE: SnowflakeQueryPlanParser (benchbox/core/query_plans/parsers/snowflake.py)
+      parses EXPLAIN USING JSON (GlobalStats + Operations, tree built from each
+      node's parentOperators). SnowflakeAdapter now overrides get_query_plan()
+      (EXPLAIN USING JSON via cursor), get_query_plan_parser(), and calls
+      _merge_plan_capture_into_result() outside the try in execute_query() so a
+      strict-mode PlanCaptureError propagates. Registered as "snowflake" in the
+      parser registry. Unit tests: tests/unit/query_plans/test_snowflake_parser.py
+      and the adapter wiring test. DEFERRED: live smoke against a real account.
+
+
       Snowflake EXPLAIN returns JSON (when using `EXPLAIN USING JSON`):
         {"GlobalStats": {...}, "Operations": [{"id": N, "operation": "...", ...}]}
       Parser maps Snowflake operation names to LogicalOperatorType:
@@ -102,8 +148,25 @@ work:
   - id: w3
     summary: "Implement BigQueryQueryPlanParser and override capture_query_plan() in BigQueryAdapter"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
+      DONE: BigQueryQueryPlanParser (benchbox/core/query_plans/parsers/bigquery.py)
+      parses the JSON-serialized job.query_plan stage list (tree built from each
+      stage's input_stages; stage logical type inferred from steps[].kind with a
+      stage-name fallback). BigQueryAdapter._capture_bq_plan(job, query_id) reads
+      the ALREADY-completed QueryJob (no second query, no EXPLAIN, no extra
+      billing), serializes the plan via _serialize_bq_query_plan(), and parses it;
+      execute_query() calls it post-result, guarded by capture_plans and a SUCCESS
+      status. The existing get_query_plan() cost-dict return is UNCHANGED;
+      get_query_plan_parser() is added for the success metric but the capture path
+      bypasses it via _capture_bq_plan(). A strict-mode PlanCaptureError is
+      re-raised in execute_query() instead of being mislabeled as a failed query.
+      Tests: tests/unit/query_plans/test_bigquery_parser.py plus direct
+      _capture_bq_plan() tests with a mock QueryJob (build, empty-plan graceful
+      degradation, strict-mode raise, and no-extra-API assertion). DEFERRED: live
+      smoke against a real project.
+
+      Original design notes:
       BigQuery plans come from the Job Statistics API, not an EXPLAIN statement.
       This is an architectural mismatch with the base class:
         - Base class result_capture.py capture_query_plan() calls
@@ -142,8 +205,23 @@ work:
   - id: w4
     summary: "Implement AzureSynapseQueryPlanParser and wire into AzureSynapseAdapter"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
+      DONE: AzureSynapseQueryPlanParser (benchbox/core/query_plans/parsers/azure_synapse.py)
+      parses the Dedicated SQL Pool distributed plan that `EXPLAIN <query>`
+      returns — a single <dsql_query> XML document. This is what the adapter's
+      get_query_plan() already retrieves (plain EXPLAIN via cursor), so no change
+      to retrieval was needed; the adapter now overrides get_query_plan_parser()
+      and calls _merge_plan_capture_into_result() outside the try in
+      execute_query(). The distributed plan is a linear pipeline of data-movement
+      operations (SHUFFLE_MOVE/BROADCAST_MOVE/... -> Other, RETURN -> Project),
+      modeled as a RETURN-rooted chain. Registered as "azure_synapse"/"synapse".
+      Tests: tests/unit/query_plans/test_azure_synapse_parser.py + wiring test.
+      OPEN QUESTION resolved per its stated default: targets the Dedicated Pool
+      EXPLAIN format the adapter retrieves today; the Synapse Serverless variant
+      (different planner) is DEFERRED pending a live fixture (see `deferred`).
+
+      Original design notes:
       Azure Synapse Dedicated Pool uses T-SQL-based EXPLAIN (XML format via
       `SET SHOWPLAN_XML ON`; or text via `SET SHOWPLAN_TEXT ON`). Serverless
       uses a different planner. Confirm which format get_query_plan() at
@@ -155,6 +233,20 @@ work:
     needs: [w1]
     status: pending
     notes: |
+      BLOCKED ON FIXTURE / DEFERRED. Firebolt's plain `EXPLAIN <query>` output
+      format could not be confirmed from vendor docs or existing code without
+      guessing its structure: this TODO describes it as "a JSON structure with a
+      tree of nodes", but Firebolt's modern EXPLAIN (with (LOGICAL)/(PHYSICAL)/
+      (ANALYZE)/(ALL) variants) is documented as a text plan, and the two
+      conflict. Per the project rule "do not fabricate fixture data — mark the
+      parser blocked-on-fixture rather than guessing its output structure", no
+      FireboltQueryPlanParser was written and firebolt.py is intentionally left
+      unmodified. UNBLOCK: record a real `EXPLAIN <simple_query>` (and, if it
+      returns JSON, the exact key names) from a live Firebolt engine into
+      tests/fixtures/query_plans/firebolt_explain_sample.{txt|json}, then
+      implement the parser + wiring + tests following the Snowflake/Fabric pattern.
+
+      Original design notes (unverified):
       Firebolt's EXPLAIN returns a JSON structure with a tree of nodes.
       Implement FireboltQueryPlanParser mapping Firebolt operator names
       (TableScan, Projection, Aggregation, Join, etc.) to LogicalOperatorType.
@@ -163,8 +255,24 @@ work:
   - id: w6
     summary: "Wire FabricWarehouseAdapter plan capture; reuse AzureSynapseQueryPlanParser if format matches"
     needs: [w1, w4]
-    status: pending
+    status: done
     notes: |
+      DONE. DECISION GATE RESULT: the formats do NOT match, so a separate parser
+      was implemented (not a reuse of AzureSynapseQueryPlanParser). Azure Synapse
+      Dedicated retrieves its plan via `EXPLAIN` -> distributed dsql XML, whereas
+      FabricWarehouseAdapter.get_query_plan() retrieves `SET SHOWPLAN_TEXT ON` ->
+      the SQL Server hierarchical text showplan (|-- connectors + indentation).
+      Different structure => FabricWarehouseQueryPlanParser
+      (benchbox/core/query_plans/parsers/fabric_warehouse.py), registered as
+      "fabric_warehouse"/"fabric". The adapter now overrides get_query_plan_parser()
+      and calls _merge_plan_capture_into_result() outside the try in execute_query().
+      Tests: tests/unit/query_plans/test_fabric_warehouse_parser.py + wiring test.
+      CAVEAT (deferred): the parser targets the documented SHOWPLAN_TEXT format
+      the adapter requests; whether Fabric Warehouse (Polaris) actually emits
+      SHOWPLAN_TEXT at runtime is unverified here (no Fabric credentials). If a
+      live run shows a different format, record the fixture and adjust the parser.
+
+      Original design notes:
       Fabric Warehouse (Synapse Serverless + Delta Lake) EXPLAIN format may
       differ from Synapse Dedicated. After collecting the Fabric fixture in w1
       and implementing AzureSynapseQueryPlanParser in w4:
@@ -185,17 +293,37 @@ work:
   - id: w7
     summary: "Implement LakesailQueryPlanParser and wire into LakesailAdapter"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Lakesail is a MySQL-wire-compatible engine. Collect EXPLAIN format in w1.
-      Implement LakesailQueryPlanParser. Wire get_query_plan_parser() and
-      the capture call in LakesailAdapter.execute_query().
+      DONE — by REUSE, no new parser. The "MySQL-wire-compatible" premise is
+      incorrect against the actual adapter: LakeSailAdapter speaks Spark Connect
+      (SparkQueryExecutionMixin) and its get_query_plan() returns Spark
+      `EXPLAIN EXTENDED` text via get_spark_query_plan(). The mixin already wires
+      execute_query() plan capture and get_query_plan_parser() -> SparkQueryPlanParser,
+      so LakeSail captures plans with no adapter change. The only addition is a
+      registry alias ("lakesail" -> SparkQueryPlanParser) for consistency with
+      get_parser_for_platform(). Tests in test_cloud_saas_plan_capture.py confirm
+      the parser is the Spark parser and that get_query_plan() output feeds it to
+      a valid DAG. DEFERRED: live smoke against a real Sail server.
 
   - id: w8
     summary: "Add unit tests for all new parsers and adapter wiring"
     needs: [w2, w3, w4, w5, w6, w7]
-    status: pending
+    status: done
     notes: |
+      DONE for the five implemented platforms (Firebolt omitted — see w5):
+        - tests/unit/query_plans/test_snowflake_parser.py
+        - tests/unit/query_plans/test_bigquery_parser.py
+        - tests/unit/query_plans/test_azure_synapse_parser.py
+        - tests/unit/query_plans/test_fabric_warehouse_parser.py
+          (separate Fabric parser was required — see w6 decision gate)
+        - tests/unit/platforms/test_cloud_saas_plan_capture.py
+          (parametrized get_query_plan_parser() non-None for all five wired
+          adapters; per-adapter execute_query() capture + graceful-degradation;
+          BigQuery via _capture_bq_plan() with a mock QueryJob; LakeSail reuse).
+      No separate LakeSail parser test (it reuses the covered SparkQueryPlanParser).
+
+      Original notes:
       Create tests/unit/query_plans/ tests for each new parser:
         test_snowflake_parser.py, test_bigquery_parser.py,
         test_azure_synapse_parser.py, test_firebolt_parser.py,
@@ -212,6 +340,29 @@ work:
 
 deps:
   needs: []
+
+deferred:
+  - summary: "Firebolt plan capture (parser + wiring + tests)"
+    reason: |
+      EXPLAIN output format unconfirmed without guessing (docs describe a text
+      plan; this TODO describes JSON). Per the no-fabrication rule, no parser was
+      written. Unblock by recording a real Firebolt EXPLAIN fixture (see w5).
+  - summary: "Live verification (w1 sample collection + per-platform smoke runs)"
+    reason: |
+      No Snowflake/BigQuery/Azure/Fabric/LakeSail credentials in this
+      environment. Parsers were built from vendor-documented EXPLAIN samples;
+      confirming the recorded shapes against running engines (and capturing
+      engine version strings) requires live accounts.
+  - summary: "Azure Synapse Serverless EXPLAIN parser variant"
+    reason: |
+      AzureSynapseQueryPlanParser targets the Dedicated Pool dsql XML that the
+      adapter retrieves today. Serverless SQL Pool uses a different planner;
+      a separate parser is deferred pending a live Serverless fixture.
+  - summary: "Confirm Fabric Warehouse emits SET SHOWPLAN_TEXT at runtime"
+    reason: |
+      The Fabric parser targets the documented SHOWPLAN_TEXT format the adapter
+      requests; whether Fabric (Polaris) actually returns that format is
+      unverified without Fabric credentials.
 
 must_preserve:
   - "All six adapters' execute_query() result dict shape must not change for non-plan fields."
@@ -286,4 +437,4 @@ metadata:
   tags: [query-plan, snowflake, bigquery, azure-synapse, firebolt, fabric-warehouse, lakesail, cloud-saas, new-parser]
   estimated_effort: "Large"
   created_date: "2026-06-02"
-  last_updated: "2026-06-02T00:00:00-04:00"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/benchbox/core/query_plans/parsers/azure_synapse.py
+++ b/benchbox/core/query_plans/parsers/azure_synapse.py
@@ -1,0 +1,202 @@
+"""Azure Synapse (Dedicated SQL Pool) query plan parser.
+
+Azure Synapse Dedicated SQL Pool answers ``EXPLAIN <query>`` with a *distributed*
+query plan rendered as a single XML document (the same ``<dsql_query>`` shape
+inherited from Parallel Data Warehouse / APS). The plan is a sequence of
+distributed operations — data-movement steps (SHUFFLE_MOVE, BROADCAST_MOVE,
+PARTITION_MOVE, TRIM_MOVE), per-node operations (ON), temp-id allocations
+(RND_ID), and a final RETURN — rather than a tree of relational operators::
+
+    <?xml version="1.0" encoding="utf-8"?>
+    <dsql_query number_nodes="1" number_distributions="60">
+      <sql>SELECT ...</sql>
+      <dsql_operations total_cost="1.23" total_number_operations="4">
+        <dsql_operation operation_type="RND_ID">
+          <identifier>TEMP_ID_3</identifier>
+        </dsql_operation>
+        <dsql_operation operation_type="ON">
+          <location permanent="false" distribution="AllComputeNodes" />
+          <sql_operations>
+            <sql_operation type="statement">CREATE TABLE ...</sql_operation>
+          </sql_operations>
+        </dsql_operation>
+        <dsql_operation operation_type="SHUFFLE_MOVE">
+          <operation_cost cost="1.0" output_rows="100" average_rowsize="20" />
+          <location distribution="AllDistributions" />
+          <source_statement>SELECT ...</source_statement>
+          <destination_table>TEMP_ID_3</destination_table>
+          <shuffle_columns>l_orderkey;</shuffle_columns>
+        </dsql_operation>
+        <dsql_operation operation_type="RETURN">
+          <location distribution="AllDistributions" />
+          <select>SELECT ...</select>
+        </dsql_operation>
+      </dsql_operations>
+    </dsql_query>
+
+Because the distributed plan is a linear pipeline, this parser models it as a
+chain: the final RETURN operation is the root and each preceding operation is
+nested as its single child, preserving execution order in the tree depth.
+
+.. note::
+   Synapse *Serverless* SQL Pool uses a different planner and does not emit this
+   ``<dsql_query>`` format. Per the gating open question on the source TODO, this
+   parser targets the Dedicated Pool EXPLAIN format that the adapter retrieves
+   today; a Serverless variant is deferred pending a live fixture.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.results.query_plan_models import (
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AzureSynapseQueryPlanParser(QueryPlanParser):
+    """Parser for Azure Synapse Dedicated Pool ``EXPLAIN`` (dsql XML) output."""
+
+    # Distributed operation type -> logical type. Data-movement and control
+    # operations have no relational analogue, so they map to OTHER; RETURN is the
+    # result-producing step and maps to PROJECT.
+    _OPERATION_MAP: dict[str, LogicalOperatorType] = {
+        "RETURN": LogicalOperatorType.PROJECT,
+        "SHUFFLE_MOVE": LogicalOperatorType.OTHER,
+        "BROADCAST_MOVE": LogicalOperatorType.OTHER,
+        "PARTITION_MOVE": LogicalOperatorType.OTHER,
+        "TRIM_MOVE": LogicalOperatorType.OTHER,
+        "MOVE": LogicalOperatorType.OTHER,
+        "COPY": LogicalOperatorType.OTHER,
+        "ON": LogicalOperatorType.OTHER,
+        "RND_ID": LogicalOperatorType.OTHER,
+    }
+
+    def __init__(self):
+        super().__init__("azure_synapse")
+
+    def _parse_impl(self, query_id: str, explain_output: str) -> QueryPlanDAG:
+        if not explain_output or not explain_output.strip():
+            raise ValueError("Empty EXPLAIN output")
+
+        text = explain_output.strip()
+        # The cursor sometimes prefixes a header row; trim to the XML document.
+        start = text.find("<")
+        if start == -1:
+            raise ValueError("Azure Synapse EXPLAIN output is not XML")
+        text = text[start:]
+
+        try:
+            root_el = ET.fromstring(text)
+        except ET.ParseError as exc:
+            raise ValueError(f"EXPLAIN output is not valid dsql XML: {exc}") from exc
+
+        operations_el = root_el.find("dsql_operations")
+        if operations_el is None and root_el.tag == "dsql_operations":
+            operations_el = root_el
+        if operations_el is None:
+            raise ValueError("No <dsql_operations> element in Synapse EXPLAIN XML")
+
+        op_elements = operations_el.findall("dsql_operation")
+        if not op_elements:
+            raise ValueError("No <dsql_operation> elements in Synapse EXPLAIN XML")
+
+        # Build a linear chain with the LAST operation (RETURN) at the root.
+        nodes = [self._convert_operation(op) for op in op_elements]
+        root = nodes[-1]
+        current = root
+        for node in reversed(nodes[:-1]):
+            current.children.append(node)
+            current = node
+
+        estimated_cost = self._coerce_float(operations_el.get("total_cost"))
+        estimated_rows = self._max_output_rows(op_elements)
+
+        return QueryPlanDAG(
+            query_id=query_id,
+            platform=self.platform_name,
+            logical_root=root,
+            estimated_cost=estimated_cost,
+            estimated_rows=estimated_rows,
+            raw_explain_output=explain_output,
+        )
+
+    def _convert_operation(self, op_el: ET.Element) -> LogicalOperator:
+        op_type = (op_el.get("operation_type") or "").strip().upper()
+        logical_type = self._OPERATION_MAP.get(op_type, LogicalOperatorType.OTHER)
+
+        properties: dict[str, Any] = {}
+        cost_el = op_el.find("operation_cost")
+        if cost_el is not None:
+            for attr in ("cost", "output_rows", "average_rowsize"):
+                value = cost_el.get(attr)
+                if value is not None:
+                    properties[attr] = value
+
+        location_el = op_el.find("location")
+        distribution = location_el.get("distribution") if location_el is not None else None
+
+        # Capture the SQL text carried by the operation, when present.
+        sql_text = None
+        for tag in ("source_statement", "select", "sql_operations"):
+            child = op_el.find(tag)
+            if child is not None:
+                if tag == "sql_operations":
+                    stmts = [
+                        (s.text or "").strip()
+                        for s in child.findall("sql_operation")
+                        if (s.text or "").strip()
+                    ]
+                    sql_text = " | ".join(stmts) if stmts else None
+                else:
+                    sql_text = (child.text or "").strip() or None
+                if sql_text:
+                    break
+
+        physical_op = self._create_physical_operator(
+            op_type or "Operation",
+            properties=properties,
+            platform_metadata={
+                "operation_type": op_type or None,
+                "distribution": distribution,
+                "sql": sql_text,
+            },
+        )
+
+        return self._create_logical_operator(
+            operator_type=logical_type,
+            children=[],
+            physical_operator=physical_op,
+        )
+
+    def _max_output_rows(self, op_elements: list[ET.Element]) -> int | None:
+        best: int | None = None
+        for op_el in op_elements:
+            cost_el = op_el.find("operation_cost")
+            if cost_el is None:
+                continue
+            rows = self._coerce_int(cost_el.get("output_rows"))
+            if rows is not None and (best is None or rows > best):
+                best = rows
+        return best
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _coerce_float(value: Any) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/benchbox/core/query_plans/parsers/azure_synapse.py
+++ b/benchbox/core/query_plans/parsers/azure_synapse.py
@@ -149,11 +149,7 @@ class AzureSynapseQueryPlanParser(QueryPlanParser):
             child = op_el.find(tag)
             if child is not None:
                 if tag == "sql_operations":
-                    stmts = [
-                        (s.text or "").strip()
-                        for s in child.findall("sql_operation")
-                        if (s.text or "").strip()
-                    ]
+                    stmts = [(s.text or "").strip() for s in child.findall("sql_operation") if (s.text or "").strip()]
                     sql_text = " | ".join(stmts) if stmts else None
                 else:
                     sql_text = (child.text or "").strip() or None

--- a/benchbox/core/query_plans/parsers/bigquery.py
+++ b/benchbox/core/query_plans/parsers/bigquery.py
@@ -91,11 +91,14 @@ class BigQueryQueryPlanParser(QueryPlanParser):
         if not isinstance(stages, list) or not stages:
             raise ValueError("BigQuery query plan must be a non-empty list of stages")
 
-        by_id: dict[Any, dict[str, Any]] = {}
+        by_id: dict[str, dict[str, Any]] = {}
         for index, stage in enumerate(stages):
             if not isinstance(stage, dict):
                 continue
-            stage_id = stage.get("id", index)
+            # Normalize ids to str: real google-cloud-bigquery returns the stage
+            # ``id`` as a string while ``input_stages`` are ints, so keying/looking
+            # up by raw value would never match and collapse the tree.
+            stage_id = str(stage.get("id", index))
             by_id[stage_id] = stage
 
         if not by_id:
@@ -201,13 +204,14 @@ class BigQueryQueryPlanParser(QueryPlanParser):
         return None
 
     @staticmethod
-    def _input_ids(stage: dict[str, Any]) -> list[Any]:
+    def _input_ids(stage: dict[str, Any]) -> list[str]:
         inputs = stage.get("input_stages")
         if inputs is None:
             return []
         if not isinstance(inputs, list):
             inputs = [inputs]
-        return list(inputs)
+        # Normalize to str to match the str-keyed by_id (see _parse_impl).
+        return [str(x) for x in inputs]
 
     @staticmethod
     def _sort_key(stage_id: Any) -> tuple[int, str]:

--- a/benchbox/core/query_plans/parsers/bigquery.py
+++ b/benchbox/core/query_plans/parsers/bigquery.py
@@ -1,0 +1,222 @@
+"""BigQuery query plan parser.
+
+Unlike EXPLAIN-based engines, BigQuery exposes no ``EXPLAIN`` statement: the
+query plan is only available *after* execution, from the completed
+``google.cloud.bigquery.QueryJob`` via its ``job.query_plan`` job-statistics
+field. ``BigQueryAdapter._capture_bq_plan`` reads that already-executed job (no
+extra API call, no extra billing), serializes the per-stage statistics to JSON,
+and hands the JSON to this parser.
+
+The serialized payload is a JSON list of *stage* objects, one per
+``QueryPlanEntry``::
+
+    [
+      {"id": 0, "name": "S00: Input", "status": "COMPLETE",
+       "records_read": 6000000, "records_written": 6000000, "input_stages": [],
+       "steps": [{"kind": "READ", "substeps": ["$1:l_orderkey", "FROM lineitem"]},
+                 {"kind": "AGGREGATE", "substeps": ["GROUP BY $10 := $1"]},
+                 {"kind": "WRITE", "substeps": ["$10, $20", "TO __stage00_output"]}]},
+      {"id": 1, "name": "S01: Output", "input_stages": [0],
+       "steps": [{"kind": "READ", ...}, {"kind": "SORT", ...}, {"kind": "WRITE", ...}]}
+    ]
+
+A stage's children are the stages named in its ``input_stages`` list; the root
+is the stage no other stage reads from (typically ``Output``). Each stage's
+dominant operator type is inferred from its ``steps[].kind`` values (READ →
+Scan, JOIN/HASH_JOIN → Join, AGGREGATE → Aggregate, SORT → Sort, ...), falling
+back to the stage ``name``.
+
+See the BigQuery ``Job.queryPlan`` / ``ExplainQueryStage`` reference for the
+field meanings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.results.query_plan_models import (
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BigQueryQueryPlanParser(QueryPlanParser):
+    """Parser for the JSON-serialized BigQuery ``job.query_plan`` structure."""
+
+    # Step ``kind`` -> logical type. Ordered by structural dominance: a stage
+    # that joins is a Join even though it also READs and WRITEs.
+    _STEP_KIND_PRIORITY: tuple[tuple[str, LogicalOperatorType], ...] = (
+        ("join", LogicalOperatorType.JOIN),
+        ("aggregate", LogicalOperatorType.AGGREGATE),
+        ("analytic", LogicalOperatorType.WINDOW),
+        ("sort", LogicalOperatorType.SORT),
+        ("limit", LogicalOperatorType.LIMIT),
+        ("filter", LogicalOperatorType.FILTER),
+        ("read", LogicalOperatorType.SCAN),
+        ("write", LogicalOperatorType.PROJECT),
+        ("compute", LogicalOperatorType.PROJECT),
+    )
+
+    # Fallback mapping from the stage ``name`` keywords (e.g. "S01: Output").
+    _NAME_KEYWORDS: tuple[tuple[str, LogicalOperatorType], ...] = (
+        ("input", LogicalOperatorType.SCAN),
+        ("join", LogicalOperatorType.JOIN),
+        ("aggregate", LogicalOperatorType.AGGREGATE),
+        ("sort", LogicalOperatorType.SORT),
+        ("limit", LogicalOperatorType.LIMIT),
+        ("output", LogicalOperatorType.PROJECT),
+        ("repartition", LogicalOperatorType.OTHER),
+        ("coalesce", LogicalOperatorType.OTHER),
+    )
+
+    def __init__(self):
+        super().__init__("bigquery")
+
+    def _parse_impl(self, query_id: str, explain_output: str) -> QueryPlanDAG:
+        if not explain_output or not explain_output.strip():
+            raise ValueError("Empty query plan payload")
+
+        try:
+            stages = json.loads(explain_output)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Query plan payload is not valid JSON: {exc}") from exc
+
+        if not isinstance(stages, list) or not stages:
+            raise ValueError("BigQuery query plan must be a non-empty list of stages")
+
+        by_id: dict[Any, dict[str, Any]] = {}
+        for index, stage in enumerate(stages):
+            if not isinstance(stage, dict):
+                continue
+            stage_id = stage.get("id", index)
+            by_id[stage_id] = stage
+
+        if not by_id:
+            raise ValueError("No stage objects found in BigQuery query plan")
+
+        # A stage is a child of every stage that lists it in input_stages.
+        referenced: set[Any] = set()
+        for stage in by_id.values():
+            for src in self._input_ids(stage):
+                if src in by_id:
+                    referenced.add(src)
+
+        roots = [sid for sid in by_id if sid not in referenced]
+        if not roots:
+            roots = [max(by_id)]  # fall back to the highest-id (last) stage
+
+        def build(stage_id: Any, visited: frozenset[Any]) -> LogicalOperator:
+            stage = by_id[stage_id]
+            children = [
+                build(src, visited | {stage_id})
+                for src in self._input_ids(stage)
+                if src in by_id and src not in visited
+            ]
+            return self._convert_stage(stage, children)
+
+        # Highest-id root is the conventional Output stage; keep deterministic order.
+        root_id = sorted(roots, key=self._sort_key, reverse=True)[0]
+        root = build(root_id, frozenset())
+
+        estimated_rows = None
+        root_stage = by_id[root_id]
+        written = self._coerce_int(root_stage.get("records_written"))
+        if written is not None:
+            estimated_rows = written
+
+        return QueryPlanDAG(
+            query_id=query_id,
+            platform=self.platform_name,
+            logical_root=root,
+            estimated_rows=estimated_rows,
+            raw_explain_output=explain_output,
+        )
+
+    def _convert_stage(self, stage: dict[str, Any], children: list[LogicalOperator]) -> LogicalOperator:
+        name = str(stage.get("name", "")).strip()
+        steps = stage.get("steps") if isinstance(stage.get("steps"), list) else []
+        kinds = [str(s.get("kind", "")).strip() for s in steps if isinstance(s, dict)]
+        logical_type = self._map_stage_type(name, kinds)
+
+        substeps: list[str] = []
+        for step in steps:
+            if isinstance(step, dict):
+                substeps.extend(str(x).strip() for x in (step.get("substeps") or []) if str(x).strip())
+
+        kwargs: dict[str, Any] = {}
+        if logical_type == LogicalOperatorType.SCAN:
+            table = self._extract_table(substeps)
+            if table:
+                kwargs["table_name"] = table
+
+        properties: dict[str, Any] = {}
+        for key in ("records_read", "records_written"):
+            value = self._coerce_int(stage.get(key))
+            if value is not None:
+                properties[key] = value
+
+        physical_op = self._create_physical_operator(
+            name or "Stage",
+            properties=properties,
+            platform_metadata={
+                "stage_id": stage.get("id"),
+                "status": stage.get("status"),
+                "step_kinds": kinds or None,
+                "substeps": substeps or None,
+            },
+        )
+
+        return self._create_logical_operator(
+            operator_type=logical_type,
+            children=children,
+            physical_operator=physical_op,
+            **kwargs,
+        )
+
+    @classmethod
+    def _map_stage_type(cls, name: str, kinds: list[str]) -> LogicalOperatorType:
+        normalized_kinds = [k.lower().replace(" ", "").replace("_", "") for k in kinds]
+        for keyword, logical_type in cls._STEP_KIND_PRIORITY:
+            if any(keyword in k for k in normalized_kinds):
+                return logical_type
+        normalized_name = name.lower()
+        for keyword, logical_type in cls._NAME_KEYWORDS:
+            if keyword in normalized_name:
+                return logical_type
+        return LogicalOperatorType.OTHER
+
+    @staticmethod
+    def _extract_table(substeps: list[str]) -> str | None:
+        for sub in substeps:
+            match = re.search(r"FROM\s+([\w.$-]+)", sub, re.IGNORECASE)
+            if match:
+                return match.group(1)
+        return None
+
+    @staticmethod
+    def _input_ids(stage: dict[str, Any]) -> list[Any]:
+        inputs = stage.get("input_stages")
+        if inputs is None:
+            return []
+        if not isinstance(inputs, list):
+            inputs = [inputs]
+        return list(inputs)
+
+    @staticmethod
+    def _sort_key(stage_id: Any) -> tuple[int, str]:
+        text = str(stage_id)
+        return (int(text), "") if text.lstrip("-").isdigit() else (1 << 30, text)
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None

--- a/benchbox/core/query_plans/parsers/fabric_warehouse.py
+++ b/benchbox/core/query_plans/parsers/fabric_warehouse.py
@@ -1,0 +1,208 @@
+"""Microsoft Fabric Warehouse query plan parser.
+
+Decision-gate note (from the source TODO's w6):
+    Azure Synapse Dedicated Pool returns its plan from ``EXPLAIN`` as a
+    distributed ``<dsql_query>`` *XML* document, whereas the Fabric Warehouse
+    adapter retrieves its plan with ``SET SHOWPLAN_TEXT ON`` — the classic
+    SQL Server hierarchical *text* showplan. The two formats are structurally
+    different, so ``AzureSynapseQueryPlanParser`` cannot be reused; Fabric needs
+    this dedicated parser. (Live confirmation that Fabric emits this exact text
+    is deferred — no Fabric credentials in CI; see the work-unit notes.)
+
+``SET SHOWPLAN_TEXT`` produces a single ``StmtText`` column: the first row is the
+submitted statement, and subsequent rows are the physical operator tree, where
+nesting is shown by the indentation of the ``|--`` connector::
+
+    SELECT l_orderkey, SUM(l_quantity) FROM lineitem ...
+      |--Compute Scalar(DEFINE:([Expr1003]=...))
+           |--Stream Aggregate(GROUP BY:([l_orderkey]) DEFINE:([Expr1003]=SUM(...)))
+                |--Sort(ORDER BY:([l_orderkey] ASC))
+                     |--Hash Match(Inner Join, HASH:([l_orderkey])=([o_orderkey]))
+                          |--Clustered Index Scan(OBJECT:([db].[dbo].[lineitem]))
+                          |--Clustered Index Scan(OBJECT:([db].[dbo].[orders]))
+
+The column position of each ``|--`` marker gives the depth; operators at the same
+depth under a common ancestor are siblings (a join has two child scans).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.results.query_plan_models import (
+    JoinType,
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FabricWarehouseQueryPlanParser(QueryPlanParser):
+    """Parser for SQL Server ``SET SHOWPLAN_TEXT`` output used by Fabric Warehouse."""
+
+    # Ordered (substring, type). The first match in the lower-cased operator name
+    # wins, so "Hash Match (Aggregate)" resolves to AGGREGATE before JOIN, and a
+    # fused "...Aggregate" before the bare "match" of a hash join.
+    _OPERATOR_KEYWORDS: tuple[tuple[str, LogicalOperatorType], ...] = (
+        ("aggregate", LogicalOperatorType.AGGREGATE),
+        ("stream aggregate", LogicalOperatorType.AGGREGATE),
+        ("hash match", LogicalOperatorType.JOIN),
+        ("nested loops", LogicalOperatorType.JOIN),
+        ("merge join", LogicalOperatorType.JOIN),
+        ("join", LogicalOperatorType.JOIN),
+        ("scan", LogicalOperatorType.SCAN),
+        ("seek", LogicalOperatorType.SCAN),
+        ("sort", LogicalOperatorType.SORT),
+        ("top", LogicalOperatorType.LIMIT),
+        ("filter", LogicalOperatorType.FILTER),
+        ("compute scalar", LogicalOperatorType.PROJECT),
+        ("concatenation", LogicalOperatorType.UNION),
+        ("compute", LogicalOperatorType.PROJECT),
+    )
+
+    _MARKER = "|--"
+    _OPERATOR_RE = re.compile(r"^(?P<name>[^(]+?)(?:\((?P<args>.*)\))?\s*$")
+    _OBJECT_RE = re.compile(r"OBJECT:\(([^)]+)\)", re.IGNORECASE)
+
+    def __init__(self):
+        super().__init__("fabric_warehouse")
+
+    def _parse_impl(self, query_id: str, explain_output: str) -> QueryPlanDAG:
+        if not explain_output or not explain_output.strip():
+            raise ValueError("Empty SHOWPLAN_TEXT output")
+
+        parsed = self._parse_lines(explain_output)
+        if not parsed:
+            raise ValueError("No plan operators found in SHOWPLAN_TEXT output")
+
+        root = self._build_tree(parsed)
+        return QueryPlanDAG(
+            query_id=query_id,
+            platform=self.platform_name,
+            logical_root=root,
+            raw_explain_output=explain_output,
+        )
+
+    def _parse_lines(self, explain_output: str) -> list[dict[str, Any]]:
+        nodes: list[dict[str, Any]] = []
+        for raw_line in explain_output.splitlines():
+            marker_idx = raw_line.find(self._MARKER)
+            if marker_idx == -1:
+                # Leading statement text (no connector) — skip.
+                continue
+            depth = marker_idx
+            body = raw_line[marker_idx + len(self._MARKER) :].strip()
+            if not body:
+                continue
+            match = self._OPERATOR_RE.match(body)
+            if match:
+                name = match.group("name").strip()
+                args = (match.group("args") or "").strip()
+            else:
+                name, args = body, ""
+            nodes.append({"depth": depth, "name": name, "args": args})
+        return nodes
+
+    def _build_tree(self, parsed: list[dict[str, Any]]) -> LogicalOperator:
+        stack: list[tuple[int, LogicalOperator]] = []
+        root: LogicalOperator | None = None
+
+        for node in parsed:
+            logical_op = self._convert_node(node)
+            while stack and stack[-1][0] >= node["depth"]:
+                stack.pop()
+            if not stack:
+                if root is None:
+                    root = logical_op
+                # A second depth-0 operator would be a separate statement; nest it
+                # under the existing root to keep a single DAG.
+                elif logical_op is not root:
+                    root.children.append(logical_op)
+            else:
+                stack[-1][1].children.append(logical_op)
+            stack.append((node["depth"], logical_op))
+
+        if root is None:
+            raise ValueError("Could not determine root operator")
+        return root
+
+    def _convert_node(self, node: dict[str, Any]) -> LogicalOperator:
+        name = node["name"]
+        args = node["args"]
+        logical_type = self._map_operator_type(name, args)
+
+        kwargs: dict[str, Any] = {}
+        if logical_type == LogicalOperatorType.SCAN:
+            table = self._extract_object(args)
+            if table:
+                kwargs["table_name"] = table
+        elif logical_type == LogicalOperatorType.JOIN:
+            kwargs["join_type"] = self._classify_join_type(args)
+            condition = self._extract_join_condition(args)
+            if condition:
+                kwargs["join_conditions"] = [condition]
+        elif logical_type == LogicalOperatorType.FILTER and args:
+            kwargs["filter_expressions"] = [args]
+
+        physical_op = self._create_physical_operator(
+            name or "Operator",
+            properties={},
+            platform_metadata={"arguments": args or None},
+        )
+        return self._create_logical_operator(
+            operator_type=logical_type,
+            children=[],
+            physical_operator=physical_op,
+            **kwargs,
+        )
+
+    @classmethod
+    def _map_operator_type(cls, name: str, args: str) -> LogicalOperatorType:
+        haystack = f"{name} {args}".lower()
+        for keyword, logical_type in cls._OPERATOR_KEYWORDS:
+            if keyword in haystack:
+                return logical_type
+        return LogicalOperatorType.OTHER
+
+    @classmethod
+    def _extract_object(cls, args: str) -> str | None:
+        match = cls._OBJECT_RE.search(args)
+        if not match:
+            return None
+        # OBJECT:([db].[schema].[table].[index]) -> table (or [table])
+        parts = [p.strip().strip("[]") for p in match.group(1).split(".") if p.strip()]
+        if not parts:
+            return None
+        # Drop a trailing index/alias segment when 4+ parts are present.
+        table_parts = parts[:3] if len(parts) >= 4 else parts
+        return ".".join(table_parts) if len(table_parts) > 1 else table_parts[-1]
+
+    @staticmethod
+    def _classify_join_type(args: str) -> JoinType:
+        lowered = args.lower()
+        if "left semi" in lowered or "semi join" in lowered:
+            return JoinType.SEMI
+        if "left anti" in lowered or "anti" in lowered:
+            return JoinType.ANTI
+        if "left outer" in lowered or "left join" in lowered:
+            return JoinType.LEFT
+        if "right outer" in lowered or "right join" in lowered:
+            return JoinType.RIGHT
+        if "full outer" in lowered:
+            return JoinType.FULL
+        return JoinType.INNER
+
+    @staticmethod
+    def _extract_join_condition(args: str) -> str | None:
+        match = re.search(r"(?:HASH|MERGE|WHERE):\(([^)]+)\)\s*=\s*\(([^)]+)\)", args, re.IGNORECASE)
+        if match:
+            return f"{match.group(1).strip()} = {match.group(2).strip()}"
+        match = re.search(r"(?:HASH|MERGE|WHERE):\(([^)]+)\)", args, re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+        return None

--- a/benchbox/core/query_plans/parsers/registry.py
+++ b/benchbox/core/query_plans/parsers/registry.py
@@ -192,12 +192,16 @@ def get_parser_registry() -> ParserRegistry:
 
 def _create_default_registry() -> ParserRegistry:
     """Create and populate the default parser registry."""
+    from benchbox.core.query_plans.parsers.azure_synapse import AzureSynapseQueryPlanParser
+    from benchbox.core.query_plans.parsers.bigquery import BigQueryQueryPlanParser
     from benchbox.core.query_plans.parsers.clickhouse import ClickHouseQueryPlanParser
     from benchbox.core.query_plans.parsers.datafusion import DataFusionQueryPlanParser
     from benchbox.core.query_plans.parsers.duckdb import DuckDBQueryPlanParser
+    from benchbox.core.query_plans.parsers.fabric_warehouse import FabricWarehouseQueryPlanParser
     from benchbox.core.query_plans.parsers.postgresql import PostgreSQLQueryPlanParser
     from benchbox.core.query_plans.parsers.presto_trino import PrestoTrinoQueryPlanParser
     from benchbox.core.query_plans.parsers.redshift import RedshiftQueryPlanParser
+    from benchbox.core.query_plans.parsers.snowflake import SnowflakeQueryPlanParser
     from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
     from benchbox.core.query_plans.parsers.sqlite import SQLiteQueryPlanParser
 
@@ -233,6 +237,23 @@ def _create_default_registry() -> ParserRegistry:
     # Register Spark parser (shared by Spark and Databricks, which runs Spark SQL).
     registry.register("spark", "0.0.0", SparkQueryPlanParser)
     registry.register("databricks", "0.0.0", SparkQueryPlanParser)
+    # LakeSail (Sail) speaks Spark Connect and emits Spark EXPLAIN plans, so it
+    # reuses the Spark parser (see LakeSailAdapter.get_query_plan).
+    registry.register("lakesail", "0.0.0", SparkQueryPlanParser)
+
+    # Register cloud SaaS warehouse parsers.
+    # Snowflake: EXPLAIN USING JSON (GlobalStats + Operations JSON).
+    registry.register("snowflake", "0.0.0", SnowflakeQueryPlanParser)
+    # BigQuery: plan from the completed job's queryPlan statistics (no EXPLAIN);
+    # captured via BigQueryAdapter._capture_bq_plan and parsed from JSON.
+    registry.register("bigquery", "0.0.0", BigQueryQueryPlanParser)
+    # Azure Synapse Dedicated Pool: EXPLAIN -> distributed dsql XML.
+    registry.register("azure_synapse", "0.0.0", AzureSynapseQueryPlanParser)
+    registry.register("synapse", "0.0.0", AzureSynapseQueryPlanParser)  # alias
+    # Fabric Warehouse: SET SHOWPLAN_TEXT -> SQL Server text showplan. Distinct
+    # from Synapse's dsql XML, so it gets its own parser (w6 decision gate).
+    registry.register("fabric_warehouse", "0.0.0", FabricWarehouseQueryPlanParser)
+    registry.register("fabric", "0.0.0", FabricWarehouseQueryPlanParser)  # alias
 
     return registry
 

--- a/benchbox/core/query_plans/parsers/snowflake.py
+++ b/benchbox/core/query_plans/parsers/snowflake.py
@@ -1,0 +1,287 @@
+"""Snowflake query plan parser.
+
+Parses the JSON document emitted by ``EXPLAIN USING JSON <query>`` into the
+harmonized :class:`QueryPlanDAG` structure.
+
+Snowflake's ``EXPLAIN USING JSON`` returns a single JSON value of the form::
+
+    {
+      "GlobalStats": {
+        "partitionsTotal": 5,
+        "partitionsAssigned": 5,
+        "bytesAssigned": 123456
+      },
+      "Operations": [
+        [
+          {"id": 0, "operation": "Result", "expressions": ["L_ORDERKEY", "..."]},
+          {"id": 1, "parentOperators": [0], "operation": "Aggregate", ...},
+          {"id": 2, "parentOperators": [1], "operation": "InnerJoin", ...},
+          {"id": 3, "parentOperators": [2], "operation": "TableScan",
+           "objects": ["TPCH.LINEITEM"], ...},
+          {"id": 4, "parentOperators": [2], "operation": "TableScan",
+           "objects": ["TPCH.ORDERS"], ...}
+        ]
+      ]
+    }
+
+``Operations`` is a list of *steps* (one list of operator nodes per statement /
+sub-plan). Each operator node carries an integer ``id``, an ``operation`` name,
+an optional ``parentOperators`` list (the ids this node feeds into), an optional
+``objects`` list (table names for scans), and an optional ``expressions`` list of
+detail strings. The root operator of a step is the node with no
+``parentOperators``; a node's children are the operators that name it as a
+parent.
+
+See the field reference under Snowflake's ``EXPLAIN`` documentation for the
+``GlobalStats`` / ``Operations`` payload shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.results.query_plan_models import (
+    JoinType,
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SnowflakeQueryPlanParser(QueryPlanParser):
+    """Parser for Snowflake ``EXPLAIN USING JSON`` output."""
+
+    # Ordered (substring, type) pairs. The first substring found in the
+    # lower-cased operation name wins, so dominant operators are listed before
+    # the generic names they may contain.
+    _OPERATOR_KEYWORDS: tuple[tuple[str, LogicalOperatorType], ...] = (
+        ("tablescan", LogicalOperatorType.SCAN),
+        ("joinfilter", LogicalOperatorType.SCAN),
+        ("scan", LogicalOperatorType.SCAN),
+        ("join", LogicalOperatorType.JOIN),
+        ("aggregate", LogicalOperatorType.AGGREGATE),
+        ("groupby", LogicalOperatorType.AGGREGATE),
+        ("sort", LogicalOperatorType.SORT),
+        ("orderby", LogicalOperatorType.SORT),
+        ("limit", LogicalOperatorType.LIMIT),
+        ("filter", LogicalOperatorType.FILTER),
+        ("withreference", LogicalOperatorType.PROJECT),
+        ("withclause", LogicalOperatorType.CTE),
+        ("generator", LogicalOperatorType.PROJECT),
+        ("projection", LogicalOperatorType.PROJECT),
+        ("result", LogicalOperatorType.PROJECT),
+        ("unionall", LogicalOperatorType.UNION),
+        ("union", LogicalOperatorType.UNION),
+        ("intersect", LogicalOperatorType.INTERSECT),
+        ("except", LogicalOperatorType.EXCEPT),
+        ("minus", LogicalOperatorType.EXCEPT),
+        ("window", LogicalOperatorType.WINDOW),
+    )
+
+    def __init__(self):
+        super().__init__("snowflake")
+
+    def _parse_impl(self, query_id: str, explain_output: str) -> QueryPlanDAG:
+        if not explain_output or not explain_output.strip():
+            raise ValueError("Empty EXPLAIN output")
+
+        try:
+            payload = json.loads(explain_output)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"EXPLAIN output is not valid JSON: {exc}") from exc
+
+        if not isinstance(payload, dict):
+            raise ValueError("Snowflake EXPLAIN JSON must be an object")
+
+        operations = payload.get("Operations")
+        if not isinstance(operations, list) or not operations:
+            raise ValueError("No 'Operations' array found in Snowflake EXPLAIN JSON")
+
+        # Operations is a list of steps; use the first step that contains nodes.
+        nodes: list[dict[str, Any]] = []
+        for step in operations:
+            if isinstance(step, list) and step:
+                nodes = [n for n in step if isinstance(n, dict)]
+                if nodes:
+                    break
+        if not nodes:
+            raise ValueError("No operator nodes found in Snowflake EXPLAIN JSON")
+
+        root = self._build_tree(nodes)
+
+        global_stats = payload.get("GlobalStats")
+        estimated_rows = None
+        if isinstance(global_stats, dict):
+            estimated_rows = self._coerce_int(global_stats.get("partitionsAssigned"))
+
+        return QueryPlanDAG(
+            query_id=query_id,
+            platform=self.platform_name,
+            logical_root=root,
+            estimated_rows=estimated_rows,
+            raw_explain_output=explain_output,
+        )
+
+    def _build_tree(self, nodes: list[dict[str, Any]]) -> LogicalOperator:
+        """Build the operator tree from the flat node list using parentOperators."""
+        by_id: dict[Any, dict[str, Any]] = {}
+        for node in nodes:
+            node_id = node.get("id")
+            if node_id is not None:
+                by_id[node_id] = node
+
+        # children_of[parent_id] = [child node ids feeding that parent]
+        children_of: dict[Any, list[Any]] = {nid: [] for nid in by_id}
+        roots: list[Any] = []
+        for node in nodes:
+            node_id = node.get("id")
+            parents = node.get("parentOperators") or []
+            if not isinstance(parents, list):
+                parents = [parents]
+            parents = [p for p in parents if p in by_id]
+            if not parents:
+                roots.append(node_id)
+            for parent in parents:
+                children_of.setdefault(parent, []).append(node_id)
+
+        if not roots:
+            # Degenerate / cyclic input: fall back to the lowest id as root.
+            roots = [min(by_id)] if by_id else []
+
+        # Guard against cycles with a visited set on each path.
+        def build(node_id: Any, visited: frozenset[Any]) -> LogicalOperator:
+            node = by_id[node_id]
+            children = [
+                build(child_id, visited | {node_id})
+                for child_id in children_of.get(node_id, [])
+                if child_id in by_id and child_id not in visited
+            ]
+            return self._convert_node(node, children)
+
+        root_id = roots[0]
+        return build(root_id, frozenset())
+
+    def _convert_node(self, node: dict[str, Any], children: list[LogicalOperator]) -> LogicalOperator:
+        operation = str(node.get("operation", "")).strip()
+        logical_type = self._map_operator_type(operation)
+        expressions = self._string_list(node.get("expressions"))
+        objects = self._string_list(node.get("objects"))
+
+        kwargs: dict[str, Any] = {}
+        if logical_type == LogicalOperatorType.SCAN:
+            table = objects[0] if objects else self._extract_table(expressions)
+            if table:
+                kwargs["table_name"] = table
+        elif logical_type == LogicalOperatorType.JOIN:
+            kwargs["join_type"] = self._classify_join_type(operation, expressions)
+            condition = self._extract_join_condition(expressions)
+            if condition:
+                kwargs["join_conditions"] = [condition]
+        elif logical_type == LogicalOperatorType.AGGREGATE:
+            group_keys = self._extract_prefixed(expressions, ("groupkeys", "grouping keys", "group by"))
+            if group_keys:
+                kwargs["group_by_keys"] = group_keys
+        elif logical_type == LogicalOperatorType.FILTER and expressions:
+            kwargs["filter_expressions"] = expressions
+
+        properties: dict[str, Any] = {}
+        for key in ("partitionsAssigned", "partitionsTotal", "bytesAssigned"):
+            value = node.get(key)
+            if value is not None:
+                properties[key] = value
+
+        physical_op = self._create_physical_operator(
+            operation or "Unknown",
+            properties=properties,
+            platform_metadata={
+                "node_id": node.get("id"),
+                "objects": objects or None,
+                "expressions": expressions or None,
+            },
+        )
+
+        return self._create_logical_operator(
+            operator_type=logical_type,
+            children=children,
+            physical_operator=physical_op,
+            **kwargs,
+        )
+
+    @classmethod
+    def _map_operator_type(cls, operation: str) -> LogicalOperatorType:
+        normalized = operation.lower().replace(" ", "").replace("_", "")
+        for keyword, logical_type in cls._OPERATOR_KEYWORDS:
+            if keyword in normalized:
+                return logical_type
+        return LogicalOperatorType.OTHER
+
+    @staticmethod
+    def _classify_join_type(operation: str, expressions: list[str]) -> JoinType:
+        haystack = (operation + " " + " ".join(expressions)).lower()
+        if "semi" in haystack:
+            return JoinType.SEMI
+        if "anti" in haystack:
+            return JoinType.ANTI
+        for keyword, join_type in (
+            ("leftouter", JoinType.LEFT),
+            ("left outer", JoinType.LEFT),
+            ("rightouter", JoinType.RIGHT),
+            ("right outer", JoinType.RIGHT),
+            ("fullouter", JoinType.FULL),
+            ("full outer", JoinType.FULL),
+            ("cross", JoinType.CROSS),
+        ):
+            if keyword in haystack:
+                return join_type
+        return JoinType.INNER
+
+    @staticmethod
+    def _extract_join_condition(expressions: list[str]) -> str | None:
+        for expr in expressions:
+            match = re.search(r"(?:joinkey|equality\s*join\s*condition|condition)\s*[:=]\s*(.+)", expr, re.IGNORECASE)
+            if match:
+                return match.group(1).strip()
+        return None
+
+    @staticmethod
+    def _extract_table(expressions: list[str]) -> str | None:
+        for expr in expressions:
+            match = re.search(r"(?:table|relation)\s*[:=]\s*([\w.$\"]+)", expr, re.IGNORECASE)
+            if match:
+                return match.group(1).strip('"')
+        return None
+
+    @staticmethod
+    def _extract_prefixed(expressions: list[str], prefixes: tuple[str, ...]) -> list[str] | None:
+        for expr in expressions:
+            lowered = expr.lower()
+            for prefix in prefixes:
+                if lowered.startswith(prefix) or f"{prefix}:" in lowered:
+                    _, _, rest = expr.partition(":")
+                    body = (rest or expr).strip().strip("[]")
+                    keys = [k.strip() for k in body.split(",") if k.strip()]
+                    if keys:
+                        return keys
+        return None
+
+    @staticmethod
+    def _string_list(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -1013,8 +1013,6 @@ class AzureSynapseAdapter(PlatformAdapter):
             self.log_verbose(f"Query {query_id} completed: {actual_row_count} rows in {execution_time:.3f}s")
             self.log_operation_complete("Azure Synapse query execution", query_id, f"returned {actual_row_count} rows")
 
-            return result_dict
-
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             self.log_verbose(f"Query {query_id} failed after {execution_time:.3f}s: {e}")
@@ -1029,6 +1027,12 @@ class AzureSynapseAdapter(PlatformAdapter):
             }
         finally:
             cursor.close()
+
+        # Capture the structured query plan outside the try/except so a strict-mode
+        # PlanCaptureError propagates instead of being mislabeled as a failed query.
+        # No-op (no EXPLAIN issued) when capture_plans is False.
+        self._merge_plan_capture_into_result(result_dict, connection, query, query_id)
+        return result_dict
 
     def _extract_table_name(self, statement: str) -> str | None:
         """Extract table name from CREATE TABLE statement."""
@@ -1129,10 +1133,21 @@ class AzureSynapseAdapter(PlatformAdapter):
         return platform_info
 
     def get_query_plan(self, connection: Any, query: str) -> str:
-        """Get query execution plan for analysis."""
+        """Get query execution plan for analysis.
+
+        Azure Synapse Dedicated SQL Pool answers ``EXPLAIN <query>`` with a
+        distributed plan as a single XML document (``<dsql_query>``), which
+        AzureSynapseQueryPlanParser parses.
+        """
         from benchbox.platforms.base.sql_execution import get_query_plan_from_cursor
 
         return get_query_plan_from_cursor(connection, query)
+
+    def get_query_plan_parser(self):
+        """Return the Azure Synapse (Dedicated Pool dsql XML) query plan parser."""
+        from benchbox.core.query_plans.parsers.azure_synapse import AzureSynapseQueryPlanParser
+
+        return AzureSynapseQueryPlanParser()
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Update statistics for query optimization."""

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -1683,14 +1683,16 @@ class BigQueryAdapter(PlatformAdapter):
             stage_id = getattr(entry, "entry_id", None)
             if stage_id is None:
                 stage_id = index
+            # Normalize ids/inputs to str so the parser can match them: real
+            # QueryPlanEntry returns entry_id as a string but input_stages as ints.
             stages.append(
                 {
-                    "id": stage_id,
+                    "id": str(stage_id),
                     "name": getattr(entry, "name", None),
                     "status": getattr(entry, "status", None),
                     "records_read": getattr(entry, "records_read", None),
                     "records_written": getattr(entry, "records_written", None),
-                    "input_stages": list(getattr(entry, "input_stages", None) or []),
+                    "input_stages": [str(s) for s in (getattr(entry, "input_stages", None) or [])],
                     "steps": steps,
                 }
             )

--- a/benchbox/platforms/bigquery.py
+++ b/benchbox/platforms/bigquery.py
@@ -11,11 +11,15 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import random
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from benchbox.core.errors import PlanCaptureError
 from benchbox.platforms.base.config_utils import make_registered_platform_config_builder
 from benchbox.platforms.base.tuning import make_informational_constraint_applier
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -1552,8 +1556,24 @@ class BigQueryAdapter(PlatformAdapter):
             # Map job_statistics to resource_usage for cost calculation
             result_dict["resource_usage"] = job_stats
 
+            # Capture the structured query plan from the already-completed job's
+            # statistics (no extra API call / EXPLAIN, no extra billing). This is
+            # the BigQuery-specific path: plans are not available pre-execution, so
+            # the base EXPLAIN-driven capture_query_plan() is bypassed entirely.
+            if self.capture_plans and result_dict.get("status") == "SUCCESS":
+                query_plan, plan_capture_time_ms = self._capture_bq_plan(query_job, query_id)
+                if query_plan:
+                    result_dict["query_plan"] = query_plan
+                    result_dict["plan_fingerprint"] = query_plan.plan_fingerprint
+                if plan_capture_time_ms is not None:
+                    result_dict["plan_capture_time_ms"] = plan_capture_time_ms
+
             return result_dict
 
+        except PlanCaptureError:
+            # Strict-mode plan-capture failure must propagate, not be mislabeled
+            # as a failed query.
+            raise
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
 
@@ -1565,6 +1585,119 @@ class BigQueryAdapter(PlatformAdapter):
                 "error": str(e),
                 "error_type": type(e).__name__,
             }
+
+    def _capture_bq_plan(self, job: Any, query_id: str) -> tuple[Any, float]:
+        """Build a QueryPlanDAG from a completed BigQuery job's plan statistics.
+
+        BigQuery exposes no EXPLAIN statement; the query plan is only available
+        after execution via ``job.query_plan`` (the queryPlan job statistics),
+        which is already resident on the completed ``QueryJob`` — reading it
+        incurs no additional API call and no additional billing.
+
+        Honors the same capture gating as the base ``capture_query_plan`` (query
+        filter, first-N, sampling) and records failures via
+        ``_record_plan_capture_failure`` so capture stays silent when
+        ``strict_plan_capture`` is False and raises ``PlanCaptureError`` when it
+        is True.
+
+        Args:
+            job: Completed ``google.cloud.bigquery.QueryJob``.
+            query_id: Query identifier.
+
+        Returns:
+            Tuple of (QueryPlanDAG | None, capture_time_ms).
+        """
+        # Apply the same query/sampling filters as the base capture path.
+        if self.plan_query_filter and query_id not in self.plan_query_filter:
+            return None, 0.0
+        if self.plan_first_n is not None:
+            iteration = self._plan_capture_iteration_counts.get(query_id, 0)
+            self._plan_capture_iteration_counts[query_id] = iteration + 1
+            if iteration >= self.plan_first_n:
+                return None, 0.0
+        if self.plan_sampling_rate is not None and random.random() > self.plan_sampling_rate:
+            return None, 0.0
+
+        start_time = time.perf_counter()
+
+        raw_plan = self._serialize_bq_query_plan(job)
+        if not raw_plan:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self._record_plan_capture_failure(
+                query_id,
+                reason="explain_failed",
+                message="Completed job exposed no query_plan statistics",
+            )
+            return None, capture_time_ms
+
+        parser = self.get_query_plan_parser()
+        if not parser:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self._record_plan_capture_failure(
+                query_id,
+                reason="parser_unavailable",
+                message="No parser available for bigquery",
+                log_warning=False,
+            )
+            return None, capture_time_ms
+
+        try:
+            plan = parser.parse_explain_output(query_id, raw_plan)
+        except PlanCaptureError:
+            raise
+        except Exception as exc:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self._record_plan_capture_failure(query_id, reason="parse_error", message=str(exc))
+            return None, capture_time_ms
+
+        if plan is None:
+            capture_time_ms = (time.perf_counter() - start_time) * 1000
+            self._record_plan_capture_failure(query_id, reason="parse_error", message="Parser returned no plan")
+            return None, capture_time_ms
+
+        capture_time_ms = (time.perf_counter() - start_time) * 1000
+        self.query_plans_captured += 1
+        return plan, capture_time_ms
+
+    @staticmethod
+    def _serialize_bq_query_plan(job: Any) -> str | None:
+        """Serialize ``job.query_plan`` (list of QueryPlanEntry) to a JSON string.
+
+        Returns None when the job carries no plan stages. Reads only attributes
+        already present on the completed job object; issues no API call.
+        """
+        entries = getattr(job, "query_plan", None)
+        if not entries:
+            return None
+
+        stages: list[dict[str, Any]] = []
+        for index, entry in enumerate(entries):
+            steps = []
+            for step in getattr(entry, "steps", None) or []:
+                steps.append(
+                    {
+                        "kind": getattr(step, "kind", None),
+                        "substeps": list(getattr(step, "substeps", None) or []),
+                    }
+                )
+            stage_id = getattr(entry, "entry_id", None)
+            if stage_id is None:
+                stage_id = index
+            stages.append(
+                {
+                    "id": stage_id,
+                    "name": getattr(entry, "name", None),
+                    "status": getattr(entry, "status", None),
+                    "records_read": getattr(entry, "records_read", None),
+                    "records_written": getattr(entry, "records_written", None),
+                    "input_stages": list(getattr(entry, "input_stages", None) or []),
+                    "steps": steps,
+                }
+            )
+
+        if not stages:
+            return None
+        return json.dumps(stages)
 
     def _convert_to_bigquery_table(self, statement: str) -> str:
         """Convert CREATE TABLE statement to BigQuery format.
@@ -1730,6 +1863,18 @@ class BigQueryAdapter(PlatformAdapter):
 
         except Exception as e:
             return {"error": str(e)}
+
+    def get_query_plan_parser(self):
+        """Return the BigQuery query plan parser.
+
+        Note: BigQuery's plan capture does NOT use the base EXPLAIN-driven
+        ``capture_query_plan()`` path (there is no EXPLAIN statement). The plan is
+        captured from the completed job by ``_capture_bq_plan()``, which calls this
+        parser directly with the JSON-serialized ``job.query_plan`` statistics.
+        """
+        from benchbox.core.query_plans.parsers.bigquery import BigQueryQueryPlanParser
+
+        return BigQueryQueryPlanParser()
 
     def close_connection(self, connection: Any) -> None:
         """Close BigQuery connection.

--- a/benchbox/platforms/fabric_warehouse.py
+++ b/benchbox/platforms/fabric_warehouse.py
@@ -667,7 +667,7 @@ class FabricWarehouseAdapter(PlatformAdapter):
 
             execution_time = elapsed_seconds(start_time)
 
-            return {
+            result_dict = {
                 "query_id": query_id,
                 "stream_id": stream_id,
                 "iteration": iteration,
@@ -690,6 +690,12 @@ class FabricWarehouseAdapter(PlatformAdapter):
             }
         finally:
             cursor.close()
+
+        # Capture the structured query plan outside the try/except so a strict-mode
+        # PlanCaptureError propagates instead of being mislabeled as a failed query.
+        # No-op (no SHOWPLAN issued) when capture_plans is False.
+        self._merge_plan_capture_into_result(result_dict, connection, query, str(query_id))
+        return result_dict
 
     def get_existing_tables(self, connection: Any) -> list[str]:
         """Get list of existing tables in the schema.
@@ -1097,6 +1103,18 @@ class FabricWarehouseAdapter(PlatformAdapter):
             return f"Failed to get query plan: {e}"
         finally:
             cursor.close()
+
+    def get_query_plan_parser(self):
+        """Return the Fabric Warehouse (SQL Server SHOWPLAN_TEXT) query plan parser.
+
+        Fabric Warehouse retrieves its plan via ``SET SHOWPLAN_TEXT`` (text
+        showplan), a different format from Azure Synapse Dedicated Pool's
+        distributed dsql XML, so it uses a dedicated parser rather than reusing
+        AzureSynapseQueryPlanParser (see the w6 decision gate).
+        """
+        from benchbox.core.query_plans.parsers.fabric_warehouse import FabricWarehouseQueryPlanParser
+
+        return FabricWarehouseQueryPlanParser()
 
     def analyze_table(self, connection: Any, table_name: str) -> None:
         """Update table statistics.

--- a/benchbox/platforms/fabric_warehouse.py
+++ b/benchbox/platforms/fabric_warehouse.py
@@ -1093,11 +1093,20 @@ class FabricWarehouseAdapter(PlatformAdapter):
         """
         cursor = connection.cursor()
         try:
-            # Enable plan capture
+            # Enable plan capture. SHOWPLAN_TEXT is a session-level setting, so it
+            # MUST be turned off even if the EXPLAINed query fails — otherwise the
+            # connection stays in SHOWPLAN mode and subsequent benchmark statements
+            # return plans instead of executing, corrupting the rest of the run.
             cursor.execute("SET SHOWPLAN_TEXT ON")
-            cursor.execute(query)
-            plan_rows = cursor.fetchall()
-            cursor.execute("SET SHOWPLAN_TEXT OFF")
+            try:
+                cursor.execute(query)
+                plan_rows = cursor.fetchall()
+            finally:
+                # Best-effort reset; never let the OFF mask the original failure.
+                try:
+                    cursor.execute("SET SHOWPLAN_TEXT OFF")
+                except Exception:
+                    pass
             return "\n".join([str(row[0]) for row in plan_rows])
         except Exception as e:
             return f"Failed to get query plan: {e}"

--- a/benchbox/platforms/snowflake.py
+++ b/benchbox/platforms/snowflake.py
@@ -1217,8 +1217,6 @@ class SnowflakeAdapter(PlatformAdapter):
                 self.log_verbose(f"Query {query_id} completed: {actual_row_count} rows in {execution_time:.3f}s")
                 self.log_operation_complete("Snowflake query execution", query_id, f"returned {actual_row_count} rows")
 
-            return result_dict
-
         except Exception as e:
             execution_time = elapsed_seconds(start_time)
             self.log_verbose(f"Query {query_id} failed after {execution_time:.3f}s: {e}")
@@ -1234,6 +1232,40 @@ class SnowflakeAdapter(PlatformAdapter):
             }
         finally:
             cursor.close()
+
+        # Capture the structured query plan outside the try/except so a strict-mode
+        # PlanCaptureError propagates instead of being mislabeled as a failed query.
+        # The helper is a no-op when capture_plans is False (no extra EXPLAIN issued).
+        self._merge_plan_capture_into_result(result_dict, connection, query, query_id)
+        return result_dict
+
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Return the Snowflake query plan as JSON via ``EXPLAIN USING JSON``.
+
+        Snowflake has no plain text EXPLAIN suitable for structured parsing;
+        ``EXPLAIN USING JSON`` returns a single-cell JSON document describing the
+        plan (``GlobalStats`` + ``Operations``) which SnowflakeQueryPlanParser
+        consumes. Returns None on failure so capture degrades gracefully.
+        """
+        cursor = connection.cursor()
+        try:
+            cursor.execute(f"EXPLAIN USING JSON {query}")
+            rows = cursor.fetchall()
+            if not rows or not rows[0]:
+                return None
+            # The JSON document is returned in the first column of the first row.
+            return str(rows[0][0])
+        except Exception as e:
+            self.logger.debug(f"Failed to get Snowflake query plan: {e}")
+            return None
+        finally:
+            cursor.close()
+
+    def get_query_plan_parser(self):
+        """Return the Snowflake query plan parser."""
+        from benchbox.core.query_plans.parsers.snowflake import SnowflakeQueryPlanParser
+
+        return SnowflakeQueryPlanParser()
 
     def _optimize_table_definition(self, statement: str) -> str:
         """Optimize table definition for Snowflake.

--- a/tests/fixtures/query_plans/azure_synapse_explain_sample.xml
+++ b/tests/fixtures/query_plans/azure_synapse_explain_sample.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dsql_query number_nodes="1" number_distributions="60" number_distributions_per_node="60">
+  <sql>SELECT l_orderkey, SUM(l_quantity) FROM lineitem JOIN orders ON l_orderkey = o_orderkey GROUP BY l_orderkey ORDER BY l_orderkey</sql>
+  <dsql_operations total_cost="2.345" total_number_operations="4">
+    <dsql_operation operation_type="RND_ID">
+      <identifier>TEMP_ID_42</identifier>
+    </dsql_operation>
+    <dsql_operation operation_type="ON">
+      <location permanent="false" distribution="AllDistributions" />
+      <sql_operations>
+        <sql_operation type="statement">CREATE TABLE [tempdb].[dbo].[TEMP_ID_42] WITH (DISTRIBUTION = HASH([l_orderkey]), HEAP) AS SELECT [l_orderkey], [l_quantity] FROM [tpch].[dbo].[lineitem]</sql_operation>
+      </sql_operations>
+    </dsql_operation>
+    <dsql_operation operation_type="SHUFFLE_MOVE">
+      <operation_cost cost="2.0" accumulative_cost="2.0" average_rowsize="16" output_rows="1500000" />
+      <location distribution="AllDistributions" />
+      <source_statement>SELECT [l_orderkey], [l_quantity] FROM [tpch].[dbo].[lineitem]</source_statement>
+      <destination_table>TEMP_ID_42</destination_table>
+      <shuffle_columns>l_orderkey;</shuffle_columns>
+    </dsql_operation>
+    <dsql_operation operation_type="RETURN">
+      <location distribution="AllDistributions" />
+      <select>SELECT [l_orderkey], SUM([l_quantity]) FROM [tempdb].[dbo].[TEMP_ID_42] GROUP BY [l_orderkey] ORDER BY [l_orderkey]</select>
+    </dsql_operation>
+  </dsql_operations>
+</dsql_query>

--- a/tests/fixtures/query_plans/bigquery_query_plan_sample.json
+++ b/tests/fixtures/query_plans/bigquery_query_plan_sample.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": 0,
+    "name": "S00: Input",
+    "status": "COMPLETE",
+    "records_read": 6001215,
+    "records_written": 6001215,
+    "input_stages": [],
+    "steps": [
+      {"kind": "READ", "substeps": ["$1:l_orderkey, $2:l_quantity", "FROM tpch.lineitem"]},
+      {"kind": "WRITE", "substeps": ["$1, $2", "TO __stage00_output"]}
+    ]
+  },
+  {
+    "id": 1,
+    "name": "S01: Input",
+    "status": "COMPLETE",
+    "records_read": 1500000,
+    "records_written": 1500000,
+    "input_stages": [],
+    "steps": [
+      {"kind": "READ", "substeps": ["$10:o_orderkey", "FROM tpch.orders"]},
+      {"kind": "WRITE", "substeps": ["$10", "TO __stage01_output"]}
+    ]
+  },
+  {
+    "id": 2,
+    "name": "S02: Join+",
+    "status": "COMPLETE",
+    "records_read": 7501215,
+    "records_written": 1500000,
+    "input_stages": [0, 1],
+    "steps": [
+      {"kind": "READ", "substeps": ["$1, $2", "FROM __stage00_output"]},
+      {"kind": "JOIN", "substeps": ["INNER HASH JOIN EACH ON $1 = $10"]},
+      {"kind": "AGGREGATE", "substeps": ["GROUP BY $20 := $1", "$21 := SUM($2)"]},
+      {"kind": "WRITE", "substeps": ["$20, $21", "TO __stage02_output"]}
+    ]
+  },
+  {
+    "id": 3,
+    "name": "S03: Output",
+    "status": "COMPLETE",
+    "records_read": 1500000,
+    "records_written": 1500000,
+    "input_stages": [2],
+    "steps": [
+      {"kind": "READ", "substeps": ["$20, $21", "FROM __stage02_output"]},
+      {"kind": "SORT", "substeps": ["$20 ASC"]},
+      {"kind": "WRITE", "substeps": ["$20, $21", "TO __output"]}
+    ]
+  }
+]

--- a/tests/fixtures/query_plans/fabric_warehouse_showplan_sample.txt
+++ b/tests/fixtures/query_plans/fabric_warehouse_showplan_sample.txt
@@ -1,0 +1,7 @@
+SELECT l_orderkey, SUM(l_quantity) FROM lineitem JOIN orders ON l_orderkey = o_orderkey GROUP BY l_orderkey ORDER BY l_orderkey
+  |--Sort(ORDER BY:([tpch].[dbo].[lineitem].[l_orderkey] ASC))
+       |--Compute Scalar(DEFINE:([Expr1004]=CONVERT_IMPLICIT(bigint,[Expr1003],0)))
+            |--Hash Match(Aggregate, HASH:([tpch].[dbo].[lineitem].[l_orderkey]) DEFINE:([Expr1003]=SUM([tpch].[dbo].[lineitem].[l_quantity])))
+                 |--Hash Match(Inner Join, HASH:([tpch].[dbo].[lineitem].[l_orderkey])=([tpch].[dbo].[orders].[o_orderkey]))
+                      |--Clustered Index Scan(OBJECT:([tpch].[dbo].[lineitem].[cci_lineitem]))
+                      |--Clustered Index Scan(OBJECT:([tpch].[dbo].[orders].[cci_orders]))

--- a/tests/fixtures/query_plans/snowflake_explain_sample.json
+++ b/tests/fixtures/query_plans/snowflake_explain_sample.json
@@ -1,0 +1,52 @@
+{
+  "GlobalStats": {
+    "partitionsTotal": 12,
+    "partitionsAssigned": 12,
+    "bytesAssigned": 154386432
+  },
+  "Operations": [
+    [
+      {
+        "id": 0,
+        "operation": "Result",
+        "expressions": ["LINEITEM.L_ORDERKEY", "SUM(LINEITEM.L_QUANTITY)"]
+      },
+      {
+        "id": 1,
+        "parentOperators": [0],
+        "operation": "Sort",
+        "expressions": ["sortKeys: [LINEITEM.L_ORDERKEY ASC NULLS LAST]"]
+      },
+      {
+        "id": 2,
+        "parentOperators": [1],
+        "operation": "Aggregate",
+        "expressions": ["aggExprs: [SUM(LINEITEM.L_QUANTITY)]", "groupKeys: [LINEITEM.L_ORDERKEY]"]
+      },
+      {
+        "id": 3,
+        "parentOperators": [2],
+        "operation": "InnerJoin",
+        "expressions": ["joinKey: (ORDERS.O_ORDERKEY = LINEITEM.L_ORDERKEY)"]
+      },
+      {
+        "id": 4,
+        "parentOperators": [3],
+        "operation": "TableScan",
+        "objects": ["TPCH_SF1.PUBLIC.LINEITEM"],
+        "expressions": ["L_ORDERKEY", "L_QUANTITY"],
+        "partitionsAssigned": 10,
+        "partitionsTotal": 10
+      },
+      {
+        "id": 5,
+        "parentOperators": [3],
+        "operation": "TableScan",
+        "objects": ["TPCH_SF1.PUBLIC.ORDERS"],
+        "expressions": ["O_ORDERKEY"],
+        "partitionsAssigned": 2,
+        "partitionsTotal": 2
+      }
+    ]
+  ]
+}

--- a/tests/unit/platforms/test_cloud_saas_plan_capture.py
+++ b/tests/unit/platforms/test_cloud_saas_plan_capture.py
@@ -247,6 +247,22 @@ class TestFabricWarehouseCapture:
             assert result["status"] == "SUCCESS"
             assert "query_plan" not in result
 
+    def test_showplan_turned_off_when_explain_query_fails(self):
+        # SHOWPLAN_TEXT is session-scoped: a failure after SET ... ON must still
+        # issue SET ... OFF, or later statements return plans instead of running.
+        with _fabric_adapter() as adapter:
+            cursor = Mock()
+            cursor.execute.side_effect = (
+                lambda sql: (_ for _ in ()).throw(RuntimeError("boom")) if sql == "BAD" else None
+            )
+            connection = Mock()
+            connection.cursor.return_value = cursor
+            plan = adapter.get_query_plan(connection, "BAD")
+            assert plan.startswith("Failed to get query plan")
+            executed = [c.args[0] for c in cursor.execute.call_args_list]
+            assert "SET SHOWPLAN_TEXT ON" in executed
+            assert "SET SHOWPLAN_TEXT OFF" in executed  # reset ran despite failure
+
 
 # ---------------------------------------------------------------------------
 # BigQuery: post-execution job-statistics capture (no EXPLAIN)

--- a/tests/unit/platforms/test_cloud_saas_plan_capture.py
+++ b/tests/unit/platforms/test_cloud_saas_plan_capture.py
@@ -1,0 +1,341 @@
+"""Adapter-level plan-capture wiring tests for the cloud SaaS warehouses.
+
+Covers the five platforms wired in this change — Snowflake, BigQuery,
+Azure Synapse, Fabric Warehouse, and LakeSail — with mocked connections so no
+cloud credentials are required:
+
+- ``get_query_plan_parser()`` returns the expected non-None parser.
+- ``execute_query()`` with ``capture_plans=True`` attaches a ``query_plan`` /
+  ``plan_fingerprint`` to the result (BigQuery via ``_capture_bq_plan`` since it
+  has no EXPLAIN statement).
+- capture failure degrades gracefully (no exception, result still SUCCESS) when
+  ``strict_plan_capture`` is False, and propagates when it is True.
+
+Firebolt is intentionally absent: its parser/wiring is deferred (blocked on a
+recorded EXPLAIN fixture) — see the source TODO's w5 notes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import benchbox.platforms.azure_synapse as synapse_module
+import benchbox.platforms.fabric_warehouse as fabric_module
+from benchbox.core.errors import PlanCaptureError
+from benchbox.core.query_plans.parsers.azure_synapse import AzureSynapseQueryPlanParser
+from benchbox.core.query_plans.parsers.bigquery import BigQueryQueryPlanParser
+from benchbox.core.query_plans.parsers.fabric_warehouse import FabricWarehouseQueryPlanParser
+from benchbox.core.query_plans.parsers.snowflake import SnowflakeQueryPlanParser
+from benchbox.core.query_plans.parsers.spark import SparkQueryPlanParser
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _fixture(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+# ---------------------------------------------------------------------------
+# Adapter builders (context managers keeping required module patches active)
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _snowflake_adapter():
+    from benchbox.platforms.snowflake import SnowflakeAdapter
+
+    with (
+        patch("benchbox.platforms.snowflake.check_platform_dependencies", return_value=(True, [])),
+        patch("benchbox.platforms.snowflake.snowflake"),
+    ):
+        adapter = SnowflakeAdapter(account="acct", username="u", password="p")
+        yield adapter
+
+
+@contextlib.contextmanager
+def _azure_synapse_adapter():
+    from benchbox.platforms.azure_synapse import AzureSynapseAdapter
+
+    mock_pyodbc = Mock()
+    with (
+        patch.object(synapse_module, "pyodbc", mock_pyodbc),
+        patch.object(synapse_module, "check_platform_dependencies", lambda *a, **k: (True, [])),
+    ):
+        adapter = AzureSynapseAdapter(server="ws.sql.azuresynapse.net", username="admin", password="secret")
+        yield adapter
+
+
+@contextlib.contextmanager
+def _fabric_adapter():
+    from benchbox.platforms.fabric_warehouse import FabricWarehouseAdapter
+
+    mock_pyodbc = MagicMock()
+    mock_pyodbc.Error = Exception
+    with (
+        patch.object(fabric_module, "pyodbc", mock_pyodbc),
+        patch.object(fabric_module, "check_platform_dependencies", lambda *a, **k: (True, [])),
+    ):
+        adapter = FabricWarehouseAdapter(workspace="ws", warehouse="wh", auth_method="default_credential")
+        yield adapter
+
+
+@contextlib.contextmanager
+def _bigquery_adapter():
+    from benchbox.platforms.bigquery import BigQueryAdapter
+
+    with (
+        patch("benchbox.platforms.bigquery.check_platform_dependencies", return_value=(True, [])),
+        patch("benchbox.platforms.bigquery.bigquery"),
+    ):
+        adapter = BigQueryAdapter(project_id="proj", dataset_id="ds")
+        yield adapter
+
+
+@contextlib.contextmanager
+def _lakesail_adapter():
+    with patch.dict(
+        "sys.modules",
+        {
+            "pyspark": MagicMock(),
+            "pyspark.sql": MagicMock(SparkSession=MagicMock()),
+            "pyspark.sql.types": MagicMock(),
+        },
+    ):
+        from benchbox.platforms.lakesail import LakeSailAdapter
+
+        yield LakeSailAdapter()
+
+
+_BUILDERS = {
+    "snowflake": (_snowflake_adapter, SnowflakeQueryPlanParser),
+    "bigquery": (_bigquery_adapter, BigQueryQueryPlanParser),
+    "azure_synapse": (_azure_synapse_adapter, AzureSynapseQueryPlanParser),
+    "fabric_warehouse": (_fabric_adapter, FabricWarehouseQueryPlanParser),
+    "lakesail": (_lakesail_adapter, SparkQueryPlanParser),
+}
+
+
+# ---------------------------------------------------------------------------
+# get_query_plan_parser() returns the expected parser for every wired adapter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("platform", sorted(_BUILDERS))
+def test_get_query_plan_parser_non_none(platform):
+    builder, expected_type = _BUILDERS[platform]
+    with builder() as adapter:
+        parser = adapter.get_query_plan_parser()
+        assert parser is not None
+        assert isinstance(parser, expected_type)
+
+
+# ---------------------------------------------------------------------------
+# Snowflake: EXPLAIN USING JSON capture
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeCapture:
+    def _connection_for(self, query_rows, plan_payload):
+        cursor = Mock()
+        cursor.fetchall.side_effect = [query_rows, plan_payload]
+        connection = Mock()
+        connection.cursor.return_value = cursor
+        return connection
+
+    def test_capture_attaches_plan(self):
+        with _snowflake_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter._get_query_statistics = lambda *a, **k: {}
+            connection = self._connection_for([(1, 2)], [(_fixture("snowflake_explain_sample.json"),)])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" in result
+            assert result["plan_fingerprint"]
+
+    def test_no_explain_when_capture_disabled(self):
+        with _snowflake_adapter() as adapter:
+            adapter.capture_plans = False
+            adapter._get_query_statistics = lambda *a, **k: {}
+            adapter.get_query_plan = Mock(side_effect=AssertionError("EXPLAIN must not run"))
+            connection = self._connection_for([(1, 2)], [])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" not in result
+            adapter.get_query_plan.assert_not_called()
+
+    def test_capture_failure_is_silent(self):
+        with _snowflake_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter.strict_plan_capture = False
+            adapter._get_query_statistics = lambda *a, **k: {}
+            adapter.get_query_plan = Mock(return_value=None)
+            connection = self._connection_for([(1, 2)], [])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" not in result
+
+
+# ---------------------------------------------------------------------------
+# Azure Synapse: EXPLAIN -> dsql XML capture
+# ---------------------------------------------------------------------------
+
+
+class TestAzureSynapseCapture:
+    def _connection_for(self, query_rows, plan_rows):
+        cursor = Mock()
+        cursor.fetchall.side_effect = [query_rows, plan_rows]
+        connection = Mock()
+        connection.cursor.return_value = cursor
+        return connection
+
+    def test_capture_attaches_plan(self):
+        with _azure_synapse_adapter() as adapter:
+            adapter.capture_plans = True
+            connection = self._connection_for([(1,)], [(_fixture("azure_synapse_explain_sample.xml"),)])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" in result
+            assert result["plan_fingerprint"]
+
+    def test_capture_failure_is_silent(self):
+        with _azure_synapse_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter.strict_plan_capture = False
+            adapter.get_query_plan = Mock(return_value="Could not get query plan: boom")
+            connection = self._connection_for([(1,)], [])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" not in result
+
+
+# ---------------------------------------------------------------------------
+# Fabric Warehouse: SET SHOWPLAN_TEXT capture
+# ---------------------------------------------------------------------------
+
+
+class TestFabricWarehouseCapture:
+    def _connection_for(self, query_rows, plan_rows):
+        cursor = Mock()
+        cursor.fetchall.side_effect = [query_rows, plan_rows]
+        connection = Mock()
+        connection.cursor.return_value = cursor
+        return connection
+
+    def test_capture_attaches_plan(self):
+        with _fabric_adapter() as adapter:
+            adapter.capture_plans = True
+            plan_rows = [(line,) for line in _fixture("fabric_warehouse_showplan_sample.txt").splitlines()]
+            connection = self._connection_for([(1,)], plan_rows)
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" in result
+            assert result["plan_fingerprint"]
+
+    def test_capture_failure_is_silent(self):
+        with _fabric_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter.strict_plan_capture = False
+            adapter.get_query_plan = Mock(return_value="Failed to get query plan: boom")
+            connection = self._connection_for([(1,)], [])
+            result = adapter.execute_query(connection, "SELECT 1", "q1")
+            assert result["status"] == "SUCCESS"
+            assert "query_plan" not in result
+
+
+# ---------------------------------------------------------------------------
+# BigQuery: post-execution job-statistics capture (no EXPLAIN)
+# ---------------------------------------------------------------------------
+
+
+def _mock_query_job(stages_json: str | None):
+    """Build a mock QueryJob whose query_plan mirrors a serialized stage list."""
+    import json as _json
+
+    job = Mock()
+    if stages_json is None:
+        job.query_plan = []
+        return job
+    entries = []
+    for stage in _json.loads(stages_json):
+        steps = []
+        for s in stage.get("steps", []):
+            step = Mock(substeps=s.get("substeps", []))
+            step.kind = s["kind"]
+            steps.append(step)
+        entry = Mock(
+            entry_id=stage.get("id"),
+            status=stage.get("status"),
+            records_read=stage.get("records_read"),
+            records_written=stage.get("records_written"),
+            input_stages=stage.get("input_stages", []),
+            steps=steps,
+        )
+        # ``name`` is a reserved Mock constructor kwarg, so assign it explicitly.
+        entry.name = stage.get("name")
+        entries.append(entry)
+    job.query_plan = entries
+    return job
+
+
+class TestBigQueryCapture:
+    def test_capture_bq_plan_builds_dag(self):
+        with _bigquery_adapter() as adapter:
+            adapter.capture_plans = True
+            job = _mock_query_job(_fixture("bigquery_query_plan_sample.json"))
+            dag, ms = adapter._capture_bq_plan(job, "q1")
+            assert dag is not None
+            assert dag.plan_fingerprint
+            assert ms >= 0
+            assert adapter.query_plans_captured == 1
+
+    def test_capture_bq_plan_no_extra_api_call(self):
+        # The job object is read directly; no client/connection .query() is issued.
+        with _bigquery_adapter() as adapter:
+            adapter.capture_plans = True
+            job = _mock_query_job(_fixture("bigquery_query_plan_sample.json"))
+            adapter._capture_bq_plan(job, "q1")
+            assert not job.query.called  # no second query/EXPLAIN against the job
+            assert not job.result.called
+
+    def test_empty_plan_degrades_silently(self):
+        with _bigquery_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter.strict_plan_capture = False
+            dag, ms = adapter._capture_bq_plan(_mock_query_job(None), "q1")
+            assert dag is None
+            assert adapter.plan_capture_failures == 1
+
+    def test_empty_plan_raises_in_strict_mode(self):
+        with _bigquery_adapter() as adapter:
+            adapter.capture_plans = True
+            adapter.strict_plan_capture = True
+            with pytest.raises(PlanCaptureError):
+                adapter._capture_bq_plan(_mock_query_job(None), "q1")
+
+
+# ---------------------------------------------------------------------------
+# LakeSail: reuses the Spark parser over Spark Connect EXPLAIN text
+# ---------------------------------------------------------------------------
+
+
+class TestLakeSailCapture:
+    def test_parser_is_spark(self):
+        with _lakesail_adapter() as adapter:
+            assert isinstance(adapter.get_query_plan_parser(), SparkQueryPlanParser)
+
+    def test_get_query_plan_feeds_spark_parser(self):
+        with _lakesail_adapter() as adapter:
+            spark = MagicMock()
+            df = MagicMock()
+            df.collect.return_value = [(line,) for line in _fixture("spark_explain_sample.txt").splitlines()]
+            spark.sql.return_value = df
+            plan_text = adapter.get_query_plan(spark, "SELECT 1")
+            dag = adapter.get_query_plan_parser().parse_explain_output("q1", plan_text)
+            assert dag is not None
+            assert dag.plan_fingerprint

--- a/tests/unit/query_plans/test_azure_synapse_parser.py
+++ b/tests/unit/query_plans/test_azure_synapse_parser.py
@@ -1,0 +1,83 @@
+"""Unit tests for AzureSynapseQueryPlanParser.
+
+Driven by a recorded Dedicated SQL Pool ``EXPLAIN`` (distributed dsql XML)
+fixture under tests/fixtures/query_plans/ so they run with no live Synapse
+workspace.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.azure_synapse import AzureSynapseQueryPlanParser
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _collect(op: LogicalOperator) -> list[LogicalOperator]:
+    nodes = [op]
+    for child in op.children:
+        nodes.extend(_collect(child))
+    return nodes
+
+
+@pytest.fixture()
+def parser():
+    return AzureSynapseQueryPlanParser()
+
+
+class TestAzureSynapsePlan:
+    def test_parses_to_valid_dag(self, parser):
+        dag = parser.parse_explain_output("q1", _load("azure_synapse_explain_sample.xml"))
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+        assert dag.platform == "azure_synapse"
+
+    def test_root_is_return_projection(self, parser):
+        dag = parser.parse_explain_output("q1", _load("azure_synapse_explain_sample.xml"))
+        assert dag.logical_root.operator_type == LogicalOperatorType.PROJECT
+        assert dag.logical_root.physical_operator.operator_type == "RETURN"
+
+    def test_distributed_chain_preserved(self, parser):
+        # The dsql plan is a linear pipeline: RETURN -> SHUFFLE_MOVE -> ON -> RND_ID.
+        dag = parser.parse_explain_output("q1", _load("azure_synapse_explain_sample.xml"))
+        nodes = _collect(dag.logical_root)
+        physical = [n.physical_operator.operator_type for n in nodes]
+        assert physical == ["RETURN", "SHUFFLE_MOVE", "ON", "RND_ID"]
+
+    def test_data_movement_maps_to_other(self, parser):
+        dag = parser.parse_explain_output("q1", _load("azure_synapse_explain_sample.xml"))
+        move = next(n for n in _collect(dag.logical_root) if n.physical_operator.operator_type == "SHUFFLE_MOVE")
+        assert move.operator_type == LogicalOperatorType.OTHER
+
+    def test_cost_and_rows_extracted(self, parser):
+        dag = parser.parse_explain_output("q1", _load("azure_synapse_explain_sample.xml"))
+        assert dag.estimated_cost == pytest.approx(2.345)
+        assert dag.estimated_rows == 1500000
+
+    def test_registered_for_synapse_aliases(self):
+        assert isinstance(get_parser_for_platform("azure_synapse"), AzureSynapseQueryPlanParser)
+        assert isinstance(get_parser_for_platform("synapse"), AzureSynapseQueryPlanParser)
+
+
+class TestAzureSynapseErrorHandling:
+    def test_empty_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "") is None
+
+    def test_non_xml_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "Could not get query plan: boom") is None
+
+    def test_missing_operations_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "<dsql_query></dsql_query>") is None

--- a/tests/unit/query_plans/test_bigquery_parser.py
+++ b/tests/unit/query_plans/test_bigquery_parser.py
@@ -67,6 +67,33 @@ class TestBigQueryPlan:
     def test_registered_for_bigquery(self):
         assert isinstance(get_parser_for_platform("bigquery"), BigQueryQueryPlanParser)
 
+    def test_mixed_id_types_do_not_collapse_tree(self, parser):
+        # Real google-cloud-bigquery returns stage ``id`` as a string but
+        # ``input_stages`` as ints; the parser must normalize both so children
+        # still attach (otherwise the plan collapses to the output node alone).
+        import json
+
+        stages = [
+            {
+                "id": "0",
+                "name": "S00: Input",
+                "input_stages": [],
+                "records_written": 10,
+                "steps": [{"kind": "READ", "substeps": ["FROM tpch.lineitem"]}],
+            },
+            {
+                "id": "1",
+                "name": "S01: Output",
+                "input_stages": [0],
+                "records_written": 10,
+                "steps": [{"kind": "READ", "substeps": []}, {"kind": "WRITE", "substeps": []}],
+            },
+        ]
+        dag = parser.parse_explain_output("q1", json.dumps(stages))
+        nodes = _collect(dag.logical_root)
+        assert len(nodes) == 2  # output -> input, not a lone output node
+        assert any(n.operator_type == LogicalOperatorType.SCAN for n in nodes)
+
 
 class TestBigQueryStageMapping:
     @pytest.mark.parametrize(

--- a/tests/unit/query_plans/test_bigquery_parser.py
+++ b/tests/unit/query_plans/test_bigquery_parser.py
@@ -1,0 +1,96 @@
+"""Unit tests for BigQueryQueryPlanParser.
+
+BigQuery has no EXPLAIN statement; plans come from the completed job's
+``query_plan`` statistics. The parser consumes the JSON-serialized stage list,
+recorded as a fixture under tests/fixtures/query_plans/ so these run with no
+live BigQuery account.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.bigquery import BigQueryQueryPlanParser
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _collect(op: LogicalOperator) -> list[LogicalOperator]:
+    nodes = [op]
+    for child in op.children:
+        nodes.extend(_collect(child))
+    return nodes
+
+
+@pytest.fixture()
+def parser():
+    return BigQueryQueryPlanParser()
+
+
+class TestBigQueryPlan:
+    def test_parses_to_valid_dag(self, parser):
+        dag = parser.parse_explain_output("q1", _load("bigquery_query_plan_sample.json"))
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+        assert dag.platform == "bigquery"
+
+    def test_root_is_output_stage(self, parser):
+        # The Output stage is read by nobody, so it is the root.
+        dag = parser.parse_explain_output("q1", _load("bigquery_query_plan_sample.json"))
+        assert "Output" in dag.logical_root.physical_operator.operator_type
+
+    def test_tree_built_from_input_stages(self, parser):
+        dag = parser.parse_explain_output("q1", _load("bigquery_query_plan_sample.json"))
+        nodes = _collect(dag.logical_root)
+        types = [n.operator_type for n in nodes]
+        assert LogicalOperatorType.JOIN in types
+        assert types.count(LogicalOperatorType.SCAN) == 2
+        tables = {n.table_name for n in nodes if n.table_name}
+        assert tables == {"tpch.lineitem", "tpch.orders"}
+
+    def test_records_written_to_estimated_rows(self, parser):
+        dag = parser.parse_explain_output("q1", _load("bigquery_query_plan_sample.json"))
+        assert dag.estimated_rows == 1500000
+
+    def test_registered_for_bigquery(self):
+        assert isinstance(get_parser_for_platform("bigquery"), BigQueryQueryPlanParser)
+
+
+class TestBigQueryStageMapping:
+    @pytest.mark.parametrize(
+        ("name", "kinds", "expected"),
+        [
+            ("S00: Input", ["READ", "WRITE"], LogicalOperatorType.SCAN),
+            ("S01: Join+", ["READ", "JOIN", "WRITE"], LogicalOperatorType.JOIN),
+            ("S02: Aggregate+", ["READ", "AGGREGATE", "WRITE"], LogicalOperatorType.AGGREGATE),
+            ("S03: Sort+", ["READ", "SORT", "WRITE"], LogicalOperatorType.SORT),
+            ("S04: Output", ["READ", "WRITE"], LogicalOperatorType.SCAN),
+            ("S05: Output", [], LogicalOperatorType.PROJECT),
+            ("S06: Mystery", [], LogicalOperatorType.OTHER),
+        ],
+    )
+    def test_map_stage_type(self, parser, name, kinds, expected):
+        assert parser._map_stage_type(name, kinds) == expected
+
+
+class TestBigQueryErrorHandling:
+    def test_empty_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "") is None
+
+    def test_invalid_json_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "[not json") is None
+
+    def test_empty_list_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "[]") is None

--- a/tests/unit/query_plans/test_fabric_warehouse_parser.py
+++ b/tests/unit/query_plans/test_fabric_warehouse_parser.py
@@ -1,0 +1,105 @@
+"""Unit tests for FabricWarehouseQueryPlanParser.
+
+Fabric Warehouse retrieves its plan via ``SET SHOWPLAN_TEXT`` (SQL Server text
+showplan) rather than Azure Synapse's distributed dsql XML, so it uses a
+dedicated parser (the w6 decision gate). Driven by a recorded SHOWPLAN_TEXT
+fixture under tests/fixtures/query_plans/ so these run with no live Fabric
+workspace.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.fabric_warehouse import FabricWarehouseQueryPlanParser
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.results.query_plan_models import JoinType, LogicalOperator, LogicalOperatorType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _collect(op: LogicalOperator) -> list[LogicalOperator]:
+    nodes = [op]
+    for child in op.children:
+        nodes.extend(_collect(child))
+    return nodes
+
+
+@pytest.fixture()
+def parser():
+    return FabricWarehouseQueryPlanParser()
+
+
+class TestFabricWarehousePlan:
+    def test_parses_to_valid_dag(self, parser):
+        dag = parser.parse_explain_output("q1", _load("fabric_warehouse_showplan_sample.txt"))
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+        assert dag.platform == "fabric_warehouse"
+
+    def test_root_is_sort(self, parser):
+        dag = parser.parse_explain_output("q1", _load("fabric_warehouse_showplan_sample.txt"))
+        assert dag.logical_root.operator_type == LogicalOperatorType.SORT
+
+    def test_tree_has_join_over_two_scans(self, parser):
+        dag = parser.parse_explain_output("q1", _load("fabric_warehouse_showplan_sample.txt"))
+        nodes = _collect(dag.logical_root)
+        types = [n.operator_type for n in nodes]
+        assert LogicalOperatorType.JOIN in types
+        assert LogicalOperatorType.AGGREGATE in types
+        assert types.count(LogicalOperatorType.SCAN) == 2
+        tables = {n.table_name for n in nodes if n.table_name}
+        assert tables == {"tpch.dbo.lineitem", "tpch.dbo.orders"}
+
+    def test_join_is_inner_with_condition(self, parser):
+        dag = parser.parse_explain_output("q1", _load("fabric_warehouse_showplan_sample.txt"))
+        join = next(n for n in _collect(dag.logical_root) if n.operator_type == LogicalOperatorType.JOIN)
+        assert join.join_type == JoinType.INNER
+        assert join.join_conditions
+
+    def test_leading_statement_line_skipped(self, parser):
+        # The first (statement) row has no |-- connector and must not be an operator.
+        dag = parser.parse_explain_output("q1", _load("fabric_warehouse_showplan_sample.txt"))
+        assert "SELECT" not in dag.logical_root.physical_operator.operator_type
+
+    def test_registered_for_fabric_aliases(self):
+        assert isinstance(get_parser_for_platform("fabric_warehouse"), FabricWarehouseQueryPlanParser)
+        assert isinstance(get_parser_for_platform("fabric"), FabricWarehouseQueryPlanParser)
+
+
+class TestFabricWarehouseOperatorNormalization:
+    @pytest.mark.parametrize(
+        ("name", "args", "expected"),
+        [
+            ("Clustered Index Scan", "OBJECT:([db].[dbo].[t])", LogicalOperatorType.SCAN),
+            ("Index Seek", "OBJECT:([db].[dbo].[t].[ix])", LogicalOperatorType.SCAN),
+            ("Hash Match", "Inner Join, HASH:([a])=([b])", LogicalOperatorType.JOIN),
+            ("Hash Match", "Aggregate, HASH:([a]) DEFINE:([x]=SUM([y]))", LogicalOperatorType.AGGREGATE),
+            ("Nested Loops", "Inner Join", LogicalOperatorType.JOIN),
+            ("Stream Aggregate", "GROUP BY:([a])", LogicalOperatorType.AGGREGATE),
+            ("Sort", "ORDER BY:([a] ASC)", LogicalOperatorType.SORT),
+            ("Compute Scalar", "DEFINE:([x]=...)", LogicalOperatorType.PROJECT),
+            ("Top", "TOP EXPRESSION", LogicalOperatorType.LIMIT),
+        ],
+    )
+    def test_map_operator_type(self, parser, name, args, expected):
+        assert parser._map_operator_type(name, args) == expected
+
+
+class TestFabricWarehouseErrorHandling:
+    def test_empty_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "") is None
+
+    def test_statement_only_returns_none(self, parser):
+        # No |-- rows at all -> no operators.
+        assert parser.parse_explain_output("q1", "SELECT 1") is None

--- a/tests/unit/query_plans/test_snowflake_parser.py
+++ b/tests/unit/query_plans/test_snowflake_parser.py
@@ -1,0 +1,105 @@
+"""Unit tests for SnowflakeQueryPlanParser.
+
+Driven by a recorded ``EXPLAIN USING JSON`` fixture under
+tests/fixtures/query_plans/ so they run with no live Snowflake account.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.query_plans.parsers.snowflake import SnowflakeQueryPlanParser
+from benchbox.core.results.query_plan_models import JoinType, LogicalOperator, LogicalOperatorType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _collect(op: LogicalOperator) -> list[LogicalOperator]:
+    nodes = [op]
+    for child in op.children:
+        nodes.extend(_collect(child))
+    return nodes
+
+
+@pytest.fixture()
+def parser():
+    return SnowflakeQueryPlanParser()
+
+
+class TestSnowflakePlan:
+    def test_parses_to_valid_dag(self, parser):
+        dag = parser.parse_explain_output("q1", _load("snowflake_explain_sample.json"))
+        assert dag is not None
+        assert dag.logical_root is not None
+        assert dag.plan_fingerprint is not None
+        assert dag.platform == "snowflake"
+
+    def test_root_is_result_projection(self, parser):
+        dag = parser.parse_explain_output("q1", _load("snowflake_explain_sample.json"))
+        assert dag.logical_root.operator_type == LogicalOperatorType.PROJECT
+        assert dag.logical_root.physical_operator.operator_type == "Result"
+
+    def test_tree_has_join_over_two_scans(self, parser):
+        dag = parser.parse_explain_output("q1", _load("snowflake_explain_sample.json"))
+        nodes = _collect(dag.logical_root)
+        types = [n.operator_type for n in nodes]
+        assert LogicalOperatorType.JOIN in types
+        assert LogicalOperatorType.AGGREGATE in types
+        assert LogicalOperatorType.SORT in types
+        assert types.count(LogicalOperatorType.SCAN) == 2
+        tables = {n.table_name for n in nodes if n.table_name}
+        assert tables == {"TPCH_SF1.PUBLIC.LINEITEM", "TPCH_SF1.PUBLIC.ORDERS"}
+
+    def test_join_classified_inner(self, parser):
+        dag = parser.parse_explain_output("q1", _load("snowflake_explain_sample.json"))
+        joins = [n for n in _collect(dag.logical_root) if n.operator_type == LogicalOperatorType.JOIN]
+        assert joins and joins[0].join_type == JoinType.INNER
+
+    def test_estimated_rows_from_global_stats(self, parser):
+        dag = parser.parse_explain_output("q1", _load("snowflake_explain_sample.json"))
+        assert dag.estimated_rows == 12
+
+    def test_registered_for_snowflake(self):
+        assert isinstance(get_parser_for_platform("snowflake"), SnowflakeQueryPlanParser)
+
+
+class TestSnowflakeOperatorNormalization:
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            ("TableScan", LogicalOperatorType.SCAN),
+            ("JoinFilter", LogicalOperatorType.SCAN),
+            ("InnerJoin", LogicalOperatorType.JOIN),
+            ("LeftOuterJoin", LogicalOperatorType.JOIN),
+            ("Aggregate", LogicalOperatorType.AGGREGATE),
+            ("Sort", LogicalOperatorType.SORT),
+            ("Filter", LogicalOperatorType.FILTER),
+            ("Result", LogicalOperatorType.PROJECT),
+            ("WithReference", LogicalOperatorType.PROJECT),
+            ("UnionAll", LogicalOperatorType.UNION),
+            ("SomethingExotic", LogicalOperatorType.OTHER),
+        ],
+    )
+    def test_map_operator_type(self, parser, operation, expected):
+        assert parser._map_operator_type(operation) == expected
+
+
+class TestSnowflakeErrorHandling:
+    def test_empty_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "") is None
+
+    def test_invalid_json_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", "not json {") is None
+
+    def test_missing_operations_returns_none(self, parser):
+        assert parser.parse_explain_output("q1", '{"GlobalStats": {}}') is None


### PR DESCRIPTION
Implements `query-plan-capture-cloud-saas` (estimated_effort: Large). Adds query
plan capture for five cloud SaaS warehouses, parsing each engine's native
EXPLAIN/plan format into the harmonized `QueryPlanDAG`.

## New parsers (registered in `parsers/registry.py`)
- **SnowflakeQueryPlanParser** — `EXPLAIN USING JSON` (`GlobalStats` + `Operations`; tree from `parentOperators`).
- **BigQueryQueryPlanParser** — JSON-serialized `job.query_plan` stages (tree from `input_stages`; logical type from `steps[].kind`).
- **AzureSynapseQueryPlanParser** — Dedicated Pool `EXPLAIN` → distributed `<dsql_query>` XML (linear data-movement pipeline).
- **FabricWarehouseQueryPlanParser** — `SET SHOWPLAN_TEXT` → SQL Server text showplan.
- **LakeSail** reuses `SparkQueryPlanParser` (Spark Connect `EXPLAIN EXTENDED`); registry alias added.

## Adapter wiring
- Snowflake / Azure Synapse / Fabric: override `get_query_plan_parser()`; capture the plan **outside** the try in `execute_query()` so a strict-mode `PlanCaptureError` propagates instead of being mislabeled as a failed query.
- **BigQuery** (architectural mismatch — no EXPLAIN statement): capture via `BigQueryAdapter._capture_bq_plan()` reading the **already-completed** `QueryJob` (no second query, no EXPLAIN, no extra billing). The existing `get_query_plan()` cost-dict return is left **unchanged**.

Honors the source TODO's `must_preserve`: result-dict shape unchanged for non-plan fields, no extra API call / EXPLAIN when `capture_plans=False`, silent capture failure when `strict_plan_capture=False`, and no extra BigQuery billing.

## Decision gates / open questions
- **Fabric (w6):** Synapse uses dsql XML via `EXPLAIN`, Fabric uses `SET SHOWPLAN_TEXT` — formats differ, so a **separate** Fabric parser was implemented (not a Synapse-parser reuse).
- **Azure Synapse (open question):** targets the Dedicated Pool format the adapter retrieves today; Serverless variant deferred per the stated default.

## Deferred (see the TODO `deferred` section)
- **Firebolt (w5):** blocked-on-fixture — its EXPLAIN format could not be confirmed without guessing, so no parser was written (`firebolt.py` untouched).
- **Live verification (w1 + smoke):** no cloud credentials in this environment; parsers were built from vendor-documented EXPLAIN samples under `tests/fixtures/query_plans/`. The item stays **In Progress** pending live verification + the Firebolt parser.

## Tests
- `tests/unit/query_plans/test_{snowflake,bigquery,azure_synapse,fabric_warehouse}_parser.py`
- `tests/unit/platforms/test_cloud_saas_plan_capture.py` — parser non-None for all five wired adapters, `execute_query()` capture, graceful degradation, BigQuery via mock `QueryJob`, LakeSail reuse.

All new tests pass. The full `tests/unit/` suite is green except for 11 pre-existing, environment-related failures (tpchavoc raw-print static check, root-user filesystem/permission tests, git changelog tests) confirmed to fail on clean `origin/develop` and untouched by this change.

https://claude.ai/code/session_01NYXznXh1CKNXQWy8key43r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYXznXh1CKNXQWy8key43r)_