### PR TITLE
docs(blog): Spark AQE deep-dive outline and evidence verification file

### DIFF
--- a/_blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md
+++ b/_blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md
@@ -1,0 +1,263 @@
+# Outline: Spark Adaptive Query Execution and the Stage-Boundary Advantage
+
+**Post type:** Platform deep-dive / architecture (execution models, not platform verdicts).
+**Target length:** 2,000-2,500 words.
+**Editorial angle:** Not "Spark solved re-optimization and others have not."
+Thesis: every engine faces the same problem (cardinality estimates go wrong,
+data is skewed), and where an engine can adapt is determined by its execution
+model, not by how advanced it is. Spark's blocking shuffle gives it a natural
+mid-query re-optimization point, and AQE is the direct exploitation of that
+point. Engines with pipelined executors adapt inside operators (Oracle, SQL
+Server, ClickHouse), engines that add a spooling shuffle gain stage-level
+adaptation exactly when they add it (Trino under fault-tolerant execution,
+BigQuery), and single-node engines have no shuffle boundary for this problem to
+live at (DuckDB). Architectural fit, not maturity.
+
+**Evidence source:** `_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md`.
+Every external claim cites a dated entry there, with its real provenance
+(verbatim from official Apache mirrors vs search-derived, labeled). BenchBox
+source findings cite file and line. No BenchBox benchmark run is claimed
+anywhere: the performance figures quoted are Databricks' own published TPC-DS
+numbers, attributed to Databricks, and the BenchBox measurement plan is written
+explicitly as future work.
+
+**Voice reminders:** "we", neutral on platforms, architectural fit not
+maturity, data over superlatives, no em-dashes or en-dashes, define terms on
+first use, footnote external facts, cite BenchBox source as file:line.
+
+## Title + frontmatter
+
+- Title (< 60 chars): "Spark AQE: Re-Optimizing Queries at Stage Boundaries"
+- One-sentence summary: how Spark re-plans queries mid-flight, why its
+  execution model makes that practical, and how other engines answer the same
+  problem differently.
+- TL;DR (2-3 sentences): optimizers guess cardinalities before execution and
+  the guesses are often wrong. Spark's shuffle boundaries fully materialize
+  intermediate results, so AQE can re-plan with exact sizes between stages.
+  Other engines adapt too, but at the points their own execution models make
+  available.
+- meta_description (150-160 chars); tags: spark, adaptive-query-execution,
+  query-optimization, data-skew, tpch-skew, benchmarking, architecture,
+  execution-models.
+
+## 1. Introduction (200-300 words)
+
+- The hook: the optimizer's oldest problem. Cost-based optimizers pick plans
+  from estimated cardinalities; estimates compound badly across joins, and a
+  wrong join strategy or partition count is locked in before the first row
+  moves. Define cardinality estimation in one parenthetical.
+- The question we explore: what does it take, architecturally, to change your
+  mind mid-query? Spark's AQE (GA in Spark 3.0, on by default since 3.2.0,
+  research file A1) is the best-known answer; it is not the only one.
+- Scope statement: this is an architecture post. We compare adaptation
+  mechanisms, not engine performance. No BenchBox timings are claimed; we close
+  with the measurement plan we intend to run.
+
+## 2. What AQE actually does (450-550 words)
+
+- 2a. The re-optimization loop. Shuffle and broadcast exchanges break the
+  operator pipeline; Databricks calls these materialization points, and query
+  stages are the plan sections between them. When a stage finishes, AQE feeds
+  exact output statistics back into the logical plan, re-runs the optimizer,
+  and launches whichever stages are now ready (A6, labeled as Databricks'
+  description). Execute, re-optimize, execute.
+- 2b. Feature 1: dynamic partition coalescing. The fixed
+  `spark.sql.shuffle.partitions` (default 200) problem: too many small tasks
+  for small intermediates, scheduling overhead. AQE merges post-shuffle
+  partitions toward `advisoryPartitionSizeInBytes` (64 MB default) using map
+  output statistics (A2).
+- 2c. Feature 2: sort-merge join to broadcast join switching. If a join side
+  turns out smaller than the adaptive broadcast threshold at run time, AQE
+  swaps in a broadcast hash join; the local shuffle reader mitigates the
+  already-paid shuffle write cost (A3, verbatim quote available).
+- 2d. Feature 3: skew join splitting. A partition counts as skewed when it
+  exceeds both 5x the median partition size and 256 MB (defaults); AQE splits
+  the oversized partition into subpartitions and replicates the matching build
+  side so the straggler becomes several evenly sized tasks (A4).
+- 2e. What it bought, per Databricks: 8x on TPC-DS q77, 2x on q5, more than
+  1.1x on 26 further queries at 1TB with statistics collection disabled.
+  Attribute clearly to Databricks, note the no-statistics setup is the
+  best-case scenario for a runtime re-optimizer, and note the Spark 3.0
+  release's overall 2x TPC-DS claim covers the whole release, not AQE alone
+  (A5, A6; both search-derived, labeled).
+
+## 3. Why the stage boundary makes it practical (350-450 words)
+
+- The load-bearing architectural fact: Spark's shuffle is blocking. The map
+  side of an exchange runs to completion and materializes its output before
+  the reduce side starts. That gives the scheduler (a) a natural pause point
+  where nothing downstream has started, and (b) exact statistics (per-partition
+  sizes from the map output) instead of estimates.
+- Re-optimizing here is cheap and safe: no running operators to unwind, no
+  partial results to discard. The plan for completed stages is frozen; only
+  the not-yet-started remainder is re-planned (A6 mechanism description).
+- The general principle we will reuse for every other engine: runtime
+  adaptation needs a point where (1) accurate statistics exist and (2)
+  changing course is cheap. Execution models differ mainly in where, and
+  whether, such points exist.
+- Honest cost note: the same blocking materialization that enables AQE is
+  overhead a fully pipelined engine avoids; stage boundaries are a trade, not
+  a free lunch. This keeps the comparison symmetric and neutral.
+
+## 4. The same problem, other execution models (600-750 words)
+
+Framing sentence up front: every engine below confronts misestimated
+cardinalities and skew; each adapts where its execution model gives it a
+foothold. Survey order groups by mechanism, not by vendor ranking.
+
+- 4a. Operator-level adaptation inside a pipelined plan.
+  <!-- content-ok: restricted_vendor -->
+  - Oracle Database (12c+ Adaptive Query Optimization): adaptive plans embed a
+    default subplan, precompiled alternatives, and a statistics collector row
+    source that buffers rows during first execution; cross the row-count
+    inflection point and the operator switches (nested loops to hash join is
+    the canonical case), then the decision sticks (C1).
+  - SQL Server (Intelligent Query Processing): batch mode adaptive joins
+    (2017, compatibility level 140) defer the hash-vs-nested-loops choice
+    until the build input has been scanned, comparing actual rows to a
+    precomputed threshold; the IQP family adds between-execution feedback
+    (memory grants) and interleaved execution for multi-statement
+    table-valued functions (C2).
+  - Common shape: choose among precompiled alternatives at specific operators
+    while the plan runs. Fits a pipelined, single-system executor where a full
+    stop-and-replan point does not exist.
+- 4b. Stage-level adaptation where a materializing shuffle exists.
+  - Trino: adaptive plan optimizations (adaptive join reordering, adaptive
+    partitioning) exist only when fault-tolerant execution is enabled, which
+    spools intermediate exchange data through an exchange manager. Trino's
+    default executor pipelines all stages concurrently and streams exchanges,
+    so there is nothing to re-plan around; add spooled exchanges and the
+    adaptation point appears. Strongest single piece of evidence for the
+    thesis (C3).
+  - BigQuery: Google's docs state the plan can be modified while the query
+    runs; repartition and coalesce stages are inserted dynamically around the
+    in-memory shuffle tier and hidden from the displayed plan (C5). Note
+    explicitly that this corrects a common framing of BigQuery as purely
+    compile-time (our research file logs the correction).
+- 4c. Reducing the need instead: Snowflake. Cascades-style top-down
+  cost-based optimization over automatically maintained metadata; the SIGMOD
+  2016 paper describes deliberately postponing some decisions (join data
+  distribution type) to execution time and leaning on per-micro-partition
+  metadata for aggressive pruning (C4). Frame precisely: a different
+  architectural answer (keep estimates from mattering as much) rather than a
+  missing feature. Also note our research file flags and discards a search
+  artifact claiming Snowflake is rule-based.
+- 4d. No shuffle boundary at all: single-node engines.
+  - DuckDB: push-based vectorized pipelines with morsel-driven parallelism;
+    pipeline breakers are shared-memory hash tables, not a distributed
+    shuffle. The 200-partitions problem does not exist; skew shows up as
+    thread load imbalance, absorbed at morsel granularity (C6).
+  - ClickHouse: vectorized execution; plan operators can swap themselves for
+    external (spilling) variants at run time based on memory pressure.
+    Runtime adaptivity exists, but it is resource-driven and operator-local,
+    not cardinality-driven re-planning (C7).
+- 4e. One-paragraph synthesis table (mechanism, trigger, granularity, when it
+  can act) with no winner column.
+
+## 5. What we found wiring AQE into BenchBox (250-350 words)
+
+First-party section, all file:line citations, no external footnotes.
+
+- BenchBox's Spark adapter enables all three AQE features by default
+  (`benchbox/platforms/spark.py:439-443`), matching upstream defaults.
+- Honest harness findings from this research (stated as bugs/limitations we
+  intend to fix, in the technical-challenge voice):
+  - The `--adaptive-enabled` CLI flag is `action="store_true", default=True`
+    (`spark.py:300`), so the command line can enable AQE but never disable it.
+  - A `spark_config` override can turn AQE off at session build time because
+    user config merges last (`spark.py:486`), but `configure_for_benchmark`
+    re-enables AQE on the live session for OLAP benchmark types before
+    queries run (`spark.py:653-669`, called from
+    `benchbox/platforms/base/adapter.py:493-494`). A clean AQE-off run
+    through `benchbox run` therefore currently requires a code change.
+  - Fixing both is the prerequisite for the measurement plan below; tracked
+    as a TODO.
+- The asset side: the TPC-H Skew benchmark generates Zipfian skew with
+  presets `none` through `extreme` (z=0.2 to z=1.0)
+  (`benchbox/core/tpch_skew/skew_config.py:29-37`), selectable via
+  `--benchmark-option skew_preset=heavy`, and its join-skew knobs target
+  exactly the relationships skew-join splitting exists for
+  (`skew_config.py:74-100`). The Spark adapter is plan-capture eligible
+  (`spark.py:199`), so plan diffs (AQE on vs off) are capturable, not just
+  timings.
+
+## 6. Planned methodology: measuring AQE with BenchBox (300-400 words)
+
+Written entirely in the future tense. Nothing here has been run; say so in the
+first sentence and again in Limitations.
+
+- Design: AQE on vs AQE off (after the harness fix), same hardware, same data,
+  cold cache, median of 5, plan capture enabled for both runs.
+- Skew axis: TPC-H Skew at SF10, presets `none`, `moderate`, `heavy`,
+  `extreme`. Candidate queries for skew-join splitting: Q21 and Q9 (largest
+  multi-way joins over lineitem, where Zipfian supplier and part skew
+  concentrates).
+- Join-strategy axis: Q5, Q7, Q8 (join trees where a filtered dimension side
+  can shrink below the broadcast threshold at run time).
+- Coalescing axis: Q3, Q5, Q7, Q18 with deliberately oversized
+  `spark.sql.shuffle.partitions` to give coalescing room to act.
+- Negative control: uniform SF10 (preset `none`), where we expect AQE close to
+  neutral; a large win there would indicate a methodology problem, not an AQE
+  win. State this expectation up front as falsifiable.
+- Deliverable: plan-capture diffs showing the switched join operators and
+  coalesced partition counts alongside timings, so readers can see what
+  changed, not just how long it took.
+
+## 7. Methodology notes + Limitations (150-250 words)
+
+- All Spark documentation quotes verified against official Apache doc mirrors
+  (access date 2026-07-04); all other vendor claims are search-derived because
+  this research environment could not fetch the primary pages, and are labeled
+  with that provenance in the research file. Re-verify before publishing the
+  draft.
+- Databricks' TPC-DS figures are Databricks' numbers from 2020 on a
+  statistics-free setup; they bound the opportunity, not typical gains.
+- No BenchBox measurements exist yet; section 6 is a plan.
+- The survey covers documented GA behavior only; no engine's roadmap is
+  speculated about.
+
+## 8. Conclusions + Next steps (150-250 words)
+
+- Restate the thesis in one paragraph: where an engine can adapt is a property
+  of its execution model. Spark re-plans between stages because its shuffle
+  materializes; pipelined engines adapt inside operators; adding a spooling
+  shuffle adds the capability; single-node engines relocate the problem.
+- No engine ranking. The practical takeaway for benchmark users: know which
+  adaptation your engine performs and design experiments (skewed data,
+  disabled statistics, on/off toggles) that actually exercise it.
+- Invite reproduction and contribution: the TPC-H Skew presets and the
+  planned AQE experiment; link the research file; open an issue to discuss.
+
+## References (footnotes)
+
+- Apache Spark Performance Tuning docs, 3.2.0 (downloads.apache.org mirror)
+  and 3.5.1 (archive.apache.org), accessed 2026-07-04: AQE definition,
+  default-on since 3.2.0, all config keys and defaults.
+- Spark 3.0.0 release notes (spark.apache.org), search-derived 2026-07-04.
+- Databricks, "Adaptive Query Execution: Speeding Up Spark SQL at Runtime",
+  2020-05-29, search-derived 2026-07-04.
+- Oracle Database SQL Tuning Guide, Adaptive Query Optimization chapter,
+  search-derived 2026-07-04.
+- Microsoft Learn, Intelligent Query Processing and adaptive joins;
+  Microsoft SQL Server blog 2017-09-28, search-derived 2026-07-04.
+- Trino documentation, Adaptive plan optimizations and Fault-tolerant
+  execution, search-derived 2026-07-04.
+- Dageville et al., "The Snowflake Elastic Data Warehouse", SIGMOD 2016,
+  search-derived 2026-07-04.
+- Google Cloud, BigQuery query plan and timeline documentation,
+  search-derived 2026-07-04.
+- DuckDB documentation and execution-model material; ClickHouse architecture
+  overview (VLDB 2024 paper mirror), search-derived 2026-07-04.
+
+## TODOs before drafting
+
+- [ ] Re-verify every search-derived claim (research file Part C, A5, A6)
+      against the live primary pages from an unrestricted network, and
+      upgrade or soften provenance labels accordingly.
+- [ ] Spot-check Spark 3.5.1-quoted defaults against the current 4.x docs.
+- [ ] File and fix the two AQE-toggle harness issues (research file B2, B4)
+      so the AQE on/off comparison in section 6 is actually runnable.
+- [ ] Run the section 6 plan; replace the future tense with measured results
+      and move the resulting evidence into the research file with dates.
+- [ ] Draft the synthesis table (4e) and check it reads neutrally with the
+      content validation checklist in `_blog/STYLE_GUIDE.md`.

