### PR TITLE
fix(clickbench): cross-surface burn-down — seed generator + fix 10 engine/error divergences

### DIFF
--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -283,22 +283,28 @@ work:
 
       IN PROGRESS. ssb: no burndown required (0 divergences); baseline empty.
 
-      clickbench: load-faithful gate now WIRED (build_clickbench_duckdb) and
-      runnable in report mode (`make clickbench-cross-surface-equivalence-report`).
-      Registered in STAGED_GATES (NOT GATES) so the coverage map does not
-      prematurely mark it guarded. Enumeration at SF=0.1: 32 of 86 cells divergent
-      (full categorized list: _project/analysis/clickbench-cross-surface-divergences.md):
-        - 10 DataFrame engine/abstraction gaps (highest priority, fix at the engine
-          layer): UnifiedLazyFrame.slice missing (Q39-42), UnifiedStrExpr.replace
-          missing (Q29), date-vs-string compare (Q37/38/43 expression), str-vs-None
-          compare (Q25/27 pandas).
-        - 22 value divergences needing per-query triage; several are clearly real
-          logic bugs (Q32/Q33 pandas return ~full row count -> dropped
-          filter/DISTINCT), plus empty-string-vs-None null-handling (Q17/Q24).
-      Burn-down (engine gaps first, then per-query) is the remaining w3 work for
-      clickbench; once clean, promote STAGED_GATES->GATES and add a blocking
-      pr.yml step + fast-lane regression (w4). joinorder_synthetic (the other
-      gateable benchmark per the applicability sweep) is the next gate to wire.
+      clickbench: load-faithful gate WIRED (build_clickbench_duckdb), STAGED_GATES
+      (NOT GATES), runnable via `make clickbench-cross-surface-equivalence-report`.
+
+      BURN-DOWN PROGRESS (full detail:
+      _project/analysis/clickbench-cross-surface-divergences.md):
+        - DETERMINISM FIX (prerequisite): the ClickBench generator was UNSEEDED, so
+          every run produced different data and top-N/tie-sensitive cells flipped
+          divergence run-to-run (the gate was flaky). Added random.seed(42) in
+          _generate_data_local (mirrors SSBDataGenerator); the gate is now
+          deterministic (verified: two runs report the identical divergence set).
+        - ALL 10 engine/error-category cells FIXED: added UnifiedStrExpr.replace
+          (Q29) and UnifiedLazyFrame.slice (Q39-42) to the shared abstraction;
+          compared EventDate to native date literals not strings (Q37-43); pandas
+          `<> ''` filters now exclude NULL via .notna() to match SQL/Polars
+          (Q25/27). 1129 dataframe/clickbench unit tests still pass.
+        - REMAINING: 27 stable value-divergence cells across 14 queries (identical across 3 runs) (Q6, Q9,
+          Q10, Q15-19, Q24, Q31-33, Q36, Q38) - per-query triage: empty-vs-None
+          null materialization (Q17/Q24), large aggregate diffs (Q16/18/32/33/36 -
+          dropped predicate/DISTINCT), and top-N tie-break ordering (Q9/10/38/15/31).
+      Once those 26 are clean, promote STAGED_GATES->GATES + a blocking pr.yml step
+      + fast-lane regression (w4). joinorder_synthetic and the other registry-bearing
+      benchmarks (per the corrected applicability sweep) are the next gates to wire.
 
   - id: w4
     summary: "Promote to bounded CI gates and add fast-lane regressions"

--- a/_project/analysis/clickbench-cross-surface-divergences.md
+++ b/_project/analysis/clickbench-cross-surface-divergences.md
@@ -2,67 +2,63 @@
 
 Snapshot from `make clickbench-cross-surface-equivalence-report`
 (`python -m benchbox.core.equivalence.cross_surface --benchmark clickbench`) at
