### PR TITLE
todo: value-digest fidelity + oracle-map reference-independence follow-ups

### DIFF
--- a/_project/TODO/main/planning/correctness-gate-value-digest-fidelity-followups.yaml
+++ b/_project/TODO/main/planning/correctness-gate-value-digest-fidelity-followups.yaml
@@ -1,0 +1,269 @@
+id: correctness-gate-value-digest-fidelity-followups
+title: "Harden the bounded-gate value digest: precision floor, type-stability, independence, and auditable regeneration"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  An adversarial falsification review of the value-digest oracle (PR #867,
+  reviewed on develop @ e4a04484 — confirmed an ancestor of origin/develop, all
+  18 stored digests reproduced by running `make test-correctness-gate` on the
+  pinned DuckDB 1.3.2) confirmed the headline win is REAL: a wrong-but-same-
+  cardinality TPC-H answer at SF=1 now turns the gate RED, the check is CI-wired
+  as a hard blocker (.github/workflows/pr.yml correctness-gate job; the aggregator
+  requires CORRECTNESS_RESULT == success for any code PR), and #867's CI ran it
+  green for ~11.5 min (not skipped). The strict arming
+  (`digest_evaluated == digest_reference_count`) was reproduced locally to require
+  all 18 digests to evaluate and match, so a missing digest disarms RED not green.
+
+  The same review reproduced four residual fidelity gaps that the AI-implemented,
+  AI-reviewed, AI-merged chain did not surface. None is a correctness regression;
+  each narrows what "value-level" actually proves and should be either fixed or
+  honestly documented:
+
+  - PRECISION FLOOR IS ABSOLUTE, NOT RELATIVE (MEDIUM). The digest normalizes real
+    numbers with `f"{value:.4f}"` (benchbox/core/results/result_digest.py
+    _format_real, _DIGEST_FLOAT_PRECISION=4). Reproduced: an error <5e-5 ABSOLUTE
+    in any single cell is invisible regardless of column magnitude
+    (delta=4.9e-5 -> identical digest; 5.0e-5 -> differs). On large-magnitude
+    columns (TPC-H revenue ~1e10) 5e-5 absolute is ~1e-15 relative — effectively
+    perfect. But on small-magnitude averaged ratio columns it is coarse: Q1's
+    `avg_disc` is ~0.049985 (a float), so a sub-5e-5-absolute (~0.1% relative)
+    aggregate/rounding bug on that column survives the gate
+    (compute_result_digest([(0.05,)]) == compute_result_digest([(0.05004,)])).
+
+  - DIGEST CONFLATES VALUE WITH TYPE REPRESENTATION (LOW). _normalize_cell renders
+    int exactly ("1478493") but float/Decimal at fixed precision
+    ("37734107.0000"). The SAME numeric value with a different Python type hashes
+    DIFFERENTLY. Stable today on pinned DuckDB 1.3.2, but it means the digest is a
+    value+type-rendering digest, and it is the blocker for any cross-engine reuse.
+
+  - EMISSION IS ENGINE-WIDE BUT THE ORACLE IS DUCKDB-ONLY (LOW). compute_result_digest
+    is called both in benchbox/platforms/duckdb.py:999 AND in the shared DBAPI
+    helper benchbox/platforms/base/sql_execution.py:80 (sqlite/postgres/datafusion/
+    ...). It is harmless today — `_stored_value_digest` only returns a reference for
+    tpch SF=1, so a non-DuckDB digest is computed-but-never-compared — but combined
+    with the type-sensitivity above it is a latent trap for the cross-engine
+    independence work below, and it sits outside the original TODO's scope_limit
+    (benchbox/platforms/) by the implementer's own admission.
+
+  - THE VALUE REFERENCE IS A SELF-SNAPSHOT, NOT AN INDEPENDENT ORACLE, AND HAS NO
+    AUTOMATED REGENERATION (MEDIUM). The 18 reference digests in
+    benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json
+    were produced by running benchbox-on-DuckDB-1.3.2 and HAND-COPYING the emitted
+    digests (provenance note says exactly this; no script/make target writes the
+    file — grep confirms only loader.py reads it). So the oracle detects CHANGE
+    from the frozen baseline (a genuine regression tripwire) but NOT correctness vs
+    an authority outside benchbox: a conceptual value bug present at freeze time is
+    enshrined, never caught. This is the same hand-curated-answer-key fragility the
+    effort claimed to avoid, one level down. There is also no one-button
+    regeneration, so a legitimate DuckDB bump means a manual re-copy.
+
+  - THE NONE-SAFE SORT PATH IS UNTESTED BY THE GATE (LOW). calculate_checksum sorts
+    rows by the None-safe `_row_sort_key`. Reproduced: 0 of the 18 SF=1 gate result
+    sets contain a NULL or mixed-type column, so for the gate's inputs the None-safe
+    surrogate is order-identical to a plain sort and its NULL/mixed-type branch
+    never fires in the gate. (Note: the None-safe sort PREDATES #867 — it existed at
+    parent ce999bd7 — so #867 only promoted the helper to module level; this is a
+    coverage gap, not a #867 regression.)
+
+  This item fixes or honestly documents each gap. It is the fidelity complement to
+  the value axis shipped in bounded-correctness-gate-value-oracle (#867, DONE); it
+  does NOT re-do the digest emission, the strict arming, or the row-count work.
+
+prior_art:
+- "benchbox/core/results/result_digest.py:_format_real/_normalize_cell/_DIGEST_FLOAT_PRECISION — the absolute-precision
+  normalization to revisit for the precision-floor and type-stability work; extend, do not fork."
+- "benchbox/core/tpchavoc/validation.py:calculate_checksum/_row_sort_key — the promoted single-result digest primitive and
+  its None-safe sort; reuse for the None-coverage test, do not add a second hash."
+- "benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json — the hand-copied reference; the regeneration
+  target must WRITE this file deterministically from a gate run, replacing the manual copy described in its provenance note."
+- "benchbox/core/expected_results/loader.py:load_tpch_value_digests — the only reader of the JSON today; a regeneration writer
+  should live near it or as a _project/scripts tool."
+- "Makefile:test-correctness-gate (BENCHBOX_EMIT_RESULT_DIGEST=1, pinned seed 17039360, SF=1, 18 query ids) — the exact run
+  whose stream-0 digests become the reference; the regeneration target must reuse this configuration, not duplicate it."
+- "benchbox/platforms/base/sql_execution.py:80 + benchbox/platforms/duckdb.py:999 — the two emission sites; the engine-scope
+  and cross-engine-independence decisions touch both."
+- "_project/DONE/main/planning/bounded-correctness-gate-value-oracle.yaml — the effort this hardens; w3 already proved
+  sensitivity to gross mutations, w1 chose absolute rounding as a non-gating open question. This item revisits that choice
+  with the reproduced floor quantified."
+- "_project/analysis/REVIEW-PROTOCOL.md — where the self-snapshot-vs-independent-oracle distinction should be documented so a
+  future reviewer does not over-read a green value gate."
+
+work:
+- id: w1
+  summary: "Quantify the precision floor and decide absolute vs relative/significant-figure normalization"
+  status: pending
+  notes: |
+    Pin the reproduced floor as a test and make an explicit keep-or-change
+    decision. The floor is 5e-5 ABSOLUTE per cell: invisible below, visible at/above
+    (modulo round-half-even at the exact midpoint). Quantify it per gate column
+    class — large Decimals (revenue) are effectively perfect; small floats
+    (Q1 avg_disc ~0.05) are only ~0.1%-relative protected. Decide between:
+    (a) keep absolute 4dp and DOCUMENT the small-ratio blind spot with the worst
+    exposed column named; or (b) switch to N significant figures / a hybrid
+    max(absolute, relative) so sensitivity is uniform in relative terms, then
+    re-verify cross-build stability at the pinned seed and regenerate the reference
+    (w4). Record the decision and its rationale next to _format_real.
+  acceptance:
+  - "A unit test pins the exact sensitivity boundary (an error just below the floor is NOT caught; just above IS), referencing a real gate column."
+  - "An explicit keep-absolute-or-switch-to-relative decision is recorded with rationale; if switched, all 18 digests still reproduce deterministically across two runs."
+
+- id: w2
+  summary: "Make the digest stable across numeric TYPE representation (int vs float vs Decimal of equal value)"
+  needs: [w1]
+  status: pending
+  notes: |
+    Decide and implement: either canonicalize integer-valued numerics to one
+    representation before hashing (so int 37734107, Decimal('37734107.00'), and
+    float 37734107.0 hash identically) and likewise normalize dates/strings of
+    equal logical value, OR explicitly document that the digest is a value+type
+    digest and is therefore DuckDB-pinned. Type-stability is a prerequisite for the
+    cross-engine independence option in w5; if w5 is deferred, document instead.
+  acceptance:
+  - "Either: equal-value cells of differing numeric type produce the SAME digest (tested); or: the value+type coupling is documented at the digest primitive and in the reference JSON provenance with the reason it is acceptable for a DuckDB-pinned oracle."
+
+- id: w3
+  summary: "Add an auditable, one-command regeneration path that WRITES tpch_value_digests_sf1.json"
+  needs: [w1]
+  status: pending
+  notes: |
+    Replace the hand-copy described in the JSON provenance note with a script /
+    make target (e.g. `make correctness-gate-digests-regen`) that runs the gate
+    configuration (BENCHBOX_EMIT_RESULT_DIGEST=1, seed 17039360, SF=1, the 18 query
+    ids) and writes the digests + provenance block back to the JSON deterministically.
+    Reuse the Makefile:test-correctness-gate configuration rather than duplicating
+    the seed/scale/query-id list. The target must be idempotent on a clean tree
+    (regenerate -> no diff) and must stamp the DuckDB version it ran under.
+  acceptance:
+  - "`make correctness-gate-digests-regen` regenerates the reference JSON from a live gate run; on a clean tree it produces NO diff (idempotent)."
+  - "The seed/scale/query-id set is read from one source shared with `make test-correctness-gate`, not re-hardcoded."
+
+- id: w4
+  summary: "Document the oracle as a regression snapshot (not an independent correctness oracle) wherever it is described"
+  needs: [w3]
+  status: pending
+  notes: |
+    The Makefile note, tests/README, the JSON provenance, and REVIEW-PROTOCOL.md
+    should state plainly that the value digest detects CHANGE from a benchbox-on-
+    DuckDB baseline (a regression tripwire), not correctness against an external
+    authority, and that a conceptual value bug present at freeze time is enshrined,
+    not caught. This closes the over-trust gap a reader of a green "value+cardinality"
+    cell would otherwise fall into. Coordinate the wording with the
+    reference-independence axis in oracle-coverage-map-reference-independence-disclosure
+    so the gate docs and the coverage map tell one consistent story.
+  acceptance:
+  - "Every place the value digest is described names it a regression snapshot vs a DuckDB-pinned baseline, with the freeze-time-bug caveat stated explicitly."
+
+- id: w5
+  summary: "Decide and scope an INDEPENDENT value cross-check (cross-engine digest agreement at SF=1)"
+  needs: [w2]
+  status: pending
+  notes: |
+    The strongest available independence upgrade: once the digest is type-stable
+    (w2), assert that a SECOND SQL engine already in CI (postgres or datafusion)
+    produces the SAME stream-0 digests as DuckDB at SF=1/pinned seed for the 18
+    queries. Two independent engines agreeing on full result values is real
+    evidence of value correctness, not a self-snapshot. This requires engine-stable
+    rendering (dates, decimals, NULL-as-None vs NaN) and confronts the engine-wide
+    emission in sql_execution.py (the F finding). Scope it as either a new
+    non-blocking sample gate or a deferred follow-up; do NOT widen this TODO into
+    implementing a full cross-engine matrix.
+  acceptance:
+  - "A decision is recorded: implement a bounded cross-engine digest-agreement check (naming the engine and its CI seam) OR defer it with the concrete blockers (type/date/NULL rendering) enumerated."
+
+- id: w6
+  summary: "Cover the None-safe / mixed-type sort path that the gate never exercises"
+  status: pending
+  notes: |
+    Reproduced: 0 of 18 SF=1 gate result sets contain NULL or mixed-type columns,
+    so calculate_checksum's None-safe `_row_sort_key` branch is untested by the
+    gate. Add (or confirm existing) unit coverage in the tpchavoc validation tests
+    that a NULL-bearing and a mixed-type column hash deterministically and never
+    raise, so a latent ordering bug in None handling cannot hide behind the gate's
+    NULL-free inputs. Pure test addition — no production change.
+  acceptance:
+  - "A unit test exercises calculate_checksum on NULL-bearing and mixed-type rows, asserting a stable, deterministic digest and no TypeError; the test fails if the None-safe surrogate is removed."
+
+deferred:
+- summary: "Backfill value digests for benchmarks beyond tpch, or for scales above SF=1."
+  reason: "Out of scope; breadth is owned by benchmark-correctness-oracle-coverage-map. This item is about the FIDELITY of the
+    existing tpch SF=1 value oracle, not its breadth."
+- summary: "A full cross-engine value-equivalence matrix across all CI engines."
+  reason: "w5 decides whether to add ONE bounded cross-engine agreement check or defer; a full matrix is a separate, larger effort
+    (cf. tpchavoc-*-engine-equivalence-sampling)."
+
+must_preserve:
+- "The #867 value axis is unchanged: digest emission behind BENCHBOX_EMIT_RESULT_DIGEST, the strict arming (digest_evaluated == digest_reference_count), and the additive row-count check keep working exactly as today."
+- "`benchbox run` default behavior, payload shape, and cost stay unchanged when the digest flag is unset (digest emission stays gate-only)."
+- "The TPC-Havoc gates that share calculate_checksum stay green — reuse the one digest definition, never fork it."
+- "`make test-correctness-gate` stays green on a correct tree and on the required PR path after any normalization change (regenerate the reference in the same change)."
+
+approach: |
+  Treat this as fidelity hardening of an already-shipped, CI-enforced oracle, not a
+  rebuild. Sequence: (w1) quantify the precision floor as a test and decide
+  absolute-vs-relative; (w2) make the digest type-stable (prerequisite for
+  independence); (w3) replace the hand-copy with an idempotent regeneration target;
+  (w4) document the regression-snapshot nature so green cells are not over-read;
+  (w5) decide whether a cross-engine agreement check is worth it now; (w6) cover the
+  None-safe sort path the gate never hits. Any change to normalization MUST
+  regenerate the 18 reference digests in the same change and prove two-run
+  determinism, or the gate will go RED on a correct tree.
+
+anti_patterns:
+- "DO NOT switch to relative precision without re-verifying cross-build stability at the pinned seed and regenerating the reference — because a naive relative rounding near zero can be LESS stable than absolute — verify in w1, regenerate in the same change."
+- "DO NOT enable cross-engine digest comparison before w2 — because the int-vs-Decimal-vs-float and date/NULL rendering differences guarantee spurious mismatches — make the digest type/engine-stable first."
+- "DO NOT add a second hash or a per-engine digest variant — because calculate_checksum is the one shared definition the TPC-Havoc gates also use — extend the single primitive."
+- "DO NOT leave the reference regenerable only by hand-copy — because an oracle no one can reproduce is the fragility this effort claimed to remove — ship a deterministic writer."
+- "DO NOT describe the value digest as proving 'correctness' — because it is a regression snapshot vs a DuckDB baseline — call it that everywhere it is documented."
+
+verification:
+- description: "Bounded gate stays green and the digest assertion still arms for all 18 queries after any normalization change"
+  command: "make test-correctness-gate"
+  expected_output: "1 passed, ran=1 skipped=0; row-count and value-digest checks evaluated for all 18 queries"
+- description: "The precision-floor test pins the exact sensitivity boundary"
+  command: "uv run -- python -m pytest tests/unit/test_correctness_gate_value_oracle.py -q"
+  expected_output: "tests pass; an error just below the floor is uncaught and just above is caught, per the pinned assertion"
+- description: "The regeneration target is idempotent on a clean tree"
+  command: "make correctness-gate-digests-regen && git diff --exit-code benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json"
+  expected_output: "no diff (regeneration reproduces the committed reference byte-for-byte)"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/"
+  - "benchbox/core/expected_results/"
+  - "benchbox/core/tpchavoc/"
+  - "benchbox/platforms/"
+  - "tests/"
+  - "Makefile"
+  - "_project/"
+  - "docs/"
+
+success_metrics:
+- "The digest's value sensitivity is quantified and either uniform in relative terms or its small-ratio blind spot is documented with the worst exposed column named."
+- "Equal-value cells of differing numeric type either hash identically or the value+type coupling is documented as a DuckDB-pinned constraint."
+- "The 18 reference digests are reproducible by one command that writes the file idempotently — no hand-copy."
+- "Every description of the value digest names it a regression snapshot vs a DuckDB baseline, not an independent correctness oracle."
+- "A decision is recorded on whether a cross-engine independence check is added now or deferred with concrete blockers."
+
+open_questions:
+- question: "Absolute 4-decimal vs N-significant-figure normalization: the absolute floor is effectively perfect on large columns and only ~0.1%-relative coarse on small averaged ratios (Q1 avg_disc). Is the small-ratio exposure worth the cross-build-stability risk of relative rounding?"
+  gating: true
+  affects: ["w1 normalization decision", "w3 reference regeneration"]
+  default: "Keep absolute 4dp for stability and DOCUMENT the small-ratio blind spot (naming avg_disc) unless w1 finds a hybrid max(absolute, relative) that is provably as stable across the pinned DuckDB at the reference seed."
+- question: "Is a cross-engine (DuckDB vs postgres/datafusion) digest-agreement check the right independence upgrade, or does engine rendering divergence make it more noise than signal?"
+  gating: false
+  affects: ["w5 independence decision"]
+  default: "Decide in w5 after w2 makes the digest type-stable; if rendering divergence (dates, decimals, NULL-vs-NaN) cannot be normalized cheaply, defer with the blockers enumerated rather than shipping a flaky cross-engine gate."
+
+# No hard deps.needs: w1-w3 (precision floor, type-stability, regeneration) are
+# independent of the coverage-map work and must not be blocked behind it. The only
+# cross-item coupling is w4's wording, captured as a soft coordination note in w4
+# and prior_art instead of a hard ordering edge.
+
+metadata:
+  tags: [correctness, oracle, value-digest, tpch, precision, regression-snapshot, ci, testing]
+  estimated_effort: "Medium"
+  created_date: "2026-06-24"
+  last_updated: "2026-06-24T00:00:00"

--- a/_project/TODO/main/planning/oracle-coverage-map-reference-independence-disclosure.yaml
+++ b/_project/TODO/main/planning/oracle-coverage-map-reference-independence-disclosure.yaml
@@ -1,0 +1,223 @@
+id: oracle-coverage-map-reference-independence-disclosure
+title: "Add a REFERENCE-INDEPENDENCE axis to the oracle coverage map so 'value-level' does not over-promise"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  An adversarial falsification review of the oracle coverage-map disclosure work
+  (PR #867, reviewed on develop @ e4a04484 — an ancestor of origin/develop) found
+  that the Strength + Scale columns shipped in oracle-coverage-map-strength-disclosure
+  (#867, DONE) are honest as far as they go (the drift check, the derived-not-
+  hardcoded strength, and the staged-vs-enforced Enforced column all survived
+  attack), but the taxonomy omits the single axis that most determines how much a
+  green cell can be trusted: whether the oracle compares against an INDEPENDENT
+  reference or against itself.
+
+  Reproduced facts (verified by reading
+  _project/scripts/generate_oracle_coverage_map.py and the committed
+  _project/analysis/oracle-coverage-map.md on develop):
+
+  - The Strength taxonomy is exactly {value-level, cardinality-only,
+    value+cardinality}. oracle_strength_and_scale returns STRENGTH_VALUE
+    ("value-level") as an UNCONDITIONAL CONSTANT for every cross-surface / variant
+    gate. It encodes WHAT is compared (full values vs row counts), never WHETHER
+    the reference is independent of the system under test.
+  - The cells labelled "value-level" — ssb / amplab / coffeeshop / clickbench
+    (cross-surface) — are SQL-vs-DataFrame self-comparisons: both surfaces derive
+    from the same shared spec, so the SQL surface is effectively the reference for
+    its own DataFrame surface. A parallel review found these catch transcription,
+    not conceptual, bugs.
+  - tpch's "value+cardinality" is ALSO self-referential on the value axis: the
+    reference digests were produced by running benchbox-on-DuckDB and frozen (see
+    correctness-gate-value-digest-fidelity-followups). So even the strongest cell
+    in the map is a regression snapshot, not an independent value oracle.
+  - Net effect: a reader who sees "value-level" reasonably infers "values are
+    proven correct" and may skip manual inspection — the exact coverage-theater the
+    map was built to remove, re-introduced one abstraction up. The map's honesty
+    about the registered-vs-enforced axis makes this gap MORE likely to be missed,
+    because the reader has already been taught the map is candid.
+
+  Two smaller disclosure defects from the same review:
+
+  - SF>1 VALUE-BLINDNESS NEEDS TWO COLUMNS TO SEE (NIT). tpch reads
+    "value+cardinality | SF=1". The prose does say "tpch/tpcds values are unguarded
+    above SF=1", but the table ROW alone (Strength without reading the Scale cell)
+    lets a skimmer conclude tpch values are guarded generally. The most-run scale
+    (SF>1) is value-blind and the row cell does not say so on its own.
+
+  - PROVENANCE SHA IS ORPHANED BY SQUASH-MERGE (NIT). The committed map stamps
+    `revision: ddd96c47...` in its drift-ignored provenance header. Reproduced:
+    that SHA is `git cat-file` "bad object" / unreachable from any ref — it was the
+    pre-squash PR-branch HEAD, discarded when #867 landed as a squash. The stamp
+    meant to let a reader locate the generation point points to a commit that does
+    not exist in history. (The same squash-orphaning explains why this review's
+    own brief cited merge SHAs f411d522/a0c62631 that are absent here; the squash
+    landed as e4a04484.)
+
+  This item adds a reference-independence axis to the map, makes the SF>1 value gap
+  unmissable from a single row, and makes the provenance stamp survive squash-merge.
+  SCOPE BOUNDARY: it does NOT re-do the Strength/Scale/Enforced columns (#867, DONE),
+  does NOT close UNGUARDED breadth (benchmark-correctness-oracle-coverage-map), and
+  does NOT touch the registered-vs-verified-green axis (cross-surface-oracle-remediation).
+
+prior_art:
+- "_project/scripts/generate_oracle_coverage_map.py:oracle_strength_and_scale/build_coverage_map/render_markdown — the generator
+  to extend with an independence axis; keep it derived from live sources, no hand-maintained label."
+- "_project/scripts/generate_oracle_coverage_map.py:STRENGTH_VALUE/STRENGTH_CARDINALITY/STRENGTH_VALUE_AND_CARDINALITY — the
+  current taxonomy constants; the independence axis is ORTHOGONAL to these (a value-level oracle can be independent or self-referential),
+  so add a new column, do not overload Strength."
+- "tests/unit/test_oracle_coverage_map.py:test_known_oracle_strength_and_scale_truth/test_expected_results_strength_is_derived_not_hardcoded
+  — the classifier-truth pattern to extend with independence assertions."
+- "_project/analysis/oracle-coverage-map.md — the committed artifact whose provenance header carries the orphaned SHA; the
+  _PROVENANCE region / _current_git_sha in the generator is where the stamp is produced."
+- "_project/DONE/main/planning/oracle-coverage-map-strength-disclosure.yaml — the effort this layers onto; reuse its derived-from-live-sources
+  discipline and its drift-ignored-provenance design; do NOT re-do Strength/Scale."
+- "_project/DONE/main/planning/bounded-correctness-gate-value-oracle.yaml — establishes that tpch's value reference is a frozen
+  benchbox snapshot, which is why even value+cardinality is self-referential on the value axis."
+- "_project/analysis/REVIEW-PROTOCOL.md — the protocol note that should also carry the squash-orphans-provenance-SHA lesson."
+
+work:
+- id: w1
+  summary: "Add a REFERENCE-INDEPENDENCE axis derived from live sources (independent vs self-referential/shared-spec)"
+  status: pending
+  notes: |
+    Classify each guarded oracle on a new axis orthogonal to Strength: does it
+    compare against a reference INDEPENDENT of the system under test, or against
+    itself? Derive from live sources, not a hand label:
+      - cross-surface (ssb/amplab/coffeeshop/clickbench): self-referential
+        (SQL surface is the reference for its own DataFrame surface; shared spec).
+      - tpch value digests: self-referential on the value axis (frozen benchbox-on-
+        DuckDB snapshot — probe the digest provenance/source).
+      - row-count answers (tpch/tpcds cardinality): semi-independent (TPC answer-set
+        cardinalities) — label honestly, do not overstate.
+    Render it as a distinct column in oracle-coverage-map.md and a field in the
+    .json so a reader sees that "value-level" on ssb means "self-referential value
+    comparison", not "values proven against an authority".
+  acceptance:
+  - "The generated map shows a reference-independence column; cross-surface cells read self-referential, the tpch value digest reads self-referential (regression snapshot), derived from live sources not hard-coded per benchmark."
+  - "The drift check (`make oracle-coverage-map-check`) is green on a clean tree with the new column."
+
+- id: w2
+  summary: "Make the SF>1 value-blindness unmissable from a single table row"
+  needs: [w1]
+  status: pending
+  notes: |
+    A reader scanning only the Strength column must not conclude tpch values are
+    guarded generally. Make the row self-contained — e.g. render Strength as
+    "value+cardinality (SF=1 only; values UNGUARDED above SF=1)" or add an explicit
+    marker — so the value gap is visible without cross-referencing the Scale cell
+    or the prose. Keep it generated/derived (the loader already raises above SF=1),
+    not a hand-typed caveat.
+  acceptance:
+  - "The tpch row alone (without reading the Scale column or prose) makes clear that values are guarded only at SF=1 and unguarded above it."
+
+- id: w3
+  summary: "Make the provenance stamp survive squash-merge (no orphaned/unreachable SHA)"
+  needs: [w1]
+  status: pending
+  notes: |
+    Reproduced: the committed provenance `revision:` points to a pre-squash
+    PR-branch commit that is unreachable after squash-merge. Replace the volatile
+    PR-branch HEAD stamp with something a reader can actually resolve on develop:
+    e.g. stamp the merge-base with origin/develop, or a content hash of the
+    source registries, or omit the SHA in favor of a "regenerate to verify"
+    instruction — whatever stays meaningful after a squash. The stamp MUST remain
+    in the drift-IGNORED region so `--check` does not churn (the #867 design
+    constraint). Record the squash-orphans-SHA lesson in REVIEW-PROTOCOL.md so
+    future analysis artifacts and reviews do not pin a SHA that the squash discards.
+  acceptance:
+  - "The coverage-map provenance stamp resolves to a commit reachable from develop (or is a content hash / regenerate-to-verify note), never a dangling PR-branch SHA."
+  - "`make oracle-coverage-map-check` still passes across two successive commits (the new stamp did not enter the drift-compared body)."
+  - "REVIEW-PROTOCOL.md documents that squash-merge orphans PR-branch SHAs, so provenance must use a develop-reachable or content-derived stamp."
+
+- id: w4
+  summary: "Pin the new axes with classifier-truth tests so they cannot silently regress"
+  needs: [w1, w2]
+  status: pending
+  notes: |
+    Extend tests/unit/test_oracle_coverage_map.py the way #867 pinned Strength/Scale:
+    assert the reference-independence label of each known oracle (cross-surface =
+    self-referential; tpch value = self-referential snapshot; row counts =
+    semi-independent), and that it is derived (flip the live signal -> label flips),
+    plus assert the SF>1 disclosure is present in the tpch row. This is the truth
+    check the drift check lacks for the new axis.
+  acceptance:
+  - "A classifier-truth test asserts the independence label of each known oracle and fails if a future change mislabels one or removes the SF>1 disclosure from the tpch row."
+
+deferred:
+- summary: "Closing the 15 UNGUARDED benchmarks or adding new oracles."
+  reason: "Owned by benchmark-correctness-oracle-coverage-map (breadth). This item improves DISCLOSURE quality of the already-guarded
+    cells, not coverage."
+- summary: "The 'registered vs verified-green' (Enforced) axis."
+  reason: "Already shipped (#867) and coordinated with cross-surface-oracle-remediation; the independence axis is orthogonal and
+    must not overload or duplicate it."
+- summary: "Building an actual independent value oracle for any benchmark."
+  reason: "That is correctness-gate-value-digest-fidelity-followups w5 (cross-engine agreement). This item only DISCLOSES the
+    independence status, it does not change any oracle's strength."
+
+must_preserve:
+- "The map stays GENERATED from live sources — no hand-maintained classification — so it cannot drift from reality."
+- "The existing Strength/Scale/Enforced columns and the drift check stay exactly as #867 shipped them; the independence axis is an ADDITIVE column."
+- "The drift check (`make oracle-coverage-map-check`) stays green on a clean tree and on the required PR path; the new column and the new provenance stamp must regenerate deterministically and stay out of the drift-compared body."
+
+approach: |
+  Layer one orthogonal column (reference-independence) onto the existing generated
+  map, derived from live sources exactly like Strength/Scale, plus two small
+  honesty fixes (self-contained SF>1 disclosure in the tpch row, squash-survivable
+  provenance stamp). Sequence: (w1) independence column; (w2) unmissable SF>1
+  disclosure; (w3) provenance stamp that survives squash + protocol note; (w4) a
+  classifier-truth test for the new axis. Keep everything that touches the
+  drift-compared body deterministic so `--check` does not churn.
+
+anti_patterns:
+- "DO NOT overload the Strength column with independence — because a value-level oracle can be independent OR self-referential — add a separate orthogonal column."
+- "DO NOT hand-label independence per benchmark — because it would rot like a hand-maintained doc — derive it from the gate identity (cross-surface = self-referential) and the digest provenance (frozen snapshot)."
+- "DO NOT put the provenance SHA in the drift-compared region — because `--check` would fail on every commit (the #867 constraint) — keep it in the ignored header."
+- "DO NOT re-stamp the volatile PR-branch HEAD — because squash-merge orphans it — use a develop-reachable SHA, a content hash, or a regenerate-to-verify note."
+- "DO NOT widen scope into closing UNGUARDED benchmarks or changing any oracle's actual strength — this item only DISCLOSES independence."
+
+verification:
+- description: "Map shows the independence column and the self-contained SF>1 disclosure, and is internally consistent"
+  command: "make oracle-coverage-map && make oracle-coverage-map-check"
+  expected_output: "regenerates with the independence column and SF>1 disclosure; --check reports up to date"
+- description: "Classifier-truth test catches a mislabeled independence value"
+  command: "uv run -- python -m pytest tests/unit/test_oracle_coverage_map.py -q"
+  expected_output: "tests pass; flipping a known oracle's independence label fails the new assertion"
+- description: "The new provenance stamp resolves on develop and does not churn the drift check"
+  command: "make oracle-coverage-map-check"
+  expected_output: "up to date; the stamped revision is resolvable from origin/develop (or is a content hash / note, not a dangling SHA)"
+
+scope_limit:
+  only_modify:
+  - "_project/scripts/generate_oracle_coverage_map.py"
+  - "_project/analysis/"
+  - "tests/unit/test_oracle_coverage_map.py"
+  - "_project/"
+  - "docs/"
+
+success_metrics:
+- "Every guarded cell discloses whether its oracle is independent or self-referential, derived from live sources."
+- "A reader can no longer mistake a self-referential 'value-level' cell for proof of value correctness."
+- "The tpch row alone makes the SF>1 value gap unmissable, without cross-referencing the Scale cell."
+- "The coverage-map provenance stamp survives squash-merge (resolvable on develop or content-derived), and the protocol note records the lesson."
+- "A classifier-truth test fails if any new-axis label is wrong."
+
+open_questions:
+- question: "How should reference-independence be derived for cross-surface gates without hand-labelling — from the gate's identity (cross-surface implies shared-spec self-reference) or from a per-gate metadata flag?"
+  gating: false
+  affects: ["w1 independence derivation"]
+  default: "Derive from the oracle KIND (cross-surface / variant-equivalence -> self-referential; expected-results value digest -> self-referential snapshot; row-count answers -> semi-independent) so it tracks the classifier without a new hand-maintained field."
+
+# No hard deps.needs: the generator already exists and this disclosure work is
+# independent of the breadth campaign (benchmark-correctness-oracle-coverage-map)
+# and the gate-fidelity work. correctness-gate-value-digest-fidelity-followups w4
+# coordinates its regression-snapshot wording with this item's independence axis,
+# but neither blocks the other; coordination is captured in prior_art instead.
+
+metadata:
+  tags: [correctness, oracle, coverage, disclosure, reference-independence, provenance, governance, ci]
+  estimated_effort: "Small"
+  created_date: "2026-06-24"
+  last_updated: "2026-06-24T00:00:00"


### PR DESCRIPTION
## What

Two **planning TODOs** authored from an adversarial falsification review of the value-digest oracle effort (PR #867, reviewed on develop @ `e4a04484` — confirmed an ancestor of `origin/develop`; all 18 stored digests reproduced by running `make test-correctness-gate` on the pinned DuckDB 1.3.2, and the `correctness-gate` CI check was confirmed green on #867). Planning only — **no production code changes**.

The review confirmed the headline win is real (a wrong-but-same-cardinality TPC-H answer at SF=1 now turns the gate RED, CI-enforced as a hard blocker), but reproduced residual fidelity/disclosure gaps that the AI-planned/implemented/reviewed/merged chain did not surface. These TODOs capture the fixes.

### `correctness-gate-value-digest-fidelity-followups.yaml`
- **Precision floor (MEDIUM):** the digest normalizes reals with `f"{v:.4f}"` — an **absolute** floor. Reproduced: an error `<5e-5` absolute is invisible regardless of magnitude. Perfect on large revenue columns, but only ~0.1%-relative protected on small averaged ratios (Q1 `avg_disc ≈ 0.049985`). w1 quantifies it as a test and decides absolute-vs-relative.
- **Type-representation sensitivity (LOW):** equal numeric values of differing Python type (int vs Decimal vs float) hash differently. w2 makes it type-stable (prerequisite for independence).
- **Self-snapshot + no auto-regeneration (MEDIUM):** the 18 reference digests are hand-copied benchbox-on-DuckDB output, not an independent oracle, with no writer script. w3 ships an idempotent regeneration target; w4 documents it honestly as a regression snapshot.
- **Independence upgrade (w5)** and **None-safe sort coverage (w6, LOW)** — 0/18 SF=1 result sets contain NULL, so that branch is untested by the gate.

### `oracle-coverage-map-reference-independence-disclosure.yaml`
- **No reference-independence axis (MEDIUM):** "value-level" is an unconditional constant; cross-surface (ssb/amplab/coffeeshop/clickbench) gates are SQL-vs-DataFrame self-comparisons and tpch's value digest is a frozen snapshot. w1 adds an orthogonal independence column so a green cell is not over-read.
- **SF>1 value gap (NIT):** w2 makes it unmissable from a single `tpch` row (not just prose + Scale cell).
- **Orphaned provenance SHA (NIT):** the committed map stamps `revision: ddd96c47…`, which is unreachable after squash-merge. w3 makes the stamp squash-survivable and records the lesson in `REVIEW-PROTOCOL.md`.

## Verification
- Both files pass `validate_todo.py` against `TODO_SCHEMA.yaml`.
- Full `validate_todo.py --all` (1148 files) clean; `todo_cli.py check-graph` clean (no cycles / dangling refs / duplicate IDs).
- No hard `deps.needs` added — the independent work units are not artificially blocked; cross-item wording coordination is captured as soft notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2c7je1zhJh3dASyZJjJVY)_