### PR TITLE
PR review follow-up sweep (pass 8): late-landing findings (#908, #915, #916)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$TOOL_INPUT_file_path\" in *.py) uv run ruff check --fix \"$TOOL_INPUT_file_path\"; uv run ruff format \"$TOOL_INPUT_file_path\" 2>/dev/null; exit 0;; *) exit 0;; esac"
+            "command": "file_path=$(python3 -c \"import json,sys; raw=sys.stdin.read().strip() or '{}'; d=json.loads(raw) if raw[:1]=='{' else {}; print((d.get('tool_input') or {}).get('file_path',''))\"); case \"$file_path\" in *.py) uv run ruff check --fix \"$file_path\"; uv run ruff format \"$file_path\" 2>/dev/null; exit 0;; *) exit 0;; esac"
           }
         ]
       },
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$TOOL_INPUT_file_path\" in *.py) uv run ty check \"$TOOL_INPUT_file_path\"; exit 0;; *) exit 0;; esac"
+            "command": "file_path=$(python3 -c \"import json,sys; raw=sys.stdin.read().strip() or '{}'; d=json.loads(raw) if raw[:1]=='{' else {}; print((d.get('tool_input') or {}).get('file_path',''))\"); case \"$file_path\" in *.py) uv run ty check \"$file_path\"; exit 0;; *) exit 0;; esac"
           }
         ]
       }

--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -545,14 +545,23 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             # Fall back to simpler API
             df = self.session_ctx.read_csv(path_str)
 
+        if column_names:
+            # DataFusion's non-.tbl read_csv ignores column_names (unlike the
+            # .tbl path), so a headerless CSV (e.g. ClickBench's generated
+            # hits.csv) keeps DataFusion's inferred names (column_1, …) rather
+            # than the benchmark schema names. Re-apply the declared names
+            # positionally so downstream schema-name lookups resolve — without
+            # this the string-column coalesce below skips every declared column
+            # and the empty text fields stay NULL instead of "".
+            df = self._apply_tbl_column_names(df, column_names)
+
         if null_marker is None and string_columns:
-            # For headerless CSV with a declared schema (e.g. ClickBench's
-            # generated hits.csv), this non-.tbl path never applies
-            # `column_names`, so the frame columns are DataFusion's inferred
-            # names (column_1, …) rather than the benchmark schema names.
-            # Guard each coalesce on membership in the frame's actual columns
-            # so a declared string column that isn't present by name does not
-            # raise on `col(<schema_name>)` and abort the load.
+            # ``null_marker is None`` means empty fields in declared string
+            # columns must stay ``""`` (ClickBench filters ``SearchPhrase <> ''``
+            # etc.). DataFusion reads an empty CSV field as NULL, so coalesce it
+            # back to "". The membership guard tolerates a declared column that
+            # genuinely isn't present (e.g. column_names was not supplied so the
+            # rename above could not align the schema names).
             present_columns = {field.name for field in df.schema()}
             for name in string_columns:
                 if name in present_columns:

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -430,9 +430,7 @@ class TestExecuteOperation:
         ):
             operation = wp_benchmark.get_operation(op_id)
             assert operation.category == "merge"  # still classified under merge
-            effective_sql, skip_reason = wp_benchmark._get_effective_write_sql(
-                operation, platform_key="duckdb"
-            )
+            effective_sql, skip_reason = wp_benchmark._get_effective_write_sql(operation, platform_key="duckdb")
             assert skip_reason is None, f"{op_id} was wrongly skipped on DuckDB: {skip_reason}"
             assert effective_sql, f"{op_id} returned no effective SQL"
 

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -417,6 +417,30 @@ class TestExecuteOperation:
         assert "MERGE" in (result.skip_reason or "")
         mock_conn.execute.assert_not_called()
 
+    def test_scd2_merge_category_ops_are_not_skipped_on_duckdb(self, wp_benchmark):
+        """SCD Type 2 ops keep the ``merge`` category for taxonomy/reporting but
+        are portable UPDATE/INSERT, so DuckDB must NOT skip them under the
+        category-wide MERGE gap. Otherwise a real ``platform_key='duckdb'`` run
+        reports them skipped and loses the coverage the catalog adds (they run
+        fine when ``execute_operation`` is called without a platform key)."""
+        for op_id in (
+            "merge_scd_type2_basic",
+            "merge_scd_type2_no_change",
+            "merge_scd_type2_new_keys_only",
+        ):
+            operation = wp_benchmark.get_operation(op_id)
+            assert operation.category == "merge"  # still classified under merge
+            effective_sql, skip_reason = wp_benchmark._get_effective_write_sql(
+                operation, platform_key="duckdb"
+            )
+            assert skip_reason is None, f"{op_id} was wrongly skipped on DuckDB: {skip_reason}"
+            assert effective_sql, f"{op_id} returned no effective SQL"
+
+        # A genuine MERGE-statement op in the same category is still skipped.
+        merge_op = wp_benchmark.get_operation("merge_simple_upsert_small")
+        _, merge_skip = wp_benchmark._get_effective_write_sql(merge_op, platform_key="duckdb")
+        assert merge_skip is not None and "MERGE" in merge_skip
+
     def test_execute_operation_uses_platform_override_when_available(self, wp_benchmark, monkeypatch):
         """Platform override SQL should be used instead of base write_sql."""
         operation = wp_benchmark.get_operation("insert_on_conflict_ignore")

