### PR TITLE
docs(track2): reconcile joinorder scaling direction to sampled-from-real

### DIFF
--- a/_project/DONE/main/planning/joinorder-track2-scaling-direction-reconciliation.yaml
+++ b/_project/DONE/main/planning/joinorder-track2-scaling-direction-reconciliation.yaml
@@ -2,7 +2,7 @@ id: joinorder-track2-scaling-direction-reconciliation
 title: "decision(track2): reconcile replicated_imdb vs sampled-from-real scaling and the stale-stats/licensing caveats"
 worktree: main
 priority: Medium
-status: Identified
+status: Completed
 category: Benchmark Development
 
 description: |
@@ -49,28 +49,48 @@ deps:
 work:
   - id: w1
     summary: "Reconcile replicated_imdb (scale-up) vs sampled-from-real (scale-down) into one decision"
-    status: pending
+    status: done
     notes: |
       Compare against the stated Track-2 research question (statistics
       maintenance x predicate selectivity). Record the pick and rationale as an
       update to, or supersession of, the 2026-06-30 decision note; update the
       scaling-strategy doc's "divergence to reconcile" section accordingly.
+      Done 2026-07-04: project-owner decision = sampled-from-real first,
+      replicated_imdb deferred (prototype stays gated). Recorded in
+      _project/decisions/joinorder-track2-scaling-direction-2026-07-04.md;
+      supersession banner + qualified Recommendation line added to the
+      2026-06-30 note (its anchored `^Recommendation:` gate line intentionally
+      no longer matches, keeping the replicated prototype blocked); resolution
+      note added to the scaling-strategy doc's divergence section.
   - id: w2
     summary: "Resolve whether the offset-replication stale-stats axis is worth pursuing"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Given value-identical disjoint replicas make selectivity scale-invariant,
       state explicitly what statistics signal replicated_imdb does/doesn't expose,
       and reconcile decision-doc lines 124-125 vs 168.
