### PR TITLE
feat(plan-fingerprint): add opt-in literal normalization for cross-seed comparison

### DIFF
--- a/_project/DONE/main/planning/query-plan-capture-fingerprint-literal-normalization.yaml
+++ b/_project/DONE/main/planning/query-plan-capture-fingerprint-literal-normalization.yaml
@@ -2,7 +2,7 @@ id: query-plan-capture-fingerprint-literal-normalization
 title: "Add optional literal normalization to plan fingerprints for cross-run regression detection"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
 category: Core Functionality
 
 description: |

--- a/benchbox/core/manifest/plan_metadata_utils.py
+++ b/benchbox/core/manifest/plan_metadata_utils.py
@@ -13,6 +13,7 @@ def create_plan_metadata_from_results(
     results: Any,  # BenchmarkResults
     platform: str | None = None,
     platform_version: str | None = None,
+    normalize_literals: bool = False,
 ) -> PlanMetadata:
     """
     Create plan metadata from benchmark results.
@@ -23,6 +24,12 @@ def create_plan_metadata_from_results(
         results: BenchmarkResults instance with query plans
         platform: Platform name (defaults to results.platform)
         platform_version: Platform version (defaults to results.platform_version)
+        normalize_literals: When True, record each query's literal-normalized
+            fingerprint (``QueryPlanDAG.normalized_fingerprint``) instead of the
+            default literal-sensitive ``plan_fingerprint``. Use this when comparing
+            runs that may use different benchmark seeds: structurally identical plans
+            then share a fingerprint even when their filter literals differ. Default
+            False preserves the existing literal-sensitive behaviour.
 
     Returns:
         PlanMetadata with fingerprints and timestamps
@@ -34,14 +41,20 @@ def create_plan_metadata_from_results(
 
     timestamp = datetime.now(timezone.utc).isoformat()
 
-    # Extract fingerprints from all phase results
+    # Extract fingerprints from all phase results. When normalize_literals is set we
+    # read the literal-normalized fingerprint and never fall back to the
+    # literal-sensitive one — silently mixing the two would defeat the seed-stable
+    # comparison this option exists for (a plan lacking the normalized property is
+    # skipped rather than recorded under the wrong scheme).
+    attr = "normalized_fingerprint" if normalize_literals else "plan_fingerprint"
     for phase_results in getattr(results, "phases", {}).values():
         for execution in phase_results.queries:
             plan = getattr(execution, "query_plan", None)
-            if plan and hasattr(plan, "plan_fingerprint") and plan.plan_fingerprint:
+            fingerprint = getattr(plan, attr, None) if plan is not None else None
+            if fingerprint:
                 query_id = execution.query_id
                 if query_id not in metadata.plan_fingerprints:
-                    metadata.plan_fingerprints[query_id] = plan.plan_fingerprint
+                    metadata.plan_fingerprints[query_id] = fingerprint
                     metadata.plan_capture_timestamp[query_id] = timestamp
                     metadata.plan_versions[query_id] = 1  # Default to version 1
 

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -108,11 +108,32 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
 from benchbox.core.errors import SerializationError
+
+# Literal-masking patterns for normalize_literals fingerprints. Numeric literals
+# (including decimals) collapse to <NUM> and single-quoted string literals to <STR>
+# so that structurally identical plans whose only difference is a data-driven
+# parameter value (e.g. a seed-varied filter threshold) hash the same. Numbers are
+# masked first so digits inside a quoted literal are folded into the <STR> token.
+_LITERAL_NUM_RE = re.compile(r"\b\d+(?:\.\d+)?\b")
+_LITERAL_STR_RE = re.compile(r"'[^']*'")
+
+
+def _mask_literals(expression: str) -> str:
+    """Replace numeric and single-quoted string literals with stable placeholders.
+
+    Masks only concrete values, never identifiers: a trailing digit on a column or
+    alias (``l_orderkey1``, ``t1``) has no leading word boundary before the digit,
+    so it is left intact. Used for the opt-in literal-normalized structural
+    signature; the default fingerprint keeps literals verbatim.
+    """
+    return _LITERAL_STR_RE.sub("<STR>", _LITERAL_NUM_RE.sub("<NUM>", expression))
+
 
 logger = logging.getLogger(__name__)
 
@@ -371,9 +392,19 @@ class LogicalOperator:
             offset_count=data.get("offset_count"),
         )
 
-    def get_structural_signature(self) -> str:
+    def get_structural_signature(self, normalize_literals: bool = False) -> str:
         """
         Get structural signature for fingerprinting.
