### PR TITLE
chore: provision cloud plugin activation + correct cloud-parity ADR

### DIFF
--- a/_project/TODO/main/planning/cloud-setup-script-plugin-activation.yaml
+++ b/_project/TODO/main/planning/cloud-setup-script-plugin-activation.yaml
@@ -1,0 +1,77 @@
+id: cloud-setup-script-plugin-activation
+title: "Activate committed Claude Code plugins in cloud via setup script"
+worktree: chore-cloud-parity-setup-script
+priority: Medium
+status: Identified
+category: "Testing and Quality Assurance"
+
+description: |
+  A fresh claude.ai/code cloud session loads committed skills and commands, but
+  NOT plugins or PostToolUse hooks. Validated 2026-06-30 (see
+  _project/decisions/claude-settings-cloud-ownership-2026-06-29.md, cloud
+  addendum):
+
+  - Plugins: not auto-installed by design. Per the docs (Claude Code >= v2.1.195)
+    a plugin enabled only by a project's .claude/settings.json from an external
+    source does not load until explicitly installed. No setting/flag/env var
+    overrides this.
+  - Hooks: PostToolUse ruff/ty hook never fires in cloud (command valid when run
+    manually); cloud likely blocks project hooks (allowManagedHooksOnly) or does
+    not wire PostToolUse in the web runtime.
+
+  scripts/cloud-claude-setup.sh now performs the plugin install step: it derives
+  the marketplace + enabled-plugin list from .claude/settings.json and runs
+  `claude plugin marketplace add` + `claude plugin install <plugin>@<marketplace>
+  --scope user`. It is idempotent and no-ops without the claude CLI / python.
+
+  Remaining work is wiring + verification, not authoring.
+
+  Hooks are intentionally OUT OF SCOPE: the ruff/ty hooks are an edit-time
+  convenience already enforced by CI (make lint / make typecheck / pr-preflight),
+  so the cloud gap is cosmetic. Do not chase hook activation in cloud.
+
+deferred:
+  - summary: "Provision PostToolUse ruff/ty hooks in cloud"
+    reason: >
+      Edit-time convenience already covered by CI; cloud may block project hooks
+      via allowManagedHooksOnly, so injecting them into VM user settings is
+      unreliable and buys nothing CI does not already guarantee.
+
+deps:
+  needs: []
+
+work:
+  - id: w1
+    summary: "Wire scripts/cloud-claude-setup.sh as the claude.ai/code env setup script"
+    status: pending
+    notes: >
+      Configured in the claude.ai/code environment settings (web UI), not a repo
+      file. Setup scripts are cached per environment.
+  - id: w2
+    summary: "Verify in a fresh cloud session: claude plugin list shows the 7 plugins and namespaced agents/commands are available"
+    needs: [w1]
+    status: pending
+  - id: w3
+    summary: "Re-run the cloud-parity validation prompt; confirm plugins now PASS"
+    needs: [w2]
+    status: pending
+    notes: "Hooks expected to stay FAIL (out of scope, documented)."
+
+impact: >
+  Brings plugin-provided agents/commands (code-modernization:*, code-simplifier:*,
+  commit-commands:*, etc.) to cloud sessions, completing the executable side of
+  cloud parity. Skills/commands already work; this closes the plugin gap.
+
+files_affected:
+  added:
+    - scripts/cloud-claude-setup.sh
+  modified:
+    - _project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+
+metadata:
+  tags:
+    - cloud-parity
+    - plugins
+    - claude-code
+  created_date: "2026-06-30"
+  estimated_effort: "Small (wiring + one verification pass)"

--- a/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+++ b/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
@@ -91,3 +91,49 @@ fails the build if any of these become git-tracked.
   dedup; would mutate user-global config for no behavioral gain.
 - **Commit all hooks including the push-guard.** Rejected: breaks cloud pushes
   and encodes personal policy as a project invariant.