+      Done 2026-07-04: resolved as "not worth pursuing for the Track-2 research
+      question" -- the axis is a uniform xN row-count staleness signal only.
+      Stated explicitly in the superseding ADR's "Why sampled-from-real"
+      section, and the 2026-06-30 note's rationale paragraph now carries the
+      bounded-signal qualification instead of the unqualified "genuine
+      statistics-maintenance axis" claim.
   - id: w3
     summary: "Tighten the licensing 'transformation not material' argument against the 'altered' term"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Address joinorder-canonical-data-licensing-2026-05-12.md:46 ("must not be
       altered") directly in the scale-stress licensing ADR, or soften "not
       material" to an explicitly-argued risk-parity judgement.
+      Done 2026-07-04 (owner chose the soften-to-risk-parity option): the
+      Posture section now concedes replication IS an alteration under the
+      upstream term, drops the "not material" claim, and argues explicit risk
+      parity with the already-accepted canonical posture; the Status header
+      records that the recommendation it was pinned for is deferred but the
+      posture stays pinned, and the superseding ADR extends the same reasoning
+      to the sampled-from-real direction.
 
 verification:
   - description: "The updated/superseding decision names exactly one chosen Track-2 scaling direction"
@@ -83,6 +103,7 @@ open_questions:
     affects:
       - "w1"
     default: "Keep both as explicitly-separate tracks; do not mix into one baseline."
+    resolved_with: "Project-owner decision 2026-07-04: scale-down (sampled-from-real) as the single Track-2 direction; replicated_imdb deferred, prototype stays gated. Recorded in _project/decisions/joinorder-track2-scaling-direction-2026-07-04.md."
 
 metadata:
   tags:

--- a/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
@@ -18,12 +18,17 @@ description: |
   recommends Option B (sampled-from-real with title-stratified preservation) as
   the leading candidate without locking in.
 
-  This is a placeholder seed at status Identified. Final design and lock-in
-  happen when Track 2 is picked up; the work units below are summary-level. The
-  parallel decision framework
-  (`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`)
-  independently recommends replicated_imdb as the lowest-risk upward baseline;
-  Track-2 kickoff reconciles the sampling (down) and replication (up) directions.
+  This is a placeholder seed at status Identified. Final design happens when
+  Track 2 is picked up; the work units below are summary-level.
+
+  Direction resolved (2026-07-04): the sampling-vs-replication divergence was
+  reconciled by project-owner decision in
+  `_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md` --
+  Track 2 implements **sampled-from-real (Option B)** as its single scaling
+  direction; replicated_imdb is deferred (its prototype seed stays gated) and
+  the 2026-06-30 decision framework's recommendation line is superseded. w1
+  below is therefore no longer a direction choice: it confirms scale-factor
+  semantics and prototype scope for the sampling axis only.
 
 deps:
   needs:
@@ -34,9 +39,11 @@ work:
     summary: "Lock in the scaling strategy from the options analysis"
     status: pending
     notes: |
-      Confirm or revise the design doc's Option B recommendation against the
-      research question at Track-2 kickoff. Decide the scale direction
-      (sampled-down vs replicated-up vs both) and the scale-factor semantics.
+      The scale direction is already decided (sampled-from-real; see the
+      2026-07-04 decision note in the description -- do not re-litigate it or
+      mix in replication). Remaining lock-in scope: scale-factor semantics for
+      the sampling axis (which fractions, how labeled), title-stratification
+      parameters, and the per-sample-point oracle regeneration plan.
 
   - id: w2
     summary: "Implement the chosen generator with a validation oracle"

--- a/_project/decisions/joinorder-scale-stress-decision-2026-06-30.md
+++ b/_project/decisions/joinorder-scale-stress-decision-2026-06-30.md
@@ -2,8 +2,18 @@
 
 Date: 2026-06-30
 
-Status: Accepted — `replicated_imdb` baseline recommended as the smallest next
-prototype; first-class statistics-phase accounting deferred to a dependency TODO.
+Status: Accepted framework; recommendation superseded 2026-07-04 (the
+`replicated_imdb` baseline pick was replaced by sampled-from-real in
+`joinorder-track2-scaling-direction-2026-07-04.md`); first-class
+statistics-phase accounting deferred to a dependency TODO.
+
+> **Recommendation superseded (2026-07-04):** the Track-2 scaling direction was
+> reconciled by project-owner decision in
+> `_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md`, which
+> picks **sampled-from-real** and defers `replicated_imdb`. This framework's
+> options analysis, validation gates, fixed-vs-parameterized split, and CI-cost
+> model remain in force; only the `replicated_imdb baseline only` recommendation
+> below is superseded.
 
 This is a decision framework, not an implementation. It decides *whether and how*
 BenchBox should add a scaled JOB-derived workload for evaluating optimizer
@@ -175,13 +185,18 @@ they publish under separate result labels.
 
 ## Recommendation and prototype scope
 
-Recommendation: replicated_imdb baseline only
+Recommendation (superseded 2026-07-04 by
+`joinorder-track2-scaling-direction-2026-07-04.md`): replicated_imdb baseline only
 
 Rationale: offset replication is the only option that (a) preserves real
 correlations, (b) reuses the canonical final-result oracle for validation, and
-(c) exposes a genuine statistics-maintenance axis (stale stats after loading
-additional replicas), all at low implementation cost and low user-mislead risk
-when labeled.
+(c) exposes a statistics-maintenance axis (stale stats after loading additional
+replicas), all at low implementation cost and low user-mislead risk when
+labeled. That axis is, however, bounded to a uniform ×N row-count staleness
+signal: because replicas are value-identical and disjoint, per-predicate
+selectivity is scale-invariant, so replication does not exercise the
+correlated/skewed mis-estimation behavior the Track-2 research question
+targets — the deciding factor in the 2026-07-04 supersession.
 It explicitly rejects **profiled graph expansion** for the first prototype:
 synthetic correlations can look plausible while destroying the very JOB signal the
 benchmark exists to measure, and graph expansion has no independent validation

--- a/_project/decisions/joinorder-scale-stress-licensing-2026-06-30.md
+++ b/_project/decisions/joinorder-scale-stress-licensing-2026-06-30.md
@@ -2,8 +2,13 @@
 
 Date: 2026-06-30
 
-Status: Pinned for `replicated_imdb` (the path recommended by
-`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`).
+Status: Pinned for `replicated_imdb` (recommended by
+`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md` at the time;
+that recommendation was superseded on 2026-07-04 by
+`joinorder-track2-scaling-direction-2026-07-04.md`, which defers
+`replicated_imdb` — this posture record stays pinned for whenever the deferred
+path is picked up, and its risk-parity reasoning is referenced by the
+superseding note for the sampled-from-real direction).
 
 This record pins the licensing posture for the recommended derived scale-up path
 so future archive publishers do not have to re-derive the analysis. It is scoped
@@ -20,10 +25,21 @@ replication of rows and keys) of the canonical IMDb-2013 Parquet archive. It add
 no new source data. Because the derived archive contains only duplicated canonical
 rows, it inherits the canonical archive's redistribution posture: the upstream
 IMDb terms limit the data to personal/non-commercial use, the Harvard Dataverse
