### PR TITLE
docs(joinorder): Track-2 groundwork — phase-model survey, scaling options, reuse guide

### DIFF
--- a/_project/DONE/main/planning/joinorder-track2-groundwork.yaml
+++ b/_project/DONE/main/planning/joinorder-track2-groundwork.yaml
@@ -2,7 +2,7 @@ id: joinorder-track2-groundwork
 title: "joinorder Track-2 groundwork: statistics-as-phase survey, scaling-strategy options, infra reuse guide"
 worktree: main
 priority: Medium-High
-status: Not Started
+status: Completed
 category: Documentation
 
 description: |
@@ -44,7 +44,7 @@ description: |
 work:
   - id: w1
     summary: "Phase-model survey: document current phase boundaries and stats-as-phase gap"
-    status: pending
+    status: done
     notes: |
       Output: `_project/design/track2-joinorder-stats-as-phase.md`
 
@@ -99,7 +99,7 @@ work:
 
   - id: w2
     summary: "Seed Track-2 TODO: stats-as-phase implementation"
-    status: pending
+    status: done
     needs: [w1]
     notes: |
       File: `_project/TODO/main/planning/track2-joinorder-stats-phase.yaml`
@@ -118,7 +118,7 @@ work:
 
   - id: w3
     summary: "Scaling-strategy options for Track 2"
-    status: pending
+    status: done
     notes: |
       Output: `_project/design/track2-joinorder-scaling-strategy.md`
 
@@ -173,7 +173,7 @@ work:
 
   - id: w4
     summary: "Seed Track-2 TODO: scaling-strategy work"
-    status: pending
+    status: done
     needs: [w3]
     notes: |
       File: `_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml`
@@ -186,7 +186,7 @@ work:
 
   - id: w5
     summary: "Reusable data-fetch infrastructure reuse guide"
-    status: pending
+    status: done
     notes: |
       PRECONDITION: this is the only work unit in this TODO that
       consumes foundation outputs. Do not start w5 until

--- a/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
@@ -1,0 +1,73 @@
+id: track2-joinorder-scaling-strategy
+title: "Track-2: select and implement the JOB scaling strategy"
+worktree: main
+priority: Medium
+status: Identified
+category: Benchmark Development
+
+description: |
+  Track-2 (future) implementation TODO seeded by joinorder-track2-groundwork w4.
+  Lock in and implement the scaling strategy for a scaled JOB-derived workload.
+
+  Options analysis and the leading candidate are in
+  `_project/design/track2-joinorder-scaling-strategy.md` (authored by
+  joinorder-track2-groundwork w3). That doc scores five options (A correlated
+  synthetic, B sampled-from-real, C multi-snapshot real, D real+augmentation,
+  E stats-only at SF=1) against real-data fidelity, scalability axis, license
+  posture, implementation complexity, and JOB-literature comparability, and
+  recommends Option B (sampled-from-real with title-stratified preservation) as
+  the leading candidate without locking in.
+
+  This is a placeholder seed at status Identified. Final design and lock-in
+  happen when Track 2 is picked up; the work units below are summary-level. The
+  parallel decision framework
+  (`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`)
+  independently recommends replicated_imdb as the lowest-risk upward baseline;
+  Track-2 kickoff reconciles the sampling (down) and replication (up) directions.
+
+work:
+  - id: w1
+    summary: "Lock in the scaling strategy from the options analysis"
+    status: pending
+    notes: |
+      Confirm or revise the design doc's Option B recommendation against the
+      research question at Track-2 kickoff. Decide the scale direction
+      (sampled-down vs replicated-up vs both) and the scale-factor semantics.
+
+  - id: w2
+    summary: "Implement the chosen generator with a validation oracle"
+    needs: [w1]
+    status: pending
+    notes: |
+      Build the generator and the validation gate (FK integrity, predicate-domain
+      frequencies, cardinalities, q-error where available) before publishing any
+      derived archive. Non-empty checks are insufficient.
+
+  - id: w3
+    summary: "Define derived workload labels and result-bundle metadata"
+    needs: [w1]
+    status: pending
+    notes: |
+      Apply the workload labels (replicated_imdb / sampled / etc.) and required
+      derived-workload metadata (strategy, dataset version, generator version,
+      seed, stats protocol). Derived results never publish as canonical joinorder.
+
+must_preserve:
+  - "Canonical joinorder remains fixed to canonical_imdb SF=1 and is never replaced by a derived scale mode."
+  - "Any derived workload reports its data-generation strategy, dataset version, generator version, seed, and stats protocol."
+  - "The scaled prototype must not start until the statistics-phase requirement is satisfied or explicitly scoped out (see track2-joinorder-stats-phase)."
+
+approach: |
+  Plan-deepening is already done in the groundwork design doc. At kickoff, lock
+  the strategy, then implement generator + validation oracle + labels. Keep the
+  derived identity explicit and never conflate it with canonical JOB.
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - scaling-strategy
+    - benchmark-design
+    - seed
+  estimated_effort: "Medium"
+  created_date: "2026-06-30"

