### PR TITLE
todo: SSB generator dimension value fidelity bug (6 canonical queries empty)

### DIFF
--- a/_project/TODO/main/active/ssb-generator-dimension-value-fidelity.yaml
+++ b/_project/TODO/main/active/ssb-generator-dimension-value-fidelity.yaml
@@ -1,0 +1,126 @@
+id: ssb-generator-dimension-value-fidelity
+title: "Fix SSB generator dimension value formats (p_category/p_brand1/c_city) — 6 canonical SSB queries return empty for everyone"
+worktree: main
+priority: High
+status: Not Started
+category: Benchmark Correctness
+
+description: |
+  The BenchBox SSB data generator emits dimension column VALUES that do not match
+  the canonical Star Schema Benchmark value formats, so several canonical SSB
+  queries match ZERO rows at every scale factor. This is a benchmark-correctness
+  defect that affects ANY user running SSB on BenchBox - not just the cross-surface
+  equivalence gate that surfaced it (cross-surface-oracle-remediation w4, #866).
+
+  Reproduced on develop (SF=0.1, but format-independent of scale):
+
+    DISTINCT p_category generated: MFGR#111, MFGR#112, MFGR#113, ... (THREE digits)
+    Canonical SSB p_category:      MFGR#<1-5><1-5>  e.g. MFGR#12 (TWO digits)
+    SELECT count(*) FROM part WHERE p_category='MFGR#12'  -> 0     (canonical literal)
+    SELECT count(*) FROM part WHERE p_category='MFGR#112' -> 571   (generated literal)
+
+    DISTINCT p_brand1 generated:   MFGR#11101, MFGR#11106, ... (extra leading digit)
+    Canonical SSB p_brand1:        MFGR#<category(2)><brand(2)> e.g. MFGR#1101 (4 digits)
+
+    DISTINCT c_city generated:     ALGERIA0, ALGERIA1, ... (nation prefix, no padding)
+    Canonical SSB c_city:          10 chars = nation[0:9]+digit, e.g. 'UNITED KI1'
+
+  Because the canonical SSB query literals (in benchbox/core/ssb/queries.py /
+  the parameter sets) reference the CANONICAL formats, the queries that filter on
+  these columns return empty:
+
+    Q2.1 (p_category='MFGR#12'), Q2.2/Q2.3 (p_brand1 range/eq),
+    Q3.3/Q3.4 (c_city IN ('UNITED KI1','UNITED KI5'), s_city pairs),
+    Q4.3 (p_category='MFGR#14')
+
+  i.e. 6 of the 13 SSB queries. This is currently MASKED in the cross-surface gate
+  by classifying those 6 as `legitimately_empty` (#866) - a stopgap that should be
+  RETIRED once this is fixed. It is NOT actually legitimate: the queries are empty
+  because the generated data is wrong, so SSB's published-query results on BenchBox
+  are wrong/empty for these queries for every user.
+
+  Root cause is in the generator's dimension value construction (an extra digit in
+  the p_category / p_brand1 manufacturer-category-brand encoding, and a different
+  c_city/s_city padding+width than canonical), NOT in the query parameters (which
+  are canonical and correct). Fix the GENERATOR to emit canonical value formats;
+  do not change the canonical query literals to chase the malformed data.
+
+prior_art:
+  - "benchbox/core/ssb/generator.py - SSBDataGenerator; the dimension value construction for part (p_category, p_brand1, p_mfgr), customer (c_city), supplier (s_city) that must match canonical SSB formats."
+  - "benchbox/core/ssb/queries.py + benchbox/core/ssb/dataframe_queries/parameters.py - the canonical query literals (e.g. p_category='MFGR#12', c_city='UNITED KI1') that are CORRECT and must not be changed to match malformed data."
+  - "https://www.cs.umb.edu/~poneil/StarSchemaB.PDF - the canonical SSB spec for p_category (MFGR#<1-5><1-5>), p_brand1 (MFGR#<cat2><brand2>), and the 10-char c_city/s_city format (nation[0:9]+digit)."
+  - "_project/TODO/main/active/cross-surface-oracle-remediation.yaml:w4 - surfaced this; its `legitimately_empty` SSB classification (#866) is the stopgap to retire once this lands."
+  - "tests/test_ssb.py - existing SSB tests; extend with value-format assertions."
+
+work:
+  - id: w1
+    summary: "Pin the canonical SSB dimension value formats with a failing test"
+    status: pending
+    notes: |
+      Before touching the generator, add tests that assert the canonical formats so
+      the fix is verifiable and cannot regress:
+        - p_category matches ^MFGR#[1-5][1-5]$ (exactly 2 digits) and the canonical
+          literals (e.g. 'MFGR#12', 'MFGR#14') each match >=1 generated row.
+        - p_brand1 matches the canonical MFGR#<cat2><brand2> width.
+        - c_city / s_city are the canonical 10-char nation-prefix+digit format and
+          the canonical literals (e.g. 'UNITED KI1') match generated rows.
+        - Every one of the 13 canonical SSB queries returns >=1 row at SF=1 (and the
+          6 currently-empty ones in particular).
+      These start RED on current develop (that is the bug).
+    acceptance:
+      - "New tests encode the canonical p_category/p_brand1/c_city/s_city formats and the non-empty-result expectation; they FAIL on current develop."
+
+  - id: w2
+    summary: "Fix the generator's dimension value construction to canonical SSB formats"
+    needs: [w1]
+    status: pending
+    notes: |
+      Correct SSBDataGenerator so p_category is MFGR#<mfgr:1-5><category:1-5> (drop
+      the extra digit), p_brand1 is MFGR#<category:2><brand:2>, p_mfgr is MFGR#<1-5>,
+      and c_city/s_city use the canonical 10-char nation-prefix+digit format. Keep the
+      generator seeded/deterministic (do not regress reproducibility). Bump any
+      generated-data cache/version key so stale data regenerates.
+    acceptance:
+      - "All w1 tests pass."
+      - "All 13 SSB queries return >=1 row at SF=1; the previously-empty Q2.1-2.3/Q3.3/Q3.4/Q4.3 now return rows."
+      - "SSB generation stays deterministic (two generations -> identical dimension values)."
+
+  - id: w3
+    summary: "Retire the cross-surface gate's `legitimately_empty` SSB stopgap and make SSB fully discriminating"
+    needs: [w2]
+    status: pending
+    notes: |
+      Once the generator emits canonical values, remove the SSB
+      `legitimately_empty` classification added in #866 (cross_surface.py SSB gate)
+      so all 13 SSB queries are DISCRIMINATING cells, and confirm the SSB
+      cross-surface gate is green with 26/26 discriminating (no vacuous cells).
+      Update the w4 progress note in cross-surface-oracle-remediation accordingly.
+    acceptance:
+      - "SSB cross-surface gate reports 26/26 DISCRIMINATING cells, 0 vacuous, green."
+      - "The `legitimately_empty` SSB entries are removed (not just re-classified)."
+
+must_preserve:
+  - "The canonical SSB query literals/parameters stay canonical - fix the data, never the queries."
+  - "SSB generation stays seeded/deterministic; the cross-surface SSB gate stays green throughout."
+  - "Other SSB tests and any downstream consumers of SSB data continue to pass."
+
+anti_patterns:
+  - "DO NOT change the query parameters to match the malformed data - that would bless the bug and keep real SSB results wrong."
+  - "DO NOT only fix the cross-surface gate (e.g. by leaving the data wrong and widening `legitimately_empty`) - the bug affects every SSB run, so fix the generator."
+
+verification:
+  - description: "Canonical-format tests pass and all SSB queries return rows"
+    command: "uv run -- python -m pytest tests/test_ssb.py -q"
+  - description: "SSB cross-surface gate fully discriminating and green"
+    command: "make ssb-cross-surface-equivalence-report"
+    expected_output: "26/26 discriminating cells, 0 vacuous, 0 divergent"
+
+success_metrics:
+  - "All 13 canonical SSB queries return non-empty correct results on BenchBox-generated SSB data."
+  - "p_category/p_brand1/c_city/s_city match the canonical SSB value formats."
+  - "The cross-surface SSB gate has zero vacuous cells and no `legitimately_empty` SSB classifications."
+
+metadata:
+  tags: [ssb, generator, benchmark-correctness, data-fidelity]
+  source: "cross-surface-oracle-remediation w4 (#866); verified on develop"
+  created_date: "2026-06-23"


