### PR TITLE
feat(query-plans): cross-engine comparable-subset projection and conformance corpus

### DIFF
--- a/_project/DONE/platform-expansion/planning/query-plan-capture-cross-engine-conformance.yaml
+++ b/_project/DONE/platform-expansion/planning/query-plan-capture-cross-engine-conformance.yaml
@@ -2,8 +2,31 @@ id: query-plan-capture-cross-engine-conformance
 title: "Define a cross-engine plan-DAG conformance corpus and decide whether fingerprints are comparable across engines"
 worktree: platform-expansion
 priority: Medium
-status: Not Started
+status: Completed
 category: Platform Expansion
+
+resolution: |
+  w1 (decision): documented in query_plan_models.py that the raw plan_fingerprint
+  is a PER-ENGINE within-version key and is explicitly NOT cross-engine comparable
+  (engines emit different wrapper/exchange/codegen operators and harmonize names
+  differently), per the gating open_question default. Cross-engine STRUCTURAL
+  comparison is provided as a separate, opt-in projection rather than by forcing
+  equality onto the raw fingerprint.
+  w2 (corpus): tests/unit/query_plans/test_cross_engine_conformance.py defines a
+  golden corpus over the recorded EXPLAIN fixtures (no live engines) for the
+  canonical "aggregate over a join of two base tables" shape. It asserts that all
+  ten engines (clickhouse/trino/presto/spark/snowflake/databend/doris/singlestore/
+  firebolt/duckdb) meet the declared backbone invariant (exactly 2 base scans, 1
+  join, 1 aggregate), that the comparable-subset signature is identical across
+  engines, and that the raw per-engine fingerprints remain distinct.
+  w3 (comparable subset): comparison.py gains structural_backbone_counts(),
+  comparable_subset_signature() and structural_backbones_match(). They drop
+  engine-variable wrapper nodes (Project/Filter/CTE/Subquery/Other) and collapse a
+  parent->child run of a MULTI-STAGE operator (aggregate/sort, e.g. partial+final
+  aggregate or merge sort) to one node, while counting joins/scans per node so
+  left-deep multi-table joins are not undercounted. Kept entirely separate from the
+  raw fingerprint, which is unchanged. Verified: pytest tests/unit/query_plans -k
+  conformance -> 23 passing; full query_plans suites green.
 
 description: |
   Operator-name harmonization was decided ad hoc in each parser with no shared conformance
@@ -32,7 +55,7 @@ prior_art:
 work:
   - id: w1
     summary: "Decide the fingerprint's purpose: per-engine regression vs cross-engine comparison (or both)"
-    status: pending
+    status: done
     notes: |
       Document the intended use in query_plan_models.py. This gates everything: if cross-engine
       comparison is out of scope, close w2/w3 as not-needed and instead document that fingerprints
@@ -40,7 +63,7 @@ work:
   - id: w2
     summary: "Build a cross-engine conformance corpus of canonical queries with expected DAG invariants"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       For a small set of canonical queries (e.g. TPC-H Q1/Q3/Q5), record expected counts/shape of
       the harmonized DAG (number of JOINs, base SCANs, AGGREGATEs) that every engine must satisfy.
@@ -49,7 +72,7 @@ work:
   - id: w3
     summary: "Add a 'comparable subset' projection so wrapper noise does not break cross-engine equality"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       If cross-engine comparison is wanted, add a normalization that drops OTHER/exchange/codegen
       wrapper nodes before comparison, so the structural backbone (scans, joins, aggregates, sorts)

