### PR TITLE
fix(datafusion): ingest trailing-delimiter TPC .tbl/.dat files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -482,15 +482,18 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
-      # Third-engine equivalence SAMPLE. Both canonical and variants are
-      # translated to the datafusion dialect and compared on the same in-process
-      # session (shared translation cancels out). DATAFUSION_TPCHAVOC_SKIPS
-      # variants are excluded, never marked equivalent.
-      - name: Run TPC-Havoc DataFusion variant-equivalence sample
+      # Third-engine equivalence SAMPLE plus the DataFusion .tbl trailing-delimiter
+      # load regression. Both canonical and variants are translated to the
+      # datafusion dialect and compared on the same in-process session (shared
+      # translation cancels out); DATAFUSION_TPCHAVOC_SKIPS variants are excluded,
+      # never marked equivalent. Both files are slow-marked, so -m "slow" selects
+      # them (overriding the default fast-lane deselect).
+      - name: Run TPC-Havoc DataFusion variant-equivalence sample and .tbl load regression
         run: |
           uv run -- python -m pytest \
             tests/integration/platforms/test_tpchavoc_datafusion_equivalence.py \
-            -m "tpchavoc" -n 0 --tb=short -v
+            tests/integration/platforms/test_datafusion_tbl_load.py \
+            -m "slow" -n 0 --tb=short -v
 
   explorer-tokens:
     name: explorer-tokens

--- a/_project/TODO/main/planning/datafusion-tbl-trailing-delimiter-load.yaml
+++ b/_project/TODO/main/planning/datafusion-tbl-trailing-delimiter-load.yaml
@@ -2,7 +2,7 @@ id: datafusion-tbl-trailing-delimiter-load
 title: "Fix DataFusion adapter ingest of trailing-delimiter TPC .tbl/.dat files"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Platform Expansion
 
 description: |
@@ -52,55 +52,67 @@ prior_art:
 work:
   - id: w0
     summary: "Fix the parquet conversion path to handle a trailing delimiter"
-    status: pending
+    status: done
     notes: |
-      In _convert_and_register_parquet / _build_pyarrow_columns / _write_csv_file_to_parquet:
-      detect the trailing delimiter per file with has_trailing_delimiter(path,
-      delimiter, schema_column_names), append TRAILING_DUMMY_COLUMN to the
-      read_options column_names via get_column_names_with_trailing when present, and
-      drop that named column from the Arrow table BEFORE writing Parquet (drop by
-      the named sentinel, never by positional index). Real columns' names, order,
-      types, and row counts must be byte-for-byte unchanged for non-trailing files.
-      Keep the existing streaming (>256 MB) path working - the dummy column must be
-      dropped in both the streaming and read_csv branches.
+      RESOLVED: in _convert_and_register_parquet, detect the trailing delimiter on
+      file_paths[0] with has_trailing_delimiter(path, delimiter, schema_column_names).
+      When present, read with TRAILING_DUMMY_COLUMN appended (via
+      get_column_names_with_trailing) AND set ConvertOptions.include_columns to the
+      real columns - so PyArrow parses the N+1 fields but the output Table contains
+      only the N real columns. Using include_columns (rather than a post-hoc
+      drop_columns) works uniformly for both the read_csv and streaming open_csv
+      branches and needs no PyArrow-version-specific RecordBatch.drop. Non-trailing
+      files use include_columns=[] ("all columns"), so they are unchanged; detection
+      is field-count aware, so TPC-DS .dat with a complete row count is untouched.
+      The trailing branch also disables PyArrow quoting/escaping (quote_char=False),
+      because raw TPC dbgen/dsdgen output is never quoted - so a text field that
+      begins with `"` (or contains a backslash) cannot be parsed as a quote/escape
+      and mis-split the row. Genuinely quoted CSV benchmarks have no trailing
+      delimiter and keep the standard quote_char='"'/escape_char handling. This
+      generalizes the defense the equivalence helper previously applied locally.
 
   - id: w1
     summary: "Fix or explicitly handle the CSV external-table path"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      DataFusion CREATE EXTERNAL TABLE cannot drop a column after the fact, so pick
