### PR TITLE
chore(todo): correct stale metadata from the holistic-review effort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,10 @@ fix every finding — issues, considerations, AND nits — before `make pr-open`
 The review-fix loop is part of "implement", not optional polish; skip only
 when the user explicitly opts out (typo fix, already-reviewed change).
 
+A drift/pinning guard and its required-CI wiring must land in the SAME PR; an
+unwired guard is non-load-bearing (it cannot fail CI), so splitting them leaves
+an unpinned-gate window until the wiring lands separately.
+
 ## Planning & TODOs
 
 TODOs live in `_project/TODO/{worktree}/{phase}/{item}.yaml`; completed items

--- a/Makefile
+++ b/Makefile
@@ -220,15 +220,17 @@ amplab-cross-surface-equivalence-report:
 coffeeshop-cross-surface-equivalence-report:
 	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark coffeeshop
 
-# Report-mode (STAGED gate): enumerate clickbench SQL<->DataFrame divergences.
-# Not a blocking CI gate yet - clickbench has open divergences to burn down (see
-# _project/analysis/clickbench-cross-surface-divergences.md) before promotion.
+# Enforced gate: clickbench SQL<->DataFrame equivalence on a bounded DuckDB cell.
+# In GATES (STAGED_GATES is empty) and run in the blocking correctness-gate (pr.yml);
+# exits non-zero on any unclassified divergence. Q18's order-less LIMIT is the one
+# classified exception (see _project/analysis/clickbench-cross-surface-divergences.md).
 clickbench-cross-surface-equivalence-report:
 	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark clickbench
 
-# Report-mode (STAGED gate): enumerate joinorder_synthetic SQL<->DataFrame
-# divergences. Not a blocking CI gate yet - see
-# _project/analysis/joinorder-synthetic-cross-surface-divergences.md.
+# Enforced gate: joinorder_synthetic SQL<->DataFrame equivalence on a bounded DuckDB
+# cell. In GATES (STAGED_GATES is empty) and run in the blocking correctness-gate
+# (pr.yml); exits non-zero on any unclassified divergence (see
+# _project/analysis/joinorder-synthetic-cross-surface-divergences.md).
 joinorder-synthetic-cross-surface-equivalence-report:
 	uv run -- python -m benchbox.core.equivalence.cross_surface --benchmark joinorder_synthetic
 

--- a/_project/DONE/main/active/plan-capture-robustness-hardening.yaml
+++ b/_project/DONE/main/active/plan-capture-robustness-hardening.yaml
@@ -103,6 +103,7 @@ scope_limit:
   only_modify:
   - "benchbox/platforms/"
   - "benchbox/core/query_plans/"
+  - "benchbox/core/plan_capture_phase.py"
   - "docs/"
   - "tests/"
 

--- a/_project/DONE/main/active/structural-debt-base-layer-tpc-and-module-split.yaml
+++ b/_project/DONE/main/active/structural-debt-base-layer-tpc-and-module-split.yaml
@@ -78,7 +78,14 @@ scope_limit:
   - "tests/"
 
 success_metrics:
