### PR TITLE
feat(query-plans): complete capture phase analyze + display-decouple TODOs

### DIFF
--- a/_project/DONE/main/planning/query-plan-capture-display-decouple.yaml
+++ b/_project/DONE/main/planning/query-plan-capture-display-decouple.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-display-decouple
 title: "Decouple show_query_plans from capture_plans and remove dead display-during-capture path"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Core Functionality
 
 description: |
@@ -58,7 +58,7 @@ prior_art:
 work:
   - id: w1
     summary: "Add --show-plans CLI flag to benchbox run, wired to show_query_plans independently"
-    status: pending
+    status: done
     notes: |
       In benchbox/cli/commands/run.py add a --show-plans boolean flag (default False).
       Remove the coupling assignment:
@@ -73,7 +73,7 @@ work:
   - id: w2
     summary: "Update docs and --help to document --show-plans flag"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Add --show-plans to docs/reference/cli/run.md under the plan capture options
       section. Describe the distinction: --capture-plans persists to the result
@@ -82,7 +82,7 @@ work:
   - id: w3
     summary: "Add test asserting display fires when show_query_plans=True and capture_plans=False"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Unit test: create DuckDBAdapter with show_query_plans=True, capture_plans=False.
       Mock display_query_plan_if_enabled. Execute a SELECT. Assert the display
@@ -137,8 +137,23 @@ success_metrics:
   - "--capture-plans persists plans without displaying to console (display suppressed)."
   - "No double-EXPLAIN in any configuration."
 
+resolution: |
+  Completed. The CLI fix (w1) and docs (w2) landed via PR #800 ("add --show-plans
+  flag, decouple plan display from capture"): run.py:487 now reads
+  s.show_query_plans = s.show_plans (the coupling to capture_plans is gone), the
+  --show-plans flag is wired through benchbox/cli/dryrun.py and run.py, and
+  docs/reference/cli/run.md documents --show-plans. The display-suppressed-during-
+  capture guard (if not self.capture_plans: ...) is present in duckdb.py. The
+  tests (w3) were the residual gap and are added here in
+  tests/unit/platforms/test_duckdb_adapter.py:
+  test_show_plans_displays_without_capture (show_query_plans=True,
+  capture_plans=False -> display fires, capture does not) and
+  test_capture_no_display_suppresses_plan_display (capture_plans=True,
+  show_query_plans=False -> display suppressed, capture runs once). Verification
+  `pytest tests/unit/platforms/ -k 'show_plans or capture_no_display'` passes.
+
 metadata:
   tags: [query-plan, cli, display, decoupling, duckdb]
   estimated_effort: "Small"
   created_date: "2026-06-11"
-  last_updated: "2026-06-11T00:00:00-04:00"
+  last_updated: "2026-06-24T00:00:00-04:00"

--- a/_project/DONE/main/planning/query-plan-capture-phase-respect-analyze.yaml
+++ b/_project/DONE/main/planning/query-plan-capture-phase-respect-analyze.yaml
@@ -3,7 +3,7 @@ title: "Make the isolated capture phase respect analyze_plans (restore the ANALY
 worktree: main
 priority: High
 category: Core Functionality
-status: Not Started
+status: Completed
 
 description: |
   The isolated post-measurement capture phase wired in by the CLI/orchestrator
@@ -49,7 +49,7 @@ prior_art:
 work:
   - id: w1
     summary: "Thread analyze_plans from the adapter into the post-measurement phase call"
-    status: pending
+    status: done
     notes: |
       In _capture_plans_post_measurement pass analyze_plans=self.analyze_plans to
       run_plan_capture_phase. Confirm run_plan_capture_phase saves/restores the
@@ -57,7 +57,7 @@ work:
   - id: w2
     summary: "Verify the is_dml_query guard still downgrades writes under ANALYZE in the phase"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       With analyze_plans=True, a write statement (INSERT/UPDATE/DELETE/MERGE/COPY,
       CTAS/CMV/SELECT INTO) must NOT be re-executed by the capture EXPLAIN. Assert
@@ -66,7 +66,7 @@ work:
   - id: w3
     summary: "Tests: phase honours analyze_plans (ANALYZE plan vs estimate) on an eligible adapter"
     needs: [w1, w2]
-    status: pending
+    status: done
     notes: |
       Integration test on DuckDB: capture_plans=True + analyze_plans=True via the
       phase yields a plan whose physical operator carries timing; analyze_plans=False
@@ -74,7 +74,7 @@ work:
   - id: w4
     summary: "Re-correct docs to match restored behavior"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Update docs/features/query-plan-analysis.md: phase-eligible adapters capture
       ANALYZE plans by default (post-measurement, ~1x extra cost), analyze_plans=false
