### PR TITLE
feat(correctness): generated benchmark oracle-coverage map + drift guard (w0/w3)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Compatibility governance drift check
         run: make compat-docs-check
 
+      - name: Oracle coverage map drift check
+        run: make oracle-coverage-map-check
+
       - name: Public contract drift check
         run: |
           uv run -- python - <<'PY'

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report oracle-coverage-map oracle-coverage-map-check compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -177,6 +177,17 @@ tpchavoc-dataframe-equivalence-report:
 # benchbox/core/equivalence/cross_surface.py). Currently gates ssb.
 ssb-cross-surface-equivalence-report:
 	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark ssb
+
+# Regenerate the benchmark correctness-oracle coverage map (which oracle, if any,
+# guards each shipped benchmark). Derived from the registry + provider/gate
+# registries; commit the refreshed _project/analysis/ artifacts.
+oracle-coverage-map:
+	uv run -- python _project/scripts/generate_oracle_coverage_map.py
+
+# Advisory CI guard: fail if the checked-in coverage map is stale (e.g. a new
+# benchmark was added without regenerating, hiding an UNGUARDED surface).
+oracle-coverage-map-check:
+	uv run -- python _project/scripts/generate_oracle_coverage_map.py --check
 
 # Real benchmark matrix across local SQL platforms x all benchmarks (heavy, opt-in)
 test-local-matrix:
@@ -602,6 +613,7 @@ ci-lint:
 	$(MAKE) skill-sync-check
 	uv run -- python _project/scripts/timing_policy_check.py --strict
 	$(MAKE) compat-docs-check
+	$(MAKE) oracle-coverage-map-check
 	$(MAKE) audit-deps
 	@echo "✅ CI lint checks passed"
 

--- a/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
+++ b/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
@@ -99,9 +99,13 @@ work:
     notes: |
       Delivered ahead of w1/w2 (the visibility guard is independent of building
       the oracles). `make oracle-coverage-map-check` (and the generator's
-      `--check`) fail when the checked-in map is stale; wired into `ci-lint`
-      alongside the other generated-artifact freshness checks, and covered by the
-      fast unit test `tests/unit/test_oracle_coverage_map.py`. Mechanism: adding a
+      `--check`) fail when the checked-in map is stale. CI surfacing on develop
+      PRs is via TWO paths: the fast unit test
+      `tests/unit/test_oracle_coverage_map.py::test_checked_in_artifacts_are_current`
+      runs in the pr.yml `code-test` job (`-m fast`), and an explicit
+      `make oracle-coverage-map-check` step sits in the pr.yml `code-lint` job
+      next to `compat-docs-check`. It is also in the `ci-lint` aggregate
+      (post-merge / local `make pr-preflight` parity). Mechanism: adding a
       benchmark changes the generated map -> the drift check fails -> the author
       must regenerate and commit, which surfaces the new benchmark's UNGUARDED
       classification in review rather than letting it slip in silently. The map's

--- a/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
+++ b/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
@@ -2,7 +2,7 @@ id: benchmark-correctness-oracle-coverage-map
 title: "Map correctness-oracle coverage across all benchmarks and close the unguarded ones"
 worktree: main
 priority: Medium
-status: Not Started
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -46,14 +46,20 @@ prior_art:
 work:
   - id: w0
     summary: "Build the authoritative correctness-oracle coverage matrix for every shipped benchmark"
-    status: pending
+    status: done
     notes: |
