### PR TITLE
fix(tpchavoc): run ClickHouse equivalence sample through production transforms

### DIFF
--- a/_project/TODO/main/planning/tpchavoc-fourth-engine-equivalence-sampling.yaml
+++ b/_project/TODO/main/planning/tpchavoc-fourth-engine-equivalence-sampling.yaml
@@ -213,6 +213,35 @@ work:
       (per-engine skip-lists) and (2) on a native-dialect engine, a small, enumerable set
       of irreducible engine result-semantics - never a silent mistranslation.
 
+  - id: w5
+    summary: "Post-review fidelity follow-ups: production query-time transforms + NULL-ordering scope"
+    needs: [w4]
+    status: done
+    notes: |
+      RESOLVED (review follow-up to the two #817 threads).
+
+      (1) Transform-wrapper parity. The sample now routes both canonical and variant SQL
+      through the SAME production query-time rewrites the real ClickHouse adapter applies
+      (ClickHouseQueryTransformer.transform - Decimal/Float casts + safe division - then
+      add_query_settings), via a new engine-agnostic `execute_transform` hook on
+      find_divergences and `_clickhouse_execute_transform`. Applied identically to both
+      sides, so shared transforms still cancel out. Re-verified at SF=0.1: the classified
+      surface is UNCHANGED (7 CLICKHOUSE_KNOWN_DIVERGENCES still diverge, no new
+      unclassified ones).
+
+      Surfaced and fixed a real production bug: safe_division wrapped a WINDOWED divisor
+      `SUM(x) OVER (...)` as the invalid `NULLIF(SUM(x), 0) OVER (...)` (ClickHouse:
+      'NULLIF ... OVER' is not a window function), which would also fail variant 8_v9 and
+      any windowed-division TPC-DS query on real ClickHouse runs. The operand scanner now
+      treats `agg(...) OVER (...)` as one operand, so it wraps as
+      `NULLIF(SUM(x) OVER (...), 0)`.
+
+      (2) NULL-ordering scope. The order-insensitive comparator (it sorts both sides)
+      structurally cannot observe a difference that shows up only as NULL placement within
+      an ORDER BY, so that axis is NOT sampled by this row-set oracle - now documented
+      explicitly in the equivalence module docstring. Covering it would need a separate
+      order-sensitive check on the NULL-bearing-sort-key subset; left out of scope here.
+
       Is a fifth engine worth sequencing? NO. We now have both a Postgres-family cohort
       (systematic-zero) and a non-Postgres-family engine (faithful + a fully classified
       result-semantic residue) agreeing that the seam introduces no translation

--- a/benchbox/core/tpchavoc/equivalence.py
+++ b/benchbox/core/tpchavoc/equivalence.py
@@ -46,8 +46,10 @@ Postgres-family engines. ClickHouse also differs on the result-semantic axes the
 prior TODOs flagged, and unlike the first three engines it does NOT yield
 systematic-zero: after excluding the variants it cannot execute
 (CLICKHOUSE_TPCHAVOC_SKIPS) and running with the engine's production TPC-H session
-configuration (SQL-standard NULL semantics via ``join_use_nulls=1``), a small
-residue of irreducible
+configuration (SQL-standard NULL semantics via ``join_use_nulls=1``) AND the same
+production query-time rewrites the real adapter applies (Decimal/Float casts, safe
+division, the ``joined_subquery_requires_alias`` SETTINGS - see
+:func:`_clickhouse_execute_transform`), a small residue of irreducible
 engine-semantic RESULT differences remains, classified in
 :data:`CLICKHOUSE_KNOWN_DIVERGENCES` (Decimal-vs-Float division truncation,
 ``SUM`` of an empty group returning 0 instead of NULL, and partial
@@ -60,6 +62,14 @@ Comparison is order-insensitive with float tolerance (the validator sorts both
 sides). Because canonical TPC-H queries carry a presentational ``ORDER BY ...
 LIMIT n`` top-N cut that the variant families treat inconsistently, the trailing
 ``LIMIT`` is stripped from both sides before comparison.
+
+One consequence: NULL ordering/placement is deliberately NOT sampled by this
+oracle. Sorting both sides is what lets variants legitimately permute row order
+without being flagged, but it also normalizes away a difference that shows up only
+as where NULLs land within an ``ORDER BY`` (e.g. ``NULLS FIRST`` vs ``NULLS
+LAST``). Such a difference is invisible here by construction; covering it would
+need a separate order-sensitive check on the subset of queries with a
+NULL-bearing sort key, which is out of scope for this row-set equivalence sample.
 
 The gate's burndown (24 divergences at the first report) resolved every
 divergence class as a variant defect:
@@ -193,6 +203,7 @@ def find_divergences(
     query_ids: list[int] | None = None,
     translate_variant: Callable[[str], str] | None = None,
     skip_variants: Collection[str] | None = None,
+    execute_transform: Callable[[str], str] | None = None,
 ) -> list[Divergence]:
     """Compare every variant of each query to canonical TPC-H on ``connection``.
 
@@ -224,6 +235,13 @@ def find_divergences(
             sweep entirely - e.g. POSTGRES_TPCHAVOC_SKIPS, which the engine
             cannot execute. Excluded variants are neither run nor counted as
             divergences; they are NEVER silently marked equivalent.
+        execute_transform: Optional callable applied to the FINAL SQL string of
+            BOTH sides (after dialect rendering and top-N stripping) immediately
+            before execution. Use to reproduce an engine's production query-time
+            rewrites (e.g. ClickHouse's Decimal/Float casts + SETTINGS) so the
+            sample exercises the real execution path; applied identically to
+            canonical and variant, so shared transforms still cancel out. Defaults
+            to identity, leaving the DuckDB/Postgres/DataFusion samples unchanged.
 
     Returns:
         One :class:`Divergence` per variant whose result is not equivalent to
@@ -231,11 +249,12 @@ def find_divergences(
     """
     ids = query_ids if query_ids is not None else benchmark.get_implemented_queries()
     render_variant = translate_variant if translate_variant is not None else _identity
+    transform_for_engine = execute_transform if execute_transform is not None else _identity
     excluded = set(skip_variants or ())
     divergences: list[Divergence] = []
     for query_id in ids:
         try:
-            original = connection.execute(strip_top_n(canonical_query(query_id))).fetchall()
+            original = connection.execute(transform_for_engine(strip_top_n(canonical_query(query_id)))).fetchall()
         except Exception as exc:  # noqa: BLE001 - a diagnostic must report, not crash, on a bad query
             divergences.append(Divergence(query_id, 0, f"canonical query failed: {exc}"))
             continue
@@ -243,7 +262,9 @@ def find_divergences(
             if f"{query_id}_v{variant_id}" in excluded:
                 continue
             try:
-                variant_sql = render_variant(strip_top_n(benchmark.get_query(f"{query_id}_v{variant_id}")))
+                variant_sql = transform_for_engine(
+                    render_variant(strip_top_n(benchmark.get_query(f"{query_id}_v{variant_id}")))
+                )
                 variant_rows = connection.execute(variant_sql).fetchall()
                 benchmark.validate_variant_equivalence(query_id, variant_id, original, variant_rows)
             except ValidationError as exc:
@@ -780,6 +801,23 @@ def build_clickhouse_with_tpch(scale_factor: float, output_dir: str | Path) -> t
     return connection, tpchavoc, tpch
 
 
+def _clickhouse_execute_transform(sql: str) -> str:
+    """Apply the SAME query-time rewrites the production ClickHouse adapter runs.
+
+    ``ClickHouseWorkloadMixin.execute_query`` rewrites every query through
+    ``ClickHouseQueryTransformer.transform`` (Decimal/Float casts + safe division)
+    and then ``add_query_settings`` (the ``joined_subquery_requires_alias = 0``
+    SETTINGS clause) before executing it. Reusing that exact sequence here makes the
+    fourth-engine sample exercise the real execution path rather than the raw SQLGlot
+    translation; it is applied identically to canonical and variant, so shared
+    transforms cancel out and only genuine variant-vs-canonical differences surface.
+    """
+    from benchbox.platforms.clickhouse.query_transformer import ClickHouseQueryTransformer
+
+    transformer = ClickHouseQueryTransformer()
+    return transformer.add_query_settings(transformer.transform(sql))
+
+
 def find_clickhouse_divergences(
     connection: Any,
     tpchavoc: TPCHavocBenchmark,
@@ -792,7 +830,9 @@ def find_clickhouse_divergences(
     Single source of truth for *how* the ClickHouse sample is run - both the CLI
     (:func:`run_clickhouse_sample`) and the integration test call this so they
     cannot drift. Canonical and variants are both translated to the NATIVE
-    clickhouse dialect through the SAME seam (NOT normalized to postgres), and
+    clickhouse dialect through the SAME seam (NOT normalized to postgres), then
+    run through the SAME production query-time transforms the real ClickHouse
+    adapter applies (see :func:`_clickhouse_execute_transform`), and
     CLICKHOUSE_TPCHAVOC_SKIPS variants are excluded (never marked equivalent).
     """
     from benchbox.sql_compat.rules.execution_filter.clickhouse_tpchavoc import CLICKHOUSE_TPCHAVOC_SKIPS
@@ -804,6 +844,7 @@ def find_clickhouse_divergences(
         query_ids=query_ids,
         translate_variant=lambda sql: tpchavoc.translate_query_text(sql, "netezza", CLICKHOUSE_TARGET_DIALECT),
         skip_variants=set(CLICKHOUSE_TPCHAVOC_SKIPS),
+        execute_transform=_clickhouse_execute_transform,
     )
 
 

--- a/benchbox/platforms/clickhouse/query_transformer.py
+++ b/benchbox/platforms/clickhouse/query_transformer.py
@@ -280,9 +280,32 @@ class ClickHouseQueryTransformer:
             end += 1
 
         if end < len(text) and text[end] == "(":
-            return cls._find_matching_parenthesis(text, end) + 1
+            call_end = cls._find_matching_parenthesis(text, end) + 1
+            # A window function ``agg(...) OVER (...)`` is a single operand: include the
+            # trailing OVER clause so safe_division wraps the whole window expression
+            # (``NULLIF(SUM(x) OVER (...), 0)``) rather than splitting it into the invalid
+            # ``NULLIF(SUM(x), 0) OVER (...)``.
+            return cls._extend_over_clause(text, call_end)
 
         return end
+
+    @classmethod
+    def _extend_over_clause(cls, text: str, index: int) -> int:
+        """Return the index past a window ``OVER (...)`` clause following *index*, if any."""
+        probe = index
+        while probe < len(text) and text[probe].isspace():
+            probe += 1
+        # Match OVER only as a standalone keyword (not an identifier prefix like ``overage``).
+        if text[probe : probe + 4].upper() != "OVER":
+            return index
+        after_kw = probe + 4
+        if after_kw < len(text) and (text[after_kw].isalnum() or text[after_kw] == "_"):
+            return index
+        while after_kw < len(text) and text[after_kw].isspace():
+            after_kw += 1
+        if after_kw < len(text) and text[after_kw] == "(":
+            return cls._find_matching_parenthesis(text, after_kw) + 1
+        return index
 
     @classmethod
     def _strip_outer_parentheses(cls, expression: str) -> str:

--- a/tests/unit/core/tpchavoc/test_equivalence_execute_transform.py
+++ b/tests/unit/core/tpchavoc/test_equivalence_execute_transform.py
@@ -1,0 +1,82 @@
+"""Fast unit coverage for the engine-agnostic ``execute_transform`` hook.
+
+The fourth-engine (ClickHouse) sample runs both canonical and variant SQL through
+the production query-time rewrites the real adapter applies. These tests pin that
+plumbing without needing chDB: a fake connection records the exact SQL executed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchbox.core.tpchavoc.equivalence import _clickhouse_execute_transform, find_divergences
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class _RecordingConnection:
+    """Fake connection capturing every executed SQL string."""
+
+    def __init__(self):
+        self.executed: list[str] = []
+
+    def execute(self, sql: str):
+        self.executed.append(sql)
+        result = MagicMock()
+        result.fetchall.return_value = [(1,)]
+        return result
+
+
+def _benchmark_with_one_query():
+    benchmark = MagicMock()
+    benchmark.get_implemented_queries.return_value = [1]
+    benchmark.get_query.return_value = "SELECT v FROM t"
+    benchmark.validate_variant_equivalence.return_value = None  # never diverges
+    return benchmark
+
+
+def test_execute_transform_applied_to_canonical_and_every_variant():
+    conn = _RecordingConnection()
+    benchmark = _benchmark_with_one_query()
+
+    divergences = find_divergences(
+        conn,
+        benchmark,
+        lambda q: "SELECT c FROM t",
+        translate_variant=lambda sql: sql,
+        execute_transform=lambda sql: f"{sql} /*X*/",
+    )
+
+    assert divergences == []
+    # 1 canonical + 10 variants, each rewritten by the transform.
+    assert len(conn.executed) == 11
+    assert all(sql.endswith(" /*X*/") for sql in conn.executed)
+    assert conn.executed[0] == "SELECT c FROM t /*X*/"
+
+
+def test_no_transform_leaves_sql_unchanged():
+    conn = _RecordingConnection()
+    benchmark = _benchmark_with_one_query()
+
+    find_divergences(conn, benchmark, lambda q: "SELECT c FROM t", translate_variant=lambda sql: sql)
+
+    # Default identity transform: the executed SQL is exactly what was rendered.
+    assert conn.executed[0] == "SELECT c FROM t"
+    assert all("/*X*/" not in sql for sql in conn.executed)
+
+
+def test_clickhouse_execute_transform_mirrors_production_sequence():
+    # transform() wraps divisors with NULLIF; add_query_settings() appends SETTINGS.
+    out = _clickhouse_execute_transform("SELECT revenue / SUM(quantity) FROM t")
+    assert "revenue / NULLIF(SUM(quantity), 0)" in out
+    assert out.rstrip().endswith("SETTINGS joined_subquery_requires_alias = 0")
+
+
+def test_clickhouse_execute_transform_keeps_windowed_divisor_intact():
+    # Regression guard tied to the safe_division window-function fix: the OVER clause
+    # stays inside the NULLIF rather than being stranded outside it.
+    out = _clickhouse_execute_transform("SELECT mkt / SUM(volume) OVER (PARTITION BY o_year) FROM t")
+    assert "NULLIF(SUM(volume) OVER (PARTITION BY o_year), 0)" in out
+    assert "NULLIF(SUM(volume), 0) OVER" not in out

--- a/tests/unit/platforms/test_clickhouse_adapter.py
+++ b/tests/unit/platforms/test_clickhouse_adapter.py
@@ -1428,3 +1428,18 @@ class TestClickHouseQueryTransformerSafeDivision:
         result = t.safe_division(sql)
         assert "'a/b'" in result
         assert "x / NULLIF(y, 0)" in result
+
+    def test_windowed_divisor_wraps_whole_window_expression(self):
+        """A windowed divisor ``SUM(x) OVER (...)`` must wrap as a single operand.
+
+        Regression: the operand scanner stopped at ``SUM(volume)`` and left the
+        trailing ``OVER (...)`` outside the NULLIF, producing the invalid
+        ``NULLIF(SUM(volume), 0) OVER (...)`` (ClickHouse: 'NULLIF ... OVER' is not a
+        window function). The whole window expression is one operand.
+        """
+        t = self._transformer()
+        sql = "SELECT mkt / SUM(volume) OVER (PARTITION BY o_year) FROM t"
+        result = t.safe_division(sql)
+        assert "mkt / NULLIF(SUM(volume) OVER (PARTITION BY o_year), 0)" in result
+        # The OVER clause must NOT be stranded outside the NULLIF.
+        assert "NULLIF(SUM(volume), 0) OVER" not in result


### PR DESCRIPTION
## Summary

Addresses the two #817 review-thread follow-ups on the fourth-engine (ClickHouse) TPC-Havoc equivalence sample.

### (1) Production transform-wrapper parity

The sample previously ran the raw SQLGlot translation, bypassing the query-time rewrites the real ClickHouse adapter applies. This PR adds an engine-agnostic `execute_transform` hook to `find_divergences` (defaults to identity — **DuckDB/Postgres/DataFusion samples are unchanged**) and wires the ClickHouse sample through `_clickhouse_execute_transform`, which mirrors `ClickHouseWorkloadMixin.execute_query` **exactly**:

```python
transformer.add_query_settings(transformer.transform(sql))
```

i.e. Decimal/Float casts + safe division, then the `joined_subquery_requires_alias = 0` SETTINGS. It's applied identically to canonical and variant, so shared transforms still cancel out. **Re-verified at SF=0.1: the classified surface is unchanged** — the 7 `CLICKHOUSE_KNOWN_DIVERGENCES` still diverge, with no new unclassified divergences.

### Bug surfaced + fixed: `safe_division` on windowed divisors

Running the real transforms exposed a genuine production bug. `safe_division` rewrote a windowed divisor `SUM(x) OVER (...)` into the **invalid** `NULLIF(SUM(x), 0) OVER (...)` — ClickHouse rejects this (`NULLIF ... OVER` is not a window function). This would also fail variant `8_v9` and any windowed-division query on real ClickHouse benchmark runs (TPC-H/TPC-DS). The operand scanner now treats `agg(...) OVER (...)` as a single operand, wrapping correctly as `NULLIF(SUM(x) OVER (...), 0)`.

### (2) NULL-ordering scope

The order-insensitive comparator (it sorts both sides — which is what lets variants legitimately permute row order) structurally cannot observe a difference that shows up only as NULL placement within an `ORDER BY`. That axis is therefore **not sampled** by this row-set oracle; the module docstring now states this explicitly rather than implying coverage. Covering it would need a separate order-sensitive check on the NULL-bearing-sort-key subset — left out of scope.

## Test plan

- **Integration** (`test_tpchavoc_clickhouse_equivalence.py`, chDB SF=0.1 sweep of ~202 variants): **4 passed** — classified baseline holds with production transforms applied.
- **Unit** (137 passed): new `test_equivalence_execute_transform.py` pins the `execute_transform` plumbing (applied to canonical + all variants, identity by default) and the ClickHouse transform sequence; new `safe_division` windowed-divisor regression test in `test_clickhouse_adapter.py`.
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgzHrUxD25tMFrxkcLZ6sj)_