### PR TITLE
fix(equivalence): order-aware comparator closes the BS2 reversed-ORDER-BY blind spot (w2)

### DIFF
--- a/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
+++ b/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
@@ -116,21 +116,43 @@ work:
 
   - id: w2
     summary: "Make the comparator order-aware and tie-aware; fix the None/NaN sort crash (BS2)"
-    status: in_progress
+    status: done
     addresses: [BS2, "review:Blind Spot 2", "review:DEMO1/2/3"]
     progress: |
-      PARTIAL (landed in #858). The tie-aware boundary relaxation shipped:
-      cross_surface.py enables tie_aware per query for trailing-LIMIT top-N
-      (_is_truncated_top_n), and validate_results_exact takes a tie_aware flag.
-      Verified effect: ClickBench collapsed from 27 wobbling divergences to a
-      STABLE 2 (green across 3 runs).
-      STILL OPEN - two halves of BS2 are NOT verified closed:
-      (1) ORDER-BY blindness: the non-tie path still full-row-sorts, so a reversed
-          ORDER BY may still pass silently (the dangerous false-negative half).
-      (2) The None/non-None Python sorted() crash that find_surface_divergences
-          mislabels as "error:" was not addressed.
-      Keep open until w10's reversed-sort mutation proves order-sensitivity and a
-      None-mixed-column test proves a clean MISMATCH (not an "error:").
+      DONE. Both previously-open halves of BS2 are now closed (additive, opt-in;
+      ResultValidator is extended, never forked).
+      (1) ORDER-BY blindness CLOSED: validate_results_exact gained an opt-in
+          order_aware mode + an order_by (result-column positions) parameter. When
+          enabled it compares rows in RETURNED order - the sequence of distinct
+          order-key values must match exactly (so a reversed ORDER BY is CAUGHT),
+          while rows sharing an order-key value are a multiset (so a legitimate tie
+          reshuffle is NOT flagged) and the final group under a trailing LIMIT is a
+          boundary tie (so the tie-aware fix from #858 does not regress). The
+          cross_surface gate resolves each query's ORDER BY to result-column
+          positions via sqlglot (_order_by_result_key) and enables order_aware only
+          when EVERY ORDER BY term maps to a projected column; an unmappable key
+          (e.g. clickbench Q24 SELECT *, Q25 ORDER BY a non-projected EventTime)
+          returns None and falls back to the order-insensitive comparison rather
+          than a silent order-blind "pass" (the residual blind spot is enumerated
+          and documented, not muted via a baseline).
+      (2) None/non-None sorted() crash FIXED: the comparator now sorts on a
+          None-safe, type-safe surrogate (_row_sort_key / _cell_sort_key) so a
+          column mixing None with a value (or mixed types) never raises TypeError;
+          a genuine None-vs-value difference is reported as a clean MISMATCH, not an
+          "error:" from sorted().
+      Verified: w10's test_reversed_sort_is_the_bs2_probe FLIPPED from "not caught"
+      to CAUGHT on ssb Q3.1 (149 ordered rows); _EXPECT_CAUGHT now expects the
+      multi-row reverse_sort caught on ssb/amplab/coffeeshop/clickbench (only
+      joinorder_synthetic's single-row no-op stays an expected miss). New fast-lane
+      unit suite tests/integration/test_validator_order_aware.py pins reversed-order
+      MISMATCH, tie/boundary tolerance, and the None-mixed-column clean MISMATCH
+      (never "error:"). All 5 enforced cross-surface gates stay green (ssb 14/26
+      discriminating, amplab 12/16, coffeeshop 22/22, clickbench 70 discriminating,
+      joinorder 26/26); tie reshuffles still not flagged. TPC-Havoc SQL (220/220)
+      and DataFrame (440/440) gates remain byte-identical green - they pass
+      order_aware=False, so their path is unchanged. Findings doc
+      _project/analysis/cross-surface-mutation-sensitivity.md updated (matrix flips
+      to caught + the documented residual non-projected-ORDER-BY blind spot).
     notes: |
       validate_results_exact (validation.py:54-79) sorts full rows then compares
       positionally, so it is simultaneously BLIND to real ORDER BY bugs (a reversed

--- a/_project/analysis/cross-surface-mutation-sensitivity.md
+++ b/_project/analysis/cross-surface-mutation-sensitivity.md
@@ -27,7 +27,7 @@ comparator:
 | --- | --- | --- | --- |
 | `flip_comparator` (`<` → `<=`) | a relaxed filter admits boundary-equal rows | append a duplicate boundary row → +1 row | **row-count** check (first check in `validate_results_exact`) |
 | `drop_group_key` | grouping on fewer keys changes the row shape | drop the leading column from every row | **column-count** check (per-row width) |
-| `reverse_sort` | a reversed `ORDER BY` | reverse the row order, multiset preserved | **order** — the comparator full-row-sorts both sides, so there is none |
+| `reverse_sort` | a reversed `ORDER BY` | reverse the row order, multiset preserved | **order** — the order-aware comparator (w2) compares the RETURNED order for any query whose `ORDER BY` maps to result columns, so a reversed order is a key-sequence mismatch |
 | `drop_join` | a dropped/incorrect join changes a joined column value | perturb one cell to a value outside the reference | **value** check (`_values_equal`, tolerance-aware) |
 
 ## Caught-vs-uncaught matrix (verified at SF=0.1)
@@ -38,43 +38,52 @@ discriminating (multi-row, ORDER BY + GROUP BY) where the benchmark has one.
 
 | Benchmark | Target | `flip_comparator` | `drop_group_key` | `reverse_sort` | `drop_join` |
 | --- | --- | --- | --- | --- | --- |
-| **ssb** | Q3.1 (149×4) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
-| **amplab** | 4 (100×6) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
-| **coffeeshop** | SA1 (93×5) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
-| **clickbench** | Q8 (20×2) | ✅ caught | ✅ caught | ❌ **not caught** | ✅ caught |
+| **ssb** | Q3.1 (149×4) | ✅ caught | ✅ caught | ✅ **caught (w2)** | ✅ caught |
+| **amplab** | 4 (100×6) | ✅ caught | ✅ caught | ✅ **caught (w2)** | ✅ caught |
+| **coffeeshop** | SA1 (93×5) | ✅ caught | ✅ caught | ✅ **caught (w2)** | ✅ caught |
+| **clickbench** | Q8 (20×2) | ✅ caught | ✅ caught | ✅ **caught (w2)** | ✅ caught |
 | **joinorder_synthetic** | 4a (1×2) | ✅ caught | ✅ caught | ⚪ no-op (single row) | ✅ caught |
 
 Every benchmark therefore has **≥3** mutation classes the gate provably catches
-(the w10 acceptance bar), and every uncaught cell is explained below.
+(the w10 acceptance bar), and the one remaining non-catch (joinorder_synthetic's
+single-row `reverse_sort`) is a degenerate no-op explained below, not a
+comparator blind spot.
 
-## The reversed-sort result is the headline BS2 probe
+## The reversed-sort probe: BS2 closed by the order-aware comparator (w2)
 
-`reverse_sort` is **not caught** on any of the four multi-row benchmarks. This
-**confirms** the unresolved half of w2/BS2: `ResultValidator.validate_results_exact`
-(`benchbox/core/tpchavoc/validation.py`) calls `sorted(original_results)` and
-`sorted(variant_results)` and compares positionally, so reversing the row order
-of a result yields two identical sorted lists — the divergence is invisible. A
-genuinely reversed `ORDER BY` in a gated DataFrame query would pass the gate
-silently. The dedicated `test_reversed_sort_is_the_bs2_probe` pins this on
-ssb Q3.1; if a future comparator change makes ORDER BY visible, that test flips
-and forces this doc and the harness's `_EXPECT_CAUGHT` table to be updated.
+`reverse_sort` is now **caught** on all four multi-row benchmarks — this is the
+closed half of w2/BS2. Previously `ResultValidator.validate_results_exact`
+(`benchbox/core/tpchavoc/validation.py`) full-row-sorted both sides and compared
+positionally, so reversing the row order yielded two identical sorted lists and
+the divergence was invisible. The w2 change adds an opt-in **order-aware** mode:
+the cross-surface gate resolves each query's `ORDER BY` to result-column
+positions (`cross_surface._order_by_result_key`, via sqlglot) and, when that
+mapping succeeds, passes `order_aware=True`. The comparator then compares rows in
+**returned order** — the sequence of distinct order-key values must match — while
+still treating each tied group as a multiset (so a legitimate tie reshuffle is
+*not* flagged) and the final group under a trailing `LIMIT` as a boundary tie (so
+the tie-aware fix does not regress). A reversed `ORDER BY` produces a reversed
+key sequence and is therefore reported. The dedicated
+`test_reversed_sort_is_the_bs2_probe` now asserts ssb Q3.1's reversed result is
+caught (and that the catch is a genuine ORDER BY mismatch, not a harness
+`error:`).
 
-This is honest evidence about the oracle's strength, not a failure of the
-harness: the oracle is strong on row-membership, column-shape, and value bugs,
-and **blind to pure ordering bugs**. It is tracked as the open half of **w2**
-(BS2). It is *not* added to any `known_divergences` baseline (that would be the
-exact anti-pattern the remediation flagged); it is recorded here as a sensitivity
-gap with a tracking item.
+The oracle is now strong on row-membership, column-shape, value, **and ordering**
+bugs for any query whose `ORDER BY` key is a projected column.
 
-### Why this blind spot is bounded in practice
+### The residual, documented order blind spot
 
-A pure ordering bug that preserves the exact result multiset is the only thing
-this misses. Any ordering bug that *also* changes which rows survive a `LIMIT`
-(the common case for a top-N) changes the row multiset and is caught by the
-row-count / value paths. The residual exposure is a reversed (or otherwise
-permuted) `ORDER BY` on a result whose rows are all returned — exactly the case
-`reverse_sort` models. Closing it requires the order-aware comparison mode
-specified in w2 (compare the ordered prefix up to the first tie group exactly).
+Order-awareness is engaged only when every `ORDER BY` term maps to a projected
+output column. A query that sorts by a column **not in its result** cannot have
+its order verified from the returned rows — e.g. clickbench Q25
+(`SELECT SearchPhrase … ORDER BY EventTime LIMIT 10`) and Q24 (`SELECT * …
+ORDER BY EventTime`). For those, `_order_by_result_key` returns `None` and the
+gate falls back to the order-insensitive comparison rather than guess (an
+order-blind fallback that silently "passed" would re-introduce exactly the BS2
+gap). These are a small, enumerated set; closing them would require projecting
+the sort key (which would change the canonical query) or a schema-resolved
+`SELECT *` expansion, both out of scope. They are recorded here, not muted via a
+baseline.
 
 ## Single-row + mostly-NULL caveat: joinorder_synthetic
 
@@ -96,11 +105,12 @@ so its drop_join can land a real value mismatch:
   an `error:`).
 - `reverse_sort` is a **no-op**: reversing a one-element list changes nothing, so
   no divergence is injected and none is reported. This is the expected,
-  degenerate outcome — it is *not* the comparator's order-blindness (which is
-  demonstrated instead on the four multi-row benchmarks above). The harness
-  records this as an expected non-catch for `joinorder_synthetic/reverse_sort`.
+  degenerate outcome — it is *not* a comparator order blind spot (the order-aware
+  catch is demonstrated instead on the four multi-row benchmarks above). The
+  harness records this as an expected non-catch for
+  `joinorder_synthetic/reverse_sort`.
 
-The multi-row reverse-sort blindness (the real BS2 probe) is established on ssb,
+The multi-row reverse-sort catch (the real BS2 probe) is established on ssb,
 amplab, coffeeshop, and clickbench, so joinorder_synthetic's single-row shape
 does not weaken the headline finding.
 
@@ -116,10 +126,12 @@ artifact). Q8 avoids both, so its `drop_join` value mutation is genuinely caught
 
 ## Tracking
 
-- **Open (w2 / BS2):** reversed `ORDER BY` passes the gate silently. Add the
-  order-aware comparison mode (ordered prefix exact, boundary tie as multiset) so
-  this mutation flips to caught. The `test_reversed_sort_is_the_bs2_probe`
-  regression will detect the moment that lands.
+- **Closed (w2 / BS2):** the order-aware comparison mode (compare returned order,
+  each tie group as a multiset, final-LIMIT group as a boundary tie) landed, so a
+  reversed `ORDER BY` whose key is a projected column now flips to caught on all
+  four multi-row benchmarks. `test_reversed_sort_is_the_bs2_probe` asserts the
+  fixed property. The residual order blind spot (ORDER BY a non-projected column,
+  e.g. clickbench Q24/Q25) is documented above, not muted via a baseline.
 - The byte-stability regression promised in **w3** is included in the same suite
   (`test_gate_output_is_byte_stable_across_two_in_process_runs`): two in-process
   ssb gate runs on the same seed produce an identical divergence set.

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -110,6 +110,124 @@ def _is_truncated_top_n(sql: str) -> bool:
     return bool(_TRAILING_LIMIT_RE.search(stripped))
 
 
+def _is_star_projection(projection: Any) -> bool:
+    """True if a SELECT projection is a wildcard (``*`` or ``t.*``), else False.
+
+    A wildcard expands to an unknown number of output columns, so it cannot be
+    enumerated to positions without the table schema. A ``Star`` nested INSIDE an
+    expression (e.g. ``COUNT(*)``) is a normal single output column and is NOT a
+    wildcard projection, so it must return False here.
+    """
+    from sqlglot import exp
+
+    return isinstance(projection, exp.Star) or (
+        isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star)
+    )
+
+
+def _order_by_result_key(sql: str) -> list[int] | None:
+    """Resolve a query's ``ORDER BY`` key to RESULT-column positions, or ``None``.
+
+    Returns the list of RESULT-row column indices (in key order) that the query's
+    ``ORDER BY`` sorts on, which the order-aware comparator
+    (:meth:`ResultValidator.validate_results_exact` with ``order_aware=True``) uses
+    to compare rows in returned order. Only the COLUMNS matter, not the sort
+    direction: a reversed ``ORDER BY`` is caught by the comparator detecting that
+    the returned sequence of distinct key values differs, which is
+    direction-independent. Returns ``None`` when no sound mapping exists, so the
+    caller falls back to the order-insensitive comparison rather than guessing:
+
+      * the query has no ``ORDER BY`` (nothing to check in returned order);
+      * the SQL does not parse (a malformed or unsupported shape);
+      * ANY ``ORDER BY`` expression does not correspond to a projected output
+        column - e.g. ``ORDER BY EventTime`` over ``SELECT SearchPhrase`` (the
+        sort key is not in the result, so the order cannot be verified from the
+        returned columns), or ``SELECT *`` (the projection is not enumerable to
+        positions without resolving the table schema). Refusing to map these is
+        deliberate: an order-blind fallback that silently "passed" an unverifiable
+        ORDER BY is exactly the BS2 blind spot, so we never claim an order check we
+        cannot perform.
+
+    The mapping resolves each ``ORDER BY`` term to a projection by, in order: a
+    1-based ordinal literal (``ORDER BY 2`` -> result column index 1); the
+    alias-or-name (so ``ORDER BY revenue`` finds ``SUM(...) AS revenue`` and
+    ``ORDER BY ol.order_date`` finds the ``order_date`` output); else the
+    normalized SQL of the underlying expression (so ``ORDER BY COUNT(*)`` finds the
+    ``COUNT(*)`` projection and ``ORDER BY DATE_TRUNC(...)`` finds its aliased
+    projection).
+    """
+    import sqlglot
+    from sqlglot import exp
+
+    try:
+        tree = sqlglot.parse_one(sql, read="duckdb")
+    except Exception:  # noqa: BLE001 - an unparseable query is just "no sound mapping"
+        return None
+    if tree is None:
+        return None
+    select = tree.find(exp.Select)
+    if select is None:
+        return None
+    order = select.args.get("order")
+    if order is None:
+        return None
+
+    # A bare `SELECT *` (or `t.*`) cannot be enumerated to output positions without
+    # resolving the table schema, so a star PROJECTION makes the mapping unsound.
+    # Only a projection that IS a star counts: a star nested inside an expression
+    # (e.g. ``COUNT(*)``) is a normal single output column, not a wildcard
+    # expansion, so it must NOT disqualify the query.
+    projections = select.expressions
+    if any(_is_star_projection(proj) for proj in projections):
+        return None
+
+    alias_to_index: dict[str, int] = {}
+    expr_to_index: dict[str, int] = {}
+    for index, proj in enumerate(projections):
+        name = proj.alias_or_name
+        if name:
+            alias_to_index.setdefault(name.lower(), index)
+        inner = proj.this if isinstance(proj, exp.Alias) else proj
+        expr_to_index.setdefault(inner.sql(dialect="duckdb", normalize=True).lower(), index)
+
+    resolved: list[int] = []
+    for ordered in order.expressions:
+        target = ordered.this
+        index = _resolve_order_term(target, projections, alias_to_index, expr_to_index)
+        if index is None:
+            # An ORDER BY term that is not a projected output column - the order
+            # cannot be verified from the returned rows. Refuse the whole key.
+            return None
+        resolved.append(index)
+    return resolved
+
+
+def _resolve_order_term(
+    target: Any,
+    projections: Sequence[Any],
+    alias_to_index: dict[str, int],
+    expr_to_index: dict[str, int],
+) -> int | None:
+    """Resolve one ``ORDER BY`` term to a result-column index, or ``None``.
+
+    Tries, in order: a 1-based positional ordinal (``ORDER BY 2``); the column
+    alias-or-name; else the normalized SQL of the expression. ``None`` means the
+    term is not a projected output column (the caller then refuses the whole key).
+    """
+    from sqlglot import exp
+
+    # 1-based ordinal: ``ORDER BY 2`` references the 2nd projected column. Only a
+    # plain integer literal in range is a valid ordinal.
+    if isinstance(target, exp.Literal) and target.is_int:
+        ordinal = int(target.name)
+        return ordinal - 1 if 1 <= ordinal <= len(projections) else None
+    if isinstance(target, exp.Column):
+        index = alias_to_index.get(target.name.lower())
+        if index is not None:
+            return index
+    return expr_to_index.get(target.sql(dialect="duckdb", normalize=True).lower())
+
+
 @dataclass(frozen=True)
 class CrossSurfaceData:
     """Everything the gate needs to compare a benchmark's two surfaces.
@@ -220,6 +338,7 @@ def find_cross_surface_divergences(
         query_id: Any,
     ) -> Iterable[tuple[str, Callable[[list[tuple[Any, ...]]], None]]]:
         query = dataframe_query(query_id)
+        sql = reference_sql(query_id)
         # tie_aware only for truncated top-N queries: a benchmark's own SQL and
         # DataFrame surfaces are independent top-N implementations, so an
         # ORDER BY ... LIMIT N whose ties span the cutoff can keep a different but
@@ -227,7 +346,17 @@ def find_cross_surface_divergences(
         # (the deterministic rows must still match exactly) - but ONLY where a
         # LIMIT can actually truncate; a non-LIMIT query is compared strictly so a
         # real divergence in a duplicated last row is never masked.
-        tie_aware = _is_truncated_top_n(reference_sql(query_id))
+        tie_aware = _is_truncated_top_n(sql)
+        # order_aware whenever the query declares an ORDER BY whose key maps to
+        # result-column positions: the comparator then checks the RETURNED order
+        # (catching a reversed ORDER BY) instead of full-row-sorting both sides,
+        # while still treating each tie group as a multiset (so a legitimate tie
+        # reshuffle is not flagged) and the LIMIT boundary as a tie when
+        # tie_aware. _order_by_result_key returns None for an unmappable ORDER BY
+        # (e.g. ORDER BY a non-projected column), so those fall back to the
+        # order-insensitive comparison rather than a silent order-blind "pass".
+        order_by = _order_by_result_key(sql)
+        order_aware = order_by is not None
         for backend in backends:
             impl = query.get_impl_for_family(backend)
             if impl is None:
@@ -242,9 +371,19 @@ def find_cross_surface_divergences(
                 backend: str = backend,
                 query_id: Any = query_id,
                 tie_aware: bool = tie_aware,
+                order_aware: bool = order_aware,
+                order_by: list[int] | None = order_by,
             ) -> None:
                 candidate = materialize_rows(impl(contexts[backend]))
-                validator.validate_results_exact(reference, candidate, query_id, 0, tie_aware=tie_aware)
+                validator.validate_results_exact(
+                    reference,
+                    candidate,
+                    query_id,
+                    0,
+                    tie_aware=tie_aware,
+                    order_aware=order_aware,
+                    order_by=order_by,
+                )
 
             yield backend, check
 

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -12,6 +12,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 import hashlib
 import math
+from collections.abc import Sequence
 from typing import Any, Optional, Union
 
 
@@ -38,6 +39,8 @@ class ResultValidator:
         variant_id: int,
         *,
         tie_aware: bool = False,
+        order_aware: bool = False,
+        order_by: Sequence[int] | None = None,
     ) -> bool:
         """Validate exact result matching between original and variant.
 