--- a/_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md
+++ b/_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md
@@ -1,0 +1,421 @@
+# Spark Adaptive Query Execution: Claim Verification
+
+> Evidence log for the platform-deep-dive post on Apache Spark's Adaptive Query
+> Execution (AQE): what the three GA features do, why Spark's stage-boundary
+> execution model makes runtime re-optimization practical there specifically, and
+> how other engines approach the same class of problem (re-optimization under bad
+> cardinality estimates and data skew). Every claim in the outline and eventual
+> draft must trace to a dated entry here. BenchBox first-party source findings and
+> external documentation claims are kept strictly separate and labeled with their
+> real verification confidence.
+
+## Objective
+
+Ground the post in three tiers of evidence:
+
+1. First-party: BenchBox source code, verified by reading the files at the cited
+   commit (no external footnote needed, file and line cited instead).
+2. Primary-source verified: verbatim quotes fetched directly from official
+   documentation, with access dates.
+3. Search-derived: claims where the primary page could not be fetched from this
+   session's network environment. These are labeled "as reported by search
+   summary, not diffed against the live page" and carry lower confidence. None of
+   them are presented in quotation marks as verbatim text.
+
+No BenchBox benchmark runs were performed for this research. No performance
+result in this file or in the outline is a BenchBox result. The only performance
+figures cited are Databricks' own published TPC-DS numbers, attributed to
+Databricks.
+
+## Dates and Network Environment
+
+- Research access date: 2026-07-04 (all fetch and search attempts below).
+- BenchBox source verified at commit `5fe58367` (tip of `develop`, 2026-07-04).
+- Network constraint: direct fetches to spark.apache.org, databricks.com,
+  docs.oracle.com, learn.microsoft.com, trino.io, trinodb.github.io,
+  docs.snowflake.com, cloud.google.com, and cs.cmu.edu all returned HTTP 403
+  from this session's egress policy (gateway CONNECT denial). The official
+  Apache documentation mirrors at downloads.apache.org and archive.apache.org
+  WERE reachable, so all Spark documentation quotes below are verbatim from
+  official Apache-hosted copies. Everything else fell back to web search and is
+  labeled accordingly.
+
+---
+
+## Part A: Spark AQE from official Apache documentation (verified, 2026-07-04)
+
+Quotes in this part are verbatim from official Apache mirror copies of the Spark
+documentation (downloads.apache.org and archive.apache.org host the same doc
+bundles that spark.apache.org serves). Confidence: high, primary source.
+
+### A1. What AQE is, and enabled by default since Spark 3.2.0
+
+- Source: <https://downloads.apache.org/spark/docs/3.2.0/sql-performance-tuning.html>
+  (official Apache mirror of the Spark 3.2.0 docs), fetched 2026-07-04.
+- Verbatim: "Adaptive Query Execution (AQE) is an optimization technique in
+  Spark SQL that makes use of the runtime statistics to choose the most
+  efficient query execution plan, which is enabled by default since Apache
+  Spark 3.2.0."
+- The umbrella configuration is `spark.sql.adaptive.enabled` (default `true`
+  since 3.2.0; AQE shipped GA but default-off in Spark 3.0.x and 3.1.x).
+- The docs list three major features: coalescing post-shuffle partitions,
+  converting sort-merge join to broadcast join, and skew join optimization.
+
+### A2. Dynamic partition coalescing
+
+- Source: same 3.2.0 page as A1, plus
+  <https://archive.apache.org/dist/spark/docs/3.5.1/sql-performance-tuning.html>
+  (official Apache archive of the Spark 3.5.1 docs), both fetched 2026-07-04.
+- Verbatim (3.2.0): "This feature coalesces the post shuffle partitions based
+  on the map output statistics when both spark.sql.adaptive.enabled and
+  spark.sql.adaptive.coalescePartitions.enabled configurations are true."
+- `spark.sql.adaptive.coalescePartitions.enabled` default: `true`.
+- `spark.sql.adaptive.advisoryPartitionSizeInBytes` default: 64 MB (3.5.1 docs).
+
+### A3. Sort-merge join to broadcast join conversion
+
+- Source: 3.5.1 archive page as in A2, fetched 2026-07-04.
+- Verbatim: "AQE converts sort-merge join to broadcast hash join when the
+  runtime statistics of any join side is smaller than the adaptive broadcast
+  hash join threshold."
+- `spark.sql.adaptive.autoBroadcastJoinThreshold` default: "(none)", falling
+  back to `spark.sql.autoBroadcastJoinThreshold`.
+- Verbatim (local shuffle reader, same page): "Spark tries to use local shuffle
+  reader to read the shuffle data when the shuffle partitioning is not needed"
+  (`spark.sql.adaptive.localShuffleReader.enabled`, default `true`). This is
+  the mitigation for the fact that the shuffle map side has already run by the
+  time the join strategy is switched.
+
+### A4. Skew join splitting
+
+- Source: 3.2.0 mirror page (A1) and 3.5.1 archive page (A2), fetched 2026-07-04.
+- Verbatim (3.2.0): "This feature dynamically handles skew in sort-merge join by
+  splitting (and replicating if needed) skewed tasks into roughly evenly sized
+  tasks. It takes effect when both spark.sql.adaptive.enabled and
+  spark.sql.adaptive.skewJoin.enabled configurations are enabled."
+- Defaults (3.5.1 config table): `spark.sql.adaptive.skewJoin.enabled` = `true`,
+  `spark.sql.adaptive.skewJoin.skewedPartitionFactor` = 5.0,
+  `spark.sql.adaptive.skewJoin.skewedPartitionThresholdInBytes` = 256 MB,
+  `spark.sql.adaptive.forceOptimizeSkewedJoin` = `false`.
+- A partition is treated as skewed when it is both larger than the median
+  partition size times the skew factor and larger than the absolute threshold
+  (both conditions, per the config descriptions on the same page).
+
+### A5. Spark 3.0 release framing and headline numbers
+
+- Provenance: SEARCH-DERIVED. spark.apache.org returned HTTP 403; the release
+  notes page (<https://spark.apache.org/releases/spark-release-3-0-0.html>) could
+  not be fetched. As reported by search summary, not diffed against the live
+  page. Confidence: medium; consistent across multiple independent results.
+- As reported: AQE is one of the headline features of Spark 3.0 (2020), and the
+  Spark 3.0 announcement material describes roughly 2x speedup over Spark 2.4
+  on a TPC-DS 30TB benchmark for the release overall (not AQE alone).
+- Draft handling: attribute the 2x figure to the Spark 3.0 announcement, note
+  it covers the whole release, and do not present it as an AQE-only or
+  BenchBox-measured number.
+
+### A6. Databricks' AQE explanation and TPC-DS figures
+
+- Provenance: SEARCH-DERIVED. databricks.com returned HTTP 403. Source page:
+  "Adaptive Query Execution: Speeding Up Spark SQL at Runtime", Databricks
+  blog, 2020-05-29,
+  <https://www.databricks.com/blog/2020/05/29/adaptive-query-execution-speeding-up-spark-sql-at-runtime.html>.
+  As reported by search summary, not diffed against the live page. Confidence:
+  medium-high; the mechanism description matches the Apache docs (Part A1-A4)
+  and the figures are widely and consistently reproduced.
+- Mechanism, as reported: a shuffle or broadcast exchange breaks the operator
+  pipeline; the blog calls these "materialization points" and uses "query
+  stages" for the plan subsections bounded by them. When a stage finishes
+  materializing, AQE updates the logical plan with runtime statistics, re-runs
+  the optimizer with adaptive-execution rules, and then executes whichever new
+  stages have all child stages materialized, repeating execute-reoptimize-execute
+  until the query completes.
+- Performance figures, as reported and ATTRIBUTED TO DATABRICKS (not BenchBox):
+  on a 1TB TPC-DS benchmark run without pre-collected statistics, Databricks
+  reported AQE giving about 8x on q77, about 2x on q5, and more than 1.1x on
+  another 26 queries.
+- Draft handling: every use of these numbers names Databricks as the source and
+  states the no-statistics setup, since that setup is favorable to a runtime
+  re-optimizer by construction.
+
+---
+
+## Part B: BenchBox first-party source verification (2026-07-04, commit 5fe58367)
+
+Verified by reading the source files directly. No external citation needed;
+cite file and line in the draft.
+
+### B1. BenchBox enables all three AQE features for Spark by default
+
+- `benchbox/platforms/spark.py:235`: `adaptive_enabled` defaults to `True`.
+- `benchbox/platforms/spark.py:439-443`: when enabled, the session conf sets
+  `spark.sql.adaptive.enabled`, `spark.sql.adaptive.coalescePartitions.enabled`,
+  and `spark.sql.adaptive.skewJoin.enabled` to `"true"`.
+
+### B2. The `--adaptive-enabled` CLI flag can never disable AQE
+
+- `benchbox/platforms/spark.py:300`: the flag is declared
+  `action="store_true", default=True`. Passing `--adaptive-enabled` sets `True`;
+  omitting it leaves the default `True`. There is no CLI spelling that produces
+  `False`. Disabling AQE from the command line is therefore not currently
+  possible; it requires the Python API (`adaptive_enabled=False`) or a
+  `spark_config` override.
+
+### B3. `spark_config` merges last at session build time
+
+- `benchbox/platforms/spark.py:486`: `conf.update(self.spark_config)` is the
+  final step of `_get_spark_conf`, so user-provided keys (for example
+  `spark.sql.adaptive.enabled: "false"`) override the adapter's defaults in the
+  SparkSession builder configuration.
+
+### B4. But `configure_for_benchmark` re-enables AQE for OLAP benchmarks at run time
+
+- `benchbox/platforms/spark.py:653-669`: for benchmark types `olap`,
+  `analytics`, `tpch`, `tpcds`, and `joinorder`, the adapter calls
+  `spark.conf.set("spark.sql.adaptive.enabled", "true")` (plus the coalesce and
+  skew-join keys) on the live session.
+- `benchbox/platforms/base/adapter.py:493-494`: `run_benchmark` calls
+  `configure_for_benchmark` before query execution, with `benchmark_type`
+  defaulting to `"olap"`.
+- Net effect: in the standard `benchbox run` pipeline, a session-level AQE
+  disable (via B3) is overwritten before queries execute. A true AQE-off
+  comparison run through the CLI pipeline currently requires a code change, not
+  just configuration. The draft states this plainly as a harness limitation we
+  found while researching the post, and the planned methodology (Part D of the
+  outline) lists fixing it as a prerequisite.
+
+### B5. TPC-H Skew presets
+
+- `benchbox/core/tpch_skew/skew_config.py:29-37`: presets `none` (uniform),
+  `light` (z=0.2), `moderate` (z=0.5, the `SkewConfiguration` default at
+  line 146), `heavy` (z=0.8), `extreme` (z=1.0, Zipf's law), and `realistic`
+  (e-commerce pattern, skew factor 0.6).
+- `benchbox/core/tpch_skew/skew_config.py:74-100`: join skew configuration
+  covers exactly the relationships that stress skewed joins:
+  customer-to-orders, part-to-lineitem, supplier-to-lineitem, and
+  lineitem-per-order variance.
+- Zipfian distribution is the default generator (`distribution_type="zipfian"`,
+  line 149).
+
+### B6. Skew preset selection from the CLI
+
+- `benchbox/cli/commands/run.py:2679`: `--benchmark-option skew_preset=heavy`
+  is the documented CLI path for `tpch_skew`.
+- `benchbox/tpch_skew.py:73-104`: the `TPCHSkew` benchmark accepts
+  `skew_preset` directly in the Python API.
+
+### B7. Plan capture eligibility
+
+- `benchbox/platforms/spark.py:199`: `plan_capture_phase_eligible = True`. The
+  Spark adapter participates in BenchBox's plan capture phase, which is the
+  hook a future AQE post could use to show `EXPLAIN`-level plan differences
+  (initial vs adaptively re-optimized plan) rather than timings alone.
+
+---
+
+## Part C: Other engines (search-derived unless noted, 2026-07-04)
+
+Direct fetches to every vendor documentation site in this part returned HTTP
+403 (see Dates and Network Environment). All entries below are therefore
+labeled: as reported by search summary, not diffed against the live page.
+Claims that conflicted with better-established sources were dropped, and one
+known search-summarizer artifact is flagged in C4.
+
+### C1. Oracle Database: Adaptive Query Optimization (12c and later)
+
+- Intended primary sources: Oracle Database SQL Tuning Guide, "Adaptive Query
+  Optimization" chapter (docs.oracle.com), and the Oracle Optimizer team blog.
+  Confidence: medium-high; the mechanism is consistently described across
+  Oracle's own tuning guide summaries, oracle-base.com, and multiple
+  practitioner writeups.
+- As reported: an adaptive plan contains a default plan plus predetermined
+  alternative subplans, with an "optimizer statistics collector" row source
+  inserted at key points. During the first execution, the collector buffers
+  rows and counts cardinality; if the actual row count crosses an inflection
+  point, execution switches to the alternative subplan (the canonical example
+  is nested loops switching to hash join). Once the choice is made, the
+  collector stops buffering and the decision sticks for subsequent executions.
+- Architectural contrast for the draft: the adaptation happens inside a single
+  running rowsource tree, choosing among precompiled alternatives for specific
+  operators. It does not re-run the whole optimizer mid-query the way AQE
+  re-optimizes at stage boundaries. Related 12c features (statistics feedback,
+  SQL plan directives) adapt future executions rather than the current one.
+
+### C2. Microsoft SQL Server: Intelligent Query Processing and Batch Mode Adaptive Joins
+
+- Intended primary sources: learn.microsoft.com "Intelligent query processing"
+  and "Understanding Adaptive joins" pages, and the Microsoft SQL Server blog
+  post "Enhancing query performance with Adaptive Query Processing in SQL
+  Server 2017" (2017-09-28). Confidence: medium-high; consistent across
+  Microsoft's own blog, Microsoft Learn summaries, and SQLPerformance.com.
+- As reported: batch mode adaptive joins shipped in SQL Server 2017 (database
+  compatibility level 140). The adaptive join operator defers the choice
+  between a hash join and a nested loops join until after the first (build)
+  input has been scanned; the optimizer computes a row-count threshold from the
+  crossover point of the two alternatives' costs, and at run time the actual
+  build-side row count picks the algorithm. Batch mode originally required a
+  columnstore index; SQL Server 2019 added batch mode on rowstore. The wider
+  IQP family also includes memory grant feedback (right-sizing grants between
+  executions) and interleaved execution for multi-statement table-valued
+  functions (pausing optimization to get a real cardinality, then resuming).
+- Architectural contrast for the draft: like Oracle, this is operator-level
+  adaptation between precompiled alternatives inside one plan, plus
+  between-execution feedback. There is no mid-query global re-optimization
+  step, and in a non-staged pipelined executor there is no natural point where
+  the full intermediate result is materialized and can be re-planned around.
+
+### C3. Trino: adaptive plan optimizations, gated behind fault-tolerant execution
+
+- Intended primary sources: trino.io/docs/current/optimizer/adaptive-plan-optimizations.html
+  and trino.io/docs/current/admin/fault-tolerant-execution.html. Confidence:
+  medium-high; the docs pages are directly indexed and their summaries agree
+  with the Trino project's own episode notes and GitHub issues.
+- As reported: Trino's adaptive plan optimizations adjust plans during
+  execution based on runtime statistics, and they are only available when
+  fault-tolerant execution (FTE) is enabled; the umbrella switch is
+  `fault-tolerant-execution-adaptive-query-planning-enabled`. Documented
+  optimizations include adaptive join reordering (swapping build and probe
+  sides based on actual input sizes, useful when table statistics are missing)
+  and adaptive partitioning adjustments. FTE works by spooling intermediate
+  exchange data through an exchange manager so tasks can be retried.
+- Architectural contrast for the draft: this is the strongest supporting
+  evidence for the stage-boundary thesis. Trino's default pipelined,
+  all-stages-running-at-once executor streams data between stages and has no
+  materialization point to re-plan at. Turning on FTE makes exchanges spooled
+  and stage-like, and exactly then runtime re-optimization becomes available.
+  The capability follows the execution model, in both directions.
+
+### C4. Snowflake: cost-based optimization, decisions postponed but not re-planned mid-query
+
+- Intended primary source: "The Snowflake Elastic Data Warehouse", SIGMOD 2016
+  (dl.acm.org/doi/10.1145/2882903.2903741). Confidence: medium-high for the
+  paper's optimizer description; the same sentences are quoted consistently
+  across multiple independent summaries.
+- As reported from the paper: Snowflake's optimizer is built on a
+  Cascades-style approach with top-down cost-based optimization; statistics
+  are automatically maintained on load and update; and the plan search space
+  is reduced by postponing many decisions until execution time, for example
+  the type of data distribution for joins.
+- FLAGGED ARTIFACT (do not use): a prior research pass surfaced a search
+  result claiming "Snowflake uses a rule-based query optimizer." This
+  contradicts the SIGMOD paper's cost-based description and is treated as a
+  search-summarizer artifact. It does not appear in the outline or draft.
+- Architectural contrast for the draft: Snowflake reduces its exposure to bad
+  compile-time estimates by keeping fresh metadata (per-micro-partition
+  min/max and distinct-value metadata drives aggressive pruning) and by
+  deferring some physical decisions into the execution layer, rather than by
+  re-invoking the optimizer at runtime. Frame as a different architectural
+  answer to the same estimation problem, not as an absence.
+
+### C5. Google BigQuery: dynamic plan adjustment during execution
+
+- Intended primary source: cloud.google.com/bigquery/docs/query-plan-explanation
+  ("Query plan and timeline") and the Google Cloud blog "BigQuery Admin
+  reference guide: Query processing". Confidence: medium-high; Google's own
+  docs summaries are explicit.
+- As reported: BigQuery can modify the query plan while a query is running.
+  The engine introduces repartition and coalesce stages dynamically to
+  rebalance data distribution across workers; these runtime-inserted stages
+  are hidden from the displayed plan. Stages communicate through a distributed
+  in-memory shuffle tier.
+- IMPORTANT CORRECTION TO THE POST'S STARTING FRAME: the original framing
+  grouped BigQuery with "compile-time optimization plus elastic scale." That
+  is not accurate per Google's own documentation: BigQuery does adapt its plan
+  at runtime, specifically around shuffle boundaries, much like Spark's
+  coalescing. The outline places BigQuery in the "adapts at shuffle
+  boundaries" group and reserves the compile-time-plus-metadata framing for
+  Snowflake (which the SIGMOD paper supports). The honest generalization is:
+  engines with a materializing or spooling shuffle tier (Spark, BigQuery,
+  Trino under FTE) adapt between stages; engines without one adapt inside
+  operators or not at all.
+
+### C6. DuckDB: no shuffle boundary to re-optimize at
+
+- Intended primary sources: DuckDB documentation and the DuckDB team's
+  published execution-model material. Confidence: medium-high; consistent
+  across the project's own docs and multiple independent architecture
+  writeups.
+- As reported: DuckDB is an in-process, single-node engine using vectorized
+  execution (roughly 2,048-value vectors), push-based pipelines, and
+  morsel-driven parallelism, parallelizing one pipeline at a time across
+  threads. There is no distributed shuffle: pipeline breakers (hash tables for
+  joins and aggregates) live in shared memory.
+- Architectural contrast for the draft: the entire problem AQE solves at the
+  200-partition shuffle boundary (wrong partition counts, stragglers from
+  skewed partitions, choosing distributed join strategies) does not exist in
+  the same form. Skew still affects hash-table build sizes and thread load
+  balance, but morsel-driven scheduling absorbs much of it at a different
+  granularity. Do not claim DuckDB "cannot" adapt; claim the stage-boundary
+  adaptation point does not exist in its model.
+
+### C7. ClickHouse: local runtime adaptivity inside operators
+
+- Intended primary source: the ClickHouse architecture overview
+  (clickhouse.com/docs/academic_overview, which mirrors the VLDB 2024 paper
+  "ClickHouse - Lightning Fast Analytics for Everyone"). Confidence: medium;
+  as reported by search summary.
+- As reported: ClickHouse uses vectorized execution in the MonetDB/X100
+  lineage, processing chunks of roughly 1,024 to 4,096 values, with
+  multi-threaded parallelism on each server. Its plan operators can create
+  other operators at run time, primarily to switch to external (spilling)
+  aggregation or join implementations based on memory consumption.
+- Architectural contrast for the draft: this is runtime adaptivity, but of a
+  local, resource-driven kind (switch this operator's implementation when
+  memory runs out), not cardinality-driven re-planning of downstream joins.
+  Same neutral framing as DuckDB: a different execution model puts the
+  adaptation point somewhere else.
+
+---
+
+## Part D: Cross-check (outline claim to evidence)
+
+- Claim: "AQE re-optimizes using runtime statistics and is enabled by default
+  since Spark 3.2.0." Evidence: A1 (verbatim, official mirror).
+- Claim: "The three GA features are partition coalescing, sort-merge-to-broadcast
+  join switching, and skew-join splitting, with defaults 64MB advisory
+  partitions, 5.0 skew factor, 256MB skew threshold." Evidence: A2, A3, A4
+  (verbatim, official mirror).
+- Claim: "Shuffle and broadcast exchanges are materialization points; AQE
+  re-plans when stages finish materializing." Evidence: A6 (search-derived,
+  attributed to Databricks; mechanism corroborated by A1-A4).
+- Claim: "Databricks reported 8x on q77, 2x on q5, and more than 1.1x on 26
+  more queries, TPC-DS 1TB without statistics." Evidence: A6 (search-derived,
+  attributed to Databricks; never presented as a BenchBox result).
+- Claim: "BenchBox enables AQE for Spark by default; the CLI flag cannot
+  disable it; run-time benchmark configuration re-enables it for OLAP
+  benchmarks." Evidence: B1, B2, B3, B4 (first-party, file:line).
+- Claim: "BenchBox's TPC-H Skew benchmark generates Zipfian join skew with
+  presets from light (z=0.2) to extreme (z=1.0)." Evidence: B5, B6
+  (first-party).
+- Claim: "Oracle adapts by switching among precompiled subplans via a
+  statistics collector; SQL Server defers the join algorithm choice behind a
+  row-count threshold." Evidence: C1, C2 (search-derived).
+- Claim: "Trino's adaptive optimizations exist only under fault-tolerant
+  execution, which spools exchange data." Evidence: C3 (search-derived).
+- Claim: "Snowflake is Cascades-style cost-based and postpones some physical
+  decisions to execution time." Evidence: C4 (search-derived from the SIGMOD
+  2016 paper).
+- Claim: "BigQuery modifies plans during execution by inserting repartition
+  and coalesce stages." Evidence: C5 (search-derived from Google's docs).
+- Claim: "DuckDB and ClickHouse have no distributed shuffle boundary; their
+  adaptivity is operator-local (memory-driven switching in ClickHouse,
+  morsel-level load balancing in DuckDB)." Evidence: C6, C7 (search-derived).
+
+## Limitations of this evidence
+
+- No BenchBox benchmark was run. The outline's results-oriented section is a
+  planned methodology only, and the draft must keep it in the future tense
+  until runs exist.
+- Every non-Spark vendor claim in Part C is search-derived because this
+  session's network policy blocked direct fetches to the primary pages. Before
+  the draft is published, each Part C quote-level claim should be re-verified
+  against the live page from an environment that can reach it, and the
+  provenance labels upgraded or the claims softened accordingly.
+- The Spark documentation quotes are from the 3.2.0 and 3.5.1 doc bundles on
+  official Apache mirrors, not from the current 4.x docs page (blocked). The
+  quoted sentences and defaults should be spot-checked against the latest docs
+  before publication in case defaults changed after 3.5.x.
+- The Databricks TPC-DS figures date from 2020, describe a deliberately
+  statistics-free setup, and are Databricks' own numbers; they characterize
+  the opportunity AQE targets, not what any current reader should expect on
+  their workload.


