### PR TITLE
fix(equivalence): boundary-tie probe for one-visible-row LIMIT ties (w1)

### DIFF
--- a/_project/DONE/main/planning/cross-surface-comparator-boundary-tie-soundness.yaml
+++ b/_project/DONE/main/planning/cross-surface-comparator-boundary-tie-soundness.yaml
@@ -2,7 +2,8 @@ id: cross-surface-comparator-boundary-tie-soundness
 title: "Cross-surface comparator: make the final-tie-group guard boundary-aware (one-visible-row LIMIT ties)"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
+completed_date: "2026-06-24"
 category: Testing and Quality Assurance
 
 description: |
@@ -50,7 +51,7 @@ prior_art:
 work:
   - id: w1
     summary: "Give the comparator a boundary-tie probe so a one-visible-row final tie is not a false positive"
-    status: pending
+    status: done
     notes: |
       The comparator needs signal it does not have today to tell a truncated
       boundary tie from a genuine deterministic last row. Candidate approaches,
@@ -67,6 +68,27 @@ work:
       single-row value bugs. Add a regression test for the keys `10,5,5`
       `LIMIT 2` boundary-tie case (currently a false positive) alongside the
       existing `(2,"good")` vs `(2,"bad")` true-positive case.
+
+      RESOLVED: took the first approach (LIMIT N+1 probe). The cross-surface gate
+      now re-runs each trailing-LIMIT order-aware query one row wider
+      (`cross_surface._bump_trailing_limit` / `_final_key_tied_beyond_limit`) and
+      threads `final_key_tied_beyond_limit` into
+      `ResultValidator.validate_results_exact`. `_validate_order_aware` accepts a
+      single-visible-row final tie group ONLY when that probe confirms the final
+      order key recurs past the cutoff; otherwise the lone row is treated as a
+      deterministic last row and a value change there is still CAUGHT. The same
+      change also lands #878's `len(orig_rows) >= 2` tightening of the order-aware
+      final-group accept (#878 was still open against develop), so a >= 2-row
+      visible tie remains an accepted boundary swap. ADDITIVE: callers that pass
+      neither `order_aware` nor `tie_aware` (the TPC-Havoc strict path) are
+      untouched - verified 220/220 variant and 440/440 DataFrame equivalence, and
+      all five enforced cross-surface gates green (0 unclassified divergent). The
+      probe runs once per query (memoized across backends). Regression tests:
+      tests/integration/test_validator_order_aware.py (one-visible-row tie accepted
+      with the probe, caught without; the `(2,"good")` vs `(2,"bad")` unique-key
+      bug still raises) and tests/unit/core/equivalence/test_cross_surface.py
+      (`_bump_trailing_limit`, `_final_key_tied_beyond_limit`, and the end-to-end
+      gate accept/catch cases).
 
 deferred:
   - summary: "Reworking the gate to compare untruncated result sets generally"

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -95,7 +95,22 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # gated benchmark, never a full platform matrix).
 EQUIVALENCE_SCALE = 0.1
 
-_TRAILING_LIMIT_RE = re.compile(r"(?is)\blimit\s+\d+\s*(?:offset\s+\d+\s*)?;?\s*$")
+# Captures a trailing ``LIMIT n`` so it can be both DETECTED (truncated top-N) and
+# REWRITTEN one row wider (the boundary-tie probe). Group 1 is ``limit `` (original
+# case/spacing), group 2 the integer, group 3 any OFFSET / statement terminator /
+# trailing whitespace - reassembled verbatim so only the count changes.
+_TRAILING_LIMIT_RE = re.compile(r"(?is)(\blimit\s+)(\d+)(\s*(?:offset\s+\d+\s*)?;?\s*)$")
+_TRAILING_COMMENT_RE = re.compile(r"\s*--[^\n]*$")
+
+
+def _strip_trailing_comment(sql: str) -> str:
+    """Strip a trailing ``-- line comment`` and surrounding whitespace from ``sql``.
+
+    Shared by the trailing-``LIMIT`` detector and rewriter so ``... limit 10 -- note``
+    is handled identically by both. Removing a trailing comment never changes query
+    semantics, so the stripped form is still valid SQL to execute.
+    """
+    return _TRAILING_COMMENT_RE.sub("", sql.strip())
 
 
 def _is_truncated_top_n(sql: str) -> bool:
@@ -109,8 +124,86 @@ def _is_truncated_top_n(sql: str) -> bool:
     everything else uses the strict comparator. A trailing line comment /
     statement terminator is stripped first so ``... limit 10 -- note`` matches.
     """
-    stripped = re.sub(r"\s*--[^\n]*$", "", sql.strip())
-    return bool(_TRAILING_LIMIT_RE.search(stripped))
+    return bool(_TRAILING_LIMIT_RE.search(_strip_trailing_comment(sql)))
+
+
+def _bump_trailing_limit(sql: str) -> str | None:
+    """Return ``sql`` with its trailing ``LIMIT n`` raised to ``LIMIT n+1``, or None.
+
+    The boundary-tie probe (:func:`_final_key_tied_beyond_limit`) needs exactly one
+    row PAST the original top-N cutoff to learn whether the final order key ties
+    across it. Raising the trailing ``LIMIT`` by one row does that while preserving
+    any ``OFFSET`` (the window simply widens by one at its end), statement
+    terminator, and trailing comment, so the probe is the same query plus one row.
+    Returns None when no trailing numeric ``LIMIT`` is present (the caller then
+    skips the probe and stays strict).
+    """
+    stripped = _strip_trailing_comment(sql)
+    match = _TRAILING_LIMIT_RE.search(stripped)
+    if match is None:
+        return None
+    bumped = int(match.group(2)) + 1
+    return f"{stripped[: match.start()]}{match.group(1)}{bumped}{match.group(3)}"
+
+
+def _final_key_tied_beyond_limit(
+    connection: Any,
+    sql: str,
+    order_by: Sequence[int],
+    reference: list[tuple[Any, ...]],
+) -> bool:
+    """True if the reference's final ORDER BY key value recurs past the LIMIT cutoff.
+
+    A trailing-``LIMIT`` top-N can cut across a tie in the order key, leaving only a
+    SUBSET of the rows that share the worst-kept key value. When exactly ONE such
+    row stays visible, the truncated result alone cannot tell that legitimate
+    boundary tie apart from a deterministic unique final row, so the comparator
+    would either mask a real single-row value bug or false-positive a valid tie pick
+    (the soundness gap this probe closes). The probe supplies the missing signal: it
+    re-runs the query one row wider (``LIMIT n+1``) and reports whether the row JUST
+    past the original cutoff carries the SAME order-key value as the last row inside
+    it. If so, the final key is genuinely tied across the cutoff and a
+    single-visible-row final-group difference is an equally-valid boundary pick; if
+    not (or there is no row past the cutoff), the final row is deterministic.
+
+    Returns False on any condition that makes the probe unsound, unnecessary, or
+    impossible - an empty reference, an out-of-range order key, a final tie group
+    that already spans >= 2 visible rows (accepted as a boundary swap without the
+    probe), an un-rewritable ``LIMIT``, or a probe-query failure - so the caller
+    keeps the strict default and the worst case is a (loud, recoverable) caught
+    mismatch, never a masked bug.
+    """
+    if not reference or not order_by:
+        return False
+    n = len(reference)
+    width = len(reference[-1])
+    if any(c < 0 or c >= width for c in order_by):
+        return False
+    # The order-aware relaxation reads this probe ONLY for a single-visible-row final
+    # tie group; a final group that already spans >= 2 rows is accepted as a boundary
+    # swap without it. So when the reference's own final group is already >= 2 rows,
+    # the result would be ignored - skip the extra LIMIT n+1 query entirely.
+    final_key = tuple(reference[-1][c] for c in order_by)
+    if n >= 2 and tuple(reference[-2][c] for c in order_by) == final_key:
+        return False
+    probe_sql = _bump_trailing_limit(sql)
+    if probe_sql is None:
+        return False
+    try:
+        probe = fetch_reference_rows(connection, probe_sql)
+    except Exception:  # noqa: BLE001 - a failed probe must not crash the gate; stay strict
+        return False
+    # No row past the original cutoff -> the final visible row is the true last row,
+    # so its key is not tied beyond the LIMIT.
+    if len(probe) <= n or len(probe[n]) <= max(order_by):
+        return False
+    # The first n probe rows are the original window (same deterministic ORDER BY key
+    # sequence as the reference), so probe[n] is the first row PAST the cutoff. The
+    # final key ties across the cutoff iff probe[n] carries that same key. Both values
+    # come from the same DuckDB result, so exact equality is the right within-result
+    # tie test (the comparator's cross-engine float tolerance does not apply here).
+    key_beyond = tuple(probe[n][c] for c in order_by)
+    return final_key == key_beyond
 
 
 def _is_star_projection(projection: Any) -> bool:
@@ -360,6 +453,28 @@ def find_cross_surface_divergences(
         # order-insensitive comparison rather than a silent order-blind "pass".
         order_by = _order_by_result_key(sql)
         order_aware = order_by is not None
+        # Boundary-tie probe, computed at most once per query (lazily, on the first
+        # backend's reference, then memoized): a trailing LIMIT can leave just ONE
+        # row of a final order-key tie visible, which the truncated result alone
+        # cannot tell apart from a deterministic unique last row. For an order-aware
+        # truncated top-N, learn whether that final key genuinely ties PAST the cutoff
+        # so the comparator accepts a single-visible-row boundary swap but still
+        # catches a real unique-final-key value bug. Every backend of a query shares
+        # the SAME reference, so the extra LIMIT n+1 query runs once, not per backend.
+        probe_result: bool | None = None  # None = not yet computed (memo sentinel)
+
+        def final_key_tied(reference: list[tuple[Any, ...]]) -> bool:
+            nonlocal probe_result
+            if probe_result is None:
+                # order_by is not None is load-bearing: it narrows the type for the
+                # call below (the runtime guard inside also rejects a falsy key).
+                probe_result = bool(
+                    tie_aware
+                    and order_by is not None
+                    and _final_key_tied_beyond_limit(connection, sql, order_by, reference)
+                )
+            return probe_result
+
         for backend in backends:
             impl = query.get_impl_for_family(backend)
             if impl is None:
@@ -386,6 +501,7 @@ def find_cross_surface_divergences(
                     tie_aware=tie_aware,
                     order_aware=order_aware,
                     order_by=order_by,
+                    final_key_tied_beyond_limit=final_key_tied(reference),
                 )
 
             yield backend, check

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -95,6 +95,7 @@ class ResultValidator:
         tie_aware: bool = False,
         order_aware: bool = False,
         order_by: Sequence[int] | None = None,
+        final_key_tied_beyond_limit: bool = False,
     ) -> bool:
         """Validate exact result matching between original and variant.
 
@@ -135,6 +136,21 @@ class ResultValidator:
                 an ``ORDER BY`` whose key is not present in the projected columns)
                 falls back to the order-insensitive comparison, never silently
                 claiming an order check it cannot perform.