@@ -57,6 +60,27 @@ class ResultValidator:
                 (non-boundary) rows still match exactly, so genuine
                 value-misplacement bugs are still caught - it is NOT whole-row
                 set-equality.
+            order_aware: When True (and ``order_by`` resolves the query's
+                ``ORDER BY`` key to result-column positions), compare the rows in
+                RETURNED order instead of full-row-sorting both sides. The
+                sequence of distinct order-key values must match exactly (so a
+                reversed ``ORDER BY`` is CAUGHT), while rows that share an
+                order-key value - an engine-arbitrary tie group - are compared as
+                a multiset (so a legitimate tie reshuffle is NOT flagged). The
+                final tie group additionally tolerates a truncated-``LIMIT``
+                boundary swap (the ``tie_aware`` relaxation), so tie false
+                positives stay fixed. Off by default, so the strict comparison is
+                unchanged for callers that do not opt in (the TPC-Havoc gates).
+            order_by: Sequence of RESULT-row column indices forming the query's
+                ``ORDER BY`` key, in key order (resolved by the caller, e.g.
+                ``cross_surface._order_by_result_key``). Only the columns matter,
+                not the sort DIRECTION: the comparator catches a reversed
+                ``ORDER BY`` by detecting that the RETURNED sequence of distinct
+                key values differs, which is direction-independent. Required for
+                ``order_aware`` to engage; an empty/None key (no ``ORDER BY``, or
+                an ``ORDER BY`` whose key is not present in the projected columns)
+                falls back to the order-insensitive comparison, never silently
+                claiming an order check it cannot perform.
 
         Returns:
             True if results match exactly
