### PR TITLE
docs(todo): canonical plan-capture isolation plan + correct status conflicts

### DIFF
--- a/_project/TODO/main/planning/query-plan-capture-canonical-isolation.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-canonical-isolation.yaml
@@ -1,0 +1,183 @@
+id: query-plan-capture-canonical-isolation
+title: "Canonical plan-capture isolation: one isolated phase for all engines, analyze_plans the only knob"
+worktree: main
+priority: High
+category: Core Functionality
+status: Not Started
+
+description: |
+  TARGET ARCHITECTURE (supersedes the additive design of
+  query-plan-capture-isolation-phase-design):
+
+  Query plan capture is, and must be, a FULLY SEPARATE and FULLY ISOLATED concern
+  from measurement runs. There is exactly one capture path: a post-measurement
+  isolated phase that runs after all timed queries complete, on a connection that
+  cannot perturb the measured run. The ONLY user-facing capture option is
+  analyze_plans: ANALYZE (re-run each query once, post-measurement, for full
+  execution detail) vs. estimated (a static EXPLAIN, no re-execution). Capture is
+  NOT interleaved with measurement for any engine, and there is no per-adapter
+  "is this engine allowed to use the phase" opt-in.
+
+  CURRENT STATE (develop, verified 2026-06-15) — how far we are:
+    - The isolated phase exists (benchbox/core/plan_capture_phase.py) and is wired
+      into ONE execution path (execution.py:_execute_all_queries / power+standard)
+      behind an opt-in capability flag (PlatformAdapter.plan_capture_phase_eligible),
+      enabled on only 6 adapters: DuckDB, MotherDuck, PostgreSQL, Redshift, SQLite,
+      DataFusion.
+    - Inline capture (capture inside execute_query) is STILL PRESENT in ~16
+      adapters and is NOT removed; for the 6 eligible adapters it is merely
+      suppressed in the power/standard path and left active everywhere else.
+    - Consequence A (dual path): the same eligible adapter captures via the
+      ISOLATED phase in power/standard mode but via the INLINE path in throughput,
+      maintenance, and combined modes (the phase logic lives only in
+      _execute_all_queries; throughput drivers do not suppress inline or run the
+      phase). Capture semantics depend on (adapter x test-type) — incoherent.
+    - Consequence B (dead knob): the phase calls run_plan_capture_phase WITHOUT
+      analyze_plans, so it is hard-coded structural-only and ignores the adapter's
+      analyze_plans. `--capture-plans` on eligible adapters silently lost ANALYZE
+      timing — a regression and the deletion of the one knob that should exist.
+      (Fixed by query-plan-capture-phase-respect-analyze.)
+    - Consequence C (wrong exclusions): Spark and Databricks are excluded from the
+      phase on the premise that they "depend on inline / side-effect capture", but
+      both use EXPLAIN EXTENDED and are FULLY isolatable with no loss. Only
+      BigQuery-class engines (plan/stats are a true side effect of the executed
+      job) are a genuine exception, and BigQuery is not wired for capture at all.
+
+  This TODO is the umbrella for reaching the target. It depends on the analyze
+  knob fix landing first, coordinates the side-effect exception policy, and tracks
+  the remaining structural work: universal eligibility, all-test-type coverage,
+  removal of the inline path, knob-surface collapse, and the post-measurement
+  divergence decision.
+
+design_note: |
+  Capture phase contract (canonical):
+    - Position: strictly after the last timed query of every test type (power,
+      throughput, maintenance, combined). Never inside the timed loop, never inside
+      a concurrent stream.
+    - Selection: each distinct executed query is captured exactly once. There is no
+      per-iteration or per-stream re-capture; the plan is a property of (query,
+      schema, engine), not of an execution. This removes the need for the inline-era
+      sampling machinery (plan_first_n / plan_sampling_rate) and its concurrency lock.
+    - Knob: analyze_plans only. True => EXPLAIN (ANALYZE) post-measurement (full
+      execution detail; each query re-run once, outside the measured window; writes
+      stay on non-ANALYZE EXPLAIN via the is_dml_query guard). False => static EXPLAIN.
+    - Eligibility: default ON for every EXPLAIN-based engine. A small, explicit
+      EXCEPTION list covers engines whose plan is only obtainable as a side effect of
+      the measured job (BigQuery; assess Snowflake) — see
+      query-plan-capture-sideeffect-engine-policy.
+    - Connection: reuse the measurement connection (so embedded :memory: engines see
+      the loaded data); isolation comes from running post-measurement, not from a
+      second connection.
+    - Divergence: when the workload mutates data mid-run (TPC-H RF1/RF2, TPC-DS
+      maintenance, combined mode, any DML query) a post-measurement capture reflects
+      POST-mutation cardinalities, which can differ from the plan that actually ran.
+      Resolution is tracked in query-plan-capture-post-measurement-divergence.
+
+work:
+  - id: w1
+    summary: "Ratify the canonical contract and update isolation-phase-design as superseded"
+    status: pending
+    notes: |
+      Record the contract above as the single source of truth. Add a superseded note
+      + pointer on query-plan-capture-isolation-phase-design (its additive cutover is
+      an intermediate step, not the destination); narrow its anti-patterns that
+      enshrine permanent inline coexistence to the true exception (BigQuery-class).
+  - id: w2
+    summary: "Default phase eligibility ON for all EXPLAIN-based engines (incl. Spark/Databricks)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Invert plan_capture_phase_eligible from opt-in to default-True, with an explicit
+      exception list for genuine side-effect engines. Enable Spark/Databricks and the
+      inline-only EXPLAIN engines (athena, doris, questdb, singlestore, presto/trino,
+      clickhouse, databend). Verify each produces a parseable plan via the phase.
+  - id: w3
+    summary: "Run the capture phase for ALL test types, not just power/standard"
+    needs: [w1]
+    status: pending
+    notes: |
+      Move the suppress-inline + post-measurement-capture logic out of
+      _execute_all_queries into a shared place that throughput, maintenance, and
+      combined drivers all reach, so capture fires once per run after the last timed
+      query regardless of test type. Do NOT capture inside concurrent streams.
+  - id: w4
+    summary: "Remove the inline capture path from EXPLAIN-based adapters and its dead complexity"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Delete the inline capture calls from execute_query in the EXPLAIN-based adapters
+      (the _merge_plan_capture_into_result / capture_query_plan blocks), leaving only
+      get_query_plan + get_query_plan_parser. Retire the now-moot sampling machinery
+      (plan_first_n/plan_sampling_rate) and the _plan_capture_iteration_counts lock
+      (added only for the concurrent inline path). Keep inline ONLY for the genuine
+      side-effect exception engines.
+  - id: w5
+    summary: "Collapse the capture knob surface to analyze_plans"
+    needs: [w4]
+    status: pending
+    notes: |
+      Reduce the user-facing surface to: --capture-plans (run the phase) and
+      analyze_plans (the one mode knob, promoted from a buried --platform-option to a
+      first-class option). Reconcile show_query_plans (display) as an orthogonal
+      concern (see query-plan-capture-display-decouple), not coupled to capture.
+  - id: w6
+    summary: "Docs + end-to-end test for the canonical model"
+    needs: [w4, w5]
+    status: pending
+    notes: |
+      Document capture as a single isolated post-measurement phase with analyze_plans
+      as the only knob; add an integration test asserting capture fires after every
+      test type, inline never fires for EXPLAIN engines, and plan_fingerprints land in
+      results identically to today.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "plan_fingerprints / query_plan / plan_capture_time_ms continue to land on query_results and aggregate stats exactly as today (compute_plan_capture_stats stays valid)."
+  - "Measured timing (per-query, power, throughput) stays free of capture cost."
+  - "Genuine side-effect engines (BigQuery) keep a working capture path defined by the side-effect-policy TODO."
+  - "DML/write-DDL is never executed twice by capture."
+
+anti_patterns:
+  - "DO NOT keep capture as a per-adapter opt-in - because it produces a dual path and per-test-type inconsistency - make the isolated phase the default for all EXPLAIN engines."
+  - "DO NOT leave inline capture in EXPLAIN-based adapters as a permanent fallback - because two live capture paths drift and contradict - remove it once the phase covers all test types."
+  - "DO NOT add knobs beyond analyze_plans - because the contract is ANALYZE-vs-estimated only - retire sampling/first_n and keep display as a separate concern."
+  - "DO NOT capture inside concurrent throughput streams - because that re-contends on stream connections - capture once after all streams finish."
+
+verification:
+  - description: "Inline capture never fires for EXPLAIN engines across all test types"
+    command: "uv run -- python -m pytest tests/integration/ -k 'capture_phase and (throughput or maintenance or combined)' -v"
+    expected_output: "capture happens only in the post-measurement phase for every test type"
+  - description: "Full platform suite green after inline removal"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -q"
+    expected_output: "0 failures, 0 errors"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/platforms/base/adapter.py"
+    - "benchbox/core/plan_capture_phase.py"
+    - "benchbox/platforms/"
+    - "benchbox/cli/commands/run.py"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/"
+
+success_metrics:
+  - "Exactly one capture path (the isolated phase) for every EXPLAIN-based engine, across every test type."
+  - "Inline capture code is removed from EXPLAIN-based adapters; only get_query_plan/get_query_plan_parser remain."
+  - "analyze_plans is the only capture knob; sampling/first_n machinery and its lock are gone."
+  - "Spark and Databricks capture via the phase; only documented side-effect engines remain on a special path."
+
+open_questions:
+  - question: "Promote analyze_plans to a first-class --analyze-plans/--no-analyze-plans flag, or keep it as --platform-option?"
+    gating: false
+    affects: ["w5"]
+    default: "Promote to a first-class capture option since it is now the sole knob."
+
+metadata:
+  tags: [query-plan, capture, isolation-phase, architecture, refactor]
+  estimated_effort: "Large"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-isolation-phase-design.yaml
@@ -4,6 +4,22 @@ worktree: main
 priority: High
 status: Completed
 category: Core Functionality
