### PR TITLE
feat(tpchavoc): sample variant equivalence on a second engine (PostgreSQL)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -438,6 +438,23 @@ jobs:
           uv run -- python -m pytest tests/integration/platforms/test_postgresql_live.py \
             -m "live_postgresql" --tb=short -v
 
+      # Second-engine equivalence SAMPLE (non-blocking, see continue-on-error
+      # above). The DuckDB SQL gate (correctness-gate job) stays the hard
+      # blocker; this samples TPC-Havoc variant equivalence one engine over to
+      # catch translation-induced divergence. Both canonical and variants are
+      # translated to the postgres dialect and compared on this same instance.
+      - name: Run TPC-Havoc PostgreSQL variant-equivalence sample
+        env:
+          PGHOST: localhost
+          PGPORT: '5432'
+          PGUSER: benchbox
+          PGPASSWORD: benchbox
+          PGDATABASE: benchbox_test
+        run: |
+          uv run -- python -m pytest \
+            tests/integration/platforms/test_tpchavoc_postgres_equivalence.py \
+            -m "live_postgresql" -n 0 --tb=short -v
+
   explorer-tokens:
     name: explorer-tokens
     needs: ci-paths

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-dataframe-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-dataframe-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -117,6 +117,16 @@ test-correctness-gate:
 # (see benchbox/core/tpchavoc/equivalence.py).
 tpchavoc-equivalence-report:
 	uv run -- python -m benchbox.core.tpchavoc.equivalence
+
+# Second-engine SAMPLE: compare every Postgres-executable TPC-Havoc SQL variant
+# to canonical TPC-H on the SAME PostgreSQL instance (both translated to the
+# postgres dialect). Excludes POSTGRES_TPCHAVOC_SKIPS (un-executable variants).
+# Needs a reachable Postgres (defaults match the postgres-integration CI service
+# container; override via PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE). Skips
+# cleanly (exit 0) if no server is reachable. The DuckDB gate above stays the
+# hard blocker; this is a non-blocking sample (see equivalence.py).
+tpchavoc-equivalence-report-postgres:
+	uv run -- python -m benchbox.core.tpchavoc.equivalence --engine postgres
 
 # Gate: compare every TPC-Havoc DataFrame variant (both backends) to canonical
 # TPC-H on real SF=0.1 DuckDB-backed data; exits non-zero on any divergence
@@ -1846,7 +1856,8 @@ help:
 	@echo "  make test-dev        Fast development cycle testing"
 	@echo "  make test-smoke      Quick smoke testing"
 	@echo "  make test-correctness-gate Run bounded real-result correctness gate"
-	@echo "  make tpchavoc-equivalence-report Gate: TPC-Havoc variant vs canonical TPC-H equivalence"
+	@echo "  make tpchavoc-equivalence-report Gate: TPC-Havoc variant vs canonical TPC-H equivalence (DuckDB)"
+	@echo "  make tpchavoc-equivalence-report-postgres Sample: TPC-Havoc variant equivalence on PostgreSQL"
 	@echo "  make tpchavoc-dataframe-equivalence-report Gate: TPC-Havoc DataFrame variants vs canonical TPC-H"
 	@echo "  make test-local-matrix Run real local benchmark matrix (stress)"
 	@echo "  make test-ci         Maintained broad local CI profile"

--- a/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-cross-dialect-equivalence-sampling
 title: "Sample TPC-Havoc variant equivalence on a second SQL engine beyond DuckDB"
 worktree: main
 priority: Medium
-status: Not Started
+status: Done
 category: Testing and Quality Assurance
 
 description: |
@@ -43,7 +43,7 @@ prior_art:
 work:
   - id: w0
     summary: "Make the equivalence oracle engine-agnostic"
-    status: pending
+    status: done
     notes: |
       Factor find_divergences so the connection/engine and the dialect used to
       render both canonical and variants are injected, not hardcoded to DuckDB.
@@ -51,10 +51,21 @@ work:
       dialect before comparison. Keep DuckDB as the default; add the engine as a
       parameter. No behavior change to the existing DuckDB gate.
 
+      RESOLVED: find_divergences now takes `translate_variant` (renders each
+      variant into the target dialect; default identity = DuckDB-native) and
+      `skip_variants` (excluded, never run, never counted). Canonical dialect is
+      injected via the caller's canonical_query (tpch.get_query(q, dialect=...)),
+      so both sides land in the same dialect through the same translate_sql_query
+      seam. The comparator (validate_variant_equivalence) is reused verbatim - no
+      per-engine fork. DuckDB path is byte-for-byte unchanged (220/220 equivalent,
+      exit 0). New report helper _report() is shared by both engines; main() gained
+      `--engine {duckdb,postgres}`. Fast no-DB plumbing test:
+      tests/integration/test_tpchavoc_equivalence_engine_agnostic.py.
+
   - id: w1
     summary: "Run the oracle on PostgreSQL in report mode and classify divergences"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Use the existing Postgres service container. Exclude variants in
       POSTGRES_TPCHAVOC_SKIPS (un-executable, not a divergence). For the rest,
@@ -64,26 +75,61 @@ work:
       exception with justification), or a real variant defect the DuckDB gate
       missed.
 