--- a/_project/TODO/main/planning/track2-joinorder-stats-phase.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-stats-phase.yaml
@@ -1,0 +1,84 @@
+id: track2-joinorder-stats-phase
+title: "Track-2: implement statistics-as-a-phase in the benchmark phase model"
+worktree: main
+priority: Medium
+status: Identified
+category: Benchmark Development
+
+description: |
+  Track-2 (future) implementation TODO seeded by joinorder-track2-groundwork w2.
+  Implements a first-class "statistics" phase between load and query so that
+  optimizer-statistics build time is measured separately from load and query
+  time. Without this separation, Track 2's research question — the interplay of
+  statistics maintenance and predicate selectivity — cannot be measured: an
+  engine with expensive auto-stats looks N seconds slower at load OR at
+  first-query, neither attribution being correct.
+
+  Implementation spec: `_project/design/track2-joinorder-stats-as-phase.md`
+  (authored by joinorder-track2-groundwork w1). That doc surveys the current
+  phase model, identifies the gap, proposes the load → statistics → query
+  ordering, and defines the migration strategy and open design questions.
+
+  This is a seed at status Identified. It stays in planning/ until Track 2 is
+  picked up; the work units below are summary-level, not a full implementation
+  plan.
+
+deps:
+  needs:
+    - joinorder-canonical-cutover
+
+work:
+  - id: w1
+    summary: "Add a statistics phase to the runner phase model (load -> statistics -> query)"
+    status: pending
+    notes: |
+      Schema change to the phase model and per-phase timing manifest. Default
+      legacy behavior (no explicit statistics phase) is preserved for existing
+      benchmarks. See the design doc's Proposed change and Migration strategy.
+
+  - id: w2
+    summary: "Add a per-engine ANALYZE / COMPUTE STATISTICS knob for the statistics phase"
+    needs: [w1]
+    status: pending
+    notes: |
+      Explicit ANALYZE call per platform adapter; where the engine auto-analyzes
+      during load, document it and report zero stats-phase wall-clock with
+      stats_mode: auto-on-load rather than double-building. Cover the engines in
+      the design doc's compatibility matrix.
+
+  - id: w3
+    summary: "Carry per-phase statistics timing in the result-bundle manifest"
+    needs: [w1]
+    status: pending
+    notes: |
+      Result-bundle field for statistics-phase timing and stats_mode metadata,
+      kept separate from load and query timing. Dataset/schema version
+      distinguishes pre- vs post-phase-model bundles.
+
+  - id: w4
+    summary: "Opt-in mechanism: enable the statistics phase for joinorder/tpch/tpcds"
+    needs: [w2, w3]
+    status: pending
+    notes: |
+      Opt-in per benchmark so historical bundles remain interpretable. joinorder,
+      tpch, tpcds enable the new phase once this lands.
+
+must_preserve:
+  - "Existing benchmarks default to the legacy load-includes-stats behavior; no historical result bundle is invalidated."
+  - "The phase-model change lands after the joinorder rename + canonical wiring (cutover), per deps.needs."
+
+approach: |
+  Implement against the design doc spec. Land the phase-model schema change
+  first, then the per-engine ANALYZE knob and result-bundle field, then opt-in
+  per benchmark. Do not detect-and-disable engine auto-analyze; document it and
+  attribute zero wall-clock with stats_mode metadata (the design doc's lean).
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - statistics-phase
+    - phase-model
+    - seed
+  estimated_effort: "Medium"
+  created_date: "2026-06-30"

--- a/_project/design/data-fetch-infra-reuse-guide.md
+++ b/_project/design/data-fetch-infra-reuse-guide.md
@@ -26,17 +26,107 @@ Required shape for real-data benchmarks:
 
 ## When to use
 
-OWNED BY: joinorder-track2-groundwork w5. Filled in alongside the
-Track-2 docs effort.
+Reach for the data-fetch infrastructure when all three hold:
+
+- **Real-data benchmark with a stable upstream source** — the data comes from a
+  durable, citable origin (a DOI, an archived snapshot URL) rather than being
+  synthesized at runtime. JoinOrder (canonical IMDb 2013) is the reference
+  instance; ClickBench, Wikipedia pageviews, and GitHub Archive are the obvious
+  next consumers.
+- **Dataset too large to commit to git (~50 MB+)** — committing it would bloat
+  the repo; instead it is fetched on demand and verified.
+- **Provenance / license attribution matters** — the source carries terms or
+  attribution that must travel with every redistribution (see the
+  `## DATA-LICENSE.md template` section).
+
+Do **not** use it for synthetic benchmarks (TPC-H, TPC-DS, write_primitives),
+which generate data deterministically and need no upstream fetch. The
+infrastructure is a manifest-driven verification step layered on top of
+BenchBox's existing datagen path convention — `resolve_benchmark_runs_dir()`
+(`benchbox/utils/path_utils.py:31`) and the run config's
+`get_datagen_path(benchmark, sf)` (`benchbox/cli/config.py:953`) — not a
+separate storage root with its own location policy.
 
 ## Step-by-step: instantiating for a new benchmark
 
-OWNED BY: joinorder-track2-groundwork w5.
+Using a hypothetical `clickbench` benchmark as the worked example:
+
+a. **Decide the canonical source.** Pin a DOI or an archived snapshot URL — a
+   durable, reproducible origin, not a live mutable endpoint. Record the source
+   snapshot date.
+
+b. **Build an offline conversion pipeline.** Add
+   `_project/scripts/build_clickbench_data.py` that downloads the source,
+   converts it to per-table Parquet, and is rerunnable from scratch. Keep it
+   offline/one-shot — it produces the archive, it is not on the benchmark hot
+   path.
+
+c. **Compute reference cardinalities via an independent oracle.** Run the query
+   set against a *different* engine than the one being benchmarked (PostgreSQL
+   for SQL workloads) to get trustworthy expected cardinalities. Never derive the
+   oracle from the same engine that will later be measured.
+
+d. **Package the archive.** Per-table Parquet + `manifest.toml` + SHA256
+   checksums + `DATA-LICENSE.md` + reference cardinalities, as one versioned
+   tarball.
+
+e. **Stage as a DRAFT GitHub Release.** Upload the archive as a draft asset;
+   publish (promote) only after UAT confirms the fetch + load + validation path.
+
+f. **Add `data_manifest.toml`** in `benchbox/core/clickbench/`, mirroring
+   `benchbox/core/joinorder/data_manifest.toml` (it carries `dataset_version`,
+   the archive URL, `archive_sha256`, `manifest_hash`, `data_archive_hash`, and
+   the license file reference — see `benchbox/core/data_fetch/manifest.py:106`).
+
+g. **Wire the benchmark to the datagen path convention.** Resolve the output
+   directory with `get_datagen_path(benchmark, sf)` and fetch into it via
+   `fetch_data(..., output_dir=...)` from `benchmark.py`. Do not invent a new
+   storage location.
+
+h. **Add `DATA-LICENSE.md`**, using joinorder's as the template (its shape is
+   pinned in the `## DATA-LICENSE.md template` section of this guide).
+
+i. **Add a per-benchmark CHANGELOG entry** recording the dataset version and
+   provenance.
 
 ## Common pitfalls (from joinorder Step 1)
 
