### PR TITLE
fix(dataframe): bump cache version so the TIME→string fix invalidates stale caches

### DIFF
--- a/benchbox/core/dataframe/data_loader.py
+++ b/benchbox/core/dataframe/data_loader.py
@@ -70,7 +70,10 @@ logger = logging.getLogger(__name__)
 # Relative cache directory suffix (resolved against runtime CWD).
 # Unified with SQL datagen under benchmark_runs/datagen/ for data reuse.
 DEFAULT_CACHE_DIR = Path("benchmark_runs") / "datagen"
-DATAFRAME_CACHE_VERSION = "v2"
+# Bump when schema/type-conversion rules change so stale cached Parquet is not
+# silently reused on rerun. v3: TIME columns now load as strings (previously an
+# all-null Time column), so pre-v3 caches must be regenerated to pick up values.
+DATAFRAME_CACHE_VERSION = "v3"
 
 # Format subdirectory names that belong to the DataFrame cache layer.
 # Used by clear_cache() to selectively remove cached conversions without
@@ -518,7 +521,7 @@ class DataCache:
         """Get the cache path for a benchmark/SF/format combination.
 
         The cache is nested inside the canonical flat datagen directory
-        (e.g. ``tpch_sf001/parquet/v2/``), reusing the same naming
+        (e.g. ``tpch_sf001/parquet/v3/``), reusing the same naming
         convention as SQL generators via :func:`get_benchmark_runs_datagen_path`.
 
         Args:


### PR DESCRIPTION
## Summary

Follow-up to the merged #836 (which made `TIME` columns load as strings instead of an all-null `Time` column). Automated review flagged that the fidelity fix wouldn't take effect on reruns that have a pre-existing cache.

The DataFrame Parquet cache keys cache hits on source file mtime/size and write config — **not** on the schema/type-conversion rules. So a `parquet/v2` cache generated before #836 (with the all-null `Time` column) is still considered valid, and a rerun without `--force-regenerate` keeps loading the stale Parquet. The TIME values never appear until the cache is manually cleared.

## Change

Bump `DATAFRAME_CACHE_VERSION` `v2` → `v3` so caches built before the conversion change are regenerated automatically. This is the standard invalidation lever (the cache path is namespaced by version, e.g. `…/parquet/v3/`).

## Testing

- `tests/unit/core/dataframe/test_data_loader.py` passes (the version is asserted via the symbolic constant, not a hardcoded string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_