### PR TITLE
fix(dataframe): two loader fidelity fixes surfaced by the cross-surface gate

### DIFF
--- a/benchbox/core/dataframe/data_loader.py
+++ b/benchbox/core/dataframe/data_loader.py
@@ -167,6 +167,10 @@ class SchemaMapper:
         "CHAR": "Utf8",
         "DATE": "Date",
         "TIMESTAMP": "Datetime",
+        # TIME has no reliable DataFrame dtype across backends (pyarrow->Parquet->Polars
+        # yields an all-null Time column; pandas has no time-only dtype), so load it as a
+        # string and let query impls parse the components, matching the SQL hour(time).
+        "TIME": "Utf8",
     }
 
     # Mapping from TPC DataType enum values to Pandas types
@@ -177,6 +181,7 @@ class SchemaMapper:
         "CHAR": "object",
         "DATE": "datetime64[ns]",
         "TIMESTAMP": "datetime64[ns]",
+        "TIME": "object",
     }
 
     # Mapping for PyArrow types (used in Parquet conversion)
@@ -187,6 +192,7 @@ class SchemaMapper:
         "CHAR": "string",
         "DATE": "date32",
         "TIMESTAMP": "timestamp[us]",
+        "TIME": "string",
     }
 
     @classmethod

--- a/benchbox/platforms/dataframe/pandas_family.py
+++ b/benchbox/platforms/dataframe/pandas_family.py
@@ -1076,22 +1076,39 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
         else:
             # CSV or TBL
             actual_delimiter = delimiter if delimiter is not None else ("|" if format_type == "tbl" else ",")
-            has_header = format_type == "csv"
 
-            # Resolve null_marker for trailing-delimiter probing via the resolver when a
+            # Resolve the CSV dialect (has_header + null_marker) via the resolver when a
             # DataSource is available (manifest path).  Without one, derive from format_type
             # so .tbl files (format_type=="tbl") keep their existing trailing-delimiter behaviour.
             # When benchmark=None, NO_BENCHMARK is used: path (a) wins when table_metadata is
             # present; otherwise path (c) of resolve_csv_dialect derives null_marker from the
             # file extension (.tbl/.dat → "", everything else → None), which is correct.
+            #
+            # has_header MUST come from the dialect, not the file extension: the SQL loaders
+            # (e.g. DuckDB) honor csv_has_header and default to headerless, so assuming every
+            # .csv carries a header here silently drops the first data row of headerless .csv
+            # benchmarks (e.g. CoffeeShop), diverging the DataFrame surface from SQL.
             if data_source is not None:
                 from benchbox.platforms.base.data_loading import NO_BENCHMARK, resolve_csv_dialect
 
                 bm = benchmark if benchmark is not None else NO_BENCHMARK
                 _dialect = resolve_csv_dialect(data_source, table_name, first_file, bm)
                 null_marker: str | None = _dialect.null_marker
-            else:
+                has_header = _dialect.has_header
+            elif benchmark is not None:
                 null_marker = "" if format_type == "tbl" else None
+                # No DataSource, but a known benchmark (e.g. the cross-surface gate loads
+                # straight from a benchmark instance): honor its declared csv_has_header,
+                # defaulting to headerless - matching resolve_csv_dialect's default and
+                # DuckDB's header=false - rather than assuming every .csv has a header,
+                # which silently drops the first data row of headerless benchmark .csv.
+                bench_header = getattr(benchmark, "csv_has_header", None)
+                has_header = bool(bench_header) if bench_header is not None else False
+            else:
+                # Ad-hoc load with no benchmark/DataSource: keep the file-extension
+                # heuristic that treats a bare .csv as headered.
+                null_marker = "" if format_type == "tbl" else None
+                has_header = format_type == "csv"
 
             # Pull this table's declared SQL types (parallel to column_names) from
             # the benchmark schema so numeric columns named like dates (e.g. SSB's

--- a/tests/unit/core/dataframe/test_data_loader_behavioral.py
+++ b/tests/unit/core/dataframe/test_data_loader_behavioral.py
@@ -53,7 +53,7 @@ class TestSchemaMapperTypeMaps:
 
     def test_polars_type_map_keys(self):
         """Verify all expected SQL types are mapped to Polars types."""
-        expected_sql_types = {"INTEGER", "DECIMAL(15,2)", "VARCHAR", "CHAR", "DATE", "TIMESTAMP"}
+        expected_sql_types = {"INTEGER", "DECIMAL(15,2)", "VARCHAR", "CHAR", "DATE", "TIMESTAMP", "TIME"}
         assert set(SchemaMapper.POLARS_TYPE_MAP.keys()) == expected_sql_types
 
     def test_polars_type_map_values_are_valid_polars_types(self):


### PR DESCRIPTION
## Summary

Running a benchmark's DataFrame surface through the production loader (instead of the old DuckDB→Arrow shortcut) surfaced two genuine loader-level data-fidelity bugs. Both caused the DataFrame surface to silently disagree with the DuckDB SQL reference. Fixed here at the loader layer, so **any** benchmark with headerless CSVs or `TIME` columns benefits — not just the one that surfaced them.

## The bugs

**1. Headerless CSV first-row drop.** The pandas loader assumed every `.csv` has a header (`has_header = format_type == "csv"`). BenchBox benchmark CSVs are headerless, so the loader consumed the **first data row** as column names — loading e.g. 1,325,999 rows where DuckDB loads 1,326,000. This was the root cause of every off-by-one cross-surface mismatch.

Fix: honor the benchmark's declared `csv_has_header` (default headerless, matching how DuckDB reads the same files). Ad-hoc/non-benchmark loads keep the original heuristic.

**2. `TIME` columns load as all-null.** `TIME` had no entry in the DataFrame schema type maps, so it fell through to type inference. In the Parquet path pyarrow infers a time type and Polars reads it back as an **all-null** `Time` column; pandas has no time-only dtype at all. Either way the values were lost, breaking time-of-day queries.

Fix: map `TIME` → string (`Utf8`/`object`/`string`) across the Polars/pandas/PyArrow maps so `TIME` columns load as their `"HH:MM:SS"` text and query impls parse the components, matching SQL's `hour(time)`.

## Testing

- `tests/unit/platforms/dataframe/` + `tests/unit/core/dataframe/` — full suites pass (1,100+ tests)
- Type-map key test updated for the new `TIME` entry
- Verified end-to-end: with these fixes the coffeeshop DataFrame surface matches the DuckDB SQL reference on all cross-surface cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_