-SF=0.1 on DuckDB. SQL is the reference for its own DataFrame surface; both
-backends (`expression`/polars, `pandas`) are compared.
+SF=0.1 on DuckDB, SQL as the reference for its own DataFrame surface (`expression`
+= Polars, `pandas`).
 
-**Result: 32 of 86 query-backend cells divergent.** The build is load-faithful
-(SQL loads via the production DuckDB loader with the real schema; DataFrame
-contexts via the production loader), so these are genuine SQL<->DataFrame
-disagreements, not build artifacts. ClickBench is therefore registered as a
-STAGED gate (runnable in report mode) — **not** an enforced `GATES` entry — until
-the divergences below are burned down. It stays UNGUARDED in the oracle coverage
-map.
+The ClickBench generator is now **seeded** (`random.seed(42)` in
+`_generate_data_local`), so the data is fixed and the gate is stable: three
+consecutive runs reported the **identical** 27-cell divergence set (0 flaky).
+Previously the unseeded generator made top-N/tie-sensitive queries flip in and out
+of divergence run-to-run. Watch-item: top-N queries with ties (`LIMIT` over tied
+values) could still vary on a query engine with nondeterministic tie ordering;
+adding deterministic tie-breaker sort keys is the belt-and-suspenders fix before
+promoting clickbench to a blocking gate.
 
-## A. DataFrame engine/abstraction gaps (10 cells) — highest priority
+## Fixed in this pass (all 10 engine/error-category cells)
 
-These are missing capabilities in the shared DataFrame abstraction; they block
-several queries on the `expression`/`pandas` backends and should be fixed at the
-engine layer (one fix clears multiple queries):
+These were hard errors, not value mismatches; all now resolved:
 
-| Symptom | Cells |
+| Fix | Cells cleared |
 | --- | --- |
-| `'UnifiedLazyFrame' object has no attribute 'slice'` | Q39, Q40, Q41, Q42 (expression) |
-| `'UnifiedStrExpr' object has no attribute 'replace'` | Q29 (expression) |
-| `cannot compare 'date/datetime/time' to a string value` | Q37, Q38, Q43 (expression) |
-| `'<' not supported between 'str' and 'NoneType'` | Q25, Q27 (pandas) |
+| `UnifiedStrExpr.replace` added (regex replace) | Q29 |
+| `UnifiedLazyFrame.slice` added (LIMIT/OFFSET) | Q39, Q40, Q41, Q42 |
+| Date columns compared to native `date` literals, not strings | Q37, Q38, Q39–Q42, Q43 |
+| Pandas `<> ''` filters exclude NULL (`.notna()`), matching SQL/Polars | Q25, Q27 |
 
-## B. Value divergences (22 cells) — per-query triage
+## Remaining: 27 value-divergence cells (14 queries) — per-query triage
 
-The DataFrame surface returns different values than SQL. Several are clearly real
-logic bugs (not small-SF ordering ties): e.g. Q32/Q33 on pandas return ≈ the full
-row count (9,994,262), implying a missing filter/`DISTINCT`; Q36 differs by ~6-16x.
+Deterministic baseline; these are genuine SQL↔DataFrame value disagreements:
 
-| Query | expression (SQL → DF) | pandas (SQL → DF) |
+| Query | expression (SQL → DF) | pandas |
 | --- | --- | --- |
 | Q6 | — | 18 → 17 |