### PR DESCRIPTION
# Pull Request

## Description

Adds the planning materials for a platform deep-dive blog post on Apache Spark's Adaptive Query Execution (AQE):

- `_blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md`: post outline (target 2,000-2,500 words) covering the three GA AQE features (dynamic partition coalescing, sort-merge-to-broadcast join switching, skew-join splitting), why Spark's stage-boundary execution model makes runtime re-optimization practical, and a neutral survey of how Oracle (Adaptive Query Optimization), SQL Server (Intelligent Query Processing), Trino (adaptive plan optimizations under fault-tolerant execution), Snowflake, BigQuery, DuckDB, and ClickHouse approach the same problem. Framed as architectural fit, not maturity; no engine ranking.
- `_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md`: the evidence log every outline claim traces to, following the structure of the existing `apply-changes-into-vs-merge-verification-2026-06-27.md` exemplar. Spark documentation claims are verbatim quotes from official Apache doc mirrors; all other vendor claims are labeled search-derived (this session's network policy blocked direct fetches to vendor doc sites) with per-claim confidence, including one flagged-and-discarded search artifact.

First-party findings logged along the way (file:line cited in the research file): the `--adaptive-enabled` CLI flag (`store_true`, `default=True`) can never disable AQE, and `configure_for_benchmark` re-enables AQE on the live session for OLAP benchmark types, so a clean AQE-off comparison through `benchbox run` currently needs a code change. Both are listed as prerequisites for the post's planned (not yet run) measurement section. No BenchBox benchmark results are claimed anywhere; the only performance figures are Databricks' published TPC-DS numbers, attributed to Databricks.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

- `make agent-write-preflight` (from a worktree): passed.
- `make pr-preflight`: passed (ci-lint green; content-only path detected, so the content guard ran pre-commit markdownlint on the changed files and fast tests were skipped, mirroring CI path filtering).
- Manual em-dash/en-dash scan of both new files: zero U+2013/U+2014 characters, per `_blog/STYLE_GUIDE.md` punctuation rules.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (Content is `_blog/` planning material only; no user-facing docs affected.)
- [x] I added regression notes for behavior changes. (No behavior changes.)
- [x] I confirmed API contract wording remains accurate. (No API surface touched.)

## Code Quality

- [x] I ran formatting and lint/type checks. (`make pr-preflight`, includes ci-lint and markdownlint.)
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (Markdown only, no code.)
- [x] I added/updated tests for behavior changes and error paths. (Not applicable; no code changes.)
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none committed.

## Notes

- Every search-derived claim in the research file (Part C, plus A5/A6) carries an explicit TODO to re-verify against the live primary page from an unrestricted network before the draft is published.
- The two AQE-toggle harness findings (research file B2, B4) are documented here as findings; filing/fixing them is deliberately left out of this content-only PR.
- The research file corrects one framing from the original brief: per Google's own docs, BigQuery does modify plans at runtime (dynamic repartition/coalesce stages), so it is grouped with the shuffle-boundary adapters rather than with compile-time-only optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Dy3NFuPpiRov5Gc9GHyBD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dy3NFuPpiRov5Gc9GHyBD)_