--- a/tests/unit/platforms/dataframe/test_datafusion_df.py
+++ b/tests/unit/platforms/dataframe/test_datafusion_df.py
@@ -246,6 +246,37 @@ class TestDataFusionDataLoading:
         assert "" in names
         assert None not in names
 
+    def test_read_csv_headerless_with_column_names_coalesces_declared_string_columns(self, tmp_path):
+        """The real ClickBench path: headerless CSV + column_names + string_columns.
+
+        DataFusion's non-.tbl read_csv ignores column_names, so without
+        re-applying them the declared schema-named string columns are not frame
+        columns (the frame has column_1, …) and the empty-string coalesce is
+        skipped, leaving empty text fields as NULL. The real benchmark run passes
+        column_names (unlike the does-not-raise test above), so a declared string
+        column's empty field must come back as "" addressed by its schema name —
+        ClickBench filters SearchPhrase <> '' and would otherwise lose those rows.
+        """
+        adapter = DataFusionDataFrameAdapter()
+
+        csv_path = tmp_path / "hits.csv"
+        # Headerless: id, then a string column whose 2nd row is an empty field.
+        csv_path.write_text("1,Alice\n2,\n")
+
+        df = adapter.read_csv(
+            csv_path,
+            has_header=False,
+            column_names=["id", "search_phrase"],
+            null_marker=None,
+            string_columns=["search_phrase"],
+        )
+
+        result = adapter.collect(df)
+        assert result.column_names == ["id", "search_phrase"]
+        phrases = result.column("search_phrase").to_pylist()
+        assert phrases == ["Alice", ""]
+        assert None not in phrases
+
     def test_read_tbl_with_column_names(self, tmp_path):
         """Test reading TPC-style .tbl with trailing delimiter."""
         adapter = DataFusionDataFrameAdapter()


### PR DESCRIPTION
## Summary

Resolves three late-landing `chatgpt-codex-connector` P2 review findings on already-merged PRs. Each is fixed on this consolidated branch off `develop` with a regression test.

### #908 — DataFusion headerless-CSV empty-string coalesce (`datafusion_df.py`)
The empty-string coalesce skipped every declared string column because DataFusion's non-`.tbl` `read_csv` ignores `column_names`, so the frame kept inferred names (`column_1`, …) and the membership guard matched nothing — leaving ClickBench's empty text fields as NULL instead of `""` (which breaks `SearchPhrase <> ''` filters). Now re-applies the declared schema names positionally (reusing `_apply_tbl_column_names`) before the coalesce, so the declared columns resolve and empty fields become `""`.

### #916 — SCD Type 2 ops skipped on DuckDB (`write_primitives`)
The new SCD Type 2 ops are portable `UPDATE`/`INSERT` but inherit the `merge` category from their `merge_*` ids, so the category-wide DuckDB MERGE skip dropped them on a real `platform_key='duckdb'` run (they only ran because the unit tests call `execute_operation` without a platform key). Adds an explicit DuckDB skip-exception set for the three SCD2 op ids so they execute on DuckDB while genuine MERGE-statement ops stay skipped. The `merge` category taxonomy is unchanged (so `test_catalog_categories` stays green).

### #915 — PostToolUse hooks never ran (`.claude/settings.json`)
The ruff/format and ty hooks read `$TOOL_INPUT_file_path`, which the hook runtime does not populate, so they silently never ran for Python edits in cloud sessions. Now parse the event JSON from stdin and extract `tool_input.file_path` (defensive against empty/non-JSON stdin) before the `*.py` match.

## Verification
- `uv run -- python -m pytest tests/unit/platforms/dataframe/test_datafusion_df.py tests/unit/core/write_primitives/test_benchmark_execution.py tests/unit/benchmarks/test_write_primitives_core.py tests/unit/core/write_primitives/test_catalog_loader.py -n 0 -q` → 281 passed
- `uv run -- python -m pytest tests/unit/test_oracle_coverage_map.py tests/unit/platforms/base/test_adapter_query_skips.py -n 0 -q` → 21 passed
- `uv run -- ruff check` on all changed files → clean
- Hook stdin extraction verified against simulated `PostToolUse` payloads (`.py` → runs, `.md`/empty/no-tool_input → safe no-op)

## Not included
The fourth late-landing finding (#913, oracle-coverage-map reference-independence labeling) is a design decision that conflicts with the maintainer's just-added truth-pinning tests; left for maintainer review rather than inverting those tests. See the PR #913 thread reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_