### PR TITLE
fix: address late-landing bot review findings across pass-9 merged PRs (sweep 9)

### DIFF
--- a/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
@@ -100,7 +100,12 @@ WHERE s.change_type = 'new'
 This is portable standard SQL. It uses a business key (`c_custkey`), a current-version
 flag (`is_current`), validity timestamps (`valid_from` and `valid_to`), and a
 change-detection fingerprint (`row_hash`) to decide what changed. There is no
-engine-specific syntax, so it runs unchanged across the engines BenchBox targets.
+engine-specific syntax, so it runs unchanged across the engines named above
+(DuckDB, PostgreSQL, Snowflake, BigQuery, and ClickHouse) — not every engine
+BenchBox targets. DataFusion is a documented exception: BenchBox's Write
+Primitives catalog marks this exact operation unsupported there
+(`platform_overrides: {"datafusion": null}`)[^op], so it is skipped rather than
+run on that engine.
 
 ### The honest line count
 

--- a/_project/DONE/main/planning/dataframe-csv-empty-string-parity-coverage.yaml
+++ b/_project/DONE/main/planning/dataframe-csv-empty-string-parity-coverage.yaml
@@ -40,10 +40,13 @@ work:
     status: done
     needs: [w0]
     notes: |
-      Extend the existing test to assert, per adapter, that a quoted empty field
-      loads as "" and a bare empty field loads as null, uniformly. Guard cudf and
-      any non-installed adapter with availability skips so the fast lane stays green
-      on a standard dev env.
+      Extend the existing test to assert, per adapter, the null-marker-dependent
+      contract: a bare empty field loads as "" when csv_null_marker is None, and
+      as null when csv_null_marker == "". This is not a single uniform outcome —
+      "uniform" means the same null-marker-conditioned rule holds identically
+      across adapters, not that a bare empty field always loads as null. Guard
+      cudf and any non-installed adapter with availability skips so the fast lane
+      stays green on a standard dev env.
 
   - id: w2
     summary: "Add a cross-surface CSV-path case (prefer_parquet=False) exercising SQL<->DataFrame parity"

--- a/_project/TODO/main/planning/adopt-apple-container-ci-parity.yaml
+++ b/_project/TODO/main/planning/adopt-apple-container-ci-parity.yaml
@@ -59,7 +59,7 @@ work:
 
   - id: w1
     summary: "Stand up a benchbox-agent container machine with home-mount"
-    needs: [w0]
+    needs: [w0, w2]
     status: pending
     notes: |
       `container machine create <image> --name benchbox-agent` with the Mac
@@ -67,7 +67,9 @@ work:
       verify `container machine run -n benchbox-agent -- bash` lands in a
       Linux shell that can see a claimed pool worktree path. THIS is the
       step the spike did not exercise -- prove machine mode + home-mount
-      work, not just `container run`.
+      work, not just `container run`. Depends on w2: `<image>` is the
+      benchbox-agent OCI image w2 builds, so the machine cannot be created
+      from it until the build exists.
 
   - id: w2
     summary: "Build the benchbox-agent OCI image (ubuntu + uv + build toolchain)"
@@ -91,6 +93,15 @@ work:
       output. clickhouse-integration is in-process chDB (no service) so it
       is in-scope here; postgres-integration needs a DB and is out of scope
       (see deps).
+
+      The worktree's `.venv` is on the home-mounted Mac filesystem shared
+      by both the macOS host and the Linux machine, so a plain `uv sync
+      --group dev` run inside the container would resolve/write Linux
+      wheels into the SAME `.venv` the macOS side uses, clobbering it for
+      the next native run. Either set `UV_PROJECT_ENVIRONMENT=.venv-linux`
+      for all `uv` invocations inside the machine (keeping the Linux venv
+      alongside, not overwriting, `.venv`), or claim a second, Linux-only
+      worktree so the two venvs never share a path.
 
   - id: w4
     summary: "DECISION GATE: do correctness/equivalence digests diverge macOS vs Linux?"

--- a/_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml
+++ b/_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml
@@ -48,12 +48,19 @@ work:
     status: done
     needs: [w0]
     notes: |