@@ -70,10 +94,29 @@ class ResultValidator:
                 f"Original: {len(original_results)}, Variant: {len(variant_results)}"
             )
 
+        # Order-aware engages only when a non-empty key is supplied AND every key
+        # column is in range for the actual result width on both sides. An
+        # out-of-range index (e.g. the caller's SQL-derived projection count ever
+        # disagreeing with the materialized result width) would make ``row[c]``
+        # raise IndexError - which a caller would mislabel as an execution "error:"
+        # rather than a clean verdict - so we fall back to the order-insensitive
+        # comparison instead of indexing a column that does not exist. The
+        # order-insensitive path is the sound default when the order key cannot be
+        # located in the result (the same stance _order_by_result_key takes for an
+        # unmappable ORDER BY).
+        if order_aware and order_by and self._order_key_in_range(order_by, original_results, variant_results):
+            return self._validate_order_aware(
+                original_results, variant_results, query_id, variant_id, order_by, tie_aware=tie_aware
+            )
+
         # Sort both result sets to handle potential ordering differences
-        # (though TPC-H queries should have deterministic ordering)
-        original_sorted = sorted(original_results)
-        variant_sorted = sorted(variant_results)
+        # (though TPC-H queries should have deterministic ordering). A NULL-bearing
+        # or mixed-type column cannot be ordered by Python ``sorted`` directly, so
+        # sort on a None-safe surrogate rather than the raw row (a bare ``sorted``
+        # would raise TypeError, which a caller would then mislabel as an execution
+        # "error:" instead of a clean MISMATCH/match - see _row_sort_key).
+        original_sorted = sorted(original_results, key=self._row_sort_key)
+        variant_sorted = sorted(variant_results, key=self._row_sort_key)
 
         detail = self._first_positional_mismatch(original_sorted, variant_sorted, query_id, variant_id)
         if detail is None:
