### PR TITLE
feat(tpchavoc): sample variant equivalence on a fourth engine (ClickHouse)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -498,6 +498,49 @@ jobs:
             tests/integration/platforms/test_datafusion_tbl_load.py \
             -m "slow" -n 0 --tb=short -v
 
+  clickhouse-integration:
+    name: clickhouse-integration
+    needs: ci-paths
+    if: ${{ needs.ci-paths.outputs.needs-code-ci == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Non-blocking: this is the FOURTH-engine equivalence SAMPLE, not a gate.
+    # The DuckDB SQL gate (correctness-gate job) stays the hard blocker.
+    # ClickHouse runs in-process via chDB (clickhouse-local), no service container,
+    # and is the first sampled engine on a NATIVE non-Postgres SQLGlot dialect, so
+    # this samples translation-induced divergence through a different seam path.
+    # Unlike the other three engines it is NOT systematic-zero - it surfaces real
+    # engine-semantic result differences classified in CLICKHOUSE_KNOWN_DIVERGENCES.
+    # continue-on-error keeps it a sample, not a blocker.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      # Fourth-engine equivalence SAMPLE. Both canonical and variants are
+      # translated to the NATIVE clickhouse dialect and compared on the same
+      # in-process chDB instance (shared translation cancels out);
+      # CLICKHOUSE_TPCHAVOC_SKIPS variants are excluded, never marked equivalent,
+      # and the residue is classified against CLICKHOUSE_KNOWN_DIVERGENCES. The
+      # live sweep is tpchavoc + slow-marked; `-m "tpchavoc"` with a pinned path
+      # selects it (overriding the default fast-lane deselect).
+      - name: Run TPC-Havoc ClickHouse variant-equivalence sample
+        run: |
+          uv run -- python -m pytest \
+            tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py \
+            -m "tpchavoc" -n 0 --tb=short -v
+
   explorer-tokens:
     name: explorer-tokens
     needs: ci-paths

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -137,6 +137,21 @@ tpchavoc-equivalence-report-postgres:
 # non-blocking sample with a DIFFERENT gap profile from Postgres (see equivalence.py).
 tpchavoc-equivalence-report-datafusion:
 	uv run -- python -m benchbox.core.tpchavoc.equivalence --engine datafusion
+
+# Fourth-engine SAMPLE: compare every ClickHouse-executable TPC-Havoc SQL variant
+# to canonical TPC-H on the SAME in-process ClickHouse instance (chDB /
+# clickhouse-local), both translated to the NATIVE clickhouse dialect (NOT
+# normalized to postgres - this is the first sampled engine on a non-Postgres
+# dialect). Excludes CLICKHOUSE_TPCHAVOC_SKIPS (variants ClickHouse cannot execute)
+# and runs with SQL-standard NULL semantics (join_use_nulls=1). Unlike the other
+# three engines this is NOT systematic-zero: CLICKHOUSE_KNOWN_DIVERGENCES records
+# the irreducible engine-semantic result differences (Decimal-vs-Float division,
+# SUM of an empty group = 0, partial correlated-subquery decorrelation). ClickHouse
+# is in-process (no service container); skips cleanly (exit 0) only if chDB is not
+# installed. The DuckDB gate above stays the hard blocker; this is a non-blocking
+# sample (see equivalence.py).
+tpchavoc-equivalence-report-clickhouse:
+	uv run -- python -m benchbox.core.tpchavoc.equivalence --engine clickhouse
 
 # Gate: compare every TPC-Havoc DataFrame variant (both backends) to canonical
 # TPC-H on real SF=0.1 DuckDB-backed data; exits non-zero on any divergence
@@ -1876,6 +1891,8 @@ help:
 	@echo "  make test-correctness-gate Run bounded real-result correctness gate"
 	@echo "  make tpchavoc-equivalence-report Gate: TPC-Havoc variant vs canonical TPC-H equivalence (DuckDB)"
 	@echo "  make tpchavoc-equivalence-report-postgres Sample: TPC-Havoc variant equivalence on PostgreSQL"
+	@echo "  make tpchavoc-equivalence-report-datafusion Sample: TPC-Havoc variant equivalence on DataFusion"
+	@echo "  make tpchavoc-equivalence-report-clickhouse Sample: TPC-Havoc variant equivalence on ClickHouse"
 	@echo "  make tpchavoc-dataframe-equivalence-report Gate: TPC-Havoc DataFrame variants vs canonical TPC-H"
 	@echo "  make ssb-cross-surface-equivalence-report Gate: SSB DataFrame surface vs its own SQL surface"
 	@echo "  make test-local-matrix Run real local benchmark matrix (stress)"

--- a/_project/TODO/main/planning/tpchavoc-fourth-engine-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-fourth-engine-equivalence-sampling.yaml
@@ -2,7 +2,7 @@ id: tpchavoc-fourth-engine-equivalence-sampling
 title: "Sample TPC-Havoc variant equivalence on a fourth SQL engine (ClickHouse)"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
 category: Testing and Quality Assurance
 
 description: |
@@ -53,72 +53,173 @@ prior_art:
 work:
   - id: w0
     summary: "Wire the ClickHouse build helper + sample path, reusing find_divergences and _report"
-    status: pending
+    status: done
     notes: |
-      Add build_clickhouse_with_tpch, find_clickhouse_divergences, run_clickhouse_sample,
-      CLICKHOUSE_TARGET_DIALECT = "clickhouse", and an empty CLICKHOUSE_KNOWN_DIVERGENCES;
-      extend main()'s --engine. Canonical via tpch.get_query(q, dialect="clickhouse"),
-      variants via tpchavoc.translate_query_text(sql, "netezza", "clickhouse") - both
-      through the SAME native-clickhouse seam so shared translation cancels out. Decide
-      in-process (clickhouse-local / chDB) vs a server container; prefer the cheapest
-      path that still gives a real ClickHouse engine. The connection must expose
-      execute(sql).fetchall() (wrap if needed) and isolate per-query errors so one bad
-      variant cannot poison the sweep. Any indexes/ORDER BY/ANALYZE-equivalents are
-      PERFORMANCE setup only and must never change results. Verify each table loaded
-      rows (>0) so a partial load cannot produce a false green.
+      RESOLVED. Added to benchbox/core/tpchavoc/equivalence.py: CLICKHOUSE_TARGET_DIALECT
+      = "clickhouse", build_clickhouse_with_tpch, find_clickhouse_divergences,
+      run_clickhouse_sample, and `--engine clickhouse` in main(). RUN MODE: in-process
+      ClickHouse via chDB (ClickHouseLocalAdapter / clickhouse-local) - the cheapest
+      faithful engine, no service container (chDB 4.1.6 is already a dev dependency).
+      The chDB client exposes execute(sql).fetchall() natively and raises per query, so
+      find_divergences' per-query error isolation works with no autocommit transaction.
+      Canonical via tpch.get_query(q, dialect="clickhouse") and variants via
+      translate_query_text(sql, "netezza", "clickhouse") - both through the SAME native
+      clickhouse seam (NOT normalized to postgres) so shared translation cancels out. The
+      comparator and _report are reused verbatim - no per-engine fork. Each table's row
+      count is verified (>0) so a partial load cannot produce a false green. MergeTree
+      ORDER BY (PK-derived by the adapter) is physical layout only and never changes
+      results. CLICKHOUSE_SESSION_SETTINGS={"join_use_nulls":1} configures SQL-standard
+      LEFT JOIN NULL semantics (the semantics canonical TPC-H and the variants assume,
+      and that the other three engines use natively); this is documented, NOT used to
+      mute a divergence - the residual divergences are still reported and the JOIN-NULL
+      default is itself recorded as an engine-semantic difference in w4. A
+      comparator-robustness fix in validation.py (_numeric_values_equal coerces both
+      operands to float) lets the reused comparator compare ClickHouse's Decimal averages
+      against canonical Float64 instead of crashing on `float - Decimal`; it is
+      engine-agnostic and keeps DuckDB/Postgres/DataFusion green.
 
   - id: w1
     summary: "Run the oracle on ClickHouse in report mode and classify divergences"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Run `python -m benchbox.core.tpchavoc.equivalence --engine clickhouse` at
-      EQUIVALENCE_SCALE. Exclude only genuinely un-executable variants via a
-      CLICKHOUSE_TPCHAVOC_SKIPS execution-filter. For the rest, classify EVERY
-      divergence as one of: (a) translation-layer bug (fixable at the seam), (b)
-      irreducible engine-semantic RESULT difference (e.g. integer vs float division,
-      NULL ordering/placement, implicit cast, Decimal-vs-Float rounding) - the class
-      this engine is chosen to surface, or (c) a real variant defect the DuckDB gate
-      missed. Capture the full divergence list as w1 evidence before finalizing.
+      RESOLVED. Ran `python -m benchbox.core.tpchavoc.equivalence --engine clickhouse` at
+      SF=0.1. The raw sweep (no skip-list, ClickHouse default settings) surfaced 28
+      divergences - the richest surface of any sampled engine, as expected for the first
+      native non-Postgres dialect. Classification:
+
+      (a) translation-layer bugs: NONE. The native-clickhouse translation is faithful;
+          every divergence is an execution gap or an engine-semantic result difference,
+          so there was no seam bug to fix (w2).
+
+      (b) irreducible engine-semantic RESULT differences -> CLICKHOUSE_KNOWN_DIVERGENCES
+          (7 entries, three classes):
+            - decimal-division-truncation (1_v4): ClickHouse SUM(decimal)/COUNT keeps the
+              operand Decimal scale (avg_qty = Decimal('25.53')) where canonical AVG
+              returns full Float64 (25.5376...). The "Decimal-vs-Float" axis this engine
+              was chosen to surface.
+            - sum-empty-group-zero (3_v7, 7_v7, 10_v7, 10_v8): ClickHouse SUM/sumIf over
+              an all-filtered group returns 0, not NULL, so variants emulating a WHERE
+              filter with SUM(...) FILTER(...) + HAVING <agg> IS NOT NULL never drop the
+              empty groups canonical's WHERE removes (extra rows: e.g. 3_v7 15224 vs 1216).
+            - correlated-subquery-decorrelation (2_v8, 13_v1): ClickHouse's partial,
+              experimental correlated-subquery decorrelation computes a different result
+              for these shapes (13_v1 correlated scalar COUNT -> NULL for an empty
+              correlation; 2_v8 doubly-correlated NOT EXISTS -> different row set).
+          The LEFT JOIN NULL-fill cases (14_v5, 16_v3, 16_v5) were the documented
+          join_use_nulls=0 default; configuring SQL-standard join_use_nulls=1 (w0)
+          resolves them, so they are NOT listed (the default itself is recorded as an
+          engine-semantic note rather than a per-variant exception).
+
+      (c) real variant defects the DuckDB gate missed: NONE. Every variant still passes
+          the DuckDB gate (220/220); the ClickHouse divergences are engine-semantic or
+          executability, never a latent variant bug.
+
+      Un-executable variants (18) -> CLICKHOUSE_TPCHAVOC_SKIPS execution-filter
+      (benchbox/sql_compat/rules/execution_filter/clickhouse_tpchavoc.py): correlated
+      subqueries in ORDER BY (3_v1, 5_v1, 10_v1, 16_v1), in aggregate-function arguments
+      (4_v7, 4_v10, 14_v8, 17_v7, 17_v10), and behind specific plan steps (13_v8, 16_v4);
+      the missing DuckDB LIST aggregate / list lambdas (1_v7, also skipped on
+      PG/DataFusion); nested aggregates (5_v4, 11_v4); SUM over a Variant(Decimal,Float64)
+      from a mixed-type CASE (3_v10, 5_v10); a window function in WHERE (3_v9); and a
+      GROUP BY on a CASE aliased to the same name as a column it references (1_v10).
+      These RAISE on ClickHouse, are excluded (never marked equivalent), and the same SQL
+      passes the DuckDB gate, confirming they are engine gaps not variant defects.
+
+      Final report-mode result: checked 202 variants - 7 divergent (all classified), 195
+      equivalent, exit 0.
 
   - id: w2
     summary: "Drive divergences down; declare true engine-semantic exceptions"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Prefer fixing the translation seam (translate_query_text / translate_sql_query)
-      over per-variant hacks - a translation bug likely spans many variants/engines.
-      Record ONLY irreducible engine-semantic RESULT differences as classified,
-      justified entries in the engine-keyed CLICKHOUSE_KNOWN_DIVERGENCES (with a class
-      and rationale). Un-executable variants stay in CLICKHOUSE_TPCHAVOC_SKIPS, never
-      marked equivalent. If the comparator's float tolerance is too tight/loose for a
-      legitimate ClickHouse numeric representation, adjust comparison tolerance rather
-      than muting a real divergence - and document why.
+      RESOLVED. No translation-seam fix was needed: w1 found zero translation-layer bugs
+      (the native-clickhouse rendering of both canonical and variants is faithful), so
+      translate_query_text / translate_sql_query were left unchanged and NO per-variant
+      hacks were added. The divergence surface was driven down two legitimate ways, each
+      documented:
+        - SQL-standard NULL semantics (join_use_nulls=1) via CLICKHOUSE_SESSION_SETTINGS,
+          resolving the three LEFT JOIN NULL-fill cases (14_v5, 16_v3, 16_v5) that arose
+          only from ClickHouse's non-standard default - the semantics the benchmark and
+          the other three engines already assume. This is a global engine configuration,
+          not a per-variant hack, and does not mute the residual divergences.
+        - comparator robustness: validation.py:_numeric_values_equal now coerces both
+          operands to float before comparing, so the reused comparator compares
+          ClickHouse's Decimal averages against canonical Float64 within tolerance instead
+          of raising TypeError. The tolerance itself (1e-10) was NOT loosened - 1_v4 is a
+          genuine ~0.007 Decimal-truncation divergence and is reported, not muted.
+      CLICKHOUSE_KNOWN_DIVERGENCES holds ONLY the 7 irreducible engine-semantic RESULT
+      differences, each with a class (decimal-division-truncation, sum-empty-group-zero,
+      correlated-subquery-decorrelation) and rationale. Un-executable variants stay in
+      CLICKHOUSE_TPCHAVOC_SKIPS (18, registered for clickhouse-local/server/cloud and
+      wired into get_platform_skip_queries), never marked equivalent. DuckDB (220/220),
+      Postgres (203/203), and DataFusion (206/206) stay green and their KNOWN_DIVERGENCES
+      / TPCHAVOC_SKIPS are unchanged.
 
   - id: w3
     summary: "Decide the routine-CI posture for the fourth engine and wire it"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
-      From w1-w2 evidence choose: (a) a bounded check in a non-blocking CI job (a
-      ClickHouse service container, or an in-process clickhouse-local step like the
-      datafusion-integration job), or (b) periodic/opt-in if the surface is dominated
-      by declared engine differences or the run is too slow/flaky for routine CI.
-      Either way the DuckDB gate stays the hard blocker. Add a Makefile target
-      (tpchavoc-equivalence-report-clickhouse) and record the decision + rationale.
+      RESOLVED. DECISION: option (a) - a bounded check in a non-blocking CI job. Added a
+      new `clickhouse-integration` job in .github/workflows/pr.yml (continue-on-error:
+      true) running tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py,
+      mirroring the in-process datafusion-integration job.
+
+      RATIONALE: the run is green against its classified baseline and fast (~22s
+      end-to-end, in-process chDB, no service container), so option (b)'s trigger ("too
+      slow/flaky") does not apply. The surface is NOT empty (7 engine-semantic
+      divergences), but it is fully classified and asserted against
+      CLICKHOUSE_KNOWN_DIVERGENCES with a companion test that the classified entries still
+      diverge (so the baseline cannot silently rot), which is exactly what a routine
+      sample should pin - so option (b)'s "dominated by declared engine differences"
+      trigger is satisfied as a stable, asserted baseline rather than an excuse to make it
+      opt-in. continue-on-error keeps it a SAMPLE: the DuckDB SQL gate (correctness-gate
+      job, KNOWN_DIVERGENCES empty) remains the only hard blocker, and we deliberately do
+      NOT gate the other ~18 platforms in routine CI (anti-pattern #1). Selected in CI
+      with `-m "tpchavoc"` + a pinned path (overriding the default fast-lane deselect),
+      like the DataFusion job. A fast, no-DB comparator guard
+      (tests/integration/test_tpchavoc_validator_numeric_coercion.py, [integration, fast])
+      runs in the routine lane to protect the validation.py coercion seam change that the
+      hard DuckDB gate also depends on. Added the Makefile target
+      `tpchavoc-equivalence-report-clickhouse`.
 
   - id: w4
     summary: "Synthesize the four-engine signal and update the cross-engine conclusion"
     needs: [w3]
-    status: pending
+    status: done
     notes: |
-      State whether the systematic-zero result survives a native-dialect engine. If it
-      holds, the seam is faithful across dialect FAMILIES (not just Postgres-shaped
-      ones) - a materially stronger claim than the three-engine result. If it breaks,
-      the divergences pinpoint the result-semantic gaps (division, NULL ordering,
-      casts) that a Postgres-shaped sample cannot see, and CLICKHOUSE_KNOWN_DIVERGENCES
-      documents them. Record whether a fifth engine is worth sequencing (it likely is
-      NOT, once both a Postgres-family and a non-Postgres-family engine agree).
+      RESOLVED. CONCLUSION: the systematic-zero result does NOT survive a native-dialect
+      engine, and that is the informative outcome - it localizes exactly the
+      result-semantic gaps a Postgres-shaped sample structurally cannot see. Across four
+      engines:
+        - DuckDB 220/220 (hard gate, KNOWN_DIVERGENCES empty),
+        - PostgreSQL 203/203 executable (KNOWN_DIVERGENCES empty),
+        - DataFusion 206/206 executable (KNOWN_DIVERGENCES empty),
+        - ClickHouse 195/202 executable equivalent, 7 classified engine-semantic
+          divergences (CLICKHOUSE_KNOWN_DIVERGENCES non-empty).
+      The three Postgres-family engines are systematic-zero because SQLGlot normalizes
+      netezza/datafusion -> postgres, so they all received one dialect family. ClickHouse
+      - the first engine on a NATIVE non-Postgres dialect - confirms the seam is still
+      FAITHFUL (zero translation-layer bugs: every divergence is an engine-semantic result
+      difference or an executability gap, none a mistranslation), but it is faithful
+      "modulo documented engine result-semantics", not systematic-zero. The differences
+      ClickHouse surfaces are precisely the axes the earlier TODOs predicted: Decimal-vs-
+      Float division truncation, SUM-of-empty-group = 0 vs NULL, LEFT JOIN NULL-fill
+      (resolved by standard join_use_nulls=1), and partial correlated-subquery
+      decorrelation. So the four-engine claim is: the dialect-translation seam is faithful
+      across dialect FAMILIES; what differs between engines is (1) WHICH variants execute
+      (per-engine skip-lists) and (2) on a native-dialect engine, a small, enumerable set
+      of irreducible engine result-semantics - never a silent mistranslation.
+
+      Is a fifth engine worth sequencing? NO. We now have both a Postgres-family cohort
+      (systematic-zero) and a non-Postgres-family engine (faithful + a fully classified
+      result-semantic residue) agreeing that the seam introduces no translation
+      divergence. A fifth engine would re-confirm executability/result-semantics that are
+      already engine-documented, at the cost of another CI surface, without testing a new
+      seam path. The DuckDB gate stays the hard blocker; the three samples stay
+      non-blocking.
 
 must_preserve:
   - "The DuckDB SQL equivalence gate stays the hard, blocking gate with empty KNOWN_DIVERGENCES (220/220, exit 0)."
@@ -184,4 +285,4 @@ metadata:
   tags: [tpchavoc, cross-dialect, equivalence, correctness, clickhouse, ci]
   estimated_effort: "Medium"
   created_date: "2026-06-15"
-  last_updated: "2026-06-15T00:00:00"
+  last_updated: "2026-06-18T00:00:00"

--- a/benchbox/core/tpchavoc/benchmark.py
+++ b/benchbox/core/tpchavoc/benchmark.py
@@ -13,6 +13,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 from __future__ import annotations
 
 import contextlib
+import re
 from pathlib import Path
 from typing import Any, Union
 
@@ -122,11 +123,14 @@ class TPCHavocBenchmark(TPCHBenchmark):
         """Return platform-specific TPC-Havoc variants excluded by compatibility policy.
 
         Accepts either a platform SELECTOR (e.g. ``"clickhouse-local"``) or an
-        adapter's DISPLAY ``platform_name`` (e.g. ``"ClickHouse Local"``, which is
-        what the live runner at platforms/base/execution.py passes), normalizing
-        spaces and underscores to hyphens so both forms map to the same key.
+        adapter's DISPLAY ``platform_name`` (which is what the live runner at
+        platforms/base/execution.py passes). The first-class adapters render
+        ``"ClickHouse Local"`` while the base ``ClickHouseAdapter`` renders
+        ``"ClickHouse (Local)"``, so any non-alphanumeric run (spaces,
+        underscores, parentheses) is collapsed to a single hyphen and trimmed,
+        mapping all of those forms to the same ``clickhouse-local`` key.
         """
-        platform = platform_name.lower().replace("_", "-").replace(" ", "-")
+        platform = re.sub(r"[^a-z0-9]+", "-", platform_name.lower()).strip("-")
         if platform == "lakesail":
             return list(LAKESAIL_TPCHAVOC_SKIPS)
         if platform == "datafusion":

--- a/benchbox/core/tpchavoc/benchmark.py
+++ b/benchbox/core/tpchavoc/benchmark.py
@@ -19,6 +19,7 @@ from typing import Any, Union
 from benchbox.core.tpch.benchmark import TPCHBenchmark
 from benchbox.core.tpchavoc.queries import TPCHavocQueryManager
 from benchbox.core.tpchavoc.validation import ResultValidator, ValidationReport
+from benchbox.sql_compat.rules.execution_filter.clickhouse_tpchavoc import CLICKHOUSE_TPCHAVOC_SKIPS
 from benchbox.sql_compat.rules.execution_filter.datafusion_tpchavoc import DATAFUSION_TPCHAVOC_SKIPS
 from benchbox.sql_compat.rules.execution_filter.lakesail_tpchavoc import LAKESAIL_TPCHAVOC_SKIPS
 from benchbox.sql_compat.rules.execution_filter.postgres_tpchavoc import POSTGRES_TPCHAVOC_SKIPS
@@ -118,12 +119,20 @@ class TPCHavocBenchmark(TPCHBenchmark):
         self.validation_report = ValidationReport()
 
     def get_platform_skip_queries(self, platform_name: str) -> list[str]:
-        """Return platform-specific TPC-Havoc variants excluded by compatibility policy."""
-        platform = platform_name.lower().replace("_", "-")
+        """Return platform-specific TPC-Havoc variants excluded by compatibility policy.
+
+        Accepts either a platform SELECTOR (e.g. ``"clickhouse-local"``) or an
+        adapter's DISPLAY ``platform_name`` (e.g. ``"ClickHouse Local"``, which is
+        what the live runner at platforms/base/execution.py passes), normalizing
+        spaces and underscores to hyphens so both forms map to the same key.
+        """
+        platform = platform_name.lower().replace("_", "-").replace(" ", "-")
         if platform == "lakesail":
             return list(LAKESAIL_TPCHAVOC_SKIPS)
         if platform == "datafusion":
             return list(DATAFUSION_TPCHAVOC_SKIPS)
+        if platform in {"clickhouse-local", "clickhouse-server", "clickhouse-cloud"}:
+            return list(CLICKHOUSE_TPCHAVOC_SKIPS)
         if platform in {"pg-duckdb", "pg-mooncake", "timescaledb"}:
             return list(POSTGRES_TPCHAVOC_SKIPS)
         return []

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -37,6 +37,25 @@ against :data:`DATAFUSION_KNOWN_DIVERGENCES`. Across DuckDB, PostgreSQL, and
 DataFusion every executable variant is result-equivalent: translation divergence
 is systematic-zero, not engine-specific.
 
+``--engine clickhouse`` adds a bounded *fourth-engine sample* on the in-process
+ClickHouse engine (chDB / ``clickhouse-local``). It is the first sampled engine
+that translates through a NATIVE, non-Postgres SQLGlot dialect
+(``normalize_dialect_for_sqlglot("clickhouse") == "clickhouse"``), so the seam
+renders both canonical and variants through a DIFFERENT code path than the three
+Postgres-family engines. ClickHouse also differs on the result-semantic axes the
+prior TODOs flagged, and unlike the first three engines it does NOT yield
+systematic-zero: after excluding the variants it cannot execute
+(CLICKHOUSE_TPCHAVOC_SKIPS) and running with the engine's production TPC-H session
+configuration (SQL-standard NULL semantics via ``join_use_nulls=1``), a small
+residue of irreducible
+engine-semantic RESULT differences remains, classified in
+:data:`CLICKHOUSE_KNOWN_DIVERGENCES` (Decimal-vs-Float division truncation,
+``SUM`` of an empty group returning 0 instead of NULL, and partial
+correlated-subquery decorrelation). The seam is still faithful - every divergence
+is an engine-semantic result difference or an executability gap, never a
+translation bug - but the four-engine signal is "faithful across dialect
+FAMILIES, modulo documented engine result-semantics", not systematic-zero.
+
 Comparison is order-insensitive with float tolerance (the validator sorts both
 sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
 LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
@@ -652,20 +671,204 @@ def run_datafusion_sample() -> int:
     )
 
 
+# The fourth engine sampled beyond DuckDB, PostgreSQL, and DataFusion. ClickHouse
+# is the first sampled engine whose SQLGlot dialect is NOT normalized to postgres
+# (normalize_dialect_for_sqlglot("clickhouse") == "clickhouse"), so both canonical
+# and variants are rendered through a DIFFERENT seam code path than the three
+# Postgres-family engines - the whole point of the choice. It runs in-process via
+# chDB (clickhouse-local), so like DataFusion there is no service container.
+CLICKHOUSE_TARGET_DIALECT = "clickhouse"
+
+# Benchmark type passed to ClickHouseTuningMixin.configure_for_benchmark so the
+# sample runs ClickHouse with the SAME session configuration the real TPC-H /
+# TPC-Havoc ClickHouse benchmark uses (rather than a hand-rolled subset that could
+# drift). Two of those settings are load-bearing for this oracle:
+#   * join_use_nulls=1: ClickHouse's DEFAULT join_use_nulls=0 fills unmatched
+#     LEFT/RIGHT JOIN rows with column-type DEFAULTS (0, '') instead of NULL - a
+#     documented departure from SQL-standard outer-join semantics that NO other
+#     sampled engine has. Canonical TPC-H and the variants are written for standard
+#     NULL semantics (they pass the DuckDB/Postgres/DataFusion samples, all of which
+#     use them), so the anti-join variants (`LEFT JOIN ... WHERE x IS NULL`) would
+#     otherwise diverge purely from this config default. join_use_nulls=1 configures
+#     ClickHouse to the standard semantics the benchmark assumes, isolating
+#     translation fidelity and the deeper result-semantic differences. This is NOT
+#     used to mute a divergence: the residual CLICKHOUSE_KNOWN_DIVERGENCES are still
+#     reported, and the JOIN-NULL default is itself recorded as an engine-semantic
+#     difference in the four-engine conclusion.
+#   * allow_experimental_correlated_subqueries=1: lets ClickHouse plan the
+#     correlated-subquery variants it can (the rest raise NOT_IMPLEMENTED and are in
+#     CLICKHOUSE_TPCHAVOC_SKIPS), matching production so the skip-list and divergence
+#     classification reflect the real engine configuration.
+# Verified: configure_for_benchmark and a hand-applied {join_use_nulls:1} produce an
+# IDENTICAL divergence/skip surface at SF=0.1, so reusing it adds production fidelity
+# (and validated SET application) without changing the classification.
+CLICKHOUSE_BENCHMARK_TYPE = "tpch"
+
+# Per-engine equivalence exceptions for the *fourth-engine sample* (ClickHouse),
+# keyed by "<query>_v<variant>". Same contract as POSTGRES_/DATAFUSION_KNOWN_
+# DIVERGENCES: an entry records an irreducible engine-semantic *result* difference
+# - ClickHouse executes the variant but computes a different answer than canonical
+# TPC-H run on ClickHouse, and the difference cannot be reconciled in the
+# translation layer (which is faithful). It is NEVER a translation bug (those are
+# fixed in the dialect seam) and NEVER a variant ClickHouse cannot execute (those
+# are excluded via CLICKHOUSE_TPCHAVOC_SKIPS, never marked equivalent).
+#
+# Unlike the three Postgres-family engines (all empty), ClickHouse - the first
+# sampled engine on a NATIVE non-Postgres dialect - is NOT systematic-zero. The
+# residue is three documented ClickHouse result-semantic classes:
+#   * decimal-division-truncation: ClickHouse `SUM(decimal)/COUNT` keeps the
+#     operand's Decimal scale, truncating an average that the variant computes as
+#     SUM/COUNT, whereas canonical `AVG(...)` returns full Float64 precision.
+#   * sum-empty-group-zero: ClickHouse `SUM`/`sumIf` over an all-filtered group
+#     returns 0, not NULL, so variants that emulate a WHERE filter with
+#     `SUM(...) FILTER(...)` + `HAVING <agg> IS NOT NULL` never drop the empty
+#     groups canonical's WHERE removes (extra rows).
+#   * correlated-subquery-decorrelation: ClickHouse's (partial, experimental)
+#     correlated-subquery decorrelation computes a different result than the
+#     standard-SQL semantics for these shapes (a correlated scalar COUNT returns
+#     NULL for an empty correlation; a doubly-correlated NOT EXISTS returns a
+#     different row set).
+CLICKHOUSE_KNOWN_DIVERGENCES: dict[str, str] = {
+    "1_v4": "decimal-division-truncation",
+    "2_v8": "correlated-subquery-decorrelation",
+    "3_v7": "sum-empty-group-zero",
+    "7_v7": "sum-empty-group-zero",
+    "10_v7": "sum-empty-group-zero",
+    "10_v8": "sum-empty-group-zero",
+    "13_v1": "correlated-subquery-decorrelation",
+}
+
+
+def build_clickhouse_with_tpch(scale_factor: float, output_dir: str | Path) -> tuple[Any, TPCHavocBenchmark, TPCH]:
+    """Generate TPC-H data and return a populated in-process ClickHouse connection.
+
+    Mirrors :func:`build_datafusion_with_tpch` for the fourth engine, reusing
+    ``ClickHouseLocalAdapter`` (embedded chDB) and its ``load_data`` (which ingests
+    the raw TPC-H ``.tbl`` files via ClickHouse's native CSV reader). The chDB
+    client exposes ``execute(sql).fetchall()`` and raises per query, so the
+    per-query error isolation in :func:`find_divergences` works without an
+    autocommit transaction. The adapter's own ``configure_for_benchmark`` is
+    applied with :data:`CLICKHOUSE_BENCHMARK_TYPE` so the sample runs with the SAME
+    validated session configuration as the real ClickHouse TPC-H benchmark (notably
+    SQL-standard ``join_use_nulls=1`` and ``allow_experimental_correlated_subqueries``).
+    Each table's row count is verified (>0) so a partial load cannot produce a
+    FALSE green by comparing empty-vs-empty. MergeTree ``ORDER BY`` (derived from
+    the PK by the adapter) is physical layout only and never changes results.
+
+    Returns:
+        ``(connection, tpchavoc_benchmark, tpch_benchmark)``.
+    """
+    from benchbox.platforms.clickhouse_local import ClickHouseLocalAdapter
+
+    data_dir, tpchavoc, tpch = _generate_tpch(scale_factor, Path(output_dir))
+
+    adapter = ClickHouseLocalAdapter(database_path=str(Path(output_dir) / "clickhouse_store"))
+    # Core/programmatic use: do not let the adapter try to manage (drop/create) a
+    # database; we create the schema directly on the fresh embedded store.
+    adapter.skip_database_management = True
+    connection = adapter.create_connection()
+    try:
+        adapter.create_schema(tpchavoc, connection)
+        table_stats, _, _ = adapter.load_data(tpchavoc, connection, data_dir)
+        empty = [table for table in _TPCH_TABLES if table_stats.get(table, 0) <= 0]
+        if empty:
+            raise RuntimeError(f"ClickHouse TPC-H load failed - no rows in {empty} (stats={table_stats})")
+        adapter.configure_for_benchmark(connection, CLICKHOUSE_BENCHMARK_TYPE)
+    except Exception:
+        _close_quietly(connection)
+        raise
+    return connection, tpchavoc, tpch
+
+
+def find_clickhouse_divergences(
+    connection: Any,
+    tpchavoc: TPCHavocBenchmark,
+    tpch: TPCH,
+    *,
+    query_ids: list[int] | None = None,
+) -> list[Divergence]:
+    """Run the ClickHouse equivalence sweep with the canonical ClickHouse wiring.
+
+    Single source of truth for *how* the ClickHouse sample is run - both the CLI
+    (:func:`run_clickhouse_sample`) and the integration test call this so they
+    cannot drift. Canonical and variants are both translated to the NATIVE
+    clickhouse dialect through the SAME seam (NOT normalized to postgres), and
+    CLICKHOUSE_TPCHAVOC_SKIPS variants are excluded (never marked equivalent).
+    """
+    from benchbox.sql_compat.rules.execution_filter.clickhouse_tpchavoc import CLICKHOUSE_TPCHAVOC_SKIPS
+
+    return find_divergences(
+        connection,
+        tpchavoc,
+        lambda q: tpch.get_query(q, dialect=CLICKHOUSE_TARGET_DIALECT),
+        query_ids=query_ids,
+        translate_variant=lambda sql: tpchavoc.translate_query_text(sql, "netezza", CLICKHOUSE_TARGET_DIALECT),
+        skip_variants=set(CLICKHOUSE_TPCHAVOC_SKIPS),
+    )
+
+
+def run_clickhouse_sample() -> int:
+    """Run the fourth-engine (ClickHouse) equivalence sample.
+
+    Both canonical TPC-H and every variant are translated to the NATIVE clickhouse
+    dialect through the SAME seam, then compared on the SAME in-process chDB
+    instance, so shared translation cancels out (anti-pattern: never compare a
+    ClickHouse variant to a DuckDB/Postgres/DataFusion canonical). Variants
+    ClickHouse cannot execute are excluded via CLICKHOUSE_TPCHAVOC_SKIPS - they are
+    never marked equivalent. A divergence is classified against
+    CLICKHOUSE_KNOWN_DIVERGENCES (non-empty: ClickHouse's native dialect surfaces
+    real engine-semantic result differences); an unclassified one returns
+    non-zero, but this is a *sample* run - the DuckDB gate remains the hard blocker.
+
+    ClickHouse runs in-process via chDB, so the only "engine unusable" case is chDB
+    not being installed; that alone is a clean skip (mirroring the DataFusion
+    sample). Schema, load (incl. the row-count guard), translation, and sweep
+    failures all propagate as real failures.
+    """
+    import tempfile
+
+    from benchbox.sql_compat.rules.execution_filter.clickhouse_tpchavoc import CLICKHOUSE_TPCHAVOC_SKIPS
+
+    try:
+        import chdb  # noqa: F401
+    except ImportError as exc:
+        print(f"ClickHouse equivalence sample SKIPPED - chDB (clickhouse-local) not installed: {exc}")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        connection, tpchavoc, tpch = build_clickhouse_with_tpch(EQUIVALENCE_SCALE, tmp)
+        try:
+            divergences = find_clickhouse_divergences(connection, tpchavoc, tpch)
+        finally:
+            _close_quietly(connection)
+
+    # Exclude un-executable variants from the denominator too: they are bounded
+    # out of scope, not failures.
+    total = len(tpchavoc.get_implemented_queries()) * 10 - len(CLICKHOUSE_TPCHAVOC_SKIPS)
+    return _report(
+        divergences,
+        total,
+        CLICKHOUSE_KNOWN_DIVERGENCES,
+        engine_label="ClickHouse",
+        baseline_name="CLICKHOUSE_KNOWN_DIVERGENCES",
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Generate data, run the oracle for the chosen engine, and print a report.
 
     ``--engine duckdb`` (default) is the hard, blocking gate. ``--engine
-    postgres`` and ``--engine datafusion`` run the bounded second- and
-    third-engine samples described in :func:`run_postgres_sample` and
-    :func:`run_datafusion_sample`.
+    postgres``, ``--engine datafusion``, and ``--engine clickhouse`` run the
+    bounded second-, third-, and fourth-engine samples described in
+    :func:`run_postgres_sample`, :func:`run_datafusion_sample`, and
+    :func:`run_clickhouse_sample`.
     """
     import argparse
 
     parser = argparse.ArgumentParser(description="TPC-Havoc variant-equivalence oracle.")
     parser.add_argument(
         "--engine",
-        choices=("duckdb", "postgres", "datafusion"),
+        choices=("duckdb", "postgres", "datafusion", "clickhouse"),
         default="duckdb",
         help="SQL engine to sample (default: duckdb, the hard gate).",
     )
@@ -674,6 +877,8 @@ def main(argv: list[str] | None = None) -> int:
         return run_postgres_sample()
     if args.engine == "datafusion":
         return run_datafusion_sample()
+    if args.engine == "clickhouse":
+        return run_clickhouse_sample()
     return run_duckdb_gate()
 
 

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -202,7 +202,7 @@ class ResultValidator:
         below. ClickHouse, for instance, returns ``Decimal`` for a
         ``SUM(decimal)/COUNT`` average where canonical ``AVG`` returns ``Float64``;
         without coercion the comparator would crash instead of reporting a clean
-        value (mis)match. This is engine-agnostic robustness, not an engine-specific
+        match or mismatch. This is engine-agnostic robustness, not an engine-specific
         path.
         """
         val1_missing = val1 is None or (isinstance(val1, float) and math.isnan(val1))

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -11,6 +11,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 """
 
 import hashlib
+import math
 from typing import Any, Optional, Union
 
 
@@ -186,7 +187,31 @@ class ResultValidator:
         return val1 == val2
 
     def _numeric_values_equal(self, val1: Union[int, float], val2: Union[int, float]) -> bool:
-        """Check if two numeric values are equal within tolerance."""
+        """Check if two numeric values are equal within tolerance.
+
+        Normalizes "missing" operands first: SQL ``NULL`` arrives as ``None`` from
+        most engines but as ``float('nan')`` from ClickHouse's Arrow/pandas decode.
+        Two missing values compare equal and a missing-vs-present pair does not, so
+        a both-NULL aggregate is not reported as a spurious divergence and a
+        NULL-vs-number stays a real one (this also keeps ``float(...)`` below from
+        ever seeing ``None``/``NaN``).
+
+        Then coerces both operands to ``float`` so a mixed-type comparison (e.g. a
+        ``decimal.Decimal`` from one engine vs a ``float`` from another) is compared
+        on a common type rather than raising ``TypeError`` on the ``val1 - val2``
+        below. ClickHouse, for instance, returns ``Decimal`` for a
+        ``SUM(decimal)/COUNT`` average where canonical ``AVG`` returns ``Float64``;
+        without coercion the comparator would crash instead of reporting a clean
+        value (mis)match. This is engine-agnostic robustness, not an engine-specific
+        path.
+        """
+        val1_missing = val1 is None or (isinstance(val1, float) and math.isnan(val1))
+        val2_missing = val2 is None or (isinstance(val2, float) and math.isnan(val2))
+        if val1_missing or val2_missing:
+            return val1_missing and val2_missing
+
+        val1 = float(val1)
+        val2 = float(val2)
         if val1 == val2:
             return True
 

--- a/benchbox/sql_compat/rules/execution_filter/clickhouse_tpchavoc.py
+++ b/benchbox/sql_compat/rules/execution_filter/clickhouse_tpchavoc.py
@@ -1,0 +1,86 @@
+"""ClickHouse execution-filter rules for unsupported TPC-Havoc variants.
+
+ClickHouse is the FOURTH engine sampled by the TPC-Havoc cross-dialect
+equivalence oracle (after DuckDB, the hard gate; PostgreSQL; and DataFusion).
+It is the first sampled engine that translates through a NATIVE, non-Postgres
+SQLGlot dialect (``normalize_dialect_for_sqlglot("clickhouse") == "clickhouse"``),
+so it exercises a different code path in the dialect seam than the three
+Postgres-family engines before it.
+
+Every entry below is a variant ClickHouse cannot *execute* as translated - it
+raises a planning (``NOT_IMPLEMENTED``), name-resolution, or type-system error,
+NOT a result divergence. The same SQL passes the DuckDB equivalence gate, so the
+variant is valid; these are simply ClickHouse engine/feature gaps. They are
+excluded from the equivalence sample (``CLICKHOUSE_TPCHAVOC_SKIPS``), never marked
+equivalent. Irreducible engine-semantic *result* differences (where ClickHouse
+executes the variant but computes a different answer than canonical TPC-H run on
+ClickHouse) live in
+``benchbox/core/tpchavoc/equivalence.py:CLICKHOUSE_KNOWN_DIVERGENCES``, not here.
+
+The dominant gap is ClickHouse's (still partial) correlated-subquery support: it
+plans some correlated shapes but rejects correlated subqueries in ORDER BY, in
+aggregate-function arguments, and behind a handful of plan steps. The remainder
+are the missing DuckDB ``LIST`` aggregate (also skipped on Postgres/DataFusion),
+ClickHouse's strict rejection of nested aggregates and of a ``SUM`` over a
+``Variant`` column produced by a mixed Decimal/Float ``CASE``, a window function
+in ``WHERE``, and a ``GROUP BY`` whose key is a ``CASE`` aliased to the same name
+as a column it references (alias shadowing). These gaps apply to the ClickHouse
+SQL engine itself, so the skips are registered for every ClickHouse deployment
+mode (local/chDB, server, cloud).
+"""
+
+from __future__ import annotations
+
+from benchbox.sql_compat.actions import CompatAction
+from benchbox.sql_compat.context import Phase
+from benchbox.sql_compat.decision import CompatibilityDecision, FailureMode, SkipQueryPayload, SupportLevel
+from benchbox.sql_compat.registry import REGISTRY
+
+CLICKHOUSE_TPCHAVOC_SKIPS: dict[str, str] = {
+    "1_v7": "ClickHouse has no DuckDB `LIST` aggregate / `list_transform`/`list_zip` lambda forms this variant uses (`Syntax error` at the `->` lambda).",
+    "1_v10": "ClickHouse rejects a GROUP BY whose key is a CASE aliased to the same name as a column it references (alias shadowing, Code 215 NOT_AN_AGGREGATE).",
+    "3_v1": "ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED).",
+    "3_v9": "ClickHouse rejects a window function used in WHERE (Code 184 ILLEGAL_AGGREGATION).",
+    "3_v10": "ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT).",
+    "4_v7": "ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED).",
+    "4_v10": "ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED).",
+    "5_v1": "ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED).",
+    "5_v4": "ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION).",
+    "5_v10": "ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT).",
+    "10_v1": "ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED).",
+    "11_v4": "ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION).",
+    "13_v8": "ClickHouse cannot lower this variant's correlated subquery (CommonSubplan plan step, Code 48 NOT_IMPLEMENTED).",
+    "14_v8": "ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED).",
+    "16_v1": "ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED).",
+    "16_v4": "ClickHouse cannot lower this variant's correlated subquery (DelayedCreatingSets plan step, Code 48 NOT_IMPLEMENTED).",
+    "17_v7": "ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED).",
+    "17_v10": "ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED).",
+}
+
+# The ClickHouse SQL engine is shared across deployment modes, so the same
+# variant-execution gaps apply to local/chDB, self-hosted server, and Cloud.
+_CLICKHOUSE_TPCHAVOC_PLATFORMS = ("clickhouse-local", "clickhouse-server", "clickhouse-cloud")
+
+for _platform in _CLICKHOUSE_TPCHAVOC_PLATFORMS:
+    for _query_id, _reason in CLICKHOUSE_TPCHAVOC_SKIPS.items():
+        REGISTRY.register(
+            CompatibilityDecision(
+                rule_id=f"execution_filter.{_platform}.tpchavoc.{_query_id}",
+                action=CompatAction.SKIP_QUERY,
+                support_level=SupportLevel.SKIPPED_QUERY,
+                failure_mode=FailureMode.UNSUPPORTED_FEATURE,
+                payload=SkipQueryPayload(
+                    reason=(
+                        f"{_reason} Evidence: 2026-06-18 TPC-Havoc fourth-engine equivalence sweep "
+                        "(`python -m benchbox.core.tpchavoc.equivalence --engine clickhouse`, SF=0.1) "
+                        "reported this stable variant execution failure on ClickHouse."
+                    ),
+                    query_id=_query_id,
+                ),
+                reason=_reason,
+            ),
+            Phase.EXECUTION_FILTER,
+            _platform,
+            benchmark="tpchavoc",
+            query_id=_query_id,
+        )

--- a/docs/compat/capability-matrix.md
+++ b/docs/compat/capability-matrix.md
@@ -4,9 +4,9 @@
 
 Every rule registered in `benchbox.sql_compat` is listed below. The registry is the authoritative source of compatibility policy; this document is regenerated from it. See [adr-sql-compat-phase-aware-pipeline.md](../development/adr/adr-sql-compat-phase-aware-pipeline.md) for the design.
 
-**Total registered rules:** 353
+**Total registered rules:** 407
 
-**Platforms covered:** 30
+**Platforms covered:** 33
 
 ## Phase coverage by platform
 
@@ -15,6 +15,9 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | athena | - | - | - | - | 1 | - | 1 |
 | bigquery | - | - | - | 2 | 1 | - | 3 |
 | clickhouse | - | 13 | 3 | 4 | 1 | - | 21 |
+| clickhouse-cloud | - | - | - | - | - | 18 | 18 |
+| clickhouse-local | - | - | - | - | - | 18 | 18 |
+| clickhouse-server | - | - | - | - | - | 18 | 18 |
 | databend | - | - | - | - | 1 | - | 1 |
 | databricks | - | - | - | 2 | 1 | - | 3 |
 | datafusion | - | - | 4 | 2 | - | 14 | 20 |
@@ -84,6 +87,75 @@ Every rule registered in `benchbox.sql_compat` is listed below. The registry is 
 | schema_emit | benchmark=tsbs_devops | rewrite_ddl | REWRITTEN | SYNTAX_ERROR | `schema_emit.clickhouse.tsbs_devops.all.mergetree_ddl` |
 | schema_emit | benchmark=write_primitives | rewrite_ddl | REWRITTEN | UNSUPPORTED_FEATURE | `schema_emit.clickhouse.write_primitives.pk_lock_table_unsupported` |
 | ddl_optimize | platform-wide | rewrite_ddl | REWRITTEN | SYNTAX_ERROR | `ddl_optimize.clickhouse.all.optimize_table_definition` |
+
+### clickhouse-cloud
+
+| phase | scope | action | support | failure mode | rule_id |
+|---|---|---|---|---|---|
+| execution_filter | benchmark=tpchavoc, query=10_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.10_v1` |
+| execution_filter | benchmark=tpchavoc, query=11_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.11_v4` |
+| execution_filter | benchmark=tpchavoc, query=13_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.13_v8` |
+| execution_filter | benchmark=tpchavoc, query=14_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.14_v8` |
+| execution_filter | benchmark=tpchavoc, query=16_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.16_v1` |
+| execution_filter | benchmark=tpchavoc, query=16_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.16_v4` |
+| execution_filter | benchmark=tpchavoc, query=17_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.17_v10` |
+| execution_filter | benchmark=tpchavoc, query=17_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.17_v7` |
+| execution_filter | benchmark=tpchavoc, query=1_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.1_v10` |
+| execution_filter | benchmark=tpchavoc, query=1_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.1_v7` |
+| execution_filter | benchmark=tpchavoc, query=3_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.3_v1` |
+| execution_filter | benchmark=tpchavoc, query=3_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.3_v10` |
+| execution_filter | benchmark=tpchavoc, query=3_v9 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.3_v9` |
+| execution_filter | benchmark=tpchavoc, query=4_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.4_v10` |
+| execution_filter | benchmark=tpchavoc, query=4_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.4_v7` |
+| execution_filter | benchmark=tpchavoc, query=5_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.5_v1` |
+| execution_filter | benchmark=tpchavoc, query=5_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.5_v10` |
+| execution_filter | benchmark=tpchavoc, query=5_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-cloud.tpchavoc.5_v4` |
+
+### clickhouse-local
+
+| phase | scope | action | support | failure mode | rule_id |
+|---|---|---|---|---|---|
+| execution_filter | benchmark=tpchavoc, query=10_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.10_v1` |
+| execution_filter | benchmark=tpchavoc, query=11_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.11_v4` |
+| execution_filter | benchmark=tpchavoc, query=13_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.13_v8` |
+| execution_filter | benchmark=tpchavoc, query=14_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.14_v8` |
+| execution_filter | benchmark=tpchavoc, query=16_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.16_v1` |
+| execution_filter | benchmark=tpchavoc, query=16_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.16_v4` |
+| execution_filter | benchmark=tpchavoc, query=17_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.17_v10` |
+| execution_filter | benchmark=tpchavoc, query=17_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.17_v7` |
+| execution_filter | benchmark=tpchavoc, query=1_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.1_v10` |
+| execution_filter | benchmark=tpchavoc, query=1_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.1_v7` |
+| execution_filter | benchmark=tpchavoc, query=3_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.3_v1` |
+| execution_filter | benchmark=tpchavoc, query=3_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.3_v10` |
+| execution_filter | benchmark=tpchavoc, query=3_v9 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.3_v9` |
+| execution_filter | benchmark=tpchavoc, query=4_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.4_v10` |
+| execution_filter | benchmark=tpchavoc, query=4_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.4_v7` |
+| execution_filter | benchmark=tpchavoc, query=5_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.5_v1` |
+| execution_filter | benchmark=tpchavoc, query=5_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.5_v10` |
+| execution_filter | benchmark=tpchavoc, query=5_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-local.tpchavoc.5_v4` |
+
+### clickhouse-server
+
+| phase | scope | action | support | failure mode | rule_id |
+|---|---|---|---|---|---|
+| execution_filter | benchmark=tpchavoc, query=10_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.10_v1` |
+| execution_filter | benchmark=tpchavoc, query=11_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.11_v4` |
+| execution_filter | benchmark=tpchavoc, query=13_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.13_v8` |
+| execution_filter | benchmark=tpchavoc, query=14_v8 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.14_v8` |
+| execution_filter | benchmark=tpchavoc, query=16_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.16_v1` |
+| execution_filter | benchmark=tpchavoc, query=16_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.16_v4` |
+| execution_filter | benchmark=tpchavoc, query=17_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.17_v10` |
+| execution_filter | benchmark=tpchavoc, query=17_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.17_v7` |
+| execution_filter | benchmark=tpchavoc, query=1_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.1_v10` |
+| execution_filter | benchmark=tpchavoc, query=1_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.1_v7` |
+| execution_filter | benchmark=tpchavoc, query=3_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.3_v1` |
+| execution_filter | benchmark=tpchavoc, query=3_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.3_v10` |
+| execution_filter | benchmark=tpchavoc, query=3_v9 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.3_v9` |
+| execution_filter | benchmark=tpchavoc, query=4_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.4_v10` |
+| execution_filter | benchmark=tpchavoc, query=4_v7 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.4_v7` |
+| execution_filter | benchmark=tpchavoc, query=5_v1 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.5_v1` |
+| execution_filter | benchmark=tpchavoc, query=5_v10 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.5_v10` |
+| execution_filter | benchmark=tpchavoc, query=5_v4 | skip_query | SKIPPED_QUERY | UNSUPPORTED_FEATURE | `execution_filter.clickhouse-server.tpchavoc.5_v4` |
 
 ### databend
 

--- a/docs/compat/skip-reference.md
+++ b/docs/compat/skip-reference.md
@@ -4,13 +4,82 @@
 
 Rules the registry applies to queries, benchmarks, and DDL statements. Split into two sections based on whether the outcome is user-visible in result counts. Each entry names the platform, the scope the rule applies to, the registered reason, and the rule_id you can grep for in `benchbox/sql_compat/rules/`.
 
-**Total rules:** 260
+**Total rules:** 314
 
-**Platforms with rules:** 18
+**Platforms with rules:** 21
 
 ## Will not run
 
 Queries or benchmarks that are **omitted from the result set** - either because the benchmark is refused at preflight (BLOCKED) or a specific query is excluded from execution (SKIPPED_QUERY). Users see these as missing entries in result counts.
+
+### clickhouse-cloud
+
+| support | scope | phase | reason | rule_id |
+|---|---|---|---|---|
+| SKIPPED_QUERY | benchmark=tpchavoc, query=10_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.10_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=11_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-cloud.tpchavoc.11_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=13_v8 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (CommonSubplan plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.13_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=14_v8 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.14_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.16_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v4 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (DelayedCreatingSets plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.16_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.17_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.17_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v10 | execution_filter | ClickHouse rejects a GROUP BY whose key is a CASE aliased to the same name as a column it references (alias shadowing, Code 215 NOT_AN_AGGREGATE). | `execution_filter.clickhouse-cloud.tpchavoc.1_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v7 | execution_filter | ClickHouse has no DuckDB `LIST` aggregate / `list_transform`/`list_zip` lambda forms this variant uses (`Syntax error` at the `->` lambda). | `execution_filter.clickhouse-cloud.tpchavoc.1_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.3_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-cloud.tpchavoc.3_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v9 | execution_filter | ClickHouse rejects a window function used in WHERE (Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-cloud.tpchavoc.3_v9` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.4_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.4_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-cloud.tpchavoc.5_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-cloud.tpchavoc.5_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-cloud.tpchavoc.5_v4` |
+
+### clickhouse-local
+
+| support | scope | phase | reason | rule_id |
+|---|---|---|---|---|
+| SKIPPED_QUERY | benchmark=tpchavoc, query=10_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.10_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=11_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-local.tpchavoc.11_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=13_v8 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (CommonSubplan plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.13_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=14_v8 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.14_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.16_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v4 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (DelayedCreatingSets plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.16_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.17_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.17_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v10 | execution_filter | ClickHouse rejects a GROUP BY whose key is a CASE aliased to the same name as a column it references (alias shadowing, Code 215 NOT_AN_AGGREGATE). | `execution_filter.clickhouse-local.tpchavoc.1_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v7 | execution_filter | ClickHouse has no DuckDB `LIST` aggregate / `list_transform`/`list_zip` lambda forms this variant uses (`Syntax error` at the `->` lambda). | `execution_filter.clickhouse-local.tpchavoc.1_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.3_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-local.tpchavoc.3_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v9 | execution_filter | ClickHouse rejects a window function used in WHERE (Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-local.tpchavoc.3_v9` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.4_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.4_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-local.tpchavoc.5_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-local.tpchavoc.5_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-local.tpchavoc.5_v4` |
+
+### clickhouse-server
+
+| support | scope | phase | reason | rule_id |
+|---|---|---|---|---|
+| SKIPPED_QUERY | benchmark=tpchavoc, query=10_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.10_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=11_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-server.tpchavoc.11_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=13_v8 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (CommonSubplan plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.13_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=14_v8 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.14_v8` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.16_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=16_v4 | execution_filter | ClickHouse cannot lower this variant's correlated subquery (DelayedCreatingSets plan step, Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.16_v4` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.17_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=17_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.17_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v10 | execution_filter | ClickHouse rejects a GROUP BY whose key is a CASE aliased to the same name as a column it references (alias shadowing, Code 215 NOT_AN_AGGREGATE). | `execution_filter.clickhouse-server.tpchavoc.1_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=1_v7 | execution_filter | ClickHouse has no DuckDB `LIST` aggregate / `list_transform`/`list_zip` lambda forms this variant uses (`Syntax error` at the `->` lambda). | `execution_filter.clickhouse-server.tpchavoc.1_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.3_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-server.tpchavoc.3_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=3_v9 | execution_filter | ClickHouse rejects a window function used in WHERE (Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-server.tpchavoc.3_v9` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v10 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.4_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=4_v7 | execution_filter | ClickHouse does not support correlated subqueries in an aggregate-function argument (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.4_v7` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v1 | execution_filter | ClickHouse does not support correlated subqueries in ORDER BY (Code 48 NOT_IMPLEMENTED). | `execution_filter.clickhouse-server.tpchavoc.5_v1` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v10 | execution_filter | ClickHouse cannot SUM a `Variant(Decimal, Float64)` column produced by this variant's mixed-type CASE (Code 43 ILLEGAL_TYPE_OF_ARGUMENT). | `execution_filter.clickhouse-server.tpchavoc.5_v10` |
+| SKIPPED_QUERY | benchmark=tpchavoc, query=5_v4 | execution_filter | ClickHouse rejects an aggregate over a select-list-alias aggregate (nested aggregate, Code 184 ILLEGAL_AGGREGATION). | `execution_filter.clickhouse-server.tpchavoc.5_v4` |
 
 ### datafusion
 

--- a/tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py
@@ -1,0 +1,126 @@
+"""Fourth-engine (ClickHouse) TPC-Havoc variant-equivalence sample.
+
+The DuckDB equivalence gate (``benchbox/core/tpchavoc/equivalence.py``, run via
+``make tpchavoc-equivalence-report``) proves every variant is result-equivalent
+to canonical TPC-H on ONE engine, DuckDB at SF=0.1. The PostgreSQL and DataFusion
+samples added two more, both systematic-zero. This test is the bounded
+*fourth-engine sample* on the in-process ClickHouse engine (chDB /
+``clickhouse-local``): it runs canonical TPC-H and every variant through the SAME
+translation to the SAME chDB instance (so shared translation cancels out),
+excludes the variants ClickHouse cannot execute (CLICKHOUSE_TPCHAVOC_SKIPS), and
+asserts no residual divergence beyond the classified CLICKHOUSE_KNOWN_DIVERGENCES
+baseline.
+
+ClickHouse is the first sampled engine that translates through a NATIVE,
+non-Postgres SQLGlot dialect (``normalize_dialect_for_sqlglot("clickhouse") ==
+"clickhouse"``), so it exercises a DIFFERENT seam code path than the three
+Postgres-family engines. Unlike them it is NOT systematic-zero:
+CLICKHOUSE_KNOWN_DIVERGENCES is non-empty and records the irreducible
+engine-semantic RESULT differences ClickHouse surfaces (Decimal-vs-Float division
+truncation, ``SUM`` of an empty group returning 0 not NULL, partial
+correlated-subquery decorrelation). The DuckDB gate remains the hard, blocking
+gate; this sample (and the gate body of the non-blocking ``clickhouse-integration``
+CI job) catches translation-induced divergence a fourth engine over without gating
+all ~20 platforms.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.equivalence import (
+    CLICKHOUSE_KNOWN_DIVERGENCES,
+    EQUIVALENCE_SCALE,
+    _close_quietly,
+    build_clickhouse_with_tpch,
+    find_clickhouse_divergences,
+)
+from benchbox.sql_compat.rules.execution_filter.clickhouse_tpchavoc import CLICKHOUSE_TPCHAVOC_SKIPS
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.tpchavoc,
+    pytest.mark.slow,
+]
+
+
+@pytest.fixture(scope="module")
+def clickhouse_divergences(tmp_path_factory):
+    """Load SF=0.1 TPC-H into an in-process chDB instance and sweep ONCE.
+
+    ClickHouse runs in-process via chDB, so "unreachable" means "chDB not
+    installed" - skip cleanly in that case (mirroring the DataFusion sample's
+    import-only skip). The 202-variant sweep is the expensive part, so it is
+    computed a single time at module scope and shared across the assertions below.
+    """
+    pytest.importorskip("chdb", reason="chDB (clickhouse-local) not installed")
+    output_dir = tmp_path_factory.mktemp("tpchavoc_ch_equivalence")
+    connection, tpchavoc, tpch = build_clickhouse_with_tpch(EQUIVALENCE_SCALE, output_dir)
+    try:
+        yield find_clickhouse_divergences(connection, tpchavoc, tpch)
+    finally:
+        _close_quietly(connection)
+
+
+def test_all_executable_variants_match_classified_baseline(clickhouse_divergences):
+    """Every ClickHouse-executable variant matches canonical TPC-H on ClickHouse,
+    modulo the classified CLICKHOUSE_KNOWN_DIVERGENCES.
+
+    Both sides are translated to the native clickhouse dialect through the same
+    seam and compared on the same chDB instance, so a divergence here points at
+    the dialect translation layer, a real variant defect, or a classified
+    engine-semantic difference - never a cross-engine mismatch against DuckDB,
+    Postgres, or DataFusion. An UNCLASSIFIED divergence (not in the baseline) is
+    the failure condition.
+    """
+    unexpected = {d.key for d in clickhouse_divergences} - set(CLICKHOUSE_KNOWN_DIVERGENCES)
+    assert not unexpected, "Unclassified variant divergence(s) from canonical TPC-H on ClickHouse: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in clickhouse_divergences if d.key in unexpected
+    )
+
+
+def test_classified_divergences_still_diverge(clickhouse_divergences):
+    """Every CLICKHOUSE_KNOWN_DIVERGENCES entry is still observed as a divergence.
+
+    Guards against a stale baseline: if a previously-classified engine-semantic
+    difference is now equivalent (e.g. a ClickHouse upgrade fixed it), the entry
+    should be removed rather than left masking a future regression.
+    """
+    observed = {d.key for d in clickhouse_divergences}
+    stale = sorted(set(CLICKHOUSE_KNOWN_DIVERGENCES) - observed)
+    assert not stale, f"CLICKHOUSE_KNOWN_DIVERGENCES entries no longer diverge - remove them: {stale}"
+
+
+def test_skipped_variants_are_excluded_never_marked_equivalent(clickhouse_divergences):
+    """CLICKHOUSE_TPCHAVOC_SKIPS variants are excluded from the sweep entirely."""
+    reported = {d.key for d in clickhouse_divergences}
+    assert reported.isdisjoint(set(CLICKHOUSE_TPCHAVOC_SKIPS)), (
+        "Un-executable (skip-list) variants must be excluded, not evaluated"
+    )
+
+
+def test_clickhouse_skip_list_wiring():
+    """The skip-list is wired to every ClickHouse deployment-mode platform.
+
+    No database needed: this pins the get_platform_skip_queries mapping so real
+    ClickHouse benchmark runs (local/server/cloud) exclude exactly the variants
+    the ClickHouse SQL engine cannot execute. It checks BOTH the platform selector
+    ("clickhouse-local") and the adapter DISPLAY name ("ClickHouse Local") - the
+    latter is what platforms/base/execution.py actually passes at runtime, so a
+    normalization regression that returned [] for real runs would fail here.
+    """
+    from benchbox.core.tpchavoc.benchmark import TPCHavocBenchmark
+
+    benchmark = TPCHavocBenchmark(scale_factor=EQUIVALENCE_SCALE)
+    selectors = ("clickhouse-local", "clickhouse-server", "clickhouse-cloud")
+    display_names = ("ClickHouse Local", "ClickHouse Server", "ClickHouse Cloud")
+    for platform in (*selectors, *display_names):
+        assert set(benchmark.get_platform_skip_queries(platform)) == set(CLICKHOUSE_TPCHAVOC_SKIPS), platform
+    assert benchmark.get_platform_skip_queries("duckdb") == []

--- a/tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py
+++ b/tests/integration/platforms/test_tpchavoc_clickhouse_equivalence.py
@@ -120,7 +120,11 @@ def test_clickhouse_skip_list_wiring():
 
     benchmark = TPCHavocBenchmark(scale_factor=EQUIVALENCE_SCALE)
     selectors = ("clickhouse-local", "clickhouse-server", "clickhouse-cloud")
-    display_names = ("ClickHouse Local", "ClickHouse Server", "ClickHouse Cloud")
-    for platform in (*selectors, *display_names):
+    # First-class adapter display names ("ClickHouse Local") and the base
+    # ClickHouseAdapter display names ("ClickHouse (Local)") - the live runner
+    # passes whichever the active adapter exposes, so all must map to the skips.
+    first_class_display = ("ClickHouse Local", "ClickHouse Server", "ClickHouse Cloud")
+    base_display = ("ClickHouse (Local)", "ClickHouse (Server)", "ClickHouse (Cloud)")
+    for platform in (*selectors, *first_class_display, *base_display):
         assert set(benchmark.get_platform_skip_queries(platform)) == set(CLICKHOUSE_TPCHAVOC_SKIPS), platform
     assert benchmark.get_platform_skip_queries("duckdb") == []

--- a/tests/integration/test_tpchavoc_validator_numeric_coercion.py
+++ b/tests/integration/test_tpchavoc_validator_numeric_coercion.py
@@ -1,0 +1,84 @@
+"""Fast, no-DB guard for the TPC-Havoc validator's numeric coercion.
+
+The cross-dialect equivalence oracle compares variant results to canonical
+TPC-H across engines that return numbers with DIFFERENT Python types: DuckDB and
+Postgres hand back ``float`` for averages, while ClickHouse returns ``Decimal``
+for a ``SUM(decimal)/COUNT`` average (and ``Float64`` for native ``AVG``). The
+shared comparator (``ResultValidator._numeric_values_equal``) must compare these
+on a common type rather than raising ``TypeError`` on ``float - Decimal``;
+otherwise the ClickHouse sample would crash on Q1 instead of reporting a clean
+value match/mismatch, and any future engine returning ``Decimal`` aggregates
+would regress the same way.
+
+This guard pins that coercion WITHOUT a database so a regression is caught in the
+fast lane (the live ClickHouse sweep is slow-marked and only runs in the
+non-blocking clickhouse-integration CI job). It is engine-agnostic: it exercises
+the reused comparator, never a per-engine fork.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from benchbox.core.tpchavoc.validation import ResultValidator, ValidationError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.tpchavoc,
+    pytest.mark.fast,
+]
+
+
+def test_numeric_equal_handles_float_vs_decimal_without_crashing():
+    """A float and an equal Decimal compare equal (no TypeError on subtraction)."""
+    validator = ResultValidator(tolerance=1e-10)
+    assert validator._numeric_values_equal(25.0, Decimal("25.0"))
+    assert validator._numeric_values_equal(Decimal("25.0"), 25.0)
+
+
+def test_numeric_equal_float_vs_decimal_within_tolerance():
+    """Tiny float/Decimal representation differences stay within tolerance."""
+    validator = ResultValidator(tolerance=1e-6)
+    assert validator._numeric_values_equal(25.537587, Decimal("25.537587"))
+
+
+def test_numeric_equal_float_vs_decimal_reports_real_mismatch():
+    """A genuine difference (ClickHouse Decimal truncation) still reports unequal.
+
+    Mirrors TPC-Havoc Q1.4 on ClickHouse: canonical AVG returns the full-precision
+    float 25.5375..., the variant's SUM/COUNT returns Decimal('25.53'); coercion
+    must NOT mute this real divergence.
+    """
+    validator = ResultValidator(tolerance=1e-10)
+    assert not validator._numeric_values_equal(25.537587116854997, Decimal("25.53"))
+
+
+def test_aggregation_results_report_clean_mismatch_for_decimal_truncation():
+    """The validator surfaces a ValidationError (not a TypeError) on float vs Decimal."""
+    validator = ResultValidator(tolerance=1e-10)
+    original = [("A", "F", 25.537587116854997)]
+    variant = [("A", "F", Decimal("25.53"))]
+    with pytest.raises(ValidationError, match="value mismatch"):
+        validator.validate_aggregation_results(original, variant, query_id=1, variant_id=4, aggregation_columns=[2])
+
+
+def test_numeric_equal_treats_nan_and_none_as_missing():
+    """SQL NULL arrives as None (most engines) or float('nan') (ClickHouse decode).
+
+    Two missing values must compare equal (no spurious divergence), a
+    missing-vs-present pair must compare unequal, and neither path may raise.
+    """
+    validator = ResultValidator(tolerance=1e-10)
+    nan = float("nan")
+    assert validator._numeric_values_equal(nan, nan)
+    assert validator._numeric_values_equal(None, None)
+    assert validator._numeric_values_equal(nan, None)
+    assert not validator._numeric_values_equal(nan, 0)
+    assert not validator._numeric_values_equal(0, nan)
+    assert not validator._numeric_values_equal(None, 5.0)


### PR DESCRIPTION
## Summary

Extends the TPC-Havoc cross-dialect equivalence oracle to a **fourth engine, ClickHouse** — the first sampled engine that translates through a **NATIVE non-Postgres SQLGlot dialect**. DuckDB (the hard gate), PostgreSQL, and DataFusion all route through a Postgres-shaped seam (`netezza`/`datafusion` → `postgres`), so their systematic-zero result could only prove the seam emits *one* dialect family faithfully. ClickHouse (`clickhouse` is a first-class SQLGlot write dialect) exercises a different seam path and the result-semantic axes prior TODOs flagged (integer/float division, NULL placement, implicit casts, Decimal-vs-Float).

Implements `_project/TODO/main/planning/tpchavoc-fourth-engine-equivalence-sampling.yaml` (w0–w4).

## What's in it

- **`equivalence.py`** — `build_clickhouse_with_tpch` (in-process chDB via `ClickHouseLocalAdapter`; row-count guard; the adapter's production `configure_for_benchmark("tpch")` session config — notably SQL-standard `join_use_nulls=1` and `allow_experimental_correlated_subqueries=1`), `find_clickhouse_divergences`, `run_clickhouse_sample`, `CLICKHOUSE_TARGET_DIALECT = "clickhouse"`, `CLICKHOUSE_KNOWN_DIVERGENCES` (7 classified entries), and `--engine clickhouse`. `find_divergences`/`validate_variant_equivalence`/`_report` are **reused verbatim — no per-engine fork**.
- **`clickhouse_tpchavoc.py`** — `CLICKHOUSE_TPCHAVOC_SKIPS` (18 un-executable variants), registered for `clickhouse-{local,server,cloud}` and wired into `get_platform_skip_queries` (normalization now handles display names with spaces, so real runs apply the skips).
- **`validation.py`** — make the shared comparator robust to `None`/`NaN` (ClickHouse NULL numerics decode to `float('nan')`) and to mixed `float`-vs-`Decimal` operands, so it reports clean (mis)matches instead of crashing. Engine-agnostic.
- **CI/tooling** — non-blocking `clickhouse-integration` job (in-process), a fast no-DB comparator guard, `make tpchavoc-equivalence-report-clickhouse`, regenerated compat docs.

## Result classification

After excluding the 18 un-executable variants (correlated-subquery `NOT_IMPLEMENTED`, missing DuckDB `LIST`, nested aggregates, `Variant` SUM, window-in-WHERE, alias-shadowing GROUP BY) and running with the engine's production TPC-H config: **202 checked, 195 equivalent, 7 classified divergences, exit 0**. The 7 are irreducible engine-semantics, not mistranslations:

| class | variants | what ClickHouse does |
|---|---|---|
| `decimal-division-truncation` | 1_v4 | `SUM(decimal)/COUNT` keeps operand Decimal scale; canonical `AVG` is full Float64 |
| `sum-empty-group-zero` | 3_v7, 7_v7, 10_v7, 10_v8 | `SUM`/`sumIf` over an all-filtered group returns 0 not NULL → `HAVING … IS NOT NULL` keeps extra rows |
| `correlated-subquery-decorrelation` | 2_v8, 13_v1 | partial correlated-subquery decorrelation yields a different result |

## Four-engine conclusion

Systematic-zero does **not** survive a native-dialect engine — but the seam is still **faithful**: every ClickHouse divergence is an enumerable engine-semantic result difference or an executability gap, never a translation bug. The claim strengthens to *faithful across dialect FAMILIES, modulo documented engine result-semantics*. A fifth engine is **not** worth sequencing. **DuckDB stays the hard 220/220 gate; Postgres (203/203) and DataFusion (206/206) stay green.**

## Verification

- DuckDB gate 220/220 exit 0; DataFusion 206/206; Postgres unchanged; ClickHouse 202/195/7 exit 0
- new live sample test + fast comparator guard pass; marker-strategy, ruff, ruff format, ty all green
- TODO validated (`validate_todo.py`, `check-graph`); compat docs in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_