-      Add a step (in pr.yml lint or content-guard, alongside the existing drift
-      checks) that queries the live develop ruleset via gh api and FAILS if
-      required_approving_review_count < 1 OR require_code_owner_review != true.
-      Reuse auto_merge_soundness_paths.py SOUNDNESS_PREFIXES for the path set it
-      narrates. If a ruleset-read token is unavailable in CI, fall back to a
-      documented manual release-runbook checklist item and record that decision.
+      Add a step in an ALWAYS-required job (e.g. pr.yml lint / code-lint), never
+      content-guard: content-guard is gated by content-guard-needed and skipped for
+      code-only PRs (ci-required-result ignores it unless content paths changed), so
+      a check placed there would let a code-only PR pass while review enforcement is
+      absent - defeating this item's stated self-healing guarantee. The step queries
+      the live develop ruleset via gh api and FAILS if require_code_owner_review !=
+      true. required_approving_review_count is deliberately NOT part of this check:
+      it is branch-wide, not CODEOWNERS-scoped, so asserting it here would gate
+      every develop PR rather than just soundness-path ones (see
+      ruleset_review_enforcement.py's module docstring). Reuse
+      auto_merge_soundness_paths.py SOUNDNESS_PREFIXES for the path set it narrates.
+      If a ruleset-read token is unavailable in CI, fall back to a documented manual
+      release-runbook checklist item and record that decision.
 
   - id: w2
     summary: "Correct the DONE success_metric and document the admin runbook step"
@@ -99,12 +106,12 @@ scope_limit:
     - "_project/DONE/main/active/auto-merge-review-gate-soundness-paths.yaml"
 
 success_metrics:
-  - "develop ruleset shows required_approving_review_count >= 1 and require_code_owner_review true."
+  - "develop ruleset shows require_code_owner_review true (required_approving_review_count is deliberately not part of the target - it is branch-wide, not CODEOWNERS-scoped, so requiring it would gate every develop PR instead of just soundness-path ones)."
   - "A soundness-path PR with zero approvals cannot be squash-merged (w3 evidence)."
   - "The CI meta-check turns red if the ruleset enforcement is ever removed."
 
 deferred:
-  - summary: "Apply the develop ruleset change: required_approving_review_count>=1 + require_code_owner_review=true."
+  - summary: "Apply the develop ruleset change: require_code_owner_review=true."
     reason: "Requires a repo admin (gh api PUT on the ruleset); cannot be done by an agent PR. Tracked as the gating human action for w3."
 
 metadata:

--- a/_project/TODO/main/planning/cloud-setup-script-plugin-activation.yaml
+++ b/_project/TODO/main/planning/cloud-setup-script-plugin-activation.yaml
@@ -46,7 +46,13 @@ work:
     status: pending
     notes: >
       Configured in the claude.ai/code environment settings (web UI), not a repo
-      file. Setup scripts are cached per environment.
+      file. Setup scripts are cached per environment BUILD, not per session: a
+      later change to .claude/settings.json enabledPlugins will not retroactively
+      reach sessions in an already-built environment, and there is no supported
+      per-session hook to bust that cache in cloud (project hooks are unreliable
+      there — see the cloud addendum's PostToolUse evidence). Document this as a
+      known limitation, not something w1 needs to solve; the manual remedy is
+      rebuilding the environment after a plugin-config change.
   - id: w2
     summary: "Verify in a fresh cloud session: claude plugin list shows the 7 plugins and namespaced agents/commands are available"
     needs: [w1]

--- a/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
@@ -25,6 +25,10 @@ description: |
   independently recommends replicated_imdb as the lowest-risk upward baseline;
   Track-2 kickoff reconciles the sampling (down) and replication (up) directions.
 
+deps:
+  needs:
+    - track2-joinorder-stats-phase
+
 work:
   - id: w1
     summary: "Lock in the scaling strategy from the options analysis"
@@ -42,6 +46,10 @@ work:
       Build the generator and the validation gate (FK integrity, predicate-domain
       frequencies, cardinalities, q-error where available) before publishing any
       derived archive. Non-empty checks are insufficient.
+
+      This is the scaled prototype starting: per must_preserve, do not begin until
+      track2-joinorder-stats-phase (see deps.needs) is satisfied or explicitly
+      scoped out.
 
   - id: w3
     summary: "Define derived workload labels and result-bundle metadata"

--- a/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
+++ b/_project/decisions/claude-settings-cloud-ownership-2026-06-29.md
@@ -124,6 +124,20 @@ What a fresh cloud clone actually realizes from committed `.claude/`:
   the VM's user settings is unreliable (may be blocked by `allowManagedHooksOnly`)
   and buys nothing CI doesn't already guarantee.
 
+### Known limitation: environment-build caching means the setup script is not per-session
+
+claude.ai/code caches environment setup scripts and runs `cloud-claude-setup.sh`
+once per environment **build**, not once per session. A later change to
+`.claude/settings.json` (adding/removing an `enabledPlugins` entry) does not
+retroactively re-run the script in sessions started from an already-built
+environment — those sessions keep whatever plugin set was installed at build
+time. Because project hooks are unreliable/blocked in cloud web execution (the
+PostToolUse evidence below), there is no supported per-session hook to detect
+and re-apply a settings-hash change either. The only remedy today is manually
+rebuilding the claude.ai/code environment after a plugin-config change and
+verifying with `claude plugin list` in the new session. This is a documented
+gap, not a defect in the script.
+
 ### Evidence (2026-06-30 cloud validation)
 
 - Fresh cloud session: `.claude/skills/*` + `.claude/commands/*` loaded and

--- a/_project/decisions/joinorder-scale-stress-decision-2026-06-30.md
+++ b/_project/decisions/joinorder-scale-stress-decision-2026-06-30.md
@@ -47,11 +47,21 @@ framing and motivates a distinct workload identity rather than re-using `joinord
 
 "Scale factor" for a JOB-derived workload is defined as **integer multiplication
 of total IMDb row count across all 21 entity classes**, not bytes and not title
-count alone. SF=N means each canonical table is replicated/expanded to
-approximately N× its canonical row count with referential integrity preserved.
-Bytes and per-query cardinality are *derived* reporting fields, not the scale
-control, because byte size varies by engine encoding and per-query cardinality is
-exactly what the workload measures.
+count alone. SF=N means each canonical *replicated* entity/fact table (not small
+lookup tables — see below) is replicated/expanded to approximately N× its
+canonical row count with referential integrity preserved. Bytes and per-query
+cardinality are *derived* reporting fields, not the scale control, because byte
+size varies by engine encoding and per-query cardinality is exactly what the
+workload measures.
+
+Small lookup tables (e.g. `company_type`, `kind_type`, `role_type`) are excluded
+from this N× multiplication and remain single-copy: their domain values are
+referenced by FK from every replica, and duplicating them would only inflate
+lookup-table row counts without exercising any of the stats-stress or
+predicate-selectivity axes this workload measures. This matches the prototype's
+must-preserve guard (`joinorder-replicated-imdb-scale-prototype.yaml`: "Lookup
+tables must not be duplicated unless the schema contract explicitly requires
+it.").
 
 Workload labels and their comparability rules:
 
@@ -80,7 +90,7 @@ implementation):
 
 | Engine | Has explicit ANALYZE? | Auto-stats on load? | Sampled mode? | Stats-phase attribution |
 | --- | --- | --- | --- | --- |
-| DuckDB | yes (ANALYZE) | yes (background) | n/a | zero wall-clock; `stats_mode: auto-on-load` |
+| DuckDB | yes (ANALYZE) | yes (background) | n/a | explicit ANALYZE phase timed |
 | PostgreSQL | yes (ANALYZE) | no | yes (default_statistics_target) | explicit ANALYZE phase timed |
 | ClickHouse | partial (per-table) | yes (on insert) | n/a | zero wall-clock; `stats_mode: auto-on-load` |
 | StarRocks | yes (ANALYZE TABLE) | no | yes (sample size knob) | explicit ANALYZE phase timed |

--- a/_project/design/track2-joinorder-stats-as-phase.md
+++ b/_project/design/track2-joinorder-stats-as-phase.md
@@ -42,7 +42,7 @@ Where statistics land today, per engine:
 | PostgreSQL | `analyze_table()` (`benchbox/platforms/postgresql.py:799`) | No — `load_data()` (`postgresql.py:559`) never calls it | First-query planning, or a manual ANALYZE outside the run |
 | DuckDB | `analyze_tables()` (`benchbox/platforms/duckdb.py:1109`) | No | Background/auto-stats after load |
 | Spark | `analyze_table()` (`benchbox/platforms/spark.py:818`) | No | Not gathered unless invoked manually |
-| Redshift | `auto_analyze` config gating ANALYZE | Only in isolated vacuum/analyze maintenance, not load | Maintenance path or first-query |
+| Redshift | `auto_analyze` config gating ANALYZE | Yes — `auto_analyze` defaults `True`; `_load_table_via_s3()` (`benchbox/platforms/redshift.py:1531`) runs `ANALYZE` right after each table's `COPY`, inside `load_data()` | Folded into load |
 | ClickHouse | none found | n/a | Auto-statistics on insert |
 | StarRocks | none found | n/a | Relies on auto/manual ANALYZE TABLE |
 

--- a/_project/scripts/ruleset_review_enforcement.py
+++ b/_project/scripts/ruleset_review_enforcement.py
@@ -9,9 +9,19 @@ enablement for PRs touching the soundness paths in
 a precondition: a soundness-path PR can still be squash-merged with zero approvals
 (manually, or by re-enabling auto-merge) unless the ``develop`` branch ruleset itself
 requires a review. This module pins that repo-layer rule -- the ``develop`` ruleset's
-``pull_request`` rule must require at least one approving review AND code-owner
-review -- so the soundness exception is enforceable at the repo layer, not just in
-code.
+``pull_request`` rule must require a code-owner review -- so the soundness exception
+is enforceable at the repo layer, not just in code.
+
+Checks ONLY ``require_code_owner_review``, never ``required_approving_review_count``:
+per GitHub's ``pull_request`` rule, ``required_approving_review_count`` applies to
+EVERY PR against the branch -- it is not scoped to CODEOWNERS-matched paths -- so
+asserting ``count >= 1`` here would push an admin toward requiring an approval on
+every develop PR, including non-soundness ones the fast squash-auto-merge default is
+meant to cover, defeating the point of a soundness-path-ONLY review gate.
+``require_code_owner_review=True`` is independently sufficient: GitHub still requires
+an owner's approval on a PR that touches a CODEOWNERS-matched soundness path
+regardless of ``required_approving_review_count``, while a PR that touches no
+CODEOWNERS-matched path is unaffected either way.
 
 The soundness path set is read from ``auto_merge_soundness_paths`` (single source of
 truth), so the narration here and the auto-merge withholding cannot drift apart.
@@ -74,8 +84,13 @@ def _pull_request_parameters(rules: list[dict[str, Any]]) -> dict[str, Any] | No
 def review_enforcement_findings(rules: list[dict[str, Any]]) -> list[str]:
     """Return human-readable reasons the ruleset fails to enforce a review.
 
-    Empty list == the ruleset enforces an approving + code-owner review, so a
-    soundness-path PR cannot be squash-merged with zero approvals.
+    Empty list == the ruleset requires a code-owner review, so a soundness-path PR
+    (CODEOWNERS-owned) cannot be squash-merged with zero approvals.
+
+    Checks ONLY ``require_code_owner_review`` -- see the module docstring for why
+    ``required_approving_review_count`` is deliberately NOT part of this check (it
+    is a branch-wide setting, not CODEOWNERS-scoped, so requiring it here would gate
+    every develop PR rather than just soundness-path ones).
     """
     params = _pull_request_parameters(rules)
     if params is None:
@@ -83,16 +98,12 @@ def review_enforcement_findings(rules: list[dict[str, Any]]) -> list[str]:
             "develop ruleset has no pull_request rule: a soundness-path PR "
             f"({', '.join(SOUNDNESS_PATH_GLOBS)}) can squash-auto-merge with zero reviews"
         ]
-    findings: list[str] = []
-    count = params.get("required_approving_review_count") or 0
-    if count < 1:
-        findings.append(f"required_approving_review_count={count} (need >= 1)")
     if not params.get("require_code_owner_review", False):
-        findings.append(
+        return [
             f"require_code_owner_review={params.get('require_code_owner_review', False)} (need true) "
             f"for CODEOWNERS-owned soundness paths: {', '.join(SOUNDNESS_PATH_GLOBS)}"
-        )
-    return findings
+        ]
+    return []
 
 
 def is_review_enforced(rules: list[dict[str, Any]]) -> bool:
@@ -147,7 +158,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"- {finding}")
         return 1
     print(f"# Ruleset review enforcement ({args.branch}) - OK")
-    print(f"- approving + code-owner review required for {', '.join(SOUNDNESS_PATH_GLOBS)}")
+    print(f"- code-owner review required for {', '.join(SOUNDNESS_PATH_GLOBS)}")
     return 0
 
 

--- a/benchbox/core/plan_capture_phase.py
+++ b/benchbox/core/plan_capture_phase.py
@@ -202,3 +202,48 @@ def run_plan_capture_phase(
 
     result.total_capture_ms = (time.perf_counter() - phase_start) * 1000
     return result
+
+
+# ---------------------------------------------------------------------------
+# Plan-capture field propagation for the TPC power/throughput drivers
+# ---------------------------------------------------------------------------
+#
+# The TPC-H/TPC-DS power and throughput drivers execute queries directly via
+# ``connection.execute()`` (bypassing ``execute_query()``'s single chokepoint),
+# reading ``cursor.platform_result`` only to check for a FAILED validation
+# status. The adapter's own ``execute_query()`` (invoked under the covers by
+# ``PlatformAdapterConnection.execute()``) still records plan-capture metadata
+# on that result dict - including ``_plan_capture_key``, the exact internal key
+# ``_attach_captured_plans`` uses to match a captured plan back to its row - but
+# nothing copied it out of ``cursor.platform_result`` into the driver's own
+# result row, so it never reached the row that ``_attach_captured_plans``
+# eventually sees.
+#
+# Losing ``_plan_capture_key`` matters specifically in COMBINED mode (power then
+# throughput on the same public query ids): ``_attach_captured_plans`` falls
+# back to matching by PUBLIC id only when a row carries no exact key, and that
+# fallback deliberately refuses to guess when a public id captured more than one
+# distinct SQL variant (e.g. throughput re-executing q1 under a seed-varied SQL
+# digest). Without the exact key, a second (throughput) capture for the same
+# public id poisons the fallback for EVERY row sharing that id - including the
+# power-phase row, whose own pre-mutation checkpoint plan was perfectly
+# unambiguous on its own.
+PLAN_CAPTURE_PROPAGATION_KEYS = (
+    "_plan_capture_key",
+    "query_plan",
+    "plan_fingerprint",
+    "plan_fingerprint_normalized",
+    "plan_capture_time_ms",
+)
+
+
+def propagate_plan_capture_fields(source: Mapping[str, Any], target: dict[str, Any]) -> None:
+    """Copy plan-capture metadata (including the internal capture key) from
+    ``source`` into ``target``, when present. No-op for absent/None fields, so it
+    is safe to call unconditionally after every query execution regardless of
+    whether plan capture is enabled for the run.
+    """
+    for key in PLAN_CAPTURE_PROPAGATION_KEYS:
+        value = source.get(key)
+        if value is not None:
+            target[key] = value

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -116,21 +116,44 @@ from typing import Any
 from benchbox.core.errors import SerializationError
 
 # Literal-masking patterns for normalize_literals fingerprints. Numeric literals
-# (including decimals) collapse to <NUM> and single-quoted string literals to <STR>
-# so that structurally identical plans whose only difference is a data-driven
-# parameter value (e.g. a seed-varied filter threshold) hash the same. Numbers are
-# masked first so digits inside a quoted literal are folded into the <STR> token.
-_LITERAL_NUM_RE = re.compile(r"\b\d+(?:\.\d+)?\b")
-_LITERAL_STR_RE = re.compile(r"'[^']*'")
+# (including decimals, and a tightly-adjacent sign like ``-5``) collapse to <NUM>
+# and single-quoted string literals to <STR> so that structurally identical plans
+# whose only difference is a data-driven parameter value (e.g. a seed-varied filter
+# threshold) hash the same. Numbers are masked first so digits inside a quoted
+# literal are folded into the <STR> token.
+#
+# The numeric pattern uses a negative lookbehind (rather than \b on both ends) so
+# it can also absorb a leading sign: \b requires a word/non-word transition
+# immediately before the sign, which does not exist between two non-word
+# characters (e.g. a space then ``-``), so a plain \b pattern could never match
+# the sign at all. Excluding identifier characters (letters, digits, ``_``,
+# ``.``, ``$``) keeps ``l_orderkey1``/``t1`` intact (the digit is preceded by a
+# letter) while still matching a tightly-adjacent sign (``col > -5``) as PART of
+# the same token. Absorbing the sign matters because without it, ``-5`` and
+# ``5`` (thresholds that cross zero across seeds) mask to ``-<NUM>`` and
+# ``<NUM>`` respectively - still distinct - instead of collapsing to the same
+# placeholder. A sign separated from its digit by whitespace (``a - b``, a
+# binary operator) is NOT absorbed: the pattern requires the sign and digit to
+# be adjacent with nothing in between. The trailing negative lookahead mirrors
+# the leading lookbehind (rather than a trailing \b) so a number is not matched
+# when immediately glued to more identifier-continuation characters either.
+_LITERAL_NUM_RE = re.compile(r"(?<![A-Za-z0-9_.$])[+-]?\d+(?:\.\d+)?(?![A-Za-z0-9_.$])")
+# ``(?:[^']|'')*`` (rather than ``[^']*``) treats a doubled single quote as an
+# escaped apostrophe INSIDE the literal rather than the end of the string, so
+# ``'O''Brien'`` masks to one <STR> token instead of splitting into two
+# (``'O'`` + ``'Brien'`` -> ``<STR><STR>``, which would leave the split itself
+# as residual value-dependent syntax in the "normalized" signature).
+_LITERAL_STR_RE = re.compile(r"'(?:[^']|'')*'")
 
 
 def _mask_literals(expression: str) -> str:
     """Replace numeric and single-quoted string literals with stable placeholders.
 
-    Masks only concrete values, never identifiers: a trailing digit on a column or
-    alias (``l_orderkey1``, ``t1``) has no leading word boundary before the digit,
-    so it is left intact. Used for the opt-in literal-normalized structural
-    signature; the default fingerprint keeps literals verbatim.
+    Masks only concrete values, never identifiers: a leading identifier character
+    immediately before a digit (a column or alias like ``l_orderkey1``, ``t1``)
+    excludes the match, so it is left intact. Used for the opt-in
+    literal-normalized structural signature; the default fingerprint keeps
+    literals verbatim.
     """
     return _LITERAL_STR_RE.sub("<STR>", _LITERAL_NUM_RE.sub("<NUM>", expression))
 

--- a/benchbox/core/tpcds/power_test.py
+++ b/benchbox/core/tpcds/power_test.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Any, Callable, Optional
 
 from benchbox.core.connection import DatabaseConnection
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 
@@ -323,6 +324,11 @@ class TPCDSPowerTest:
                             "error", result_dict.get("row_count_validation_error", "Query validation failed")
                         )
                         raise RuntimeError(error_msg)
+                    # Propagate captured plan metadata (including the internal
+                    # _plan_capture_key) so a combined power+throughput run can match
+                    # this row by its exact key rather than the ambiguous public-id
+                    # fallback in _attach_captured_plans.
+                    propagate_plan_capture_fields(result_dict, query_result)
 
                 if hasattr(connection, "commit"):
                     connection.commit()

--- a/benchbox/core/tpcds/throughput_test.py
+++ b/benchbox/core/tpcds/throughput_test.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Any, Callable, Optional
 
 from benchbox.core.connection import DatabaseConnection
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.core.throughput.result import ThroughputResult, ThroughputStreamResult
 from benchbox.core.throughput.runner import StreamRunner
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -304,7 +305,9 @@ class TPCDSThroughputTest:
             query_id, seed=stream_seed, scale_factor=scale_factor, dialect=self.target_dialect
         )
 
-    def _run_single_stream_query(self, connection, query_text: str, query_display_id: str, stream_id: int) -> None:
+    def _run_single_stream_query(
+        self, connection, query_text: str, query_display_id: str, stream_id: int
+    ) -> dict[str, Any] | None:
         if hasattr(connection, "set_query_context"):
             connection.set_query_context(query_display_id, stream_id=stream_id)
         cursor = connection.execute(query_text)
@@ -312,6 +315,7 @@ class TPCDSThroughputTest:
             cursor.fetchall()
         if hasattr(connection, "commit"):
             connection.commit()
+        return getattr(cursor, "platform_result", None)
 
     def _execute_single_query(
         self,
@@ -342,10 +346,17 @@ class TPCDSThroughputTest:
             query_text = self._get_stream_query_text(query_id, variant, stream_seed, config.scale_factor)
             label = f"Stream_{stream_id}_Position_{position + 1}_Query_{query_display_id}"
             try:
-                self._run_single_stream_query(connection, query_text, query_display_id, stream_id)
+                platform_result = self._run_single_stream_query(connection, query_text, query_display_id, stream_id)
             finally:
                 with self._capture_lock:
                     self.captured_items.append((label, query_text))
+
+            if platform_result is not None:
+                # Propagate captured plan metadata (including the internal
+                # _plan_capture_key) so a combined power+throughput run can match
+                # this row by its exact key rather than the ambiguous public-id
+                # fallback in _attach_captured_plans.
+                propagate_plan_capture_fields(platform_result, query_result)
 
             query_result.update(
                 {

--- a/benchbox/core/tpch/platform_power.py
+++ b/benchbox/core/tpch/platform_power.py
@@ -9,6 +9,7 @@ from benchbox.core.constants import (
     TPCH_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
     TPCH_POWER_DEFAULT_WARMUP_ITERATIONS,
 )
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 
 TPCH_BENCHMARK_ID = "tpch"
 PowerConnectionAdapterFactory = Callable[[Any, str, float], Any]
@@ -40,6 +41,10 @@ def _power_query_result(
         platform_result["result_digest"] = query_result["result_digest"]
     if not query_result["success"]:
         platform_result["error"] = query_result.get("error", "Unknown error")
+    # Carry the internal _plan_capture_key (and any captured plan fields) through
+    # to the row _attach_captured_plans sees, so it can match by exact key instead
+    # of the ambiguous public-id fallback (see plan_capture_phase.py).
+    propagate_plan_capture_fields(query_result, platform_result)
     return platform_result
 
 

--- a/benchbox/core/tpch/power_test.py
+++ b/benchbox/core/tpch/power_test.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 
@@ -308,6 +309,11 @@ class TPCHPowerTest:
                                     "error", result_dict.get("row_count_validation_error", "Query validation failed")
                                 )
                                 raise RuntimeError(error_msg)
+                            # Propagate captured plan metadata (including the internal
+                            # _plan_capture_key) so it reaches the result bundle and
+                            # so _attach_captured_plans can match this row by its
+                            # exact key rather than the ambiguous public-id fallback.
+                            propagate_plan_capture_fields(result_dict, query_result)
 
                         if hasattr(self.connection, "commit"):
                             self.connection.commit()

--- a/benchbox/core/tpch/throughput_test.py
+++ b/benchbox/core/tpch/throughput_test.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Optional
 
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.core.throughput.result import ThroughputResult, ThroughputStreamResult
 from benchbox.core.throughput.runner import StreamRunner
 from benchbox.utils.clock import elapsed_seconds, mono_time
@@ -244,6 +245,11 @@ class TPCHThroughputTest:
                                     "error", result_dict.get("row_count_validation_error", "Query validation failed")
                                 )
                                 raise RuntimeError(error_msg)
+                            # Propagate captured plan metadata (including the internal
+                            # _plan_capture_key) so a combined power+throughput run can
+                            # match this row by its exact key rather than the ambiguous
+                            # public-id fallback in _attach_captured_plans.
+                            propagate_plan_capture_fields(result_dict, query_result)
 
                         if hasattr(connection, "commit"):
                             connection.commit()

--- a/benchbox/core/write_primitives/README.md
+++ b/benchbox/core/write_primitives/README.md
@@ -254,15 +254,17 @@ Operations use SQLGlot dialect translation by default, with `platform_overrides`
 a platform override is `null`, `_get_effective_write_sql()` returns a skip reason and
 the operation is recorded as `SKIPPED` in results.
 
-### DataFusion (v51.0.0) - 64 Skipped Operations
+### DataFusion (v51.0.0) - 62 Skipped Operations
 
 DataFusion is an Arrow-native query engine that operates on **immutable record batches**.
 This architecture provides excellent read/scan performance but means row-level mutation
 (UPDATE, DELETE) is not implemented - there is no write path for existing data. MERGE
 depends on UPDATE/DELETE and is therefore also unsupported.
 
-All 64 skips fall into categories dictated by this architectural constraint. None have
-viable alternative SQL syntax within DataFusion's current capability set.
+All 62 skips fall into categories dictated by this architectural constraint. None have
+viable alternative SQL syntax within DataFusion's current capability set. (Two further
+BULK_LOAD operations carry a `datafusion: null` catalog override but are NOT part of
+this skip total - see "BULK_LOAD Edge Cases" below.)
 
 #### UPDATE - 15 operations (queries 13-27)
 
@@ -309,9 +311,18 @@ UPDATE/INSERT against existing rows and carry explicit `datafusion: null` overri
 | `insert_on_conflict_ignore` | `Plan("Insert-on clause not supported")` - no constraint enforcement makes ON CONFLICT meaningless |
 | `insert_returning_clause` | `Plan("Insert-returning clause not supported")` |
 
-#### BULK_LOAD Edge Cases - 2 operations
+#### BULK_LOAD Edge Cases - 2 operations (NOT counted in the 62-skip total)
 
-| Operation | Reason |
+These carry a `datafusion: null` `platform_overrides` entry in the catalog, but that
+entry is never consulted for DataFusion: `DataFusionAdapter.preprocess_operation_sql()`
+rewrites every `bulk_load`-category operation and passes the result as `sql_override`,
+and `_get_effective_write_sql()` returns `sql_override` before it ever checks
+`platform_overrides`. So on an actual DataFusion run these two are ATTEMPTED via the
+rewritten SQL, not surfaced as `SKIPPED` - the `datafusion: null` override is
+vestigial for this pair. Listed here for the catalog-metadata record, not as part of
+the 62-skip count above.
+
+| Operation | Catalog override reason (not applied at runtime) |
 |-----------|--------|
 | `bulk_load_error_handling_skip_bad_rows` | DataFusion's CSV reader has no `IGNORE_ERRORS` equivalent; all rows must be valid |
 | `bulk_load_upsert_mode` | Requires MERGE INTO, which is unsupported |

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -374,6 +374,7 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
         operation: Any,
         platform_key: str | None = None,
         sql_override: str | None = None,
+        connection: DatabaseConnection | None = None,
     ) -> tuple[str | None, str | None]:
         """Resolve effective write SQL (including platform overrides) or return skip reason.
 
@@ -381,6 +382,13 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
             operation: WriteOperation with write_sql and platform_overrides
             platform_key: Platform dialect key (e.g. 'datafusion', 'duckdb') passed by adapter
             sql_override: Pre-processed SQL from adapter (e.g. bulk_load rewrite)
+            connection: Live connection, used ONLY to check whether a staging table
+                the operation depends on was left empty because its TPC-H source was
+                absent at setup (see :meth:`_check_staging_table_population`). When
+                ``None`` (e.g. a direct unit-test call with no connection), that
+                check is skipped rather than blocking - the caller could not verify
+                emptiness either way, so this mirrors the fail-open behavior of
+                :meth:`_check_bulk_load_file_dependencies` for a missing files_dir.
 
         Returns:
             Tuple of (effective_sql, skip_reason). If skip_reason is not None,
@@ -428,7 +436,49 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 f"Operation '{operation.id}' is skipped because required bulk-load files are missing: {missing_file}"
             )
 
+        if (empty_reason := self._check_staging_table_population(effective_sql, connection)) is not None:
+            return None, f"Operation '{operation.id}' is skipped because {empty_reason}"
+
         return effective_sql, None
+
+    def _check_staging_table_population(self, write_sql: str, connection: DatabaseConnection | None) -> str | None:
+        """Return a skip reason if ``write_sql`` depends on a staging table that was
+        left EMPTY because its TPC-H source table was absent at setup.
+
+        A minimal fixture that loads only orders/lineitem (no customer/supplier)
+        makes ``setup()`` skip populating ``scd2_ops_dim_customer`` /
+        ``scd2_ops_stage_customer`` (SCD Type 2) and ``delete_ops_supplier`` (GDPR
+        deletion) - see ``_OPTIONAL_WHEN_SOURCE_MISSING`` - while ``is_setup()``
+        still reports True, since those tables are not REQUIRED for the overall
+        setup check. Without this guard, an operation referencing one of them would
+        run its write SQL and validation queries against an EMPTY table: the SCD2
+        anti-join/count-zero validations, and a DELETE with no matching rows, both
+        trivially pass on empty data, so the operation reports SUCCESS without
+        exercising anything - corrupting reported coverage instead of surfacing the
+        missing prerequisite. Checked live (row count), not from setup()'s
+        one-time population result, so a mid-run reset() or a differently-scoped
+        connection is still caught.
+
+        ``connection=None`` (e.g. a direct unit-test call with no connection) skips
+        this check rather than blocking - the caller could not verify emptiness
+        either way, mirroring :meth:`_check_bulk_load_file_dependencies`'s fail-open
+        behavior for a missing ``files_dir``.
+        """
+        if connection is None:
+            return None
+        for table_name, capability_note in _OPTIONAL_WHEN_SOURCE_MISSING.items():
+            if not re.search(rf"\b{re.escape(table_name)}\b", write_sql):
+                continue
+            try:
+                quoted = self._quote_identifier(table_name)
+                result = connection.execute(f"SELECT COUNT(*) FROM {quoted}").fetchone()
+                row_count = result[0] if result else 0
+            except Exception:
+                # Table missing entirely (never created) is the same "unavailable" case.
+                row_count = 0
+            if row_count == 0:
+                return f"staging table '{table_name}' is empty (source data was unavailable at setup): {capability_note}"
+        return None
 
     def _check_bulk_load_file_dependencies(self, operation: Any) -> str | None:
         """Return a comma-separated list of missing file-dependency paths, if any.
@@ -1102,7 +1152,7 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
 
         try:
             effective_sql, skip_reason = self._get_effective_write_sql(
-                operation, platform_key=platform_key, sql_override=sql_override
+                operation, platform_key=platform_key, sql_override=sql_override, connection=connection
             )
             if skip_reason is not None:
                 self.log_verbose(f"Skipping operation {operation_id}: {skip_reason}")

--- a/benchbox/core/write_primitives/benchmark.py
+++ b/benchbox/core/write_primitives/benchmark.py
@@ -477,7 +477,9 @@ class WritePrimitivesBenchmark(TransactionalBenchmarkBase["OperationResult"]):
                 # Table missing entirely (never created) is the same "unavailable" case.
                 row_count = 0
             if row_count == 0:
-                return f"staging table '{table_name}' is empty (source data was unavailable at setup): {capability_note}"
+                return (
+                    f"staging table '{table_name}' is empty (source data was unavailable at setup): {capability_note}"
+                )
         return None
 
     def _check_bulk_load_file_dependencies(self, operation: Any) -> str | None:

--- a/benchbox/platforms/base/execution.py
+++ b/benchbox/platforms/base/execution.py
@@ -40,6 +40,7 @@ from benchbox.core.constants import (
 )
 from benchbox.core.errors import PlanCaptureError
 from benchbox.core.operations import OperationExecutor
+from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.core.power_harnesses import (
     resolve_combined_harness,
     resolve_maintenance_harness,
@@ -327,6 +328,11 @@ class TestDriversMixin:
                     }
                     if not query_result["success"]:
                         platform_result["error"] = query_result.get("error", "Unknown error")
+                    # Carry the internal _plan_capture_key (and any captured plan
+                    # fields) through to the row _attach_captured_plans sees, so a
+                    # combined power+throughput run matches by exact key instead of
+                    # the ambiguous public-id fallback.
+                    propagate_plan_capture_fields(query_result, platform_result)
                     query_results.append(platform_result)
 
             return query_results
@@ -421,6 +427,11 @@ class TestDriversMixin:
                     }
                     if not qr.get("success"):
                         platform_result["error"] = qr.get("error", "Unknown error")
+                    # Carry the internal _plan_capture_key (and any captured plan
+                    # fields) through to the row _attach_captured_plans sees, so a
+                    # combined power+throughput run matches by exact key instead of
+                    # the ambiguous public-id fallback.
+                    propagate_plan_capture_fields(qr, platform_result)
                     query_results.append(platform_result)
 
             return query_results

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -100,8 +100,8 @@ gh api repos/joeharris76/BenchBox/rulesets/15611785 --jq '
 
 ### Soundness-path review enforcement (pending admin action)
 
-The `develop-squash-only` ruleset's `pull_request` rule must require an approving
-review AND code-owner review so a PR touching the CODEOWNERS-owned soundness paths
+The `develop-squash-only` ruleset's `pull_request` rule must require a code-owner
+review so a PR touching the CODEOWNERS-owned soundness paths
 (`benchbox/core/equivalence/**`, `benchbox/core/query_plans/parsers/**`,
 `benchbox/core/**/validation.py`) cannot be squash-merged with zero approvals. The
 auto-merge code side already withholds auto-merge enablement for those paths
@@ -113,16 +113,24 @@ TODO.
 Target state:
 
 ```text
-required_approving_review_count: 1
 require_code_owner_review: true
 ```
 
-Live state at this writing: `required_approving_review_count: 0`,
-`require_code_owner_review: false` — not yet enforced. Applying it is a deferred
-repo-admin action: the develop-PR `GITHUB_TOKEN` has no `administration` scope, so it
-can neither read nor write the ruleset; only an admin PAT can.
+`required_approving_review_count` is deliberately NOT part of the target state:
+GitHub's `pull_request` rule applies that count to EVERY PR against the branch, not
+just CODEOWNERS-matched paths, so requiring `>= 1` would gate every develop PR
+instead of just soundness-path ones — defeating the fast squash-auto-merge default.
+`require_code_owner_review: true` is independently sufficient: GitHub still requires
+an owner's approval on a PR that touches a CODEOWNERS-matched soundness path
+regardless of the count setting.
 
-Verify (manual or release-canary; needs a ruleset-read token such as
+Live state at this writing: `require_code_owner_review: false` — not yet enforced.
+Applying it is a deferred repo-admin action: the develop-PR `GITHUB_TOKEN` has no
+`administration` scope, so it can neither read nor write the ruleset; only an admin
+PAT can.
+
+Verify (manual only — this check is NOT wired into `release-canary.yml`, which only
+runs `ruleset_drift_check.py`; needs a ruleset-read token such as
 `RULESET_DRIFT_TOKEN`):
 
 ```bash
@@ -131,15 +139,15 @@ gh api repos/joeharris76/BenchBox/rules/branches/develop \
 ```
 
 The predicate exits non-zero and names the offending field while review enforcement
-is missing, and exits zero once the ruleset requires an approving + code-owner
-review. Its pinned logic is guarded by
-`tests/unit/release/test_ruleset_review_enforcement.py` in the required fast lane.
+is missing, and exits zero once the ruleset requires a code-owner review. Its pinned
+logic is guarded by `tests/unit/release/test_ruleset_review_enforcement.py` in the
+required fast lane; the live-ruleset check above must be run by hand (or added to
+`release-canary.yml` as a follow-up) until it is wired into CI.
 
 Apply (admin only — the deferred action that closes the gap):
 
 ```bash
-# Fetch the current ruleset, set the pull_request rule parameters
-#   required_approving_review_count: 1
+# Fetch the current ruleset, set the pull_request rule parameter
 #   require_code_owner_review: true
 # then PUT it back.
 gh api repos/joeharris76/BenchBox/rulesets/15611785 > /tmp/develop-ruleset.json

--- a/scripts/cloud-claude-setup.sh
+++ b/scripts/cloud-claude-setup.sh
@@ -17,6 +17,17 @@
 # _project/decisions/claude-settings-cloud-ownership-2026-06-29.md (cloud addendum).
 #
 # Idempotent and safe to re-run. No-op when the `claude` CLI or python is absent.
+#
+# Staleness caveat: claude.ai/code caches environment setup scripts and runs
+# them once per environment BUILD, not once per session. If .claude/settings.json
+# changes (plugin added/removed) after an environment was built, existing
+# sessions in that environment will NOT pick up the change automatically —
+# there is no supported per-session hook to bust this cache (project hooks are
+# unreliable/blocked in cloud web execution; see the cloud addendum in
+# _project/decisions/claude-settings-cloud-ownership-2026-06-29.md). Rebuild
+# the claude.ai/code environment (or otherwise force a fresh environment build)
+# after changing enabledPlugins/extraKnownMarketplaces, then verify with
+# `claude plugin list` in the new session.
 set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"

--- a/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
+++ b/tests/integration/test_dataframe_csv_empty_string_null_semantics.py
@@ -144,6 +144,17 @@ def _make_pyspark() -> Any:
     return PySparkDataFrameAdapter(master="local[1]", driver_memory="1g", shuffle_partitions=1)
 
 
+def _make_dask() -> Any:
+    # DaskDataFrameAdapter defaults use_distributed=True, which starts a
+    # LocalCluster (worker processes) in the constructor -- BEFORE
+    # _adapter_context's scoped dask.config.set(scheduler="synchronous") can make
+    # the later .compute() calls local. This entire test file is marked `fast`, so
+    # a coverage-only check must not need worker processes (can fail or be slow on
+    # resource-constrained dev/CI hosts). use_distributed=False keeps Dask on the
+    # single-process synchronous/threaded path this fast lane requires.
+    return DaskDataFrameAdapter(use_distributed=False)
+
+
 def _java_17_plus_available() -> bool:
     """PySpark SQL mode needs Java 17/21; skip (not fail) on a Java-less dev env."""
     import re
@@ -165,7 +176,7 @@ _ADAPTER_CASES = [
     _AdapterCase("pyspark", PYSPARK_AVAILABLE and _java_17_plus_available(), _make_pyspark),
     _AdapterCase("pandas", PANDAS_AVAILABLE, PandasDataFrameAdapter),
     _AdapterCase("polars", POLARS_AVAILABLE, PolarsDataFrameAdapter),
-    _AdapterCase("dask", DASK_AVAILABLE, DaskDataFrameAdapter),
+    _AdapterCase("dask", DASK_AVAILABLE, _make_dask),
     _AdapterCase("modin", MODIN_AVAILABLE, ModinDataFrameAdapter),
     _AdapterCase("cudf", CUDF_AVAILABLE, CuDFDataFrameAdapter),
 ]

--- a/tests/integration/test_plan_capture_combined_divergence.py
+++ b/tests/integration/test_plan_capture_combined_divergence.py
@@ -16,12 +16,18 @@ These exercise the resolution (query-plan-capture-post-measurement-divergence):
   plans are captured against the pre-mutation data state they were measured
   against, while the maintenance writes are captured once in the final pass.
 - Capture is driven by the recorded-query buffer (digest-keyed, SUCCESS-only),
-  and plans attach to result rows by exact capture key or, for the TPC
-  power/throughput drivers that rebuild rows WITHOUT the internal key, by the
-  bare public query_id. This is the production row shape — verified against the
-  real DuckDB TPC-H power path in ``test_real_tpch_power_capture_attaches_plans``
-  — so the tests below deliberately build rows the way the drivers do (no
-  ``_plan_capture_key``) rather than hand-injecting a field production drops.
+  and plans attach to result rows by exact capture key or, as a FALLBACK for a
+  row that carries no key at all, by the bare public query_id. The TPC
+  power/throughput drivers (``benchbox/core/{tpch,tpcds}/{power,throughput}_test.py``
+  + their ``platform_power.py`` row-shapers) now propagate the internal
+  ``_plan_capture_key`` from the adapter's ``execute_query()`` result all the
+  way through to the row ``_attach_captured_plans`` sees, specifically so a
+  COMBINED run (power then throughput on the same public query ids) matches
+  each row by its EXACT key instead of the public-id fallback — see
+  ``test_combined_power_then_throughput_same_public_id_different_sql`` below.
+  The public-id fallback below still exercises the general mechanism (e.g. for
+  a hypothetical driver that cannot supply a key), verified end-to-end against
+  the real DuckDB TPC-H power path in ``test_real_tpch_power_capture_attaches_plans``.
 
 They run against a real (file-based) DuckDB so EXPLAIN sees the live row counts.
 """
@@ -188,11 +194,14 @@ def test_read_only_combined_capture_attaches_via_public_id(file_adapter):
 
 
 def test_ambiguous_query_id_variants_not_misattached(file_adapter):
-    """A query_id that ran as two distinct SQL variants must not be mis-paired.
-
-    Throughput streams render the same query_id with different seeds. When the rows
-    carry no capture key, the public-id fallback cannot tell which row ran which
-    variant, so it must leave them unattached rather than attach a wrong plan.
+    """A query_id that ran as two distinct SQL variants must not be mis-paired
+    WHEN NEITHER ROW CARRIES A CAPTURE KEY (the public-id-fallback safety net, for
+    a driver that cannot supply one). Production TPC power/throughput rows DO carry
+    the key today (see test_combined_power_then_throughput_same_public_id_different_sql
+    below, which covers the real combined-mode case via the exact-key path instead),
+    but the fallback itself must still refuse to guess for a keyless row: it cannot
+    tell which row ran which variant, so it must leave them unattached rather than
+    attach a wrong plan.
     """
     conn = file_adapter.create_connection()
     try:
@@ -287,10 +296,11 @@ def test_checkpoint_is_noop_when_phase_inactive(file_adapter):
 def test_real_tpch_power_capture_attaches_plans(tmp_path):
     """End-to-end: the real TPC-H power driver path attaches captured plans to rows.
 
-    Regression guard for the production code path the method-level tests model:
-    the TPC-H power driver rebuilds result rows WITHOUT the internal capture key,
-    so capture must be buffer-driven and attachment must fall back to the public
-    query_id. Generates a tiny SF (data-gen marks this ``slow``).
+    Regression guard for the production code path the method-level tests model.
+    The TPC-H power driver now propagates the internal capture key through to its
+    result rows (see the module docstring), so this also confirms that
+    propagation does not break the ordinary single-run case. Generates a tiny SF
+    (data-gen marks this ``slow``).
     """
     from benchbox.core.tpch.benchmark import TPCHBenchmark
 
@@ -319,5 +329,61 @@ def test_real_tpch_power_capture_attaches_plans(tmp_path):
                 continue
             assert row.get("plan_fingerprint"), f"power row {row.get('query_id')} got no plan"
             assert row.get("query_plan") is not None
+    finally:
+        conn.close()
+
+
+@pytest.mark.slow
+def test_combined_power_then_throughput_same_public_id_different_sql(tmp_path):
+    """Regression for the P1 finding: a default combined run (power -> throughput)
+    executes the SAME public query ids twice, and throughput's per-stream seed
+    renders DIFFERENT SQL text for the SAME id, so the two executions capture under
+    DIFFERENT internal keys. Before the fix, neither TPC driver's rows carried
+    ``_plan_capture_key`` at all, so BOTH attached only via the public-id fallback -
+    and the fallback poisons ANY public id that captured more than one distinct SQL
+    variant, leaving BOTH the power row and the throughput row unattached (even
+    though the power row's own pre-mutation-checkpoint plan was perfectly
+    unambiguous on its own). With the fix, both rows carry their OWN exact capture
+    key, so each attaches its own plan regardless of the other phase's variant.
+    """
+    from benchbox.core.tpch.benchmark import TPCHBenchmark
+
+    db_path = str(tmp_path / "combined.duckdb")
+    adapter = DuckDBAdapter(database_path=db_path, capture_plans=True)
+    conn = adapter.create_connection()
+    try:
+        bench = TPCHBenchmark(scale_factor=0.01, output_dir=str(tmp_path / "data"))
+        bench.generate_data()
+        adapter.create_schema(bench, conn)
+        adapter.load_data(bench, conn, str(tmp_path / "data"))
+
+        run_config = {
+            "benchmark_name": "tpch",
+            "test_execution_type": "combined",
+            "scale_factor": 0.01,
+            "seed": 1,
+            "iterations": 1,
+            "warm_up_iterations": 0,
+            "num_streams": 2,
+            "query_subset": [6],  # Q6 has seed-parameterized date/discount predicates.
+            "options": {"requested_phases": ["power", "throughput"]},
+        }
+        results = adapter._execute_queries_by_type(bench, conn, run_config)
+
+        power_rows = [r for r in results if r.get("test_type") == "power" and r.get("status") == "SUCCESS"]
+        throughput_rows = [r for r in results if r.get("test_type") == "throughput" and r.get("status") == "SUCCESS"]
+        assert power_rows, "combined run produced no successful power rows"
+        assert throughput_rows, "combined run produced no successful throughput rows"
+
+        # Every successful row -- power AND throughput -- must have its own captured
+        # plan, regardless of whether the other phase captured the SAME public id
+        # under a different SQL variant.
+        for row in power_rows + throughput_rows:
+            assert row.get("plan_fingerprint"), (
+                f"{row.get('test_type')} row for query {row.get('query_id')} got no plan "
+                "(public-id ambiguity from the other phase must not poison this row)"
+            )
+            assert row.get("query_plan") is not None
+            assert "_plan_capture_key" not in row, "the internal key must be consumed, not leaked to the caller"
     finally:
         conn.close()

--- a/tests/unit/core/query_plans/test_fingerprint_normalization.py
+++ b/tests/unit/core/query_plans/test_fingerprint_normalization.py
@@ -122,6 +122,39 @@ class TestStructuralSignatureNormalization:
         assert "table:orders" in normalized
         assert "group:o_orderstatus" in normalized
 
+    def test_escaped_apostrophe_string_literal_masks_as_one_token(self):
+        """A doubled single quote is an escaped apostrophe INSIDE the literal, not the
+        end of the string. Without treating '' as an escape, 'O''Brien' would split
+        into two adjacent string literals ('O' + 'Brien'), leaving <STR><STR> - the
+        split itself residual value-dependent syntax - in the "normalized" signature,
+        so two seed-varied names could still normalize to different signatures."""
+        op = _scan("c_name = 'O''Brien'")
+        normalized = op.get_structural_signature(normalize_literals=True)
+        assert normalized.count("<STR>") == 1, normalized
+        assert "<STR><STR>" not in normalized
+
+    def test_signed_numeric_literal_collapses_regardless_of_sign(self):
+        """A threshold that crosses zero across seeds (e.g. -5 vs 5) must still
+        normalize to the SAME signature. Masking only the digit run (leaving a bare
+        sign character outside the placeholder) would leave -<NUM> and <NUM> as
+        distinct tokens - literal-sensitive residue defeating the whole point of
+        cross-seed normalization."""
+        negative = _scan("l_tax_credit > -5")
+        positive = _scan("l_tax_credit > 5")
+
+        assert negative.get_structural_signature() != positive.get_structural_signature()
+        assert negative.get_structural_signature(normalize_literals=True) == positive.get_structural_signature(
+            normalize_literals=True
+        )
+
+    def test_spaced_minus_operator_is_not_absorbed_as_a_sign(self):
+        """A '-' separated from its operand by whitespace is a binary operator, not a
+        literal's sign, and must stay OUTSIDE the masked token (only the two numeric
+        operands are masked)."""
+        op = _scan("l_discount = 0.05 - 0.01")
+        normalized = op.get_structural_signature(normalize_literals=True)
+        assert normalized.endswith("<NUM> - <NUM>"), normalized
+
     def test_normalization_recurses_into_children(self):
         """Child operator literals are masked too (signature is recursive)."""
         a = LogicalOperator(

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -1594,6 +1594,81 @@ def test_get_effective_write_sql_duckdb_runs_portable_merge(fast_bench):
     assert sql == operation.write_sql
 
 
+class _FakeCountConnection:
+    """Minimal connection stand-in: SELECT COUNT(*) FROM <table> returns a canned count."""
+
+    def __init__(self, counts_by_table: dict[str, int]):
+        self._counts_by_table = counts_by_table
+
+    def execute(self, sql: str):
+        for table, count in self._counts_by_table.items():
+            if table in sql:
+                return SimpleNamespace(fetchone=lambda count=count: (count,))
+        raise RuntimeError(f"unexpected query in fake connection: {sql}")
+
+
+def test_get_effective_write_sql_skips_scd2_when_customer_staging_is_empty(fast_bench):
+    """A minimal fixture (orders/lineitem only, no customer) leaves
+    scd2_ops_dim_customer/scd2_ops_stage_customer empty; is_setup() still reports
+    True since those tables are not REQUIRED, so without this guard the SCD2 op
+    would execute its UPDATE/INSERT and anti-join validations against empty
+    tables and trivially report SUCCESS - corrupting coverage rather than
+    surfacing that the prerequisite is missing."""
+    operation = fast_bench.get_operation("merge_scd_type2_basic")
+    empty_connection = _FakeCountConnection({"scd2_ops_dim_customer": 0, "scd2_ops_stage_customer": 0})
+
+    sql, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb", connection=empty_connection)
+
+    assert sql is None
+    assert skip is not None
+    assert "empty" in skip.lower()
+    assert "scd2_ops_dim_customer" in skip or "scd2_ops_stage_customer" in skip
+
+
+def test_get_effective_write_sql_runs_scd2_when_customer_staging_is_populated(fast_bench):
+    """The common case (full 8-table load): staging tables are non-empty, op runs."""
+    operation = fast_bench.get_operation("merge_scd_type2_basic")
+    populated_connection = _FakeCountConnection({"scd2_ops_dim_customer": 40, "scd2_ops_stage_customer": 10})
+
+    sql, skip = fast_bench._get_effective_write_sql(
+        operation, platform_key="duckdb", connection=populated_connection
+    )
+
+    assert skip is None
+    assert sql == operation.write_sql
+
+
+def test_get_effective_write_sql_without_connection_does_not_check_staging_population(fast_bench):
+    """No connection supplied (e.g. a direct unit-test call) -> the emptiness check
+    is skipped rather than blocking, matching the existing tests in this file that
+    call _get_effective_write_sql with no connection at all."""
+    operation = fast_bench.get_operation("merge_scd_type2_basic")
+
+    sql, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb")
+
+    assert skip is None
+    assert sql == operation.write_sql
+
+
+def test_get_effective_write_sql_empty_supplier_staging_skips_gdpr_delete(fast_bench):
+    """The same emptiness guard covers delete_ops_supplier (GDPR deletion ops),
+    not just SCD2 - both are keyed in _OPTIONAL_WHEN_SOURCE_MISSING because both
+    lose their source table (supplier / customer) on a minimal fixture."""
+    operation = SimpleNamespace(
+        id="delete_gdpr_suppliers_5pct",
+        write_sql="DELETE FROM delete_ops_supplier WHERE s_suppkey <= 5",
+        platform_overrides={},
+        category="delete",
+    )
+    empty_connection = _FakeCountConnection({"delete_ops_supplier": 0})
+
+    sql, skip = fast_bench._get_effective_write_sql(operation, connection=empty_connection)
+
+    assert sql is None
+    assert skip is not None
+    assert "delete_ops_supplier" in skip
+
+
 def test_get_effective_write_sql_duckdb_gate_matches_catalog(fast_bench):
     """The real catalog: portable SCD2 ops run on DuckDB while legacy MERGE INTO ops skip."""
     portable_ops = (

--- a/tests/unit/core/write_primitives/test_benchmark_execution.py
+++ b/tests/unit/core/write_primitives/test_benchmark_execution.py
@@ -1630,9 +1630,7 @@ def test_get_effective_write_sql_runs_scd2_when_customer_staging_is_populated(fa
     operation = fast_bench.get_operation("merge_scd_type2_basic")
     populated_connection = _FakeCountConnection({"scd2_ops_dim_customer": 40, "scd2_ops_stage_customer": 10})
 
-    sql, skip = fast_bench._get_effective_write_sql(
-        operation, platform_key="duckdb", connection=populated_connection
-    )
+    sql, skip = fast_bench._get_effective_write_sql(operation, platform_key="duckdb", connection=populated_connection)
 
     assert skip is None
     assert sql == operation.write_sql

--- a/tests/unit/release/test_ruleset_review_enforcement.py
+++ b/tests/unit/release/test_ruleset_review_enforcement.py
@@ -55,19 +55,21 @@ def test_enforced_ruleset_passes() -> None:
     assert rre.review_enforcement_findings(rules) == []
 
 
-def test_unenforced_ruleset_fails_on_both_axes() -> None:
+def test_unenforced_ruleset_fails() -> None:
     # The live develop state at authoring time: zero approvals, no code-owner review.
     findings = rre.review_enforcement_findings(_pr_rule(count=0, code_owner=False))
     assert findings, "an unenforced ruleset must produce findings (it currently does not)"
-    blob = " ".join(findings)
-    assert "required_approving_review_count=0" in blob
-    assert "require_code_owner_review=False" in blob
+    assert "require_code_owner_review=False" in " ".join(findings)
 
 
-def test_zero_count_alone_fails() -> None:
-    findings = rre.review_enforcement_findings(_pr_rule(count=0, code_owner=True))
-    assert any("required_approving_review_count" in f for f in findings)
-    assert not any("require_code_owner_review" in f for f in findings)
+def test_required_approving_review_count_is_not_checked() -> None:
+    """required_approving_review_count is branch-wide, not CODEOWNERS-scoped, so
+    asserting it here would gate EVERY develop PR, not just soundness-path ones.
+    A ruleset with require_code_owner_review=True passes regardless of count -
+    including count=0, GitHub's live-state default."""
+    assert rre.review_enforcement_findings(_pr_rule(count=0, code_owner=True)) == []
+    assert rre.review_enforcement_findings(_pr_rule(count=1, code_owner=True)) == []
+    assert rre.review_enforcement_findings(_pr_rule(count=5, code_owner=True)) == []
 
 
 def test_missing_code_owner_alone_fails() -> None:


### PR DESCRIPTION
## Description

Consolidated fix for late-landing `chatgpt-codex-connector` review comments posted after merge on #933, #936, #934, #931, #924, #923, #930, #926, #921, #922, #925, #927. This is sweep pass 9 of the ongoing review-followup process. #712 is intentionally excluded per standing instruction (release PR).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <file>` for every touched TODO YAML
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph`
- `uv run -- ruff check <touched files>` — clean
- `uv run -- ty check <touched files>` — clean (one pre-existing, unrelated `no-matching-overload` warning in `tpch/throughput_test.py`, confirmed present without this diff via `git stash`)
- `uv run -- python -m pytest tests/unit/core/query_plans/test_fingerprint_normalization.py tests/unit/core/write_primitives/test_benchmark_execution.py tests/unit/release/test_ruleset_review_enforcement.py -q` — 172 passed
- `uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -q -m "medium or slow"` — 9 passed
- `uv run -- python -m pytest tests/integration/test_dataframe_csv_empty_string_null_semantics.py -q` — 2 pre-existing pyspark failures unrelated to this change (Java 17/21 not available in this environment; confirmed identical failure via `git stash` on the touched test file), all others pass
- `uv run -- python -m pytest tests/unit/core/write_primitives/ -q` — 344 passed

## Summary of fixes

- **query_plan_models literal normalization (#933)** — fix sign/escaped-apostrophe handling so seed-varied numeric/string literals collapse to the same structural signature.
- **ruleset_review_enforcement (#934)** — drop the `required_approving_review_count` check (branch-wide, not CODEOWNERS-scoped) from the enforcement predicate; reword the runbook and admin-enforcement TODO to match.
- **write_primitives (#931)** — guard against false-success when an optional staging table is empty because its TPC-H source table is absent from a minimal fixture.
- **Plan-capture key propagation (#924)** — thread `_plan_capture_key` and sibling fields through every TPC-H/TPC-DS power+throughput hop via a new shared `propagate_plan_capture_fields` helper, so captured plans attach correctly across combined power/throughput runs.
- **write_primitives README (#923)** — correct DataFusion's stated skip count from 64 to 62; two BULK_LOAD ops carry a vestigial `platform_overrides` entry that `preprocess_operation_sql()` + `sql_override` short-circuit at runtime.
- **adopt-apple-container-ci-parity TODO (#930)** — fix w1/w2 ordering (machine creation needs the built image first) and flag the shared-home-mount `uv sync` venv-clobber risk.
- **track2-joinorder-stats-as-phase design doc + scaling-strategy TODO (#926)** — correct the Redshift ANALYZE-during-load misattribution (confirmed via code trace: `auto_analyze` defaults `True`, `_load_table_via_s3()` runs `ANALYZE` right after `COPY`) and gate scaled-prototype implementation on the stats-phase TODO.
- **joinorder-scale-stress decision (#921)** — carve small lookup tables out of the SF=N replication multiplier (single-copy, matching the prototype's must_preserve guard) and time DuckDB's explicit ANALYZE per the decision's own rule instead of zeroing it.
- **apply-changes-into-vs-standard-sql blog draft (#922)** — stop claiming the SCD2 SQL runs unchanged across every BenchBox-target engine; DataFusion is a documented `platform_overrides: {"datafusion": null}` exception for `merge_scd_type2_basic`.
- **dataframe-csv-empty-string-parity-coverage TODO (#925)** — reword the "uniform" contract to be explicit that it's null-marker-conditioned (`""` when `csv_null_marker is None`, `null` when `csv_null_marker == ""`), not a single always-null outcome.
- **cloud-claude-setup.sh + cloud-ownership decision doc + TODO (#927)** — document the environment-build caching gap (the setup script does not re-run per session) and the manual-rebuild remedy, since project hooks are unreliable in cloud web execution.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files added.

## Notes

Reply-and-resolve on each source PR's review thread follows this PR being opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_