-      ONE: (a) declare the trailing dummy column in the external-table schema (only
-      when has_trailing_delimiter is true) and expose the table through a view that
-      projects away the dummy, mirroring the existing _create_external_table_union
-      view trick; or (b) route trailing-delimiter .tbl/.dat through the parquet
-      conversion path. Whichever, query results and row counts must be identical to
-      the parquet path. If neither is cleanly feasible, at minimum raise a clear,
-      actionable error instead of silently mis-parsing.
+      RESOLVED: chose option (b). In _load_table_csv, once the schema is known,
+      detect a trailing delimiter (has_trailing_delimiter over the schema column
+      names) and, when present, delegate to _load_table_parquet (which routes to the
+      now-fixed _convert_and_register_parquet). This reuses w0's correct read+project
+      logic instead of duplicating a declare-then-project-away view across both the
+      direct and union CSV sub-paths. Results and row counts are identical; only the
+      storage form (Parquet in the working dir) differs. Well-formed CSVs (no
+      trailing delimiter) keep the CREATE EXTERNAL TABLE path unchanged.
 
   - id: w2
     summary: "Add an integration test loading real TPC-H .tbl via the adapter"
     needs: [w0, w1]
-    status: pending
+    status: done
     notes: |
-      Generate real TPC-H at a tiny SF and load through DataFusionAdapter.load_data
-      for BOTH data_format="parquet" and data_format="csv"; assert per-table row
-      counts match the generator and that the dummy column never appears in a
-      SELECT * schema or in COUNT(*) (no leaked/extra column, no row miscount). This
-      is the regression guard that the bug stays fixed.
+      RESOLVED: tests/integration/platforms/test_datafusion_tbl_load.py generates
+      real TPC-H .tbl at SF=0.01 once (module fixture) and loads via
+      DataFusionAdapter.load_data parametrized over data_format in {parquet, csv}.
+      Asserts every table has >0 rows, that TRAILING_DUMMY_COLUMN never appears in
+      lineitem's information_schema columns, that the real column count is exact
+      (16), and that COUNT(*) matches the reported load stats. Marked slow (it
+      generates data), so it runs in the non-blocking datafusion-integration CI job
+      alongside the equivalence sample (selected via -m "slow").
 
   - id: w3
     summary: "Simplify the third-engine equivalence helper to reuse the adapter"
     needs: [w0, w1, w2]
-    status: pending
+    status: done
     notes: |
