### PR TITLE
fix: PR review follow-up sweep (pass 7) — findings on PRs #892/#896–#906

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -360,6 +360,15 @@ jobs:
             tests/integration/test_cross_surface_mutation_sensitivity.py::test_targets_cover_every_enforced_gate \
             -m "slow" -n 0 --tb=short -q
 
+      - name: Run cross-surface GATES Make/CI pinning guard
+        run: |
+          # Medium-marked ratchet, so the fast-lane selection below skips it;
+          # invoke the node explicitly so a new GATES entry without its Make
+          # target + correctness-gate CI step fails required CI.
+          uv run -- python -m pytest \
+            tests/unit/test_standardized_test_commands.py::TestMakefileCommands::test_cross_surface_gates_are_pinned_in_make_and_ci \
+            -m "medium" -n 0 --tb=short -q
+
       - name: Run fast tests
         run: |
           # -p pytest_cov re-enables coverage plugin (disabled by default in pytest.ini)

--- a/_project/TODO/benchmark-expansion/planning/write-primitives-scd-type2-coverage.yaml
+++ b/_project/TODO/benchmark-expansion/planning/write-primitives-scd-type2-coverage.yaml
@@ -129,11 +129,15 @@ scope_limit:
   only_modify:
     - "benchbox/core/write_primitives/catalog/operations.yaml"
     - "benchbox/core/write_primitives/schema_specs.yaml"
+    # Required: setup/reset populate only the hard-coded table_population_map and
+    # reset_map in benchmark.py, so the new scd2_ops_* staging tables must be
+    # registered there too — otherwise they are created empty and never reset.
+    # Limit edits to those two maps (do not touch unrelated benchmark logic).
+    - "benchbox/core/write_primitives/benchmark.py"
     - "docs/benchmarks/write-primitives.md"
     - "tests/unit/benchmarks/test_write_primitives_core.py"
     - "tests/integration/test_write_primitives_duckdb.py"
   do_not_modify:
-    - "benchbox/core/write_primitives/benchmark.py"
     - "benchbox/core/runner.py"
     - "benchbox/cli/"
 
@@ -146,6 +150,10 @@ work:
       surrogate sk, c_custkey business key, attribute subset, row_hash,
       is_current bool, valid_from, valid_to. Change-staging derived dynamically
       from TPC-H (changed + unchanged + new keys) with effective_ts + row_hash.
+      Register the new scd2_ops_* staging tables in benchmark.py's
+      table_population_map (so they are populated at setup) and reset_map (so they
+      are restored on cleanup) — a spec-only addition would leave them empty and
+      un-reset.
   - id: w2
     summary: Add merge_scd_type2_basic operation to operations.yaml
     needs: [w1]

--- a/_project/TODO/main/planning/auto-merge-review-gate-soundness-paths.yaml
+++ b/_project/TODO/main/planning/auto-merge-review-gate-soundness-paths.yaml
@@ -42,20 +42,33 @@ work:
       all other paths on the existing auto-merge default.
 
   - id: w2
-    summary: "Make pr-open and the auto-merge backstop skip auto-merge when the diff touches a soundness path"
+    summary: "Make pr-open skip auto-merge when the diff touches a soundness path"
     status: pending
     needs: [w1]
     notes: |
       Adjust the pr-open flow so it does NOT auto-enable squash auto-merge when the
       changed files intersect the soundness paths (diff --name-only against the path
       set). For those PRs, open without auto-merge so the required review gates the
-      merge.
+      merge. Document the behavior in AGENTS.md/CLAUDE.md in the terse house style.
 
-      Apply the same predicate to .github/workflows/auto-merge-on-open.yml, which is
+  - id: w3
+    summary: "Gate the auto-merge-on-open backstop workflow on the same soundness-path predicate"
+    status: pending
+    needs: [w1]
+    notes: |
+      .github/workflows/auto-merge-on-open.yml currently runs `gh pr merge --auto
+      --squash` UNCONDITIONALLY for every non-draft PR opened against develop. That is
       the GitHub-side backstop for PRs opened via the UI, `gh pr create`, or any path
