### PR TITLE
fix/uat skipped unreachable release accounting

### DIFF
--- a/_project/DONE/main/active/uat-skipped-unreachable-release-accounting.yaml
+++ b/_project/DONE/main/active/uat-skipped-unreachable-release-accounting.yaml
@@ -2,8 +2,9 @@ id: uat-skipped-unreachable-release-accounting
 title: "Account for skipped/unreachable UAT cells in release-report candidate counts (release-evidence integrity)"
 worktree: main
 priority: High
-status: In Progress
+status: Completed
 category: Release Tooling
+completed_date: "2026-06-28"
 
 description: |
   UAT records skipped and unreachable cells, but the release report's candidate

--- a/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
+++ b/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
@@ -43,7 +43,7 @@ work:
 
   - id: w1
     summary: "Make report totals reconcile and surface unreachable loudly"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Update the report/validate accounting so the summary reports passed /

--- a/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
+++ b/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
@@ -55,7 +55,7 @@ work:
 
   - id: w2
     summary: "Regression test the reconciliation"
-    status: pending
+    status: done
     needs: [w1]
     notes: |
       Add a test on the report generator asserting totals reconcile for the w0

--- a/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
+++ b/_project/TODO/main/active/uat-skipped-unreachable-release-accounting.yaml
@@ -2,7 +2,7 @@ id: uat-skipped-unreachable-release-accounting
 title: "Account for skipped/unreachable UAT cells in release-report candidate counts (release-evidence integrity)"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Release Tooling
 
 description: |
@@ -29,7 +29,7 @@ prior_art:
 work:
   - id: w0
     summary: "Reproduce and characterize the undercount with a fixture (re-validate the claim)"
-    status: pending
+    status: done
     needs: []
     notes: |
       Build a small fixture CELLS_JSONL of UAT cell records with N defined cells, K

--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -185,6 +185,11 @@ def _handle_report(args: argparse.Namespace) -> int:
             {
                 "tsv": str(summary.tsv_path),
                 "rows": summary.rows,
+                "candidates": summary.candidate_count,
+                "attempted": summary.attempted_count,
+                "skipped": summary.skipped_count,
+                "unreachable": summary.unreachable_count,
+                "total_defined": summary.total_defined_count,
                 "passed": summary.pass_count,
                 "failed": summary.fail_count,
                 "timed_out": summary.timeout_count,

--- a/tests/uat/fixtures/report-accounting-skipped-unreachable-cells.jsonl
+++ b/tests/uat/fixtures/report-accounting-skipped-unreachable-cells.jsonl
@@ -1,0 +1,5 @@
+{"platform":"duckdb","benchmark":"tpch","scale":0.01,"status":"passed","exit_code":0,"elapsed_s":1.0,"log_path":"/tmp/duckdb-tpch-0.01.log","result_path":"/tmp/duckdb-tpch-0.01.json","submit_terminal_state":"submittable"}
+{"platform":"duckdb","benchmark":"tpch","scale":0.1,"status":"failed","exit_code":1,"elapsed_s":2.0,"log_path":"/tmp/duckdb-tpch-0.1.log","result_path":null,"submit_terminal_state":"submittable"}
+{"platform":"duckdb","benchmark":"tpch","scale":1.0,"status":"skipped","exit_code":0,"elapsed_s":0.0,"log_path":"/tmp/duckdb-tpch-1.0.log","result_path":null,"submit_terminal_state":"submittable"}
+{"platform":"sqlite","benchmark":"tpch","scale":0.01,"status":"skipped-unreachable","exit_code":0,"elapsed_s":0.0,"log_path":"/tmp/sqlite-tpch-0.01.log","result_path":null,"submit_terminal_state":"submittable"}
+{"platform":"sqlite","benchmark":"tpch","scale":0.1,"status":"passed","exit_code":0,"elapsed_s":1.5,"log_path":"/tmp/sqlite-tpch-0.1.log","result_path":"/tmp/sqlite-tpch-0.1.json","submit_terminal_state":"submittable"}

--- a/tests/uat/fixtures/report-accounting-skipped-unreachable-observed.txt
+++ b/tests/uat/fixtures/report-accounting-skipped-unreachable-observed.txt
@@ -1,0 +1,22 @@
+Command:
+uv run -- python -m tests.uat._cli report --cells-jsonl tests/uat/fixtures/report-accounting-skipped-unreachable-cells.jsonl --output-tsv "$tmpdir/matrix_summary.tsv"
+
+Reviewed base:
+develop @ 7f171f28c
+
+Fixture shape:
+total_defined=5 passed=2 failed=1 skipped=1 unreachable=1
+
+Observed pre-fix CLI JSON:
+rows=5 passed=2 failed=1 timed_out=0
+No attempted, skipped, unreachable, or total_defined fields are emitted.
+
+Observed pre-fix TSV footer:
+# rows=5 candidates=5 executed=5 compatibility_pruned=0 early_stop_pruned=0 passed=2 failed=1 timed_out=0
+# run_status=COMPLETED
+
+Defect:
+The skipped and skipped-unreachable rows are rendered as ordinary rows, but the
+summary has no reconciling denominator. It reports executed=5 even though only
+three rows were attempted, and unreachable is not surfaced as a release-gate
+signal.

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -464,6 +464,9 @@ def run_sweep(  # noqa: C901
                     len(getattr(execute_outcome, "compatibility_pruned", ())) if execute_outcome else 0
                 ),
                 early_stop_pruned_count=(len(getattr(execute_outcome, "pruned", ())) if execute_outcome else 0),
+                skipped_unreachable_count=(
+                    len(getattr(execute_outcome, "skipped_unreachable", ())) if execute_outcome else 0
+                ),
                 source_info=source_info,
             )
             phase_exit_codes[phase] = summary.exit_code()