+
+        Args:
+            normalize_literals: When True, mask numeric/string literals in the
+                predicate fields (filter_expressions, join_conditions,
+                projection_expressions) to ``<NUM>``/``<STR>`` so that plans which
+                differ only by a data-driven parameter value (e.g. a seed-varied
+                filter threshold) produce the same signature. Default False keeps
+                literals verbatim (the established, literal-sensitive behaviour).
+                Column/identifier fields (table_name, group_by_keys, sort_keys,
+                aggregation_functions, etc.) are never masked.
 
         Returns only structural elements that affect query semantics:
         - operator_type: Type of logical operation
@@ -409,14 +440,21 @@ class LogicalOperator:
             join_type_str = get_join_type_str(self.join_type)
             signature_parts.append(f"join:{join_type_str}")
 
-        # Join conditions - sorted for set-like semantics (order doesn't affect result)
+        # Join conditions - sorted for set-like semantics (order doesn't affect result).
+        # Mask each predicate's literals before sorting so the set is seed-stable.
         if self.join_conditions:
-            conditions_str = ",".join(sorted(self.join_conditions))
+            conditions = (
+                [_mask_literals(c) for c in self.join_conditions] if normalize_literals else self.join_conditions
+            )
+            conditions_str = ",".join(sorted(conditions))
             signature_parts.append(f"join_cond:{conditions_str}")
 
         # Filter expressions - sorted for set-like semantics
         if self.filter_expressions:
-            filters_str = ",".join(sorted(self.filter_expressions))
+            filters = (
+                [_mask_literals(f) for f in self.filter_expressions] if normalize_literals else self.filter_expressions
+            )
+            filters_str = ",".join(sorted(filters))
             signature_parts.append(f"filters:{filters_str}")
 
         # Aggregation functions - sorted for set-like semantics
@@ -436,9 +474,15 @@ class LogicalOperator:
             sort_str = ",".join(str(sorted(sk.items())) for sk in self.sort_keys)
             signature_parts.append(f"sort:{sort_str}")
 
-        # Projection expressions - order preserved (affects output columns)
+        # Projection expressions - order preserved (affects output columns).
+        # Mask literals (e.g. computed constants) but keep column order/identifiers.
         if self.projection_expressions:
-            proj_str = ",".join(self.projection_expressions)
+            projections = (
+                [_mask_literals(p) for p in self.projection_expressions]
+                if normalize_literals
+                else self.projection_expressions
+            )
+            proj_str = ",".join(projections)
             signature_parts.append(f"proj:{proj_str}")
 
         # Limit count - affects result set size
@@ -452,7 +496,7 @@ class LogicalOperator:
         # Recursively include children signatures
         if self.children:
             for child in self.children:
-                signature_parts.append(child.get_structural_signature())
+                signature_parts.append(child.get_structural_signature(normalize_literals=normalize_literals))
 
         return "|".join(signature_parts)
 
@@ -493,24 +537,48 @@ class QueryPlanDAG:
 
     def __post_init__(self) -> None:
         """Compute plan fingerprint after initialization."""
+        # Lazy cache for the literal-normalized fingerprint. A plain attribute, not a
+        # dataclass field, so it stays out of asdict()/to_dict() serialization and
+        # __eq__ — the default plan_fingerprint remains the only persisted fingerprint.
+        self._normalized_fingerprint: str | None = None
         if self.plan_fingerprint is None:
             self.plan_fingerprint = self.compute_plan_fingerprint()
             self.fingerprint_integrity = FingerprintIntegrity.VERIFIED
 
