### PR TITLE
docs(write_primitives): reconcile README operation counts with registry

### DIFF
--- a/benchbox/core/write_primitives/README.md
+++ b/benchbox/core/write_primitives/README.md
@@ -24,8 +24,8 @@ Following the **primitives benchmark pattern**, this benchmark:
 
 ## Benchmark Statistics
 
-- **Total Operations**: 117 (109 baseline + 8 sketch — TRANSACTION ops moved to transaction_primitives)
-- **Categories**: 7 (INSERT 12, UPDATE 15, DELETE 14, BULK_LOAD 36, MERGE 20, DDL 12, SKETCH 8)
+- **Total Operations**: 136 (112 baseline + 24 sketch — TRANSACTION ops moved to transaction_primitives)
+- **Categories**: 7 (INSERT 12, UPDATE 15, DELETE 14, BULK_LOAD 36, MERGE 23, DDL 12, SKETCH 24)
 - **Data Formats**: CSV, Parquet (uncompressed, gzip, zstd, snappy, bzip2)
 - **Scale Factors**: Flexible (0.01 to 10.0+)
 - **Platform Support**: All platforms via dialect translation + platform-specific overrides
@@ -74,7 +74,7 @@ Tests bulk loading from files with various formats and compression:
 - Parquet loads (12): uncompressed, snappy, gzip, zstd × (1K, 100K, 1M rows)
 - Special loads (12): column subset, transformations, error handling, parallel, upsert, append vs replace modes, custom delimiters, NULL handling, custom date formats
 
-### 5. MERGE Operations (18 operations)
+### 5. MERGE Operations (23 operations)
 
 Tests MERGE/UPSERT patterns including INSERT, UPDATE, and DELETE:
 - Simple UPSERT
@@ -88,6 +88,14 @@ Tests MERGE/UPSERT patterns including INSERT, UPDATE, and DELETE:
 - CTE sources
 - MERGE...RETURNING
 - Error handling (duplicate sources)
+- SCD Type 2 dimension maintenance — three ops that exercise history-retaining
+  merges via portable UPDATE-then-INSERT, keyed on a business key:
+  - `merge_scd_type2_basic` — canonical close-old-plus-insert-new for changed
+    and new keys
+  - `merge_scd_type2_no_change` — idempotency check: an unchanged batch closes
+    no rows and inserts no new versions
+  - `merge_scd_type2_new_keys_only` — insert-only path where every staged key is
+    brand-new, so no existing rows are closed
 
 ### 6. DDL Operations (12 operations)
 
@@ -109,12 +117,14 @@ Tests transaction control and isolation levels:
 - Nested SAVEPOINTs with partial rollback
 - Isolation levels (READ COMMITTED, SERIALIZABLE)
 
-### Sketch persistence operations (8 operations)
+### Sketch persistence operations (24 operations)
 
 Tests the **persist + merge + requery** lifecycle for Apache DataSketches
 sketch artifacts — the differentiated half of the modern approximate-
 analytics story (vendors compete on millisecond-merge across partitioned
 sketch columns, not on one-shot aggregate latency).
+
+**Core lifecycle (8 ops)** — Theta / KLL / Top-K families at default parameters:
 
 - `sketch_ddl_create_persistent_table` — CREATE/DROP overhead for a
   BINARY-column persistence table
@@ -131,10 +141,36 @@ sketch columns, not on one-shot aggregate latency).
   `approx_top_k_lineitem` in read_primitives)
 - `sketch_drop_persistent_table` — DROP overhead for a sketch-bearing table
 