+
+## Addendum (2026-06-30): cloud activation reality — committed config is necessary but not sufficient
+
+A live validation in a fresh `claude.ai/code` cloud session, cross-checked
+against the official Claude Code docs, corrected an optimistic assumption baked
+into the original Decision (and into #895's commit message, which claimed "any
+environment auto-installs the same plugins"). **That claim is false for cloud.**
+
+What a fresh cloud clone actually realizes from committed `.claude/`:
+
+| Class | Cloud-activates from committed config? | Why |
+|---|---|---|
+| Skills (`.claude/skills/**`) | **Yes** | Passive data (prompt files); no trust/install needed. |
+| Commands (`.claude/commands/**`) | **Yes** | Same — passive prompt files. |
+| Plugins (`enabledPlugins` + `extraKnownMarketplaces`) | **No — by design** | Plugins execute arbitrary code. Per the docs (Claude Code ≥ v2.1.195), a plugin enabled only by a project's `.claude/settings.json` from an external source "doesn't load until the team member installs it." No setting, flag, or env var auto-installs project-declared marketplaces. |
+| Hooks (`hooks.PostToolUse`) | **No — empirically** | Docs say project hooks are *not* approval-gated and run by default locally, but are **silent on cloud web execution**; the validation proved the PostToolUse hook never fires in cloud (the command works when run manually). Likely the managed VM applies `allowManagedHooksOnly` or does not wire PostToolUse in the web runtime. |
+
+### Decision (cloud activation)
+
+- **Skills/commands are the real cloud-parity win** and require nothing further.
+- **Plugins**: provision via a setup script (`scripts/cloud-claude-setup.sh`)
+  that runs `claude plugin marketplace add` + `claude plugin install
+  <plugin>@<marketplace> --scope user`, deriving the marketplace/plugin list
+  from `.claude/settings.json` so it never drifts. Wire it as the BenchBox
+  `claude.ai/code` environment setup script. (The committed `enabledPlugins`
+  block stays — it remains correct for local trusted sessions and is the source
+  of truth the setup script reads.)
+- **Hooks**: deliberately **not** provisioned for cloud. The PostToolUse hooks
+  are an edit-time *convenience*; the same `ruff`/`ty` enforcement already runs
+  in CI (`make lint` / `make typecheck`) and `pr-preflight`. Injecting them into
+  the VM's user settings is unreliable (may be blocked by `allowManagedHooksOnly`)
+  and buys nothing CI doesn't already guarantee.
+
+### Evidence (2026-06-30 cloud validation)
+
+- Fresh cloud session: `.claude/skills/*` + `.claude/commands/*` loaded and
+  invocable; `blog` correctly absent. Settings parsed on disk.
+- Marketplace cache empty, `installed_plugins.json` = `{}`, no namespaced
+  plugin agents (`code-modernization:*`, `code-simplifier:*`, …) in the session.
+- PostToolUse hook live-test: a deliberately mis-formatted `.py` written via the
+  Write tool was **not** reformatted (cold and warm venv); `uv run ruff` applied
+  the same fix when run manually → hook inactive, command valid.
+- Docs: Discover/Install plugins, Hooks overview, web-quickstart (setup scripts
+  are the only documented cloud provisioning hook), admin-setup / permissions
+  (`allowManagedHooksOnly`, managed `enabledPlugins` are the only *guaranteed*
+  activation path, enterprise-only).

--- a/scripts/cloud-claude-setup.sh
+++ b/scripts/cloud-claude-setup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# cloud-claude-setup.sh — activate committed Claude Code plugins in a cloud
+# (claude.ai/code) or other fresh/headless session.
+#
+# Why this exists: a committed .claude/settings.json DECLARES plugins
+# (enabledPlugins + extraKnownMarketplaces) but Claude Code does NOT auto-install
+# marketplace plugins in a fresh clone — plugins run arbitrary code, so install
+# is gated behind an explicit step (docs: Discover/Install plugins, >= v2.1.195).
+# Skills and commands load from .claude/ on their own; plugins do not. This
+# script performs the per-environment install step. Wire it up as the BenchBox
+# claude.ai/code environment setup script.
+#
+# Scope: PLUGINS ONLY. Project hooks are intentionally NOT provisioned here — the
+# PostToolUse ruff/ty hooks are an edit-time convenience already enforced by CI
+# (make lint / make typecheck / pr-preflight), and cloud may block project hooks
+# via allowManagedHooksOnly. See
+# _project/decisions/claude-settings-cloud-ownership-2026-06-29.md (cloud addendum).
+#
+# Idempotent and safe to re-run. No-op when the `claude` CLI or python is absent.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SETTINGS="$ROOT/.claude/settings.json"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "cloud-claude-setup: 'claude' CLI not found; skipping plugin install." >&2
+  exit 0
+fi
+
+PY=python3
+command -v "$PY" >/dev/null 2>&1 || PY=python
+if ! command -v "$PY" >/dev/null 2>&1; then
+  echo "cloud-claude-setup: no python interpreter; skipping." >&2
+  exit 0
+fi
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "cloud-claude-setup: $SETTINGS not found; nothing to do." >&2
+  exit 0
+fi
+
+# 1. Register declared marketplaces (name<TAB>github-repo) from settings.json.
+while IFS=$'\t' read -r name repo; do
+  [ -n "${repo:-}" ] || continue
+  echo "cloud-claude-setup: marketplace add ${name} (${repo})"
+  claude plugin marketplace add "$repo" || true
+done < <("$PY" - "$SETTINGS" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+for n, cfg in (d.get("extraKnownMarketplaces") or {}).items():
+    src = cfg.get("source", {})
+    if src.get("source") == "github" and src.get("repo"):
+        print(f"{n}\t{src['repo']}")
+PY
+)
+
+# 2. Install every enabled plugin (key form: plugin@marketplace) to user scope.
+fail=0
+while IFS= read -r plugin; do
+  [ -n "$plugin" ] || continue
+  echo "cloud-claude-setup: install ${plugin}"
+  if ! claude plugin install "$plugin" --scope user; then
+    echo "  (install failed: ${plugin})" >&2
+    fail=1
+  fi
+done < <("$PY" - "$SETTINGS" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+for key, enabled in (d.get("enabledPlugins") or {}).items():
+    if enabled:
+        print(key)
+PY
+)
+
+echo "cloud-claude-setup: done. Verify with 'claude plugin list'."
+exit "$fail"


### PR DESCRIPTION
Cloud validation (2026-06-30) showed committed plugins/hooks do not
auto-activate in a fresh claude.ai/code session: plugins are gated behind an
explicit install (by design -- they run arbitrary code), and the PostToolUse
hooks never fire in the cloud web runtime. Skills and commands do load. So
committing them to .claude/settings.json is necessary but not sufficient for
cloud.

- scripts/cloud-claude-setup.sh: setup script that installs the declared
  marketplace + enabledPlugins via `claude plugin install ... --scope user`,
  derived from .claude/settings.json (no drift). Idempotent; no-ops without the
  claude CLI/python. Wire it as the claude.ai/code environment setup script.
- ADR: cloud-activation addendum recording what actually realizes from committed
  config, correcting #895's "any environment auto-installs" claim.
- TODO: wiring + verification follow-up; hooks deliberately out of scope (CI
  already enforces ruff/ty via make lint / make typecheck / pr-preflight).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