-    def compute_plan_fingerprint(self) -> str:
+    def compute_plan_fingerprint(self, normalize_literals: bool = False) -> str:
         """
         Compute SHA256 hash of logical operator tree structure.
 
         Only includes structural elements (operator types, join types, table names).
         Excludes costs, row counts, operator IDs, and other non-structural properties.
 
+        Args:
+            normalize_literals: When True, mask numeric/string literals in predicate
+                fields before hashing, so structurally identical plans that differ
+                only by a data-driven parameter value hash the same. Default False
+                preserves the literal-sensitive fingerprint.
+
         Returns:
             Hexadecimal SHA256 hash string
         """
         if self.logical_root is None:
             return hashlib.sha256(b"EMPTY_PLAN").hexdigest()
-        structural_signature = self.logical_root.get_structural_signature()
+        structural_signature = self.logical_root.get_structural_signature(normalize_literals=normalize_literals)
         return hashlib.sha256(structural_signature.encode("utf-8")).hexdigest()
+
+    @property
+    def normalized_fingerprint(self) -> str:
+        """Literal-normalized structural fingerprint (computed lazily, then cached).
+
+        Equivalent to ``compute_plan_fingerprint(normalize_literals=True)`` but
+        memoised on first access, mirroring how ``plan_fingerprint`` is held once.
+        Stable across runs whose plans differ only by seed-varied literal values,
+        so it is the fingerprint to compare for cross-seed regression detection.
+        The default ``plan_fingerprint`` is left untouched (literal-sensitive).
+        """
+        if self._normalized_fingerprint is None:
+            self._normalized_fingerprint = self.compute_plan_fingerprint(normalize_literals=True)
+        return self._normalized_fingerprint
 
     def verify_fingerprint(self) -> bool:
         """
@@ -551,6 +619,7 @@ class QueryPlanDAG:
         """
         self.plan_fingerprint = self.compute_plan_fingerprint()
         self.fingerprint_integrity = FingerprintIntegrity.VERIFIED
+        self._normalized_fingerprint = None
 
     def apply_raw_output_policy(
         self,
@@ -699,7 +768,7 @@ class QueryPlanDAG:
         )
 
 
-def compute_plan_fingerprint(logical_root: LogicalOperator) -> str:
+def compute_plan_fingerprint(logical_root: LogicalOperator, normalize_literals: bool = False) -> str:
     """
     Compute SHA256 hash of logical operator tree structure.
 
@@ -708,11 +777,13 @@ def compute_plan_fingerprint(logical_root: LogicalOperator) -> str:
 
     Args:
         logical_root: Root of the logical operator tree
+        normalize_literals: When True, mask numeric/string literals in predicate
+            fields before hashing (see ``LogicalOperator.get_structural_signature``).
 
     Returns:
         Hexadecimal SHA256 hash string
     """
-    structural_signature = logical_root.get_structural_signature()
+    structural_signature = logical_root.get_structural_signature(normalize_literals=normalize_literals)
     return hashlib.sha256(structural_signature.encode("utf-8")).hexdigest()
 
 

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -623,11 +623,44 @@ Plans are fingerprinted using SHA256 of the logical structure:
 | Adding an index the planner starts using | **May differ** — only when it changes the *logical* structure (e.g. an index join replacing a hash join). A pure scan-method switch (Seq Scan → Index Scan on the same table) keeps the **same fingerprint**, because scan variants normalize to a logical `Scan` and physical operator details are excluded from the hash. Use `compare-plans` or the physical-plan details to detect scan-method changes. |
 | Engine minor version upgrade with no plan change | **Usually same** — not guaranteed across major versions |
 | `analyze_plans=true` vs `analyze_plans=false` (DuckDB) | **Same fingerprint** — timing/cardinality excluded from hash |
