### PR TITLE
refactor(execution): route throughput/maintenance/combined via harness registry

### DIFF
--- a/_project/DONE/main/planning/execution-harness-extraction-throughput-maintenance-combined.yaml
+++ b/_project/DONE/main/planning/execution-harness-extraction-throughput-maintenance-combined.yaml
@@ -2,7 +2,8 @@ id: execution-harness-extraction-throughput-maintenance-combined
 title: "Extend capability-based power-harness dispatch to throughput, maintenance, and combined tests"
 worktree: main
 priority: Medium
-status: Not Started
+status: Completed
+completed_date: "2026-06-30"
 category: Code Quality and Technical Debt
 
 description: |
@@ -34,7 +35,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-confirm the residual literals and the guard test scope on fresh develop"
-    status: pending
+    status: done
     needs: []
     notes: |
       Grep execution.py for `benchmark_id == "tpc` and record each method + line
@@ -44,7 +45,7 @@ work:
 
   - id: w1
     summary: "Extract throughput dispatch to capability resolution"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Move the TPC-H/TPC-DS throughput bodies behind a resolve_*_harness lookup,
@@ -53,7 +54,7 @@ work:
 
   - id: w2
     summary: "Extract maintenance dispatch to capability resolution"
-    status: pending
+    status: done
     needs: [w0]
     notes: |
       Same treatment for _execute_maintenance_test, preserving the
@@ -61,7 +62,7 @@ work:
 
   - id: w3
     summary: "Extract combined dispatch to capability resolution"
-    status: pending
+    status: done
     needs: [w1, w2]
     notes: |
       _execute_combined_test composes power+throughput+maintenance; route it through
@@ -69,7 +70,7 @@ work:
 
   - id: w4
     summary: "Broaden the guard test to all four dispatch methods and restore the strong metric"
