### PR TITLE
docs(todo): replace stale cross-surface rollout TODO with breadth-only slim

### DIFF
--- a/_project/TODO/main/planning/cross-surface-gate-rollout-followups.yaml
+++ b/_project/TODO/main/planning/cross-surface-gate-rollout-followups.yaml
@@ -1,137 +1,82 @@
 id: cross-surface-gate-rollout-followups
-title: "Cross-surface gate follow-ups: schema-type-faithful DataFrame loader + remaining gate rollout"
+title: "Cross-surface gate breadth rollout: wire the remaining gateable benchmarks + fallback oracle"
 worktree: main
-priority: High
+priority: Medium
 status: Not Started
 category: Testing and Quality Assurance
 
 description: |
-  Follow-up backlog spun out of benchmark-cross-surface-equivalence-gate once the
-  first wave of gates shipped: ssb and coffeeshop are enforced on develop, amplab
-  is landing via #835, and clickbench and joinorder_synthetic are wired in
-  STAGED_GATES (report mode). It compiles the remaining, independently-actionable
-  findings so the parent campaign's w2/w3/w4 are not a single sprawling work item.
+  Breadth-only follow-up to the cross-surface SQL<->DataFrame equivalence gate.
+  It tracks ONE thing: extending the gate to the dual-surface benchmarks that do
+  not yet have one, plus a fallback oracle for the benchmarks that ship no
+  DataFrame query surface at all.
 
-  The headline finding is a SHARED, load-faithfulness gap in the production
-  DataFrame loader, re-confirmed on current develop (branch tip ad05c5b7) by
-  re-running `make joinorder-synthetic-cross-surface-equivalence-report`:
+  STATE OF THE CAMPAIGN (so this file is not misread as still-open hardening
+  work). The enforced GATES are now ssb, amplab, coffeeshop, clickbench, and
+  joinorder_synthetic; STAGED_GATES is empty. The oracle's correctness and
+  trustworthiness - schema-type-faithful loading, the order/tie-aware comparator,
+  gate-boundary determinism, the vacuous-empty-vs-empty guard, and
+  mutation-testing the oracle's SENSITIVITY - was the cross-surface-oracle-
+  remediation campaign (w1-w10), which is COMPLETE. This file does not revisit any
+  of that; it only adds gate COVERAGE for more benchmarks, assuming that hardened
+  loader/comparator is in place.
 