@@ -112,8 +112,26 @@ success_metrics:
   - "analyze_plans is the single effective capture-detail knob in both phase and inline paths."
   - "No write statement is executed twice during capture."
 
+resolution: |
+  Completed. The code fix (w1/w2) landed via PR #827 ("ratify canonical capture
+  contract and restore the analyze knob"):
+  _capture_plans_post_measurement now passes
+  analyze_plans=getattr(self, "analyze_plans", True) to run_plan_capture_phase,
+  and run_plan_capture_phase saves/restores the adapter's analyze_plans. The
+  is_dml_query guard keeps writes on a non-ANALYZE EXPLAIN even with
+  analyze_plans=True. Tests (w3) cover all three cases:
+  test_phase_honors_analyze_plans_true (ANALYZE -> per-operator timing),
+  test_phase_structural_only_when_analyze_disabled (estimate -> no timing), and
+  test_dml_executed_exactly_once (INSERT runs exactly once under the default
+  analyze_plans=True). Docs (w4) re-corrected here: the "Capture Isolation"
+  section of docs/features/query-plan-analysis.md no longer claims the phase is
+  structural-only; it now documents that the phase honours analyze_plans
+  (ANALYZE by default, ~1x extra cost outside the measured window) with the DML
+  downgrade. Verification `pytest tests/integration/test_plan_capture_phase.py
+  -k analyze` passes.
+
 metadata:
   tags: [query-plan, capture, isolation-phase, analyze, regression]
   estimated_effort: "Small"
   created_date: "2026-06-15"
-  last_updated: "2026-06-15T00:00:00-04:00"
+  last_updated: "2026-06-24T00:00:00-04:00"

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -93,14 +93,20 @@ the successfully-executed queries on the measurement connection and merges the r
 `plan_fingerprint` / `query_plan` back into each query result. This means:
 
 - **No EXPLAIN on the measurement path.** Plan capture never interleaves with a timed query or
-  holds the connection between measured queries.
-- **Structural-only capture.** The phase always uses non-`ANALYZE` `EXPLAIN`, so capture adds no
-  re-execution cost and the structural `plan_fingerprint` is unchanged. Captured plans therefore
-  carry estimated (not actual) operator cardinality/timing; the measured execution times in the
-  result bundle are the authoritative timings.
-- **DML runs exactly once.** Because the phase never uses `ANALYZE`, an
-  INSERT/UPDATE/DELETE/MERGE/COPY (or CTAS / `SELECT ... INTO`) query is captured without being
-  re-executed.
+  holds the connection between measured queries — the EXPLAIN pass runs strictly after the timed
+  loop, so measured per-query execution times are never inflated by capture cost.
+- **Honours `analyze_plans` — the single capture-detail knob.** With `analyze_plans=true`
+  (the default for these engines) the phase re-runs each SELECT once with `EXPLAIN (ANALYZE)`
+  *after* measurement, so captured plans carry actual per-operator timing and cardinality
+  (~1× extra query cost, outside the measured window). With
+  `--platform-option analyze_plans=false` the phase uses a static (non-`ANALYZE`) `EXPLAIN`,
+  giving estimated plans only with no re-execution cost (~1-5 ms). The structural
+  `plan_fingerprint` is identical either way (it excludes timing/cardinality by design); the
+  measured execution times in the result bundle remain the authoritative timings.
+- **DML runs exactly once.** Even with `analyze_plans=true`, an
+  INSERT/UPDATE/DELETE/MERGE/COPY (or CTAS / `SELECT ... INTO`) query is downgraded to a
+  non-`ANALYZE` `EXPLAIN` by the shared `is_dml_query` write guard, so writes are captured
+  without being re-executed a second time.
 - **Sampling honoured.** `--plan-queries`, `--plan-first-n`, and `--plan-sampling-rate` apply to
   the phase exactly as before.
 

--- a/tests/unit/platforms/test_duckdb_adapter.py
+++ b/tests/unit/platforms/test_duckdb_adapter.py
@@ -869,6 +869,62 @@ class TestDuckDBAdapter:
         assert isinstance(result["execution_time_seconds"], float)
 
     @patch("benchbox.platforms.duckdb.duckdb")