-      Replace the hand-rolled PyArrow load in
-      benchbox/core/tpchavoc/equivalence.py:build_datafusion_with_tpch with a call
-      to adapter.load_data (mirroring build_duckdb_with_tpch / build_postgres_with_tpch),
-      removing the private _map_schema_type_to_pyarrow access and the duplicated
-      trailing-delimiter handling. Keep the per-table row-count guard (>0) so a
-      partial load still cannot produce a false green, and keep the DataFusion
-      equivalence sample green (206/206 executable variants, exit 0).
+      RESOLVED: build_datafusion_with_tpch now calls adapter.create_schema +
+      adapter.load_data (mirroring build_duckdb_with_tpch / build_postgres_with_tpch),
+      removing the hand-rolled PyArrow read, the duplicated trailing-delimiter
+      handling, and the private _map_schema_type_to_pyarrow access flagged in the
+      PR #806 review. The deliberate quote_char=False defense the helper applied
+      locally is preserved - it now lives in the adapter's trailing branch (w0), so
+      it covers every TPC load, not just this sample. The per-table row-count guard
+      (>0) is preserved. The DataFusion equivalence sample stays green: 206/206
+      executable variants, exit 0.
 
 must_preserve:
   - "Query results and row counts are unchanged: the trailing dummy column never leaks into a result schema, COUNT(*), or row total."

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -549,73 +549,29 @@ def build_datafusion_with_tpch(scale_factor: float, output_dir: str | Path) -> t
     """Generate TPC-H data and return a populated in-process DataFusion connection.
 
     Mirrors :func:`build_duckdb_with_tpch`/:func:`build_postgres_with_tpch` for the
-    third engine. DataFusion is in-process, so there is no service container and no
-    per-statement transaction to isolate: ``ctx.sql(...)`` failures raise per query
-    and are caught by :func:`find_divergences` without poisoning the sweep.
-
-    The generated TPC-H ``.tbl`` files carry a field-terminating trailing pipe.
-    Both of ``DataFusionAdapter.load_data``'s CSV paths reject it (the
-    CREATE EXTERNAL TABLE path has no trailing-delimiter option, and the
-    CSV->Parquet path reads with the bare schema column count and errors on the
-    extra field), and the adapter is outside this change's scope. So this helper
-    loads each table via PyArrow directly - handling the trailing delimiter with
-    the shared file-format helpers - and registers Arrow batches into the session,
-    reusing the adapter's session setup and its own type mapping for fidelity.
-    DECIMAL columns map to float64 exactly as the adapter's Parquet path does; the
-    comparator is float-tolerant and both sides run on this same instance, so this
-    never changes results. Each table's row count is verified (>0) so a partial
-    load cannot produce a FALSE green by comparing empty-vs-empty.
+    third engine, reusing ``DataFusionAdapter.load_data`` (which now ingests the
+    field-terminating trailing delimiter in raw TPC-H ``.tbl`` files). DataFusion is
+    in-process, so there is no service container and no per-statement transaction to
+    isolate: ``ctx.sql(...)`` failures raise per query and are caught by
+    :func:`find_divergences` without poisoning the sweep. Each table's row count is
+    verified (>0) so a partial load cannot produce a FALSE green by comparing
+    empty-vs-empty (the adapter's loader raises on its own load errors).
 
     Returns:
         ``(connection, tpchavoc_benchmark, tpch_benchmark)``.
     """
-    import pyarrow as pa
-    import pyarrow.csv as pacsv
-
     from benchbox.platforms.datafusion import DataFusionAdapter
-    from benchbox.utils.file_format import (
-        TRAILING_DUMMY_COLUMN,
-        get_column_names_with_trailing,
-        has_trailing_delimiter,
-    )
 
     data_dir, tpchavoc, tpch = _generate_tpch(scale_factor, Path(output_dir))
 
     adapter = DataFusionAdapter(working_dir=str(Path(output_dir) / "datafusion_working"))
     connection = adapter.create_connection()
     try:
-        schema = tpchavoc.get_schema()
-        for table in _TPCH_TABLES:
-            columns = schema[table]["columns"]
-            column_names = [column["name"].lower() for column in columns]
-            column_types: dict[str, Any] = {}
-            for column in columns:
-                arrow_type = DataFusionAdapter._map_schema_type_to_pyarrow(column["type"].upper(), pa)
-                if arrow_type is not None:
-                    column_types[column["name"].lower()] = arrow_type
-
-            tbl_path = data_dir / f"{table}.tbl"
-            if not tbl_path.exists():
-                raise RuntimeError(f"DataFusion TPC-H load failed - missing data file {tbl_path}")
-
-            trailing = has_trailing_delimiter(tbl_path, "|", column_names)
-            read_names = get_column_names_with_trailing(column_names, trailing)
-            arrow_table = pacsv.read_csv(
-                tbl_path,
-                read_options=pacsv.ReadOptions(column_names=read_names),
-                # Raw TPC-H .tbl is pipe-delimited with NO quoting; disable PyArrow's
-                # default quote_char so a literal `"` in a text field cannot be parsed
-                # as a quote and mis-split the row.
-                parse_options=pacsv.ParseOptions(delimiter="|", quote_char=False),
-                convert_options=pacsv.ConvertOptions(
-                    column_types=column_types, null_values=[""], strings_can_be_null=True
-                ),
-            )
-            if trailing:
-                arrow_table = arrow_table.drop_columns([TRAILING_DUMMY_COLUMN])
-            if arrow_table.num_rows <= 0:
-                raise RuntimeError(f"DataFusion TPC-H load failed - no rows in {table} ({tbl_path})")
-            connection.register_record_batches(table, [arrow_table.to_batches()])
+        adapter.create_schema(tpchavoc, connection)
+        table_stats, _, _ = adapter.load_data(tpchavoc, connection, data_dir)
+        empty = [table for table in _TPCH_TABLES if table_stats.get(table, 0) <= 0]
+        if empty:
+            raise RuntimeError(f"DataFusion TPC-H load failed - no rows in {empty} (stats={table_stats})")
     except Exception:
         _close_quietly(connection)
         raise

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -36,6 +36,11 @@ from benchbox.platforms.base import DriverIsolationCapability, PlatformAdapter
 from benchbox.platforms.base.data_loading import NO_BENCHMARK, DataSource, resolve_csv_dialect
 from benchbox.platforms.base.no_constraint_mixin import NoConstraintEnforcementMixin
 from benchbox.utils.clock import elapsed_seconds, mono_time