### PR DESCRIPTION
## What

Files a first-class TODO for a **benchmark-correctness bug** surfaced by the cross-surface w4 work (#866): the BenchBox **SSB generator emits non-canonical dimension values**, so 6 of the 13 canonical SSB queries return **empty for every user**, at every scale.

**Planning artifact only — no code change.**

## The bug (verified on develop, not trusted)

```
DISTINCT p_category generated: MFGR#111, MFGR#112, ...   (THREE digits)
Canonical SSB p_category:      MFGR#<1-5><1-5>           (TWO digits, e.g. MFGR#12)

WHERE p_category='MFGR#12'  -> 0 rows     (canonical query literal)
WHERE p_category='MFGR#112' -> 571 rows   (generated literal)
```

Also `p_brand1` carries an extra leading digit, and `c_city`/`s_city` use a non-canonical padding/width (`ALGERIA0` vs the canonical 10-char `nation[0:9]+digit`). Affected queries: **Q2.1–2.3, Q3.3, Q3.4, Q4.3**.

## Why it matters

This is **not** a gate artifact — anyone running SSB on BenchBox gets empty/wrong results for those queries. The cross-surface gate currently classifies the 6 as `legitimately_empty` (#866) as a stopgap; that classification is **masking a real bug** and should be retired once the generator is fixed.

## The TODO (3 items)

1. **w1** — pin canonical formats with tests that fail on current develop.
2. **w2** — fix `SSBDataGenerator` value construction (fix the data, **not** the canonical query literals).
3. **w3** — retire the `legitimately_empty` SSB stopgap; SSB gate goes 26/26 discriminating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT)_