-deposit is CC0 1.0, and CC0 does not override IMDb's retained rights. The
-transformation is **not material** to the licensing question (it does not launder
-the upstream terms), so redistribution of `replicated_imdb` carries the same
-residual risk that the project owner already accepted for canonical `joinorder`.
+deposit is CC0 1.0, and CC0 does not override IMDb's retained rights.
+
+Offset replication **is** an alteration under the upstream help-page term that
+IMDb data "must not be altered/republished/resold/repurposed"
+(`joinorder-canonical-data-licensing-2026-05-12.md`), and this record does not
+claim otherwise. The judgement here is an explicitly-argued **risk parity**
+(reworded 2026-07-04; the earlier phrasing "the transformation is not material"
+engaged only the laundering question and left the "altered" term unaddressed):
+the canonical archive's accepted posture already engages the alteration and
+republishing terms — the hosted canonical Parquet is itself a format conversion
+and re-hosting of the Dataverse deposit — and mechanical duplication of existing
+rows adds no new expressive content, does not launder the upstream terms, and
+creates no exposure of a different *kind*. Redistribution of `replicated_imdb`
+therefore carries the same accepted-not-cleared residual risk as canonical
+`joinorder`, and stands or falls with it (a takedown of one applies to both).
 
 If a future scale-up path adds genuinely new synthesized data (e.g.
 `expanded_imdb` profiled graph expansion or a fully `synthetic_schema`

--- a/_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md
+++ b/_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md
@@ -1,0 +1,97 @@
+# ADR: Track-2 JOB Scaling Direction — sampled-from-real first
+
+Date: 2026-07-04
+
+Status: Accepted (project-owner decision, 2026-07-04). Supersedes the
+recommendation section of
+`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`; the rest of
+that framework (options analysis, validation gates, fixed-vs-parameterized,
+CI-cost model) remains in force.
+
+## Decision
+
+Track 2 pursues **one** scaling direction first: **sampled-from-real**
+(Option B in `_project/design/track2-joinorder-scaling-strategy.md` —
+title-stratified downsampling of the canonical IMDb-2013 archive with
+referential-integrity preservation).
+
+`replicated_imdb` (offset replication, the 2026-06-30 framework's pick) is
+**deferred, not rejected**: its prototype seed
+(`_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml`)
+stays gated and must not start unless a future decision re-approves an upward
+axis. The two directions are not pursued as parallel tracks; a second track
+requires its own decision note. Option E (stats-only at SF=1) remains the
+correctness fallback if the sampling axis cannot be validated.
+
+## Why sampled-from-real
+
+The two documents disagreed because they answered different research questions.
+The question Track 2 is actually chartered on — recorded in
+`_project/design/track2-joinorder-stats-as-phase.md` ("Track 2's research
+question is the interplay of statistics maintenance and predicate selectivity")
+— is served by an axis on which per-predicate selectivities and correlations
+genuinely move between scale points. Title-stratified sampling provides that:
+each sample point has different predicate-match counts, different join-fanout
+distributions, and a real opportunity for the optimizer to mis-estimate.
+
+Offset replication cannot provide it. Because replicas are value-identical and
+disjoint, per-predicate selectivity is scale-invariant by construction; the
+only staleness a stats-maintenance phase can expose on replicated data is a
+uniform ×N row-count miss. That is a real but degenerate signal — it does not
+exercise the correlated/skewed mis-estimation behavior the research question
+targets. (This resolves the tension inside the 2026-06-30 note, which conceded
+"predicate selectivity drift is bounded because replicas are disjoint" while
+still describing the axis as "a genuine statistics-maintenance axis".)
+
+Replication's remaining advantage — the canonical final-result oracle is
+replica-invariant (the 113 scalar `MIN` results are unchanged), so validation
+is nearly free — is an argument about implementation cost, not about the
+research question. It is why replication stays on the shelf rather than being
+rejected: if a genuine "larger-than-SF=1" question is chartered later
+(distributed-execution thresholds, memory cliffs), replication is still the
+lowest-risk upward path.
+
+## Accepted costs
+
+- **Per-sample-point oracle regeneration.** Sampled data changes query results,
+  so each published sample point needs its own reference oracle computed with
+  the existing PostgreSQL pipeline (the `reference_cardinalities.json`
+  precedent, including known-zero tracking — downsampling will push more of the
+  113 queries to zero underlying rows at small fractions, and each sample
+  point's known-zero set must be recorded rather than assumed).
+- **The 2026-06-30 framework's validation gates apply unchanged** (FK
+  integrity, predicate-domain frequencies, join-subgraph cardinalities,
+  q-error where available). Sampling makes these gates *more* load-bearing
+  than replication would, since there is no replica-invariance shortcut.
+- **Stats-phase dependency carries over.** The sampling track inherits the same
+  gate: no publication-quality statistics-maintenance claims before
+  `track2-joinorder-stats-phase` lands.
+
+## Licensing
+
+A sampled derived archive is, like replication, an alteration of the canonical
+data. The risk-parity reasoning in
+`_project/decisions/joinorder-scale-stress-licensing-2026-06-30.md` (as
+reworded on 2026-07-04 to engage the upstream "must not be altered" term
+directly) applies a fortiori: sampling removes rows and adds no new expressive
+content, so it inherits the canonical archive's accepted redistribution posture
+under the same explicitly-argued judgement. Any *hosted* sampled archive
+re-pins attribution, provenance (source `dataset_version`, sampling fraction,
+seed), and takedown routing through the same process before publication; a
+BYO/local-generation path needs no hosted asset.
+
+## Consequences
+
+- `_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml` is the
+  implementation vehicle for the sampled-from-real axis when Track 2 is picked
+  up; its design source is the scaling-strategy groundwork doc, whose
+  "divergence to reconcile" section now records this resolution.
+- The `joinorder-replicated-imdb-scale-prototype` verification gate
+  (`grep '^Recommendation: (replicated_imdb baseline|staged combination)'`
+  over `joinorder-scale-stress-decision-*.md`) intentionally no longer passes:
+  the 2026-06-30 note's recommendation line is marked superseded, so the
+  prototype stays blocked exactly as its own w1 guardrail requires.
+- Result labeling rules from the framework are unchanged: sampled datasets
+  publish as a derived, explicitly-labeled workload (`sampled_imdb` or the
+  name the implementation TODO fixes), never as canonical JOB, and are not
+  comparable to the JOB literature.

--- a/_project/design/track2-joinorder-scaling-strategy.md
+++ b/_project/design/track2-joinorder-scaling-strategy.md
@@ -131,6 +131,14 @@ rather than sampling rows independently, which would shear the joins.
 
 This is a recommendation, not a lock-in.
 
+> **Resolved (2026-07-04):** the divergence described below was reconciled by
+> project-owner decision in
+> `_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md`:
+> Track 2 pursues **Option B (sampled-from-real)** as its single scaling
+> direction; `replicated_imdb` is deferred (its prototype seed stays gated),
+> and the two directions are not run as parallel tracks. The paragraph below
+> is kept as the record of why the reconciliation was needed.
+
 A genuine divergence to reconcile at kickoff: the separate scale-stress
 *decision framework*
 (`_project/decisions/joinorder-scale-stress-decision-2026-06-30.md`) reaches a


### PR DESCRIPTION
# Pull Request

## Description

Implements `joinorder-track2-scaling-direction-reconciliation` (the Track-2 review's decision seed) with the project-owner decisions recorded 2026-07-04: **sampled-from-real (Option B)** is the single Track-2 scaling direction; `replicated_imdb` is **deferred, not rejected**; and the licensing "not material" claim is **softened to an explicitly-argued risk-parity judgement** that engages the upstream "must not be altered" term directly.

- **New ADR** `_project/decisions/joinorder-track2-scaling-direction-2026-07-04.md` — the pick, the research-question rationale (stats maintenance × predicate selectivity favors an axis where selectivities actually move), the resolution of the degenerate stale-stats concern (replication exposes only a uniform ×N row-count staleness signal), accepted costs (per-sample-point oracle regeneration incl. per-point known-zero tracking), and licensing carry-over.
- **2026-06-30 decision framework** — Status line qualified + supersession banner; the Recommendation line is marked superseded so the replicated-imdb prototype's anchored `^Recommendation:` verification gate intentionally no longer passes (sum now 0), keeping that prototype blocked exactly as its own w1 guardrail requires. The `^Stats phase gate:` sum stays 1. The rationale paragraph now carries the bounded-signal qualification instead of the unqualified "genuine statistics-maintenance axis" claim.
- **Scale-stress licensing ADR** — Posture section concedes replication IS an alteration under the upstream term, drops "not material", and argues explicit risk parity with the already-accepted canonical posture; Status header records the deferral without unpinning the posture.
- **Scaling-strategy design doc** — divergence section marked resolved with a pointer to the ADR; original reconciliation record kept.
- **`track2-joinorder-scaling-strategy` seed** — description/w1 updated so future Track-2 implementers do not re-litigate the settled direction (was still describing the reconciliation as pending).
- **Reconciliation seed → DONE** — w1–w3 done with completion notes; gating open question carries `resolved_with`.

## Type of Change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore

## Testing

- Seed's own verification: `grep -niE 'recommend|decision|chosen|supersed'` on the 2026-06-30 doc now states a single chosen direction + supersession ✅
- Prototype gate regression check: `^Recommendation: (replicated_imdb baseline|staged combination)` sums to **0** across `joinorder-scale-stress-decision-*.md` (prototype stays blocked); `^Stats phase gate:` sums to **1** ✅
- `validate_todo.py` ✅ on both touched seeds; `todo_cli.py check-graph` ✅ (105 items, no cycles/dangling refs)

## Public Contract Check

- [x] This PR does not change public/beta/deprecated/generated/experimental/repo-only contract surfaces (internal `_project/` decision/design/planning docs only).
- [x] No result-schema / MCP-parameter / platform-support / wrapper / adapter-hook / generated-doc impact.
- [x] No platform/benchmark count claim added to shipped docs.

## Documentation

- [x] No user-facing docs changed (internal decision records only).
- [x] No behavior change.
- [x] API contract wording unaffected.

## Code Quality

- [x] No code changed; seeds validated with `validate_todo.py` + `check-graph`.
- [x] No backwards-compat/migration impact.
- [x] N/A — no behavior change.
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or binaries committed — markdown/YAML text only.

## Notes

- Decisions were made by the project owner in-session (direction, licensing framing, release-asset restore); this PR records the first two. The release-asset restore itself remains owner action under the seed merged in #951.
- Code review (high effort) ran on this diff; both findings (stale co-recommendation text in the strategy seed; unqualified `^Status:` line in the superseded doc) were fixed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh)_