+      RESOLVED: Ran `python -m benchbox.core.tpchavoc.equivalence --engine postgres`
+      against a live Postgres at SF=0.1 (canonical + variants both translated
+      netezza->postgres through translate_query_text; the 17 POSTGRES_TPCHAVOC_SKIPS
+      excluded). Result: 203/203 executable variants equivalent - ZERO divergences.
+      No translation-layer bugs, no genuine engine-semantic differences, no variant
+      defects the DuckDB gate missed. Classification surface is empty: the dialect
+      translation seam is faithful for these families on PostgreSQL.
+
+      Setup notes (perf, not semantics): the generated DDL carries no keys/indexes
+      (it targets columnar engines), so correlated-subquery variants planned as
+      O(n*m) nested loops on Postgres; the build helper adds the standard TPC-H
+      PK/FK indexes + ANALYZE and a per-statement timeout. These change run time
+      only, never results.
+
   - id: w2
     summary: "Fix translation/variant bugs; declare true engine exceptions"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Drive w1's divergences down. Prefer fixing the translation layer over
       per-variant hacks (a translation bug likely affects many variants/engines).
       Record irreducible engine-semantic differences as classified, justified
       exceptions keyed by (engine, variant).
 
+      RESOLVED: Nothing to drive down - w1's divergence surface was already empty,
+      so there were no translation-layer bugs to fix and no per-variant hacks were
+      added. POSTGRES_KNOWN_DIVERGENCES is the engine-keyed exception table
+      (mirrors KNOWN_DIVERGENCES) and stays EMPTY: no irreducible engine-semantic
+      difference needed declaring. POSTGRES_TPCHAVOC_SKIPS semantics unchanged.
+
   - id: w3
     summary: "Decide the routine-CI posture for the second engine and wire it"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Based on w1-w2 evidence, choose: (a) a bounded Postgres equivalence gate in
       the existing non-blocking postgres-integration job, or (b) a periodic/opt-in
       check if the divergence surface is dominated by declared engine differences.
       Whichever, the DuckDB gate stays the hard blocker; the second engine is a
       sample, not a 20-engine matrix. Record the decision and the rationale.
