### PR TITLE
todo: correctness-gate value oracle + coverage-map disclosure follow-ups

### DIFF
--- a/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
+++ b/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
@@ -1,0 +1,216 @@
+id: bounded-correctness-gate-value-oracle
+title: "Add value-level validation to the bounded TPC-H/TPC-DS correctness gate (it is row-count-only today)"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  An adversarial review of the bounded correctness gate (#830, reviewed on
+  develop) reproduced that the gate named "correctness" only validates ROW
+  COUNTS, never result VALUES. The hardening in #830 (no-skip JUnit guard,
+  strict-arming hoist, discrimination ratchet) is real and survives attack, but
+  it ratchets on cardinality SHAPE, not on detection of a wrong answer.
+
+  Reproduced facts (all verified by reading code / running the gate on develop):
+
+  - `_validate_against_expected_results`
+    (tests/integration/test_local_platform_benchmark_matrix.py) calls
+    `validator.validate_query_result(actual_row_count=int(query["rows"]), ...)`.
+    The only thing compared is a row count. All 18 bounded-gate TPC-H queries are
+    EXACT-mode, but EXACT means "exact row count", not "exact values"
+    (benchbox/core/expected_results/models.py).
+  - The result payload the gate consumes carries ONLY a per-query row count
+    (`{"id", "ms", "rows"}` - benchbox/core/results/schema.py). It contains no
+    values, checksums, or digests, so value validation is not merely absent: it
+    is impossible without extending the result contract.
+  - Consequence: a value-mutating bug that preserves cardinality ships GREEN. The
+    canonical example is TPC-H Q1 (`sum(l_extendedprice*(1-l_discount))`), which
+    returns 4 grouped rows no matter how wrong the revenue arithmetic is; the gate
+    asserts rows==4 and passes. Wrong rounding, a swapped column, an off-by-one in
+    an aggregate, or a wrong but same-cardinality join all pass.
+  - Scale: TPC-H/TPC-DS expected results exist ONLY at SF=1
+    (benchbox/core/expected_results/loader.py raises for any other scale), and the
+    bounded gate pins SF=1 (_select_scale), so even the row-count oracle covers
+    exactly one scale.
+  - The reference qgen seed is already pinned for the gate (get_reference_seed in
+    benchbox/core/tpch/benchmark.py), so at SF=1 the result VALUES are
+    deterministic - which is precisely what makes a stored value digest feasible.
+
+  This item adds the missing value axis to the bounded gate so a wrong-but-same-
+  cardinality answer is caught, and corrects the docs/naming that oversell the
+  gate's current guarantee. It is the value-level complement to the cardinality
+  hardening already shipped in testing-approach-oracle-hardening (#830, DONE).
+
+prior_art:
+  - "benchbox/core/tpchavoc/validation.py:81 validate_results_checksum / _calculate_checksum - an EXISTING value-level digest comparator the bounded gate should reuse rather than inventing a new one; it already backs the TPC-Havoc gates."
+  - "benchbox/core/tpch/benchmark.py:35 get_reference_seed - the pinned seed that makes SF=1 result values deterministic; the stored reference digests must be computed at this seed."
+  - "benchbox/core/expected_results/registry.py - the expected-results provider registry where stored reference digests (keyed by benchmark/query_id/SF) would live alongside the existing row-count answers."
+  - "benchbox/core/results/schema.py / normalizer.py - the result payload contract that today carries only `rows`; a per-query result digest field would be added here (gate-only, behind a flag, to avoid runtime cost on normal runs)."
+  - "tests/integration/test_local_platform_benchmark_matrix.py:_validate_against_expected_results - the validation seam to extend; keep the row-count check, add the digest check."
+  - "_project/DONE/main/planning/testing-approach-oracle-hardening.yaml - #830 cardinality hardening this complements; do NOT redo the no-skip/strict/ratchet work, add the value axis it explicitly deferred."
+  - "_project/TODO/main/active/cross-surface-oracle-remediation.yaml:w10 - the parallel mutation-sensitivity harness for the cross-surface oracle; share the planted-mutation test approach rather than building a second one."
+
+work:
+  - id: w1
+    summary: "Emit a deterministic per-query result digest into the result payload (gate-only, behind a flag)"
+    status: pending
+    notes: |
+      Extend the runner/normalizer so a benchmark run can emit a canonical,
+      order-normalized digest of each stream-0 query's full result set, written
+      into the per-query result JSON next to `rows`. Reuse
+      validate_results_checksum/_calculate_checksum (tpchavoc/validation.py:81) for
+      the digest function so SQL and the gate share one definition. Gate it behind
+      an env flag (e.g. BENCHBOX_EMIT_RESULT_DIGEST=1) set only by
+      `make test-correctness-gate`, so normal `benchbox run` keeps its current
+      cost and payload shape.
+      Canonicalization must be value-correct, not order-correct: sort full rows
+      before hashing (matching the existing comparator) so unordered queries are
+      stable, and normalize numeric formatting/rounding so a digest is reproducible
+      across DuckDB builds at the pinned seed.
+    acceptance:
+      - "With the flag set, the bounded gate's result JSON carries a stable digest per stream-0 query; two consecutive gate runs at the pinned seed produce identical digests."
+      - "With the flag unset, `benchbox run` output (payload shape + cost) is unchanged - verified by an existing matrix run."
+
+  - id: w2
+    summary: "Store reference value digests for the 18 bounded TPC-H queries at SF=1/pinned seed and assert them in the gate"
+    needs: [w1]
+    status: pending
+    notes: |
+      Compute the reference digests once at SF=1 with the pinned reference seed,
+      store them via the expected-results registry (keyed by benchmark/query_id/
+      scale), and extend `_validate_against_expected_results` to compare the emitted
+      digest to the stored one IN ADDITION to the row count. The digest check must
+      be subject to the SAME strict-arming the row-count check already has (every
+      configured query must produce a non-SKIP value validation under
+      BENCHBOX_STRICT_EXPECTED_RESULTS), so a missing digest disarms RED, not green.
+      Keep the change additive: a benchmark/scale without stored digests still
+      validates row counts and (non-strict) skips the digest, exactly as today.
+    acceptance:
+      - "`make test-correctness-gate` validates both row counts AND value digests for all 18 TPC-H queries at SF=1; the gate is green on a correct tree."
+      - "Under strict mode, a missing/unevaluated digest for a configured query fails RED (no silent value-skip)."
+
+  - id: w3
+    summary: "Prove sensitivity: a value mutation that preserves cardinality turns the gate RED"
+    needs: [w2]
+    status: pending
+    notes: |
+      Add a sensitivity test (coordinate with cross-surface-oracle-remediation w10's
+      mutation harness) that injects a value-only error which preserves row count -
+      e.g. perturb a Q1 aggregate value, swap two columns of equal cardinality, or
+      change rounding - and asserts the gate goes RED. This converts the
+      discrimination-ratchet from "the query set could detect cardinality changes"
+      to "the gate provably detects a wrong value", closing the headline review gap.
+    acceptance:
+      - ">=3 cardinality-preserving value mutations are each provably caught by the gate (RED)."
+      - "Any value-mutation class the digest cannot catch is documented with the reason."
+
+  - id: w4
+    summary: "Correct the docs/naming that oversell the gate, including the required CI job's real scope"
+    needs: [w2]
+    status: pending
+    notes: |
+      The review found two disclosure defects independent of the value fix:
+        - the Makefile note / tests/README / #830 docs describe the gate as
+          deliberately NOT proving values; once w2 lands, update them to state the
+          gate proves value+cardinality at SF=1/pinned-seed, and that values are
+          unguarded above SF=1.
+        - the required `correctness-gate` CI job (.github/workflows/pr.yml) actually
+          runs SIX gates - test-correctness-gate plus tpchavoc variant, tpchavoc
+          DataFrame, and ssb/amplab/coffeeshop cross-surface (all value-level) - but
+          the ratchet test (test_standardized_test_commands.py
+          test_develop_pr_invokes_bounded_correctness_gate) only asserts
+          `make test-correctness-gate` is present, so a reader infers the job is
+          row-count-only. Add a ratchet asserting the value-level gate steps are
+          present, and document the job's true composition.
+    acceptance:
+      - "Gate docs (Makefile note, tests/README) accurately state value+cardinality@SF=1 and the SF>1 value gap."
+      - "A test pins that the required correctness-gate CI job runs the value-level cross-surface/tpchavoc steps, not only the row-count gate."
+
+  - id: w5
+    summary: "Quantify and decide the TPC-DS loose +/-50% band"
+    status: pending
+    notes: |
+      TPC-DS validation runs in LOOSE mode with a +/-50% default tolerance
+      (benchbox/core/expected_results/models.py loose_tolerance_percent=50.0), so a
+      regression that shifts TPC-DS cardinality by <50% hides. Scope it honestly:
+      this loose band lives in the broad stress matrix, NOT in the bounded
+      `make test-correctness-gate` (which is tpch-duckdb only), so it is less
+      load-bearing than a reader of the review might assume. Decide per query
+      whether the pinned-seed run is deterministic enough to tighten TPC-DS toward
+      EXACT (or RANGE with a tight band), or document why loose is retained, and
+      record the decision next to the TPC-DS provider.
+    acceptance:
+      - "The +/-50% TPC-DS band is documented with its scope (stress matrix, not the bounded gate) and an explicit keep-or-tighten decision per query class."
+
+deferred:
+  - summary: "Backfill stored value digests for benchmarks beyond tpch/tpcds, or for scales above SF=1."
+    reason: "Out of scope; breadth is owned by benchmark-correctness-oracle-coverage-map (w1/w2) and the cross-surface gate. This item fixes the value-blindness of the EXISTING bounded tpch/tpcds gate at its existing SF=1 cell."
+  - summary: "Harden the no-skip JUnit guard to count child <skipped/> elements instead of trusting suite-level attributes."
+    reason: "Currently unreachable - pytest sets suite skip attributes consistently with children, and the report is generated in-process to a mktemp file with no external control. Noted as a latent hardening only."
+
+must_preserve:
+  - "The #830 cardinality hardening is unchanged: no-skip JUnit guard, strict arming, and the discrimination ratchet keep working exactly as today."
+  - "`benchbox run` default behavior, payload shape, and cost are unchanged when the digest flag is unset (digest emission is gate-only)."
+  - "The existing row-count validation stays in place and authoritative; the digest check is additive, never a replacement."
+  - "TPC-Havoc gates that already use validate_results_checksum stay green - reuse, do not fork, the comparator."
+
+approach: |
+  Reuse the existing value-level comparator (validate_results_checksum) and the
+  pinned reference seed rather than building new machinery. Sequence: (w1) make
+  the runner emit a deterministic digest behind a gate-only flag; (w2) store the
+  18 SF=1 reference digests in the expected-results registry and assert them under
+  the same strict-arming as the row-count check; (w3) prove sensitivity with
+  planted cardinality-preserving mutations (shared with cross-surface w10); (w4)
+  fix the docs/naming and the CI-scope ratchet; (w5) settle the TPC-DS loose band.
+
+anti_patterns:
+  - "DO NOT compute the digest over only the row count or a single column - because that reproduces the value-blindness - hash the full, order-normalized result set."
+  - "DO NOT emit the digest on every `benchbox run` - because it adds cost to normal benchmarking and changes the payload for all consumers - gate it behind a flag the correctness gate sets."
+  - "DO NOT fork ResultValidator for the bounded gate - because TPC-Havoc depends on it - reuse validate_results_checksum / _calculate_checksum."
+  - "DO NOT exempt the digest check from strict arming - because a missing digest would then silently disarm the value oracle exactly like the old scale-gated strict block did - require non-SKIP under strict mode."
+  - "DO NOT re-implement the no-skip/strict/ratchet work from #830 - it is done - only add the value axis."
+
+verification:
+  - description: "Bounded gate validates values and cardinality and is green on a correct tree"
+    command: "make test-correctness-gate"
+    expected_output: "1 passed, ran=1 skipped=0; both row-count and digest checks evaluated for all 18 queries"
+  - description: "A planted cardinality-preserving value mutation turns the gate RED"
+    command: "apply a Q1 aggregate-value mutation, then run the sensitivity test (w3)"
+    expected_output: "the gate fails on a value-digest mismatch despite unchanged row count"
+  - description: "TPC-Havoc value gates remain green (comparator reuse did not regress them)"
+    command: "make tpchavoc-equivalence-report && make tpchavoc-dataframe-equivalence-report"
+    expected_output: "both exit 0 with unchanged output"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/expected_results/"
+    - "benchbox/core/results/"
+    - "benchbox/core/tpch/"
+    - "tests/"
+    - "Makefile"
+    - "_project/"
+    - "docs/"
+    - ".github/workflows/"
+
+success_metrics:
+  - "The bounded TPC-H gate catches a wrong-but-same-cardinality answer (value digest), not just a wrong row count."
+  - "A missing reference digest disarms the gate RED under strict mode, never green."
+  - "Gate docs and the required-CI-job ratchet accurately describe what is proven (value+cardinality@SF=1) and what is not (values above SF=1)."
+  - "The TPC-DS loose +/-50% band has a documented scope and an explicit keep-or-tighten decision."
+
+open_questions:
+  - question: "Should the value digest be a single full-result hash (cheapest, but a mismatch gives no column-level locality) or a small per-column checksum vector (slightly more storage, far better failure diagnostics)?"
+    gating: true
+    affects: ["w1 digest shape", "w2 stored reference shape"]
+    default: "Start with a single order-normalized full-result hash (reuses _calculate_checksum directly); add per-column checksums only if w3 shows mismatches are hard to localize."
+  - question: "Are all 18 TPC-H SF=1 result sets value-stable across the DuckDB versions BenchBox supports at the pinned seed, or do float-formatting differences require a rounding normalization before hashing?"
+    gating: false
+    affects: ["w1 canonicalization", "w2 reference digest stability"]
+    default: "Normalize numeric values to a fixed precision before hashing; verify stability across the supported DuckDB cap in w1."
+
+metadata:
+  tags: [correctness, oracle, expected-results, tpch, tpcds, ci, testing, value-validation]
+  estimated_effort: "Medium"
+  created_date: "2026-06-23"
+  last_updated: "2026-06-23T00:00:00"

--- a/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
+++ b/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
@@ -16,10 +16,11 @@ description: |
 
   - `_validate_against_expected_results`
     (tests/integration/test_local_platform_benchmark_matrix.py) calls
-    `validator.validate_query_result(actual_row_count=int(query["rows"]), ...)`.
-    The only thing compared is a row count. All 18 bounded-gate TPC-H queries are
-    EXACT-mode, but EXACT means "exact row count", not "exact values"
-    (benchbox/core/expected_results/models.py).
+    `validator.validate_query_result(actual_row_count=int(query["rows"]), ...)`,
+    and that method (benchbox/core/validation/query_validation.py:99) compares only
+    counts. All 18 gate-configured TPC-H queries are EXACT-mode, but EXACT means
+    "exact row count", not "exact values"
+    (benchbox/core/expected_results/models.py ValidationMode).
   - The result payload the gate consumes carries ONLY a per-query row count
     (`{"id", "ms", "rows"}` - benchbox/core/results/schema.py). It contains no
     values, checksums, or digests, so value validation is not merely absent: it
@@ -43,7 +44,8 @@ description: |
   hardening already shipped in testing-approach-oracle-hardening (#830, DONE).
 
 prior_art:
-  - "benchbox/core/tpchavoc/validation.py:81 validate_results_checksum / _calculate_checksum - an EXISTING value-level digest comparator the bounded gate should reuse rather than inventing a new one; it already backs the TPC-Havoc gates."
+  - "benchbox/core/tpchavoc/validation.py:229 _calculate_checksum - the EXISTING single-result digest primitive to reuse for w1 (emit a digest); currently private, so promote/expose it rather than inventing a new hash. It already backs the TPC-Havoc gates."
+  - "benchbox/core/tpchavoc/validation.py:81 validate_results_checksum - the EXISTING pairwise (original vs variant) checksum comparator to reuse for w2 (compare emitted digest vs stored reference); not a digest emitter itself."
   - "benchbox/core/tpch/benchmark.py:35 get_reference_seed - the pinned seed that makes SF=1 result values deterministic; the stored reference digests must be computed at this seed."
   - "benchbox/core/expected_results/registry.py - the expected-results provider registry where stored reference digests (keyed by benchmark/query_id/SF) would live alongside the existing row-count answers."
   - "benchbox/core/results/schema.py / normalizer.py - the result payload contract that today carries only `rows`; a per-query result digest field would be added here (gate-only, behind a flag, to avoid runtime cost on normal runs)."
@@ -58,9 +60,9 @@ work:
     notes: |
       Extend the runner/normalizer so a benchmark run can emit a canonical,
       order-normalized digest of each stream-0 query's full result set, written
-      into the per-query result JSON next to `rows`. Reuse
-      validate_results_checksum/_calculate_checksum (tpchavoc/validation.py:81) for
-      the digest function so SQL and the gate share one definition. Gate it behind
+      into the per-query result JSON next to `rows`. Reuse `_calculate_checksum`
+      (tpchavoc/validation.py:229, the single-result digest primitive; promote it
+      from private) so SQL and the gate share one digest definition. Gate it behind
       an env flag (e.g. BENCHBOX_EMIT_RESULT_DIGEST=1) set only by
       `make test-correctness-gate`, so normal `benchbox run` keeps its current
       cost and payload shape.
@@ -87,7 +89,7 @@ work:
       Keep the change additive: a benchmark/scale without stored digests still
       validates row counts and (non-strict) skips the digest, exactly as today.
     acceptance:
-      - "`make test-correctness-gate` validates both row counts AND value digests for all 18 TPC-H queries at SF=1; the gate is green on a correct tree."
+      - "`make test-correctness-gate` validates both row counts AND value digests for all 18 gate-configured TPC-H queries at SF=1; the gate is green on a correct tree."
       - "Under strict mode, a missing/unevaluated digest for a configured query fails RED (no silent value-skip)."
 
   - id: w3
@@ -167,7 +169,7 @@ approach: |
 anti_patterns:
   - "DO NOT compute the digest over only the row count or a single column - because that reproduces the value-blindness - hash the full, order-normalized result set."
   - "DO NOT emit the digest on every `benchbox run` - because it adds cost to normal benchmarking and changes the payload for all consumers - gate it behind a flag the correctness gate sets."
-  - "DO NOT fork ResultValidator for the bounded gate - because TPC-Havoc depends on it - reuse validate_results_checksum / _calculate_checksum."
+  - "DO NOT fork ResultValidator for the bounded gate - because TPC-Havoc depends on it - reuse _calculate_checksum (digest) and validate_results_checksum (comparison)."
   - "DO NOT exempt the digest check from strict arming - because a missing digest would then silently disarm the value oracle exactly like the old scale-gated strict block did - require non-SKIP under strict mode."
   - "DO NOT re-implement the no-skip/strict/ratchet work from #830 - it is done - only add the value axis."
 

--- a/_project/TODO/main/planning/oracle-coverage-map-strength-disclosure.yaml
+++ b/_project/TODO/main/planning/oracle-coverage-map-strength-disclosure.yaml
@@ -1,0 +1,187 @@
+id: oracle-coverage-map-strength-disclosure
+title: "Make the oracle coverage map disclose oracle STRENGTH and SCALE, not just existence"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  An adversarial review of the oracle coverage map (#834, reviewed on develop)
+  found the map collapses very different guarantees into a single word, "guarded".
+  The drift machinery is sound and on the required PR path - it was verified to go
+  RED on a mutated artifact and a removed GATES entry - but it protects the map's
+  CONSISTENCY with the generator, not the TRUTH of what "guarded" implies.
+
+  Reproduced facts (verified against develop @ 8596ab51):
+
+  - `build_coverage_map` / `classify_oracles`
+    (_project/scripts/generate_oracle_coverage_map.py) emit one primary oracle per
+    benchmark and a boolean `guarded`. They do NOT record how STRONG that oracle is
+    or at what SCALE it holds. The rendered map shows e.g.
+    `tpch | expected-results | guarded` with no qualifier.
+  - The guaranteed strengths differ enormously and are not distinguished:
+      * expected-results (tpch, tpcds): ROW-COUNT only today, and ONLY at SF=1
+        (loader raises for other scales). Cardinality, one scale.
+      * cross-surface (ssb, amplab, coffeeshop): VALUE-level (validate_results_exact
+        sorts full result sets and compares cell-by-cell with tol 1e-10,
+        benchbox/core/tpchavoc/validation.py), but self-referential (SQL is the
+        reference for its own DataFrame surface) at the bounded SF=0.1.
+      * variant-equivalence (tpchavoc): value-level vs canonical TPC-H.
+  - A reviewer reading a green "guarded" cell reasonably infers "correctness is
+    proven" and may skip manual value inspection. That is the coverage-theater risk
+    the map was meant to remove, re-introduced one abstraction up: the map is honest
+    about its DENOMINATOR (6/23 guarded, 17 named UNGUARDED) but not about the
+    QUALITY of each guarded cell.
+
+  This item adds two disclosure axes to the generated map - oracle STRENGTH-TYPE
+  (value-level / cardinality-only / structural) and SCALE coverage - plus a
+  classifier-correctness test so the new axes cannot silently regress, and an
+  artifact-provenance note that addresses the review-staleness failure mode.
+
+  SCOPE BOUNDARY (do not duplicate): a separate, higher-priority axis -
+  "gate-registered vs verified-green" - is already owned by
+  cross-surface-oracle-remediation w9. This item owns the orthogonal STRENGTH-TYPE
+  + SCALE + provenance axes and must layer onto whatever naming w9 lands.
+
+prior_art:
+  - "_project/scripts/generate_oracle_coverage_map.py:classify_oracles/build_coverage_map/render_markdown - the generator to extend with strength + scale columns; keep it derived from live sources, no hand-maintained doc."
+  - "benchbox/core/expected_results/models.py - ValidationMode (EXACT/RANGE/LOOSE) and the row-count-only nature of the expected-results oracle; the source of the 'cardinality-only' strength label for tpch/tpcds."
+  - "benchbox/core/expected_results/loader.py - raises for non-SF=1 TPC-H/TPC-DS; the source of the 'SF=1 only' scale label."
+  - "benchbox/core/equivalence/cross_surface.py:GATES + tpchavoc/validation.py:validate_results_exact - the value-level comparator backing cross-surface/variant gates; the source of the 'value-level' strength label and the SF=0.1 scale label."
+  - "tests/unit/test_oracle_coverage_map.py - the existing drift/completeness/exemplar tests to extend with strength/scale classifier assertions."
+  - "_project/TODO/main/active/cross-surface-oracle-remediation.yaml:w9 - owns 'registered vs verified-green'; coordinate, do NOT duplicate that axis here."
+  - "_project/TODO/main/planning/benchmark-correctness-oracle-coverage-map.yaml - owns coverage BREADTH (closing the 17 UNGUARDED); this item is about disclosure QUALITY of the guarded cells, not breadth."
+
+work:
+  - id: w1
+    summary: "Classify and render oracle STRENGTH-TYPE per benchmark (value-level / cardinality-only / structural)"
+    status: pending
+    notes: |
+      Extend classify_oracles/build_coverage_map to attach a strength-type to each
+      oracle, derived from live sources: expected-results -> cardinality-only (read
+      the provider's ValidationMode; it is row-count regardless of EXACT/LOOSE);
+      cross-surface and variant-equivalence -> value-level (they use
+      validate_results_exact). Render it as a distinct column in
+      oracle-coverage-map.md and a field in the .json so a reader sees
+      `tpch | expected-results | cardinality-only` vs
+      `ssb | cross-surface | value-level`.
+    acceptance:
+      - "The generated map shows a strength-type column; tpch/tpcds read 'cardinality-only', ssb/amplab/coffeeshop/tpchavoc read 'value-level'."
+      - "The strength-type is derived from live sources (provider mode / comparator), not hard-coded per benchmark."
+
+  - id: w2
+    summary: "Disclose SCALE coverage per oracle (e.g. expected-results = SF=1 only)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a scale-coverage signal to each guarded row: expected-results guard only
+      at SF=1 (loader raises otherwise); cross-surface/variant gates run at the
+      bounded SF (0.1). Derive from the same live sources where possible (probe the
+      provider's available scales; read the gate's bounded scale). Render it so a
+      reader cannot mistake "guarded" for "guarded at the scale I run".
+    acceptance:
+      - "Each guarded row discloses the scale(s) at which its oracle actually holds (tpch/tpcds = SF=1 only)."
+      - "The map's summary or notes state plainly that no expected-results oracle exists above SF=1."
+
+  - id: w3
+    summary: "Stamp analysis-artifact provenance and document the review-reproducibility protocol"
+    status: pending
+    notes: |
+      The review went stale because it was run against a develop SHA that advanced
+      underneath it (a parallel second-opinion hit the same trap). Two concrete,
+      conflict-free fixes:
+        - Provenance: stamp _project/analysis correctness artifacts that are read
+          out-of-band (the divergence analyses, and a non-drift-compared header of
+          the coverage map) with the generation date and git SHA, so a reader can
+          tell when an artifact predates current develop.
+        - Protocol: document in the relevant README / review-protocol note that an
+          adversarial correctness review MUST pin the reviewed SHA and re-run
+          `git merge-base --is-ancestor <reviewed-sha> origin/develop` at write
+          time, or review against a tag.
+      CRITICAL DESIGN CONSTRAINT: the coverage map's drift check requires committed
+      == regenerated byte-for-byte. A volatile SHA inside the drift-compared region
+      would make `--check` fail on every commit. Put provenance in a region the
+      drift check ignores (or normalizes), never in the compared body.
+    acceptance:
+      - "Out-of-band analysis artifacts carry generation date + SHA provenance."
+      - "`make oracle-coverage-map-check` still passes on a clean tree across multiple commits (provenance did NOT make the drift check churn)."
+      - "The review-protocol note documents the pin-SHA + ancestry-recheck requirement."
+
+  - id: w4
+    summary: "Add a classifier-correctness test so strength/scale labels cannot silently regress"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      The existing drift test only proves committed == regenerated (consistency,
+      not truth). Add assertions that pin the TRUTH of the new axes for known
+      oracles: tpch/tpcds are cardinality-only + SF=1; ssb/amplab/coffeeshop/
+      tpchavoc are value-level. This is the truth check the drift check lacks, and
+      it guards the strength dimension itself.
+    acceptance:
+      - "tests/unit/test_oracle_coverage_map.py asserts the strength-type and scale of each known oracle, failing if a future change mislabels one."
+
+deferred:
+  - summary: "A 'gate-registered vs verified-green' strength signal in the map."
+    reason: "Owned by cross-surface-oracle-remediation w9; this item layers strength-TYPE + scale onto whatever naming that lands, and must not duplicate it."
+  - summary: "Closing the 17 UNGUARDED benchmarks."
+    reason: "Owned by benchmark-correctness-oracle-coverage-map w1/w2 (breadth). This item improves disclosure of the already-guarded cells."
+
+must_preserve:
+  - "The map stays GENERATED from live sources - no hand-maintained classification - so it cannot drift from reality."
+  - "The drift check (`make oracle-coverage-map-check`) stays green on a clean tree and on the required PR path; new columns must regenerate deterministically."
+  - "The existing summary semantics (N guarded / M UNGUARDED, the UNGUARDED dispatch lists) are preserved; strength/scale are additive columns."
+
+approach: |
+  Keep the generator the single source of truth and derive both new axes from live
+  sources (provider ValidationMode + available scales; comparator identity + bounded
+  SF) so they cannot be faked. Sequence: (w1) strength-type column; (w2) scale
+  column; (w3) provenance + protocol, carefully kept out of the drift-compared body;
+  (w4) a truth test for the new labels. Coordinate naming with
+  cross-surface-oracle-remediation w9 rather than competing with it.
+
+anti_patterns:
+  - "DO NOT hard-code the strength/scale per benchmark - because it would rot exactly like a hand-maintained doc - derive from the provider/comparator/loader."
+  - "DO NOT embed a volatile git SHA in the drift-compared region of the coverage map - because `--check` would fail on every commit - put provenance where the drift comparison ignores it."
+  - "DO NOT duplicate the 'registered vs verified-green' axis from cross-surface-oracle-remediation w9 - coordinate with it."
+  - "DO NOT widen scope into closing UNGUARDED benchmarks - that is benchmark-correctness-oracle-coverage-map; this is disclosure quality only."
+
+verification:
+  - description: "Map shows strength + scale and is internally consistent"
+    command: "make oracle-coverage-map && make oracle-coverage-map-check"
+    expected_output: "regenerates with strength/scale columns; --check reports up to date"
+  - description: "Classifier-truth test catches a mislabeled oracle"
+    command: "uv run -- python -m pytest tests/unit/test_oracle_coverage_map.py -q"
+    expected_output: "tests pass; flipping a known oracle's strength label fails the new assertion"
+  - description: "Provenance does not make the drift check churn"
+    command: "make oracle-coverage-map-check  (on two successive commits without registry/gate changes)"
+    expected_output: "up to date both times"
+
+scope_limit:
+  only_modify:
+    - "_project/scripts/generate_oracle_coverage_map.py"
+    - "_project/analysis/"
+    - "tests/unit/test_oracle_coverage_map.py"
+    - "_project/"
+    - "docs/"
+
+success_metrics:
+  - "Every guarded cell in the coverage map discloses its oracle strength-type and scale coverage, derived from live sources."
+  - "A reader can distinguish 'value-level at SF=0.1' from 'cardinality-only at SF=1' at a glance."
+  - "A classifier-truth test fails if a known oracle's strength/scale is mislabeled."
+  - "Out-of-band analysis artifacts carry provenance, and the review-protocol note requires SHA pinning + ancestry recheck."
+
+open_questions:
+  - question: "Once bounded-correctness-gate-value-oracle adds value digests to tpch/tpcds, the expected-results strength flips from 'cardinality-only' to 'value-level@SF=1'. Should the strength label be computed from the provider's actual capabilities (auto-updates) or stated statically?"
+    gating: false
+    affects: ["w1 strength derivation"]
+    default: "Compute from the provider's actual capability (presence of stored digests) so the label tracks reality without a manual edit; cross-reference bounded-correctness-gate-value-oracle."
+
+deps:
+  needs:
+    - "benchmark-correctness-oracle-coverage-map"
+
+metadata:
+  tags: [correctness, oracle, coverage, governance, ci, disclosure, provenance]
+  estimated_effort: "Small"
+  created_date: "2026-06-23"
+  last_updated: "2026-06-23T00:00:00"


### PR DESCRIPTION
## Summary

Captures the actionable follow-ups from an adversarial review (and a second-opinion audit) of the bounded correctness gate (#830) and the oracle coverage map (#834) as two new, schema-valid TODO items. **Planning artifacts only — no production code changes.**

The review confirmed the gates' *machinery* is solid (no-skip JUnit guard fails closed, strict arming, drift check on the required PR path) but found two genuine gaps not already owned by an existing TODO:

1. **The bounded TPC-H/TPC-DS gate validates row counts only.** The result payload it consumes carries only a per-query `rows` count (`benchbox/core/results/schema.py`) — no values — so a value-mutating bug that preserves cardinality (wrong aggregate, rounding, swapped column) ships green. The reference qgen seed is already pinned, so SF=1 result *values* are deterministic and a stored value digest is feasible.
2. **The coverage map collapses oracle strength + scale into one word, "guarded".** It does not distinguish value-level (cross-surface, `validate_results_exact`, tol 1e-10) from cardinality-only (expected-results, SF=1 only), so a reader infers more protection than exists.

## New TODOs

| Item | Priority | Owns |
| --- | --- | --- |
| `bounded-correctness-gate-value-oracle` | Medium-High | Value-level digest validation on the bounded tpch/tpcds gate (emit digest → store+assert under strict arming → prove sensitivity with planted mutations → fix docs/CI-scope framing → settle the TPC-DS loose ±50% band) |
| `oracle-coverage-map-strength-disclosure` | Medium | Strength-type + scale + provenance disclosure in the generated map, plus a classifier-truth test |

## Scope discipline (no duplication)

Deliberately fenced off from the existing owners, with explicit `prior_art`/`deferred`/`deps` cross-references:
- **Cross-surface** shared-spec/false-independence (w7), guarded-vs-verified-green (w9), and mutation sensitivity (w10) stay with `cross-surface-oracle-remediation`.
- **Coverage breadth** (closing the 17 UNGUARDED benchmarks) stays with `benchmark-correctness-oracle-coverage-map`.

## Verification

- Both files pass `validate_todo.py` (non-strict; `prior_art` is a known pre-existing strict-schema gap shared with other items).
- `todo_cli check-graph` passes — 79 items, no cycles or dangling refs; the `deps.needs` edge resolves.
- An independent quality-review pass verified every code citation against develop @ `8596ab51`; its three MINOR citation/wording findings were applied (second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DcRXidH26Xr4MyHoGRANY

---
_Generated by [Claude Code](https://claude.ai/code/session_014DcRXidH26Xr4MyHoGRANY)_