@@ -83,6 +126,210 @@ class ResultValidator:
             return True
 
         raise ValidationError(detail)
+
+    def _first_column_count_mismatch(
+        self,
+        original: list[tuple[Any, ...]],
+        variant: list[tuple[Any, ...]],
+        query_id: int,
+        variant_id: int,
+    ) -> str | None:
+        """Return the first row whose two sides differ in column count, or None.
+
+        Assumes equal row counts (the caller checked). Used by the order-aware path
+        to surface a projection-width change (e.g. a dropped GROUP BY key) as a
+        clean column-count MISMATCH before indexing the order-key columns, rather
+        than letting an out-of-range index raise.
+        """
+        for i, (orig_row, var_row) in enumerate(zip(original, variant)):
+            if len(orig_row) != len(var_row):
+                return (
+                    f"Q{query_id}.{variant_id}: Column count mismatch at row {i}. "
+                    f"Original: {len(orig_row)}, Variant: {len(var_row)}"
+                )
+        return None
+
+    @staticmethod
+    def _order_key_in_range(
+        key_columns: Sequence[int],
+        original: list[tuple[Any, ...]],
+        variant: list[tuple[Any, ...]],
+    ) -> bool:
+        """True if every order-key column index is valid for every row on both sides.
+
+        Guards the order-aware path from an ``IndexError`` when the caller's
+        SQL-derived column positions ever exceed the actual result width (so an
+        unsound mapping falls back to the order-insensitive comparison instead of
+        crashing into a mislabeled ``error:``). An empty result trivially satisfies
+        this (there is no row to index).
+        """
+        if not key_columns:
+            return False
+        max_index = max(key_columns)
+        if max_index < 0:
+            return False
+        return all(len(row) > max_index for row in original) and all(len(row) > max_index for row in variant)
+
+    def _validate_order_aware(
+        self,
+        original: list[tuple[Any, ...]],
+        variant: list[tuple[Any, ...]],
+        query_id: int,
+        variant_id: int,
+        key_columns: Sequence[int],
+        *,
+        tie_aware: bool,
+    ) -> bool:
+        """Compare two results in RETURNED order, tolerating only tie-group reshuffles.
+
+        ``original`` is the trusted reference in its ``ORDER BY`` order. The key is
+        ``key_columns`` (positions into the result row). Rows are partitioned, in
+        returned order, into consecutive runs sharing the same order-key value (a
+        tie group). The COMPARISON:
+
+          1. The sequence of order-key values must be identical between the two
+             results (same values, same order). A reversed ``ORDER BY`` produces a
+             reversed key sequence and is therefore CAUGHT here - this is the BS2
+             fix.
+          2. Within each tie group the row ORDER is engine-arbitrary, so the two
+             groups are compared as MULTISETS (full-row), not positionally. A
+             legitimate tie reshuffle passes; a value bug inside a group still
+             fails the multiset check.
+          3. The FINAL tie group may be truncated by a trailing ``LIMIT`` that
+             cuts across the tie, so when ``tie_aware`` is set its membership is
+             allowed to differ as an ambiguous boundary swap. This is sound because
+             the group is keyed by the ACTUAL ``ORDER BY`` value (every row in it
+             shares the order key) and the total row count already matched, so the
+             difference can only be an equally-valid tie pick across the cutoff -
+             not a reordering of distinct order-key values.
+
+        Raises ``ValidationError`` on the first divergence, mirroring the strict
+        path's contract.
+        """
+        # Column-count guard. The order-key columns index into every row, so a
+        # candidate row that is too NARROW (e.g. a dropped GROUP BY key shrank the
+        # projection) must surface as a clean column-count MISMATCH here, not as an
+        # IndexError that the harness would mislabel as an execution "error:". Check
+        # both sides positionally up front; a width difference is a real divergence.
+        detail = self._first_column_count_mismatch(original, variant, query_id, variant_id)
+        if detail is not None:
+            raise ValidationError(detail)
+
+        original_groups = self._group_by_order_key(original, key_columns)
+        variant_groups = self._group_by_order_key(variant, key_columns)
+
+        if len(original_groups) != len(variant_groups):
+            raise ValidationError(
+                f"Q{query_id}.{variant_id}: ORDER BY tie-group count mismatch. "
+                f"Original: {len(original_groups)}, Variant: {len(variant_groups)} "
+                f"(order-key columns {key_columns}) - the returned order differs."
+            )
+
+        last_index = len(original_groups) - 1
+        for i, ((orig_key, orig_rows), (var_key, var_rows)) in enumerate(zip(original_groups, variant_groups)):
+            if not self._order_keys_equal(orig_key, var_key):
+                raise ValidationError(
+                    f"Q{query_id}.{variant_id}: ORDER BY key mismatch at position {i}. "
+                    f"Original key: {orig_key}, Variant key: {var_key} "
+                    f"(order-key columns {key_columns}) - the returned order differs "
+                    f"(e.g. a reversed ORDER BY)."
+                )
+            if self._multisets_equal(orig_rows, var_rows):
+                continue
+            # The FINAL group under a trailing LIMIT is the truncated boundary: all
+            # its rows share the order key (that is what defines the group), and the
+            # total row count already matched, so any membership difference here is
+            # an equally-valid tie pick across the LIMIT cutoff - accept it (the
+            # tie-aware relaxation). This is sound BECAUSE the group is keyed by the
+            # actual ORDER BY value, so we never mistake a genuinely-ordered row for
+            # a boundary tie the way the order-blind heuristic could. Earlier groups
+            # are complete windows and must match as multisets, so a value bug there
+            # is still caught.
+            if i == last_index and tie_aware:
+                continue
+            detail = self._first_positional_mismatch(
+                sorted(orig_rows, key=self._row_sort_key),
+                sorted(var_rows, key=self._row_sort_key),
+                query_id,
+                variant_id,
+            )
+            raise ValidationError(
+                detail
+                or (
+                    f"Q{query_id}.{variant_id}: ORDER BY tie group at position {i} differs as a multiset "
+                    f"(order-key {orig_key})."
+                )
+            )
+        return True
+
+    def _group_by_order_key(
+        self, rows: list[tuple[Any, ...]], key_columns: list[int]
+    ) -> list[tuple[tuple[Any, ...], list[tuple[Any, ...]]]]:
+        """Partition ``rows`` (in returned order) into consecutive same-key runs.
+
+        Returns a list of ``(order_key_tuple, rows_in_that_group)`` preserving the
+        returned order of the groups. Consecutive rows whose order-key columns are
+        equal (via :meth:`_values_equal`, so float tolerance / NULL handling match
+        the rest of the comparator) form one group.
+        """
+        groups: list[tuple[tuple[Any, ...], list[tuple[Any, ...]]]] = []
+        for row in rows:
+            key = tuple(row[c] for c in key_columns)
+            if groups and self._order_keys_equal(groups[-1][0], key):
+                groups[-1][1].append(row)
+            else:
+                groups.append((key, [row]))
+        return groups
+
+    def _order_keys_equal(self, a: tuple[Any, ...], b: tuple[Any, ...]) -> bool:
+        """Element-wise order-key equality using the comparator's value semantics."""
+        return len(a) == len(b) and all(self._values_equal(x, y) for x, y in zip(a, b))
+
+    def _multisets_equal(self, left: list[tuple[Any, ...]], right: list[tuple[Any, ...]]) -> bool:
+        """True if ``left`` and ``right`` are equal as full-row multisets.
+
+        Sorts both on the None-safe :meth:`_row_sort_key` (so a NULL-mixed column
+        never raises) and compares positionally with :meth:`_values_equal`, so the
+        float tolerance and NULL handling stay identical to the strict path.
+        """
+        if len(left) != len(right):
+            return False
+        left_sorted = sorted(left, key=self._row_sort_key)
+        right_sorted = sorted(right, key=self._row_sort_key)
+        return all(self._order_keys_equal(lhs, rhs) for lhs, rhs in zip(left_sorted, right_sorted))
+
+    def _row_sort_key(self, row: tuple[Any, ...]) -> tuple[Any, ...]:
+        """A total, never-raising sort key for a result row.
+
+        Python ``sorted`` raises ``TypeError`` on a column mixing ``None`` with a
+        value (``None < 1`` is unorderable) and on a column mixing types. This
+        surrogate replaces every cell with a ``(type_rank, type_name, value)``
+        triple so ordering is deterministic and total without raising: ``None``
+        sorts before any value, and values of different types are grouped by a
+        stable type name rather than compared across types. It is used ONLY to
+        impose a stable order for positional comparison; equality is still decided
+        by :meth:`_values_equal`, so this never changes a match/mismatch verdict -
+        it only stops a NULL-bearing or mixed-type column from raising (which a
+        caller would otherwise mislabel as an execution ``error:`` rather than a
+        clean MISMATCH).
+        """
+        return tuple(self._cell_sort_key(value) for value in row)
+
+    @staticmethod
+    def _cell_sort_key(value: Any) -> tuple[Any, ...]:
+        """A None-safe, type-safe sort surrogate for one cell (see _row_sort_key).
+
+        ``bool`` is folded into the numeric bucket (``bool`` subclasses ``int``)
+        so it sorts CONSISTENTLY with :meth:`_values_equal`, which treats
+        ``True == 1``: a column mixing ``True`` and ``1`` must sort them adjacently,
+        or two equal cells would land at different positions and break the
+        positional comparison after sorting.
+        """
+        if value is None:
+            return (0, "", 0.0)
+        if isinstance(value, (int, float)):  # includes bool (subclass of int)
+            return (1, "num", float(value))
+        return (1, type(value).__name__, str(value))
 
     def _first_positional_mismatch(
         self,
@@ -303,9 +550,10 @@ class ResultValidator:
                 f"Original: {len(original_results)}, Variant: {len(variant_results)}"
             )
 