+superseded_by: query-plan-capture-canonical-isolation
+
+# SUPERSEDED (2026-06-15): The cutover this item delivered is an ADDITIVE,
+# opt-in-per-adapter intermediate step, NOT the destination. It (a) makes the
+# isolated phase opt-in via plan_capture_phase_eligible on only 6 adapters while
+# leaving inline capture present in ~16 adapters, (b) only runs in the
+# power/standard path (throughput/maintenance/combined still capture inline, so an
+# eligible adapter behaves differently by test type), and (c) hard-codes the phase
+# to structural-only, silently dropping ANALYZE timing and killing the
+# analyze_plans knob. The canonical target — ONE isolated phase for ALL EXPLAIN
+# engines, across ALL test types, with analyze_plans as the only knob and inline
+# capture REMOVED — is tracked by query-plan-capture-canonical-isolation (and its
+# siblings: -phase-respect-analyze, -sideeffect-engine-policy,
+# -post-measurement-divergence). The anti-patterns below that enshrine permanent
+# inline coexistence apply ONLY to genuine side-effect engines (BigQuery), not to
+# EXPLAIN-based engines.
 
 # PROGRESS:
 #   2026-06-14 (PR #798): w1 (design note) DONE; w2 (thread safety) DONE; phase

--- a/_project/TODO/main/planning/query-plan-capture-phase-respect-analyze.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-phase-respect-analyze.yaml
@@ -1,0 +1,119 @@
+id: query-plan-capture-phase-respect-analyze
+title: "Make the isolated capture phase respect analyze_plans (restore the ANALYZE knob)"
+worktree: main
+priority: High
+category: Core Functionality
+status: Not Started
+
+description: |
+  The isolated post-measurement capture phase wired in by the CLI/orchestrator
+  cutover (benchbox/platforms/base/execution.py:_capture_plans_post_measurement,
+  landed ~2026-06-15) calls run_plan_capture_phase() WITHOUT passing analyze_plans:
+
+      phase = run_plan_capture_phase(self, success_queries, connection=connection,
+                                     respect_sampling_filters=True)
+
+  run_plan_capture_phase defaults analyze_plans=False and overwrites
+  self.analyze_plans for the duration of the phase. The net effect: for every
+  phase-eligible adapter (DuckDB, MotherDuck, PostgreSQL, Redshift, SQLite,
+  DataFusion) `--capture-plans` now produces STRUCTURAL-ONLY plans with no
+  execution statistics — even when the user left analyze_plans at its True
+  default or explicitly passed --platform-option analyze_plans=true.
+
+  Two problems:
+    1. Silent regression. Before the cutover, `--capture-plans` on DuckDB/Postgres
+       captured EXPLAIN (ANALYZE) plans with actual per-operator timing and
+       cardinality. After it, eligible adapters silently lost that — the captured
+       plan is now an estimate. Docs (query-plan-analysis.md, recently corrected
+       in #793) again describe behavior the code no longer has.
+    2. It deletes the one knob that SHOULD exist. The intended contract is that
+       ANALYZE-vs-estimated is the only user-facing capture option. The phase
+       currently hard-codes estimated and ignores analyze_plans entirely, so the
+       knob is dead for exactly the adapters that go through the phase, while it
+       still works for the inline (non-eligible) adapters — an incoherent split.
+
+  Fix: the phase must thread the adapter's analyze_plans through to
+  run_plan_capture_phase(..., analyze_plans=self.analyze_plans). With analyze_plans
+  True (default) the phase issues EXPLAIN (ANALYZE) post-measurement (full
+  execution detail, re-running each query once AFTER the timed loop so measurement
+  is unaffected); with analyze_plans False it issues a static EXPLAIN (estimate,
+  no re-execution). The shared is_dml_query write guard must still downgrade
+  writes to non-ANALYZE EXPLAIN so the post-measurement re-run does not mutate the
+  loaded data a second time.
+
+prior_art:
+  - "benchbox/platforms/base/execution.py — _capture_plans_post_measurement (drops analyze_plans)"
+  - "benchbox/core/plan_capture_phase.py — run_plan_capture_phase(analyze_plans=False default)"
+  - "benchbox/platforms/base/result_capture.py — is_dml_query write guard (keeps DML on non-ANALYZE EXPLAIN)"
+
+work:
+  - id: w1
+    summary: "Thread analyze_plans from the adapter into the post-measurement phase call"
+    status: pending
+    notes: |
+      In _capture_plans_post_measurement pass analyze_plans=self.analyze_plans to
+      run_plan_capture_phase. Confirm run_plan_capture_phase saves/restores the
+      adapter's analyze_plans correctly (it already does for capture_plans).
+  - id: w2
+    summary: "Verify the is_dml_query guard still downgrades writes under ANALYZE in the phase"
+    needs: [w1]
+    status: pending
+    notes: |
+      With analyze_plans=True, a write statement (INSERT/UPDATE/DELETE/MERGE/COPY,
+      CTAS/CMV/SELECT INTO) must NOT be re-executed by the capture EXPLAIN. Assert
+      the adapter's get_query_plan emits a non-ANALYZE EXPLAIN for DML even when
+      analyze_plans=True, in the phase context.
+  - id: w3
+    summary: "Tests: phase honours analyze_plans (ANALYZE plan vs estimate) on an eligible adapter"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      Integration test on DuckDB: capture_plans=True + analyze_plans=True via the
+      phase yields a plan whose physical operator carries timing; analyze_plans=False
+      yields no timing. Assert a DML query runs exactly once with analyze_plans=True.
+  - id: w4
+    summary: "Re-correct docs to match restored behavior"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update docs/features/query-plan-analysis.md: phase-eligible adapters capture
+      ANALYZE plans by default (post-measurement, ~1x extra cost), analyze_plans=false
+      gives estimates. Note the capture re-run is outside the measured window.
+
+deps:
+  needs: []
+
+must_preserve:
+  - "Per-query execution_time_seconds and measured throughput/power metrics must remain free of capture cost (phase runs strictly after the timed loop)."
+  - "DML/write-DDL must not be re-executed by capture even when analyze_plans=True (is_dml_query guard stays in force)."
+  - "analyze_plans=False must remain available for cheap estimate-only capture."
+
+anti_patterns:
+  - "DO NOT keep the phase hard-coded to structural-only - because it silently drops ANALYZE timing and kills the one capture knob - pass analyze_plans through instead."
+  - "DO NOT re-run writes under ANALYZE in the phase - because it double-mutates the loaded data - keep the is_dml_query downgrade."
+
+verification:
+  - description: "Phase honours analyze_plans on DuckDB (ANALYZE -> timing; estimate -> none)"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_phase.py -k analyze -v"
+    expected_output: "analyze_plans=True yields per-operator timing; False yields none"
+  - description: "DML executes once with analyze_plans=True in the phase"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_phase.py -k dml_single_execution -v"
+    expected_output: "INSERT runs once; plan captured without ANALYZE re-execution"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/core/plan_capture_phase.py"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/integration/"
+
+success_metrics:
+  - "`--capture-plans` on phase-eligible adapters captures ANALYZE plans again by default."
+  - "analyze_plans is the single effective capture-detail knob in both phase and inline paths."
+  - "No write statement is executed twice during capture."
+
+metadata:
+  tags: [query-plan, capture, isolation-phase, analyze, regression]
+  estimated_effort: "Small"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/_project/TODO/main/planning/query-plan-capture-post-measurement-divergence.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-post-measurement-divergence.yaml
@@ -1,0 +1,102 @@
+id: query-plan-capture-post-measurement-divergence
+title: "Resolve post-measurement plan divergence when the workload mutates data mid-run"
+worktree: main
+priority: Medium-High
+category: Core Functionality
+
+status: Not Started
+
+description: |
+  The isolated capture phase runs AFTER all timed queries, on the measurement
+  connection. For read-only workloads this is exactly correct. But when the
+  workload MUTATES data during the run, the post-measurement capture sees the
+  POST-mutation database state, so the captured plan (and its cardinality
+  estimates / chosen join order) can differ from the plan the optimizer actually
+  chose when the query ran during measurement.
+
+  Concretely (verified 2026-06-15):
+    - Standard power and throughput query sets are SELECT-only (TPC-H/TPC-DS
+      permutations contain no DML), so no divergence there.
+    - Maintenance tests (TPC-H RF1/RF2 inserts+deletes, TPC-DS data maintenance)
+      and combined mode (power -> throughput -> maintenance) DO change table
+      cardinalities. In combined mode the maintenance step runs AFTER the measured
+      query phases, so a single post-run capture reflects post-maintenance data.
+    - Any benchmark whose query set itself contains DML has the same exposure.
+
+  This was a non-issue while capture was inline (the plan was captured at the
+  moment each query ran). Moving capture to a post-measurement phase introduces the
+  divergence, so the canonical-isolation work must resolve it rather than silently
+  capturing a plan that never ran.
+
+  Options to evaluate:
+    A) Capture-before-mutation: run the isolated capture pass at the point in the
+       lifecycle BEFORE the first data-mutating step (e.g. before maintenance in
+       combined mode), still outside any timed loop.
+    B) Per-phase capture: capture once per measured sub-phase (after power, before
+       maintenance) so each captured plan matches the data state it ran against.
+    C) Documented read-only contract: capture only for read-only runs; for runs that
+       mutate data, emit a clear warning that captured plans reflect end-of-run state
+       (and/or skip capture for the mutating queries).
+  The chosen option must keep capture out of the timed window and out of concurrent
+  streams.
+
+prior_art:
+  - "benchbox/platforms/base/execution.py — _capture_plans_post_measurement; _execute_combined_test (power->throughput->maintenance)"
+  - "benchbox/core/tpch/maintenance_test.py — RF1/RF2 (insert/delete, changes cardinalities)"
+
+work:
+  - id: w1
+    summary: "Characterize divergence: which test types / benchmarks mutate data before capture"
+    status: pending
+    notes: |
+      Enumerate the run shapes where the post-measurement DB state differs from the
+      measured state (combined mode, maintenance, DML-containing query sets). Quantify
+      whether captured fingerprints actually change for representative cases.
+  - id: w2
+    summary: "Decide the resolution (before-mutation / per-phase / documented contract)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Choose per the trade-offs; coordinate with query-plan-capture-canonical-isolation
+      w3 (all-test-type coverage) since both touch where in the lifecycle the phase fires.
+  - id: w3
+    summary: "Implement + test the chosen resolution"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add a test on DuckDB combined mode (or a DML-containing query set) asserting the
+      captured plan matches the data state it was measured against (or that the
+      documented warning fires and capture is skipped/labelled accordingly).
+
+deps:
+  needs:
+    - query-plan-capture-canonical-isolation
+
+must_preserve:
+  - "Read-only workloads keep capturing correct plans with no behavior change."
+  - "Capture stays outside the timed window and outside concurrent streams."
+
+anti_patterns:
+  - "DO NOT silently capture a post-mutation plan for a query that ran against pre-mutation data - because the fingerprint then describes a plan that never executed - capture before mutation or label/skip it."
+  - "DO NOT move capture back inside the timed loop to dodge this - because that re-contaminates measurement - solve it within the isolated-phase model."
+
+verification:
+  - description: "Combined/DML run captures a plan matching the measured data state (or warns)"
+    command: "uv run -- python -m pytest tests/integration/ -k 'capture and (combined or maintenance or mutation)' -v"
+    expected_output: "captured plan matches measured-state expectation or documented warning fires"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/core/plan_capture_phase.py"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/"
+
+success_metrics:
+  - "No run captures a plan that reflects a data state different from the one the query was measured against, without an explicit, documented label/warning."
+
+metadata:
+  tags: [query-plan, capture, isolation-phase, correctness, dml, maintenance]
+  estimated_effort: "Medium"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/_project/TODO/main/planning/query-plan-capture-sideeffect-engine-policy.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-sideeffect-engine-policy.yaml
@@ -1,0 +1,106 @@
+id: query-plan-capture-sideeffect-engine-policy
+title: "Define plan capture for side-effect engines (BigQuery) under the isolated-phase model"
+worktree: main
+priority: Medium
+category: Platform Expansion
+status: Not Started
+
+description: |
+  The canonical model (query-plan-capture-canonical-isolation) makes plan capture a
+  single isolated post-measurement phase for all EXPLAIN-based engines. A small set
+  of engines do not fit that model cleanly: their execution plan and statistics are
+  obtainable ONLY as a side effect of running the actual workload query, not from a
+  standalone EXPLAIN on a separate connection.
+
+  Verified classification (2026-06-15):
+    - BigQuery: GENUINE EXCEPTION. get_query_plan uses a dry-run that returns only a
+      cost/bytes estimate (a dict, not a parseable plan), while the real execution
+      plan/stage timing live on the executed QueryJob (job.query_plan, slot_ms,
+      bytes_billed). An isolated EXPLAIN/dry-run re-run yields only the estimate, and
+      a real re-run costs bytes (money) and duplicates the measured query. BigQuery is
+      ALSO not currently wired for capture at all (no parser, dict return type).
+    - Spark / Databricks: NOT exceptions — EXPLAIN EXTENDED is a standalone static
+      plan, fully isolatable with no loss. They belong in the phase (handled by the
+      canonical-isolation TODO), not here.
+    - Snowflake / other cloud SaaS: assess against the same test — EXPLAIN-able and
+      isolatable, or plan-as-job-side-effect?
+
+  This TODO decides and documents the policy for the genuine side-effect class and
+  wires it consistently. Options to weigh per engine:
+    A) Estimated-only in the phase: run the engine's dry-run/EXPLAIN in the isolated
+       phase, accept that no actual-execution detail is captured (analyze_plans is a
+       no-op for these engines), document the limitation.
+    B) Harvest from the measured job: capture the plan from the already-executed
+       job/profile during/after its own execution (the one inline exception),
+       explicitly carved out and documented as NOT going through the isolated phase.
+  The decision must keep "no second paid execution" for BigQuery and must not
+  reintroduce a general inline path for EXPLAIN-based engines.
+
+prior_art:
+  - "benchbox/platforms/bigquery.py:1714 get_query_plan (dry-run estimate, dict) and :1506 job_stats (actual)"
+  - "benchbox/platforms/base/spark_execution_mixin.py / databricks/adapter.py — EXPLAIN EXTENDED (isolatable)"
+  - "query-plan-capture-cloud-saas — parser + wiring work for Snowflake/BigQuery/Synapse/Firebolt/Fabric/Lakesail"
+  - "query-plan-capture-cloud-live-snowflake-bigquery — live CI for these engines"
+
+work:
+  - id: w1
+    summary: "Classify each cloud SaaS engine as isolatable-EXPLAIN vs side-effect-only"
+    status: pending
+    notes: |
+      For Snowflake, BigQuery, Azure Synapse, Firebolt, Fabric Warehouse, Lakesail:
+      determine whether a standalone EXPLAIN reproduces the plan (=> phase, like the
+      EXPLAIN engines) or whether the plan/stats are only on the executed job (=>
+      side-effect exception). Record the classification.
+  - id: w2
+    summary: "Decide the side-effect policy (estimated-in-phase vs harvest-from-job) and document it"
+    needs: [w1]
+    status: pending
+    notes: |
+      Pick option A or B per side-effect engine. Constraints: no second paid BigQuery
+      execution; analyze_plans semantics defined (likely a no-op for these); the
+      EXPLAIN-engine path stays inline-free.
+  - id: w3
+    summary: "Wire the chosen policy for BigQuery (and any other side-effect engine)"
+    needs: [w2]
+    status: pending
+    notes: |
+      Implement capture for BigQuery per the decision, coordinating with
+      query-plan-capture-cloud-saas (parser + wiring). Ensure it does not depend on
+      or reintroduce the removed EXPLAIN-engine inline path.
+
+deps:
+  needs:
+    - query-plan-capture-canonical-isolation
+
+must_preserve:
+  - "No second billed BigQuery query execution is introduced for capture."
+  - "Spark/Databricks remain on the isolated phase (not classified here)."
+  - "EXPLAIN-based engines keep exactly one (isolated) capture path."
+
+anti_patterns:
+  - "DO NOT force BigQuery through a standalone EXPLAIN re-run - because dry-run loses actual stats and a real re-run costs money - harvest from the executed job or accept estimate-only per the decision."
+  - "DO NOT use the BigQuery exception to justify keeping inline capture for EXPLAIN engines - because they are fully isolatable - the exception is narrow and explicit."
+
+verification:
+  - description: "BigQuery capture path documented and does not issue a second billed query"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k bigquery -q"
+    expected_output: "BigQuery capture follows the documented side-effect policy"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/bigquery.py"
+    - "benchbox/platforms/"
+    - "benchbox/core/query_plans/"
+    - "docs/features/query-plan-analysis.md"
+    - "tests/"
+
+success_metrics:
+  - "Every cloud SaaS engine is classified isolatable vs side-effect with evidence."
+  - "Side-effect engines have a documented capture policy that adds no extra paid execution."
+  - "The narrow exception does not leak back into the EXPLAIN-engine path."
+
+metadata:
+  tags: [query-plan, capture, bigquery, snowflake, side-effect, cloud]
+  estimated_effort: "Medium"
+  created_date: "2026-06-15"
+  last_updated: "2026-06-15T00:00:00-04:00"

