### PR TITLE
fix(equivalence): PR review follow-up sweep (pass 5) — H2O-DB Q9 detail-specific exception (#884)

### DIFF
--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -956,15 +956,45 @@ _H2ODB_PERCENTILE_DECIMAL = (
     "yields the DataFrame value, so the only difference is DuckDB's DECIMAL result "
     "scale - a deterministic, sub-cent presentational/dtype difference, not a logic bug."
 )
-# Detail-aware acceptance for the Q9 residue: classify ONLY a single value mismatch
-# whose two numeric values differ by at most half a cent (the DECIMAL(8,2) rounding
-# bound, with a little float-formatting slack - still far below a full cent). A wrong
-# median, a wrong grouping, a row/column-count mismatch, an execution error, or any
-# larger value bug (e.g. an interpolation-method regression) does NOT parse as a
-# sub-cent numeric residue, so Q9 stays guarded against real result regressions
-# instead of the bare key tolerating every Q9 difference.
+# Detail-aware acceptance for the Q9 residue. The documented exception is ONLY the
+# p90 PERCENTILE_CONT DECIMAL(8,2) scale residue: a SINGLE value, sub-half-cent,
+# living in the p90 output column. Q9's projection is
+#   col 0 = passenger_count (grouping key),
+#   col 1 = median_fare_amount (PERCENTILE_CONT(0.5)),
+#   col 2 = p90_fare_amount    (PERCENTILE_CONT(0.9)),
+# and the validator reports a divergence as the FIRST positional mismatch
+# ("Value mismatch at row {i}, column {j}. Original: {orig}, Variant: {variant}").
+# So the predicate is sound only if it pins the difference to the EXACT documented
+# cell and signature, not merely "the first value is sub-cent":
+#   * it must be a Value mismatch (NOT a row/column-count mismatch, an execution
+#     error, or a reference failure - those detail strings do not match and are
+#     rejected);
+#   * it must be in column 2 (the p90 column). A grouping-key (col 0) or median
+#     (col 1) mismatch - even a sub-cent one - is REJECTED, so a wrong median or a
+#     wrong group no longer slips through on a small numeric delta;
+#   * both values must be numeric and differ by at most half a cent (the
+#     DECIMAL(8,2) rounding bound, with a hair of float-formatting slack - still
+#     far below a full cent), so any >=1-cent value bug is rejected; and
+#   * the SQL (Original) value must already be at the column's 2-decimal scale and
+#     the DataFrame (Variant) value must differ only beyond that scale - the actual
+#     DECIMAL-rounding signature - so an arbitrary "both happen to be close" pair
+#     does not qualify.
+# A wrong median, a wrong grouping key, a row/column-count mismatch, an execution
+# error, or any larger value bug (e.g. an interpolation-method regression) fails one
+# of these checks, so Q9 stays guarded against real result regressions instead of the
+# bare key tolerating every Q9 difference.
+#
+# Residual blind spot (validator-imposed, documented): the validator reports only the
+# FIRST positional mismatch, so a SECOND, later Q9 bug behind an accepted p90 residue
+# cannot be seen from the detail string alone. Pinning the accepted cell to the exact
+# p90 column + sub-half-cent + 2-decimal-scale signature minimizes the surface of that
+# blind spot (only the documented cell is ever the "first" accepted mismatch); closing
+# it fully would require the validator to surface ALL mismatches, not one.
+_H2ODB_Q9_P90_COLUMN = 2
 _H2ODB_Q9_RESIDUE_MAX = 0.005 + 1e-6
-_VALUE_MISMATCH_RE = re.compile(r"Value mismatch\b.*?Original:\s*(.+?),\s*Variant:\s*(.+)$")
+_VALUE_MISMATCH_RE = re.compile(
+    r"Value mismatch at row \d+, column (?P<col>\d+)\. Original:\s*(?P<orig>.+?),\s*Variant:\s*(?P<variant>.+)$"
+)
 _NUMBER_RE = re.compile(r"[-+]?\d*\.\d+|[-+]?\d+")
 
 
@@ -973,14 +1003,45 @@ def _first_number(text: str) -> float | None:
     return float(match.group()) if match else None
 
 
+def _is_two_decimal_scale(value: str) -> bool:
+    """True if ``value`` is a plain decimal already rounded to <= 2 fractional digits.
+
+    The SQL (Original) side of the documented residue is a DECIMAL(8,2), so it never
+    carries a 3rd fractional digit; the DataFrame (Variant) side keeps full float
+    precision. Requiring the Original to be at 2-decimal scale pins the difference to
+    DuckDB's DECIMAL-scale rounding rather than an arbitrary near-equal pair.
+    """
+    number = _NUMBER_RE.search(value)
+    if number is None:
+        return False
+    _, _, frac = number.group().partition(".")
+    return len(frac) <= 2
+
+
 def _h2odb_q9_decimal_residue(divergence: SurfaceDivergence) -> bool:
-    """True iff a Q9 divergence is the documented sub-cent DECIMAL-scale residue."""
+    """True iff a Q9 divergence is the documented sub-cent p90 DECIMAL-scale residue.
+
+    Pins the accepted difference to the EXACT documented cell (the p90 column, a
+    single sub-half-cent value at the SQL column's 2-decimal scale) so a wrong
+    median, a wrong grouping key, a structural mismatch, an execution error, or any
+    >=1-cent value bug is rejected rather than tolerated.
+    """
     match = _VALUE_MISMATCH_RE.search(str(divergence.detail))
     if match is None:
         return False
-    orig = _first_number(match.group(1))
-    variant = _first_number(match.group(2))
+    # Only the p90 column (index 2) carries the documented residue; a grouping-key
+    # or median mismatch - sub-cent or not - is a real Q9 regression.
+    if int(match.group("col")) != _H2ODB_Q9_P90_COLUMN:
+        return False
+    orig_text = match.group("orig")
+    variant_text = match.group("variant")
+    orig = _first_number(orig_text)
+    variant = _first_number(variant_text)
     if orig is None or variant is None:
+        return False
+    # The SQL value must already be at DECIMAL(8,2) scale (the rounding signature);
+    # the DataFrame value differs only beyond that scale, sub-half-cent.
+    if not _is_two_decimal_scale(orig_text):
         return False
     return abs(orig - variant) <= _H2ODB_Q9_RESIDUE_MAX
 

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -346,6 +346,22 @@ class CrossSurfaceData:
 
 
 @dataclass(frozen=True)
+class ClassifiedDivergence:
+    """A baselined divergence accepted ONLY when ``accepts`` matches the live cell.
+
+    A bare ``str`` baseline entry tolerates ANY divergence on its key, which masks a
+    real regression that happens to land on the same query/backend. A
+    ``ClassifiedDivergence`` instead tolerates a divergence only when its ``accepts``
+    predicate confirms the actual cell detail is the specific, defensible difference
+    described by ``reason`` - so a genuinely wrong value on the same key is still
+    reported as an unclassified gate failure.
+    """
+
+    reason: str
+    accepts: Callable[[SurfaceDivergence], bool]
+
+
+@dataclass(frozen=True)
 class CrossSurfaceGate:
     """Per-benchmark wiring for a cross-surface SQL<->DataFrame gate."""
 
@@ -356,7 +372,7 @@ class CrossSurfaceGate:
     # DataFrame surface, so every cell must match. Add a classified entry only
     # for a deliberate, defensible presentational difference - never to mute a
     # regression.
-    known_divergences: dict[str, str] = field(default_factory=dict)
+    known_divergences: dict[str, str | ClassifiedDivergence] = field(default_factory=dict)
     # Queries whose SQL reference legitimately returns 0 rows at the bounded
     # cell, keyed by query id, with a rationale string. A both-empty cell
     # compares empty-vs-empty and is NON-discriminating (every backend trivially
@@ -940,7 +956,39 @@ _H2ODB_PERCENTILE_DECIMAL = (
     "yields the DataFrame value, so the only difference is DuckDB's DECIMAL result "
     "scale - a deterministic, sub-cent presentational/dtype difference, not a logic bug."
 )
-_H2ODB_KNOWN_DIVERGENCES: dict[str, str] = dict.fromkeys(("Q9_expression", "Q9_pandas"), _H2ODB_PERCENTILE_DECIMAL)
+# Detail-aware acceptance for the Q9 residue: classify ONLY a single value mismatch
+# whose two numeric values differ by at most half a cent (the DECIMAL(8,2) rounding
+# bound, with a little float-formatting slack - still far below a full cent). A wrong
+# median, a wrong grouping, a row/column-count mismatch, an execution error, or any
+# larger value bug (e.g. an interpolation-method regression) does NOT parse as a
+# sub-cent numeric residue, so Q9 stays guarded against real result regressions
+# instead of the bare key tolerating every Q9 difference.
+_H2ODB_Q9_RESIDUE_MAX = 0.005 + 1e-6
+_VALUE_MISMATCH_RE = re.compile(r"Value mismatch\b.*?Original:\s*(.+?),\s*Variant:\s*(.+)$")
+_NUMBER_RE = re.compile(r"[-+]?\d*\.\d+|[-+]?\d+")
+
+
+def _first_number(text: str) -> float | None:
+    match = _NUMBER_RE.search(text)
+    return float(match.group()) if match else None
+
+
+def _h2odb_q9_decimal_residue(divergence: SurfaceDivergence) -> bool:
+    """True iff a Q9 divergence is the documented sub-cent DECIMAL-scale residue."""
+    match = _VALUE_MISMATCH_RE.search(str(divergence.detail))
+    if match is None:
+        return False
+    orig = _first_number(match.group(1))
+    variant = _first_number(match.group(2))
+    if orig is None or variant is None:
+        return False
+    return abs(orig - variant) <= _H2ODB_Q9_RESIDUE_MAX
+
+
+_H2ODB_KNOWN_DIVERGENCES: dict[str, str | ClassifiedDivergence] = dict.fromkeys(
+    ("Q9_expression", "Q9_pandas"),
+    ClassifiedDivergence(_H2ODB_PERCENTILE_DECIMAL, _h2odb_q9_decimal_residue),
+)
 
 
 # Registry of ENFORCED gated benchmarks: clean, blocking cross-surface gates whose
@@ -1046,11 +1094,27 @@ def run_gate(gate: CrossSurfaceGate) -> int:
     )
 
 