-      that skips `make pr-open`. If the workflow keeps auto-enabling merge for
-      soundness-path PRs, the local pr-open guard is bypassable. Document the behavior
-      in AGENTS.md/CLAUDE.md in the terse house style.
+      that skips `make pr-open`. While it stays unconditional it RE-ENABLES auto-merge
+      on soundness-path PRs even when w2 opened them without it, defeating the
+      review-before-auto-merge goal.
+
+      Gate this workflow on the SAME soundness-path predicate w2 uses: detect whether
+      the PR diff intersects the soundness paths (e.g. a paths/paths-ignore filter or
+      a diff --name-only check in the job) and SKIP the `gh pr merge --auto --squash`
+      step for those PRs. Keep the cheap auto-merge default for every non-soundness
+      diff. The predicate MUST be the single shared source the regression test pins,
+      so the local pr-open guard and this backstop never diverge.
 
 must_preserve:
   - "The cheap squash-auto-merge default is unchanged for all non-soundness paths."
@@ -74,6 +87,9 @@ scope_limit:
     - "_project/scripts/"
     - "AGENTS.md"
     - "CLAUDE.md"
+    # The verification step requires this regression test; allow the
+    # implementer to add it without breaching the guardrail.
+    - "tests/unit/test_auto_merge_soundness_paths.py"
 
 success_metrics:
   - "PRs touching the comparator or plan parsers cannot squash-auto-merge without a review; everything else stays on the fast default."

--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -546,8 +546,17 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             df = self.session_ctx.read_csv(path_str)
 
         if null_marker is None and string_columns:
+            # For headerless CSV with a declared schema (e.g. ClickBench's
+            # generated hits.csv), this non-.tbl path never applies
+            # `column_names`, so the frame columns are DataFusion's inferred
+            # names (column_1, …) rather than the benchmark schema names.
+            # Guard each coalesce on membership in the frame's actual columns
+            # so a declared string column that isn't present by name does not
+            # raise on `col(<schema_name>)` and abort the load.
+            present_columns = {field.name for field in df.schema()}
             for name in string_columns:
-                df = df.with_column(name, f.coalesce(col(name), lit("")))
+                if name in present_columns:
+                    df = df.with_column(name, f.coalesce(col(name), lit("")))
 
         return df
 

--- a/tests/integration/test_cross_surface_mutation_sensitivity.py
+++ b/tests/integration/test_cross_surface_mutation_sensitivity.py
@@ -270,7 +270,9 @@ def _build_gate_cell(gate_name: str, tmp_path: Any) -> _GateCell:
     """Build one benchmark's bounded cell and capture the target's reference count."""
     gate = GATES[gate_name]
     data = gate.build(gate.scale_factor, tmp_path)
-    contexts = build_production_contexts(data.benchmark, data.data_dir, backends=gate.backends)
+    contexts = build_production_contexts(
+        data.benchmark, data.data_dir, backends=gate.backends, scale_factor=gate.scale_factor
+    )
     reference_row_count = len(fetch_reference_rows(data.connection, data.reference_sql(_TARGETS[gate_name])))
     return _GateCell(gate_name=gate_name, data=data, contexts=contexts, reference_row_count=reference_row_count)
 