+    def test_show_plans_displays_without_capture(self, mock_duckdb):
+        """--show-plans is decoupled from --capture-plans.
+
+        With show_query_plans=True and capture_plans=False the plan is displayed
+        to the console but NOT captured into the result bundle, exercising the
+        flag decoupling (run.py no longer ties show_query_plans to capture_plans).
+        """
+        mock_connection = Mock()
+        mock_result = Mock()
+        mock_result.fetchall.return_value = [(1,)]
+        mock_connection.execute.return_value = mock_result
+        mock_duckdb.connect.return_value = mock_connection
+
+        adapter = DuckDBAdapter(show_query_plans=True, capture_plans=False)
+
+        with (
+            patch.object(adapter, "display_query_plan_if_enabled") as mock_display,
+            patch.object(adapter, "capture_query_plan") as mock_capture,
+        ):
+            result = adapter.execute_query(mock_connection, "SELECT 1", "q1")
+
+        assert result["status"] == "SUCCESS"
+        # Display fires for show_query_plans=True, capture_plans=False.
+        mock_display.assert_called_once()
+        # Capture must not run when capture_plans is False.
+        mock_capture.assert_not_called()
+
+    @patch("benchbox.platforms.duckdb.duckdb")
+    def test_capture_no_display_suppresses_plan_display(self, mock_duckdb):
+        """--capture-plans suppresses console display to avoid a double EXPLAIN.
+
+        With capture_plans=True and show_query_plans=False the plan is captured
+        into the result bundle but the display call is suppressed (the guard in
+        execute_query), so get_query_plan/EXPLAIN runs once, not twice.
+        """
+        mock_connection = Mock()
+        mock_result = Mock()
+        mock_result.fetchall.return_value = [(1,)]
+        mock_connection.execute.return_value = mock_result
+        mock_duckdb.connect.return_value = mock_connection
+
+        adapter = DuckDBAdapter(show_query_plans=False, capture_plans=True)
+
+        with (
+            patch.object(adapter, "display_query_plan_if_enabled") as mock_display,
+            patch.object(adapter, "capture_query_plan", return_value=(None, 0.0)) as mock_capture,
+        ):
+            result = adapter.execute_query(mock_connection, "SELECT 1", "q1")
+
+        assert result["status"] == "SUCCESS"
+        # Display suppressed while capturing (prevents the double-EXPLAIN path).
+        mock_display.assert_not_called()
+        # Capture runs exactly once.
+        mock_capture.assert_called_once()
+
+    @patch("benchbox.platforms.duckdb.duckdb")
     def test_get_query_plan(self, mock_duckdb):
         """Test query plan retrieval via EXPLAIN (ANALYZE, FORMAT JSON) / EXPLAIN (FORMAT JSON)."""
         mock_connection = Mock()


### PR DESCRIPTION
## Summary

Closes the two **Query-plan capture — Core Functionality** TODOs by finishing the residual doc/test work on top of the code that already landed in `develop`, then marking both TODOs `Completed` and moving them to `_project/DONE`.

While implementing, I found that the **code** for both TODOs had already merged into `develop` (not yet in `main`):
- `query-plan-capture-phase-respect-analyze` → PR #827 wired `analyze_plans` through `_capture_plans_post_measurement` → `run_plan_capture_phase`, with integration tests.
- `query-plan-capture-display-decouple` → PR #800 added `--show-plans`, removed the `show_query_plans = capture_plans` coupling, and added the display-suppressed-during-capture guard.

What was genuinely left undone were two work items, completed here.

## Changes

### `query-plan-capture-phase-respect-analyze` (w4 — docs)
The "Capture Isolation" section of `docs/features/query-plan-analysis.md` still described the phase as **structural-only / always non-`ANALYZE`**, contradicting the restored behavior. Re-corrected it: the phase honours `analyze_plans` (ANALYZE by default, ~1× extra cost **outside** the measured window; `analyze_plans=false` for estimates), with the `is_dml_query` write guard keeping DML on a non-`ANALYZE` EXPLAIN so writes are never re-executed.

### `query-plan-capture-display-decouple` (w3 — tests)
The dedicated unit tests were the missing piece. Added two tests in `tests/unit/platforms/test_duckdb_adapter.py`:
- `test_show_plans_displays_without_capture` — `show_query_plans=True, capture_plans=False` → display fires, capture does not.
- `test_capture_no_display_suppresses_plan_display` — `capture_plans=True, show_query_plans=False` → display suppressed, capture runs once (no double EXPLAIN).

### Bookkeeping
Both TODO YAMLs marked `status: Completed` (with resolution notes) and moved `_project/TODO → _project/DONE`.

## Verification
- `pytest tests/integration/test_plan_capture_phase.py -k analyze` ✅
- `pytest tests/unit/platforms/ -k 'show_plans or capture_no_display'` ✅
- `pytest tests/integration/test_plan_capture_phase.py tests/unit/platforms/test_duckdb_adapter.py` → 74 passed ✅
- `benchbox run --help-topic all` shows `--show-plans` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuvBqqKeDGhLixGRjSfpXK)_