### PR TITLE
feat(equivalence): gate the CoffeeShop cross-surface SQL↔DataFrame surface

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -401,6 +401,9 @@ jobs:
       - name: Run SSB cross-surface SQL<->DataFrame equivalence gate
         run: make ssb-cross-surface-equivalence-report
 
+      - name: Run CoffeeShop cross-surface SQL<->DataFrame equivalence gate
+        run: make coffeeshop-cross-surface-equivalence-report
+
   postgres-integration:
     name: postgres-integration
     needs: ci-paths

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ POOL_CLAIM_MARKER_STALE_SECONDS ?= 600
 # truth instead of repeating the four-deep nested expansion.
 POOL_REPO_CMD = basename "$$(dirname "$$(realpath "$$(git rev-parse --git-common-dir)")")"
 
-.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
+.PHONY: test test-unit test-integration test-tpch test-all test-fast test-unlock test-medium test-slow test-stress test-pytest clean lint lint-markers lint-explorer-tokens lint-site-theme-tokens artifact-hygiene audit-sha-check agent-write-preflight install develop coverage coverage-fast coverage-all coverage-html coverage-report coverage-check test-duckdb test-sqlite test-read-primitives test-benchmarks test-ci typecheck validate-imports catalog-schema-check format dependency-check docs-build docs-serve docs-clean docs-linkcheck docs-validate docs-check docs-images test-pyspark ci-lint ci-test ci-docs ci-local security-audit spellcheck docstring-coverage test-package test-integration-smoke test-correctness-gate test-local-matrix joinorder-verify-reference-results complexity-check complexity-report duplicate-check duplicate-check-verbose duplicate-check-json skill-sync skill-sync-check skill-sync-lock-audit mutation-test tpchavoc-equivalence-report tpchavoc-equivalence-report-postgres tpchavoc-equivalence-report-datafusion tpchavoc-equivalence-report-clickhouse tpchavoc-dataframe-equivalence-report ssb-cross-surface-equivalence-report coffeeshop-cross-surface-equivalence-report oracle-coverage-map oracle-coverage-map-check cross-surface-applicability-report compile-tpcds-binaries parity-fixtures parity-check compat-docs compat-docs-check pr-preflight pr-preflight-fast-tests pr-content-guard pr-open pr-status pr-review-followups pr-review-followups-list dev-loop-metrics shrink-rollup worktree-pool-init worktree-pool-status worktree-pool-check worktree-claim worktree-claim-locked worktree-claim-attempt worktree-release worktree-pool-reset worktree-pool-sweep-stale worktree-pool-disk-clean worktree-list worktree-prune todo-reindex
 
 # Primary test commands using pytest marker system
 test: test-fast
@@ -174,9 +174,12 @@ tpchavoc-dataframe-equivalence-report:
 # its OWN SQL surface on real SF=0.1 DuckDB-backed data; exits non-zero on any
 # divergence beyond the benchmark's baseline. SQL is the reference for its own
 # DataFrame surface, so no hand-curated answer key is needed (see
-# benchbox/core/equivalence/cross_surface.py). Currently gates ssb.
+# benchbox/core/equivalence/cross_surface.py). Currently gates ssb and coffeeshop.
 ssb-cross-surface-equivalence-report:
 	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark ssb
+
+coffeeshop-cross-surface-equivalence-report:
+	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark coffeeshop
 
 # Regenerate the benchmark correctness-oracle coverage map (which oracle, if any,
 # guards each shipped benchmark). Derived from the registry + provider/gate
@@ -1924,6 +1927,7 @@ help:
 	@echo "  make tpchavoc-equivalence-report-clickhouse Sample: TPC-Havoc variant equivalence on ClickHouse"
 	@echo "  make tpchavoc-dataframe-equivalence-report Gate: TPC-Havoc DataFrame variants vs canonical TPC-H"
 	@echo "  make ssb-cross-surface-equivalence-report Gate: SSB DataFrame surface vs its own SQL surface"
