### PR TITLE
todo: land orphaned #861 review fixes (scope allowlist + drop hard dep)

### DIFF
--- a/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
+++ b/_project/TODO/main/planning/bounded-correctness-gate-value-oracle.yaml
@@ -189,6 +189,7 @@ scope_limit:
     - "benchbox/core/expected_results/"
     - "benchbox/core/results/"
     - "benchbox/core/tpch/"
+    - "benchbox/core/tpchavoc/"
     - "tests/"
     - "Makefile"
     - "_project/"

--- a/_project/TODO/main/planning/oracle-coverage-map-strength-disclosure.yaml
+++ b/_project/TODO/main/planning/oracle-coverage-map-strength-disclosure.yaml
@@ -176,9 +176,11 @@ open_questions:
     affects: ["w1 strength derivation"]
     default: "Compute from the provider's actual capability (presence of stored digests) so the label tracks reality without a manual edit; cross-reference bounded-correctness-gate-value-oracle."
 
-deps:
-  needs:
-    - "benchmark-correctness-oracle-coverage-map"
+# No hard deps.needs: this disclosure work is independent of the breadth campaign
+# (the generator already exists), so it must not be blocked behind
+# benchmark-correctness-oracle-coverage-map reaching DONE. Coordination with that
+# item and with cross-surface-oracle-remediation w9 is captured in prior_art /
+# deferred / anti_patterns instead.
 
 metadata:
   tags: [correctness, oracle, coverage, governance, ci, disclosure, provenance]


### PR DESCRIPTION
## Summary

Follow-up to #861, which **auto-merged before its automated review landed** (merged 01:35:25Z; the codex P2 comments arrived 01:38:25Z). Both review fixes were valid, validated, and the threads were resolved — but the commit raced the squash-merge and was orphaned on the dead branch. This PR lands those two small fixes on `develop`.

## Fixes (both flagged P2 on #861, both confirmed against develop)

1. **`bounded-correctness-gate-value-oracle.yaml`** — add `benchbox/core/tpchavoc/` to `scope_limit.only_modify`. w1/prior_art require promoting and reusing `_calculate_checksum` from `benchbox/core/tpchavoc/validation.py`, but the allowlist omitted that path — so an implementer under the scoped-change guard could not expose the helper without forking the digest, contradicting the anti-pattern.
2. **`oracle-coverage-map-strength-disclosure.yaml`** — drop the hard `deps.needs: [benchmark-correctness-oracle-coverage-map]`. That edge made `todo_cli ready` treat the disclosure work as blocked until the broader breadth campaign reaches DONE, even though the generator already exists and the work is independent. Coordination is retained via `prior_art`/`deferred`/`anti_patterns`.

## Verification
- Both files pass `validate_todo.py`; `todo_cli check-graph` clean (79 items, no cycles/dangling refs).
- `oracle-coverage-map-strength-disclosure` now shows as ready (no longer dep-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DcRXidH26Xr4MyHoGRANY

---
_Generated by [Claude Code](https://claude.ai/code/session_014DcRXidH26Xr4MyHoGRANY)_