-        # Sort both result sets
-        original_sorted = sorted(original_results)
-        variant_sorted = sorted(variant_results)
+        # Sort both result sets on the None-safe surrogate so a NULL-bearing or
+        # mixed-type column never raises TypeError (see _row_sort_key).
+        original_sorted = sorted(original_results, key=self._row_sort_key)
+        variant_sorted = sorted(variant_results, key=self._row_sort_key)
 
         for i, (orig_row, var_row) in enumerate(zip(original_sorted, variant_sorted)):
             if len(orig_row) != len(var_row):
@@ -392,9 +640,12 @@ class ResultValidator:
 
     def _calculate_checksum(self, results: list[tuple[Any, ...]]) -> str:
         """Calculate MD5 checksum of result set."""
-        # Convert results to a consistent string representation
+        # Convert results to a consistent string representation. Sort on the
+        # None-safe surrogate so a NULL-bearing or mixed-type column never raises
+        # TypeError here (matching the order-insensitive comparison path), which a
+        # caller would otherwise mislabel as an execution "error:".
         result_str = ""
-        for row in sorted(results):
+        for row in sorted(results, key=self._row_sort_key):
             row_str = "|".join(str(val) if val is not None else "NULL" for val in row)
             result_str += row_str + "\n"
 

--- a/tests/integration/test_cross_surface_mutation_sensitivity.py
+++ b/tests/integration/test_cross_surface_mutation_sensitivity.py
@@ -182,14 +182,16 @@ def _perturb_value(value: Any) -> Any:
 #          findings doc and asserted as a documented blind spot, never silently
 #          ignored.
 _EXPECT_CAUGHT: dict[tuple[str, str], bool] = {
-    # reverse_sort is the BS2 order-blindness probe: the comparator full-row-sorts
-    # both sides, so a reversed order over a multi-row result passes silently.
-    ("ssb", "reverse_sort"): False,
-    ("amplab", "reverse_sort"): False,
-    ("coffeeshop", "reverse_sort"): False,
-    ("clickbench", "reverse_sort"): False,
+    # reverse_sort is the BS2 order-blindness probe. The order-aware comparator
+    # (w2: validate_results_exact(order_aware=True), enabled per query whose
+    # ORDER BY maps to result-column positions) now compares the RETURNED order, so
+    # a reversed ORDER BY over a multi-row result with a discriminating order key is
+    # CAUGHT. Every multi-row target here declares such an ORDER BY (ssb Q3.1
+    # d_year/revenue, amplab "4" total_revenue DESC, coffeeshop SA1
+    # order_date/region, clickbench Q8 COUNT(*) DESC), so each flips to caught.
     # joinorder_synthetic is single-row: reversing a 1-row list is a no-op, so the
-    # mutation injects no divergence at all (a degenerate, expected miss).
+    # mutation injects no divergence at all (a degenerate, expected miss) - it stays
+    # the one documented reverse_sort blind spot.
     ("joinorder_synthetic", "reverse_sort"): False,
 }
 