-OWNED BY: joinorder-track2-groundwork w5.
+Each of these bit the joinorder Step-1 effort and has a concrete guard:
+
+- **Encoding round-trip gates.** Unicode NFC/NFD normalization can silently
+  rewrite string keys during conversion, breaking joins and predicate matches.
+  Add an explicit encoding round-trip gate that fails the build if a column's
+  bytes change under normalization.
+- **Predicate-domain validation.** A converted dataset can pass row-count and
+  non-empty checks yet return empty results for every query because predicate
+  literal values no longer exist in the data (queries-empty-by-construction).
+  Validate that each query's predicate domain is actually present.
+- **Reference cardinalities via an independent oracle.** Computing expected
+  cardinalities with the same engine that will be benchmarked launders that
+  engine's bugs into the "ground truth." Use a separate oracle (PostgreSQL).
+- **DRAFT-then-promote the GitHub Release.** Publishing the release asset before
+  UAT means a broken archive is already the public default. Stage as DRAFT,
+  promote only after the fetch + load + validation path is confirmed.
 
 ## Infrastructure components reused
 
-OWNED BY: joinorder-track2-groundwork w5.
+A new benchmark inherits all of these rather than rebuilding them:
+
+- **Existing datagen path convention** — `resolve_benchmark_runs_dir()` +
+  `get_datagen_path(benchmark, sf)` resolve under
+  `BENCHBOX_OUTPUT_DIR` / `benchmark_runs/datagen/<benchmark>_<sf>/`. The
+  fetched data lands on the same path every other benchmark uses; there is no
+  benchmark-specific storage root.
+- **`benchbox.core.data_fetch`** — manifest parsing (`manifest.py`), the
+  downloader (`downloader.py`), the manager (`manager.py`), typed errors
+  (`errors.py`), concurrency control (`locking.py`), and SHA256 verification of
+  both the archive (`archive_sha256`) and the aggregate per-table data
+  (`data_archive_hash`).
+- **`benchmark_registry` surface field** — marks the benchmark public vs
+  internal so it appears (or not) in the public benchmark list.
+- **`bundle_publisher` `dataset_version`** — the result-bundle records the
+  `dataset_version` it ran against (`benchbox/core/results/models.py:383`,
+  `benchbox/core/publishing/store.py`), so results are traceable to an exact
+  dataset.
+- **`scale_factor` enforcement gate** — the shared SF validation rejects
+  unsupported scale factors before any fetch or load begins.

