### PR TITLE
test(correctness): mutation-sensitivity suite for cross-surface gates (w10)

### DIFF
--- a/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
+++ b/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
@@ -428,9 +428,48 @@ work:
 
   - id: w10
     summary: "Mutation-test the oracle to measure SENSITIVITY, not just specificity (C2 - the central question)"
-    status: pending
+    status: done
     needs: [w2, w4]
     addresses: [C2, "review:CRITICAL C2", "deeper-question 2", "claim 9"]
+    progress: |
+      DONE: a systematic mutation-sensitivity suite lands in
+      tests/integration/test_cross_surface_mutation_sensitivity.py and its
+      caught-vs-uncaught matrix is committed as evidence in
+      _project/analysis/cross-surface-mutation-sensitivity.md. For every enforced
+      gated benchmark (read live from GATES: ssb, amplab, coffeeshop, clickbench,
+      joinorder_synthetic) it wraps ONE target query's DataFrame impl at test time
+      (dataclasses.replace on the DataFrameQuery - the production registries are
+      NOT touched) and drives the real gate machinery
+      (find_cross_surface_divergences + the reused ResultValidator) on the bounded
+      SF=0.1 cell. No production code or comparator changed, so TPC-Havoc stays
+      byte-identical-green.
+
+      Matrix (both backends; verified at SF=0.1):
+        flip_comparator (<->-<=, +1 row)  : CAUGHT on all 5 (row-count path)
+        drop_group_key  (drop leading col): CAUGHT on all 5 (column-count path)
+        drop_join       (value perturb)   : CAUGHT on all 5 (value path)
+        reverse_sort    (reverse rows)    : NOT CAUGHT on the 4 multi-row gates
+                                            (ssb/amplab/coffeeshop/clickbench);
+                                            no-op on joinorder_synthetic (every
+                                            gated query is a single-row scalar).
+      So each gated benchmark has >=3 mutation classes the gate provably catches
+      (acceptance #1), and the one uncaught class is documented (acceptance #2).
+
+      HONEST FINDING (the C2 answer): the reversed-sort miss CONFIRMS the open half
+      of w2/BS2 - validate_results_exact full-row-sorts both sides before
+      comparing, so a reversed ORDER BY that preserves the multiset passes
+      silently. This is recorded (NOT baselined - that would be the anti-pattern)
+      with a tracking note pointing back at w2; the dedicated
+      test_reversed_sort_is_the_bs2_probe will flip to failing the moment an
+      order-aware comparator lands, forcing the doc + the harness _EXPECT_CAUGHT
+      table to be updated. The oracle is strong on row-membership, column-shape,
+      and value bugs and blind only to pure ordering bugs - it did NOT find "no
+      bugs" because it is vacuous; w4's empty-cell guard plus this suite's
+      non-empty-target assertion (test_unmutated_target_is_green) rule that out.
+
+      Also folds in the w3 byte-stability regression
+      (test_gate_output_is_byte_stable_across_two_in_process_runs): two in-process
+      ssb gate runs on the same seed produce an identical divergence set.
     notes: |
       The campaign measured only that the gates PASS (specificity); it never measured
       whether they CATCH a seeded bug (sensitivity). Add a mutation-test harness that,

--- a/_project/analysis/cross-surface-mutation-sensitivity.md
+++ b/_project/analysis/cross-surface-mutation-sensitivity.md
@@ -1,0 +1,125 @@
+# Cross-surface oracle: mutation-sensitivity evidence (w10 / C2)
+
+The cross-surface SQL↔DataFrame campaign measured only that the gates **pass**
+(specificity). It never measured whether they **catch a seeded bug**
+(sensitivity). PR #859 added a single planted-divergence regression per enforced
+gate, but there was no *systematic* mutation suite. This file records the
+systematic result: for every enforced gated benchmark (read live from
+`benchbox.core.equivalence.cross_surface.GATES`) we inject a known DataFrame-side
+error into one query and observe whether the **real** gate machinery
+(`find_cross_surface_divergences`, driving the reused `ResultValidator`) goes RED.
+
+The harness lives in
+`tests/integration/test_cross_surface_mutation_sensitivity.py`. It wraps the
+target query's DataFrame impl at test time (via `dataclasses.replace` on the
+`DataFrameQuery`) — it never edits the production query registries — runs the
+real impl, materializes its rows through the same `materialize_rows` the gate
+uses, applies one controlled perturbation, and returns the mutated rows. The
+comparator is exercised end to end on the bounded SF=0.1 cell.
+
+## Mutation classes
+
+Each mutation models the **observable result shape** of a real DataFrame logic
+bug of that class, and is designed to exercise a distinct detection path of the
+comparator:
+
+| Mutation | Models | Result-shape change | Detection path |
+| --- | --- | --- | --- |
+| `flip_comparator` (`<` → `<=`) | a relaxed filter admits boundary-equal rows | append a duplicate boundary row → +1 row | **row-count** check (first check in `validate_results_exact`) |
+| `drop_group_key` | grouping on fewer keys changes the row shape | drop the leading column from every row | **column-count** check (per-row width) |
+| `reverse_sort` | a reversed `ORDER BY` | reverse the row order, multiset preserved | **order** — the comparator full-row-sorts both sides, so there is none |
+| `drop_join` | a dropped/incorrect join changes a joined column value | perturb one cell to a value outside the reference | **value** check (`_values_equal`, tolerance-aware) |
+
+## Caught-vs-uncaught matrix (verified at SF=0.1)
+
+Each cell is the verdict for **both** backends (`expression` + `pandas`); a
+"caught" mutation produced a divergence on both. Target queries were chosen to be
+discriminating (multi-row, ORDER BY + GROUP BY) where the benchmark has one.
+
+| Benchmark | Target | `flip_comparator` | `drop_group_key` | `reverse_sort` | `drop_join` |
+| --- | --- | --- | --- | --- | --- |
+| **ssb** | Q3.1 (149×4) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
+| **amplab** | 4 (100×6) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
+| **coffeeshop** | SA1 (93×5) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
+| **clickbench** | Q8 (20×2) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
+| **joinorder_synthetic** | 4a (1×2) | ✅ caught | ✅ caught | ⚪ no-op (single row) | ✅ caught |
+
+Every benchmark therefore has **≥3** mutation classes the gate provably catches
+(the w10 acceptance bar), and every uncaught cell is explained below.
+
+## The reversed-sort result is the headline BS2 probe
+
+`reverse_sort` is **not caught** on any of the four multi-row benchmarks. This
+**confirms** the unresolved half of w2/BS2: `ResultValidator.validate_results_exact`
+(`benchbox/core/tpchavoc/validation.py`) calls `sorted(original_results)` and
+`sorted(variant_results)` and compares positionally, so reversing the row order
+of a result yields two identical sorted lists — the divergence is invisible. A
+genuinely reversed `ORDER BY` in a gated DataFrame query would pass the gate
+silently. The dedicated `test_reversed_sort_is_the_bs2_probe` pins this on
+ssb Q3.1; if a future comparator change makes ORDER BY visible, that test flips
+and forces this doc and the harness's `_EXPECT_CAUGHT` table to be updated.
+
+This is honest evidence about the oracle's strength, not a failure of the
+harness: the oracle is strong on row-membership, column-shape, and value bugs,
+and **blind to pure ordering bugs**. It is tracked as the open half of **w2**
+(BS2). It is *not* added to any `known_divergences` baseline (that would be the
+exact anti-pattern the remediation flagged); it is recorded here as a sensitivity
+gap with a tracking item.
+
+### Why this blind spot is bounded in practice
+
+A pure ordering bug that preserves the exact result multiset is the only thing
+this misses. Any ordering bug that *also* changes which rows survive a `LIMIT`
+(the common case for a top-N) changes the row multiset and is caught by the
+row-count / value paths. The residual exposure is a reversed (or otherwise
+permuted) `ORDER BY` on a result whose rows are all returned — exactly the case
+`reverse_sort` models. Closing it requires the order-aware comparison mode
+specified in w2 (compare the ordered prefix up to the first tie group exactly).
+
+## Single-row + mostly-NULL caveat: joinorder_synthetic
+
+Every gated `joinorder_synthetic` query is a single-row scalar aggregate
+(verified at SF=0.1: all 13 queries return exactly one row). Worse, **most of
+them return all-NULL** at the bounded cell — these are JOB-style "find the
+min/argmin matching row" queries whose match simply does not exist in the
+SF=0.1 data, so the aggregate is NULL (1a/1b/5a/6a/7a/8a/9a/10a/11a/12a are all
+`(None, …)`). That is a **BS3-vacuous** result: a NULL-vs-NULL comparison is
+non-discriminating, and a value mutation has nothing to perturb. This is itself
+honest evidence — the gate is *running* on these queries but proving little at
+SF=0.1; see w4 (vacuous-cell hygiene). The mutation target is therefore **4a**,
+one of the few queries that returns a non-NULL row (`('3.2', 'A Action Action')`),
+so its drop_join can land a real value mismatch:
+
+- `flip_comparator`, `drop_group_key`, `drop_join` are all caught (row-count,
+  column-count, and value paths respectively work on a single row; drop_join
+  perturbs the rightmost string column, yielding a genuine value mismatch — not
+  an `error:`).
+- `reverse_sort` is a **no-op**: reversing a one-element list changes nothing, so
+  no divergence is injected and none is reported. This is the expected,
+  degenerate outcome — it is *not* the comparator's order-blindness (which is
+  demonstrated instead on the four multi-row benchmarks above). The harness
+  records this as an expected non-catch for `joinorder_synthetic/reverse_sort`.
+
+The multi-row reverse-sort blindness (the real BS2 probe) is established on ssb,
+amplab, coffeeshop, and clickbench, so joinorder_synthetic's single-row shape
+does not weaken the headline finding.
+
+## Note on clickbench target choice
+
+The clickbench target is **Q8** (`GROUP BY AdvEngineID ORDER BY COUNT(*) DESC`,
+**no** trailing `LIMIT` → the strict comparator, with a discriminating order
+key). The obvious multi-key candidate, Q31, is vacuous for value mutations at
+SF=0.1: its `COUNT(*)` order key is constant (every one of its 10 rows ties at
+1) *and* it carries a trailing `LIMIT`, so the tie-aware path accepts any
+single-row perturbation as an equally-valid boundary swap (a BS3-adjacent
+artifact). Q8 avoids both, so its `drop_join` value mutation is genuinely caught.
+
+## Tracking
+
+- **Open (w2 / BS2):** reversed `ORDER BY` passes the gate silently. Add the
+  order-aware comparison mode (ordered prefix exact, boundary tie as multiset) so
+  this mutation flips to caught. The `test_reversed_sort_is_the_bs2_probe`
+  regression will detect the moment that lands.
+- The byte-stability regression promised in **w3** is included in the same suite
+  (`test_gate_output_is_byte_stable_across_two_in_process_runs`): two in-process
+  ssb gate runs on the same seed produce an identical divergence set.

