### PR TITLE
feat(equivalence): promote clickbench + joinorder_synthetic to enforced cross-surface gates (w4)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -407,6 +407,12 @@ jobs:
       - name: Run CoffeeShop cross-surface SQL<->DataFrame equivalence gate
         run: make coffeeshop-cross-surface-equivalence-report
 
+      - name: Run ClickBench cross-surface SQL<->DataFrame equivalence gate
+        run: make clickbench-cross-surface-equivalence-report
+
+      - name: Run JoinOrder-synthetic cross-surface SQL<->DataFrame equivalence gate
+        run: make joinorder-synthetic-cross-surface-equivalence-report
+
   postgres-integration:
     name: postgres-integration
     needs: ci-paths

--- a/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
+++ b/_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml
@@ -379,10 +379,37 @@ work:
   - id: w4
     summary: "Promote to bounded CI gates and add fast-lane regressions"
     needs: [w3, w8, w9]
-    status: in_progress
+    status: done
     notes: |
-      One bounded small-SF DuckDB cell per gated benchmark, wired into the
-      correctness-gate CI job and a Make target, mirroring
+      DONE for the two STAGED gates (the prerequisite-driven promotion w8/w9
+      unblocked). clickbench and joinorder_synthetic moved STAGED_GATES -> GATES in
+      cross_surface.py; both wired as BLOCKING steps in the pr.yml correctness-gate
+      job (make clickbench-cross-surface-equivalence-report,
+      make joinorder-synthetic-cross-surface-equivalence-report) beside ssb/amplab/
+      coffeeshop; medium-marker fast-lane regressions added
+      (tests/integration/test_{clickbench,joinorder_synthetic}_cross_surface_equivalence.py)
+      mirroring test_ssb_cross_surface_equivalence.py; unit test updated
+      (test_clickbench_and_joinorder_are_enforced_gates). Proved each FAILS on a
+      planted divergence (clickbench Q1 count+1000 -> Q1_expression+Q1_pandas;
+      joinorder 1a value+99999 -> 1a_expression+1a_pandas; no collateral).
+      clickbench's only baseline entry is the order-less Q18; joinorder_synthetic is
+      clean. Regenerated the oracle coverage map (make oracle-coverage-map) - both
+      now show cross-surface "guarded" (15 UNGUARDED, was 17 dual-surface) - and
+      committed it; updated the coverage-map TODO w1 dispatch note. STAGED_GATES is
+      now empty. ssb/amplab/coffeeshop and TPC-Havoc gates re-verified green.
+
+      FOLLOW-ON (separate focused gate PRs, tracked by
+      benchmark-correctness-oracle-coverage-map w1, NOT a blocker for this item):
+      wire the remaining gateable dual-surface benchmarks one PR each - datavault,
+      flightdata, h2odb, nyctaxi, read_primitives (152-id intersection), tpcds_obt
+      (partial), tpch_skew, tsbs_devops (several need id normalization or a bounded
+      data-source check first), and joinorder (SF=1-only; covered by
+      joinorder_synthetic). Each follows the same recipe: build_<bench>_duckdb,
+      register in GATES, add a pr.yml step + a fast-lane test, prove a planted
+      divergence fails, regenerate the coverage map.
+
+      Original plan: one bounded small-SF DuckDB cell per gated benchmark, wired into
+      the correctness-gate CI job and a Make target, mirroring
       tpchavoc-(dataframe-)equivalence-report. Add a medium-marker pytest per
       benchmark like tests/integration/test_tpchavoc_variant_equivalence.py.
       Prove each gate fails when a deliberate divergence is introduced into one
@@ -701,4 +728,4 @@ metadata:
   tags: [equivalence, correctness, dataframe, sql, ci, tpch, tpcds, ssb]
   estimated_effort: "Large"
   created_date: "2026-06-16"
-  last_updated: "2026-06-21T23:30:00"
+  last_updated: "2026-06-22T00:30:00"

--- a/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
+++ b/_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml
@@ -80,13 +80,16 @@ work:
       oracle) rather than the cross-surface gate.
 
       STATUS SYNC (2026-06-21) from benchmark-cross-surface-equivalence-gate: ssb,