-      Enumerate benchmarks from the registry. For each, record: surfaces shipped
-      (SQL / DataFrame / both); has stored expected results?; has a live
-      equivalence gate?; is cross-surface applicable?; resulting current-oracle =
-      {expected-results | variant-equivalence | cross-surface | cross-engine |
-      NONE}. Land the matrix as a checked-in artifact (and ideally a generated
-      check), not a one-off doc, so it stays current.
+      Implemented `_project/scripts/generate_oracle_coverage_map.py` (per the
+      gating open_question default: GENERATED from live sources, not a curated
+      doc). It reads the benchmark registry (surfaces via `num_queries` /
+      `supports_dataframe`), the expected-results provider registry, the
+      cross-surface `GATES` registry, and TPC-Havoc gate-module presence, and
+      emits checked-in artifacts `_project/analysis/oracle-coverage-map.{md,json}`.
+
+      Current state (23 benchmarks): 4 GUARDED — tpch/tpcds (expected-results),
+      tpchavoc (variant-equivalence + cross-surface-variant), ssb (cross-surface)
+      — and 19 UNGUARDED. Of the 19: 17 are dual-surface (cross-surface gate
+      candidates, w1) and 2 are single-surface SQL-only (ai_primitives,
+      vector_search) needing a fallback oracle (w2).
 
   - id: w1
     summary: "Dispatch dual-surface, no-oracle benchmarks to the cross-surface gate"
@@ -63,6 +69,15 @@ work:
       For benchmarks the matrix shows as dual-surface with oracle=NONE, the fix is
       benchmark-cross-surface-equivalence-gate. Cross-reference rather than
       re-implement; this item only tracks that they get covered there.
+
+      Dispatch list from the w0 map (17 dual-surface UNGUARDED): amplab,
+      clickbench, coffeeshop, datavault, flightdata, h2odb, joinorder,
+      joinorder_synthetic, metadata_primitives, nyctaxi, read_primitives, tpcdi,
+      tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives.
+      CAVEAT (see map): write/DML/nondeterministic ones (write_primitives,
+      transaction_primitives, metadata_primitives, tpcdi) may not be
+      result-comparable across surfaces and likely belong in w2 (invariant
+      oracle) rather than the cross-surface gate.
 
   - id: w2
     summary: "Choose and apply a fallback oracle for single-surface, no-oracle benchmarks"
@@ -80,12 +95,21 @@ work:
   - id: w3
     summary: "Make 'no oracle' visible and prevent silent regressions in coverage"
     needs: [w1, w2]
-    status: pending
+    status: done
     notes: |
-      Document the policy that every shipped benchmark declares a correctness
-      oracle, and add a lightweight check (advisory first) that lists benchmarks
-      with oracle=NONE so a newly-added benchmark without one is surfaced in CI
-      rather than discovered later.
+      Delivered ahead of w1/w2 (the visibility guard is independent of building
+      the oracles). `make oracle-coverage-map-check` (and the generator's
+      `--check`) fail when the checked-in map is stale; wired into `ci-lint`
+      alongside the other generated-artifact freshness checks, and covered by the
+      fast unit test `tests/unit/test_oracle_coverage_map.py`. Mechanism: adding a
+      benchmark changes the generated map -> the drift check fails -> the author
+      must regenerate and commit, which surfaces the new benchmark's UNGUARDED
+      classification in review rather than letting it slip in silently. The map's
+      UNGUARDED list is the always-current "no oracle" inventory. Advisory in the
+      sense that UNGUARDED is allowed-and-visible; only staleness is blocked.
+
+      w1/w2 (actually building oracles for the 19 UNGUARDED benchmarks) remain the
+      open campaign; the w0 map makes them dispatchable.
 
 deferred:
   - summary: "Backfill full expected-results answer keys for every benchmark"