+	@echo "  make coffeeshop-cross-surface-equivalence-report Gate: CoffeeShop DataFrame surface vs its own SQL surface"
 	@echo "  make test-local-matrix Run real local benchmark matrix (stress)"
 	@echo "  make test-ci         Maintained broad local CI profile"
 	@echo ""

--- a/_project/analysis/cross-surface-applicability.md
+++ b/_project/analysis/cross-surface-applicability.md
@@ -2,13 +2,12 @@
 
 **Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and asks the production DataFrame resolver how many DataFrame *queries* each actually ships. `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts cross-surface candidates.
 
-**Summary:** 17 dual-surface unguarded candidates — 2 GATEABLE (ship DataFrame queries), 15 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
+**Summary:** 16 dual-surface unguarded candidates — 2 GATEABLE (ship DataFrame queries), 14 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
 
 | Benchmark | Status | SQL queries | DataFrame queries | Note |
 | --- | --- | --- | --- | --- |
 | amplab | no-df-query-surface | 8 | 0 | → w2 fallback oracle |
 | clickbench | gateable | 43 | 43 | → cross-surface gate (w3) |
-| coffeeshop | no-df-query-surface | 11 | 0 | → w2 fallback oracle |
 | datavault | no-df-query-surface | 22 | 0 | → w2 fallback oracle |
 | flightdata | no-df-query-surface | 20 | 0 | → w2 fallback oracle |
 | h2odb | no-df-query-surface | 10 | 0 | → w2 fallback oracle |
@@ -27,4 +26,4 @@
 ## Campaign dispatch
 
 - **Cross-surface gate (w3)** — ships DataFrame queries, 1:1 with SQL: clickbench, joinorder_synthetic. These need a load-faithful per-benchmark builder (see the SSB builder in `benchbox.core.equivalence.cross_surface`) before the gate can enumerate real divergences; a generic build is not load-faithful.
-- **w2 fallback oracle** — no comparable DataFrame query surface, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: amplab, coffeeshop, datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives.
+- **w2 fallback oracle** — no comparable DataFrame query surface, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: amplab, datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives.

--- a/_project/analysis/oracle-coverage-map.json
+++ b/_project/analysis/oracle-coverage-map.json
@@ -37,11 +37,13 @@
     },
     {
       "benchmark": "coffeeshop",
-      "cross_surface_applicable": true,
+      "cross_surface_applicable": false,
       "dual_surface": true,
-      "guarded": false,
-      "oracles": [],
-      "primary_oracle": "NONE",
+      "guarded": true,
+      "oracles": [
+        "cross-surface"
+      ],
+      "primary_oracle": "cross-surface",
       "surfaces": [
         "sql",
         "dataframe"

--- a/_project/analysis/oracle-coverage-map.md
+++ b/_project/analysis/oracle-coverage-map.md
@@ -2,14 +2,14 @@
 
 **Generated** by `_project/scripts/generate_oracle_coverage_map.py` from the benchmark registry, the expected-results provider registry, and the equivalence-gate registries. Do not edit by hand — run the generator and commit. `tests/unit/test_oracle_coverage_map.py` fails if this drifts.
 
-**Summary:** 23 shipped benchmarks — 4 guarded, 19 UNGUARDED (17 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
+**Summary:** 23 shipped benchmarks — 5 guarded, 18 UNGUARDED (16 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
 
 | Benchmark | Surfaces | Oracle | Notes |
 | --- | --- | --- | --- |
 | ai_primitives | sql | NONE | single-surface → needs fallback oracle (w2) |
 | amplab | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | clickbench | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| coffeeshop | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| coffeeshop | sql+dataframe | cross-surface | cross-surface |
 | datavault | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | flightdata | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | h2odb | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
@@ -36,5 +36,5 @@ These ship with no automated correctness oracle today. Dual-surface ones are dis
 
 > Caveat (w2 oracle choice): write/DML/nondeterministic benchmarks (`write_primitives`, `transaction_primitives`, `metadata_primitives`, `tpcdi`) are listed as dual-surface, but their two surfaces may not be result-comparable; prefer structural-invariant oracles (row counts, post-state assertions) over cross-surface equality for those.
 
-- Dual-surface (cross-surface candidates): amplab, clickbench, coffeeshop, datavault, flightdata, h2odb, joinorder, joinorder_synthetic, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives
+- Dual-surface (cross-surface candidates): amplab, clickbench, datavault, flightdata, h2odb, joinorder, joinorder_synthetic, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives
 - Single-surface (fallback-oracle needed): ai_primitives, vector_search

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -278,10 +278,56 @@ def build_ssb_duckdb(scale_factor: float, output_dir: Path) -> CrossSurfaceData:
     )
 
 
+def build_coffeeshop_duckdb(scale_factor: float, output_dir: Path) -> CrossSurfaceData:
+    """Generate CoffeeShop data, load it into in-memory DuckDB, and wire both surfaces.
+
+    Platform/generator imports are deferred so importing this module stays cheap.
+    """
+    import duckdb
+
+    from benchbox.core.coffeeshop.benchmark import CoffeeShopBenchmark
+    from benchbox.core.coffeeshop.dataframe_queries import COFFEESHOP_DATAFRAME_QUERIES
+    from benchbox.core.coffeeshop.generator import CoffeeShopDataGenerator
+    from benchbox.core.coffeeshop.schema import TABLES
+    from benchbox.platforms.duckdb import DuckDBAdapter
+
+    output_dir = Path(output_dir)
+    CoffeeShopDataGenerator(scale_factor=scale_factor, output_dir=output_dir).generate_data()
+    benchmark = CoffeeShopBenchmark(scale_factor=scale_factor, output_dir=output_dir)
+
+    connection = duckdb.connect(":memory:")
+    try:
+        for statement in benchmark.get_create_tables_sql(dialect="duckdb").strip().split(";"):
+            if statement.strip():
+                connection.execute(statement.strip())
+        table_stats, _, _ = DuckDBAdapter(database=":memory:").load_data(benchmark, connection, output_dir)
+
+        # A silent empty/partial load would make every query compare
+        # empty-vs-empty and report a FALSE green, so verify each table loaded.
+        table_names = [table["name"] for table in TABLES.values()]
+        stats_lower = {str(name).lower(): rows for name, rows in table_stats.items()}
+        empty = [name for name in table_names if stats_lower.get(name.lower(), 0) <= 0]
+        if empty:
+            raise RuntimeError(f"CoffeeShop load failed - no rows in {empty} (stats={table_stats})")
+    except Exception:
+        connection.close()
+        raise
+
+    return CrossSurfaceData(
+        connection=connection,
+        query_ids=list(benchmark.get_queries().keys()),
+        reference_sql=lambda query_id: benchmark.get_query(query_id),
+        dataframe_query=lambda query_id: COFFEESHOP_DATAFRAME_QUERIES.get_or_raise(query_id),
+        benchmark=benchmark,
+        data_dir=output_dir,
+    )
+
+
 # Registry of gated benchmarks. Add a benchmark by registering its build
 # function (and any classified known divergences) here.
 GATES: dict[str, CrossSurfaceGate] = {
     "ssb": CrossSurfaceGate(name="ssb", build=build_ssb_duckdb),
+    "coffeeshop": CrossSurfaceGate(name="coffeeshop", build=build_coffeeshop_duckdb),
 }
 
 

--- a/tests/integration/test_coffeeshop_cross_surface_equivalence.py
+++ b/tests/integration/test_coffeeshop_cross_surface_equivalence.py
@@ -1,0 +1,71 @@
+"""Result-equivalence regression test for the CoffeeShop cross-surface gate.
+
+This is the fast, default-lane companion to the full CoffeeShop cross-surface
+equivalence gate in ``benchbox/core/equivalence/cross_surface.py`` (run via
+``make coffeeshop-cross-surface-equivalence-report``, wired into the PR CI), the
+same shape as ``tests/integration/test_ssb_cross_surface_equivalence.py``. It
+executes every CoffeeShop query's DataFrame surface (both backends) against its
+OWN SQL surface on a bounded SF=0.1 DuckDB cell and asserts they agree - SQL is
+the trusted reference for its own DataFrame surface, so no hand-curated answer
+key is needed.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("polars", reason="Polars not installed")
+pytest.importorskip("pandas", reason="Pandas not installed")
+pytest.importorskip("duckdb", reason="DuckDB not installed")
+
+from benchbox.core.equivalence.cross_surface import (
+    EQUIVALENCE_SCALE,
+    GATES,
+    build_production_contexts,
+    count_executed_cells,
+    find_cross_surface_divergences,
+)
+from benchbox.core.tpchavoc.validation import ResultValidator
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.medium,
+    pytest.mark.duckdb,
+]
+
+
+def test_coffeeshop_dataframe_surface_equivalent_to_sql(tmp_path):
+    """Every CoffeeShop DataFrame query (both backends) must match its own SQL surface."""
+    gate = GATES["coffeeshop"]
+    data = gate.build(EQUIVALENCE_SCALE, tmp_path)
+    connection = data.connection
+    try:
+        contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+        divergences = find_cross_surface_divergences(
+            connection,
+            query_ids=data.query_ids,
+            reference_sql=data.reference_sql,
+            dataframe_query=data.dataframe_query,
+            contexts=contexts,
+            validator=ResultValidator(tolerance=gate.tolerance),
+            backends=gate.backends,
+        )
+        coverage = count_executed_cells(data.query_ids, data.dataframe_query, gate.backends)
+    finally:
+        connection.close()
+
+    # Both gated backends must actually compare something - a fully-unimplemented
+    # backend would make the gate silently green by comparing nothing.
+    missing = sorted(backend for backend, count in coverage.items() if count == 0)
+    assert not missing, f"gated CoffeeShop backend(s) implement no queries: {missing}"
+
+    # The baseline is empty; tolerate only entries explicitly classified there,
+    # never an unclassified regression.
+    unexpected = {d.key for d in divergences} - set(gate.known_divergences)
+    assert not unexpected, "CoffeeShop DataFrame surface diverges from SQL: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in divergences if d.key in unexpected
+    )


### PR DESCRIPTION
## Summary

Now that CoffeeShop's DataFrame surface matches its own DuckDB SQL reference on every query (via the merged #836 loader fixes and #837 impl fixes), this enrolls it in the cross-surface equivalence gate alongside SSB — so the green surface stays green going forward.

## Changes

- **Register the gate**: `build_coffeeshop_duckdb` + `GATES["coffeeshop"]` in `cross_surface.py` (no `known_divergences` — it's fully equivalent). Mirrors `build_ssb_duckdb`, including the per-table non-empty load check that guards against a false green.
- **Make target + CI**: `make coffeeshop-cross-surface-equivalence-report`, run in PR CI right after the SSB gate step.
- **Integration test**: `tests/integration/test_coffeeshop_cross_surface_equivalence.py`, the fast default-lane companion mirroring the SSB regression test.
- **Regenerated artifacts**: `oracle-coverage-map` and `cross-surface-applicability` now show coffeeshop as **guarded** by the cross-surface gate (5 guarded; coffeeshop drops out of the unguarded-candidate list).

## Verification

```
$ make coffeeshop-cross-surface-equivalence-report
coffeeshop cross-surface SQL<->DataFrame equivalence @ SF=0.1 (DuckDB-backed)
  compared 22 of 22 query-backend cells (0 not implemented) - 0 divergent
SQL and DataFrame surfaces are equivalent (modulo classified exceptions).
```

- New integration test passes (SF=0.1, both backends, all 11 queries).
- `oracle-coverage-map` / `cross-surface-applicability` artifact-currency tests pass after regeneration.

Depends on #836 and #837 (both merged to `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017nZBWGFNZeZGHDm3usxyev)_