### PR TITLE
fix(query-plans): stop cost/cardinality estimates leaking into plan fingerprints

### DIFF
--- a/_project/DONE/platform-expansion/planning/query-plan-capture-fingerprint-estimate-leak.yaml
+++ b/_project/DONE/platform-expansion/planning/query-plan-capture-fingerprint-estimate-leak.yaml
@@ -2,8 +2,36 @@ id: query-plan-capture-fingerprint-estimate-leak
 title: "Stop cost/cardinality estimates leaking into plan fingerprints; add a cross-parser signature-hygiene invariant"
 worktree: platform-expansion
 priority: Medium-High
-status: Not Started
+status: Completed
 category: Platform Expansion
+
+resolution: |
+  w1 (quantify the leak): confirmed empirically against live engines. Two parsers
+  fold estimate-bearing EXPLAIN detail into signature fields: DuckDB (FORMAT JSON
+  `extra_info` dict carries `Estimated Cardinality`, folded into
+  join_conditions/aggregation_functions/filter_expressions/sort_keys) and
+  DataFusion (EXPLAIN ANALYZE appends a `metrics=[output_rows=..]` block that the
+  filter detail captured). PostgreSQL and Redshift route cost/rows into dedicated,
+  non-hashed `properties`, so they were already clean; all other recorded fixtures
+  were verified clean.
+  w2 (strip estimates): added shared helpers `strip_estimates(text)` and
+  `strip_estimate_keys(mapping)` in parsers/base.py as the single place the rule
+  lives. DuckDB now strips estimate keys from the dict (raw kept in
+  platform_metadata); DataFusion strips the metrics block from the detail before
+  structural extraction. The strip is anchored to unambiguous estimate wording
+  (`Estimated Cardinality`, `EC:`, `metrics=[...]`, `(cost=N..N rows=N width=N)`)
+  so a genuine predicate on a column named cost/rows/num_rows/cardinality/ec is
+  never corrupted.
+  w3 (invariant): added tests/unit/query_plans/test_fingerprint_hygiene.py — a
+  registry-wide test that (a) asserts every registered parser's signature carries
+  no estimate token, with a coverage guard so a new parser must add a fixture, and
+  (b) asserts estimate-only-different fixtures produce identical fingerprints.
+  Updated the query_plan_models.py stability contract to drop the per-engine
+  stats-independence caveat now that the invariant enforces it.
+  Known impact: fingerprint VALUES for DuckDB/DataFusion JOIN/FILTER/AGGREGATE/SORT
+  plans change vs pre-fix captures (the intended correction). This is consistent
+  with the documented "not comparable across engine versions" property; stored
+  history/baseline fingerprints from before this change are recomputed on next run.
 
 description: |
   The plan fingerprint is documented (query_plan_models.py, added in #768) as a LOGICAL,
@@ -40,7 +68,7 @@ prior_art:
 work:
   - id: w1
     summary: "Quantify the leak: which parsers fold estimate/cost text into signature fields"
-    status: pending
+    status: done
     notes: |
       For each registered parser (duckdb, postgresql, redshift, datafusion, sqlite, presto,
       trino, clickhouse, spark) capture two fixtures of the same query that differ only in
@@ -49,7 +77,7 @@ work:
   - id: w2
     summary: "Strip estimate/cost tokens from signature-bearing fields in offending parsers"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       In each offending parser, keep the raw EXPLAIN detail in physical_operator.platform_metadata
       (not hashed) and place only the structural part (join keys, group keys, filter predicate
@@ -58,7 +86,7 @@ work:
   - id: w3
     summary: "Add a cross-parser signature-hygiene invariant test"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Create tests/unit/query_plans/test_fingerprint_hygiene.py. For every parser in the
       registry, parse two estimate-only-different fixtures and assert identical plan_fingerprint.

--- a/benchbox/core/query_plans/parsers/base.py
+++ b/benchbox/core/query_plans/parsers/base.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import logging
 import re
 from abc import ABC, abstractmethod
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, TypeVar
 
 from benchbox.core.errors import PlanParseError
 from benchbox.core.results.query_plan_models import (
@@ -23,6 +24,136 @@ from benchbox.core.results.query_plan_models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Signature hygiene: keeping cost/cardinality estimates out of the fingerprint
+# ---------------------------------------------------------------------------
+#
+# The plan fingerprint is a LOGICAL, stats-independent structural hash (see the
+# stability contract in ``query_plan_models.py``). A parser that folds an
+# operator's raw EXPLAIN detail into a signature-bearing logical field
+# (join_conditions, filter_expressions, aggregation_functions, sort_keys, ...)
+# leaks any cost/cardinality estimate carried in that text into the hash, so a
+# stats refresh or a different table size silently changes the fingerprint.
+#
+# The helpers below are the single place that strips estimate/cost tokens before
+# such text reaches a signature-bearing field. Raw detail (including estimates)
+# may still be retained in ``physical_operator.platform_metadata``, which is not
+# hashed. A registry-wide invariant test enforces that no parser leaks these
+# tokens (tests/unit/query_plans/test_fingerprint_hygiene.py).
+
+# Substrings that mark a structured (dict) EXPLAIN key as estimate-bearing.
+# Matched case-insensitively against the lower-cased key name. Deliberately
+# avoids short ambiguous fragments (e.g. "ec") that collide with structural keys
+# such as "Projections".
+_ESTIMATE_KEY_SUBSTRINGS: tuple[str, ...] = (
+    "cardinality",
+    "estimated",
+    "cost",
+    "selectivity",
+)
+
+# Exact (normalized) key names that hold estimates without matching the
+# substrings above. Deliberately omits schema-dependent names (e.g. "width")
+# that could be a genuine structural field rather than a statistic.
+_ESTIMATE_KEY_EXACT: frozenset[str] = frozenset(
+    {
+        "rows",
+        "ec",
+        "output_rows",
+        "row_count",
+        "num_rows",
+        "plan_rows",
+        "output_bytes",
+        "output_batches",
+    }
+)
+
+# DataFusion EXPLAIN ANALYZE appends a ``metrics=[...]`` block (output_rows,
+# elapsed_compute, selectivity, ...) at the END of operator detail lines. The
+# inner value list can itself contain brackets (e.g. ``partitioning=[Hash([a],4)]``),
+# so match greedily to the final ``]`` rather than the first inner one.
+_METRICS_BLOCK_RE = re.compile(r",?\s*metrics=\[.*\]", re.IGNORECASE)
+
+# PostgreSQL / Redshift style cost parenthetical: ``(cost=1.0..2.0 rows=5 width=4)``.
+# Anchored to the ``cost=N..N`` range form so a genuine predicate that merely
+# starts with a column named ``cost`` (e.g. ``(cost=5 AND x=1)``) is NOT removed.
+_COST_PAREN_RE = re.compile(
+    r"\s*\(\s*cost=[\d.]+\.\.[\d.]+(?:\s+rows=\d+)?(?:\s+width=\d+)?\s*\)",
+    re.IGNORECASE,
+)
+
+# Inline estimate tokens with an explicit estimate phrasing followed by a number.
+# Restricted to unambiguous estimate wording (``Estimated Cardinality``, ``EC:``)
+# so genuine predicates are never corrupted -- a column literally named ``cost``,
+# ``rows``, ``num_rows``, ``cardinality`` or ``ec`` (e.g. ``ec = 7``) is left
+# intact. DataFusion's ``output_rows``/``selectivity`` estimates only ever appear
+# inside the ``metrics=[...]`` block removed above, and DuckDB's structured
+# estimate keys are removed by ``strip_estimate_keys``.
+_INLINE_ESTIMATE_RE = re.compile(
+    r"""
+    (?:
+        (?:estimated\s+cardinality | estimated\s+cost | estimated\s+rows)
+        \s*[:=]\s*\d[\d.,]*%?
+        | \bEC:\s*\d[\d.,]*%?
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+T = TypeVar("T")
+
+
+def _key_is_estimate(key: str) -> bool:
+    """Return True if a structured EXPLAIN key holds a cost/cardinality estimate."""
+    normalized = str(key).strip().lower()
+    if normalized in _ESTIMATE_KEY_EXACT:
+        return True
+    return any(token in normalized for token in _ESTIMATE_KEY_SUBSTRINGS)
+
+
+def strip_estimate_keys(mapping: Mapping[str, T]) -> dict[str, T]:
+    """
+    Drop estimate-bearing keys from a structured EXPLAIN ``extra_info`` dict.
+
+    Used by parsers (e.g. DuckDB FORMAT JSON) whose ``extra_info`` is a dict that
+    mixes structural fields (``Conditions``, ``Groups``, ``Aggregates``) with
+    estimate fields (``Estimated Cardinality``). Only the structural keys should
+    reach a signature-bearing logical field; the estimate keys are removed here.
+
+    The input mapping is not mutated; a new dict is returned.
+    """
+    return {key: value for key, value in mapping.items() if not _key_is_estimate(key)}
+
+
+def strip_estimates(text: str) -> str:
+    """
+    Remove cost/cardinality/estimate tokens from a free-text EXPLAIN detail string.
+
+    This is the single rule for keeping estimates out of signature-bearing fields
+    in text-format parsers. It removes:
+
+    - DataFusion ``metrics=[...]`` blocks (``output_rows``, ``selectivity``, ...)
+    - PostgreSQL/Redshift ``(cost=N..N rows=N width=N)`` cost parentheticals
+    - inline ``Estimated Cardinality: N`` / ``EC: N`` tokens
+
+    Genuine predicate text is preserved: removal is anchored to explicit estimate
+    wording, so a predicate on a column literally named ``cost``, ``rows`` or
+    ``num_rows`` (e.g. ``(cost=5 AND x=1)`` or ``num_rows = 5``) is left intact.
+    Returns the cleaned, whitespace-normalized string.
+    """
+    if not text:
+        return text
+    cleaned = _METRICS_BLOCK_RE.sub("", text)
+    cleaned = _COST_PAREN_RE.sub("", cleaned)
+    cleaned = _INLINE_ESTIMATE_RE.sub("", cleaned)
+    # Tidy separators left behind by removals (trailing commas, empty brackets).
+    cleaned = re.sub(r"\[\s*\]", "", cleaned)
+    cleaned = re.sub(r"\s*,\s*(?=,|$)", "", cleaned)
+    cleaned = re.sub(r",\s*$", "", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip().strip(",").strip()
 
 
 class QueryPlanParser(ABC):

--- a/benchbox/core/query_plans/parsers/datafusion.py
+++ b/benchbox/core/query_plans/parsers/datafusion.py
@@ -26,7 +26,7 @@ import logging
 import re
 from typing import Any
 
-from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.query_plans.parsers.base import QueryPlanParser, strip_estimates
 from benchbox.core.results.query_plan_models import (
     JoinType,
     LogicalOperator,
@@ -336,7 +336,12 @@ class DataFusionQueryPlanParser(QueryPlanParser):
         Args:
             node: Operator node dictionary (modified in place)
         """
-        details = node.get("details", "")
+        # EXPLAIN ANALYZE appends a ``metrics=[output_rows=.., selectivity=..]`` block
+        # (and other estimates) to the detail line. Strip it before extracting the
+        # structural fields so cardinality estimates never reach a signature-bearing
+        # field. The raw detail (with metrics) is preserved in platform_metadata via
+        # node["details"], which is not hashed.
+        details = strip_estimates(node.get("details", ""))
         operator = node.get("operator", "").lower()
 
         if "scan" in operator or "datasource" in operator or "parquet" in operator:

--- a/benchbox/core/query_plans/parsers/duckdb.py
+++ b/benchbox/core/query_plans/parsers/duckdb.py
@@ -66,7 +66,11 @@ import logging
 import re
 from typing import Any
 
-from benchbox.core.query_plans.parsers.base import QueryPlanParser
+from benchbox.core.query_plans.parsers.base import (
+    QueryPlanParser,
+    strip_estimate_keys,
+    strip_estimates,
+)
 from benchbox.core.results.query_plan_models import (
     LogicalOperator,
     LogicalOperatorType,
@@ -263,8 +267,17 @@ class DuckDBQueryPlanParser(QueryPlanParser):
         # Extract operator-specific information
         kwargs: dict[str, Any] = {}
         raw_extra = node.get("extra_info", "")
-        # DuckDB returns extra_info as a dict in FORMAT JSON responses; normalise to string
-        extra_info = raw_extra if isinstance(raw_extra, str) else json.dumps(raw_extra)
+        # DuckDB returns extra_info as a dict in FORMAT JSON responses; normalise to string.
+        # `extra_info` keeps the raw detail (incl. estimates) for platform_metadata / table
+        # extraction; `logical_extra` is the estimate-stripped form for signature-bearing
+        # fields so the fingerprint stays stats-independent (see strip_estimates docstring).
+        if isinstance(raw_extra, dict):
+            extra_info = json.dumps(raw_extra)
+            stripped_extra = strip_estimate_keys(raw_extra)
+            logical_extra = json.dumps(stripped_extra) if stripped_extra else ""
+        else:
+            extra_info = raw_extra
+            logical_extra = strip_estimates(raw_extra)
 
         if operator_type == LogicalOperatorType.SCAN:
             # Try to extract table name from extra_info
@@ -273,21 +286,21 @@ class DuckDBQueryPlanParser(QueryPlanParser):
                 kwargs["table_name"] = table_name
 
         elif operator_type == LogicalOperatorType.FILTER:
-            if extra_info:
-                kwargs["filter_expressions"] = [extra_info]
+            if logical_extra:
+                kwargs["filter_expressions"] = [logical_extra]
 
         elif operator_type == LogicalOperatorType.JOIN:
             kwargs["join_type"] = self._extract_join_type_from_operator(operator_name)
-            if extra_info:
-                kwargs["join_conditions"] = [extra_info]
+            if logical_extra:
+                kwargs["join_conditions"] = [logical_extra]
 
         elif operator_type == LogicalOperatorType.AGGREGATE:
-            if extra_info:
-                kwargs["aggregation_functions"] = [extra_info]
+            if logical_extra:
+                kwargs["aggregation_functions"] = [logical_extra]
 
         elif operator_type == LogicalOperatorType.SORT:
-            if extra_info:
-                kwargs["sort_keys"] = [{"expr": extra_info, "direction": "ASC"}]
+            if logical_extra:
+                kwargs["sort_keys"] = [{"expr": logical_extra, "direction": "ASC"}]
 
         # Create physical operator with DuckDB-specific details.
         # EXPLAIN (ANALYZE, FORMAT JSON) uses operator_timing/operator_cardinality;

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -26,22 +26,19 @@ What the fingerprint deliberately EXCLUDES:
   - operator IDs and any other non-structural physical-operator properties
 
 Stability guarantees (what a stable fingerprint means):
-  - **Stats-independent — engine-dependent caveat.** The signature excludes the
-    dedicated cost / row-estimate fields (``estimated_cost``, ``estimated_rows``,
-    and the per-operator ``properties`` that hold cost/cardinality/timing). For a
-    plain table scan, and for engines whose EXPLAIN omits estimates from operator
-    detail (e.g. SQLite ``EXPLAIN QUERY PLAN``), a ``VACUUM``/``ANALYZE`` or other
-    statistics refresh that only changes row estimates does NOT change the
-    fingerprint. **However, this is not universal:** some platform parsers fold an
-    operator's raw EXPLAIN ``extra_info`` string into a signature-bearing field
-    (e.g. the DuckDB parser stores ``extra_info`` into ``join_conditions`` for
-    JOIN, ``aggregation_functions`` for AGGREGATE, ``filter_expressions`` for
-    FILTER, and ``sort_keys`` for SORT). On DuckDB that ``extra_info`` includes an
-    ``Estimated Cardinality``, so a JOIN/AGGREGATE/FILTER/SORT fingerprint CAN
-    change when cardinality estimates change (after a stats refresh, or simply at a
-    different table size). Treat full stats-independence as a property of
-    scan-shaped/leaf plans and of engines that keep estimates out of operator
-    detail — verify per engine before relying on it for non-trivial plans.
+  - **Stats-independent.** The signature excludes the dedicated cost / row-estimate
+    fields (``estimated_cost``, ``estimated_rows``, and the per-operator
+    ``properties`` that hold cost/cardinality/timing). A ``VACUUM``/``ANALYZE`` or
+    other statistics refresh that only changes row estimates does NOT change the
+    fingerprint. Parsers that fold an operator's raw EXPLAIN detail into a
+    signature-bearing field (e.g. the DuckDB FORMAT JSON ``extra_info`` dict, which
+    carries an ``Estimated Cardinality``) strip the cost/cardinality tokens before
+    the text reaches the hashed field, via the shared helpers in
+    ``benchbox/core/query_plans/parsers/base.py`` (``strip_estimates`` /
+    ``strip_estimate_keys``). A registry-wide invariant
+    (``tests/unit/query_plans/test_fingerprint_hygiene.py``) enforces that no
+    parser leaks estimate text into the signature, so this guarantee holds for
+    every registered engine rather than needing per-engine verification.
   - **Logical, not physical — with an engine-dependent caveat.** The signature is
     built from the *logical* operator tree, so the physical access method is
     generally NOT reflected: an index scan and a sequential scan of the same table

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -506,6 +506,37 @@ class TestDuckDBFingerprintIntegration:
             "Adding an index is a physical change; the logical fingerprint must be stable"
         )
 
+    def test_fingerprint_stable_across_row_count_change(self, adapter):
+        """A GROUP BY fingerprint must not change with table size.
+
+        Regression test for the estimate leak: DuckDB's FORMAT JSON ``extra_info``
+        carries an ``Estimated Cardinality`` that previously folded into the
+        AGGREGATE/SCAN signature fields, so the same query hashed differently at
+        500 vs 5000 rows. The fingerprint must be stats-independent.
+        """
+        query = "SELECT grp, sum(amount) AS s FROM sized GROUP BY grp ORDER BY grp"
+
+        def fingerprint_for(row_count: int) -> str:
+            connection = adapter.create_connection()
+            try:
+                connection.execute("CREATE TABLE sized (id INTEGER, amount DOUBLE, grp INTEGER)")
+                connection.executemany(
+                    "INSERT INTO sized VALUES (?, ?, ?)",
+                    [(i, float(i), i % 5) for i in range(1, row_count)],
+                )
+                plan, _ = adapter.capture_query_plan(connection, query, f"grp_{row_count}")
+                assert plan is not None
+                return plan.plan_fingerprint
+            finally:
+                adapter.close_connection(connection)
+
+        small = fingerprint_for(500)
+        large = fingerprint_for(5000)
+        assert small == large, (
+            "GROUP BY fingerprint changed with row count; cardinality estimates must "
+            "not leak into the structural signature"
+        )
+
     def test_fingerprint_differs_for_logically_distinct_plans(self, adapter, conn):
         # A self-join adds a second table scan to the logical tree, so the
         # signature differs by construction (two Scan nodes vs one), independent of

--- a/tests/unit/query_plans/test_fingerprint_hygiene.py
+++ b/tests/unit/query_plans/test_fingerprint_hygiene.py
@@ -1,0 +1,345 @@
+"""Cross-parser signature-hygiene invariant.
+
+The plan fingerprint is a LOGICAL, stats-independent structural hash (see the
+stability contract in ``benchbox/core/results/query_plan_models.py``). A parser
+that folds an operator's raw EXPLAIN detail into a signature-bearing logical
+field leaks any cost/cardinality estimate carried in that text into the hash, so
+a stats refresh (VACUUM/ANALYZE) or a different table size silently changes the
+fingerprint. That is a bug, and historically the DuckDB parser had it (its
+FORMAT JSON ``extra_info`` dict carries ``Estimated Cardinality``).
+
+This module enforces the rule for every registered parser:
+
+1. ``test_no_parser_leaks_estimate_tokens_into_signature`` parses a recorded
+   fixture per platform and asserts the structural signature contains no
+   cost/cardinality/estimate token. Driven by recorded fixtures under
+   ``tests/fixtures/query_plans/`` (plus inline samples for the parsers that
+   ship no file fixture) so it runs with no live service.
+2. ``test_registry_is_fully_covered`` asserts every registered platform has a
+   hygiene fixture, so a newly added parser cannot silently skip the invariant.
+3. ``test_estimate_only_changes_do_not_change_fingerprint`` parses two fixtures
+   that differ ONLY in estimate values and asserts an identical fingerprint.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.parsers.base import strip_estimate_keys, strip_estimates
+from benchbox.core.query_plans.parsers.registry import (
+    get_parser_for_platform,
+    get_parser_registry,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+# Tokens that must never appear in a structural signature: digit-bearing
+# cost/cardinality/estimate text, plus the DataFusion ``metrics=[...]`` block.
+# Kept aligned with the estimate vocabulary stripped in base.py: this tripwire
+# flags the unambiguous estimate forms (so it never false-positives on a genuine
+# predicate column named ``cost``/``rows``) while covering every standalone
+# estimate token the stripper knows about (selectivity, num_rows, ...).
+_ESTIMATE_TOKEN_RE = re.compile(
+    r"""
+    estimated\s+cardinality
+    | estimated\s+cost
+    | estimated\s+rows
+    | cardinality\s*[:=]\s*\d
+    | \bEC:\s*\d
+    | output_rows\s*[:=]\s*\d
+    | plan_rows\s*[:=]\s*\d
+    | num_rows\s*[:=]\s*\d
+    | row_count\s*[:=]\s*\d
+    | selectivity\s*[:=]\s*\d
+    | metrics\s*=\s*\[
+    | \(\s*cost=[\d.]+\.\.
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Inline fixtures for parsers that ship no recorded file fixture. Each carries a
+# cost/cardinality estimate in the raw EXPLAIN so the leak path is exercised.
+# ---------------------------------------------------------------------------
+
+
+def _postgresql_explain(plan_rows: int, total_cost: float) -> str:
+    """PostgreSQL EXPLAIN (FORMAT JSON): estimates live in dedicated keys."""
+    return json.dumps(
+        [
+            {
+                "Plan": {
+                    "Node Type": "Aggregate",
+                    "Strategy": "Hashed",
+                    "Total Cost": total_cost,
+                    "Plan Rows": plan_rows,
+                    "Group Key": ["o_orderpriority"],
+                    "Plans": [
+                        {
+                            "Node Type": "Seq Scan",
+                            "Relation Name": "orders",
+                            "Total Cost": total_cost,
+                            "Plan Rows": plan_rows * 10,
+                            "Filter": "(o_totalprice > 10)",
+                        }
+                    ],
+                }
+            }
+        ]
+    )
+
+
+def _redshift_explain(rows: int, total_cost: str) -> str:
+    """Redshift text EXPLAIN: estimates in ``(cost=.. rows=.. width=..)``."""
+    return (
+        f"XN HashAggregate  (cost=50.00..{total_cost} rows={rows} width=40)\n"
+        f"  ->  XN Seq Scan on lineitem  (cost=0.00..25.00 rows={rows * 10} width=40)\n"
+        f"        Filter: (l_quantity > 5)"
+    )
+
+
+def _datafusion_explain(output_rows: int) -> str:
+    """DataFusion EXPLAIN ANALYZE physical plan: estimates in ``metrics=[...]``."""
+    return (
+        f"physical_plan | FilterExec: id@0 > 1, "
+        f"metrics=[output_rows={output_rows}, elapsed_compute=9us, "
+        f"selectivity=98% ({output_rows}/{output_rows + 1})]\n"
+        f"              |   DataSourceExec: partitions=1, partition_sizes=[1], metrics=[]"
+    )
+
+
+def _duckdb_explain(cardinality: int) -> str:
+    """DuckDB EXPLAIN (FORMAT JSON): ``extra_info`` dict carries Estimated Cardinality."""
+    return json.dumps(
+        [
+            {
+                "name": "PERFECT_HASH_GROUP_BY",
+                "extra_info": {
+                    "Groups": "#0",
+                    "Aggregates": "sum(#1)",
+                    "Estimated Cardinality": str(cardinality),
+                },
+                "children": [
+                    {
+                        "name": "SEQ_SCAN",
+                        "extra_info": {
+                            "Table": "orders",
+                            "Filters": "id>1",
+                            "Estimated Cardinality": str(cardinality * 20),
+                        },
+                        "children": [],
+                    }
+                ],
+            }
+        ]
+    )
+
+
+def _sqlite_explain() -> str:
+    return "QUERY PLAN\n`--SEARCH orders USING INDEX idx_orders (id=?)"
+
+
+# ---------------------------------------------------------------------------
+# Per-platform hygiene fixtures. Every registered platform must resolve here.
+# File-backed entries reuse the recorded EXPLAIN fixtures; inline entries cover
+# the parsers that ship no file fixture.
+# ---------------------------------------------------------------------------
+
+_FILE_FIXTURES: dict[str, str] = {
+    "duckdb": "motherduck_duckdb_explain_sample.json",
+    "motherduck": "motherduck_duckdb_explain_sample.json",
+    "clickhouse": "clickhouse_explain_plan_sample.txt",
+    "presto": "presto_explain_sample.json",
+    "athena": "athena_explain_sample.json",
+    "trino": "trino_explain_sample.json",
+    "starburst": "trino_explain_sample.json",
+    "spark": "spark_explain_sample.txt",
+    "databricks": "spark_explain_sample.txt",
+    "lakesail": "spark_explain_sample.txt",
+    "velox": "velox_explain_extended_sample.txt",
+    "databend": "databend_explain_sample.txt",
+    "questdb": "questdb_explain_sample.txt",
+    "doris": "doris_shape_plan_sample.txt",
+    "singlestore": "singlestore_explain_sample.txt",
+    "snowflake": "snowflake_explain_sample.json",
+    "firebolt": "firebolt_explain_sample.txt",
+    "azure_synapse": "azure_synapse_explain_sample.xml",
+    "fabric_warehouse": "fabric_warehouse_showplan_sample.txt",
+    "bigquery": "bigquery_query_plan_sample.json",
+}
+
+_INLINE_FIXTURES: dict[str, str] = {
+    "postgresql": _postgresql_explain(5, 125.5),
+    "postgres": _postgresql_explain(5, 125.5),
+    "redshift": _redshift_explain(100, "55.00"),
+    "datafusion": _datafusion_explain(48),
+    "sqlite": _sqlite_explain(),
+}
+
+
+def _signature_fixture(platform: str) -> str:
+    if platform in _FILE_FIXTURES:
+        return _load(_FILE_FIXTURES[platform])
+    return _INLINE_FIXTURES[platform]
+
+
+# Estimate-only pairs: two EXPLAIN renderings of the same plan that differ ONLY
+# in cost/cardinality values. The fingerprint must be identical.
+#
+# duckdb and datafusion exercise the strip helpers directly (their estimates sit
+# in a signature-bearing field before stripping). postgresql and redshift route
+# estimates into non-hashed `properties`; their pairs assert the complementary
+# guarantee that those parsers keep estimates out of the signature entirely.
+_ESTIMATE_PAIRS: dict[str, tuple[str, str]] = {
+    "duckdb": (_duckdb_explain(5), _duckdb_explain(90_000)),
+    "datafusion": (_datafusion_explain(48), _datafusion_explain(90_000)),
+    "postgresql": (_postgresql_explain(5, 125.5), _postgresql_explain(70_000, 9_000_000.0)),
+    "redshift": (_redshift_explain(100, "55.00"), _redshift_explain(99_000, "990000.00")),
+}
+
+
+def _registered_platforms() -> list[str]:
+    return sorted(get_parser_registry().get_all_platforms())
+
+
+class TestRegistryCoverage:
+    def test_registry_is_fully_covered(self):
+        """Every registered parser must have a hygiene fixture (future-proofing)."""
+        registered = set(_registered_platforms())
+        covered = set(_FILE_FIXTURES) | set(_INLINE_FIXTURES)
+        missing = registered - covered
+        assert not missing, (
+            f"Parsers {sorted(missing)} are registered but have no signature-hygiene "
+            "fixture. Add one to tests/unit/query_plans/test_fingerprint_hygiene.py "
+            "so the no-estimate-leak invariant covers them."
+        )
+
+
+class TestSignatureHygiene:
+    @pytest.mark.parametrize("platform", _registered_platforms())
+    def test_no_parser_leaks_estimate_tokens_into_signature(self, platform):
+        """No registered parser may fold cost/cardinality text into the signature."""
+        parser = get_parser_for_platform(platform)
+        assert parser is not None, f"No parser registered for {platform}"
+
+        dag = parser.parse_explain_output("hygiene", _signature_fixture(platform))
+        assert dag is not None, f"{platform} fixture failed to parse"
+        assert dag.logical_root is not None
+
+        signature = dag.logical_root.get_structural_signature()
+        leak = _ESTIMATE_TOKEN_RE.search(signature)
+        assert leak is None, (
+            f"{platform} parser leaked an estimate token {leak.group(0)!r} into the "
+            f"structural signature:\n{signature}\n"
+            "Strip cost/cardinality via strip_estimates()/strip_estimate_keys() before "
+            "storing detail into a signature-bearing field."
+        )
+
+    @pytest.mark.parametrize("platform", sorted(_ESTIMATE_PAIRS))
+    def test_estimate_only_changes_do_not_change_fingerprint(self, platform):
+        """Two plans that differ only in estimates must share a fingerprint."""
+        low_text, high_text = _ESTIMATE_PAIRS[platform]
+        parser = get_parser_for_platform(platform)
+
+        low = parser.parse_explain_output("low", low_text)
+        high = parser.parse_explain_output("high", high_text)
+        assert low is not None and high is not None
+
+        assert low.plan_fingerprint == high.plan_fingerprint, (
+            f"{platform} fingerprint changed when only the cost/cardinality estimate "
+            "changed; the fingerprint must be stats-independent.\n"
+            f"low : {low.logical_root.get_structural_signature()}\n"
+            f"high: {high.logical_root.get_structural_signature()}"
+        )
+
+
+class TestStripHelpers:
+    """Direct contract tests for the shared strip helpers."""
+
+    def test_strip_estimate_keys_drops_estimate_fields_only(self):
+        extra = {
+            "Groups": "#0",
+            "Aggregates": "sum(#1)",
+            "Estimated Cardinality": "12345",
+        }
+        cleaned = strip_estimate_keys(extra)
+        assert cleaned == {"Groups": "#0", "Aggregates": "sum(#1)"}
+        # Input is not mutated.
+        assert "Estimated Cardinality" in extra
+
+    @pytest.mark.parametrize(
+        "key",
+        ["Estimated Cardinality", "Estimated Cost", "Cardinality", "rows", "EC", "Selectivity"],
+    )
+    def test_strip_estimate_keys_recognises_estimate_keys(self, key):
+        assert strip_estimate_keys({key: "1", "Conditions": "a=b"}) == {"Conditions": "a=b"}
+
+    @pytest.mark.parametrize(
+        "structural_key",
+        ["Projections", "Conditions", "Groups", "Aggregates", "Order By", "Table", "Filters"],
+    )
+    def test_strip_estimate_keys_keeps_structural_keys(self, structural_key):
+        # "Projections" contains the substring "ec"; it must NOT be treated as an estimate.
+        result = strip_estimate_keys({structural_key: "value"})
+        assert result == {structural_key: "value"}
+
+    def test_strip_estimates_removes_metrics_block(self):
+        out = strip_estimates("id@0 > 1, metrics=[output_rows=48, selectivity=98% (48/49)]")
+        assert out == "id@0 > 1"
+
+    def test_strip_estimates_removes_cost_parenthetical(self):
+        out = strip_estimates("Seq Scan on orders (cost=0.00..15.50 rows=500 width=48)")
+        assert "cost=" not in out
+        assert "rows=" not in out
+        assert out.startswith("Seq Scan on orders")
+
+    def test_strip_estimates_removes_inline_estimated_cardinality(self):
+        out = strip_estimates("Filters: id>1 Estimated Cardinality: 119")
+        assert "119" not in out
+        assert "id>1" in out
+
+    def test_strip_estimates_preserves_predicate_with_estimate_like_column(self):
+        # A genuine predicate on a column literally named 'cost' must survive: removal
+        # is anchored to explicit estimate wording, not bare cost=/rows=.
+        out = strip_estimates("(cost_center = 5 AND rows_flag = 1)")
+        assert out == "(cost_center = 5 AND rows_flag = 1)"
+
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            "(cost=5 AND x=1)",  # column named 'cost', not a (cost=N..N) estimate paren
+            "WHERE num_rows = 5",  # column named 'num_rows'
+            "amount > 100 AND ec = 7",  # column named 'ec' with '=', not the 'EC:' estimate token
+            "(rows = 5 OR cardinality = 7)",  # columns named 'rows'/'cardinality'
+        ],
+    )
+    def test_strip_estimates_does_not_corrupt_genuine_predicates(self, predicate):
+        # Regression: the cost parenthetical and inline-token removals must be anchored
+        # to estimate wording so they never delete a real predicate whose column name
+        # collides with an estimate keyword.
+        assert strip_estimates(predicate) == predicate
+
+    def test_strip_estimates_removes_metrics_block_with_nested_brackets(self):
+        # Regression: the metrics block can embed bracketed values (partitioning), so the
+        # removal must reach the final ']' instead of stopping at the first inner one.
+        out = strip_estimates("expr=[a@0 ASC], metrics=[output_rows=5, partitioning=[Hash([a],4)]]")
+        assert out == "expr=[a@0 ASC]"
+        assert "output_rows" not in out and "metrics=" not in out
+
+    def test_strip_estimates_handles_empty(self):
+        assert strip_estimates("") == ""


### PR DESCRIPTION
## Summary

The plan fingerprint is documented as a **logical, stats-independent** structural hash — a `VACUUM`/`ANALYZE` or row-count change must not change it. Two parsers violated that by folding estimate-bearing EXPLAIN detail into signature-bearing fields:

- **DuckDB** FORMAT JSON `extra_info` is a dict carrying `Estimated Cardinality`, folded into `join_conditions`/`aggregation_functions`/`filter_expressions`/`sort_keys`. (Confirmed live: a GROUP BY hashed differently at 200 vs 9000 rows.)
- **DataFusion** EXPLAIN ANALYZE appends a `metrics=[output_rows=..]` block that the filter detail captured.

PostgreSQL and Redshift route cost/rows into dedicated, non-hashed `properties`, so they were already clean; all other recorded fixtures were verified clean.

### Changes
- Added shared `strip_estimates(text)` / `strip_estimate_keys(mapping)` helpers in `parsers/base.py` — the single place the estimate-stripping rule lives.
- DuckDB strips estimate keys from the `extra_info` dict (raw kept in the non-hashed `physical_operator.platform_metadata`); DataFusion strips the `metrics=[...]` block from the detail before structural extraction.
- The strip is anchored to **unambiguous** estimate wording (`Estimated Cardinality`, `EC:`, `metrics=[...]`, `(cost=N..N rows=N width=N)`) so a genuine predicate on a column literally named `cost`/`rows`/`num_rows`/`cardinality`/`ec` is never corrupted.
- New `tests/unit/query_plans/test_fingerprint_hygiene.py`: registry-wide invariant asserting (a) no parser leaks an estimate token into the signature, with a coverage guard so a new parser must add a fixture, and (b) estimate-only-different fixtures hash identically (DuckDB/DataFusion exercise the strip path; PostgreSQL/Redshift assert the complementary properties-path guarantee).
- Live DuckDB row-count stability regression test in `test_duckdb_plan_capture.py`.
- Updated the `query_plan_models.py` stability contract to drop the per-engine stats-independence caveat now that the invariant enforces it.

## Testing
- `uv run -- python -m pytest tests/unit/core/query_plans/ tests/unit/query_plans/ tests/unit/platforms/test_duckdb_plan_capture.py -q` → **576 passed**
- `ruff check` / `ruff format --check` / `ty check` → all green
- `make pr-preflight`: lint/format/type green and all query-plan suites pass. The 19 failing tests are pre-existing **sandbox-environmental** (worktree pool absent, delta/ducklake extensions missing, root-writable-dir CLI tests, git changelog/squash) — none import or touch the changed files.

## Deviations from the TODO
- The TODO suggested `strip_estimates(text)`; I added a second `strip_estimate_keys(mapping)` helper because DuckDB's `extra_info` is a structured dict (key-based stripping is cleaner and safer than regex over JSON).
- **Known impact:** fingerprint *values* for DuckDB/DataFusion JOIN/FILTER/AGGREGATE/SORT plans change vs pre-fix captures — this is the intended correction and is consistent with the documented "not comparable across engine versions" property; stored history/baseline fingerprints recompute on the next run.

Closes `query-plan-capture-fingerprint-estimate-leak` (moved to `_project/DONE/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fT8yfjtBSL1jUZUQArwvx)_