@@ -511,6 +514,9 @@ def _emit_abort_artifacts(
         cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
         compatibility_pruned_count=len(compatibility_pruned),
         early_stop_pruned_count=early_stop_pruned_count,
+        skipped_unreachable_count=len(getattr(execute_outcome, "skipped_unreachable", ()))
+        if execute_outcome is not None
+        else 0,
         source_info=source_info,
         run_status="ABORTED",
         abort_phase=aborted_phase,

--- a/tests/uat/phases/report.py
+++ b/tests/uat/phases/report.py
@@ -23,6 +23,9 @@ REPORT_HEADER = (
     "submit_terminal_state\tvalidator_status\tsource_commit_sha\tsource_dirty"
 )
 
+_SKIPPED_STATUSES = frozenset({"skipped"})
+_UNREACHABLE_STATUSES = frozenset({"skipped-unreachable", "skipped_unreachable", "unreachable"})
+
 
 class SourceInfo(Protocol):
     commit_sha: str
@@ -38,6 +41,10 @@ class ReportSummary(PhaseResult):
     timeout_count: int
     candidate_count: int
     executed_count: int
+    attempted_count: int
+    skipped_count: int
+    unreachable_count: int
+    total_defined_count: int
     compatibility_pruned_count: int
     early_stop_pruned_count: int
     cross_scale_clean_pairs: int
@@ -71,6 +78,10 @@ def terminal_state(cell: CellResult) -> str:
     """Classify the terminal state visible in durable UAT artifacts."""
     if cell.status == "passed":
         return "passed"
+    if _is_skipped_status(cell.status):
+        return "skipped"
+    if _is_unreachable_status(cell.status):
+        return "unreachable"
     if cell.status == "timed-out" or cell.exit_code == 124:
         return "timeout"
     if cell.exit_code in {-9, 137}:
@@ -132,6 +143,7 @@ def write_report(
     validator_status_by_path: dict[Path, str] | None = None,
     compatibility_pruned_count: int = 0,
     early_stop_pruned_count: int = 0,
+    skipped_unreachable_count: int = 0,
     source_info: SourceInfo | None = None,
     run_status: str = "COMPLETED",
     abort_phase: str | None = None,
@@ -141,11 +153,17 @@ def write_report(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     rows = list(cells)
     executed_count = len(rows)
-    candidate_count = executed_count + compatibility_pruned_count + early_stop_pruned_count
 
     pass_count = sum(1 for r in rows if r.status == "passed")
     fail_count = sum(1 for r in rows if r.status == "failed")
     timeout_count = sum(1 for r in rows if r.status == "timed-out")
+    row_skipped_count = sum(1 for r in rows if _is_skipped_status(r.status))
+    row_unreachable_count = sum(1 for r in rows if _is_unreachable_status(r.status))
+    attempted_count = executed_count - row_skipped_count - row_unreachable_count
+    skipped_count = row_skipped_count + compatibility_pruned_count + early_stop_pruned_count
+    unreachable_count = row_unreachable_count + skipped_unreachable_count
+    total_defined_count = attempted_count + skipped_count + unreachable_count
+    candidate_count = total_defined_count
 
     with output_path.open("w", encoding="utf-8") as fh:
         fh.write(REPORT_HEADER + "\n")
@@ -163,10 +181,22 @@ def write_report(
             f"executed={executed_count} "
             f"compatibility_pruned={compatibility_pruned_count} "
             f"early_stop_pruned={early_stop_pruned_count} "
+            f"attempted={attempted_count} "
+            f"skipped={skipped_count} "
+            f"unreachable={unreachable_count} "
+            f"total_defined={total_defined_count} "
             f"passed={pass_count} "
             f"failed={fail_count} "
             f"timed_out={timeout_count}\n"
         )
+        fh.write(
+            "# "
+            f"release_accounting passed={pass_count} failed={fail_count} timed_out={timeout_count} "
+            f"attempted={attempted_count} skipped={skipped_count} unreachable={unreachable_count} "
+            f"total_defined={total_defined_count}\n"
+        )
+        if unreachable_count:
+            fh.write(f"# UNREACHABLE_CELLS={unreachable_count} release_gate_attention=required\n")
         footer = f"# run_status={run_status}"
         if source_info is not None:
             footer += f" source_commit_sha={source_info.commit_sha} source_dirty={str(source_info.dirty).lower()}"
@@ -192,6 +222,10 @@ def write_report(
         timeout_count=timeout_count,
         candidate_count=candidate_count,
         executed_count=executed_count,
+        attempted_count=attempted_count,
+        skipped_count=skipped_count,
+        unreachable_count=unreachable_count,
+        total_defined_count=total_defined_count,
         compatibility_pruned_count=compatibility_pruned_count,
         early_stop_pruned_count=early_stop_pruned_count,
         cross_scale_clean_pairs=clean_pairs,
@@ -204,6 +238,18 @@ def write_report(
 
 def _footer_value(value: str) -> str:
     return value.replace("\t", " ").replace("\n", " ")
+
+
+def _normalized_status(status: str) -> str:
+    return status.strip().lower()
+
+
+def _is_skipped_status(status: str) -> bool:
+    return _normalized_status(status) in _SKIPPED_STATUSES
+
+
+def _is_unreachable_status(status: str) -> bool:
+    return _normalized_status(status) in _UNREACHABLE_STATUSES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/uat/test_report_accounting.py
+++ b/tests/uat/test_report_accounting.py
@@ -1,0 +1,73 @@
+"""Regression coverage for UAT release-accounting denominators."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.uat import _cli as uat_cli
+from tests.uat.phases import report
+from tests.uat.runner import CellResult
+
+pytestmark = pytest.mark.fast
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "report-accounting-skipped-unreachable-cells.jsonl"
+
+
+def _cell(platform: str, benchmark: str, scale: float, status: str = "passed") -> CellResult:
+    return CellResult(
+        platform=platform,
+        benchmark=benchmark,
+        scale=scale,
+        status=status,
+        exit_code=0 if status in {"passed", "skipped", "skipped-unreachable"} else 1,
+        elapsed_s=1.0 if status in {"passed", "failed", "timed-out"} else 0.0,
+        log_path=Path(f"/tmp/{platform}_{benchmark}_{scale}.log"),
+        result_path=Path(f"/tmp/{platform}_{benchmark}_{scale}.json") if status == "passed" else None,
+    )
+
+
+def test_report_cli_reconciles_skipped_and_unreachable_fixture(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(FIXTURE), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["rows"] == 5
+    assert payload["attempted"] == 3
+    assert payload["skipped"] == 1
+    assert payload["unreachable"] == 1
+    assert payload["total_defined"] == 5
+    assert payload["passed"] + payload["failed"] + payload["timed_out"] == payload["attempted"]
+    assert payload["attempted"] + payload["skipped"] + payload["unreachable"] == payload["total_defined"]
+
+    text = output_tsv.read_text(encoding="utf-8")
+    assert "attempted=3 skipped=1 unreachable=1 total_defined=5" in text
+    assert "# UNREACHABLE_CELLS=1 release_gate_attention=required" in text
+
+
+def test_report_counts_execute_unreachable_cells_outside_rows(tmp_path: Path):
+    summary = report.write_report(
+        [
+            _cell("duckdb", "tpch", 0.01, status="passed"),
+            _cell("duckdb", "tpch", 0.1, status="failed"),
+            _cell("duckdb", "tpch", 1.0, status="timed-out"),
+        ],
+        output_path=tmp_path / "matrix_summary.tsv",
+        compatibility_pruned_count=2,
+        early_stop_pruned_count=1,
+        skipped_unreachable_count=4,
+    )
+
+    assert summary.attempted_count == 3
+    assert summary.skipped_count == 3
+    assert summary.unreachable_count == 4
+    assert summary.total_defined_count == 10
+    assert summary.candidate_count == 10
+
+    text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
+    assert "compatibility_pruned=2 early_stop_pruned=1 attempted=3 skipped=3 unreachable=4 total_defined=10" in text
+    assert "# UNREACHABLE_CELLS=4 release_gate_attention=required" in text


### PR DESCRIPTION
## Summary
- Add explicit UAT report denominator fields for attempted, skipped, unreachable, and total_defined.
- Pass execute-phase skipped_unreachable counts into normal and abort report artifacts.
- Add a regression fixture and tests proving skipped/unreachable cells reconcile and unreachable cells are surfaced loudly.

## Verification
- `uv run -- python -m pytest tests/uat/test_report_accounting.py -q` -> 2 passed
- `uv run -- python -m pytest tests/uat/test_report_accounting.py tests/uat/test_report.py -q` -> 15 passed
- `make test-fast` -> 23755 passed, 11 skipped
- `make lint`
- `make typecheck` -> exit 0 with existing diagnostics
- `make pr-preflight` -> 23756 passed, 10 skipped, 4 subtests passed

## Notes
- Branch-protection/admin changes are not part of this item; this is release report evidence accounting only.