--- a/_project/analysis/oracle-coverage-map.json
+++ b/_project/analysis/oracle-coverage-map.json
@@ -1,0 +1,287 @@
+{
+  "benchmarks": [
+    {
+      "benchmark": "ai_primitives",
+      "cross_surface_applicable": false,
+      "dual_surface": false,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql"
+      ]
+    },
+    {
+      "benchmark": "amplab",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "clickbench",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "coffeeshop",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "datavault",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "flightdata",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "h2odb",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "joinorder",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "joinorder_synthetic",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "metadata_primitives",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "nyctaxi",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "read_primitives",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "ssb",
+      "cross_surface_applicable": false,
+      "dual_surface": true,
+      "guarded": true,
+      "oracles": [
+        "cross-surface"
+      ],
+      "primary_oracle": "cross-surface",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpcdi",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpcds",
+      "cross_surface_applicable": false,
+      "dual_surface": true,
+      "guarded": true,
+      "oracles": [
+        "expected-results"
+      ],
+      "primary_oracle": "expected-results",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpcds_obt",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpch",
+      "cross_surface_applicable": false,
+      "dual_surface": true,
+      "guarded": true,
+      "oracles": [
+        "expected-results"
+      ],
+      "primary_oracle": "expected-results",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpch_skew",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tpchavoc",
+      "cross_surface_applicable": false,
+      "dual_surface": true,
+      "guarded": true,
+      "oracles": [
+        "variant-equivalence",
+        "cross-surface-variant"
+      ],
+      "primary_oracle": "variant-equivalence",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "transaction_primitives",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "tsbs_devops",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    },
+    {
+      "benchmark": "vector_search",
+      "cross_surface_applicable": false,
+      "dual_surface": false,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql"
+      ]
+    },
+    {
+      "benchmark": "write_primitives",
+      "cross_surface_applicable": true,
+      "dual_surface": true,
+      "guarded": false,
+      "oracles": [],
+      "primary_oracle": "NONE",
+      "surfaces": [
+        "sql",
+        "dataframe"
+      ]
+    }
+  ]
+}