+            final_key_tied_beyond_limit: A boundary-tie probe result for the
+                order-aware path, supplied by the caller (e.g.
+                ``cross_surface._final_key_tied_beyond_limit``, which re-runs the
+                trailing-``LIMIT`` query one row wider). True when the reference's
+                FINAL ``ORDER BY`` key value genuinely recurs PAST the ``LIMIT``
+                cutoff, so a final tie group that shows only ONE visible row is a
+                truncated boundary tie (one arbitrary pick among rows tied at the
+                worst-kept key) rather than a deterministic last row. It only
+                RELAXES the order-aware final-group check, and only for a
+                single-visible-row group: a final group with >= 2 visible tied rows
+                is already accepted as a boundary swap, and a single-visible-row
+                group whose key does NOT tie past the cutoff stays a CAUGHT mismatch
+                (so a unique-final-key value bug like ``(2,"good")`` vs
+                ``(2,"bad")`` is still reported). Off by default, so callers that do
+                not run the probe keep the strict single-row behavior.
 
         Returns:
             True if results match exactly
@@ -160,7 +176,13 @@ class ResultValidator:
         # unmappable ORDER BY).
         if order_aware and order_by and self._order_key_in_range(order_by, original_results, variant_results):
             return self._validate_order_aware(
-                original_results, variant_results, query_id, variant_id, order_by, tie_aware=tie_aware
+                original_results,
+                variant_results,
+                query_id,
+                variant_id,
+                order_by,
+                tie_aware=tie_aware,
+                final_key_tied_beyond_limit=final_key_tied_beyond_limit,
             )
 
         # Sort both result sets to handle potential ordering differences
