### PR TITLE
fix(correctness): cross-surface applicability via registry detection (12 gateable, not 2)

### DIFF
--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -241,34 +241,36 @@ work:
       clean but is re-confirmed there. Remaining ungated benchmarks are reported on
       the production substrate as each gate is built (now needs w5/w6/w7).
 
-      APPLICABILITY SWEEP (new): before running gates, a sweep
+      APPLICABILITY SWEEP: a reproducible sweep
       (_project/scripts/cross_surface_applicability_sweep.py ->
       _project/analysis/cross-surface-applicability.md, locked by
-      tests/unit/test_cross_surface_applicability.py) found that the coverage map's
-      cross-surface candidate set is a LOADING-based UPPER BOUND. Of the 17
-      dual-surface UNGUARDED benchmarks, the production resolver
-      (get_dataframe_queries_for_benchmark) surfaces DataFrame queries for only:
-        - clickbench (43 sql / 43 df) and joinorder_synthetic (13/13) -> GATEABLE.
-      `supports_dataframe=True` means DataFrame LOADING, not shipped DataFrame query
-      implementations, so it over-counts gate candidates.
+      tests/unit/test_cross_surface_applicability.py) classifies the dual-surface
+      UNGUARDED benchmarks by whether they ship a DataFrame query `QueryRegistry`
+      (the registry the cross-surface gate builders consume directly) - the
+      authoritative gate-applicability signal. `supports_dataframe` over-counts
+      (it is a LOADING flag); the production query *resolver* under-counts (it
+      misses per-benchmark `<BENCH>_DATAFRAME_QUERIES` registries - e.g. it
+      returned 0 for coffeeshop, which #842 nonetheless gated). Registry detection
+      fixes both.
 
-      CORRECTION (post #842): the resolver signal also UNDER-counts. coffeeshop was
-      gated by #842 using a COFFEESHOP_DATAFRAME_QUERIES registry that the production
-      resolver does NOT surface (it returned 0 for coffeeshop in this sweep). So the
-      resolver is the wrong applicability signal: benchmarks expose DataFrame queries
-      via per-benchmark `<BENCH>_DATAFRAME_QUERIES` registries the resolver doesn't
-      wire up. FOLLOW-UP: change the applicability sweep to detect those registries
-      (importable) rather than the resolver count, then re-run to find the true
-      gateable set (likely > 2; amplab/datavault/etc. may have registries too). The
-      benchmarks still dispatched to a w2 fallback oracle are only those with NO
-      DataFrame query registry at all.
+      RESULT (16 unguarded candidates; coffeeshop already gated/excluded):
+        - GATEABLE, ids overlap as-is (6): clickbench, flightdata, h2odb,
+          joinorder, joinorder_synthetic, read_primitives (152/157 ids).
+        - GATEABLE, needs id normalization first (6): amplab, datavault, nyctaxi,
+          tpch_skew, tsbs_devops (ids Q-prefixed/friendly vs SQL ids), tpcds_obt
+          (only 3 DF queries vs 89 SQL - partial).
+        - w2 FALLBACK, NO DataFrame query registry (4): metadata_primitives,
+          tpcdi, transaction_primitives, write_primitives. Only these four need a
+          differential second-engine or curated expected-results oracle.
+      So the cross-surface gate burn-down is ~12 benchmarks, not 2 (the earlier
+      resolver-based "only 2" was wrong).
 
       CAVEAT proven during the sweep: a GENERIC build is not load-faithful (it
       loads DataFrame contexts without the schema/headers the production loader
       applies, yielding spurious "column not found" divergences), so enumerating
       REAL divergence counts requires a load-faithful per-benchmark builder like
-      build_ssb_duckdb. That builder work is w3 (clickbench done; joinorder_synthetic
-      and any newly-found gateable benchmarks next).
+      build_ssb_duckdb. That builder work is w3 (clickbench done; the other 11
+      gateable benchmarks next, normalizing ids where the sweep flags it).
 
   - id: w3
     summary: "Burn down divergences (fix the wrong surface) or declare intentional ones"

--- a/_project/analysis/cross-surface-applicability.md
+++ b/_project/analysis/cross-surface-applicability.md
@@ -1,29 +1,30 @@
 # Cross-surface applicability sweep
 
-**Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and asks the production DataFrame resolver how many DataFrame *queries* each actually ships. `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts cross-surface candidates.
+**Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and detects which ship a DataFrame query `QueryRegistry` (the registry the cross-surface gate builders consume). `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts candidates; the production query *resolver* under-counts (it misses per-benchmark `<BENCH>_DATAFRAME_QUERIES` registries). Registry detection is the authoritative gate-applicability signal.
 
-**Summary:** 16 dual-surface unguarded candidates — 2 GATEABLE (ship DataFrame queries), 14 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
+**Summary:** 16 dual-surface unguarded candidates — 12 cross-surface gateable (ship a DataFrame query registry), 4 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
 
-| Benchmark | Status | SQL queries | DataFrame queries | Note |
-| --- | --- | --- | --- | --- |
-| amplab | no-df-query-surface | 8 | 0 | → w2 fallback oracle |
-| clickbench | gateable | 43 | 43 | → cross-surface gate (w3) |
-| datavault | no-df-query-surface | 22 | 0 | → w2 fallback oracle |
-| flightdata | no-df-query-surface | 20 | 0 | → w2 fallback oracle |
-| h2odb | no-df-query-surface | 10 | 0 | → w2 fallback oracle |
-| joinorder | no-df-query-surface | 113 | 0 | → w2 fallback oracle |
-| joinorder_synthetic | gateable | 13 | 13 | → cross-surface gate (w3) |
-| metadata_primitives | no-df-query-surface | 62 | 0 | → w2 fallback oracle |
-| nyctaxi | no-df-query-surface | 25 | 0 | → w2 fallback oracle |
-| read_primitives | no-df-query-surface | 157 | 0 | → w2 fallback oracle |
-| tpcdi | no-df-query-surface | 38 | 0 | → w2 fallback oracle |
-| tpcds_obt | no-df-query-surface | 89 | 0 | → w2 fallback oracle |
-| tpch_skew | no-df-query-surface | 22 | 0 | → w2 fallback oracle |
-| transaction_primitives | no-df-query-surface | 23 | 0 | → w2 fallback oracle |
-| tsbs_devops | no-df-query-surface | 18 | 0 | → w2 fallback oracle |
-| write_primitives | no-df-query-surface | 109 | 0 | → w2 fallback oracle |
+| Benchmark | Status | SQL queries | DataFrame queries | Raw id overlap | Note |
+| --- | --- | --- | --- | --- | --- |
+| amplab | gateable-needs-id-mapping | 8 | 8 | 0 | → cross-surface gate after id normalization (w3) |
+| clickbench | gateable | 43 | 43 | 43 | → cross-surface gate (w3) |
+| datavault | gateable-needs-id-mapping | 22 | 22 | 0 | → cross-surface gate after id normalization (w3) |
+| flightdata | gateable | 20 | 20 | 20 | → cross-surface gate (w3) |
+| h2odb | gateable | 10 | 10 | 10 | → cross-surface gate (w3) |
+| joinorder | gateable | 113 | 113 | 113 | → cross-surface gate (w3) |
+| joinorder_synthetic | gateable | 13 | 13 | 13 | → cross-surface gate (w3) |
+| metadata_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
+| nyctaxi | gateable-needs-id-mapping | 25 | 25 | 0 | → cross-surface gate after id normalization (w3) |
+| read_primitives | gateable | 157 | 152 | 152 | → cross-surface gate (w3) |
+| tpcdi | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
+| tpcds_obt | gateable-needs-id-mapping | 89 | 3 | 0 | → cross-surface gate after id normalization (w3) |
+| tpch_skew | gateable-needs-id-mapping | 22 | 22 | 0 | → cross-surface gate after id normalization (w3) |
+| transaction_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
+| tsbs_devops | gateable-needs-id-mapping | 18 | 18 | 0 | → cross-surface gate after id normalization (w3) |
+| write_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
 
 ## Campaign dispatch
 
-- **Cross-surface gate (w3)** — ships DataFrame queries, 1:1 with SQL: clickbench, joinorder_synthetic. These need a load-faithful per-benchmark builder (see the SSB builder in `benchbox.core.equivalence.cross_surface`) before the gate can enumerate real divergences; a generic build is not load-faithful.
-- **w2 fallback oracle** — no comparable DataFrame query surface, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: amplab, datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives.
+- **Cross-surface gate, ids overlap as-is (w3):** clickbench, flightdata, h2odb, joinorder, joinorder_synthetic, read_primitives.
+- **Cross-surface gate, needs id normalization first (w3):** amplab, datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops — a DataFrame query registry exists but its ids differ from the SQL ids by a naming convention (e.g. `1` vs `Q1`); normalize in the builder.
+- **w2 fallback oracle** — no DataFrame query registry, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: metadata_primitives, tpcdi, transaction_primitives, write_primitives.

--- a/_project/scripts/cross_surface_applicability_sweep.py
+++ b/_project/scripts/cross_surface_applicability_sweep.py
@@ -4,36 +4,48 @@
 The oracle coverage map flags a benchmark as a cross-surface candidate when it is
 dual-surface (ships SQL queries AND has ``supports_dataframe=True``) and currently
 unguarded. But ``supports_dataframe`` is a *loading* capability flag: it does NOT
-guarantee the benchmark ships comparable DataFrame *query* implementations. The
+mean the benchmark ships comparable DataFrame *query* implementations. The
 cross-surface gate compares a query's SQL result to its DataFrame result, so it is
-only applicable to benchmarks that actually ship DataFrame queries with 1:1 id
-correspondence to their SQL queries.
+only applicable to benchmarks that ship DataFrame *queries*.
 
-This sweep drills into each cross-surface candidate from the coverage map and asks
-the authoritative production resolver
-(``benchbox.core.dataframe.query_resolution.get_dataframe_queries_for_benchmark``,
-the same path the production DataFrame adapter uses) how many DataFrame queries it
-actually resolves. The result re-scopes the unguarded-benchmark campaign:
+Signal: each benchmark that ships a DataFrame query surface exposes a
+``QueryRegistry`` (a ``<BENCH>_DATAFRAME_QUERIES`` instance) in its
+``benchbox.core.<bench>.dataframe_queries`` module/package -- this is the registry
+the cross-surface gate builders (e.g. ``build_clickbench_duckdb``) consume
+directly. Detecting that registry is the authoritative gate-applicability signal.
 
-  - GATEABLE: ships DataFrame queries -> dispatch to the cross-surface gate (w3).
-  - no DataFrame query surface -> NOT cross-surface-gateable; needs a w2 fallback
-    oracle (differential second-engine or a curated expected-results subset).
+History: an earlier version of this sweep used the production query *resolver*
+(``get_dataframe_queries_for_benchmark``). That under-counted: the resolver only
+special-cases tpch/tpcds/clickbench plus a generic ``get_dataframe_queries()``
+method, so benchmarks that expose only a ``<BENCH>_DATAFRAME_QUERIES`` registry
+(e.g. coffeeshop -- which was nonetheless successfully gated in #842) resolved to
+zero and were wrongly dispatched to a fallback oracle. Registry detection fixes
+that.
 
-It is report-mode (regenerate the committed artifact); resolving DataFrame queries
-needs only a benchmark instance, not generated data, so the sweep is cheap. Note
-that running the gate to enumerate actual divergences additionally requires a
-load-faithful per-benchmark build (see the SSB builder in
-``benchbox.core.equivalence.cross_surface``); a generic build is not load-faithful
-and produces spurious column errors, so divergence COUNTS are deferred to the
-per-benchmark gate wiring (w3), starting with the two gateable benchmarks here.
+Classification per candidate:
+  - ``gateable``: has a registry whose ids overlap the SQL ids as-is -> wire a
+    cross-surface gate on the overlapping ids (w3).
+  - ``gateable-needs-id-mapping``: has a registry but its ids do not overlap the
+    SQL ids verbatim (a prefix/naming convention differs, e.g. ``1`` vs ``Q1``);
+    gateable after a mechanical id normalization in the builder (w3).
+  - ``no-df-query-surface``: no DataFrame query registry -> NOT cross-surface
+    gateable; needs a w2 fallback oracle (differential second-engine or a curated
+    expected-results subset).
+  - ``blocked``: could not instantiate the benchmark or read its registry.
+
+Report-mode (regenerate the committed artifact). Detecting a registry + reading
+SQL ids needs only an import + a benchmark instance (no generated data), so the
+sweep is cheap. Enumerating real divergences still requires a load-faithful
+per-benchmark gate builder (see ``build_ssb_duckdb`` /
+``build_clickbench_duckdb``).
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -43,44 +55,79 @@ if str(_REPO_ROOT) not in sys.path:
 ARTIFACT = _REPO_ROOT / "_project" / "analysis" / "cross-surface-applicability.md"
 
 # Scales to try when instantiating a benchmark (some reject the default small SF
-# and require a canonical scale, e.g. joinorder=1.0, tpcds_obt>=1.0). Resolving
-# DataFrame queries needs no generated data, so a larger scale here is still cheap.
+# and require a canonical scale, e.g. joinorder=1.0, tpcds_obt>=1.0). Reading SQL
+# ids needs no generated data, so a larger scale here is still cheap.
 _INSTANTIATE_SCALES = (0.01, 1.0)
 
+GATEABLE = "gateable"
+GATEABLE_NEEDS_ID_MAPPING = "gateable-needs-id-mapping"
+NO_DF_QUERY_SURFACE = "no-df-query-surface"
+BLOCKED = "blocked"
 
-def _resolve_dataframe_query_count(benchmark_id: str) -> tuple[str, dict[str, Any]]:
-    """Classify a benchmark's cross-surface applicability.
+# Statuses that mean "a DataFrame query surface exists, so a cross-surface gate is
+# applicable" (directly or after id normalization).
+_GATEABLE_STATUSES = frozenset({GATEABLE, GATEABLE_NEEDS_ID_MAPPING})
 
-    Returns ``(status, detail)`` where status is one of "gateable",
-    "no-df-query-surface", or "blocked".
+
+def _dataframe_query_registry(benchmark_id: str) -> Any | None:
+    """Return the benchmark's DataFrame ``QueryRegistry``, or ``None`` if it ships none.
+
+    Each benchmark with a DataFrame query surface exposes a ``QueryRegistry``
+    instance in ``benchbox.core.<bench>.dataframe_queries``; the cross-surface gate
+    builders consume it directly. Detect it by type rather than by a derived name,
+    because the constant name is not uniform (e.g. ``ODB_DATAFRAME_QUERIES`` for
+    h2odb, ``JOINORDER_DATAFRAME_QUERIES`` for both joinorder variants).
     """
+    from benchbox.core.dataframe.query import QueryRegistry
+
+    try:
+        module = importlib.import_module(f"benchbox.core.{benchmark_id}.dataframe_queries")
+    except ModuleNotFoundError:
+        return None
+    for value in vars(module).values():
+        if isinstance(value, QueryRegistry):
+            return value
+    return None
+
+
+def _instantiate(benchmark_id: str) -> tuple[Any | None, float | None, str]:
     from benchbox.core.benchmark_registry import get_benchmark_class
-    from benchbox.core.dataframe.query_resolution import get_dataframe_queries_for_benchmark
 
     cls = get_benchmark_class(benchmark_id)
-    instance = None
-    used_scale = None
     last_error = ""
     for scale in _INSTANTIATE_SCALES:
         try:
-            instance = cls(scale_factor=scale)
-            used_scale = scale
-            break
+            return cls(scale_factor=scale), scale, ""
         except Exception as exc:  # noqa: BLE001 - record why instantiation failed, do not crash the sweep
             last_error = f"{type(exc).__name__}: {exc}"
-    if instance is None:
-        return "blocked", {"error": last_error}
+    return None, None, last_error
+
+
+def classify_applicability(benchmark_id: str) -> tuple[str, dict[str, Any]]:
+    """Classify a benchmark's cross-surface gate applicability via registry detection."""
+    registry = _dataframe_query_registry(benchmark_id)
+    if registry is None:
+        return NO_DF_QUERY_SURFACE, {"df_queries": 0}
 
     try:
-        sql_count = len(instance.get_queries())
-        config = SimpleNamespace(name=benchmark_id, stream_id=0)
-        df_queries = get_dataframe_queries_for_benchmark(config, instance, 0) or []
-        df_count = len(df_queries)
-    except Exception as exc:  # noqa: BLE001 - a resolution error is a finding, not a crash
-        return "blocked", {"error": f"df-resolve {type(exc).__name__}: {exc}"}
+        df_ids = [str(q) for q in registry.get_query_ids()]
+    except Exception as exc:  # noqa: BLE001 - a registry read error is a finding, not a crash
+        return BLOCKED, {"error": f"registry {type(exc).__name__}: {exc}"}
 
-    status = "gateable" if df_count > 0 else "no-df-query-surface"
-    return status, {"sql_queries": sql_count, "df_queries": df_count, "scale": used_scale}
+    instance, used_scale, error = _instantiate(benchmark_id)
+    if instance is None:
+        return BLOCKED, {"error": error, "df_queries": len(df_ids)}
+
+    sql_ids = [str(q) for q in instance.get_queries().keys()]
+    raw_overlap = len(set(sql_ids) & set(df_ids))
+    detail = {
+        "sql_queries": len(sql_ids),
+        "df_queries": len(df_ids),
+        "raw_id_overlap": raw_overlap,
+        "scale": used_scale,
+    }
+    status = GATEABLE if raw_overlap > 0 else GATEABLE_NEEDS_ID_MAPPING
+    return status, detail
 
 
 def build_applicability_sweep() -> list[dict[str, Any]]:
@@ -90,15 +137,15 @@ def build_applicability_sweep() -> list[dict[str, Any]]:
     candidates = [row["benchmark"] for row in build_coverage_map() if row["dual_surface"] and not row["guarded"]]
     rows: list[dict[str, Any]] = []
     for benchmark_id in candidates:
-        status, detail = _resolve_dataframe_query_count(benchmark_id)
+        status, detail = classify_applicability(benchmark_id)
         rows.append({"benchmark": benchmark_id, "status": status, **detail})
     return rows
 
 
 def render_markdown(rows: list[dict[str, Any]]) -> str:
-    gateable = [r for r in rows if r["status"] == "gateable"]
-    no_surface = [r for r in rows if r["status"] == "no-df-query-surface"]
-    blocked = [r for r in rows if r["status"] == "blocked"]
+    gateable = [r for r in rows if r["status"] in _GATEABLE_STATUSES]
+    no_surface = [r for r in rows if r["status"] == NO_DF_QUERY_SURFACE]
+    blocked = [r for r in rows if r["status"] == BLOCKED]
 
     lines: list[str] = []
     lines.append("# Cross-surface applicability sweep")
@@ -106,46 +153,61 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     lines.append(
         "**Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. "
         "Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage "
-        "map and asks the production DataFrame resolver how many DataFrame *queries* "
-        "each actually ships. `supports_dataframe` (the coverage map's signal) is a "
-        "DataFrame *loading* flag and over-counts cross-surface candidates."
+        "map and detects which ship a DataFrame query `QueryRegistry` (the registry "
+        "the cross-surface gate builders consume). `supports_dataframe` (the coverage "
+        "map's signal) is a DataFrame *loading* flag and over-counts candidates; the "
+        "production query *resolver* under-counts (it misses per-benchmark "
+        "`<BENCH>_DATAFRAME_QUERIES` registries). Registry detection is the "
+        "authoritative gate-applicability signal."
     )
     lines.append("")
     lines.append(
         f"**Summary:** {len(rows)} dual-surface unguarded candidates — "
-        f"{len(gateable)} GATEABLE (ship DataFrame queries), "
+        f"{len(gateable)} cross-surface gateable (ship a DataFrame query registry), "
         f"{len(no_surface)} have no DataFrame query surface (need a w2 fallback oracle), "
         f"{len(blocked)} blocked."
     )
     lines.append("")
-    lines.append("| Benchmark | Status | SQL queries | DataFrame queries | Note |")
-    lines.append("| --- | --- | --- | --- | --- |")
+    lines.append("| Benchmark | Status | SQL queries | DataFrame queries | Raw id overlap | Note |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
     for r in rows:
-        if r["status"] == "blocked":
-            note = r.get("error", "")
-            sql_n = df_n = "—"
-        else:
-            note = "→ cross-surface gate (w3)" if r["status"] == "gateable" else "→ w2 fallback oracle"
-            sql_n = r.get("sql_queries", "—")
-            df_n = r.get("df_queries", "—")
-        lines.append(f"| {r['benchmark']} | {r['status']} | {sql_n} | {df_n} | {note} |")
+        if r["status"] == BLOCKED:
+            lines.append(f"| {r['benchmark']} | {BLOCKED} | — | {r.get('df_queries', '—')} | — | {r.get('error', '')} |")
+            continue
+        if r["status"] == NO_DF_QUERY_SURFACE:
+            note = "→ w2 fallback oracle (no DataFrame query registry)"
+            lines.append(f"| {r['benchmark']} | {r['status']} | — | 0 | — | {note} |")
+            continue
+        note = (
+            "→ cross-surface gate (w3)"
+            if r["status"] == GATEABLE
+            else "→ cross-surface gate after id normalization (w3)"
+        )
+        lines.append(
+            f"| {r['benchmark']} | {r['status']} | {r.get('sql_queries', '—')} | "
+            f"{r.get('df_queries', '—')} | {r.get('raw_id_overlap', '—')} | {note} |"
+        )
     lines.append("")
     lines.append("## Campaign dispatch")
     lines.append("")
+    direct = [r["benchmark"] for r in rows if r["status"] == GATEABLE]
+    needs_mapping = [r["benchmark"] for r in rows if r["status"] == GATEABLE_NEEDS_ID_MAPPING]
     lines.append(
-        "- **Cross-surface gate (w3)** — ships DataFrame queries, 1:1 with SQL: "
-        + (", ".join(r["benchmark"] for r in gateable) or "none")
-        + ". These need a load-faithful per-benchmark builder (see the SSB builder in "
-        "`benchbox.core.equivalence.cross_surface`) before the gate can enumerate real "
-        "divergences; a generic build is not load-faithful."
+        "- **Cross-surface gate, ids overlap as-is (w3):** " + (", ".join(direct) or "none") + "."
     )
     lines.append(
-        "- **w2 fallback oracle** — no comparable DataFrame query surface, so the "
-        "cross-surface gate cannot reach them; they need a differential second-engine "
-        "check or a curated expected-results subset: " + (", ".join(r["benchmark"] for r in no_surface) or "none") + "."
+        "- **Cross-surface gate, needs id normalization first (w3):** "
+        + (", ".join(needs_mapping) or "none")
+        + " — a DataFrame query registry exists but its ids differ from the SQL ids "
+        "by a naming convention (e.g. `1` vs `Q1`); normalize in the builder."
+    )
+    lines.append(
+        "- **w2 fallback oracle** — no DataFrame query registry, so the cross-surface "
+        "gate cannot reach them; they need a differential second-engine check or a "
+        "curated expected-results subset: " + (", ".join(r["benchmark"] for r in no_surface) or "none") + "."
     )
     if blocked:
-        lines.append("- **Blocked** (instantiate/resolve): " + ", ".join(r["benchmark"] for r in blocked) + ".")
+        lines.append("- **Blocked** (instantiate/registry): " + ", ".join(r["benchmark"] for r in blocked) + ".")
     lines.append("")
     return "\n".join(lines)
 
@@ -169,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
 
     ARTIFACT.parent.mkdir(parents=True, exist_ok=True)
     ARTIFACT.write_text(rendered, encoding="utf-8")
-    gateable = [r["benchmark"] for r in rows if r["status"] == "gateable"]
+    gateable = [r["benchmark"] for r in rows if r["status"] in _GATEABLE_STATUSES]
     print(f"Wrote {ARTIFACT.relative_to(_REPO_ROOT)}")
     print(f"{len(rows)} candidates, {len(gateable)} gateable: {', '.join(gateable)}")
     return 0

--- a/tests/unit/test_cross_surface_applicability.py
+++ b/tests/unit/test_cross_surface_applicability.py
@@ -21,6 +21,10 @@ if str(_REPO_ROOT) not in sys.path:
 
 from _project.scripts.cross_surface_applicability_sweep import (  # noqa: E402
     ARTIFACT,
+    BLOCKED,
+    GATEABLE,
+    GATEABLE_NEEDS_ID_MAPPING,
+    NO_DF_QUERY_SURFACE,
     build_applicability_sweep,
     render_markdown,
 )
@@ -30,27 +34,43 @@ pytestmark = [
     pytest.mark.medium,
 ]
 
+# Benchmarks that ship NO DataFrame query registry, so the cross-surface gate
+# cannot reach them - they need a w2 fallback oracle (differential second-engine
+# or curated expected-results). This is the stable, meaningful invariant: if a
+# benchmark gains a DataFrame query registry it should drop off this list (and
+# become gateable), and a new benchmark without one should be added deliberately.
+_W2_FALLBACK_BENCHMARKS = {"metadata_primitives", "tpcdi", "transaction_primitives", "write_primitives"}
+
 
 @pytest.fixture(scope="module")
 def rows() -> list[dict]:
     return build_applicability_sweep()
 
 
-def test_only_clickbench_and_joinorder_synthetic_are_gateable(rows):
-    """Exactly the two benchmarks that ship DataFrame queries are cross-surface gateable.
+def test_w2_fallback_set_is_exactly_the_registry_less_benchmarks(rows):
+    """Only benchmarks with no DataFrame query registry are dispatched to a w2 fallback.
 
-    If this set changes (a benchmark gains/loses a DataFrame query surface), update
-    the sweep artifact and the cross-surface gate dispatch deliberately.
+    Registry detection (not the production resolver) is the gate-applicability
+    signal: e.g. coffeeshop ships a registry and was gated in #842, even though the
+    resolver returned zero for it.
     """
-    gateable = {r["benchmark"] for r in rows if r["status"] == "gateable"}
-    assert gateable == {"clickbench", "joinorder_synthetic"}, f"cross-surface gateable set changed: {sorted(gateable)}"
+    no_surface = {r["benchmark"] for r in rows if r["status"] == NO_DF_QUERY_SURFACE}
+    assert no_surface == _W2_FALLBACK_BENCHMARKS, f"w2-fallback set changed: {sorted(no_surface)}"
+
+
+def test_registry_bearing_benchmarks_are_gateable(rows):
+    """clickbench (direct) and a known id-mapping case are classified gateable."""
+    by_id = {r["benchmark"]: r["status"] for r in rows}
+    assert by_id.get("clickbench") == GATEABLE
+    # amplab ships a registry but its ids are Q-prefixed vs the SQL ids -> needs mapping.
+    assert by_id.get("amplab") == GATEABLE_NEEDS_ID_MAPPING
 
 
 def test_no_candidate_is_silently_dropped(rows):
-    """Every candidate is classified (gateable / no-df-query-surface / blocked)."""
+    """Every candidate is classified into a known status."""
     assert rows, "applicability sweep produced no candidates"
     for r in rows:
-        assert r["status"] in {"gateable", "no-df-query-surface", "blocked"}, r
+        assert r["status"] in {GATEABLE, GATEABLE_NEEDS_ID_MAPPING, NO_DF_QUERY_SURFACE, BLOCKED}, r
 
 
 def test_committed_artifact_is_current(rows):


### PR DESCRIPTION
Corrects the cross-surface applicability signal surfaced as wrong by the #842
coffeeshop merge.

## The bug
The applicability sweep (#838) classified gate candidates with the production
query **resolver** (`get_dataframe_queries_for_benchmark`). That resolver only
special-cases tpch/tpcds/clickbench plus a generic `get_dataframe_queries()`
method, so benchmarks that expose only a `<BENCH>_DATAFRAME_QUERIES` **registry**
resolved to zero and were wrongly dispatched to a w2 fallback. **coffeeshop**
proved it: it ships `COFFEESHOP_DATAFRAME_QUERIES` and was gated in #842, yet the
old sweep called it "no DataFrame query surface". (The sweep also over-counted via
`supports_dataframe`, a loading flag.)

## The fix
Detect the per-benchmark DataFrame query **`QueryRegistry`** (the registry the
cross-surface gate builders consume directly), found by type in
`benchbox.core.<bench>.dataframe_queries`. New classification of the 16 unguarded
dual-surface candidates:

| Bucket | Count | Benchmarks |
| --- | --- | --- |
| **gateable** (ids overlap as-is) | 6 | clickbench, flightdata, h2odb, joinorder, joinorder_synthetic, read_primitives |
| **gateable, needs id normalization** | 6 | amplab, datavault, nyctaxi, tpch_skew, tsbs_devops, tpcds_obt |
| **w2 fallback** (no registry) | 4 | metadata_primitives, tpcdi, transaction_primitives, write_primitives |

So the cross-surface gate burn-down is **~12 benchmarks, not 2** — matching the
TODO's own w1 inventory. Only 4 benchmarks genuinely need a differential/curated
oracle.

## Verification
- `tests/unit/test_cross_surface_applicability.py` — 4/4 (now locks the stable
  invariant: the registry-less w2-fallback set).
- `make cross-surface-applicability-report` regenerated; `--check` clean.
- `ruff`/`ty` clean; cross-surface TODO w2 updated; graph passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_