### PR TITLE
Add --normalize-plan-literals CLI flag end-to-end

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -650,10 +650,21 @@ def _platform_option_config_entries(s: types.SimpleNamespace) -> dict[str, Any]:
     return entries
 
 
-def _strict_translation_config_entry(s: types.SimpleNamespace) -> dict[str, bool]:
-    if not getattr(s, "strict_translation", False):
-        return {}
-    return {"strict_translation": True}
+def _strict_translation_config_entry(s: types.SimpleNamespace) -> dict[str, Any]:
+    entries: dict[str, Any] = {"normalize_plan_literals": s.normalize_plan_literals}
+    if getattr(s, "strict_translation", False):
+        entries["strict_translation"] = True
+    return entries
+
+
+def _plan_capture_override_entries(s: types.SimpleNamespace) -> dict[str, Any]:
+    return {
+        "capture_plans": s.capture_plans,
+        "strict_plan_capture": s.strict_plan_capture,
+        "plan_queries": s.plan_queries,
+        "normalize_plan_literals": s.normalize_plan_literals,
+        "execution_mode": s.resolved_mode,
+    }
 
 
 def _validate_non_interactive(s: types.SimpleNamespace) -> None:
@@ -1265,7 +1276,6 @@ def _run_dry_run(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
-            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1323,11 +1333,7 @@ def _dry_run_build_db_config(s: types.SimpleNamespace, db_manager: DatabaseManag
         **s.verbosity_payload,
         "tuning_enabled": s.tuning_enabled,
         "force_upload": bool(s.force_upload),
-        "capture_plans": s.capture_plans,
-        "strict_plan_capture": s.strict_plan_capture,
-        "plan_queries": s.plan_queries,
-        "normalize_plan_literals": s.normalize_plan_literals,
-        "execution_mode": s.resolved_mode,
+        **_plan_capture_override_entries(s),
     }
     if s.loaded_unified_config:
         overrides["unified_tuning_configuration"] = s.loaded_unified_config
@@ -1384,11 +1390,7 @@ def _run_direct(s: types.SimpleNamespace) -> None:
         "show_query_plans": s.show_query_plans,
         "tuning_enabled": s.tuning_enabled,
         "force_upload": bool(s.force_upload),
-        "capture_plans": s.capture_plans,
-        "strict_plan_capture": s.strict_plan_capture,
-        "plan_queries": s.plan_queries,
-        "normalize_plan_literals": s.normalize_plan_literals,
-        "execution_mode": s.resolved_mode,
+        **_plan_capture_override_entries(s),
     }
     if s.loaded_unified_config:
         overrides["unified_tuning_configuration"] = s.loaded_unified_config