+| Same query, **different benchmark seed** (data-driven filter literal) | **Differs by default** — filter/join/projection *literals* are part of the hash, so a seed-varied threshold (`l_quantity < 1234.56` vs `< 2345.67`) changes the fingerprint even though the plan shape is identical. Use literal normalization (below) for seed-independent comparison. |
 
 **What fingerprint equality does NOT guarantee:**
 - That query performance is the same (costs may differ with identical logical structure)
 - That the plan is optimal for the current data distribution
 - Stability across major engine version upgrades
+
+> **Cross-run comparison requires identical seeds (or literal normalization).**
+> Because the default fingerprint embeds filter expression literals, comparing
+> fingerprints across two runs that used *different* benchmark seeds produces false
+> positives: a query whose only change is a seed-driven filter value (e.g.
+> `customer_acctbal < 1234.56` → `< 2345.67`) appears "changed" when the plan shape
+> did not. Either hold the seed constant across the runs you compare, or use the
+> literal-normalized fingerprint below.
+
+#### Literal normalization (seed-independent fingerprints)
+
+Literal normalization is an **opt-in** structural fingerprint that masks numeric and
+single-quoted string literals in the filter, join, and projection predicates to
+`<NUM>` / `<STR>` before hashing. Two structurally identical plans whose only
+difference is a seed-varied literal then share a fingerprint, so cross-run
+regression detection stops flagging seed changes as plan changes. Identifier fields
+— table names, group-by / sort keys, aggregation functions, operator and join types
+— are **never** masked, so a genuine structural change still changes the fingerprint.
+
+Normalization is opt-in and never alters the default `plan_fingerprint` (which stays
+literal-sensitive, for users who intentionally track filter-threshold changes):
+
+- **API:** `QueryPlanDAG.normalized_fingerprint` (a lazily-computed, cached property)
+  or `compute_plan_fingerprint(normalize_literals=True)` returns the masked hash;
+  `LogicalOperator.get_structural_signature(normalize_literals=True)` exposes the
+  underlying signature.
+- **Cross-run metadata:** `create_plan_metadata_from_results(..., normalize_literals=True)`
+  records the normalized fingerprint per query for seed-independent comparison.
+
+A `benchbox run --normalize-plan-literals` flag to surface the normalized fingerprint
+directly in the result bundle is planned; today the normalized fingerprint is
+available through the API above and the metadata helper.
 
 **Recommended use:**
 - Within a single run: deduplicate identical plans across concurrent streams

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -367,6 +367,16 @@ These flags control monitoring, progress display, memory handling, and caching b
     been removed. On DuckDB the default `EXPLAIN (ANALYZE, FORMAT JSON)` re-runs each query once;
     use `--no-analyze-plans` for estimated plans without that overhead.
 
