### PR TITLE
docs: PR review follow-up sweep (pass 4) — findings on PRs #881/#885

### DIFF
--- a/_project/TODO/main/planning/oracle-coverage-map-reference-independence-disclosure.yaml
+++ b/_project/TODO/main/planning/oracle-coverage-map-reference-independence-disclosure.yaml
@@ -154,8 +154,13 @@ deferred:
   reason: "Already shipped (#867) and coordinated with cross-surface-oracle-remediation; the independence axis is orthogonal and
     must not overload or duplicate it."
 - summary: "Building an actual independent value oracle for any benchmark."
-  reason: "That is correctness-gate-value-digest-fidelity-followups w5 (cross-engine agreement). This item only DISCLOSES the
-    independence status, it does not change any oracle's strength."
+  reason: "This item only DISCLOSES the independence status; it does not change any oracle's strength. The closest scoped
+    upgrade is correctness-gate-value-digest-fidelity-followups w5 (cross-engine digest agreement, DuckDB vs
+    postgres/datafusion at SF=1) — but that is only SEMI-independent: both engines run the SAME BenchBox-authored SQL over the
+    SAME generated data, so a conceptual query bug or a data-generation bug agrees across both engines and is NOT caught by it.
+    A FULLY independent value oracle (an external answer key / spec-derived expected values that does not share BenchBox's
+    query implementation or generator) is distinct, currently-unowned work; it is recorded here as an explicit roadmap gap so
+    cross-engine agreement is never mistaken for it."
 
 must_preserve:
 - "The map stays GENERATED from live sources — no hand-maintained classification — so it cannot drift from reality."

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -95,14 +95,19 @@ the successfully-executed queries on the measurement connection and merges the r
 - **No EXPLAIN on the measurement path.** Plan capture never interleaves with a timed query or
   holds the connection between measured queries — the EXPLAIN pass runs strictly after the timed
   loop, so measured per-query execution times are never inflated by capture cost.
-- **Honours `analyze_plans` — the single capture-detail knob.** With `analyze_plans=true`
-  (the default for these engines) the phase re-runs each SELECT once with `EXPLAIN (ANALYZE)`
-  *after* measurement, so captured plans carry actual per-operator timing and cardinality
-  (~1× extra query cost, outside the measured window). With
-  `--platform-option analyze_plans=false` the phase uses a static (non-`ANALYZE`) `EXPLAIN`,
-  giving estimated plans only with no re-execution cost (~1-5 ms). The structural
-  `plan_fingerprint` is identical either way (it excludes timing/cardinality by design); the
-  measured execution times in the result bundle remain the authoritative timings.
+- **Honours `analyze_plans` on the engines that support ANALYZE.** On DuckDB,
+  MotherDuck, and PostgreSQL — the engines whose `EXPLAIN` has an ANALYZE mode —
+  `analyze_plans=true` (the default) re-runs each SELECT once with `EXPLAIN
+  (ANALYZE)` *after* measurement, so captured plans carry actual per-operator
+  timing and cardinality (~1× extra query cost, outside the measured window), and
+  `--platform-option analyze_plans=false` uses a static (non-`ANALYZE`) `EXPLAIN`
+  giving estimated plans only with no re-execution cost (~1-5 ms). SQLite
+  (`EXPLAIN QUERY PLAN`), DataFusion, and Redshift (plain `EXPLAIN`) have no
+  ANALYZE mode: they always capture a static, estimated plan and the
+  `analyze_plans` toggle has no effect on those adapters (no per-operator timing
+  is available). The structural `plan_fingerprint` is identical either way (it
+  excludes timing/cardinality by design); the measured execution times in the
+  result bundle remain the authoritative timings.
 - **DML runs exactly once.** Even with `analyze_plans=true`, an
   INSERT/UPDATE/DELETE/MERGE/COPY (or CTAS / `SELECT ... INTO`) query is downgraded to a
   non-`ANALYZE` `EXPLAIN` by the shared `is_dml_query` write guard, so writes are captured


### PR DESCRIPTION
Fourth pass of the review-follow-up sweep — reviewer threads on PRs merged since pass 3 (#881, #885; plus #880 resolved-by-reality, #878 maintainer-resolved). Docs/TODO only; no source-code change.

## Fixes
- **query-plan-analysis docs (#881)** — scoped the `analyze_plans` ANALYZE-timing claim to the engines that actually support it. Verified in the adapters: DuckDB / MotherDuck / PostgreSQL honor `analyze_plans` (re-run with `EXPLAIN ANALYZE`); SQLite (`EXPLAIN QUERY PLAN`), DataFusion and Redshift (plain `EXPLAIN`) have **no** ANALYZE mode and always capture a static estimated plan — the toggle has no effect there. The prior text implied per-operator timing for all six EXPLAIN-based engines.
- **oracle-independence-disclosure TODO (#885)** — the deferred "build an actual independent value oracle" entry no longer equates that work with w5 (cross-engine digest agreement). w5 is only **semi-independent**: both engines run the same BenchBox-authored SQL over the same generated data, so a conceptual query bug or a data-generation bug agrees across both and is not caught. A fully independent external/spec-derived oracle is now recorded as a distinct, currently-unowned roadmap gap so cross-engine agreement is never mistaken for it.

## Resolved by reality (no change)
- **#880** — the reviewer noted (at that PR's commit) that #878's `len(orig_rows) >= 2` final-group guard had not yet landed. It is now on `develop` (`validation.py:_validate_order_aware`), and the boundary-tie soundness TODO accurately describes it; the one-visible-row probe is tracked as w1 (implemented in #886).
- **#878** — the one-visible-row false-positive thread was already answered and decided by the maintainer (land the guard as-is; boundary-aware probe as a follow-up = #886).

## Testing
TODO schema validation passes for both edited/affected YAMLs; `make spellcheck` passes. No source code changed, so the unit suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_