### PR TITLE
fix(dataframe): type-aware date-column inference in the production loader (w6)

### DIFF
--- a/benchbox/platforms/dataframe/benchmark_mixin.py
+++ b/benchbox/platforms/dataframe/benchmark_mixin.py
@@ -189,8 +189,18 @@ class BenchmarkExecutionMixin:
         table_name: str,
         file_paths: list[Path],
         column_names: list[str] | None = None,
+        delimiter: str | None = None,
+        format_hint: str | None = None,
+        *,
+        data_source: Any | None = None,
+        benchmark: Any | None = None,
     ) -> int:
-        """Load a table into context."""
+        """Load a table into context.
+
+        ``benchmark`` (when provided) lets adapters consult the schema's column
+        types - e.g. to avoid date-parsing an integer datekey column named like a
+        date.
+        """
 
     @abstractmethod
     def execute_query(
@@ -582,8 +592,13 @@ class BenchmarkExecutionMixin:
         data_paths: dict[str, Path | list[Path]],
         column_names_map: dict[str, list[str]],
         csv_delimiter: str | None,
+        benchmark: Any | None = None,
     ) -> tuple[dict[str, int], dict[str, TableLoadingStats]]:
         """Load all tables into the execution context.
+
+        ``benchmark`` (when provided) is passed through to ``load_table`` so
+        adapters can consult the schema's column types - e.g. to avoid parsing an
+        integer datekey column named like a date as a date.
 
         Returns:
             Tuple of (table_stats, per_table_loading_stats)
@@ -600,7 +615,12 @@ class BenchmarkExecutionMixin:
                 column_names = column_names_map.get(table_name.lower())
                 file_paths = [file_path] if not isinstance(file_path, list) else file_path
                 row_count = self.load_table(
-                    ctx, table_name.lower(), file_paths, column_names=column_names, delimiter=csv_delimiter
+                    ctx,
+                    table_name.lower(),
+                    file_paths,
+                    column_names=column_names,
+                    delimiter=csv_delimiter,
+                    benchmark=benchmark,
                 )
                 load_time_ms = int((elapsed_seconds(load_start)) * 1000)
 
@@ -703,7 +723,9 @@ class BenchmarkExecutionMixin:
         column_names_map, csv_delimiter = self._resolve_column_names_and_delimiter(benchmark_config, benchmark_instance)
 
         # Load tables into context
-        return self._load_tables_into_context(ctx, data_paths, column_names_map, csv_delimiter)
+        return self._load_tables_into_context(
+            ctx, data_paths, column_names_map, csv_delimiter, benchmark=benchmark_instance
+        )
 
     def _execute_queries_phase(
         self,

--- a/benchbox/platforms/dataframe/cudf_df.py
+++ b/benchbox/platforms/dataframe/cudf_df.py
@@ -209,6 +209,7 @@ class CuDFDataFrameAdapter(PandasFamilyAdapter[CuDFDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; cuDF infers types
     ) -> CuDFDF:
         """Read a CSV file into a cuDF DataFrame.
 

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -400,6 +400,7 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; Dask infers types
     ) -> DaskDF:
         """Read a CSV file into a Dask DataFrame.
 

--- a/benchbox/platforms/dataframe/modin_df.py
+++ b/benchbox/platforms/dataframe/modin_df.py
@@ -271,6 +271,7 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; Modin infers types
     ) -> ModinDF:
         """Read a CSV file into a Modin DataFrame.
 

--- a/benchbox/platforms/dataframe/pandas_df.py
+++ b/benchbox/platforms/dataframe/pandas_df.py
@@ -59,16 +59,45 @@ def _parse_date_value(value: Any) -> Any:
     return pd.to_datetime(value).date()
 
 