+def _classification(known: dict[str, str | ClassifiedDivergence], divergence: SurfaceDivergence) -> str | None:
+    """Return the reason a divergence is tolerated, or None if it is unclassified.
+
+    A bare-string baseline entry tolerates ANY divergence on that key (back-compat).
+    A :class:`ClassifiedDivergence` entry tolerates the divergence only when its
+    ``accepts`` predicate confirms the live cell, so a regression on a baselined key
+    is still unclassified.
+    """
+    entry = known.get(divergence.key)
+    if entry is None:
+        return None
+    if isinstance(entry, ClassifiedDivergence):
+        return entry.reason if entry.accepts(divergence) else None
+    return entry
+
+
 def _report(
     divergences: list[SurfaceDivergence],
     total: int,
     coverage: dict[str, int],
-    known: dict[str, str],
+    known: dict[str, str | ClassifiedDivergence],
     *,
     benchmark: str,
     reference_row_counts: dict[Any, int] | None = None,
@@ -1077,7 +1141,10 @@ def _report(
     reference_row_counts = reference_row_counts or {}
 
     found = {d.key for d in divergences}
-    new = sorted(found - set(known))
+    # A divergence is classified only if its key is baselined AND (for a detail-aware
+    # ClassifiedDivergence entry) the live cell matches the entry's predicate, so a
+    # real regression on a baselined key is still reported as unclassified.
+    new = sorted({d.key for d in divergences if _classification(known, d) is None})
     resolved = sorted(set(known) - found)
     missing_backends = sorted(backend for backend, count in coverage.items() if count == 0)
     executed = sum(coverage.values())
@@ -1116,7 +1183,7 @@ def _report(
 
     by_class: dict[str, list[SurfaceDivergence]] = {}
     for divergence in sorted(divergences, key=lambda d: d.key):
-        klass = known.get(divergence.key, "UNCLASSIFIED")
+        klass = _classification(known, divergence) or "UNCLASSIFIED"
         by_class.setdefault(klass, []).append(divergence)
     for klass in sorted(by_class):
         print(f"  [{klass}]")

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -463,6 +463,52 @@ def test_h2odb_is_an_enforced_gate_with_classified_percentile_exception():
     assert GATES["h2odb"].scale_factor == 0.01
 
 
+def test_h2odb_q9_baseline_tolerates_only_the_sub_cent_residue_not_real_bugs():
+    """The Q9 baseline is detail-aware: it classifies ONLY the sub-cent DECIMAL
+    residue, so a genuine Q9 regression on the same key still fails the gate."""
+    from benchbox.core.equivalence.cross_surface import GATES
+
+    known = GATES["h2odb"].known_divergences
+    coverage = {"expression": 1, "pandas": 1}
+
+    # The documented residue: p90 differs by < half a cent on both backends ->
+    # classified, the gate passes.
+    residue = [
+        SurfaceDivergence("Q9", "expression", "Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"),
+        SurfaceDivergence("Q9", "pandas", "Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"),
+    ]
+    assert (
+        _report(residue, total=2, coverage=coverage, known=known, benchmark="h2odb", reference_row_counts={"Q9": 6})
+        == 0
+    )
+
+    # A real value bug on the SAME key (wrong median, off by ten) is not sub-cent,
+    # so it is unclassified and the gate FAILS - the bare key no longer masks it.
+    real_bug = [
+        SurfaceDivergence("Q9", "pandas", "Q9.0: Value mismatch at row 0, column 1. Original: 50.0, Variant: 60.0"),
+    ]
+    assert (
+        _report(real_bug, total=2, coverage=coverage, known=known, benchmark="h2odb", reference_row_counts={"Q9": 6})
+        == 1
+    )
+
+
+def test_h2odb_q9_residue_predicate_rejects_structural_and_large_diffs():
+    """The Q9 acceptance predicate accepts a sub-cent value mismatch and nothing else."""
+    from benchbox.core.equivalence.cross_surface import _h2odb_q9_decimal_residue
+
+    def d(detail: str) -> SurfaceDivergence:
+        return SurfaceDivergence("Q9", "pandas", detail)
+
+    assert _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"))
+    # Reject: a full value bug (>= a cent), a wrong grouping (row/column-count
+    # mismatch), and an execution error.
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 0, column 1. Original: 50.0, Variant: 60.0"))
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Row count mismatch. Original: 6, Variant: 5"))
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Column count mismatch at row 0. Original: 3, Variant: 2"))
+    assert not _h2odb_q9_decimal_residue(d("error: boom"))
+
+
 def test_order_by_result_key_maps_alias_name_expr_and_ordinal():
     """_order_by_result_key resolves the ORDER BY shapes the gated queries use."""
     from benchbox.core.equivalence.cross_surface import _order_by_result_key as resolve

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -474,7 +474,9 @@ def test_h2odb_q9_baseline_tolerates_only_the_sub_cent_residue_not_real_bugs():
     # The documented residue: p90 differs by < half a cent on both backends ->
     # classified, the gate passes.
     residue = [
-        SurfaceDivergence("Q9", "expression", "Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"),
+        SurfaceDivergence(
+            "Q9", "expression", "Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"
+        ),
         SurfaceDivergence("Q9", "pandas", "Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"),
     ]
     assert (
@@ -492,21 +494,68 @@ def test_h2odb_q9_baseline_tolerates_only_the_sub_cent_residue_not_real_bugs():
         == 1
     )
 
+    # A SUB-CENT bug in the WRONG column (the median, col 1, not the documented p90
+    # col 2) is a real Q9 regression - the gate FAILS. The magnitude-only predicate
+    # wrongly tolerated this; pinning the accepted cell to the p90 column catches it.
+    wrong_column = [
+        SurfaceDivergence("Q9", "pandas", "Q9.0: Value mismatch at row 4, column 1. Original: 77.87, Variant: 77.874"),
+    ]
+    assert (
+        _report(
+            wrong_column, total=2, coverage=coverage, known=known, benchmark="h2odb", reference_row_counts={"Q9": 6}
+        )
+        == 1
+    )
+
 
 def test_h2odb_q9_residue_predicate_rejects_structural_and_large_diffs():
-    """The Q9 acceptance predicate accepts a sub-cent value mismatch and nothing else."""
+    """The Q9 acceptance predicate accepts a sub-cent p90 value mismatch and nothing
+    else.
+
+    The documented exception is ONLY the p90 PERCENTILE_CONT DECIMAL(8,2) scale
+    residue (Q9 projects col 0 = passenger_count, col 1 = median, col 2 = p90), so the
+    predicate must pin the EXACT cell: the p90 column, a single sub-half-cent value at
+    the SQL column's 2-decimal scale. A sub-cent mismatch in the median or the
+    grouping key, a structural mismatch, an execution error, or any >=1-cent value bug
+    is rejected.
+    """
     from benchbox.core.equivalence.cross_surface import _h2odb_q9_decimal_residue
 
     def d(detail: str) -> SurfaceDivergence:
         return SurfaceDivergence("Q9", "pandas", detail)
 
+    # ACCEPT: the documented residue - p90 column (2), Original at DECIMAL(8,2) scale,
+    # Variant differs only in the 3rd decimal, sub-half-cent.
     assert _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.874"))
-    # Reject: a full value bug (>= a cent), a wrong grouping (row/column-count
+
+    # REJECT: a full value bug (>= a cent), a wrong grouping (row/column-count
     # mismatch), and an execution error.
     assert not _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 0, column 1. Original: 50.0, Variant: 60.0"))
     assert not _h2odb_q9_decimal_residue(d("Q9.0: Row count mismatch. Original: 6, Variant: 5"))
     assert not _h2odb_q9_decimal_residue(d("Q9.0: Column count mismatch at row 0. Original: 3, Variant: 2"))
     assert not _h2odb_q9_decimal_residue(d("error: boom"))
+
+    # REJECT: a SUB-CENT mismatch in the WRONG column. The bare-magnitude predicate
+    # wrongly accepted these (only the value delta was checked); pinning to the p90
+    # column (2) rejects a sub-cent median (col 1) or grouping-key (col 0) bug, which
+    # are real Q9 regressions, not the documented p90 DECIMAL residue.
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 4, column 1. Original: 77.87, Variant: 77.874"))
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 4, column 0. Original: 4.00, Variant: 4.004"))
+
+    # REJECT: a >=1-cent value bug in the p90 column (right column, wrong magnitude).
+    assert not _h2odb_q9_decimal_residue(d("Q9.0: Value mismatch at row 4, column 2. Original: 77.87, Variant: 77.90"))
+
+    # REJECT: a p90, sub-cent delta whose Original is NOT at DECIMAL(8,2) scale - so it
+    # lacks the DuckDB DECIMAL-rounding signature (both sides carry a 3rd decimal),
+    # which is not the documented presentational difference.
+    assert not _h2odb_q9_decimal_residue(
+        d("Q9.0: Value mismatch at row 4, column 2. Original: 77.874, Variant: 77.877")
+    )
+
+    # ACCEPT: the median (col 1) is allowed to be the documented residue too only when
+    # it is p90 - it is NOT - so this stays rejected even though it is sub-cent. (Guard
+    # against a future loosening: only column 2 is ever accepted.)
+    assert not _h2odb_q9_decimal_residue(d("Q9.5: Value mismatch at row 5, column 1. Original: 77.91, Variant: 77.915"))
 
 
 def test_order_by_result_key_maps_alias_name_expr_and_ordinal():


### PR DESCRIPTION
Fifth pass of the review-follow-up sweep — reviewer threads on PRs merged since pass 4 (#884; plus #889 maintainer-resolved).

## Fix (#884)
The H2O-DB cross-surface gate's Q9 known-divergence baseline was keyed only by `SurfaceDivergence.key`, so `_report` classified **any** `Q9_expression`/`Q9_pandas` divergence as the documented exception — a wrong median, a wrong grouping, or the Polars quantile slipping back to nearest interpolation would all pass as "known." The reviewer flagged this leaves Q9 effectively unguarded against real regressions.

Normalizing the SQL reference instead isn't faithfully possible (DuckDB's DECIMAL rounding isn't standard float round-half-away — e.g. `77.915 → 77.91`), as the existing rationale comment documents. So the exception is now **detail-specific**:

- **`ClassifiedDivergence(reason, accepts)`** — a baselined entry accepted only when its predicate matches the live cell. A bare-string entry keeps the prior "tolerate any divergence on this key" behavior, so clickbench Q18 etc. are unchanged.
- **`_report`** classifies via `_classification(known, divergence)`: a divergence on a baselined key whose predicate **rejects** it is reported as `UNCLASSIFIED` and fails the gate.
- **`_h2odb_q9_decimal_residue`** tolerates only a single value mismatch whose two numeric values differ by ≤ half a cent (the DECIMAL(8,2) rounding bound). A row/column-count mismatch (wrong grouping), an execution error, or any ≥1-cent value bug (median / interpolation regression) is no longer masked.

## Verification
- The **real `h2odb` gate stays green**: Q9 residue is `77.87` vs `77.874` (0.004), classified → `SQL and DataFrame surfaces are equivalent (modulo classified exceptions)`, exit 0.
- New unit tests assert a sub-cent residue passes while a real Q9 value bug, a wrong grouping, and an execution error all **fail** the gate (`test_h2odb_q9_baseline_tolerates_only_the_sub_cent_residue_not_real_bugs`, `test_h2odb_q9_residue_predicate_rejects_structural_and_large_diffs`).
- `tests/unit/core/equivalence/` + `tests/unit/core/tpchavoc/` + the h2odb cross-surface test: 103 passed. `ruff` and `make typecheck` clean.

## Maintainer-resolved (no change)
- **#889** — the phase-capture `query_id`-keyed variant gap was already answered by the maintainer (pre-existing isolated-phase behavior; the per-stream/seed variant-keying fix is tracked as w4 of `query-plan-capture-post-measurement-divergence`, benefiting all engines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_