--- a/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-dml-guard.yaml
+++ b/_project/TODO/platform-expansion/planning/query-plan-capture-postgresql-dml-guard.yaml
@@ -2,8 +2,18 @@ id: query-plan-capture-postgresql-dml-guard
 title: "Add DML guard to PostgreSQLAdapter.get_query_plan() to prevent double-execution of writes"
 worktree: platform-expansion
 priority: High
-status: Not Started
+status: Completed
 category: Platform Expansion
+
+# STATUS CORRECTION (2026-06-15): This was mis-marked Not Started. The guard
+# SHIPPED: PostgreSQLAdapter.get_query_plan() now calls the shared is_dml_query()
+# (benchbox/platforms/base/result_capture.py) and downgrades DML to non-ANALYZE
+# EXPLAIN (PR #784), and #786 extended is_dml_query to cover write-DDL
+# (CTAS / CREATE MATERIALIZED VIEW / SELECT ... INTO) for PostgreSQL, DuckDB and
+# MotherDuck. The guard REMAINS LOAD-BEARING under the isolated-capture redesign:
+# once query-plan-capture-phase-respect-analyze restores ANALYZE in the phase, the
+# post-measurement re-run would re-execute writes without this downgrade. A later
+# TODO sweep should move this file to _project/DONE/.
 
 description: |
   PostgreSQLAdapter.get_query_plan() at benchbox/platforms/postgresql.py:704 always