-- "platforms/base/execution.py carries no literal TPC benchmark names in its dispatch path."
+# w1 here extracted ONLY the power-test dispatch path; the throughput/maintenance/combined dispatch
+# methods still carried literal benchmark_id branches afterward (the original wording overstated this
+# as the whole dispatch). The follow-up named below extends the same registry to all four and broadens
+# the guard test; this is the accurate power-path-scoped claim plus that cross-link.
+- "platforms/base/execution.py: the POWER-test dispatch path carries no literal TPC benchmark names
+  (#914 w1). The throughput/maintenance/combined dispatch methods are routed through the same
+  power_harnesses capability registry -- and the dispatch-literal guard test broadened to all four
+  methods -- by the follow-up execution-harness-extraction-throughput-maintenance-combined."
 - "cross_surface.py builders live per-benchmark and share one empty-table guard."
 
 metadata:

--- a/_project/DONE/main/planning/holistic-review-followup-metadata-truth.yaml
+++ b/_project/DONE/main/planning/holistic-review-followup-metadata-truth.yaml
@@ -2,7 +2,8 @@ id: holistic-review-followup-metadata-truth
 title: "Correct stale metadata, overstated metrics, and close-out discipline from the holistic-review effort"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
+completed_date: "2026-06-30"
 category: Documentation
 
 description: |
@@ -37,7 +38,7 @@ prior_art:
 work:
   - id: w1
     summary: "Fix the #909 scope_limit omission in its DONE YAML"
-    status: pending
+    status: done
     needs: []
     notes: |
       #909: add benchbox/core/plan_capture_phase.py to scope_limit.only_modify (the
@@ -46,7 +47,7 @@ work:
 
   - id: w2
     summary: "Reword the #914 power-path metric and cross-link the refactor follow-up"
-    status: pending
+    status: done
     needs: []
     notes: |
       Reword #914 w1 success_metric to "the power-dispatch path carries no literal
@@ -55,7 +56,7 @@ work:
 
   - id: w3
     summary: "Refresh the #906 Makefile STAGED/not-blocking comments to match actual enforcement"
-    status: pending
+    status: done
     needs: []
     notes: |
       Makefile:222-237 — drop the "STAGED gate / not a blocking CI gate yet" wording
@@ -64,7 +65,7 @@ work:
 
   - id: w4
     summary: "Add the guard+wiring close-out rule and verify no unpinned-gate window for #906"
-    status: pending
+    status: done
     needs: []
     notes: |
       Add to AGENTS.md: a drift/pinning guard and its required-CI wiring must land in


### PR DESCRIPTION
Documentation/metadata-only honesty fixes for truth defects the adversarial holistic review found in already-merged DONE items (closes `holistic-review-followup-metadata-truth`). No source-code behavior changes.

## Changes
- **w1 — #909 scope omission**: added `benchbox/core/plan_capture_phase.py` to `plan-capture-robustness-hardening.yaml` `scope_limit.only_modify` (the merged diff legitimately touched it and the item's own prior_art names it).
- **w2 — #914 overstated metric**: the success_metric claimed "no literal TPC names in execution.py dispatch" — true only for the power path. Reworded to scope the clean claim to the POWER dispatch path (#914 w1) and attribute throughput/maintenance/combined extraction + the broadened guard test to the follow-up `execution-harness-extraction-throughput-maintenance-combined`. **Merge-order-robust:** true on develop now (only power is literal-free) and after the follow-up lands; that follow-up cannot edit this metric (outside its `scope_limit`), so this item owns the final text per the batch coordination note.
- **w3 — #906 stale Makefile comments**: clickbench and joinorder-synthetic comments said "Report-mode (STAGED gate)… Not a blocking CI gate yet", but both are in `GATES` (`STAGED_GATES` is `{}`) and run in the blocking `correctness-gate` (pr.yml). Refreshed to "Enforced gate… in GATES… blocking correctness-gate". Comment-only — recipe lines untouched.
- **w4 — guard+wiring house rule + #906 window check**: added to AGENTS.md "Default write-task close-out": a drift/pinning guard and its required-CI wiring must land in the SAME PR (an unwired guard is non-load-bearing). **History verified:** the cross-surface GATES pinning guard (`test_cross_surface_gates_are_pinned_in_make_and_ci`) landed as a test in #906 (`8f1351f1`, no pr.yml wiring) and its required-CI step landed in #908 (`6baffe1d`); **no commit touched `cross_surface.py` or `Makefile` between the two merges**, so the GATES set was unchanged and no unpinned-gate window actually existed (the guard was merely non-load-bearing in the gap).

## must_preserve / anti_patterns
- No source-code behavior change — DONE YAMLs, Makefile comments, and AGENTS.md text only. Verified: no non-comment Makefile additions; no `.py` changes.
- Validator + graph stay green: `validate_todo.py --all` ✅ all valid; `todo_cli.py check-graph` ✅ no cycles/dangling refs.

Independent review: all four claims verified factually accurate against the live repo (GATES/STAGED membership, correctness-gate steps, Q18 classified exception, #906/#908 history), merge-order-robust #914 wording, no markdownlint issue, validators green. No skipped nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jb4WFFT3SBDJF57MP4GXYZ)_