-    status: pending
+    status: done
     needs: [w3]
     notes: |
       Extend test_power_dispatch_path_has_no_literal_tpc_benchmark_names (or add a

--- a/benchbox/core/power_harnesses.py
+++ b/benchbox/core/power_harnesses.py
@@ -1,4 +1,13 @@
-"""Power-test harness capability registry."""
+"""TPC test-phase harness capability registry.
+
+#914 extracted the *power*-test dispatch behind ``resolve_power_harness`` so
+``platforms/base/execution.py`` carried no literal TPC benchmark names on that path.
+This extends the same capability registry to the remaining phases (throughput,
+maintenance) and to the combined runner, so every dispatch method routes by
+capability lookup instead of a literal ``benchmark_id == "tpch" / "tpcds"`` branch.
+The per-benchmark phase *bodies* still live on the adapter mixin; only the routing
+moves here.
+"""
 
 from __future__ import annotations
 
@@ -6,21 +15,77 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class PowerHarnessCapability:
-    """Adapter capability for a benchmark-specific power-test harness."""
+class PhaseHarnessCapability:
+    """Adapter capability mapping a benchmark id to one phase's harness method."""
 
     benchmark_id: str
     adapter_method: str
 
 
-POWER_HARNESS_CAPABILITIES: tuple[PowerHarnessCapability, ...] = (
-    PowerHarnessCapability("tpch", "_execute_tpch_power_test"),
-    PowerHarnessCapability("tpcds", "_execute_tpcds_power_test"),
+# Back-compat alias: power was the first phase extracted (#914).
+PowerHarnessCapability = PhaseHarnessCapability
+
+
+@dataclass(frozen=True)
+class CombinedHarnessCapability:
+    """Adapter capability for the combined runner: a label + the three phase methods."""
+
+    benchmark_id: str
+    label: str
+    power_method: str
+    throughput_method: str
+    maintenance_method: str
+
+
+POWER_HARNESS_CAPABILITIES: tuple[PhaseHarnessCapability, ...] = (
+    PhaseHarnessCapability("tpch", "_execute_tpch_power_test"),
+    PhaseHarnessCapability("tpcds", "_execute_tpcds_power_test"),
+)
+
+THROUGHPUT_HARNESS_CAPABILITIES: tuple[PhaseHarnessCapability, ...] = (
+    PhaseHarnessCapability("tpch", "_execute_tpch_throughput_test"),
+    PhaseHarnessCapability("tpcds", "_execute_tpcds_throughput_test"),
+)
+
+MAINTENANCE_HARNESS_CAPABILITIES: tuple[PhaseHarnessCapability, ...] = (
+    PhaseHarnessCapability("tpch", "_execute_tpch_maintenance_test"),
+    PhaseHarnessCapability("tpcds", "_execute_tpcds_maintenance_test"),
+)
+
+COMBINED_HARNESS_CAPABILITIES: tuple[CombinedHarnessCapability, ...] = (
+    CombinedHarnessCapability(
+        "tpch", "TPC-H", "_execute_tpch_power_test", "_execute_tpch_throughput_test", "_execute_tpch_maintenance_test"
+    ),
+    CombinedHarnessCapability(
+        "tpcds",
+        "TPC-DS",
+        "_execute_tpcds_power_test",
+        "_execute_tpcds_throughput_test",
+        "_execute_tpcds_maintenance_test",
+    ),
 )
 
 _POWER_HARNESS_BY_ID = {capability.benchmark_id: capability for capability in POWER_HARNESS_CAPABILITIES}
+_THROUGHPUT_HARNESS_BY_ID = {capability.benchmark_id: capability for capability in THROUGHPUT_HARNESS_CAPABILITIES}
+_MAINTENANCE_HARNESS_BY_ID = {capability.benchmark_id: capability for capability in MAINTENANCE_HARNESS_CAPABILITIES}
+_COMBINED_HARNESS_BY_ID = {capability.benchmark_id: capability for capability in COMBINED_HARNESS_CAPABILITIES}
 
 
-def resolve_power_harness(benchmark_id: str) -> PowerHarnessCapability | None:
+def resolve_power_harness(benchmark_id: str) -> PhaseHarnessCapability | None:
     """Return the registered power-test harness for a canonical benchmark id."""
     return _POWER_HARNESS_BY_ID.get(benchmark_id)
+
+
+def resolve_throughput_harness(benchmark_id: str) -> PhaseHarnessCapability | None:
+    """Return the registered throughput-test harness for a canonical benchmark id."""
+    return _THROUGHPUT_HARNESS_BY_ID.get(benchmark_id)
+
+
+def resolve_maintenance_harness(benchmark_id: str) -> PhaseHarnessCapability | None:
+    """Return the registered maintenance-test harness for a canonical benchmark id."""
+    return _MAINTENANCE_HARNESS_BY_ID.get(benchmark_id)
+
+
+def resolve_combined_harness(benchmark_id: str) -> CombinedHarnessCapability | None:
+    """Return the registered combined-runner harness for a canonical benchmark id."""
+    return _COMBINED_HARNESS_BY_ID.get(benchmark_id)

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -40,7 +40,12 @@ from benchbox.core.constants import (
 )
 from benchbox.core.errors import PlanCaptureError
 from benchbox.core.operations import OperationExecutor
-from benchbox.core.power_harnesses import resolve_power_harness
+from benchbox.core.power_harnesses import (
+    resolve_combined_harness,
+    resolve_maintenance_harness,
+    resolve_power_harness,
+    resolve_throughput_harness,
+)
 from benchbox.core.results.builder import benchmark_family, normalize_benchmark_id
 from benchbox.core.results.models import QUERY_RUN_TYPE_MEASUREMENT, QUERY_RUN_TYPE_WARMUP
 from benchbox.core.tpch.platform_power import _power_query_result, _power_test_error_result
@@ -740,15 +745,13 @@ class TestDriversMixin:
         benchmark_name = self._resolve_benchmark_slug(benchmark, run_config)
         benchmark_id = normalize_benchmark_id(benchmark_name)
 
-        if benchmark_id == "tpch":
-            return self._execute_tpch_throughput_test(benchmark, connection, run_config)
-        elif benchmark_id == "tpcds":
-            return self._execute_tpcds_throughput_test(benchmark, connection, run_config)
-        else:
-            console.print(f"[yellow]⚠️ Throughput test not supported for benchmark: {benchmark_name}[/yellow]")
-            console.print("[yellow]  Falling back to standard query execution[/yellow]")
-            run_config["_effective_execution_type"] = "power"
-            return self._execute_all_queries(benchmark, connection, run_config)
+        harness = resolve_throughput_harness(benchmark_id)
+        if harness is not None:
+            return getattr(self, harness.adapter_method)(benchmark, connection, run_config)
+        console.print(f"[yellow]⚠️ Throughput test not supported for benchmark: {benchmark_name}[/yellow]")
+        console.print("[yellow]  Falling back to standard query execution[/yellow]")
+        run_config["_effective_execution_type"] = "power"
+        return self._execute_all_queries(benchmark, connection, run_config)
 
     def _execute_maintenance_test(self, benchmark, connection: Any, run_config: dict) -> list[dict[str, Any]]:
         """Execute TPC Maintenance Test with data maintenance operations."""
@@ -757,15 +760,13 @@ class TestDriversMixin:
         benchmark_name = self._resolve_benchmark_slug(benchmark, run_config)
         benchmark_id = normalize_benchmark_id(benchmark_name)
 
-        if benchmark_id == "tpch":
-            return self._execute_tpch_maintenance_test(benchmark, connection, run_config)
-        elif benchmark_id == "tpcds":
-            return self._execute_tpcds_maintenance_test(benchmark, connection, run_config)
-        else:
-            console.print(f"[yellow]⚠️ Maintenance test not supported for benchmark: {benchmark_name}[/yellow]")
-            console.print("[yellow]  Falling back to standard query execution[/yellow]")
-            run_config["_effective_execution_type"] = "power"
-            return self._execute_all_queries(benchmark, connection, run_config)
+        harness = resolve_maintenance_harness(benchmark_id)
+        if harness is not None:
+            return getattr(self, harness.adapter_method)(benchmark, connection, run_config)
+        console.print(f"[yellow]⚠️ Maintenance test not supported for benchmark: {benchmark_name}[/yellow]")
+        console.print("[yellow]  Falling back to standard query execution[/yellow]")
+        run_config["_effective_execution_type"] = "power"
+        return self._execute_all_queries(benchmark, connection, run_config)
 
     def _execute_combined_test(self, benchmark, connection: Any, run_config: dict) -> list[dict[str, Any]]:
         """Execute requested combined TPC phases.
@@ -781,61 +782,27 @@ class TestDriversMixin:
         benchmark_name = self._resolve_benchmark_slug(benchmark, run_config)
         benchmark_id = normalize_benchmark_id(benchmark_name)
 
-        if benchmark_id == "tpcds":
-            console.print("[blue]Running combined TPC-DS test[/blue]")
-
-            # Execute each test phase
-            all_results = []
-
-            # Phase 1: Power Test
-            if "power" in requested_phases:
-                console.print("[cyan]Phase: Power Test[/cyan]")
-                power_results = self._execute_tpcds_power_test(benchmark, connection, run_config)
-                all_results.extend(power_results)
-
-            # Phase 2: Throughput Test
-            if "throughput" in requested_phases:
-                console.print("[cyan]Phase: Throughput Test[/cyan]")
-                throughput_results = self._execute_tpcds_throughput_test(benchmark, connection, run_config)
-                all_results.extend(throughput_results)
-
-            # Phase 3: Maintenance Test
-            if "maintenance" in requested_phases:
-                console.print("[cyan]Phase: Maintenance Test[/cyan]")
-                maintenance_results = self._execute_tpcds_maintenance_test(benchmark, connection, run_config)
-                all_results.extend(maintenance_results)
-
-            return all_results
-        elif benchmark_id == "tpch":
-            console.print("[blue]Running combined TPC-H test[/blue]")
-
-            # Execute each test phase
-            all_results = []
-
-            # Phase 1: Power Test
-            if "power" in requested_phases:
-                console.print("[cyan]Phase: Power Test[/cyan]")
-                power_results = self._execute_tpch_power_test(benchmark, connection, run_config)
-                all_results.extend(power_results)
-
-            # Phase 2: Throughput Test
-            if "throughput" in requested_phases:
-                console.print("[cyan]Phase: Throughput Test[/cyan]")
-                throughput_results = self._execute_tpch_throughput_test(benchmark, connection, run_config)
-                all_results.extend(throughput_results)
-
-            # Phase 3: Maintenance Test
-            if "maintenance" in requested_phases:
-                console.print("[cyan]Phase: Maintenance Test[/cyan]")
-                maintenance_results = self._execute_tpch_maintenance_test(benchmark, connection, run_config)
-                all_results.extend(maintenance_results)
-
-            return all_results
-        else:
+        combined = resolve_combined_harness(benchmark_id)
+        if combined is None:
             console.print(f"[yellow]⚠️ Combined test not supported for benchmark: {benchmark_name}[/yellow]")
             console.print("[yellow]  Falling back to standard query execution[/yellow]")
             run_config["_effective_execution_type"] = "power"
             return self._execute_all_queries(benchmark, connection, run_config)
+
+        console.print(f"[blue]Running combined {combined.label} test[/blue]")
+
+        # Execute each requested phase in order (power -> throughput -> maintenance).
+        all_results: list[dict[str, Any]] = []
+        phases = (
+            ("power", "Power Test", combined.power_method),
+            ("throughput", "Throughput Test", combined.throughput_method),
+            ("maintenance", "Maintenance Test", combined.maintenance_method),
+        )
+        for phase_key, phase_label, method_name in phases:
+            if phase_key in requested_phases:
+                console.print(f"[cyan]Phase: {phase_label}[/cyan]")
+                all_results.extend(getattr(self, method_name)(benchmark, connection, run_config))
+        return all_results
 
     def _get_runtime_platform_version(self, connection: Any | None) -> str | None:
         """Return the current platform version for version-gated compat rules."""

--- a/tests/unit/platforms/test_base_adapter.py
+++ b/tests/unit/platforms/test_base_adapter.py
@@ -1875,13 +1875,26 @@ class TestBenchmarkIdentityInExecutionMetadata:
 class TestTPCExecutionRouting:
     """Exercise benchmark-family routing for specialized TPC helpers."""
 
-    def test_power_dispatch_path_has_no_literal_tpc_benchmark_names(self):
+    def test_dispatch_paths_have_no_literal_tpc_benchmark_names(self):
+        """No dispatch method routes on a literal TPC benchmark name.
+
+        #914 extracted the power path; the throughput/maintenance/combined dispatch
+        now routes via the same capability registry, so the headline metric ("no
+        literal TPC names in execution.py dispatch") holds across all four methods,
+        not power-only.
+        """
         from benchbox.platforms.base.execution import TestDriversMixin
 
-        source = inspect.getsource(TestDriversMixin._execute_power_test)
-
-        assert '"tpch"' not in source
-        assert '"tpcds"' not in source
+        dispatch_methods = (
+            TestDriversMixin._execute_power_test,
+            TestDriversMixin._execute_throughput_test,
+            TestDriversMixin._execute_maintenance_test,
+            TestDriversMixin._execute_combined_test,
+        )
+        for method in dispatch_methods:
+            source = inspect.getsource(method)
+            assert '"tpch"' not in source, f"{method.__name__} routes on a literal benchmark name"
+            assert '"tpcds"' not in source, f"{method.__name__} routes on a literal benchmark name"
 
     def test_execute_power_test_routes_tpch_via_run_config_benchmark_name(self):
         # Routing now reads benchmark_name from run_config, not display_name sniffing.


### PR DESCRIPTION
Extends #914's capability-based power-harness dispatch to the throughput, maintenance, and combined test paths, so `platforms/base/execution.py` carries no literal TPC benchmark names in ANY of its four dispatch methods — and broadens the guard test so the #914 headline metric is actually pinned, not power-path-only (closes `execution-harness-extraction-throughput-maintenance-combined`).

## w0 — re-validation (live truth)
On develop, `_execute_power_test` already routed via `resolve_power_harness` (no literals). Residual `benchmark_id == "tpch"/"tpcds"` literals remained in `_execute_throughput_test` (2), `_execute_maintenance_test` (2), and `_execute_combined_test` (2 branches). The guard `test_power_dispatch_path_has_no_literal_tpc_benchmark_names` inspected only `_execute_power_test`, so the broad metric read as met when it was not.

## Changes (behavior-preserving / dispatch-only)
- **w1–w3** `power_harnesses.py`: extend the registry with `resolve_throughput_harness`, `resolve_maintenance_harness`, and `resolve_combined_harness` (the last carries the family label + the three phase-method names). `PowerHarnessCapability` kept as a back-compat alias of the generalized `PhaseHarnessCapability`.
- `execution.py`: `_execute_throughput_test` / `_execute_maintenance_test` route via `resolve_*_harness(benchmark_id)` with the unchanged non-TPC fallback; `_execute_combined_test` replaces its two near-identical `tpcds`/`tpch` branches with one generic loop driven by `resolve_combined_harness` — identical console prints ("Running combined TPC-DS/TPC-H test", "Phase: …"), identical phase order (power→throughput→maintenance), `requested_phases` gating, per-family method calls, and unsupported-benchmark fallback.
- **Dispatch-only, mirroring #914**: the per-family phase *bodies* (`_execute_tpcds_throughput_test` etc., which carry the stream/cursor + `connection_factory`/`_make_stream_cursor` + `set_config_validation_mode` wiring) are NOT touched — only the routing moves to the registry. This keeps execution byte-identical. (Moving bodies into `core/tpc{h,ds}/` would be a separate, riskier structural move not required by the metric.)
- **w4** `tests/unit/platforms/test_base_adapter.py`: broadened the guard to `test_dispatch_paths_have_no_literal_tpc_benchmark_names`, inspecting all four dispatch methods (substring `literal_tpc_benchmark_names` kept so the `-k` selector still matches).

## #914 metric coordination (item 6)
The #914 DONE success_metric is the full claim ("no literal TPC names in execution.py dispatch") — overstated before this refactor, now TRUE. Its DONE YAML is **outside this item's `scope_limit`** (code + tests only), so per the TODO's "or coordinate with holistic-review-followup-metadata-truth" clause the metric is owned by item 6. Since item 5 lands the full-and-true claim, item 6 keeps the full metric (does not downgrade it to power-path-only) — guard-test scope and metric text stay consistent.

## Verification
- `pytest tests/unit/platforms/ -k literal_tpc_benchmark_names` → passes across all 4 methods (load-bearing: revert any dispatch literal → red).
- `pytest tests -m fast -k 'execution or power or throughput or maintenance or combined'` → 1973 passed, 4 skipped.
- 61 routing/dispatch + 8 combined-dispatch tests (phase ordering, gating, both families, fallback) pass. No literals remain. ruff + ty clean.

Independent review (behavior-preservation focus): no defects — a 32-case equivalence harness (tpch/tpcds/clickbench/empty-id × all 8 phase subsets) found 0 mismatches for the combined refactor; throughput/maintenance fallback unchanged; all six per-family phase bodies byte-identical (HEAD vs working tree); registry mappings verified typo-free; 182 unit tests pass. No skipped nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb4WFFT3SBDJF57MP4GXYZ)_