### PR TITLE
fix(correctness): distinguish registered vs verified-green coverage; honest applicability (w9)

### DIFF
--- a/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
+++ b/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
@@ -345,8 +345,32 @@ work:
 
   - id: w9
     summary: "Tighten coverage-map / applicability honesty (M1, M2)"
-    status: pending
+    status: done
     addresses: [M1, M2, "review:MEDIUM M1/M2", "claims 6,7"]
+    progress: |
+      DONE. Both honesty signals landed (re-derived from the LIVE registries, not
+      hardcoded).
+      M1 (coverage map): generate_oracle_coverage_map.py now records
+      cross_surface_enforced per benchmark (True for enforced GATES = CI-blocking
+      hence green-or-CI-fails, False for STAGED_GATES = registered-but-not-run, None
+      for non-cross-surface). The md gains an "Enforced" column plus a "What an
+      oracle here means" preamble stating that 'guarded' is REGISTERED, not green;
+      the json carries the new field. The 5 enforced gates (amplab, clickbench,
+      coffeeshop, joinorder_synthetic, ssb) report "enforced (CI-blocking)"; STAGED
+      is currently empty. Drift test (oracle-coverage-map-check) regenerated + green.
+      M2 (applicability): cross_surface_applicability_sweep.py downgrades the
+      zero-verified-overlap benchmarks from gateable to a new candidate-unverified
+      status; _GATEABLE_STATUSES no longer counts them as coverage. The live sweep
+      now reports 4 gateable (flightdata, h2odb, joinorder, read_primitives) and 5
+      candidate-unverified (datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops).
+      amplab is no longer in this list at all (promoted to an enforced gate in #859),
+      so the original "6" is 5 unguarded candidates here.
+      Tests: tests/unit/test_oracle_coverage_map.py gains
+      test_cross_surface_enforced_distinguishes_registered_from_verified_green;
+      tests/unit/test_cross_surface_applicability.py pins the new
+      candidate-unverified set and asserts none are counted gateable. Both committed
+      artifacts regenerated; both -check/drift targets and both unit test modules
+      green; ruff/format/ty clean.
     notes: |
       - generate_oracle_coverage_map.py derives 'guarded' from GATES dict membership
         (85/111) and never checks the gate is green. Either run each gate (or read

--- a/_project/analysis/cross-surface-applicability.md
+++ b/_project/analysis/cross-surface-applicability.md
@@ -2,26 +2,28 @@
 
 **Generated** by `_project/scripts/cross_surface_applicability_sweep.py`. Drills into the dual-surface UNGUARDED benchmarks from the oracle coverage map and detects which ship a DataFrame query `QueryRegistry` (the registry the cross-surface gate builders consume). `supports_dataframe` (the coverage map's signal) is a DataFrame *loading* flag and over-counts candidates; the production query *resolver* under-counts (it misses per-benchmark `<BENCH>_DATAFRAME_QUERIES` registries). Registry detection is the authoritative gate-applicability signal.
 
-**Summary:** 13 dual-surface unguarded candidates — 9 cross-surface gateable (ship a DataFrame query registry), 4 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
+**Gateable means VERIFIED, not merely registered.** A benchmark is counted as `gateable` only when its DataFrame query ids overlap the SQL query ids verbatim — a confirmed SQL<->DataFrame correspondence the gate can compare. A benchmark whose registry has ZERO verbatim id overlap is `candidate-unverified`, NOT gateable: wiring a gate would require *guessing* which DataFrame query answers which SQL query, and the campaign's own TODO warns "do NOT guess". These need an independent, per-benchmark id mapping confirmed first (and some, like `tpcds_obt` at 3 DataFrame vs ~89 SQL queries, may never be a clean correspondence).
+
+**Summary:** 13 dual-surface unguarded candidates — 4 cross-surface gateable (verified verbatim id overlap), 5 candidate-unverified (registry exists but ZERO verified id overlap — needs a confirmed id mapping first), 4 have no DataFrame query surface (need a w2 fallback oracle), 0 blocked.
 
 | Benchmark | Status | SQL queries | DataFrame queries | Raw id overlap | Note |
 | --- | --- | --- | --- | --- | --- |
-| datavault | gateable-needs-id-mapping | 22 | 22 | 0 | → cross-surface gate after id normalization (w3) |
+| datavault | candidate-unverified | 22 | 22 | 0 | → confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess) |
 | flightdata | gateable | 20 | 20 | 20 | → cross-surface gate (w3) |
 | h2odb | gateable | 10 | 10 | 10 | → cross-surface gate (w3) |
 | joinorder | gateable | 113 | 113 | 113 | → cross-surface gate (w3) |
 | metadata_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
-| nyctaxi | gateable-needs-id-mapping | 25 | 25 | 0 | → cross-surface gate after id normalization (w3) |
+| nyctaxi | candidate-unverified | 25 | 25 | 0 | → confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess) |
 | read_primitives | gateable | 157 | 152 | 152 | → cross-surface gate (w3) |
 | tpcdi | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
-| tpcds_obt | gateable-needs-id-mapping | 89 | 3 | 0 | → cross-surface gate after id normalization (w3) |
-| tpch_skew | gateable-needs-id-mapping | 22 | 22 | 0 | → cross-surface gate after id normalization (w3) |
+| tpcds_obt | candidate-unverified | 89 | 3 | 0 | → confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess) |
+| tpch_skew | candidate-unverified | 22 | 22 | 0 | → confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess) |
 | transaction_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
