### PR TITLE
fix(plan-capture): capture read-phase plans before mid-run mutation

### DIFF
--- a/_project/DONE/main/planning/query-plan-capture-post-measurement-divergence.yaml
+++ b/_project/DONE/main/planning/query-plan-capture-post-measurement-divergence.yaml
@@ -4,7 +4,7 @@ worktree: main
 priority: Medium-High
 category: Core Functionality
 
-status: Not Started
+status: Completed
 
 description: |
   The isolated capture phase runs AFTER all timed queries, on the measurement

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -32,7 +32,7 @@ import contextlib
 import signal
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from benchbox.core.constants import (
     GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
@@ -52,6 +52,21 @@ from benchbox.utils.dialect_utils import SQLTranslationError
 from benchbox.utils.printing import quiet_console
 
 __all__ = ["TestDriversMixin", "_power_query_result", "_power_test_error_result"]
+
+
+class _CapturedPlan(NamedTuple):
+    """One query's captured plan, accumulated across isolated capture passes.
+
+    Stored in the per-run ``_captured_plans`` accumulator keyed by capture key so a
+    pre-mutation checkpoint and the final post-measurement pass can each contribute
+    plans that are attached to result rows exactly once. ``plan`` is ``None`` when
+    capture failed or the query was filtered out; ``capture_ms`` is recorded even
+    then so plan-capture timing is reported honestly.
+    """
+
+    plan: Any
+    fingerprint: str | None
+    capture_ms: float | None
 
 
 class TestDriversMixin:
@@ -424,6 +439,11 @@ class TestDriversMixin:
 
         from benchbox.core.tpcds.maintenance_test import TPCDSMaintenanceTest
 
+        # Maintenance mutates table cardinalities. Capture any read-phase plans
+        # recorded so far (combined mode: power/throughput) against the current
+        # pre-mutation data state, before this phase changes it.
+        self._plan_capture_checkpoint(connection)
+
         console = quiet_console
 
         try:
@@ -510,6 +530,11 @@ class TestDriversMixin:
         """Execute TPC-H Maintenance Test using production TPCHMaintenanceTest implementation."""
 
         from benchbox.core.tpch.maintenance_test import TPCHMaintenanceTest
+
+        # Maintenance mutates table cardinalities. Capture any read-phase plans
+        # recorded so far (combined mode: power/throughput) against the current
+        # pre-mutation data state, before this phase changes it.
+        self._plan_capture_checkpoint(connection)
 
         console = quiet_console
 
@@ -612,8 +637,13 @@ class TestDriversMixin:
             return self._dispatch_queries_by_type(benchmark, connection, run_config)
 
         # Isolate capture: record executed queries during the timed run, capture after.
+        # ``_captured_plans`` is the per-run accumulator keyed by capture key; it lets
+        # capture happen in more than one isolated pass (a pre-mutation checkpoint plus
+        # the final pass) while plans are attached to result rows exactly once at the
+        # end. Reset here so a reused adapter never carries plans across runs.
         self._plan_capture_phase_active = True
         self._phase_recorded_queries = {}
+        self._captured_plans = {}
         try:
             results = self._dispatch_queries_by_type(benchmark, connection, run_config)
         finally:
@@ -1207,48 +1237,124 @@ class TestDriversMixin:
         The ``plan_query_filter`` query-selection set (``--plan-queries``) is still
         honoured; the per-iteration / per-stream sampling machinery
         (``plan_first_n`` / ``plan_sampling_rate``) has been retired.
+
+        Capture and attachment are split: :meth:`_capture_recorded_plans` runs the
+        isolated EXPLAIN pass and accumulates plans by capture key, while
+        :meth:`_attach_captured_plans` merges them into the result rows. This lets a
+        workload that mutates data mid-run capture its read-phase plans earlier, at a
+        pre-mutation checkpoint (:meth:`_plan_capture_checkpoint`), so a captured plan
+        always reflects the data state its query was measured against rather than the
+        post-mutation end state — while still attaching every plan exactly once here.
+
+        ``results`` is accepted for backward compatibility but capture is driven by
+        ``queries`` (the recorded-query buffer), which is already SUCCESS-only.
+        """
+        self._capture_recorded_plans(connection, queries)
+        self._attach_captured_plans(results)
+
+    def _capture_recorded_plans(self, connection: Any, queries: dict[str, str]) -> None:
+        """Run the isolated EXPLAIN pass for not-yet-captured recorded queries.
+
+        ``queries`` is the recorded-query buffer (``_phase_recorded_queries``),
+        keyed by capture key (``<public_id>#<sql_digest>``) and populated only for
+        queries that SUCCEEDED during the timed run. Capture is buffer-driven rather
+        than results-driven because the TPC power/throughput drivers rebuild their
+        result rows and drop the internal capture key — so a results-driven selection
+        would silently capture nothing for them. Each not-yet-captured key is
+        EXPLAINed exactly once and stored in the per-run ``_captured_plans``
+        accumulator; a key captured by an earlier pass (a pre-mutation checkpoint) is
+        skipped, so its plan reflects the data state present at its FIRST capture.
         """
         from benchbox.core.plan_capture_phase import run_plan_capture_phase
 
-        # The recorded buffer is keyed by an internal capture key derived from the
-        # result's query_id plus exact executed SQL. Result rows produced before that
-        # key existed (or tests constructing rows by hand) fall back to str(query_id).
-        success_queries = {
-            str(result.get("_plan_capture_key") or result["query_id"]): queries[
-                str(result.get("_plan_capture_key") or result["query_id"])
-            ]
-            for result in results
-            if result.get("status") == "SUCCESS"
-            and str(result.get("_plan_capture_key") or result.get("query_id")) in queries
-        }
-        if not success_queries:
+        captured = self._ensure_plan_capture_accumulator()
+        pending = {key: sql for key, sql in queries.items() if key not in captured}
+        if not pending:
             return
 
         phase = run_plan_capture_phase(
             self,
-            success_queries,
+            pending,
             connection=connection,
             analyze_plans=getattr(self, "analyze_plans", True),
         )
 
+        for capture_key in pending:
+            captured[capture_key] = _CapturedPlan(
+                plan=phase.plans.get(capture_key),
+                fingerprint=phase.fingerprints.get(capture_key),
+                capture_ms=phase.per_query_capture_ms.get(capture_key),
+            )
+
+    def _attach_captured_plans(self, results: list[dict[str, Any]]) -> None:
+        """Merge accumulated captured plans into result rows.
+
+        Per-row SUCCESS guard mirrors the inline capture chokepoint: a captured plan
+        is attached only to rows whose own status succeeded; a failed row sharing a
+        query_id must never be annotated as plan-captured (it would skew downstream
+        plan stats). The internal ``_plan_capture_key`` is popped from every row.
+
+        A row is matched to its captured plan by exact capture key when it carries
+        one (the standard ``_execute_all_queries`` path), else by its public
+        query_id — the TPC power/throughput drivers rebuild result rows without the
+        capture key, leaving only the bare id. The public-id fallback attaches a plan
+        only when that id maps to a single captured variant; a query_id that ran as
+        multiple distinct SQL variants (e.g. seed-varied throughput streams) is left
+        unattached rather than risk pairing a row with another variant's plan.
+        """
+        from benchbox.platforms.base.result_capture import _plan_capture_public_id
+
+        captured = self._ensure_plan_capture_accumulator()
+
+        # Public-id -> the single captured variant for that id, or None when the id
+        # ran as several distinct variants (ambiguous: do not guess which row ran which).
+        by_public_id: dict[str, _CapturedPlan | None] = {}
+        for capture_key, entry in captured.items():
+            public_id = _plan_capture_public_id(capture_key)
+            by_public_id[public_id] = None if public_id in by_public_id else entry
+
         for result in results:
-            # Per-row SUCCESS guard mirrors the inline capture chokepoint: a captured
-            # plan is attached only to rows whose own status succeeded. ``success_queries``
-            # selects a query for capture if *any* row succeeded, but a failed row sharing
-            # that query_id must never be annotated as plan-captured (it would skew
-            # downstream plan stats).
             if result.get("status") != "SUCCESS":
                 result.pop("_plan_capture_key", None)
                 continue
             query_id = str(result.get("query_id"))
-            capture_key = str(result.pop("_plan_capture_key", None) or query_id)
-            plan = phase.plans.get(capture_key)
-            if plan is not None:
-                plan.query_id = query_id
-                result["query_plan"] = plan
-                result["plan_fingerprint"] = phase.fingerprints.get(capture_key)
-            if capture_key in phase.per_query_capture_ms:
-                result["plan_capture_time_ms"] = phase.per_query_capture_ms[capture_key]
+            row_key = result.pop("_plan_capture_key", None)
+            entry = captured.get(str(row_key)) if row_key else by_public_id.get(query_id)
+            if entry is None:
+                continue
+            if entry.plan is not None:
+                entry.plan.query_id = query_id
+                result["query_plan"] = entry.plan
+                result["plan_fingerprint"] = entry.fingerprint
+            if entry.capture_ms is not None:
+                result["plan_capture_time_ms"] = entry.capture_ms
+
+    def _ensure_plan_capture_accumulator(self) -> dict[str, _CapturedPlan]:
+        """Return the per-run captured-plan accumulator, creating it if absent.
+
+        ``_execute_queries_by_type`` resets this at the start of every run; the lazy
+        fallback here keeps direct callers of ``_capture_plans_post_measurement``
+        (tests, bespoke pipelines) working without going through that wrapper.
+        """
+        captured = getattr(self, "_captured_plans", None)
+        if captured is None:
+            captured = {}
+            self._captured_plans = captured
+        return captured
+
+    def _plan_capture_checkpoint(self, connection: Any) -> None:
+        """Capture recorded plans now, before a subsequent data-mutating phase.
+
+        No-op unless the isolated capture phase is active (so it never fires for
+        non-eligible adapters or read-only inline capture). Captures the read-phase
+        plans recorded so far against the current pre-mutation data state so they are
+        not later EXPLAINed against post-mutation cardinalities (the combined-mode
+        divergence). Attachment still happens once, in the final post-measurement
+        pass; this only fixes *when* each read plan is captured.
+        """
+        if not getattr(self, "_plan_capture_phase_active", False):
+            return
+        self._capture_recorded_plans(connection, dict(self._phase_recorded_queries))
 
     # -------------------------------------------------------------------------
     # Dry-run and SQL capture helpers (extracted w9)

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -128,6 +128,42 @@ stage timing are only available from the executed `QueryJob`), so it sets
 `plan_capture_phase_eligible = False` and harvests its plan from the completed job rather than
 through the isolated phase. `analyze_plans` is a no-op for it.
 
+#### Mid-run data mutation: capture before the mutation
+
+The isolated `EXPLAIN` pass runs *after* the timed loop, so for a **read-only** workload it sees the
+exact data state every query was measured against — captured plans and their cardinality estimates
+match what the optimizer chose during measurement. Standard TPC-H/TPC-DS **power** and **throughput**
+sets are `SELECT`-only, so this is always true for them.
+
+A workload that **mutates data mid-run** would otherwise break that guarantee. In **combined mode**
+the order is *power → throughput → maintenance*: the maintenance step (TPC-H RF1/RF2 inserts+deletes,
+TPC-DS data maintenance) changes table cardinalities, so a single capture pass at the very end would
+`EXPLAIN` the power/throughput read queries against the **post-maintenance** data — describing a plan
+the optimizer never chose during measurement.
+
+BenchBox resolves this by capturing **before the mutation**. A capture *checkpoint* runs at the start
+of the maintenance phase — after the read phases, before any maintenance write — so the
+power/throughput plans are EXPLAINed against the pre-maintenance state they were measured against.
+The maintenance writes themselves are then captured in the final post-measurement pass (downgraded to
+a non-`ANALYZE` `EXPLAIN`, so they are never re-executed). Each query is still captured exactly once,
+and plans are attached to result rows once, at the end. The checkpoint runs strictly between phases —
+never inside a timed query or a concurrent throughput stream — so measured timings are unaffected.
+
+Capture is driven by the recorded-query buffer (every distinct query that succeeded during the timed
+run), and each captured plan is attached to its result row by the exact recorded query, or — for the
+TPC power/throughput drivers, whose result rows carry only the query id — by that query id when it
+maps to a single executed SQL variant.
+
+> **Seed-varied throughput streams and bespoke DML query sets.** When one query id runs as *several*
+> distinct SQL variants in the same run (e.g. throughput streams rendered with different seeds), a
+> result row that carries only the query id cannot be matched to the specific variant it ran, so its
+> plan is left unattached rather than risk pairing it with another variant's plan (literal-normalized
+> fingerprints, tracked separately, make these variants structurally equal). Likewise, a *bespoke*
+> query set that runs an `INSERT`/`UPDATE`/`DELETE` partway through and then more `SELECT`s has no
+> maintenance phase boundary, so the isolated model captures those later reads against the end-of-run
+> state. Keep data-mutating steps in a maintenance phase (or a separate run) when you need read-query
+> fingerprints to reflect their measured data state.
+
 ### Captured Fields
 
 Each query result includes three plan-related fields when `--capture-plans` is active:

--- a/tests/integration/test_plan_capture_combined_divergence.py
+++ b/tests/integration/test_plan_capture_combined_divergence.py
@@ -1,0 +1,323 @@
+# Copyright 2026 Joe Harris / BenchBox Project
+#
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Integration tests for combined-mode plan-capture divergence.
+
+The isolated capture phase runs after the timed loop. For a read-only workload
+that is exactly correct, but a workload that MUTATES data mid-run (combined mode:
+power -> throughput -> maintenance) would otherwise have its read-phase plans
+EXPLAINed against the POST-maintenance data state — describing a plan the
+optimizer never chose during measurement.
+
+These exercise the resolution (query-plan-capture-post-measurement-divergence):
+
+- A capture *checkpoint* fires before the maintenance mutation so read-phase
+  plans are captured against the pre-mutation data state they were measured
+  against, while the maintenance writes are captured once in the final pass.
+- Capture is driven by the recorded-query buffer (digest-keyed, SUCCESS-only),
+  and plans attach to result rows by exact capture key or, for the TPC
+  power/throughput drivers that rebuild rows WITHOUT the internal key, by the
+  bare public query_id. This is the production row shape — verified against the
+  real DuckDB TPC-H power path in ``test_real_tpch_power_capture_attaches_plans``
+  — so the tests below deliberately build rows the way the drivers do (no
+  ``_plan_capture_key``) rather than hand-injecting a field production drops.
+
+They run against a real (file-based) DuckDB so EXPLAIN sees the live row counts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.platforms.base.result_capture import _plan_capture_key
+from benchbox.platforms.duckdb import DuckDBAdapter
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.medium,  # required speed marker: real (file-based) DuckDB I/O
+]
+
+
+@pytest.fixture
+def file_adapter(tmp_path):
+    """A file-based DuckDB adapter so a phase connection sees the loaded data."""
+    db_path = str(tmp_path / "divergence.duckdb")
+    return DuckDBAdapter(database_path=db_path, capture_plans=True)
+
+
+def _seed(conn, rows: int) -> None:
+    conn.execute("CREATE TABLE t (id INTEGER, val INTEGER)")
+    conn.executemany("INSERT INTO t VALUES (?, ?)", [(i, i % 7) for i in range(rows)])
+
+
+def _row_count(conn) -> int:
+    return conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+
+
+def _spy_data_state_at_capture(adapter, monkeypatch) -> dict[str, int]:
+    """Patch capture_query_plan to record the table row count seen at each call.
+
+    Returns a dict mapping capture key -> row count visible to that EXPLAIN, so a
+    test can assert *which* data state each query's plan was captured against.
+    """
+    seen: dict[str, int] = {}
+    original = adapter.capture_query_plan
+
+    def _spy(connection, sql, capture_key):
+        seen[str(capture_key)] = _row_count(connection)
+        return original(connection, sql, capture_key)
+
+    monkeypatch.setattr(adapter, "capture_query_plan", _spy)
+    return seen
+
+
+def _begin_phase(adapter) -> None:
+    adapter._plan_capture_phase_active = True
+    adapter._phase_recorded_queries = {}
+    adapter._captured_plans = {}
+
+
+def _record(adapter, query_id: str, sql: str) -> str:
+    """Record a SUCCESS query into the buffer exactly as the chokepoint does."""
+    key = _plan_capture_key(query_id, sql)
+    adapter._phase_recorded_queries[key] = sql
+    return key
+
+
+def test_combined_maintenance_mutation_captures_read_plan_before_mutation(file_adapter, monkeypatch):
+    """A pre-maintenance checkpoint captures read plans against the measured state.
+
+    Simulates the combined-mode lifecycle at the capture seam using the production
+    row shape (power/throughput rows carry only the bare query_id, no capture key):
+    the read phase is recorded and checkpoint-captured, then a maintenance mutation
+    lands, then the final post-measurement pass captures the write. The read query's
+    plan must be EXPLAINed against the pre-mutation row count, never the post one,
+    and must still attach to its row via the public-id fallback.
+    """
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 10)
+        seen = _spy_data_state_at_capture(file_adapter, monkeypatch)
+        _begin_phase(file_adapter)
+
+        # --- Read phase (power/throughput): record + build a result row ---
+        read_sql = "SELECT id, val FROM t WHERE val > 2 ORDER BY id"
+        read_key = _record(file_adapter, "q_read", read_sql)
+        read_row = {"query_id": "q_read", "status": "SUCCESS", "stream_id": 0}  # no _plan_capture_key
+
+        # Checkpoint fires before maintenance: read plan captured at 10 rows.
+        file_adapter._plan_capture_checkpoint(conn)
+        assert seen.get(read_key) == 10, "read plan must be captured before the mutation"
+
+        # --- Maintenance phase: data mutates, then a write is recorded ---
+        conn.executemany("INSERT INTO t VALUES (?, ?)", [(100 + i, i % 7) for i in range(90)])
+        assert _row_count(conn) == 100
+
+        maint_sql = "DELETE FROM t WHERE id > 95"
+        maint_key = _record(file_adapter, "q_maint", maint_sql)
+        maint_row = {"query_id": "q_maint", "status": "SUCCESS", "stream_id": 0}
+
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(
+            conn,
+            dict(file_adapter._phase_recorded_queries),
+            [read_row, maint_row],
+        )
+
+        # Read plan captured exactly once, at the pre-mutation state (10 rows); the
+        # final pass must NOT re-EXPLAIN it against the post-mutation 100 rows.
+        assert seen[read_key] == 10
+        # The maintenance write is captured in the final pass (post-mutation is the
+        # state it actually ran against).
+        assert seen[maint_key] == 100
+
+        # Both rows carry their captured plan, attached via the public-id fallback.
+        assert read_row.get("plan_fingerprint")
+        assert read_row.get("query_plan") is not None
+        assert read_row["query_plan"].query_id == "q_read"
+        assert maint_row.get("plan_fingerprint")
+    finally:
+        conn.close()
+
+
+def test_combined_maintenance_capture_does_not_reexecute_write(file_adapter):
+    """The maintenance DELETE captured in the final pass must not run a second time."""
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 20)
+        _begin_phase(file_adapter)
+
+        maint_sql = "DELETE FROM t WHERE id < 5"
+        _record(file_adapter, "q_maint", maint_sql)
+        conn.execute(maint_sql)  # the measured execution (runs once)
+        after_measured = _row_count(conn)
+        assert after_measured == 15
+
+        maint_row = {"query_id": "q_maint", "status": "SUCCESS"}
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(conn, dict(file_adapter._phase_recorded_queries), [maint_row])
+
+        # Capturing the plan must not re-run the DELETE (structural EXPLAIN only).
+        assert _row_count(conn) == after_measured, "capture must not re-execute the write"
+        assert maint_row.get("plan_fingerprint")
+    finally:
+        conn.close()
+
+
+def test_read_only_combined_capture_attaches_via_public_id(file_adapter):
+    """Read-only rows in TPC shape (no capture key) still get plans, no checkpoint needed."""
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 12)
+        _begin_phase(file_adapter)
+
+        rows = []
+        for qid, sql in (("q1", "SELECT COUNT(*) FROM t"), ("q2", "SELECT id FROM t WHERE val = 3")):
+            _record(file_adapter, qid, sql)
+            rows.append({"query_id": qid, "status": "SUCCESS"})  # no _plan_capture_key
+
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(conn, dict(file_adapter._phase_recorded_queries), rows)
+
+        for row in rows:
+            assert row.get("plan_fingerprint"), f"no fingerprint for {row['query_id']}"
+            assert row.get("query_plan") is not None
+    finally:
+        conn.close()
+
+
+def test_ambiguous_query_id_variants_not_misattached(file_adapter):
+    """A query_id that ran as two distinct SQL variants must not be mis-paired.
+
+    Throughput streams render the same query_id with different seeds. When the rows
+    carry no capture key, the public-id fallback cannot tell which row ran which
+    variant, so it must leave them unattached rather than attach a wrong plan.
+    """
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 8)
+        _begin_phase(file_adapter)
+
+        # Same public id, two different SQL texts -> two distinct buffer keys.
+        _record(file_adapter, "q", "SELECT id FROM t WHERE val > 1")
+        _record(file_adapter, "q", "SELECT id FROM t WHERE val > 4")
+        rows = [
+            {"query_id": "q", "status": "SUCCESS", "stream_id": 0},
+            {"query_id": "q", "status": "SUCCESS", "stream_id": 1},
+        ]
+
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(conn, dict(file_adapter._phase_recorded_queries), rows)
+
+        for row in rows:
+            assert row.get("plan_fingerprint") is None, "ambiguous variant must not be guessed"
+            assert row.get("query_plan") is None
+    finally:
+        conn.close()
+
+
+def test_standard_path_exact_key_attaches_each_variant(file_adapter):
+    """Rows that DO carry an exact capture key (standard path) keep per-variant fidelity."""
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 8)
+        _begin_phase(file_adapter)
+
+        sql_a = "SELECT id FROM t WHERE val > 1"
+        sql_b = "SELECT id FROM t WHERE val > 4"
+        key_a = _record(file_adapter, "q", sql_a)
+        key_b = _record(file_adapter, "q", sql_b)
+        rows = [
+            {"query_id": "q", "status": "SUCCESS", "stream_id": 0, "_plan_capture_key": key_a},
+            {"query_id": "q", "status": "SUCCESS", "stream_id": 1, "_plan_capture_key": key_b},
+        ]
+
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(conn, dict(file_adapter._phase_recorded_queries), rows)
+
+        # Each row attaches the plan for the exact SQL it ran; the key is consumed.
+        assert rows[0].get("plan_fingerprint")
+        assert rows[1].get("plan_fingerprint")
+        assert "_plan_capture_key" not in rows[0]
+        assert "_plan_capture_key" not in rows[1]
+    finally:
+        conn.close()
+
+
+def test_failed_row_not_annotated_and_key_cleared(file_adapter):
+    """A FAILED row sharing a query_id must never be annotated; its key is cleared."""
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 6)
+        _begin_phase(file_adapter)
+        sql = "SELECT id FROM t"
+        key = _record(file_adapter, "q", sql)
+        ok_row = {"query_id": "q", "status": "SUCCESS", "_plan_capture_key": key}
+        bad_row = {"query_id": "q", "status": "FAILED", "_plan_capture_key": key}
+
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._capture_plans_post_measurement(
+            conn, dict(file_adapter._phase_recorded_queries), [ok_row, bad_row]
+        )
+
+        assert ok_row.get("plan_fingerprint")
+        assert bad_row.get("plan_fingerprint") is None
+        assert "_plan_capture_key" not in bad_row
+    finally:
+        conn.close()
+
+
+def test_checkpoint_is_noop_when_phase_inactive(file_adapter):
+    """The checkpoint must do nothing outside the isolated capture phase."""
+    conn = file_adapter.create_connection()
+    try:
+        _seed(conn, 5)
+        file_adapter._plan_capture_phase_active = False
+        file_adapter._phase_recorded_queries = {}
+        file_adapter._captured_plans = {}
+
+        file_adapter._plan_capture_checkpoint(conn)
+        assert file_adapter._captured_plans == {}, "no capture should happen when phase inactive"
+    finally:
+        conn.close()
+
+
+@pytest.mark.slow
+def test_real_tpch_power_capture_attaches_plans(tmp_path):
+    """End-to-end: the real TPC-H power driver path attaches captured plans to rows.
+
+    Regression guard for the production code path the method-level tests model:
+    the TPC-H power driver rebuilds result rows WITHOUT the internal capture key,
+    so capture must be buffer-driven and attachment must fall back to the public
+    query_id. Generates a tiny SF (data-gen marks this ``slow``).
+    """
+    from benchbox.core.tpch.benchmark import TPCHBenchmark
+
+    db_path = str(tmp_path / "power.duckdb")
+    adapter = DuckDBAdapter(database_path=db_path, capture_plans=True)
+    conn = adapter.create_connection()
+    try:
+        bench = TPCHBenchmark(scale_factor=0.01, output_dir=str(tmp_path / "data"))
+        bench.generate_data()
+        adapter.create_schema(bench, conn)
+        adapter.load_data(bench, conn, str(tmp_path / "data"))
+
+        run_config = {
+            "benchmark_name": "tpch",
+            "test_execution_type": "power",
+            "scale_factor": 0.01,
+            "iterations": 1,
+            "warm_up_iterations": 0,
+            "query_subset": [1, 6],
+        }
+        results = adapter._execute_queries_by_type(bench, conn, run_config)
+
+        assert results, "power test produced no rows"
+        for row in results:
+            if row.get("status") != "SUCCESS":
+                continue
+            assert row.get("plan_fingerprint"), f"power row {row.get('query_id')} got no plan"
+            assert row.get("query_plan") is not None
+    finally:
+        conn.close()


### PR DESCRIPTION
The isolated capture phase runs after the timed loop, so in combined mode
(power -> throughput -> maintenance) read-phase plans were EXPLAINed against
the POST-maintenance data state — a plan the optimizer never chose during
measurement. Fire a capture checkpoint at the start of each maintenance
executor so read plans are captured against their pre-mutation (measured)
state; maintenance writes are still captured once in the final pass and never
re-executed.

While verifying, found that TPC power/throughput result rows are rebuilt
without the internal _plan_capture_key, so the post-measurement phase attached
NO plan to them at all (digest-keyed buffer vs bare-id rows). Make capture
buffer-driven and attach by exact key or, for those rows, by public query_id
when it maps to a single executed SQL variant; ambiguous seed-varied variants
are left unattached rather than mis-paired. Captured plans are accumulated in a
typed per-run structure and attached exactly once.

Verified end-to-end against the real DuckDB TPC-H power path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