@@ -402,24 +404,33 @@ def test_mutation_sensitivity(kind: str, gate_cell: _GateCell) -> None:
 
 @pytest.mark.parametrize("gate_cell", ["ssb"], indirect=True)
 def test_reversed_sort_is_the_bs2_probe(gate_cell: _GateCell) -> None:
-    """Headline BS2 probe: a reversed ORDER BY passes silently on a multi-row gate.
+    """Headline BS2 probe: a reversed ORDER BY is now CAUGHT on a multi-row gate.
 
-    The unresolved half of w2/BS2 is whether the comparator catches a reversed
-    ORDER BY. It full-row-sorts both sides before comparing, so it cannot. This
-    test pins that property directly on ssb Q3.1 (149 ordered rows): the reversed
-    result yields ZERO divergences. If a future comparator change makes ORDER BY
-    visible, this test flips and forces the findings doc + _EXPECT_CAUGHT update.
+    The previously-open half of w2/BS2 was whether the comparator catches a
+    reversed ORDER BY. It used to full-row-sort both sides before comparing, so it
+    could not - and this test pinned the silent pass. The w2 order-aware comparator
+    closes that blind spot: for a query whose ORDER BY maps to result-column
+    positions (ssb Q3.1 sorts by d_year ASC, revenue DESC -> result columns 2, 3),
+    ``validate_results_exact(order_aware=True)`` compares the RETURNED order, so a
+    reversed result now diverges. This test pins the FIXED property directly on ssb
+    Q3.1 (149 ordered rows): the reversed result yields >= 1 divergence, and it is a
+    genuine ORDER BY mismatch, not a harness ``error:``.
     """
     # The probe is only meaningful over a genuinely ordered, multi-row result: a
-    # 0/1-row reference would make "not caught" vacuous rather than a comparator
+    # 0/1-row reference would make the result an artifact rather than a comparator
     # property.
     assert gate_cell.reference_row_count >= 2, (
         f"ssb {_TARGETS['ssb']} returned only {gate_cell.reference_row_count} row(s); reverse-sort probe is vacuous."
     )
     divergences = _run_target_gate(gate_cell, mutation="reverse_sort")
-    assert not divergences, (
-        "ssb Q3.1 reversed-sort was caught - the comparator is now ORDER BY-aware; "
-        "update _project/analysis/cross-surface-mutation-sensitivity.md and _EXPECT_CAUGHT."
+    assert divergences, (
+        "ssb Q3.1 reversed-sort was NOT caught - the order-aware comparator (w2) "
+        "should make a reversed ORDER BY visible on this multi-row gate."
+    )
+    errored = [d for d in divergences if d.detail.startswith("error:")]
+    assert not errored, (
+        f"ssb Q3.1 reversed-sort was flagged only via a harness execution error, "
+        f"not an ORDER BY mismatch: {[(d.key, d.detail) for d in errored]}"
     )
 
 

--- a/tests/integration/test_validator_order_aware.py
+++ b/tests/integration/test_validator_order_aware.py
@@ -1,0 +1,179 @@
+"""Fast, no-DB guards for the order-aware comparator + None-safe sort (w2/BS2).
+
+The shared :class:`~benchbox.core.tpchavoc.validation.ResultValidator` gained an
+opt-in ``order_aware`` mode (used by the cross-surface SQL<->DataFrame gates for
+any query that declares an ``ORDER BY`` whose key maps to result-column
+positions) and a None-safe sort surrogate. These guards pin the two halves of
+BS2 WITHOUT a database so a regression is caught in the fast lane:
+
+* ORDER-BY blindness: a reversed ``ORDER BY`` over a multi-row result must be a
+  MISMATCH (previously it passed silently because both sides were full-row
+  sorted), while a legitimate tie-group reshuffle and a truncated-LIMIT boundary
+  swap must still PASS (the tie-aware fix must not regress).
+* The None/non-None ``sorted()`` crash: a result column mixing ``None`` with a
+  value must yield a clean MISMATCH (if it differs) or a clean pass (if equal),
+  never a ``TypeError`` that the gate would mislabel as an ``error:``.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpchavoc.validation import ResultValidator, ValidationError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.tpchavoc,
+    pytest.mark.fast,
+]
+
+
+def _validator() -> ResultValidator:
+    return ResultValidator(tolerance=1e-10)
+
+
+# --- Order-aware: a reversed ORDER BY is now CAUGHT ------------------------------
+
+
+def test_order_aware_reversed_order_is_a_mismatch():
+    """A reversed ORDER BY over a multi-row result is reported (the BS2 fix)."""
+    validator = _validator()
+    # ORDER BY col0 ASC, col1 DESC -> order key columns [0, 1].
+    reference = [(1, 100, "a"), (1, 90, "b"), (2, 50, "c"), (3, 10, "d")]
+    order_by = [0, 1]
+    # Identical order passes.
+    assert validator.validate_results_exact(reference, list(reference), 3, 1, order_aware=True, order_by=order_by)
+    # Reversed order is a MISMATCH (it would have passed under the full-row sort).
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_results_exact(
+            reference, list(reversed(reference)), 3, 1, order_aware=True, order_by=order_by, tie_aware=True
+        )
+    assert "ORDER BY" in str(exc_info.value)
+
+
+def test_order_aware_passes_under_legacy_full_row_sort():
+    """The same reversed result passes the old order-insensitive comparison.
+
+    Pins that the catch is genuinely the NEW order-aware path, not a pre-existing
+    property: without ``order_aware`` the comparator full-row-sorts and the
+    reversed result (same multiset) still passes.
+    """
+    validator = _validator()
+    reference = [(1, 100, "a"), (1, 90, "b"), (2, 50, "c"), (3, 10, "d")]
+    assert validator.validate_results_exact(reference, list(reversed(reference)), 3, 1)
+
+
+# --- Order-aware: legitimate tie reshuffles and boundary swaps still PASS --------
+
+
+def test_order_aware_tie_group_reshuffle_is_not_flagged():
+    """Rows sharing an order-key value are a multiset; reshuffling them passes."""
+    validator = _validator()
+    # ORDER BY col0 ASC; the last group (col0 == 2) ties over rows b and c.
+    reference = [(1, "a"), (2, "b"), (2, "c")]
+    reshuffled = [(1, "a"), (2, "c"), (2, "b")]
+    order_by = [0]
+    assert validator.validate_results_exact(reference, reshuffled, 3, 1, order_aware=True, order_by=order_by)
+
+
+def test_order_aware_truncated_limit_boundary_swap_is_not_flagged():
+    """A trailing-LIMIT boundary tie swap on the final group still passes."""
+    validator = _validator()
+    # ORDER BY col0 DESC ... LIMIT 3 over rows tied at the boundary value 5:
+    # each surface keeps a different but equally-valid subset of the tied rows.
+    reference = [(9, "x"), (5, "a"), (5, "b")]
+    variant = [(9, "x"), (5, "a"), (5, "c")]
+    order_by = [0]
+    assert validator.validate_results_exact(
+        reference, variant, 3, 1, order_aware=True, order_by=order_by, tie_aware=True
+    )
+
+
+def test_order_aware_value_bug_in_non_tie_row_is_caught():
+    """A value bug in a deterministically-ordered (non-tie) row is still a MISMATCH."""
+    validator = _validator()
+    reference = [(1, 100, "a"), (2, 90, "b"), (3, 50, "c")]
+    bug = [(1, 100, "a"), (2, 90, "WRONG"), (3, 50, "c")]
+    order_by = [0]
+    with pytest.raises(ValidationError):
+        validator.validate_results_exact(reference, bug, 3, 1, order_aware=True, order_by=order_by, tie_aware=True)
+
+
+def test_order_aware_dropped_column_is_a_clean_column_count_mismatch():
+    """A narrower candidate (dropped projection) reports a column-count MISMATCH.
+
+    The order-key columns index into every row, so a too-narrow candidate must
+    surface as a clean MISMATCH, not an IndexError the gate would mislabel
+    ``error:``.
+    """
+    validator = _validator()
+    reference = [(1, 100, "a"), (2, 90, "b")]
+    dropped = [(100, "a"), (90, "b")]  # leading column dropped
+    order_by = [0]
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_results_exact(reference, dropped, 3, 1, order_aware=True, order_by=order_by)
+    assert "Column count mismatch" in str(exc_info.value)
+
+
+def test_order_aware_falls_back_when_no_order_key():
+    """``order_aware`` with an empty/None key uses the order-insensitive path."""
+    validator = _validator()
+    reference = [(2, "b"), (1, "a")]
+    same_multiset_reordered = [(1, "a"), (2, "b")]
+    # No order key supplied -> falls back to the order-insensitive comparison,
+    # which passes the reordered multiset (never claims an order check it lacks).
+    assert validator.validate_results_exact(reference, same_multiset_reordered, 3, 1, order_aware=True, order_by=None)
+    assert validator.validate_results_exact(reference, same_multiset_reordered, 3, 1, order_aware=True, order_by=[])
+
+
+def test_order_aware_out_of_range_key_falls_back_without_indexerror():
+    """An order-key index past the result width falls back, never raises IndexError.
+
+    If the caller's SQL-derived column position ever exceeds the actual result
+    width, the order-aware path must NOT index a missing column (an IndexError the
+    gate would mislabel ``error:``); it falls back to the order-insensitive
+    comparison instead.
+    """
+    validator = _validator()
+    reference = [(1, "a"), (2, "b")]  # width 2; index 5 is out of range
+    # Identical -> clean pass via the fallback, no IndexError.
+    assert validator.validate_results_exact(reference, list(reference), 3, 1, order_aware=True, order_by=[5])
+    # A reversed order with an out-of-range key is NOT caught (fallback is
+    # order-insensitive) - but crucially it does not raise.
+    assert validator.validate_results_exact(reference, list(reversed(reference)), 3, 1, order_aware=True, order_by=[5])
+
+
+# --- None-safe sort: a NULL-mixed column never raises from sorted() --------------
+
+
+def test_none_mixed_column_equal_passes_without_crashing():
+    """A column mixing None and a value compares equal without a sorted() TypeError."""
+    validator = _validator()
+    rows = [(1, None), (2, 5), (3, None)]
+    # A bare ``sorted`` on these rows would raise (None < int); the None-safe
+    # surrogate makes it a clean pass.
+    assert validator.validate_results_exact(rows, list(rows), 3, 1)
+
+
+def test_none_mixed_column_difference_is_a_clean_mismatch_not_an_error():
+    """A genuine None-vs-value difference is a MISMATCH, never an execution error."""
+    validator = _validator()
+    reference = [(1, None), (2, 5)]
+    variant = [(1, 7), (2, 5)]  # None -> 7 on the first row
+    with pytest.raises(ValidationError) as exc_info:
+        validator.validate_results_exact(reference, variant, 3, 1)
+    message = str(exc_info.value)
+    assert "mismatch" in message.lower()
+    assert "error:" not in message
+
+
+def test_mixed_type_column_does_not_raise_typeerror():
+    """A column mixing types (int and str) sorts without raising TypeError."""
+    validator = _validator()
+    # Equal multisets with a type-mixed column: must compare without crashing.
+    rows = [(1, "x"), (2, 7)]
+    assert validator.validate_results_exact(rows, list(reversed(rows)), 3, 1)

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -321,3 +321,35 @@ def test_clickbench_and_joinorder_are_enforced_gates():
     assert GATES["joinorder_synthetic"].known_divergences == {}
     # ssb stays the enforced precedent.
     assert "ssb" in GATES
