### PR TITLE
refactor(equivalence): extract benchmark-agnostic cross-surface harness

### DIFF
--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -2,7 +2,7 @@ id: benchmark-cross-surface-equivalence-gate
 title: "Generalize the result-equivalence harness and gate SQL<->DataFrame equivalence for dual-surface benchmarks"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -50,7 +50,7 @@ prior_art:
 work:
   - id: w0
     summary: "Extract a benchmark-agnostic cross-surface equivalence harness from the TPC-Havoc DataFrame gate"
-    status: pending
+    status: done
     notes: |
       Factor the data-build + run-SQL + run-DataFrame + compare loop out of
       tpchavoc/dataframe_equivalence.py into a shared core helper parameterized by
@@ -59,6 +59,17 @@ work:
       with NO behavior change (its gate must stay green and byte-equivalent in
       result). Reuse validate_variant_equivalence / the result validator and the
       DuckDB data builder; do not fork them.
+
+      DONE: shared harness landed at benchbox/core/equivalence/dataframe_surface.py
+      (build_dataframe_contexts, materialize_rows, fetch_reference_rows,
+      find_surface_divergences, SurfaceDivergence, _normalize_value). The TPC-Havoc
+      DataFrame gate (benchbox/core/tpchavoc/dataframe_equivalence.py) is now a thin
+      wrapper over it: it injects the canonical-TPC-H reference, the variant/backend
+      cell enumeration, and the reused validate_variant_equivalence comparator +
+      build_duckdb_with_tpch data builder. Gate re-verified byte-equivalent:
+      "checked 440 variant-backend cells - 0 divergent, 440 equivalent". Fast-lane
+      tests/integration/test_tpchavoc_dataframe_variant_equivalence.py still passes;
+      new fast-lane unit coverage at tests/unit/core/equivalence/.
 
   - id: w1
     summary: "Inventory dual-surface benchmarks and confirm SQL<->DataFrame query-id correspondence"

