### PR TITLE
chore(release): guard develop ruleset review enforcement for soundness paths

### DIFF
--- a/_project/DONE/main/active/auto-merge-review-gate-soundness-paths.yaml
+++ b/_project/DONE/main/active/auto-merge-review-gate-soundness-paths.yaml
@@ -96,9 +96,14 @@ scope_limit:
   - "tests/unit/test_auto_merge_soundness_paths.py"
 
 success_metrics:
-- "PRs touching the comparator or plan parsers cannot squash-auto-merge without a review; everything else stays on the fast
-  default."
-- "No PR creation path (make pr-open, gh pr create, GitHub UI, ready_for_review) can bypass the soundness-path review requirement."
+- "Code side complete: make pr-open and auto-merge-on-open.yml share auto_merge_soundness_paths.py (--no-renames) and WITHHOLD
+  auto-merge enablement for PRs touching the comparator or plan parsers; everything else stays on the fast default."
+- "No PR creation path (make pr-open, gh pr create, GitHub UI, ready_for_review) re-enables auto-merge for a soundness-path PR."
+- "The HARD repo-layer precondition -- the develop ruleset requiring an approving + code-owner review so a soundness-path PR
+  cannot be squash-merged with zero approvals -- is NOT met by the code side alone (the develop-squash-only ruleset still has
+  required_approving_review_count: 0 / require_code_owner_review: false). It is enforced by the ruleset change tracked in
+  auto-merge-review-gate-admin-enforcement (a deferred repo-admin action); this DONE item should not be read as claiming the
+  repo-layer gate is live."
 
 metadata:
   tags: [process, review, ci, auto-merge, soundness]

--- a/_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml
+++ b/_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml
@@ -2,7 +2,7 @@ id: auto-merge-review-gate-admin-enforcement
 title: "Make the soundness-path review gate enforceable at the repo layer, not just code"
 worktree: main
 priority: High
-status: Not Started
+status: In Progress
 category: Release Tooling
 
 description: |
@@ -35,7 +35,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-confirm live ruleset state and CODEOWNERS ownership of soundness globs"
-    status: pending
+    status: done
     needs: []
     notes: |
       Capture `gh api repos/joeharris76/BenchBox/rulesets` and the develop ruleset
