### PR TITLE
todo: extend the result-equivalence-gate discipline to benchmarks that lack it

### DIFF
--- a/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
+++ b/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
@@ -1,0 +1,150 @@
+id: benchmark-correctness-oracle-coverage-map
+title: "Map correctness-oracle coverage across all benchmarks and close the unguarded ones"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  The TPC-Havoc equivalence work established that a benchmark can have a real
+  correctness oracle without a hand-maintained answer key (variant-vs-canonical
+  and SQL-vs-DataFrame, compared live on a bounded DuckDB cell). Applying that
+  lens across the suite exposes how little of it is actually guarded:
+
+  - Stored expected results exist for ONLY tpch and tpcds
+    (benchbox/core/expected_results/tpch_results.py, tpcds_results.py).
+  - Live equivalence gates exist for ONLY tpchavoc (SQL variant + DataFrame),
+    plus cross-engine sampling for tpchavoc (PRs #803/#806).
+  - Every other benchmark - ssb, clickbench, amplab, coffeeshop, datavault,
+    flightdata, joinorder, joinorder_synthetic, nyctaxi, tsbs_devops, tpcds_obt,
+    tpch_skew, and the primitive suites (read/write/transaction/metadata/ai),
+    tpcdi - executes "green" with NO automated check that any result is correct.
+
+  Two complementary mechanisms cover most of this gap. The cross-surface
+  SQL<->DataFrame gate (owned by benchmark-cross-surface-equivalence-gate)
+  handles dual-surface benchmarks. THIS item owns (a) the coverage map itself -
+  a single authoritative matrix of which oracle, if any, guards each shipped
+  benchmark - and (b) the benchmarks that cross-surface cannot reach: single-
+  surface benchmarks (one of SQL or DataFrame only) and benchmarks whose two
+  surfaces are not result-comparable. Those need a different oracle: a
+  differential check against a second engine on the same SQL, a small curated
+  expected-results subset, or a documented structural invariant - chosen per
+  benchmark from evidence.
+
+  The end state is a policy: every shipped benchmark declares its correctness
+  oracle, and a benchmark with "none" is visible (and ideally flagged), so the
+  suite cannot quietly grow more unverified surfaces.
+
+prior_art:
+  - "benchbox/core/expected_results/registry.py - register_benchmark_provider / list of registered providers; the place a coverage check would read 'has expected results'."
+  - "benchbox/core/tpchavoc/equivalence.py and dataframe_equivalence.py - the live-oracle exemplars (variant + cross-surface)."
+  - "_project/TODO/main/planning/benchmark-cross-surface-equivalence-gate.yaml - the dual-surface mechanism this map dispatches to; do not duplicate it."
+  - "_project/TODO/main/planning/tpchavoc-cross-dialect-equivalence-sampling.yaml and tpchavoc-third-engine-equivalence-sampling.yaml - the cross-engine/differential exemplars for the single-surface fallback."
+  - "_project/TODO/main/planning/testing-approach-correctness-gates.yaml - the existing real-result gate / test-quality work; this map is complementary (coverage inventory + ungated-benchmark campaign), not a re-do of it."
+  - "benchbox/core/benchmark_registry.py - the authoritative list of shipped benchmarks to enumerate the map against."
+
+work:
+  - id: w0
+    summary: "Build the authoritative correctness-oracle coverage matrix for every shipped benchmark"
+    status: pending
+    notes: |
+      Enumerate benchmarks from the registry. For each, record: surfaces shipped
+      (SQL / DataFrame / both); has stored expected results?; has a live
+      equivalence gate?; is cross-surface applicable?; resulting current-oracle =
+      {expected-results | variant-equivalence | cross-surface | cross-engine |
+      NONE}. Land the matrix as a checked-in artifact (and ideally a generated
+      check), not a one-off doc, so it stays current.
+
+  - id: w1
+    summary: "Dispatch dual-surface, no-oracle benchmarks to the cross-surface gate"
+    needs: [w0]
+    status: pending
+    notes: |
+      For benchmarks the matrix shows as dual-surface with oracle=NONE, the fix is
+      benchmark-cross-surface-equivalence-gate. Cross-reference rather than
+      re-implement; this item only tracks that they get covered there.
+
+  - id: w2
+    summary: "Choose and apply a fallback oracle for single-surface, no-oracle benchmarks"
+    needs: [w0]
+    status: pending
+    notes: |
+      For benchmarks with only one comparable surface (or non-comparable
+      surfaces), pick the cheapest credible oracle per benchmark: differential
+      vs a second engine on the same SQL (reuse the cross-dialect harness), a
+      small curated expected-results subset via the existing registry, or a
+      documented structural invariant where results are nondeterministic.
+      Prioritize the canonical/most-used benchmarks. Verify each against an
+      independent reference, never against the surface under test alone.
+
+  - id: w3
+    summary: "Make 'no oracle' visible and prevent silent regressions in coverage"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      Document the policy that every shipped benchmark declares a correctness
+      oracle, and add a lightweight check (advisory first) that lists benchmarks
+      with oracle=NONE so a newly-added benchmark without one is surfaced in CI
+      rather than discovered later.
+
+deferred:
+  - summary: "Backfill full expected-results answer keys for every benchmark"
+    reason: "Expensive and brittle to maintain; live oracles (cross-surface / differential) cover most of the value at a fraction of the upkeep. Only curate expected-results where no live oracle is feasible."
+
+must_preserve:
+  - "Existing oracles (tpch/tpcds expected results, tpchavoc gates) are unchanged and remain authoritative for their benchmarks."
+  - "benchbox run default behavior is unchanged for every benchmark; coverage work is additive."
+  - "No new hard CI gate lands noisy/flaky; advisory-first, promote to blocking only once stable."
+
+approach: |
+  Inventory first (w0): a single, ideally generated, coverage matrix is the
+  artifact that makes the gap legible and dispatchable. Then route dual-surface
+  gaps to the cross-surface gate (w1) and solve single-surface gaps with the
+  cheapest credible per-benchmark oracle (w2), reusing existing harnesses
+  (cross-surface, cross-dialect, expected-results registry) rather than new
+  machinery. Close with a policy + advisory check (w3) so coverage cannot
+  silently erode.
+
+anti_patterns:
+  - "DO NOT duplicate the cross-surface gate here - because it has its own item - dispatch to it for dual-surface benchmarks."
+  - "DO NOT mandate full expected-results answer keys everywhere - because the maintenance cost is why coverage is thin today - prefer live oracles."
+  - "DO NOT verify a benchmark against the surface under test - because that is circular - use an independent reference (other surface, other engine, or curated key)."
+  - "DO NOT land the coverage check as a hard blocker first - because a noisy gate erodes trust - advisory until proven."
+
+verification:
+  - description: "Coverage matrix enumerates every registered benchmark with its current oracle"
+    command: "run the coverage map generator; diff against the registry"
+    expected_output: "every shipped benchmark appears with an oracle classification (including NONE)"
+  - description: "A single-surface benchmark gains an independent oracle that catches a planted defect"
+    command: "pick one w2 benchmark, plant a wrong result, run its new oracle"
+    expected_output: "the oracle flags the defect"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/"
+    - "tests/"
+    - "_project/"
+    - ".github/workflows/"
+    - "Makefile"
+    - "docs/"
+
+open_questions:
+  - question: "Where should the coverage matrix live so it stays current - a generated artifact derived from the registry + gate presence, or a curated doc reviewed in CI?"
+    gating: true
+    affects: ["w0 deliverable shape"]
+    default: "Generated from the registry plus detection of expected-results providers and equivalence gates, emitted as a checked-in artifact with an advisory CI check; curated notes only for the per-benchmark oracle CHOICE rationale."
+  - question: "For nondeterministic or write-path benchmarks (write/transaction primitives, tpcdi), is result-equivalence even the right oracle, or should they assert structural invariants instead?"
+    gating: false
+    affects: ["w2 oracle choice"]
+    default: "Use structural/invariant oracles (row counts, post-state assertions) for write/nondeterministic paths; reserve result-equivalence for deterministic read queries."
+
+success_metrics:
+  - "A current, authoritative coverage matrix classifies every shipped benchmark's correctness oracle."
+  - "Every benchmark that had oracle=NONE either gains one (cross-surface, differential, or curated) or has a documented, accepted reason it cannot."
+  - "A new benchmark shipped without a correctness oracle is surfaced by an advisory CI check."
+
+metadata:
+  tags: [correctness, equivalence, coverage, governance, ci, benchmarks]
+  estimated_effort: "Large"
+  created_date: "2026-06-16"
+  last_updated: "2026-06-16T00:00:00"

--- a/_project/TODO/main/planning/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/planning/benchmark-cross-surface-equivalence-gate.yaml
@@ -1,0 +1,165 @@
+id: benchmark-cross-surface-equivalence-gate
+title: "Generalize the result-equivalence harness and gate SQL<->DataFrame equivalence for dual-surface benchmarks"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  TPC-Havoc now ships two result-equivalence gates that proved a discipline:
+  execute a candidate query and a trusted reference over the SAME bounded
+  small-SF DuckDB dataset and compare results live (order-insensitive, float-
+  tolerant), with no hand-maintained expected answers. The SQL gate
+  (benchbox/core/tpchavoc/equivalence.py) compares each SQL variant to canonical
+  TPC-H; the DataFrame gate (benchbox/core/tpchavoc/dataframe_equivalence.py)
+  compares each DataFrame variant to canonical TPC-H SQL. Together they found and
+  fixed ~42 silent correctness defects.
+
+  That discipline is currently TPC-Havoc-only, by construction. But ~14
+  benchmarks ship a DataFrame query surface (amplab, clickbench, coffeeshop,
+  datavault, flightdata, joinorder, nyctaxi, read_primitives, ssb, tpcds,
+  tpcds_obt, tpch, tpch_skew, tsbs_devops) in ADDITION to their SQL surface, and
+  nothing checks that the two surfaces agree. Worse, stored expected results
+  exist for ONLY tpch and tpcds (benchbox/core/expected_results/tpch_results.py,
+  tpcds_results.py) - so for every other dual-surface benchmark there is NO
+  correctness oracle of any kind: SQL and DataFrame implementations both execute
+  "green" while their results are unverified and may silently disagree.
+
+  Cross-surface equivalence is the cheap, maintenance-free oracle for exactly
+  this gap: SQL and DataFrame are independent implementations of the same logical
+  query, so a divergence proves at least one is wrong - without needing a
+  hand-curated answer key. This work generalizes the TPC-Havoc DataFrame-gate
+  harness into a shared, benchmark-agnostic helper, then rolls out a bounded
+  SQL<->DataFrame equivalence gate to the dual-surface benchmarks, SQL as the
+  reference for its own DataFrame surface.
+
+  Note: for tpch/tpcds the expected-results registry already validates each
+  surface against a stored answer key (transitive equivalence), so they are
+  lower priority here; the highest value is the dual-surface benchmarks with NO
+  oracle today (ssb first - canonical and small - then clickbench, joinorder,
+  coffeeshop, etc.).
+
+prior_art:
+  - "benchbox/core/tpchavoc/dataframe_equivalence.py - build_dataframe_contexts, materialize_rows, fetch_canonical_rows, find_dataframe_divergences, main; the template to generalize (it already compares a DataFrame result to a SQL reference on DuckDB)."
+  - "benchbox/core/tpchavoc/equivalence.py - build_duckdb_with_tpch, find_divergences, strip_top_n, KNOWN_DIVERGENCES, main; the SQL-side harness and the empty-baseline fail-on-divergence pattern."
+  - "tests/integration/test_tpchavoc_variant_equivalence.py - the fast default-lane regression companion; mirror it per gated benchmark."
+  - "benchbox/core/expected_results/ (registry.py, tpch_results.py, tpcds_results.py) - the only existing correctness oracles; documents that coverage stops at tpch/tpcds."
+  - "benchbox/core/runner/dataframe_runner.py and benchbox/platforms/dataframe/benchmark_mixin.py - how DataFrame queries actually execute and materialize; the gate must use the same execution path, not a bespoke one."
+  - "benchbox/core/<bench>/dataframe_queries(.py or package) and <bench>/queries.py (or get_queries) for each dual-surface benchmark - the two surfaces to compare (note: some, e.g. ssb/tpcds/clickbench, ship dataframe_queries as a package directory rather than a single module)."
+
+work:
+  - id: w0
+    summary: "Extract a benchmark-agnostic cross-surface equivalence harness from the TPC-Havoc DataFrame gate"
+    status: pending
+    notes: |
+      Factor the data-build + run-SQL + run-DataFrame + compare loop out of
+      tpchavoc/dataframe_equivalence.py into a shared core helper parameterized by
+      benchmark (DDL/data builder, SQL query accessor, DataFrame query accessor,
+      validator). Re-express the existing TPC-Havoc DataFrame gate on top of it
+      with NO behavior change (its gate must stay green and byte-equivalent in
+      result). Reuse validate_variant_equivalence / the result validator and the
+      DuckDB data builder; do not fork them.
+
+  - id: w1
+    summary: "Inventory dual-surface benchmarks and confirm SQL<->DataFrame query-id correspondence"
+    needs: [w0]
+    status: pending
+    notes: |
+      For each benchmark with both surfaces, confirm the SQL and DataFrame query
+      sets cover the same logical queries (matching ids/keys) and can run on a
+      shared DuckDB cell. Record which are in scope, which are single-surface
+      (out of scope here - owned by benchmark-correctness-oracle-coverage-map),
+      and any that need per-benchmark normalization (top-N/LIMIT, column order).
+
+  - id: w2
+    summary: "Run the cross-surface gate in report mode over the ungated dual-surface benchmarks and enumerate divergences"
+    needs: [w1]
+    status: pending
+    notes: |
+      Prioritize benchmarks with NO expected-results oracle: ssb, clickbench,
+      joinorder, coffeeshop, amplab, nyctaxi, flightdata, tsbs_devops, tpcds_obt,
+      tpch_skew, read_primitives. Report (benchmark, query, kind, deltas) without
+      asserting. Capture stdout to /tmp and summarize counts in the PR/TODO.
+
+  - id: w3
+    summary: "Burn down divergences (fix the wrong surface) or declare intentional ones"
+    needs: [w2]
+    status: pending
+    notes: |
+      For each divergence, determine which surface is wrong and fix it; verify the
+      fix makes the two surfaces agree. Where a difference is intentional and
+      defensible (e.g. a surface deliberately omits a presentational LIMIT),
+      record it as a classified, justified known-divergence entry, mirroring the
+      TPC-Havoc baseline discipline (default: empty baseline, every query matches).
+
+  - id: w4
+    summary: "Promote to bounded CI gates and add fast-lane regressions"
+    needs: [w3]
+    status: pending
+    notes: |
+      One bounded small-SF DuckDB cell per gated benchmark, wired into the
+      correctness-gate CI job and a Make target, mirroring
+      tpchavoc-(dataframe-)equivalence-report. Add a medium-marker pytest per
+      benchmark like tests/integration/test_tpchavoc_variant_equivalence.py.
+      Prove each gate fails when a deliberate divergence is introduced into one
+      surface.
+
+deferred:
+  - summary: "Cross-surface equivalence on a second engine"
+    reason: "Cross-engine sampling is its own discipline (see tpchavoc-cross-dialect-equivalence-sampling); keep these gates DuckDB-bounded first."
+  - summary: "Benchmarks that ship only one surface"
+    reason: "Cross-surface cannot apply; their oracle gap is owned by benchmark-correctness-oracle-coverage-map."
+
+must_preserve:
+  - "The TPC-Havoc SQL and DataFrame gates stay green with empty KNOWN_DIVERGENCES and unchanged behavior."
+  - "benchbox run default (execution-only) behavior is unchanged for every benchmark; the gates are additive."
+  - "ResultValidator tolerance/checksum semantics are unchanged; reuse, do not fork, the comparator and the DuckDB data builder."
+
+approach: |
+  Generalize the proven TPC-Havoc DataFrame gate rather than inventing a new
+  comparator: extract a shared harness (w0), inventory applicability (w1), land
+  report-mode across the ungated dual-surface benchmarks (w2), burn down (w3),
+  then flip bounded CI gates with fast-lane companions (w4). SQL is the live
+  reference for its own DataFrame surface; no hand-maintained answer keys.
+
+anti_patterns:
+  - "DO NOT write a new result comparator or data builder - because the TPC-Havoc harness already does this - generalize and reuse it."
+  - "DO NOT execute DataFrame queries via a bespoke path - because the gate must reflect the real product run path - use the DataFrame runner/mixin."
+  - "DO NOT gate a full platform matrix - because routine PRs must stay cheap - one bounded small-SF DuckDB cell per benchmark."
+  - "DO NOT silence a real divergence by adding it to the baseline - because the baseline is for intentional differences only - fix the wrong surface."
+
+verification:
+  - description: "Generalized harness reproduces the existing TPC-Havoc DataFrame gate result"
+    command: "make tpchavoc-dataframe-equivalence-report"
+    expected_output: "still 0 divergent (re-expressed on the shared harness, unchanged)"
+  - description: "A new dual-surface gate fails when one surface is deliberately broken"
+    command: "introduce a wrong projection in one SSB DataFrame query, run the SSB cross-surface gate"
+    expected_output: "gate FAILS (non-zero), naming the divergent query"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/"
+    - "tests/"
+    - ".github/workflows/"
+    - "Makefile"
+
+open_questions:
+  - question: "Should the shared harness live in a new benchbox/core module (e.g. core/equivalence/) with TPC-Havoc re-exporting from it, or stay under tpchavoc with others importing it?"
+    gating: true
+    affects: ["w0 placement"]
+    default: "New core/equivalence/ module owning the benchmark-agnostic harness; tpchavoc equivalence.py / dataframe_equivalence.py become thin benchmark-specific wrappers re-exporting it, so their public entry points and gates are unchanged."
+  - question: "For benchmarks whose DataFrame and SQL surfaces intentionally differ in presentation (e.g. LIMIT/top-N or column aliasing), is set-equality after the existing top-N normalization sufficient, or do some need per-benchmark normalization?"
+    gating: false
+    affects: ["w1 normalization", "w3 classification"]
+    default: "Reuse the TPC-Havoc strip_top_n / validator normalization; add per-benchmark normalization only where w2 evidence shows an intentional, defensible presentational difference."
+
+success_metrics:
+  - "A single shared harness backs both the TPC-Havoc gates and the new cross-surface gates; no duplicated comparator/data-builder."
+  - "Every dual-surface benchmark with no expected-results oracle has a bounded SQL<->DataFrame equivalence gate that is green on develop."
+  - "Introducing a divergence into either surface of a gated benchmark fails CI."
+
+metadata:
+  tags: [equivalence, correctness, dataframe, sql, ci, tpch, tpcds, ssb]
+  estimated_effort: "Large"
+  created_date: "2026-06-16"
+  last_updated: "2026-06-16T00:00:00"


### PR DESCRIPTION
## Summary

Adds two complementary planning TODOs that extend the result-equivalence-gate discipline proven on TPC-Havoc to the benchmarks that still lack any correctness oracle.

**Why:** the TPC-Havoc gates (SQL variant + DataFrame, plus cross-engine sampling in #803/#806) are the only correctness oracles in the suite beyond stored expected results — and expected results exist for **only `tpch` and `tpcds`** (`benchbox/core/expected_results/{tpch,tpcds}_results.py`). Every other benchmark — `ssb`, `clickbench`, `amplab`, `coffeeshop`, `datavault`, `flightdata`, `joinorder`, `nyctaxi`, `tsbs_devops`, `tpcds_obt`, `tpch_skew`, the primitive suites, `tpcdi` — executes "green" with **no automated check that any result is correct**, and ~14 ship a DataFrame surface with no SQL↔DataFrame equivalence check.

## The two TODOs

1. **`benchmark-cross-surface-equivalence-gate`** (High) — generalize the TPC-Havoc DataFrame-gate harness (`dataframe_equivalence.py`) into a shared, benchmark-agnostic helper, then roll out a bounded **SQL↔DataFrame equivalence gate** to the dual-surface benchmarks that have no oracle today. SQL is the live reference for its own DataFrame surface — no hand-maintained answer keys. w0 extract harness → w1 inventory applicability → w2 report-mode → w3 burn down → w4 bounded CI gates + fast-lane tests.
2. **`benchmark-correctness-oracle-coverage-map`** (Medium) — build an authoritative per-benchmark **oracle-coverage matrix** (expected-results / variant-equivalence / cross-surface / cross-engine / NONE), dispatch dual-surface gaps to the gate above, choose a **fallback oracle** (differential vs a second engine, curated expected-results subset, or structural invariant) for the single-surface benchmarks cross-surface can't reach, and add an advisory check so a new benchmark shipped without an oracle is surfaced.

They are deliberately non-overlapping: #1 is the mechanism for dual-surface benchmarks; #2 owns the coverage map and the cases #1 can't reach. Both are complementary to (not a re-do of) the existing `testing-approach-correctness-gates`.

## Review performed
- `validate_todo.py`: both valid.
- `todo_cli.py check-graph`: passes (84 items, no dangling references / cycles).
- Correctness pass: every factual claim grounded in the repo (expected-results coverage, dual-surface inventory), and all cited `prior_art` paths verified to exist (corrected one `ssb` path that is a package dir, not a `.py`).
- Reindexed.

No code changes — planning TODOs only.

https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpw7mc1gcoQVTtz4HQZwyk)_