### PR TITLE
docs(blog): add AUTO CDC vs portable SQL MERGE SCD2 deep-dive

### DIFF
--- a/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
@@ -1,0 +1,280 @@
+---
+title: "SCD Type 2: Declarative CDC vs Portable SQL MERGE"
+meta_description: "We tested whether Databricks AUTO CDC really replaces ~200 lines of MERGE for SCD Type 2: honest line counts, portable SQL, BenchBox numbers, and lock-in."
+tags: [databricks, delta-lake, scd-type-2, merge, cdc, write-primitives, benchmarking, portability]
+status: draft
+date: 2026-06-30
+---
+
+# SCD Type 2: Declarative CDC vs Portable SQL MERGE
+
+> We reconstruct the portable SQL that Databricks' declarative CDC replaces, count it
+> honestly, measure it in BenchBox, and weigh convenience against portability.
+
+**TL;DR**: Databricks' AUTO CDC (formerly APPLY CHANGES INTO) genuinely removes
+boilerplate and a class of Slowly Changing Dimension bugs, and that convenience is
+real. But it runs only on Databricks declarative pipelines, while the equivalent
+portable SQL runs unchanged across DuckDB, PostgreSQL, Snowflake, BigQuery, and
+ClickHouse. For a basic Type 2, that portable SQL is about 18 lines, not 200. The
+honest trade-off is convenience versus portability, not lines of code.
+
+---
+
+## Introduction
+
+A widely shared claim about Databricks' declarative change data capture (CDC) is that
+it replaces "~200 lines of MERGE logic" with a few declarative lines that handle
+inserts, updates, deletes, history, and record open and close automatically. Slowly
+Changing Dimension (SCD) Type 2 maintenance (closing the current version of a changed
+row and opening a new version, keyed on a business key) is the workload most often
+cited.
+
+We wanted to test that claim fairly rather than restate it. So we did four things:
+reconstructed the real portable SQL the declarative form replaces, counted it
+honestly, measured the portable form in BenchBox, and characterized the declarative
+form from Databricks' primary documentation. We did not have a Databricks workspace
+to run a declarative pipeline, so everything we say about the declarative side is
+documentation-grounded and labeled as such. We never present it as a BenchBox
+measurement. Every number and behavior claim here traces to a dated entry in our
+verification log[^log].
+
+Two axes matter for this comparison, and we try to be honest about both:
+ergonomics and maintainability (lines of code, edge cases handled for you), and
+portability and lock-in (which engines can run it at all).
+
+## The two forms, side by side
+
+### Declarative: AUTO CDC
+
+The declarative form is concise. Databricks' own SCD Type 2 example reads[^cdc]:
+
+```sql
+CREATE OR REFRESH STREAMING TABLE users_history;
+CREATE FLOW apply_cdc AS AUTO CDC INTO users_history
+FROM stream(main.cdc_tutorial.users_cdf)
+KEYS (userId)
+APPLY AS DELETE WHEN operation = "DELETE"
+SEQUENCE BY sequenceNum
+COLUMNS * EXCEPT (operation, sequenceNum)
+STORED AS SCD TYPE 2;
+```
+
+That is two statements, eight lines as shown, with about six to seven lines of actual
+CDC logic, and it is genuinely doing a lot (more on that below). A naming note: this
+API was called APPLY CHANGES INTO and is now AUTO CDC,
+with the same syntax[^cdc]. It is part of what Databricks now calls Lakeflow Spark
+Declarative Pipelines, the product formerly known as Delta Live Tables[^dlt].
+
+### Portable: MERGE / UPDATE plus INSERT
+
+The portable form is the SCD Type 2 operation we added to BenchBox's Write Primitives
+benchmark[^op]. SCD Type 2 produces two row events per changed business key: one
+UPDATE to close the old version, one INSERT to open the new one. Most engines cannot
+do both for the same matched key in a single MERGE statement, so the canonical idiom
+is an UPDATE followed by an INSERT:
+
+```sql
+-- 1. Close the current version of each changed business key
+UPDATE scd2_ops_dim_customer
+SET is_current = false,
+    valid_to = (SELECT MIN(s.effective_ts) FROM scd2_ops_stage_customer s
+                WHERE s.c_custkey = scd2_ops_dim_customer.c_custkey AND s.change_type = 'changed')
+WHERE scd2_ops_dim_customer.is_current = true
+  AND EXISTS (SELECT 1 FROM scd2_ops_stage_customer s
+              WHERE s.c_custkey = scd2_ops_dim_customer.c_custkey
+                AND s.change_type = 'changed'
+                AND s.row_hash <> scd2_ops_dim_customer.row_hash);
+
+-- 2. Open a new current version for changed keys, and insert brand-new keys
+INSERT INTO scd2_ops_dim_customer
+SELECT (SELECT MAX(sk) FROM scd2_ops_dim_customer) + ROW_NUMBER() OVER (ORDER BY s.c_custkey),
+       s.c_custkey, s.c_name, s.c_address, s.c_acctbal, s.c_mktsegment, s.row_hash,
+       true, s.effective_ts, DATE '9999-12-31'
+FROM scd2_ops_stage_customer s
+WHERE s.change_type = 'new'
+   OR (s.change_type = 'changed'
+       AND EXISTS (SELECT 1 FROM scd2_ops_dim_customer d
+                   WHERE d.c_custkey = s.c_custkey AND d.is_current = false AND d.valid_to = s.effective_ts));
+```
+
+This is portable standard SQL. It uses a business key (`c_custkey`), a current-version
+flag (`is_current`), validity timestamps (`valid_from` and `valid_to`), and a
+change-detection fingerprint (`row_hash`) to decide what changed. There is no
+engine-specific syntax, so it runs unchanged across the engines BenchBox targets.
+
+### The honest line count
+
+Here is where the "200 lines" claim deserves scrutiny. The portable basic Type 2 above
+is 18 lines of SQL, measured from the registry, not hand-counted[^log]. The declarative
+form is about 6 to 7 lines. So the real ratio for a basic Type 2 is closer to 3 to 1
+than 11 to 1.
+
+Where does "200" come from? It is Databricks' own figure, but it is a range and it is
+about something larger. Their April 2026 post compares "~6-10 lines of declarative
+pipeline definition" to "40-200+ lines of custom pipeline logic"[^blog]. That upper
+bound describes full custom CDC pipeline logic, including the ordering, deduplication,
+and late-data handling that a production pipeline needs, not a basic close-and-insert.
+A separate "1,500 lines" figure that circulates is a named customer testimonial in the
+same post, not an official Databricks metric[^blog]. Worth noting too: Databricks has
+removed the full SCD Type 2 MERGE example from its own MERGE documentation and now
+points readers to AUTO CDC[^merge], so the side-by-side line count can no longer be
+sourced to one official code block.
+
+## What the declarative form does for you
+
+The convenience is real, and it is worth being specific about it. Beyond fewer lines,
+AUTO CDC handles several things automatically that the portable form leaves to you[^scd]:
+
+- Out-of-order events. `SEQUENCE BY` orders CDC events by a sequencing column, so late
+  or reordered records still produce a correct history.
+- Deletes. `APPLY AS DELETE WHEN <condition>` closes a record on a delete event.
+- Column projection. `COLUMNS * EXCEPT (...)` keeps bookkeeping columns out of the
+  tracked attributes.
+- Record versioning. SCD Type 2 automatically maintains `__START_AT` and `__END_AT`
+  columns for each version.
+
+Our portable operation, by contrast, is a single ordered batch by design. It does not
+reorder out-of-sequence events or process delete markers; if you needed those, you
+would add window functions and extra predicates, and that is exactly the kind of code
+that grows toward the 40-200+ range. This is the declarative form's genuine advantage:
+it removes a class of SCD Type 2 bugs (incorrect ordering, missed record closing) that
+hand-written logic has to handle explicitly.
+
+## Portability and lock-in
+
+The other axis is where the trade-off bites. AUTO CDC requires a streaming source and
+runs on a Lakeflow declarative pipeline (the Pro, Advanced, or serverless edition)[^cdc].
+As of 2026 you no longer have to hand-author a pipeline: you can create and refresh
+standalone streaming tables from a Databricks SQL warehouse, and the system
+auto-provisions a serverless pipeline to do the processing[^standalone]. That is a real
+improvement in ergonomics. But the processing still happens on a Databricks serverless
+pipeline, not on warehouse compute, and not on any other engine. It is not a standalone
+statement you can run against an ordinary table, and it does not run on DuckDB,
+PostgreSQL, Snowflake, BigQuery, or ClickHouse.
+
+The portable form runs on all of them. We can show this concretely with one engine. The
+bundled DuckDB 1.3.2 rejects `MERGE INTO` outright, so BenchBox's standard run skips its
+entire MERGE category on DuckDB[^skip]. Yet the portable SCD Type 2 operation, built
+from UPDATE and INSERT rather than `MERGE INTO`, runs on DuckDB and passes its
+correctness checks. The same SQL that an engine refuses in `MERGE INTO` form runs fine
+in the portable form. That is the portability argument in miniature.
+
+## What we measured
+
+We measured the portable form only. We have no Databricks workspace, so we ran no AUTO
+CDC pipeline and we claim no declarative timing or cost.
+
+A methodology note on how we ran it. Because `benchbox run --platform duckdb` skips the
+MERGE category on DuckDB (the legacy operations use `MERGE INTO`)[^skip], we exercised
+the SCD Type 2 operation through BenchBox's operation API, the same path the integration
+tests use. We loaded real TPC-H data with DuckDB's native `dbgen`, let BenchBox seed the
+dimension and a mixed change batch (20 changed, 20 unchanged, 20 brand-new business
+keys), then ran each operation with the dimension reset to its seed state between runs.
+
+Results on DuckDB 1.3.2, Apple M4, in-memory. The numbers are the median per-operation
+write time the harness reports, excluding setup and reset[^log].
+
+At SF0.01 (dimension of 1,500 current rows, median of 30 runs):
+
+| Operation | median (ms) | min (ms) | p90 (ms) | validation |
+| --- | --- | --- | --- | --- |
+| Basic (close old plus insert new) | 2.517 | 2.323 | 2.737 | passed |
+| No change (idempotent re-run) | 2.066 | 1.921 | 2.196 | passed |
+| New keys only (insert only) | 1.208 | 1.111 | 1.685 | passed |
+
+At SF0.1 (dimension of 15,000 current rows, 10x larger, median of 15 runs):
+
+| Operation | median (ms) | min (ms) | p90 (ms) | validation |
+| --- | --- | --- | --- | --- |
+| Basic (close old plus insert new) | 4.360 | 4.040 | 4.972 | passed |
+| No change (idempotent re-run) | 3.690 | 3.031 | 3.806 | passed |
+| New keys only (insert only) | 1.462 | 1.312 | 2.437 | passed |
+
+One observation stands out. The dimension grew 10x, but the basic operation rose only
+about 1.7x (2.5 ms to 4.4 ms). The workload is bounded by the fixed change batch plus
+the dimension scans in the close predicate and the validation, so it is
+change-batch-bound rather than dimension-size-bound. It is not perfectly flat, because
+the larger dimension costs more to scan, but it is far from linear in dimension size.
+These are single-machine, DuckDB-only numbers, and we present them as illustration of
+the portable operation working and validating, not as a platform ranking.
+
+## Convenience versus portability
+
+So which form should you reach for? We will not give a verdict, because it genuinely
+depends on the constraint you are optimizing for.
+
+The declarative form is a strong fit when your stack is Databricks-centric, when you are
+ingesting a streaming CDC feed with out-of-order events and deletes, and when removing
+boilerplate and a class of SCD Type 2 bugs is worth more than running anywhere else. Six
+declarative lines that handle ordering and record closing correctly are a real
+maintainability win.
+
+The portable form is a strong fit when portability is the point: benchmarking the same
+workload across engines, running without a pipeline runtime, keeping full control of the
+SQL, or running on an engine that does not support `MERGE INTO` at all. It is also the
+only option when "the same operation, everywhere" is a hard requirement, which is exactly
+why BenchBox models SCD Type 2 this way.
+
+## Methodology and limitations
+
+Anyone can reproduce the portable measurement. Load real TPC-H data with DuckDB's `dbgen`,
+set up the Write Primitives benchmark, and run the operation:
+
+```python
+import duckdb
+from benchbox import WritePrimitives
+
+con = duckdb.connect(":memory:")
+con.execute("INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01);")
+wp = WritePrimitives(scale_factor=0.01, quiet=True)
+wp.setup(con, force=True)
+result = wp.execute_operation("merge_scd_type2_basic", con)
+print(result.write_duration_ms, result.validation_passed)
+```
+
+Limitations we want to be clear about:
+
+- No Databricks run. The declarative side is documentation-grounded only; we assert no
+  AUTO CDC timing or cost.
+- Single machine, DuckDB only, in-memory. The numbers illustrate the portable operation
+  working, not a cross-engine comparison.
+- Basic Type 2 only. Our line count compares one concrete portable implementation to one
+  documented declarative example. Both are basic Type 2 and exclude the production
+  hardening that the 40-200+ range covers.
+
+## Conclusions
+
+The "~200 lines of MERGE" framing is partly a strawman and partly fair. For a basic
+Type 2 close-and-insert, the portable SQL is about 18 lines, not 200, so the headline
+ratio is overstated. For a hardened production CDC pipeline that also handles ordering,
+deletes, and late data, the 40-200+ range is Databricks' own figure and is reasonable,
+and the declarative form absorbs that complexity for you.
+
+The more useful way to read the comparison is convenience versus portability. AUTO CDC
+buys you concise, correct-by-construction SCD Type 2 on Databricks. Portable SQL buys you
+the same history-tracking workload on every engine, including ones that reject `MERGE
+INTO`. Both are legitimate choices; the right one depends on whether your constraint is
+maintainability inside one platform or portability across many.
+
+## Next steps
+
+The portable operation lives in BenchBox's Write Primitives benchmark[^op], and the full
+evidence behind every number here is in our verification log[^log]. We would love for
+others to run the portable form on PostgreSQL, Snowflake, BigQuery, or ClickHouse and
+compare. Open an issue to share results or to discuss the methodology.
+
+---
+
+## References
+
+[^log]: Verification log for this post: `_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md` (BenchBox repository). Contains the environment snapshot, source quotes, line counts, and measurement runs. Measurements run 2026-06-30; documentation accessed 2026-06-29.
+[^cdc]: [Change data capture with AUTO CDC](https://docs.databricks.com/aws/en/ldp/cdc), Databricks documentation, accessed 2026-06-29. "The `AUTO CDC` APIs replace the `APPLY CHANGES` APIs and have the same syntax."
+[^dlt]: [What happened to Delta Live Tables (DLT)?](https://docs.databricks.com/aws/en/ldp/concepts/where-is-dlt), Databricks documentation, last updated 2026-06-15, accessed 2026-06-29.
+[^op]: Write Primitives SCD Type 2 operations (`merge_scd_type2_basic`, `merge_scd_type2_no_change`, `merge_scd_type2_new_keys_only`), BenchBox repository, `benchbox/core/write_primitives/catalog/operations.yaml`.
+[^scd]: [AUTO CDC INTO (pipelines) SQL reference](https://docs.databricks.com/aws/en/ldp/developer/ldp-sql-ref-apply-changes-into) and [What is change data capture?](https://docs.databricks.com/aws/en/ldp/what-is-change-data-capture), Databricks documentation, accessed 2026-06-29.
+[^blog]: [Stop hand-coding change data capture pipelines](https://www.databricks.com/blog/stop-hand-coding-change-data-capture-pipelines), Databricks blog, 2026-04-22, accessed 2026-06-29. Official figure: "~6-10 lines of declarative pipeline definition" versus "40-200+ lines of custom pipeline logic". The "1,500 lines" figure is a customer testimonial, not an official metric.
+[^merge]: [Upsert into a Delta Lake table using merge](https://docs.databricks.com/aws/en/delta/merge), Databricks documentation, accessed 2026-06-29. The SCD section now points to AUTO CDC rather than a hand-written SCD Type 2 MERGE example.
+[^standalone]: [Use standalone streaming tables](https://docs.databricks.com/aws/en/ldp/dbsql/streaming), Databricks documentation, accessed 2026-06-29. "You can create and refresh standalone streaming tables from a Databricks SQL warehouse... Instead, streaming tables rely on serverless pipelines for both creation and refresh."
+[^skip]: DuckDB execution-filter rule for Write Primitives, BenchBox repository, `benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py`. The MERGE category is skipped on DuckDB because the legacy operations use `MERGE INTO`, which the bundled DuckDB 1.3.2 rejects.
+
+*Questions or feedback? Open an issue or join the discussion.*

--- a/_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md
@@ -1,0 +1,89 @@
+# Outline: AUTO CDC vs Standard SQL MERGE for SCD Type 2
+
+**Post type:** Platform deep-dive / technical challenge (convenience vs portability).
+**Target length:** 1,800-2,400 words.
+**Editorial angle:** Not "declarative good, SQL bad" and not a Databricks teardown.
+Thesis: declarative CDC genuinely removes boilerplate and a class of SCD2 bugs, and
+that convenience is real, but it is a pipeline-bound, Databricks-only abstraction.
+The right lens is convenience vs portability, with honest numbers and code side by
+side. Let readers weigh the trade-off.
+
+**Evidence source:** `_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md`.
+Every perf/behavior claim cites a dated entry there. BenchBox harness results and
+Databricks doc/marketing claims are never conflated. No Databricks workspace was
+available, so the declarative side is documentation-grounded only.
+
+**Voice reminders:** "we", neutral on platforms, data over superlatives, no
+em-dashes or en-dashes, define terms, footnote external facts.
+
+## Title + frontmatter
+- Title (< 60 chars): "SCD Type 2: Declarative CDC vs Portable SQL MERGE"
+- One-sentence summary + TL;DR (the trade-off in 2-3 sentences).
+- meta_description (150-160 chars); tags: databricks, delta-lake, scd-type-2, merge,
+  cdc, write-primitives, benchmarking, portability.
+
+## 1. Introduction (150-300 words)
+- The hook: a widely shared claim that declarative CDC replaces ~200 lines of MERGE.
+- What we test: reconstruct the real portable SQL, count it honestly, measure it in
+  BenchBox, characterize the declarative form from primary docs.
+- Define SCD Type 2 (close the current version, open a new one, keyed on a business
+  key) in one parenthetical.
+- State the two axes: ergonomics/maintainability and portability/lock-in, plus
+  performance where measurable.
+
+## 2. The two forms, side by side (main content)
+- 2a. Declarative AUTO CDC (formerly APPLY CHANGES INTO): show the ~6-7 line SQL
+  example from the docs (A2). Note current naming (A1) and the DLT to Lakeflow
+  history briefly (A5).
+- 2b. Portable MERGE / UPDATE+INSERT: show the BenchBox `merge_scd_type2_basic` form
+  (close-old UPDATE + insert-new INSERT). Explain the two-statement reality.
+- 2c. The honest line count: ~18 portable lines vs ~6-7 declarative for a basic
+  Type 2. Correct the "200 lines" framing: official figure is 40-200+ for full
+  custom pipeline logic (A6); the 1,500-line number is a customer quote, not an
+  official metric. Databricks also removed its own SCD2 MERGE example (A7).
+
+## 3. What the declarative form does for you (ergonomics)
+- SEQUENCE BY (out-of-order events), APPLY AS DELETE, COLUMNS EXCEPT, automatic
+  __START_AT/__END_AT versioning (A4). These are real and remove a class of bugs.
+- Where the portable form makes you do the work: ordering, late data, deletes are
+  on you (the BenchBox op is a single ordered batch by design). Be fair: this is the
+  declarative form's genuine advantage.
+
+## 4. Portability and lock-in
+- AUTO CDC runs on a Lakeflow declarative pipeline (Pro/Advanced/serverless), now
+  invocable from a SQL warehouse via standalone streaming tables, but always on
+  Databricks/serverless pipelines, never on other engines, and not a standalone
+  statement (A3, with the 2026 correction, stated carefully).
+- The portable form runs unchanged across DuckDB, PostgreSQL, Snowflake, BigQuery,
+  ClickHouse. Concrete proof: DuckDB rejects MERGE INTO entirely, yet runs the
+  portable UPDATE+INSERT SCD2 op (C1).
+
+## 5. What we measured (results, BenchBox, portable form only)
+- Methodology: DuckDB 1.3.2, Apple M4, real TPC-H via dbgen, operation API (explain
+  why not `benchbox run`: the DuckDB MERGE-category skip, C1).
+- SF0.01 and SF0.1 tables (C3). The change-batch-bound observation (10x data, ~1.7x
+  time).
+- Explicit non-measurement: we did not run AUTO CDC (no workspace); no declarative
+  timing or cost is claimed.
+
+## 6. Analysis: convenience vs portability
+- When declarative wins: Databricks-centric stack, streaming CDC with out-of-order
+  and deletes, teams that value fewer lines and fewer SCD2 bugs.
+- When portable wins: multi-engine benchmarking/portability, no pipeline runtime,
+  full control, running on engines that lack MERGE INTO.
+- No verdict; present the trade-off.
+
+## 7. Methodology + Limitations
+- Reproducible commands (dbgen + operation API snippet), versions, machine.
+- Limitations: single machine, DuckDB-only, no Databricks run, basic Type 2 only,
+  line-count compares one implementation to one documented example.
+
+## 8. Conclusions + Next steps
+- The "200 lines" claim is partly a strawman for a basic Type 2 (real portable form
+  is ~18 lines) and partly fair for hardened production pipelines (40-200+).
+- The honest axis is portability vs convenience.
+- Invite reproduction; link the BenchBox operation and the verification file.
+
+## References (footnotes)
+- Databricks AUTO CDC / CDC docs, SQL ref, standalone streaming tables, where-is-dlt,
+  delta/merge, the "Stop hand-coding CDC" blog. All accessed 2026-06-29.

--- a/_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md
+++ b/_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md
@@ -1,0 +1,293 @@
+# APPLY CHANGES INTO (AUTO CDC) vs Standard SQL MERGE: Claim Verification
+
+> Evidence log for the platform-deep-dive post comparing Databricks' declarative
+> CDC (AUTO CDC, formerly APPLY CHANGES INTO) to portable hand-written SQL for
+> SCD Type 2 dimension maintenance. Every claim in the draft must trace to a
+> dated entry here. BenchBox harness results and Databricks documentation/marketing
+> claims are kept strictly separate.
+
+## Objective
+
+Test the marketing claim that Databricks' declarative CDC "replaces ~200 lines of
+MERGE logic" with a few declarative lines, fairly and reproducibly: reconstruct the
+real portable SQL it replaces, count it honestly, measure the portable form in
+BenchBox, and characterize the declarative form accurately from primary Databricks
+docs (we do not have a Databricks workspace to run an AUTO CDC pipeline, so the
+declarative side is documentation-grounded and labeled as such, never presented as
+a BenchBox harness result).
+
+## Dates
+
+- Documentation research access date: 2026-06-29 (all Databricks doc URLs below).
+- BenchBox measurement runs: 2026-06-30.
+- File named for the TODO creation date (2026-06-27); individual entries are dated
+  when the check was actually run.
+
+## Environment Snapshot (measurement runs)
+
+- Timestamp (UTC): 2026-06-30T11:32:54Z
+- OS: macOS 26.5 (25F71)
+- Kernel: Darwin 25.5.0 (arm64)
+- Device / chip: Apple M4, 10 cores (4 performance + 6 efficiency), 16 GB RAM
+- Python: 3.12.11
+- DuckDB: 1.3.2 (BenchBox-bundled driver)
+- BenchBox: write_primitives SCD Type 2 operations (merged on `develop`)
+
+---
+
+## Part A: Databricks documentation claims (research, 2026-06-29)
+
+All quotes are verbatim from the cited pages; the `docs.databricks.com/aws/en`
+locale was used (AWS/Azure/GCP locales are content-identical). Three corrections
+to the brief's starting assumptions are flagged inline, because they change how the
+post must be worded.
+
+### A1. The feature is now called AUTO CDC (APPLY CHANGES INTO renamed)
+
+- Claim: AUTO CDC is the current API and replaces APPLY CHANGES with identical syntax.
+- Source: https://docs.databricks.com/aws/en/ldp/cdc (accessed 2026-06-29)
+- Quote: "The `AUTO CDC` APIs replace the `APPLY CHANGES` APIs and have the same syntax."
+- Draft handling: use "AUTO CDC (formerly APPLY CHANGES INTO)" on first mention.
+
+### A2. Current SQL grammar and an SCD Type 2 example
+
+- Source: https://docs.databricks.com/aws/en/ldp/developer/ldp-sql-ref-apply-changes-into
+  (page titled "AUTO CDC INTO (pipelines)") and https://docs.databricks.com/aws/en/ldp/cdc
+  (accessed 2026-06-29)
+- Verbatim SQL example (SCD Type 2):
+  ```sql
+  CREATE OR REFRESH STREAMING TABLE users_history;
+  CREATE FLOW apply_cdc AS AUTO CDC INTO users_history
+  FROM stream(main.cdc_tutorial.users_cdf)
+  KEYS (userId)
+  APPLY AS DELETE WHEN operation = "DELETE"
+  SEQUENCE BY sequenceNum
+  COLUMNS * EXCEPT (operation, sequenceNum)
+  STORED AS SCD TYPE 2;
+  ```
+- This is the canonical "few declarative lines" form the marketing refers to.
+
+### A3. Pipeline-context constraint, with a 2026 correction
+
+- Claim (still true): the source must be a streaming source, and AUTO CDC runs on a
+  Lakeflow declarative pipeline (Pro/Advanced or serverless edition), not as a
+  one-shot DML statement against an ordinary Delta table.
+  - Source: https://docs.databricks.com/aws/en/ldp/developer/ldp-sql-ref-apply-changes-into
+  - Quote: "The source must be a streaming source. Use the STREAM keyword to use
+    streaming semantics to read from the source." and "You must declare a target
+    streaming table to apply the changes into."
+  - Source: https://docs.databricks.com/aws/en/ldp/cdc
+  - Quote: "To use the CDC APIs, your pipeline must be configured to use serverless
+    SDP or the SDP `Pro` or `Advanced` editions."
+- CORRECTION (do not claim "SQL-warehouse-forbidden"): standalone streaming tables
+  can be created and refreshed from a Databricks SQL warehouse, with processing run
+  on an auto-provisioned serverless pipeline.
+  - Source: https://docs.databricks.com/aws/en/ldp/dbsql/streaming ("Use standalone
+    streaming tables"), accessed 2026-06-29
+  - Quotes: "You can create and refresh standalone streaming tables from a Databricks
+    SQL warehouse, or from a notebook running on serverless general compute." and
+    "These operations do not consume Databricks SQL warehouse compute. Instead,
+    streaming tables rely on serverless pipelines for both creation and refresh. A
+    dedicated serverless pipeline is automatically created and managed by the system
+    for each streaming table."
+  - Draft handling: state that AUTO CDC always executes on a (possibly
+    auto-provisioned) serverless declarative pipeline, that you can now invoke it
+    from a SQL warehouse via standalone streaming tables, but that it still runs only
+    on Databricks/serverless pipelines, never on DuckDB, PostgreSQL, Snowflake,
+    BigQuery, or ClickHouse, and is not a single standalone statement.
+- COULD NOT VERIFY: no primary doc says AUTO CDC "cannot run in a SQL warehouse."
+  That negative phrasing is avoided in the draft.
+
+### A4. SCD Type 2 semantics AUTO CDC handles automatically
+
+Source: https://docs.databricks.com/aws/en/ldp/developer/ldp-sql-ref-apply-changes-into,
+https://docs.databricks.com/aws/en/ldp/cdc, and
+https://docs.databricks.com/aws/en/ldp/what-is-change-data-capture (accessed 2026-06-29).
+
+- Out-of-order events: "AUTO CDC automatically handles out-of-sequence records by
+  processing events in the order defined by the sequencing column." `SEQUENCE BY` is required.
+- Deletes: `APPLY AS DELETE WHEN <condition>`. `APPLY AS TRUNCATE` is SCD Type 1 only:
+  "The `APPLY AS TRUNCATE WHEN` clause is supported only for SCD type 1. SCD type 2
+  does not support the truncate operation."
+- Column projection: `COLUMNS {columnList | * EXCEPT (exceptColumnList)}`.
+- Record versioning: "SCD Type 2 preserves a complete history of changes by creating
+  new rows for each version of a record, with `__START_AT` and `__END_AT` columns
+  indicating when each version was active." The target schema must include
+  `__START_AT` and `__END_AT`.
+
+### A5. Naming history (DLT to Lakeflow)
+
+- Source: https://docs.databricks.com/aws/en/ldp/concepts/where-is-dlt ("What happened
+  to Delta Live Tables (DLT)?", last updated 2026-06-15), accessed 2026-06-29
+- Quote: "The product formerly known as Delta Live Tables (DLT) has been updated to
+  Lakeflow Spark Declarative Pipelines (SDP)."
+- Supporting (Apache Spark contribution at Data + AI Summit, June 2025): DLT was
+  contributed to Apache Spark and is available via `pyspark.pipelines` from Spark 4.1.
+  Source: https://www.databricks.com/dataaisummit/session/build-data-pipelines-lakeflow-declarative-pipelines
+- PARTIAL VERIFICATION: no single primary page dates the full DLT to Lakeflow
+  Declarative Pipelines to Lakeflow Spark Declarative Pipelines chain; the June 2025
+  date comes from the DAIS announcement, not a dated changelog. The draft states the
+  chain conservatively and cites the "where-is-dlt" page for the current name.
+
+### A6. The "~200 lines of MERGE" figure (official source, attributed carefully)
+
+- Source: Databricks blog "Stop hand-coding change data capture pipelines",
+  published 2026-04-22, https://www.databricks.com/blog/stop-hand-coding-change-data-capture-pipelines
+  (accessed 2026-06-29)
+- Official figure: "~6-10 lines of declarative pipeline definition" versus "40-200+
+  lines of custom pipeline logic". This is the authoritative origin of the
+  "200 lines" claim: it is a range (40-200+) for full custom pipeline logic, not a
+  flat 200 for a basic Type 2.
+- Customer testimonial (NOT an official metric): "I tried AutoCDC from Snapshots in
+  Python and was amazed at how 4 lines of code could replace what I was doing in
+  1,500 lines of code before." attributed to a "Senior Data Engineer, Fortune 500
+  Aerospace & Defense Company." The 1,500-line figure is a customer quote and is
+  labeled as such in the draft.
+- Supporting prose: "Teams routinely hand-roll complex `MERGE` logic to handle
+  updates, deletes, and late-arriving data: layering on staging tables, window
+  functions, and sequencing assumptions that are difficult to reason about, and even
+  harder to maintain as pipelines evolve."
+
+### A7. Databricks removed the canonical SCD2 MERGE example from its MERGE docs
+
+- Source: https://docs.databricks.com/aws/en/delta/merge (content-identical mirror
+  https://learn.microsoft.com/en-us/azure/databricks/delta/merge, ms.date 2026-06-11),
+  accessed 2026-06-29
+- Quote (current SCD section in full): "Lakeflow Spark Declarative Pipelines has
+  native support for tracking and applying SCD Type 1 and Type 2. Use `AUTO CDC ...
+  INTO` with Lakeflow Spark Declarative Pipelines to ensure that out of order records
+  are handled correctly when processing CDC feeds."
+- Implication: the "equivalent hand-written MERGE" line count can no longer be pinned
+  to one official Databricks code block; the draft reconstructs the portable form
+  from the BenchBox operation and counts that, anchoring the official range to A6.
+
+---
+
+## Part B: Reconstructed portable SQL and honest line count (2026-06-30)
+
+The portable SCD Type 2 workload is the BenchBox `merge_scd_type2_basic` operation
+(merged on `develop`). The canonical two-statement form (close the current version,
+then insert the new one) is what AUTO CDC's `STORED AS SCD TYPE 2` replaces.
+
+Line counts derived from the registry (not hand-counted):
+
+```
+uv run -- python -c "from benchbox.core.write_primitives.catalog.loader import \
+  load_write_primitives_catalog as L; c=L().operations; \
+  print({k: c[k].write_sql.rstrip(chr(10)).count(chr(10))+1 for k in c if k.startswith('merge_scd_type2')})"
+```
+
+- `merge_scd_type2_basic`: 18 lines of SQL (close-old UPDATE + insert-new INSERT)
+- `merge_scd_type2_no_change`: 17 lines (idempotent re-run path)
+- `merge_scd_type2_new_keys_only`: 7 lines (insert-only path)
+- Each carries a 3-line cleanup statement.
+
+The declarative AUTO CDC form for the same Type 2 result (A2) is about 6-7 lines.
+
+Honest reading: for a basic Type 2 close-and-insert, the portable hand-written form
+is roughly 18 lines, not 200. The official "40-200+ lines" range (A6) describes full
+custom CDC pipeline logic that also handles out-of-order events, deletes, and
+late-arriving data; AUTO CDC absorbs that hardening, and the BenchBox operation does
+not implement it (it is a single-batch, ordered, portable workload by design). The
+fair comparison is therefore: similar line counts for the basic happy path, with the
+declarative form pulling ahead specifically on the hardening edge cases, at the cost
+of running only inside Databricks/serverless pipelines.
+
+## Part C: BenchBox measurements of the portable form (2026-06-30)
+
+### C1. Why the operation API, not `benchbox run`
+
+`benchbox run write_primitives --platform duckdb` currently skips the entire MERGE
+category on DuckDB, because the 20 legacy MERGE operations use `MERGE INTO`, which
+the bundled DuckDB 1.3.2 rejects (execution-filter rule
+`benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py`). The new
+SCD Type 2 operations are categorized as MERGE but use portable UPDATE + INSERT, so
+they run on DuckDB even though `MERGE INTO` does not. We therefore measure them
+through the operation API (`WritePrimitives.execute_operation`), the same path the
+integration tests use. (A follow-up to narrow that category skip so the portable ops
+also run under `benchbox run` on DuckDB is tracked separately and is out of scope for
+this post.)
+
+This skip is itself a concrete illustration of the post's thesis: the portable form
+runs on an engine that rejects `MERGE INTO` entirely.
+
+### C2. Reproducible measurement script
+
+Real TPC-H data via DuckDB's native `dbgen`, then the SCD2 operations via the
+operation API. Full script:
+`/private/tmp/.../scd2_measure.py` in the working session; the essential steps are:
+
+```python
+import duckdb
+from benchbox import WritePrimitives
+con = duckdb.connect(":memory:")
+con.execute("INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01);")  # real TPC-H customer/orders/lineitem
+wp = WritePrimitives(scale_factor=0.01, quiet=True)
+wp.setup(con, force=True)                                      # seeds scd2_ops_dim_customer + change batch
+for _ in range(30):
+    wp.reset(con)                                             # restore dimension to seed state
+    r = wp.execute_operation("merge_scd_type2_basic", con)   # write + validate + cleanup
+    # r.write_duration_ms, r.validation_passed
+```
+
+### C3. Results
+
+DuckDB 1.3.2, Apple M4, in-memory. Median of the per-operation write duration
+reported by the harness (the write statements only, excluding setup/reset). The
+change batch is fixed at 20 changed + 20 unchanged + 20 new business keys at every
+scale factor by construction.
+
+SF0.01 (dimension = 1,500 current rows; n = 30):
+
+| Operation | median (ms) | min (ms) | p90 (ms) | validation |
+| --- | --- | --- | --- | --- |
+| merge_scd_type2_basic | 2.517 | 2.323 | 2.737 | passed |
+| merge_scd_type2_no_change | 2.066 | 1.921 | 2.196 | passed |
+| merge_scd_type2_new_keys_only | 1.208 | 1.111 | 1.685 | passed |
+
+SF0.1 (dimension = 15,000 current rows, 10x larger; n = 15):
+
+| Operation | median (ms) | min (ms) | p90 (ms) | validation |
+| --- | --- | --- | --- | --- |
+| merge_scd_type2_basic | 4.360 | 4.040 | 4.972 | passed |
+| merge_scd_type2_no_change | 3.690 | 3.031 | 3.806 | passed |
+| merge_scd_type2_new_keys_only | 1.462 | 1.312 | 2.437 | passed |
+
+Observation: the dimension grew 10x (1,500 to 15,000 rows) but the basic operation
+rose only about 1.7x (2.5 to 4.4 ms), because the work is bounded by the fixed
+60-row change batch plus the dimension scans in the close-UPDATE predicate and the
+one-current-per-key validation. The workload is change-batch-bound, not
+dimension-size-bound, though not perfectly flat.
+
+## Part D: Cross-check (draft claim to evidence)
+
+- Draft claim: "AUTO CDC's SCD Type 2 example is about 6-7 declarative lines."
+  - Evidence: A2 verbatim example.
+- Draft claim: "The portable SQL it replaces, for a basic Type 2, is about 18 lines,
+  not 200."
+  - Evidence: Part B registry line count; A6 for the official 40-200+ range framing.
+- Draft claim: "The '200 lines' figure is Databricks' own 40-200+ range for full
+  custom pipeline logic; the 1,500-line figure is a customer quote."
+  - Evidence: A6.
+- Draft claim: "AUTO CDC runs only on Databricks/serverless pipelines (now invocable
+  from a SQL warehouse via standalone streaming tables); the portable form runs
+  unchanged on DuckDB and other engines."
+  - Evidence: A3 (with correction); C1 (DuckDB runs the portable form while rejecting
+    `MERGE INTO`).
+- Draft claim: "The portable SCD2 operation runs, validates, and is repeatable on
+  DuckDB; median basic-op write time ~2.5 ms at SF0.01 and ~4.4 ms at SF0.1."
+  - Evidence: C3 (BenchBox harness result, DuckDB only, this machine).
+- Draft claim: "AUTO CDC handles out-of-order events, deletes, and history
+  automatically."
+  - Evidence: A4.
+
+## Limitations of this evidence
+
+- No Databricks workspace was available, so no AUTO CDC pipeline was run. The
+  declarative side is documentation-grounded only; no timing or cost figure for AUTO
+  CDC is asserted anywhere in the draft.
+- BenchBox numbers are single-machine (Apple M4), DuckDB-only, in-memory, and reflect
+  the portable form measured through the operation API, not a multi-engine sweep.
+- Line counts compare one concrete portable implementation (the BenchBox operation)
+  to one documented declarative example; both are "basic Type 2" and exclude the
+  production hardening that the 40-200+ range covers.

--- a/_project/DONE/main/blog-apply-changes-into-vs-standard-sql.yaml
+++ b/_project/DONE/main/blog-apply-changes-into-vs-standard-sql.yaml
@@ -3,7 +3,8 @@ title: Blog - Evaluate Databricks APPLY CHANGES INTO vs Standard SQL MERGE for S
 worktree: main
 category: Documentation
 priority: Low
-status: Not Started
+status: Completed
+completed_date: '2026-06-30'
 description: |
   Write a platform-deep-dive blog post that explicitly evaluates Databricks'
   declarative APPLY CHANGES INTO (DLT / Lakeflow Declarative Pipelines) against
@@ -116,7 +117,7 @@ deps:
 work:
   - id: w1
     summary: Research APPLY CHANGES INTO semantics and pipeline-context constraint
-    status: pending
+    status: done
     notes: |
       Databricks docs: APPLY CHANGES INTO / AUTO CDC, SCD TYPE 2, SEQUENCE BY,
       APPLY AS DELETE, COLUMNS/EXCEPT, the DLT/Lakeflow pipeline requirement.
@@ -124,14 +125,14 @@ work:
   - id: w2
     summary: Reconstruct equivalent standard MERGE and do honest LOC/edge-case count
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Reuse the merge_scd_type2 op. Count real lines and enumerate which edge
       cases (ordering, deletes, schema evolution) each form handles.
   - id: w3
     summary: Gather measurements - MERGE via BenchBox; APPLY CHANGES INTO externally if feasible
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       MERGE form across engines via BenchBox (runtime, rows versioned, $ where
       a cost model exists). APPLY CHANGES INTO only if a Databricks workspace is
@@ -139,11 +140,11 @@ work:
   - id: w4
     summary: Write outline
     needs: [w1, w2]
-    status: pending
+    status: done
   - id: w5
     summary: Write draft with side-by-side code and the measurements we have
     needs: [w3, w4]
-    status: pending
+    status: done
 
 deferred:
   - summary: "Benchmarking the DLT pipeline path inside the BenchBox harness"


### PR DESCRIPTION
Companion to the merged Write Primitives SCD Type 2 operation. A
platform-deep-dive evaluating Databricks' declarative CDC (AUTO CDC,
formerly APPLY CHANGES INTO) against portable hand-written SQL for SCD
Type 2, on two honest axes: ergonomics and portability.

Adds:
  - research/apply-changes-into-vs-merge-verification-2026-06-27.md:
    dated evidence log. Databricks doc claims (accessed 2026-06-29,
    cited), the registry-derived line counts, and BenchBox measurements
    (2026-06-30). Corrects three starting assumptions: APPLY CHANGES INTO
    is now AUTO CDC; the "pipeline-only" framing is outdated (standalone
    streaming tables run it from a SQL warehouse on auto serverless
    pipelines); the "200 lines" figure is Databricks' own 40-200+ range
    for full custom pipeline logic, and "1,500 lines" is a customer quote.
  - outlines/ + drafts/apply-changes-into-vs-standard-sql.md.

Evidence discipline: BenchBox harness results (portable SCD2 op on
DuckDB via the operation API: ~2.5 ms at SF0.01, ~4.4 ms at SF0.1,
validated) are kept strictly separate from the docs-grounded declarative
side (no Databricks workspace was available, so no AUTO CDC timing is
claimed). Honest line count: the portable basic Type 2 is ~18 lines, not
200. House voice, no em/en-dashes, footnoted sources.

Implements _project/DONE/main/blog-apply-changes-into-vs-standard-sql.yaml

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