--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -147,6 +147,27 @@ def _handle_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def _read_skipped_unreachable_sidecar(cells_jsonl: Path) -> int:
+    """Read the skipped-unreachable count persisted alongside ``cells.jsonl``.
+
+    The durable sweep writes ``<cells.jsonl>.accounting.json`` next to the cell
+    stream because skipped-unreachable cells are ``Cell`` records, not
+    ``CellResult`` rows, and so cannot appear in the JSONL. Returns 0 when the
+    sidecar is absent or unreadable (older artifacts predate it).
+    """
+    import json as _json
+
+    sidecar = cells_jsonl.with_name(cells_jsonl.name + ".accounting.json")
+    if not sidecar.exists():
+        return 0
+    try:
+        with sidecar.open(encoding="utf-8") as fh:
+            payload = _json.load(fh)
+        return int(payload.get("skipped_unreachable_count", 0))
+    except (OSError, ValueError, TypeError):
+        return 0
+
+
 def _handle_report(args: argparse.Namespace) -> int:
     """Implements `make uat-report`. Reads cells from a JSON-lines stream."""
     import json as _json
@@ -173,12 +194,18 @@ def _handle_report(args: argparse.Namespace) -> int:
                     submit_terminal_state=payload.get("submit_terminal_state", "submittable"),
                 )
             )
