### PR TITLE
test(ci): promote deepest holistic-review reproducers into required CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -423,6 +423,27 @@ jobs:
             tests/unit/test_standardized_test_commands.py::TestMakefileCommands::test_cross_surface_gates_are_pinned_in_make_and_ci \
             -m "medium" -n 0 --tb=short -q
 
+      - name: Run promoted h2odb mutation-catch reproducer (#901)
+        run: |
+          # #901's mutation-sensitivity catch assertions are slow-marked, so the
+          # fast-lane selection below skips them; invoke the h2odb cell (the gate
+          # whose scale fidelity #901 fixed: gate.scale_factor=0.01 matching
+          # production) explicitly so a regression in its mutation catch fails
+          # required CI instead of only at the main-release boundary (test.yml).
+          # Bounded: the single load-bearing gate cell, not the full slow matrix.
+          uv run -- python -m pytest \
+            tests/integration/test_cross_surface_mutation_sensitivity.py \
+            -m "slow" -n 0 -k "h2odb" --tb=short -q
+
+      - name: Run promoted plan-capture-phase reproducers (#909)
+        run: |
+          # #909's connection-fencing and plan-identity reproducers are
+          # medium-marked and otherwise run only in test.yml; invoke them here so
+          # they execute in the required develop-PR gate, not one ring out.
+          uv run -- python -m pytest \
+            tests/integration/test_plan_capture_phase.py \
+            -m "medium" -n 0 --tb=short -q
+
       - name: Run fast tests
         run: |
           # -p pytest_cov re-enables coverage plugin (disabled by default in pytest.ini)

--- a/_project/DONE/main/planning/required-ci-coverage-deepest-reproducers.yaml
+++ b/_project/DONE/main/planning/required-ci-coverage-deepest-reproducers.yaml
@@ -2,7 +2,8 @@ id: required-ci-coverage-deepest-reproducers
 title: "Pull the deepest holistic-review regression reproducers into required develop-PR CI"
 worktree: main
 priority: High
-status: Not Started
+status: Completed
+completed_date: "2026-06-30"
 category: Testing and Quality Assurance
 
 description: |
@@ -47,7 +48,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-confirm the three gaps on fresh develop before editing (markers, env-var usages, lane membership)"
-    status: pending
+    status: done
     needs: []
     notes: |
       From a fresh worktree off develop: grep BENCHBOX_PLANT_PLAN_CAPTURE_GATE_DEFECT
@@ -64,7 +65,7 @@ work:
 
   - id: w1
     summary: "Add a standing automated negative test that the plan-capture gate fails on a planted defect (#900 F3)"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Add test (or CI step) that runs the plan-capture gate subprocess with
@@ -76,7 +77,7 @@ work:
 
   - id: w2
     summary: "Promote the load-bearing mutation-catch cells into required code-test (#901 F4)"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Add an explicit-node step to code-test invoking the h2odb mutation-sensitivity
@@ -87,7 +88,7 @@ work:
 
   - id: w3
     summary: "Add the w2/w3 plan-capture-phase reproducers to a required develop-PR job (#909 F5)"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Add an explicit-node step to code-test:
@@ -98,7 +99,7 @@ work:
 
   - id: w4
     summary: "Prove each new required step is load-bearing (fails when its fix is reverted)"
-    status: pending
+    status: done
     needs: [w1, w2, w3]
     notes: |
       For each added step, locally break the underlying fix and confirm the required

--- a/tests/integration/test_plan_capture_gate.py
+++ b/tests/integration/test_plan_capture_gate.py
@@ -9,6 +9,8 @@ fingerprints are stable, and write statements are not double-executed by capture
 from __future__ import annotations
 
 import os
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -136,3 +138,49 @@ def test_plan_capture_gate_dml_is_not_double_executed(engine_case) -> None:
     assert result.failed == 0, f"{case.platform} failed to structurally capture DML"
     assert result.captured == 1
     assert result.fingerprints["insert"]
+
+
+def test_plan_capture_gate_catches_planted_defect() -> None:
+    """Standing negative test: the gate goes RED on a planted plan-capture defect.
+
+    #900 shipped the ``BENCHBOX_PLANT_PLAN_CAPTURE_GATE_DEFECT=drop_fingerprint``
+    planting switch but nothing in CI ever set it, so the "gate catches a dropped
+    fingerprint" proof was a one-time manual demo with no standing guard. This runs
+    the gate's positive node in a subprocess with the defect planted and asserts the
+    gate FAILS on the dropped fingerprint -- regression-protecting the catch
+    capability itself, not just the happy path.
+
+    The subprocess targets only the positive node (not this test), so it cannot
+    recurse. This test is ``fast``-marked (module-level), so it runs in the required
+    plan-capture-gate job, which executes the whole file.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    node = (
+        "tests/integration/test_plan_capture_gate.py::"
+        "test_plan_capture_gate_parses_plans_and_stabilizes_fingerprints[duckdb]"
+    )
+    # Strip xdist/coverage coordination vars so this nested run (which executes
+    # under the fast lane's own xdist workers + coverage) does not try to attach to
+    # the parent controller or double-count coverage.
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("PYTEST_XDIST", "COV_CORE")) and key != "PYTEST_CURRENT_TEST"
+    }
+    env["BENCHBOX_PLANT_PLAN_CAPTURE_GATE_DEFECT"] = "drop_fingerprint"
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", node, "-n", "0", "-p", "no:cacheprovider", "-q"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode != 0, (
+        "plan-capture gate PASSED with a planted dropped-fingerprint defect; "
+        f"the catch capability has regressed.\n{combined}"
+    )
+    assert "produced no fingerprint" in combined, (
+        "plan-capture gate failed for an unexpected reason rather than the dropped "
+        f"fingerprint; the negative test is no longer load-bearing.\n{combined}"
+    )


### PR DESCRIPTION
Promotes the three deepest holistic-review regression reproducers into the required develop-PR CI gate, so a PR introducing such a reproducer can no longer self-merge without running its own deepest guard (closes `required-ci-coverage-deepest-reproducers`).

## w0 — re-validation on fresh develop (live truth)
- `BENCHBOX_PLANT_PLAN_CAPTURE_GATE_DEFECT`: read **only** by `tests/integration/test_plan_capture_gate.py` (`_plant_defect_if_requested`); set by nothing in CI. **Drift correction:** the live switch value is `drop_fingerprint`, not the YAML's `=1` (the gate raises `unknown planted plan-capture defect` for any other value).
- `test_cross_surface_mutation_sensitivity.py` module `pytestmark = [integration, slow, duckdb]` — substantive catch cells are `slow`, excluded from the fast lane.
- `test_plan_capture_phase.py` module `pytestmark = [integration, medium]` — runs only in test.yml.
- `ci-required-result.needs` (pr.yml) includes `code-test` (`test (ubuntu-latest, 3.12)`) and `plan-capture-gate`. Both new step homes are already required.
- No `cli-lean-import-guarantee` PR in flight → no pr.yml required-lane merge coordination needed.

## Changes
- **w1 (#900):** new standing negative test `test_plan_capture_gate_catches_planted_defect` in the gate file. Spawns the positive node in a subprocess with the defect planted and asserts the gate goes RED on the dropped fingerprint. `fast`-marked → runs in the required `plan-capture-gate` job (which runs the whole file). Subprocess targets only the positive node (no recursion) and strips xdist/coverage env so it is clean under the fast lane.
- **w2 (#901):** explicit-node step in `code-test` running the h2odb mutation cell + `test_unmutated_target_is_green[h2odb]` (`-m slow -n 0 -k h2odb`), mirroring the existing `pr.yml` drift-guard pattern. Bounded to the single load-bearing gate cell (~9s), not the slow matrix.
- **w3 (#909):** explicit-node step in `code-test` running the plan-capture-phase connection-fencing + plan-identity reproducers (`-m medium -n 0`, ~3s).

## w4 — load-bearing proof (break → required step RED → restore; breakage NOT committed)
- **w1:** removed the gate's `assert plan.plan_fingerprint` catch → `test_plan_capture_gate_catches_planted_defect` failed: "plan-capture gate PASSED with a planted dropped-fingerprint defect; the catch capability has regressed." Restored.
- **w3:** reverted the connection-fencing fix (`close_connection = owns_connection` → `True`) in `plan_capture_phase.py` → `test_capture_phase_reuses_supplied_connection` failed with `Connection already closed!`. Restored.
- **w2:** the literal #901 scale revert (`_build_gate_cell` back to `EQUIVALENCE_SCALE`) does **not** turn the step red — the harness rebuilds contexts from the same generated data, so it self-corrects (only slower). Honest finding: the promoted h2odb cells are load-bearing on the **mutation-catch capability**, not the scale constant. Proven by neutralizing the seeded mutation (`_mutate_rows` → no-op) → all 4 expected-caught h2odb cells failed with "SENSITIVITY GAP: … the comparator missed a seeded bug it should detect." Restored.

## Verification
- `make plan-capture-gate` → 5 passed (was 4).
- `BENCHBOX_PLANT_PLAN_CAPTURE_GATE_DEFECT=drop_fingerprint pytest <positive node>` → exit 1 (catch proven).
- `pytest test_plan_capture_phase.py -m medium -n 0` → 17 passed.
- `pytest test_cross_surface_mutation_sensitivity.py -m slow -k h2odb` → 5 passed.
- ruff clean; pr.yml YAML valid.

No new always-on slow matrix; every added step lives in a job already in `ci-required-result.needs`, none `continue-on-error`.

Code review (high effort, independent verifier): no correctness findings; vacuous-pass, subprocess-recursion/env, repo-root resolution, and marker-collection concerns all empirically refuted. No skipped nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb4WFFT3SBDJF57MP4GXYZ)_