### PR TITLE
fix(coffeeshop): correct DataFrame impl bugs to match the SQL reference

### DIFF
--- a/benchbox/core/coffeeshop/dataframe_queries/queries.py
+++ b/benchbox/core/coffeeshop/dataframe_queries/queries.py
@@ -83,8 +83,13 @@ def sa1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
-    merged = filtered.merge(dl, left_on="location_record_id", right_on="record_id")
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    # order_lines is denormalized (carries its own location_id/region); drop those
+    # before the join so the grouped/filtered columns come from dim_locations, as
+    # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
+    merged = filtered.drop(columns=["location_id", "region"]).merge(
+        dl, left_on="location_record_id", right_on="record_id"
+    )
     grouped = merged.groupby(["order_date", "region"], as_index=False).agg(
         order_count=("order_id", "nunique"),
         gross_revenue=("total_price", "sum"),
@@ -115,7 +120,7 @@ def sa2_expression_impl(ctx: DataFrameContext) -> Any:
         ol.with_columns(col("order_date").dt.year().alias("year"))
         .filter(col("year") == lit(year))
         .join(dp, left_on="product_record_id", right_on="record_id")
-        .group_by("subcategory", "product_name")
+        .group_by("subcategory", "name")
         .agg(
             col("quantity").sum().alias("total_quantity"),
             col("total_price").sum().alias("total_revenue"),
@@ -134,7 +139,10 @@ def sa2_pandas_impl(ctx: DataFrameContext) -> Any:
     ol = ctx.get_table("order_lines")
     dp = ctx.get_table("dim_products")
     filtered = ol[ol["order_date"].dt.year == year]
-    merged = filtered.merge(dp, left_on="product_record_id", right_on="record_id")
+    # Drop order_lines' denormalized product_id before the join so dim_products'
+    # columns (product_id/name/subcategory/validity) are used unambiguously, as
+    # the SQL does, rather than pandas suffixing the product_id collision.
+    merged = filtered.drop(columns=["product_id"]).merge(dp, left_on="product_record_id", right_on="record_id")
     return (
         merged.groupby(["subcategory", "name"], as_index=False)
         .agg(total_quantity=("quantity", "sum"), total_revenue=("total_price", "sum"))
@@ -248,8 +256,13 @@ def sa4_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
-    merged = filtered.merge(dl, left_on="location_record_id", right_on="record_id")
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    # order_lines is denormalized (carries its own location_id/region); drop those
+    # before the join so the grouped/filtered columns come from dim_locations, as
+    # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
+    merged = filtered.drop(columns=["location_id", "region"]).merge(
+        dl, left_on="location_record_id", right_on="record_id"
+    )
     grouped = merged.groupby(["region"], as_index=False).agg(
         orders=("order_id", "nunique"),
         revenue=("total_price", "sum"),
@@ -301,8 +314,13 @@ def sa5_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
-    merged = filtered.merge(dl, left_on="location_record_id", right_on="record_id")
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    # order_lines is denormalized (carries its own location_id/region); drop those
+    # before the join so the grouped/filtered columns come from dim_locations, as
+    # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
+    merged = filtered.drop(columns=["location_id", "region"]).merge(
+        dl, left_on="location_record_id", right_on="record_id"
+    )
     return (
         merged.groupby(["location_id", "city", "state", "region"], as_index=False)
         .agg(orders=("order_id", "nunique"), revenue=("total_price", "sum"), avg_line_value=("total_price", "mean"))
@@ -351,8 +369,11 @@ def pr1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dp = ctx.get_table("dim_products")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
-    merged = filtered.merge(dp, left_on="product_record_id", right_on="record_id")
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    # Drop order_lines' denormalized product_id before the join so dim_products'
+    # columns (product_id/name/subcategory/validity) are used unambiguously, as
+    # the SQL does, rather than pandas suffixing the product_id collision.
+    merged = filtered.drop(columns=["product_id"]).merge(dp, left_on="product_record_id", right_on="record_id")
     merged = merged[(merged["order_date"] >= merged["from_date"]) & (merged["order_date"] <= merged["to_date"])]
     return (
         merged.groupby(["subcategory"], as_index=False)
@@ -410,7 +431,7 @@ def pr2_pandas_impl(ctx: DataFrameContext) -> Any:
     end_date = params.get("end_date", "2024-12-31")
 
     ol = ctx.get_table("order_lines")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)].copy()
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))].copy()
     conditions = [
         filtered["unit_price"] < 4,
         filtered["unit_price"] < 6,
@@ -536,8 +557,13 @@ def tm1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
-    merged = filtered.merge(dl, left_on="location_record_id", right_on="record_id")
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    # order_lines is denormalized (carries its own location_id/region); drop those
+    # before the join so the grouped/filtered columns come from dim_locations, as
+    # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
+    merged = filtered.drop(columns=["location_id", "region"]).merge(
+        dl, left_on="location_record_id", right_on="record_id"
+    )
     merged = merged[merged["region"] == region].copy()
     merged["hour"] = merged["order_time"].dt.hour
     conditions = [
@@ -595,7 +621,7 @@ def qc1_pandas_impl(ctx: DataFrameContext) -> Any:
     end_date = params.get("end_date", "2024-12-31")
 
     ol = ctx.get_table("order_lines")
-    filtered = ol[(ol["order_date"] >= start_date) & (ol["order_date"] <= end_date)]
+    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
     total_lines = len(filtered)
     unique_orders = filtered["order_id"].nunique()
     total_items = filtered["quantity"].sum()
@@ -660,7 +686,12 @@ def qc2_pandas_impl(ctx: DataFrameContext) -> Any:
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
     filtered = ol[(ol["order_date"].dt.year >= start_year) & (ol["order_date"].dt.year <= end_year)].copy()
-    merged = filtered.merge(dl, left_on="location_record_id", right_on="record_id")
+    # order_lines is denormalized (carries its own location_id/region); drop those
+    # before the join so the grouped/filtered columns come from dim_locations, as
+    # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
+    merged = filtered.drop(columns=["location_id", "region"]).merge(
+        dl, left_on="location_record_id", right_on="record_id"
+    )
     month = merged["order_date"].dt.month
     conditions = [
         month.isin([12, 1, 2]),

--- a/benchbox/core/coffeeshop/dataframe_queries/queries.py
+++ b/benchbox/core/coffeeshop/dataframe_queries/queries.py
@@ -565,7 +565,9 @@ def tm1_pandas_impl(ctx: DataFrameContext) -> Any:
         dl, left_on="location_record_id", right_on="record_id"
     )
     merged = merged[merged["region"] == region].copy()
-    merged["hour"] = merged["order_time"].dt.hour
+    # order_time is loaded as an "HH:MM:SS" string; parse the hour from the leading
+    # two characters rather than via .dt (matching the SQL's hour(order_time)).
+    merged["hour"] = merged["order_time"].astype("string").str[:2].astype("int64")
     conditions = [
         (merged["hour"] >= 5) & (merged["hour"] <= 10),
         (merged["hour"] >= 11) & (merged["hour"] <= 14),

--- a/benchbox/core/coffeeshop/dataframe_queries/queries.py
+++ b/benchbox/core/coffeeshop/dataframe_queries/queries.py
@@ -31,6 +31,24 @@ def _parse_date(value: str | date) -> date:
     return date.fromisoformat(value)
 
 
+def _date_between(series: Any, start: str | date, end: str | date) -> Any:
+    """Boolean mask selecting an order_date column within [start, end] (inclusive).
+
+    Production loads DATE columns as pyarrow ``date32`` (date-valued), so comparing
+    against ``datetime.date`` bounds is correct. Some contexts/fixtures instead
+    provide ``datetime64[ns]``; pandas refuses to compare those against ``date``, so
+    align the bounds to ``Timestamp`` when the column is datetime-typed.
+    """
+    import pandas as pd
+
+    low, high = _parse_date(start), _parse_date(end)
+    # Guard the dtype check with isinstance so non-Series inputs (e.g. expression
+    # mocks in unit tests) skip introspection and just use the comparison operators.
+    if isinstance(series, pd.Series) and pd.api.types.is_datetime64_any_dtype(series):
+        low, high = pd.Timestamp(low), pd.Timestamp(high)
+    return (series >= low) & (series <= high)
+
+
 from benchbox.core.dataframe.context import DataFrameContext
 from benchbox.core.dataframe.query import DataFrameQuery, QueryCategory
 
@@ -83,11 +101,11 @@ def sa1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     # order_lines is denormalized (carries its own location_id/region); drop those
     # before the join so the grouped/filtered columns come from dim_locations, as
     # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
-    merged = filtered.drop(columns=["location_id", "region"]).merge(
+    merged = filtered.drop(columns=["location_id", "region"], errors="ignore").merge(
         dl, left_on="location_record_id", right_on="record_id"
     )
     grouped = merged.groupby(["order_date", "region"], as_index=False).agg(
@@ -125,6 +143,8 @@ def sa2_expression_impl(ctx: DataFrameContext) -> Any:
             col("quantity").sum().alias("total_quantity"),
             col("total_price").sum().alias("total_revenue"),
         )
+        # SQL selects "dp.name AS product_name"; match that output schema.
+        .rename({"name": "product_name"})
         .sort("total_revenue", descending=True)
         .limit(limit)
     )
@@ -142,10 +162,14 @@ def sa2_pandas_impl(ctx: DataFrameContext) -> Any:
     # Drop order_lines' denormalized product_id before the join so dim_products'
     # columns (product_id/name/subcategory/validity) are used unambiguously, as
     # the SQL does, rather than pandas suffixing the product_id collision.
-    merged = filtered.drop(columns=["product_id"]).merge(dp, left_on="product_record_id", right_on="record_id")
+    merged = filtered.drop(columns=["product_id"], errors="ignore").merge(
+        dp, left_on="product_record_id", right_on="record_id"
+    )
     return (
         merged.groupby(["subcategory", "name"], as_index=False)
         .agg(total_quantity=("quantity", "sum"), total_revenue=("total_price", "sum"))
+        # SQL selects "dp.name AS product_name"; match that output schema.
+        .rename(columns={"name": "product_name"})
         .sort_values("total_revenue", ascending=False)
         .head(limit)
     )
@@ -256,11 +280,11 @@ def sa4_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     # order_lines is denormalized (carries its own location_id/region); drop those
     # before the join so the grouped/filtered columns come from dim_locations, as
     # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
-    merged = filtered.drop(columns=["location_id", "region"]).merge(
+    merged = filtered.drop(columns=["location_id", "region"], errors="ignore").merge(
         dl, left_on="location_record_id", right_on="record_id"
     )
     grouped = merged.groupby(["region"], as_index=False).agg(
@@ -314,11 +338,11 @@ def sa5_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     # order_lines is denormalized (carries its own location_id/region); drop those
     # before the join so the grouped/filtered columns come from dim_locations, as
     # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
-    merged = filtered.drop(columns=["location_id", "region"]).merge(
+    merged = filtered.drop(columns=["location_id", "region"], errors="ignore").merge(
         dl, left_on="location_record_id", right_on="record_id"
     )
     return (
@@ -369,11 +393,13 @@ def pr1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dp = ctx.get_table("dim_products")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     # Drop order_lines' denormalized product_id before the join so dim_products'
     # columns (product_id/name/subcategory/validity) are used unambiguously, as
     # the SQL does, rather than pandas suffixing the product_id collision.
-    merged = filtered.drop(columns=["product_id"]).merge(dp, left_on="product_record_id", right_on="record_id")
+    merged = filtered.drop(columns=["product_id"], errors="ignore").merge(
+        dp, left_on="product_record_id", right_on="record_id"
+    )
     merged = merged[(merged["order_date"] >= merged["from_date"]) & (merged["order_date"] <= merged["to_date"])]
     return (
         merged.groupby(["subcategory"], as_index=False)
@@ -431,7 +457,7 @@ def pr2_pandas_impl(ctx: DataFrameContext) -> Any:
     end_date = params.get("end_date", "2024-12-31")
 
     ol = ctx.get_table("order_lines")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))].copy()
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)].copy()
     conditions = [
         filtered["unit_price"] < 4,
         filtered["unit_price"] < 6,
@@ -560,11 +586,11 @@ def tm1_pandas_impl(ctx: DataFrameContext) -> Any:
 
     ol = ctx.get_table("order_lines")
     dl = ctx.get_table("dim_locations")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     # order_lines is denormalized (carries its own location_id/region); drop those
     # before the join so the grouped/filtered columns come from dim_locations, as
     # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
-    merged = filtered.drop(columns=["location_id", "region"]).merge(
+    merged = filtered.drop(columns=["location_id", "region"], errors="ignore").merge(
         dl, left_on="location_record_id", right_on="record_id"
     )
     merged = merged[merged["region"] == region].copy()
@@ -626,7 +652,7 @@ def qc1_pandas_impl(ctx: DataFrameContext) -> Any:
     end_date = params.get("end_date", "2024-12-31")
 
     ol = ctx.get_table("order_lines")
-    filtered = ol[(ol["order_date"] >= _parse_date(start_date)) & (ol["order_date"] <= _parse_date(end_date))]
+    filtered = ol[_date_between(ol["order_date"], start_date, end_date)]
     total_lines = len(filtered)
     unique_orders = filtered["order_id"].nunique()
     total_items = filtered["quantity"].sum()
@@ -694,7 +720,7 @@ def qc2_pandas_impl(ctx: DataFrameContext) -> Any:
     # order_lines is denormalized (carries its own location_id/region); drop those
     # before the join so the grouped/filtered columns come from dim_locations, as
     # the SQL uses (dl.*), instead of pandas suffixing the collision to _x/_y.
-    merged = filtered.drop(columns=["location_id", "region"]).merge(
+    merged = filtered.drop(columns=["location_id", "region"], errors="ignore").merge(
         dl, left_on="location_record_id", right_on="record_id"
     )
     month = merged["order_date"].dt.month

--- a/benchbox/core/coffeeshop/dataframe_queries/queries.py
+++ b/benchbox/core/coffeeshop/dataframe_queries/queries.py
@@ -520,7 +520,10 @@ def tm1_expression_impl(ctx: DataFrameContext) -> Any:
         .join(dl, left_on="location_record_id", right_on="record_id")
         .filter(col("region") == lit(region))
     )
-    with_hour = joined.with_columns(col("order_time").dt.hour().alias("hour"))
+    # order_time is loaded as an "HH:MM:SS" string (TIME has no reliable DataFrame
+    # dtype), so parse the hour from the leading two characters rather than via a
+    # datetime accessor, matching the SQL's hour(order_time).
+    with_hour = joined.with_columns(col("order_time").str.slice(0, 2).cast_int().alias("hour"))
     with_part = with_hour.with_columns(
         ctx.when((col("hour") >= lit(5)) & (col("hour") <= lit(10)))
         .then(lit("Morning"))

--- a/tests/unit/core/coffeeshop/test_coffeeshop_query_impls.py
+++ b/tests/unit/core/coffeeshop/test_coffeeshop_query_impls.py
@@ -153,9 +153,9 @@ def _pandas_ctx():
             "total_price": [5.0, 3.0, 8.0, 4.0],
             "quantity": [1, 2, 1, 1],
             "unit_price": [5.0, 3.0, 8.0, 4.0],
-            "order_time": pd.to_datetime(
-                ["2023-01-10 08:00", "2023-01-10 12:00", "2023-01-15 16:00", "2024-06-01 20:00"]
-            ),
+            # Production loads TIME columns as "HH:MM:SS" strings (TIME has no
+            # reliable DataFrame dtype), so the fixture mirrors that contract.
+            "order_time": ["08:00:00", "12:00:00", "16:00:00", "20:00:00"],
         }
     )
     dim_locations = pd.DataFrame(
@@ -171,7 +171,6 @@ def _pandas_ctx():
         {
             "record_id": [10, 20],
             "subcategory": ["Coffee", "Tea"],
-            "product_name": ["Espresso", "Green Tea"],
             "name": ["Espresso", "Green Tea"],
             "product_id": [1001, 1002],
             "from_date": pd.to_datetime(["2022-01-01", "2022-01-01"]),
@@ -309,7 +308,7 @@ def test_sa5_expression_impl():
 def test_sa5_pandas_impl():
     from benchbox.core.coffeeshop.dataframe_queries.queries import sa5_pandas_impl
 
-    ctx = _mock_ctx()
+    ctx = _pandas_ctx()
     result = sa5_pandas_impl(ctx)
     assert result is not None
 
@@ -330,7 +329,7 @@ def test_pr1_expression_impl():
 def test_pr1_pandas_impl():
     from benchbox.core.coffeeshop.dataframe_queries.queries import pr1_pandas_impl
 
-    ctx = _mock_ctx()
+    ctx = _pandas_ctx()
     result = pr1_pandas_impl(ctx)
     assert result is not None
 

--- a/tests/unit/core/test_dataframe_query_execution.py
+++ b/tests/unit/core/test_dataframe_query_execution.py
@@ -396,7 +396,9 @@ class TestCoffeeShopDataFrameQueriesExecution:
             {
                 "record_id": [1, 2],
                 "product_id": [101, 102],
-                "product_name": ["Latte", "Espresso"],
+                # Production dim_products exposes the raw column as "name"; SA2's SQL
+                # aliases it to product_name in its output.
+                "name": ["Latte", "Espresso"],
                 "category": ["Hot Drinks", "Hot Drinks"],
                 "subcategory": ["Coffee", "Coffee"],
                 "cost": [1.50, 1.00],


### PR DESCRIPTION
## Summary

Burns down the CoffeeShop DataFrame surface against the DuckDB SQL reference via the cross-surface equivalence gate. Fixes the benchmark-level impl bugs that made the Expression and pandas surfaces disagree with SQL. With this **all 22 cross-surface cells (11 queries × {expression, pandas}) match the SQL reference**.

## Fixes

- **date32-vs-string comparisons** crashed/mis-filtered → parse the date literal before comparing
- **dimension-join collisions**: the denormalized fact carries `region`/`location_id`/`product_id`, colliding with dim columns on join → drop duplicate keys before merge and read from the dim columns
- **`sa2_expression`** selected `product_name` where the dim column is `name`
- **TM1 day-part hour**: parse the hour from the `order_time` `"HH:MM:SS"` string (both backends) rather than a datetime accessor, matching SQL's `hour(order_time)`

## Dependency

> [!IMPORTANT]
> Depends on #836. The TM1 expression fix assumes `TIME` columns load as strings (fixed in #836), and full green also requires the headerless-CSV fix there. **Merge #836 first** (or merge them together); this branch alone is not fully green on `develop`.

## Testing

Verified end-to-end with #836 applied: the cross-surface gate reports **zero divergences** across all 11 CoffeeShop queries on both DataFrame backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_