### PR TITLE
chore: commit plugin marketplace config for cloud parity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "code-modernization@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
Cloud/web (claude.ai/code) sessions clone only the repo, so the
user-global plugin set is absent and namespaced agents
(code-modernization:*, code-simplifier:*) plus their slash commands are
unavailable there.

Add .claude/settings.json with extraKnownMarketplaces + enabledPlugins
(mirrors the local working set exactly) so any environment auto-installs
the same plugins from the public marketplace.

Deferred: skills (skill-sync mirrors) pending the skill-sync
committed-snapshot work; hooks pending the settings.json ownership
decision in skill-sync.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