--- a/tests/integration/test_cross_surface_mutation_sensitivity.py
+++ b/tests/integration/test_cross_surface_mutation_sensitivity.py
@@ -1,0 +1,458 @@
+"""Mutation-sensitivity suite for the cross-surface SQL<->DataFrame gates (w10).
+
+The cross-surface campaign only ever measured that the gates PASS (specificity);
+it never measured whether they CATCH a seeded bug (sensitivity). PR #859 added a
+single planted-divergence regression per enforced gate, but no SYSTEMATIC
+mutation suite. This module fills that gap: for every ENFORCED gated benchmark
+(read live from :data:`benchbox.core.equivalence.cross_surface.GATES`) it injects
+a known DataFrame-side error into ONE query and asserts the real gate machinery
+(:func:`find_cross_surface_divergences`, driving the reused
+:class:`~benchbox.core.tpchavoc.validation.ResultValidator`) reports a divergence
+- i.e. goes RED.
+
+The mutation is applied by WRAPPING the target query's DataFrame impl at test
+time (via :func:`dataclasses.replace` on the :class:`DataFrameQuery`), never by
+editing the production query registries. The wrapper runs the real impl,
+materializes its result rows through the same ``materialize_rows`` the gate uses,
+applies one controlled perturbation, and returns the mutated rows as a frame the
+comparator consumes - so the test exercises the production comparator end to end.
+
+Four mutation classes, each chosen to exercise a distinct detection path of the
+comparator (see :func:`_mutate_rows`):
+
+* ``flip_comparator`` (``<`` -> ``<=``): a relaxed comparator admits the
+  boundary-equal rows, so the result gains rows. Modeled by appending a duplicate
+  boundary row -> a ROW-COUNT mismatch.
+* ``drop_group_key``: grouping on fewer keys merges groups and changes the row
+  shape. Modeled by dropping the leading column -> a COLUMN-COUNT mismatch.
+* ``reverse_sort``: a reversed ``ORDER BY``. Modeled by reversing the row order
+  while preserving the multiset. THIS IS THE BS2 PROBE: the comparator
+  full-row-sorts both sides before comparing (validation.py), so a reversed order
+  over a multi-row result is INVISIBLE to it. We assert the honest, documented
+  outcome per benchmark rather than pretend the gate catches it.
+* ``drop_join``: a dropped/incorrect join changes joined column values. Modeled
+  by perturbing one cell value -> a VALUE mismatch.
+
+The caught-vs-uncaught matrix this suite asserts is recorded as committed
+evidence in ``_project/analysis/cross-surface-mutation-sensitivity.md``.
+
+These tests build one bounded SF=0.1 DuckDB cell per benchmark (the same cell the
+gates use) and are marked ``slow``; the heavier benchmarks (amplab, clickbench)
+generate large data, so the whole suite is opt-in via ``-m slow``.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Callable
+
+import pytest
+
+pytest.importorskip("polars", reason="Polars not installed")
+pytest.importorskip("pandas", reason="Pandas not installed")
+pytest.importorskip("duckdb", reason="DuckDB not installed")
+
+import polars as pl
+
+from benchbox.core.equivalence.cross_surface import (
+    EQUIVALENCE_SCALE,
+    GATES,
+    build_production_contexts,
+    find_cross_surface_divergences,
+)
+from benchbox.core.equivalence.dataframe_surface import fetch_reference_rows, materialize_rows
+from benchbox.core.tpchavoc.validation import ResultValidator
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.duckdb,
+]
+
+
+# One discriminating target query per ENFORCED gated benchmark. Each was chosen
+# (via a reference-shape probe at SF=0.1) to be the kind of query the mutation
+# acts on: a multi-row, multi-column, ORDER BY + GROUP BY result wherever the
+# benchmark has one, so reverse_sort and drop_group_key are non-degenerate. The
+# membership of GATES itself is asserted below so this map cannot silently drift
+# from the enforced set.
+#
+# clickbench deliberately targets Q8 (GROUP BY AdvEngineID ORDER BY COUNT(*) DESC,
+# NO trailing LIMIT -> the STRICT comparator, with a DISCRIMINATING order key).
+# Q31, the obvious multi-key candidate, is vacuous at SF=0.1: its COUNT(*) order
+# key is constant (every row ties at 1) AND it carries a trailing LIMIT, so the
+# tie-aware path accepts any single-row perturbation as a boundary swap (a BS3
+# artifact). Q8 avoids both.
+#
+# joinorder_synthetic is the documented exception: every one of its gated queries
+# is a single-row scalar aggregate, so a "reversed sort" is a no-op mutation
+# (reversing a 1-row list changes nothing) and "drop_group_key" degenerates to a
+# bare column drop. Worse, MOST of its queries return all-NULL at SF=0.1 (the
+# JOB-style "find the min/argmin" match does not exist in the bounded cell - a
+# BS3-vacuous result). Target 4a is one of the few that returns a non-NULL row
+# (`('3.2', 'A Action Action')`), so its drop_join lands a real value mismatch.
+# We still run it for the row-count/column-count/value paths and record both the
+# single-row and mostly-NULL caveats in the findings doc.
+_TARGETS: dict[str, str] = {
+    "ssb": "Q3.1",  # 149 rows x 4 cols, ORDER BY + GROUP BY
+    "amplab": "4",  # 100 rows x 6 cols, ORDER BY + GROUP BY
+    "coffeeshop": "SA1",  # 93 rows x 5 cols, ORDER BY + GROUP BY (hand-written impls)
+    "clickbench": "Q8",  # 20 rows x 2 cols, GROUP BY + ORDER BY, no LIMIT (strict path)
+    "joinorder_synthetic": "4a",  # 1 row x 2 non-NULL string cols (single-row caveat)
+}
+
+
+def _mutate_rows(rows: list[tuple[Any, ...]], kind: str) -> list[tuple[Any, ...]]:
+    """Apply one controlled perturbation to materialized result rows.
+
+    Each branch models the OBSERVABLE result shape of a real DataFrame logic bug
+    of that class - the harness measures whether the gate's comparator catches a
+    divergence of that shape, which is exactly the sensitivity question (C2).
+    """
+    if kind == "flip_comparator":
+        # `<` -> `<=` admits boundary-equal rows: the result GAINS a row.
+        return rows + [rows[-1]]
+    if kind == "drop_group_key":
+        # Grouping on fewer keys changes the row shape; drop the leading column.
+        return [row[1:] for row in rows]
+    if kind == "reverse_sort":
+        # A reversed ORDER BY: same multiset, opposite order (the BS2 probe).
+        return list(reversed(rows))
+    if kind == "drop_join":
+        # A dropped/incorrect join changes a joined column's value; perturb one
+        # cell on the first row to a value that is the SAME Python type as the cell
+        # (so the replacement frame keeps the column's dtype - a type-incompatible
+        # sentinel would raise a frame-construction error and be miscounted as an
+        # "error:" divergence for the wrong reason) and that differs by a
+        # MAGNITUDE-INDEPENDENT amount (so the comparator's relative float tolerance
+        # of 1e-10 can never mask it - a bare ``value + 1`` is within tolerance for
+        # a large aggregate like SUM(revenue) >= ~1e10).
+        first = list(rows[0])
+        column = _perturbable_column(first)
+        first[column] = _perturb_value(first[column])
+        return [tuple(first)] + list(rows[1:])
+    raise ValueError(f"unknown mutation kind: {kind}")
+
+
+def _is_number(value: Any) -> bool:
+    """True for a real numeric scalar (int/float), excluding bool."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _perturbable_column(row: list[Any]) -> int:
+    """Index of the rightmost numeric (preferred) or string cell to perturb.
+
+    A numeric cell is preferred because the magnitude-independent numeric
+    perturbation in :func:`_perturb_value` is guaranteed to exceed the comparator's
+    relative tolerance; a string cell is the fallback. Raising on a row with
+    neither keeps the harness honest - a value mutation that cannot land a
+    type-safe, tolerance-beating change is a test-setup error, surfaced loudly
+    rather than silently passing for the wrong reason.
+    """
+    for index in range(len(row) - 1, -1, -1):
+        if _is_number(row[index]):
+            return index
+    for index in range(len(row) - 1, -1, -1):
+        if isinstance(row[index], str):
+            return index
+    raise ValueError(f"drop_join mutation needs a numeric or string column to perturb; row={row!r}")
+
+
+def _perturb_value(value: Any) -> Any:
+    """Return a same-type value that differs from ``value`` beyond any tolerance.
+
+    For a number, ``-value - 1`` flips the sign and offsets: the relative
+    difference is ~2 for any large magnitude (well above the 1e-10 relative
+    tolerance) and the absolute difference is >= 1 for a value near zero (above
+    the absolute tolerance), so the mismatch is ALWAYS reported. For a string,
+    append a marker guaranteed to make it distinct.
+    """
+    if _is_number(value):
+        return -value - 1
+    return f"{value}_ZZZ_MUTATION"
+
+
+# Per benchmark+mutation: whether the gate is EXPECTED to catch the seeded bug.
+# True  -> the mutation must make the gate go RED (sensitivity proven).
+# False -> the gate provably cannot catch it; the reason is recorded in the
+#          findings doc and asserted as a documented blind spot, never silently
+#          ignored.
+_EXPECT_CAUGHT: dict[tuple[str, str], bool] = {
+    # reverse_sort is the BS2 order-blindness probe: the comparator full-row-sorts
+    # both sides, so a reversed order over a multi-row result passes silently.
+    ("ssb", "reverse_sort"): False,
+    ("amplab", "reverse_sort"): False,
+    ("coffeeshop", "reverse_sort"): False,
+    ("clickbench", "reverse_sort"): False,
+    # joinorder_synthetic is single-row: reversing a 1-row list is a no-op, so the
+    # mutation injects no divergence at all (a degenerate, expected miss).
+    ("joinorder_synthetic", "reverse_sort"): False,
+}
+
+
+def _expect_caught(benchmark: str, kind: str) -> bool:
+    """Default to expecting the mutation caught unless recorded as a blind spot."""
+    return _EXPECT_CAUGHT.get((benchmark, kind), True)
+
+
+def _mutated_dataframe_query(
+    dataframe_query: Callable[[Any], Any],
+    target: str,
+    kind: str,
+) -> Callable[[Any], Any]:
+    """Return a ``dataframe_query`` that injects ``kind`` into ``target`` only.
+
+    Wraps each implemented backend of the target query so its returned frame is
+    replaced by the mutated rows; every other query is passed through unchanged,
+    and the production registry is never mutated.
+    """
+
+    def wrap(impl: Callable[[Any], Any] | None) -> Callable[[Any], Any] | None:
+        if impl is None:
+            return None
+
+        def wrapped(ctx: Any) -> Any:
+            rows = materialize_rows(impl(ctx))
+            if not rows:
+                # No rows to mutate (vacuous cell) - return as-is; the harness
+                # asserts the chosen targets are non-empty, so this never fires
+                # for a real target, only defends against an accidental pick.
+                return pl.DataFrame()
+            mutated = _mutate_rows(rows, kind)
+            schema = [f"c{i}" for i in range(len(mutated[0]))]
+            return pl.DataFrame(mutated, schema=schema, orient="row")
+
+        return wrapped
+
+    def dispatch(query_id: Any) -> Any:
+        query = dataframe_query(query_id)
+        if str(query_id) != target:
+            return query
+        return replace(
+            query,
+            pandas_impl=wrap(query.pandas_impl),
+            expression_impl=wrap(query.expression_impl),
+        )
+
+    return dispatch
+
+
+@dataclass
+class _GateCell:
+    """One benchmark's bounded cell, built ONCE and reused across its mutations.
+
+    Building the SF=0.1 cell (data generation + the production CSV->parquet load
+    into both backend contexts) is the dominant cost - tens of seconds, up to
+    minutes for the heavier benchmarks. Rebuilding it per mutation would be ~5x the
+    work AND would let two xdist workers regenerate the same heavy benchmark
+    concurrently (observed to OOM a worker mid-parquet-write -> a truncated file).
+    So a module-scoped fixture builds each benchmark's cell once; the mutations
+    only re-wrap the target impl (cheap) and re-run the comparator on the shared,
+    read-only contexts.
+    """
+
+    gate_name: str
+    data: Any
+    contexts: dict[str, Any]
+    reference_row_count: int
+
+
+def _build_gate_cell(gate_name: str, tmp_path: Any) -> _GateCell:
+    """Build one benchmark's bounded cell and capture the target's reference count."""
+    gate = GATES[gate_name]
+    data = gate.build(EQUIVALENCE_SCALE, tmp_path)
+    contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+    reference_row_count = len(fetch_reference_rows(data.connection, data.reference_sql(_TARGETS[gate_name])))
+    return _GateCell(gate_name=gate_name, data=data, contexts=contexts, reference_row_count=reference_row_count)
+
+
+def _run_target_gate(cell: _GateCell, *, mutation: str | None = None) -> list[Any]:
+    """Run the gate over the single target query of an already-built cell.
+
+    Running only the target query (the rest are unmutated and already green) keeps
+    the comparison cheap while still driving the real gate machinery. The mutation,
+    when given, wraps only the target impl - the shared contexts are never mutated,
+    so reusing one cell across all mutations is safe.
+    """
+    gate = GATES[cell.gate_name]
+    data = cell.data
+    target = _TARGETS[cell.gate_name]
+    dataframe_query = data.dataframe_query
+    if mutation is not None:
+        dataframe_query = _mutated_dataframe_query(data.dataframe_query, target, mutation)
+    return find_cross_surface_divergences(
+        data.connection,
+        query_ids=[target],
+        reference_sql=data.reference_sql,
+        dataframe_query=dataframe_query,
+        contexts=cell.contexts,
+        validator=ResultValidator(tolerance=gate.tolerance),
+        backends=gate.backends,
+    )
+
+
+_MUTATIONS = ("flip_comparator", "drop_group_key", "reverse_sort", "drop_join")
+
+
+# Module-scoped per-benchmark cell, built once PER WORKER. With xdist's default
+# `load` distribution a benchmark's cells can still land on different workers (each
+# builds its own copy into its own ``tmp_path_factory`` dir - no shared file, so no
+# cross-worker corruption), but a single worker never rebuilds the same benchmark
+# for each of its mutations - it builds once and reuses. That bounds heavy data
+# generation to at most one concurrent build per worker, which removed the
+# OOM/truncated-parquet failures seen when every mutation rebuilt from scratch. The
+# connection is closed by the fixture finalizer.
+@pytest.fixture(scope="module")
+def gate_cell(request: Any, tmp_path_factory: Any) -> Any:
+    """Build (once per worker) and yield the requested benchmark's bounded cell."""
+    gate_name = request.param
+    tmp_path = tmp_path_factory.mktemp(f"mutcell_{gate_name}")
+    cell = _build_gate_cell(gate_name, tmp_path)
+    try:
+        yield cell
+    finally:
+        cell.data.connection.close()
+
+
+def test_targets_cover_every_enforced_gate() -> None:
+    """The mutation targets must track the live enforced GATES set exactly.
+
+    Guards against drift: if a benchmark is added to or removed from GATES the
+    suite fails until a target query is chosen for it, so a newly-enforced gate
+    can never silently escape sensitivity testing.
+    """
+    assert set(_TARGETS) == set(GATES), (
+        "mutation targets out of sync with enforced GATES: "
+        f"missing={set(GATES) - set(_TARGETS)} extra={set(_TARGETS) - set(GATES)}"
+    )
+
+
+# Indirect parametrization on the ``gate_cell`` fixture (built once per benchmark).
+# The id is the benchmark name. The fixture's request.param is named ``gate_cell``
+# (not ``benchmark``): pytest-benchmark registers a ``benchmark`` fixture, so a
+# parameter of that name collides with it and crashes the xdist worker.
+@pytest.mark.parametrize("gate_cell", sorted(_TARGETS), indirect=True)
+def test_unmutated_target_is_green(gate_cell: _GateCell) -> None:
+    """Sanity floor: the chosen target query is non-empty and diverges from nothing.
+
+    A mutation-sensitivity result is only meaningful if the un-mutated cell is
+    already green and discriminating (non-empty). This pins both: an empty target
+    would make every "not caught" result a BS3 artifact rather than a comparator
+    property.
+    """
+    gate_name = gate_cell.gate_name
+    target = _TARGETS[gate_name]
+    divergences = _run_target_gate(gate_cell, mutation=None)
+    assert not divergences, f"{gate_name} target {target} is not green before mutation: {divergences}"
+    # Non-vacuity floor. >= 2 (not just >= 1) so reverse_sort is a real ordering
+    # change, not a single-row no-op - except joinorder_synthetic, whose every
+    # gated query is a single-row scalar (the documented single-row caveat); there
+    # we still require a non-empty (>= 1) reference so the cell is not vacuous.
+    minimum = 1 if gate_name == "joinorder_synthetic" else 2
+    assert gate_cell.reference_row_count >= minimum, (
+        f"{gate_name} target {target} returned {gate_cell.reference_row_count} reference row(s) "
+        f"at SF={EQUIVALENCE_SCALE}; a vacuous/too-small target would make 'not caught' results a "
+        f"BS3 artifact - pick a discriminating target."
+    )
+
+
+@pytest.mark.parametrize("gate_cell", sorted(_TARGETS), indirect=True)
+@pytest.mark.parametrize("kind", _MUTATIONS)
+def test_mutation_sensitivity(kind: str, gate_cell: _GateCell) -> None:
+    """A seeded DataFrame bug either makes the gate RED, or is a documented miss.
+
+    For each (benchmark, mutation) the expected outcome is recorded in
+    :data:`_EXPECT_CAUGHT`. A "caught" mutation asserts the gate reports >=1
+    divergence (sensitivity proven). A "not caught" mutation asserts the gate
+    reports ZERO divergences - the honest evidence that the comparator is blind to
+    that mutation class (the reversed-sort BS2 blindness, or a single-row
+    degenerate no-op), cross-referenced in
+    ``_project/analysis/cross-surface-mutation-sensitivity.md``.
+    """
+    gate_name = gate_cell.gate_name
+    target = _TARGETS[gate_name]
+    divergences = _run_target_gate(gate_cell, mutation=kind)
+    caught = bool(divergences)
+    expected = _expect_caught(gate_name, kind)
+
+    if expected:
+        assert caught, (
+            f"SENSITIVITY GAP: {gate_name} {target} {kind} was NOT caught by the gate "
+            f"(expected RED). The comparator missed a seeded bug it should detect."
+        )
+        # The catch must be a genuine result mismatch, not an ``error:`` from the
+        # harness failing to build the mutated frame (which would "pass" for the
+        # wrong reason - see find_surface_divergences' execution-error branch).
+        errored = [d for d in divergences if d.detail.startswith("error:")]
+        assert not errored, (
+            f"{gate_name} {target} {kind} was caught only via a harness execution error, "
+            f"not a result mismatch: {[(d.key, d.detail) for d in errored]}"
+        )
+    else:
+        assert not caught, (
+            f"{gate_name} {target} {kind} was unexpectedly CAUGHT "
+            f"({[d.key for d in divergences]}). A documented blind spot is now closed - "
+            f"update _EXPECT_CAUGHT and the findings doc."
+        )
+
+
+@pytest.mark.parametrize("gate_cell", ["ssb"], indirect=True)
+def test_reversed_sort_is_the_bs2_probe(gate_cell: _GateCell) -> None:
+    """Headline BS2 probe: a reversed ORDER BY passes silently on a multi-row gate.
+
+    The unresolved half of w2/BS2 is whether the comparator catches a reversed
+    ORDER BY. It full-row-sorts both sides before comparing, so it cannot. This
+    test pins that property directly on ssb Q3.1 (149 ordered rows): the reversed
+    result yields ZERO divergences. If a future comparator change makes ORDER BY
+    visible, this test flips and forces the findings doc + _EXPECT_CAUGHT update.
+    """
+    # The probe is only meaningful over a genuinely ordered, multi-row result: a
+    # 0/1-row reference would make "not caught" vacuous rather than a comparator
+    # property.
+    assert gate_cell.reference_row_count >= 2, (
+        f"ssb {_TARGETS['ssb']} returned only {gate_cell.reference_row_count} row(s); reverse-sort probe is vacuous."
+    )
+    divergences = _run_target_gate(gate_cell, mutation="reverse_sort")
+    assert not divergences, (
+        "ssb Q3.1 reversed-sort was caught - the comparator is now ORDER BY-aware; "
+        "update _project/analysis/cross-surface-mutation-sensitivity.md and _EXPECT_CAUGHT."
+    )
+
+
+def test_gate_output_is_byte_stable_across_two_in_process_runs(tmp_path: Any) -> None:
+    """w3 byte-stability regression: two in-process runs on one seed agree exactly.
+
+    w3's second acceptance criterion is a regression that asserts gate output is
+    byte-stable across two in-process runs on the same seed. We run the ssb gate's
+    full query set twice in the same process and assert the divergence sets (keys
+    and details) are identical, pinning the determinism the tie-aware comparator
+    provides.
+    """
+    benchmark = "ssb"
+    gate = GATES[benchmark]
+
+    def run_once(sub: Any) -> list[tuple[str, str]]:
+        data = gate.build(EQUIVALENCE_SCALE, sub)
+        connection = data.connection
+        try:
+            contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+            divergences = find_cross_surface_divergences(
+                connection,
+                query_ids=data.query_ids,
+                reference_sql=data.reference_sql,
+                dataframe_query=data.dataframe_query,
+                contexts=contexts,
+                validator=ResultValidator(tolerance=gate.tolerance),
+                backends=gate.backends,
+            )
+        finally:
+            connection.close()
+        return sorted((d.key, d.detail) for d in divergences)
+
+    first = run_once(tmp_path / "run1")
+    second = run_once(tmp_path / "run2")
+    assert first == second, f"ssb gate output not byte-stable across runs: {first!r} != {second!r}"


