### PR TITLE
feat/cross surface known divergence baseline hygiene

### DIFF
--- a/_project/DONE/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
+++ b/_project/DONE/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
@@ -2,8 +2,9 @@ id: cross-surface-known-divergence-baseline-hygiene
 title: "Fail (or force baseline update) when a known cross-surface divergence no longer reproduces"
 worktree: main
 priority: Medium-High
-status: In Progress
+status: Completed
 category: Testing and Quality Assurance
+completed_date: "2026-06-28"
 
 description: |
   Cross-surface gates carry classified known_divergences (e.g. ClickBench Q18's

--- a/_project/TODO/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
+++ b/_project/TODO/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
@@ -2,7 +2,7 @@ id: cross-surface-known-divergence-baseline-hygiene
 title: "Fail (or force baseline update) when a known cross-surface divergence no longer reproduces"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: In Progress
 category: Testing and Quality Assurance
 
 description: |
@@ -30,7 +30,7 @@ prior_art:
 work:
   - id: w1
     summary: "Detect resolved-but-listed known divergences and fail (or require --update-baseline)"
-    status: pending
+    status: done
     needs: []
     notes: |
       In the gate runner, after comparison, check each known_divergences entry: if

--- a/_project/TODO/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
+++ b/_project/TODO/main/active/cross-surface-known-divergence-baseline-hygiene.yaml
@@ -43,7 +43,7 @@ work:
 
   - id: w2
     summary: "Test both directions: stale entry fails, live entry still accepted"
-    status: pending
+    status: done
     needs: [w1]
     notes: |
       Add tests: (a) a known-divergence entry whose cell now matches fails the gate

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -1340,6 +1340,8 @@ def _report(
       * any unclassified cross-surface divergence,
       * any gated backend that implemented no queries (which would otherwise make
         the gate silently green by comparing nothing on that backend), and
+      * any known divergence whose cell is now equivalent, so stale baselines are
+        removed in a reviewed change instead of masking a future regression, and
       * any VACUOUS query - one whose SQL reference returns 0 rows, so every
         backend compares empty-vs-empty and trivially "matches" without
         discriminating anything - UNLESS it is explicitly classified in
@@ -1419,11 +1421,14 @@ def _report(
             f"legitimately_empty: {unclassified_empty} - make them discriminating or classify them with a rationale"
         )
     if resolved:
-        print(f"Previously-known divergences now equivalent - update the baseline: {resolved}")
+        print(
+            "GATE FAILURE - previously-known divergences now equivalent: "
+            f"{resolved} - remove the stale baseline entry in a reviewed change"
+        )
     if not new and not resolved and not missing_backends and not unclassified_empty:
         suffix = " (modulo classified exceptions)" if (known or classified_empty) else ""
         print(f"SQL and DataFrame surfaces are equivalent{suffix}.")
-    return 1 if (new or missing_backends or unclassified_empty) else 0
+    return 1 if (new or resolved or missing_backends or unclassified_empty) else 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -422,6 +422,62 @@ def test_report_with_real_divergence_still_fails_for_nonempty_query():
     assert exit_code == 1
 
 
+def test_known_divergence_baseline_fails_when_entry_is_resolved(capsys):
+    """A known-divergence entry must be removed once the live cell matches again."""
+    coverage = {"expression": 1, "pandas": 1}
+
+    exit_code = _report(
+        [],
+        total=2,
+        coverage=coverage,
+        known={"Q1_pandas": "documented test baseline"},
+        benchmark="fake",
+        reference_row_counts={"Q1": 5},
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "GATE FAILURE - previously-known divergences now equivalent: ['Q1_pandas']" in out
+    assert "remove the stale baseline entry" in out
+
+
+def test_known_divergence_baseline_accepts_live_entry(capsys):
+    """A still-reproducing, baselined divergence remains accepted."""
+    coverage = {"expression": 1, "pandas": 1}
+
+    exit_code = _report(
+        [SurfaceDivergence("Q1", "pandas", "accepted mismatch")],
+        total=2,
+        coverage=coverage,
+        known={"Q1_pandas": "documented test baseline"},
+        benchmark="fake",
+        reference_row_counts={"Q1": 5},
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "[documented test baseline]" in out
+    assert "SQL and DataFrame surfaces are equivalent (modulo classified exceptions)." in out
+
+
+def test_known_divergence_baseline_does_not_hide_new_unclassified_divergence(capsys):
+    """An unlisted divergence is still a gate failure."""
+    coverage = {"expression": 1, "pandas": 1}
+
+    exit_code = _report(
+        [SurfaceDivergence("Q2", "pandas", "new mismatch")],
+        total=2,
+        coverage=coverage,
+        known={},
+        benchmark="fake",
+        reference_row_counts={"Q2": 5},
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "GATE FAILURE - unclassified cross-surface divergences: ['Q2_pandas']" in out
+
+
 def test_clickbench_and_joinorder_are_enforced_gates():
     """ClickBench and joinorder_synthetic are promoted to enforced GATES (w4).
 


### PR DESCRIPTION
## Summary
- Make resolved known cross-surface divergences a gate failure instead of a warning.
- Keep still-reproducing classified divergences accepted, and keep new unclassified divergences failing.
- Add baseline-focused unit coverage for stale, live, and new divergence cases.

## Verification
- `uv run -- python -m pytest tests/unit/core/equivalence/test_cross_surface.py -q -k baseline` -> 4 passed
- Temporary fake SSB known divergence + `make ssb-cross-surface-equivalence-report` -> expected failure naming `Q1.1_pandas` as resolved
- Removed fake entry + `make ssb-cross-surface-equivalence-report` -> pass
- `make test-fast` -> 23756 passed, 11 skipped
- `make lint`
- `make typecheck` -> exit 0 with existing diagnostics
- `make pr-preflight` -> 23757 passed, 10 skipped, 4 subtests passed

## Notes
- No automatic baseline rewrite flag was added; default behavior now fails and instructs removal in a reviewed change, which satisfies the no-silent-prune guardrail.
