### PR TITLE
fix/dataframe csv empty string null uniform

### DIFF
--- a/_project/DONE/main/active/dataframe-csv-empty-string-null-uniform.yaml
+++ b/_project/DONE/main/active/dataframe-csv-empty-string-null-uniform.yaml
@@ -2,8 +2,9 @@ id: dataframe-csv-empty-string-null-uniform
 title: "Normalize empty-string-vs-null semantics across all DataFrame adapters on the CSV-direct load path"
 worktree: main
 priority: Medium-High
-status: In Progress
+status: Completed
 category: Core Functionality
+completed_date: "2026-06-28"
 
 description: |
   The empty-string-vs-null contract is centralized at the Parquet conversion layer

--- a/_project/TODO/main/active/dataframe-csv-empty-string-null-uniform.yaml
+++ b/_project/TODO/main/active/dataframe-csv-empty-string-null-uniform.yaml
@@ -49,7 +49,7 @@ work:
 
   - id: w2
     summary: "Gate the fix: ClickBench cross-surface on PySpark/DataFusion with prefer_parquet=False"
-    status: pending
+    status: done
     needs: [w1]
     notes: |
       Extend coverage to run a null-marker-less benchmark (ClickBench) cross-surface

--- a/_project/TODO/main/active/dataframe-csv-empty-string-null-uniform.yaml
+++ b/_project/TODO/main/active/dataframe-csv-empty-string-null-uniform.yaml
@@ -2,7 +2,7 @@ id: dataframe-csv-empty-string-null-uniform
 title: "Normalize empty-string-vs-null semantics across all DataFrame adapters on the CSV-direct load path"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: In Progress
 category: Core Functionality
 
 description: |
@@ -37,7 +37,7 @@ prior_art:
 work:
   - id: w1
     summary: "Add a shared null_marker-aware empty-string post-coercion on the CSV-direct path"
-    status: pending
+    status: done
     needs: []
     notes: |
       Add one shared post-load step (in benchmark_mixin/shared_loading) that, when

--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -500,6 +500,7 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
         has_header: bool = True,
         column_names: list[str] | None = None,
         null_marker: str | None = None,
+        string_columns: list[str] | None = None,
     ) -> DataFusionLazyDF:
         """Read a CSV file into a DataFusion DataFrame.
 
@@ -508,9 +509,10 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             delimiter: Field delimiter
             has_header: Whether file has header row
             column_names: Optional column names (overrides header)
-            null_marker: Unused for DataFusion — TPC-style trailing delimiters are handled
-                via detect_data_format() which routes .tbl/.dat files through
-                _read_tbl_via_datafusion / _read_tbl_via_pyarrow above.
+            null_marker: ``None`` means empty fields stay ``""`` in declared
+                string columns; non-``None`` preserves NULL semantics.
+            string_columns: Declared string columns whose empty CSV fields must
+                stay ``""`` when ``null_marker`` is ``None``.
 
         Returns:
             DataFusion DataFrame with the file contents
@@ -542,6 +544,10 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
         except TypeError:
             # Fall back to simpler API
             df = self.session_ctx.read_csv(path_str)
+
+        if null_marker is None and string_columns:
+            for name in string_columns:
+                df = df.with_column(name, f.coalesce(col(name), lit("")))
 
         return df
 

--- a/benchbox/platforms/dataframe/expression_family.py
+++ b/benchbox/platforms/dataframe/expression_family.py
@@ -1558,28 +1558,20 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
         Returns:
             Combined DataFrame
         """
+        read_kwargs: dict[str, Any] = {
+            "delimiter": delimiter,
+            "has_header": has_header,
+            "column_names": column_names,
+            "null_marker": null_marker,
+        }
+        if string_columns:
+            read_kwargs["string_columns"] = string_columns
+
         if len(file_paths) == 1:
-            return self.read_csv(
-                file_paths[0],
-                delimiter=delimiter,
-                has_header=has_header,
-                column_names=column_names,
-                null_marker=null_marker,
-                string_columns=string_columns,
-            )
+            return self.read_csv(file_paths[0], **read_kwargs)
 
         # Multiple files - load and concatenate
-        dfs = [
-            self.read_csv(
-                f,
-                delimiter=delimiter,
-                has_header=has_header,
-                column_names=column_names,
-                null_marker=null_marker,
-                string_columns=string_columns,
-            )
-            for f in file_paths
-        ]
+        dfs = [self.read_csv(f, **read_kwargs) for f in file_paths]
         return self._concat_dataframes(dfs)
 
     def concat_dataframes(self, dfs: list[LazyDF]) -> LazyDF:

--- a/benchbox/platforms/dataframe/expression_family.py
+++ b/benchbox/platforms/dataframe/expression_family.py
@@ -44,6 +44,7 @@ from benchbox.platforms.dataframe._result_helpers import (
     build_success_result_dict,
 )
 from benchbox.platforms.dataframe.benchmark_mixin import BenchmarkExecutionMixin
+from benchbox.platforms.dataframe.shared_loading import declared_string_columns, resolve_dataframe_csv_dialect
 from benchbox.platforms.dataframe.tuning_mixin import TuningConfigurableMixin
 from benchbox.platforms.dataframe.unified_frame import UnifiedExpr, UnifiedLazyFrame, UnifiedWhen
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -935,6 +936,7 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
         has_header: bool = True,
         column_names: list[str] | None = None,
         null_marker: str | None = None,
+        string_columns: list[str] | None = None,
     ) -> LazyDF:
         """Read a CSV file into a DataFrame.
 
@@ -944,6 +946,8 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
             has_header: Whether file has header row
             column_names: Optional column names (overrides header)
             null_marker: When not None, enables trailing-delimiter probing (TPC-style rows end with a spurious delimiter).
+            string_columns: Declared string columns whose empty CSV fields must
+                stay ``""`` when ``null_marker`` is ``None``.
 
         Returns:
             LazyFrame/DataFrame with the file contents
@@ -1236,20 +1240,15 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
             effective_delimiter = delimiter or ("|" if format_type == "tbl" else ",")
             has_header = format_type == "csv" and delimiter is None
 
-            # Resolve null_marker for trailing-delimiter probing via the resolver when a
-            # DataSource is available (manifest path).  Without one, derive from format_type
-            # so .tbl files (format_type=="tbl") keep their existing trailing-delimiter behaviour.
-            # When benchmark=None, NO_BENCHMARK is used: path (a) wins when table_metadata is
-            # present; otherwise path (c) of resolve_csv_dialect derives null_marker from the
-            # file extension (.tbl/.dat → "", everything else → None), which is correct.
-            if data_source is not None:
-                from benchbox.platforms.base.data_loading import NO_BENCHMARK, resolve_csv_dialect
-
-                bm = benchmark if benchmark is not None else NO_BENCHMARK
-                _dialect = resolve_csv_dialect(data_source, table_name, first_file, bm)
-                null_marker: str | None = _dialect.null_marker
-            else:
-                null_marker = "" if format_type == "tbl" else None
+            null_marker, has_header = resolve_dataframe_csv_dialect(
+                data_source=data_source,
+                table_name=table_name,
+                first_file=first_file,
+                benchmark=benchmark,
+                format_type=format_type,
+                default_has_header=has_header,
+            )
+            string_columns = declared_string_columns(benchmark, table_name, column_names)
 
             df = self._load_csv_files(
                 file_paths,
@@ -1257,6 +1256,7 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
                 has_header=has_header,
                 column_names=column_names,
                 null_marker=null_marker,
+                string_columns=string_columns,
             )
 
         # Register table
@@ -1542,6 +1542,7 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
         has_header: bool,
         column_names: list[str] | None,
         null_marker: str | None = None,
+        string_columns: list[str] | None = None,
     ) -> LazyDF:
         """Load CSV/TBL files.
 