-      amplab (#835, PR open), coffeeshop are GATED; clickbench and joinorder_synthetic
-      are WIRED in report mode (STAGED_GATES) and promote to enforced GATES once that
-      campaign's w8 (tie-aware top-N comparator) and w9 (loader dtype-from-schema)
-      land. Remaining dual-surface dispatch targets: datavault, flightdata, h2odb,
-      joinorder (SF=1-only - use joinorder_synthetic), nyctaxi, read_primitives,
-      tpcds_obt, tpch_skew, tsbs_devops (several need id normalization first). This
-      item only tracks coverage; the gates themselves are owned there.
+      amplab, coffeeshop are GATED, and clickbench + joinorder_synthetic are now
+      PROMOTED to enforced GATES (campaign w4) - their prerequisites landed (w9
+      loader dtype/empty-string semantics, w8 tie-aware top-N comparator), both run
+      as blocking pr.yml steps with medium-marker fast-lane tests, and the oracle
+      coverage map (regenerated here) shows both as cross-surface "guarded". So 5
+      dual-surface benchmarks are guarded. Remaining dual-surface dispatch targets
+      (one focused gate PR each, several need id normalization or a bounded
+      data-source check first): datavault, flightdata, h2odb, joinorder (SF=1-only -
+      use joinorder_synthetic), nyctaxi, read_primitives, tpcds_obt, tpch_skew,
+      tsbs_devops. This item only tracks coverage; the gates themselves are owned there.
 
   - id: w2
     summary: "Choose and apply a fallback oracle for single-surface, no-oracle benchmarks"

--- a/_project/analysis/cross-surface-applicability.md
+++ b/_project/analysis/cross-surface-applicability.md
@@ -2,16 +2,14 @@
 
 **Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and detects which ship a DataFrame query `QueryRegistry` (the registry the cross-surface gate builders consume). `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts candidates; the production query *resolver* under-counts (it misses per-benchmark `<BENCH>_DATAFRAME_QUERIES` registries). Registry detection is the authoritative gate-applicability signal.
 
-**Summary:** 15 dual-surface unguarded candidates — 11 cross-surface gateable (ship a DataFrame query registry), 4 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
+**Summary:** 13 dual-surface unguarded candidates — 9 cross-surface gateable (ship a DataFrame query registry), 4 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
 
 | Benchmark | Status | SQL queries | DataFrame queries | Raw id overlap | Note |
 | --- | --- | --- | --- | --- | --- |
-| clickbench | gateable | 43 | 43 | 43 | → cross-surface gate (w3) |
 | datavault | gateable-needs-id-mapping | 22 | 22 | 0 | → cross-surface gate after id normalization (w3) |
 | flightdata | gateable | 20 | 20 | 20 | → cross-surface gate (w3) |
 | h2odb | gateable | 10 | 10 | 10 | → cross-surface gate (w3) |
 | joinorder | gateable | 113 | 113 | 113 | → cross-surface gate (w3) |
-| joinorder_synthetic | gateable | 13 | 13 | 13 | → cross-surface gate (w3) |
 | metadata_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
 | nyctaxi | gateable-needs-id-mapping | 25 | 25 | 0 | → cross-surface gate after id normalization (w3) |
 | read_primitives | gateable | 157 | 152 | 152 | → cross-surface gate (w3) |
@@ -24,6 +22,6 @@
 
 ## Campaign dispatch
 
-- **Cross-surface gate, ids overlap as-is (w3):** clickbench, flightdata, h2odb, joinorder, joinorder_synthetic, read_primitives.
+- **Cross-surface gate, ids overlap as-is (w3):** flightdata, h2odb, joinorder, read_primitives.
 - **Cross-surface gate, needs id normalization first (w3):** datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops — a DataFrame query registry exists but its ids differ from the SQL ids by a naming convention (e.g. `1` vs `Q1`); normalize in the builder.
 - **w2 fallback oracle** — no DataFrame query registry, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: metadata_primitives, tpcdi, transaction_primitives, write_primitives.

--- a/_project/analysis/oracle-coverage-map.json
+++ b/_project/analysis/oracle-coverage-map.json
@@ -27,11 +27,13 @@
     },
     {
       "benchmark": "clickbench",
-      "cross_surface_applicable": true,
+      "cross_surface_applicable": false,
       "dual_surface": true,
-      "guarded": false,
-      "oracles": [],
-      "primary_oracle": "NONE",
+      "guarded": true,
+      "oracles": [
+        "cross-surface"
+      ],
+      "primary_oracle": "cross-surface",
       "surfaces": [
         "sql",
         "dataframe"
@@ -101,11 +103,13 @@
     },
     {
       "benchmark": "joinorder_synthetic",
-      "cross_surface_applicable": true,
+      "cross_surface_applicable": false,
       "dual_surface": true,
-      "guarded": false,
-      "oracles": [],
-      "primary_oracle": "NONE",
+      "guarded": true,
+      "oracles": [
+        "cross-surface"
+      ],
+      "primary_oracle": "cross-surface",
       "surfaces": [
         "sql",
         "dataframe"

--- a/_project/analysis/oracle-coverage-map.md
+++ b/_project/analysis/oracle-coverage-map.md
@@ -2,19 +2,19 @@
 
 **Generated** by `_project/scripts/generate_oracle_coverage_map.py` from the benchmark registry, the expected-results provider registry, and the equivalence-gate registries. Do not edit by hand — run the generator and commit. `tests/unit/test_oracle_coverage_map.py` fails if this drifts.
 
-**Summary:** 23 shipped benchmarks — 6 guarded, 17 UNGUARDED (15 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
+**Summary:** 23 shipped benchmarks — 8 guarded, 15 UNGUARDED (13 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
 
 | Benchmark | Surfaces | Oracle | Notes |
 | --- | --- | --- | --- |
 | ai_primitives | sql | NONE | single-surface → needs fallback oracle (w2) |
 | amplab | sql+dataframe | cross-surface | cross-surface |
-| clickbench | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| clickbench | sql+dataframe | cross-surface | cross-surface |
 | coffeeshop | sql+dataframe | cross-surface | cross-surface |
 | datavault | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | flightdata | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | h2odb | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | joinorder | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| joinorder_synthetic | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder_synthetic | sql+dataframe | cross-surface | cross-surface |
 | metadata_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | nyctaxi | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
 | read_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
@@ -36,5 +36,5 @@ These ship with no automated correctness oracle today. Dual-surface ones are dis
 
 > Caveat (w2 oracle choice): write/DML/nondeterministic benchmarks (`write_primitives`, `transaction_primitives`, `metadata_primitives`, `tpcdi`) are listed as dual-surface, but their two surfaces may not be result-comparable; prefer structural-invariant oracles (row counts, post-state assertions) over cross-surface equality for those.
 
-- Dual-surface (cross-surface candidates): clickbench, datavault, flightdata, h2odb, joinorder, joinorder_synthetic, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives
+- Dual-surface (cross-surface candidates): datavault, flightdata, h2odb, joinorder, metadata_primitives, nyctaxi, read_primitives, tpcdi, tpcds_obt, tpch_skew, transaction_primitives, tsbs_devops, write_primitives
 - Single-surface (fallback-oracle needed): ai_primitives, vector_search

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -49,11 +49,13 @@ queries via :meth:`DataFrameQuery.get_impl_for_family` (the same accessor
 ``DataFrameAdapter.execute_query`` uses) - rather than any bespoke engine, and
 the comparator is reused from the shared harness, never forked.
 
-Currently gated: ssb (canonical and small; SQL and DataFrame ids correspond 1:1
-as ``Q1.1`` .. ``Q4.3``) and amplab (8 queries; the SQL ids ``"1"``, ``"1a"``,
-``"2"`` .. ``"5"`` map 1:1 to the DataFrame ids by a mechanical ``Q`` prefix:
-``"Q1"``, ``"Q1a"``, ``"Q2"`` .. ``"Q5"``). Additional dual-surface benchmarks
-are added by registering a :class:`CrossSurfaceGate` in :data:`GATES`.
+Currently gated (enforced :data:`GATES`): ssb (canonical and small; SQL and
+DataFrame ids correspond 1:1 as ``Q1.1`` .. ``Q4.3``), amplab (8 queries; the SQL
+ids ``"1"``, ``"1a"``, ``"2"`` .. ``"5"`` map 1:1 to the DataFrame ids by a
+mechanical ``Q`` prefix: ``"Q1"``, ``"Q1a"``, ``"Q2"`` .. ``"Q5"``), coffeeshop,
+clickbench (the one classified exception is the order-less ``Q18``) and
+joinorder_synthetic. Additional dual-surface benchmarks are added by registering a
+:class:`CrossSurfaceGate` in :data:`GATES`.
 
 Copyright 2026 Joe Harris / BenchBox Project
 
@@ -485,21 +487,6 @@ def build_joinorder_synthetic_duckdb(scale_factor: float, output_dir: Path) -> C
     )
 
 
-# Registry of ENFORCED gated benchmarks: clean, blocking cross-surface gates whose
-# DataFrame surface matches its SQL surface. The oracle coverage map reads this set
-# to classify a benchmark as cross-surface "guarded", so only clean+enforced gates
-# belong here (registering a red gate here would be coverage theater).
-GATES: dict[str, CrossSurfaceGate] = {
-    "ssb": CrossSurfaceGate(name="ssb", build=build_ssb_duckdb),
-    "amplab": CrossSurfaceGate(name="amplab", build=build_amplab_duckdb),
-    "coffeeshop": CrossSurfaceGate(name="coffeeshop", build=build_coffeeshop_duckdb),
-}
-
-# Staged gates: the load-faithful builder is wired and runnable in report mode, but
-# the benchmark still has open cross-surface divergences to burn down before it can
-# be promoted into GATES (and made a blocking CI gate). Kept OUT of GATES so the
-# coverage map does not prematurely mark these benchmarks "guarded". See
-# `make <name>-cross-surface-equivalence-report` to enumerate their divergences.
 # Q18 is `SELECT UserID, SearchPhrase, COUNT(*) ... GROUP BY ... LIMIT 10` with NO
 # ORDER BY: at SF=0.1 the GROUP BY yields ~97k groups and the bare LIMIT keeps an
 # arbitrary 10, so the SQL and DataFrame surfaces each return a different - but
@@ -512,7 +499,19 @@ _CLICKBENCH_TIE_AMBIGUOUS = (
     "Q18 is LIMIT 10 with no ORDER BY over ~97k groups - an arbitrary, order-less top-N selection"
 )
 
-STAGED_GATES: dict[str, CrossSurfaceGate] = {
+# Registry of ENFORCED gated benchmarks: clean, blocking cross-surface gates whose
+# DataFrame surface matches its SQL surface. The oracle coverage map reads this set
+# to classify a benchmark as cross-surface "guarded", so only clean+enforced gates
+# belong here (registering a red gate here would be coverage theater).
+GATES: dict[str, CrossSurfaceGate] = {
+    "ssb": CrossSurfaceGate(name="ssb", build=build_ssb_duckdb),
+    "amplab": CrossSurfaceGate(name="amplab", build=build_amplab_duckdb),
+    "coffeeshop": CrossSurfaceGate(name="coffeeshop", build=build_coffeeshop_duckdb),
+    # Promoted from STAGED_GATES once the two cross-cutting prerequisites landed:
+    # w9 (loader applies schema column TYPES + DuckDB empty-string semantics) made
+    # joinorder_synthetic 26/26 and cleared ClickBench Q17/Q24; w8 (tie-aware
+    # comparator) cleared ClickBench's tie-ambiguous top-N cells. ClickBench's only
+    # baseline entry is the order-less Q18 (see above).
     "clickbench": CrossSurfaceGate(
         name="clickbench",
         build=build_clickbench_duckdb,
@@ -523,6 +522,15 @@ STAGED_GATES: dict[str, CrossSurfaceGate] = {
     ),
     "joinorder_synthetic": CrossSurfaceGate(name="joinorder_synthetic", build=build_joinorder_synthetic_duckdb),
 }
+
+# Staged gates: a load-faithful builder is wired and runnable in report mode, but
+# the benchmark still has open cross-surface divergences to burn down before it can
+# be promoted into GATES (and made a blocking CI gate). Kept OUT of GATES so the
+# coverage map does not prematurely mark these benchmarks "guarded". Currently empty
+# - clickbench and joinorder_synthetic graduated to GATES; the next gateable
+# benchmarks (datavault, flightdata, h2odb, nyctaxi, read_primitives, tpcds_obt,
+# tpch_skew, tsbs_devops) land here first when their builders are wired.
+STAGED_GATES: dict[str, CrossSurfaceGate] = {}
 
 
 def get_gate(name: str) -> CrossSurfaceGate:

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -64,6 +64,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -90,6 +91,23 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # gates' SF=0.1 DuckDB cell so routine PRs stay cheap (one bounded cell per
 # gated benchmark, never a full platform matrix).
 EQUIVALENCE_SCALE = 0.1
+
+_TRAILING_LIMIT_RE = re.compile(r"(?is)\blimit\s+\d+\s*(?:offset\s+\d+\s*)?;?\s*$")
+
+
+def _is_truncated_top_n(sql: str) -> bool:
+    """True if a SQL query ends in a ``LIMIT n`` (a truncated top-N candidate).
+
+    The tie-aware boundary relaxation is only sound where a ``LIMIT`` can actually
+    truncate a tie across the cutoff. Applying it to a full (un-truncated) result
+    set whose last order-key value is duplicated could let a real divergence in a
+    determined boundary row pass as an ambiguous "tie swap", so the gate enables
+    ``tie_aware`` per query ONLY for queries that carry a trailing ``LIMIT``;
+    everything else uses the strict comparator. A trailing line comment /
+    statement terminator is stripped first so ``... limit 10 -- note`` matches.
+    """
+    stripped = re.sub(r"\s*--[^\n]*$", "", sql.strip())
+    return bool(_TRAILING_LIMIT_RE.search(stripped))
 
 
 @dataclass(frozen=True)
@@ -171,6 +189,14 @@ def find_cross_surface_divergences(
         query_id: Any,
     ) -> Iterable[tuple[str, Callable[[list[tuple[Any, ...]]], None]]]:
         query = dataframe_query(query_id)
+        # tie_aware only for truncated top-N queries: a benchmark's own SQL and
+        # DataFrame surfaces are independent top-N implementations, so an
+        # ORDER BY ... LIMIT N whose ties span the cutoff can keep a different but
+        # equally-valid subset of the tied rows. Accept that boundary-tie ambiguity
+        # (the deterministic rows must still match exactly) - but ONLY where a
+        # LIMIT can actually truncate; a non-LIMIT query is compared strictly so a
+        # real divergence in a duplicated last row is never masked.
+        tie_aware = _is_truncated_top_n(reference_sql(query_id))
         for backend in backends:
             impl = query.get_impl_for_family(backend)
             if impl is None:
@@ -184,15 +210,10 @@ def find_cross_surface_divergences(
                 impl: Any = impl,
                 backend: str = backend,
                 query_id: Any = query_id,
+                tie_aware: bool = tie_aware,
             ) -> None:
                 candidate = materialize_rows(impl(contexts[backend]))
-                # tie_aware: a benchmark's own SQL and DataFrame surfaces are
-                # independent top-N implementations, so an ORDER BY ... LIMIT N
-                # whose ties span the cutoff can keep a different but equally-valid
-                # subset of the tied rows. Accept that boundary-tie ambiguity (the
-                # deterministic rows must still match exactly) rather than
-                # false-flagging it.
-                validator.validate_results_exact(reference, candidate, query_id, 0, tie_aware=True)
+                validator.validate_results_exact(reference, candidate, query_id, 0, tie_aware=tie_aware)
 
             yield backend, check
 

--- a/tests/integration/test_clickbench_cross_surface_equivalence.py
+++ b/tests/integration/test_clickbench_cross_surface_equivalence.py
@@ -1,0 +1,72 @@
+"""Result-equivalence regression test for the ClickBench cross-surface gate.
+
+The fast, default-lane companion to the full ClickBench cross-surface gate in
+``benchbox/core/equivalence/cross_surface.py`` (run via
+``make clickbench-cross-surface-equivalence-report``, wired into the
+``correctness-gate`` CI job), mirroring
+``tests/integration/test_ssb_cross_surface_equivalence.py``. It executes every
+ClickBench query's DataFrame surface (both backends) against its OWN SQL surface
+on a bounded SF=0.1 DuckDB cell and asserts they agree - SQL is the trusted
+reference for its own DataFrame surface, so no hand-curated answer key is needed.
+The comparison runs through the tie-aware comparator (top-N boundary ties are
+accepted); the only classified exception is the genuinely order-less Q18.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("polars", reason="Polars not installed")
+pytest.importorskip("pandas", reason="Pandas not installed")
+pytest.importorskip("duckdb", reason="DuckDB not installed")
+
+from benchbox.core.equivalence.cross_surface import (
+    EQUIVALENCE_SCALE,
+    GATES,
+    build_production_contexts,
+    count_executed_cells,
+    find_cross_surface_divergences,
+)
+from benchbox.core.tpchavoc.validation import ResultValidator
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.medium,
+    pytest.mark.duckdb,
+]
+
+
+def test_clickbench_dataframe_surface_equivalent_to_sql(tmp_path):
+    """Every ClickBench DataFrame query (both backends) must match its own SQL surface."""
+    gate = GATES["clickbench"]
+    data = gate.build(EQUIVALENCE_SCALE, tmp_path)
+    connection = data.connection
+    try:
+        contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+        divergences = find_cross_surface_divergences(
+            connection,
+            query_ids=data.query_ids,
+            reference_sql=data.reference_sql,
+            dataframe_query=data.dataframe_query,
+            contexts=contexts,
+            validator=ResultValidator(tolerance=gate.tolerance),
+            backends=gate.backends,
+        )
+        coverage = count_executed_cells(data.query_ids, data.dataframe_query, gate.backends)
+    finally:
+        connection.close()
+
+    # Both gated backends must actually compare something - a fully-unimplemented
+    # backend would make the gate silently green by comparing nothing.
+    missing = sorted(backend for backend, count in coverage.items() if count == 0)
+    assert not missing, f"gated ClickBench backend(s) implement no queries: {missing}"
+
+    # Only the classified order-less Q18 is tolerated; never an unclassified regression.
+    unexpected = {d.key for d in divergences} - set(gate.known_divergences)
+    assert not unexpected, "ClickBench DataFrame surface diverges from SQL: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in divergences if d.key in unexpected
+    )

--- a/tests/integration/test_joinorder_synthetic_cross_surface_equivalence.py
+++ b/tests/integration/test_joinorder_synthetic_cross_surface_equivalence.py
@@ -1,0 +1,71 @@
+"""Result-equivalence regression test for the joinorder_synthetic cross-surface gate.
+
+The fast, default-lane companion to the full joinorder_synthetic cross-surface
+gate in ``benchbox/core/equivalence/cross_surface.py`` (run via
+``make joinorder-synthetic-cross-surface-equivalence-report``, wired into the
+``correctness-gate`` CI job), mirroring
+``tests/integration/test_ssb_cross_surface_equivalence.py``. It executes every
+joinorder_synthetic query's DataFrame surface (both backends) against its OWN SQL
+surface on a bounded SF=0.1 DuckDB cell and asserts they agree - SQL is the
+trusted reference for its own DataFrame surface, so no hand-curated answer key is
+needed. The baseline is empty (every cell must match).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("polars", reason="Polars not installed")
+pytest.importorskip("pandas", reason="Pandas not installed")
+pytest.importorskip("duckdb", reason="DuckDB not installed")
+
+from benchbox.core.equivalence.cross_surface import (
+    EQUIVALENCE_SCALE,
+    GATES,
+    build_production_contexts,
+    count_executed_cells,
+    find_cross_surface_divergences,
+)
+from benchbox.core.tpchavoc.validation import ResultValidator
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.medium,
+    pytest.mark.duckdb,
+]
+
+
+def test_joinorder_synthetic_dataframe_surface_equivalent_to_sql(tmp_path):
+    """Every joinorder_synthetic DataFrame query (both backends) must match its own SQL surface."""
+    gate = GATES["joinorder_synthetic"]
+    data = gate.build(EQUIVALENCE_SCALE, tmp_path)
+    connection = data.connection
+    try:
+        contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+        divergences = find_cross_surface_divergences(
+            connection,
+            query_ids=data.query_ids,
+            reference_sql=data.reference_sql,
+            dataframe_query=data.dataframe_query,
+            contexts=contexts,
+            validator=ResultValidator(tolerance=gate.tolerance),
+            backends=gate.backends,
+        )
+        coverage = count_executed_cells(data.query_ids, data.dataframe_query, gate.backends)
+    finally:
+        connection.close()
+
+    # Both gated backends must actually compare something - a fully-unimplemented
+    # backend would make the gate silently green by comparing nothing.
+    missing = sorted(backend for backend, count in coverage.items() if count == 0)
+    assert not missing, f"gated joinorder_synthetic backend(s) implement no queries: {missing}"
+
+    # Empty baseline: every query/backend cell must match.
+    unexpected = {d.key for d in divergences} - set(gate.known_divergences)
+    assert not unexpected, "joinorder_synthetic DataFrame surface diverges from SQL: " + ", ".join(
+        f"{d.key} ({d.detail})" for d in divergences if d.key in unexpected
+    )

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -60,8 +60,7 @@ class _FakeQuery:
         return self._impls.get(family)
 
 
-def _make_inputs(reference_rows, impls_by_backend):
-    sql = "SELECT * FROM t"
+def _make_inputs(reference_rows, impls_by_backend, sql="SELECT * FROM t"):
     connection = _FakeConnection({sql: reference_rows})
 
     def reference_sql(_qid):
@@ -102,6 +101,48 @@ def test_divergent_backend_is_reported_with_backend_cell():
         validator=ResultValidator(),
     )
     assert [(d.query_id, d.cell, d.key) for d in divergences] == [("Q1.1", "pandas", "Q1.1_pandas")]
+
+
+def test_tie_aware_only_applies_to_truncated_top_n_queries():
+    """A boundary-tie swap is tolerated for a LIMIT query but NOT a non-LIMIT one.
+
+    The tie-aware relaxation is only sound where a LIMIT can truncate a tie across
+    the cutoff; for a full (non-LIMIT) result set a changed duplicated-last-row is
+    a real divergence and must still be reported (it is not an ambiguous swap).
+    """
+    # Reference ordered by the last column DESC; boundary value 3 is duplicated.
+    ref = [(1, 5), (2, 3), (3, 3)]
+    swapped = [(1, 5), (2, 3), (99, 3)]  # a different row at the boundary tie value
+
+    # Non-LIMIT query: strict comparison -> the swap is reported.
+    connection, reference_sql, dataframe_query, contexts = _make_inputs(
+        ref, {"expression": swapped}, sql="SELECT a, c FROM t ORDER BY c DESC"
+    )
+    strict = find_cross_surface_divergences(
+        connection,
+        query_ids=["Q1"],
+        reference_sql=reference_sql,
+        dataframe_query=dataframe_query,
+        contexts=contexts,
+        validator=ResultValidator(),
+        backends=("expression",),
+    )
+    assert [d.key for d in strict] == ["Q1_expression"], "non-LIMIT swap must be reported, not masked"
+
+    # Same swap under an ORDER BY ... LIMIT query: accepted as a boundary tie.
+    connection, reference_sql, dataframe_query, contexts = _make_inputs(
+        ref, {"expression": swapped}, sql="SELECT a, c FROM t ORDER BY c DESC LIMIT 3"
+    )
+    relaxed = find_cross_surface_divergences(
+        connection,
+        query_ids=["Q1"],
+        reference_sql=reference_sql,
+        dataframe_query=dataframe_query,
+        contexts=contexts,
+        validator=ResultValidator(),
+        backends=("expression",),
+    )
+    assert relaxed == [], "boundary-tie swap under a LIMIT query should be tolerated"
 
 
 def test_missing_backend_impl_is_skipped_not_a_divergence():

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -164,19 +164,23 @@ def test_reference_failure_records_one_cell_and_skips_candidates():
     assert "no such table" in divergences[0].detail
 
 
-def test_clickbench_is_staged_not_enforced():
-    """ClickBench is wired as a STAGED gate (report mode) but NOT an enforced GATES entry.
+def test_clickbench_and_joinorder_are_enforced_gates():
+    """ClickBench and joinorder_synthetic are promoted to enforced GATES (w4).
 
-    It still has open SQL<->DataFrame divergences (see
-    _project/analysis/clickbench-cross-surface-divergences.md), so it must stay out
-    of GATES - the oracle coverage map reads GATES to mark a benchmark "guarded",
-    and registering a red gate there would be coverage theater. `get_gate` must
-    still resolve it for report-mode runs.
+    Once the two cross-cutting prerequisites landed - w9 (loader applies schema
+    column TYPES + DuckDB empty-string semantics) and w8 (tie-aware comparator) -
+    both staged gates went clean and graduated from STAGED_GATES to GATES, so the
+    oracle coverage map marks them cross-surface "guarded". ClickBench's only
+    baseline entry is the genuinely order-less Q18.
     """
     from benchbox.core.equivalence.cross_surface import GATES, STAGED_GATES, get_gate
 
-    assert "clickbench" in STAGED_GATES
-    assert "clickbench" not in GATES
+    assert "clickbench" in GATES
+    assert "joinorder_synthetic" in GATES
+    assert "clickbench" not in STAGED_GATES
     assert get_gate("clickbench").name == "clickbench"
+    assert set(GATES["clickbench"].known_divergences) == {"Q18_expression", "Q18_pandas"}
+    # joinorder_synthetic is clean (empty baseline).
+    assert GATES["joinorder_synthetic"].known_divergences == {}
     # ssb stays the enforced precedent.
     assert "ssb" in GATES

--- a/tests/unit/test_cross_surface_applicability.py
+++ b/tests/unit/test_cross_surface_applicability.py
@@ -59,12 +59,13 @@ def test_w2_fallback_set_is_exactly_the_registry_less_benchmarks(rows):
 
 
 def test_registry_bearing_benchmarks_are_gateable(rows):
-    """clickbench (direct) and a known id-mapping case are classified gateable."""
+    """h2odb (direct) and a known id-mapping case are classified gateable."""
     by_id = {r["benchmark"]: r["status"] for r in rows}
-    assert by_id.get("clickbench") == GATEABLE
+    assert by_id.get("h2odb") == GATEABLE
     # datavault ships a registry but its ids are friendly/Q-prefixed vs the SQL ids
-    # -> needs mapping. (amplab was previously the example here; it is now an
-    # enforced cross-surface gate, so it no longer appears among unguarded candidates.)
+    # -> needs mapping. (amplab, then clickbench/joinorder_synthetic, were previously
+    # the direct example here; all are now enforced cross-surface gates, so they no
+    # longer appear among the unguarded candidates.)
     assert by_id.get("datavault") == GATEABLE_NEEDS_ID_MAPPING
 
 


### PR DESCRIPTION
## Summary

Resolves **w4** of the cross-surface SQL↔DataFrame equivalence gate campaign: promote **clickbench** and **joinorder_synthetic** from `STAGED_GATES` to enforced, blocking `GATES`. Both went clean once their cross-cutting prerequisites landed — **w9** (loader applies schema column TYPES + DuckDB empty-string semantics; #857, merged) and **w8** (tie-aware top-N comparator; #858).

> **Stacked on #858 (w8).** This PR's diff includes the w8 commit until #858 merges; once it does, only the w4 commit remains. Auto-merge will order them.

### Changes
- **`cross_surface.py`**: move `clickbench` (only baseline entry is the order-less `Q18`) and `joinorder_synthetic` (empty baseline) into `GATES`; `STAGED_GATES` is now empty.
- **`pr.yml`**: add blocking correctness-gate steps for both, beside ssb/amplab/coffeeshop.
- **Fast-lane medium-marker regressions**: `test_{clickbench,joinorder_synthetic}_cross_surface_equivalence.py`, mirroring `test_ssb_cross_surface_equivalence.py`.
- **Unit**: `test_clickbench_and_joinorder_are_enforced_gates` replaces the staged assertion; the applicability-sweep example is retargeted to `h2odb` (clickbench/joinorder are no longer unguarded candidates).
- **Regenerated** the oracle coverage map (both now show cross-surface **guarded**; 15 UNGUARDED) and the applicability artifact; updated the coverage-map TODO w1 dispatch note.

## Evidence
- Each gate **FAILS on a planted divergence** (no masking): clickbench `Q1` count+1000 → `Q1_expression`+`Q1_pandas`; joinorder `1a` value+99999 → `1a_expression`+`1a_pandas` — no collateral.
- New fast-lane tests pass; `ssb`/`amplab`/`coffeeshop` and TPC-Havoc gates re-verified green.
- Oracle coverage map shows `clickbench` and `joinorder_synthetic` as `cross-surface | cross-surface` (guarded).

## Follow-on (separate focused gate PRs, tracked by the coverage-map TODO)
Wire the remaining gateable dual-surface benchmarks one PR each: `datavault`, `flightdata`, `h2odb`, `nyctaxi`, `read_primitives`, `tpcds_obt`, `tpch_skew`, `tsbs_devops` (several need id normalization or a bounded data-source check first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eVSwcGbDp5K2R6fUxnpDh)_