@@ -1472,7 +1474,6 @@ def _run_direct(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
-            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1607,11 +1608,7 @@ def _data_or_load_build_db_config(s: types.SimpleNamespace, db_manager: Database
         "force_recreate": s.force_regenerate,
         "tuning_enabled": s.tuning_enabled,
         "force_upload": bool(s.force_upload),
-        "capture_plans": s.capture_plans,
-        "strict_plan_capture": s.strict_plan_capture,
-        "plan_queries": s.plan_queries,
-        "normalize_plan_literals": s.normalize_plan_literals,
-        "execution_mode": s.resolved_mode,
+        **_plan_capture_override_entries(s),
     }
     if s.loaded_unified_config:
         overrides["unified_tuning_configuration"] = s.loaded_unified_config
@@ -1726,7 +1723,6 @@ def _run_data_or_load_only(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
-            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1986,7 +1982,6 @@ def _interactive_try_quick_restart(s: types.SimpleNamespace) -> bool:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
-            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -2618,10 +2613,8 @@ def _interactive_handle_result(s: types.SimpleNamespace, result: Any, orchestrat
     "normalize_plan_literals",
     is_flag=True,
     help=(
-        "Also record a literal-normalized plan fingerprint (plan_fingerprint_normalized) "
-        "alongside the default fingerprint when capturing plans. Plans that differ only in "
-        "literal constants (e.g. query parameter substitutions) collapse to the same "
-        "normalized fingerprint. Requires --capture-plans."
+        "Also record a literal-normalized fingerprint (plan_fingerprint_normalized) so queries "
+        "differing only in literal constants collapse to the same value. Requires --capture-plans."
     ),
 )
 # Compression

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -1265,6 +1265,7 @@ def _run_dry_run(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
+            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1325,6 +1326,7 @@ def _dry_run_build_db_config(s: types.SimpleNamespace, db_manager: DatabaseManag
         "capture_plans": s.capture_plans,
         "strict_plan_capture": s.strict_plan_capture,
         "plan_queries": s.plan_queries,
+        "normalize_plan_literals": s.normalize_plan_literals,
         "execution_mode": s.resolved_mode,
     }
     if s.loaded_unified_config:
@@ -1385,6 +1387,7 @@ def _run_direct(s: types.SimpleNamespace) -> None:
         "capture_plans": s.capture_plans,
         "strict_plan_capture": s.strict_plan_capture,
         "plan_queries": s.plan_queries,
+        "normalize_plan_literals": s.normalize_plan_literals,
         "execution_mode": s.resolved_mode,
     }
     if s.loaded_unified_config:
@@ -1469,6 +1472,7 @@ def _run_direct(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
+            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1606,6 +1610,7 @@ def _data_or_load_build_db_config(s: types.SimpleNamespace, db_manager: Database
         "capture_plans": s.capture_plans,
         "strict_plan_capture": s.strict_plan_capture,
         "plan_queries": s.plan_queries,
+        "normalize_plan_literals": s.normalize_plan_literals,
         "execution_mode": s.resolved_mode,
     }
     if s.loaded_unified_config:
@@ -1721,6 +1726,7 @@ def _run_data_or_load_only(s: types.SimpleNamespace) -> None:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
+            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -1980,6 +1986,7 @@ def _interactive_try_quick_restart(s: types.SimpleNamespace) -> bool:
             ),
             **({"presort": s.presort} if s.presort is not None else {}),
             **_strict_translation_config_entry(s),
+            "normalize_plan_literals": s.normalize_plan_literals,
             **_platform_option_config_entries(s),
             **({"benchmark_options": s.parsed_benchmark_options} if s.parsed_benchmark_options else {}),
         },
@@ -2606,6 +2613,17 @@ def _interactive_handle_result(s: types.SimpleNamespace, result: Any, orchestrat
     default=None,
     help="Plan capture config: queries:1,6,17,strict:true (capture is once-per-query; use --analyze-plans for detail)",
 )
+@advanced_option(
+    "--normalize-plan-literals",
+    "normalize_plan_literals",
+    is_flag=True,
+    help=(
+        "Also record a literal-normalized plan fingerprint (plan_fingerprint_normalized) "
+        "alongside the default fingerprint when capturing plans. Plans that differ only in "
+        "literal constants (e.g. query parameter substitutions) collapse to the same "
+        "normalized fingerprint. Requires --capture-plans."
+    ),
+)
 # Compression
 @advanced_option(
     "--compression",
@@ -2732,6 +2750,7 @@ def run(
     show_plans: bool,
     strict_translation: bool,
     plan_config: PlanCaptureConfig | None,
+    normalize_plan_literals: bool,
     compression: CompressionConfig | None,
     table_format: TableFormatConfig | None,
     presort: str | None,
@@ -2791,6 +2810,7 @@ def run(
         show_plans=show_plans,
         strict_translation=strict_translation,
         plan_config=plan_config,
+        normalize_plan_literals=normalize_plan_literals,
         compression=compression,
         table_format=table_format,
         presort=presort,

--- a/benchbox/cli/dryrun.py
+++ b/benchbox/cli/dryrun.py
@@ -47,6 +47,7 @@ def generate_cli_command(
     analyze_plans: bool | None = None,
     show_plans: bool = False,
     strict_translation: bool = False,
+    normalize_plan_literals: bool = False,
     validation: str | None = None,
     verbose: int = 0,
     platform_options: dict[str, str] | None = None,
@@ -79,6 +80,7 @@ def generate_cli_command(
         official: TPC-compliant mode
         capture_plans: Capture query execution plans
         strict_translation: Fail when SQL dialect translation falls back
+        normalize_plan_literals: Also record a literal-normalized plan fingerprint
         validation: Validation mode (exact, loose, range, disabled, full)
         verbose: Verbosity level (0=off, 1=-v, 2=-vv)
         platform_options: Platform-specific key=value options
@@ -146,6 +148,7 @@ def generate_cli_command(
         (capture_plans, "--capture-plans"),
         (show_plans, "--show-plans"),
         (strict_translation, "--strict-translation"),
+        (normalize_plan_literals, "--normalize-plan-literals"),
         (global_cache, "--global-cache"),
         (publish, "--publish"),
     ]

--- a/benchbox/core/plan_capture_phase.py
+++ b/benchbox/core/plan_capture_phase.py
@@ -73,6 +73,9 @@ class PlanCapturePhaseResult:
     Attributes:
         plans: query_id -> parsed ``QueryPlanDAG`` for queries captured.
         fingerprints: query_id -> structural ``plan_fingerprint``.
+        normalized_fingerprints: query_id -> literal-normalized fingerprint, only
+            populated when the adapter's ``normalize_plan_literals`` option is
+            enabled (see --normalize-plan-literals); absent otherwise.
         per_query_capture_ms: query_id -> wall-clock ms spent on that capture.
         total_capture_ms: wall-clock ms for the whole phase (incl. connection).
         captured: number of queries with a parsed plan.
@@ -81,6 +84,7 @@ class PlanCapturePhaseResult:
 
     plans: dict[str, Any] = field(default_factory=dict)
     fingerprints: dict[str, str] = field(default_factory=dict)
+    normalized_fingerprints: dict[str, str] = field(default_factory=dict)
     per_query_capture_ms: dict[str, float] = field(default_factory=dict)
     total_capture_ms: float = 0.0
     captured: int = 0
@@ -169,6 +173,8 @@ def run_plan_capture_phase(
             if plan is not None:
                 result.plans[query_id] = plan
                 result.fingerprints[query_id] = plan.plan_fingerprint
+                if getattr(adapter, "normalize_plan_literals", False):
+                    result.normalized_fingerprints[query_id] = plan.normalized_fingerprint
                 result.captured += 1
             else:
                 result.failed += 1

--- a/benchbox/core/results/builder.py
+++ b/benchbox/core/results/builder.py
@@ -971,6 +971,8 @@ class ResultBuilder:
                 result_dict["query_plan"] = result.query_plan
             if result.plan_fingerprint is not None:
                 result_dict["plan_fingerprint"] = result.plan_fingerprint
+            if result.plan_fingerprint_normalized is not None:
+                result_dict["plan_fingerprint_normalized"] = result.plan_fingerprint_normalized
             if result.plan_capture_time_ms is not None:
                 result_dict["plan_capture_time_ms"] = result.plan_capture_time_ms
             if result.result_digest is not None:

--- a/benchbox/core/results/models.py
+++ b/benchbox/core/results/models.py
@@ -158,6 +158,7 @@ class QueryExecution:
     # Query plan capture (structured DAG representation)
     query_plan: QueryPlanDAG | None = None  # Captured query execution plan
     plan_fingerprint: str | None = None  # SHA256 hash for fast plan comparison
+    plan_fingerprint_normalized: str | None = None  # Literal-normalized fingerprint (opt-in)
     plan_capture_time_ms: float | None = None  # Time spent capturing plan (EXPLAIN + parse)
 
 

--- a/benchbox/core/results/query_normalizer.py
+++ b/benchbox/core/results/query_normalizer.py
@@ -110,6 +110,7 @@ class QueryResultInput:
     # Query plan capture (passed through to BenchmarkResults.query_results for companion file)
     query_plan: Any | None = None
     plan_fingerprint: str | None = None
+    plan_fingerprint_normalized: str | None = None
     plan_capture_time_ms: float | None = None
     # Gate-only value-digest oracle (BENCHBOX_EMIT_RESULT_DIGEST): full-result
     # digest of a stream-0 query. None on a normal run (no payload change).
@@ -196,6 +197,7 @@ def normalize_query_result(
         dataframe_skip_summary=raw_result.get("dataframe_skip_summary"),
         query_plan=raw_result.get("query_plan"),
         plan_fingerprint=raw_result.get("plan_fingerprint"),
+        plan_fingerprint_normalized=raw_result.get("plan_fingerprint_normalized"),
         plan_capture_time_ms=raw_result.get("plan_capture_time_ms"),
         result_digest=raw_result.get("result_digest"),
     )

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -168,7 +168,11 @@ _STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
 # Match numeric literals that are standalone tokens. The negative lookbehind on
 # identifier characters keeps column names that embed digits intact (e.g. ``c1``,
 # ``l_orderkey``) while still collapsing real constants like ``1995`` or ``0.05``.
-_NUMERIC_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9_.$])\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+# ``#`` is excluded too: DuckDB (and others) emit ordinal column references like
+# ``#0``/``#1`` for projected/grouped columns, and without this exclusion every
+# ordinal collapses to the same ``#?`` placeholder, hiding a genuine structural
+# change (a different column referenced) behind what looks like a literal.
+_NUMERIC_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9_.$#])\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
 _LITERAL_PLACEHOLDER = "?"
 
 

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -160,6 +160,34 @@ def _mask_literals(expression: str) -> str:
 
 logger = logging.getLogger(__name__)
 
+# Literal-normalization patterns for normalized plan fingerprints.
+# A normalized fingerprint collapses queries that differ only in literal
+# constants (e.g. TPC-H parameter substitutions) to the same hash by replacing
+# string/date literals and standalone numeric literals with a placeholder.
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+# Match numeric literals that are standalone tokens. The negative lookbehind on
+# identifier characters keeps column names that embed digits intact (e.g. ``c1``,
+# ``l_orderkey``) while still collapsing real constants like ``1995`` or ``0.05``.
+_NUMERIC_LITERAL_RE = re.compile(r"(?<![A-Za-z0-9_.$])\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+_LITERAL_PLACEHOLDER = "?"
+
+
+def _normalize_literal_text(text: str) -> str:
+    """Replace SQL literal constants in an expression string with a placeholder.
+
+    Used to compute literal-normalized plan fingerprints so that queries which
+    differ only in constant values share a fingerprint. String/date literals are
+    replaced first, then standalone numeric literals. Identifiers containing
+    digits are preserved because the numeric pattern only matches digits not
+    immediately preceded by an identifier character.
+    """
+    if not text:
+        return text
+    normalized = _STRING_LITERAL_RE.sub(_LITERAL_PLACEHOLDER, text)
+    normalized = _NUMERIC_LITERAL_RE.sub(_LITERAL_PLACEHOLDER, normalized)
+    return normalized
+
+
 # Track unknown operator types that have been logged to avoid log flooding
 _logged_unknown_operator_types: set[str] = set()
 _logged_unknown_join_types: set[str] = set()
@@ -449,7 +477,16 @@ class LogicalOperator:
         - Expressions compared as unordered sets: join_conditions, filter_expressions, aggregation_functions
         - Expressions with order significance: group_by_keys, sort_keys, projection_expressions
         - Numeric values included directly: limit_count, offset_count
+
+        Args:
+            normalize_literals: When True, literal constants embedded in expressions
+                (and the limit/offset counts) are replaced with a placeholder so
+                that plans which differ only in constant values collapse to the
+                same signature. Identifiers are preserved.
         """
+        # Local literal normalizer (identity when normalization is disabled).
+        norm = _normalize_literal_text if normalize_literals else (lambda value: value)
+
         # Build signature from structural elements only
         operator_type_str = get_operator_type_str(self.operator_type)
         signature_parts = [operator_type_str]
@@ -482,19 +519,19 @@ class LogicalOperator:
 
         # Aggregation functions - sorted for set-like semantics
         if self.aggregation_functions:
-            aggs_str = ",".join(sorted(self.aggregation_functions))
+            aggs_str = ",".join(sorted(norm(a) for a in self.aggregation_functions))
             signature_parts.append(f"aggs:{aggs_str}")
 
         # Group by keys - order preserved (affects output row grouping)
         if self.group_by_keys:
-            group_str = ",".join(self.group_by_keys)
+            group_str = ",".join(norm(g) for g in self.group_by_keys)
             signature_parts.append(f"group:{group_str}")
 
         # Sort keys - order preserved (affects output ordering)
         if self.sort_keys:
             # Sort keys is a list of dicts, convert to deterministic string
             # Sort items within each dict for consistent representation
-            sort_str = ",".join(str(sorted(sk.items())) for sk in self.sort_keys)
+            sort_str = ",".join(norm(str(sorted(sk.items()))) for sk in self.sort_keys)
             signature_parts.append(f"sort:{sort_str}")
 
         # Projection expressions - order preserved (affects output columns).
@@ -508,13 +545,15 @@ class LogicalOperator:
             proj_str = ",".join(projections)
             signature_parts.append(f"proj:{proj_str}")
 
-        # Limit count - affects result set size
+        # Limit count - affects result set size (a literal constant when normalizing)
         if self.limit_count is not None:
-            signature_parts.append(f"limit:{self.limit_count}")
+            limit_repr = _LITERAL_PLACEHOLDER if normalize_literals else self.limit_count
+            signature_parts.append(f"limit:{limit_repr}")
 
-        # Offset count - affects which rows are returned
+        # Offset count - affects which rows are returned (a literal constant when normalizing)
         if self.offset_count is not None:
-            signature_parts.append(f"offset:{self.offset_count}")
+            offset_repr = _LITERAL_PLACEHOLDER if normalize_literals else self.offset_count
+            signature_parts.append(f"offset:{offset_repr}")
 
         # Recursively include children signatures
         if self.children:

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -103,6 +103,7 @@ def _normalize_query_result(qr: Any) -> dict[str, Any]:
         "error_type",
         "query_plan",
         "plan_fingerprint",
+        "plan_fingerprint_normalized",
         "dataframe_skip_summary",
         "result_digest",
     ):
@@ -1028,12 +1029,15 @@ def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
         query_id = str(qr.get("query_id", qr.get("id", "")))
         query_plan = qr.get("query_plan")
         plan_fingerprint = qr.get("plan_fingerprint")
+        plan_fingerprint_normalized = qr.get("plan_fingerprint_normalized")
         capture_time = qr.get("plan_capture_time_ms")
 
         if query_plan is not None:
             plan_entry: dict[str, Any] = {}
             if plan_fingerprint:
                 plan_entry["fingerprint"] = plan_fingerprint
+            if plan_fingerprint_normalized:
+                plan_entry["fingerprint_normalized"] = plan_fingerprint_normalized
             if capture_time:
                 plan_entry["capture_time_ms"] = round(capture_time, 1)
 

--- a/benchbox/core/runner/runner.py
+++ b/benchbox/core/runner/runner.py
@@ -707,6 +707,7 @@ def _build_run_config_from_options(
         capture_plans=benchmark_config.capture_plans,
         analyze_plans=getattr(benchmark_config, "analyze_plans", None),
         strict_plan_capture=benchmark_config.strict_plan_capture,
+        normalize_plan_literals=bool(options.get("normalize_plan_literals", False)),
         table_format=table_format,
         table_format_compression=str(options.get("table_format_compression", "snappy") or "snappy"),
         table_format_partition_cols=_parse_partition_cols(options.get("table_format_partition_cols")),

--- a/benchbox/core/schemas.py
+++ b/benchbox/core/schemas.py
@@ -111,6 +111,7 @@ class RunConfig(BaseModel):
     # first-class --analyze-plans/--no-analyze-plans flag sets it True/False.
     analyze_plans: bool | None = None
     strict_plan_capture: bool = False
+    normalize_plan_literals: bool = False
     # PyPI distribution name (e.g. "psycopg", "duckdb") - no extras markers or version specifiers
     driver_package: Optional[str] = None
     driver_version: Optional[str] = None

--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -138,6 +138,9 @@ class PlatformAdapter(
         # estimated-plan-only capture with no re-execution overhead.
         self.analyze_plans: bool = config.get("analyze_plans", True)
         self.strict_plan_capture = config.get("strict_plan_capture", False)
+        # When True, also record a literal-normalized plan fingerprint alongside
+        # the default fingerprint during plan capture (see --normalize-plan-literals).
+        self.normalize_plan_literals = config.get("normalize_plan_literals", False)
         self.plan_capture_timeout_seconds = int(config.get("plan_capture_timeout_seconds", 30))
         # Plan capture query selection. plan_query_filter restricts capture to an
         # explicit set of query ids; it is orthogonal to the retired per-iteration /
@@ -465,6 +468,8 @@ class PlatformAdapter(
             self.analyze_plans = bool(run_config.get("analyze_plans"))
         if "strict_plan_capture" in run_config:
             self.strict_plan_capture = bool(run_config.get("strict_plan_capture"))
+        if "normalize_plan_literals" in run_config:
+            self.normalize_plan_literals = bool(run_config.get("normalize_plan_literals"))
         if "plan_capture_timeout_seconds" in run_config:
             self.plan_capture_timeout_seconds = int(run_config.get("plan_capture_timeout_seconds"))
 

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -67,12 +67,15 @@ class _CapturedPlan(NamedTuple):
     pre-mutation checkpoint and the final post-measurement pass can each contribute
     plans that are attached to result rows exactly once. ``plan`` is ``None`` when
     capture failed or the query was filtered out; ``capture_ms`` is recorded even
-    then so plan-capture timing is reported honestly.
+    then so plan-capture timing is reported honestly. ``normalized_fingerprint`` is
+    only populated when the adapter's ``normalize_plan_literals`` option is enabled
+    (see --normalize-plan-literals); otherwise it stays ``None``.
     """
 
     plan: Any
     fingerprint: str | None
     capture_ms: float | None
+    normalized_fingerprint: str | None = None
 
 
 class TestDriversMixin:
@@ -1262,6 +1265,7 @@ class TestDriversMixin:
                 plan=phase.plans.get(capture_key),
                 fingerprint=phase.fingerprints.get(capture_key),
                 capture_ms=phase.per_query_capture_ms.get(capture_key),
+                normalized_fingerprint=phase.normalized_fingerprints.get(capture_key),
             )
 
     def _attach_captured_plans(self, results: list[dict[str, Any]]) -> None:
@@ -1304,6 +1308,8 @@ class TestDriversMixin:
                 entry.plan.query_id = query_id
                 result["query_plan"] = entry.plan
                 result["plan_fingerprint"] = entry.fingerprint
+                if entry.normalized_fingerprint is not None:
+                    result["plan_fingerprint_normalized"] = entry.normalized_fingerprint
             if entry.capture_ms is not None:
                 result["plan_capture_time_ms"] = entry.capture_ms
 

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -993,7 +993,9 @@ class ResultCaptureMixin:
 
         No-op when ``capture_plans`` is False or ``result["status"]`` is not
         ``"SUCCESS"``. On success, sets ``query_plan`` and ``plan_fingerprint`` when
-        a plan was parsed, and always records ``plan_capture_time_ms`` when measured.
+        a plan was parsed (plus ``plan_fingerprint_normalized`` when the adapter's
+        ``normalize_plan_literals`` option is enabled), and always records
+        ``plan_capture_time_ms`` when measured.
 
         Args:
             result: Result dict to mutate in place.
@@ -1020,6 +1022,8 @@ class ResultCaptureMixin:
         if query_plan:
             result["query_plan"] = query_plan
             result["plan_fingerprint"] = query_plan.plan_fingerprint
+            if getattr(self, "normalize_plan_literals", False):
+                result["plan_fingerprint_normalized"] = query_plan.normalized_fingerprint
         if plan_capture_time_ms is not None:
             result["plan_capture_time_ms"] = plan_capture_time_ms
 

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -667,6 +667,33 @@ available through the API above and the metadata helper.
 - Cross-run regression detection: flag queries where the fingerprint changed between runs on the same engine version
 - Cross-platform comparison: use `compare-plans` for structural similarity; fingerprints will differ across platforms
 
+### Literal-Normalized Fingerprints
+
+By default the fingerprint includes literal constants (filter values, limits, etc.),
+so two queries that differ only in their parameter substitutions produce different
+fingerprints. Pass `--normalize-plan-literals` (together with `--capture-plans`) to
+*also* record a literal-normalized fingerprint that collapses such queries to the
+same value:
+
+```bash
+benchbox run --platform duckdb --benchmark tpch --capture-plans --normalize-plan-literals
+```
+
+When enabled, each captured plan in the `*.plans.json` companion file gains a
+`fingerprint_normalized` key alongside the default `fingerprint`. The default
+fingerprint is never changed. Literal normalization replaces string/date literals
+and standalone numeric literals (and `LIMIT`/`OFFSET` counts) with a placeholder
+while preserving identifiers, so structurally identical queries with different
+constants share a normalized fingerprint.
+
+The capability is also available programmatically:
+
+```python
+plan.plan_fingerprint          # literal-sensitive (default)
+plan.normalized_fingerprint    # literal-normalized
+plan.compute_plan_fingerprint(normalize_literals=True)
+```
+
 ### Comparison Algorithm
 
 The comparison engine uses:

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -355,6 +355,9 @@ These flags control monitoring, progress display, memory handling, and caching b
   (estimated) plan with no re-execution. Write statements are never re-executed regardless (DML
   stays on a non-`ANALYZE` `EXPLAIN`).
 
+- `--normalize-plan-literals`: In addition to the default fingerprint, record a literal-normalized fingerprint (`fingerprint_normalized` in the plans companion file) that collapses queries differing only in literal constants (e.g. parameter substitutions) to the same value. Requires `--capture-plans`; the default `fingerprint` is left unchanged.
+  - Example: `--capture-plans --normalize-plan-literals`
+
 - `--plan-config TEXT`: Fine-grained control over query plan capture
   - Format: comma-separated key:value pairs
   - Keys:

--- a/tests/integration/test_tpcds_power_test.py
+++ b/tests/integration/test_tpcds_power_test.py
@@ -414,6 +414,88 @@ class TestTPCDSPowerTest:
         mock_cursor.fetchall.assert_called()
         mock_connection.commit.assert_called()
 
+    def test_execute_one_query_propagates_captured_plan_fields(self):
+        """--capture-plans / --normalize-plan-literals on TPC-DS power: the adapter's
+        captured plan/fingerprints live on cursor.platform_result, but _execute_one_query
+        only checked it for a FAILED status - it never copied query_plan/plan_fingerprint
+        into the query result, so plan capture stats reported zero captured plans and the
+        plans companion file never got the fingerprints (mirrors TPC-H power_test.py's
+        propagation)."""
+        from benchbox.core.tpcds.power_test import TPCDSPowerTestConfig, TPCDSPowerTestResult
+
+        mock_benchmark = self.create_mock_benchmark()
+        power_test = TPCDSPowerTest(benchmark=mock_benchmark, connection_string="sqlite::memory:")
+        power_test.config = TPCDSPowerTestConfig(scale_factor=1.0)
+
+        captured_plan = object()
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("row1",)]
+        mock_cursor.platform_result = {
+            "status": "SUCCESS",
+            "query_plan": captured_plan,
+            "plan_fingerprint": "abc123",
+            "plan_fingerprint_normalized": "def456",
+            "plan_capture_time_ms": 4.2,
+        }
+        mock_connection = Mock(spec=["execute", "commit"])
+        mock_connection.execute.return_value = mock_cursor
+
+        result = TPCDSPowerTestResult(
+            config=power_test.config,
+            start_time="",
+            end_time="",
+            total_time=0.0,
+            power_at_size=0.0,
+            queries_executed=0,
+            queries_successful=0,
+            query_results=[],
+            success=True,
+            errors=[],
+        )
+
+        power_test._execute_one_query(0, 1, mock_connection, stream_param_seed=1, result=result)
+
+        assert len(result.query_results) == 1
+        query_result = result.query_results[0]
+        assert query_result["success"] is True
+        assert query_result["query_plan"] is captured_plan
+        assert query_result["plan_fingerprint"] == "abc123"
+        assert query_result["plan_fingerprint_normalized"] == "def456"
+        assert query_result["plan_capture_time_ms"] == 4.2
+
+    def test_execute_one_query_omits_plan_fields_when_capture_disabled(self):
+        """No plan-capture keys on platform_result -> none copied (no-op propagation)."""
+        from benchbox.core.tpcds.power_test import TPCDSPowerTestConfig, TPCDSPowerTestResult
+
+        mock_benchmark = self.create_mock_benchmark()
+        power_test = TPCDSPowerTest(benchmark=mock_benchmark, connection_string="sqlite::memory:")
+        power_test.config = TPCDSPowerTestConfig(scale_factor=1.0)
+
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("row1",)]
+        mock_cursor.platform_result = {"status": "SUCCESS"}
+        mock_connection = Mock(spec=["execute", "commit"])
+        mock_connection.execute.return_value = mock_cursor
+
+        result = TPCDSPowerTestResult(
+            config=power_test.config,
+            start_time="",
+            end_time="",
+            total_time=0.0,
+            power_at_size=0.0,
+            queries_executed=0,
+            queries_successful=0,
+            query_results=[],
+            success=True,
+            errors=[],
+        )
+
+        power_test._execute_one_query(0, 1, mock_connection, stream_param_seed=1, result=result)
+
+        query_result = result.query_results[0]
+        assert "query_plan" not in query_result
+        assert "plan_fingerprint" not in query_result
+
     @patch("benchbox.core.tpcds.power_test.DatabaseConnection")
     def test_query_execution_error_handling(self, mock_db_connection):
         """Test error handling during query execution."""

--- a/tests/system/test_module_size_thresholds.py
+++ b/tests/system/test_module_size_thresholds.py
@@ -22,7 +22,7 @@ MAX_LINES_DEFAULT = 1_200
 ALLOWLIST = {
     Path(
         "benchbox/cli/commands/run.py"
-    ): 2_828,  # CLI tuning + query subset + validation + visualization + help + compression + interactive wizard + post-run charts + driver_version/auto_install options + --publish flag + --benchmark-option + --iterations + explicit utf-8 encoding + run() McCabe 285 → <18 extraction helpers + benchmark-aware --scale defaulting (PR #351 review follow-up) + --strict-translation fail-closed policy + liquid_clustering_auto strategy wiring + propagate show_query_plans to interactive database_config + first-class --analyze-plans/--no-analyze-plans flag (canonical plan-capture knob)
+    ): 2_841,  # CLI tuning + query subset + validation + visualization + help + compression + interactive wizard + post-run charts + driver_version/auto_install options + --publish flag + --benchmark-option + --iterations + explicit utf-8 encoding + run() McCabe 285 → <18 extraction helpers + benchmark-aware --scale defaulting (PR #351 review follow-up) + --strict-translation fail-closed policy + liquid_clustering_auto strategy wiring + propagate show_query_plans to interactive database_config + first-class --analyze-plans/--no-analyze-plans flag (canonical plan-capture knob) + --normalize-plan-literals flag (PR #939; added footprint deduped via shared _strict_translation_config_entry/_plan_capture_override_entries helpers to minimize growth)
     Path("benchbox/core/tpcds/benchmark/runner.py"): 2_120,  # orchestrates all benchmark phases
     Path("benchbox/core/tpcdi/generator/data.py"): 1_600,  # generator coordination remains complex
 }

--- a/tests/unit/cli/test_normalize_plan_literals_flag.py
+++ b/tests/unit/cli/test_normalize_plan_literals_flag.py
@@ -23,8 +23,8 @@ from benchbox.cli.config import ConfigManager
 from benchbox.cli.dryrun import generate_cli_command
 
 pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.fast,
+    pytest.mark.unit,
+    pytest.mark.medium,
 ]
 
 

--- a/tests/unit/cli/test_normalize_plan_literals_flag.py
+++ b/tests/unit/cli/test_normalize_plan_literals_flag.py
@@ -1,0 +1,117 @@
+"""Tests for the --normalize-plan-literals CLI flag.
+
+Copyright 2026 Joe Harris / BenchBox Project
+Licensed under the MIT License.
+
+Covers the flag end-to-end:
+- the flag is a recognized CLI option and is reproduced by the dry-run command
+  generator, and
+- when set on a real run, a literal-normalized fingerprint is recorded in the
+  exported plans companion file under a separate key.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from benchbox.cli.commands.run import run
+from benchbox.cli.config import ConfigManager
+from benchbox.cli.dryrun import generate_cli_command
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+]
+
+
+def _load_plans_companion(results_dir):
+    """Return the parsed plans companion payload from a results directory."""
+    matches = glob.glob(str(results_dir / "*.plans.json"))
+    assert matches, f"No plans companion file written in {results_dir}"
+    with open(matches[0], encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class TestNormalizePlanLiteralsFlagAccepted:
+    """The flag is wired into the CLI surface and dry-run reproduction."""
+
+    def test_flag_is_a_recognized_option(self):
+        param_names = {p.name for p in run.params}
+        assert "normalize_plan_literals" in param_names
+
+    def test_dry_run_command_generator_reproduces_flag(self):
+        cmd = generate_cli_command(
+            platform="duckdb",
+            benchmark="tpch",
+            scale=0.01,
+            capture_plans=True,
+            normalize_plan_literals=True,
+        )
+        assert "--normalize-plan-literals" in cmd
+
+    def test_dry_run_command_generator_omits_flag_when_unset(self):
+        cmd = generate_cli_command(
+            platform="duckdb",
+            benchmark="tpch",
+            scale=0.01,
+            capture_plans=True,
+            normalize_plan_literals=False,
+        )
+        assert "--normalize-plan-literals" not in cmd
+
+
+class TestNormalizePlanLiteralsFingerprintInResults:
+    """A real run records the normalized fingerprint only when the flag is set."""
+
+    def _run(self, monkeypatch, tmp_path, extra_args):
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            run,
+            [
+                "--platform",
+                "duckdb",
+                "--benchmark",
+                "tpch",
+                "--scale",
+                "0.01",
+                "--phases",
+                "power",
+                "--queries",
+                "1",
+                "--capture-plans",
+                "--non-interactive",
+                "--quiet",
+                *extra_args,
+            ],
+            obj={"config": ConfigManager()},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        return tmp_path / "benchmark_runs" / "results"
+
+    def test_normalized_fingerprint_present_when_flag_set(self, monkeypatch, tmp_path):
+        results_dir = self._run(monkeypatch, tmp_path, ["--normalize-plan-literals"])
+        payload = _load_plans_companion(results_dir)
+
+        plans = payload["queries"]
+        assert plans, "Expected at least one captured plan"
+        for entry in plans.values():
+            assert "fingerprint" in entry
+            assert "fingerprint_normalized" in entry
+            # Normalized fingerprint is still a valid SHA256 hash.
+            assert len(entry["fingerprint_normalized"]) == 64
+
+    def test_normalized_fingerprint_absent_without_flag(self, monkeypatch, tmp_path):
+        results_dir = self._run(monkeypatch, tmp_path, [])
+        payload = _load_plans_companion(results_dir)
+
+        plans = payload["queries"]
+        assert plans, "Expected at least one captured plan"
+        for entry in plans.values():
+            assert "fingerprint" in entry
+            assert "fingerprint_normalized" not in entry

--- a/tests/unit/core/results/test_query_plan_models.py
+++ b/tests/unit/core/results/test_query_plan_models.py
@@ -20,6 +20,7 @@ from benchbox.core.results.query_plan_models import (
     LogicalOperatorType,
     PhysicalOperator,
     QueryPlanDAG,
+    _normalize_literal_text,
     compute_plan_fingerprint,
 )
 
@@ -1168,6 +1169,94 @@ class TestFingerprintCoverage:
         )
 
         assert plan1.plan_fingerprint != plan2.plan_fingerprint
+
+
+class TestLiteralNormalization:
+    """Test the normalize_literals structural-signature / fingerprint option."""
+
+    def test_numeric_and_string_literals_are_masked(self) -> None:
+        assert _normalize_literal_text("l_quantity > 24") == "l_quantity > ?"
+        assert _normalize_literal_text("c_name = 'ALICE'") == "c_name = ?"
+
+    def test_ordinal_column_references_are_preserved(self) -> None:
+        """DuckDB (and others) emit ordinal refs like #0/#1 for projected/grouped
+        columns. Without excluding '#' from the numeric-literal lookbehind, every
+        ordinal collapses to the same '#?' placeholder, so plans that group/sort/
+        project DIFFERENT columns would spuriously fingerprint identically."""
+        assert _normalize_literal_text("#0") == "#0"
+        assert _normalize_literal_text("#1") == "#1"
+        assert _normalize_literal_text("group by #0, #1") == "group by #0, #1"
+        # A genuine numeric literal alongside an ordinal ref is still masked.
+        assert _normalize_literal_text("#0 > 24") == "#0 > ?"
+
+    def test_normalize_literals_distinguishes_different_ordinal_refs(self) -> None:
+        """End-to-end: two plans referencing different ordinal columns must NOT
+        collapse to the same normalized fingerprint."""
+        plan_col0 = QueryPlanDAG(
+            query_id="q1",
+            platform="duckdb",
+            logical_root=LogicalOperator(
+                operator_id="agg_1",
+                operator_type=LogicalOperatorType.AGGREGATE,
+                group_by_keys=["#0"],
+                children=[
+                    LogicalOperator(operator_id="scan_1", operator_type=LogicalOperatorType.SCAN, table_name="orders"),
+                ],
+            ),
+        )
+        plan_col1 = QueryPlanDAG(
+            query_id="q2",
+            platform="duckdb",
+            logical_root=LogicalOperator(
+                operator_id="agg_1",
+                operator_type=LogicalOperatorType.AGGREGATE,
+                group_by_keys=["#1"],
+                children=[
+                    LogicalOperator(operator_id="scan_1", operator_type=LogicalOperatorType.SCAN, table_name="orders"),
+                ],
+            ),
+        )
+
+        assert plan_col0.compute_plan_fingerprint(normalize_literals=True) != plan_col1.compute_plan_fingerprint(
+            normalize_literals=True
+        )
+
+    def test_normalize_literals_collapses_only_constant_differences(self) -> None:
+        """Plans differing only in a literal constant DO collapse under normalization,
+        while the default (literal-sensitive) fingerprint still distinguishes them."""
+        plan_a = QueryPlanDAG(
+            query_id="q1",
+            platform="duckdb",
+            logical_root=LogicalOperator(
+                operator_id="filter_1",
+                operator_type=LogicalOperatorType.FILTER,
+                filter_expressions=["l_quantity > 24"],
+                children=[
+                    LogicalOperator(
+                        operator_id="scan_1", operator_type=LogicalOperatorType.SCAN, table_name="lineitem"
+                    ),
+                ],
+            ),
+        )
+        plan_b = QueryPlanDAG(
+            query_id="q2",
+            platform="duckdb",
+            logical_root=LogicalOperator(
+                operator_id="filter_1",
+                operator_type=LogicalOperatorType.FILTER,
+                filter_expressions=["l_quantity > 30"],
+                children=[
+                    LogicalOperator(
+                        operator_id="scan_1", operator_type=LogicalOperatorType.SCAN, table_name="lineitem"
+                    ),
+                ],
+            ),
+        )
+
+        assert plan_a.plan_fingerprint != plan_b.plan_fingerprint
+        assert plan_a.compute_plan_fingerprint(normalize_literals=True) == plan_b.compute_plan_fingerprint(
+            normalize_literals=True
+        )
 
 
 class TestFingerprintVerification:


### PR DESCRIPTION
Wires the literal-normalized plan fingerprint capability through to the CLI
and result bundle.

Prerequisite (was deferred / not yet present on this branch): add literal
normalization to the fingerprint layer — QueryPlanDAG.normalized_fingerprint,
compute_plan_fingerprint(normalize_literals=True),
LogicalOperator.get_structural_signature(normalize_literals=True), and a
normalize_literals option on create_plan_metadata_from_results(). Normalization
replaces string/date and standalone numeric literals (and LIMIT/OFFSET counts)
with a placeholder while preserving identifiers, so queries differing only in
constants collapse to the same fingerprint.

CLI flag:
- run.py: --normalize-plan-literals advanced option, threaded into
  BenchmarkConfig.options and the adapter config overrides.
- dryrun.py: registered in generate_cli_command so dry-run reproduces the flag.
- adapter/RunConfig/runner: plumb normalize_plan_literals to the adapter.
- duckdb capture path: record result["plan_fingerprint_normalized"] alongside
  plan_fingerprint when enabled (default fingerprint unchanged).

Result bundle: thread plan_fingerprint_normalized through QueryResultInput,
the result builder, QueryExecution, and schema export (fingerprint_normalized
in the .plans.json companion). Also fixes the TPC-H power-test paths
(power_test.py, execution.py) which previously dropped captured plan metadata
when repackaging query results, so captured fingerprints actually reach the
bundle.

Docs updated (query-plan-analysis.md, reference/cli/run.md) and a CLI-level
test added.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMitKfpvtnS6nfTqCPCXRR