### PR TITLE
chore: close out cloud-parity hooks, drift guard, and pin-swap TODO

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,27 @@
     "claude-md-management@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "code-modernization@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$TOOL_INPUT_file_path\" in *.py) uv run ruff check --fix \"$TOOL_INPUT_file_path\"; uv run ruff format \"$TOOL_INPUT_file_path\" 2>/dev/null; exit 0;; *) exit 0;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "case \"$TOOL_INPUT_file_path\" in *.py) uv run ty check \"$TOOL_INPUT_file_path\"; exit 0;; *) exit 0;; esac"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -363,6 +363,25 @@ jobs:
         # stale snapshot. Switch to `npx -y skill-sync@<ver>` once published.
         run: npx -y github:joeharris76/skill-sync#d3c9c45 verify --project .
 
+      - name: Untracked skill-mirror drift guard (cloud parity)
+        # The codex/gemini/antigravity mirrors and the curated-out `blog` skill are
+        # deliberately untracked: cloud is Claude-only and `blog` is published
+        # separately. `skill-sync verify` only inspects the tracked `claude` target
+        # (it skips untracked targets and `ignore`d paths), so it cannot catch these
+        # being force-added. Fail the build if any become git-tracked.
+        # Rationale: _project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+        run: |
+          tracked=$(git ls-files -- \
+            '.codex/skills' '.codex/shared-skills' '.codex/shared-skills.lock.json' \
+            '.gemini/skills' '.antigravity/skills' \
+            '.claude/skills/blog')
+          if [ -n "$tracked" ]; then
+            echo "ERROR: deliberately-untracked skill mirrors are now git-tracked:" >&2
+            echo "$tracked" >&2
+            echo "Untrack them with 'git rm --cached -r <path>' (regenerate locally via 'make skill-sync')." >&2
+            exit 1
+          fi
+
   code-test:
     name: test (ubuntu-latest, 3.12)
     needs: ci-paths

--- a/_project/TODO/main/planning/skill-sync-npm-pin-swap.yaml
+++ b/_project/TODO/main/planning/skill-sync-npm-pin-swap.yaml
@@ -1,0 +1,66 @@
+id: skill-sync-npm-pin-swap
+title: "Swap CI skill-sync verify from github-sha pin to npm version"
+worktree: chore-skill-sync-npm-pin-swap
+priority: Low
+status: Blocked
+category: "Testing and Quality Assurance"
+
+description: |
+  The cloud/CI integrity gate that verifies the tracked skill snapshot runs
+  skill-sync via a github-sha pin because the tool is not published to npm:
+
+    .github/workflows/pr.yml (skill-sync tracked snapshot verify step):
+      run: npx -y github:joeharris76/skill-sync#d3c9c45 verify --project .
+
+  The github pin is reproducible and tokenless, so this is acceptable as an
+  interim. Costs vs an npm dependency: a full repo clone on every CI run, no
+  semver, and reliance on GitHub availability.
+
+  When skill-sync is published to npm, replace the single call site with:
+
+      run: npx -y skill-sync@<ver> verify --project .
+
+  Update the adjacent comment, and optionally repoint the Makefile default
+  `SKILL_SYNC ?= /Users/joe/Developer/skill-sync/dist/cli/index.js` to the
+  npm-installed binary so local `make skill-sync` / `make skill-sync-verify`
+  use the published tool too. The Makefile and `.pre-commit-config.yaml`
+  already resolve skill-sync via the override-able `SKILL_SYNC` path, so the
+  only hard-coded github pin is the one CI line above.
+
+deferred:
+  - summary: "Publish skill-sync to npm"
+    reason: >
+      Lives in the separate joeharris76/skill-sync repo and is a deliberate
+      decision (the tool may stay github-only). This TODO is the consumer-side
+      swap; it unblocks only once that publish happens.
+
+deps:
+  needs: []
+
+work:
+  - id: w1
+    summary: "Replace github-sha pin with npx -y skill-sync@<ver> in pr.yml verify step"
+    status: pending
+    notes: "Single call site. Update the adjacent explanatory comment too."
+  - id: w2
+    summary: "Optionally repoint Makefile SKILL_SYNC default at the npm binary"
+    needs: [w1]
+    status: pending
+
+impact: >
+  Removes per-CI-run github clone latency and gives the integrity gate a
+  semver-pinned dependency. Low urgency: the sha pin is already reproducible
+  and tokenless.
+
+files_affected:
+  modified:
+    - .github/workflows/pr.yml
+    - Makefile
+
+metadata:
+  tags:
+    - skill-sync
+    - cloud-parity
+    - ci
+  created_date: "2026-06-29"
+  estimated_effort: "Small (1 line + comment once unblocked)"