-The three ★ ops are the **headline tests** that validate the
-"millisecond merge" claim. Validation contracts use tolerance-based
-`expected_value_min/max` because sketch outputs are non-deterministic
-across engines and runs.
+**Accuracy/size parameter sweeps (6 ops)** — same merge lifecycle at smaller
+and larger sketch sizes to expose the accuracy-vs-storage trade-off:
+
+- `sketch_query_theta_union_merge_lgk10` / `_lgk14` — Theta at lg_k=10
+  (~5KB, ~3.1% RSE) and lg_k=14 (~64KB, ~0.8% RSE)
+- `sketch_query_kll_quantiles_merge_k100` / `_k1000` — KLL at k=100
+  (~1.5KB, ~1.65% rank error) and k=1000 (~15KB, ~0.59% rank error)
+- `sketch_query_topk_combine_lgmm8` / `_lgmm10` — Top-K at lg_max_map_size=8
+  (256 buckets, ~600B) and lg_max_map_size=10 (1024 buckets, ~2KB)
+
+**Extended DuckDB-only families (8 ops)** — CPC (distinct) and REQ (quantile)
+sketches available through the `datasketches` community extension:
+
+- `sketch_cpc_create_persistent_table` / `sketch_cpc_insert_per_partition` /
+  ★ `sketch_cpc_query_union_merge` / `sketch_cpc_drop_persistent_table` —
+  CPC distinct-count lifecycle (union-merge + approximate distinct)
+- `sketch_req_create_persistent_table` / `sketch_req_insert_per_partition` /
+  ★ `sketch_req_query_quantile_merge` / `sketch_req_drop_persistent_table` —
+  REQ quantile lifecycle (merge + median extraction)
+
+**PySpark DataFrame headlines (2 ops)** — exercise the persist+merge cycle
+through the DataFrame API rather than SQL:
+
+- ★ `sketch_df_hll_persist_merge` — per-group HLL sketches, persist + merge
+- ★ `sketch_df_topk_persist_merge` — per-group Top-K, persist + merge
+  (Spark 4.1+ only — uses `F.approx_top_k`)
+
+The ★ ops are the **headline tests** that validate the "millisecond merge"
+claim. Validation contracts use tolerance-based `expected_value_min/max`
+because sketch outputs are non-deterministic across engines and runs.
 
 | Sketch family   | DataSketches binary-portable engines              | Native-but-distinct engines                    | No support       |
 |-----------------|---------------------------------------------------|-----------------------------------------------|------------------|
@@ -218,14 +254,14 @@ Operations use SQLGlot dialect translation by default, with `platform_overrides`
 a platform override is `null`, `_get_effective_write_sql()` returns a skip reason and
 the operation is recorded as `SKIPPED` in results.
 
-### DataFusion (v51.0.0) - 62 Skipped Operations
+### DataFusion (v51.0.0) - 64 Skipped Operations
 
 DataFusion is an Arrow-native query engine that operates on **immutable record batches**.
 This architecture provides excellent read/scan performance but means row-level mutation
 (UPDATE, DELETE) is not implemented - there is no write path for existing data. MERGE
 depends on UPDATE/DELETE and is therefore also unsupported.
 
-All 62 skips fall into categories dictated by this architectural constraint. None have
+All 64 skips fall into categories dictated by this architectural constraint. None have
 viable alternative SQL syntax within DataFusion's current capability set.
 
 #### UPDATE - 15 operations (queries 13-27)
@@ -243,12 +279,15 @@ rewrite vs. in-place update) and is therefore not substituted.
 Same architectural constraint as UPDATE. Includes the 2 GDPR-pattern deletes
 (queries 94-95) which also require DELETE.
 
-#### MERGE - 20 operations (queries 76-93, 96-97)
+#### MERGE - 23 operations (queries 76-93, 96-100)
 
 `NotImplemented("Unsupported SQL statement: MERGE INTO...")`
 
 MERGE requires UPDATE and/or DELETE capabilities, neither of which DataFusion supports.
 Covers all upsert patterns, conditional update/insert, ETL aggregation, and deduplication.
+Includes the 3 SCD Type 2 ops (queries 98-100: `merge_scd_type2_basic`,
+`merge_scd_type2_no_change`, `merge_scd_type2_new_keys_only`), which depend on
+UPDATE/INSERT against existing rows and carry explicit `datafusion: null` overrides.
 
 #### DDL Mutations - 8 operations
 
@@ -270,13 +309,12 @@ Covers all upsert patterns, conditional update/insert, ETL aggregation, and dedu
 | `insert_on_conflict_ignore` | `Plan("Insert-on clause not supported")` - no constraint enforcement makes ON CONFLICT meaningless |
 | `insert_returning_clause` | `Plan("Insert-returning clause not supported")` |
 
