### PR TITLE
feat(query-plans): isolate plan capture for every test type (w3)

### DIFF
--- a/_project/TODO/main/planning/query-plan-capture-canonical-isolation.yaml
+++ b/_project/TODO/main/planning/query-plan-capture-canonical-isolation.yaml
@@ -20,14 +20,29 @@ progress_note: |
       non-ANALYZE EXPLAIN via the is_dml_query guard, never re-executed). Restored
       ANALYZE timing for the eligible adapters. Tests:
       tests/integration/test_plan_capture_phase.py (phase honours analyze_plans
-      true/false; DML executed exactly once) -> 9 passing.
+      true/false; DML executed exactly once).
+    - w3 (isolate ALL test types) DONE: the suppress-inline + post-measurement
+      capture was hoisted out of _execute_all_queries into the single dispatch point
+      _execute_queries_by_type, so capture is now isolated for power, throughput,
+      maintenance AND combined. During the timed run (for phase-eligible engines) the
+      shared inline chokepoint (_merge_plan_capture_into_result) RECORDS each executed
+      query into _phase_recorded_queries (thread-safe, for concurrent streams) instead
+      of running EXPLAIN inline; the plans are captured once, post-measurement, on the
+      same connection and merged into every result row sharing a query_id. This also
+      fixes a latent bug: throughput previously ran inline EXPLAIN interleaved with the
+      timed streams yet discarded the plan (the throughput row-builder never copied it)
+      — now no interleaved work and the plan actually lands. Tests: phase runs for
+      non-power test types; plans attach to all rows sharing a query_id; EXPLAIN never
+      runs while the isolation flag is active. Full platforms suite (7659) green.
   Deferred to follow-up PRs (Large, cross-adapter, needs live/cloud-engine
   validation — not attempted blind in a sandbox):
     - w2: invert plan_capture_phase_eligible to default-ON for all EXPLAIN engines
       with an explicit side-effect exception list (BigQuery; assess Snowflake);
-      enable Spark/Databricks and the inline-only EXPLAIN engines.
-    - w3: run the phase for ALL test types (throughput/maintenance/combined), not
-      just power/standard, without capturing inside concurrent streams.
+      enable Spark/Databricks and the inline-only EXPLAIN engines. The central
+      isolation mechanism (w3) is now in place, so this becomes the flag flip + an
+      exception list rather than per-driver work — but enabling cloud/DataFrame-family
+      adapters whose post-hoc EXPLAIN can't be exercised in this sandbox is the part
+      with genuine unverifiable risk.
     - w4: remove the inline capture path from the ~16 EXPLAIN-based adapters and
       retire the sampling machinery (plan_first_n / plan_sampling_rate) + lock.
     - w5: collapse the knob surface to analyze_plans (+ first-class --analyze-plans).
@@ -122,7 +137,7 @@ work:
   - id: w3
     summary: "Run the capture phase for ALL test types, not just power/standard"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Move the suppress-inline + post-measurement-capture logic out of
       _execute_all_queries into a shared place that throughput, maintenance, and

--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -151,6 +151,15 @@ class PlatformAdapter(
         # guarded by a lock to keep plan_first_n a correct per-query-id counter.
         self._plan_capture_iteration_counts: dict[str, int] = {}
         self._plan_capture_lock = threading.Lock()
+        # Isolated-phase plan capture (see TestDriversMixin._execute_queries_by_type).
+        # When ``_plan_capture_phase_active`` is True, the inline capture chokepoint
+        # (_merge_plan_capture_into_result) records each executed query into
+        # ``_phase_recorded_queries`` instead of running EXPLAIN inline, so capture is
+        # fully isolated from the timed run for every test type. The plans are captured
+        # once, post-measurement, by the isolated phase. The buffer is written from
+        # concurrent throughput streams, so writes are guarded by _plan_capture_lock.
+        self._plan_capture_phase_active: bool = False
+        self._phase_recorded_queries: dict[str, str] = {}
         self.tuning_enabled = config.get("tuning_enabled", False)
         # Driver runtime contract metadata (set by adapter factory / runtime resolution).
         self.driver_package = config.get("driver_package")

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -911,7 +911,38 @@ class TestDriversMixin:
             ]
 
     def _execute_queries_by_type(self, benchmark, connection: Any, run_config: dict) -> list[dict[str, Any]]:
-        """Execute queries based on test execution type."""
+        """Execute queries for the requested test type, with isolated plan capture.
+
+        Plan capture is fully isolated from measured execution for EVERY test type
+        (power, throughput, maintenance, combined). For phase-eligible EXPLAIN-based
+        engines, inline capture is suppressed for the entire timed run — the inline
+        chokepoint records each executed query instead — and all plans are captured in
+        a single post-measurement pass on the same connection, strictly after the last
+        timed query and never inside a concurrent stream. This is the canonical
+        contract (see ``benchbox/core/plan_capture_phase.py``); engines that obtain a
+        plan only as a side effect of the measured job keep inline capture.
+        """
+        phase_eligible = (
+            bool(getattr(self, "capture_plans", False))
+            and getattr(self, "plan_capture_phase_eligible", False)
+            and not getattr(self, "dry_run_mode", False)
+        )
+        if not phase_eligible:
+            return self._dispatch_queries_by_type(benchmark, connection, run_config)
+
+        # Isolate capture: record executed queries during the timed run, capture after.
+        self._plan_capture_phase_active = True
+        self._phase_recorded_queries = {}
+        try:
+            results = self._dispatch_queries_by_type(benchmark, connection, run_config)
+        finally:
+            self._plan_capture_phase_active = False
+
+        self._capture_plans_post_measurement(connection, dict(self._phase_recorded_queries), results)
+        return results
+
+    def _dispatch_queries_by_type(self, benchmark, connection: Any, run_config: dict) -> list[dict[str, Any]]:
+        """Route to the per-test-type driver (no plan-capture concerns)."""
         test_execution_type = run_config.get("test_execution_type", "standard")
 
         if test_execution_type == "power":
@@ -1376,20 +1407,12 @@ class TestDriversMixin:
         if hasattr(signal, "SIGTERM"):
             original_sigterm = signal.signal(signal.SIGTERM, signal_handler)
 
-        # Isolated plan-capture phase: for eligible EXPLAIN-based engines, suppress
-        # inline capture during the timed loop and capture all plans in a single
-        # post-measurement pass (see _capture_plans_post_measurement). This keeps
-        # EXPLAIN off the measurement path entirely. Side-effect-capture platforms
-        # (BigQuery/Spark) keep inline capture (plan_capture_phase_eligible=False).
-        phase_eligible = (
-            bool(getattr(self, "capture_plans", False))
-            and getattr(self, "plan_capture_phase_eligible", False)
-            and not getattr(self, "dry_run_mode", False)
-        )
-        saved_capture_plans = getattr(self, "capture_plans", False)
-        if phase_eligible:
-            self.capture_plans = False
-
+        # Plan capture isolation is handled centrally by _execute_queries_by_type
+        # (it records executed queries during the timed loop and runs a single
+        # post-measurement capture phase for every test type). This loop only
+        # executes the timed queries; for phase-eligible engines the inline capture
+        # chokepoint records instead of running EXPLAIN, so nothing extra is needed
+        # here.
         try:
             console.print(
                 f"[cyan]Running {total_queries} {benchmark_name} queries. Press Ctrl+C to cancel (will stop after current query).[/cyan]"
@@ -1436,11 +1459,6 @@ class TestDriversMixin:
             signal.signal(signal.SIGINT, original_sigint)
             if hasattr(signal, "SIGTERM") and original_sigterm is not None:
                 signal.signal(signal.SIGTERM, original_sigterm)
-            if phase_eligible:
-                self.capture_plans = saved_capture_plans
-
-        if phase_eligible:
-            self._capture_plans_post_measurement(connection, queries, results)
 
         self._log_execution_summary(results, total_queries, cancelled)
 
@@ -1452,12 +1470,19 @@ class TestDriversMixin:
         queries: dict[str, str],
         results: list[dict[str, Any]],
     ) -> None:
-        """Capture query plans in an isolated pass after the timed loop.
+        """Capture query plans in an isolated pass after the timed run.
+
+        Driven by ``_execute_queries_by_type`` for EVERY test type (power,
+        throughput, maintenance, combined): ``queries`` is the set of distinct
+        executed queries recorded by the inline chokepoint during the timed run
+        (``_phase_recorded_queries``), so the capture covers exactly what ran and
+        fires once per distinct query — never inside a concurrent stream.
 
         Runs ``run_plan_capture_phase`` for the successfully-executed queries on
         the *measurement* connection, strictly after all timed queries have run,
         then merges ``query_plan`` / ``plan_fingerprint`` / ``plan_capture_time_ms``
-        into the matching result dicts.
+        into every result row sharing that ``query_id`` (a throughput run has one
+        row per stream for the same query).
 
         The measurement connection is reused (rather than a fresh one) so embedded
         in-memory engines still see the loaded data; isolation comes from running
@@ -1479,10 +1504,14 @@ class TestDriversMixin:
         """
         from benchbox.core.plan_capture_phase import run_plan_capture_phase
 
+        # The recorded buffer is keyed by str(query_id); result rows may carry a
+        # non-str query_id (TPC-H power/throughput rows use the integer query
+        # permutation id), so coerce to str on every lookup or the merge silently
+        # never matches and plans fail to land.
         success_queries = {
-            result["query_id"]: queries[result["query_id"]]
+            str(result["query_id"]): queries[str(result["query_id"])]
             for result in results
-            if result.get("status") == "SUCCESS" and result.get("query_id") in queries
+            if result.get("status") == "SUCCESS" and str(result.get("query_id")) in queries
         }
         if not success_queries:
             return
@@ -1496,7 +1525,7 @@ class TestDriversMixin:
         )
 
         for result in results:
-            query_id = result.get("query_id")
+            query_id = str(result.get("query_id"))
             plan = phase.plans.get(query_id)
             if plan is not None:
                 result["query_plan"] = plan

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -463,6 +463,11 @@ class ResultCaptureMixin:
         self.plan_capture_failures = 0
         self.plan_capture_errors: list[dict[str, Any]] = []
         self._plan_capture_iteration_counts: dict[str, int] = {}
+        # Isolated-phase recording buffer (see _execute_queries_by_type): cleared per
+        # run for symmetry with the other plan-capture state, so a prior run's
+        # recorded queries can never leak into the next.
+        self._plan_capture_phase_active = False
+        self._phase_recorded_queries: dict[str, str] = {}
         # The lock is created in PlatformAdapter.__init__; create it defensively
         # for hosts that reset stats without going through __init__ (e.g. tests
         # that mix in this class directly). Reset runs before any worker threads
@@ -930,6 +935,16 @@ class ResultCaptureMixin:
             query_id: Query identifier.
         """
         if not self.capture_plans or result.get("status") != "SUCCESS":
+            return
+        if getattr(self, "_plan_capture_phase_active", False):
+            # Isolated-phase mode: do NOT run EXPLAIN inline (that would interleave
+            # capture with the timed query). Record the executed query so the
+            # post-measurement phase captures it exactly once. Written from concurrent
+            # throughput streams, so guard the buffer with the shared lock.
+            recorded_id = result.get("query_id") or query_id
+            if recorded_id is not None:
+                with self._plan_capture_lock:
+                    self._phase_recorded_queries.setdefault(str(recorded_id), query)
             return
         query_plan, plan_capture_time_ms = self.capture_query_plan(connection, query, query_id)
         if query_plan:

--- a/tests/integration/test_plan_capture_phase.py
+++ b/tests/integration/test_plan_capture_phase.py
@@ -167,28 +167,41 @@ class TestIntegratedCapturePhase:
             conn.close()
 
     def test_inline_capture_suppressed_during_measurement(self, file_adapter, monkeypatch):
-        """Inline capture must be OFF during the timed loop; the phase fills plans after."""
+        """Inline EXPLAIN must NOT run during the timed loop; the phase fills plans after.
+
+        The query is executed through the full dispatch so the central isolation
+        wrapper is active. During the timed run the inline chokepoint records the
+        query (phase-active) instead of running EXPLAIN; capture_query_plan must only
+        be invoked by the post-measurement phase.
+        """
         _seed_table(file_adapter)
         conn = file_adapter.create_connection()
 
