### PR TITLE
fix(dataframe): empty-string contract on non-pandas CSV adapters (cross-surface w6)

### DIFF
--- a/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
+++ b/_project/TODO/main/active/cross-surface-oracle-remediation.yaml
@@ -331,10 +331,21 @@ work:
       (59 cases). Verified: dataframe + joinorder unit suites (1298 passed),
       joinorder_synthetic and ssb cross-surface gates green (0 divergent),
       tpchavoc-equivalence-report unchanged (220 equivalent).
-      STILL OPEN (do not close w6): the production-loader-path gate cell (M4
-      loader bypass), the remaining raw-CSV adapter empty-string contract
-      (Polars/modin/dask/cudf scan_csv), applying declared STRING dtypes on the
-      production load path, and closing the joinorder_synthetic deferral. The
+      ADAPTER EMPTY-STRING CONTRACT DONE (raw-CSV path): carried the dialect-aware
+      empty-string->'' contract from the pandas adapter to the other DataFrame
+      adapters' read_csv. Polars now passes missing_utf8_is_empty_string=(null_marker
+      is None) to scan_csv; modin/dask/cudf now read declared text columns as object
+      and restore '' for empty fields when null_marker is None (NULL when ''),
+      reusing _pandas_string_columns. So a prefer_parquet=False (or CSV-recommending)
+      load no longer reintroduces the empty-string->null divergence (Q6/Q17/Q18) on
+      those surfaces. Verified: polars read_csv unit test (both dialect cases),
+      adapter coverage suites (139 passed), no import cycle, ssb gate still green.
+      modin/cudf are not installed in this env so their read_csv was not runtime-
+      exercised, but the change is the same pattern proven on the pandas adapter.
+      STILL OPEN (do not close w6): the production-loader-path DTYPE-asserting gate
+      cell (M4 - the gate already compares values through the loader and caught the
+      TEXT/TIMESTAMP bugs, so this is additive), applying declared STRING dtypes on
+      the production load path, and closing the joinorder_synthetic deferral. The
       loader PYARROW/polars/pandas type-map gaps (L2) were done in #857.
     notes: |
       The gate's loader bypass (dataframe_surface.py:74-125 materializes from typed

--- a/benchbox/platforms/dataframe/cudf_df.py
+++ b/benchbox/platforms/dataframe/cudf_df.py
@@ -55,6 +55,7 @@ except ImportError:
     PANDAS_AVAILABLE = False
 
 from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration
+from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
@@ -209,7 +210,7 @@ class CuDFDataFrameAdapter(PandasFamilyAdapter[CuDFDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
-        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; cuDF infers types
+        column_types: list[str] | None = None,
     ) -> CuDFDF:
         """Read a CSV file into a cuDF DataFrame.
 
@@ -234,8 +235,15 @@ class CuDFDataFrameAdapter(PandasFamilyAdapter[CuDFDF]):
             read_kwargs["header"] = header
 
         # Add column names if provided
+        string_columns: list[str] = []
         if names:
             read_kwargs["names"] = names
+            # Read declared text columns as object and (below) restore '' for empty
+            # fields, mirroring the pandas adapter so the empty-string contract holds
+            # on cuDF's raw-CSV path too.
+            string_columns = _pandas_string_columns(names, column_types, set())
+            if string_columns:
+                read_kwargs["dtype"] = dict.fromkeys(string_columns, "object")
 
         # Trailing-delimiter probing only for TPC-style sources (null_marker is not None).
         if null_marker is not None and names and has_trailing_delimiter(path, delimiter, names):
@@ -243,6 +251,15 @@ class CuDFDataFrameAdapter(PandasFamilyAdapter[CuDFDF]):
             read_kwargs["names"] = extended_names
 
         df = cudf.read_csv(path, **read_kwargs)
+
+        # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
+        # '' -> NULL), as the pandas adapter does.
+        if null_marker is None and string_columns:
+            for column in string_columns:
+                if column in df.columns:
+                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
+                    # whose multi-column assignment support differs from pandas.
+                    df[column] = df[column].fillna("")
 
         # Drop trailing column if present
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/dask_df.py
+++ b/benchbox/platforms/dataframe/dask_df.py
@@ -57,6 +57,7 @@ except ImportError:
     PANDAS_AVAILABLE = False
 
 from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration
+from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns
 from benchbox.platforms.dataframe.pandas_family import (
     PandasFamilyAdapter,
 )
@@ -400,7 +401,7 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
-        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; Dask infers types
+        column_types: list[str] | None = None,
     ) -> DaskDF:
         """Read a CSV file into a Dask DataFrame.
 
@@ -428,8 +429,16 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
             read_kwargs["header"] = None
 
         # Add column names if provided
+        string_columns: list[str] = []
         if names:
             read_kwargs["names"] = names
+            # Read declared text columns as object so a numeric-looking string is
+            # not inferred as a number, and (below) restore '' for empty fields -
+            # mirroring the pandas adapter so the empty-string contract holds on the
+            # raw-CSV path too (see _pandas_string_columns).
+            string_columns = _pandas_string_columns(names, column_types, set())
+            if string_columns:
+                read_kwargs["dtype"] = dict.fromkeys(string_columns, "object")
 
         # Trailing-delimiter probing only for TPC-style sources (null_marker is not None).
         if null_marker is not None and names and has_trailing_delimiter(path, delimiter, names):
@@ -437,6 +446,16 @@ class DaskDataFrameAdapter(PandasFamilyAdapter[DaskDF]):
             read_kwargs["names"] = extended_names
 
         df = dd.read_csv(path, **read_kwargs)
+
+        # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
+        # '' -> NULL), as the pandas adapter does, so an empty text field does not
+        # surface as None where the SQL reference emits ''.
+        if null_marker is None and string_columns:
+            for column in string_columns:
+                if column in df.columns:
+                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
+                    # whose multi-column assignment support differs from pandas.
+                    df[column] = df[column].fillna("")
 
         # Drop trailing column if present (lazy operation)
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/modin_df.py
+++ b/benchbox/platforms/dataframe/modin_df.py
@@ -123,6 +123,7 @@ except ImportError:
 
 # These imports must come after Ray/Modin initialization above
 from benchbox.core.dataframe.tuning import DataFrameTuningConfiguration  # noqa: E402
+from benchbox.platforms.dataframe.pandas_df import _pandas_string_columns  # noqa: E402
 from benchbox.platforms.dataframe.pandas_family import (  # noqa: E402
     PandasFamilyAdapter,
 )
@@ -271,7 +272,7 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         header: int | None = 0,
         names: list[str] | None = None,
         null_marker: str | None = None,
-        column_types: list[str] | None = None,  # noqa: ARG002 - accepted for signature parity; Modin infers types
+        column_types: list[str] | None = None,
     ) -> ModinDF:
         """Read a CSV file into a Modin DataFrame.
 
@@ -292,8 +293,15 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
         }
 
         # Add column names if provided
+        string_columns: list[str] = []
         if names:
             read_kwargs["names"] = names
+            # Read declared text columns as object and (below) restore '' for empty
+            # fields, mirroring the pandas adapter so the empty-string contract holds
+            # on Modin's raw-CSV path too.
+            string_columns = _pandas_string_columns(names, column_types, set())
+            if string_columns:
+                read_kwargs["dtype"] = dict.fromkeys(string_columns, "object")
 
         # Trailing-delimiter probing only for TPC-style sources (null_marker is not None).
         if null_marker is not None and names and has_trailing_delimiter(path, delimiter, names):
@@ -301,6 +309,15 @@ class ModinDataFrameAdapter(PandasFamilyAdapter[ModinDF]):
             read_kwargs["names"] = extended_names
 
         df = mpd.read_csv(path, **read_kwargs)
+
+        # Match the SQL dialect's empty-field semantics (null_marker None -> keep '';
+        # '' -> NULL), as the pandas adapter does.
+        if null_marker is None and string_columns:
+            for column in string_columns:
+                if column in df.columns:
+                    # Per-column (not df[list]=...) so it works across dask/modin/cudf,
+                    # whose multi-column assignment support differs from pandas.
+                    df[column] = df[column].fillna("")
 
         # Drop trailing column if present
         if TRAILING_DUMMY_COLUMN in df.columns:

--- a/benchbox/platforms/dataframe/polars_df.py
+++ b/benchbox/platforms/dataframe/polars_df.py
@@ -265,7 +265,10 @@ class PolarsDataFrameAdapter(ExpressionFamilyAdapter[PolarsDF, PolarsLazyDF, Pol
             delimiter: Field delimiter
             has_header: Whether file has header row
             column_names: Optional column names (overrides header)
-            null_marker: Unused for Polars (truncate_ragged_lines handles trailing delimiters natively).
+            null_marker: The SQL dialect's null marker. ``None`` means empty fields
+                stay '' in string columns (match DuckDB/pandas); ``""`` means empty
+                fields are NULL. (Trailing delimiters are handled natively by
+                truncate_ragged_lines.)
 
         Returns:
             Polars LazyFrame with the file contents
@@ -277,6 +280,16 @@ class PolarsDataFrameAdapter(ExpressionFamilyAdapter[PolarsDF, PolarsLazyDF, Pol
             "ignore_errors": True,
             # Handle files with or without trailing delimiters
             "truncate_ragged_lines": True,
+            # Mirror the SQL dialect's empty-field semantics, matching the pandas
+            # CSV path: when the loader keeps empty fields as '' (null_marker is
+            # None, e.g. ClickBench) keep '' in string columns so the raw-CSV path
+            # agrees with the SQL reference (DuckDB keeps ''), the Parquet path
+            # (strings_can_be_null=False) and pandas; when the dialect treats empty
+            # as NULL (null_marker == '', e.g. JoinOrder) leave Polars' default
+            # empty->null. Without this, a prefer_parquet=False load reintroduces the
+            # empty-string->null divergence (the cross-surface Q6/Q17/Q18 bug) on the
+            # Polars surface. Numeric columns always treat an empty field as null.
+            "missing_utf8_is_empty_string": null_marker is None,
         }
 
         # Add row limit if specified

--- a/tests/unit/platforms/dataframe/test_polars_df.py
+++ b/tests/unit/platforms/dataframe/test_polars_df.py
@@ -333,6 +333,33 @@ class TestPolarsDataLoading:
         df = lf.collect()
         assert df.columns == ["id", "name", "amount"]
 
+    def test_read_csv_empty_string_follows_null_marker(self, tmp_path):
+        """Empty text fields stay '' when null_marker is None, NULL when '' (w6).
+
+        Mirrors the pandas adapter and the SQL dialect: ClickBench keeps '' (the
+        cross-surface Q6/Q17/Q18 contract), JoinOrder treats empty as NULL. Without
+        this, Polars' raw-CSV path maps empty -> null and reintroduces the bug under
+        prefer_parquet=False.
+        """
+        import polars as pl
+
+        adapter = PolarsDataFrameAdapter()
+        csv_path = tmp_path / "t.csv"
+        csv_path.write_text("a|1\n|2\nb|\n")
+
+        kept = adapter.read_csv(
+            csv_path, delimiter="|", has_header=False, column_names=["s", "n"], null_marker=None
+        ).collect()
+        assert kept["s"].to_list() == ["a", "", "b"]
+        assert kept["s"].null_count() == 0
+
+        nulled = adapter.read_csv(
+            csv_path, delimiter="|", has_header=False, column_names=["s", "n"], null_marker=""
+        ).collect()
+        assert nulled["s"].to_list() == ["a", None, "b"]
+        assert nulled["s"].null_count() == 1
+        assert nulled.schema["n"] == pl.Int64  # numeric column unaffected
+
     def test_read_csv_respects_n_rows(self, tmp_path):
         """Test CSV scanning honors the adapter row limit."""
         adapter = PolarsDataFrameAdapter(n_rows=2)


### PR DESCRIPTION
## What

Closes the **non-pandas raw-CSV adapter** sub-part of **w6** in `cross-surface-oracle-remediation.yaml`.

w1 fixed the empty-string→`''` contract for the Parquet path and the **pandas** CSV path, but the other DataFrame adapters' raw-CSV reads still mapped an empty field to **null** — so a `prefer_parquet=False` (or CSV-recommending) load reintroduced the cross-surface **Q6/Q17/Q18** divergence on those surfaces.

## Change — dialect-aware, mirroring `pandas_df.read_csv`

- **Polars**: `scan_csv` now gets `missing_utf8_is_empty_string=(null_marker is None)` — empty fields in string columns stay `''` when the SQL dialect keeps `''` (ClickBench) and become NULL when it nulls them (JoinOrder); numeric columns unaffected.
- **modin / dask / cudf**: read declared text columns as `object` (via the shared `_pandas_string_columns`) and restore `''` for empty fields when `null_marker is None`, applied **per-column** so it works across each backend's assignment semantics.

## Verification

- New Polars `read_csv` unit test covers **both dialect cases** (`null_marker=None` → `''`; `null_marker=""` → NULL) and confirms numeric columns are unaffected.
- Adapter coverage suites pass (139 + 22); **dask** is installed and exercised. **modin/cudf are not installed in this environment**, so their `read_csv` wasn't runtime-exercised — but the change is the exact pattern proven on the pandas adapter.
- No import cycle; **ssb** cross-surface gate still green.

## Scope

This is the adapter sub-part of w6. Still open (tracked in the TODO): the production-loader-path **dtype-asserting gate cell** (the gate already compares values through the loader and caught the TEXT/TIMESTAMP bugs, so this is additive) and applying declared STRING dtypes on the production load path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV7kxqBDwHYiRWZsNRkAB8)_