### PR TITLE
feat(correctness): cross-surface applicability sweep re-scopes the gate campaign (w2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report oracle-coverage-map oracle-coverage-map-check compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -188,6 +188,12 @@ oracle-coverage-map:
 # benchmark was added without regenerating, hiding an UNGUARDED surface).
 oracle-coverage-map-check:
 	uv run -- python _project/scripts/generate_oracle_coverage_map.py --check
+
+# Cross-surface applicability drill-down (report mode): which dual-surface
+# unguarded benchmarks actually ship comparable DataFrame queries (cross-surface
+# gateable) vs which only support DataFrame loading (need a w2 fallback oracle).
+cross-surface-applicability-report:
+	uv run -- python _project/scripts/cross_surface_applicability_sweep.py
 
 # Real benchmark matrix across local SQL platforms x all benchmarks (heavy, opt-in)
 test-local-matrix:

--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -236,6 +236,30 @@ work:
       clean but is re-confirmed there. Remaining ungated benchmarks are reported on
       the production substrate as each gate is built (now needs w5/w6/w7).
 
+      APPLICABILITY SWEEP (new): before running gates, a sweep
+      (_project/scripts/cross_surface_applicability_sweep.py ->
+      _project/analysis/cross-surface-applicability.md, locked by
+      tests/unit/test_cross_surface_applicability.py) found that the coverage map's
+      cross-surface candidate set is a LOADING-based UPPER BOUND. Of the 17
+      dual-surface UNGUARDED benchmarks, only TWO actually ship comparable
+      DataFrame queries (authoritative production resolver):
+        - clickbench (43 sql / 43 df) and joinorder_synthetic (13/13) -> GATEABLE.
+      The other 15 (amplab, coffeeshop, datavault, flightdata, h2odb, joinorder,
+      metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew,
+      transaction_primitives, tsbs_devops, write_primitives) resolve 0 DataFrame
+      queries: `supports_dataframe=True` means DataFrame LOADING, not shipped
+      DataFrame query implementations. They are NOT cross-surface-gateable and are
+      dispatched to w2-of-the-coverage-map (fallback oracle: differential
+      second-engine or curated expected-results), NOT this gate.
+
+      So this gate's burn-down is bounded to clickbench + joinorder_synthetic.
+      CAVEAT proven during the sweep: a GENERIC build is not load-faithful (it
+      loads DataFrame contexts without the schema/headers the production loader
+      applies, yielding spurious "column not found" divergences), so enumerating
+      REAL divergence counts requires a load-faithful per-benchmark builder like
+      build_ssb_duckdb. That builder work is w3 (start with clickbench, then
+      joinorder_synthetic).
+
   - id: w3
     summary: "Burn down divergences (fix the wrong surface) or declare intentional ones"
     needs: [w2]

--- a/_project/analysis/cross-surface-applicability.md
+++ b/_project/analysis/cross-surface-applicability.md
@@ -1,0 +1,30 @@
+# Cross-surface applicability sweep
+
+**Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and asks the production DataFrame resolver how many DataFrame *queries* each actually ships. `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts cross-surface candidates.
+
+**Summary:** 17 dual-surface unguarded candidates — 2 GATEABLE (ship DataFrame queries), 15 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
+
+| Benchmark | Status | SQL queries | DataFrame queries | Note |
+| --- | --- | --- | --- | --- |
+| amplab | no-df-query-surface | 8 | 0 | → w2 fallback oracle |
+| clickbench | gateable | 43 | 43 | → cross-surface gate (w3) |
+| coffeeshop | no-df-query-surface | 11 | 0 | → w2 fallback oracle |
+| datavault | no-df-query-surface | 22 | 0 | → w2 fallback oracle |
+| flightdata | no-df-query-surface | 20 | 0 | → w2 fallback oracle |
+| h2odb | no-df-query-surface | 10 | 0 | → w2 fallback oracle |
+| joinorder | no-df-query-surface | 113 | 0 | → w2 fallback oracle |
+| joinorder_synthetic | gateable | 13 | 13 | → cross-surface gate (w3) |
+| metadata_primitives | no-df-query-surface | 62 | 0 | → w2 fallback oracle |
+| nyctaxi | no-df-query-surface | 25 | 0 | → w2 fallback oracle |
+| read_primitives | no-df-query-surface | 157 | 0 | → w2 fallback oracle |
+| tpcdi | no-df-query-surface | 38 | 0 | → w2 fallback oracle |
+| tpcds_obt | no-df-query-surface | 89 | 0 | → w2 fallback oracle |
+| tpch_skew | no-df-query-surface | 22 | 0 | → w2 fallback oracle |
+| transaction_primitives | no-df-query-surface | 23 | 0 | → w2 fallback oracle |
+| tsbs_devops | no-df-query-surface | 18 | 0 | → w2 fallback oracle |
+| write_primitives | no-df-query-surface | 109 | 0 | → w2 fallback oracle |
+
+## Campaign dispatch
+
+- **Cross-surface gate (w3)** — ships DataFrame queries, 1:1 with SQL: clickbench, joinorder_synthetic. These need a load-faithful per-benchmark builder (see the SSB builder in `benchbox.core.equivalence.cross_surface`) before the gate can enumerate real divergences; a generic build is not load-faithful.
+- **w2 fallback oracle** — no comparable DataFrame query surface, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: amplab, coffeeshop, datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives.

--- a/_project/scripts/cross_surface_applicability_sweep.py
+++ b/_project/scripts/cross_surface_applicability_sweep.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Cross-surface applicability sweep (benchmark-cross-surface-equivalence-gate w2).
+
+The oracle coverage map flags a benchmark as a cross-surface candidate when it is
+dual-surface (ships SQL queries AND has ``supports_dataframe=True``) and currently
+unguarded. But ``supports_dataframe`` is a *loading* capability flag: it does NOT
+guarantee the benchmark ships comparable DataFrame *query* implementations. The
+cross-surface gate compares a query's SQL result to its DataFrame result, so it is
+only applicable to benchmarks that actually ship DataFrame queries with 1:1 id
+correspondence to their SQL queries.
+
+This sweep drills into each cross-surface candidate from the coverage map and asks
+the authoritative production resolver
+(``benchbox.core.dataframe.query_resolution.get_dataframe_queries_for_benchmark``,
+the same path the production DataFrame adapter uses) how many DataFrame queries it
+actually resolves. The result re-scopes the unguarded-benchmark campaign:
+
+  - GATEABLE: ships DataFrame queries -> dispatch to the cross-surface gate (w3).
+  - no DataFrame query surface -> NOT cross-surface-gateable; needs a w2 fallback
+    oracle (differential second-engine or a curated expected-results subset).
+
+It is report-mode (regenerate the committed artifact); resolving DataFrame queries
+needs only a benchmark instance, not generated data, so the sweep is cheap. Note
+that running the gate to enumerate actual divergences additionally requires a
+load-faithful per-benchmark build (see the SSB builder in
+``benchbox.core.equivalence.cross_surface``); a generic build is not load-faithful
+and produces spurious column errors, so divergence COUNTS are deferred to the
+per-benchmark gate wiring (w3), starting with the two gateable benchmarks here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+ARTIFACT = _REPO_ROOT / "_project" / "analysis" / "cross-surface-applicability.md"
+
+# Scales to try when instantiating a benchmark (some reject the default small SF
+# and require a canonical scale, e.g. joinorder=1.0, tpcds_obt>=1.0). Resolving
+# DataFrame queries needs no generated data, so a larger scale here is still cheap.
+_INSTANTIATE_SCALES = (0.01, 1.0)
+
+
+def _resolve_dataframe_query_count(benchmark_id: str) -> tuple[str, dict[str, Any]]:
+    """Classify a benchmark's cross-surface applicability.
+
+    Returns ``(status, detail)`` where status is one of "gateable",
+    "no-df-query-surface", or "blocked".
+    """
+    from benchbox.core.benchmark_registry import get_benchmark_class
+    from benchbox.core.dataframe.query_resolution import get_dataframe_queries_for_benchmark
+
+    cls = get_benchmark_class(benchmark_id)
+    instance = None
+    used_scale = None
+    last_error = ""
+    for scale in _INSTANTIATE_SCALES:
+        try:
+            instance = cls(scale_factor=scale)
+            used_scale = scale
+            break
+        except Exception as exc:  # noqa: BLE001 - record why instantiation failed, do not crash the sweep
+            last_error = f"{type(exc).__name__}: {exc}"
+    if instance is None:
+        return "blocked", {"error": last_error}
+
+    try:
+        sql_count = len(instance.get_queries())
+        config = SimpleNamespace(name=benchmark_id, stream_id=0)
+        df_queries = get_dataframe_queries_for_benchmark(config, instance, 0) or []
+        df_count = len(df_queries)
+    except Exception as exc:  # noqa: BLE001 - a resolution error is a finding, not a crash
+        return "blocked", {"error": f"df-resolve {type(exc).__name__}: {exc}"}
+
+    status = "gateable" if df_count > 0 else "no-df-query-surface"
+    return status, {"sql_queries": sql_count, "df_queries": df_count, "scale": used_scale}
+
+
+def build_applicability_sweep() -> list[dict[str, Any]]:
+    """Drill into every dual-surface UNGUARDED benchmark from the coverage map."""
+    from _project.scripts.generate_oracle_coverage_map import build_coverage_map
+
+    candidates = [row["benchmark"] for row in build_coverage_map() if row["dual_surface"] and not row["guarded"]]
+    rows: list[dict[str, Any]] = []
+    for benchmark_id in candidates:
+        status, detail = _resolve_dataframe_query_count(benchmark_id)
+        rows.append({"benchmark": benchmark_id, "status": status, **detail})
+    return rows
+
+
+def render_markdown(rows: list[dict[str, Any]]) -> str:
+    gateable = [r for r in rows if r["status"] == "gateable"]
+    no_surface = [r for r in rows if r["status"] == "no-df-query-surface"]
+    blocked = [r for r in rows if r["status"] == "blocked"]
+
+    lines: list[str] = []
+    lines.append("# Cross-surface applicability sweep")
+    lines.append("")
+    lines.append(
+        "**Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. "
+        "Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage "
+        "map and asks the production DataFrame resolver how many DataFrame *queries* "
+        "each actually ships. `supports_dataframe` (the coverage map's signal) is a "
+        "DataFrame *loading* flag and over-counts cross-surface candidates."
+    )
+    lines.append("")
+    lines.append(
+        f"**Summary:** {len(rows)} dual-surface unguarded candidates — "
+        f"{len(gateable)} GATEABLE (ship DataFrame queries), "
+        f"{len(no_surface)} have no DataFrame query surface (need a w2 fallback oracle), "
+        f"{len(blocked)} blocked."
+    )
+    lines.append("")
+    lines.append("| Benchmark | Status | SQL queries | DataFrame queries | Note |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for r in rows:
+        if r["status"] == "blocked":
+            note = r.get("error", "")
+            sql_n = df_n = "—"
+        else:
+            note = "→ cross-surface gate (w3)" if r["status"] == "gateable" else "→ w2 fallback oracle"
+            sql_n = r.get("sql_queries", "—")
+            df_n = r.get("df_queries", "—")
+        lines.append(f"| {r['benchmark']} | {r['status']} | {sql_n} | {df_n} | {note} |")
+    lines.append("")
+    lines.append("## Campaign dispatch")
+    lines.append("")
+    lines.append(
+        "- **Cross-surface gate (w3)** — ships DataFrame queries, 1:1 with SQL: "
+        + (", ".join(r["benchmark"] for r in gateable) or "none")
+        + ". These need a load-faithful per-benchmark builder (see the SSB builder in "
+        "`benchbox.core.equivalence.cross_surface`) before the gate can enumerate real "
+        "divergences; a generic build is not load-faithful."
+    )
+    lines.append(
+        "- **w2 fallback oracle** — no comparable DataFrame query surface, so the "
+        "cross-surface gate cannot reach them; they need a differential second-engine "
+        "check or a curated expected-results subset: " + (", ".join(r["benchmark"] for r in no_surface) or "none") + "."
+    )
+    if blocked:
+        lines.append("- **Blocked** (instantiate/resolve): " + ", ".join(r["benchmark"] for r in blocked) + ".")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Fail if the committed artifact is stale.")
+    args = parser.parse_args(argv)
+
+    rows = build_applicability_sweep()
+    rendered = render_markdown(rows)
+    if args.check:
+        if not ARTIFACT.exists():
+            print(f"missing artifact: {ARTIFACT.relative_to(_REPO_ROOT)} (run the sweep)")
+            return 1
+        if ARTIFACT.read_text(encoding="utf-8") != rendered:
+            print(f"stale artifact: {ARTIFACT.relative_to(_REPO_ROOT)} (run the sweep and commit)")
+            return 1
+        print("cross-surface applicability sweep is up to date.")
+        return 0
+
+    ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
+    ARTIFACT.write_text(rendered, encoding="utf-8")
+    gateable = [r["benchmark"] for r in rows if r["status"] == "gateable"]
+    print(f"Wrote {ARTIFACT.relative_to(_REPO_ROOT)}")
+    print(f"{len(rows)} candidates, {len(gateable)} gateable: {', '.join(gateable)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cross_surface_applicability.py
+++ b/tests/unit/test_cross_surface_applicability.py
@@ -1,0 +1,61 @@
+"""Lock the cross-surface applicability finding (benchmark-cross-surface-equivalence-gate w2).
+
+The sweep distinguishes dual-surface benchmarks that ship comparable DataFrame
+*queries* (cross-surface gateable) from those that only support DataFrame
+*loading* (`supports_dataframe=True` but no DataFrame query surface -> need a w2
+fallback oracle). These tests pin the current gateable set and keep the committed
+artifact honest. Marked ``medium`` because resolving applicability instantiates
+every candidate benchmark.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from _project.scripts.cross_surface_applicability_sweep import (  # noqa: E402
+    ARTIFACT,
+    build_applicability_sweep,
+    render_markdown,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.medium,
+]
+
+
+@pytest.fixture(scope="module")
+def rows() -> list[dict]:
+    return build_applicability_sweep()
+
+
+def test_only_clickbench_and_joinorder_synthetic_are_gateable(rows):
+    """Exactly the two benchmarks that ship DataFrame queries are cross-surface gateable.
+
+    If this set changes (a benchmark gains/loses a DataFrame query surface), update
+    the sweep artifact and the cross-surface gate dispatch deliberately.
+    """
+    gateable = {r["benchmark"] for r in rows if r["status"] == "gateable"}
+    assert gateable == {"clickbench", "joinorder_synthetic"}, f"cross-surface gateable set changed: {sorted(gateable)}"
+
+
+def test_no_candidate_is_silently_dropped(rows):
+    """Every candidate is classified (gateable / no-df-query-surface / blocked)."""
+    assert rows, "applicability sweep produced no candidates"
+    for r in rows:
+        assert r["status"] in {"gateable", "no-df-query-surface", "blocked"}, r
+
+
+def test_committed_artifact_is_current(rows):
+    """The checked-in sweep artifact must match a fresh run."""
+    assert ARTIFACT.exists(), f"missing {ARTIFACT}"
+    assert ARTIFACT.read_text(encoding="utf-8") == render_markdown(rows), (
+        "cross-surface applicability artifact is stale; run `make cross-surface-applicability-report` and commit"
+    )


### PR DESCRIPTION
Report-mode divergence sweep for `benchmark-cross-surface-equivalence-gate` **w2**.

## The finding (re-scopes the campaign)
The oracle coverage map (#834) flags **17 dual-surface UNGUARDED** benchmarks as
cross-surface candidates. But `supports_dataframe` is a DataFrame **loading** flag
— it does **not** mean the benchmark ships comparable DataFrame **query**
implementations, which the cross-surface gate requires.

This sweep asks the authoritative production resolver
(`get_dataframe_queries_for_benchmark`, the path the production DataFrame adapter
uses) how many DataFrame queries each candidate actually ships:

| Result | Benchmarks |
| --- | --- |
| **GATEABLE** (ships DataFrame queries, 1:1 with SQL) | `clickbench` (43/43), `joinorder_synthetic` (13/13) |
| **No DataFrame query surface** → w2 fallback oracle | the other 15 (amplab, coffeeshop, datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives) |

So the cross-surface gate burn-down is **2 benchmarks, not 17**; the other 15 need
a differential second-engine or curated expected-results oracle (coverage-map w2),
not this gate.

## Proven caveat (why divergence *counts* aren't here yet)
A generic build is **not load-faithful**: it loads DataFrame contexts without the
schema/headers the production loader applies, producing spurious "column not found"
divergences (empirically demonstrated). Enumerating real divergences therefore
requires a load-faithful per-benchmark builder like `build_ssb_duckdb` — that's w3,
starting with the two gateable benchmarks.

## Deliverables
- `_project/scripts/cross_surface_applicability_sweep.py` + `make cross-surface-applicability-report` → `_project/analysis/cross-surface-applicability.md` (reproducible).
- `tests/unit/test_cross_surface_applicability.py` (medium) locks the gateable set and artifact currency.
- Cross-surface gate TODO **w2** updated with the finding + dispatch.

## Verification
- `tests/unit/test_cross_surface_applicability.py` — 3/3 pass.
- `make cross-surface-applicability-report` → up to date; `--check` clean.
- `ruff check`/`format` + `ty check` clean; TODO validates + graph passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_