-        seen_capture_plans: list[bool] = []
-        original = file_adapter._merge_plan_capture_into_result
+        # Spy on the actual inline EXPLAIN entry point and record whether the
+        # isolation flag was active at each call.
+        phase_active_at_call: list[bool] = []
+        original_capture = file_adapter.capture_query_plan
 
-        def _spy(result, connection, query, query_id):
-            # Record the flag the inline path checks at call time.
-            seen_capture_plans.append(file_adapter.capture_plans)
-            return original(result, connection, query, query_id)
+        def _capture_spy(connection, query, query_id):
+            phase_active_at_call.append(file_adapter._plan_capture_phase_active)
+            return original_capture(connection, query, query_id)
 
-        monkeypatch.setattr(file_adapter, "_merge_plan_capture_into_result", _spy)
+        monkeypatch.setattr(file_adapter, "capture_query_plan", _capture_spy)
 
         try:
             benchmark = _FakeBenchmark({"q_select": "SELECT * FROM t"})
-            results = file_adapter._execute_all_queries(benchmark, conn, {"benchmark_name": "generic"})
+            results = file_adapter._execute_queries_by_type(
+                benchmark, conn, {"benchmark_name": "generic", "test_execution_type": "standard"}
+            )
 
-            # Inline path saw capture_plans=False for every timed query (suppressed)...
-            assert seen_capture_plans == [False]
-            # ...yet the plan was still captured by the post-measurement phase.
+            # capture_query_plan ran exactly once (the post-measurement phase), and
+            # never while the timed loop's isolation flag was active.
+            assert len(phase_active_at_call) == 1
+            assert phase_active_at_call == [False], "EXPLAIN must run only in the post-measurement phase"
+            # The plan still landed via the phase.
             assert results[0].get("plan_fingerprint")
+            # The isolation flag is cleared after the run.
+            assert file_adapter._plan_capture_phase_active is False
         finally:
             conn.close()
 
@@ -230,6 +243,74 @@ class TestIntegratedCapturePhase:
             phys = plan.logical_root.physical_operator
             timing = phys.properties.get("timing") if phys else None
             assert timing is None or timing == 0, "analyze_plans=False must not run ANALYZE"
+        finally:
+            conn.close()
+
+    def test_phase_runs_for_non_power_test_types(self, file_adapter, monkeypatch):
+        """Capture must be isolated for every test type, not just power/standard.
+
+        Drives the dispatch with test_execution_type='throughput'; the central
+        isolation wrapper must record during the timed run and capture in the
+        post-measurement phase (EXPLAIN never runs inline during measurement).
+        """
+        _seed_table(file_adapter)
+        conn = file_adapter.create_connection()
+
+        phase_active_at_call: list[bool] = []
+        original_capture = file_adapter.capture_query_plan
+
+        def _capture_spy(connection, query, query_id):
+            phase_active_at_call.append(file_adapter._plan_capture_phase_active)
+            return original_capture(connection, query, query_id)
+
+        monkeypatch.setattr(file_adapter, "capture_query_plan", _capture_spy)
+        try:
+            benchmark = _FakeBenchmark({"q": "SELECT id, val FROM t"})
+            # Non-TPC benchmark falls back to _execute_all_queries under the wrapper.
+            results = file_adapter._execute_queries_by_type(
+                benchmark, conn, {"benchmark_name": "generic", "test_execution_type": "throughput"}
+            )
+            assert results[0].get("plan_fingerprint"), "plan must land for throughput type"
+            assert phase_active_at_call == [False], "EXPLAIN must run only post-measurement"
+        finally:
+            conn.close()
+
+    def test_plans_attach_to_all_rows_sharing_query_id(self, file_adapter):
+        """Throughput produces one row per stream for a query; all must get the plan."""
+        _seed_table(file_adapter)
+        conn = file_adapter.create_connection()
+        try:
+            # Two result rows for the same query_id, as concurrent streams produce.
+            results = [
+                {"query_id": "q", "status": "SUCCESS", "stream_id": 0},
+                {"query_id": "q", "status": "SUCCESS", "stream_id": 1},
+            ]
+            file_adapter._capture_plans_post_measurement(conn, {"q": "SELECT * FROM t"}, results)
+
+            for row in results:
+                assert row.get("plan_fingerprint"), f"row stream {row['stream_id']} missing plan"
+                assert row.get("query_plan") is not None
+            # Same query captured once: both rows share the identical fingerprint.
+            assert results[0]["plan_fingerprint"] == results[1]["plan_fingerprint"]
+        finally:
+            conn.close()
+
+    def test_plans_land_for_integer_query_ids(self, file_adapter):
+        """TPC-H power/throughput rows carry an INTEGER query_id; plans must still land.
+
+        Regression test: the recorded buffer is str-keyed, so an int query_id on the
+        result row would never match the merge unless both sides are coerced to str.
+        """
+        _seed_table(file_adapter)
+        conn = file_adapter.create_connection()
+        try:
+            # Buffer recorded under str keys (as the inline chokepoint stores them);
+            # result rows carry the raw integer query id (as TPC-H builds them).
+            results = [{"query_id": 6, "status": "SUCCESS", "stream_id": 0}]
+            file_adapter._capture_plans_post_measurement(conn, {"6": "SELECT * FROM t"}, results)
+
+            assert results[0].get("plan_fingerprint"), "plan must land for an integer query_id"
+            assert results[0].get("query_plan") is not None
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