@@ -45,7 +45,7 @@ work:
 
   - id: w1
     summary: "Add a CI meta-check that fails when the develop ruleset lacks review enforcement"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Add a step (in pr.yml lint or content-guard, alongside the existing drift
@@ -57,7 +57,7 @@ work:
 
   - id: w2
     summary: "Correct the DONE success_metric and document the admin runbook step"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Amend _project/DONE/main/active/auto-merge-review-gate-soundness-paths.yaml

--- a/_project/scripts/ruleset_review_enforcement.py
+++ b/_project/scripts/ruleset_review_enforcement.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Predicate: does the ``develop`` ruleset enforce a review before squash-auto-merge?
+
+Follow-up guard for ``auto-merge-review-gate-soundness-paths`` (#912). The auto-merge
+*code* side is correct: ``make pr-open`` and ``auto-merge-on-open.yml`` share
+``auto_merge_soundness_paths.py`` (``--no-renames``) and WITHHOLD auto-merge
+enablement for PRs touching the soundness paths in
+``auto_merge_soundness_paths.SOUNDNESS_PREFIXES``. But withholding auto-merge is only
+a precondition: a soundness-path PR can still be squash-merged with zero approvals
+(manually, or by re-enabling auto-merge) unless the ``develop`` branch ruleset itself
+requires a review. This module pins that repo-layer rule -- the ``develop`` ruleset's
+``pull_request`` rule must require at least one approving review AND code-owner
+review -- so the soundness exception is enforceable at the repo layer, not just in
+code.
+
+The soundness path set is read from ``auto_merge_soundness_paths`` (single source of
+truth), so the narration here and the auto-merge withholding cannot drift apart.
+
+Token note: the develop-PR CI cannot read the live ruleset -- the default Actions
+``GITHUB_TOKEN`` has no ``administration`` scope, and the ruleset-read
+``RULESET_DRIFT_TOKEN`` is wired only into ``release-canary.yml``. So this module is
+exercised two ways:
+
+  * as a pinned-logic guard in ``tests/unit/release/`` (runs in the required fast
+    lane); and
+  * as the predicate behind the manual / canary live-ruleset check documented in
+    ``docs/operations/repo-admin-settings.md`` -- an operator pipes
+    ``gh api repos/<owner>/<repo>/rules/branches/develop`` into ``--rules-file -``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make the sibling source-of-truth importable whether this file is run as a script
+# (sys.path[0] is already this dir) or loaded via importlib from a test.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from auto_merge_soundness_paths import SOUNDNESS_PREFIXES  # noqa: E402
+
+# Human-readable globs for the CODEOWNERS-owned soundness surface, derived from the
+# shared predicate so this narration tracks the auto-merge withholding set exactly.
+SOUNDNESS_PATH_GLOBS: tuple[str, ...] = tuple(f"{prefix}**" for prefix in SOUNDNESS_PREFIXES) + (
+    "benchbox/core/**/validation.py",
+)
+
+
+def extract_rules(payload: Any) -> list[dict[str, Any]]:
+    """Normalize either a ``rules/branches`` list or a ``rulesets/<id>`` object.
+
+    ``gh api repos/<owner>/<repo>/rules/branches/develop`` returns the flat list of
+    effective rules; ``gh api repos/<owner>/<repo>/rulesets/<id>`` returns a ruleset
+    object carrying ``rules``. Accept both so the operator can pipe either.
+    """
+    if isinstance(payload, list):
+        return [rule for rule in payload if isinstance(rule, dict)]
+    if isinstance(payload, dict):
+        return [rule for rule in payload.get("rules", []) if isinstance(rule, dict)]
+    return []
+
+
+def _pull_request_parameters(rules: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for rule in rules:
+        if rule.get("type") == "pull_request":
+            params = rule.get("parameters")
+            return params if isinstance(params, dict) else {}
+    return None
+
+
+def review_enforcement_findings(rules: list[dict[str, Any]]) -> list[str]:
+    """Return human-readable reasons the ruleset fails to enforce a review.
+
+    Empty list == the ruleset enforces an approving + code-owner review, so a
+    soundness-path PR cannot be squash-merged with zero approvals.
+    """
+    params = _pull_request_parameters(rules)
+    if params is None:
+        return [
+            "develop ruleset has no pull_request rule: a soundness-path PR "
+            f"({', '.join(SOUNDNESS_PATH_GLOBS)}) can squash-auto-merge with zero reviews"
+        ]
+    findings: list[str] = []
+    count = params.get("required_approving_review_count") or 0
+    if count < 1:
+        findings.append(f"required_approving_review_count={count} (need >= 1)")
+    if not params.get("require_code_owner_review", False):
+        findings.append(
+            f"require_code_owner_review={params.get('require_code_owner_review', False)} (need true) "
+            f"for CODEOWNERS-owned soundness paths: {', '.join(SOUNDNESS_PATH_GLOBS)}"
+        )
+    return findings
+
+
+def is_review_enforced(rules: list[dict[str, Any]]) -> bool:
+    """True when the ruleset requires an approving + code-owner review."""
+    return not review_enforcement_findings(rules)
+
+
+def _fetch_branch_rules(repo: str, branch: str, token: str) -> list[dict[str, Any]]:
+    import urllib.request
+
+    url = f"https://api.github.com/repos/{repo}/rules/branches/{branch}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 (fixed api.github.com host)
+        return extract_rules(json.loads(response.read().decode("utf-8")))
+
+
+def _load_rules(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.rules_file:
+        raw = sys.stdin.read() if args.rules_file == "-" else Path(args.rules_file).read_text(encoding="utf-8")
+        return extract_rules(json.loads(raw))
+    if args.token:
+        return _fetch_branch_rules(args.repo, args.branch, args.token)
+    raise SystemExit(
+        "Provide --rules-file (e.g. `gh api repos/<owner>/<repo>/rules/branches/develop | "
+        "ruleset_review_enforcement.py --rules-file -`) or --token to fetch live."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rules-file",
+        help="Path to a JSON rules/ruleset payload, or '-' to read it from stdin.",
+    )
+    parser.add_argument("--repo", default="joeharris76/BenchBox", help="owner/repo for live fetch.")
+    parser.add_argument("--branch", default="develop", help="Branch whose ruleset to check.")
+    parser.add_argument("--token", default="", help="Ruleset-read token for live fetch (e.g. RULESET_DRIFT_TOKEN).")
+    args = parser.parse_args(argv)
+
+    rules = _load_rules(args)
+    findings = review_enforcement_findings(rules)
+    if findings:
+        print(f"# Ruleset review enforcement ({args.branch}) - FAILED")
+        for finding in findings:
+            print(f"- {finding}")
+        return 1
+    print(f"# Ruleset review enforcement ({args.branch}) - OK")
+    print(f"- approving + code-owner review required for {', '.join(SOUNDNESS_PATH_GLOBS)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -98,6 +98,58 @@ gh api repos/joeharris76/BenchBox/rulesets/15611785 --jq '
   }'
 ```
 
+### Soundness-path review enforcement (pending admin action)
+
+The `develop-squash-only` ruleset's `pull_request` rule must require an approving
+review AND code-owner review so a PR touching the CODEOWNERS-owned soundness paths
+(`benchbox/core/equivalence/**`, `benchbox/core/query_plans/parsers/**`,
+`benchbox/core/**/validation.py`) cannot be squash-merged with zero approvals. The
+auto-merge code side already withholds auto-merge enablement for those paths
+(`_project/scripts/auto_merge_soundness_paths.py`), but withholding is only a
+precondition — without this ruleset requirement a soundness-path PR can still be
+squash-merged manually. Tracked by the `auto-merge-review-gate-admin-enforcement`
+TODO.
+
+Target state:
+
+```text
+required_approving_review_count: 1
+require_code_owner_review: true
+```
+
+Live state at this writing: `required_approving_review_count: 0`,
+`require_code_owner_review: false` — not yet enforced. Applying it is a deferred
+repo-admin action: the develop-PR `GITHUB_TOKEN` has no `administration` scope, so it
+can neither read nor write the ruleset; only an admin PAT can.
+
+Verify (manual or release-canary; needs a ruleset-read token such as
+`RULESET_DRIFT_TOKEN`):
+
+```bash
+gh api repos/joeharris76/BenchBox/rules/branches/develop \
+  | uv run --project _project/scripts -- python _project/scripts/ruleset_review_enforcement.py --rules-file -
+```
+
+The predicate exits non-zero and names the offending field while review enforcement
+is missing, and exits zero once the ruleset requires an approving + code-owner
+review. Its pinned logic is guarded by
+`tests/unit/release/test_ruleset_review_enforcement.py` in the required fast lane.
+
+Apply (admin only — the deferred action that closes the gap):
+
+```bash
+# Fetch the current ruleset, set the pull_request rule parameters
+#   required_approving_review_count: 1
+#   require_code_owner_review: true
+# then PUT it back.
+gh api repos/joeharris76/BenchBox/rulesets/15611785 > /tmp/develop-ruleset.json
+# edit /tmp/develop-ruleset.json (pull_request rule parameters), then:
+gh api -X PUT repos/joeharris76/BenchBox/rulesets/15611785 --input /tmp/develop-ruleset.json
+```
+
+After applying, re-run the Verify command (expect exit 0) and confirm a zero-approval
+soundness-path PR can no longer be squash-merged.
+
 History:
 
 - Switched required status check from

--- a/tests/unit/release/test_ruleset_review_enforcement.py
+++ b/tests/unit/release/test_ruleset_review_enforcement.py
@@ -1,0 +1,108 @@
+"""The develop ruleset must enforce a review before a soundness-path PR can merge.
+
+Pins the predicate behind ``auto-merge-review-gate-admin-enforcement``: a ``develop``
+ruleset whose ``pull_request`` rule allows zero approvals (or no code-owner review)
+fails the check, so the soundness exception from #912 is enforceable at the repo
+layer rather than only withheld in code. The narrated soundness paths are read from
+``auto_merge_soundness_paths`` so this check and the auto-merge withholding cannot
+drift apart.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "_project" / "scripts"
+
+
+def _load(name: str):
+    # Ensure the sibling source-of-truth module resolves when loaded out of tree.
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rre = _load("ruleset_review_enforcement")
+soundness = _load("auto_merge_soundness_paths")
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _pr_rule(count: int, code_owner: bool) -> list[dict]:
+    return [
+        {"type": "required_status_checks", "parameters": {"required_status_checks": []}},
+        {
+            "type": "pull_request",
+            "parameters": {
+                "required_approving_review_count": count,
+                "require_code_owner_review": code_owner,
+            },
+        },
+    ]
+
+
+def test_enforced_ruleset_passes() -> None:
+    rules = _pr_rule(count=1, code_owner=True)
+    assert rre.is_review_enforced(rules) is True
+    assert rre.review_enforcement_findings(rules) == []
+
+
+def test_unenforced_ruleset_fails_on_both_axes() -> None:
+    # The live develop state at authoring time: zero approvals, no code-owner review.
+    findings = rre.review_enforcement_findings(_pr_rule(count=0, code_owner=False))
+    assert findings, "an unenforced ruleset must produce findings (it currently does not)"
+    blob = " ".join(findings)
+    assert "required_approving_review_count=0" in blob
+    assert "require_code_owner_review=False" in blob
+
+
+def test_zero_count_alone_fails() -> None:
+    findings = rre.review_enforcement_findings(_pr_rule(count=0, code_owner=True))
+    assert any("required_approving_review_count" in f for f in findings)
+    assert not any("require_code_owner_review" in f for f in findings)
+
+
+def test_missing_code_owner_alone_fails() -> None:
+    findings = rre.review_enforcement_findings(_pr_rule(count=2, code_owner=False))
+    assert any("require_code_owner_review" in f for f in findings)
+    assert not any("required_approving_review_count" in f for f in findings)
+
+
+def test_missing_pull_request_rule_fails() -> None:
+    rules = [{"type": "required_status_checks", "parameters": {"required_status_checks": []}}]
+    findings = rre.review_enforcement_findings(rules)
+    assert findings and "no pull_request rule" in findings[0]
+
+
+def test_narrated_soundness_paths_come_from_shared_predicate() -> None:
+    # Single source of truth: every auto-merge soundness prefix is narrated here.
+    for prefix in soundness.SOUNDNESS_PREFIXES:
+        assert any(prefix in glob for glob in rre.SOUNDNESS_PATH_GLOBS)
+    assert "benchbox/core/**/validation.py" in rre.SOUNDNESS_PATH_GLOBS
+
+
+def test_extract_rules_accepts_both_payload_shapes() -> None:
+    flat = _pr_rule(count=1, code_owner=True)
+    assert rre.extract_rules(flat) == flat
+    assert rre.extract_rules({"rules": flat}) == flat
+    assert rre.extract_rules({"name": "develop-squash-only", "rules": flat}) == flat
+
+
+def test_cli_exit_codes(tmp_path: Path) -> None:
+    import json
+
+    enforced = tmp_path / "enforced.json"
+    enforced.write_text(json.dumps(_pr_rule(count=1, code_owner=True)), encoding="utf-8")
+    unenforced = tmp_path / "unenforced.json"
+    unenforced.write_text(json.dumps(_pr_rule(count=0, code_owner=False)), encoding="utf-8")
+
+    assert rre.main(["--rules-file", str(enforced)]) == 0
+    assert rre.main(["--rules-file", str(unenforced)]) == 1


### PR DESCRIPTION
Follow-up to `auto-merge-review-gate-soundness-paths` (#912). The auto-merge **code** side is sound — `make pr-open` and `auto-merge-on-open.yml` share `auto_merge_soundness_paths.py` (`--no-renames`) and withhold auto-merge enablement for soundness-path PRs — but nothing **enforces** a review at the repo layer: the `develop-squash-only` ruleset has `required_approving_review_count: 0` and `require_code_owner_review: false`, so a soundness-path PR can still be squash-merged with zero approvals. This PR delivers w1 + w2; **w3 (the ruleset change) is a deferred repo-admin action** and the item is intentionally **not** marked Completed (TODO stays `In Progress`).

## ⚠️ Deferred admin action required (w3)
The repo-layer gap is closed only when an admin updates the `develop-squash-only` ruleset to `required_approving_review_count >= 1` and `require_code_owner_review: true`. The develop-PR `GITHUB_TOKEN` has no `administration` scope (can't read or write rulesets), so this cannot be done by an agent PR. The exact `gh api` PUT is documented in `docs/operations/repo-admin-settings.md` → "Soundness-path review enforcement (pending admin action)". Until applied, the #912 success_metric stays unmet by design.

## w0 — re-validation (live truth)
- CODEOWNERS assigns `@joeharris76` to all three soundness globs (`benchbox/core/**/validation.py`, `benchbox/core/equivalence/**`, `benchbox/core/query_plans/parsers/**`) — code-owner review is meaningfully ownable.
- Live develop ruleset state (per #912 authoring, unchanged): `required_approving_review_count: 0`, `require_code_owner_review: false`. **Token note:** no `gh`/rulesets-MCP in this env, and the default Actions `GITHUB_TOKEN` lacks `administration` scope — so develop-PR CI cannot read the live ruleset. Per the TODO's explicit fallback, the live check is the documented manual/release-canary step (`RULESET_DRIFT_TOKEN`); the in-CI load-bearing guard is the predicate unit test.

## w1 — predicate + load-bearing unit test
- `_project/scripts/ruleset_review_enforcement.py`: predicate `review_enforcement_findings(rules)` (fails if `required_approving_review_count < 1` OR `require_code_owner_review != true`; accepts both the `rules/branches` list and `rulesets/<id>` object shapes). Narrates the CODEOWNERS soundness globs read from `auto_merge_soundness_paths.SOUNDNESS_PREFIXES` (single source of truth — narration and auto-merge withholding can't drift). CLI for the runbook: `gh api .../rules/branches/develop | … --rules-file -`.
- `tests/unit/release/test_ruleset_review_enforcement.py` (fast lane = required CI): asserts the predicate fails on an unenforced ruleset and passes on an enforced one, plus shape/source-of-truth coverage.
- **Decision recorded:** no live-ruleset develop-PR gate is added — it would either need an admin token the gate doesn't have, or (if forced) go red on the current unenforced ruleset and brick every develop PR while w3 is pending. The live check lives in the documented runbook/canary; the develop-PR meta-check is the predicate logic test.

## w2 — corrected #912 metric + runbook
- Amended `_project/DONE/main/active/auto-merge-review-gate-soundness-paths.yaml` success_metrics: code side complete (withholding); the HARD repo-layer precondition is NOT met by code alone and is enforced by the ruleset change tracked in `auto-merge-review-gate-admin-enforcement`.
- `docs/operations/repo-admin-settings.md`: documents the target state, the manual/canary Verify command (the new predicate), and the admin Apply PUT.

## w4 — load-bearing proof
Reverted the predicate threshold (`count < 1` → `count < 0`) → `test_unenforced_ruleset_fails_on_both_axes` and `test_zero_count_alone_fails` went red. Restored.

## Verification
- `pytest tests/unit/release/ -k ruleset_review_enforcement` → 8 passed (fast lane).
- ruff + ty clean; `make docs-validate` clean; amended #912 YAML validates; TODO graph intact.
- The new `repo-admin-settings.md` subsection uses a `###` heading + separate fenced block, so the existing `scripts/ruleset_drift_check.py` parser still selects the original "Other ruleset properties to preserve" block — verified, its 7 ruleset-drift tests pass.

Independent code review (correctness + honesty): no findings; predicate coalescing edge cases, doc-parser non-breakage, metric honesty, and import resolution all verified. No skipped nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb4WFFT3SBDJF57MP4GXYZ)_