+from benchbox.utils.file_format import (
+    TRAILING_DUMMY_COLUMN,
+    get_column_names_with_trailing,
+    has_trailing_delimiter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -878,6 +883,29 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         schema_info = self._table_schemas.get(table_name, {})
         columns = schema_info.get("columns", [])
 
+        # Raw TPC .tbl/.dat files use a field-TERMINATING delimiter (a row of N
+        # values ends with a trailing delimiter, splitting into N+1 fields).
+        # DataFusion's CSV reader has no "ignore trailing delimiter" option and a
+        # fixed CREATE EXTERNAL TABLE schema cannot drop the extra field, so route
+        # such files through the Parquet conversion path, which reads them with a
+        # dummy column and projects it away. Results and row counts are identical;
+        # only the storage form (Parquet in the working dir) differs. Detection is
+        # field-count aware, so well-formed CSVs keep the external-table path.
+        if columns and has_trailing_delimiter(file_paths[0], delimiter, [col["name"] for col in columns]):
+            self.log_verbose(
+                f"{table_name}: trailing-delimiter source detected; loading via Parquet conversion "
+                "(DataFusion CSV external tables cannot drop the extra trailing field)"
+            )
+            return self._load_table_parquet(
+                connection,
+                table_name,
+                file_paths,
+                data_dir,
+                csv_format=csv_format,
+                data_source=data_source,
+                benchmark=benchmark,
+            )
+
         # Build column schema for CREATE EXTERNAL TABLE
         if columns:
             # Use actual column names and types from schema
@@ -1364,13 +1392,46 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
 
         self.log_very_verbose(f"Converting {len(file_paths)} CSV file(s) to Parquet for {table_name}")
 
+        # Raw TPC .tbl/.dat files use a field-TERMINATING delimiter: a row of N
+        # values ends with a trailing delimiter and so splits into N+1 fields.
+        # When that happens, read with an extra dummy column so PyArrow does not
+        # error on the extra field, and project the output back to just the real
+        # columns via include_columns. Detection is field-count aware (it skips
+        # files like TPC-DS time_dim whose row already has exactly N fields), so a
+        # well-formed file is read unchanged. include_columns=[] means "all
+        # columns", the correct default for the non-trailing case.
+        read_column_names = column_names
+        include_columns: list[str] = []
+        is_trailing = column_names is not None and has_trailing_delimiter(file_paths[0], delimiter, column_names)
+        if is_trailing:
+            read_column_names = get_column_names_with_trailing(column_names, True)
+            include_columns = column_names
+            self.log_very_verbose(
+                f"Detected trailing delimiter for {table_name}; reading with a dummy "
+                f"'{TRAILING_DUMMY_COLUMN}' column and projecting it away"
+            )
+
         read_opts = csv.ReadOptions(
-            column_names=column_names,
-            autogenerate_column_names=(column_names is None and not dialect.has_header),
+            column_names=read_column_names,
+            autogenerate_column_names=(read_column_names is None and not dialect.has_header),
             skip_rows=1 if column_names is not None and dialect.has_header else 0,
         )
-        parse_opts = csv.ParseOptions(delimiter=delimiter, quote_char='"', escape_char="\\")
-        conv_opts = csv.ConvertOptions(null_values=[""], strings_can_be_null=True, column_types=column_types)
+        # A field-terminating trailing delimiter is characteristic of raw TPC
+        # dbgen/dsdgen output, which is NOT quoted or escaped. Disable quoting and
+        # escaping for that case so a text field that legitimately begins with `"`
+        # (or contains a backslash) cannot be parsed as a quote/escape and mis-split
+        # the row. Genuinely quoted CSV benchmarks have no trailing delimiter and so
+        # keep the standard quote_char='"' / escape_char='\\' handling.
+        if is_trailing:
+            parse_opts = csv.ParseOptions(delimiter=delimiter, quote_char=False)
+        else:
+            parse_opts = csv.ParseOptions(delimiter=delimiter, quote_char='"', escape_char="\\")
+        conv_opts = csv.ConvertOptions(
+            null_values=[""],
+            strings_can_be_null=True,
+            column_types=column_types,
+            include_columns=include_columns,
+        )
 
         # writer_ref is a single-slot list so the helper can lazily open the shared writer
         writer_ref: list[Any] = [None]

--- a/tests/integration/platforms/test_datafusion_tbl_load.py
+++ b/tests/integration/platforms/test_datafusion_tbl_load.py
@@ -1,0 +1,78 @@
+"""Regression test: DataFusionAdapter ingests trailing-delimiter TPC-H .tbl files.
+
+Raw TPC-H ``.tbl`` (and TPC-DS ``.dat``) data files use a field-TERMINATING
+delimiter: a row of N values ends with a trailing ``|`` and so splits into N+1
+fields. Both of ``DataFusionAdapter.load_data``'s paths used to reject this (the
+CSV->Parquet path read with the bare schema column count and errored on the extra
+field; the CREATE EXTERNAL TABLE path has no ignore-trailing-delimiter option).
+This test loads real TPC-H ``.tbl`` through the adapter for BOTH ``data_format``
+values and asserts correct row counts and that the trailing dummy column never
+leaks into a registered table's schema.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+]
+
+_TPCH_TABLES = ("lineitem", "orders", "partsupp", "part", "customer", "supplier", "nation", "region")
+_LINEITEM_COLUMN_COUNT = 16
+
+
+@pytest.fixture(scope="module")
+def tpch_tbl_dir(tmp_path_factory):
+    """Generate real TPC-H .tbl data at a tiny scale ONCE for the parametrized loads."""
+    from benchbox.core.tpch.generator import TPCHDataGenerator
+
+    output_dir = tmp_path_factory.mktemp("datafusion_tbl_load")
+    generated = TPCHDataGenerator(scale_factor=0.01, output_dir=output_dir).generate()
+    return next(Path(paths[0] if isinstance(paths, list) else paths).parent for paths in generated.values())
+
+
+@pytest.mark.parametrize("data_format", ["parquet", "csv"])
+def test_datafusion_loads_trailing_delimiter_tbl(tpch_tbl_dir, tmp_path, data_format):
+    """Real TPC-H .tbl loads on both formats with correct counts and no leaked column."""
+    pytest.importorskip("datafusion", reason="DataFusion not installed")
+
+    from benchbox import TPCH
+    from benchbox.platforms.datafusion import DataFusionAdapter
+
+    benchmark = TPCH(scale_factor=0.01)
+    adapter = DataFusionAdapter(working_dir=str(tmp_path / f"wd_{data_format}"), data_format=data_format)
+    connection = adapter.create_connection()
+    adapter.create_schema(benchmark, connection)
+
+    table_stats, _, _ = adapter.load_data(benchmark, connection, tpch_tbl_dir)
+
+    for table in _TPCH_TABLES:
+        assert table_stats.get(table, 0) > 0, f"{table} loaded 0 rows under {data_format}: {table_stats}"
+
+    # The trailing dummy column must never leak into a registered table's schema,
+    # and the real column count must be exact (no extra/shifted columns).
+    columns = [
+        row[0]
+        for row in connection.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = 'lineitem'"
+        ).fetchall()
+    ]
+    assert TRAILING_DUMMY_COLUMN not in columns, f"dummy column leaked under {data_format}: {columns}"
+    assert len(columns) == _LINEITEM_COLUMN_COUNT, f"unexpected lineitem schema under {data_format}: {columns}"
+
+    # The registered row count is queryable and matches the reported load stats.
+    queried = connection.execute("SELECT COUNT(*) FROM lineitem").fetchall()[0][0]
+    assert queried == table_stats["lineitem"]


### PR DESCRIPTION
## What

Fixes `DataFusionAdapter.load_data` so it can ingest raw TPC-H `.tbl` (and TPC-DS `.dat`) files that carry a field-**terminating** trailing delimiter — a row of N values ends with a trailing `|` and so splits into N+1 fields. Implements the plan from #807.

## Why

Both adapter load paths failed on this:
- **Parquet path** (default): read with the bare schema column count → `ArrowInvalid: Expected N columns, got N+1`.
- **CSV external-table path**: `CREATE EXTERNAL TABLE` has no ignore-trailing-delimiter option, so the extra field broke parsing.

Surfaced in #806, where the third-engine equivalence sample had to hand-roll a PyArrow load (and reach into a private adapter method) to work around it.

## Changes

- **w0 — `_convert_and_register_parquet`:** when `has_trailing_delimiter` is true, read with `TRAILING_DUMMY_COLUMN` appended and project it away via `ConvertOptions.include_columns`. This works for **both** the `read_csv` and streaming `open_csv` branches and needs no PyArrow-version-specific `drop_columns`. Detection is field-count aware (well-formed files unchanged; `include_columns=[]` = all columns). The trailing branch also disables quoting/escaping (`quote_char=False`) since raw TPC output is never quoted — so a text field beginning with `"` can't mis-split a row.
- **w1 — `_load_table_csv`:** delegate trailing-delimiter files to the (now-fixed) parquet conversion; well-formed CSVs keep the external-table path unchanged.
- **w3 — `equivalence.py:build_datafusion_with_tpch`:** simplified to reuse `adapter.create_schema` + `adapter.load_data`, removing the hand-rolled PyArrow load and private `_map_schema_type_to_pyarrow` access flagged in the #806 review. The quote-disabling defense the helper applied locally now lives in the adapter and covers **every** TPC load. Row-count guard preserved; sample stays **206/206**.
- **w2 — regression test:** `tests/integration/platforms/test_datafusion_tbl_load.py` loads real TPC-H `.tbl` at SF=0.01 for **both** `data_format` values, asserting per-table row counts, exact column count, and that the dummy column never leaks. Marked `slow`; runs in the non-blocking `datafusion-integration` CI job alongside the equivalence sample.
- TODO ledger marked Completed with per-unit resolution notes.

## Verification

- New tests pass (parquet + csv); existing **17** DataFusion integration tests pass (no regression).
- DataFusion equivalence sample **206/206, exit 0**; DuckDB hard gate unaffected (exit 0).
- `ruff check`, `ruff format --check`, marker-strategy, TODO validation all pass. (Pre-existing `ty` warning on the untouched `RuntimeEnv` import only.)

## Review

Ran a focused correctness review of the cross-cutting adapter change. Applied the one real finding (restore `quote_char=False` for the trailing/raw-TPC branch). The rest were pre-existing or consistent with the codebase: trailing-detection on `file_paths[0]` mirrors `data_loading.py` (TPC shards are homogeneous); the `create_schema`-before-`load_data` ordering is the established adapter contract; TPC-DS `time_dim`-style terminating-but-complete rows are a separate pre-existing concern this diff intentionally does not touch.

Note: scope here touches `benchbox/platforms/datafusion.py` (beyond #806's scope), which is the correct home for this defect fix per #807.

https://claude.ai/code/session_01K3L6FQa68foEmM8upaC3c1

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3L6FQa68foEmM8upaC3c1)_