--- a/benchbox/core/equivalence/__init__.py
+++ b/benchbox/core/equivalence/__init__.py
@@ -1,0 +1,34 @@
+"""Benchmark-agnostic result-equivalence harness.
+
+Shared machinery for the live, answer-key-free correctness oracles: execute a
+candidate surface and a trusted reference over the SAME bounded DuckDB data and
+compare results with a reused validator. The TPC-Havoc gates
+(:mod:`benchbox.core.tpchavoc.equivalence`,
+:mod:`benchbox.core.tpchavoc.dataframe_equivalence`) are thin benchmark-specific
+wrappers over this package, and the cross-surface SQL<->DataFrame gates reuse the
+same harness rather than forking a new comparator or data builder.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from benchbox.core.equivalence.dataframe_surface import (
+    DATAFRAME_BACKENDS,
+    SurfaceDivergence,
+    build_dataframe_contexts,
+    fetch_reference_rows,
+    find_surface_divergences,
+    materialize_rows,
+)
+
+__all__ = [
+    "DATAFRAME_BACKENDS",
+    "SurfaceDivergence",
+    "build_dataframe_contexts",
+    "fetch_reference_rows",
+    "find_surface_divergences",
+    "materialize_rows",
+]

--- a/benchbox/core/equivalence/dataframe_surface.py
+++ b/benchbox/core/equivalence/dataframe_surface.py
@@ -1,0 +1,233 @@
+"""Benchmark-agnostic cross-surface result-equivalence harness.
+
+This module factors the proven TPC-Havoc DataFrame gate
+(:mod:`benchbox.core.tpchavoc.dataframe_equivalence`) into a shared, benchmark-
+agnostic helper so the *same* discipline - execute a candidate surface and a
+trusted reference over the SAME bounded DuckDB data and compare results live,
+with no hand-maintained answer key - can be rolled out to any benchmark that
+ships a DataFrame surface.
+
+The reusable pieces are:
+
+* :func:`build_dataframe_contexts` - materialize a benchmark's tables from a
+  populated DuckDB connection into the two shipped DataFrame backend contexts
+  (Polars expression family, Arrow-backed Pandas family), with ``DECIMAL``
+  columns cast to ``DOUBLE`` to mirror the production loader's schema mapping.
+* :func:`materialize_rows` - normalize whatever a DataFrame implementation
+  returns (a unified-frame wrapper, a Polars lazy/eager frame, or a Pandas
+  frame) into ordered row tuples of plain Python scalars.
+* :func:`fetch_reference_rows` - run reference SQL on the DuckDB connection and
+  normalize its rows through the same scalar vocabulary.
+* :func:`find_surface_divergences` - the data-build-agnostic compare loop:
+  fetch the reference once per logical query, then run each candidate cell and
+  validate it against that reference, recording one :class:`SurfaceDivergence`
+  per cell that diverges (or errors).
+
+The comparator/validator and the DuckDB data builder are NEVER forked here:
+callers inject their existing validator (e.g.
+:meth:`TPCHavocBenchmark.validate_variant_equivalence` or a
+:class:`~benchbox.core.tpchavoc.validation.ResultValidator`) and their existing
+data builder (e.g.
+:func:`~benchbox.core.tpchavoc.equivalence.build_duckdb_with_tpch`).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from decimal import Decimal
+from typing import Any
+
+# The two shipped DataFrame reference backends. They are independent
+# implementations (Polars expression family vs Pandas) and can diverge
+# independently, so a gate that cares about the DataFrame surface checks both.
+DATAFRAME_BACKENDS = ("expression", "pandas")
+
+_MIDNIGHT = time(0, 0, 0)
+
+
+@dataclass(frozen=True)
+class SurfaceDivergence:
+    """A single (query, cell) whose candidate result differs from the reference.
+
+    ``cell`` is a benchmark-defined label for the candidate under test (e.g.
+    ``"v3:expression"`` for a TPC-Havoc DataFrame variant/backend, or
+    ``"expression"`` for a benchmark's single DataFrame surface on one backend).
+    """
+
+    query_id: Any
+    cell: str
+    detail: str
+
+    @property
+    def key(self) -> str:
+        """Stable ``<query>_<cell>`` identifier (or ``<query>`` if cell-less)."""
+        return f"{self.query_id}_{self.cell}" if self.cell else f"{self.query_id}"
+
+
+def build_dataframe_contexts(connection: Any, tables: Iterable[Any]) -> dict[str, Any]:
+    """Materialize ``tables`` on ``connection`` into both DataFrame backend contexts.
+
+    Tables are exported once through Arrow with ``DECIMAL`` columns cast to
+    ``DOUBLE``, mirroring the production DataFrame loader's schema mapping
+    (``DECIMAL(15,2) -> Float64`` / ``double``), then registered with the
+    reference adapter context of each backend: Polars lazy frames for the
+    expression family and Arrow-backed Pandas frames (production loads Parquet
+    with ``dtype_backend="pyarrow"``) for the pandas family.
+
+    Platform imports are deferred so importing this module does not pull Polars
+    or Pandas into the core import graph.
+
+    Args:
+        connection: A DuckDB connection already populated with the benchmark's
+            data.
+        tables: The benchmark's table schemas; each must expose ``.name`` and a
+            ``.columns`` iterable of columns exposing ``.name`` and a
+            ``.data_type`` whose ``.value`` is the SQL type string.
+
+    Returns:
+        Mapping of backend name (see :data:`DATAFRAME_BACKENDS`) to a context
+        with all of the benchmark's tables registered.
+    """
+    import pandas as pd
+    import polars as pl
+
+    from benchbox.platforms.dataframe.pandas_df import PandasDataFrameAdapter
+    from benchbox.platforms.dataframe.polars_df import PolarsDataFrameAdapter
+
+    expression_ctx = PolarsDataFrameAdapter().create_context()
+    pandas_ctx = PandasDataFrameAdapter().create_context()
+    for table in tables:
+        projections = [
+            f"CAST({column.name} AS DOUBLE) AS {column.name}"
+            if column.data_type.value.startswith("DECIMAL")
+            else column.name
+            for column in table.columns
+        ]
+        # fetch_arrow_table() (not .arrow()) so the result is a materialized
+        # pyarrow.Table on every DuckDB version, including >=1.4 where
+        # .arrow() returns a RecordBatchReader.
+        arrow = connection.execute(f"SELECT {', '.join(projections)} FROM {table.name.lower()}").fetch_arrow_table()
+        expression_ctx.register_table(table.name, pl.from_arrow(arrow).lazy())
+        pandas_ctx.register_table(table.name, arrow.to_pandas(types_mapper=pd.ArrowDtype))
+    return {"expression": expression_ctx, "pandas": pandas_ctx}
+
+
+def materialize_rows(result: Any) -> list[tuple[Any, ...]]:
+    """Materialize a DataFrame query result to normalized row tuples.
+
+    Accepts whatever a DataFrame implementation returns on either backend - a
+    ``UnifiedLazyFrame``/``UnifiedPandasFrame`` wrapper, a Polars lazy or eager
+    frame, or a Pandas frame - and produces plain row tuples in the frame's
+    column order with values normalized via :func:`_normalize_value`.
+    """
+    native = getattr(result, "native", result)
+    if hasattr(native, "collect"):
+        native = native.collect()
+    if hasattr(native, "rows"):
+        raw_rows = native.rows()
+    elif hasattr(native, "itertuples"):
+        raw_rows = native.itertuples(index=False, name=None)
+    else:
+        raise TypeError(f"cannot materialize result of type {type(native).__name__}")
+    return [tuple(_normalize_value(value) for value in row) for row in raw_rows]
+
+
+def fetch_reference_rows(connection: Any, reference_sql: str) -> list[tuple[Any, ...]]:
+    """Execute reference SQL on ``connection`` and return normalized row tuples.
+
+    The query is executed as-is - including any presentational top-N ``LIMIT``
+    - because the DataFrame implementations reproduce that cut. Values pass
+    through the same normalization as the DataFrame side so the comparator sees
+    one scalar vocabulary.
+    """
+    rows = connection.execute(reference_sql).fetchall()
+    return [tuple(_normalize_value(value) for value in row) for row in rows]
+
+
+def find_surface_divergences(
+    query_ids: Iterable[Any],
+    *,
+    reference_rows: Callable[[Any], list[tuple[Any, ...]]],
+    candidate_cells: Callable[[Any], Iterable[tuple[str, Callable[[list[tuple[Any, ...]]], None]]]],
+    validation_error: type[BaseException],
+    reference_failure_cell: str = "reference",
+) -> list[SurfaceDivergence]:
+    """Compare each query's candidate cells to a trusted reference, live.
+
+    The data build, the reference, the candidate enumeration, and the validator
+    are all injected so this loop is benchmark-agnostic: it owns only the
+    fetch-reference-once-then-check-each-cell control flow and the per-cell
+    error isolation, never the comparator or the data builder.
+
+    Args:
+        query_ids: The logical queries to check.
+        reference_rows: Callable returning the trusted reference rows for a
+            query id (e.g. canonical SQL executed on DuckDB, normalized). A
+            failure here is recorded as a single divergence on
+            ``reference_failure_cell`` and the query is skipped (its candidate
+            cells cannot be compared without a reference).
+        candidate_cells: Callable yielding, for a query id, ``(cell, check)``
+            pairs. ``cell`` is the benchmark-defined cell label; ``check`` takes
+            the reference rows and must materialize the candidate and validate
+            it against the reference, raising on any mismatch or execution error.
+        validation_error: The exception type a ``check`` raises for a genuine
+            result mismatch (its ``str`` is used verbatim as the detail). Any
+            other exception is treated as an execution error (``error: ...``).
+            Required (not defaulted) so a caller never silently reclassifies an
+            implementation crash as a result mismatch; pass :class:`Exception`
+            explicitly to opt into "every failure is a mismatch".
+        reference_failure_cell: Cell label used when the reference itself fails.
+
+    Returns:
+        One :class:`SurfaceDivergence` per cell whose candidate result is not
+        equivalent to the reference (plus one per query whose reference failed).
+    """
+    divergences: list[SurfaceDivergence] = []
+    for query_id in query_ids:
+        try:
+            reference = reference_rows(query_id)
+        except Exception as exc:  # noqa: BLE001 - a diagnostic must report, not crash, on a bad query
+            divergences.append(SurfaceDivergence(query_id, reference_failure_cell, f"reference query failed: {exc}"))
+            continue
+        for cell, check in candidate_cells(query_id):
+            try:
+                check(reference)
+            except validation_error as exc:  # type: ignore[misc] - configurable mismatch type
+                divergences.append(SurfaceDivergence(query_id, cell, str(exc)))
+            except Exception as exc:  # noqa: BLE001 - surface execution errors as divergences
+                divergences.append(SurfaceDivergence(query_id, cell, f"error: {exc}"))
+    return divergences
+
+
+def _normalize_value(value: Any) -> Any:
+    """Normalize one result value to a plain Python scalar.
+
+    Maps DuckDB ``Decimal`` to float (the DataFrame surface computes in
+    float64), midnight timestamps to dates (Pandas materializes DATE columns
+    as midnight ``Timestamp``), missing values (``None``/``NaN``/Pandas
+    ``NA``/``NaT``) to ``None``, and unwraps NumPy/Arrow scalars via
+    ``.item()``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime):  # before date: datetime subclasses date
+        return value.date() if value.time() == _MIDNIGHT else value
+    if isinstance(value, float):  # before .item(): NumPy floats subclass float
+        return None if math.isnan(value) else float(value)
+    if isinstance(value, (str, bytes, int, date)):
+        return value
+    if type(value).__name__ in ("NAType", "NaTType"):  # pandas.NA / pandas.NaT without importing pandas
+        return None
+    item = getattr(value, "item", None)  # NumPy / Arrow scalar wrappers
+    if callable(item):
+        return _normalize_value(item())
+    return value

--- a/benchbox/core/tpchavoc/dataframe_equivalence.py
+++ b/benchbox/core/tpchavoc/dataframe_equivalence.py
@@ -19,11 +19,19 @@ DuckDB (never to the variant's SQL namesake and never to a sibling DataFrame
 variant), and **exits non-zero** if any variant/backend cell diverges beyond
 :data:`KNOWN_DIVERGENCES` (currently empty - every cell must match).
 
-It deliberately reuses the SQL gate's data builder
-(:func:`~benchbox.core.tpchavoc.equivalence.build_duckdb_with_tpch`) and the
-existing comparator (:meth:`TPCHavocBenchmark.validate_variant_equivalence`);
-the only new logic is materializing tables into DataFrame contexts and variant
-results into ordered row tuples.
+It is a thin benchmark-specific wrapper over the shared, benchmark-agnostic
+harness in :mod:`benchbox.core.equivalence.dataframe_surface`: it reuses that
+harness's DataFrame materialization
+(:func:`~benchbox.core.equivalence.dataframe_surface.materialize_rows`,
+:func:`~benchbox.core.equivalence.dataframe_surface.build_dataframe_contexts`,
+:func:`~benchbox.core.equivalence.dataframe_surface.fetch_reference_rows`) and
+its compare loop
+(:func:`~benchbox.core.equivalence.dataframe_surface.find_surface_divergences`),
+the SQL gate's data builder
+(:func:`~benchbox.core.tpchavoc.equivalence.build_duckdb_with_tpch`), and the
+existing comparator (:meth:`TPCHavocBenchmark.validate_variant_equivalence`).
+The only TPC-Havoc-specific logic here is the canonical reference accessor, the
+variant/backend cell enumeration, and the Q11 scale-aware parameter wiring.
 
 Two normalization choices differ from the SQL gate, both forced by the
 surface:
@@ -58,21 +66,32 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
-from datetime import date, datetime, time
-from decimal import Decimal
-from typing import Any, Callable
+from collections.abc import Callable, Iterable
+from typing import Any
 
+from benchbox.core.equivalence.dataframe_surface import (
+    DATAFRAME_BACKENDS,
+    SurfaceDivergence,
+    build_dataframe_contexts as _build_dataframe_contexts,
+    fetch_reference_rows,
+    find_surface_divergences,
+    materialize_rows,
+)
 from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
 from benchbox.core.tpchavoc.equivalence import EQUIVALENCE_SCALE, build_duckdb_with_tpch
 from benchbox.core.tpchavoc.validation import ValidationError
 
-# Both shipped DataFrame backends are gated: they are independent
-# implementations (expression_impl vs pandas_impl) and can diverge
-# independently. The reference adapters are Polars (expression family) and
-# Pandas (pandas family).
-DATAFRAME_BACKENDS = ("expression", "pandas")
+# Re-exported from the shared harness so existing imports of these names from
+# this module keep working; the comparator/data-builder are never forked.
+__all__ = [
+    "DATAFRAME_BACKENDS",
+    "KNOWN_DIVERGENCES",
+    "build_dataframe_contexts",
+    "fetch_canonical_rows",
+    "find_dataframe_divergences",
+    "main",
+    "materialize_rows",
+]
 
 # Variant/backend cells tolerated to diverge from canonical TPC-H at
 # EQUIVALENCE_SCALE, with the reason class. Empty: every DataFrame variant must
@@ -81,36 +100,17 @@ DATAFRAME_BACKENDS = ("expression", "pandas")
 # Keyed by "<query>_v<variant>:<backend>".
 KNOWN_DIVERGENCES: dict[str, str] = {}
 
-_MIDNIGHT = time(0, 0, 0)
-
-
-@dataclass(frozen=True)
-class DataFrameDivergence:
-    """A variant/backend cell whose result differs from canonical TPC-H."""
-
-    query_id: int
-    variant_id: int
-    backend: str
-    detail: str
-
-    @property
-    def key(self) -> str:
-        """Stable ``<query>_v<variant>:<backend>`` identifier."""
-        return f"{self.query_id}_v{self.variant_id}:{self.backend}"
+# Canonical TPC-H SQL reference rows are normalized the same way as the
+# DataFrame side; re-exported under the historical name for callers/tests.
+fetch_canonical_rows = fetch_reference_rows
 
 
 def build_dataframe_contexts(connection: Any) -> dict[str, Any]:
     """Materialize the TPC-H tables on ``connection`` into both DataFrame contexts.
 