+
+
+def test_order_by_result_key_maps_alias_name_expr_and_ordinal():
+    """_order_by_result_key resolves the ORDER BY shapes the gated queries use."""
+    from benchbox.core.equivalence.cross_surface import _order_by_result_key as resolve
+
+    # plain output column names
+    assert resolve("SELECT a, b FROM t ORDER BY a, b") == [0, 1]
+    # an alias (ORDER BY revenue -> SUM(...) AS revenue at position 0)
+    assert resolve("SELECT sum(x) AS revenue, y FROM t GROUP BY y ORDER BY revenue DESC") == [0]
+    # a qualified column resolves by its bare name to the output position
+    assert resolve("SELECT ol.d, dl.r FROM o ol JOIN d dl ON 1=1 ORDER BY ol.d, dl.r") == [0, 1]
+    # an aggregate EXPRESSION (COUNT(*)) - a nested star must NOT disqualify it
+    assert resolve("SELECT k, COUNT(*) AS c FROM t GROUP BY k ORDER BY COUNT(*) DESC") == [1]
+    # a 1-based ordinal maps to the result column index
+    assert resolve("SELECT a, b FROM t ORDER BY 2 DESC") == [1]
+
+
+def test_order_by_result_key_refuses_unmappable_keys():
+    """An ORDER BY whose key is not a projected column yields None (no order claim).
+
+    These fall back to the order-insensitive comparison rather than a silent
+    order-blind "pass" - the documented residual blind spot.
+    """
+    from benchbox.core.equivalence.cross_surface import _order_by_result_key as resolve
+
+    assert resolve("SELECT a FROM t") is None  # no ORDER BY
+    assert resolve("SELECT * FROM t ORDER BY x") is None  # SELECT * - unenumerable
+    assert resolve("SELECT t.* FROM t ORDER BY x") is None  # qualified star
+    assert resolve("SELECT a FROM t ORDER BY b") is None  # ORDER BY a non-projected column
+    assert resolve("SELECT a, b FROM t ORDER BY 5") is None  # out-of-range ordinal
+    assert resolve("this is not sql ;;;") is None  # unparseable


