### PR TITLE
fix(joinorder_synthetic): seed generator + audit gateable-benchmark generator seeding

### DIFF
--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -308,6 +308,18 @@ work:
       + fast-lane regression (w4). joinorder_synthetic and the other registry-bearing
       benchmarks (per the corrected applicability sweep) are the next gates to wire.
 
+      GENERATOR SEEDING AUDIT (_project/analysis/gateable-generator-seeding-audit.md):
+      an unseeded generator makes any cross-surface gate flaky (as ClickBench was).
+      Audited every gateable benchmark's generator. Most are seeded (ssb, amplab,
+      h2odb, tpch_skew, tsbs_devops, clickbench) or RNG-free (coffeeshop static
+      seed-data, read_primitives). FIX: joinorder_synthetic used unseeded random
+      and is the next gate to wire - added random.seed(42) in its
+      _generate_data_local; verified its data tables are now byte-identical across
+      runs (the only residual file-byte diff is the manifest timestamp, which the
+      gate does not read). The five external/derived-data benchmarks (datavault,
+      flightdata, joinorder, nyctaxi, tpcds_obt) have no synthetic RNG; confirm
+      their bounded data source is stable when wiring each.
+
   - id: w4
     summary: "Promote to bounded CI gates and add fast-lane regressions"
     needs: [w3]

--- a/_project/analysis/gateable-generator-seeding-audit.md
+++ b/_project/analysis/gateable-generator-seeding-audit.md
@@ -1,0 +1,50 @@
+# Gateable-benchmark generator seeding audit
+
+Wiring a cross-surface equivalence gate for a benchmark whose generator is
+**unseeded** produces a *flaky* gate: each run generates different data, so
+top-N/tie-sensitive queries flip in and out of divergence (this is exactly what
+happened with ClickBench — see `clickbench-cross-surface-divergences.md`). Before
+wiring more gates, this audit records the data-determinism status of every
+cross-surface-gateable benchmark (from `cross-surface-applicability.md`).
+
+Method: inspect each benchmark's `generator.py` for RNG use (`random.*`, numpy)
+and for a seed (`random.seed`, `default_rng`, ...). For benchmarks with no
+`generator.py`, the data comes from an external/derived source whose determinism
+depends on that source.
+
+| Benchmark | RNG | Seeded? | Gate determinism |
+| --- | --- | --- | --- |
+| ssb | random | ✅ `random.seed(42)` | deterministic (gated) |
+| coffeeshop | none (static seed-data files) | n/a | deterministic (gated) |
+| clickbench | random | ✅ seeded (this campaign) | deterministic (staged gate) |
+| amplab | random | ✅ seeded | deterministic |
+| h2odb | random | ✅ seeded | deterministic |
+| tpch_skew | random | ✅ seeded | deterministic |
+| tsbs_devops | random | ✅ seeded | deterministic |
+| joinorder_synthetic | random | ✅ **seeded in this change** | deterministic (verified) |
+| read_primitives | none | n/a | deterministic |
+| datavault | (no generator.py) | — | verify source before gating |
+| flightdata | (no generator.py — real data) | — | verify source before gating |
+| joinorder | (no generator.py — canonical IMDb) | — | likely deterministic (fixed source) |
+| nyctaxi | (no generator.py — real data) | — | verify source before gating |
+| tpcds_obt | (no generator.py — derived from TPC-DS) | — | inherits TPC-DS determinism |
+
+## Fix applied here
+
+`joinorder_synthetic` used `random.*` (synthetic titles/names/ids) with **no
+seed** — it would have produced a flaky gate. Added `random.seed(42)` at the start
+of `_generate_data_local` (mirrors SSB/ClickBench). Verified: two generations now
+produce **byte-identical data tables** (the residual file-byte difference is only
+the manifest's embedded timestamp, which the gate does not read).
+
+## Notes / follow-ups
+
+- **Manifest timestamps**: generated `manifest`/`*.json` files embed a generation
+  timestamp, so raw-file-byte comparisons are not a reliable determinism signal —
+  compare *data tables* (the gate reads those, not the manifest).
+- The five external/derived-data benchmarks (datavault, flightdata, joinorder,
+  nyctaxi, tpcds_obt) have no synthetic RNG; their gate determinism depends on a
+  fixed data source. Confirm the bounded data source is stable when wiring each.
+- Next gate to wire is `joinorder_synthetic` (now deterministic) or another
+  id-overlapping benchmark (flightdata/h2odb/read_primitives), per
+  `cross-surface-applicability.md`.

--- a/benchbox/core/joinorder_synthetic/generator.py
+++ b/benchbox/core/joinorder_synthetic/generator.py
@@ -129,6 +129,11 @@ class JoinOrderGenerator(CompressionMixin, CloudStorageGeneratorMixin):
 
     def _generate_data_local(self, output_dir: Path) -> dict[str, Path]:
         """Generate data locally (original implementation)."""
+        # Seed for reproducible data (mirrors SSB/ClickBench generators). Without
+        # this the `random.*` synthetic rows differ every run, which makes
+        # top-N/tie-sensitive consumers (e.g. the cross-surface equivalence gate)
+        # non-deterministic.
+        random.seed(42)
         # Temporarily modify instance output_dir to use provided output_dir
         original_output_dir = self.output_dir
         self.output_dir = output_dir


### PR DESCRIPTION
De-risks the cross-surface gate campaign by auditing generator seeding before
wiring more gates.

## Why
The ClickBench burn-down (#844) showed an **unseeded generator makes a
cross-surface gate flaky** — different data each run, so top-N/tie-sensitive cells
flip in and out of divergence. Wiring a gate for an unseeded benchmark would
inherit that flakiness.

## Audit (`_project/analysis/gateable-generator-seeding-audit.md`)
Checked every cross-surface-gateable benchmark's generator:
- **Seeded / safe:** ssb, amplab, h2odb, tpch_skew, tsbs_devops, clickbench.
- **RNG-free / deterministic:** coffeeshop (static seed-data files), read_primitives.
- **Unseeded → fixed here:** `joinorder_synthetic`.
- **External/derived data (no generator.py):** datavault, flightdata, joinorder, nyctaxi, tpcds_obt — no synthetic RNG; confirm the bounded data source when wiring each.

## Fix
`joinorder_synthetic` (the next gate to wire) used unseeded `random.*` for
synthetic titles/names/ids. Added `random.seed(42)` in `_generate_data_local`
(mirrors SSB/ClickBench). **Verified: two generations now produce byte-identical
data tables** — the only residual file-byte difference is the manifest's embedded
timestamp, which the gate does not read.

## Verification
- joinorder_synthetic data-table hash identical across 2 runs (manifest excluded).
- 85 joinorder_synthetic unit tests pass; `ruff` clean; TODO validates + graph passes.

Note recorded for the campaign: manifest/`*.json` files embed a timestamp, so
raw-file-byte comparisons aren't a reliable determinism signal — compare data
tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC4mHtG6yiaiHkdHDkyTAj)_