@@ -233,6 +255,7 @@ class ResultValidator:
         key_columns: Sequence[int],
         *,
         tie_aware: bool,
+        final_key_tied_beyond_limit: bool = False,
     ) -> bool:
         """Compare two results in RETURNED order, tolerating only tie-group reshuffles.
 
@@ -251,11 +274,22 @@ class ResultValidator:
              fails the multiset check.
           3. The FINAL tie group may be truncated by a trailing ``LIMIT`` that
              cuts across the tie, so when ``tie_aware`` is set its membership is
-             allowed to differ as an ambiguous boundary swap. This is sound because
-             the group is keyed by the ACTUAL ``ORDER BY`` value (every row in it
-             shares the order key) and the total row count already matched, so the
-             difference can only be an equally-valid tie pick across the cutoff -
-             not a reordering of distinct order-key values.
+             allowed to differ as an ambiguous boundary swap - but ONLY when the
+             group is genuinely a tie at the cutoff, not a deterministic last row:
+               * >= 2 visible rows share the final order key, so a real tie is
+                 present in the result and a membership swap among them is an
+                 equally-valid boundary pick; OR
+               * exactly ONE visible row remains, but ``final_key_tied_beyond_limit``
+                 (the caller's boundary-tie probe) confirms the final key genuinely
+                 ties PAST the ``LIMIT`` cutoff, so the lone row is one arbitrary
+                 pick among rows tied at the worst-kept key.
+             A single visible row whose key does NOT tie beyond the cutoff is a
+             deterministic last row: a difference there is a real value change
+             (e.g. ``(2,"good")`` vs ``(2,"bad")``) and is still CAUGHT. This is
+             sound because the group is keyed by the ACTUAL ``ORDER BY`` value and
+             the total row count already matched, so an accepted difference can only
+             be an equally-valid tie pick across the cutoff - not a reordering of
+             distinct order-key values.
 
         Raises ``ValidationError`` on the first divergence, mirroring the strict
         path's contract.
@@ -291,17 +325,27 @@ class ResultValidator:
             if self._multisets_equal(orig_rows, var_rows):
                 continue
             # The FINAL group under a trailing LIMIT can be a truncated boundary
-            # tie: all its rows share the order key, the total row count already
-            # matched, so a membership difference is an equally-valid tie pick across
-            # the LIMIT cutoff. Accept it (the tie-aware relaxation) - BUT only when
-            # the group is a genuine tie of >= 2 rows sharing the final key, mirroring
-            # the strict ">= 2 reference rows at the boundary value" guard the
-            # order-blind tie-aware path applies. A single-row final group has nothing
-            # to reshuffle, so a difference there is a real value change (or a
-            # unique-final-key regression) on the last row and must still be CAUGHT -
-            # an unconditional skip here would mask it. Earlier groups are complete
-            # windows and always compared as multisets, so a value bug there is caught.
-            if i == last_index and tie_aware and len(orig_rows) >= 2:
+            # tie: all its rows share the order key (that is what defines the group)
+            # and the total row count already matched, so a membership difference can
+            # be an equally-valid tie pick across the cutoff. Accept it ONLY when the
+            # group is genuinely a tie at the boundary, not a deterministic last row:
+            #   * >= 2 visible rows share the final key (a real tie is present in the
+            #     result, so a swap among them is an ambiguous boundary pick), OR
+            #   * exactly one visible row but the caller's boundary-tie probe says
+            #     that key ties PAST the LIMIT (final_key_tied_beyond_limit).
+            # A single visible row whose key does NOT tie beyond the cutoff is
+            # deterministic, so a difference there (e.g. (2,"good") vs (2,"bad")) is a
+            # real value change and falls through to be CAUGHT below. This is sound
+            # because the group is keyed by the actual ORDER BY value, so a
+            # genuinely-ordered row is never mistaken for a boundary tie. Earlier
+            # groups are complete windows and must match as multisets, so a value bug
+            # there is still caught. (Residual limitation, inherited from the #872/#878
+            # design: the >= 2 branch accepts a final-group multiset difference even
+            # when the LIMIT did not truncate that tie - e.g. a complete, table-
+            # exhausted final group. The boundary-tie probe only refines the
+            # single-visible-row case it was scoped to; it is NOT the order-blind
+            # path's stronger boundary-value+extreme proof.)
+            if i == last_index and tie_aware and (len(orig_rows) >= 2 or final_key_tied_beyond_limit):
                 continue
             detail = self._first_positional_mismatch(
                 sorted(orig_rows, key=self._row_sort_key),

--- a/tests/integration/test_validator_order_aware.py
+++ b/tests/integration/test_validator_order_aware.py
@@ -93,13 +93,28 @@ def test_order_aware_truncated_limit_boundary_swap_is_not_flagged():
     )
 
 
+def test_order_aware_value_bug_in_non_tie_row_is_caught():
+    """A value bug in a deterministically-ordered (non-tie) row is still a MISMATCH."""
+    validator = _validator()
+    reference = [(1, 100, "a"), (2, 90, "b"), (3, 50, "c")]
+    bug = [(1, 100, "a"), (2, 90, "WRONG"), (3, 50, "c")]
+    order_by = [0]
+    with pytest.raises(ValidationError):
+        validator.validate_results_exact(reference, bug, 3, 1, order_aware=True, order_by=order_by, tie_aware=True)
+
+
+# --- Order-aware: one-visible-row boundary tie vs unique-final-key value bug ------
+
+
 def test_order_aware_single_row_final_group_value_bug_is_caught():
     """A value change on a UNIQUE final order-key row is caught, not masked as a tie.
 