### PR DESCRIPTION
## Summary

A deep adversarial review of the query-plan-capture surface, prompted by the design principle that **capture must be a fully separate, fully isolated concern from measurement, with `analyze_plans` (ANALYZE vs estimated) as the only knob**. This PR is **planning-only** (TODO YAML; no production code): it records the corrected target, fixes status conflicts, and lays out a coherent migration.

## What the review found (verified against `develop` @ `b9a1e348`)

The isolated phase shipped as an **additive, opt-in-per-adapter intermediate** that does **not** meet the bar:
- **Dual path:** the phase is opt-in via `plan_capture_phase_eligible` on only **6** adapters (DuckDB, MotherDuck, PostgreSQL, Redshift, SQLite, DataFusion); inline capture is still present in **~16** adapters and only suppressed in the power/standard path.
- **Per-test-type inconsistency:** the phase runs only in `_execute_all_queries`; **throughput / maintenance / combined still capture inline**, so the *same* eligible adapter captures differently depending on test type.
- **Dead knob / silent regression:** `_capture_plans_post_measurement` calls `run_plan_capture_phase` without `analyze_plans`, hard-coding structural-only. `--capture-plans` on eligible adapters **silently lost ANALYZE timing**, and the one knob that should exist is ignored.
- **Wrong exclusions:** Spark and Databricks are excluded as "side-effect" engines, but both use `EXPLAIN EXTENDED` and are **fully isolatable**. Only **BigQuery** is a genuine exception (plan/stats are a true side effect of the executed job — and it isn't even wired for capture today).
- **Blind spot:** post-measurement capture reflects **post-mutation** cardinalities for data-mutating runs (combined mode, TPC-H RF1/RF2 maintenance, DML query sets) — capturing a plan that may differ from what actually ran.

## New TODOs (the corrected plan)
| ID | Priority | What it tracks |
|----|----------|----------------|
| `query-plan-capture-canonical-isolation` | High | Umbrella: one isolated phase for **all** EXPLAIN engines, across **all** test types, `analyze_plans` the only knob, inline capture **removed**. |
| `query-plan-capture-phase-respect-analyze` | High | Fix the regression — thread `analyze_plans` through the phase (restore ANALYZE timing + the knob). |
| `query-plan-capture-sideeffect-engine-policy` | Medium | Define BigQuery-class capture under the isolated model (no second *paid* execution). |
| `query-plan-capture-post-measurement-divergence` | Medium-High | Resolve plan divergence when the workload mutates data mid-run. |

## Status corrections
- `query-plan-capture-isolation-phase-design`: marked `superseded_by: canonical-isolation` (its cutover is an intermediate additive step, not the destination; its inline-coexistence anti-patterns narrowed to the genuine BigQuery exception).
- `query-plan-capture-postgresql-dml-guard`: **Not Started → Completed** (the shared `is_dml_query` guard shipped via #784/#786; still load-bearing once ANALYZE returns to the phase).

## Overlap/conflict notes (no change required here)
- The two parser-live-validation TODOs (`-parser-live-validation` vs `-misc-parser-live-validation`) are a deliberate rollout split, not duplicates.
- `query-plan-capture-display-decouple` should be re-scoped under the canonical model (display is orthogonal to capture mode) — tracked as work unit w5 of the umbrella rather than edited here.

## Validation
- [x] `validate_todo.py` passes on all 6 changed files
- [x] `todo_cli.py check-graph` — no cycles, no dangling references (81 items)
- [x] `make todo-reindex` regenerates cleanly

https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU3LCaAnmqXnbsMkfww3yg)_