### PR DESCRIPTION
## What

Close the open half of **w2 / Blind Spot 2** in the cross-surface oracle remediation: the comparator was **order-blind** (a reversed `ORDER BY` passed silently) and crashed on a `None`/non-`None` mixed column (mislabeled `error:`). This adds an **additive, opt-in order-aware mode** to the shared `ResultValidator` and a None-safe sort surrogate — the validator is extended, never forked.

### Changes
- **`ResultValidator.validate_results_exact`** gains `order_aware` + `order_by` (result-column positions). When enabled it compares rows in **returned order**: the sequence of distinct order-key values must match exactly (a reversed `ORDER BY` is now **caught**), while rows sharing an order-key value (an engine-arbitrary tie group) are compared as a **multiset** (a legitimate tie reshuffle is *not* flagged), and the final group under a trailing `LIMIT` is tolerated as a boundary tie (the #858 tie-aware fix does not regress). Out-of-range key indices fall back to the order-insensitive path rather than raising.
- **None/mixed-type sort crash fixed**: a None-safe, type-safe `_row_sort_key`/`_cell_sort_key` surrogate replaces bare `sorted()` across the exact, aggregation, and checksum paths. A column mixing `None` with a value now yields a clean **MISMATCH** (if different) or pass (if equal), never a `TypeError` mislabeled `error:`. Equality is still decided by `_values_equal`, so verdicts are unchanged.
- **`cross_surface._order_by_result_key`** resolves a query's `ORDER BY` to result-column positions via **sqlglot** (alias-or-name, then normalized-expr match, then 1-based ordinal). It returns `None` — falling back to the order-insensitive comparison — for any `ORDER BY` whose key is **not a projected column** (e.g. clickbench `Q24 SELECT *`, `Q25 ORDER BY EventTime` over `SELECT SearchPhrase`). We never claim an order check we cannot perform; the residual blind spot is **documented, not muted via a baseline**.
- The cross-surface gate enables `order_aware` per query whose `ORDER BY` maps cleanly.

## Why

The w10 mutation suite proved the reversed-`ORDER BY` probe was **not caught** on any multi-row gate (`validate_results_exact` full-row-sorted both sides). This is the dangerous false-negative half of BS2. The fix restores ORDER BY signal while keeping the tie-noise fix and adding NULL robustness.

## Evidence — w10 reversed-sort matrix (before → after)

| Benchmark | Target | `reverse_sort` before | `reverse_sort` after |
| --- | --- | --- | --- |
| ssb | Q3.1 (149×4) | ❌ not caught | ✅ **caught** |
| amplab | 4 (100×6) | ❌ not caught | ✅ **caught** |
| coffeeshop | SA1 (93×5) | ❌ not caught | ✅ **caught** |
| clickbench | Q8 (20×2) | ❌ not caught | ✅ **caught** |
| joinorder_synthetic | 4a (1×2) | ⚪ no-op (single row) | ⚪ no-op (documented) |

`test_reversed_sort_is_the_bs2_probe` was rewritten to assert the reversed result is now caught (and that the catch is a genuine ORDER BY mismatch, not a harness `error:`).

## Verification
- **5 enforced cross-surface gates green**: ssb 14/26 discriminating, amplab 12/16, coffeeshop 22/22, clickbench 70 discriminating (only the classified order-less Q18 baseline), joinorder_synthetic 26/26. Tie reshuffles still not flagged.
- **TPC-Havoc byte-identical green**: SQL 220/220, DataFrame 440/440 (they pass `order_aware=False`, path unchanged).
- New fast-lane unit suite `tests/integration/test_validator_order_aware.py` + `_order_by_result_key` resolver tests: reversed-order MISMATCH, tie/boundary tolerance, column-count guard, out-of-range-key fallback, ordinal/alias/expr mapping, and the None-mixed-column clean MISMATCH (never `error:`).
- Full w10 mutation-sensitivity suite green (the multi-row `reverse_sort` cells flipped to caught).

Closes the open half of **w2** in `cross-surface-oracle-remediation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2zGrrkir4BiH58ekco4TT)_