### PR TITLE
test(correctness-gate): harden oracle — strict arming, no-skip guard, discrimination ratchet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,19 @@ test-smoke: test-quick
 # is the 18 TPC-H queries whose answer-set cardinalities are stable across dbgen
 # builds; Q11/Q16/Q18/Q20 are excluded because their HAVING/threshold boundaries make
 # the stored row count vary with the generated data (see tests/README.md).
+# The JUnit-report guard fails the target if the selected node SKIPs instead of
+# running: pytest exits 0 on a selected skip, which would otherwise pass the gate
+# without executing the benchmark. The report goes to a private temp file (not the
+# repo-root test-results.xml that pytest-ci.ini also writes) and is removed after
+# parsing; both the pytest status and the guard status are propagated.
 test-correctness-gate:
-	BENCHBOX_STRICT_EXPECTED_RESULTS=1 BENCHBOX_CORRECTNESS_GATE_QUERY_IDS=1,2,3,4,5,6,7,8,9,10,12,13,14,15,17,19,21,22 uv run -- python -m pytest -m stress "tests/integration/test_local_platform_benchmark_matrix.py::test_local_platform_benchmark_matrix[tpch-duckdb]" -n 0 --tb=short --timeout=1200 -v
+	@REPORT="$$(mktemp)"; \
+	BENCHBOX_STRICT_EXPECTED_RESULTS=1 BENCHBOX_CORRECTNESS_GATE_QUERY_IDS=1,2,3,4,5,6,7,8,9,10,12,13,14,15,17,19,21,22 uv run -- python -m pytest -m stress "tests/integration/test_local_platform_benchmark_matrix.py::test_local_platform_benchmark_matrix[tpch-duckdb]" -n 0 --tb=short --timeout=1200 -v --junitxml="$$REPORT"; \
+	PYTEST_STATUS=$$?; \
+	uv run -- python -c "import sys, xml.etree.ElementTree as ET; root = ET.parse(sys.argv[1]).getroot(); suites = [root] if root.tag == 'testsuite' else root.findall('testsuite'); tests = sum(int(s.get('tests') or 0) for s in suites); skipped = sum(int(s.get('skipped') or 0) for s in suites); errors = sum(int(s.get('errors') or 0) for s in suites); failures = sum(int(s.get('failures') or 0) for s in suites); print('correctness gate guard: ran=%d skipped=%d failures=%d errors=%d' % (tests, skipped, failures, errors)); sys.exit(0 if (tests == 1 and skipped == 0 and errors == 0 and failures == 0) else 'correctness gate: expected exactly 1 node to run with 0 skipped/failed/errored; a selected skip means duckdb/tpch dropped from the stable matrix or the node-id drifted')" "$$REPORT"; \
+	GUARD_STATUS=$$?; \
+	rm -f "$$REPORT"; \
+	test $$PYTEST_STATUS -eq 0 && test $$GUARD_STATUS -eq 0
 
 # Gate: compare every TPC-Havoc SQL variant to canonical TPC-H on real SF=0.1
 # DuckDB data; exits non-zero on any divergence beyond KNOWN_DIVERGENCES

--- a/_project/TODO/main/planning/testing-approach-correctness-gates.yaml
+++ b/_project/TODO/main/planning/testing-approach-correctness-gates.yaml
@@ -135,8 +135,10 @@ work:
           `_build_query_result_with_validation`;
         - deleted the stale `tests/unit/test_adjective_cleanup.py` smoke file;
         - deleted the two committed `.py.new` integration stubs;
-        - removed the nonexistent `specialized/` directory and hand-maintained
-          E2E test counts from `tests/README.md`;
+        - removed hand-maintained E2E test counts from `tests/README.md`
+          (NOTE: the stale `specialized/` directory reference was NOT actually
+          removed here despite the original wording; it was corrected later
+          under testing-approach-oracle-hardening w5);
         - removed the mock-the-`identify` SQL translation tests now covered by
           the real sqlglot snapshot test, and strengthened two weak observable
           SQL assertions;

--- a/_project/TODO/main/planning/testing-approach-oracle-hardening.yaml
+++ b/_project/TODO/main/planning/testing-approach-oracle-hardening.yaml
@@ -2,7 +2,7 @@ id: testing-approach-oracle-hardening
 title: "Harden the testing correctness gate and close review follow-ups"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
 category: Testing and Quality Assurance
 
 description: |