-    The final-group tie relaxation only applies to a genuine tie (>= 2 rows sharing
-    the final key). When the final key is unique, its single row is deterministic, so
-    a non-key value change there (``good`` -> ``bad``) is a real regression and must
-    still raise even with ``tie_aware``.
+    The final-group tie relaxation only applies to a genuine tie (>= 2 visible rows
+    sharing the final key, OR a probe confirming the key ties past the LIMIT). When
+    the final key is unique and no probe says otherwise, its single row is
+    deterministic, so a non-key value change there (``good`` -> ``bad``) is a real
+    regression and must still raise even with ``tie_aware``. This pins #878's intent
+    (the single-row final group is no longer unconditionally accepted).
     """
     validator = _validator()
     reference = [(1, "ok"), (2, "good")]
@@ -109,14 +124,36 @@ def test_order_aware_single_row_final_group_value_bug_is_caught():
         validator.validate_results_exact(reference, bug, 3, 1, order_aware=True, order_by=order_by, tie_aware=True)
 
 
-def test_order_aware_value_bug_in_non_tie_row_is_caught():
-    """A value bug in a deterministically-ordered (non-tie) row is still a MISMATCH."""
+def test_order_aware_one_visible_row_boundary_tie_accepted_only_with_probe():
+    """A one-visible-row final tie is accepted ONLY when the probe says it ties past LIMIT.
+
+    Keys ``10, 5, 5`` with ``LIMIT 2`` return ``[10, 5]`` - exactly one row of the
+    boundary tie (key 5) stays visible, so two surfaces picking different ``5`` rows
+    is valid SQL. That single-visible-row final group is structurally identical to a
+    genuine unique-final-key value bug in the truncated result, so it is accepted
+    ONLY when ``final_key_tied_beyond_limit`` (the cross-surface boundary-tie probe)
+    confirms the key 5 recurs past the cutoff; without that signal the same diff
+    stays a CAUGHT mismatch (the conservative default).
+    """
     validator = _validator()
-    reference = [(1, 100, "a"), (2, 90, "b"), (3, 50, "c")]
-    bug = [(1, 100, "a"), (2, 90, "WRONG"), (3, 50, "c")]
+    reference = [(10, "x"), (5, "a")]
+    variant = [(10, "x"), (5, "b")]  # the lone visible boundary-tie member differs
     order_by = [0]
+    # Probe confirms key 5 is tied beyond LIMIT 2 -> the swap is a valid boundary pick.
+    assert validator.validate_results_exact(
+        reference,
+        variant,
+        3,
+        1,
+        order_aware=True,
+        order_by=order_by,
+        tie_aware=True,
+        final_key_tied_beyond_limit=True,
+    )
+    # Default (no probe signal): the same single-row difference is CAUGHT, so a genuine
+    # unique-final-key value bug is never masked.
     with pytest.raises(ValidationError):
-        validator.validate_results_exact(reference, bug, 3, 1, order_aware=True, order_by=order_by, tie_aware=True)
+        validator.validate_results_exact(reference, variant, 3, 1, order_aware=True, order_by=order_by, tie_aware=True)
 
 
 def test_order_aware_dropped_column_is_a_clean_column_count_mismatch():

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import pytest
 
 from benchbox.core.equivalence.cross_surface import (
+    _bump_trailing_limit,
+    _final_key_tied_beyond_limit,
     _report,
     count_executed_cells,
     find_cross_surface_divergences,
@@ -148,6 +150,125 @@ def test_tie_aware_only_applies_to_truncated_top_n_queries():
         backends=("expression",),
     )
     assert relaxed == [], "boundary-tie swap under a LIMIT query should be tolerated"
+
+
+# --- Boundary-tie probe: a one-visible-row final tie is not a false positive -----
+
+
+@pytest.mark.parametrize(
+    "sql, expected",
+    [
+        ("SELECT a FROM t ORDER BY a DESC LIMIT 2", "SELECT a FROM t ORDER BY a DESC LIMIT 3"),
+        ("SELECT a FROM t ORDER BY a LIMIT 10 OFFSET 5", "SELECT a FROM t ORDER BY a LIMIT 11 OFFSET 5"),
+        ("select a from t order by a limit 1;", "select a from t order by a limit 2;"),
+        ("SELECT a FROM t ORDER BY a LIMIT 7 -- top seven", "SELECT a FROM t ORDER BY a LIMIT 8"),
+        ("SELECT a FROM t ORDER BY a", None),  # no trailing LIMIT -> not rewritable
+    ],
+)
+def test_bump_trailing_limit_raises_the_cutoff_by_one(sql, expected):
+    """The probe rewriter raises ``LIMIT n`` to ``n+1``, preserving OFFSET/terminator."""
+    assert _bump_trailing_limit(sql) == expected
+
+
+def test_final_key_tied_beyond_limit_true_when_key_recurs_past_cutoff():
+    """The probe reports True when the row past the cutoff shares the final order key."""
+    sql = "SELECT a, b FROM t ORDER BY a DESC LIMIT 2"
+    # Keys 10, 5, 5 under LIMIT 2 -> visible [10, 5]; the row just past the cutoff is
+    # another key-5 row, so the final key 5 ties across the LIMIT.
+    connection = _FakeConnection({"SELECT a, b FROM t ORDER BY a DESC LIMIT 3": [(10, "x"), (5, "a"), (5, "b")]})
+    reference = [(10, "x"), (5, "a")]
+    assert _final_key_tied_beyond_limit(connection, sql, [0], reference) is True
+
+
+def test_final_key_tied_beyond_limit_false_when_no_row_past_cutoff():
+    """The probe reports False when the table is exhausted at the cutoff (deterministic)."""
+    sql = "SELECT a, b FROM t ORDER BY a DESC LIMIT 2"
+    # Only two rows total: LIMIT 3 returns the same two, nothing past the cutoff, so
+    # the final row is deterministic - a difference there is a real value bug.
+    connection = _FakeConnection({"SELECT a, b FROM t ORDER BY a DESC LIMIT 3": [(10, "x"), (5, "good")]})
+    reference = [(10, "x"), (5, "good")]
+    assert _final_key_tied_beyond_limit(connection, sql, [0], reference) is False
+
+
+def test_final_key_tied_beyond_limit_false_when_next_row_is_a_distinct_key():
+    """A distinct order key just past the cutoff means the final row is deterministic."""
+    sql = "SELECT a, b FROM t ORDER BY a DESC LIMIT 2"
+    # The row past the cutoff has key 3 (not the boundary value 5), so key 5 is NOT
+    # tied across the LIMIT - the lone visible key-5 row is the true last row.
+    connection = _FakeConnection({"SELECT a, b FROM t ORDER BY a DESC LIMIT 3": [(10, "x"), (5, "a"), (3, "c")]})
+    reference = [(10, "x"), (5, "a")]
+    assert _final_key_tied_beyond_limit(connection, sql, [0], reference) is False
+
+
+def test_one_visible_row_boundary_tie_is_not_a_divergence_via_probe():
+    """End-to-end: a one-visible-row boundary tie is accepted once the probe confirms it.
+
+    Reference top-2 is ``[10, 5]`` with the boundary key 5 tied past the LIMIT (a
+    third key-5 row exists). The DataFrame surface keeps a DIFFERENT but equally-valid
+    key-5 row, so the lone final group differs - and the gate must NOT flag it,
+    because the boundary-tie probe (``LIMIT 3``) shows key 5 recurs past the cutoff.
+    """
+    sql = "SELECT a, b FROM t ORDER BY a DESC LIMIT 2"
+    reference = [(10, "x"), (5, "a")]
+    candidate = [(10, "x"), (5, "b")]  # the lone visible boundary-tie member differs
+    connection = _FakeConnection(
+        {
+            sql: reference,
+            "SELECT a, b FROM t ORDER BY a DESC LIMIT 3": [(10, "x"), (5, "a"), (5, "b")],
+        }
+    )
+
+    def reference_sql(_qid):
+        return sql
+
+    def dataframe_query(_qid):
+        return _FakeQuery({"expression": lambda ctx: _FakeFrame(candidate)})
+
+    divergences = find_cross_surface_divergences(
+        connection,
+        query_ids=["Q1"],
+        reference_sql=reference_sql,
+        dataframe_query=dataframe_query,
+        contexts={"expression": object()},
+        validator=ResultValidator(),
+        backends=("expression",),
+    )
+    assert divergences == [], "a probe-confirmed one-visible-row boundary tie must not be flagged"
+
+
+def test_one_visible_row_final_value_bug_is_caught_when_not_tied_past_limit():
+    """End-to-end: a unique-final-key value bug is still caught when the probe says deterministic.
+
+    Same single-row final-group shape as the boundary-tie case, but the probe
+    (``LIMIT 3``) finds NO row tied past the cutoff, so the final row is deterministic
+    and the ``good`` -> ``bad`` change is a real divergence the gate must report.
+    """
+    sql = "SELECT a, b FROM t ORDER BY a DESC LIMIT 2"
+    reference = [(10, "x"), (5, "good")]
+    candidate = [(10, "x"), (5, "bad")]
+    connection = _FakeConnection(
+        {
+            sql: reference,
+            "SELECT a, b FROM t ORDER BY a DESC LIMIT 3": [(10, "x"), (5, "good")],
+        }
+    )
+
+    def reference_sql(_qid):
+        return sql
+
+    def dataframe_query(_qid):
+        return _FakeQuery({"expression": lambda ctx: _FakeFrame(candidate)})
+
+    divergences = find_cross_surface_divergences(
+        connection,
+        query_ids=["Q1"],
+        reference_sql=reference_sql,
+        dataframe_query=dataframe_query,
+        contexts={"expression": object()},
+        validator=ResultValidator(),
+        backends=("expression",),
+    )
+    assert [d.key for d in divergences] == ["Q1_expression"], "a deterministic final-row bug must still be caught"
 
 
 def test_missing_backend_impl_is_skipped_not_a_divergence():


### PR DESCRIPTION
## What & why

Implements `w1` of the `cross-surface-comparator-boundary-tie-soundness` TODO (the follow-up spun out of **#878** / Codex discussion r3462372977, on top of the order-aware comparator from **#872**).

The cross-surface SQL↔DataFrame comparator's order-aware path could not distinguish a **legitimate one-visible-row boundary tie** from a **genuine unique-final-key value bug**. When a trailing `LIMIT` cuts mid-tie and leaves exactly one tied row visible (keys `10, 5a, 5b` with `LIMIT 2` → `[10, 5]`), two surfaces picking different `5` rows is valid SQL — but from the truncated result alone that single visible row is structurally identical to a deterministic last-row value change (`(2,"good")` vs `(2,"bad")`). #878's `len(orig_rows) >= 2` final-group accept correctly catches the single-row value bug but false-positives the one-visible-row boundary tie.

## The fix — a boundary-tie probe

- **`cross_surface.py`**: for each trailing-`LIMIT` order-aware query, re-run it one row wider (`LIMIT n+1`) via `_bump_trailing_limit` / `_final_key_tied_beyond_limit` and learn whether the final `ORDER BY` key genuinely recurs **past** the cutoff. The probe runs **once per query** (memoized across backends) and is skipped entirely when the reference's final group already spans ≥2 rows (its result would be ignored).
- **`validation.py`**: thread that fact as `final_key_tied_beyond_limit` into `ResultValidator.validate_results_exact` → `_validate_order_aware`. A **single-visible-row** final tie group is accepted **only** when the probe confirms the key ties past the `LIMIT`; otherwise the lone row is deterministic and a value change there is still **caught**. The `>= 2` branch (from #878) keeps accepting a multi-row visible tie as a boundary swap.

## Hard constraints honored

- **ADDITIVE**: callers passing neither `order_aware` nor `tie_aware` (the TPC-Havoc strict path) are byte-identical — `final_key_tied_beyond_limit` defaults `False` and is only read by the order-aware single-row branch.
- **Default still catches single-row value bugs** (no regression of #878's intent).
- The validator stays connection-free; the probe (which owns the DuckDB connection + SQL) only threads a `bool` in.

## Tests

- `tests/integration/test_validator_order_aware.py`: one-visible-row tie **accepted with** the probe and **caught without** it; the `(2,"good")` vs `(2,"bad")` unique-final-key change still raises.
- `tests/unit/core/equivalence/test_cross_surface.py`: `_bump_trailing_limit` (LIMIT/OFFSET/terminator/comment cases), `_final_key_tied_beyond_limit` (tied past cutoff / table exhausted / distinct next key), and the end-to-end gate accept/catch cases.

## Verification (re-run after rebasing onto current `develop`)

- `uv run -- python -m pytest tests/unit/core/tpchavoc tests/integration/test_validator_order_aware.py tests/unit/core/equivalence/test_cross_surface.py` → green.
- All **six** enforced cross-surface gates green, **0 unclassified divergent** (ssb / amplab / coffeeshop / clickbench / joinorder_synthetic / h2odb; clickbench's `Q18` and h2odb's `Q9` divergent are the classified baselines).
- TPC-Havoc unchanged: **220/220** variant and **440/440** DataFrame equivalence.
- `make lint` and `make typecheck` clean.
- Self-reviewed with the `code-review` skill (high effort); findings addressed (simplified the probe memoization, added a skip-when-unnecessary short-circuit, corrected an inaccurate "mirrors the order-blind path" doc claim, and honestly documented the residual `>= 2` limitation inherited from the #872/#878 design).

## Rebase note

#878 **merged** after this branch was opened. This PR was rebased onto current `develop` (which now contains #878's `>= 2` guard) — the conflict in `_validate_order_aware` was resolved by keeping this PR's superseding guard `(len(orig_rows) >= 2 or final_key_tied_beyond_limit)`, and the duplicate `test_order_aware_single_row_final_group_value_bug_is_caught` (added by both #878 and here) was de-duplicated.

TODO moved to `_project/DONE/...` with `w1` done; `validate_todo` + `check-graph` pass; indexes regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gQiYGvhULTsaHK3tTsNkN