### PR TITLE
chore(todo): seed joinorder Track-2 review follow-ups

### DIFF
--- a/_project/TODO/main/planning/joinorder-canonical-validation-test-coverage.yaml
+++ b/_project/TODO/main/planning/joinorder-canonical-validation-test-coverage.yaml
@@ -1,0 +1,118 @@
+id: joinorder-canonical-validation-test-coverage
+title: "test(joinorder): FK-integrity, full-archive cardinality, and encoding assertions for canonical data"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review). The strong
+  JOB-grade assurances (FK integrity, 113-query reference cardinalities, UTF-8
+  fidelity) run only at BUILD time (_project/scripts/build_joinorder_data.py) and
+  against the 50-row tiny fixture (tests/unit/core/joinorder/
+  test_canonical_queries.py). No automated test reproduces them on the FULL
+  canonical archive a user actually loads; full-data reproduction is currently
+  gated only by manual UAT (cutover w17). Three specific gaps:
+
+    a. No FK referential-integrity test for canonical joinorder anywhere in
+       tests/. NOTE: schema.py:67-68 documents that the canonical data has
+       LEGITIMATE dangling references and FKs are opt-in -- so the test must pin
+       WHICH references are legitimately dangling vs corruption, using the build
+       pipeline's known set, not assert full closure.
+    b. No automated full-archive cardinality test. The 113-query oracle
+       (_project/joinorder/reference_cardinalities.json, an independent
+       PostgreSQL 16.2 oracle) is asserted only against the tiny fixture at
+       unit-test time.
+    c. No runtime encoding/normalization assertion on the full archive
+       (transitively covered by SHA256 today, but not directly tested).
+
+  These tests need the downloaded ~GB archive, so they REUSE the existing
+  opt-in markers (`slow` + `integration`, or `stress` for the heaviest;
+  registered in pyproject.toml:429-455, excluded from default CI) rather than
+  inventing a new marker, and live under tests/integration/. Intent: a
+  CI-gateable reproduction of the build-time assurances, replacing reliance on
+  manual UAT.
+
+deps:
+  needs:
+    - joinorder-canonical-cutover
+
+work:
+  - id: w1
+    summary: "Add an opt-in full-archive cardinality test against reference_cardinalities.json"
+    status: pending
+    notes: |
+      Load the canonical archive into DuckDB, run the 113 queries, assert
+      underlying/reference cardinalities match
+      _project/joinorder/reference_cardinalities.json (including the 5 known-zero
+      queries 2c/5a/5b/10b/32a). Mark with the existing `slow`+`integration`
+      markers (or `stress`); do not run by default. Mirror
+      test_canonical_queries.py assertions at full scale.
+  - id: w2
+    summary: "Add an FK referential-integrity test pinning the legitimate dangling-ref set"
+    needs: [w1]
+    status: pending
+    notes: |
+      Assert each declared FK resolves EXCEPT the documented legitimate dangling
+      references (schema.py:67-68). Source the allowed-dangling set from the build
+      pipeline's closure logic (build_joinorder_data.py) rather than re-deriving
+      it. Same existing opt-in markers.
+  - id: w3
+    summary: "Add a full-archive UTF-8 / NULL-vs-empty fidelity assertion"
+    needs: [w1]
+    status: pending
+    notes: |
+      Reproduce the build-time encoding round-trip check
+      (build_joinorder_data.py validate_encoding_round_trip) on the loaded
+      archive for the name/title tables. Same existing opt-in markers.
+
+must_preserve:
+  - "The default `uv run -- python -m pytest` unit run stays fast; the new tests are opt-in behind the existing slow/integration (or stress) markers and do not run by default."
+  - "The existing tiny-fixture oracle test tests/unit/core/joinorder/test_canonical_queries.py is unchanged."
+
+prior_art:
+  - "pyproject.toml:429-455:markers (slow/integration/stress) -- reuse the existing opt-in markers; DO NOT register a new one."
+  - "tests/integration/test_joinorder_synthetic_cross_surface_equivalence.py -- reuse the tests/integration/ location and marker style for the new full-archive tests."
+  - "tests/unit/core/joinorder/test_canonical_queries.py -- extend its cardinality/known-zero/null-empty assertions from the tiny fixture to the full archive."
+  - "_project/scripts/build_joinorder_data.py:validate_encoding_round_trip -- reuse the build-time fidelity check as the reference for w3."
+  - "_project/joinorder/reference_cardinalities.json -- reuse the independent PostgreSQL oracle as the expected values for w1."
+
+approach: |
+  Put the three checks in tests/integration/ (new file, e.g.
+  test_joinorder_full_archive.py), each marked @pytest.mark.slow +
+  @pytest.mark.integration and skipped unless the canonical archive is present.
+  Drive assertions off the committed reference artifacts under _project/joinorder/
+  and the build pipeline's known-dangling set, so the tests re-express build-time
+  guarantees at load time without re-implementing them.
+
+anti_patterns:
+  - "DO NOT assert full FK closure -- schema.py:67-68 documents legitimate dangling references; pin the known set instead."
+  - "DO NOT run these full-archive tests in the default unit suite -- they need the ~GB download; reuse the existing slow/integration/stress markers."
+  - "DO NOT register a new pytest marker -- the opt-in markers already exist in pyproject.toml."
+
+verification:
+  - description: "New full-archive tests are collected but skipped by default without the archive/marker"
+    command: "uv run -- python -m pytest tests/ -k joinorder_full_archive --collect-only -q"
+    expected_output: "tests collected; skipped by default without the archive/marker"
+  - description: "Default joinorder unit tests still pass and stay fast"
+    command: "uv run -- python -m pytest tests/unit/core/joinorder/ -q"
+    expected_output: "0 failures"
+
+scope_limit:
+  only_modify:
+    - "tests/integration/"
+    - "tests/unit/core/joinorder/"
+  do_not_modify:
+    - "benchbox/core/joinorder/"
+    - "pyproject.toml"
+
+metadata:
+  tags:
+    - joinorder
+    - testing
+    - fk-integrity
+    - cardinality
+    - encoding
+    - review-finding
+  estimated_effort: "Medium"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-runtime-row-count-validation.yaml
+++ b/_project/TODO/main/planning/joinorder-runtime-row-count-validation.yaml
@@ -1,0 +1,110 @@
+id: joinorder-runtime-row-count-validation
+title: "joinorder: enforce exact per-table row counts in post-load validation"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review), Medium.
+
+  The runtime post-load validator routes the canonical JoinOrder benchmark to
+  `GenericRowCountStrategy`, which only checks that each table is non-empty --
+  even though `benchbox/core/joinorder/data_manifest.toml` already carries the
+  exact per-table `row_count` for all 21 IMDb tables. A load into the SUT that
+  silently drops or duplicates rows (e.g. a partial COPY, a type-coercion drop)
+  leaves a non-empty but wrong-count table, which yields wrong join cardinalities
+  and a meaningless optimizer benchmark, undetected.
+
+  Evidence (re-runnable against the current tree):
+    - benchbox/platforms/base/validation.py:428 -- benchmark-name routing falls
+      through to `GenericRowCountStrategy` for anything not tpch/tpcds/ssb;
+      joinorder hits the `else`.
+    - benchbox/platforms/base/validation.py:351-356 --
+      `GenericRowCountStrategy.get_expected_range` returns None.
+    - benchbox/platforms/base/validation.py:456-458 -- with no expected range
+      the validator errors only when `actual_rows == 0`.
+    - benchbox/core/joinorder/benchmark.py:291-303 -- `get_table_row_count`
+      already surfaces the manifest's exact `row_count`, unused by the validator.
+
+  Severity is bounded because the source Parquet files are SHA256-verified at
+  fetch (benchbox/core/data_fetch/manager.py), so this gap is specifically about
+  load-into-SUT fidelity, not source corruption. But the exact counts are already
+  on hand, so closing it is cheap. This also retires finding #6 (the manifest
+  `row_count` field being decorative) for the joinorder path.
+
+  SOUNDNESS PATH: this touches the shared row-count validator used by other
+  benchmarks. Preserve tpch/tpcds/ssb behavior exactly and keep the non-empty
+  fallback for genuinely-unknown benchmarks.
+
+deps:
+  needs:
+    - joinorder-canonical-cutover
+
+work:
+  - id: w1
+    summary: "Add a manifest-driven exact row-count strategy for joinorder"
+    status: pending
+    notes: |
+      Add a JoinOrder row-count strategy following the existing per-benchmark
+      RowCountStrategy pattern. It reads the 21 exact per-table counts from the
+      loaded data_manifest.toml (via ParsedManifest / get_table_row_count) and
+      asserts equality (tolerance 0). Do not hardcode counts.
+  - id: w2
+    summary: "Route the joinorder benchmark to the exact strategy in validation.py"
+    needs: [w1]
+    status: pending
+    notes: |
+      Extend the benchmark-name dispatch at validation.py:~420-429 to select the
+      new strategy for joinorder. Leave the tpch/tpcds/ssb branches and the
+      GenericRowCountStrategy fallback untouched.
+  - id: w3
+    summary: "Unit-test exact and drifted row counts for joinorder validation"
+    needs: [w2]
+    status: pending
+    notes: |
+      In tests/unit/platforms/test_platform_validation.py assert a matching count
+      passes and a table short by N rows fails with a count-specific error (not
+      merely the empty-table error). Mirror the tpch/tpcds/ssb strategy tests.
+
+must_preserve:
+  - "TPCH/TPCDS/SSB RowCountStrategy selection and expected ranges are unchanged (benchbox/platforms/base/validation.py:423-427)."
+  - "GenericRowCountStrategy non-empty fallback still applies to benchmarks with no manifest counts."
+  - "No change to the joinorder fetch/SHA256 path in benchbox/core/data_fetch/."
+
+prior_art:
+  - "benchbox/platforms/base/validation.py:TPCHRowCountStrategy -- reuse the per-benchmark strategy subclass pattern for a JoinOrder strategy."
+  - "benchbox/core/joinorder/benchmark.py:get_table_row_count -- reuse to source exact per-table counts from the manifest rather than hardcoding."
+
+approach: |
+  Follow the existing RowCountStrategy subclass pattern (TPCH/TPCDS/SSB). The
+  joinorder strategy sources its expected counts from the parsed manifest, so it
+  is data-driven, not hardcoded. Wire it into the same benchmark-name dispatch
+  that already routes the other three, then add tests exercising both the
+  matching and the drifted case.
+
+anti_patterns:
+  - "DO NOT hardcode the 21 row counts in validation.py -- read them from the loaded manifest so a manifest bump stays authoritative."
+  - "DO NOT change the GenericRowCountStrategy fallback -- other benchmarks legitimately depend on non-empty-only."
+
+verification:
+  - description: "Platform validation unit tests pass (incl. new joinorder count test)"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_platform_validation.py -q"
+    expected_output: "all tests pass, 0 failures"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/validation.py"
+    - "tests/unit/platforms/test_platform_validation.py"
+  do_not_modify:
+    - "benchbox/core/data_fetch/"
+
+metadata:
+  tags:
+    - joinorder
+    - validation
+    - row-count
+    - review-finding
+    - soundness-adjacent
+  estimated_effort: "Small"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-scale-stress-oracle-correction.yaml
+++ b/_project/TODO/main/planning/joinorder-scale-stress-oracle-correction.yaml
@@ -1,0 +1,84 @@
+id: joinorder-scale-stress-oracle-correction
+title: "docs(scale-stress): fix replica-count oracle rule for scalar-MIN JOB queries and close prototype dep-trap"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review), Medium --
+  two coupled corrections around the `replicated_imdb` scale-stress prototype.
+
+  1. Oracle-scaling rule is wrong for all 113 JOB queries. The decision doc
+     states "Canonical oracle x replica count"
+     (_project/decisions/joinorder-scale-stress-decision-2026-06-30.md:115) and
+     "reference cardinalities scale by the replica count..." (:122-123). But
+     every one of the 113 JOB queries is a scalar `SELECT MIN(...)` with no
+     GROUP BY (re-runnable: load benchbox.core.joinorder.queries and count --
+     0/113 have GROUP BY, 0/113 have COUNT), so each returns exactly ONE row and
+     the MIN value is invariant under value-identical offset replication. The
+     final-result oracle therefore scales x1, not x replica count; only
+     intermediate/join-subgraph cardinalities scale by N. An implementer who
+     multiplies the canonical result oracle by replica count would build a
+     validation gate that fails on all 113 queries. The same doc's line 141-142
+     already distinguishes final-result from join-subgraph cardinalities, so it
+     is partially self-correcting -- reword the headline to match.
+
+  2. Latent dependency trap in the prototype seed. The prototype's own w1
+     verification (joinorder-replicated-imdb-scale-prototype.yaml:49-52) requires
+     that IF the decision note uses the
+     `Stats phase gate: dependency:track2-joinorder-stats-phase` gate (it does,
+     per the decision note), then `track2-joinorder-stats-phase` must be added to
+     the prototype's deps.needs before coding. Today the prototype's deps.needs
+     lists only `joinorder-scale-stress-decision-framework` (lines 17-19).
+     Harmless while Not Started, but it will trip whoever starts w1. Add the
+     missing dep now.
+
+  Mostly doc/metadata; no production code. If
+  joinorder-track2-scaling-direction-reconciliation flips the direction away from
+  replicated_imdb, w1 still applies (the stated rule is simply wrong as written);
+  w2 would become moot.
+
+deps:
+  needs:
+    - joinorder-scale-stress-decision-framework
+
+work:
+  - id: w1
+    summary: "Reword the decision doc's oracle-scaling rule to match scalar-MIN semantics"
+    status: pending
+    notes: |
+      Fix decision-2026-06-30.md:115 and :122-123 so the FINAL-result oracle is
+      stated as invariant (x1) for the 113 scalar-MIN queries, and the
+      x-replica-count relationship is scoped to intermediate/join-subgraph
+      cardinalities (consistent with the same doc's line 141-142 gate list).
+  - id: w2
+    summary: "Add track2-joinorder-stats-phase to the replicated-prototype deps.needs"
+    status: pending
+    notes: |
+      Edit joinorder-replicated-imdb-scale-prototype.yaml deps.needs to include
+      track2-joinorder-stats-phase, satisfying that item's own w1 verification
+      gate. Re-run check-graph afterward.
+
+verification:
+  - description: "Decision doc scopes the x-replica-count rule to join-subgraph, not final-result, cardinalities"
+    command: "grep -n 'replica count' _project/decisions/joinorder-scale-stress-decision-2026-06-30.md"
+    expected_output: "the x-replica-count relationship is qualified to join-subgraph cardinalities, final results stated invariant"
+  - description: "Prototype deps.needs includes the stats-phase item and the graph stays clean"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passed; no dangling references"
+
+scope_limit:
+  only_modify:
+    - "_project/decisions/joinorder-scale-stress-decision-2026-06-30.md"
+    - "_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml"
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - scale-stress
+    - docs
+    - review-finding
+  estimated_effort: "Small"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-stats-phase-doc-fixes.yaml
+++ b/_project/TODO/main/planning/joinorder-stats-phase-doc-fixes.yaml
@@ -1,0 +1,72 @@
+id: joinorder-stats-phase-doc-fixes
+title: "docs(track2): correct Redshift stats-on-load claim and adapter count in stats-as-phase design"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review). Two factual
+  errors in `_project/design/track2-joinorder-stats-as-phase.md` (PR #926) that
+  should be fixed before the Track-2 stats-phase work is picked up, because they
+  misstate the current-state survey the design reasons from. The central
+  "statistics-as-a-phase gap" thesis is sound and is NOT being retracted -- only
+  the two overstated data points are corrected.
+
+  1. Redshift row is wrong (Medium). The per-engine table
+     (stats-as-phase.md:46) claims Redshift ANALYZE runs "Only in isolated
+     vacuum/analyze maintenance, not load." In fact
+     benchbox/platforms/redshift.py:1531 runs `ANALYZE {qualified_table}` inside
+     `_load_table_via_s3` (the load path, called from load_data at :1825)
+     whenever `self.auto_analyze` is true -- and auto_analyze DEFAULTS TO True
+     (redshift.py:175). So Redshift gathers statistics during load by default.
+     The doc's line-49 "no centralized call site" phrasing is fine only for the
+     analyze_table METHOD; the broader "no engine gathers stats in the lifecycle"
+     reading is false and should be tightened.
+
+  2. "26+ adapters" is overstated (Low). stats-as-phase.md:49 says
+     `analyze_table()` "exists in 26+ adapters". The actual count of files
+     defining `analyze_table`/`analyze_tables` under benchbox/platforms/ is 16
+     (re-runnable: `grep -rlnE "def analyze_tables?\b" benchbox/platforms/ | wc -l`
+     -> 16). 26+ is only reachable by counting inherited methods across adapter
+     classes; state that basis or correct to 16.
+
+  Doc-only; no code change.
+
+work:
+  - id: w1
+    summary: "Correct the Redshift row and tighten the lifecycle-gap framing"
+    status: pending
+    notes: |
+      Fix stats-as-phase.md:46 to state Redshift runs ANALYZE in the S3 load path
+      by default (auto_analyze default True, redshift.py:175,1531), and narrow the
+      line-49 framing to the precise claim: the analyze_table METHOD has no
+      centralized runner call site (not "no engine gathers stats").
+  - id: w2
+    summary: "Correct the adapter count from 26+ to the verified 16 (or state the basis)"
+    status: pending
+    notes: |
+      Update stats-as-phase.md:49 to 16 defining files, or explicitly say
+      "26+ adapter classes counting inherited methods; 16 files define it".
+
+verification:
+  - description: "The false 'not load' Redshift claim is gone"
+    command: "grep -n 'not load' _project/design/track2-joinorder-stats-as-phase.md || true"
+    expected_output: "no line asserting Redshift ANALYZE is 'not load'"
+  - description: "No unqualified '26+ adapters' claim remains"
+    command: "grep -n '26+ adapters' _project/design/track2-joinorder-stats-as-phase.md || true"
+    expected_output: "no unqualified '26+ adapters' claim remains"
+
+scope_limit:
+  only_modify:
+    - "_project/design/track2-joinorder-stats-as-phase.md"
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - docs
+    - stats-phase
+    - review-finding
+  estimated_effort: "Small"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-strip-primary-keys-hardening.yaml
+++ b/_project/TODO/main/planning/joinorder-strip-primary-keys-hardening.yaml
@@ -1,0 +1,96 @@
+id: joinorder-strip-primary-keys-hardening
+title: "ddl_helpers: harden strip_primary_keys against leading-comma and string-literal edge cases"
+worktree: main
+priority: Low
+status: Not Started
+category: Core Functionality
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review), Low -- two
+  latent (currently dormant) defects in the shared PRIMARY KEY stripping helper
+  used by the Presto/Trino DDL path (PR #917 / #674 lineage).
+
+  1. Leading-comma artifact. When a table-level PK is the FIRST item in the
+     column-defs paren, removal leaves invalid SQL:
+       strip_primary_keys("CREATE TABLE t (PRIMARY KEY (a), a INT)")
+         -> "CREATE TABLE t (, a INT)"
+     `_TRAILING_COMMA_RE` (benchbox/platforms/base/ddl_helpers.py:51) only cleans
+     `,)` before a closing paren, never `(,` after an opening paren.
+
+  2. String/COMMENT-literal false positive. The keyword gate
+     (`"PRIMARY KEY" in stmt.upper()`, ddl_helpers.py:135) plus the inline regex
+     (`_INLINE_PK_RE`, :108, applied :161) are not SQL-string-aware, so a comment
+     literal containing the words is corrupted:
+       "id INT COMMENT 'the PRIMARY KEY column'" -> "... 'the column' ..."
+     This mirrors the documented FK limitation (ddl_helpers.py:72-80), but the
+     strip_primary_keys docstring carries no such warning.
+
+  Live exposure is ZERO today: every BenchBox schema generator appends the PK
+  clause LAST (e.g. benchbox/core/ssb/schema.py:59 joined with ",\n"), and no
+  shipped schema uses such comment literals; all 137 existing tests pass. This is
+  defensive hardening of a helper shared across six adapters, not a live bug.
+
+work:
+  - id: w1
+    summary: "Clean a leading comma after the opening paren in strip_primary_keys"
+    status: pending
+    notes: |
+      Add a post-removal cleanup for `(<ws>,` -> `(` alongside the existing
+      trailing-comma cleanup (ddl_helpers.py:~164), symmetric with
+      _TRAILING_COMMA_RE. Keep it minimal.
+  - id: w2
+    summary: "Document the string-literal limitation on strip_primary_keys"
+    status: pending
+    notes: |
+      Add the same not-SQL-string-aware caveat the FK helper already carries
+      (ddl_helpers.py:72-80). Do NOT attempt a full SQL parser; a docstring
+      warning matching the FK helper is the accepted bar.
+  - id: w3
+    summary: "Add regression tests for both edge cases"
+    needs: [w1, w2]
+    status: pending
+    notes: |
+      In tests/unit/platforms/base/test_ddl_helpers.py: PK-first-in-paren yields
+      valid SQL (no leading comma); a COMMENT literal containing 'PRIMARY KEY' is
+      preserved OR the documented limitation is asserted. Extend
+      TestStripPrimaryKeys.
+
+must_preserve:
+  - "All current strip_primary_keys behaviors: inline PK, nested table-level PK balanced-paren walk, FK preservation, named CONSTRAINT PK, trailing-comma cleanup (137 tests across tests/unit/platforms/base/test_ddl_helpers.py + tests/unit/platforms/test_trino_adapter.py)."
+  - "Presto and Trino _optimize_table_definition ordering (strip PK before connector rewrites) is unchanged."
+
+prior_art:
+  - "benchbox/platforms/base/ddl_helpers.py:strip_foreign_keys -- reuse its documented string-literal caveat wording for the PK helper."
+  - "benchbox/platforms/base/ddl_helpers.py:_TRAILING_COMMA_RE -- extend with a symmetric leading-comma cleanup."
+
+approach: |
+  Both fixes stay inside strip_primary_keys and its module-level regexes. For
+  w1, add a leading-comma cleanup mirroring the existing _TRAILING_COMMA_RE
+  substitution right after PK removal. For w2, copy the strip_foreign_keys
+  string-literal caveat into the strip_primary_keys docstring. Land the tests
+  (w3) against both cases before considering the item done; no adapter or
+  connector-rewrite code changes.
+
+anti_patterns:
+  - "DO NOT add a full SQL parser -- the helper is regex-based by design; match the FK helper's documented-limitation bar instead."
+
+verification:
+  - description: "DDL helper + Trino adapter tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/base/test_ddl_helpers.py tests/unit/platforms/test_trino_adapter.py -q"
+    expected_output: "all pass (>=137), 0 failures"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/ddl_helpers.py"
+    - "tests/unit/platforms/base/test_ddl_helpers.py"
+
+metadata:
+  tags:
+    - joinorder
+    - ddl
+    - trino
+    - presto
+    - review-finding
+    - hardening
+  estimated_effort: "Small"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-track2-scaling-direction-reconciliation.yaml
+++ b/_project/TODO/main/planning/joinorder-track2-scaling-direction-reconciliation.yaml
@@ -1,0 +1,95 @@
+id: joinorder-track2-scaling-direction-reconciliation
+title: "decision(track2): reconcile replicated_imdb vs sampled-from-real scaling and the stale-stats/licensing caveats"
+worktree: main
+priority: Medium
+status: Identified
+category: Benchmark Development
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review) -- a design
+  reconciliation the project must make before Track-2 scaling is coded. Three
+  linked, unresolved concerns:
+
+  1. Two un-reconciled Track-2 directions. The decision doc recommends the
+     `replicated_imdb` baseline -- scale UP via offset replication
+     (_project/decisions/joinorder-scale-stress-decision-2026-06-30.md:5). The
+     scaling-strategy design leads with "Option B -- sampled-from-real" -- scale
+     DOWN (_project/design/track2-joinorder-scaling-strategy.md:116), and
+     self-discloses the divergence (lines 134-151, "a genuine divergence to
+     reconcile at kickoff"). The project has two leading candidates locked in by
+     neither.
+
+  2. The replicated_imdb "stale-statistics axis" is largely degenerate. Because
+     offset replicas are value-identical and disjoint, per-predicate selectivity
+     is scale-invariant; the only staleness exposed is a uniform xN row-count
+     miss, not the correlated/skewed mis-estimation the framework's own
+     hypothesis targets (decision doc lines 124-125 concede "drift is bounded
+     because replicas are disjoint" while line 168 still markets a "genuine
+     statistics-maintenance axis"). Decide whether that axis is worth the
+     replication cost, or whether sampled-from-real better serves the stated
+     research question.
+
+  3. Licensing framing. The scale-stress licensing ADR concludes the
+     transformation is "not material" to redistribution risk
+     (joinorder-scale-stress-licensing-2026-06-30.md:24), but it engages only the
+     "launder" concept and never the earlier ADR's operative "must not be
+     altered" term (joinorder-canonical-data-licensing-2026-05-12.md:46). Offset
+     replication IS an alteration, which arguably raises rather than matches the
+     risk. Bottom-line posture (accepted residual risk, not cleared) is
+     consistent, but "not material" should be defended against "altered" or
+     softened.
+
+  Output: an updated/superseding decision that picks a single Track-2 scaling
+  direction and records the resolution of concerns 2 and 3. No code.
+
+deps:
+  needs:
+    - joinorder-scale-stress-decision-framework
+
+work:
+  - id: w1
+    summary: "Reconcile replicated_imdb (scale-up) vs sampled-from-real (scale-down) into one decision"
+    status: pending
+    notes: |
+      Compare against the stated Track-2 research question (statistics
+      maintenance x predicate selectivity). Record the pick and rationale as an
+      update to, or supersession of, the 2026-06-30 decision note; update the
+      scaling-strategy doc's "divergence to reconcile" section accordingly.
+  - id: w2
+    summary: "Resolve whether the offset-replication stale-stats axis is worth pursuing"
+    needs: [w1]
+    status: pending
+    notes: |
+      Given value-identical disjoint replicas make selectivity scale-invariant,
+      state explicitly what statistics signal replicated_imdb does/doesn't expose,
+      and reconcile decision-doc lines 124-125 vs 168.
+  - id: w3
+    summary: "Tighten the licensing 'transformation not material' argument against the 'altered' term"
+    needs: [w1]
+    status: pending
+    notes: |
+      Address joinorder-canonical-data-licensing-2026-05-12.md:46 ("must not be
+      altered") directly in the scale-stress licensing ADR, or soften "not
+      material" to an explicitly-argued risk-parity judgement.
+
+verification:
+  - description: "The updated/superseding decision names exactly one chosen Track-2 scaling direction"
+    command: "grep -niE 'recommend|decision|chosen|supersed' _project/decisions/joinorder-scale-stress-decision-2026-06-30.md"
+    expected_output: "a single chosen scaling direction is stated (replicated_imdb OR sampled-from-real, not both as co-leading)"
+
+open_questions:
+  - question: "Does the Track-2 research question require scale-up (replicated_imdb), scale-down (sampled-from-real), or both on separate tracks?"
+    gating: true
+    affects:
+      - "w1"
+    default: "Keep both as explicitly-separate tracks; do not mix into one baseline."
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - scale-stress
+    - decision
+    - review-finding
+  estimated_effort: "Medium"
+  created_date: "2026-07-02"

--- a/_project/TODO/main/planning/joinorder-trino-pk-ddl-validate-path-fix.yaml
+++ b/_project/TODO/main/planning/joinorder-trino-pk-ddl-validate-path-fix.yaml
@@ -1,0 +1,47 @@
+id: joinorder-trino-pk-ddl-validate-path-fix
+title: "chore(todo): repoint the completed trino-primary-key-ddl validate command to its DONE path"
+worktree: main
+priority: Low
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Adversarial review finding (2026-07-02, joinorder Track-2 review), Nit --
+  judgment call (a). The completed item
+  _project/DONE/main/planning/joinorder-trino-primary-key-ddl.yaml:62 still has
+  its own `validate` command point at the pre-move
+  `_project/TODO/main/planning/joinorder-trino-primary-key-ddl.yaml` path
+  (orphaned by an auto-merge race). Running that command now fails because the
+  file lives under DONE/. It is cosmetic -- no gate depends on it and check-graph
+  passes -- and ~20% of DONE items (51/248) share the stale-TODO-path convention,
+  so this is a consistency tidy, not a correctness fix. Captured per the review
+  request to record every finding; safe to batch with other low-priority tidies.
+
+work:
+  - id: w1
+    summary: "Repoint the DONE item's validate command (and files_affected path) to the DONE/ location"
+    status: pending
+    notes: |
+      Edit joinorder-trino-primary-key-ddl.yaml:62 (and the matching
+      files_affected entry at :89) to reference
+      _project/DONE/main/planning/joinorder-trino-primary-key-ddl.yaml, then
+      validate the file.
+
+verification:
+  - description: "The DONE item still validates after the path repoint"
+    command: "uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/DONE/main/planning/joinorder-trino-primary-key-ddl.yaml"
+    expected_output: "is valid"
+
+scope_limit:
+  only_modify:
+    - "_project/DONE/main/planning/joinorder-trino-primary-key-ddl.yaml"
+
+metadata:
+  tags:
+    - joinorder
+    - todo-hygiene
+    - trino
+    - review-finding
+    - nit
+  estimated_effort: "Small"
+  created_date: "2026-07-02"


### PR DESCRIPTION
## Description

Converts the seven actionable findings from the adversarial joinorder Track-2
close-out review (PRs #917/#921/#926 + full joinorder surface) into validated
TODO seeds under `_project/TODO/main/planning/`. This PR adds **planning YAML
only** — no code, docs-surface, or contract changes. Each seed carries specific
`work[]` units, `verification`, and (for code items) `must_preserve` /
`approach` / `anti_patterns` / `scope_limit` / `prior_art` guardrails.

| Seed | Sev | What it captures |
|---|---|---|
| `joinorder-runtime-row-count-validation` | Med | joinorder post-load validation is non-empty-only (`validation.py:428` → `GenericRowCountStrategy`) despite exact per-table counts in the manifest; enforce them. Soundness-adjacent (shared validator). |
| `joinorder-strip-primary-keys-hardening` | Low | Two dormant `strip_primary_keys` edge cases (leading-comma after `(`, `PRIMARY KEY` inside a string/COMMENT literal). Zero live exposure today. |
| `joinorder-stats-phase-doc-fixes` | Med | Redshift ANALYZE runs on load by default (`redshift.py:175,1531`), contradicting the design doc; `26+ adapters` is actually 16. |
| `joinorder-scale-stress-oracle-correction` | Med | `oracle × replica count` is wrong for the 113 scalar-`MIN` JOB queries (final result is 1 row, replica-invariant); also closes the prototype `deps.needs` trap. |
| `joinorder-canonical-validation-test-coverage` | Med | FK-integrity, full-archive cardinality, and encoding assertions — reusing the existing `slow`/`integration`/`stress` markers, not a new one. |
| `joinorder-track2-scaling-direction-reconciliation` | Med | Reconcile the two un-reconciled scaling directions + degenerate stale-stats axis + licensing "altered" framing. |
| `joinorder-trino-pk-ddl-validate-path-fix` | Low/nit | Repoint a completed item's stale self-referential `validate` path (`TODO/` → `DONE/`). |

## Type of Change

- [x] Documentation (planning TODO seeds)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore

## Testing

All seven seeds validate and the dependency graph is clean:

```
uv run --project _project/scripts -- python _project/scripts/validate_todo.py <each seed>
# -> ✅ is valid!  (x7)

uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph
# -> Graph validation passed: no cycles, no dangling references, 86 items checked
```

`deps.needs` cross-refs (`joinorder-canonical-cutover`,
`joinorder-scale-stress-decision-framework`) resolve to existing DONE items.

## Public Contract Check

- [x] This PR does not change public/beta/deprecated/generated/experimental/repo-only contract surfaces (planning YAML only).
- [x] No result-schema / MCP-parameter / platform-support / wrapper / adapter-hook / generated-doc impact.
- [x] No platform/benchmark count claim added to shipped docs (count corrections are captured as future work in a seed, not asserted here).

## Documentation

- [x] No user-facing docs changed (planning artifacts only).
- [x] No behavior change.
- [x] API contract wording unaffected.

## Code Quality

- [x] No code changed; seeds validated with `validate_todo.py` + `check-graph`.
- [x] No backwards-compat/migration impact.
- [x] N/A — no behavior change (each seed defers its own tests to implementation).
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or binaries committed — seven text YAML files only.

## Notes

- These are **seeds** (status `Not Started` / `Identified`); they schedule work,
  they do not perform the fixes. The row-count validation seed is flagged
  soundness-adjacent because it touches the shared `RowCountStrategy` dispatch.
- The refuted finding (PR #926 vs #924 preflight conflict — confirmed zero shared
  paths) intentionally has no seed.
- Full review context is in the session that produced this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P46rPDepAF4oJzrpEsy8SD)_