### PR TITLE
fix(postgresql): capture plans on cursor-backed power-test streams

### DIFF
--- a/benchbox/platforms/postgresql.py
+++ b/benchbox/platforms/postgresql.py
@@ -713,7 +713,13 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         """
         from benchbox.platforms.base.result_capture import is_dml_query
 
-        cursor = connection.cursor()
+        # In TPC-DS power/throughput streaming paths a per-stream cursor is passed as
+        # `connection` (see _make_stream_cursor / PlatformAdapterConnection); a real
+        # connection exposes a callable `.cursor()`, a cursor does not. Detect which we
+        # were given so cursor-backed streams capture plans instead of silently failing,
+        # and only close a cursor we created (never the caller's stream cursor).
+        _owns_cursor = callable(getattr(connection, "cursor", None))
+        cursor = connection.cursor() if _owns_cursor else connection
 
         # Use FORMAT JSON so PostgreSQLQueryPlanParser can parse the output.
         # ANALYZE and BUFFERS give actual timing and I/O info for SELECT queries,
@@ -733,7 +739,8 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
         try:
             cursor.execute(explain_query)
             plan_rows = cursor.fetchall()
-            cursor.close()
+            if _owns_cursor:
+                cursor.close()
             # PostgreSQL returns the full JSON as the first column of the first row.
             # psycopg decodes FORMAT JSON output as a Python object; re-serialize
             # to a string so PostgreSQLQueryPlanParser.parse_explain_output() receives
@@ -744,7 +751,8 @@ class PostgreSQLAdapter(PsycopgConnectionMixin, PlatformAdapter):
             return raw
 
         except Exception as e:
-            cursor.close()
+            if _owns_cursor:
+                cursor.close()
             self.logger.debug(f"Failed to get query plan: {e}")
             return None
 

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -54,6 +54,22 @@ class TestPostgreSQLPlanCapture:
         result = adapter.get_query_plan(conn, "SELECT 1")
         assert result is None
 
+    def test_get_query_plan_accepts_cursor_backed_stream(self, adapter):
+        """A per-stream cursor (no callable .cursor()) is used directly, so streamed
+        TPC-DS power/throughput runs still capture plans instead of silently failing."""
+        # psycopg cursors expose execute/fetchall but NOT a .cursor() factory; spec
+        # restricts the mock so getattr(stream_cursor, "cursor") is absent.
+        stream_cursor = MagicMock(spec=["execute", "fetchall", "close"])
+        stream_cursor.fetchall.return_value = [('[{"Plan": {"Node Type": "Seq Scan"}}]',)]
+
+        result = adapter.get_query_plan(stream_cursor, "SELECT 1")
+
+        assert result is not None
+        assert "Seq Scan" in result
+        stream_cursor.execute.assert_called_once()
+        # The caller owns the stream cursor; plan capture must not close it.
+        stream_cursor.close.assert_not_called()
+
     def test_execute_query_with_capture_adds_plan_fields(self, adapter, monkeypatch):
         conn = _make_connection()
 


### PR DESCRIPTION
## Summary

Follow-up to the #781 review thread (cursor-backed-stream plan capture), which the non-overlapping sweep in #829 deliberately left as a tracked item.

In TPC-DS power/throughput paths, `PlatformAdapterConnection` passes a **per-stream cursor** as the `connection` argument to `execute_query` (via `_make_stream_cursor`). PostgreSQL `get_query_plan` then called `connection.cursor()` unconditionally — but a psycopg cursor has no `.cursor()` factory, so the call raised, was swallowed by the `except`, and the query (which executed successfully) recorded **no captured plan**. Query results were unaffected; only plan-capture metadata was silently dropped on streamed runs with `--capture-plans`.

## Fix

Detect whether a real connection (callable `.cursor()`) or an already-open cursor was passed, and use it directly in the latter case — mirroring the QuestDB cursor handling landing in #824:

```python
_owns_cursor = callable(getattr(connection, "cursor", None))
cursor = connection.cursor() if _owns_cursor else connection
```

Only a cursor we created is closed; the caller's stream cursor is left open for the stream to manage.

## Test plan

- Adds `test_get_query_plan_accepts_cursor_backed_stream` (a `spec`-restricted cursor mock with no `.cursor()` factory) asserting a plan is captured and the stream cursor is **not** closed.
- `uv run -- python -m pytest tests/unit/platforms/test_postgresql_plan_capture.py tests/unit/platforms/test_postgresql_adapter.py` — 75 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgzHrUxD25tMFrxkcLZ6sj)_