### PR TITLE
fix(write_primitives): run portable SCD2 merge ops on DuckDB

### DIFF
--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -37,8 +37,7 @@ from benchbox.core.write_primitives.schema import (
     get_create_table_sql,
 )
 from benchbox.sql_compat.rules.execution_filter.duckdb_write_primitives import (
-    DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS,
-    DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS,
+    duckdb_write_primitive_skip_reason,
 )
 from benchbox.sql_compat.rules.execution_filter.postgres_write_primitives import (
     POSTGRES_WRITE_PRIMITIVES_CATEGORY_SKIPS,
@@ -412,17 +411,9 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 )
 
         if (platform_key or "").lower() == "duckdb":
-            category = getattr(operation, "category", "")
-            if category in DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS:
-                return None, (
-                    f"Operation '{operation.id}' is skipped on DuckDB: "
-                    f"{DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS[category]}"
-                )
-            if operation.id in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS:
-                return None, (
-                    f"Operation '{operation.id}' is skipped on DuckDB: "
-                    f"{DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS[operation.id]}"
-                )
+            duckdb_skip_reason = duckdb_write_primitive_skip_reason(operation)
+            if duckdb_skip_reason is not None:
+                return None, (f"Operation '{operation.id}' is skipped on DuckDB: {duckdb_skip_reason}")
 
         effective_sql = operation.write_sql
 

--- a/benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py
+++ b/benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py
@@ -7,13 +7,44 @@ from benchbox.sql_compat.context import Phase
 from benchbox.sql_compat.decision import CompatibilityDecision, FailureMode, SkipQueryPayload, SupportLevel
 from benchbox.sql_compat.registry import REGISTRY
 
-DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS = {
-    "merge": "DuckDB 1.3.2 rejects the catalog's MERGE statements; keep them explicit skips until the bundled driver supports MERGE.",
+# Bundled DuckDB 1.3.2 rejects ``MERGE INTO``. The skip is gated on the presence of that token in
+# an operation's write_sql rather than on the whole ``merge`` operation category, because the
+# category also covers portable SCD Type 2 ops (merge_scd_type2_basic / _no_change /
+# _new_keys_only) that are expressed as UPDATE + INSERT and which DuckDB runs and validates
+# correctly. Token-gating keeps those portable ops executing and automatically covers any future
+# MERGE INTO operation with no per-operation skip list to maintain.
+#
+# Evidence: DuckDB 1.3.2 local execution verification on 2026-06-30 — the 20 legacy MERGE INTO
+# ops still raise a parser error, while the portable SCD Type 2 ops execute and validate green
+# (tests/integration/test_write_primitives_duckdb.py -k scd2).
+DUCKDB_MERGE_INTO_TOKEN = "MERGE INTO"
+
+DUCKDB_WRITE_PRIMITIVES_MERGE_SKIP_REASON = (
+    "DuckDB 1.3.2 rejects the catalog's MERGE INTO statements; keep them explicit skips until the "
+    "bundled driver supports MERGE. Portable merge operations written as UPDATE/INSERT run normally."
+)
+
+# Operation-level skips keyed by id, for gaps that cannot be detected from the write_sql token.
+DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS = {
+    "bulk_load_upsert_mode": DUCKDB_WRITE_PRIMITIVES_MERGE_SKIP_REASON,
 }
 
-DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS = {
-    "bulk_load_upsert_mode": DUCKDB_WRITE_PRIMITIVES_CATEGORY_SKIPS["merge"],
-}
+
+def duckdb_write_primitive_skip_reason(operation) -> str | None:
+    """Return a skip reason if ``operation`` cannot execute on bundled DuckDB, else ``None``.
+
+    Gating on the ``MERGE INTO`` token rather than the broad ``merge`` category lets portable merge
+    operations — e.g. the SCD Type 2 ops expressed as UPDATE + INSERT — run on DuckDB while genuine
+    ``MERGE INTO`` statements continue to skip cleanly.
+    """
+    write_sql = (getattr(operation, "write_sql", "") or "").upper()
+    if DUCKDB_MERGE_INTO_TOKEN in write_sql:
+        return DUCKDB_WRITE_PRIMITIVES_MERGE_SKIP_REASON
+    operation_id = getattr(operation, "id", None)
+    if operation_id in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS:
+        return DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS[operation_id]
+    return None
+
 
 for _query_id, _reason in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS.items():
     REGISTRY.register(
@@ -23,7 +54,7 @@ for _query_id, _reason in DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS.items():
             support_level=SupportLevel.SKIPPED_QUERY,
             failure_mode=FailureMode.UNSUPPORTED_FEATURE,
             payload=SkipQueryPayload(
-                reason=f"{_reason} Evidence: DuckDB 1.3.2 local parser verification on 2026-05-29.",
+                reason=f"{_reason} Evidence: DuckDB 1.3.2 local execution verification on 2026-06-30.",
                 query_id=_query_id,
             ),
             reason=_reason,

--- a/docs/compat/skip-reference.md
+++ b/docs/compat/skip-reference.md
@@ -109,7 +109,7 @@ Queries or benchmarks that are **omitted from the result set** - either because 
 | SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_isolation_serializable | execution_filter | DuckDB rejects explicit SET TRANSACTION ISOLATION LEVEL syntax. | `execution_filter.duckdb.transaction_primitives.transaction_isolation_serializable` |
 | SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_savepoint_deep_nesting | execution_filter | DuckDB rejects SAVEPOINT syntax in transaction_primitives operations. | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_deep_nesting` |
 | SKIPPED_QUERY | benchmark=transaction_primitives, query=transaction_savepoint_nested | execution_filter | DuckDB rejects SAVEPOINT syntax in transaction_primitives operations. | `execution_filter.duckdb.transaction_primitives.transaction_savepoint_nested` |
-| SKIPPED_QUERY | benchmark=write_primitives, query=bulk_load_upsert_mode | execution_filter | DuckDB 1.3.2 rejects the catalog's MERGE statements; keep them explicit skips until the bundled driver supports MERGE. | `execution_filter.duckdb.write_primitives.bulk_load_upsert_mode` |
+| SKIPPED_QUERY | benchmark=write_primitives, query=bulk_load_upsert_mode | execution_filter | DuckDB 1.3.2 rejects the catalog's MERGE INTO statements; keep them explicit skips until the bundled driver supports MERGE. Portable merge operations written as UPDATE/INSERT run normally. | `execution_filter.duckdb.write_primitives.bulk_load_upsert_mode` |
 
 ### lakesail
 

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -1563,6 +1563,58 @@ def test_get_effective_write_sql_no_overrides(fast_bench):
     assert skip is None
 
 
+def test_get_effective_write_sql_duckdb_skips_merge_into(fast_bench):
+    """DuckDB 1.3.2 rejects MERGE INTO, so such ops are gated out by the SQL token."""
+    operation = SimpleNamespace(
+        id="merge_simple_upsert_small",
+        write_sql="MERGE INTO t AS target USING s ON t.k = s.k WHEN MATCHED THEN UPDATE SET v = s.v",
+        platform_overrides={},
+        category="merge",
+    )
+    sql, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb")
+    assert sql is None
+    assert skip is not None
+    assert "MERGE INTO" in skip
+
+
+def test_get_effective_write_sql_duckdb_runs_portable_merge(fast_bench):
+    """Portable merge ops (UPDATE + INSERT, no MERGE INTO) run on DuckDB despite the merge category.
+
+    The skip is gated on the ``MERGE INTO`` token, not on the broad ``merge`` category, so portable
+    SCD Type 2 style ops are not skipped.
+    """
+    operation = SimpleNamespace(
+        id="merge_scd_type2_basic",
+        write_sql="UPDATE dim SET is_current = false WHERE k IN (SELECT k FROM stage);\nINSERT INTO dim SELECT * FROM stage",
+        platform_overrides={},
+        category="merge",
+    )
+    sql, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb")
+    assert skip is None
+    assert sql == operation.write_sql
+
+
+def test_get_effective_write_sql_duckdb_gate_matches_catalog(fast_bench):
+    """The real catalog: portable SCD2 ops run on DuckDB while legacy MERGE INTO ops skip."""
+    portable_ops = (
+        "merge_scd_type2_basic",
+        "merge_scd_type2_no_change",
+        "merge_scd_type2_new_keys_only",
+    )
+    for op_id in portable_ops:
+        operation = fast_bench.get_operation(op_id)
+        assert operation.category == "merge"
+        assert "MERGE INTO" not in operation.write_sql.upper()
+        _, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb")
+        assert skip is None, f"{op_id} should run on DuckDB, got skip: {skip}"
+
+    legacy = fast_bench.get_operation("merge_simple_upsert_small")
+    assert "MERGE INTO" in legacy.write_sql.upper()
+    _, legacy_skip = fast_bench._get_effective_write_sql(legacy, platform_key="duckdb")
+    assert legacy_skip is not None
+    assert "MERGE INTO" in legacy_skip
+
+
 def test_get_effective_write_sql_skips_when_file_dependencies_missing(fast_bench, tmp_path):
     """Bulk-load operations should be skipped when required files are unavailable."""
     fast_bench.data_generator.files_dir = tmp_path


### PR DESCRIPTION
## Description

The DuckDB `write_primitives` execution filter skipped the **entire `merge`
operation category** on DuckDB, because the 20 legacy MERGE operations use
`MERGE INTO`, which the bundled DuckDB 1.3.2 rejects.

That over-broad category skip also caught the three portable SCD Type 2 ops
(`merge_scd_type2_basic`, `merge_scd_type2_no_change`,
`merge_scd_type2_new_keys_only`), which are written as portable
`UPDATE` + `INSERT` (no `MERGE INTO`) and run and validate correctly on DuckDB.
As a result, a real `benchbox run write_primitives --platform duckdb` reported
them as **SKIPPED** instead of executing them.

This PR narrows the gate: a DuckDB write_primitives op is skipped only when its
`write_sql` contains the `MERGE INTO` token, via a new
`duckdb_write_primitive_skip_reason()` helper. This keeps the portable merge ops
executing, still skips the legacy `MERGE INTO` ops cleanly, and automatically
covers any future portable or `MERGE INTO` op with **no per-operation list to
maintain** (the robust option requested).

Changes:
- Replace the `merge` category skip with a SQL-token gate in
  `benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py` and
  route `benchmark._get_effective_write_sql()` through the new helper.
- Update the rule's dated evidence comment (2026-06-30 local DuckDB execution
  verification; `tests/integration/test_write_primitives_duckdb.py -k scd2`).
- Regenerate `docs/compat/skip-reference.md` for the refreshed skip reason.

## Type of Change

- [x] Bug fix

## Testing

- `make pr-preflight` — lint, type-check, `compat-docs-check`, and the fast
  test lane pass. (The only failing fast tests — pyspark CSV null semantics,
  Delta `delta_scan` smoke, and two CLI invalid-output-dir cases — are
  pre-existing, environment-specific failures on the clean `develop` base,
  unrelated to this change.)
- `pytest tests/integration/test_write_primitives_duckdb.py -k scd2` — 6 passed
  (portable SCD2 ops execute and validate green on real DuckDB).
- New unit tests in `tests/unit/core/write_primitives/test_benchmark_execution.py`
  assert the token gate against synthetic ops and the real catalog: the three
  portable SCD2 merge ops resolve to **run** on DuckDB while legacy `MERGE INTO`
  ops still **skip**.
- Verified the resolver directly: `merge_scd_type2_*` → RUN; all 20 legacy
  `MERGE INTO` ops and `bulk_load_upsert_mode` → SKIP.

## Public Contract Check

- [x] No public/generated contract surface changes beyond the regenerated
      `docs/compat/skip-reference.md`, which is produced from registry metadata.
- [x] The DuckDB skip registry entry (`bulk_load_upsert_mode`) is unchanged in
      scope; only its reason wording was refreshed.

## Documentation

- [x] Regenerated `docs/compat/skip-reference.md`.
- [x] Updated the rule module's evidence comment with regression notes.

## Code Quality

- [x] Ran `ruff format`/`ruff check`/`ty check`.
- [x] Reviewed importers — only `benchmark.py` consumed the removed constants.
- [x] Added unit tests for the new gate behavior.

## Artifact Hygiene

- [x] No raw screenshots, logs, or temporary binary artifacts committed.

## Notes

Robustness: the gate keys on the `MERGE INTO` SQL token rather than the `merge`
category or a hand-maintained allowlist, so new portable merge ops run on DuckDB
automatically and new `MERGE INTO` ops skip automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM353JL1xoEN4qCzMS1eba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KM353JL1xoEN4qCzMS1eba)_