@@ -35,107 +35,150 @@ description: |
 work:
   - id: w0
     summary: "Refresh and pin the review evidence against current develop"
-    status: pending
+    status: done
     notes: |
-      Re-run the compact evidence checks before editing code:
-        - confirm no testing files changed after #737 for the gate/doc paths
-          under review;
-        - record SF=1 TPC-H expected row counts for the current and proposed
-          gate query sets;
-        - collect `medium and not fast and not integration and not (slow or
-          stress or resource_heavy or live_integration)` count;
-        - prove a selected skipped matrix node exits 0 today;
-        - confirm the stale `tests/specialized/` README reference and the
-          mismatched completion note in the prior TODO.
-      Keep raw stdout in `/tmp` or CI artifacts and summarize only the command,
-      checked SHA, PASS/FAIL, and key counts in the PR body or TODO notes.
+      Evidence refreshed on develop @ f6761668 (after #744 landed). KEY FINDING:
+      the TODO premise is partly stale -- PR #744 (2026-06-01, same day) already
+      broadened the gate query set from the near-vacuous `6,14,15,17,19` to the
+      18-query set `1,2,3,4,5,6,7,8,9,10,12,13,14,15,17,19,21,22` AND pinned the
+      reference qgen seed for EXACT validation.
+        - SF=1 expected counts for the 18-query gate set: Q9=175, Q2=100, Q21=100,
+          Q13=42, Q10=20, Q3=10, Q22=7, Q4/Q5/Q7/Q8/Q1/Q12 in 2..5, and 5 one-row
+          (Q6,Q14,Q15,Q17,Q19). Three queries >=100; not one-row-dominated.
+        - The TODO's suggested adds (Q11=1048, Q16=18314, Q20=186) are DELIBERATELY
+          excluded by #744 as dbgen-build-unstable (threshold/HAVING cardinality).
+          Empirically all 22 pass on this Linux build + pinned seed, but #744 added
+          the seed-pinning and the exclusion together, so the cross-dbgen-build
+          concern stands -- did NOT add them (would fight a deliberate decision and
+          risk cross-platform CI flake). See success_metrics reconciliation below.
+        - medium-only count: 990 (`medium and not fast and not integration and not
+          (slow or stress or resource_heavy or live_integration)`).
+        - Confirmed strict block was still gated behind `tpch && scale_factor>=1.0`
+          (w2 defect real); Makefile gate had no no-skip guard (w3 defect real).
+        - Confirmed stale `tests/specialized/` reference in tests/README.md (dir
+          absent; only `tests/unit/tpcds/test_minimal_queries.py` exists) and the
+          false "removed" claim in testing-approach-correctness-gates.yaml w4.
 
   - id: w1
     summary: "Replace the near-vacuous gate query subset with a discriminating row-count mix"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Update `BENCHBOX_CORRECTNESS_GATE_QUERY_IDS` to include multiple
-      answer-backed queries with high or mid cardinality at SF=1, such as
-      Q16=18314, Q11=1048, Q20=186, and Q9=175. It is acceptable to retain one
-      scalar aggregate for coverage variety, but the configured set must not
-      be dominated by one-row queries.
+      RECONCILED with current develop: the query-set broadening this item asked
+      for was already done by #744 (see w0). The specific adds suggested here
+      (Q16/Q11/Q20) are the dbgen-build-unstable queries #744 deliberately
+      excluded, so the remaining deliverable is the RATCHET, plus codifying the
+      exclusion so the two decisions cannot silently diverge.
 
-      Add a ratchet in `tests/unit/test_standardized_test_commands.py` that
-      loads the expected TPC-H answer counts and fails if the gate query set
-      regresses to all one-row or otherwise low-discrimination coverage.
+      Added `TestCorrectnessGateOracle` in
+      `tests/unit/test_standardized_test_commands.py`:
+        - `test_gate_query_set_is_answer_backed_and_discriminating`: parses the
+          configured ids from the Makefile, loads SF=1 answer counts, and fails
+          if the set is not answer-backed, becomes one-row-dominated, or drops
+          below two queries with cardinality >=100.
+        - `test_gate_excludes_dbgen_unstable_threshold_queries`: fails if
+          Q11/Q16/Q18/Q20 are reintroduced.
 
   - id: w2
     summary: "Make strict expected-results mode fail when configured checks are disarmed"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Hoist the strict zero-check failure out from behind the current
-      `tpch && scale_factor >= 1.0` branch. When strict mode is enabled and a
-      non-empty configured query subset exists, every configured query must
-      produce a non-SKIP validation result or the matrix test must fail with a
-      clear message.
+      Hoisted the strict-mode assertion in
+      `tests/integration/test_local_platform_benchmark_matrix.py`
+      `_validate_against_expected_results` out from behind
+      `benchmark_name == "tpch" and scale_factor >= 1.0`. Strict mode now fails
+      whenever a non-empty configured subset does not fully evaluate (every
+      configured query must produce a non-SKIP validation), regardless of
+      benchmark/scale. Non-strict callers are untouched (still skip unsupported
+      validation), preserving the must_preserve contract.
 
-      Add focused unit or helper-level tests that demonstrate the guard fails
-      for unsupported scale/benchmark drift instead of silently passing. Keep
-      non-strict stress-matrix behavior unchanged for platforms or benchmarks
-      without stored answer files.
+      Helper-level tests in `TestCorrectnessGateOracle`:
+      `test_strict_mode_fails_on_scale_drift` (tpch SF=0.1 -> all SKIP -> fail),
+      `test_strict_mode_fails_on_benchmark_drift` (unknown benchmark -> fail),
+      `test_strict_mode_passes_when_all_configured_queries_evaluate`, and
+      `test_non_strict_mode_tolerates_unsupported_validation`.
 
   - id: w3
     summary: "Fail the correctness-gate target when the selected node is skipped"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
-      Add an explicit ran-count/skip-count guard around `make
-      test-correctness-gate` so the target fails unless exactly the intended
-      parametrized node runs and zero selected nodes skip. Prefer a small,
-      repo-local parser over brittle stdout scraping if pytest output changes.
+      `make test-correctness-gate` now writes a JUnit report to a private `mktemp`
+      file (not the repo-root `test-results.xml` that pytest-ci.ini also writes),
+      and a guard parses it (ElementTree, not stdout scraping), failing unless
+      exactly one node ran with zero skipped/failed/errored; the report is removed
+      after parsing and both the pytest and guard exit statuses are propagated.
+      Verified: real gate run -> guard prints `ran=1 skipped=0 failures=0 errors=0`,
+      exit 0; a synthetic skipped=1 report -> guard exits 1.
 
-      Add a ratchet that would fail if the gate node is removed from
-      `LOCAL_SQL_STABLE_MATRIX`, if the node id drifts, or if the target no
-      longer enforces the no-skip condition.
+      Ratchets in `TestCorrectnessGateOracle`:
+      `test_gate_target_enforces_no_skip` (target must emit JUnit + assert skip
+      count) and `test_gate_node_is_in_stable_matrix` (tpch-duckdb must stay in
+      `LOCAL_SQL_STABLE_MATRIX`). Node-id drift is already covered by the existing
+      `test_correctness_gate_nodeid_collects_under_stress`.
 
   - id: w4
     summary: "Triage medium-only tests into explicit automated routing decisions"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Treat the existing medium policy as a decision point, not as proof that
-      the population is harmless. Produce a compact inventory of medium-only
-      tests by directory/module and identify correctness-relevant clusters
-      that should be promoted to `fast`, an integration workflow, or the
-      correctness gate.
+      Compact inventory (990 medium-only tests, by top directory):
+        tests/unit/core 287, tests/unit (root) 160, tests/unit/platforms 71,
+        tests/unit/utils 70, tests/validation 44, tests/unit/tpch 41,
+        tests/e2e 31, tests/unit/cli 28, tests/unit/examples 25,
+        tests/examples 21, tests/unit/monitoring 10, tests/unit/mcp 9,
+        tests/unit/visualization 6, tests/unit/benchmarks 4, smaller tails.
 
-      Do not promote all medium tests wholesale. The deliverable is a bounded
-      set of explicit promotions plus a documented rationale for clusters left
-      as local-only medium coverage.
+      Routing decisions:
+        - Correctness-gate oracle cluster (the new `TestCorrectnessGateOracle`
+          + the pre-existing gate ratchets in
+          `tests/unit/test_standardized_test_commands.py`): KEPT at medium.
+          Rationale: the gate itself is a dedicated REQUIRED CI job
+          (`correctness-gate` in pr.yml / test.yml) that runs the real oracle on
+          every code-impacting PR, so these meta-guards do not also need the fast
+          lane; they prevent local config regression and run via the medium lane
+          and the explicit gate verification. The marker policy
+          (test_marker_strategy.py) enforces a single module-level speed marker
+          and bans per-test fast/medium decorators, so a within-module subset
+          promotion is intentionally not available -- promoting would mean
+          flipping the whole module, which would sweep the subprocess-collection
+          ratchet into the fast lane (undesirable cost).
+        - Recommended follow-up promotions (OUT of this TODO's file scope, hence
+          recorded not executed): `tests/unit/tpch` answer/cardinality tests and
+          `tests/validation` result-validation tests are the most
+          correctness-relevant clusters and are candidates for `fast` or an
+          integration workflow; each needs its own module-level marker change.
+        - Left local-only (medium): broad `tests/examples`, `tests/unit/examples`,
+          `tests/unit/visualization`, `tests/unit/monitoring`, and most
+          `tests/unit/utils` -- developer-facing / non-result-correctness suites
+          whose CI cost outweighs the marginal blocking value.
 
   - id: w5
     summary: "Repair stale testing docs and the false prior completion claim"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
-      Remove or correct the nonexistent `tests/specialized/` section in
-      `tests/README.md`. Update
-      `_project/TODO/main/planning/testing-approach-correctness-gates.yaml`
-      so w4 no longer claims the stale reference was removed when it was not.
-      Keep the Databricks coverage-theater fix and other genuinely completed
-      cleanup notes intact.
+      Removed the stale "Minimal tests have been moved to the `specialized/`
+      directory" note (and its two nonexistent file references) from
+      `tests/README.md`. Corrected
+      `testing-approach-correctness-gates.yaml` w4 so it no longer claims the
+      `specialized/` reference was removed there; it now points to this TODO's
+      w5. Databricks coverage-theater and other genuine cleanup notes left
+      intact.
 
   - id: w6
     summary: "Document the corrected gate contract and residual oracle limits"
     needs: [w2, w3, w4, w5]
-    status: pending
+    status: done
     notes: |
-      Update the testing docs to say exactly what the gate proves: real
-      generate/load/power execution, completion/cardinality checks, and
-      answer-backed row-count validation for a discriminating subset. Also
-      document what it still does not prove: row-value correctness for scalar
-      aggregates or full result-set equality.
-
-      If value-level validation is needed, capture it as a deferred follow-up
-      rather than pretending higher-cardinality row counts solve that entire
-      class of bugs.
+      Expanded the "Automated Gate Contract" section of `tests/README.md` to
+      state exactly what the gate proves -- discriminating answer-backed subset,
+      strict arming (fails when any configured check SKIPs, not gated on
+      benchmark/scale), and the no-skip JUnit guard -- and what it still does not
+      prove: result-value correctness (cardinality only) and the high-cardinality
+      threshold queries (Q11/Q16) excluded for dbgen-build stability. Value-level
+      comparison remains the recorded `deferred` follow-up.
 
 deferred:
   - summary: "Add value-level answer-set validation for selected TPC-H queries"
@@ -222,7 +265,13 @@ scope_limit:
     - "benchmark_runs/"
 
 success_metrics:
-  - "The correctness gate query subset includes at least two SF=1 TPC-H queries with expected row counts above 100 and at least one above 1000."
+  # NOTE (reconciled with develop @ #744, see w0/w1): the original ">=1 query
+  # above 1000 rows" metric is unachievable without the dbgen-build-unstable
+  # threshold queries (Q11=1048, Q16=18314) that #744 deliberately excluded.
+  # Restated to the stable, discriminating shape the ratchet enforces; the
+  # high-cardinality / value-level gap is tracked under `deferred`.
+  - "The correctness gate query subset is answer-backed, not dominated by one-row queries, and includes at least two SF=1 TPC-H queries with expected row counts >=100, and a ratchet fails if it regresses."
+  - "The dbgen-build-unstable threshold queries (Q11/Q16/Q18/Q20) stay excluded, enforced by a ratchet."
   - "Strict configured expected-results mode fails if any configured query is skipped, unsupported, or not checked."
   - "`make test-correctness-gate` fails when its selected node skips instead of treating skip as success."
   - "The stale `tests/specialized/` README reference is gone or corrected, and the prior TODO no longer falsely claims it was removed."

--- a/tests/README.md
+++ b/tests/README.md
@@ -96,9 +96,25 @@ The standard gates are intentionally split by the risk they are meant to catch:
   stored TPC-H answer files with EXACT row-count checking. The gated subset is the
   18 TPC-H queries whose answer-set cardinalities are stable across dbgen builds;
   Q11/Q16/Q18/Q20 are excluded because their HAVING/threshold boundaries make the
-  stored row count vary with the generated data. Note this validates result
-  *cardinality*, not result *values* — value-level answer comparison (the
-  `_sources/tpc-h/dbgen/answers` + `cmpq.pl` checksum path) remains future work.
+  stored row count vary with the generated data. The subset is deliberately
+  *discriminating* — it is not dominated by one-row queries and includes multiple
+  high-cardinality answer-backed queries (e.g. Q9=175, Q2/Q21=100) — so a wrong
+  join/filter/aggregate that still emits one row is caught. The subset shape is
+  ratcheted in `tests/unit/test_standardized_test_commands.py`
+  (`TestCorrectnessGateOracle`). What the gate proves and what it does not:
+  - **Strict arming**: with `BENCHBOX_STRICT_EXPECTED_RESULTS=1`, every configured
+    query *must* produce a non-SKIP row-count validation or the run fails. This is
+    not gated on benchmark name or scale, so a future CI speedup that retargets the
+    gate (a different benchmark, or SF<1 where no answer files exist) cannot
+    silently disarm the oracle.
+  - **No-skip guard**: the Makefile target emits a JUnit report and fails unless
+    exactly one node ran with zero skips. `pytest` exits 0 when a *selected* node
+    SKIPs (e.g. duckdb unavailable, or the case dropped from the stable matrix),
+    which would otherwise pass the gate without executing anything.
+  - **Cardinality, not values**: this validates result *cardinality*, not result
+    *values* — value-level answer comparison (the `_sources/tpc-h/dbgen/answers` +
+    `cmpq.pl` checksum path) remains future work, as do the high-cardinality
+    threshold queries (Q11/Q16) excluded above for dbgen-build stability.
 - `make test-integration`: non-live, non-stress integration coverage for broader
   local and main/release validation.
 - `make test-local-matrix`: opt-in stress matrix for the full local platform
@@ -530,10 +546,6 @@ The test suite includes several unified utilities for efficient testing:
 - `utilities/test_runner.py`: Enhanced test runner with caching capabilities
 
 These utilities provide a modern, efficient approach to testing and validation.
-
-**Note**: Minimal tests have been moved to the `specialized/` directory:
-- `specialized/test_tpch_minimal.py`: Minimal tests for TPC-H that don't require data generation
-- `specialized/test_tpcds_minimal.py`: Minimal tests for TPC-DS that don't require data generation
 
 ## Support
 

--- a/tests/integration/test_local_platform_benchmark_matrix.py
+++ b/tests/integration/test_local_platform_benchmark_matrix.py
@@ -343,19 +343,30 @@ def _validate_against_expected_results(
                 f"actual={validation.actual_row_count}, mode={validation.validation_mode.value}"
             )
 
-    # Optional strict mode: require expected-results checks for the bounded PR gate.
-    if (
-        benchmark_name == "tpch"
-        and scale_factor >= 1.0
-        and os.environ.get("BENCHBOX_STRICT_EXPECTED_RESULTS", "").strip().lower() in {"1", "true", "yes", "on"}
-    ):
-        expected_checked = len(expected_query_ids or ())
-        if expected_checked:
-            assert checked == expected_checked, (
-                f"TPC-H validation evaluated {checked} query row counts, expected {expected_checked}"
+    # Strict mode: when enabled, every configured expected-results check must
+    # actually evaluate (non-SKIP). This is deliberately NOT gated on benchmark
+    # name or scale factor. The previous `benchmark_name == "tpch" and
+    # scale_factor >= 1.0` guard meant a future CI speedup that retargeted the
+    # gate (a different benchmark, or SF<1) would silently disarm the oracle:
+    # every configured query would SKIP, `checked` would be 0, and the assertion
+    # was never reached. Now strict mode fails whenever a configured subset does
+    # not fully evaluate, regardless of benchmark/scale. The default non-strict
+    # matrix still skips unsupported expected-results validation (see callers).
+    strict = os.environ.get("BENCHBOX_STRICT_EXPECTED_RESULTS", "").strip().lower() in {"1", "true", "yes", "on"}
+    if strict:
+        configured = set(expected_query_ids or ())
+        if configured:
+            assert checked == len(configured), (
+                f"strict expected-results: evaluated {checked} of {len(configured)} configured "
+                f"{benchmark_name} queries (sf={scale_factor}); every configured query must produce a "
+                f"non-SKIP row-count validation. Unevaluated queries indicate missing answer files, a "
+                f"skipped/failed query, or scale/benchmark drift that disarmed the gate."
             )
         else:
-            assert checked > 0, "TPC-H validation did not evaluate any query against stored expected results"
+            assert checked > 0, (
+                f"strict expected-results: no {benchmark_name} queries (sf={scale_factor}) were validated "
+                f"against stored expected results"
+            )
 
     assert not failures, "Row-count validation failures:\n" + "\n".join(failures)
 

--- a/tests/unit/test_standardized_test_commands.py
+++ b/tests/unit/test_standardized_test_commands.py
@@ -12,6 +12,11 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.integration.test_local_platform_benchmark_matrix import (
+    LOCAL_SQL_STABLE_MATRIX,
+    _validate_against_expected_results,
+)
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.medium,
@@ -382,3 +387,128 @@ class TestMakefileCommands:
         assert len(test_lines) > 5, "Should have multiple pytest-based commands"
         for line in test_lines:
             assert line.startswith("\tuv run -- python -m pytest"), f"Line should use pytest: {line}"
+
+
+def _gate_query_ids() -> list[str]:
+    """Configured correctness-gate query ids.
+
+    Derived from the ``CORRECTNESS_GATE_QUERY_IDS`` constant, which
+    ``test_makefile_correctness_gate_runs_expected_results_backed_matrix_slice``
+    already pins to the actual Makefile target, so this stays a single source of truth.
+    """
+    return [q for q in CORRECTNESS_GATE_QUERY_IDS.split(",") if q]
+
+
+class TestCorrectnessGateOracle:
+    """Ratchets and behavioral guards that keep the bounded correctness gate discriminating.
+
+    These guard the *oracle* (query-set discrimination, strict-mode arming, no-skip), not
+    just the command spelling. They stay in the module-default ``unit``/``medium`` tier:
+    the correctness gate itself runs as a dedicated required CI job (``correctness-gate`` in
+    ``.github/workflows/pr.yml``) on every code-impacting PR, so these meta-guards do not
+    also need the fast lane -- they prevent local config regression and run via the medium
+    lane and the explicit gate verification command.
+    """
+
+    # TPC-H queries whose SF=1 answer-set cardinality varies across dbgen builds because
+    # their HAVING/threshold boundaries are data-sensitive. #744 deliberately excluded them
+    # from the gate even with the reference seed pinned; keep them out (see Makefile note).
+    DBGEN_UNSTABLE_QUERY_IDS = {"11", "16", "18", "20"}
+
+    def test_gate_query_set_is_answer_backed_and_discriminating(self):
+        """The gate subset must stay answer-backed and not regress to all/mostly one-row.
+
+        #737 originally gated ``6,14,15,17,19`` -- every one of which returns exactly one
+        row at SF=1, so row-count validation could not catch wrong joins, filters, or
+        aggregate values that still emit a single row. This ratchet fails if the set drifts
+        back toward that near-vacuous shape.
+        """
+        from benchbox.core.expected_results.tpch_results import load_tpch_expected_results
+
+        ids = _gate_query_ids()
+        row_counts = load_tpch_expected_results(scale_factor=1.0)
+
+        missing = [q for q in ids if q not in row_counts]
+        assert not missing, f"gate queries lack stored SF=1 answer cardinalities: {missing}"
+
+        one_row = [q for q in ids if row_counts[q] == 1]
+        multi_row = [q for q in ids if row_counts[q] > 1]
+        high_card = [q for q in ids if row_counts[q] >= 100]
+
+        assert len(multi_row) > len(one_row), (
+            f"correctness gate is dominated by one-row queries "
+            f"({len(one_row)} one-row vs {len(multi_row)} multi-row); add answer-backed "
+            f"high/mid-cardinality queries so wrong single-row answers are detectable"
+        )
+        assert len(high_card) >= 2, (
+            f"correctness gate needs at least two answer-backed queries with SF=1 cardinality "
+            f">=100 for discrimination; have {sorted(high_card, key=int)}"
+        )
+
+    def test_gate_excludes_dbgen_unstable_threshold_queries(self):
+        """The dbgen-build-unstable threshold queries must stay out of the gate."""
+        included = self.DBGEN_UNSTABLE_QUERY_IDS.intersection(_gate_query_ids())
+        assert not included, (
+            f"correctness gate must exclude dbgen-build-unstable threshold queries "
+            f"{sorted(included, key=int)}; their HAVING/threshold cardinality varies across "
+            f"dbgen builds (see #744 and the test-correctness-gate Makefile note)"
+        )
+
+    def test_gate_target_enforces_no_skip(self):
+        """The gate target must fail if its selected node skips or does not run exactly once.
+
+        ``pytest`` exits 0 when a *selected* node SKIPs (e.g. duckdb unavailable, or the case
+        is excluded from the stable matrix), which would let ``make test-correctness-gate``
+        pass without running anything. The target must emit a JUnit report and assert exactly
+        one test ran with zero skips/errors/failures.
+        """
+        gate_body = _makefile_target_body((Path.cwd() / "Makefile").read_text(), "test-correctness-gate")
+        assert "--junitxml=" in gate_body, "gate must emit a JUnit report to verify the node actually ran"
+        # The guard parses that report (no brittle stdout scraping) and must assert the exact
+        # ran/skip condition. Pin the condition tokens so a disarmed guard (e.g. relaxing to
+        # `skipped >= 0`, or dropping the exit) is caught, not just the presence of "skipped".
+        assert "tests == 1" in gate_body, "gate guard must require exactly one node to run"
+        assert "skipped == 0" in gate_body, "gate guard must require zero selected skips"
+        assert "PYTEST_STATUS" in gate_body, "gate must also propagate the pytest exit status"
+
+    def test_gate_node_is_in_stable_matrix(self):
+        """The (duckdb, tpch) node the gate targets must remain in the stable matrix.
+
+        If it is dropped/renamed, the parametrized node would skip and -- absent the no-skip
+        guard above -- the gate would pass vacuously.
+        """
+        assert "tpch" in LOCAL_SQL_STABLE_MATRIX.get("duckdb", set()), (
+            "gate node tpch-duckdb is no longer in LOCAL_SQL_STABLE_MATRIX; the gate would skip"
+        )
+
+    def test_strict_mode_fails_on_scale_drift(self, monkeypatch):
+        """Strict expected-results mode must fail when configured checks SKIP under scale drift.
+
+        Regression guard for the previously ``scale_factor >= 1.0``-gated strict block: a gate
+        retargeted to SF<1 would SKIP every stored-answer check, silently disarming the oracle
+        while still exiting 0. SF=0.1 has no stored TPC-H answer file, so validation SKIPs and
+        ``checked`` stays 0 -- under strict mode that is now a hard failure.
+        """
+        monkeypatch.setenv("BENCHBOX_STRICT_EXPECTED_RESULTS", "1")
+        payload = {"queries": [{"id": "9", "stream": 0, "status": "SUCCESS", "rows": 175}]}
+        with pytest.raises(AssertionError, match="strict expected-results"):
+            _validate_against_expected_results(payload, "tpch", 0.1, expected_query_ids={"9"})
+
+    def test_strict_mode_fails_on_benchmark_drift(self, monkeypatch):
+        """Strict mode must fail when a configured benchmark has no stored answers."""
+        monkeypatch.setenv("BENCHBOX_STRICT_EXPECTED_RESULTS", "1")
+        payload = {"queries": [{"id": "1", "stream": 0, "status": "SUCCESS", "rows": 5}]}
+        with pytest.raises(AssertionError, match="strict expected-results"):
+            _validate_against_expected_results(payload, "tpch_future_variant", 1.0, expected_query_ids={"1"})
+
+    def test_strict_mode_passes_when_all_configured_queries_evaluate(self, monkeypatch):
+        """Strict mode passes when every configured query evaluates against stored answers."""
+        monkeypatch.setenv("BENCHBOX_STRICT_EXPECTED_RESULTS", "1")
+        payload = {"queries": [{"id": "9", "stream": 0, "status": "SUCCESS", "rows": 175}]}
+        _validate_against_expected_results(payload, "tpch", 1.0, expected_query_ids={"9"})
+
+    def test_non_strict_mode_tolerates_unsupported_validation(self, monkeypatch):
+        """Default (non-strict) matrix behavior must still skip unsupported validation, not fail."""
+        monkeypatch.delenv("BENCHBOX_STRICT_EXPECTED_RESULTS", raising=False)
+        payload = {"queries": [{"id": "9", "stream": 0, "status": "SUCCESS", "rows": 175}]}
+        _validate_against_expected_results(payload, "tpch", 0.1, expected_query_ids={"9"})


### PR DESCRIPTION
Follow-up to the bounded DuckDB/TPC-H correctness gate (#737/#744), implementing
`testing-approach-oracle-hardening`. Closes the remaining oracle gaps found in
review, **reconciled against current develop** (the original review transcript
was partly stale — see below).

## w0 — evidence refresh (key finding)
PR #744 (same day as the TODO) already broadened the gate query set from the
near-vacuous `6,14,15,17,19` to the 18-query set and pinned the reference qgen
seed for EXACT validation. The TODO's suggested adds (Q11/Q16/Q20) are exactly
the threshold queries #744 **deliberately excluded** as dbgen-build-unstable, so
they were *not* re-added (would fight a recent, documented decision and risk
cross-platform CI flake). The remaining real gaps were w2/w3 plus the ratchet,
docs, and triage.

## What changed
- **w2 — strict arming**: hoisted the strict expected-results assertion in
  `_validate_against_expected_results` out from behind
  `benchmark_name == "tpch" and scale_factor >= 1.0`. Strict mode now fails
  whenever a configured subset does not fully evaluate (every configured query
  must produce a non-SKIP validation), regardless of benchmark/scale, so a future
  CI retarget cannot silently disarm the oracle. Non-strict callers unchanged
  (still skip unsupported validation).
- **w3 — no-skip guard**: `make test-correctness-gate` writes a JUnit report to a
  private `mktemp` file (not the repo-root `test-results.xml` that
  `pytest-ci.ini` also writes), parses it with ElementTree, and fails unless
  exactly one node ran with zero skipped/failed/errored. `pytest` exits 0 on a
  *selected* skip, which previously passed the gate without executing anything.
  Both the pytest and guard statuses propagate; the report is removed after.
- **w1/w2/w3 — ratchets** in a new `TestCorrectnessGateOracle`: query set must
  stay answer-backed and not one-row-dominated (≥2 queries with SF=1 cardinality
  ≥100), Q11/Q16/Q18/Q20 stay excluded, the gate node stays in
  `LOCAL_SQL_STABLE_MATRIX`, the target keeps its no-skip guard, and strict
  arming is proven on scale/benchmark drift.
- **w5 — docs**: removed the stale `tests/specialized/` reference from
  `tests/README.md` (dir doesn't exist) and corrected the false "removed" claim
  in `testing-approach-correctness-gates.yaml`.
- **w6 — docs**: documented what the gate proves (discriminating answer-backed
  subset, strict arming, no-skip) and does not (result values; high-cardinality
  threshold queries excluded for dbgen-build stability).
- **w4 — triage**: medium-only inventory (990 tests) and routing decisions
  recorded in the TODO; gate-oracle ratchets kept at medium since the gate runs
  as its own required CI job.

## Verification
- `make test-correctness-gate` — green (41s, ran=1 skipped=0); guard fails on
  synthetic skip (exit 1) and on a childless report (graceful, no traceback).
- `tests/unit/test_standardized_test_commands.py` + `tests/unit/test_marker_strategy.py`
  — 40/40 pass.
- `ruff check`/`format` + `ty check` clean; TODO validates + graph passes.
- Code review (2 agents) run; all actionable findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_