### PR DESCRIPTION
## What

Adds a systematic **mutation-sensitivity** suite for the cross-surface SQL↔DataFrame gates, plus the w3 byte-stability regression. Closes **w10** of `cross-surface-oracle-remediation` (C2 — the central question).

`tests/integration/test_cross_surface_mutation_sensitivity.py` + committed evidence in `_project/analysis/cross-surface-mutation-sensitivity.md`.

## Why

The campaign only ever measured that the gates **pass** (specificity); it never measured whether they **catch a seeded bug** (sensitivity). #859 added a single planted divergence per gate, but no systematic suite. The open question (C2): is the oracle strong enough to find logic bugs, or did it find "no bugs" because it is too weak/vacuous?

## How

For every **enforced** gated benchmark (read live from `cross_surface.GATES`: ssb, amplab, coffeeshop, clickbench, joinorder_synthetic) the suite wraps **one** target query's DataFrame impl at test time via `dataclasses.replace` on the `DataFrameQuery` — the **production query registries are never touched** — and drives the **real** gate machinery (`find_cross_surface_divergences` + the reused `ResultValidator`) on the bounded SF=0.1 cell. Each benchmark's cell is built **once** (module-scoped fixture) and reused across its mutations.

Four mutation classes, each exercising a distinct comparator detection path:

| Mutation | Models | Detection path |
| --- | --- | --- |
| `flip_comparator` (`<`→`<=`) | relaxed filter admits boundary rows (+1 row) | row-count |
| `drop_group_key` | grouping on fewer keys (drop leading col) | column-count |
| `reverse_sort` | reversed `ORDER BY` (reverse rows, multiset kept) | order — comparator full-row-sorts, so none |
| `drop_join` | wrong join changes a value (type-safe, magnitude-independent perturbation) | value |

## Evidence: caught-vs-uncaught matrix (both backends, verified at SF=0.1)

| Benchmark | Target | `flip_comparator` | `drop_group_key` | `reverse_sort` | `drop_join` |
| --- | --- | --- | --- | --- | --- |
| ssb | Q3.1 (149×4) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
| amplab | 4 (100×6) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
| coffeeshop | SA1 (93×5) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
| clickbench | Q8 (20×2) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
| joinorder_synthetic | 4a (1×2) | ✅ caught | ✅ caught | ⚪ no-op (single row) | ✅ caught |

Every gated benchmark has **≥3** mutation classes the gate provably catches (w10 acceptance #1); every uncaught cell is documented with the reason (acceptance #2).

## The headline finding (the C2 answer)

`reverse_sort` is **not caught** on any of the four multi-row benchmarks. This **confirms the open half of w2/BS2**: `ResultValidator.validate_results_exact` full-row-sorts both sides before comparing, so a reversed `ORDER BY` that preserves the multiset passes silently. This is honest evidence — the oracle is strong on row-membership, column-shape, and value bugs and **blind only to pure ordering bugs**. It is **not** baselined (that would be the anti-pattern the remediation flagged); it is recorded as a sensitivity gap with a tracking note back to w2, and `test_reversed_sort_is_the_bs2_probe` will flip the moment an order-aware comparator lands. The suite also pins the cell as **non-vacuous** (`test_unmutated_target_is_green` asserts ≥2 reference rows), so "not caught" is a real comparator property, not a BS3 empty-cell artifact.

Caveat recorded for joinorder_synthetic: every gated query is a single-row scalar and **most return all-NULL at SF=0.1** (BS3-vacuous); target `4a` is one of the few non-NULL rows.

## Constraints

- No production code or comparator changed → TPC-Havoc SQL and DataFrame gates stay byte-identical-green.
- Bounded one-cell-per-benchmark SF=0.1 model preserved; suite marked `slow`.
- All 28 tests pass under `pytest -m slow` (verified per benchmark under xdist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT)_