### PR TITLE
chore(todo): track live-cluster validation of misc plan-capture fixtures

### DIFF
--- a/_project/DONE/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
+++ b/_project/DONE/platform-expansion/planning/query-plan-capture-misc-platforms.yaml
@@ -242,7 +242,10 @@ deferred:
       box-drawing property keys, QuestDB's scan sub-operator names, Doris's
       EXPLAIN SHAPE PLAN availability on the deployed version, and SingleStore's
       "|---" connector spacing). The error-sentinel guard already prevents a
-      mismatched/failed EXPLAIN from producing a bogus plan."
+      mismatched/failed EXPLAIN from producing a bogus plan.
+      TRACKED in its own item: query-plan-capture-misc-parser-live-validation
+      (sibling of query-plan-capture-parser-live-validation, which covers the
+      Presto/Trino, ClickHouse, and Spark synthetic-fixture parsers)."
 
 deps:
   needs: []

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-misc-parser-live-validation.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-misc-parser-live-validation.yaml
@@ -1,0 +1,146 @@
+id: query-plan-capture-misc-parser-live-validation
+title: "Validate the Databend / QuestDB / Doris / SingleStore plan parsers against real EXPLAIN output"
+worktree: platform-expansion
+priority: Medium
+status: Not Started
+category: Platform Expansion
+
+description: |
+  query-plan-capture-misc-platforms (PR #802) implemented and wired four new
+  plan parsers, but no live instance was available, so their fixtures under
+  tests/fixtures/query_plans/ were SYNTHESIZED from each engine's documented
+  EXPLAIN format rather than captured from a running server:
+    - DatabendQueryPlanParser   ← databend_explain_sample.txt   (box-drawing tree)
+    - QuestDBQueryPlanParser     ← questdb_explain_sample.txt     (indented text tree)
+    - DorisQueryPlanParser       ← doris_shape_plan_sample.txt    (EXPLAIN SHAPE PLAN)
+    - SingleStoreQueryPlanParser ← singlestore_explain_sample.txt ("|---" chain-tree)
+
+  Each parser and its fixture encode the SAME assumptions about output shape, so
+  the green unit tests in tests/unit/platforms/test_misc_plan_capture.py prove
+  self-consistency, NOT correctness against a real engine. Likely drift points to
+  re-check against live output:
+    - Databend: exact box-drawing property keys ("join type:", "table:") and
+      whether the connector prefix is a clean 4-char-per-level run.
+    - QuestDB: scan sub-operator names (PageFrame/DataFrame, "Frame forward scan
+      on: <table>", "Row forward scan") and the non-uniform indentation step.
+    - Doris: that the deployed version's Nereids planner supports
+      `EXPLAIN SHAPE PLAN` and emits the dash-indented Physical* tree this parser
+      expects (older/fragment EXPLAIN output would not parse).
+    - SingleStore: the "|---" connector spacing and whether the base pipeline is
+      really a parent->child chain in the deployed version.
+
+  This is the same class of gap as query-plan-capture-parser-live-validation
+  (Presto/Trino, ClickHouse, Spark) — kept as a SEPARATE item so the misc-platform
+  rollout's validation stays traceable. Consider folding the two together if a
+  single live-validation harness ends up covering both sets.
+
+  This TODO does NOT require provisioning clusters now. It makes the gap explicit
+  and trackable and adds the validation hooks so it can be closed when
+  credentials/instances exist.
+
+prerequisites:
+  - "Databend: running Databend server or Databend Cloud (DATABEND_HOST, DATABEND_USER, DATABEND_PASSWORD)"
+  - "QuestDB: running QuestDB 7.x+ instance (QUESTDB_HOST, QUESTDB_PORT)"
+  - "Doris: running Apache Doris 2.0+ cluster with the Nereids planner (DORIS_HOST, DORIS_USER, DORIS_PASSWORD)"
+  - "SingleStore: SingleStore Managed Service / Helios (SINGLESTORE_HOST, SINGLESTORE_USER, SINGLESTORE_PASSWORD)"
+
+prior_art:
+  - "query-plan-capture-parser-live-validation.yaml — sibling item for Presto/Trino, ClickHouse, Spark; mirror its provenance + live-skipif approach"
+  - "benchbox/core/query_plans/parsers/{databend,questdb,doris,singlestore}.py — the synthetic-fixture parsers"
+  - "tests/fixtures/query_plans/{databend_explain_sample.txt,questdb_explain_sample.txt,doris_shape_plan_sample.txt,singlestore_explain_sample.txt} — synthetic samples to diff against real output"
+  - "tests/integration/test_postgresql_plan_capture_integration.py (#768) — skipif(HOST) live-integration pattern to replicate"
+  - "_project/DONE/platform-expansion/planning/query-plan-capture-misc-platforms.yaml — the merged work whose deferred item this tracks"
+
+work:
+  - id: w1
+    summary: "Mark the four misc fixtures as synthetic with the engine/version they model"
+    status: pending
+    notes: |
+      Annotate databend_explain_sample.txt, questdb_explain_sample.txt,
+      doris_shape_plan_sample.txt, and singlestore_explain_sample.txt with
+      provenance (synthetic vs captured-from <engine> <version>), consistent with
+      whatever marker query-plan-capture-parser-live-validation w1 chooses (sibling
+      .meta.json or header comment) so the two efforts share one convention.
+
+  - id: w2
+    summary: "Capture real EXPLAIN and diff against the synthetic fixtures"
+    needs: [w1]
+    status: pending
+    notes: |
+      With a live instance per platform, run the representative queries and capture
+      real output:
+        - Databend:    EXPLAIN <query>
+        - QuestDB:     EXPLAIN <query>
+        - Doris:       EXPLAIN SHAPE PLAN <query>  (and confirm Nereids is active)
+        - SingleStore: EXPLAIN <query>
+      Diff against tests/fixtures/query_plans/. Where the real output differs,
+      update the fixture AND the parser's operator-name map / indentation handling.
+      Keep the synthetic fixture as fast no-credential coverage; add the captured
+      one alongside (do not delete the synthetic one).
+
+  - id: w3
+    summary: "Add CI-gated live integration tests for Databend, QuestDB, Doris, SingleStore"
+    needs: [w1]
+    status: pending
+    notes: |
+      Mirror tests/integration/test_postgresql_plan_capture_integration.py: one
+      file (or parametrized module) per engine, module-level skipif on the relevant
+      *_HOST/credentials env var. Each runs a real EXPLAIN over a live instance and
+      asserts the adapter's get_query_plan_parser() yields a non-None QueryPlanDAG
+      with a fingerprint and the expected root/scan operators. Skipped by default;
+      runnable in a UAT/CI job that provisions the engine.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Live integration tests must skip gracefully (not fail) when credentials/instances are absent."
+  - "Existing synthetic-fixture unit tests remain as fast, no-credential coverage."
+  - "The error-sentinel guard behavior (a failed/garbage EXPLAIN never yields a bogus plan) must not regress."
+
+approach: |
+  Honest bookkeeping for the misc-platform plan-capture rollout: mark what is
+  synthetic (w1), capture-and-diff against a real engine when one is available
+  (w2), and add the opt-in live hooks so the item can be closed later (w3).
+  Coordinate the provenance convention and, ideally, the integration-test harness
+  with the sibling query-plan-capture-parser-live-validation item.
+
+anti_patterns:
+  - "DO NOT hard-fail CI when an engine is unavailable - these are opt-in live tests; gate every one on an explicit credential/host env var."
+  - "DO NOT delete the synthetic fixtures when live ones arrive - they provide fast no-credential coverage; keep both and mark provenance."
+  - "DO NOT mark this Completed on green synthetic-only tests - completion requires at least one real EXPLAIN diffed per platform (w2)."
+
+verification:
+  - description: "Live integration tests skip cleanly without credentials"
+    command: "uv run -- python -m pytest tests/integration -k 'plan_capture and (databend or questdb or doris or singlestore)' -v"
+    expected_output: "Tests skipped with a clear 'live <engine> not available' message"
+  - description: "Synthetic-fixture unit tests still pass (no-credential coverage retained)"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_misc_plan_capture.py -q"
+    expected_output: "All tests pass, 0 failures"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/query_plans/parsers/databend.py"
+    - "benchbox/core/query_plans/parsers/questdb.py"
+    - "benchbox/core/query_plans/parsers/doris.py"
+    - "benchbox/core/query_plans/parsers/singlestore.py"
+    - "tests/fixtures/query_plans/"
+    - "tests/integration/"
+    - "tests/unit/platforms/"
+
+success_metrics:
+  - "Each of the four misc fixtures is marked synthetic with the engine/version it models."
+  - "At least one real EXPLAIN per platform has been captured and diffed against its fixture, with parser/fixture updates applied where they differed."
+  - "CI-gated live integration tests exist for Databend, QuestDB, Doris, and SingleStore and skip cleanly by default."
+
+open_questions:
+  - question: "Fold this into query-plan-capture-parser-live-validation (one live-validation harness for all synthetic parsers) or keep it separate per rollout?"
+    gating: false
+    affects: ["w3"]
+    default: "Keep separate for now; share the provenance convention and integration-test scaffold, and merge only if the harness becomes identical."
+
+metadata:
+  tags: [query-plan, databend, questdb, doris, singlestore, testing, validation, integration]
+  estimated_effort: "Medium"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"


### PR DESCRIPTION
Promotes the deferred live-cluster validation note from the merged `query-plan-capture-misc-platforms` work (#802) into its own trackable TODO so it won't get lost.

## Why
The Databend / QuestDB / Doris / SingleStore plan parsers landed in #802 were validated **only against synthesized EXPLAIN fixtures** — no live clusters were available. That's tracked as a `deferred` note inside a `DONE` item, which is easy to lose.

## What this does
- **Adds** `_project/TODO/platform-expansion/planning/query-plan-capture-misc-parser-live-validation.yaml`:
  - w1 — mark the four fixtures as synthetic (provenance);
  - w2 — capture real EXPLAIN (`EXPLAIN SHAPE PLAN` for Doris) and diff against the fixtures, updating parser/fixture where they differ;
  - w3 — CI-gated live integration tests (skipif on `*_HOST`/credentials), mirroring the existing PostgreSQL plan-capture integration pattern.
- **Cross-links** the existing sibling `query-plan-capture-parser-live-validation` (which covers the Presto/Trino, ClickHouse, Spark synthetic-fixture parsers) and **back-links** from the DONE item's `deferred` section.

Note: this overlaps in spirit with the sibling item. I kept it separate (per the request) and flagged "fold together?" as a non-gating `open_question`, sharing the provenance convention and integration-test scaffold.

`validate_todo.py --all` → 1129 valid; indexes regenerated (gitignored). Doc-only change.

https://claude.ai/code/session_01TuFzEo6XJj37zUTmX6Ak89

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuFzEo6XJj37zUTmX6Ak89)_