--- a/benchbox/core/query_plans/comparison.py
+++ b/benchbox/core/query_plans/comparison.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from benchbox.core.results.query_plan_models import (
     LogicalOperator,
+    LogicalOperatorType,
     QueryPlanDAG,
     get_join_type_str,
     get_operator_type_str,
@@ -25,6 +26,160 @@ from benchbox.core.results.query_plan_models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Cross-engine comparable subset (wrapper-stripped structural backbone)
+# ---------------------------------------------------------------------------
+#
+# The raw plan_fingerprint is a PER-ENGINE within-version key and is deliberately
+# NOT comparable across engines (see the stability contract in
+# query_plan_models.py): engines emit different wrapper/exchange/codegen operators
+# and harmonize names differently (ClickHouse Expression -> Project, Presto Output
+# -> Project, Spark Exchange -> Other), so the same logical query hashes differently
+# on each engine.
+#
+# This projection provides the SEPARATE, opt-in cross-engine view: it reduces a
+# harmonized DAG to its structural backbone — the relational skeleton of base
+# scans, joins, aggregates and set operations — by
+#   1. dropping engine-variable wrapper nodes (Project/Filter/CTE/Subquery/Other),
+#      which carry no cross-engine-stable structural meaning, and
+#   2. collapsing a parent->child run of the SAME backbone type into one node, so a
+#      partial+final aggregate (Spark/Databend) or a multi-stage sort (Doris) counts
+#      once — the single logical operation it represents.
+#
+# The result is a multiset of backbone operator types that IS comparable across
+# engines for the same logical query. It is intentionally kept separate from the
+# raw fingerprint, which remains unchanged for within-engine regression detection.
+
+# Operator types that form the cross-engine structural backbone. Everything else
+# (Project / Filter / CTE / Subquery / Other) is treated as engine-variable wrapper
+# noise and dropped from the comparable subset.
+BACKBONE_OPERATOR_TYPES: frozenset[str] = frozenset(
+    {
+        LogicalOperatorType.SCAN.value,
+        LogicalOperatorType.JOIN.value,
+        LogicalOperatorType.AGGREGATE.value,
+        LogicalOperatorType.SORT.value,
+        LogicalOperatorType.LIMIT.value,
+        LogicalOperatorType.UNION.value,
+        LogicalOperatorType.INTERSECT.value,
+        LogicalOperatorType.EXCEPT.value,
+        LogicalOperatorType.WINDOW.value,
+    }
+)
+
+# Backbone operators that engines split into a parent->child run of the SAME type as
+# stages of ONE logical operation: a partial+final aggregate (Spark/Databend) or a
+# multi-stage / merge sort (Doris). Only these collapse. JOIN, SCAN and the set
+# operators are NOT collapsed: a parent Join over a child Join is a multi-table join
+# (two distinct joins), and a Scan over a Scan is two distinct base scans — collapsing
+# those would undercount the relational skeleton the projection exists to measure.
+COLLAPSIBLE_OPERATOR_TYPES: frozenset[str] = frozenset(
+    {
+        LogicalOperatorType.AGGREGATE.value,
+        LogicalOperatorType.SORT.value,
+    }
+)
+
+
+def _backbone_type(node: LogicalOperator) -> str | None:
+    """Return the backbone operator-type string for a node, or None if it is wrapper noise."""
+    type_str = get_operator_type_str(node.operator_type, warn_unknown=False)
+    return type_str if type_str in BACKBONE_OPERATOR_TYPES else None
+
+
+def structural_backbone_counts(
+    root: LogicalOperator,
+    *,
+    only: set[str] | frozenset[str] | None = None,
+) -> dict[str, int]:
+    """Reduce a harmonized DAG to a cross-engine comparable multiset of backbone operators.
+
+    Wrapper/engine-variable nodes (Project/Filter/CTE/Subquery/Other) are dropped. A
+    parent->child run of the same *collapsible* backbone type
+    (``COLLAPSIBLE_OPERATOR_TYPES`` — aggregate, sort) is collapsed to a single node,
+    so a partial+final aggregate or a multi-stage sort counts once. The collapse looks
+    through dropped wrapper nodes, so ``Aggregate -> Exchange -> Aggregate`` still
+    counts as one aggregate. Non-collapsible backbone operators (joins, scans, set
+    operators) are always counted per node, so a left-deep 3-table join correctly
+    reports two joins.
+
+    Args:
+        root: Root of the harmonized logical operator tree.
+        only: Optional set of backbone operator-type strings to restrict the result to
+            (keys not present are reported as 0). Use to compare a declared invariant
+            subset (e.g. {"Scan", "Join", "Aggregate"}) across engines. Must be
+            non-empty when provided.
+
+    Returns:
+        Mapping of backbone operator-type string -> count.
+    """
+    if only is not None and not only:
+        raise ValueError("`only` must be a non-empty set of operator types, or None to include all")
+
+    counts: dict[str, int] = {}
+
+    def walk(node: LogicalOperator, collapsing_type: str | None) -> None:
+        backbone = _backbone_type(node)
+        if backbone is None:
+            # Wrapper node: drop it but keep the collapse context so a run of the same
+            # collapsible backbone type separated by wrappers still collapses.
+            for child in node.children:
+                walk(child, collapsing_type)
+            return
+        # Count the node unless it continues a collapsible same-type run.
+        if not (backbone in COLLAPSIBLE_OPERATOR_TYPES and backbone == collapsing_type):
+            counts[backbone] = counts.get(backbone, 0) + 1
+        # Only propagate a collapse context for collapsible types; otherwise reset it so
+        # an unrelated descendant of the same type is still counted.
+        next_collapsing = backbone if backbone in COLLAPSIBLE_OPERATOR_TYPES else None
+        for child in node.children:
+            walk(child, next_collapsing)
+
+    walk(root, None)
+
+    if only is not None:
+        return {key: counts.get(key, 0) for key in only}
+    return counts
+
+
+def comparable_subset_signature(
+    root: LogicalOperator,
+    *,
+    only: set[str] | frozenset[str] | None = None,
+) -> str:
+    """Deterministic string signature of the cross-engine structural backbone.
+
+    Unlike ``QueryPlanDAG.plan_fingerprint`` (per-engine, not cross-engine comparable),
+    this signature is stable across engines for the same logical query because it is
+    built from the wrapper-stripped, collapsed backbone. Two plans from different
+    engines that share a backbone produce the same signature.
+
+    Args:
+        root: Root of the harmonized logical operator tree.
+        only: Optional restriction set (see ``structural_backbone_counts``).
+
+    Returns:
+        Signature like ``"Aggregate:1|Join:1|Scan:2"`` (sorted by operator type).
+    """
+    counts = structural_backbone_counts(root, only=only)
+    return "|".join(f"{op_type}:{counts[op_type]}" for op_type in sorted(counts))
+
+
+def structural_backbones_match(
+    left: LogicalOperator,
+    right: LogicalOperator,
+    *,
+    only: set[str] | frozenset[str] | None = None,
+) -> bool:
+    """Return True if two plans share the same cross-engine structural backbone.
+
+    This is the cross-engine equivalent of ``plan_fingerprint`` equality: it compares
+    the wrapper-stripped backbone multisets, so it is meaningful across engines for the
+    same logical query (whereas raw fingerprint equality is not).
+    """
+    return structural_backbone_counts(left, only=only) == structural_backbone_counts(right, only=only)
 
 
 @dataclass

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -73,10 +73,34 @@ What fingerprint equality does NOT guarantee, and explicit non-guarantees:
   - **Equality does not imply equal performance** (costs/timing are excluded),
     and inequality does not imply a regression (it may be a benign shape change).
 
+Decision — the fingerprint is a PER-ENGINE within-version key (not cross-engine):
+  The raw fingerprint's intended and only supported purpose is per-engine,
+  within-version structural regression detection and within-run deduplication.
+  Cross-engine equality is explicitly OUT OF SCOPE for the raw fingerprint, because
+  engines emit different wrapper/exchange/codegen operators and harmonize operator
+  names differently (ClickHouse ``Expression`` -> Project, Presto ``Output`` ->
+  Project, Spark ``Exchange`` -> Other), so the same logical query legitimately
+  hashes differently on each engine. Forcing cross-engine equality onto the raw
+  fingerprint would require lossy normalization that would weaken its within-engine
+  regression signal.
+
+  When a cross-engine STRUCTURAL comparison is wanted, use the separate, opt-in
+  *comparable subset* projection in ``benchbox/core/query_plans/comparison.py``
+  (``structural_backbone_counts`` / ``comparable_subset_signature`` /
+  ``structural_backbones_match``). It reduces a harmonized DAG to its relational
+  backbone (base scans, joins, aggregates, set operations) by dropping
+  engine-variable wrapper nodes and collapsing partial+final / multi-stage runs of
+  the same operator, yielding a multiset that IS comparable across engines for the
+  same logical query. A cross-engine conformance corpus
+  (``tests/unit/query_plans/test_cross_engine_conformance.py``) asserts that
+  canonical queries meet declared backbone invariants on every engine while their
+  raw fingerprints remain distinct.
+
 Recommended use: stable for structural plan comparison and within-run
 deduplication on a single engine version. Suitable for "did the plan shape
 change?" regression detection when the engine version is held constant; not
-suitable as a cross-version or cross-engine equality key.
+suitable as a cross-version or cross-engine equality key — for cross-engine
+structural comparison use the comparable-subset projection above.
 """
 
 from __future__ import annotations

--- a/tests/unit/query_plans/test_cross_engine_conformance.py
+++ b/tests/unit/query_plans/test_cross_engine_conformance.py
@@ -1,0 +1,280 @@
+"""Cross-engine plan-DAG conformance corpus and comparable-subset projection.
+
+The raw ``plan_fingerprint`` is a PER-ENGINE within-version key and is NOT
+comparable across engines (see the decision in
+``benchbox/core/results/query_plan_models.py``). Cross-engine STRUCTURAL
+comparison is instead provided by the wrapper-stripped *comparable subset*
+projection in ``comparison.py``.
+
+This module:
+
+1. ``TestComparableSubsetProjection`` — unit-tests the projection
+   (``structural_backbone_counts`` / ``comparable_subset_signature`` /
+   ``structural_backbones_match``): wrapper nodes are dropped and consecutive
+   runs of a multi-stage operator (aggregate/sort) collapse to one, while joins
+   and scans are always counted per node.
+2. ``TestCrossEngineConformanceCorpus`` — a golden corpus of recorded EXPLAIN
+   fixtures (no live engines). For each canonical query it asserts every engine's
+   harmonized DAG meets the declared backbone invariant (e.g. exactly 2 base
+   scans, 1 join, 1 aggregate), that the comparable-subset signature is IDENTICAL
+   across engines, and that the raw per-engine fingerprints remain DISTINCT.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchbox.core.query_plans.comparison import (
+    comparable_subset_signature,
+    structural_backbone_counts,
+    structural_backbones_match,
+)
+from benchbox.core.query_plans.parsers.registry import get_parser_for_platform
+from benchbox.core.results.query_plan_models import (
+    LogicalOperator,
+    LogicalOperatorType,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "query_plans"
+
+
+def _load(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _op(op_type: LogicalOperatorType, children=None) -> LogicalOperator:
+    return LogicalOperator(
+        operator_type=op_type,
+        operator_id=f"{op_type.value.lower()}_{id(children)}",
+        children=children or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-engine conformance corpus.
+#
+# Each canonical query maps to (declared backbone invariant, {engine: fixture}).
+# The fixtures are the recorded EXPLAIN samples shared by the query-plan-capture
+# family; they all render the same canonical shape: an aggregate over a join of two
+# base tables. Engines differ in wrapper/exchange nodes, partial+final aggregates
+# and multi-stage sorts — the comparable-subset projection normalizes those away.
+# ---------------------------------------------------------------------------
+
+_CORPUS: dict[str, dict] = {
+    "tpch_join_aggregate": {
+        # Relational backbone every engine must agree on for this canonical shape.
+        "invariant": {
+            LogicalOperatorType.SCAN.value: 2,
+            LogicalOperatorType.JOIN.value: 1,
+            LogicalOperatorType.AGGREGATE.value: 1,
+        },
+        "fixtures": {
+            "clickhouse": "clickhouse_explain_plan_sample.txt",
+            "trino": "trino_explain_sample.json",
+            "presto": "presto_explain_sample.json",
+            "spark": "spark_explain_sample.txt",
+            "snowflake": "snowflake_explain_sample.json",
+            "databend": "databend_explain_sample.txt",
+            "doris": "doris_shape_plan_sample.txt",
+            "singlestore": "singlestore_explain_sample.txt",
+            "firebolt": "firebolt_explain_sample.txt",
+            "duckdb": "motherduck_duckdb_explain_sample.json",
+        },
+    },
+}
+
+
+def _corpus_cases():
+    cases = []
+    for query_id, spec in _CORPUS.items():
+        for engine, fixture in spec["fixtures"].items():
+            cases.append(pytest.param(query_id, engine, fixture, id=f"{query_id}-{engine}"))
+    return cases
+
+
+class TestComparableSubsetProjection:
+    """Unit contract for the wrapper-stripped, collapsing backbone projection."""
+
+    def test_drops_wrapper_nodes(self):
+        # Project/Filter/Other wrappers must not appear in the backbone counts.
+        tree = _op(
+            LogicalOperatorType.PROJECT,
+            [
+                _op(
+                    LogicalOperatorType.FILTER,
+                    [
+                        _op(
+                            LogicalOperatorType.OTHER,
+                            [_op(LogicalOperatorType.SCAN)],
+                        )
+                    ],
+                )
+            ],
+        )
+        assert structural_backbone_counts(tree) == {LogicalOperatorType.SCAN.value: 1}
+
+    def test_collapses_consecutive_same_type(self):
+        # A partial+final aggregate (parent->child Aggregate run) counts once.
+        tree = _op(
+            LogicalOperatorType.AGGREGATE,
+            [_op(LogicalOperatorType.AGGREGATE, [_op(LogicalOperatorType.SCAN)])],
+        )
+        assert structural_backbone_counts(tree) == {
+            LogicalOperatorType.AGGREGATE.value: 1,
+            LogicalOperatorType.SCAN.value: 1,
+        }
+
+    def test_collapse_looks_through_wrappers(self):
+        # Aggregate -> Other(exchange) -> Aggregate still collapses to one aggregate.
+        tree = _op(
+            LogicalOperatorType.AGGREGATE,
+            [
+                _op(
+                    LogicalOperatorType.OTHER,
+                    [_op(LogicalOperatorType.AGGREGATE, [_op(LogicalOperatorType.SCAN)])],
+                )
+            ],
+        )
+        assert structural_backbone_counts(tree)[LogicalOperatorType.AGGREGATE.value] == 1
+
+    def test_stacked_joins_are_not_collapsed(self):
+        # A left-deep 3-table join (Join over Join over scans) is TWO distinct joins;
+        # joins are not collapsible, so they must both be counted.
+        tree = _op(
+            LogicalOperatorType.JOIN,
+            [
+                _op(
+                    LogicalOperatorType.JOIN,
+                    [_op(LogicalOperatorType.SCAN), _op(LogicalOperatorType.SCAN)],
+                ),
+                _op(LogicalOperatorType.SCAN),
+            ],
+        )
+        counts = structural_backbone_counts(tree)
+        assert counts[LogicalOperatorType.JOIN.value] == 2
+        assert counts[LogicalOperatorType.SCAN.value] == 3
+
+    def test_stacked_scans_are_not_collapsed(self):
+        # A scan over a scan (e.g. a scan of a materialized CTE) is two base scans.
+        tree = _op(LogicalOperatorType.SCAN, [_op(LogicalOperatorType.SCAN)])
+        assert structural_backbone_counts(tree)[LogicalOperatorType.SCAN.value] == 2
+
+    def test_unrelated_aggregates_separated_by_join_both_count(self):
+        # Two aggregates that are NOT a parent->child run (separated by a join) are
+        # distinct logical aggregations and must both count.
+        tree = _op(
+            LogicalOperatorType.AGGREGATE,
+            [
+                _op(
+                    LogicalOperatorType.JOIN,
+                    [
+                        _op(LogicalOperatorType.AGGREGATE, [_op(LogicalOperatorType.SCAN)]),
+                        _op(LogicalOperatorType.SCAN),
+                    ],
+                )
+            ],
+        )
+        assert structural_backbone_counts(tree)[LogicalOperatorType.AGGREGATE.value] == 2
+
+    def test_empty_only_is_rejected(self):
+        tree = _op(LogicalOperatorType.SCAN)
+        with pytest.raises(ValueError):
+            structural_backbone_counts(tree, only=set())
+
+    def test_sibling_scans_counted_separately(self):
+        # A join over two scans must count both scans (siblings, not a collapsed run).
+        tree = _op(
+            LogicalOperatorType.JOIN,
+            [_op(LogicalOperatorType.SCAN), _op(LogicalOperatorType.SCAN)],
+        )
+        counts = structural_backbone_counts(tree)
+        assert counts[LogicalOperatorType.SCAN.value] == 2
+        assert counts[LogicalOperatorType.JOIN.value] == 1
+
+    def test_only_restriction_reports_missing_as_zero(self):
+        tree = _op(LogicalOperatorType.SCAN)
+        counts = structural_backbone_counts(tree, only={LogicalOperatorType.SCAN.value, LogicalOperatorType.JOIN.value})
+        assert counts == {LogicalOperatorType.SCAN.value: 1, LogicalOperatorType.JOIN.value: 0}
+
+    def test_signature_is_deterministic_and_sorted(self):
+        tree = _op(
+            LogicalOperatorType.JOIN,
+            [_op(LogicalOperatorType.SCAN), _op(LogicalOperatorType.SCAN)],
+        )
+        assert comparable_subset_signature(tree) == "Join:1|Scan:2"
+
+    def test_backbones_match_ignores_wrappers(self):
+        bare = _op(
+            LogicalOperatorType.JOIN,
+            [_op(LogicalOperatorType.SCAN), _op(LogicalOperatorType.SCAN)],
+        )
+        wrapped = _op(
+            LogicalOperatorType.PROJECT,
+            [
+                _op(
+                    LogicalOperatorType.JOIN,
+                    [
+                        _op(LogicalOperatorType.OTHER, [_op(LogicalOperatorType.SCAN)]),
+                        _op(LogicalOperatorType.SCAN),
+                    ],
+                )
+            ],
+        )
+        assert structural_backbones_match(bare, wrapped) is True
+
+
+class TestCrossEngineConformanceCorpus:
+    """Canonical queries must meet the declared backbone invariants on every engine."""
+
+    @pytest.mark.parametrize("query_id, engine, fixture", _corpus_cases())
+    def test_engine_meets_backbone_invariant(self, query_id, engine, fixture):
+        invariant = _CORPUS[query_id]["invariant"]
+        dag = get_parser_for_platform(engine).parse_explain_output(query_id, _load(fixture))
+        assert dag is not None, f"{engine} fixture {fixture} failed to parse"
+
+        counts = structural_backbone_counts(dag.logical_root, only=set(invariant))
+        assert counts == invariant, (
+            f"{engine} backbone {counts} does not meet the {query_id} invariant {invariant}. "
+            "A parser's operator harmonization changed; justify it or fix the mapping."
+        )
+
+    @pytest.mark.parametrize("query_id", sorted(_CORPUS))
+    def test_comparable_subset_is_identical_across_engines(self, query_id):
+        # Compares the reliably-cross-engine relational core (the declared invariant
+        # keys: scans/joins/aggregates). Presentation operators (Sort/Limit/Window) are
+        # deliberately excluded because engines surface them inconsistently in EXPLAIN
+        # (e.g. Trino's fixture has a Limit, Presto/Spark have neither, others a Sort),
+        # so they are not part of the cross-engine comparable subset by design.
+        invariant = _CORPUS[query_id]["invariant"]
+        signatures = {}
+        for engine, fixture in _CORPUS[query_id]["fixtures"].items():
+            dag = get_parser_for_platform(engine).parse_explain_output(query_id, _load(fixture))
+            signatures[engine] = comparable_subset_signature(dag.logical_root, only=set(invariant))
+
+        distinct = set(signatures.values())
+        assert len(distinct) == 1, (
+            f"Comparable-subset signatures diverged across engines for {query_id}: {signatures}. "
+            "The wrapper-stripped backbone must be identical across engines for the same query."
+        )
+
+    @pytest.mark.parametrize("query_id", sorted(_CORPUS))
+    def test_raw_fingerprints_remain_per_engine_distinct(self, query_id):
+        # The comparable subset matches across engines, but the RAW fingerprint must
+        # stay per-engine (distinct), documenting that it is not a cross-engine key.
+        fingerprints = {}
+        for engine, fixture in _CORPUS[query_id]["fixtures"].items():
+            dag = get_parser_for_platform(engine).parse_explain_output(query_id, _load(fixture))
+            fingerprints[engine] = dag.plan_fingerprint
+
+        # Engines harmonize wrappers differently, so raw fingerprints are distinct.
+        assert len(set(fingerprints.values())) == len(fingerprints), (
+            "Raw per-engine fingerprints unexpectedly collided across engines; "
+            "the raw fingerprint is documented as NOT cross-engine comparable."
+        )


### PR DESCRIPTION
## Summary

Operator-name harmonization was decided ad hoc per parser with no shared conformance target, so there was no basis for cross-engine plan comparison and no documented decision on whether the fingerprint is cross-engine comparable. This TODO forces the decision (gating open question) and builds the missing artifact.

### w1 — Decision (documented in `query_plan_models.py`)
The raw `plan_fingerprint` is a **per-engine within-version key** and is explicitly **NOT cross-engine comparable** — engines emit different wrapper/exchange/codegen operators and harmonize names differently (ClickHouse `Expression`→Project, Presto `Output`→Project, Spark `Exchange`→Other), so the same logical query legitimately hashes differently per engine. This is the gating open question's default resolution. Cross-engine comparison is provided as a separate, opt-in projection rather than forced onto the raw fingerprint.

### w3 — Comparable-subset projection (`comparison.py`)
New `structural_backbone_counts()`, `comparable_subset_signature()`, `structural_backbones_match()`. They reduce a harmonized DAG to its relational backbone by:
- dropping engine-variable wrapper nodes (Project/Filter/CTE/Subquery/Other), and
- collapsing a parent→child run of a **multi-stage** operator (`COLLAPSIBLE_OPERATOR_TYPES` = aggregate, sort — partial+final aggregate, merge sort) to one node, **while counting joins/scans per node** so a left-deep multi-table join is not undercounted.

Kept entirely separate from the raw fingerprint, which is unchanged.

### w2 — Conformance corpus (`tests/unit/query_plans/test_cross_engine_conformance.py`)
Over the recorded EXPLAIN fixtures (no live engines), asserts that all ten engines (clickhouse/trino/presto/spark/snowflake/databend/doris/singlestore/firebolt/duckdb) meet the canonical two-table-join-aggregate backbone invariant (**2 scans, 1 join, 1 aggregate**), that the comparable-subset signature is identical across engines, and that the raw per-engine fingerprints remain **distinct**.

## Testing
- `uv run -- python -m pytest tests/unit/query_plans -k conformance -q` → **23 passed** (the TODO verification selector)
- `uv run -- python -m pytest tests/unit/core/query_plans/ tests/unit/query_plans/ -q` → **526 passed**
- `ruff check`/`format` and `ty check` green on changed files.

## Review notes
`/code-review` (high effort) caught that an unrestricted same-type collapse would undercount left-deep `Join→Join` (multi-table joins) and `Scan→Scan`. Fixed by restricting collapse to `COLLAPSIBLE_OPERATOR_TYPES` (aggregate/sort) only, with regression tests for stacked joins/scans and aggregates-separated-by-a-join. Also added an empty-`only` guard.

Closes `query-plan-capture-cross-engine-conformance` (moved to `_project/DONE/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fT8yfjtBSL1jUZUQArwvx)_