-| tsbs_devops | gateable-needs-id-mapping | 18 | 18 | 0 | → cross-surface gate after id normalization (w3) |
+| tsbs_devops | candidate-unverified | 18 | 18 | 0 | → confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess) |
 | write_primitives | no-df-query-surface | — | 0 | — | → w2 fallback oracle (no DataFrame query registry) |
 
 ## Campaign dispatch
 
 - **Cross-surface gate, ids overlap as-is (w3):** flightdata, h2odb, joinorder, read_primitives.
-- **Cross-surface gate, needs id normalization first (w3):** datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops — a DataFrame query registry exists but its ids differ from the SQL ids by a naming convention (e.g. `1` vs `Q1`); normalize in the builder.
+- **Candidate-unverified (NOT gateable yet):** datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops — a DataFrame query registry exists but ZERO ids overlap the SQL ids verbatim, so there is no verified query correspondence. Each needs an independent, per-benchmark id mapping confirmed (the campaign TODO says "do NOT guess") before a gate can be wired; do not count these as coverage.
 - **w2 fallback oracle** — no DataFrame query registry, so the cross-surface gate cannot reach them; they need a differential second-engine check or a curated expected-results subset: metadata_primitives, tpcdi, transaction_primitives, write_primitives.

--- a/_project/analysis/oracle-coverage-map.json
+++ b/_project/analysis/oracle-coverage-map.json
@@ -3,6 +3,7 @@
     {
       "benchmark": "ai_primitives",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": null,
       "dual_surface": false,
       "guarded": false,
       "oracles": [],
@@ -14,6 +15,7 @@
     {
       "benchmark": "amplab",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -28,6 +30,7 @@
     {
       "benchmark": "clickbench",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -42,6 +45,7 @@
     {
       "benchmark": "coffeeshop",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -56,6 +60,7 @@
     {
       "benchmark": "datavault",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -68,6 +73,7 @@
     {
       "benchmark": "flightdata",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -80,6 +86,7 @@
     {
       "benchmark": "h2odb",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -92,6 +99,7 @@
     {
       "benchmark": "joinorder",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -104,6 +112,7 @@
     {
       "benchmark": "joinorder_synthetic",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -118,6 +127,7 @@
     {
       "benchmark": "metadata_primitives",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -130,6 +140,7 @@
     {
       "benchmark": "nyctaxi",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -142,6 +153,7 @@
     {
       "benchmark": "read_primitives",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -154,6 +166,7 @@
     {
       "benchmark": "ssb",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": true,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -168,6 +181,7 @@
     {
       "benchmark": "tpcdi",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -180,6 +194,7 @@
     {
       "benchmark": "tpcds",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -194,6 +209,7 @@
     {
       "benchmark": "tpcds_obt",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -206,6 +222,7 @@
     {
       "benchmark": "tpch",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -220,6 +237,7 @@
     {
       "benchmark": "tpch_skew",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -232,6 +250,7 @@
     {
       "benchmark": "tpchavoc",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": true,
       "oracles": [
@@ -247,6 +266,7 @@
     {
       "benchmark": "transaction_primitives",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -259,6 +279,7 @@
     {
       "benchmark": "tsbs_devops",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],
@@ -271,6 +292,7 @@
     {
       "benchmark": "vector_search",
       "cross_surface_applicable": false,
+      "cross_surface_enforced": null,
       "dual_surface": false,
       "guarded": false,
       "oracles": [],
@@ -282,6 +304,7 @@
     {
       "benchmark": "write_primitives",
       "cross_surface_applicable": true,
+      "cross_surface_enforced": null,
       "dual_surface": true,
       "guarded": false,
       "oracles": [],

--- a/_project/analysis/oracle-coverage-map.md
+++ b/_project/analysis/oracle-coverage-map.md
@@ -2,33 +2,35 @@
 
 **Generated** by `_project/scripts/generate_oracle_coverage_map.py` from the benchmark registry, the expected-results provider registry, and the equivalence-gate registries. Do not edit by hand — run the generator and commit. `tests/unit/test_oracle_coverage_map.py` fails if this drifts.
 
-**Summary:** 23 shipped benchmarks — 8 guarded, 15 UNGUARDED (13 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle).
+**What an oracle here means.** A benchmark is listed as *guarded* when an oracle is REGISTERED for it — it is **not** a claim that the oracle is currently green. The distinction matters most for cross-surface gates: only a gate in the enforced `GATES` registry is run as a CI-blocking step (so it is green or CI fails); a gate in `STAGED_GATES` is registered but not run in CI, so its registration proves nothing about correctness. The **Enforced** column reports this *cross-surface* enforcement status: `enforced (CI-blocking)`, `staged (NOT CI-enforced)`, or `—` for any benchmark that is not cross-surface-gated. A `—` therefore says nothing about whether a *non*-cross-surface oracle is enforced: the expected-results (tpch, tpcds) and TPC-Havoc variant oracles are CI-enforced via their own test suites despite showing `—` here.
 
-| Benchmark | Surfaces | Oracle | Notes |
-| --- | --- | --- | --- |
-| ai_primitives | sql | NONE | single-surface → needs fallback oracle (w2) |
-| amplab | sql+dataframe | cross-surface | cross-surface |
-| clickbench | sql+dataframe | cross-surface | cross-surface |
-| coffeeshop | sql+dataframe | cross-surface | cross-surface |
-| datavault | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| flightdata | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| h2odb | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| joinorder | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| joinorder_synthetic | sql+dataframe | cross-surface | cross-surface |
-| metadata_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| nyctaxi | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| read_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| ssb | sql+dataframe | cross-surface | cross-surface |
-| tpcdi | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| tpcds | sql+dataframe | expected-results | expected-results |
-| tpcds_obt | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| tpch | sql+dataframe | expected-results | expected-results |
-| tpch_skew | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| tpchavoc | sql+dataframe | variant-equivalence | variant-equivalence, cross-surface-variant |
-| transaction_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| tsbs_devops | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
-| vector_search | sql | NONE | single-surface → needs fallback oracle (w2) |
-| write_primitives | sql+dataframe | NONE | dual-surface → dispatch to cross-surface gate (w1) |
+**Summary:** 23 shipped benchmarks — 8 guarded (oracle registered), 15 UNGUARDED (13 reachable by the cross-surface gate, 2 single-surface needing a fallback oracle). Cross-surface gates: 5 CI-enforced, 0 staged (not CI-enforced).
+
+| Benchmark | Surfaces | Oracle | Enforced | Notes |
+| --- | --- | --- | --- | --- |
+| ai_primitives | sql | NONE | — | single-surface → needs fallback oracle (w2) |
+| amplab | sql+dataframe | cross-surface | enforced (CI-blocking) | cross-surface |
+| clickbench | sql+dataframe | cross-surface | enforced (CI-blocking) | cross-surface |
+| coffeeshop | sql+dataframe | cross-surface | enforced (CI-blocking) | cross-surface |
+| datavault | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| flightdata | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| h2odb | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| joinorder_synthetic | sql+dataframe | cross-surface | enforced (CI-blocking) | cross-surface |
+| metadata_primitives | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| nyctaxi | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| read_primitives | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| ssb | sql+dataframe | cross-surface | enforced (CI-blocking) | cross-surface |
+| tpcdi | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpcds | sql+dataframe | expected-results | — | expected-results |
+| tpcds_obt | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpch | sql+dataframe | expected-results | — | expected-results |
+| tpch_skew | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tpchavoc | sql+dataframe | variant-equivalence | — | variant-equivalence, cross-surface-variant |
+| transaction_primitives | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| tsbs_devops | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
+| vector_search | sql | NONE | — | single-surface → needs fallback oracle (w2) |
+| write_primitives | sql+dataframe | NONE | — | dual-surface → dispatch to cross-surface gate (w1) |
 
 ## UNGUARDED benchmarks
 

--- a/_project/scripts/cross_surface_applicability_sweep.py
+++ b/_project/scripts/cross_surface_applicability_sweep.py
@@ -24,10 +24,15 @@ that.
 
 Classification per candidate:
   - ``gateable``: has a registry whose ids overlap the SQL ids as-is -> wire a
-    cross-surface gate on the overlapping ids (w3).
-  - ``gateable-needs-id-mapping``: has a registry but its ids do not overlap the
-    SQL ids verbatim (a prefix/naming convention differs, e.g. ``1`` vs ``Q1``);
-    gateable after a mechanical id normalization in the builder (w3).
+    cross-surface gate on the overlapping ids (w3). A non-zero VERIFIED id overlap
+    is what makes a benchmark genuinely gateable.
+  - ``candidate-unverified``: has a registry but ZERO ids overlap the SQL ids
+    verbatim, so there is no verified SQL<->DataFrame query correspondence. A gate
+    here would require GUESSING which DataFrame query maps to which SQL query, and
+    the campaign's own TODO warns "do NOT guess" (e.g. nyctaxi/tsbs). This is NOT
+    counted as gateable coverage: it needs an independent, per-benchmark id mapping
+    to be confirmed first (some, like tpcds_obt at 3 DF vs ~89 SQL queries, may
+    never be a clean correspondence). The honest status the M2 review demanded.
   - ``no-df-query-surface``: no DataFrame query registry -> NOT cross-surface
     gateable; needs a w2 fallback oracle (differential second-engine or a curated
     expected-results subset).
@@ -60,13 +65,15 @@ ARTIFACT = _REPO_ROOT / "_project" / "analysis" / "cross-surface-applicability.m
 _INSTANTIATE_SCALES = (0.01, 1.0)
 
 GATEABLE = "gateable"
-GATEABLE_NEEDS_ID_MAPPING = "gateable-needs-id-mapping"
+CANDIDATE_UNVERIFIED = "candidate-unverified"
 NO_DF_QUERY_SURFACE = "no-df-query-surface"
 BLOCKED = "blocked"
 
-# Statuses that mean "a DataFrame query surface exists, so a cross-surface gate is
-# applicable" (directly or after id normalization).
-_GATEABLE_STATUSES = frozenset({GATEABLE, GATEABLE_NEEDS_ID_MAPPING})
+# Statuses that mean "a cross-surface gate is genuinely applicable today". Only a
+# VERIFIED id overlap counts: a zero-overlap registry (``candidate-unverified``)
+# is deliberately excluded, because counting an unverified id mapping as coverage
+# is exactly the theater the M2 review flagged.
+_GATEABLE_STATUSES = frozenset({GATEABLE})
 
 
 def _dataframe_query_registry(benchmark_id: str) -> Any | None:
@@ -142,7 +149,11 @@ def classify_applicability(benchmark_id: str) -> tuple[str, dict[str, Any]]:
         "raw_id_overlap": raw_overlap,
         "scale": used_scale,
     }
-    status = GATEABLE if raw_overlap > 0 else GATEABLE_NEEDS_ID_MAPPING
+    # Honesty (M2): only a VERIFIED (non-zero) verbatim id overlap is gateable. A
+    # zero-overlap registry has no confirmed SQL<->DataFrame query correspondence,
+    # so it is a ``candidate-unverified`` until an independent id mapping is
+    # confirmed per benchmark -- never silently counted as gateable coverage.
+    status = GATEABLE if raw_overlap > 0 else CANDIDATE_UNVERIFIED
     return status, detail
 
 
@@ -160,6 +171,7 @@ def build_applicability_sweep() -> list[dict[str, Any]]:
 
 def render_markdown(rows: list[dict[str, Any]]) -> str:
     gateable = [r for r in rows if r["status"] in _GATEABLE_STATUSES]
+    candidate_unverified = [r for r in rows if r["status"] == CANDIDATE_UNVERIFIED]
     no_surface = [r for r in rows if r["status"] == NO_DF_QUERY_SURFACE]
     blocked = [r for r in rows if r["status"] == BLOCKED]
 
@@ -178,8 +190,22 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     )
     lines.append("")
     lines.append(
+        "**Gateable means VERIFIED, not merely registered.** A benchmark is counted "
+        "as `gateable` only when its DataFrame query ids overlap the SQL query ids "
+        "verbatim — a confirmed SQL<->DataFrame correspondence the gate can compare. "
+        "A benchmark whose registry has ZERO verbatim id overlap is "
+        "`candidate-unverified`, NOT gateable: wiring a gate would require *guessing* "
+        "which DataFrame query answers which SQL query, and the campaign's own TODO "
+        'warns "do NOT guess". These need an independent, per-benchmark id mapping '
+        "confirmed first (and some, like `tpcds_obt` at 3 DataFrame vs ~89 SQL "
+        "queries, may never be a clean correspondence)."
+    )
+    lines.append("")
+    lines.append(
         f"**Summary:** {len(rows)} dual-surface unguarded candidates — "
-        f"{len(gateable)} cross-surface gateable (ship a DataFrame query registry), "
+        f"{len(gateable)} cross-surface gateable (verified verbatim id overlap), "
+        f"{len(candidate_unverified)} candidate-unverified (registry exists but ZERO "
+        f"verified id overlap — needs a confirmed id mapping first), "
         f"{len(no_surface)} have no DataFrame query surface (need a w2 fallback oracle), "
         f"{len(blocked)} blocked."
     )
@@ -188,7 +214,9 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     lines.append("| --- | --- | --- | --- | --- | --- |")
     for r in rows:
         if r["status"] == BLOCKED:
-            lines.append(f"| {r['benchmark']} | {BLOCKED} | — | {r.get('df_queries', '—')} | — | {r.get('error', '')} |")
+            lines.append(
+                f"| {r['benchmark']} | {BLOCKED} | — | {r.get('df_queries', '—')} | — | {r.get('error', '')} |"
+            )
             continue
         if r["status"] == NO_DF_QUERY_SURFACE:
             note = "→ w2 fallback oracle (no DataFrame query registry)"
@@ -197,7 +225,7 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
         note = (
             "→ cross-surface gate (w3)"
             if r["status"] == GATEABLE
-            else "→ cross-surface gate after id normalization (w3)"
+            else "→ confirm an independent SQL↔DataFrame id mapping before gating (do NOT guess)"
         )
         lines.append(
             f"| {r['benchmark']} | {r['status']} | {r.get('sql_queries', '—')} | "
@@ -207,15 +235,15 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     lines.append("## Campaign dispatch")
     lines.append("")
     direct = [r["benchmark"] for r in rows if r["status"] == GATEABLE]
-    needs_mapping = [r["benchmark"] for r in rows if r["status"] == GATEABLE_NEEDS_ID_MAPPING]
+    unverified = [r["benchmark"] for r in candidate_unverified]
+    lines.append("- **Cross-surface gate, ids overlap as-is (w3):** " + (", ".join(direct) or "none") + ".")
     lines.append(
-        "- **Cross-surface gate, ids overlap as-is (w3):** " + (", ".join(direct) or "none") + "."
-    )
-    lines.append(
-        "- **Cross-surface gate, needs id normalization first (w3):** "
-        + (", ".join(needs_mapping) or "none")
-        + " — a DataFrame query registry exists but its ids differ from the SQL ids "
-        "by a naming convention (e.g. `1` vs `Q1`); normalize in the builder."
+        "- **Candidate-unverified (NOT gateable yet):** "
+        + (", ".join(unverified) or "none")
+        + " — a DataFrame query registry exists but ZERO ids overlap the SQL ids "
+        "verbatim, so there is no verified query correspondence. Each needs an "
+        "independent, per-benchmark id mapping confirmed (the campaign TODO says "
+        '"do NOT guess") before a gate can be wired; do not count these as coverage.'
     )
     lines.append(
         "- **w2 fallback oracle** — no DataFrame query registry, so the cross-surface "

--- a/_project/scripts/generate_oracle_coverage_map.py
+++ b/_project/scripts/generate_oracle_coverage_map.py
@@ -65,12 +65,18 @@ def classify_oracles(
     *,
     expected_results_providers: set[str],
     cross_surface_gates: set[str],
+    staged_cross_surface_gates: set[str],
 ) -> list[str]:
     """Return every correctness oracle that currently guards ``benchmark_id``.
 
     Detection is from live sources only; adding a real oracle (a provider, a
     ``GATES`` entry, or a TPC-Havoc gate module) automatically reclassifies the
     benchmark on the next regeneration.
+
+    A cross-surface oracle is detected from membership in either the enforced
+    ``GATES`` registry or the (currently empty) ``STAGED_GATES`` registry; the
+    caller records *which* of the two via ``cross_surface_enforced`` so a
+    registered-but-not-CI-enforced gate is never reported as enforced coverage.
     """
     oracles: list[str] = []
     if benchmark_id in expected_results_providers:
@@ -82,7 +88,7 @@ def classify_oracles(
             oracles.append(ORACLE_VARIANT_EQUIVALENCE)
         if _module_exists("benchbox.core.tpchavoc.dataframe_equivalence"):
             oracles.append(ORACLE_CROSS_SURFACE_VARIANT)
-    if benchmark_id in cross_surface_gates:
+    if benchmark_id in cross_surface_gates or benchmark_id in staged_cross_surface_gates:
         oracles.append(ORACLE_CROSS_SURFACE)
     return oracles
 
@@ -108,11 +114,12 @@ def _surfaces(metadata: dict[str, Any]) -> tuple[bool, bool]:
 def build_coverage_map() -> list[dict[str, Any]]:
     """Build the coverage matrix: one classified row per shipped benchmark."""
     from benchbox.core.benchmark_registry import get_benchmark_metadata, list_benchmark_ids
-    from benchbox.core.equivalence.cross_surface import GATES
+    from benchbox.core.equivalence.cross_surface import GATES, STAGED_GATES
     from benchbox.core.expected_results.registry import get_registry
 
     expected_results_providers = set(get_registry().list_available_benchmarks())
     cross_surface_gates = set(GATES.keys())
+    staged_cross_surface_gates = set(STAGED_GATES.keys())
 
     rows: list[dict[str, Any]] = []
     for benchmark_id in sorted(list_benchmark_ids()):
@@ -123,12 +130,21 @@ def build_coverage_map() -> list[dict[str, Any]]:
             benchmark_id,
             expected_results_providers=expected_results_providers,
             cross_surface_gates=cross_surface_gates,
+            staged_cross_surface_gates=staged_cross_surface_gates,
         )
         primary = primary_oracle(oracles)
         # A dual-surface benchmark with no oracle is reachable by the cross-surface
         # SQL<->DataFrame gate (the w1 dispatch target). A single-surface benchmark
         # is not and needs a fallback oracle (w2).
         dual_surface = has_sql and has_dataframe
+        # Honesty signal (M1): a cross-surface oracle's mere REGISTRATION does not
+        # prove it is green. Distinguish a CI-enforced (blocking) gate -- which is
+        # green-or-CI-fails -- from a STAGED gate that is registered but not run in
+        # CI. ``None`` for benchmarks with no cross-surface gate at all.
+        if ORACLE_CROSS_SURFACE in oracles:
+            cross_surface_enforced: bool | None = benchmark_id in cross_surface_gates
+        else:
+            cross_surface_enforced = None
         rows.append(
             {
                 "benchmark": benchmark_id,
@@ -137,10 +153,27 @@ def build_coverage_map() -> list[dict[str, Any]]:
                 "oracles": oracles,
                 "primary_oracle": primary,
                 "guarded": primary != ORACLE_NONE,
+                "cross_surface_enforced": cross_surface_enforced,
                 "cross_surface_applicable": dual_surface and primary == ORACLE_NONE,
             }
         )
     return rows
+
+
+def _enforcement_label(row: dict[str, Any]) -> str:
+    """Honesty signal for a cross-surface gate: CI-enforced vs merely registered.
+
+    ``cross_surface_enforced`` is ``True`` for an enforced (CI-blocking) gate,
+    ``False`` for a STAGED (registered-but-not-run-in-CI) gate, and ``None`` when
+    the benchmark has no cross-surface gate. Only an enforced gate is green-or-
+    CI-fails; a staged gate's registration proves nothing about correctness.
+    """
+    enforced = row.get("cross_surface_enforced")
+    if enforced is True:
+        return "enforced (CI-blocking)"
+    if enforced is False:
+        return "staged (NOT CI-enforced)"
+    return "—"
 
 
 def render_markdown(rows: list[dict[str, Any]]) -> str:
@@ -148,6 +181,8 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     unguarded = [r for r in rows if not r["guarded"]]
     dispatchable = [r for r in unguarded if r["cross_surface_applicable"]]
     single_surface_gap = [r for r in unguarded if not r["cross_surface_applicable"]]
+    enforced_cross_surface = [r for r in rows if r.get("cross_surface_enforced") is True]
+    staged_cross_surface = [r for r in rows if r.get("cross_surface_enforced") is False]
 
     lines: list[str] = []
     lines.append("# Benchmark correctness-oracle coverage map")
@@ -160,24 +195,47 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
     )
     lines.append("")
     lines.append(
-        f"**Summary:** {len(rows)} shipped benchmarks — {len(guarded)} guarded, "
-        f"{len(unguarded)} UNGUARDED ({len(dispatchable)} reachable by the "
-        f"cross-surface gate, {len(single_surface_gap)} single-surface needing a "
-        f"fallback oracle)."
+        "**What an oracle here means.** A benchmark is listed as *guarded* when an "
+        "oracle is REGISTERED for it — it is **not** a claim that the oracle is "
+        "currently green. The distinction matters most for cross-surface gates: only "
+        "a gate in the enforced `GATES` registry is run as a CI-blocking step (so it "
+        "is green or CI fails); a gate in `STAGED_GATES` is registered but not run "
+        "in CI, so its registration proves nothing about correctness. The "
+        "**Enforced** column reports this *cross-surface* enforcement status: "
+        "`enforced (CI-blocking)`, `staged (NOT CI-enforced)`, or `—` for any "
+        "benchmark that is not cross-surface-gated. A `—` therefore says nothing "
+        "about whether a *non*-cross-surface oracle is enforced: the expected-results "
+        "(tpch, tpcds) and TPC-Havoc variant oracles are CI-enforced via their own "
+        "test suites despite showing `—` here."
     )
     lines.append("")
-    lines.append("| Benchmark | Surfaces | Oracle | Notes |")
-    lines.append("| --- | --- | --- | --- |")
+    lines.append(
+        f"**Summary:** {len(rows)} shipped benchmarks — {len(guarded)} guarded "
+        f"(oracle registered), {len(unguarded)} UNGUARDED ({len(dispatchable)} "
+        f"reachable by the cross-surface gate, {len(single_surface_gap)} "
+        f"single-surface needing a fallback oracle). Cross-surface gates: "
+        f"{len(enforced_cross_surface)} CI-enforced, {len(staged_cross_surface)} "
+        f"staged (not CI-enforced)."
+    )
+    lines.append("")
+    lines.append("| Benchmark | Surfaces | Oracle | Enforced | Notes |")
+    lines.append("| --- | --- | --- | --- | --- |")
     for r in rows:
         surfaces = "+".join(r["surfaces"]) or "—"
         oracle = r["primary_oracle"]
         if r["guarded"]:
             note = ", ".join(r["oracles"])
+            # M1 honesty: a STAGED cross-surface gate is registered but not run in
+            # CI, so spell that out in the row note too -- never let the Oracle
+            # column alone imply a verified gate.
+            if r.get("cross_surface_enforced") is False:
+                note += " (registered, NOT CI-enforced)"
         elif r["cross_surface_applicable"]:
             note = "dual-surface → dispatch to cross-surface gate (w1)"
         else:
             note = "single-surface → needs fallback oracle (w2)"
-        lines.append(f"| {r['benchmark']} | {surfaces} | {oracle} | {note} |")
+        enforced = _enforcement_label(r)
+        lines.append(f"| {r['benchmark']} | {surfaces} | {oracle} | {enforced} | {note} |")
     lines.append("")
     lines.append("## UNGUARDED benchmarks")
     lines.append("")

--- a/tests/unit/test_cross_surface_applicability.py
+++ b/tests/unit/test_cross_surface_applicability.py
@@ -22,8 +22,8 @@ if str(_REPO_ROOT) not in sys.path:
 from _project.scripts.cross_surface_applicability_sweep import (  # noqa: E402
     ARTIFACT,
     BLOCKED,
+    CANDIDATE_UNVERIFIED,
     GATEABLE,
-    GATEABLE_NEEDS_ID_MAPPING,
     NO_DF_QUERY_SURFACE,
     build_applicability_sweep,
     render_markdown,
@@ -58,22 +58,43 @@ def test_w2_fallback_set_is_exactly_the_registry_less_benchmarks(rows):
     assert no_surface == _W2_FALLBACK_BENCHMARKS, f"w2-fallback set changed: {sorted(no_surface)}"
 
 
+# Benchmarks whose DataFrame registry has ZERO verbatim id overlap with the SQL
+# ids: there is no VERIFIED SQL<->DataFrame query correspondence, so they are
+# `candidate-unverified` (honest M2 classification), NOT gateable. Wiring a gate
+# would require guessing an id mapping, which the campaign TODO forbids. (amplab,
+# clickbench, joinorder_synthetic were previously here; all are now enforced
+# cross-surface gates, so they no longer appear among the unguarded candidates.)
+_CANDIDATE_UNVERIFIED_BENCHMARKS = {"datavault", "nyctaxi", "tpcds_obt", "tpch_skew", "tsbs_devops"}
+
+
 def test_registry_bearing_benchmarks_are_gateable(rows):
-    """h2odb (direct) and a known id-mapping case are classified gateable."""
+    """h2odb (verified verbatim overlap) is gateable; a zero-overlap registry is not."""
     by_id = {r["benchmark"]: r["status"] for r in rows}
     assert by_id.get("h2odb") == GATEABLE
-    # datavault ships a registry but its ids are friendly/Q-prefixed vs the SQL ids
-    # -> needs mapping. (amplab, then clickbench/joinorder_synthetic, were previously
-    # the direct example here; all are now enforced cross-surface gates, so they no
-    # longer appear among the unguarded candidates.)
-    assert by_id.get("datavault") == GATEABLE_NEEDS_ID_MAPPING
+    # datavault ships a registry but its ids do not overlap the SQL ids verbatim
+    # (friendly/Q-prefixed names), so there is no verified correspondence: it is
+    # candidate-unverified, NOT counted as gateable coverage.
+    assert by_id.get("datavault") == CANDIDATE_UNVERIFIED
+
+
+def test_zero_overlap_registries_are_candidate_unverified_not_gateable(rows):
+    """An unverified id mapping is never counted as gateable coverage (M2 honesty).
+
+    Each of these ships a DataFrame query registry but with ZERO verbatim id
+    overlap, so a gate would require guessing the SQL<->DataFrame mapping. They
+    must be classified `candidate-unverified`, never `gateable`.
+    """
+    unverified = {r["benchmark"] for r in rows if r["status"] == CANDIDATE_UNVERIFIED}
+    assert unverified == _CANDIDATE_UNVERIFIED_BENCHMARKS, f"candidate-unverified set changed: {sorted(unverified)}"
+    gateable = {r["benchmark"] for r in rows if r["status"] == GATEABLE}
+    assert _CANDIDATE_UNVERIFIED_BENCHMARKS.isdisjoint(gateable), "a zero-overlap benchmark was counted as gateable"
 
 
 def test_no_candidate_is_silently_dropped(rows):
     """Every candidate is classified into a known status."""
     assert rows, "applicability sweep produced no candidates"
     for r in rows:
-        assert r["status"] in {GATEABLE, GATEABLE_NEEDS_ID_MAPPING, NO_DF_QUERY_SURFACE, BLOCKED}, r
+        assert r["status"] in {GATEABLE, CANDIDATE_UNVERIFIED, NO_DF_QUERY_SURFACE, BLOCKED}, r
 
 
 def test_committed_artifact_is_current(rows):

--- a/tests/unit/test_oracle_coverage_map.py
+++ b/tests/unit/test_oracle_coverage_map.py
@@ -81,3 +81,35 @@ def test_cross_surface_applicable_implies_dual_surface_and_unguarded(rows):
         if r["cross_surface_applicable"]:
             assert r["dual_surface"], f"{r['benchmark']} flagged cross-surface but is single-surface"
             assert not r["guarded"], f"{r['benchmark']} flagged cross-surface but already guarded"
+
+
+def test_cross_surface_enforced_distinguishes_registered_from_verified_green(rows):
+    """A cross-surface gate's CI-enforcement (M1 honesty) is recorded and accurate.
+
+    ``cross_surface_enforced`` separates a CI-enforced (blocking, hence green-or-
+    CI-fails) gate from one merely registered: it is ``True`` for gates in the
+    enforced ``GATES`` registry, ``False`` for ``STAGED_GATES`` (registered but not
+    run in CI), and ``None`` for benchmarks with no cross-surface gate. Mere
+    registration must never be reported as enforced coverage.
+    """
+    from benchbox.core.equivalence.cross_surface import GATES, STAGED_GATES
+
+    by_id = {r["benchmark"]: r for r in rows}
+    for benchmark_id in GATES:
+        assert by_id[benchmark_id]["cross_surface_enforced"] is True, (
+            f"{benchmark_id} is in enforced GATES but not reported as CI-enforced"
+        )
+    for benchmark_id in STAGED_GATES:
+        assert by_id[benchmark_id]["cross_surface_enforced"] is False, (
+            f"{benchmark_id} is STAGED (not CI-enforced) but reported as enforced"
+        )
+    # The currently-enforced cross-surface gates must be reported as such.
+    assert {"ssb", "coffeeshop", "amplab", "clickbench", "joinorder_synthetic"} <= set(GATES), (
+        "expected enforced cross-surface gate set changed; update the coverage-map honesty test"
+    )
+    for r in rows:
+        # A non-cross-surface benchmark carries no enforcement signal.
+        if ORACLE_CROSS_SURFACE not in r["oracles"]:
+            assert r["cross_surface_enforced"] is None, (
+                f"{r['benchmark']} has no cross-surface gate but carries an enforcement flag"
+            )


### PR DESCRIPTION
## What

Implements **w9** of `cross-surface-oracle-remediation` — the M1/M2 honesty fixes for the oracle coverage map and the cross-surface applicability sweep.

**M1 — coverage map: registered != verified-green.**
`generate_oracle_coverage_map.py` derived `guarded` purely from `GATES` membership and never distinguished a CI-enforced gate from a merely-registered one. Now each row carries a `cross_surface_enforced` signal:
- `True` — in the enforced `GATES` registry (CI-blocking, so green-or-CI-fails)
- `False` — in `STAGED_GATES` (registered but NOT run in CI)
- `None` — no cross-surface gate

The markdown gains an **Enforced** column and a "what an oracle here means" preamble stating plainly that `guarded` means *registered*, not green, and that a `—` in the Enforced column means "not cross-surface-gated" (expected-results/TPC-Havoc oracles are enforced via their own suites). The JSON carries the new field. A STAGED gate's row note is also annotated `(registered, NOT CI-enforced)` so the Oracle column can never imply a verified gate on its own.

**M2 — applicability: don't count an unverified id mapping as gateable.**
`cross_surface_applicability_sweep.py` classified zero-verified-overlap benchmarks as gateable. They are now a new `candidate-unverified` status, **excluded** from `_GATEABLE_STATUSES` / the gateable count, with a per-benchmark "confirm an independent SQL↔DataFrame id mapping (do NOT guess)" note.

## Why

Closes the M1/M2 "governance/theater" findings: a registered-but-red gate was reportable as coverage, and 5–6 benchmarks with **zero** verified SQL↔DataFrame id overlap (the campaign's own TODO warns "do NOT guess" for nyctaxi/tsbs; tpcds_obt is 3 DataFrame vs ~89 SQL queries) were counted as gateable.

## Evidence (live-derived, not hardcoded)

- Enforced cross-surface gates reported `enforced (CI-blocking)`: **amplab, clickbench, coffeeshop, joinorder_synthetic, ssb**. `STAGED_GATES` is empty → 0 staged.
- Downgraded to `candidate-unverified`: **datavault, nyctaxi, tpcds_obt, tpch_skew, tsbs_devops**. (amplab is no longer an unguarded candidate — promoted to an enforced gate in #859, hence 5 here, not the original 6.)
- `gateable` (verified verbatim overlap) is now: flightdata, h2odb, joinorder, read_primitives.
- Both committed artifacts regenerated; `make oracle-coverage-map-check` and the applicability sweep `--check` are green.
- `tests/unit/test_oracle_coverage_map.py` (+ new `test_cross_surface_enforced_distinguishes_registered_from_verified_green`) and `tests/unit/test_cross_surface_applicability.py` (+ new `test_zero_overlap_registries_are_candidate_unverified_not_gateable`, pinned candidate-unverified set): **10 passed**.
- ruff / ruff format / ty clean on the changed scripts.

w9 closed out (status → done, progress note added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT)_