@@ -1551,6 +1552,8 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
             has_header: Whether files have headers
             column_names: Optional column names
             null_marker: Passed through to read_csv for trailing-delimiter probing.
+            string_columns: Declared string columns whose empty CSV fields must
+                stay ``""`` when ``null_marker`` is ``None``.
 
         Returns:
             Combined DataFrame
@@ -1562,6 +1565,7 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
                 has_header=has_header,
                 column_names=column_names,
                 null_marker=null_marker,
+                string_columns=string_columns,
             )
 
         # Multiple files - load and concatenate
@@ -1572,6 +1576,7 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
                 has_header=has_header,
                 column_names=column_names,
                 null_marker=null_marker,
+                string_columns=string_columns,
             )
             for f in file_paths
         ]

--- a/benchbox/platforms/dataframe/pandas_family.py
+++ b/benchbox/platforms/dataframe/pandas_family.py
@@ -46,6 +46,7 @@ from benchbox.platforms.dataframe._result_helpers import (
     build_success_result_dict,
 )
 from benchbox.platforms.dataframe.benchmark_mixin import BenchmarkExecutionMixin
+from benchbox.platforms.dataframe.shared_loading import resolve_dataframe_csv_dialect
 from benchbox.platforms.dataframe.tuning_mixin import TuningConfigurableMixin
 from benchbox.platforms.dataframe.unified_pandas_frame import UnifiedPandasFrame
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -1077,48 +1078,18 @@ class PandasFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, ABC,
             # CSV or TBL
             actual_delimiter = delimiter if delimiter is not None else ("|" if format_type == "tbl" else ",")
 
-            # Resolve the CSV dialect (has_header + null_marker) via the resolver when a
-            # DataSource is available (manifest path).  Without one, derive from format_type
-            # so .tbl files (format_type=="tbl") keep their existing trailing-delimiter behaviour.
-            # When benchmark=None, NO_BENCHMARK is used: path (a) wins when table_metadata is
-            # present; otherwise path (c) of resolve_csv_dialect derives null_marker from the
-            # file extension (.tbl/.dat → "", everything else → None), which is correct.
-            #
             # has_header MUST come from the dialect, not the file extension: the SQL loaders
             # (e.g. DuckDB) honor csv_has_header and default to headerless, so assuming every
             # .csv carries a header here silently drops the first data row of headerless .csv
             # benchmarks (e.g. CoffeeShop), diverging the DataFrame surface from SQL.
-            if data_source is not None:
-                from benchbox.platforms.base.data_loading import NO_BENCHMARK, resolve_csv_dialect
-
-                bm = benchmark if benchmark is not None else NO_BENCHMARK
-                _dialect = resolve_csv_dialect(data_source, table_name, first_file, bm)
-                null_marker: str | None = _dialect.null_marker
-                has_header = _dialect.has_header
-            elif benchmark is not None:
-                # No DataSource, but a known benchmark (e.g. the cross-surface gate
-                # loads straight from a benchmark instance): resolve the dialect the
-                # SAME way the DuckDB SQL reference does so null_marker AND
-                # has_header match it. This matters for empty-field handling: a .csv
-                # benchmark that sets csv_null_marker="" (e.g. JoinOrder) nulls empty
-                # fields, while one that does not (e.g. ClickBench) keeps "" - the
-                # file-extension heuristic alone returned None for both and diverged
-                # from SQL on the latter.
-                from benchbox.platforms.base.data_loading import DataSource, resolve_csv_dialect
-
-                _dialect = resolve_csv_dialect(
-                    DataSource(source_type="benchmark_instance", tables={}),
-                    table_name,
-                    first_file,
-                    benchmark,
-                )
-                null_marker = _dialect.null_marker
-                has_header = _dialect.has_header
-            else:
-                # Ad-hoc load with no benchmark/DataSource: keep the file-extension
-                # heuristic that treats a bare .csv as headered.
-                null_marker = "" if format_type == "tbl" else None
-                has_header = format_type == "csv"
+            null_marker, has_header = resolve_dataframe_csv_dialect(
+                data_source=data_source,
+                table_name=table_name,
+                first_file=first_file,
+                benchmark=benchmark,
+                format_type=format_type,
+                default_has_header=format_type == "csv",
+            )
 
             # Pull this table's declared SQL types (parallel to column_names) from
             # the benchmark schema so numeric columns named like dates (e.g. SSB's

