### PR TITLE
chore(todo): add Apple container + Mocker migration TODOs

### DIFF
--- a/_project/TODO/main/planning/adopt-apple-container-ci-parity.yaml
+++ b/_project/TODO/main/planning/adopt-apple-container-ci-parity.yaml
@@ -1,0 +1,226 @@
+id: adopt-apple-container-ci-parity
+title: "Adopt Apple container for local Linux CI-parity validation before PRs"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Developer Experience
+
+description: |
+  Every PR-gating job in .github/workflows/pr.yml runs on `ubuntu-latest`,
+  but the project is developed on Apple-silicon macOS. So every PR is a
+  macOS -> Linux leap of faith: a pure-Python check can pass locally on
+  macOS and then fail in CI on locale, path-case, float formatting, dict/
+  hash ordering, line endings, or `uv` lock/arch resolution differences.
+  The correctness-gate and the *-cross-surface-equivalence-report jobs are
+  the sharp edge here -- they compare result digests against pinned Linux
+  reference results, exactly the class of value that can format/round
+  differently across OS.
+
+  Apple's `container` (v1.0.0, GA) runs Linux containers as lightweight VMs
+  on Apple silicon and ships a `container machine` mode: a persistent Linux
+  environment with the Mac home directory mounted in, so you "edit on the
+  Mac, build inside Linux". This lets us reproduce the *pure-Python* Linux
+  PR gate locally before submitting -- the one capability native macOS
+  cannot provide.
+
+  Scope of THIS TODO is the runtime/agent substrate only: stand up Apple
+  `container` + a `benchbox-agent` machine, run the pure-Python gate inside
+  it, decide whether in-Linux digests actually diverge from macOS-local,
+  and (if warranted) add an opt-in `make ci-linux` wrapper. It explicitly
+  does NOT cover Docker Compose / `make test-docker-*` (no Compose support
+  in `container`); that is tracked separately in
+  migrate-test-docker-stacks-to-mocker.
+
+  Spike evidence (2026-06-30, host macOS 26.5 / arm64): `brew install
+  container` -> container CLI 1.0.0; `container system start` +
+  `container system kernel set --recommended` (kata-static 3.28.0) brought
+  the runtime up; a single Linux container published ports to the Mac
+  `localhost` and served real traffic (questdb REST `localhost:19000/exec`
+  -> result; postgres `localhost:5432` psycopg round-trip -> PostgreSQL
+  18.4, RW returned 42). `container machine` mode is documented and GA but
+  was NOT itself exercised in the spike -- w0/w1 must confirm it.
+
+work:
+  - id: w0
+    summary: "Re-validate cited spike evidence against current container version"
+    status: pending
+    notes: |
+      Evidence-durability gate per _project/verification-logs/README.md.
+      The description cites container CLI 1.0.0 on macOS 26.5/arm64 and
+      observed localhost reachability. Before w1, confirm:
+        - `container --version` (record the version actually installed now).
+        - `container system status` reports the apiserver running after
+          `container system start`.
+        - host is Apple silicon + macOS 26+ (`uname -m`, `sw_vers`).
+      Capture raw stdout to `/tmp/adopt-apple-container-ci-parity-w0.log`
+      or a CI artifact; commit only a compact summary (command, version,
+      PASS/FAIL, key lines) into this TODO or the PR body. If `container`
+      no longer installs/starts on the current macOS, re-scope before w1.
+
+  - id: w1
+    summary: "Stand up a benchbox-agent container machine with home-mount"
+    needs: [w0]
+    status: pending
+    notes: |
+      `container machine create <image> --name benchbox-agent` with the Mac
+      home mounted; `container machine set -n benchbox-agent cpus/memory`;
+      verify `container machine run -n benchbox-agent -- bash` lands in a
+      Linux shell that can see a claimed pool worktree path. THIS is the
+      step the spike did not exercise -- prove machine mode + home-mount
+      work, not just `container run`.
+
+  - id: w2
+    summary: "Build the benchbox-agent OCI image (ubuntu + uv + build toolchain)"
+    needs: [w0]
+    status: pending
+    notes: |
+      ubuntu:24.04 + git, build-essential, curl, ca-certificates, uv
+      (and the system libs BenchBox's deps need to `uv sync --group dev`).
+      Build with `container build --arch arm64 --tag local/benchbox-agent`.
+      arm64 only unless a check specifically needs x86 parity.
+
+  - id: w3
+    summary: "Run the pure-Python PR gate inside the machine; capture results"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      Inside a claimed worktree, run the Linux-reproducible subset of
+      pr.yml: `uv sync --group dev`, `make ci-local`, `make
+      test-correctness-gate`, and the *-cross-surface-equivalence-report
+      targets the correctness-gate job runs. Record pass/fail + any digest
+      output. clickhouse-integration is in-process chDB (no service) so it
+      is in-scope here; postgres-integration needs a DB and is out of scope
+      (see deps).
+
+  - id: w4
+    summary: "DECISION GATE: do correctness/equivalence digests diverge macOS vs Linux?"
+    needs: [w3]
+    status: pending
+    notes: |
+      Run the same correctness-gate + equivalence targets natively on macOS
+      AND inside the Linux machine; diff the digests/outputs. This decides
+      the tool's value:
+        - If macOS-local already matches the pinned Linux references, the
+          parity win is marginal -> stop at "documented optional tool".
+        - If they diverge, container parity is the ONLY way to validate
+          these gates pre-PR -> proceed to w5 and recommend it.
+      Document the observed divergence (or lack of it) explicitly in the
+      TODO/PR -- this is the central finding.
+
+  - id: w5
+    summary: "Add opt-in `make ci-linux` wrapper (gated on w4 = diverges)"
+    needs: [w4]
+    status: pending
+    notes: |
+      Only if w4 shows divergence (or as a convenience even if not, at
+      reviewer discretion). Add a `ci-linux` target that runs the gate
+      bundle inside `container machine run -n benchbox-agent`. Keep it
+      additive and clearly named -- distinct from `test-docker-*`. Must be
+      a no-op-with-clear-message on non-Apple-silicon / non-macOS-26 hosts,
+      never a hard CI dependency.
+
+  - id: w6
+    summary: "Document setup + usage in AGENTS.md (terse, house style)"
+    needs: [w5]
+    status: pending
+    notes: |
+      One dense block: prerequisites (Apple silicon, macOS 26), one-time
+      setup (install/start/kernel/machine-create), and the pre-PR command.
+      Match the existing terse documentation style; no bash tutorials that
+      restate `container --help`.
+
+deferred:
+  - summary: "Reproduce postgres-integration (needs a live Postgres) inside container"
+    reason: >
+      Needs a database service, which is the Docker Compose problem tracked
+      in migrate-test-docker-stacks-to-mocker. postgres-integration is also
+      a non-blocking sample, not the hard gate.
+  - summary: "Make ci-linux a required/enforced step or run it in CI"
+    reason: >
+      Apple container is Apple-silicon + macOS-26 only; it cannot be a
+      required step for contributors on other hardware, and CI already runs
+      real ubuntu. Local opt-in only.
+
+prior_art:
+  - "Makefile:794 ci-local — extend: ci-linux wraps the same gate bundle but executes it inside `container machine run`."
+  - "Makefile:1065 agent-write-preflight — pattern: agent-/ci- prefixed Make targets that guard/parameterize the dev loop; follow its naming + guard style for ci-linux."
+  - "docker/lakesail/Dockerfile, docker/velox/Dockerfile — reuse as reference for the benchbox-agent image build; do not reuse the DB stack compose files."
+
+must_preserve:
+  - "make ci-local and the correctness-gate / *-cross-surface-equivalence-report targets keep working unchanged when run natively on macOS (ci-linux is purely additive)."
+  - "No PR-gating CI job gains a dependency on Apple container; .github/workflows/ stays ubuntu-latest."
+  - "test-docker-* targets are untouched by this TODO."
+
+approach: |
+  Treat Apple container as a *parity sandbox*, not a general test runner --
+  routine fast tests stay native on macOS (faster, no VM hop). The only
+  reason to pay the VM cost is to reproduce Linux-specific behavior the Mac
+  cannot. Build benchbox-agent once, reuse the persistent machine across
+  sessions (home-mounted), and gate the whole adoption on the w4 finding so
+  we do not add a wrapper target that earns its keep only marginally.
+
+anti_patterns:
+  - "DO NOT route routine `pytest -m fast` through the container — it already runs natively on macOS; the VM hop only adds latency."
+  - "DO NOT make ci-linux a hard prerequisite of pr-open or any CI job — most contributors are not on Apple-silicon macOS 26 — keep it opt-in with a clear skip message."
+  - "DO NOT rebuild the agent image per run — create the machine once and reuse it; rebuild only when the toolchain changes."
+
+verification:
+  - description: "Apple container runtime is up"
+    command: "container system status"
+    expected_output: "apiserver reported running"
+  - description: "benchbox-agent machine reaches a Linux shell that can sync deps"
+    command: "container machine run -n benchbox-agent -- bash -lc 'uname -a && uv --version'"
+    expected_output: "Linux ... aarch64; uv version prints"
+  - description: "Pure-Python gate runs to completion inside the machine"
+    command: "container machine run -n benchbox-agent -- bash -lc 'cd <worktree> && uv sync --group dev && make ci-local'"
+    expected_output: "ci-local completes; pass/fail recorded for w3"
+  - description: "Digest divergence finding captured (w4)"
+    command: "make test-correctness-gate  # native macOS vs inside machine, diff outputs"
+    expected_output: "documented whether macOS-local digests match pinned Linux references"
+
+scope_limit:
+  only_modify:
+    - "Makefile"
+    - "AGENTS.md"
+    - "docker/benchbox-agent/Dockerfile"
+  do_not_modify:
+    - ".github/workflows/"
+    - "docker/*/docker-compose.yml"
+    - "benchbox/core/"
+
+deps:
+  needs: []
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "developer-experience"
+    - "apple-container"
+    - "ci-parity"
+    - "tooling"
+  estimated_effort: "Medium"
+  created_date: "2026-06-30"
+  last_updated: "2026-06-30T12:00:00"
+
+impact:
+  business_value: |
+    Cuts the macOS->Linux PR feedback loop from "push and wait for CI to
+    fail" to a local pre-flight, reducing CI round-trips on the slowest,
+    soundness-critical gates (correctness + cross-surface equivalence).
+  technical_debt: |
+    Establishes the Apple container runtime foundation that
+    migrate-test-docker-stacks-to-mocker builds on, and reduces reliance on
+    Docker Desktop for the agent/dev loop.
+
+success_metrics:
+  - "A documented one-command pre-PR check reproduces the pure-Python pr.yml gate on Linux from an Apple-silicon Mac."
+  - "w4 produces an explicit, recorded finding on macOS-vs-Linux digest divergence for the correctness/equivalence gates."
+  - "Zero change to CI workflow files and zero change to test-docker-* behavior."
+
+open_questions:
+  - question: "Do the correctness-gate / equivalence digests actually differ between macOS-local and Linux?"
+    gating: true
+    affects: ["w4 success_metric: digest-divergence finding"]
+    default: "Assume they can diverge (pinned references are Linux); validate empirically in w4 before recommending adoption."
+  - "Are other active contributors on Apple silicon + macOS 26, or is this a single-developer convenience?"

--- a/_project/TODO/main/planning/migrate-test-docker-stacks-to-mocker.yaml
+++ b/_project/TODO/main/planning/migrate-test-docker-stacks-to-mocker.yaml
@@ -1,0 +1,234 @@
+id: migrate-test-docker-stacks-to-mocker
+title: "Adopt Mocker as the local Compose backend for make test-docker-* stacks"
+worktree: main
+priority: Medium
+status: Not Started
+category: Developer Experience
+
+description: |
+  Goal: let `make test-docker-*` run on Apple `container` via Mocker (a
+  Docker-compatible CLI over Apple's Containerization framework) instead of
+  Docker Desktop, removing Docker Desktop's always-on VM -- the dominant
+  source of the "Docker Desktop overhead" this effort started from. Apple
+  `container` itself has NO Docker Compose support; Mocker is the wrapper
+  that adds it.
+
+  BenchBox's integration layer is Compose-native. The generic targets call
+  (Makefile:436 / Makefile:480 / Makefile:489-540):
+    docker compose -p <project> -f docker/<platform>/docker-compose.yml up -d --wait
+    docker compose -p <project> -f docker/<platform>/docker-compose.yml down -v
+  across DOCKER_PLATFORMS (Makefile:433): clickhouse trino presto postgresql
+  starrocks doris databend influxdb cedardb firebolt questdb singlestore.
+  Any backend must honor `-p`, `-f`, `up -d --wait` (healthcheck gating),
+  host->container port publishing, and `down -v` (named-volume removal).
+
+  Spike evidence (2026-06-30, host macOS 26.5 / arm64; container CLI 1.0.0;
+  Mocker 0.5.4 from us/tap) against UNMODIFIED docker/questdb (1 svc) and
+  docker/postgresql (2 svc, named volume):
+    PASS  `-p` project naming                     (container bbspike-questdb-questdb-1)
+    PASS  `up -d --wait` health gating            (-w/--wait + --wait-timeout real flags; up returned only once serving)
+    PASS  host->container reachability            (localhost:19000/exec -> result; psycopg localhost:5432 -> PG 18.4, RW=42)
+    PASS  `down` teardown                         (stopped+removed, ports closed)
+    PASS  `restart: unless-stopped` parse
+    FAIL  `down -v` named-volume removal          (-v documented but bbspike-pg-postgresql18-data SURVIVED; needed manual `mocker volume rm`)
+
+  The single blocker is the `down -v` volume leak: `make test-docker-down-*`
+  relies on `-v` for fresh state, so a leaked named volume means STALE DATA
+  carries across runs (e.g. a reused Postgres data dir) -- a correctness
+  risk for benchmarks, not a cosmetic one. Networking -- the feature every
+  Compose wrapper is reported to struggle with -- worked. Until `down -v`
+  is fixed or teardown is wrapped, Mocker is NOT safe as the default
+  test-docker-* backend.
+
+work:
+  - id: w0
+    summary: "Re-validate spike findings against current Mocker/container versions"
+    status: pending
+    notes: |
+      Evidence-durability gate per _project/verification-logs/README.md.
+      The description pins Mocker 0.5.4 / container 1.0.0 and a specific
+      `down -v` bug. Before w1, re-run the minimal repro:
+        - `mocker --version`, `container --version` (record actuals).
+        - questdb up -d --wait; assert localhost:9003 -> HTTP 200.
+        - postgresql up -d --wait; `down -v`; then `mocker volume ls` and
+          assert whether the named volume is GONE (bug fixed) or PRESENT
+          (bug persists).
+      Capture raw stdout to `/tmp/migrate-test-docker-stacks-to-mocker-w0.log`
+      or a CI artifact; commit only a compact summary (versions, PASS/FAIL
+      per check). If `down -v` now removes the volume, w4's gate flips open.
+
+  - id: w1
+    summary: "Build a Compose-lifecycle parity harness for questdb + postgresql"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add `_project/scripts/mocker_compose_parity.sh` with scripted
+      assertions over the exact Makefile invocation: up -d --wait returns
+      only when healthy, published port serves a real query, down -v leaves
+      NO container and NO named volume. Same script runs against Docker and
+      Mocker (engine as an arg) so parity is measured, not assumed. This
+      becomes the acceptance test reused for every stack in w2/w3.
+
+  - id: w2
+    summary: "Validate multi-service stacks (doris=3, starrocks=3, databend=4)"
+    needs: [w1]
+    status: pending
+    notes: |
+      depends_on ordering + --wait gating + inter-service networking on the
+      heavier stacks -- the spike only covered 1- and 2-service stacks.
+      IP-consistency / container-to-container networking is the documented
+      weak spot of the wrapper ecosystem; prove it or record the failure.
+
+  - id: w3
+    summary: "Run a full end-to-end make test-docker-<platform> on Mocker"
+    needs: [w1]
+    status: pending
+    notes: |
+      Not just compose lifecycle -- an actual `make test-docker-questdb`
+      (or -postgresql) that loads benchmark data and runs queries through
+      the BenchBox connector against the Mocker-hosted stack, and passes.
+      This is the real acceptance bar.
+
+  - id: w4
+    summary: "DECISION GATE: down -v volume removal fixed, or teardown wrapped?"
+    needs: [w0, w2, w3]
+    status: pending
+    notes: |
+      Hard gate. Resolve one of:
+        (a) a Mocker release removes the named volume on `down -v` (w0
+            confirms) -> proceed to default-eligible; OR
+        (b) wrap teardown in the Makefile with an explicit volume prune
+            after `down -v` (e.g. `mocker volume rm`/`prune` scoped to the
+            project) so fresh state is guaranteed regardless; OR
+        (c) neither acceptable at parity -> do NOT adopt Mocker as default;
+            fall back (see deferred: colima/OrbStack) and close this TODO
+            as "evaluated, not adopted" with the finding recorded.
+
+  - id: w5
+    summary: "Wire opt-in engine selection into test-docker-* (default stays docker)"
+    needs: [w4]
+    status: pending
+    notes: |
+      Introduce a CONTAINER_ENGINE (or COMPOSE_ENGINE) Make variable
+      defaulting to `docker`; `=mocker` swaps the compose driver. Do NOT
+      globally alias docker->mocker and do NOT change the default until w3
+      passes and w4 resolves (a) or (b). Keep docker/*/docker-compose.yml
+      files unchanged (they must stay portable Compose specs).
+
+  - id: w6
+    summary: "Document Mocker-as-local-engine + the CI boundary in AGENTS.md"
+    needs: [w5]
+    status: pending
+    notes: |
+      State explicitly: Mocker is Apple-silicon/macOS-26 LOCAL-DEV only and
+      MUST NOT run in CI (CI is ubuntu + real docker). Terse, house style.
+
+deferred:
+  - summary: "colima or OrbStack as the lighter Compose engine instead of Mocker"
+    reason: >
+      User scope is explicitly Apple container + Mocker. colima/OrbStack are
+      mature drop-in `docker compose` backends that would also remove Docker
+      Desktop with zero Makefile change, and are the recommended FALLBACK if
+      w4 resolves (c). Recorded here so the rejected-for-now alternative is
+      not re-litigated.
+  - summary: "Negative --wait test (a healthcheck that never passes)"
+    reason: >
+      Confirm `up --wait` actually fails/times out on an unhealthy service
+      rather than hanging or false-passing. Nice-to-have hardening, not on
+      the adoption critical path.
+
+prior_art:
+  - "Makefile:436 test-docker-up-% / Makefile:480 test-docker-% — extend: parameterize the `docker compose` driver via CONTAINER_ENGINE rather than forking the targets."
+  - "Makefile:433 DOCKER_PLATFORMS — reuse: the engine swap must cover this exact platform list."
+  - "docker/<platform>/docker-compose.yml — reuse UNCHANGED: backend must consume the existing Compose specs; do not author Mocker-specific files."
+  - "adopt-apple-container-ci-parity — extend: builds on the Apple container runtime that TODO stands up (Mocker delegates to `container`)."
+
+must_preserve:
+  - "Default `make test-docker-*` behavior on Docker is unchanged until the decision gate (w4) explicitly flips the default."
+  - "docker/*/docker-compose.yml remain standard Compose files usable by Docker and CI."
+  - "Fresh-state guarantee: after teardown, no named volume from the stack survives (the property the down -v bug breaks)."
+  - "CI (.github/workflows/) continues to use docker on ubuntu; Mocker never enters CI."
+
+approach: |
+  Measure parity, do not assume it. Reuse the w1 harness as the acceptance
+  test for every stack and for the full end-to-end run, comparing Docker and
+  Mocker on identical compose files. Gate default adoption on the down -v
+  fix (or an explicit teardown wrap), because the failure mode is silent
+  stale-data corruption of benchmark results, not a visible error. Engine
+  selection is an opt-in Make variable so the migration is reversible and
+  CI is unaffected.
+
+anti_patterns:
+  - "DO NOT globally alias `docker`->`mocker` — because CI and other tooling expect real docker — gate it behind an explicit CONTAINER_ENGINE Make variable instead."
+  - "DO NOT flip the test-docker-* default to Mocker before w3 passes and w4 resolves — because a leaked volume silently reuses stale benchmark data — keep docker the default until proven."
+  - "DO NOT run Mocker in CI — because it is Apple-silicon/macOS-only — restrict it to the local dev loop and assert that in docs."
+  - "DO NOT edit docker/*/docker-compose.yml to suit Mocker — because they must stay portable Compose specs for Docker + CI — fix wiring in the Makefile."
+
+verification:
+  - description: "down -v leaves no named volume (the gating property)"
+    command: "mocker compose -p bbtest -f docker/postgresql/docker-compose.yml up -d --wait && mocker compose -p bbtest -f docker/postgresql/docker-compose.yml down -v && mocker volume ls"
+    expected_output: "no bbtest-* volume listed after down -v"
+  - description: "Multi-service stack comes up healthy with dependency ordering"
+    command: "mocker compose -p bbtest -f docker/starrocks/docker-compose.yml up -d --wait"
+    expected_output: "all services started; --wait returns 0 only when healthy"
+  - description: "Full end-to-end benchmark run against a Mocker-hosted stack"
+    command: "CONTAINER_ENGINE=mocker make test-docker-questdb"
+    expected_output: "data loads and queries run; target passes"
+  - description: "Default engine unchanged"
+    command: "make test-docker-postgresql  # no CONTAINER_ENGINE set"
+    expected_output: "uses docker; behavior identical to today"
+
+scope_limit:
+  only_modify:
+    - "Makefile"
+    - "AGENTS.md"
+    - "_project/scripts/mocker_compose_parity.sh"
+  do_not_modify:
+    - "docker/"
+    - ".github/workflows/"
+    - "benchbox/"
+    - "tests/"
+
+deps:
+  needs:
+    - adopt-apple-container-ci-parity
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "developer-experience"
+    - "apple-container"
+    - "mocker"
+    - "docker-compose"
+    - "tooling"
+  estimated_effort: "Medium-Large"
+  created_date: "2026-06-30"
+  last_updated: "2026-06-30T12:00:00"
+
+impact:
+  business_value: |
+    Removes Docker Desktop's always-on VM from the dev loop -- the dominant
+    overhead this effort targeted -- by hosting the integration stacks on
+    Apple container via Mocker, while keeping the Compose files and CI
+    untouched.
+  technical_debt: |
+    Adds an engine-selection seam to the Makefile. Risk concentrated in the
+    down -v fresh-state guarantee, which is explicitly gated.
+
+success_metrics:
+  - "CONTAINER_ENGINE=mocker make test-docker-<platform> passes end-to-end for at least one representative platform, including the down -v fresh-state guarantee."
+  - "Multi-service stacks (doris/starrocks/databend) verified up healthy on Mocker, or their failure recorded as a blocker."
+  - "Docker remains the default and CI is unchanged; Mocker adoption is reversible via the engine variable."
+  - "Decision gate w4 resolved with a recorded outcome: adopt-default / wrap-teardown / not-adopted-fallback."
+
+open_questions:
+  - question: "Does `down -v` remove named volumes in the Mocker version under evaluation?"
+    gating: true
+    affects: ["w4 success_metric: down -v fresh-state guarantee"]
+    default: "As of 0.5.4 it does NOT — treat as broken and require fix-or-wrap before defaulting to Mocker."
+  - question: "Do 3+ service stacks get reliable container-to-container networking / IP consistency on Apple container?"
+    gating: true
+    affects: ["w2 success_metric: multi-service stacks verified"]
+    default: "Unproven beyond 2 services in the spike — validate in w2 before adoption."
+  - "Should the engine variable be CONTAINER_ENGINE or COMPOSE_ENGINE for clarity vs existing Make conventions?"


### PR DESCRIPTION
Two planning TODOs for the switch off Docker Desktop, split by risk:

- adopt-apple-container-ci-parity: stand up Apple container (GA 1.0)
  machine mode to reproduce the pure-Python ubuntu-latest PR gate
  locally pre-PR. Decision gate w4: do correctness/equivalence digests
  diverge macOS vs Linux (determines the tool's value).

- migrate-test-docker-stacks-to-mocker: adopt Mocker as the local
  Compose backend for make test-docker-*. Hard decision gate w4 on the
  down -v named-volume leak found in the 2026-06-30 spike (Mocker 0.5.4
  / container 1.0.0); colima/OrbStack recorded as fallback. depends on
  the container runtime TODO.

Both lead with a w0 evidence-revalidation unit (spike cites pinned
versions + observed behavior) and document validation steps + scope.