-    Tables are exported once through Arrow with ``DECIMAL`` columns cast to
-    ``DOUBLE``, mirroring the production DataFrame loader's schema mapping
-    (``DECIMAL(15,2) -> Float64`` / ``double``), then registered with the
-    reference adapter context of each backend: Polars lazy frames for the
-    expression family and Arrow-backed Pandas frames (production loads Parquet
-    with ``dtype_backend="pyarrow"``) for the pandas family.
-
-    Platform imports are deferred so importing this module does not pull
-    Polars or Pandas into the core import graph.
+    Thin TPC-H-specific wrapper over
+    :func:`benchbox.core.equivalence.dataframe_surface.build_dataframe_contexts`,
+    supplying the TPC-H table schema.
 
     Args:
         connection: A DuckDB connection already populated with TPC-H data.
@@ -119,61 +119,9 @@ def build_dataframe_contexts(connection: Any) -> dict[str, Any]:
         Mapping of backend name (see :data:`DATAFRAME_BACKENDS`) to a context
         with all eight TPC-H tables registered.
     """
-    import pandas as pd
-    import polars as pl
-
     from benchbox.core.tpch.schema import TABLES
-    from benchbox.platforms.dataframe.pandas_df import PandasDataFrameAdapter
-    from benchbox.platforms.dataframe.polars_df import PolarsDataFrameAdapter
 
-    expression_ctx = PolarsDataFrameAdapter().create_context()
-    pandas_ctx = PandasDataFrameAdapter().create_context()
-    for table in TABLES:
-        projections = [
-            f"CAST({column.name} AS DOUBLE) AS {column.name}"
-            if column.data_type.value.startswith("DECIMAL")
-            else column.name
-            for column in table.columns
-        ]
-        # fetch_arrow_table() (not .arrow()) so the result is a materialized
-        # pyarrow.Table on every DuckDB version, including >=1.4 where
-        # .arrow() returns a RecordBatchReader.
-        arrow = connection.execute(f"SELECT {', '.join(projections)} FROM {table.name.lower()}").fetch_arrow_table()
-        expression_ctx.register_table(table.name, pl.from_arrow(arrow).lazy())
-        pandas_ctx.register_table(table.name, arrow.to_pandas(types_mapper=pd.ArrowDtype))
-    return {"expression": expression_ctx, "pandas": pandas_ctx}
-
-
-def materialize_rows(result: Any) -> list[tuple[Any, ...]]:
-    """Materialize a DataFrame query result to normalized row tuples.
-
-    Accepts whatever a variant implementation returns on either backend - a
-    ``UnifiedLazyFrame``/``UnifiedPandasFrame`` wrapper, a Polars lazy or eager
-    frame, or a Pandas frame - and produces plain row tuples in the frame's
-    column order with values normalized via :func:`_normalize_value`.
-    """
-    native = getattr(result, "native", result)
-    if hasattr(native, "collect"):
-        native = native.collect()
-    if hasattr(native, "rows"):
-        raw_rows = native.rows()
-    elif hasattr(native, "itertuples"):
-        raw_rows = native.itertuples(index=False, name=None)
-    else:
-        raise TypeError(f"cannot materialize result of type {type(native).__name__}")
-    return [tuple(_normalize_value(value) for value in row) for row in raw_rows]
-
-
-def fetch_canonical_rows(connection: Any, canonical_sql: str) -> list[tuple[Any, ...]]:
-    """Execute canonical TPC-H SQL and return normalized row tuples.
-
-    The query is executed as-is - including its presentational top-N ``LIMIT``
-    - because the DataFrame implementations reproduce that cut (see module
-    docstring). Values pass through the same normalization as the DataFrame
-    side so the comparator sees one scalar vocabulary.
-    """
-    rows = connection.execute(canonical_sql).fetchall()
-    return [tuple(_normalize_value(value) for value in row) for row in rows]
+    return _build_dataframe_contexts(connection, TABLES)
 
 
 def find_dataframe_divergences(
@@ -184,7 +132,7 @@ def find_dataframe_divergences(
     *,
     query_ids: list[int] | None = None,
     backends: tuple[str, ...] = DATAFRAME_BACKENDS,
-) -> list[DataFrameDivergence]:
+) -> list[SurfaceDivergence]:
     """Compare every DataFrame variant of each query to canonical TPC-H.
 
     Args:
@@ -199,16 +147,40 @@ def find_dataframe_divergences(
         backends: Backends to gate; defaults to both shipped backends.
 
     Returns:
-        One :class:`DataFrameDivergence` per variant/backend cell whose result
-        is not equivalent to canonical TPC-H. Reuses
-        :meth:`TPCHavocBenchmark.validate_variant_equivalence`.
+        One :class:`SurfaceDivergence` per variant/backend cell whose result is
+        not equivalent to canonical TPC-H (cell label ``v<variant>:<backend>``).
+        Reuses :meth:`TPCHavocBenchmark.validate_variant_equivalence` and the
+        shared :func:`find_surface_divergences` loop.
     """
     from benchbox.core.tpch import dataframe_queries as tpch_dataframe_queries
     from benchbox.core.tpch.dataframe_queries import set_parameter_overrides, set_scale_factor
 
     ids = query_ids if query_ids is not None else benchmark.get_implemented_queries()
     registry = benchmark.get_dataframe_queries()
-    divergences: list[DataFrameDivergence] = []
+
+    def reference_rows(query_id: int) -> list[tuple[Any, ...]]:
+        return fetch_canonical_rows(connection, canonical_query(query_id))
+
+    def candidate_cells(
+        query_id: int,
+    ) -> Iterable[tuple[str, Callable[[list[tuple[Any, ...]]], None]]]:
+        for variant_id in range(1, 11):
+            query = registry.get_or_raise(f"Q{query_id}v{variant_id}")
+            for backend in backends:
+                impl = query.expression_impl if backend == "expression" else query.pandas_impl
+
+                def check(
+                    reference: list[tuple[Any, ...]],
+                    *,
+                    impl: Any = impl,
+                    backend: str = backend,
+                    variant_id: int = variant_id,
+                ) -> None:
+                    candidate = materialize_rows(impl(contexts[backend]))
+                    benchmark.validate_variant_equivalence(query_id, variant_id, reference, candidate)
+
+                yield f"v{variant_id}:{backend}", check
+
     # Compare against the scale-aware defaults alone. The DataFrame Q11 default
     # is now scale-aware (0.0001 / SF), exactly like canonical qgen and the
     # unseeded production run path, so no gate-local fraction override is needed:
@@ -219,27 +191,16 @@ def find_dataframe_divergences(
     set_parameter_overrides(None)
     set_scale_factor(benchmark.scale_factor)
     try:
-        for query_id in ids:
-            try:
-                canonical_rows = fetch_canonical_rows(connection, canonical_query(query_id))
-            except Exception as exc:  # noqa: BLE001 - a diagnostic must report, not crash, on a bad query
-                divergences.append(DataFrameDivergence(query_id, 0, "canonical", f"canonical query failed: {exc}"))
-                continue
-            for variant_id in range(1, 11):
-                query = registry.get_or_raise(f"Q{query_id}v{variant_id}")
-                for backend in backends:
-                    impl = query.expression_impl if backend == "expression" else query.pandas_impl
-                    try:
-                        variant_rows = materialize_rows(impl(contexts[backend]))
-                        benchmark.validate_variant_equivalence(query_id, variant_id, canonical_rows, variant_rows)
-                    except ValidationError as exc:
-                        divergences.append(DataFrameDivergence(query_id, variant_id, backend, str(exc)))
-                    except Exception as exc:  # noqa: BLE001 - surface execution errors as divergences
-                        divergences.append(DataFrameDivergence(query_id, variant_id, backend, f"error: {exc}"))
+        return find_surface_divergences(
+            ids,
+            reference_rows=reference_rows,
+            candidate_cells=candidate_cells,
+            validation_error=ValidationError,
+            reference_failure_cell="v0:canonical",
+        )
     finally:
         set_parameter_overrides(previous_overrides)
         set_scale_factor(previous_scale_factor)
-    return divergences
 
 
 def main() -> int:
@@ -270,7 +231,7 @@ def main() -> int:
         f"{len(divergences)} divergent, {total - len(divergences)} equivalent\n"
     )
 
-    by_class: dict[str, list[DataFrameDivergence]] = {}
+    by_class: dict[str, list[SurfaceDivergence]] = {}
     for divergence in sorted(divergences, key=lambda d: _sort_key(d.key)):
         klass = KNOWN_DIVERGENCES.get(divergence.key, "UNCLASSIFIED")
         by_class.setdefault(klass, []).append(divergence)
@@ -287,33 +248,6 @@ def main() -> int:
     if not new and not resolved:
         print("All DataFrame variants equivalent to canonical TPC-H (modulo KNOWN_DIVERGENCES).")
     return 1 if new else 0
-
-
-def _normalize_value(value: Any) -> Any:
-    """Normalize one result value to a plain Python scalar.
-
-    Maps DuckDB ``Decimal`` to float (the DataFrame surface computes in
-    float64), midnight timestamps to dates (Pandas materializes DATE columns
-    as midnight ``Timestamp``), missing values (``None``/``NaN``/Pandas
-    ``NA``/``NaT``) to ``None``, and unwraps NumPy/Arrow scalars via
-    ``.item()``.
-    """
-    if value is None:
-        return None
-    if isinstance(value, Decimal):
-        return float(value)
-    if isinstance(value, datetime):  # before date: datetime subclasses date
-        return value.date() if value.time() == _MIDNIGHT else value
-    if isinstance(value, float):  # before .item(): NumPy floats subclass float
-        return None if math.isnan(value) else float(value)
-    if isinstance(value, (str, bytes, int, date)):
-        return value
-    if type(value).__name__ in ("NAType", "NaTType"):  # pandas.NA / pandas.NaT without importing pandas
-        return None
-    item = getattr(value, "item", None)  # NumPy / Arrow scalar wrappers
-    if callable(item):
-        return _normalize_value(item())
-    return value
 
 
 def _sort_key(key: str) -> tuple[int, int, str]:

--- a/tests/unit/core/equivalence/__init__.py
+++ b/tests/unit/core/equivalence/__init__.py
@@ -1,0 +1,6 @@
+"""Tests for the benchmark-agnostic result-equivalence harness.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""

--- a/tests/unit/core/equivalence/test_dataframe_surface.py
+++ b/tests/unit/core/equivalence/test_dataframe_surface.py
@@ -1,0 +1,161 @@
+"""Unit tests for the benchmark-agnostic cross-surface equivalence harness.
+
+These lock the control-flow contract of
+:func:`benchbox.core.equivalence.dataframe_surface.find_surface_divergences`
+and the value normalization that every gate built on the harness depends on,
+without needing DuckDB / Polars / Pandas (those are exercised by the
+integration-lane TPC-Havoc gates).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from benchbox.core.equivalence.dataframe_surface import (
+    SurfaceDivergence,
+    _normalize_value,
+    find_surface_divergences,
+    materialize_rows,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+class _Mismatch(Exception):
+    """Stand-in for a validator's mismatch exception type."""
+
+
+def _equal_check(reference, candidate):
+    """A check closure that raises _Mismatch when rows differ."""
+
+    def check(actual_reference):
+        assert actual_reference == reference
+        if candidate != reference:
+            raise _Mismatch(f"rows differ: {candidate} != {reference}")
+
+    return check
+
+
+def test_all_cells_equivalent_yields_no_divergences() -> None:
+    divergences = find_surface_divergences(
+        [1, 2],
+        reference_rows=lambda q: [(q,)],
+        candidate_cells=lambda q: [
+            ("expression", _equal_check([(q,)], [(q,)])),
+            ("pandas", _equal_check([(q,)], [(q,)])),
+        ],
+        validation_error=_Mismatch,
+    )
+    assert divergences == []
+
+
+def test_mismatch_uses_validator_message_verbatim() -> None:
+    divergences = find_surface_divergences(
+        [7],
+        reference_rows=lambda q: [(1,)],
+        candidate_cells=lambda q: [("pandas", _equal_check([(1,)], [(2,)]))],
+        validation_error=_Mismatch,
+    )
+    assert len(divergences) == 1
+    only = divergences[0]
+    assert only.query_id == 7
+    assert only.cell == "pandas"
+    assert only.key == "7_pandas"
+    assert only.detail == "rows differ: [(2,)] != [(1,)]"
+
+
+def test_execution_error_is_prefixed_and_isolated_per_cell() -> None:
+    def boom(_reference):
+        raise RuntimeError("kaboom")
+
+    divergences = find_surface_divergences(
+        [3],
+        reference_rows=lambda q: [(0,)],
+        candidate_cells=lambda q: [
+            ("expression", boom),
+            ("pandas", _equal_check([(0,)], [(0,)])),
+        ],
+        validation_error=_Mismatch,
+    )
+    # The bad cell is reported with an ``error:`` prefix; the good sibling cell
+    # in the same query is unaffected (per-cell isolation).
+    assert [(d.cell, d.detail) for d in divergences] == [("expression", "error: kaboom")]
+
+
+def test_reference_failure_records_one_divergence_and_skips_cells() -> None:
+    calls: list[int] = []
+
+    def reference_rows(q):
+        raise ValueError("no data")
+
+    def candidate_cells(q):
+        calls.append(q)
+        return [("expression", _equal_check([], []))]
+
+    divergences = find_surface_divergences(
+        [5],
+        reference_rows=reference_rows,
+        candidate_cells=candidate_cells,
+        validation_error=_Mismatch,
+        reference_failure_cell="v0:canonical",
+    )
+    assert calls == []  # candidate cells never enumerated without a reference
+    assert len(divergences) == 1
+    assert divergences[0].cell == "v0:canonical"
+    assert divergences[0].detail == "reference query failed: no data"
+
+
+def test_surface_divergence_key_format() -> None:
+    assert SurfaceDivergence(3, "v3:expression", "x").key == "3_v3:expression"
+    assert SurfaceDivergence(9, "", "x").key == "9"
+
+
+class _FakeEagerFrame:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def rows(self):
+        return self._rows
+
+
+class _FakeLazyFrame:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def collect(self):
+        return _FakeEagerFrame(self._rows)
+
+
+class _Wrapper:
+    def __init__(self, native):
+        self.native = native
+
+
+def test_materialize_rows_collects_and_normalizes() -> None:
+    frame = _FakeLazyFrame([(Decimal("1.50"), datetime(2020, 1, 1, 0, 0, 0)), (None, float("nan"))])
+    assert materialize_rows(_Wrapper(frame)) == [(1.5, date(2020, 1, 1)), (None, None)]
+
+
+def test_materialize_rows_rejects_unknown_result() -> None:
+    with pytest.raises(TypeError):
+        materialize_rows(object())
+
+
+def test_normalize_value_scalar_mappings() -> None:
+    assert _normalize_value(None) is None
+    assert _normalize_value(Decimal("2.25")) == 2.25
+    assert _normalize_value(datetime(2021, 6, 1, 0, 0, 0)) == date(2021, 6, 1)
+    assert _normalize_value(datetime(2021, 6, 1, 12, 30, 0)) == datetime(2021, 6, 1, 12, 30, 0)
+    assert _normalize_value(float("nan")) is None
+    assert _normalize_value("abc") == "abc"
+    assert _normalize_value(5) == 5


### PR DESCRIPTION
Implements **w0** of `benchmark-cross-surface-equivalence-gate` (High): extract a benchmark-agnostic cross-surface equivalence harness from the TPC-Havoc DataFrame gate so the same answer-key-free oracle discipline can be rolled out to any dual-surface benchmark.

## What changed
- **New `benchbox/core/equivalence/dataframe_surface.py`** — the shared, benchmark-agnostic harness:
  - `build_dataframe_contexts(connection, tables)` — parameterized by a benchmark's table schema (was hard-wired to TPC-H `TABLES`).
  - `materialize_rows`, `fetch_reference_rows`, `_normalize_value` — moved verbatim.
  - `find_surface_divergences(...)` — the data-build-agnostic compare loop: fetch the reference once per query, then run each injected candidate cell and validate it, with per-cell error isolation and mismatch-vs-execution-error classification. The validator and data builder are **injected, never forked**.
  - `SurfaceDivergence` — cell-labelled divergence record.
- **`benchbox/core/tpchavoc/dataframe_equivalence.py`** — re-expressed as a thin wrapper: it injects the canonical-TPC-H reference accessor, the variant/backend cell enumeration, and the Q11 scale-aware parameter wiring, reusing the existing `validate_variant_equivalence` comparator and `build_duckdb_with_tpch` data builder. All public names preserved (`build_dataframe_contexts`, `materialize_rows`, `fetch_canonical_rows`, `find_dataframe_divergences`, `KNOWN_DIVERGENCES`, `DATAFRAME_BACKENDS`).
- **`tests/unit/core/equivalence/`** — fast-lane unit coverage for the harness control flow (reference-failure, mismatch vs execution-error formatting, per-cell isolation) and value normalization (no DuckDB/Polars needed).

## Verification
- `make tpchavoc-dataframe-equivalence-report` → **`checked 440 variant-backend cells - 0 divergent, 440 equivalent`** (byte-equivalent to develop).
- `tests/integration/test_tpchavoc_dataframe_variant_equivalence.py` passes (fast lane).
- New `tests/unit/core/equivalence/` (8 tests) passes; `tests/unit/core/tpchavoc/` (64) still green.
- `ruff check` / `ruff format --check` / `ty check` clean on changed files.

## Review notes
A high-effort self-review (8 finder angles + verify) ran; two findings were fixed before pushing: removed a speculative dead `backends` param from the shared `build_dataframe_contexts` (builds both backends, faithful to the original), and made `validation_error` a required keyword on `find_surface_divergences` (no silent reclassification of crashes as mismatches). Report-formatting duplication between the SQL and DataFrame gates pre-existed this change and is left for a later increment — out of w0 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_