--- a/_project/analysis/oracle-coverage-map.md
+++ b/_project/analysis/oracle-coverage-map.md
@@ -1,0 +1,40 @@
+# Benchmark correctness-oracle coverage map
+
+**Generated** by `_project/scripts/generate_oracle_coverage_map.py` from the benchmark registry, the expected-results provider registry, and the equivalence-gate registries. Do not edit by hand — run the generator and commit. `tests/unit/test_oracle_coverage_map.py` fails if this drifts.
+
+**Summary:** 23 shipped benchmarks — 4 guarded, 19 UNGUARDED (17 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
+
+| Benchmark | Surfaces | Oracle | Notes |
+| --- | --- | --- | --- |
+| ai_primitives | sql | NONE | single-surface → needs fallback oracle (w2) |
+| amplab | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| clickbench | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| coffeeshop | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| datavault | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| flightdata | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| h2odb | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder_synthetic | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| metadata_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| nyctaxi | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| read_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| ssb | sql+dataframe | cross-surface | cross-surface |
+| tpcdi | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| tpcds | sql+dataframe | expected-results | expected-results |
+| tpcds_obt | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| tpch | sql+dataframe | expected-results | expected-results |
+| tpch_skew | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| tpchavoc | sql+dataframe | variant-equivalence | variant-equivalence, cross-surface-variant |
+| transaction_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| tsbs_devops | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| vector_search | sql | NONE | single-surface → needs fallback oracle (w2) |
+| write_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+
+## UNGUARDED benchmarks
+
+These ship with no automated correctness oracle today. Dual-surface ones are dispatched to `benchmark-cross-surface-equivalence-gate` (w1); single-surface ones need a per-benchmark fallback — differential vs a second engine, a small curated expected-results subset, or a documented structural invariant (w2).
+
+> Caveat (w2 oracle choice): write/DML/nondeterministic benchmarks (`write_primitives`, `transaction_primitives`, `metadata_primitives`, `tpcdi`) are listed as dual-surface, but their two surfaces may not be result-comparable; prefer structural-invariant oracles (row counts, post-state assertions) over cross-surface equality for those.
+
+- Dual-surface (cross-surface candidates): amplab, clickbench, coffeeshop, datavault, flightdata, h2odb, joinorder, joinorder_synthetic, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives
+- Single-surface (fallback-oracle needed): ai_primitives, vector_search

--- a/_project/scripts/generate_oracle_coverage_map.py
+++ b/_project/scripts/generate_oracle_coverage_map.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Generate the benchmark correctness-oracle coverage map.
+
+The map is the authoritative, *generated* answer to "which correctness oracle, if
+any, guards each shipped benchmark?" It is derived from live sources so it cannot
+drift from reality:
+
+  - the benchmark registry (``benchbox.core.benchmark_registry``) for the set of
+    shipped benchmarks and their surfaces (SQL / DataFrame);
+  - the expected-results provider registry
+    (``benchbox.core.expected_results.registry``) for stored answer keys;
+  - the cross-surface gate registry
+    (``benchbox.core.equivalence.cross_surface.GATES``) for SQL<->DataFrame gates;
+  - module presence for the bespoke TPC-Havoc variant / variant-DataFrame gates.
+
+Run ``python _project/scripts/generate_oracle_coverage_map.py`` to (re)write the
+checked-in artifacts under ``_project/analysis/``. Run with ``--check`` to fail if
+those artifacts are stale (used by ``tests/unit/test_oracle_coverage_map.py``).
+
+This script owns w0 (the matrix) and feeds w3 (drift/UNGUARDED visibility) of the
+``benchmark-correctness-oracle-coverage-map`` TODO. It deliberately does NOT build
+per-benchmark oracles (w1/w2); it makes the gap legible and dispatchable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Oracle kinds, strongest/most-specific first. "primary" oracle = the first of
+# these a benchmark has; UNGUARDED benchmarks have none.
+ORACLE_EXPECTED_RESULTS = "expected-results"
+ORACLE_VARIANT_EQUIVALENCE = "variant-equivalence"
+ORACLE_CROSS_SURFACE_VARIANT = "cross-surface-variant"
+ORACLE_CROSS_SURFACE = "cross-surface"
+ORACLE_NONE = "NONE"
+
+_ORACLE_PRIORITY = [
+    ORACLE_EXPECTED_RESULTS,
+    ORACLE_VARIANT_EQUIVALENCE,
+    ORACLE_CROSS_SURFACE_VARIANT,
+    ORACLE_CROSS_SURFACE,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = _REPO_ROOT / "_project" / "analysis"
+JSON_ARTIFACT = ARTIFACT_DIR / "oracle-coverage-map.json"
+MARKDOWN_ARTIFACT = ARTIFACT_DIR / "oracle-coverage-map.md"
+
+
+def _module_exists(dotted: str) -> bool:
+    """True if an importable module exists, without importing it."""
+    try:
+        return importlib.util.find_spec(dotted) is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def classify_oracles(
+    benchmark_id: str,
+    *,
+    expected_results_providers: set[str],
+    cross_surface_gates: set[str],
+) -> list[str]:
+    """Return every correctness oracle that currently guards ``benchmark_id``.
+
+    Detection is from live sources only; adding a real oracle (a provider, a
+    ``GATES`` entry, or a TPC-Havoc gate module) automatically reclassifies the
+    benchmark on the next regeneration.
+    """
+    oracles: list[str] = []
+    if benchmark_id in expected_results_providers:
+        oracles.append(ORACLE_EXPECTED_RESULTS)
+    # TPC-Havoc ships its own bespoke gates (variant-vs-canonical SQL, and
+    # SQL-variant-vs-DataFrame-variant); detect them by module presence.
+    if benchmark_id == "tpchavoc":
+        if _module_exists("benchbox.core.tpchavoc.equivalence"):
+            oracles.append(ORACLE_VARIANT_EQUIVALENCE)
+        if _module_exists("benchbox.core.tpchavoc.dataframe_equivalence"):
+            oracles.append(ORACLE_CROSS_SURFACE_VARIANT)
+    if benchmark_id in cross_surface_gates:
+        oracles.append(ORACLE_CROSS_SURFACE)
+    return oracles
+
+
+def primary_oracle(oracles: list[str]) -> str:
+    for kind in _ORACLE_PRIORITY:
+        if kind in oracles:
+            return kind
+    return ORACLE_NONE
+
+
+def _surfaces(metadata: dict[str, Any]) -> tuple[bool, bool]:
+    """Return ``(has_sql, has_dataframe)`` for a benchmark's metadata.
+
+    Every shipped benchmark exposes SQL queries (``num_queries`` > 0); DataFrame
+    is gated by the registry's ``supports_dataframe`` flag.
+    """
+    has_sql = bool(metadata.get("num_queries") or 0)
+    has_dataframe = bool(metadata.get("supports_dataframe", False))
+    return has_sql, has_dataframe
+
+
+def build_coverage_map() -> list[dict[str, Any]]:
+    """Build the coverage matrix: one classified row per shipped benchmark."""
+    from benchbox.core.benchmark_registry import get_benchmark_metadata, list_benchmark_ids
+    from benchbox.core.equivalence.cross_surface import GATES
+    from benchbox.core.expected_results.registry import get_registry
+
+    expected_results_providers = set(get_registry().list_available_benchmarks())
+    cross_surface_gates = set(GATES.keys())
+
+    rows: list[dict[str, Any]] = []
+    for benchmark_id in sorted(list_benchmark_ids()):
+        metadata = get_benchmark_metadata(benchmark_id) or {}
+        has_sql, has_dataframe = _surfaces(metadata)
+        surfaces = [s for s, present in (("sql", has_sql), ("dataframe", has_dataframe)) if present]
+        oracles = classify_oracles(
+            benchmark_id,
+            expected_results_providers=expected_results_providers,
+            cross_surface_gates=cross_surface_gates,
+        )
+        primary = primary_oracle(oracles)
+        # A dual-surface benchmark with no oracle is reachable by the cross-surface
+        # SQL<->DataFrame gate (the w1 dispatch target). A single-surface benchmark
+        # is not and needs a fallback oracle (w2).
+        dual_surface = has_sql and has_dataframe
+        rows.append(
+            {
+                "benchmark": benchmark_id,
+                "surfaces": surfaces,
+                "dual_surface": dual_surface,
+                "oracles": oracles,
+                "primary_oracle": primary,
+                "guarded": primary != ORACLE_NONE,
+                "cross_surface_applicable": dual_surface and primary == ORACLE_NONE,
+            }
+        )
+    return rows
+
+
+def render_markdown(rows: list[dict[str, Any]]) -> str:
+    guarded = [r for r in rows if r["guarded"]]
+    unguarded = [r for r in rows if not r["guarded"]]
+    dispatchable = [r for r in unguarded if r["cross_surface_applicable"]]
+    single_surface_gap = [r for r in unguarded if not r["cross_surface_applicable"]]
+
+    lines: list[str] = []
+    lines.append("# Benchmark correctness-oracle coverage map")
+    lines.append("")
+    lines.append(
+        "**Generated** by `_project/scripts/generate_oracle_coverage_map.py` from the "
+        "benchmark registry, the expected-results provider registry, and the "
+        "equivalence-gate registries. Do not edit by hand — run the generator and "
+        "commit. `tests/unit/test_oracle_coverage_map.py` fails if this drifts."
+    )
+    lines.append("")
+    lines.append(
+        f"**Summary:** {len(rows)} shipped benchmarks — {len(guarded)} guarded, "
+        f"{len(unguarded)} UNGUARDED ({len(dispatchable)} reachable by the "
+        f"cross-surface gate, {len(single_surface_gap)} single-surface needing a "
+        f"fallback oracle)."
+    )
+    lines.append("")
+    lines.append("| Benchmark | Surfaces | Oracle | Notes |")
+    lines.append("| --- | --- | --- | --- |")
+    for r in rows:
+        surfaces = "+".join(r["surfaces"]) or "—"
+        oracle = r["primary_oracle"]
+        if r["guarded"]:
+            note = ", ".join(r["oracles"])
+        elif r["cross_surface_applicable"]:
+            note = "dual-surface → dispatch to cross-surface gate (w1)"
+        else:
+            note = "single-surface → needs fallback oracle (w2)"
+        lines.append(f"| {r['benchmark']} | {surfaces} | {oracle} | {note} |")
+    lines.append("")
+    lines.append("## UNGUARDED benchmarks")
+    lines.append("")
+    lines.append(
+        "These ship with no automated correctness oracle today. Dual-surface ones "
+        "are dispatched to `benchmark-cross-surface-equivalence-gate` (w1); "
+        "single-surface ones need a per-benchmark fallback — differential vs a "
+        "second engine, a small curated expected-results subset, or a documented "
+        "structural invariant (w2)."
+    )
+    lines.append("")
+    lines.append(
+        "> Caveat (w2 oracle choice): write/DML/nondeterministic benchmarks "
+        "(`write_primitives`, `transaction_primitives`, `metadata_primitives`, "
+        "`tpcdi`) are listed as dual-surface, but their two surfaces may not be "
+        "result-comparable; prefer structural-invariant oracles (row counts, "
+        "post-state assertions) over cross-surface equality for those."
+    )
+    lines.append("")
+    lines.append(
+        "- Dual-surface (cross-surface candidates): " + (", ".join(r["benchmark"] for r in dispatchable) or "none")
+    )
+    lines.append(
+        "- Single-surface (fallback-oracle needed): "
+        + (", ".join(r["benchmark"] for r in single_surface_gap) or "none")
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_json(rows: list[dict[str, Any]]) -> str:
+    return json.dumps({"benchmarks": rows}, indent=2, sort_keys=True) + "\n"
+
+
+def write_artifacts(rows: list[dict[str, Any]]) -> None:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_ARTIFACT.write_text(render_json(rows), encoding="utf-8")
+    MARKDOWN_ARTIFACT.write_text(render_markdown(rows), encoding="utf-8")
+
+
+def check_artifacts(rows: list[dict[str, Any]]) -> list[str]:
+    """Return a list of human-readable drift problems (empty == in sync)."""
+    problems: list[str] = []
+    expected_json = render_json(rows)
+    expected_md = render_markdown(rows)
+    for path, expected in ((JSON_ARTIFACT, expected_json), (MARKDOWN_ARTIFACT, expected_md)):
+        if not path.exists():
+            problems.append(f"missing artifact: {path.relative_to(_REPO_ROOT)} (run the generator)")
+        elif path.read_text(encoding="utf-8") != expected:
+            problems.append(f"stale artifact: {path.relative_to(_REPO_ROOT)} (run the generator and commit)")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the checked-in artifacts are current; non-zero exit if stale.",
+    )
+    args = parser.parse_args(argv)
+
+    rows = build_coverage_map()
+    if args.check:
+        problems = check_artifacts(rows)
+        if problems:
+            print("oracle coverage map is out of date:")
+            for problem in problems:
+                print(f"  - {problem}")
+            return 1
+        print("oracle coverage map is up to date.")
+        return 0
+
+    write_artifacts(rows)
+    unguarded = [r["benchmark"] for r in rows if not r["guarded"]]
+    print(f"Wrote {MARKDOWN_ARTIFACT.relative_to(_REPO_ROOT)} and {JSON_ARTIFACT.relative_to(_REPO_ROOT)}")
+    print(f"{len(rows)} benchmarks, {len(unguarded)} UNGUARDED: {', '.join(unguarded)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_oracle_coverage_map.py
+++ b/tests/unit/test_oracle_coverage_map.py
@@ -1,0 +1,83 @@
+"""Guards for the benchmark correctness-oracle coverage map (w0/w3).
+
+These keep the generated map (``_project/analysis/oracle-coverage-map.{md,json}``)
+honest and current:
+
+  - drift: the checked-in artifacts must match a fresh regeneration, so the map
+    cannot silently fall behind the registry / gates;
+  - completeness: every shipped benchmark is classified;
+  - exemplars: the known oracles (tpch/tpcds expected-results, tpchavoc variant
+    gate, ssb cross-surface) stay classified as such (locks in must_preserve);
+  - new-benchmark visibility: a newly added benchmark with no oracle changes the
+    generated map, which trips the drift check — forcing the author to regenerate
+    and consciously record it as UNGUARDED rather than discovering it later.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# The generator lives in _project/scripts (a project tool, not shipped in the
+# package); ensure the repo root is importable so `_project.scripts` resolves.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from _project.scripts.generate_oracle_coverage_map import (  # noqa: E402
+    ORACLE_CROSS_SURFACE,
+    ORACLE_EXPECTED_RESULTS,
+    ORACLE_NONE,
+    ORACLE_VARIANT_EQUIVALENCE,
+    build_coverage_map,
+    check_artifacts,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+@pytest.fixture(scope="module")
+def rows() -> list[dict]:
+    return build_coverage_map()
+
+
+def test_checked_in_artifacts_are_current(rows):
+    """The committed map must match a fresh regeneration (run the generator + commit)."""
+    problems = check_artifacts(rows)
+    assert not problems, "oracle coverage map is stale:\n" + "\n".join(problems)
+
+
+def test_every_shipped_benchmark_is_classified(rows):
+    """Every registry benchmark appears exactly once with a primary oracle."""
+    from benchbox.core.benchmark_registry import list_benchmark_ids
+
+    mapped = {r["benchmark"] for r in rows}
+    assert mapped == set(list_benchmark_ids()), "coverage map and registry disagree on benchmark set"
+    assert len(rows) == len(mapped), "duplicate benchmark rows in coverage map"
+    for r in rows:
+        assert r["primary_oracle"], f"{r['benchmark']} has no primary_oracle classification"
+        assert (r["primary_oracle"] == ORACLE_NONE) == (not r["guarded"]), (
+            f"{r['benchmark']} guarded/primary_oracle disagree"
+        )
+
+
+def test_known_oracles_stay_classified(rows):
+    """The existing oracles must remain recognized (must_preserve)."""
+    by_id = {r["benchmark"]: r for r in rows}
+    assert ORACLE_EXPECTED_RESULTS in by_id["tpch"]["oracles"]
+    assert ORACLE_EXPECTED_RESULTS in by_id["tpcds"]["oracles"]
+    assert ORACLE_VARIANT_EQUIVALENCE in by_id["tpchavoc"]["oracles"]
+    assert ORACLE_CROSS_SURFACE in by_id["ssb"]["oracles"]
+
+
+def test_cross_surface_applicable_implies_dual_surface_and_unguarded(rows):
+    """The w1 dispatch flag must be self-consistent."""
+    for r in rows:
+        if r["cross_surface_applicable"]:
+            assert r["dual_surface"], f"{r['benchmark']} flagged cross-surface but is single-surface"
+            assert not r["guarded"], f"{r['benchmark']} flagged cross-surface but already guarded"


### PR DESCRIPTION
Implements **w0 + w3** of `benchmark-correctness-oracle-coverage-map`: make the
"which correctness oracle guards each benchmark?" gap legible and
regression-proof. It deliberately does **not** build the per-benchmark oracles
(w1/w2) — those remain the open campaign the map now dispatches.

## w0 — generated coverage matrix
`_project/scripts/generate_oracle_coverage_map.py` derives the matrix from live
sources (no hand-maintained doc to rot):
- benchmark registry — surfaces (`num_queries` → SQL, `supports_dataframe` → DF);
- expected-results provider registry;
- cross-surface `GATES` registry;
- TPC-Havoc gate-module presence.

It emits checked-in artifacts `_project/analysis/oracle-coverage-map.{md,json}`.

**Current state of 23 benchmarks: 4 GUARDED, 19 UNGUARDED.**
- Guarded: `tpch`/`tpcds` (expected-results), `tpchavoc` (variant + cross-surface-variant), `ssb` (cross-surface).
- Unguarded: 17 dual-surface (cross-surface gate candidates, w1) + 2 single-surface SQL-only (`ai_primitives`, `vector_search`, need a fallback oracle, w2).

## w3 — visibility guard (no silent regression)
`make oracle-coverage-map-check` (generator `--check`) fails when the committed
map is stale. CI surfacing on develop PRs via **two** paths:
- the fast unit test `tests/unit/test_oracle_coverage_map.py` runs in the `code-test` job (`-m fast`);
- an explicit `make oracle-coverage-map-check` step in the `code-lint` job (next to `compat-docs-check`), also in the `ci-lint` aggregate for local `make pr-preflight` parity.

Adding a benchmark changes the generated map → the drift check fails → the author
must regenerate and commit, which surfaces the new benchmark's UNGUARDED
classification in review rather than letting it slip in later.

## Verification
- `tests/unit/test_oracle_coverage_map.py` — 4/4 pass (drift, completeness, exemplars, dispatch-flag consistency).
- `make oracle-coverage-map-check` green on clean tree, non-zero on a mutated artifact.
- `ruff check`/`format` + `ty check` clean; `make artifact-hygiene` clean; TODO validates + graph passes.
- Code review (1 agent) run; its one finding (ci-lint runs post-merge, not on PRs) is fixed by the explicit pr.yml `code-lint` step in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_