Follow-up to #827 (which landed w1 + the analyze-knob): this makes plan capture **fully isolated from measured execution for every test type** — power, throughput, maintenance, and combined — directly addressing the canonical-isolation intent (capture must never perturb a measured run, regardless of type). This is **w3** of `query-plan-capture-canonical-isolation`.

### Problem
The suppress-inline + post-measurement capture lived only in `_execute_all_queries`, so phase-eligible engines isolated capture in power/standard but captured **inline (interleaved with the timed query)** in throughput/maintenance/combined (Consequence A). Worse: throughput ran inline `EXPLAIN` **inside the timed concurrent streams** and then **discarded the plan** (the throughput row-builder never copied `plan_fingerprint`) — pure wasted, measurement-perturbing work.

### Change
Hoist isolation to the single dispatch point `_execute_queries_by_type`:
- For phase-eligible engines it sets `_plan_capture_phase_active` for the entire timed run and runs **one** post-measurement capture afterward.
- While active, the shared inline chokepoint (`_merge_plan_capture_into_result`) **records** each executed query into a thread-safe buffer (`_phase_recorded_queries`) instead of running `EXPLAIN`, so capture never interleaves with a timed query and never runs inside a concurrent stream.
- Plans are captured once per distinct query, post-measurement, on the same connection, and merged into **every result row sharing that `query_id`** (throughput has one row per stream).
- The redundant phase block is removed from `_execute_all_queries` (warmup + iterations nest under the one wrapper → captured exactly once).

Maintenance refresh ops (RF1/RF2) bypass `execute_query` (direct connection) and were never `EXPLAIN`-captured — unchanged, no regression.

## Review fixes (high-effort `/code-review`)
- **Critical:** TPC-H builds result rows with **integer** `query_id`s while the buffer/phase are `str`-keyed, so the merge silently never matched (plans wouldn't land for TPC-H power/throughput). Fixed by coercing to `str(query_id)` on both selection and merge; added `test_plans_land_for_integer_query_ids` (fails without the fix).
- Reset `_phase_recorded_queries` in `_reset_plan_capture_stats` for lifecycle symmetry (no stale cross-run leak).
- Verified safe: concurrent-stream writes are lock-guarded and streams are joined (`ThreadPoolExecutor`) before the buffer snapshot, so no write-after-flag-flip race; no double/missed capture in the warmup nesting.

## Testing
- `uv run -- python -m pytest tests/integration/test_plan_capture_phase.py -q` → **12 passed** (new: phase runs for non-power test types; EXPLAIN never runs while the isolation flag is active; plans attach to all rows sharing a `query_id`; plans land for integer `query_id`).
- `pytest tests/unit/platforms/ ...` → **7659 passed** (full platforms suite) earlier on this change; capture suites **290 passed**.
- `ruff check`/`format` green; `ty check` clean on changed files.

Advances `query-plan-capture-canonical-isolation` (**w3 done**; w2 eligibility-broadening, w4 inline-deletion, w5 knob-collapse, w6 docs remain — w2/w4 are the parts that need live cloud-engine validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fT8yfjtBSL1jUZUQArwvx)_