-    13 queries x 2 backends = 26 cells; 10 divergent, 16 passing.
-
-  After #846 fixed column NAME extraction for DDL-string schemas
-  (benchbox/core/dataframe/schema_utils.py: column_name/column_sql_type), the
-  loader applies column names but still TYPE-INFERS dtypes from the sampled data
-  instead of applying the schema's declared SQL types. At a bounded SF the
-  inference is wrong in two ways, both of which the gate caught (all 10 remaining
-  joinorder_synthetic cells):
-
-    - Class A - all-null nullable string column inferred as `null` dtype, so a
-      string op fails ("expected String type, got: null"). 6 cells, Polars
-      expression backend: 1a, 1b, 5a, 8a, 9a, 10a (e.g. movie_companies.note,
-      declared TEXT, entirely NULL in the SF=0.1 sample).
-    - Class B - a column declared TEXT but holding numeric-looking values inferred
-      as `float64`, so a comparison to a string literal fails ("cannot compare
-      string with numeric type (f64)" / "Invalid comparison between dtype=float64
-      and str"). 4 cells, BOTH backends: 4a, 12a.
-
-  This is NOT a joinorder_synthetic quirk: the DuckDB SQL reference gets correct
-  types from CREATE TABLE, so any benchmark with sparse-nullable or
-  numeric-looking string columns will diverge once gated, and a real
-  Polars/Pandas run at bounded scale hits the same fragility. Both classes are
-  fixed by ONE loader-layer change: apply the declared schema dtypes on DataFrame
-  load (types are already available via column_sql_type). It is the gating
-  blocker for promoting joinorder_synthetic (and likely future benchmarks) from
-  STAGED_GATES to enforced GATES.
+  Authoritative inventory: _project/analysis/cross-surface-applicability.md
+  (registry-detection sweep). Of the dual-surface unguarded candidates, 9 ship a
+  DataFrame query registry and are not yet gated (4 with ids that overlap as-is, 5
+  needing id normalization), and 4 ship no DataFrame query surface and need a
+  fallback oracle. Those three groups are w0, w1, w2 below.
 
 prior_art:
-  - "_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml - the parent campaign (w0-w7); this file is its rollout-phase follow-up backlog."
-  - "_project/analysis/joinorder-synthetic-cross-surface-divergences.md - the 10-cell symptom table + root cause + fix direction; re-confirmed accurate on current code."
-  - "_project/analysis/clickbench-cross-surface-divergences.md - clickbench staged-gate burndown detail (value divergences, distinct from the dtype gap here)."
-  - "_project/analysis/cross-surface-applicability.md - which dual-surface benchmarks are gateable as-is, need id normalization, or need a w2 fallback oracle."
-  - "benchbox/core/dataframe/schema_utils.py - column_name/column_sql_type (the DDL-string parse landed in #846); the schema-type-application fix builds on column_sql_type."
-  - "benchbox/core/dataframe/data_loader.py - _get_schema_info / the headerless-CSV column_names path; where inferred dtypes are applied today and where schema types must be applied instead."
-  - "benchbox/core/equivalence/cross_surface.py - GATES (ssb, coffeeshop, amplab) and STAGED_GATES (clickbench, joinorder_synthetic); promotion target."
+  - "_project/TODO/main/active/benchmark-cross-surface-equivalence-gate.yaml - the parent campaign (harness + the first enforced gates); its w4 also lists remaining benchmarks, which this file makes concrete."
+  - "_project/TODO/main/active/cross-surface-oracle-remediation.yaml - the COMPLETED oracle correctness/trust campaign (w1-w10: loader types, tie-aware comparator, determinism, vacuous-cell guard, mutation testing). This breadth rollout assumes its fixes, and does not duplicate them."
+  - "_project/analysis/cross-surface-applicability.md - the authoritative gateable / needs-id-normalization / no-DataFrame-registry classification used below."
+  - "benchbox/core/equivalence/cross_surface.py - build_<bench>_duckdb + the GATES registry; copy an existing builder (build_ssb_duckdb / build_amplab_duckdb) per new benchmark, and map ids in the builder where the sweep flags normalization."
+  - "_project/analysis/gateable-generator-seeding-audit.md - a gate is flaky unless its generator is seeded/stable; check each benchmark here before wiring."
+  - "tests/integration/test_amplab_cross_surface_equivalence.py - the medium-marker fast-lane regression to mirror per newly-gated benchmark."
 
 work:
   - id: w0
-    summary: "Make the production DataFrame loader apply declared schema column TYPES instead of inferring dtypes"
+    summary: "Wire cross-surface gates for the benchmarks whose SQL and DataFrame ids already overlap"
     status: pending
     notes: |
-      The single root-cause fix. When loading a benchmark's DataFrame contexts,
-      map each column's declared SQL type (column_sql_type) to the corresponding
-      Arrow/Polars/Pandas dtype and apply it, so a VARCHAR/TEXT column loads as
-      string (even if all-null or numeric-looking in the sample) and INTEGER loads
-      as int, instead of relying on per-file inference. Mirror how the DuckDB SQL
-      reference gets types from CREATE TABLE - the schema is the source of truth.
-
-      ACCEPTANCE: `make joinorder-synthetic-cross-surface-equivalence-report`
-      reports 0 divergent (was 10); no regression in the existing dataframe /
-      equivalence unit suites or the already-green ssb/coffeeshop/amplab/clickbench
-      gates. Verify both error classes are gone (Class A all-null String; Class B
-      numeric-looking TEXT). Keep it a loader-layer change - no per-query casts,
-      no gate-local workarounds.
+      Per cross-surface-applicability.md, ids overlap as-is (no normalization):
+      flightdata (20), h2odb (10), joinorder (113), read_primitives (157 SQL vs
+      152 DF - gate the overlapping 152). One focused gate PR each, copying the
+      build_<bench>_duckdb + GATES pattern and adding a medium-marker fast-lane
+      test. CAVEATS to resolve per benchmark before gating:
+        - flightdata and joinorder use real/downloaded data (no synthetic
+          generator) - pin a bounded, stable data source so the gate is
+          deterministic; joinorder may be SF=1.0-only, so confirm a cheap bounded
+          cell is even feasible before committing to gate it.
+        - read_primitives: gate only the 152 ids present on both surfaces; record
+          the 5 SQL-only ids as intentionally out of cross-surface scope.
+      If a new gate surfaces a NEW oracle-correctness bug (not a benchmark logic
+      bug), reopen cross-surface-oracle-remediation rather than patching here.
 
   - id: w1
-    summary: "Promote joinorder_synthetic from STAGED_GATES to enforced GATES"
-    needs: [w0]
+    summary: "Wire cross-surface gates for the benchmarks that need SQL<->DataFrame id normalization first"
     status: pending
     notes: |
-      Once w0 makes the gate clean: move joinorder_synthetic from STAGED_GATES to
-      GATES in cross_surface.py, add the blocking pr.yml correctness-gate step
-      (make joinorder-synthetic-cross-surface-equivalence-report) and a
-      medium-marker fast-lane regression (mirror
-      tests/integration/test_amplab_cross_surface_equivalence.py). Prove the gate
-      fails on a planted single-cell defect. Update the parent campaign w3/w4 and
-      the analysis doc Status section.
+      Per cross-surface-applicability.md, a DataFrame query registry exists but its
+      ids differ from the SQL ids by a naming convention (e.g. `1` vs `Q1`):
+      datavault (22), nyctaxi (25), tsbs_devops (18). Plus two partial/low-value
+      cases: tpcds_obt (only 3 DF queries vs 89 SQL - gate the 3, mark the rest
+      out of scope) and tpch_skew (22; low value, TPC-H-derived - gate only if the
+      id mapping is cheap). Normalize the id mapping inside the builder (as
+      build_amplab_duckdb maps `1`->`Q1`), then proceed exactly as w0.
 
   - id: w2
-    summary: "Burn down the clickbench staged gate and promote to enforced GATES"
+    summary: "Provide a fallback oracle for the dual-loadable benchmarks that ship no DataFrame query surface"
     status: pending
     notes: |
-      clickbench is wired in STAGED_GATES with ~27 stable value-divergence cells
-      across ~14 queries (detail: _project/analysis/clickbench-cross-surface-
-      divergences.md): empty-vs-None null materialization (Q17/Q24), large
-      aggregate diffs from a dropped predicate/DISTINCT (Q16/18/32/33/36), and
-      top-N tie-break ordering (Q9/10/38/15/31). These are NOT the w0 dtype class -
-      triage each (fix the wrong surface, or classify a defensible presentational
-      divergence) until the baseline is clean, then STAGED_GATES -> GATES + a
-      blocking pr.yml step + fast-lane regression.
-
-  - id: w3
-    summary: "Wire cross-surface gates for the remaining gateable dual-surface benchmarks"
-    status: pending
-    notes: |
-      Per _project/analysis/cross-surface-applicability.md (the authoritative
-      registry-detection sweep), the gateable benchmarks NOT yet wired (excluding
-      ssb/coffeeshop/amplab already gated and clickbench/joinorder_synthetic
-      already staged - those are w1/w2 here). One focused gate PR each, reusing the
-      build_<bench>_duckdb + GATES pattern:
-        - ids overlap as-is (4): flightdata (20), h2odb (10), joinorder (113),
-          read_primitives (157 SQL vs 152 DF - gate the overlapping 152). NOTE
-          flightdata and joinorder use real/downloaded data (no synthetic
-          generator), so confirm a bounded, stable data source before gating.
-        - need id normalization first (5): datavault (22), nyctaxi (25),
-          tsbs_devops (18) - DataFrame registry ids differ from SQL ids by a
-          naming convention (e.g. `1` vs `Q1`), normalize in the builder;
-          tpcds_obt (only 3 DF queries vs 89 SQL - partial); tpch_skew (22, low
-          value - TPC-H-derived, gate only if cheap).
-      Does NOT hard-depend on w0: a benchmark whose columns avoid the Class A/B
-      dtype symptom can be gated independently, but any that hit "expected String
-      type"/"compare string with numeric" are blocked on w0's loader fix. Each
-      builder must be load-faithful (real production loader) and the generator
-      seeded/stable, or the gate is flaky (see the seeding audit:
-      _project/analysis/gateable-generator-seeding-audit.md).
-
-  - id: w4
-    summary: "Provide a w2 fallback oracle for the single-surface (no DataFrame registry) benchmarks"
-    status: pending
-    notes: |
-      Four dual-loadable benchmarks ship NO DataFrame query registry, so
-      cross-surface equivalence does not apply: metadata_primitives, tpcdi,
-      transaction_primitives, write_primitives. These need a different
-      maintenance-light oracle - a differential second-engine comparison or a
-      curated bounded expected-results set - tracked here so the coverage map does
-      not silently leave them UNGUARDED. Lowest priority of this backlog.
+      Four benchmarks load into DataFrames but ship NO DataFrame query registry,
+      so cross-surface equivalence cannot reach them: metadata_primitives, tpcdi,
+      transaction_primitives, write_primitives. They have NO correctness oracle of
+      any kind today. Give each a maintenance-light oracle - a differential
+      second-engine comparison or a curated bounded expected-results subset - so
+      the coverage map does not silently leave them UNGUARDED. Lowest priority of
+      this file.
 
 deferred:
   - summary: "Cross-surface equivalence on a second engine (beyond DuckDB-backed cells)"


### PR DESCRIPTION
## Summary

Corrects a stale TODO on develop. **TODO/docs only — no code changes.**

PR #850 was approved to be *slimmed* to its non-overlapping scope, but its auto-merge fired on the first CI pass and landed the **original, un-slimmed** TODO before the slim commit could land. As a result develop carries a redundant, now-doubly-stale doc whose `w0/w1/w2` (loader dtype fix, joinorder_synthetic promotion, clickbench burndown) describe work since **completed** by the `cross-surface-oracle-remediation` campaign (w1–w10, now **Completed**) and PRs #856/#857 — those benchmarks are now **enforced** `GATES` and `STAGED_GATES` is empty.

This PR replaces it (−111/+56) with the breadth-only scope that is genuinely still open and not tracked elsewhere:

- **w0** — wire ids-overlap benchmarks: `flightdata`, `h2odb`, `joinorder`, `read_primitives`.
- **w1** — wire needs-id-normalization benchmarks: `datavault`, `nyctaxi`, `tsbs_devops`, plus partial `tpcds_obt` and low-value `tpch_skew`.
- **w2** — fallback oracle for the 4 no-DataFrame-registry benchmarks (`metadata_primitives`, `tpcdi`, `transaction_primitives`, `write_primitives`).

The description now states the oracle-hardening campaign is complete and the first five gates (ssb, amplab, coffeeshop, clickbench, joinorder_synthetic) are enforced. Inventory reconciled against `_project/analysis/cross-surface-applicability.md`. `validate_todo.py` ✅ and `todo_cli check-graph` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yph2sV9omJaDYZrev1yRm

---
_Generated by [Claude Code](https://claude.ai/code/session_017yph2sV9omJaDYZrev1yRm)_