-| Q14 | games → education | — |
-| Q15 | 6 → 9 (row 1) | — |
-| Q16 | 77766 → 138185 | 77766 → 138185 |
-| Q17 | "" → None (col 1) | 138185 → 87538 |
-| Q18 | 85246 → 7233 | 85246 → 6 |
-| Q19 | 6597 → 43822 | 6597 → 6 |
-| Q24 | "" → None (col 14) | "" → None (col 14) |
-| Q31 | 0 → 1 | 0 → 50 |
-| Q32 | 1075964 → 817388 | 1075964 → 9994262 |
-| Q33 | 185610 → 821440 | 185610 → 9994262 |
-| Q36 | 171949499 → 1002602998 | 171949499 → 2870038854 |
-| Q38 | (date-compare error, group A) | About Us → Blog |
+| Q9 | 584 → 407 (row 8) | (same) |
+| Q10 | 196 → 117 (row 4) | (same) |
+| Q15 | 10 → 1 | (same) |
+| Q16 | 7599 → 44197 | (same) |
+| Q17 | "" → None (col 1) | (same) |
+| Q18 | 2594 → 20880 | (same) |
+| Q19 | 281576 → 211201 | (same) |
+| Q24 | "" → None (col 14) | (same) |
+| Q31 | 4 → 10 | (same) |
+| Q32 | 1751543 → 549458 | (same) |
+| Q33 | 183107 → 1533813 | (same) |
+| Q36 | 27418322 → 288711262 | (same) |
+| Q38 | Home Page → Blog (row 1) | (same) |
 
-Sub-notes:
+Patterns for the burn-down:
 - **Empty-string vs None** (Q17 col 1, Q24 col 14): SQL emits `""`, the DataFrame
-  surface emits `None`. Likely a null-handling difference in DataFrame
-  materialization; confirm whether the source value is genuinely empty or NULL
-  before deciding which surface is correct (do not mute as "presentational").
-- **≈full-row-count results** (Q32/Q33 pandas = 9,994,262): a dropped predicate /
-  missing `DISTINCT` in the DataFrame impl — real logic bug.
+  surface emits `None` — a null-materialization difference; confirm the source
+  value before deciding which surface is correct.
+- **Large aggregate differences** (Q16/Q18/Q32/Q33/Q36): a dropped predicate,
+  missing `DISTINCT`, or wrong aggregation in the DataFrame impl.
+- **Top-N row-value differences** (Q9 row 8, Q10 row 4, Q38 row 1, Q15, Q31):
+  likely the DataFrame top-N breaks ties differently than the SQL `ORDER BY`;
+  align the sort keys/tie-breakers (now reproducible thanks to the seed).
 
-## Burn-down dispatch (cross-surface gate w3)
+## Status
 
-1. Fix the group-A engine gaps first (`UnifiedLazyFrame.slice`,
-   `UnifiedStrExpr.replace`, date/string comparison, str/None comparison) — these
-   clear ~10 cells and likely benefit other benchmarks' DataFrame surfaces.
-2. Triage group-B value divergences per query against the SQL reference; fix the
-   wrong surface (usually the DataFrame impl) without changing query identity.
-3. When clean, promote `clickbench` from `STAGED_GATES` into `GATES`, add a
-   `clickbench-cross-surface` blocking step to `.github/workflows/pr.yml`
-   (mirroring SSB), and a fast-lane regression.
+ClickBench stays in `STAGED_GATES` (report mode), **not** `GATES`: these 26 are
+real bugs, not presentational, so they must be fixed (not added to a
+`known_divergences` baseline). Promote to `GATES` + a blocking `pr.yml` step only
+once clean.

--- a/benchbox/core/clickbench/dataframe_queries/queries.py
+++ b/benchbox/core/clickbench/dataframe_queries/queries.py
@@ -28,7 +28,12 @@ def _hits(ctx: DataFrameContext) -> Any:
 
 def _expr_july_mask(ctx: DataFrameContext, start: str = _DATE_FROM, end: str = _DATE_TO) -> Any:
     col, lit = ctx.col, ctx.lit
-    return (col("CounterID") == lit(62)) & (col("EventDate") >= lit(start)) & (col("EventDate") <= lit(end))
+    # EventDate is a Date column; compare against native date literals. Comparing a
+    # date column to a string literal raises in Polars ("cannot compare
+    # date/datetime to a string value"), unlike the SQL reference where the string
+    # is parsed as a date.
+    start_date, end_date = date.fromisoformat(start), date.fromisoformat(end)
+    return (col("CounterID") == lit(62)) & (col("EventDate") >= lit(start_date)) & (col("EventDate") <= lit(end_date))
 
 
 def _expr_filter(ctx: DataFrameContext, hits: Any, code: str) -> Any:
@@ -95,17 +100,20 @@ def _pandas_filter(hits: Any, code: str) -> Any:
     if code == "adv_ne_0":
         return hits[hits["AdvEngineID"] != 0]
     if code == "phone_model_nonempty":
-        return hits[hits["MobilePhoneModel"] != ""]
+        return hits[hits["MobilePhoneModel"].notna() & (hits["MobilePhoneModel"] != "")]
     if code == "search_nonempty":
-        return hits[hits["SearchPhrase"] != ""]
+        return hits[hits["SearchPhrase"].notna() & (hits["SearchPhrase"] != "")]
     if code == "url_google":
         return hits[hits["URL"].str.contains("google", na=False)]
     if code == "google_search":
-        return hits[hits["URL"].str.contains("google", na=False) & (hits["SearchPhrase"] != "")]
+        return hits[
+            hits["URL"].str.contains("google", na=False) & hits["SearchPhrase"].notna() & (hits["SearchPhrase"] != "")
+        ]
     if code == "google_title":
         return hits[
             hits["Title"].str.contains("Google", na=False)
             & ~hits["URL"].str.contains(".google.", na=False, regex=False)
+            & hits["SearchPhrase"].notna()
             & (hits["SearchPhrase"] != "")
         ]
     if code == "user_lookup":

--- a/benchbox/core/clickbench/generator.py
+++ b/benchbox/core/clickbench/generator.py
@@ -179,6 +179,13 @@ class ClickBenchDataGenerator(CompressionMixin, CloudStorageGeneratorMixin):
 
     def _generate_data_local(self, output_dir: Path, tables: Optional[list[str]] = None) -> dict[str, Path]:
         """Generate data locally (original implementation)."""
+        # Seed for reproducible data (SSBDataGenerator seeds similarly). Without
+        # this the `random.*` row values differ every run, making top-N /
+        # tie-sensitive queries (e.g. the cross-surface equivalence gate)
+        # non-deterministic. Seeded per generation call so reused generator
+        # instances still produce identical data; like the other generators this
+        # seeds the module-global RNG.
+        random.seed(42)
         if tables is None:
             tables = ["hits"]
 

--- a/benchbox/platforms/dataframe/unified_frame.py
+++ b/benchbox/platforms/dataframe/unified_frame.py
@@ -181,6 +181,35 @@ class UnifiedStrExpr:
             return UnifiedExpr(df_f.regexp_like(self._expr, pattern))
         return UnifiedExpr(self._expr.str.contains(pattern))
 