+
+      RESOLVED - DECISION: option (a). Wired the Postgres equivalence sample into
+      the EXISTING non-blocking postgres-integration job in .github/workflows/pr.yml
+      (continue-on-error: true) as a new pytest step over
+      tests/integration/platforms/test_tpchavoc_postgres_equivalence.py.
+
+      RATIONALE: the divergence surface is empty and the run is green and fast
+      (~40s over the already-running Postgres service container, far inside the
+      job's 15-min budget), so it is NOT "dominated by declared engine differences"
+      - option (b)'s trigger does not apply. A bounded check that is green today
+      turns any future translation regression on Postgres into immediate signal,
+      while continue-on-error keeps it a SAMPLE: the DuckDB SQL gate (correctness-gate
+      job, KNOWN_DIVERGENCES empty) remains the only hard blocker. We deliberately
+      do NOT gate the other ~18 platforms in routine CI (anti-pattern #1); the third
+      engine is sequenced in `deferred` once the two-engine signal warrants it.
 
 deferred:
   - summary: "Extend cross-engine equivalence sampling to a third engine (ClickHouse/DataFusion/Spark)"

--- a/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-cross-dialect-equivalence-sampling
 title: "Sample TPC-Havoc variant equivalence on a second SQL engine beyond DuckDB"
 worktree: main
 priority: Medium
-status: Done
+status: Completed
 category: Testing and Quality Assurance
 
 description: |

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -467,6 +467,8 @@ def run_postgres_sample() -> int:
     """
     import tempfile
 
+    import psycopg
+
     from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
 
     try:
@@ -476,8 +478,12 @@ def run_postgres_sample() -> int:
                 divergences = find_postgres_divergences(connection, tpchavoc, tpch)
             finally:
                 connection.close()
-    except Exception as exc:  # noqa: BLE001 - infra (no server) must not look like a divergence
-        print(f"PostgreSQL equivalence sample SKIPPED - could not run against PostgreSQL: {exc}")
+    except psycopg.OperationalError as exc:
+        # ONLY an unreachable / unusable server is a skip. Schema, load (incl. the
+        # row-count guard), translation, and sweep failures must propagate as real
+        # failures - otherwise this report could not catch the regressions it exists
+        # to surface.
+        print(f"PostgreSQL equivalence sample SKIPPED - could not connect to PostgreSQL: {exc}")
         return 0
 
     # Exclude un-executable variants from the denominator too: they are bounded

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -7,12 +7,25 @@ but nothing in the default run or in CI ever called it for a real variant, so
 divergences were silent (see ``_project/TODO/main/active/
 tpchavoc-variant-equivalence-gate.yaml``).
 
-This module wires that existing validator over a real, small-scale DuckDB
-dataset: ``python -m benchbox.core.tpchavoc.equivalence`` (or
+This module wires that existing validator over a real, small-scale dataset:
+``python -m benchbox.core.tpchavoc.equivalence`` (or
 ``make tpchavoc-equivalence-report``) compares every variant of every
 implemented query to canonical TPC-H, prints a report, and **exits non-zero**
 if any variant diverges beyond the classified baseline in
 :data:`KNOWN_DIVERGENCES` (currently empty - every variant must match).
+
+The oracle is engine-agnostic: :func:`find_divergences` takes the connection
+and a rendering of both canonical and variants into a target dialect, and reuses
+the SAME comparator across engines (it is never forked per engine). DuckDB at
+SF=0.1 is the default and the hard, blocking gate. ``--engine postgres`` runs a
+bounded *second-engine sample* against the Postgres service container: variants
+are written once but run on ~20 platforms after dialect translation, so
+"equivalent on DuckDB" does not imply "equivalent everywhere". The sample runs
+canonical TPC-H and the variants through the SAME translation to the SAME
+Postgres instance (so shared translation cancels out), excludes the variants
+PostgreSQL cannot execute (POSTGRES_TPCHAVOC_SKIPS), and classifies any residue
+against :data:`POSTGRES_KNOWN_DIVERGENCES`. It catches the largest class of
+translation-induced divergence one engine over without gating all ~20 platforms.
 
 Comparison is order-insensitive with float tolerance (the validator sorts both
 sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
@@ -47,9 +60,10 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
 from benchbox.core.tpchavoc.validation import ValidationError
@@ -68,7 +82,26 @@ EQUIVALENCE_SCALE = 0.1
 # every variant must match canonical. Add an entry (with a class and a tracking
 # TODO) only for a divergence that is deliberate, never to mute a regression.
 # Keyed by "<query>_v<variant>".
+#
+# This is the DuckDB gate's baseline and MUST stay empty - DuckDB at SF=0.1 is
+# the hard, blocking equivalence gate (see ``main``/``correctness-gate`` CI job).
 KNOWN_DIVERGENCES: dict[str, str] = {}
+
+# Per-engine equivalence exceptions for the *second-engine sample* (PostgreSQL),
+# keyed by "<query>_v<variant>". An entry here records a divergence that is an
+# irreducible engine-semantic difference (NOT a translation bug, NOT a variant
+# defect) - e.g. a result shape that PostgreSQL produces differently from
+# canonical TPC-H run on PostgreSQL and that cannot be reconciled in the
+# translation layer. Translation bugs are fixed in the dialect seam
+# (benchbox/core/tpch/benchmark.py:translate_query_text) so the fix generalizes;
+# they are NEVER muted here. Variants PostgreSQL cannot execute at all are
+# excluded via POSTGRES_TPCHAVOC_SKIPS, never marked equivalent.
+#
+# Empty: the Postgres sample (SF=0.1, both canonical and variants translated to
+# the postgres dialect through the same seam) found zero divergences over the
+# 203 executable variants - the translation layer is faithful and no variant is
+# silently wrong on PostgreSQL while green on DuckDB.
+POSTGRES_KNOWN_DIVERGENCES: dict[str, str] = {}
 
 _TRAILING_LIMIT = re.compile(r"(?is)\s+limit\s+\d+\s*;?\s*$")
 
@@ -103,26 +136,58 @@ def strip_top_n(sql: str) -> str:
     return _TRAILING_LIMIT.sub("", normalized)
 
 
+def _identity(sql: str) -> str:
+    """Default translation: render SQL unchanged (the DuckDB-native path)."""
+    return sql
+
+
 def find_divergences(
     connection: Any,
     benchmark: TPCHavocBenchmark,
     canonical_query: Callable[[int], str],
     *,
     query_ids: list[int] | None = None,
+    translate_variant: Callable[[str], str] | None = None,
+    skip_variants: Collection[str] | None = None,
 ) -> list[Divergence]:
     """Compare every variant of each query to canonical TPC-H on ``connection``.
 
+    Engine-agnostic: the connection/engine is injected, and ``canonical_query``
+    and ``translate_variant`` are responsible for rendering both sides into the
+    SAME target dialect before comparison so that shared translation cancels out
+    and only genuine variant-vs-canonical differences surface. The comparator
+    itself - :meth:`TPCHavocBenchmark.validate_variant_equivalence` - is reused
+    verbatim across engines; it is never forked per engine.
+
+    The default (no ``translate_variant``) is the DuckDB-native path: variants
+    run as authored and canonical is whatever ``canonical_query`` returns, with
+    no extra translation - so the existing DuckDB gate is unchanged. For a second
+    engine (e.g. PostgreSQL), pass ``canonical_query`` that renders canonical in
+    the engine's dialect (``tpch.get_query(q, dialect="postgres")``) and a
+    ``translate_variant`` that renders each variant into that SAME dialect
+    (``benchmark.translate_query_text(sql, "netezza", "postgres")``).
+
     Args:
-        connection: A DBAPI/DuckDB connection already populated with TPC-H data.
+        connection: A connection (DuckDB, or psycopg in autocommit) already
+            populated with TPC-H data; must support ``execute(sql).fetchall()``.
         benchmark: The TPC-Havoc benchmark providing variants and the validator.
-        canonical_query: Callable returning the canonical TPC-H SQL for a query id.
+        canonical_query: Callable returning the canonical TPC-H SQL for a query
+            id, already rendered in the target engine's dialect.
         query_ids: Subset of query ids to check; defaults to all implemented.
+        translate_variant: Optional callable rendering a variant's SQL into the
+            target engine's dialect. Defaults to identity (DuckDB-native).
+        skip_variants: Variant keys ("<query>_v<variant>") to exclude from the
+            sweep entirely - e.g. POSTGRES_TPCHAVOC_SKIPS, which the engine
+            cannot execute. Excluded variants are neither run nor counted as
+            divergences; they are NEVER silently marked equivalent.
 
     Returns:
         One :class:`Divergence` per variant whose result is not equivalent to
         canonical TPC-H. Reuses :meth:`TPCHavocBenchmark.validate_variant_equivalence`.
     """
     ids = query_ids if query_ids is not None else benchmark.get_implemented_queries()
+    render_variant = translate_variant if translate_variant is not None else _identity
+    excluded = set(skip_variants or ())
     divergences: list[Divergence] = []
     for query_id in ids:
         try:
@@ -131,8 +196,10 @@ def find_divergences(
             divergences.append(Divergence(query_id, 0, f"canonical query failed: {exc}"))
             continue
         for variant_id in range(1, 11):
+            if f"{query_id}_v{variant_id}" in excluded:
+                continue
             try:
-                variant_sql = strip_top_n(benchmark.get_query(f"{query_id}_v{variant_id}"))
+                variant_sql = render_variant(strip_top_n(benchmark.get_query(f"{query_id}_v{variant_id}")))
                 variant_rows = connection.execute(variant_sql).fetchall()
                 benchmark.validate_variant_equivalence(query_id, variant_id, original, variant_rows)
             except ValidationError as exc:
@@ -140,6 +207,25 @@ def find_divergences(
             except Exception as exc:  # noqa: BLE001 - surface execution/sort errors as divergences
                 divergences.append(Divergence(query_id, variant_id, f"error: {exc}"))
     return divergences
+
+
+def _generate_tpch(scale_factor: float, output_dir: Path) -> tuple[Path, TPCHavocBenchmark, TPCH]:
+    """Generate TPC-H data and the paired benchmarks for an engine build.
+
+    Shared by both engine builders so the (fragile) data-dir resolution lives in
+    one place. Generator import is deferred to keep this module cheap to import.
+
+    Returns:
+        ``(data_dir, tpchavoc_benchmark, tpch_benchmark)``.
+    """
+    from benchbox import TPCH
+    from benchbox.core.tpch.generator import TPCHDataGenerator
+
+    generated = TPCHDataGenerator(scale_factor=scale_factor, output_dir=output_dir).generate()
+    data_dir = next(Path(paths[0] if isinstance(paths, list) else paths).parent for paths in generated.values())
+    tpchavoc = TPCHavocBenchmark(scale_factor=scale_factor, output_dir=output_dir)
+    tpch = TPCH(scale_factor=scale_factor, output_dir=output_dir)
+    return data_dir, tpchavoc, tpch
 
 
 def build_duckdb_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple[Any, TPCHavocBenchmark, TPCH]:
@@ -153,16 +239,9 @@ def build_duckdb_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple
     """
     import duckdb
 
-    from benchbox import TPCH
-    from benchbox.core.tpch.generator import TPCHDataGenerator
     from benchbox.platforms.duckdb import DuckDBAdapter
 
-    output_dir = Path(output_dir)
-    generated = TPCHDataGenerator(scale_factor=scale_factor, output_dir=output_dir).generate()
-    data_dir = next(Path(paths[0] if isinstance(paths, list) else paths).parent for paths in generated.values())
-
-    tpchavoc = TPCHavocBenchmark(scale_factor=scale_factor, output_dir=output_dir)
-    tpch = TPCH(scale_factor=scale_factor, output_dir=output_dir)
+    data_dir, tpchavoc, tpch = _generate_tpch(scale_factor, Path(output_dir))
 
     connection = duckdb.connect(":memory:")
     for statement in tpchavoc.get_create_tables_sql(dialect="duckdb").strip().split(";"):
@@ -172,32 +251,144 @@ def build_duckdb_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple
     return connection, tpchavoc, tpch
 
 
-def main() -> int:
-    """Generate data, run the oracle, and print a categorized report.
+# The second engine sampled beyond DuckDB. PostgreSQL is the natural first pick:
+# a Postgres 17 service container already exists in CI (postgres-integration job)
+# and POSTGRES_TPCHAVOC_SKIPS bounds which variants are even executable on it.
+POSTGRES_TARGET_DIALECT = "postgres"
 
-    Returns non-zero if any variant diverges beyond :data:`KNOWN_DIVERGENCES` -
-    this is the TPC-Havoc semantic-equivalence gate.
+# Per-statement ceiling for the Postgres sample. Indexed at SF=0.1 every variant
+# runs in <5s; the ceiling only fences a pathological plan so the sample reports
+# a bounded error instead of hanging the (time-boxed) CI job.
+POSTGRES_STATEMENT_TIMEOUT_MS = 120_000
+
+# Standard TPC-H primary-key / foreign-key indexes. The generated DDL carries no
+# keys or indexes (it targets columnar engines), so PostgreSQL otherwise plans
+# correlated-subquery variants as O(n*m) nested loops. These indexes are a
+# performance setup detail only - they never change query *results*, just keep
+# the sample tractable inside CI's budget.
+POSTGRES_TPCH_INDEXES: tuple[str, ...] = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_region ON region(r_regionkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_nation ON nation(n_nationkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_part ON part(p_partkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_supplier ON supplier(s_suppkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_partsupp ON partsupp(ps_partkey, ps_suppkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_customer ON customer(c_custkey)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS pk_orders ON orders(o_orderkey)",
+    "CREATE INDEX IF NOT EXISTS ix_lineitem_orderkey ON lineitem(l_orderkey)",
+    "CREATE INDEX IF NOT EXISTS ix_lineitem_partkey ON lineitem(l_partkey)",
+    "CREATE INDEX IF NOT EXISTS ix_lineitem_suppkey ON lineitem(l_suppkey)",
+    "CREATE INDEX IF NOT EXISTS ix_partsupp_suppkey ON partsupp(ps_suppkey)",
+    "CREATE INDEX IF NOT EXISTS ix_orders_custkey ON orders(o_custkey)",
+)
+
+_TPCH_TABLES = ("lineitem", "orders", "partsupp", "part", "customer", "supplier", "nation", "region")
+
+
+def postgres_connection_config() -> dict[str, Any]:
+    """PostgreSQL connection settings for the equivalence sample.
+
+    Defaults match the Postgres service container in the ``postgres-integration``
+    CI job (and the live integration tests); each is overridable via the
+    standard ``PG*``/``POSTGRES_*`` environment variables for local runs.
     """
-    import tempfile
+    import os
 
-    with tempfile.TemporaryDirectory() as tmp:
-        connection, tpchavoc, tpch = build_duckdb_with_tpch(EQUIVALENCE_SCALE, tmp)
-        try:
-            divergences = find_divergences(connection, tpchavoc, lambda q: tpch.get_query(q))
-        finally:
-            connection.close()
+    return {
+        "host": os.environ.get("PGHOST", os.environ.get("POSTGRES_HOST", "localhost")),
+        "port": int(os.environ.get("PGPORT", os.environ.get("POSTGRES_PORT", "5432"))),
+        "username": os.environ.get("PGUSER", os.environ.get("POSTGRES_USER", "benchbox")),
+        "password": os.environ.get("PGPASSWORD", os.environ.get("POSTGRES_PASSWORD", "benchbox")),
+        "database": os.environ.get("PGDATABASE", os.environ.get("POSTGRES_DB", "benchbox_test")),
+    }
 
-    total = len(tpchavoc.get_implemented_queries()) * 10
+
+def build_postgres_with_tpch(
+    scale_factor: float,
+    output_dir: str | Path,
+    *,
+    connection_config: dict[str, Any] | None = None,
+) -> tuple[Any, TPCHavocBenchmark, TPCH]:
+    """Generate TPC-H data and return a populated PostgreSQL connection.
+
+    Mirrors :func:`build_duckdb_with_tpch` for the second engine. The returned
+    connection is in autocommit mode with a statement timeout, so the per-query
+    error isolation in :func:`find_divergences` works (a failed statement aborts
+    only itself, not the rest of the sweep). Platform/generator imports are
+    deferred so importing this module stays cheap.
+
+    Returns:
+        ``(connection, tpchavoc_benchmark, tpch_benchmark)``.
+    """
+    from benchbox.platforms.postgresql import PostgreSQLAdapter
+
+    data_dir, tpchavoc, tpch = _generate_tpch(scale_factor, Path(output_dir))
+
+    # The per-statement ceiling is applied by the adapter at connect time (it
+    # injects `-c statement_timeout=...`), not as a post-hoc SET, so the harness
+    # does not have to know Postgres GUC syntax.
+    config = {
+        **(connection_config or postgres_connection_config()),
+        "statement_timeout": POSTGRES_STATEMENT_TIMEOUT_MS,
+    }
+    adapter = PostgreSQLAdapter(**config)
+    adapter.skip_database_management = True
+    connection = adapter.create_connection()
+
+    try:
+        # Idempotent setup: drop any prior TPC-H tables so repeated runs against a
+        # persistent database start clean (CI's container DB is already fresh).
+        cursor = connection.cursor()
+        for table in _TPCH_TABLES:
+            cursor.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')
+        connection.commit()
+        cursor.close()
+
+        adapter.create_schema(tpchavoc, connection)
+        # PostgreSQLAdapter.load_data swallows per-file COPY failures (logs, rolls
+        # back, records 0 rows). A silent empty/partial load would make every
+        # variant compare empty-vs-empty and report a FALSE green, so verify each
+        # table actually loaded rows before sampling.
+        table_stats, _, _ = adapter.load_data(tpchavoc, connection, data_dir)
+        empty = [table for table in _TPCH_TABLES if table_stats.get(table, 0) <= 0]
+        if empty:
+            raise RuntimeError(f"PostgreSQL TPC-H load failed - no rows in {empty} (stats={table_stats})")
+
+        # End the load transaction before switching to autocommit for the sweep,
+        # so a failed statement aborts only itself (per-query error isolation).
+        connection.rollback()
+        connection.autocommit = True
+        for index_sql in POSTGRES_TPCH_INDEXES:
+            connection.execute(index_sql)
+        connection.execute("ANALYZE")
+    except Exception:
+        connection.close()
+        raise
+    return connection, tpchavoc, tpch
+
+
+def _report(
+    divergences: list[Divergence],
+    total: int,
+    known: dict[str, str],
+    *,
+    engine_label: str,
+    baseline_name: str,
+) -> int:
+    """Print a categorized divergence report and return the gate exit code.
+
+    Shared by every engine so the comparator/report is never forked. Returns
+    non-zero only when a divergence is unclassified (i.e. not in ``known``).
+    """
     found = {d.key for d in divergences}
-    new = sorted(found - set(KNOWN_DIVERGENCES), key=_sort_key)
-    resolved = sorted(set(KNOWN_DIVERGENCES) - found, key=_sort_key)
+    new = sorted(found - set(known), key=_sort_key)
+    resolved = sorted(set(known) - found, key=_sort_key)
 
-    print(f"TPC-Havoc variant equivalence vs canonical TPC-H @ SF={EQUIVALENCE_SCALE} (DuckDB)")
+    print(f"TPC-Havoc variant equivalence vs canonical TPC-H @ SF={EQUIVALENCE_SCALE} ({engine_label})")
     print(f"  checked {total} variants - {len(divergences)} divergent, {total - len(divergences)} equivalent\n")
 
     by_class: dict[str, list[Divergence]] = {}
     for divergence in sorted(divergences, key=lambda d: _sort_key(d.key)):
-        klass = KNOWN_DIVERGENCES.get(divergence.key, "UNCLASSIFIED")
+        klass = known.get(divergence.key, "UNCLASSIFIED")
         by_class.setdefault(klass, []).append(divergence)
     for klass in sorted(by_class):
         print(f"  [{klass}]")
@@ -208,10 +399,119 @@ def main() -> int:
     if new:
         print(f"GATE FAILURE - unclassified divergences from canonical TPC-H: {new}")
     if resolved:
-        print(f"Previously-known divergences now equivalent - update KNOWN_DIVERGENCES: {resolved}")
+        print(f"Previously-known divergences now equivalent - update {baseline_name}: {resolved}")
     if not new and not resolved:
-        print("All variants equivalent to canonical TPC-H (modulo KNOWN_DIVERGENCES).")
+        print("All variants equivalent to canonical TPC-H (modulo classified exceptions).")
     return 1 if new else 0
+
+
+def run_duckdb_gate() -> int:
+    """The hard, blocking DuckDB equivalence gate (KNOWN_DIVERGENCES must be empty)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        connection, tpchavoc, tpch = build_duckdb_with_tpch(EQUIVALENCE_SCALE, tmp)
+        try:
+            divergences = find_divergences(connection, tpchavoc, lambda q: tpch.get_query(q))
+        finally:
+            connection.close()
+
+    total = len(tpchavoc.get_implemented_queries()) * 10
+    return _report(
+        divergences,
+        total,
+        KNOWN_DIVERGENCES,
+        engine_label="DuckDB",
+        baseline_name="KNOWN_DIVERGENCES",
+    )
+
+
+def find_postgres_divergences(
+    connection: Any,
+    tpchavoc: TPCHavocBenchmark,
+    tpch: TPCH,
+    *,
+    query_ids: list[int] | None = None,
+) -> list[Divergence]:
+    """Run the PostgreSQL equivalence sweep with the canonical Postgres wiring.
+
+    Single source of truth for *how* the Postgres sample is run - both the CLI
+    (:func:`run_postgres_sample`) and the integration test call this so they
+    cannot drift. Canonical and variants are both translated to the postgres
+    dialect through the SAME seam, and POSTGRES_TPCHAVOC_SKIPS variants are
+    excluded (never marked equivalent).
+    """
+    from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
+
+    return find_divergences(
+        connection,
+        tpchavoc,
+        lambda q: tpch.get_query(q, dialect=POSTGRES_TARGET_DIALECT),
+        query_ids=query_ids,
+        translate_variant=lambda sql: tpchavoc.translate_query_text(sql, "netezza", POSTGRES_TARGET_DIALECT),
+        skip_variants=set(POSTGRES_TPCHAVOC_SKIPS),
+    )
+
+
+def run_postgres_sample() -> int:
+    """Run the second-engine (PostgreSQL) equivalence sample.
+
+    Both canonical TPC-H and every variant are translated to the postgres dialect
+    through the SAME seam, then compared on the SAME Postgres instance, so shared
+    translation cancels out (anti-pattern: never compare a Postgres variant to a
+    DuckDB canonical). Variants PostgreSQL cannot execute are excluded via
+    POSTGRES_TPCHAVOC_SKIPS - they are never marked equivalent. A divergence is
+    classified against POSTGRES_KNOWN_DIVERGENCES; an unclassified one returns
+    non-zero, but this is a *sample* run from the non-blocking postgres job - the
+    DuckDB gate remains the hard blocker.
+    """
+    import tempfile
+
+    from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            connection, tpchavoc, tpch = build_postgres_with_tpch(EQUIVALENCE_SCALE, tmp)
+            try:
+                divergences = find_postgres_divergences(connection, tpchavoc, tpch)
+            finally:
+                connection.close()
+    except Exception as exc:  # noqa: BLE001 - infra (no server) must not look like a divergence
+        print(f"PostgreSQL equivalence sample SKIPPED - could not run against PostgreSQL: {exc}")
+        return 0
+
+    # Exclude un-executable variants from the denominator too: they are bounded
+    # out of scope, not failures.
+    total = len(tpchavoc.get_implemented_queries()) * 10 - len(POSTGRES_TPCHAVOC_SKIPS)
+    return _report(
+        divergences,
+        total,
+        POSTGRES_KNOWN_DIVERGENCES,
+        engine_label="PostgreSQL",
+        baseline_name="POSTGRES_KNOWN_DIVERGENCES",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Generate data, run the oracle for the chosen engine, and print a report.
+
+    ``--engine duckdb`` (default) is the hard, blocking gate. ``--engine
+    postgres`` runs the bounded second-engine sample described in
+    :func:`run_postgres_sample`.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description="TPC-Havoc variant-equivalence oracle.")
+    parser.add_argument(
+        "--engine",
+        choices=("duckdb", "postgres"),
+        default="duckdb",
+        help="SQL engine to sample (default: duckdb, the hard gate).",
+    )
+    args = parser.parse_args(argv)
+    if args.engine == "postgres":
+        return run_postgres_sample()
+    return run_duckdb_gate()
 
 
 def _sort_key(key: str) -> tuple[int, int]:

--- a/tests/integration/platforms/test_tpchavoc_postgres_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_postgres_equivalence.py
@@ -1,0 +1,91 @@
+"""Second-engine (PostgreSQL) TPC-Havoc variant-equivalence sample.
+
+The DuckDB equivalence gate (``benchbox/core/tpchavoc/equivalence.py``, run via
+``make tpchavoc-equivalence-report``) proves every variant is result-equivalent
+to canonical TPC-H on ONE engine, DuckDB at SF=0.1. But variants are authored
+once and run, after dialect translation, on ~20 platforms - so "equivalent on
+DuckDB" does not imply "equivalent everywhere". This test is the bounded
+*second-engine sample*: it runs canonical TPC-H and every variant through the
+SAME translation to the SAME PostgreSQL instance (so shared translation cancels
+out), excludes the variants PostgreSQL cannot execute (POSTGRES_TPCHAVOC_SKIPS),
+and asserts no residual divergence beyond the classified POSTGRES_KNOWN_DIVERGENCES
+baseline (empty).
+
+This is the gate body of the non-blocking ``postgres-integration`` CI job. The
+DuckDB gate remains the hard, blocking gate; this sample catches the largest
+class of translation-induced divergence one engine over without gating all ~20
+platforms.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.equivalence import (
+    EQUIVALENCE_SCALE,
+    POSTGRES_KNOWN_DIVERGENCES,
+    build_postgres_with_tpch,
+    find_postgres_divergences,
+    postgres_connection_config,
+)
+from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
+
+from .conftest import skip_unless_docker_service
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.docker_integration,
+    pytest.mark.live_integration,
+    pytest.mark.live_postgresql,
+    pytest.mark.tpchavoc,
+    pytest.mark.slow,
+]
+
+
+@pytest.fixture(scope="module")
+def postgres_divergences(tmp_path_factory):
+    """Load SF=0.1 TPC-H into the live Postgres and run the sweep ONCE.
+
+    The 203-variant sweep is the expensive part, so it is computed a single time
+    at module scope and shared across the assertions below (keeping the
+    non-blocking CI job well inside its budget).
+    """
+    config = postgres_connection_config()
+    skip_unless_docker_service(config["host"], config["port"], platform="PostgreSQL")
+    output_dir = tmp_path_factory.mktemp("tpchavoc_pg_equivalence")
+    connection, tpchavoc, tpch = build_postgres_with_tpch(
+        EQUIVALENCE_SCALE, output_dir, connection_config=config
+    )
+    try:
+        yield find_postgres_divergences(connection, tpchavoc, tpch)
+    finally:
+        connection.close()
+
+
+def test_all_executable_variants_equivalent_on_postgres(postgres_divergences):
+    """Every Postgres-executable variant matches canonical TPC-H on Postgres.
+
+    Both sides are translated to the postgres dialect through the same seam and
+    compared on the same instance, so a divergence here points at the dialect
+    translation layer (or a real variant defect), never at a DuckDB-vs-Postgres
+    engine mismatch.
+    """
+    unexpected = {d.key for d in postgres_divergences} - set(POSTGRES_KNOWN_DIVERGENCES)
+    assert not unexpected, "Variant(s) diverge from canonical TPC-H on PostgreSQL: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in postgres_divergences if d.key in unexpected
+    )
+
+
+def test_skipped_variants_are_excluded_never_marked_equivalent(postgres_divergences):
+    """POSTGRES_TPCHAVOC_SKIPS variants are excluded from the sweep entirely."""
+    reported = {d.key for d in postgres_divergences}
+    assert reported.isdisjoint(set(POSTGRES_TPCHAVOC_SKIPS)), (
+        "Un-executable (skip-list) variants must be excluded, not evaluated"
+    )

--- a/tests/integration/platforms/test_tpchavoc_postgres_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_postgres_equivalence.py
@@ -60,9 +60,7 @@ def postgres_divergences(tmp_path_factory):
     config = postgres_connection_config()
     skip_unless_docker_service(config["host"], config["port"], platform="PostgreSQL")
     output_dir = tmp_path_factory.mktemp("tpchavoc_pg_equivalence")
-    connection, tpchavoc, tpch = build_postgres_with_tpch(
-        EQUIVALENCE_SCALE, output_dir, connection_config=config
-    )
+    connection, tpchavoc, tpch = build_postgres_with_tpch(EQUIVALENCE_SCALE, output_dir, connection_config=config)
     try:
         yield find_postgres_divergences(connection, tpchavoc, tpch)
     finally:

--- a/tests/integration/test_tpchavoc_equivalence_engine_agnostic.py
+++ b/tests/integration/test_tpchavoc_equivalence_engine_agnostic.py
@@ -25,6 +25,7 @@ from benchbox.core.tpchavoc.equivalence import find_divergences
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.fast,
     pytest.mark.tpchavoc,
 ]
 

--- a/tests/integration/test_tpchavoc_equivalence_engine_agnostic.py
+++ b/tests/integration/test_tpchavoc_equivalence_engine_agnostic.py
@@ -1,0 +1,114 @@
+"""Engine-agnostic plumbing tests for the TPC-Havoc equivalence oracle.
+
+These exercise the w0 refactor of :func:`find_divergences` - the dialect
+``translate_variant`` injection and the ``skip_variants`` exclusion - WITHOUT a
+live database, using a recording fake connection. The live cross-engine
+behavior is covered by ``tests/integration/platforms/
+test_tpchavoc_postgres_equivalence.py``; this is the fast deterministic guard
+that the seam itself stays correct (variant translation is applied, canonical is
+not double-translated, and skipped variants are never executed nor counted).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
+from benchbox.core.tpchavoc.equivalence import find_divergences
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.tpchavoc,
+]
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+
+class _RecordingConnection:
+    """Minimal connection: records executed SQL and returns canned rows."""
+
+    def __init__(self, rows: list[tuple]) -> None:
+        self.rows = rows
+        self.executed: list[str] = []
+
+    def execute(self, sql: str) -> _FakeResult:
+        self.executed.append(sql)
+        return _FakeResult(self.rows)
+
+
+@pytest.fixture
+def havoc_benchmark() -> TPCHavocBenchmark:
+    # No data generation/loading needed - get_query only renders SQL text.
+    return TPCHavocBenchmark(scale_factor=0.1)
+
+
+def test_default_path_is_identity_and_runs_every_variant(havoc_benchmark):
+    """No translate_variant => variants run as authored (DuckDB-native path)."""
+    connection = _RecordingConnection(rows=[(1,)])
+
+    divergences = find_divergences(
+        connection,
+        havoc_benchmark,
+        lambda _q: "SELECT 1 AS canonical",
+        query_ids=[3],
+    )
+
+    assert divergences == []
+    # 1 canonical + 10 variants, none translated (no marker injected).
+    assert connection.executed[0] == "SELECT 1 AS canonical"
+    assert sum(1 for s in connection.executed if "canonical" in s) == 1
+    assert not any("/*translated*/" in s for s in connection.executed)
+
+
+def test_translate_variant_applies_only_to_variants(havoc_benchmark):
+    """translate_variant renders variant SQL; canonical is left untouched."""
+    connection = _RecordingConnection(rows=[(1,)])
+
+    divergences = find_divergences(
+        connection,
+        havoc_benchmark,
+        lambda _q: "SELECT 1 AS canonical",
+        query_ids=[3],
+        translate_variant=lambda sql: sql + " /*translated*/",
+    )
+
+    assert divergences == []
+    canonical_sql = [s for s in connection.executed if "canonical" in s]
+    variant_sql = [s for s in connection.executed if "canonical" not in s]
+    assert len(canonical_sql) == 1
+    assert "/*translated*/" not in canonical_sql[0], "canonical must not be re-translated"
+    assert variant_sql, "variants should have been executed"
+    assert all(s.endswith("/*translated*/") for s in variant_sql), "every variant must be translated"
+
+
+def test_skip_variants_are_excluded_not_executed_not_counted(havoc_benchmark):
+    """Skipped variants are never executed and never reported as divergences."""
+    connection = _RecordingConnection(rows=[(1,)])
+
+    skipped = {"3_v2", "3_v5"}
+    divergences = find_divergences(
+        connection,
+        havoc_benchmark,
+        lambda _q: "SELECT 1 AS canonical",
+        query_ids=[3],
+        skip_variants=skipped,
+    )
+
+    assert divergences == []
+    # 1 canonical + (10 - 2 skipped) = 9 variant executions.
+    assert len(connection.executed) == 1 + (10 - len(skipped))
+    keys = {d.key for d in divergences}
+    assert keys.isdisjoint(skipped)


### PR DESCRIPTION
## Why

The TPC-Havoc SQL equivalence gate (PR #770) proves every variant is result-equivalent to canonical TPC-H on **one** engine: DuckDB at SF=0.1. But variants are written once and run, after dialect translation, on ~20 platforms. "Equivalent on DuckDB" does not imply "equivalent everywhere" — dialect translation can shift NULL ordering, integer-vs-float division, DISTINCT/window/QUALIFY/aggregate-FILTER semantics, implicit casts, date arithmetic — exactly the constructs the variant families lean on. So a variant can be execution-green and silently *wrong* on engine X while the DuckDB gate stays green.

This adds **one bounded second-engine sample (PostgreSQL)** — not a 20-engine CI matrix. Postgres is the natural first pick: a Postgres 17 service container already exists in CI, and `POSTGRES_TPCHAVOC_SKIPS` already bounds which variants are even executable on it.

## What

**w0 — Engine-agnostic oracle.** `find_divergences` now takes `translate_variant` (renders each variant into the target dialect; default identity = DuckDB-native) and `skip_variants` (excluded — never run, never counted). Canonical dialect is injected via `canonical_query`. The comparator (`validate_variant_equivalence`) is reused verbatim — **no per-engine fork**. The DuckDB gate is byte-for-byte unchanged (220/220 equivalent, exit 0); `KNOWN_DIVERGENCES` stays empty. A shared `_report()` helper and `main(--engine {duckdb,postgres})` dispatch are added.

**w1/w2 — PostgreSQL sample.** Both canonical and variants are translated to the postgres dialect through the **same** seam and compared on the **same** instance (shared translation cancels out — never a Postgres-variant-vs-DuckDB-canonical compare); the 17 `POSTGRES_TPCHAVOC_SKIPS` are excluded. **Result: 203/203 executable variants equivalent — zero divergences.** No translation-layer bugs, no engine-semantic differences, no variant defects the DuckDB gate missed. `POSTGRES_KNOWN_DIVERGENCES` (engine-keyed exception table) stays empty — nothing to declare, no per-variant hacks.

**w3 — Routine-CI posture (decision: option a).** Wire the sample into the **existing non-blocking** `postgres-integration` job (`continue-on-error: true`). Rationale: the divergence surface is empty and the run is fast (~40s on the already-running service container, well inside the 15-min budget), so it is **not** dominated by declared engine differences (option b's trigger). A bounded check that is green today turns any future Postgres translation regression into immediate signal, while the **DuckDB SQL gate remains the only hard blocker**. The other ~18 platforms are deliberately not gated in routine CI; a third engine is sequenced in the TODO's `deferred`.

## Notes
- Standard TPC-H PK/FK indexes + `ANALYZE` are added in the Postgres build helper (the generated DDL is keyless, so correlated-subquery variants would otherwise plan as O(n·m) nested loops). **Performance only — never results.**
- The statement timeout is applied via the adapter's connection config (not a raw GUC `SET`).
- A row-count guard fails the load rather than silently comparing empty-vs-empty (caught in review).

## Anti-patterns honored
- No routine-CI gating of all ~20 platforms.
- A `POSTGRES_TPCHAVOC_SKIPS` entry is never treated as an equivalence pass.
- No per-variant patching of translation-layer concerns (none were needed; surface empty).
- Never compares a Postgres variant result to a DuckDB canonical result — same engine, same dialect, both sides.

## Tests
- `tests/integration/test_tpchavoc_equivalence_engine_agnostic.py` — fast, no-DB plumbing guard (translate_variant applied to variants only; skip_variants excluded).
- `tests/integration/platforms/test_tpchavoc_postgres_equivalence.py` — live sample (203/203 equivalent; skips excluded). Run locally against a live Postgres 16: all pass.
- DuckDB gate re-run: 220/220 equivalent, exit 0 — unchanged.

Closes the `tpchavoc-cross-dialect-equivalence-sampling` TODO (w0–w3 done; w3 decision recorded in the ledger).

https://claude.ai/code/session_012f5ioRV9Zx7spFiLBatjS5

---
_Generated by [Claude Code](https://claude.ai/code/session_012f5ioRV9Zx7spFiLBatjS5)_