--- a/_project/design/track2-joinorder-scaling-strategy.md
+++ b/_project/design/track2-joinorder-scaling-strategy.md
@@ -1,0 +1,151 @@
+# Track-2 JOB Scaling-Strategy Options
+
+Status: Design exploration (Track-2 groundwork). Recommends a leading candidate
+but does **not** lock in. Final selection happens at Track-2 kickoff.
+
+Context: Track 1 restores `joinorder` as canonical IMDb 2013 (SF=1). Track 2
+asks "scaled JOB — *scaled how?*". This doc enumerates the candidate scaling
+strategies, scores each against five dimensions, and names one leading candidate
+with reasoning. It is plan-deepening before the work is picked up; a multi-option
+"we'll see" outcome is not acceptable, so a single candidate is defended below.
+
+Companion docs: the phase-model gap is surveyed in
+`track2-joinorder-stats-as-phase.md`; a parallel *decision framework* with a
+slightly different option framing lives in
+`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`. The two are
+reconciled at the end of this doc.
+
+## Scoring dimensions
+
+Every option is scored against the same five dimensions:
+
+1. **Real-data fidelity** — does it preserve the real IMDb correlations and skew
+   that are the actual JOB signal?
+2. **Scalability axis** — does it provide a controllable axis of dataset sizes?
+3. **License posture** — does it stay within the canonical dataset's already
+   reviewed redistribution posture, or open new licensing questions?
+4. **Implementation complexity** — generator, validation oracle, and packaging
+   cost.
+5. **JOB-literature comparability** — can results still be related to the
+   Leis et al. JOB literature, or do they diverge?
+
+## Options
+
+### Option A — Correlated synthetic generator
+
+Extend the synthetic generator with Zipf / power-law / cross-table correlations
+(a new `joinorder_synthetic` mode, or a new `joinorder_correlated` benchmark).
+
+- Real-data fidelity: **low** — correlations are modeled guesses, not the real
+  IMDb correlations JOB measures.
+- Scalability axis: **excellent** — arbitrary scale by construction.
+- License posture: **clean** — fully synthetic, no IMDb redistribution.
+- Implementation complexity: **high** — correlation model design + validation.
+- JOB-literature comparability: **none** — different data, different answers.
+
+### Option B — Sampled-from-real (downsample canonical)
+
+Take a fraction of canonical IMDb 2013 preserving full referential integrity
+(e.g. title-stratified sampling that keeps each sampled title's full join
+subgraph).
+
+- Real-data fidelity: **high** — real correlations preserved within the sample.
+- Scalability axis: **good (downward)** — a controllable multi-point axis below
+  SF=1; combinable with replication for an upward axis.
+- License posture: **clean (inherited)** — a strict subset of the already
+  reviewed canonical archive; no new source data.
+- Implementation complexity: **low–medium** — sampling + integrity closure +
+  oracle re-derivation on the subset.
+- JOB-literature comparability: **partial** — same dataset lineage and same
+  fixed queries; cardinalities differ from the published SF=1 numbers but the
+  signal is the same kind.
+
+### Option C — Real with multiple snapshots (current IMDb)
+
+Use `datasets.imdbws.com` (post-2017 format) with different snapshot dates as the
+scale axis.
+
+- Real-data fidelity: **high** — real, naturally growing data.
+- Scalability axis: **good** — snapshot dates give a real growth axis.
+- License posture: **new review required** — different upstream artifact and
+  terms from the JOB-paper Dataverse deposit.
+- Implementation complexity: **high** — schema differs from JOB 2013; queries
+  and oracle must be re-derived per snapshot.
+- JOB-literature comparability: **none** — not the JOB-paper dataset, so results
+  diverge from the literature.
+
+### Option D — Real with augmentation (canonical + synthetic additions)
+
+Start from canonical IMDb 2013 and layer synthetic correlated rows on top.
+
+- Real-data fidelity: **mixed** — real backbone, synthetic tail; the synthetic
+  part is still a guess that can dilute the signal.
+- Scalability axis: **good (upward)** — augment to arbitrary size.
+- License posture: **inherited + new** — canonical posture for the backbone, new
+  questions for the synthesized additions.
+- Implementation complexity: **high** — must blend without breaking correlations
+  or referential integrity; partial oracle only.
+- JOB-literature comparability: **weak** — fixed queries run, but augmented
+  cardinalities are no longer the JOB cardinalities.
+
+### Option E — Skip scaling; stats-maintenance interplay at SF=1 only
+
+Reframe Track 2 from "scaled JOB" to "stats-maintenance JOB" at canonical scale:
+study statistics freshness/sampling interplay on fixed SF=1 data.
+
+- Real-data fidelity: **maximal** — unmodified canonical data.
+- Scalability axis: **none** — loses the scaling axis entirely.
+- License posture: **clean (inherited)** — canonical archive unchanged.
+- Implementation complexity: **lowest** — no generator; only the statistics
+  phase (see `track2-joinorder-stats-as-phase.md`).
+- JOB-literature comparability: **full** — it *is* canonical JOB plus a stats
+  protocol.
+
+## Decision matrix
+
+| Option | Real-data fidelity | Scalability axis | License posture | Impl. complexity | JOB comparability |
+| --- | --- | --- | --- | --- | --- |
+| A correlated synthetic | Low | Excellent | Clean | High | None |
+| B sampled-from-real | High | Good (down) | Clean (inherited) | Low–Medium | Partial |
+| C multi-snapshot real | High | Good | New review | High | None |
+| D real + augmentation | Mixed | Good (up) | Inherited + new | High | Weak |
+| E stats-only at SF=1 | Maximal | None | Clean (inherited) | Lowest | Full |
+
+## Leading candidate
+
+**Leading candidate: Option B — sampled-from-real with title-stratified
+referential-integrity preservation.**
+
+Reasoning tied to the five dimensions: the JOB signal *is* the real IMDb
+correlation structure, so any option that scores low on real-data fidelity (A) or
+weak/mixed (D) risks destroying the very thing the benchmark measures — this
+eliminates A and D for a first move. Option C scores well on fidelity and scale
+but fails license posture (new upstream artifact and review) and JOB
+comparability (different dataset), making it a poor *first* step. That leaves B
+and E, both of which are license-clean and high-fidelity. E is the simplest but
+sacrifices the scaling axis entirely; B keeps a controllable axis while preserving
+real correlations and the lowest implementation cost among the scale-capable
+options. Title-stratified sampling (keep each sampled title's full join subgraph)
+is what makes B's fidelity hold up: it preserves per-title correlation structure
+rather than sampling rows independently, which would shear the joins.
+
+This is a recommendation, not a lock-in.
+
+A genuine divergence to reconcile at kickoff: the separate scale-stress
+*decision framework*
+(`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`) reaches a
+**different** leading candidate — `replicated_imdb` (offset replication, an
+*upward* baseline) — under a different framing. That doc evaluates only
+scale-*up* strategies (replication, expansion, parameterized generation,
+synthetic, augmentation) and does **not** consider downsampling at all; its
+question is optimizer degradation as data grows. This groundwork doc, framed
+around preserving the JOB correlation signal with the lowest-risk *scaling axis*,
+leads with Option B (downward sampling). These are not the same recommendation,
+and they are not automatically complementary: they reflect two different research
+questions (multi-point fidelity vs upward stress). Track-2 kickoff must pick the
+framing first — does the research question require *larger-than-SF=1* data (favor
+replication) or a controllable, maximal-fidelity multi-point axis (favor
+sampling)? — and only then select the strategy. Both candidates are license-clean
+and oracle-reusable, and Option B composes with offset replication if kickoff
+decides it wants both directions. Option E remains the correctness fallback if a
+defensible scaling axis cannot be validated.

--- a/_project/design/track2-joinorder-stats-as-phase.md
+++ b/_project/design/track2-joinorder-stats-as-phase.md
@@ -1,0 +1,124 @@
+# Track-2 Phase-Model Survey: Statistics-as-a-Phase
+
+Status: Design survey (Track-2 groundwork). Surveys the current phase model,
+identifies the statistics-as-a-phase gap, sketches the change, and seeds the
+Track-2 implementation TODO (`track2-joinorder-stats-phase`). No code changes.
+
+Track 2 evaluates "the interplay of statistics maintenance and predicate
+selectivity." That measurement is only valid if statistics-build time is
+attributed to its own phase. This doc establishes that BenchBox has no such
+phase today and specifies the change at principal-engineer depth so the Track-2
+implementer starts from a concrete plan.
+
+## Current phase model
+
+BenchBox expresses benchmark execution as a small set of lifecycle phases plus
+nested setup/execution sub-phases.
+
+- **Lifecycle phases** — `LifecyclePhases` dataclass with three booleans:
+  `generate`, `load`, `execute` (`benchbox/core/runner/runner.py:600`).
+- **CLI phase vocabulary** — `_parse_phases_list()` accepts
+  `{generate, load, warmup, power, throughput, maintenance}`
+  (`benchbox/cli/commands/run.py:689`) and the orchestrator maps them back onto
+  `LifecyclePhases` (`benchbox/cli/orchestrator.py:279`), where any of
+  `warmup/power/throughput/maintenance` collapses into `execute`.
+- **Setup sub-phases** — `DataGenerationPhase`, `SchemaCreationPhase`,
+  `DataLoadingPhase`, `ValidationPhase`, grouped by the `SetupPhase` aggregator
+  (`benchbox/core/results/models.py:131`).
+- **Execution sub-phases** — `PowerTestPhase`, `ThroughputTestPhase`,
+  `MaintenanceTestPhase` (and platform-specific `MigrationPhase`), grouped by the
+  `ExecutionPhases` aggregator (`benchbox/core/results/models.py:245`).
+
+Each phase dataclass carries an aggregate `duration_ms` field, and query-level
+timing is captured by `QueryTiming` (execution/parse/optimization/fetch splits,
+`benchbox/core/results/timing.py:24`) collected via `TimingCollector.time_phase()`
+(`benchbox/core/results/timing.py:159`). So per-phase timing infrastructure
+already exists — there is simply no statistics phase plugged into it.
+
+Where statistics land today, per engine:
+
+| Engine | Explicit ANALYZE method | Called during lifecycle? | Where stats actually accrue |
+| --- | --- | --- | --- |
+| PostgreSQL | `analyze_table()` (`benchbox/platforms/postgresql.py:799`) | No — `load_data()` (`postgresql.py:559`) never calls it | First-query planning, or a manual ANALYZE outside the run |
+| DuckDB | `analyze_tables()` (`benchbox/platforms/duckdb.py:1109`) | No | Background/auto-stats after load |
+| Spark | `analyze_table()` (`benchbox/platforms/spark.py:818`) | No | Not gathered unless invoked manually |
+| Redshift | `auto_analyze` config gating ANALYZE | Only in isolated vacuum/analyze maintenance, not load | Maintenance path or first-query |
+| ClickHouse | none found | n/a | Auto-statistics on insert |
+| StarRocks | none found | n/a | Relies on auto/manual ANALYZE TABLE |
+
+The pattern is consistent: `analyze_table()` exists in 26+ adapters but has **no
+centralized call site** in the runner. Statistics gathering is therefore
+scattered, optional, and unattributed.
+
+## Why this matters
+
+Track 2's research question is the interplay of statistics maintenance and
+predicate selectivity. If stats-build time is silently folded into load (engines
+that auto-analyze after COPY/INSERT) or into query (engines that build stats at
+first-query planning), the measurement is invalid before it starts.
+
+Concrete failure mode: an engine with sophisticated auto-statistics that takes
+30s to build looks **30s slower at load** (auto-on-load engines) **or 30s slower
+at first-query** (lazy-stats engines) — and neither attribution is correct. Two
+engines with identical raw load and query performance but different stats
+strategies would be ranked differently purely by where their stats time happens
+to land. Because BenchBox has the per-phase `duration_ms` machinery but no
+statistics phase, this misattribution is the current default, not an edge case.
+
+## Proposed change
+
+Introduce an explicit statistics phase between load and query: ordering becomes
+`load → statistics → query`.
+
+- **New phase dataclass** — add a `StatisticsGatheringPhase` (sibling of
+  `DataLoadingPhase` / `ValidationPhase` in `benchbox/core/results/models.py`)
+  carrying `duration_ms`, plus a `stats_mode` field.
+- **Centralized call site** — the runner invokes the platform `analyze_table()` /
+  `analyze_tables()` in this phase after load completes, instead of leaving each
+  adapter's method unreferenced.
+- **Per-engine knob** — engines with explicit ANALYZE run it and time it.
+  Engines that auto-analyze during load are **documented, not double-built**:
+  they report zero stats-phase wall-clock with `stats_mode: auto-on-load` so the
+  attribution is unambiguous (the lean here is *document, not disable* —
+  auto-analyze is what production engines do, so measuring it is realistic).
+- **CLI vocabulary** — add `statistics` to the `_parse_phases_list()` valid set
+  (`benchbox/cli/commands/run.py:689`) and the orchestrator mapping
+  (`benchbox/cli/orchestrator.py:279`); default runs keep it off.
+- **Result-bundle manifest** — carry the statistics-phase `duration_ms` and
+  `stats_mode` separately from load and query timing, alongside the existing
+  `dataset_version` identity fields (`benchbox/core/results/models.py:383`).
+
+## Migration strategy
+
+The change must not invalidate historical result bundles or in-flight
+comparisons.
+
+- **Backwards compatibility** — existing benchmarks default to *no explicit
+  statistics phase* (legacy load-includes-stats behavior). The new phase is
+  off unless requested, so old runs and new runs of legacy benchmarks remain
+  comparable.
+- **Opt-in** — `joinorder`, `tpch`, `tpcds` enable the statistics phase once
+  Track 2 lands; other benchmarks are untouched.
+- **Bundle interpretability** — `dataset_version` plus the benchmark schema
+  version distinguish pre- vs post-phase-model bundles
+  (`benchbox/core/results/models.py:383`, `benchbox/core/data_fetch/manifest.py:106`),
+  so a consumer can tell whether a bundle's load timing includes or excludes
+  stats. No historical bundle is rewritten.
+
+## Open design questions
+
+- **Detect-and-disable vs document auto-analyze** — lean: *document, not
+  disable*. Auto-analyze is what production engines do, so measuring it (and
+  attributing zero explicit stats wall-clock via `stats_mode: auto-on-load`) is
+  more realistic than forcing engines into an artificial no-auto-stats mode.
+- **Per-table vs whole-database ANALYZE** — JOB has 21 tables. Decide whether to
+  measure each table's stats build separately (richer attribution, more
+  telemetry) or aggregate to one phase number. Lean: aggregate phase total with
+  optional per-table breakdown in `timing_breakdown`.
+- **Cold-stats vs warm-stats across runs** — when stats persist between runs,
+  does the subsequent query phase see them or not? Track 2 needs both modes
+  (fresh-stats and stale-stats-after-additional-load) to study maintenance, so
+  the phase must support an explicit reset/persist control.
+- **Idempotence** — re-running ANALYZE on already-analyzed data should produce
+  the same plan; this is the sanity check that the phase is measuring stats build
+  rather than incidental cache warmth.