+    def replace(self, pattern: Any, value: Any) -> UnifiedExpr:
+        """Regex-replace matches of ``pattern`` with ``value`` (capture groups via ``$1``).
+
+        Mirrors SQL ``REGEXP_REPLACE``. ``pattern``/``value`` may be plain strings or
+        wrapped literal expressions. Polars replaces only the first match; for the
+        anchored whole-string patterns this is used for that is equivalent to a full
+        replace.
+
+        Args:
+            pattern: Regex pattern to match.
+            value: Replacement string (may reference capture groups, e.g. ``$1``).
+
+        Returns:
+            UnifiedExpr with the replaced string.
+        """
+        pattern = _unwrap_unified_expr(pattern)
+        value = _unwrap_unified_expr(value)
+        if self._is_pyspark:
+            from pyspark.sql.functions import regexp_replace
+
+            return UnifiedExpr(regexp_replace(self._expr, pattern, value))
+        if self._is_datafusion:
+            from datafusion import functions as df_f, lit as df_lit
+
+            pattern = pattern if _is_datafusion_expr(pattern) else df_lit(pattern)
+            value = value if _is_datafusion_expr(value) else df_lit(value)
+            return UnifiedExpr(df_f.regexp_replace(self._expr, pattern, value))
+        return UnifiedExpr(self._expr.str.replace(pattern, value))
+
     def slice(self, offset: int, length: int | None = None) -> UnifiedExpr:
         """Extract substring.
 
@@ -3899,6 +3928,32 @@ class UnifiedLazyFrame(Generic[DF, Expr]):
     def head(self, n: int = 10) -> UnifiedLazyFrame:
         """Get first n rows (alias for limit)."""
         return self.limit(n)
+
+    def slice(self, offset: int, length: int | None = None) -> UnifiedLazyFrame:
+        """Return ``length`` rows starting at ``offset`` (SQL ``LIMIT length OFFSET offset``).
+
+        Args:
+            offset: Zero-based start row.
+            length: Number of rows to return; ``None`` means all rows from ``offset``.
+
+        Returns:
+            UnifiedLazyFrame with the sliced rows.
+        """
+        if _is_polars_df(self._df):
+            result = self._df.slice(offset, length)
+        elif _is_datafusion_df(self._df):
+            # DataFusion has no .slice(); it offsets via limit(count, offset=).
+            if length is None:
+                raise NotImplementedError("UnifiedLazyFrame.slice without a length is not supported for DataFusion")
+            result = self._df.limit(length, offset=offset)
+        elif _is_pyspark_df(self._df):
+            # PySpark has no native offset slice (it would need a row_number window);
+            # not exercised by the current cross-surface gates.
+            raise NotImplementedError("UnifiedLazyFrame.slice is not implemented for PySpark")
+        else:
+            # Fallback: rely on a native polars-style slice if present.
+            result = self._df.slice(offset, length)
+        return UnifiedLazyFrame(result, self._adapter)
 
     # =========================================================================
     # Rename Operations


### PR DESCRIPTION
Burns down the clickbench SQL↔DataFrame cross-surface gate (STAGED) and makes it
stable — task #2 of the unguarded-benchmark campaign.

## Determinism (the prerequisite finding)
The ClickBench generator was **unseeded**, so each run produced different data and
tie-sensitive top-N cells flipped divergence run-to-run — the gate was flaky and
unusable as an oracle. Added `random.seed(42)` in `_generate_data_local`; **three
consecutive gate runs now report the identical 27-cell divergence set.**

This is worth auditing across the *other* registry-bearing benchmarks before
wiring their gates.

## All 10 engine/error-category cells fixed
| Fix | Cells |
| --- | --- |
| `UnifiedStrExpr.replace` added (regex replace) | Q29 |
| `UnifiedLazyFrame.slice` added (LIMIT/OFFSET; polars native, datafusion limit+offset, pyspark NotImplemented) | Q39–42 |
| `EventDate` compared to native `date` literals, not strings (Polars rejects date-vs-string) | Q37–43 |
| Pandas `<> ''` filters exclude NULL (`.notna()`), matching SQL/Polars | Q25/Q27 |

`UnifiedStrExpr.replace`/`UnifiedLazyFrame.slice` mirror the file's existing
backend-dispatch conventions. **1129 dataframe/clickbench unit tests pass.**

## Review
A focused review was run; its one real finding (the `slice` else-branch assumed a
polars-style `.slice` that DataFusion lacks) is fixed with an explicit DataFusion
`limit(length, offset=offset)` branch.

## Remaining (documented backlog)
27 stable value-divergence cells across 14 queries (Q6, Q9, Q10, Q15–19, Q24,
Q31–33, Q36, Q38) — per-query triage: empty-vs-None materialization, large
aggregate diffs (dropped predicate/`DISTINCT`), and top-N tie-breaks. Full detail
in `_project/analysis/clickbench-cross-surface-divergences.md`. clickbench stays in
`STAGED_GATES` (not a blocking gate) until clean — these are real bugs, not
presentational, so they are **not** muted as a `known_divergences` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_