--- a/benchbox/platforms/dataframe/polars_df.py
+++ b/benchbox/platforms/dataframe/polars_df.py
@@ -257,6 +257,7 @@ class PolarsDataFrameAdapter(ExpressionFamilyAdapter[PolarsDF, PolarsLazyDF, Pol
         has_header: bool = True,
         column_names: list[str] | None = None,
         null_marker: str | None = None,
+        string_columns: list[str] | None = None,
     ) -> PolarsLazyDF:
         """Read a CSV file into a Polars LazyFrame.
 
@@ -269,6 +270,8 @@ class PolarsDataFrameAdapter(ExpressionFamilyAdapter[PolarsDF, PolarsLazyDF, Pol
                 stay '' in string columns (match DuckDB/pandas); ``""`` means empty
                 fields are NULL. (Trailing delimiters are handled natively by
                 truncate_ragged_lines.)
+            string_columns: Accepted for expression-family parity; Polars applies
+                this via ``missing_utf8_is_empty_string`` for UTF-8 columns.
 
         Returns:
             Polars LazyFrame with the file contents

--- a/benchbox/platforms/dataframe/pyspark_df.py
+++ b/benchbox/platforms/dataframe/pyspark_df.py
@@ -443,6 +443,7 @@ class PySparkDataFrameAdapter(ExpressionFamilyAdapter[PySparkDF, PySparkLazyDF, 
         has_header: bool = True,
         column_names: list[str] | None = None,
         null_marker: str | None = None,
+        string_columns: list[str] | None = None,
     ) -> PySparkLazyDF:
         """Read a CSV file into a PySpark DataFrame.
 
@@ -452,6 +453,8 @@ class PySparkDataFrameAdapter(ExpressionFamilyAdapter[PySparkDF, PySparkLazyDF, 
             has_header: Whether file has header row
             column_names: Optional column names (overrides header)
             null_marker: When not None, enables trailing-delimiter probing (TPC-style rows end with a spurious delimiter).
+            string_columns: Declared string columns whose empty CSV fields must
+                stay ``""`` when ``null_marker`` is ``None``.
 
         Returns:
             PySpark DataFrame with the file contents
@@ -472,6 +475,11 @@ class PySparkDataFrameAdapter(ExpressionFamilyAdapter[PySparkDF, PySparkLazyDF, 
         else:
             # Let Spark infer schema
             df = reader.option("inferSchema", "true").csv(path_str)
+
+        if null_marker is None and string_columns:
+            present = [name for name in string_columns if name in df.columns]
+            if present:
+                df = df.fillna("", subset=present)
 
         return df
 

--- a/benchbox/platforms/dataframe/shared_loading.py
+++ b/benchbox/platforms/dataframe/shared_loading.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from benchbox.core.dataframe.schema_utils import column_name, iter_schema_columns
+from benchbox.core.dataframe.schema_utils import (
+    column_name,
+    column_sql_type,
+    get_benchmark_schema_columns,
+    iter_schema_columns,
+)
 
 
 @runtime_checkable
@@ -31,6 +36,77 @@ class LoadableAdapter(Protocol):
         format_hint: str | None = None,
     ) -> int: ...
     def _log_verbose(self, msg: str) -> None: ...
+
+
+def resolve_dataframe_csv_dialect(
+    *,
+    data_source: Any | None,
+    table_name: str,
+    first_file: Path,
+    benchmark: Any | None,
+    format_type: str,
+    default_has_header: bool,
+) -> tuple[str | None, bool]:
+    """Resolve CSV null/header semantics for DataFrame direct CSV loads.
+
+    This mirrors the SQL loader's dialect resolver whenever a manifest or
+    benchmark instance is available. Only ad-hoc loads with neither input fall
+    back to the historical file-extension heuristic.
+    """
+    if data_source is not None:
+        from benchbox.platforms.base.data_loading import NO_BENCHMARK, resolve_csv_dialect
+
+        bm = benchmark if benchmark is not None else NO_BENCHMARK
+        dialect = resolve_csv_dialect(data_source, table_name, first_file, bm)
+        return dialect.null_marker, dialect.has_header
+
+    if benchmark is not None:
+        from benchbox.platforms.base.data_loading import DataSource, resolve_csv_dialect
+
+        dialect = resolve_csv_dialect(
+            DataSource(source_type="benchmark_instance", tables={}),
+            table_name,
+            first_file,
+            benchmark,
+        )
+        return dialect.null_marker, dialect.has_header
+
+    return ("" if format_type == "tbl" else None), default_has_header
+
+
+def declared_string_columns(
+    benchmark: Any | None,
+    table_name: str,
+    column_names: list[str] | None,
+) -> list[str]:
+    """Return declared string/text columns for a benchmark table."""
+    if benchmark is None or not column_names:
+        return []
+
+    try:
+        schema = get_benchmark_schema_columns(benchmark)
+    except Exception:  # noqa: BLE001 - schema hooks are heterogeneous across benchmarks
+        return []
+
+    table_schema = schema.get(table_name.lower()) or schema.get(table_name)
+    if not table_schema:
+        return []
+
+    from benchbox.core.dataframe.data_loader import SchemaMapper
+
+    types_by_name: dict[str, str] = {}
+    columns = list(table_schema) if isinstance(table_schema, (list, tuple)) else iter_schema_columns(table_schema)
+    for column in columns:
+        name = column_name(column)
+        if name:
+            types_by_name[name.lower()] = column_sql_type(column, default="")
+
+    string_columns: list[str] = []
+    for name in column_names:
+        sql_type = types_by_name.get(name.lower())
+        if sql_type and SchemaMapper.sql_type_to_pyarrow(sql_type) == "string":
+            string_columns.append(name)
+    return string_columns
 
 
 def load_tables_from_data_source_impl(

--- a/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
+++ b/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
@@ -11,7 +11,10 @@ from benchbox.platforms.dataframe.benchmark_mixin import DataFrameRunOptions
 from benchbox.platforms.dataframe.datafusion_df import DATAFUSION_DF_AVAILABLE, DataFusionDataFrameAdapter
 from benchbox.platforms.dataframe.pyspark_df import PYSPARK_AVAILABLE, PySparkDataFrameAdapter
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
 
 
 class _CsvNullMarkerBenchmark:

--- a/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
+++ b/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
@@ -1,0 +1,92 @@
+"""CSV-direct empty-string/null semantics for DataFrame adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchbox.platforms.dataframe.benchmark_mixin import DataFrameRunOptions
+from benchbox.platforms.dataframe.datafusion_df import DATAFUSION_DF_AVAILABLE, DataFusionDataFrameAdapter
+from benchbox.platforms.dataframe.pyspark_df import PYSPARK_AVAILABLE, PySparkDataFrameAdapter
+
+pytestmark = pytest.mark.integration
+
+
+class _CsvNullMarkerBenchmark:
+    name = "csv_null_marker_fixture"
+    display_name = "CSV Null Marker Fixture"
+    scale_factor = 0.01
+    csv_delimiter = ","
+    csv_has_header = True
+
+    def __init__(self, csv_path: Path, null_marker: str | None) -> None:
+        self.csv_null_marker = null_marker
+        self.tables = {"events": csv_path}
+
+    def get_schema(self) -> dict[str, dict[str, list[dict[str, str]]]]:
+        return {
+            "events": {
+                "columns": [
+                    {"name": "id", "type": "INTEGER"},
+                    {"name": "phrase", "type": "VARCHAR"},
+                ]
+            }
+        }
+
+
+def _write_events_csv(tmp_path: Path) -> Path:
+    csv_path = tmp_path / "events.csv"
+    csv_path.write_text("id,phrase\n1,\n2,abc\n", encoding="utf-8")
+    return csv_path
+
+
+def _load_phrase_values(adapter: Any, csv_path: Path, null_marker: str | None) -> list[Any]:
+    benchmark = _CsvNullMarkerBenchmark(csv_path, null_marker)
+    ctx = adapter.load_benchmark_into_context(
+        benchmark,
+        csv_path.parent,
+        options=DataFrameRunOptions(prefer_parquet=False),
+    )
+    native_table = ctx._tables["events"]
+    pdf = adapter.to_pandas(native_table)
+    return pdf.sort_values("id")["phrase"].tolist()
+
+
+@pytest.mark.skipif(not DATAFUSION_DF_AVAILABLE, reason="DataFusion DataFrame adapter is not installed")
+def test_datafusion_csv_direct_keeps_empty_string_when_null_marker_is_none(tmp_path: Path) -> None:
+    values = _load_phrase_values(DataFusionDataFrameAdapter(), _write_events_csv(tmp_path), null_marker=None)
+
+    assert values == ["", "abc"]
+
+
+@pytest.mark.skipif(not PYSPARK_AVAILABLE, reason="PySpark DataFrame adapter is not installed")
+def test_pyspark_csv_direct_keeps_empty_string_when_null_marker_is_none(tmp_path: Path) -> None:
+    adapter = PySparkDataFrameAdapter(master="local[1]", driver_memory="1g", shuffle_partitions=1)
+    try:
+        values = _load_phrase_values(adapter, _write_events_csv(tmp_path), null_marker=None)
+    finally:
+        adapter.close()
+
+    assert values == ["", "abc"]
+
+
+@pytest.mark.skipif(not DATAFUSION_DF_AVAILABLE, reason="DataFusion DataFrame adapter is not installed")
+def test_datafusion_csv_direct_preserves_null_when_null_marker_is_empty_string(tmp_path: Path) -> None:
+    values = _load_phrase_values(DataFusionDataFrameAdapter(), _write_events_csv(tmp_path), null_marker="")
+
+    assert values[0] is None
+    assert values[1] == "abc"
+
+
+@pytest.mark.skipif(not PYSPARK_AVAILABLE, reason="PySpark DataFrame adapter is not installed")
+def test_pyspark_csv_direct_preserves_null_when_null_marker_is_empty_string(tmp_path: Path) -> None:
+    adapter = PySparkDataFrameAdapter(master="local[1]", driver_memory="1g", shuffle_partitions=1)
+    try:
+        values = _load_phrase_values(adapter, _write_events_csv(tmp_path), null_marker="")
+    finally:
+        adapter.close()
+
+    assert values[0] is None
+    assert values[1] == "abc"


### PR DESCRIPTION
## Summary
- Add a shared DataFrame CSV dialect resolver for direct CSV loads so expression and pandas families use the same null/header semantics.
- Thread declared string columns into expression-family CSV readers and restore empty strings for PySpark/DataFusion when `null_marker is None`.
- Add fast integration coverage for DataFusion and PySpark proving null-marker-less CSV keeps `""`, while `null_marker=""` still produces NULL.

## Verification
- `uv run -- python -m pytest tests/integration/test_dataframe_csv_empty_string_null_semantics.py -q` -> 4 passed
- Affected unit slices + marker policy -> 15 passed
- `make test-fast` -> 23759 passed, 11 skipped after removing ignored generated `benchmark_runs/` artifact
- `make lint`
- `make typecheck` -> exit 0 with existing diagnostics
- `make pr-preflight` -> 23759 passed, 11 skipped, 4 subtests passed after clearing ignored generated `benchmark_runs/` artifact