+    # Skipped-unreachable cells are not JSONL rows; the durable sweep writes
+    # their count to a sidecar next to cells.jsonl. Read it back so a
+    # regenerated report keeps `total_defined` faithful instead of printing
+    # `unreachable: 0` for an incomplete sweep.
+    skipped_unreachable_count = _read_skipped_unreachable_sidecar(Path(args.cells_jsonl))
     rungs = _split_csv(args.rungs)
     summary = write_report(
         cells,
         output_path=Path(args.output_tsv),
         rungs=rungs,
         cross_scale_floor=args.cross_scale_floor,
+        skipped_unreachable_count=skipped_unreachable_count,
     )
     print(
         json.dumps(

--- a/tests/uat/orchestrator.py
+++ b/tests/uat/orchestrator.py
@@ -323,9 +323,18 @@ def run_sweep(  # noqa: C901
                     source_info=source_info,
                     aborted_phase=phase,
                     abort_reason=abort_reason,
+                    # run_execute annotates the abort with the unreachable
+                    # cells skipped before the disk-floor trip; without this
+                    # the abort report would drop them from total_defined.
+                    skipped_unreachable_count=getattr(exc, "skipped_unreachable_count", 0),
                 )
                 break
-            _write_cells_jsonl(cells_jsonl, execute_outcome.results, source_info=source_info)
+            _write_cells_jsonl(
+                cells_jsonl,
+                execute_outcome.results,
+                source_info=source_info,
+                skipped_unreachable_count=len(getattr(execute_outcome, "skipped_unreachable", ())),
+            )
             _write_compatibility_pruned_jsonl(
                 compatibility_pruned_jsonl,
                 getattr(execute_outcome, "compatibility_pruned", ()),
@@ -497,6 +506,7 @@ def _emit_abort_artifacts(
     source_info: RunSourceInfo,
     aborted_phase: str,
     abort_reason: str | None,
+    skipped_unreachable_count: int | None = None,
 ) -> None:
     cells = tuple(getattr(execute_outcome, "results", ())) if execute_outcome is not None else tuple(attempted)
     compatibility_pruned = (
@@ -505,7 +515,20 @@ def _emit_abort_artifacts(
         else _compatibility_pruned_for_config(config)
     )
     early_stop_pruned_count = len(getattr(execute_outcome, "pruned", ())) if execute_outcome is not None else 0
-    _write_cells_jsonl(log_dir / "cells.jsonl", cells, source_info=source_info)
+    # When the execute outcome is available, derive the unreachable count from
+    # it; otherwise (e.g. a mid-sweep DiskFloorAbort that bypassed the normal
+    # return) fall back to the count threaded in via `skipped_unreachable_count`
+    # so the abort report still reflects platforms skipped before the abort.
+    if skipped_unreachable_count is None:
+        skipped_unreachable_count = (
+            len(getattr(execute_outcome, "skipped_unreachable", ())) if execute_outcome is not None else 0
+        )
+    _write_cells_jsonl(
+        log_dir / "cells.jsonl",
+        cells,
+        source_info=source_info,
+        skipped_unreachable_count=skipped_unreachable_count,
+    )
     _write_compatibility_pruned_jsonl(log_dir / "compatibility_pruned.jsonl", compatibility_pruned)
     report_phase.write_report(
         cells,
@@ -514,9 +537,7 @@ def _emit_abort_artifacts(
         cross_scale_floor=config.report.cross_scale_coverage_min_pairs,
         compatibility_pruned_count=len(compatibility_pruned),
         early_stop_pruned_count=early_stop_pruned_count,
-        skipped_unreachable_count=len(getattr(execute_outcome, "skipped_unreachable", ()))
-        if execute_outcome is not None
-        else 0,
+        skipped_unreachable_count=skipped_unreachable_count,
         source_info=source_info,
         run_status="ABORTED",
         abort_phase=aborted_phase,
@@ -534,8 +555,27 @@ def _compatibility_pruned_for_config(config: UATConfig) -> tuple[Any, ...]:
     return tuple(exec_phase.enumerate_cells_with_pruning(config).compatibility_pruned)
 
 
-def _write_cells_jsonl(path: Path, cells: Iterable[CellResult], *, source_info: RunSourceInfo) -> None:
+def _cells_accounting_path(cells_jsonl: Path) -> Path:
+    """Sidecar that persists accounting counts not representable as cell rows."""
+    return cells_jsonl.with_name(cells_jsonl.name + ".accounting.json")
+
+
+def _write_cells_jsonl(
+    path: Path,
+    cells: Iterable[CellResult],
+    *,
+    source_info: RunSourceInfo,
+    skipped_unreachable_count: int = 0,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    # The skipped-unreachable cells are `Cell` records (not `CellResult` rows)
+    # and are therefore not part of the JSONL stream. Persist their count in a
+    # sidecar so a report regenerated from `cells.jsonl` (make uat-report) can
+    # read it back and keep `total_defined` faithful.
+    accounting_path = _cells_accounting_path(path)
+    with accounting_path.open("w", encoding="utf-8") as acc_fh:
+        json.dump({"skipped_unreachable_count": int(skipped_unreachable_count)}, acc_fh)
+        acc_fh.write("\n")
     with path.open("w", encoding="utf-8") as fh:
         for cell in cells:
             terminal_state = report_phase.terminal_state(cell)

--- a/tests/uat/phases/execute.py
+++ b/tests/uat/phases/execute.py
@@ -185,22 +185,39 @@ def run_execute(
                     else:
                         platform_abort_reason = startup_reason
             if platform_abort_reason is None and not docker_startup_failed:
-                _run_or_skip_platform(
-                    config,
-                    platform=platform,
-                    platform_pairs=platform_pairs,
-                    by_pb=by_pb,
-                    results=results,
-                    pruned=pruned,
-                    skipped_unreachable=skipped_unreachable,
-                    completed_pairs=completed_pairs,
-                    already_pruned=already_pruned,
-                    databases_root=databases_root,
-                    cleanup_enabled=cleanup_enabled,
-                    runner=runner,
-                    log_dir=log_dir,
-                    benchmark_runs_dir=benchmark_runs_dir,
-                )
+                try:
+                    _run_or_skip_platform(
+                        config,
+                        platform=platform,
+                        platform_pairs=platform_pairs,
+                        by_pb=by_pb,
+                        results=results,
+                        pruned=pruned,
+                        skipped_unreachable=skipped_unreachable,
+                        completed_pairs=completed_pairs,
+                        already_pruned=already_pruned,
+                        databases_root=databases_root,
+                        cleanup_enabled=cleanup_enabled,
+                        runner=runner,
+                        log_dir=log_dir,
+                        benchmark_runs_dir=benchmark_runs_dir,
+                    )
+                except Exception as exc:  # noqa: BLE001 - re-raised after annotation
+                    # A mid-sweep DiskFloorAbort propagates out of the runner
+                    # here, bypassing the normal ExecuteOutcome return. The
+                    # skipped-unreachable cells accumulated for earlier
+                    # platforms would otherwise be lost (run_execute never
+                    # returns), causing the abort report to under-count
+                    # `total_defined`. Annotate the exception with the count
+                    # so the orchestrator can thread it into the abort
+                    # artifact. The platform teardown still runs via the
+                    # enclosing `finally` before the exception propagates.
+                    if not hasattr(exc, "skipped_unreachable_count"):
+                        try:
+                            exc.skipped_unreachable_count = len(skipped_unreachable)  # type: ignore[attr-defined]
+                        except (AttributeError, TypeError):
+                            pass
+                    raise
         finally:
             docker_state, teardown_abort_reason = _teardown_docker_platform_if_needed(
                 config,

--- a/tests/uat/test_orchestrator.py
+++ b/tests/uat/test_orchestrator.py
@@ -518,3 +518,80 @@ def test_manifest_runner_reuses_attempted_cells_and_runs_complement(tmp_path: Pa
     assert calls == [0.1]
     assert [result.scale for result in outcome.results] == [0.01, 0.1]
     assert outcome.results[0].result_path == tmp_path / "prior.json"
+
+
+def _source_info() -> orchestrator.RunSourceInfo:
+    return orchestrator.RunSourceInfo(commit_sha="deadbeef", commit_short_sha="deadbee", dirty=False)
+
+
+def test_write_cells_jsonl_persists_skipped_unreachable_sidecar(tmp_path: Path):
+    cells_jsonl = tmp_path / "cells.jsonl"
+    orchestrator._write_cells_jsonl(
+        cells_jsonl,
+        (),
+        source_info=_source_info(),
+        skipped_unreachable_count=3,
+    )
+    sidecar = cells_jsonl.with_name("cells.jsonl.accounting.json")
+    assert sidecar.exists()
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["skipped_unreachable_count"] == 3
+
+
+def test_abort_artifacts_thread_skipped_unreachable_when_outcome_missing(tmp_path: Path):
+    cfg = validate_config(
+        {
+            "name": "abort-accounting",
+            "phases": ["execute"],
+            "platforms": {"include": ["duckdb"]},
+            "benchmarks": {"include": ["tpch"]},
+            "scales": {"rungs": [0.01]},
+        }
+    )
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    orchestrator._emit_abort_artifacts(
+        config=cfg,
+        log_dir=log_dir,
+        attempted=(),
+        execute_outcome=None,
+        source_info=_source_info(),
+        aborted_phase="execute",
+        abort_reason="free space 1.0 GiB < cutoff 5.0 GiB",
+        skipped_unreachable_count=2,
+    )
+    # The abort report must reflect the unreachable cells skipped before the
+    # disk-floor trip, not the zero implied by execute_outcome=None.
+    partial = log_dir / "matrix_summary.partial.tsv"
+    text = partial.read_text(encoding="utf-8")
+    assert "unreachable=2" in text
+    assert "# UNREACHABLE_CELLS=2 release_gate_attention=required" in text
+    # And the sidecar carries the count for report regeneration.
+    sidecar = (log_dir / "cells.jsonl").with_name("cells.jsonl.accounting.json")
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["skipped_unreachable_count"] == 2
+
+
+def test_disk_floor_abort_carries_skipped_unreachable_count():
+    cfg = validate_config(
+        {
+            "name": "disk-floor-annotate",
+            "platforms": {"include": ["duckdb", "clickhouse-server"]},
+            "benchmarks": {"include": ["tpch"]},
+            "scales": {"rungs": [0.01]},
+        }
+    )
+
+    def runner(platform, benchmark, scale, **kwargs):
+        raise orchestrator.DiskFloorAbort("free space 1.0 GiB < cutoff 5.0 GiB")
+
+    # duckdb is processed first and recorded as skipped-unreachable; the
+    # reachable clickhouse-server stack then trips the disk-floor runner. The
+    # raised abort must carry the already-accumulated unreachable count (1).
+    with patch.object(exec_phase, "platform_is_reachable", side_effect=lambda p, **_: p != "duckdb"):
+        with pytest.raises(orchestrator.DiskFloorAbort) as excinfo:
+            exec_phase.run_execute(
+                cfg,
+                log_dir=Path("/tmp"),
+                databases_root=Path("/tmp/databases"),
+                runner=runner,
+            )
+    assert getattr(excinfo.value, "skipped_unreachable_count", None) == 1

--- a/tests/uat/test_report_accounting.py
+++ b/tests/uat/test_report_accounting.py
@@ -71,3 +71,72 @@ def test_report_counts_execute_unreachable_cells_outside_rows(tmp_path: Path):
     text = (tmp_path / "matrix_summary.tsv").read_text(encoding="utf-8")
     assert "compatibility_pruned=2 early_stop_pruned=1 attempted=3 skipped=3 unreachable=4 total_defined=10" in text
     assert "# UNREACHABLE_CELLS=4 release_gate_attention=required" in text
+
+
+def test_report_cli_reads_skipped_unreachable_sidecar(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A report regenerated from cells.jsonl must read skipped-unreachable
+    cells back from the durable sidecar instead of printing unreachable: 0."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_jsonl.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "platform": "duckdb",
+                    "benchmark": "tpch",
+                    "scale": 0.01,
+                    "status": "passed",
+                    "exit_code": 0,
+                    "elapsed_s": 1.0,
+                    "log_path": "/tmp/a.log",
+                    "result_path": "/tmp/a.json",
+                }
+            )
+            for _ in range(2)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # The durable sweep writes this sidecar next to cells.jsonl.
+    cells_jsonl.with_name("cells.jsonl.accounting.json").write_text(
+        json.dumps({"skipped_unreachable_count": 3}), encoding="utf-8"
+    )
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unreachable"] == 3
+    assert payload["attempted"] == 2
+    assert payload["total_defined"] == 5
+    text = output_tsv.read_text(encoding="utf-8")
+    assert "# UNREACHABLE_CELLS=3 release_gate_attention=required" in text
+
+
+def test_report_cli_without_sidecar_defaults_unreachable_zero(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """Older artifacts predate the sidecar; the report must still regenerate."""
+    cells_jsonl = tmp_path / "cells.jsonl"
+    cells_jsonl.write_text(
+        json.dumps(
+            {
+                "platform": "duckdb",
+                "benchmark": "tpch",
+                "scale": 0.01,
+                "status": "passed",
+                "exit_code": 0,
+                "elapsed_s": 1.0,
+                "log_path": "/tmp/a.log",
+                "result_path": "/tmp/a.json",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output_tsv = tmp_path / "matrix_summary.tsv"
+
+    exit_code = uat_cli.main(["report", "--cells-jsonl", str(cells_jsonl), "--output-tsv", str(output_tsv)])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["unreachable"] == 0
+    assert payload["total_defined"] == 1

--- a/tests/unit/platforms/dataframe/test_datafusion_df.py
+++ b/tests/unit/platforms/dataframe/test_datafusion_df.py
@@ -200,6 +200,52 @@ class TestDataFusionDataLoading:
         result = adapter.collect(df)
         assert result.num_rows == 2
 
+    def test_read_csv_headerless_with_schema_string_columns_does_not_raise(self, tmp_path):
+        """Headerless non-.tbl CSV with declared schema names.
+
+        ClickBench's generated hits.csv is written without a header and the
+        non-.tbl CSV path never applies `column_names`, so the frame columns
+        are DataFusion's inferred names (column_1, …). The empty-string
+        coalesce for declared `string_columns` must guard on the frame's
+        actual columns instead of calling col(<schema_name>) blindly, which
+        would raise and abort the load before any rows are counted.
+        """
+        adapter = DataFusionDataFrameAdapter()
+
+        csv_path = tmp_path / "hits.csv"
+        # Headerless: column_2 (the would-be string column) has an empty field.
+        csv_path.write_text("1,Alice\n2,\n")
+
+        df = adapter.read_csv(
+            csv_path,
+            has_header=False,
+            null_marker=None,
+            # Declared benchmark schema name that is NOT a frame column.
+            string_columns=["url"],
+        )
+
+        result = adapter.collect(df)
+        assert result.num_rows == 2
+
+    def test_read_csv_coalesces_present_string_columns_to_empty(self, tmp_path):
+        """Columns that ARE present keep the empty-string coalesce contract."""
+        adapter = DataFusionDataFrameAdapter()
+
+        csv_path = tmp_path / "with_header.csv"
+        csv_path.write_text("id,name\n1,Alice\n2,\n")
+
+        df = adapter.read_csv(
+            csv_path,
+            has_header=True,
+            null_marker=None,
+            string_columns=["name"],
+        )
+
+        result = adapter.collect(df)
+        names = result.column("name").to_pylist()
+        assert "" in names
+        assert None not in names
+
     def test_read_tbl_with_column_names(self, tmp_path):
         """Test reading TPC-style .tbl with trailing delimiter."""
         adapter = DataFusionDataFrameAdapter()


### PR DESCRIPTION
Seventh pass — reviewer threads on PRs merged since pass 6 (#892, #896, #897, #901, #902, #904, #906). Each verified against `develop` first.

## Code
- **datafusion_df (#904)** — guard the empty-string coalesce loop on the frame's *actual* columns. On the headerless-CSV-with-declared-schema path (e.g. ClickBench `hits.csv`), DataFusion's columns are inferred names (`column_1`, …), not the schema names, so `col(<schema_name>)` raised and aborted the load before row counting. Now only declared string columns that are present are coalesced.

## UAT release-accounting (#902)
- **`_cli` (#902a)** — persist the skipped-unreachable count into a durable sidecar (`cells.jsonl.accounting.json`) and read it back when regenerating the report, so `make uat-report CELLS_JSONL=…` no longer prints `unreachable: 0` for a sweep that skipped a platform as unreachable.
- **orchestrator + phases/execute (#902b)** — thread the already-accumulated skipped-unreachable count through the `DiskFloorAbort` path so the abort artifact no longer drops earlier-skipped cells from `total_defined`.

## CI / tests
- **pr.yml (#906)** — invoke the cross-surface GATES Make/CI pinning ratchet explicitly in the required `code-test` job. It is `medium`-marked so the fast-lane selection skipped it, and marking it `fast` is forbidden by the repo's marker-strategy guard — so an explicit node invocation (mirroring the peer mutation-drift guard) is the correct fix.
- **mutation sensitivity (#901)** — pass `scale_factor=gate.scale_factor` into `build_production_contexts` so non-default gates (`h2odb`=0.01, `read_primitives`=0.05) load contexts under the same SF as the enforced `run_gate`, not the `EQUIVALENCE_SCALE` (0.1) fallback.

## TODO
- **auto-merge-review-gate-soundness-paths (#896/#897)** — add the required regression-test path to `scope_limit.only_modify`, and split out a **w3** that explicitly gates the `auto-merge-on-open.yml` backstop on the same soundness-path predicate as w2.
- **write-primitives-scd-type2-coverage (#892)** — move `benchmark.py` into `only_modify` (scoped to `table_population_map`/`reset_map`) so the new `scd2_ops_*` staging tables can be populated and reset, with a note added to w1.

## Testing
Regression tests added for #904 and #902. `tests/unit/platforms/dataframe/test_datafusion_df.py` + `tests/uat/` + `test_standardized_test_commands.py` → 134 passed; `ruff` clean; `pr.yml` valid YAML; the mutation test collects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_