### PR TITLE
feat(tpchavoc): sample variant equivalence on a third engine (DataFusion)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -455,6 +455,43 @@ jobs:
             tests/integration/platforms/test_tpchavoc_postgres_equivalence.py \
             -m "live_postgresql" -n 0 --tb=short -v
 
+  datafusion-integration:
+    name: datafusion-integration
+    needs: ci-paths
+    if: ${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Non-blocking: this is the THIRD-engine equivalence SAMPLE, not a gate.
+    # The DuckDB SQL gate (correctness-gate job) stays the hard blocker.
+    # DataFusion is in-process (no service container), and its execution gaps
+    # DIFFER from Postgres's, so this samples translation-induced divergence a
+    # third engine over. continue-on-error keeps it a sample, not a blocker.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      # Third-engine equivalence SAMPLE. Both canonical and variants are
+      # translated to the datafusion dialect and compared on the same in-process
+      # session (shared translation cancels out). DATAFUSION_TPCHAVOC_SKIPS
+      # variants are excluded, never marked equivalent.
+      - name: Run TPC-Havoc DataFusion variant-equivalence sample
+        run: |
+          uv run -- python -m pytest \
+            tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py \
+            -m "tpchavoc" -n 0 --tb=short -v
+
   explorer-tokens:
     name: explorer-tokens
     needs: ci-paths

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-dataframe-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-dataframe-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -127,6 +127,16 @@ tpchavoc-equivalence-report:
 # hard blocker; this is a non-blocking sample (see equivalence.py).
 tpchavoc-equivalence-report-postgres:
 	uv run -- python -m benchbox.core.tpchavoc.equivalence --engine postgres
+
+# Third-engine SAMPLE: compare every DataFusion-executable TPC-Havoc SQL variant
+# to canonical TPC-H on the SAME in-process DataFusion session (both translated
+# to the datafusion dialect, which the seam normalizes to postgres). Excludes
+# DATAFUSION_TPCHAVOC_SKIPS (variants DataFusion cannot plan). DataFusion is
+# in-process (no service container); skips cleanly (exit 0) only if DataFusion is
+# not installed. The DuckDB gate above stays the hard blocker; this is a
+# non-blocking sample with a DIFFERENT gap profile from Postgres (see equivalence.py).
+tpchavoc-equivalence-report-datafusion:
+	uv run -- python -m benchbox.core.tpchavoc.equivalence --engine datafusion
 
 # Gate: compare every TPC-Havoc DataFrame variant (both backends) to canonical
 # TPC-H on real SF=0.1 DuckDB-backed data; exits non-zero on any divergence

--- a/_project/TODO/main/planning/tpchavoc-third-engine-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-third-engine-equivalence-sampling.yaml
@@ -1,0 +1,196 @@
+id: tpchavoc-third-engine-equivalence-sampling
+title: "Sample TPC-Havoc variant equivalence on a third SQL engine (DataFusion)"
+worktree: main
+priority: Medium
+status: Completed
+category: Testing and Quality Assurance
+
+description: |
+  The TPC-Havoc cross-dialect equivalence oracle already samples two engines: the
+  DuckDB SQL gate (PR #770, the hard blocker, KNOWN_DIVERGENCES empty) and a bounded
+  PostgreSQL sample (PR #803, POSTGRES_KNOWN_DIVERGENCES empty, 203/203 executable
+  variants equivalent). That two-engine signal said the dialect-translation seam was
+  faithful - but on engines whose gaps are SIMILAR (both PostgreSQL-family). The
+  `deferred` item of tpchavoc-cross-dialect-equivalence-sampling asked whether that
+  fidelity is systematic or Postgres-specific.
+
+  This TODO is that sequenced follow-on: a THIRD engine with a DIFFERENT gap profile.
+  A variant is written once and run, after dialect translation, on ~20 platforms;
+  "equivalent on DuckDB" does not imply "equivalent everywhere" (translation can shift
+  NULL ordering, integer-vs-float division, DISTINCT/window/QUALIFY/aggregate-FILTER
+  semantics, implicit casts, date arithmetic). A third engine whose limitations differ
+  from Postgres tests whether the zero-divergence result generalizes.
+
+  Engine choice: DataFusion. It (a) has an existing BenchBox adapter, (b) is in-process
+  (no service container - the cheapest possible CI cost), and (c) has a DIFFERENT gap
+  profile from Postgres: its limitations are in PHYSICAL PLANNING of correlated
+  EXISTS/IN/scalar sub-queries (plus a missing LIST aggregate and an empty-tuple parser
+  gap), whereas Postgres's are select-list-alias-in-HAVING/WHERE and aggregate-in-window.
+  This is still a SAMPLE, not a 20-engine matrix; the DuckDB gate stays the hard blocker.
+
+prior_art:
+  - "benchbox/core/tpchavoc/equivalence.py - the engine-agnostic oracle (find_divergences + the shared _report); reuse it, do NOT fork. Mirror build_postgres_with_tpch / find_postgres_divergences / run_postgres_sample / POSTGRES_KNOWN_DIVERGENCES."
+  - "benchbox/sql_compat/rules/execution_filter/postgres_tpchavoc.py POSTGRES_TPCHAVOC_SKIPS - the per-variant execution skips pattern; un-executable variants are excluded, never marked equivalent."
+  - "benchbox/sql_compat/rules/execution_filter/lakesail_tpchavoc.py - LakeSail (Apache Sail) is DataFusion-based; its TPC-Havoc skip set is a SUPERSET of DataFusion's, corroborating that the DataFusion failures are genuine engine limitations."
+  - "benchbox/utils/dialect_utils.py normalize_dialect_for_sqlglot - maps 'datafusion' -> 'postgres' for SQLGlot, so both canonical and variants go through the same translation seam."
+  - "_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml - the Completed two-engine TODO whose `deferred` item this implements."
+
+work:
+  - id: w0
+    summary: "Wire DataFusion build + sample path, reusing find_divergences and _report"
+    status: done
+    notes: |
+      Added build_datafusion_with_tpch (in-process SessionContext via DataFusionAdapter;
+      TPC-H .tbl loaded through PyArrow with the shared trailing-delimiter helpers because
+      the adapter's own CSV path does not strip the field-terminating pipe; per-table
+      row-count guard so a partial load cannot produce a false green), find_datafusion_
+      divergences (canonical via tpch.get_query(q, dialect="datafusion"); variants via
+      translate_query_text(sql, "netezza", "datafusion"); both normalize to postgres so
+      shared translation cancels out), and run_datafusion_sample. main() gained
+      `--engine datafusion`. The comparator and _report are reused verbatim - no per-engine
+      fork. DataFusion is in-process so per-query errors isolate naturally (no autocommit
+      needed) and there is no service to be unreachable; the only clean SKIP is DataFusion
+      not being installed.
+
+  - id: w1
+    summary: "Run the oracle on DataFusion in report mode and classify divergences"
+    needs: [w0]
+    status: done
+    notes: |
+      Ran `python -m benchbox.core.tpchavoc.equivalence --engine datafusion` at SF=0.1.
+      Raw sweep (no skip-list) surfaced 14 divergences - ALL of them DataFusion EXECUTION
+      failures, none result mismatches:
+        - 1_v7: missing LIST aggregate ("Invalid function 'list'").
+        - 4_v7, 4_v10, 14_v8: EXISTS not supported in physical plan for the variant shape.
+        - 16_v7, 16_v10: IN sub-query not supported in physical plan.
+        - 7_v1, 9_v1, 17_v7, 17_v10: scalar sub-query not supported in physical plan.
+        - 8_v1, 12_v1: scalar_subquery_to_join optimizer rule fails (field resolution / ambiguous count(*)).
+        - 6_v2, 14_v2: generated empty-tuple sub-query ("Empty tuple not supported yet").
+      The same SQL passes the DuckDB gate, so these are genuine DataFusion engine
+      limitations, NOT translation bugs and NOT variant defects. Classification: all 14 are
+      "engine cannot execute" -> excluded via DATAFUSION_TPCHAVOC_SKIPS (the execution-filter
+      analog of POSTGRES_TPCHAVOC_SKIPS), never marked equivalent. Corroboration: all 14 are
+      a strict subset of LAKESAIL_TPCHAVOC_SKIPS (Sail is DataFusion-based). After excluding
+      them, 206/206 executable variants are result-equivalent - ZERO result divergences.
+
+  - id: w2
+    summary: "Fix translation/variant bugs; declare true engine exceptions"
+    needs: [w1]
+    status: done
+    notes: |
+      Nothing to drive down: w1's result-divergence surface was already empty, so there were
+      no translation-layer bugs to fix at the seam (translate_query_text / translate_sql_query)
+      and no per-variant hacks were added. DATAFUSION_KNOWN_DIVERGENCES is the engine-keyed
+      result-equivalence exception table (mirrors POSTGRES_KNOWN_DIVERGENCES) and stays EMPTY:
+      no irreducible engine-semantic RESULT difference needed declaring. The only DataFusion-
+      specific surface is executability, captured in DATAFUSION_TPCHAVOC_SKIPS (14 variants,
+      registered for the "datafusion" platform and wired into get_platform_skip_queries).
+
+  - id: w3
+    summary: "Decide the routine-CI posture for the third engine and wire it"
+    needs: [w2]
+    status: done
+    notes: |
+      DECISION: option (a) - a bounded check in a non-blocking CI job. Added a new
+      `datafusion-integration` job in .github/workflows/pr.yml (continue-on-error: true)
+      running tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py.
+
+      RATIONALE: the residual result-divergence surface is empty and the run is green and
+      fast (~15s end-to-end, in-process, no service container), so option (b)'s trigger
+      ("surface dominated by declared engine differences" or "too slow/flaky") does not
+      apply. Unlike Postgres there is no pre-existing service container to reuse, but
+      DataFusion is in-process so a dedicated job is still cheap; a dedicated NON-blocking
+      job keeps the sample's semantics explicit at the job level and keeps the hard
+      correctness-gate job clean. continue-on-error keeps it a SAMPLE: the DuckDB SQL gate
+      (correctness-gate job, KNOWN_DIVERGENCES empty) remains the only hard blocker. We
+      deliberately do NOT gate the other ~17 platforms in routine CI (anti-pattern #1).
+      Also added the Makefile target `tpchavoc-equivalence-report-datafusion`.
+
+  - id: w4
+    summary: "Synthesize the three-engine signal"
+    needs: [w3]
+    status: done
+    notes: |
+      CONCLUSION: translation divergence is SYSTEMATIC-ZERO, not engine-specific. Across
+      three engines with materially different feature sets - DuckDB (220/220), PostgreSQL
+      (203/203 executable), and now DataFusion (206/206 executable) - every variant that
+      the engine can execute is result-equivalent to canonical TPC-H run through the SAME
+      translation on the SAME instance. Crucially, DataFusion's gap profile DIFFERS from
+      Postgres's (physical-planning of correlated sub-queries vs HAVING/WHERE alias and
+      aggregate-in-window limits), and the skip sets barely overlap (only 1_v7 and 4_v7),
+      yet the equivalence result is identical: zero result divergences, empty
+      <ENGINE>_KNOWN_DIVERGENCES. The differences between engines live entirely in WHICH
+      variants execute (bounded by the per-engine skip-lists), never in the RESULTS of the
+      ones that do. The dialect-translation seam is faithful for these families.
+
+      Is a fourth engine worth sequencing? Not urgently. Three engines spanning columnar
+      (DuckDB), PostgreSQL-family (Postgres), and Arrow/DataFusion-family now agree. The
+      highest-information next contrast would be an engine that differs SEMANTICALLY on
+      results (NULL ordering, integer division, implicit casts) rather than on
+      executability - e.g. ClickHouse or a Spark dialect - but that costs a service
+      container and should only be sequenced if a concrete translation concern motivates
+      it. Recorded in `deferred` below, gated on such evidence.
+
+deferred:
+  - summary: "Sample a fourth engine that contrasts on RESULT semantics (e.g. ClickHouse or Spark), not just executability"
+    reason: "Three engines agree on zero result divergence; a fourth adds information only if it differs on result semantics (NULL ordering, integer division, implicit casts). That costs a service container - sequence it only when a concrete translation concern motivates it, not as a reflexive fan-out."
+
+must_preserve:
+  - "The DuckDB SQL equivalence gate stays the hard, blocking gate with empty KNOWN_DIVERGENCES (still 220/220, exit 0)."
+  - "The PostgreSQL sample stays green; POSTGRES_KNOWN_DIVERGENCES and POSTGRES_TPCHAVOC_SKIPS semantics are unchanged (still 203/203)."
+  - "Reuse validate_variant_equivalence, find_divergences, and _report; do not fork the comparator/oracle per engine."
+  - "DATAFUSION_TPCHAVOC_SKIPS entries are excluded, never marked equivalent; only DataFusion-not-installed is a clean SKIP - schema/load/translation/sweep failures propagate."
+
+approach: |
+  Mirror the PostgreSQL second-engine pattern for DataFusion: a build helper, a
+  find_<engine>_divergences, a run_<engine>_sample, an engine-keyed KNOWN_DIVERGENCES,
+  and an execution-filter skip module for the variants the engine genuinely cannot run
+  (w0). Run the oracle in report mode and classify every divergence (w1), fix any
+  translation bug at the seam and declare only irreducible engine RESULT differences as
+  exceptions (w2), wire a bounded non-blocking CI posture from the evidence (w3), and
+  synthesize the three-engine signal (w4). DuckDB stays the hard gate.
+
+anti_patterns:
+  - "DO NOT gate all ~20 platforms in routine CI - one more engine, decided from evidence."
+  - "DO NOT treat a DATAFUSION_TPCHAVOC_SKIPS entry as an equivalence pass - those variants don't execute; exclude them, never mark them equivalent."
+  - "DO NOT patch individual variants for what is a translation-layer bug - fix the translation seam so the fix generalizes across variants and engines."
+  - "DO NOT compare a DataFusion variant result to a DuckDB or Postgres canonical - run canonical on the SAME engine, same dialect, both sides."
+
+verification:
+  - description: "DataFusion report-mode oracle enumerates divergences excluding un-executable variants"
+    command: "make tpchavoc-equivalence-report-datafusion"
+    expected_output: "checked 206 variants - 0 divergent, 206 equivalent; exit 0"
+  - description: "DuckDB hard gate and live DataFusion sample both green"
+    command: "make tpchavoc-equivalence-report"
+    expected_output: "checked 220 variants - 0 divergent, 220 equivalent; exit 0"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/"
+    - "benchbox/sql_compat/"
+    - "tests/integration/"
+    - ".github/workflows/"
+    - "Makefile"
+    - "_project/TODO/"
+
+open_questions:
+  - question: "Third engine: DataFusion (in-process, gaps differ from Postgres) vs ClickHouse/Spark (harder contrast, service container)?"
+    gating: true
+    affects: ["w0 engine choice"]
+    default: "DataFusion - cheapest setup (in-process, no container) with a genuinely different gap profile from Postgres, so the sample adds information about whether translation divergence generalizes."
+  - question: "Reference: run canonical TPC-H on the same engine/dialect as the variants?"
+    gating: false
+    affects: ["w1 reference choice"]
+    default: "Yes - canonical and variants both translated to the datafusion dialect and compared on the same session, so shared translation cancels out and only genuine variant-vs-canonical differences surface."
+
+success_metrics:
+  - "The equivalence oracle runs on a third SQL engine (DataFusion) and reports variant divergences from canonical TPC-H."
+  - "Translation-induced divergences are fixed at the seam; irreducible engine RESULT differences are classified and justified (none needed - DATAFUSION_KNOWN_DIVERGENCES empty)."
+  - "A documented CI-posture decision exists (non-blocking datafusion-integration job) with the DuckDB gate remaining the hard blocker."
+  - "A three-engine conclusion is recorded: translation divergence is systematic-zero, not engine-specific."
+
+metadata:
+  tags: [tpchavoc, cross-dialect, equivalence, correctness, datafusion, ci]
+  estimated_effort: "Medium"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00"

--- a/benchbox/core/tpchavoc/benchmark.py
+++ b/benchbox/core/tpchavoc/benchmark.py
@@ -19,6 +19,7 @@ from typing import Any, Union
 from benchbox.core.tpch.benchmark import TPCHBenchmark
 from benchbox.core.tpchavoc.queries import TPCHavocQueryManager
 from benchbox.core.tpchavoc.validation import ResultValidator, ValidationReport
+from benchbox.sql_compat.rules.execution_filter.datafusion_tpchavoc import DATAFUSION_TPCHAVOC_SKIPS
 from benchbox.sql_compat.rules.execution_filter.lakesail_tpchavoc import LAKESAIL_TPCHAVOC_SKIPS
 from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
 
@@ -121,6 +122,8 @@ class TPCHavocBenchmark(TPCHBenchmark):
         platform = platform_name.lower().replace("_", "-")
         if platform == "lakesail":
             return list(LAKESAIL_TPCHAVOC_SKIPS)
+        if platform == "datafusion":
+            return list(DATAFUSION_TPCHAVOC_SKIPS)
         if platform in {"pg-duckdb", "pg-mooncake", "timescaledb"}:
             return list(POSTGRES_TPCHAVOC_SKIPS)
         return []

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -27,6 +27,16 @@ PostgreSQL cannot execute (POSTGRES_TPCHAVOC_SKIPS), and classifies any residue
 against :data:`POSTGRES_KNOWN_DIVERGENCES`. It catches the largest class of
 translation-induced divergence one engine over without gating all ~20 platforms.
 
+``--engine datafusion`` adds a bounded *third-engine sample* on the in-process
+DataFusion engine (no service container). Its execution gaps DIFFER from
+Postgres's - correlated EXISTS/IN/scalar sub-query physical planning rather than
+HAVING/WHERE alias and aggregate-in-window limits - so it tests whether the
+translation fidelity is systematic or Postgres-specific. Variants DataFusion
+cannot plan are excluded via DATAFUSION_TPCHAVOC_SKIPS; any residue is classified
+against :data:`DATAFUSION_KNOWN_DIVERGENCES`. Across DuckDB, PostgreSQL, and
+DataFusion every executable variant is result-equivalent: translation divergence
+is systematic-zero, not engine-specific.
+
 Comparison is order-insensitive with float tolerance (the validator sorts both
 sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
 LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
@@ -102,6 +112,21 @@ KNOWN_DIVERGENCES: dict[str, str] = {}
 # 203 executable variants - the translation layer is faithful and no variant is
 # silently wrong on PostgreSQL while green on DuckDB.
 POSTGRES_KNOWN_DIVERGENCES: dict[str, str] = {}
+
+# Per-engine equivalence exceptions for the *third-engine sample* (DataFusion),
+# keyed by "<query>_v<variant>". Same contract as POSTGRES_KNOWN_DIVERGENCES: an
+# entry records an irreducible engine-semantic *result* difference, never a
+# translation bug (fixed in the dialect seam) and never a variant DataFusion
+# cannot execute (those are excluded via DATAFUSION_TPCHAVOC_SKIPS).
+#
+# Empty: the DataFusion sample (SF=0.1, both canonical and variants translated to
+# the datafusion dialect - which the seam normalizes to postgres - through the
+# same path) found zero *result* divergences over the 206 executable variants.
+# DataFusion's gaps are confined to which variants it can plan at all (the 14
+# DATAFUSION_TPCHAVOC_SKIPS), a DIFFERENT gap profile from PostgreSQL's; on the
+# variants it does execute the translation layer is just as faithful. Three
+# engines now agree: translation divergence is systematic-zero, not engine-specific.
+DATAFUSION_KNOWN_DIVERGENCES: dict[str, str] = {}
 
 _TRAILING_LIMIT = re.compile(r"(?is)\s+limit\s+\d+\s*;?\s*$")
 
@@ -498,25 +523,198 @@ def run_postgres_sample() -> int:
     )
 
 
+# The third engine sampled beyond DuckDB and PostgreSQL. DataFusion is the
+# cheapest contrast: it is in-process (no service container), and its execution
+# gaps DIFFER from PostgreSQL's (correlated EXISTS/IN/scalar sub-query physical
+# planning rather than HAVING/WHERE alias and aggregate-in-window limits), so the
+# sample adds information about whether translation divergence is systematic or
+# engine-specific. The seam normalizes "datafusion" to the postgres dialect, so
+# both sides go through the same translation and shared translation cancels out.
+DATAFUSION_TARGET_DIALECT = "datafusion"
+
+
+def _close_quietly(connection: Any) -> None:
+    """Close a connection if it exposes ``close()``.
+
+    DataFusion's in-process session has no ``close()`` (it is GC'd), so callers
+    that mirror the DB-API ``finally: connection.close()`` shape stay uniform
+    across engines without special-casing DataFusion at every call site.
+    """
+    close = getattr(connection, "close", None)
+    if callable(close):
+        close()
+
+
+def build_datafusion_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple[Any, TPCHavocBenchmark, TPCH]:
+    """Generate TPC-H data and return a populated in-process DataFusion connection.
+
+    Mirrors :func:`build_duckdb_with_tpch`/:func:`build_postgres_with_tpch` for the
+    third engine. DataFusion is in-process, so there is no service container and no
+    per-statement transaction to isolate: ``ctx.sql(...)`` failures raise per query
+    and are caught by :func:`find_divergences` without poisoning the sweep.
+
+    The generated TPC-H ``.tbl`` files carry a field-terminating trailing pipe.
+    Both of ``DataFusionAdapter.load_data``'s CSV paths reject it (the
+    CREATE EXTERNAL TABLE path has no trailing-delimiter option, and the
+    CSV->Parquet path reads with the bare schema column count and errors on the
+    extra field), and the adapter is outside this change's scope. So this helper
+    loads each table via PyArrow directly - handling the trailing delimiter with
+    the shared file-format helpers - and registers Arrow batches into the session,
+    reusing the adapter's session setup and its own type mapping for fidelity.
+    DECIMAL columns map to float64 exactly as the adapter's Parquet path does; the
+    comparator is float-tolerant and both sides run on this same instance, so this
+    never changes results. Each table's row count is verified (>0) so a partial
+    load cannot produce a FALSE green by comparing empty-vs-empty.
+
+    Returns:
+        ``(connection, tpchavoc_benchmark, tpch_benchmark)``.
+    """
+    import pyarrow as pa
+    import pyarrow.csv as pacsv
+
+    from benchbox.platforms.datafusion import DataFusionAdapter
+    from benchbox.utils.file_format import (
+        TRAILING_DUMMY_COLUMN,
+        get_column_names_with_trailing,
+        has_trailing_delimiter,
+    )
+
+    data_dir, tpchavoc, tpch = _generate_tpch(scale_factor, Path(output_dir))
+
+    adapter = DataFusionAdapter(working_dir=str(Path(output_dir) / "datafusion_working"))
+    connection = adapter.create_connection()
+    try:
+        schema = tpchavoc.get_schema()
+        for table in _TPCH_TABLES:
+            columns = schema[table]["columns"]
+            column_names = [column["name"].lower() for column in columns]
+            column_types: dict[str, Any] = {}
+            for column in columns:
+                arrow_type = DataFusionAdapter._map_schema_type_to_pyarrow(column["type"].upper(), pa)
+                if arrow_type is not None:
+                    column_types[column["name"].lower()] = arrow_type
+
+            tbl_path = data_dir / f"{table}.tbl"
+            if not tbl_path.exists():
+                raise RuntimeError(f"DataFusion TPC-H load failed - missing data file {tbl_path}")
+
+            trailing = has_trailing_delimiter(tbl_path, "|", column_names)
+            read_names = get_column_names_with_trailing(column_names, trailing)
+            arrow_table = pacsv.read_csv(
+                tbl_path,
+                read_options=pacsv.ReadOptions(column_names=read_names),
+                parse_options=pacsv.ParseOptions(delimiter="|"),
+                convert_options=pacsv.ConvertOptions(
+                    column_types=column_types, null_values=[""], strings_can_be_null=True
+                ),
+            )
+            if trailing:
+                arrow_table = arrow_table.drop_columns([TRAILING_DUMMY_COLUMN])
+            if arrow_table.num_rows <= 0:
+                raise RuntimeError(f"DataFusion TPC-H load failed - no rows in {table} ({tbl_path})")
+            connection.register_record_batches(table, [arrow_table.to_batches()])
+    except Exception:
+        _close_quietly(connection)
+        raise
+    return connection, tpchavoc, tpch
+
+
+def find_datafusion_divergences(
+    connection: Any,
+    tpchavoc: TPCHavocBenchmark,
+    tpch: TPCH,
+    *,
+    query_ids: list[int] | None = None,
+) -> list[Divergence]:
+    """Run the DataFusion equivalence sweep with the canonical DataFusion wiring.
+
+    Single source of truth for *how* the DataFusion sample is run - both the CLI
+    (:func:`run_datafusion_sample`) and the integration test call this so they
+    cannot drift. Canonical and variants are both translated to the datafusion
+    dialect through the SAME seam (the seam normalizes datafusion -> postgres for
+    SQLGlot), and DATAFUSION_TPCHAVOC_SKIPS variants are excluded (never marked
+    equivalent).
+    """
+    from benchbox.sql_compat.rules.execution_filter.datafusion_tpchavoc import DATAFUSION_TPCHAVOC_SKIPS
+
+    return find_divergences(
+        connection,
+        tpchavoc,
+        lambda q: tpch.get_query(q, dialect=DATAFUSION_TARGET_DIALECT),
+        query_ids=query_ids,
+        translate_variant=lambda sql: tpchavoc.translate_query_text(sql, "netezza", DATAFUSION_TARGET_DIALECT),
+        skip_variants=set(DATAFUSION_TPCHAVOC_SKIPS),
+    )
+
+
+def run_datafusion_sample() -> int:
+    """Run the third-engine (DataFusion) equivalence sample.
+
+    Both canonical TPC-H and every variant are translated to the datafusion
+    dialect through the SAME seam, then compared on the SAME in-process DataFusion
+    session, so shared translation cancels out (anti-pattern: never compare a
+    DataFusion variant to a DuckDB or Postgres canonical). Variants DataFusion
+    cannot execute are excluded via DATAFUSION_TPCHAVOC_SKIPS - they are never
+    marked equivalent. A divergence is classified against DATAFUSION_KNOWN_DIVERGENCES;
+    an unclassified one returns non-zero, but this is a *sample* run - the DuckDB
+    gate remains the hard blocker.
+
+    DataFusion is in-process, so the only "engine unusable" case is the library
+    not being installed; that alone is a clean skip (mirroring the Postgres
+    sample's connect-only skip). Schema, load (incl. the row-count guard),
+    translation, and sweep failures all propagate as real failures.
+    """
+    import tempfile
+
+    from benchbox.sql_compat.rules.execution_filter.datafusion_tpchavoc import DATAFUSION_TPCHAVOC_SKIPS
+
+    try:
+        import datafusion  # noqa: F401
+    except ImportError as exc:
+        print(f"DataFusion equivalence sample SKIPPED - DataFusion not installed: {exc}")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        connection, tpchavoc, tpch = build_datafusion_with_tpch(EQUIVALENCE_SCALE, tmp)
+        try:
+            divergences = find_datafusion_divergences(connection, tpchavoc, tpch)
+        finally:
+            _close_quietly(connection)
+
+    # Exclude un-executable variants from the denominator too: they are bounded
+    # out of scope, not failures.
+    total = len(tpchavoc.get_implemented_queries()) * 10 - len(DATAFUSION_TPCHAVOC_SKIPS)
+    return _report(
+        divergences,
+        total,
+        DATAFUSION_KNOWN_DIVERGENCES,
+        engine_label="DataFusion",
+        baseline_name="DATAFUSION_KNOWN_DIVERGENCES",
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Generate data, run the oracle for the chosen engine, and print a report.
 
     ``--engine duckdb`` (default) is the hard, blocking gate. ``--engine
-    postgres`` runs the bounded second-engine sample described in
-    :func:`run_postgres_sample`.
+    postgres`` and ``--engine datafusion`` run the bounded second- and
+    third-engine samples described in :func:`run_postgres_sample` and
+    :func:`run_datafusion_sample`.
     """
     import argparse
 
     parser = argparse.ArgumentParser(description="TPC-Havoc variant-equivalence oracle.")
     parser.add_argument(
         "--engine",
-        choices=("duckdb", "postgres"),
+        choices=("duckdb", "postgres", "datafusion"),
         default="duckdb",
         help="SQL engine to sample (default: duckdb, the hard gate).",
     )
     args = parser.parse_args(argv)
     if args.engine == "postgres":
         return run_postgres_sample()
+    if args.engine == "datafusion":
+        return run_datafusion_sample()
     return run_duckdb_gate()
 
 

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -603,7 +603,10 @@ def build_datafusion_with_tpch(scale_factor: float, output_dir: str | Path) -> t
             arrow_table = pacsv.read_csv(
                 tbl_path,
                 read_options=pacsv.ReadOptions(column_names=read_names),
-                parse_options=pacsv.ParseOptions(delimiter="|"),
+                # Raw TPC-H .tbl is pipe-delimited with NO quoting; disable PyArrow's
+                # default quote_char so a literal `"` in a text field cannot be parsed
+                # as a quote and mis-split the row.
+                parse_options=pacsv.ParseOptions(delimiter="|", quote_char=False),
                 convert_options=pacsv.ConvertOptions(
                     column_types=column_types, null_values=[""], strings_can_be_null=True
                 ),

--- a/benchbox/sql_compat/rules/execution_filter/datafusion_tpchavoc.py
+++ b/benchbox/sql_compat/rules/execution_filter/datafusion_tpchavoc.py
@@ -1,0 +1,71 @@
+"""DataFusion execution-filter rules for unsupported TPC-Havoc variants.
+
+DataFusion is the THIRD engine sampled by the TPC-Havoc cross-dialect
+equivalence oracle (after DuckDB, the hard gate, and PostgreSQL, the second
+engine). Unlike PostgreSQL, DataFusion's gaps are concentrated in *physical
+planning* of correlated sub-queries (EXISTS / IN / scalar sub-queries in
+positions its planner cannot lower), the missing ``LIST`` aggregate, and a
+parser limitation on the generated empty-tuple sub-query syntax - a DIFFERENT
+gap profile from PostgreSQL's HAVING/WHERE select-list-alias and
+aggregate-in-window restrictions.
+
+Every entry below is a variant DataFusion cannot *execute* (it raises a planning
+or feature-not-implemented error), NOT a result divergence: the same SQL passes
+the DuckDB equivalence gate, so the variant is valid and DataFusion's residual
+equivalence surface is empty. These are excluded from the equivalence sample
+(``DATAFUSION_TPCHAVOC_SKIPS``), never marked equivalent. Result-equivalence
+exceptions, if any were ever needed, live in
+``benchbox/core/tpchavoc/equivalence.py:DATAFUSION_KNOWN_DIVERGENCES`` (empty).
+
+This skip set is a strict subset of ``LAKESAIL_TPCHAVOC_SKIPS``: Apache Sail
+(LakeSail) is itself DataFusion-based, so it shares these physical-planning
+limitations and adds further ones of its own - corroborating that these are
+genuine engine limitations rather than translation artifacts.
+"""
+
+from __future__ import annotations
+
+from benchbox.sql_compat.actions import CompatAction
+from benchbox.sql_compat.context import Phase
+from benchbox.sql_compat.decision import CompatibilityDecision, FailureMode, SkipQueryPayload, SupportLevel
+from benchbox.sql_compat.registry import REGISTRY
+
+DATAFUSION_TPCHAVOC_SKIPS: dict[str, str] = {
+    "1_v7": "DataFusion has no `LIST` aggregate used by this variant (`Invalid function 'list'`).",
+    "4_v7": "DataFusion physical planning does not support EXISTS in this variant shape.",
+    "4_v10": "DataFusion physical planning does not support EXISTS in this variant shape.",
+    "6_v2": "DataFusion rejects the generated empty-tuple sub-query (`Empty tuple not supported yet`).",
+    "7_v1": "DataFusion physical planning does not support the scalar sub-query in this variant shape.",
+    "8_v1": "DataFusion `scalar_subquery_to_join` optimizer rule fails to resolve a sub-query field for this variant.",
+    "9_v1": "DataFusion physical planning does not support the scalar sub-query in this variant shape.",
+    "12_v1": "DataFusion `scalar_subquery_to_join` optimizer rule reports an ambiguous `count(*)` for this variant.",
+    "14_v2": "DataFusion rejects the generated empty-tuple sub-query (`Empty tuple not supported yet`).",
+    "14_v8": "DataFusion physical planning does not support EXISTS in this variant shape.",
+    "16_v7": "DataFusion physical planning does not support the IN sub-query in this variant shape.",
+    "16_v10": "DataFusion physical planning does not support the IN sub-query in this variant shape.",
+    "17_v7": "DataFusion physical planning does not support the scalar sub-query in this variant shape.",
+    "17_v10": "DataFusion physical planning does not support the scalar sub-query in this variant shape.",
+}
+
+for _query_id, _reason in DATAFUSION_TPCHAVOC_SKIPS.items():
+    REGISTRY.register(
+        CompatibilityDecision(
+            rule_id=f"execution_filter.datafusion.tpchavoc.{_query_id}",
+            action=CompatAction.SKIP_QUERY,
+            support_level=SupportLevel.SKIPPED_QUERY,
+            failure_mode=FailureMode.UNSUPPORTED_FEATURE,
+            payload=SkipQueryPayload(
+                reason=(
+                    f"{_reason} Evidence: 2026-06-15 TPC-Havoc third-engine equivalence sweep "
+                    "(`python -m benchbox.core.tpchavoc.equivalence --engine datafusion`, SF=0.1) "
+                    "reported this stable variant execution failure on DataFusion."
+                ),
+                query_id=_query_id,
+            ),
+            reason=_reason,
+        ),
+        Phase.EXECUTION_FILTER,
+        "datafusion",
+        benchmark="tpchavoc",
+        query_id=_query_id,
+    )

--- a/docs/compat/capability-matrix.md
+++ b/docs/compat/capability-matrix.md
@@ -4,7 +4,7 @@
 
 Every rule registered in `benchbox.sql_compat` is listed below. The registry is the authoritative source of compatibility policy; this document is regenerated from it. See [adr-sql-compat-phase-aware-pipeline.md](../development/adr/adr-sql-compat-phase-aware-pipeline.md) for the design.
 
-**Total registered rules:** 339
+**Total registered rules:** 353
 
 **Platforms covered:** 30
 
@@ -17,7 +17,7 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | clickhouse | - | 13 | 3 | 4 | 1 | - | 21 |
 | databend | - | - | - | - | 1 | - | 1 |
 | databricks | - | - | - | 2 | 1 | - | 3 |
-| datafusion | - | - | 4 | 2 | - | - | 6 |
+| datafusion | - | - | 4 | 2 | - | 14 | 20 |
 | doris | - | 7 | - | 2 | 1 | - | 10 |
 | duckdb | - | - | - | - | - | 6 | 6 |
 | fabric_dw | - | - | - | - | 1 | - | 1 |
@@ -109,6 +109,20 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | query_adapter | benchmark=tpch, query=20 | rewrite_query | REWRITTEN | SILENT_CORRUPTION | `query_adapter.datafusion.tpch.q20_correlated_to_cte` |
 | schema_emit | benchmark=transaction_primitives | rewrite_ddl | SKIPPED_DDL_FRAGMENT | SYNTAX_ERROR | `schema_emit.datafusion.transaction_primitives.pk_lock_table_unsupported` |
 | schema_emit | benchmark=write_primitives | rewrite_ddl | SKIPPED_DDL_FRAGMENT | SYNTAX_ERROR | `schema_emit.datafusion.write_primitives.pk_lock_table_unsupported` |
+| execution_filter | benchmark=tpchavoc, query=12_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.12_v1` |
+| execution_filter | benchmark=tpchavoc, query=14_v2 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.14_v2` |
+| execution_filter | benchmark=tpchavoc, query=14_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.14_v8` |
+| execution_filter | benchmark=tpchavoc, query=16_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.16_v10` |
+| execution_filter | benchmark=tpchavoc, query=16_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.16_v7` |
+| execution_filter | benchmark=tpchavoc, query=17_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.17_v10` |
+| execution_filter | benchmark=tpchavoc, query=17_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.17_v7` |
+| execution_filter | benchmark=tpchavoc, query=1_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.1_v7` |
+| execution_filter | benchmark=tpchavoc, query=4_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.4_v10` |
+| execution_filter | benchmark=tpchavoc, query=4_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.4_v7` |
+| execution_filter | benchmark=tpchavoc, query=6_v2 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.6_v2` |
+| execution_filter | benchmark=tpchavoc, query=7_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.7_v1` |
+| execution_filter | benchmark=tpchavoc, query=8_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.8_v1` |
+| execution_filter | benchmark=tpchavoc, query=9_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.datafusion.tpchavoc.9_v1` |
 
 ### doris
 

--- a/docs/compat/skip-reference.md
+++ b/docs/compat/skip-reference.md
@@ -4,13 +4,32 @@
 
 Rules the registry applies to queries, benchmarks, and DDL statements. Split into two sections based on whether the outcome is user-visible in result counts. Each entry names the platform, the scope the rule applies to, the registered reason, and the rule_id you can grep for in `benchbox/sql_compat/rules/`.
 
-**Total rules:** 246
+**Total rules:** 260
 
 **Platforms with rules:** 18
 
 ## Will not run
 
 Queries or benchmarks that are **omitted from the result set** - either because the benchmark is refused at preflight (BLOCKED) or a specific query is excluded from execution (SKIPPED_QUERY). Users see these as missing entries in result counts.
+
+### datafusion
+
+| support | scope | phase | reason | rule_id |
+|---|---|---|---|---|
+| SKIPPED_QUERY | benchmark=tpchavoc, query=12_v1 | execution_filter | DataFusion `scalar_subquery_to_join` optimizer rule reports an ambiguous `count(*)` for this variant. | `execution_filter.datafusion.tpchavoc.12_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=14_v2 | execution_filter | DataFusion rejects the generated empty-tuple sub-query (`Empty tuple not supported yet`). | `execution_filter.datafusion.tpchavoc.14_v2` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=14_v8 | execution_filter | DataFusion physical planning does not support EXISTS in this variant shape. | `execution_filter.datafusion.tpchavoc.14_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v10 | execution_filter | DataFusion physical planning does not support the IN sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.16_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v7 | execution_filter | DataFusion physical planning does not support the IN sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.16_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v10 | execution_filter | DataFusion physical planning does not support the scalar sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.17_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v7 | execution_filter | DataFusion physical planning does not support the scalar sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.17_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v7 | execution_filter | DataFusion has no `LIST` aggregate used by this variant (`Invalid function 'list'`). | `execution_filter.datafusion.tpchavoc.1_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v10 | execution_filter | DataFusion physical planning does not support EXISTS in this variant shape. | `execution_filter.datafusion.tpchavoc.4_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v7 | execution_filter | DataFusion physical planning does not support EXISTS in this variant shape. | `execution_filter.datafusion.tpchavoc.4_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=6_v2 | execution_filter | DataFusion rejects the generated empty-tuple sub-query (`Empty tuple not supported yet`). | `execution_filter.datafusion.tpchavoc.6_v2` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=7_v1 | execution_filter | DataFusion physical planning does not support the scalar sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.7_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=8_v1 | execution_filter | DataFusion `scalar_subquery_to_join` optimizer rule fails to resolve a sub-query field for this variant. | `execution_filter.datafusion.tpchavoc.8_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=9_v1 | execution_filter | DataFusion physical planning does not support the scalar sub-query in this variant shape. | `execution_filter.datafusion.tpchavoc.9_v1` |
 
 ### duckdb
 

--- a/tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py
@@ -1,0 +1,86 @@
+"""Third-engine (DataFusion) TPC-Havoc variant-equivalence sample.
+
+The DuckDB equivalence gate (``benchbox/core/tpchavoc/equivalence.py``, run via
+``make tpchavoc-equivalence-report``) proves every variant is result-equivalent
+to canonical TPC-H on ONE engine, DuckDB at SF=0.1. The PostgreSQL sample added
+a second engine. This test is the bounded *third-engine sample* on the
+in-process DataFusion engine: it runs canonical TPC-H and every variant through
+the SAME translation to the SAME DataFusion session (so shared translation
+cancels out), excludes the variants DataFusion cannot plan
+(DATAFUSION_TPCHAVOC_SKIPS), and asserts no residual divergence beyond the
+classified DATAFUSION_KNOWN_DIVERGENCES baseline (empty).
+
+DataFusion's execution gaps DIFFER from PostgreSQL's (correlated EXISTS / IN /
+scalar sub-query physical planning rather than HAVING/WHERE alias and
+aggregate-in-window limits), so a green result here tests whether the
+translation fidelity is systematic across engines or Postgres-specific. The
+DuckDB gate remains the hard, blocking gate; this sample (and the gate body of
+the non-blocking ``datafusion-integration`` CI job) catches translation-induced
+divergence a third engine over without gating all ~20 platforms.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.equivalence import (
+    DATAFUSION_KNOWN_DIVERGENCES,
+    EQUIVALENCE_SCALE,
+    _close_quietly,
+    build_datafusion_with_tpch,
+    find_datafusion_divergences,
+)
+from benchbox.sql_compat.rules.execution_filter.datafusion_tpchavoc import DATAFUSION_TPCHAVOC_SKIPS
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.tpchavoc,
+    pytest.mark.slow,
+]
+
+
+@pytest.fixture(scope="module")
+def datafusion_divergences(tmp_path_factory):
+    """Load SF=0.1 TPC-H into an in-process DataFusion session and sweep ONCE.
+
+    DataFusion is in-process, so "unreachable" means "not installed" - skip
+    cleanly in that case (mirroring the Postgres sample's connect-only skip). The
+    206-variant sweep is the expensive part, so it is computed a single time at
+    module scope and shared across the assertions below.
+    """
+    pytest.importorskip("datafusion", reason="DataFusion not installed")
+    output_dir = tmp_path_factory.mktemp("tpchavoc_df_equivalence")
+    connection, tpchavoc, tpch = build_datafusion_with_tpch(EQUIVALENCE_SCALE, output_dir)
+    try:
+        yield find_datafusion_divergences(connection, tpchavoc, tpch)
+    finally:
+        _close_quietly(connection)
+
+
+def test_all_executable_variants_equivalent_on_datafusion(datafusion_divergences):
+    """Every DataFusion-executable variant matches canonical TPC-H on DataFusion.
+
+    Both sides are translated to the datafusion dialect through the same seam and
+    compared on the same session, so a divergence here points at the dialect
+    translation layer (or a real variant defect), never at a cross-engine
+    mismatch against DuckDB or Postgres.
+    """
+    unexpected = {d.key for d in datafusion_divergences} - set(DATAFUSION_KNOWN_DIVERGENCES)
+    assert not unexpected, "Variant(s) diverge from canonical TPC-H on DataFusion: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in datafusion_divergences if d.key in unexpected
+    )
+
+
+def test_skipped_variants_are_excluded_never_marked_equivalent(datafusion_divergences):
+    """DATAFUSION_TPCHAVOC_SKIPS variants are excluded from the sweep entirely."""
+    reported = {d.key for d in datafusion_divergences}
+    assert reported.isdisjoint(set(DATAFUSION_TPCHAVOC_SKIPS)), (
+        "Un-executable (skip-list) variants must be excluded, not evaluated"
+    )

--- a/tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py
@@ -84,3 +84,21 @@ def test_skipped_variants_are_excluded_never_marked_equivalent(datafusion_diverg
     assert reported.isdisjoint(set(DATAFUSION_TPCHAVOC_SKIPS)), (
         "Un-executable (skip-list) variants must be excluded, not evaluated"
     )
+
+
+def test_datafusion_skip_list_wiring_and_lakesail_subset():
+    """The skip-list is wired to the 'datafusion' platform and stays a Sail subset.
+
+    No database needed: this pins the get_platform_skip_queries mapping (so real
+    DataFusion benchmark runs exclude exactly the un-executable variants) and the
+    documented claim that DataFusion's planning gaps are a strict subset of
+    LakeSail's (Apache Sail is DataFusion-based), which corroborates that these
+    are genuine engine limitations rather than translation artifacts.
+    """
+    from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
+    from benchbox.sql_compat.rules.execution_filter.lakesail_tpchavoc import LAKESAIL_TPCHAVOC_SKIPS
+
+    benchmark = TPCHavocBenchmark(scale_factor=EQUIVALENCE_SCALE)
+    assert set(benchmark.get_platform_skip_queries("datafusion")) == set(DATAFUSION_TPCHAVOC_SKIPS)
+    assert benchmark.get_platform_skip_queries("duckdb") == []
+    assert set(DATAFUSION_TPCHAVOC_SKIPS) <= set(LAKESAIL_TPCHAVOC_SKIPS)


### PR DESCRIPTION
## Why

A TPC-Havoc variant is written once and run, after dialect translation, on ~20 platforms. "Equivalent on DuckDB" does not imply "equivalent everywhere." The DuckDB SQL gate (#770, hard blocker) and the PostgreSQL sample (#803, `POSTGRES_KNOWN_DIVERGENCES` empty, 203/203 executable) gave a **two-engine** signal — but on engines with *similar* (PostgreSQL-family) gaps. This is the sequenced `deferred` follow-on of `tpchavoc-cross-dialect-equivalence-sampling`: a **third engine with a different gap profile**, to test whether the translation seam's fidelity is systematic or Postgres-specific.

## Engine choice: DataFusion

- **In-process** — the cheapest possible CI cost (no service container).
- **Different gap profile from Postgres**: DataFusion's limitations are in *physical planning* of correlated EXISTS/IN/scalar sub-queries (plus a missing `LIST` aggregate and an empty-tuple parser gap), whereas Postgres's are select-list-alias-in-HAVING/WHERE and aggregate-in-window. The skip-lists barely overlap (only `1_v7`, `4_v7`).

## What changed (reuses the oracle — no per-engine fork)

- `equivalence.py`: `build_datafusion_with_tpch`, `find_datafusion_divergences`, `run_datafusion_sample`, an empty engine-keyed `DATAFUSION_KNOWN_DIVERGENCES`, and `--engine datafusion`. Both canonical and variants are translated to the `datafusion` dialect (the seam normalizes it to `postgres`) and compared on the **same** in-process session, so shared translation cancels out. Reuses `find_divergences` + the shared `_report`.
- `datafusion_tpchavoc.py`: `DATAFUSION_TPCHAVOC_SKIPS` — the **14 variants DataFusion cannot plan**, registered for the `datafusion` platform and wired into `get_platform_skip_queries`. These are *excluded, never marked equivalent*. They are a **strict subset of `LAKESAIL_TPCHAVOC_SKIPS`** (Apache Sail is DataFusion-based), corroborating that they are genuine engine limitations, not translation artifacts.
- Live in-process integration test (module-scoped, sweep once, skips cleanly if DataFusion is absent) + a fast no-DB guard pinning the skip-list wiring and the LakeSail-subset claim.
- New non-blocking `datafusion-integration` CI job, `make tpchavoc-equivalence-report-datafusion`, and a new TODO ledger entry.

## Result (w1)

Raw sweep surfaced **14 divergences — all DataFusion *execution* failures, zero result mismatches** (the same SQL passes the DuckDB gate). Classified as engine-can't-execute → skip-list. After exclusion: **206/206 executable variants result-equivalent at SF=0.1, zero divergences** → `DATAFUSION_KNOWN_DIVERGENCES` empty, mirroring Postgres.

## CI posture (w3)

Option (a): a bounded check in a **non-blocking** `datafusion-integration` job (`continue-on-error: true`). The surface is empty and the run is fast (~15s, in-process), so option (b)'s trigger does not apply. The **DuckDB SQL gate stays the only hard blocker**. We deliberately do not gate the other ~17 platforms in routine CI.

## Three-engine conclusion (w4)

**Translation divergence is systematic-zero, not engine-specific.** Across DuckDB (220/220), PostgreSQL (203/203 executable), and DataFusion (206/206 executable) — engines with materially different feature sets and barely-overlapping skip-lists — every variant the engine can execute is result-equivalent to canonical TPC-H run through the same translation on the same instance. Cross-engine differences live entirely in *which* variants execute (bounded by per-engine skip-lists), never in the *results* of the ones that do. A fourth engine is worth sequencing only if it contrasts on *result* semantics (NULL ordering, integer division, implicit casts) — recorded in `deferred`, gated on such evidence.

## Verification

- DuckDB hard gate: **220/220, exit 0** (unchanged, `KNOWN_DIVERGENCES` empty).
- PostgreSQL sample: unchanged (`POSTGRES_KNOWN_DIVERGENCES`/`POSTGRES_TPCHAVOC_SKIPS` untouched); clean-skips without a server.
- DataFusion sample: **206/206, exit 0**; live integration test green (3 tests).
- `ruff check`, `ruff format --check`, `ty check`, `tests/unit/test_marker_strategy.py`, fast no-DB plumbing test all pass.
- New TODO ledger validates.

https://claude.ai/code/session_01K3L6FQa68foEmM8upaC3c1

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3L6FQa68foEmM8upaC3c1)_