### PR TITLE
docs(todo): plan TPC power-driver plan persistence + phase ANALYZE opt-in

### DIFF
--- a/_project/TODO/main/planning/query-plan-capture-phase-analyze-opt-in.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-phase-analyze-opt-in.yaml
@@ -1,0 +1,145 @@
+id: query-plan-capture-phase-analyze-opt-in
+title: "Add an opt-in to capture ANALYZE plans in the post-measurement phase"
+worktree: main
+priority: Low
+status: Not Started
+category: Core Functionality
+
+description: |
+  As of #805, plan capture for phase-eligible engines (DuckDB, MotherDuck,
+  SQLite, DataFusion, PostgreSQL, Redshift) runs in an isolated post-measurement
+  phase that is STRUCTURAL-ONLY: `_capture_plans_post_measurement` calls
+  `run_plan_capture_phase(..., analyze_plans=False)` unconditionally. This is the
+  intended default (no re-execution cost, DML runs exactly once), and the
+  structural `plan_fingerprint` is unaffected.
+
+  The trade-off: captured `query_plan` objects for these engines no longer carry
+  ACTUAL per-operator timing/cardinality (the `EXPLAIN ANALYZE` stats). Before
+  #805, `benchbox run --platform duckdb --capture-plans` (with the default
+  `analyze_plans=true`) produced ANALYZE plans inline. `--platform-option
+  analyze_plans=true` is now effectively ignored by the phase, so there is no way
+  to get actual-stats plans for eligible engines.
+
+  This TODO adds an explicit opt-in that re-enables ANALYZE capture IN THE PHASE,
+  while preserving the structural-only default and the DML-exactly-once guarantee
+  (the shared `is_dml_query` guard already downgrades writes to non-ANALYZE
+  EXPLAIN even when ANALYZE is requested, so DML is never re-executed). ANALYZE
+  in the phase re-executes SELECTs once post-measurement — off the timed path —
+  so it costs roughly 1x query time per captured SELECT, paid only when opted in.
+
+prior_art:
+  - "benchbox/platforms/base/execution.py:_capture_plans_post_measurement (~line 1457) — calls run_plan_capture_phase(analyze_plans=False); the single place to thread the opt-in"
+  - "benchbox/core/plan_capture_phase.py:run_plan_capture_phase — already accepts analyze_plans=<bool>; no signature change needed"
+  - "benchbox/platforms/base/result_capture.py:is_dml_query — downgrades DML/write-DDL to non-ANALYZE even when analyze=True, preserving DML-once"
+  - "benchbox/platforms/base/adapter.py:138 — self.analyze_plans = config.get('analyze_plans', True); existing platform-option already parsed"
+  - "benchbox/cli/commands/run.py:2584 — existing --platform-option analyze_plans help text; CLI surface to extend or reuse"
+
+work:
+  - id: w1
+    summary: "Decide the opt-in surface (resolve the gating open_question)"
+    status: pending
+    notes: |
+      Choose between (a) a new dedicated setting `plan_capture_analyze` (default
+      False) decoupled from `analyze_plans`, or (b) reusing the existing
+      `analyze_plans` platform-option to drive the phase. Recommendation: (a) — a
+      new flag keeps the #805 structural-only DEFAULT intact (analyze_plans
+      defaults to True, so reusing it would silently revert #805 to ~1x-cost
+      capture by default). Document the chosen semantics.
+
+  - id: w2
+    summary: "Thread the opt-in through _capture_plans_post_measurement"
+    needs: [w1]
+    status: pending
+    notes: |
+      Pass analyze_plans=<opt-in value> (default False) into run_plan_capture_phase
+      from _capture_plans_post_measurement. No change to run_plan_capture_phase
+      itself (it already supports analyze_plans). Update the helper docstring.
+
+  - id: w3
+    summary: "Wire the opt-in from CLI/config onto the adapter"
+    needs: [w2]
+    status: pending
+    notes: |
+      Register the chosen flag (CLI flag or --platform-option key) in
+      benchbox/cli/commands/run.py and store it on the adapter (alongside the
+      existing plan-capture settings in PlatformAdapter.__init__). Default off.
+
+  - id: w4
+    summary: "Tests: opt-in yields ANALYZE plans; default stays structural; DML still once"
+    needs: [w3]
+    status: pending
+    notes: |
+      DuckDB file-based (extend tests/integration/test_plan_capture_phase.py):
+        - opt-in ON: captured plan for a SELECT carries actual operator
+          timing/cardinality (ANALYZE fields present in the parsed DAG).
+        - opt-in OFF (default): plan is structural-only (no ANALYZE fields) —
+          guards the #805 default.
+        - DML query with opt-in ON: row count unchanged (is_dml_query still
+          downgrades to non-ANALYZE → executed exactly once).
+
+  - id: w5
+    summary: "Docs: document the ANALYZE opt-in and its cost/DML-safety"
+    needs: [w4]
+    status: pending
+    notes: |
+      Update docs/features/query-plan-analysis.md "Capture Isolation
+      (post-measurement phase)" to describe the opt-in: structural-only by
+      default; opt-in re-enables ANALYZE (≈1x query cost per SELECT, paid
+      post-measurement); DML always runs once regardless.
+
+deps:
+  needs:
+    - "query-plan-capture-isolation-phase-design"
+
+must_preserve:
+  - "Structural-only remains the DEFAULT for the phase (the #805 behavior) — the opt-in must be off unless explicitly requested."
+  - "DML/write-DDL runs exactly once even with ANALYZE opted in (is_dml_query downgrade)."
+  - "plan_fingerprint values are unchanged whether or not ANALYZE is used (fingerprint excludes timing/cardinality)."
+  - "Measurement timings are unaffected — ANALYZE re-execution happens only in the post-measurement phase, never on the timed path."
+
+approach: |
+  Smallest viable change: run_plan_capture_phase already accepts analyze_plans, so
+  the work is (1) pick the opt-in surface (prefer a new plan_capture_analyze flag
+  to avoid disturbing the structural-only default), (2) pass it through
+  _capture_plans_post_measurement, (3) parse/store it from the CLI. Lean on the
+  existing is_dml_query guard for DML safety rather than adding new write
+  detection.
+
+anti_patterns:
+  - "DO NOT reuse analyze_plans (default True) as the phase opt-in without care — it would silently revert the #805 structural-only default to ~1x-cost capture for every eligible engine."
+  - "DO NOT add a second DML guard — is_dml_query already downgrades writes even under ANALYZE; reuse it."
+  - "DO NOT move ANALYZE re-execution onto the measurement path — it belongs strictly in the post-measurement phase."
+
+verification:
+  - description: "Opt-in captures ANALYZE stats; default stays structural"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_phase.py -k analyze -v"
+    expected_output: "opt-in run shows actual operator timing/cardinality; default run does not; DML row count unchanged"
+  - description: "Existing plan-capture suite still passes"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_phase.py tests/integration/test_plan_capture_e2e.py -v"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/platforms/base/adapter.py"
+    - "benchbox/cli/commands/run.py"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/integration/"
+    - "_project/TODO/main/planning/query-plan-capture-phase-analyze-opt-in.yaml"
+
+success_metrics:
+  - "An explicit opt-in produces ANALYZE plans (actual operator timing/cardinality) for eligible engines via --capture-plans."
+  - "Without the opt-in, the phase remains structural-only (the #805 default)."
+  - "DML queries run exactly once with the opt-in enabled."
+
+open_questions:
+  - question: "Reuse the existing analyze_plans platform-option, or add a dedicated plan_capture_analyze flag?"
+    gating: true
+    affects: ["w1", "w3"]
+    default: "Add a dedicated plan_capture_analyze flag (default False); leaves analyze_plans (default True, used for inline/non-eligible platforms and display) untouched and preserves the #805 structural-only default for the phase."
+
+metadata:
+  tags: [query-plan, capture, analyze, opt-in, ergonomics]
+  estimated_effort: "Small"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/_project/TODO/main/planning/query-plan-capture-tpc-power-driver-persistence.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-tpc-power-driver-persistence.yaml
@@ -1,0 +1,170 @@
+id: query-plan-capture-tpc-power-driver-persistence
+title: "Persist captured query plans for the TPC-H and TPC-DS power drivers"
+worktree: main
+priority: Medium
+status: Not Started
+category: Core Functionality
+
+description: |
+  `--capture-plans` is effectively a no-op for the two flagship benchmarks,
+  TPC-H and TPC-DS. The generic query pipeline (`_execute_all_queries`) captures
+  and persists plans (inline pre-#805, isolated post-measurement phase as of
+  #805), but the TPC power drivers do not:
+
+  1. `_power_query_result()` (benchbox/platforms/base/execution.py) — the adapter
+     that converts a `TPCHPowerTest` / `TPCDSPowerTest` per-query result into the
+     platform result shape — DROPS the plan fields. It copies query_id, timing,
+     status, rows, stream/position/iteration, but never `query_plan`,
+     `plan_fingerprint`, or `plan_capture_time_ms`. So even if a plan were
+     captured, it would not reach the result bundle.
+  2. `TPCHPowerTest` / `TPCDSPowerTest` themselves do no plan capture, and the
+     post-measurement phase wired in #805 lives only in `_execute_all_queries`,
+     not in `_execute_tpch_power_test` / `_execute_tpcds_power_test`.
+
+  Net effect: `benchbox run --platform duckdb --benchmark tpch --capture-plans`
+  produces a bundle with NO plans for any query. This TODO closes that gap by
+  (a) plumbing the plan fields through `_power_query_result`, and (b) running the
+  isolated post-measurement capture phase for the TPC power paths, reusing the
+  `_capture_plans_post_measurement` machinery from #805.
+
+  The exact executed SQL (with TPC parameter substitution) is available from the
+  power test: `TPCHPowerTest` builds `query_text` via `benchmark.get_query(...)`
+  and records `(label, query_text)` in `self.captured_items` (and an equivalent
+  label->SQL map). The capture phase must use that substituted SQL — not the raw
+  templates — so the captured plan matches what actually ran.
+
+prior_art:
+  - "benchbox/platforms/base/execution.py:_capture_plans_post_measurement — the #805 post-measurement phase helper to reuse (reuses the measurement connection, structural-only, respects sampling filters)"
+  - "benchbox/platforms/base/execution.py:_power_query_result — drops query_plan/plan_fingerprint/plan_capture_time_ms; must be extended to carry them"
+  - "benchbox/platforms/base/execution.py:_execute_tpch_power_test (~line 119) — measurement iterations end before `return all_results`; phase hook goes there"
+  - "benchbox/platforms/base/execution.py:_execute_tpcds_power_test (~line 352) — same structure as TPC-H"
+  - "benchbox/core/tpch/power_test.py:283 — query_text = benchmark.get_query(query_id, ...) and captured_items.append((label, query_text)); the substituted SQL source"
+  - "benchbox/core/plan_capture_phase.py:run_plan_capture_phase — the building block (connection reuse + respect_sampling_filters)"
+  - "benchbox/platforms/base/adapter.py:plan_capture_phase_eligible — opt-in flag already True for DuckDB/MotherDuck/SQLite/DataFusion/PostgreSQL/Redshift"
+
+work:
+  - id: w1
+    summary: "Plumb plan fields through _power_query_result"
+    status: pending
+    notes: |
+      Extend _power_query_result() to copy query_plan, plan_fingerprint, and
+      plan_capture_time_ms from the source query_result dict when present (mirror
+      how _merge_plan_capture_into_result names them). No capture logic here —
+      just stop dropping the fields so a later-merged plan survives to the bundle.
+
+  - id: w2
+    summary: "Expose the executed (substituted) SQL keyed by query_id from the TPC power tests"
+    status: pending
+    notes: |
+      The phase needs {query_id: executed_sql}. Source it from the power test's
+      captured_items / label->SQL map (TPCHPowerTest builds query_text via
+      benchmark.get_query with the run's seed/stream). Provide a small accessor or
+      reuse captured_items rather than re-deriving templates, so the captured plan
+      matches the executed text. Resolve the gating open_question first (which
+      iteration's substitution to capture).
+
+  - id: w3
+    summary: "Run the post-measurement capture phase in _execute_tpch_power_test"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      After all MEASUREMENT iterations complete (not warmup, not per-iteration),
+      and only when capture_plans + plan_capture_phase_eligible, call
+      _capture_plans_post_measurement(connection, {query_id: executed_sql},
+      results) over the measurement results. Reuse the measurement connection
+      exactly as _execute_all_queries does. Do NOT run during warmup and do NOT
+      capture per iteration (capture once over the final measurement set).
+
+  - id: w4
+    summary: "Run the post-measurement capture phase in _execute_tpcds_power_test"
+    needs: [w3]
+    status: pending
+    notes: |
+      Apply the same hook as w3 to the TPC-DS power driver. Factor the shared
+      logic (collect success query_ids -> executed SQL -> phase -> merge) into a
+      single helper so TPC-H and TPC-DS do not drift.
+
+  - id: w5
+    summary: "Integration tests: plans persist for TPC-H/TPC-DS power runs"
+    needs: [w4]
+    status: pending
+    notes: |
+      DuckDB, small scale (SF 0.01), benchmark=tpch then tpcds, capture_plans=True.
+      Assert: every successful measurement query result carries a 64-char hex
+      plan_fingerprint; capture happens once post-measurement (not per iteration);
+      power metrics (Power@Size, timings) are unchanged vs a no-capture run within
+      tolerance. Reuse the DuckDB file-based pattern from
+      tests/integration/test_plan_capture_phase.py.
+
+  - id: w6
+    summary: "Docs: note TPC-H/TPC-DS now persist plans via the post-measurement phase"
+    needs: [w5]
+    status: pending
+    notes: |
+      Update docs/features/query-plan-analysis.md "Capture Isolation
+      (post-measurement phase)" section to state the phase now also covers the
+      TPC-H/TPC-DS power drivers (previously generic-only).
+
+deps:
+  needs:
+    - "query-plan-capture-isolation-phase-design"
+
+must_preserve:
+  - "TPC-H/TPC-DS Power@Size and per-query timings must be unaffected — capture runs strictly after all measurement iterations, off the timed path."
+  - "Throughput (concurrent multi-stream) paths must NOT gain the phase — _execute_tpch_throughput_test / _execute_tpcds_throughput_test stay capture-free (stream isolation is out of scope, per the isolation-phase TODO anti-patterns)."
+  - "Warmup iterations must not trigger capture."
+  - "Generic-path capture behavior from #805 (_execute_all_queries) is unchanged."
+
+approach: |
+  Land w1 (the field plumbing) first — it is independently safe and makes any
+  later-merged plan observable. Then add the executed-SQL accessor (w2) and wire
+  the shared phase hook into the TPC-H driver (w3), reusing
+  _capture_plans_post_measurement verbatim (it already reuses the measurement
+  connection, is structural-only, and honours sampling filters). Factor a single
+  TPC helper before duplicating into TPC-DS (w4) so the two drivers cannot drift.
+  Capture once over the final measurement iteration's results, not per iteration.
+
+anti_patterns:
+  - "DO NOT capture per measurement iteration — capture once after the loop; plans are structural and identical across iterations, so per-iteration capture is wasted EXPLAIN work."
+  - "DO NOT add capture to the throughput concurrent-stream drivers — that is explicitly out of scope (see query-plan-capture-isolation-phase-design anti_patterns)."
+  - "DO NOT capture from raw query templates — use the power test's substituted query_text so the plan matches the executed SQL."
+  - "DO NOT re-introduce inline capture inside the timed query loop — keep EXPLAIN off the measurement path."
+
+verification:
+  - description: "TPC-H power run with DuckDB persists plan fingerprints"
+    command: "uv run -- python -m pytest tests/integration/ -k 'tpc and capture' -v"
+    expected_output: "Every successful TPC-H/TPC-DS measurement query result has a plan_fingerprint"
+  - description: "Generic-path and existing plan-capture tests still pass"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_phase.py tests/integration/test_plan_capture_e2e.py -v"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/core/tpch/power_test.py"
+    - "benchbox/core/tpcds/power_test.py"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/integration/"
+    - "_project/TODO/main/planning/query-plan-capture-tpc-power-driver-persistence.yaml"
+
+success_metrics:
+  - "benchbox run --benchmark tpch --capture-plans (DuckDB) produces a bundle with a plan_fingerprint for every successful measurement query."
+  - "Same for tpcds."
+  - "TPC-H/TPC-DS Power@Size and timings are unchanged (within run-to-run tolerance) with vs without --capture-plans."
+  - "No capture occurs in warmup iterations or throughput streams."
+
+open_questions:
+  - question: "Each measurement iteration runs a different stream_id/seed, so TPC parameter substitution differs per iteration. Which iteration's executed SQL should the single post-measurement capture use?"
+    gating: true
+    affects: ["w2", "w3"]
+    default: "Capture using the LAST measurement iteration's substituted SQL (the connection state and substitutions most recently exercised); record stream_id in the captured plan record for provenance."
+  - question: "Should the captured plan records be keyed per (query_id) or per (query_id, stream_id) for TPC, given multi-iteration substitution?"
+    gating: false
+    affects: ["w1", "w5"]
+    default: "Per query_id for the power phase (single representative structural plan); throughput per-stream provenance remains out of scope."
+
+metadata:
+  tags: [query-plan, tpch, tpcds, capture, power-test]
+  estimated_effort: "Medium"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"


### PR DESCRIPTION
Adds two planning TODOs capturing the follow-ups identified after the plan-capture isolation work (#798/#805). Planning-only — no code changes.

## `query-plan-capture-tpc-power-driver-persistence` (Medium)

`--capture-plans` is effectively a **no-op for TPC-H and TPC-DS** today: `_power_query_result` drops `query_plan`/`plan_fingerprint`/`plan_capture_time_ms`, and the post-measurement capture phase from #805 is wired only into the generic `_execute_all_queries` path — not the TPC power drivers. The plan:
- plumb the plan fields through `_power_query_result` (w1),
- expose the executed (parameter-substituted) SQL from the power tests (w2),
- run `_capture_plans_post_measurement` once after the measurement iterations in the TPC-H and TPC-DS power drivers (w3/w4), excluding warmup and the throughput concurrent-stream paths,
- tests + docs (w5/w6).

Includes a gating open-question on which measurement iteration's substituted SQL to capture.

## `query-plan-capture-phase-analyze-opt-in` (Low)

#805 made phase capture **structural-only** for eligible engines, so `EXPLAIN ANALYZE` plans (actual operator timing/cardinality) are no longer reachable via `--capture-plans`. The plan: add an explicit opt-in that re-enables ANALYZE in the post-measurement phase while keeping the structural-only **default** and the **DML-exactly-once** guarantee (the existing `is_dml_query` guard downgrades writes even under ANALYZE). `run_plan_capture_phase` already accepts `analyze_plans`, so the change is small.

## Review / correctness

Both files validate against `TODO_SCHEMA.yaml` (`validate_todo.py` ✅), `todo_cli.py check-graph` is clean (79 items, no cycles/dangling refs; `deps.needs → query-plan-capture-isolation-phase-design` resolves), and `tests/unit/test_todo_executable_docs.py` passes. Every `prior_art` anchor was verified against the current code (e.g. `_power_query_result` dropping plan fields; `_capture_plans_post_measurement` calling `run_plan_capture_phase(analyze_plans=False)`; TPC power tests building substituted `query_text` via `benchmark.get_query(...)`).

https://claude.ai/code/session_017QzkP7Z4himacTdL1sDreX

---
_Generated by [Claude Code](https://claude.ai/code/session_017QzkP7Z4himacTdL1sDreX)_