-def _pandas_parse_date_columns(names: list[str] | None) -> tuple[list[str], list[str]]:
-    """Infer date and timestamp columns for raw CSV/TBL loads with explicit schemas."""
+# SQL type prefixes that are numeric, not temporal. A column named like a date
+# but declared with one of these (e.g. SSB's INTEGER ``lo_orderdate`` YYYYMMDD
+# datekeys) is a key, not a date, and must never be coerced to a date dtype.
+_NUMERIC_SQL_TYPE_PREFIXES = ("INT", "BIGINT", "SMALLINT", "TINYINT", "DECIMAL", "NUMERIC", "FLOAT", "DOUBLE", "REAL")
+
+
+def _is_numeric_sql_type(sql_type: str | None) -> bool:
+    """True if ``sql_type`` is a numeric SQL type (so a date-named column is a key)."""
+    if not sql_type:
+        return False
+    upper = sql_type.upper()
+    return any(upper.startswith(prefix) for prefix in _NUMERIC_SQL_TYPE_PREFIXES)
+
+
+def _pandas_parse_date_columns(
+    names: list[str] | None,
+    column_types: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Infer date and timestamp columns for raw CSV/TBL loads with explicit schemas.
+
+    When ``column_types`` (parallel to ``names``) is supplied, a column whose
+    declared SQL type is numeric is never treated as a date/timestamp even if its
+    name ends in ``date``/``time`` - this keeps integer datekey columns (e.g. SSB
+    ``lo_orderdate``) from being mis-parsed as dates.
+    """
     if not names:
         return [], []
+
+    types_by_name: dict[str, str] = {}
+    if column_types and len(column_types) == len(names):
+        types_by_name = {name.lower(): sql_type for name, sql_type in zip(names, column_types)}
 
     date_columns: list[str] = []
     datetime_columns: list[str] = []
     for name in names:
         lower_name = name.lower()
         if lower_name.endswith("_sk"):
+            continue
+        if _is_numeric_sql_type(types_by_name.get(lower_name)):
             continue
         if lower_name.endswith(("datetime", "_datetime", "timestamp", "_timestamp", "_dts")):
             datetime_columns.append(name)
@@ -246,6 +275,7 @@ class PandasDataFrameAdapter(PandasFamilyAdapter[PandasDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,
     ) -> PandasDF:
         """Read a CSV file into a Pandas DataFrame.
 
@@ -255,6 +285,9 @@ class PandasDataFrameAdapter(PandasFamilyAdapter[PandasDF]):
             header: Row to use as header (None for no header)
             names: Column names (if header is None)
             null_marker: When not None, enables trailing-delimiter probing (TPC-style rows end with a spurious delimiter).
+            column_types: Optional SQL types parallel to ``names``; used to keep
+                numeric columns named like dates (e.g. integer datekeys) from
+                being parsed as dates.
 
         Returns:
             Pandas DataFrame with the file contents
@@ -269,7 +302,7 @@ class PandasDataFrameAdapter(PandasFamilyAdapter[PandasDF]):
         # Add column names if provided
         if names:
             read_kwargs["names"] = names
-            date_columns, datetime_columns = _pandas_parse_date_columns(names)
+            date_columns, datetime_columns = _pandas_parse_date_columns(names, column_types)
             if date_columns:
                 read_kwargs["converters"] = dict.fromkeys(date_columns, _parse_date_value)
             if datetime_columns:

--- a/benchbox/platforms/dataframe/pandas_family.py
+++ b/benchbox/platforms/dataframe/pandas_family.py
@@ -60,6 +60,38 @@ logger = logging.getLogger(__name__)
 DF = TypeVar("DF")  # DataFrame type (e.g., pd.DataFrame)
 
 
+def _schema_column_types(
+    benchmark: Any,
+    table_name: str,
+    column_names: list[str] | None,
+) -> list[str | None] | None:
+    """Return the SQL types parallel to ``column_names`` from the benchmark schema.
+
+    Returns ``None`` (so the caller falls back to name-only heuristics) when the
+    benchmark, its schema, or this table's columns are unavailable. Per-column
+    entries are ``None`` when a type is unknown; only columns with a known
+    numeric type are excluded from date parsing downstream.
+    """
+    if benchmark is None or not column_names:
+        return None
+    try:
+        from benchbox.core.dataframe.schema_utils import get_benchmark_schema_columns
+
+        schema = get_benchmark_schema_columns(benchmark)
+    except Exception:  # noqa: BLE001 - a schema lookup must never break data loading
+        return None
+    if not schema:
+        return None
+    columns = schema.get(table_name)
+    if columns is None:
+        lowered = {key.lower(): value for key, value in schema.items()}
+        columns = lowered.get(table_name.lower())
+    if not columns:
+        return None
+    type_by_name = {column.get("name", "").lower(): column.get("type") for column in columns}
+    return [type_by_name.get(name.lower()) for name in column_names]
+
+
 class PandasFamilyContext(DataFrameContextImpl[DF], Generic[DF]):
     """Context implementation for Pandas-family adapters.
 
@@ -527,6 +559,7 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,
     ) -> DF:
         """Read a CSV file into a DataFrame.
 
@@ -536,6 +569,8 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
             header: Row to use as header (None for no header)
             names: Column names (if header is None)
             null_marker: When not None, enables trailing-delimiter probing (TPC-style rows end with a spurious delimiter).
+            column_types: Optional SQL types parallel to ``names``, used to keep
+                numeric columns named like dates from being parsed as dates.
 
         Returns:
             DataFrame with the file contents
@@ -1058,12 +1093,18 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
             else:
                 null_marker = "" if format_type == "tbl" else None
 
+            # Pull this table's declared SQL types (parallel to column_names) from
+            # the benchmark schema so numeric columns named like dates (e.g. SSB's
+            # INTEGER lo_orderdate datekeys) are not mis-parsed as dates.
+            column_types = _schema_column_types(benchmark, table_name, column_names)
+
             df = self._load_csv_files(
                 file_paths,
                 delimiter=actual_delimiter,
                 has_header=has_header,
                 column_names=column_names,
                 null_marker=null_marker,
+                column_types=column_types,
             )
 
         # Register table
@@ -1319,6 +1360,7 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
         has_header: bool,
         column_names: list[str] | None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,
     ) -> DF:
         """Load CSV/TBL files.
 
@@ -1328,6 +1370,8 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
             has_header: Whether files have headers
             column_names: Optional column names
             null_marker: Passed through to read_csv for trailing-delimiter probing.
+            column_types: Optional SQL types parallel to ``column_names``, passed
+                through so numeric columns named like dates are not date-parsed.
 
         Returns:
             Combined DataFrame
@@ -1344,6 +1388,7 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
                 header=header,
                 names=names,
                 null_marker=null_marker,
+                column_types=column_types,
             )
 
         # Multiple files - load and concatenate
@@ -1354,6 +1399,7 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
                 header=header,
                 names=names,
                 null_marker=null_marker,
+                column_types=column_types,
             )
             for f in file_paths
         ]

--- a/tests/unit/core/results/test_result_parity.py
+++ b/tests/unit/core/results/test_result_parity.py
@@ -219,8 +219,10 @@ class ExportParityDataFrameAdapter(BenchmarkExecutionMixin):
         file_paths: list[Any],
         column_names: list[str] | None = None,
         delimiter: str | None = None,
+        benchmark: Any | None = None,
+        **kwargs: Any,
     ) -> int:
-        _ = (ctx, table_name, file_paths, column_names, delimiter)
+        _ = (ctx, table_name, file_paths, column_names, delimiter, benchmark)
         return 1
 
     def execute_query(

--- a/tests/unit/platforms/dataframe/test_benchmark_mixin.py
+++ b/tests/unit/platforms/dataframe/test_benchmark_mixin.py
@@ -38,7 +38,7 @@ class DummyAdapter(BenchmarkExecutionMixin):
     def create_context(self):
         return SimpleNamespace()
 
-    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None):
+    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None, benchmark=None, **kwargs):
         self.loaded_paths[table_name] = file_paths
         return 1
 
@@ -79,7 +79,7 @@ class DummyPandasProfiledAdapter(DummyAdapter):
 
 
 class FailingLoadAdapter(DummyAdapter):
-    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None):
+    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None, benchmark=None, **kwargs):
         raise RuntimeError("load failed")
 
 

--- a/tests/unit/platforms/dataframe/test_benchmark_mixin_behavioral.py
+++ b/tests/unit/platforms/dataframe/test_benchmark_mixin_behavioral.py
@@ -50,7 +50,7 @@ class StubAdapter(BenchmarkExecutionMixin):
     def create_context(self) -> SimpleNamespace:
         return SimpleNamespace()
 
-    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None):
+    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None, benchmark=None, **kwargs):
         self.loaded_tables[table_name] = file_paths
         return 10
 
@@ -92,7 +92,7 @@ class ExceptionQueryAdapter(StubAdapter):
 class FailingLoadAdapter(StubAdapter):
     """Adapter where load_table always raises."""
 
-    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None):
+    def load_table(self, ctx, table_name, file_paths, column_names=None, delimiter=None, benchmark=None, **kwargs):
         raise RuntimeError("disk read error")
 
 

--- a/tests/unit/platforms/dataframe/test_dataframe_csv_dialect_resolver.py
+++ b/tests/unit/platforms/dataframe/test_dataframe_csv_dialect_resolver.py
@@ -52,6 +52,7 @@ class _PandasStub(PandasFamilyAdapter[dict]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,
     ) -> dict:
         self.calls.append({"path": path, "delimiter": delimiter, "null_marker": null_marker})
         return {"rows": 0, "_columns": names or []}

--- a/tests/unit/platforms/dataframe/test_pandas_df.py
+++ b/tests/unit/platforms/dataframe/test_pandas_df.py
@@ -716,3 +716,74 @@ class TestPandasNotAvailable:
 
         # This just tests that the flag exists and is boolean
         assert isinstance(PANDAS_AVAILABLE, bool)
+
+
+class TestTypeAwareDateColumnInference:
+    """The CSV date heuristic must use schema types, not just column names.
+
+    Regression for SSB: ``lo_orderdate`` / ``lo_commitdate`` are INTEGER YYYYMMDD
+    datekeys whose names end in ``date``; the name-only heuristic tried to
+    date-parse them and crashed the pandas loader.
+    """
+
+    def test_numeric_date_named_column_is_not_a_date(self):
+        from benchbox.platforms.dataframe.pandas_df import _pandas_parse_date_columns
+
+        names = ["lo_orderkey", "lo_orderdate", "lo_commitdate", "lo_revenue"]
+        types = ["INTEGER", "INTEGER", "INTEGER", "INTEGER"]
+        date_cols, datetime_cols = _pandas_parse_date_columns(names, types)
+        assert date_cols == []
+        assert datetime_cols == []
+
+    def test_string_date_named_column_is_still_a_date(self):
+        from benchbox.platforms.dataframe.pandas_df import _pandas_parse_date_columns
+
+        # SSB d_date is VARCHAR; a real string date must still be parsed.
+        names = ["d_datekey", "d_date"]
+        types = ["INTEGER", "VARCHAR(18)"]
+        date_cols, _ = _pandas_parse_date_columns(names, types)
+        assert date_cols == ["d_date"]
+
+    def test_without_types_falls_back_to_name_heuristic(self):
+        from benchbox.platforms.dataframe.pandas_df import _pandas_parse_date_columns
+
+        # No types supplied -> unchanged legacy behavior (name-only).
+        names = ["o_orderdate", "o_custkey"]
+        date_cols, _ = _pandas_parse_date_columns(names, None)
+        assert date_cols == ["o_orderdate"]
+
+    def test_mismatched_types_length_is_ignored(self):
+        from benchbox.platforms.dataframe.pandas_df import _pandas_parse_date_columns
+
+        # A types list that does not align with names is ignored (safe fallback).
+        names = ["o_orderdate", "o_custkey"]
+        date_cols, _ = _pandas_parse_date_columns(names, ["INTEGER"])  # wrong length
+        assert date_cols == ["o_orderdate"]
+
+    def test_is_numeric_sql_type(self):
+        from benchbox.platforms.dataframe.pandas_df import _is_numeric_sql_type
+
+        assert _is_numeric_sql_type("INTEGER")
+        assert _is_numeric_sql_type("integer")
+        assert _is_numeric_sql_type("BIGINT")
+        assert _is_numeric_sql_type("DECIMAL(15,2)")
+        assert not _is_numeric_sql_type("VARCHAR(18)")
+        assert not _is_numeric_sql_type("DATE")
+        assert not _is_numeric_sql_type(None)
+
+    def test_read_csv_does_not_date_parse_integer_datekeys(self, tmp_path):
+        """End-to-end: read_csv with an integer datekey column must not crash or coerce."""
+        from benchbox.platforms.dataframe.pandas_df import PandasDataFrameAdapter
+
+        csv = tmp_path / "lineorder.tbl"
+        csv.write_text("1|19920101|100\n2|19980815|200\n")
+        adapter = PandasDataFrameAdapter()
+        df = adapter.read_csv(
+            csv,
+            delimiter="|",
+            header=None,
+            names=["lo_orderkey", "lo_orderdate", "lo_revenue"],
+            column_types=["INTEGER", "INTEGER", "INTEGER"],
+        )
+        # lo_orderdate stays an integer datekey (not a date) and loads cleanly.
+        assert df["lo_orderdate"].tolist() == [19920101, 19980815]

--- a/tests/unit/platforms/dataframe/test_pandas_family.py
+++ b/tests/unit/platforms/dataframe/test_pandas_family.py
@@ -45,6 +45,7 @@ class MockPandasAdapter(PandasFamilyAdapter[dict]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
+        column_types: list[str] | None = None,
     ) -> dict:
         return {"type": "csv", "path": str(path), "delimiter": delimiter}
 


### PR DESCRIPTION
Implements **w6** of `benchmark-cross-surface-equivalence-gate` (the loader prerequisite for the production-loader gate substrate). This is a genuine production bug fix, not gate-only.

## The bug
The Pandas reference loader (`pandas_df._pandas_parse_date_columns`) inferred date columns by **name suffix alone** (`*date`/`*_date`), then coerced them to `date32`. Benchmarks whose schema uses an **integer YYYYMMDD datekey** column named like a date — e.g. SSB's `INTEGER lo_orderdate`/`lo_commitdate` (values like `19947424`, not even valid dates) — **crashed the loader** (`month must be in 1..12`). SSB's pandas DataFrame run was broken independent of the gate; the cross-surface work surfaced it.

## The fix
Make date inference **type-aware**: when the benchmark's schema column types are available, a column whose declared SQL type is **numeric** is never treated as a date even if its name ends in `date`/`time`. Real string-date columns (e.g. SSB `d_date VARCHAR`) are still parsed. When types are absent the behavior is unchanged (name-only fallback), so non-schema callers are unaffected.

### Threading (contained)
The load path already carries the benchmark, so I pass it through `_load_data_phase` → `_load_tables_into_context` → `load_table`, where the Pandas adapter derives this table's column types from the schema (`_schema_column_types`) and passes them down `load_table` → `_load_csv_files` → `read_csv` → `_pandas_parse_date_columns`. The abstract `load_table` signature is made honest (`delimiter`/`format_hint`/`data_source`/`benchmark` were already passed but undeclared); sibling pandas-family `read_csv` overrides (cudf/dask/modin) accept the new `column_types` kwarg for signature parity (they infer types themselves).

## Verification
- SSB now loads via the **production DataFrame loader** and its cross-surface comparison is clean (**26/26, 0 divergent**) — confirmed by an end-to-end spike.
- Full `tests/unit/platforms/dataframe/` suite (**1123**) green; new unit tests in `test_pandas_df.py` lock the type-aware behavior and the integer-datekey regression.
- `ruff`/`ty` clean on changed source (one pre-existing `invalid-return-type` on develop is untouched).

## Next
w5 (gate substrate using this loader) + w7 (re-base the SSB gate onto it) follow in a separate PR. The production loader also surfaced **real** coffeeshop divergences (date-vs-string impl bugs, value mismatches) — those are w3 burndown, tracked separately, not masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_