+> **Cross-run fingerprint comparison and benchmark seeds.** The default
+> `plan_fingerprint` embeds filter/join/projection literals, so comparing fingerprints
+> across runs that used *different* seeds yields false positives when only a
+> seed-driven filter value changed. Hold the seed constant across compared runs, or
+> use the opt-in **literal-normalized** fingerprint
+> (`QueryPlanDAG.normalized_fingerprint`,
+> `create_plan_metadata_from_results(..., normalize_literals=True)`), which masks
+> literals so seed-varied plans compare equal. See
+> [Query Plan Analysis → Literal normalization](../../features/query-plan-analysis.md#literal-normalization-seed-independent-fingerprints).
+
 ## Related
 
 - [Configuration](configuration.md) - Configuration files and environment variables

--- a/tests/unit/core/query_plans/test_fingerprint_normalization.py
+++ b/tests/unit/core/query_plans/test_fingerprint_normalization.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Joe Harris / BenchBox Project
+#
+# Licensed under the MIT License. See LICENSE file in the project root for details.
+
+"""Unit tests for opt-in literal normalization in plan fingerprints.
+
+The default ``plan_fingerprint`` embeds filter/join/projection literals verbatim,
+so two runs with different benchmark seeds produce different fingerprints for
+structurally identical plans (a false-positive "plan changed" signal). The
+opt-in ``normalize_literals`` path masks numeric/string literals to
+``<NUM>``/``<STR>`` so seed-varied plans share a fingerprint, while leaving the
+default behaviour and all identifier fields untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from benchbox.core.manifest.plan_metadata_utils import create_plan_metadata_from_results
+from benchbox.core.results.query_plan_models import (
+    LogicalOperator,
+    LogicalOperatorType,
+    QueryPlanDAG,
+    compute_plan_fingerprint,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+def _scan(filter_expr: str | None = None, **kwargs) -> LogicalOperator:
+    """A SCAN operator over ``lineitem`` with an optional filter predicate."""
+    return LogicalOperator(
+        operator_type=LogicalOperatorType.SCAN,
+        operator_id="scan_1",
+        table_name="lineitem",
+        filter_expressions=[filter_expr] if filter_expr is not None else None,
+        **kwargs,
+    )
+
+
+def _dag(root: LogicalOperator, query_id: str = "q1") -> QueryPlanDAG:
+    return QueryPlanDAG(query_id=query_id, platform="duckdb", logical_root=root)
+
+
+class TestStructuralSignatureNormalization:
+    def test_numeric_literal_difference_collapses_when_normalized(self):
+        """Filters differing only by a numeric literal share a normalized signature."""
+        a = _scan("l_quantity < 1234.56")
+        b = _scan("l_quantity < 2345.67")
+
+        # Default (literal-sensitive) signatures differ...
+        assert a.get_structural_signature() != b.get_structural_signature()
+        # ...but normalized signatures are identical.
+        assert a.get_structural_signature(normalize_literals=True) == b.get_structural_signature(
+            normalize_literals=True
+        )
+        assert "<NUM>" in a.get_structural_signature(normalize_literals=True)
+
+    def test_string_literal_difference_collapses_when_normalized(self):
+        """Filters differing only by a quoted string literal normalize equal."""
+        a = _scan("l_shipmode = 'AIR'")
+        b = _scan("l_shipmode = 'RAIL'")
+
+        assert a.get_structural_signature() != b.get_structural_signature()
+        assert a.get_structural_signature(normalize_literals=True) == b.get_structural_signature(
+            normalize_literals=True
+        )
+        assert "<STR>" in a.get_structural_signature(normalize_literals=True)
+
+    def test_default_signature_unchanged_by_new_parameter(self):
+        """normalize_literals=False (default) is byte-identical to the legacy call."""
+        op = _scan("l_quantity < 1234.56")
+        assert op.get_structural_signature() == op.get_structural_signature(normalize_literals=False)
+        # The literal is preserved verbatim in the default signature.
+        assert "1234.56" in op.get_structural_signature()
+        assert "<NUM>" not in op.get_structural_signature()
+
+    def test_projection_columns_are_not_altered(self):
+        """Projection identifiers (no literals) are unchanged by normalization."""
+        op = LogicalOperator(
+            operator_type=LogicalOperatorType.PROJECT,
+            operator_id="proj_1",
+            projection_expressions=["l_orderkey", "l_extendedprice"],
+        )
+        assert op.get_structural_signature(normalize_literals=True) == op.get_structural_signature()
+
+    def test_projection_literal_is_masked_but_column_kept(self):
+        """A computed-constant projection masks the literal yet keeps the column name."""
+        op = LogicalOperator(
+            operator_type=LogicalOperatorType.PROJECT,
+            operator_id="proj_1",
+            projection_expressions=["l_extendedprice * 0.05 AS tax"],
+        )
+        normalized = op.get_structural_signature(normalize_literals=True)
+        assert "l_extendedprice" in normalized
+        assert "<NUM>" in normalized
+        assert "0.05" not in normalized
+
+    def test_identifiers_with_trailing_digits_not_masked(self):
+        """Column/alias identifiers ending in digits keep their digits."""
+        op = _scan("t1.l_orderkey1 > 5")
+        normalized = op.get_structural_signature(normalize_literals=True)
+        assert "t1.l_orderkey1" in normalized, normalized
+        # The standalone literal 5 IS masked.
+        assert "> <NUM>" in normalized
+
+    def test_table_and_grouping_identifiers_not_normalized(self):
+        """table_name / group_by_keys are identifiers and must survive normalization."""
+        op = LogicalOperator(
+            operator_type=LogicalOperatorType.AGGREGATE,
+            operator_id="agg_1",
+            table_name="orders",
+            group_by_keys=["o_orderstatus"],
+            children=[_scan("o_totalprice > 1000")],
+        )
+        normalized = op.get_structural_signature(normalize_literals=True)
+        assert "table:orders" in normalized
+        assert "group:o_orderstatus" in normalized
+
+    def test_normalization_recurses_into_children(self):
+        """Child operator literals are masked too (signature is recursive)."""
+        a = LogicalOperator(
+            operator_type=LogicalOperatorType.LIMIT,
+            operator_id="limit_1",
+            limit_count=10,
+            children=[_scan("l_quantity < 100")],
+        )
+        b = LogicalOperator(
+            operator_type=LogicalOperatorType.LIMIT,
+            operator_id="limit_1",
+            limit_count=10,
+            children=[_scan("l_quantity < 999")],
+        )
+        assert a.get_structural_signature() != b.get_structural_signature()
+        assert a.get_structural_signature(normalize_literals=True) == b.get_structural_signature(
+            normalize_literals=True
+        )
+
+
+class TestComputePlanFingerprint:
+    def test_dag_fingerprint_normalized_matches_across_literals(self):
+        """QueryPlanDAG.compute_plan_fingerprint(normalize_literals=True) is seed-stable."""
+        a = _dag(_scan("l_quantity < 1234.56"))
+        b = _dag(_scan("l_quantity < 2345.67"))
+
+        assert a.compute_plan_fingerprint() != b.compute_plan_fingerprint()
+        assert a.compute_plan_fingerprint(normalize_literals=True) == b.compute_plan_fingerprint(
+            normalize_literals=True
+        )
+
+    def test_default_plan_fingerprint_unchanged(self):
+        """The stored plan_fingerprint equals the explicit non-normalized computation."""
+        dag = _dag(_scan("l_quantity < 1234.56"))
+        assert dag.plan_fingerprint == dag.compute_plan_fingerprint(normalize_literals=False)
+
+    def test_normalized_fingerprint_property_cached_and_matches_method(self):
+        """normalized_fingerprint matches the method and returns a cached object.
+
+        Asserts the public contract only: SHA256 hexdigests are not interned, so an
+        ``is`` identity check across two accesses proves the value is cached rather
+        than recomputed each time.
+        """
+        dag = _dag(_scan("l_quantity < 1234.56"))
+        first = dag.normalized_fingerprint
+        assert first == dag.compute_plan_fingerprint(normalize_literals=True)
+        assert dag.normalized_fingerprint is first  # cached (not recomputed)
+
+    def test_normalized_fingerprint_stable_across_seeds(self):
+        """Two seed-varied DAGs share normalized_fingerprint but differ by default."""
+        a = _dag(_scan("l_shipmode = 'AIR'"))
+        b = _dag(_scan("l_shipmode = 'RAIL'"))
+        assert a.plan_fingerprint != b.plan_fingerprint
+        assert a.normalized_fingerprint == b.normalized_fingerprint
+
+    def test_refresh_fingerprint_invalidates_normalized_cache(self):
+        """After a tree mutation + refresh, normalized_fingerprint tracks the new tree."""
+        dag = _dag(_scan("l_quantity < 100"))
+        before = dag.normalized_fingerprint  # populate cache against the original tree
+        dag.logical_root.table_name = "orders"  # a structural change the mask cannot hide
+        dag.refresh_fingerprint()
+        after = dag.normalized_fingerprint
+        # The cache was invalidated: the property reflects the mutated tree, not the
+        # stale pre-refresh value, and still equals a fresh masked computation.
+        assert after != before
+        assert after == dag.compute_plan_fingerprint(normalize_literals=True)
+
+    def test_module_level_compute_honors_normalize_literals(self):
+        """The standalone compute_plan_fingerprint() honors the flag too."""
+        a = _scan("l_quantity < 1234.56")
+        b = _scan("l_quantity < 2345.67")
+        assert compute_plan_fingerprint(a) != compute_plan_fingerprint(b)
+        assert compute_plan_fingerprint(a, normalize_literals=True) == compute_plan_fingerprint(
+            b, normalize_literals=True
+        )
+
+
+class TestPlanMetadataNormalization:
+    @staticmethod
+    def _results(query_plan: QueryPlanDAG) -> SimpleNamespace:
+        execution = SimpleNamespace(query_id=query_plan.query_id, query_plan=query_plan)
+        phase = SimpleNamespace(queries=[execution])
+        return SimpleNamespace(platform="duckdb", platform_version="1.0", phases={"power": phase})
+
+    def test_metadata_default_uses_literal_sensitive_fingerprint(self):
+        """Without the flag, two seeds record different fingerprints (the bug)."""
+        meta_a = create_plan_metadata_from_results(self._results(_dag(_scan("l_quantity < 1234.56"))))
+        meta_b = create_plan_metadata_from_results(self._results(_dag(_scan("l_quantity < 2345.67"))))
+        assert meta_a.plan_fingerprints["q1"] != meta_b.plan_fingerprints["q1"]
+
+    def test_metadata_normalized_is_seed_stable(self):
+        """With normalize_literals=True, the recorded fingerprints match across seeds."""
+        meta_a = create_plan_metadata_from_results(
+            self._results(_dag(_scan("l_quantity < 1234.56"))), normalize_literals=True
+        )
+        meta_b = create_plan_metadata_from_results(
+            self._results(_dag(_scan("l_quantity < 2345.67"))), normalize_literals=True
+        )
+        assert meta_a.plan_fingerprints["q1"] == meta_b.plan_fingerprints["q1"]
+
+    def test_metadata_normalized_differs_from_default(self):
+        """The normalized fingerprint is genuinely a different value from the default."""
+        plan = _dag(_scan("l_quantity < 1234.56"))
+        default_meta = create_plan_metadata_from_results(self._results(plan))
+        normalized_meta = create_plan_metadata_from_results(self._results(plan), normalize_literals=True)
+        assert default_meta.plan_fingerprints["q1"] != normalized_meta.plan_fingerprints["q1"]


### PR DESCRIPTION
The default plan_fingerprint embeds filter/join/projection literals, so comparing
fingerprints across runs with different benchmark seeds produces false positives
(a query whose only change is a seed-varied filter value looks "changed"). Add an
opt-in literal-normalized fingerprint that masks numeric/string literals in those
predicate fields to <NUM>/<STR> before hashing; identifier fields (table names,
group-by/sort keys, aggregations, operator/join types) are never masked, so a
genuine structural change still changes the fingerprint.

- LogicalOperator.get_structural_signature(normalize_literals=False)
- QueryPlanDAG.compute_plan_fingerprint(normalize_literals=False) +
  lazily-computed, cached QueryPlanDAG.normalized_fingerprint property
- module-level compute_plan_fingerprint(logical_root, normalize_literals=False)
- create_plan_metadata_from_results(normalize_literals=False) for seed-stable
  cross-run metadata (records only genuine normalized fingerprints; never silently
  mixes in literal-sensitive ones)

The default plan_fingerprint is byte-identical to before (normalize_literals=False).
Documents the seed-sensitivity caveat and the normalization API in
query-plan-analysis.md and run.md.

Scope note: the --normalize-plan-literals CLI flag (TODO w4) is deferred — wiring
it requires the dry-run completeness path in benchbox/cli/dryrun.py, outside this
TODO's scope_limit; tracked as a follow-up. The capability ships via the API above.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