--- a/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+++ b/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
@@ -1,0 +1,93 @@
+# Claude Code Settings Ownership & Cloud Parity - 2026-06-29
+
+## Decision
+
+The project owns `.claude/settings.json` directly (no skill-sync feature
+manages it). Three classes of Claude Code configuration are handled distinctly
+so that cloud/web (`claude.ai/code`) and CI — which clone only the repo — get
+the same agent behavior as a local machine, without leaking machine- or
+policy-specific configuration into the shared tree:
+
+1. **Plugins + marketplaces** — committed to `.claude/settings.json`
+   (`extraKnownMarketplaces` + `enabledPlugins`). Done in #895.
+2. **Skills** — committed via skill-sync's tracked `claude` target
+   (`.claude/skills/**`, `ignore: [blog]`). Done in #898.
+3. **Hooks** — only *portable, project-scoped* hooks are committed to
+   `.claude/settings.json`. *Machine/policy-specific* hooks stay in the user's
+   global `~/.claude/settings.json` and are never committed.
+
+### Hook portability split
+
+Committed (portable — `uv run`, non-blocking `exit 0`, no machine paths, no
+private-repo coupling):
+
+| Hook | Command |
+|---|---|
+| `PostToolUse` `Edit\|Write` `*.py` | `ruff check --fix` + `ruff format` |
+| `PostToolUse` `Edit\|Write` `*.py` | `ty check` |
+
+Deliberately **excluded** (machine/policy-specific):
+
+| Hook | Why excluded |
+|---|---|
+| `PreToolUse` `Bash` push/PR guard | References a private remote (`benchbox-private`) and blocks pushes. Committing it would break legitimate pushes in any clone — including cloud — and encodes a personal policy, not a project invariant. |
+
+### Untracked mirrors (deliberate, guarded)
+
+`.codex/skills`, `.gemini/skills`, `.antigravity/skills`, and the curated-out
+`.claude/skills/blog/` stay untracked: cloud is Claude-only (the other CLIs'
+mirrors add no value there) and `blog` is curated/published separately. These
+rely on the skill-sync-managed `.gitignore` block, which `skill-sync verify`
+does **not** police (it only inspects the tracked `claude` target). A dedicated
+CI step (`Untracked skill-mirror drift guard` in `.github/workflows/pr.yml`)
+fails the build if any of these become git-tracked.
+
+## Rationale
+
+- **Why the project owns settings.json, not skill-sync.** skill-sync manages
+  `.gitignore`/`.gitattributes` blocks and the tracked skill snapshot; it has no
+  settings.json/hooks feature, and it is an unpublished side-tool. Coupling
+  hooks to it would be heavier and add a dependency for no benefit. #895 already
+  set the precedent of the project committing `.claude/settings.json` directly.
+- **Why duplicating portable hooks into the project file is safe.** Claude Code
+  merges hooks across user + project + local settings and **deduplicates
+  identical command hooks** (by exact command string). The committed commands
+  are byte-identical to the global ones, so locally they run **once** (deduped)
+  and in cloud only the project copy exists (runs once). The user's global
+  `~/.claude/settings.json` is therefore left untouched.
+- **Why the push-guard is excluded.** It is non-portable by construction: it
+  hard-codes `benchbox-private` and blocks `git push`. In a public clone or
+  cloud session it would either no-op confusingly or actively break pushes.
+  Push/branch protection is enforced server-side (branch rules, CI) — the local
+  hook is a convenience for one machine, not a project invariant.
+- **Why a separate drift guard for the mirrors.** `verifyTrackedTargets` in
+  skill-sync iterates only targets with `tracked: true` (it `continue`s past
+  untracked targets) and skips `ignore`d paths. So a `git add -f .codex/skills`
+  or a regression in the `.gitignore` managed block would be invisible to the
+  existing integrity gate. The guard is a 3-line `git ls-files` check — no new
+  dependency.
+
+## Evidence
+
+- Global `~/.claude/settings.json` (2026-06-29) contained exactly three hooks:
+  the two `PostToolUse` `.py` formatters/type-checks (portable) and one
+  `PreToolUse` `Bash` push/PR guard referencing `benchbox-private` (non-portable).
+- Claude Code hooks reference: "All matching hooks run in parallel, and
+  identical handlers are deduplicated automatically. Command hooks are
+  deduplicated by command string and `args`."
+- skill-sync `verifyTrackedTargets` (dist `chunk-6V2RFA5R.js`, ~line 1486):
+  `if (!cfg.tracked) continue;` and the `exclusions` skip at the stray-path
+  check confirm untracked targets and `ignore`d paths are out of scope.
+- `npm view skill-sync` → 404 (not published); CI pins
+  `github:joeharris76/skill-sync#d3c9c45`. Swap to `npx -y skill-sync@<ver>`
+  tracked as a follow-up TODO.
+
+## Alternatives rejected
+
+- **Teach skill-sync to manage a hooks block in settings.json** (like its
+  `.gitignore` block). Rejected: heavier, couples the project to an unpublished
+  tool, and dedup already makes direct project ownership safe.
+- **Move the portable hooks out of the user global file.** Unnecessary given
+  dedup; would mutate user-global config for no behavioral gain.
+- **Commit all hooks including the push-guard.** Rejected: breaks cloud pushes
+  and encodes personal policy as a project invariant.


### PR DESCRIPTION
Completes the remaining open items from the skills/agent-config cloud
parity effort (#895, #898).

- .claude/settings.json: commit the two portable PostToolUse .py hooks
  (ruff check --fix + format; ty check) so cloud/web sessions get the same
  edit-time lint/type behavior. Byte-identical to the global hooks, so Claude
  Code dedupes them locally (no double-run) and ~/.claude/settings.json is
  untouched. The PreToolUse push/PR guard stays user-global -- it references a
  private remote and would break pushes in any clone.
- .github/workflows/pr.yml: add a drift guard that fails CI if the
  deliberately-untracked codex/gemini/antigravity mirrors or the curated-out
  blog skill become git-tracked. skill-sync verify only inspects the tracked
  claude target, so it cannot catch this.
- _project/decisions/claude-settings-cloud-ownership-2026-06-29.md: ADR for the
  ownership model and hook portability split.
- _project/TODO/main/planning/skill-sync-npm-pin-swap.yaml: tracked (Blocked)
  follow-up to swap the CI github-sha pin to npx skill-sync@<ver> once published.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