-#### BULK_LOAD Edge Cases - 3 operations
+#### BULK_LOAD Edge Cases - 2 operations
 
 | Operation | Reason |
 |-----------|--------|
 | `bulk_load_error_handling_skip_bad_rows` | DataFusion's CSV reader has no `IGNORE_ERRORS` equivalent; all rows must be valid |
 | `bulk_load_upsert_mode` | Requires MERGE INTO, which is unsupported |
-| `bulk_load_date_format_custom` | External table CSV options don't support `date_format`; non-ISO dates cause ArrowError cast failures |
 
 #### Upstream Tracking
 
@@ -298,7 +336,7 @@ benchbox/core/write_primitives/
 └── catalog/
     ├── __init__.py
     ├── loader.py                # YAML catalog loader
-    └── operations.yaml          # 113 operation definitions
+    └── operations.yaml          # 136 operation definitions
 ```
 
 ## License


### PR DESCRIPTION
## Description

The `benchbox/core/write_primitives/README.md` package doc carried stale,
internally-inconsistent operation counts that predated and were not fully
reconciled by the SCD Type 2 coverage change. This PR reconciles **all** count
references to values derived from the operation registry (not hand-guessed),
fixes the internal 18-vs-20-vs-23 MERGE inconsistency, and documents the new
SCD Type 2 and extended sketch operations.

Authoritative numbers were derived from:

```
uv run -- python -c "from benchbox import WritePrimitives; from collections import Counter; ops=WritePrimitives(0.01).get_all_operations(); print(len(ops), dict(Counter(o.category for o in ops.values())))"
# -> 112 {'insert': 12, 'update': 15, 'delete': 14, 'bulk_load': 36, 'merge': 23, 'ddl': 12}
uv run -- python -c "from benchbox.core.write_primitives.catalog.loader import load_write_primitives_catalog as L; print(len(L().operations))"
# -> 136
```

Changes:

- **Total Operations** 117 → **136** (112 baseline + 24 sketch); baseline now
  reflects the 3 new SCD2 merge ops.
- **Categories**: MERGE 20 → **23**, SKETCH 8 → **24**.
- **MERGE section header** 18 → **23** (resolves the 18-vs-20-vs-23
  inconsistency) and documents the three SCD Type 2 ops
  (`merge_scd_type2_basic` / `_no_change` / `_new_keys_only`).
- **Sketch section** expanded from 8 to all **24** ops (core lifecycle,
  accuracy/size parameter sweeps, DuckDB-only CPC/REQ families, PySpark
  DataFrame headlines).
- **DataFusion skips** 62 → **64**: MERGE 20 → 23 (incl. the SCD2 ops, which
  carry `datafusion: null`), query range `96-97` → `96-100`; BULK_LOAD 3 → 2,
  dropping `bulk_load_date_format_custom` which no longer has a `datafusion`
  override.
- **File Structure** yaml comment 113 → **136** operation definitions.

## Type of Change

- [x] Documentation

## Testing

- `make pr-preflight` — `ci-lint` passed. The fast test phase surfaced 5
  failures (`test_cli_dryrun`/`test_cli_output` output-dir error handling,
  PySpark CSV null semantics, Delta Lake smoke). All 5 reproduce on a clean
  `develop` checkout without this change and are environmental (running as root
  means the expected `OSError`/`FileNotFoundError` is not raised; missing
  PySpark/Delta runtime extensions). A markdown-only README edit cannot affect
  Python test behavior.
- Cross-checked every count in the README against the two registry commands
  above.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces. *(Docs-only; no contract surface changes.)*
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact. *(No impact — README prose only.)*
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative.
      *(All counts now derived from the registry.)*

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes. *(N/A — count corrections.)*
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks. *(`make ci-lint` via pr-preflight.)*
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [ ] I added/updated tests for behavior changes and error paths. *(Docs-only.)*
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size: *(none committed.)*

## Notes

- The branch was re-based onto `origin/develop` because the SCD Type 2 coverage
  change (and therefore the ops referenced here) lives on `develop`, not `main`.
- Follow-up worth considering: a registry-driven check could assert these README
  counts to prevent future drift (the template's Public Contract item already
  hints at this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019GsAZRenucsbPXbQMQbWq6)_