### PR DESCRIPTION
Close joinorder-track2-groundwork (design-doc deliverable, no code).

- Add _project/design/track2-joinorder-stats-as-phase.md: surveys the
  current phase model (LifecyclePhases, setup/execution sub-phases,
  per-phase duration_ms timing), documents the statistics-as-a-phase gap
  (analyze_table() exists in 26+ adapters but is never called in the
  lifecycle; auto-stats time is misattributed to load or first-query),
  proposes load -> statistics -> query, migration strategy preserving
  old bundles, open questions.
- Add _project/design/track2-joinorder-scaling-strategy.md: five options
  A-E scored across five dimensions, leading candidate Option B
  (sampled-from-real, title-stratified). Honestly flags the divergence
  with the scale-stress decision doc's replicated_imdb recommendation
  (different framing) for Track-2 kickoff to reconcile.
- Fill the four owned sections of data-fetch-infra-reuse-guide.md
  (When to use / Step-by-step / Common pitfalls / Infrastructure
  components reused); DATA-LICENSE.md template section left untouched
  (cutover-owned, section-level merge contract).
- Seed track2-joinorder-stats-phase.yaml (deps: joinorder-canonical-cutover)
  and track2-joinorder-scaling-strategy.yaml, both status Identified.
- Mark groundwork TODO Completed, move to DONE/main/planning.

All 5 TODO verifications pass; seeds validate; TODO graph valid (no
dangling refs). code-review findings fixed: get_datagen_path file
attribution corrected (cli/config.py:953), unsound cross-doc
reconciliation reframed as an honest divergence, phase-class citations
made precise.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
