### PR TITLE
fix(spark): make AQE genuinely toggleable end to end

### DIFF
--- a/_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md
+++ b/_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md
@@ -210,6 +210,18 @@ cite file and line in the draft.
   Spark adapter participates in BenchBox's plan capture phase, which is the
   hook a future AQE post could use to show `EXPLAIN`-level plan differences
   (initial vs adaptively re-optimized plan) rather than timings alone.
+- CORRECTION (2026-07-04, post-merge review on PR #954, fixed in the outline
+  by PR #955): the capture hook is `get_spark_query_plan`
+  (`benchbox/platforms/_spark_helpers.py:112-131`), which runs a fresh
+  `EXPLAIN EXTENDED <query>`. That returns the static, pre-adaptive compile
+  plan, not the executed plan with AQE's runtime decisions applied, so plan
+  capture as it stands can show AQE-on vs AQE-off differences in the initial
+  plan only. Showing the actual switched join operators and coalesced
+  partition counts requires capturing the final adaptive plan (Spark event
+  logs or the post-execution `executedPlan`), which is follow-up work, not
+  an existing capability. The original expectation in the entry above is
+  retained for the record; the outline's section 5/6 wording was corrected
+  accordingly.
 
 ---
 

--- a/_project/TODO/main/planning/spark-aqe-blog-reverify-claims.yaml
+++ b/_project/TODO/main/planning/spark-aqe-blog-reverify-claims.yaml
@@ -1,0 +1,102 @@
+id: spark-aqe-blog-reverify-claims
+title: "Re-verify search-derived claims in the Spark AQE research file against live primary sources"
+worktree: main
+priority: Medium
+status: Not Started
+category: Content
+
+description: |
+  The Spark AQE blog research file
+  (_blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md,
+  merged in PR #954) was produced in a network environment whose egress policy
+  returned HTTP 403 for direct fetches to every vendor documentation site
+  (spark.apache.org, databricks.com, docs.oracle.com, learn.microsoft.com,
+  trino.io, docs.snowflake.com, cloud.google.com, and mirrors). Only the
+  official Apache doc mirrors (downloads.apache.org, archive.apache.org) were
+  reachable, so the Spark documentation claims (Part A1-A4) are verbatim and
+  primary-source verified, but everything else is labeled search-derived:
+  "as reported by search summary, not diffed against the live page".
+
+  Before the post is drafted and published, each search-derived entry must be
+  re-verified against the live primary page from an environment that can reach
+  it, and the provenance labels upgraded (to verbatim quotes with access dates)
+  or the claims softened/dropped. The research file's own Limitations section
+  and the outline's TODO list
+  (_blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md)
+  call this out explicitly.
+
+  Entries to re-verify (see the research file for the intended primary URLs):
+    - A5: Spark 3.0 release notes framing and the release-wide 2x TPC-DS claim.
+    - A6: Databricks AQE blog (2020-05-29): materialization-point mechanism
+      description and the q77 8x / q5 2x / 26-queries-over-1.1x figures.
+    - C1: Oracle SQL Tuning Guide, adaptive query plans / statistics collector.
+    - C2: Microsoft Learn, batch mode adaptive joins and the IQP family
+      (2017 / compat level 140 / batch mode on rowstore in 2019).
+    - C3: Trino adaptive plan optimizations and fault-tolerant execution docs
+      (FTE-only gating, config property names, exchange spooling).
+    - C4: Snowflake SIGMOD 2016 paper (Cascades-style cost-based optimizer,
+      decisions postponed to execution time). Note the research file flags and
+      discards a "rule-based optimizer" search artifact; keep it discarded.
+    - C5: BigQuery query-plan documentation (runtime plan modification,
+      dynamic repartition/coalesce stages).
+    - C6/C7: DuckDB execution-model material; ClickHouse academic overview
+      (VLDB 2024 paper) for the operator-level runtime adaptivity claim.
+  Also spot-check the Spark 3.5.1-quoted config defaults against the current
+  4.x documentation in case defaults changed after 3.5.x.
+
+work:
+  - id: w1
+    summary: "Fetch each primary URL listed in research file entries A5, A6, and C1-C7; capture verbatim quotes with access dates"
+    status: pending
+
+  - id: w2
+    summary: "Update the research file: upgrade provenance labels for confirmed claims, soften or remove any claim the live page does not support, and refresh the cross-check table"
+    needs: [w1]
+    status: pending
+
+  - id: w3
+    summary: "Spot-check Spark 4.x docs for changed AQE defaults and update A1-A4 version notes if needed"
+    needs: [w1]
+    status: pending
+
+  - id: w4
+    summary: "Update the outline TODO checklist and re-run markdownlint plus the em/en-dash scan on both files"
+    needs: [w2, w3]
+    status: pending
+
+must_preserve:
+  - "The research file's tiered provenance discipline: first-party (file:line), primary-source verbatim (with access date), search-derived (labeled) - never silently promote a claim."
+  - "No fabricated or implied BenchBox benchmark results; the measurement plan stays future tense until runs exist (tracked separately by the outline's own TODO list)."
+  - "Zero em-dashes and en-dashes in _blog content (STYLE_GUIDE.md punctuation rule)."
+
+anti_patterns:
+  - "DO NOT replace the dated 2026-07-04 entries in place without noting the re-verification date - because the file is a dated evidence log - append or annotate entries with the new access date."
+  - "DO NOT keep a claim just because removing it weakens the narrative - because the post's credibility rests on the verification file - soften or drop unsupported claims."
+
+verification:
+  - description: "Both blog files pass markdownlint and contain zero U+2013/U+2014 characters"
+    command: "npx --yes markdownlint-cli@0.43.0 --disable MD013 MD033 MD041 -- _blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md _blog/platform-deep-dives/research/spark-aqe-verification-*.md"
+    expected_output: "exit 0; separate grep for em/en dashes returns nothing"
+  - description: "Every remaining search-derived label in the research file is intentional and explained"
+    command: "grep -n 'search-derived\\|SEARCH-DERIVED' _blog/platform-deep-dives/research/spark-aqe-verification-*.md"
+    expected_output: "each hit is either upgraded to a verbatim quote or carries a note explaining why it could not be verified"
+
+scope_limit:
+  only_modify:
+    - "_blog/platform-deep-dives/research/"
+    - "_blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md"
+    - "_project/TODO/"
+
+technical_requirements:
+  constraints:
+    - "Requires a network environment that can reach vendor documentation sites directly (the 2026-07-04 session's egress policy could not)."
+
+success_metrics:
+  - "Every external claim in the research file is either primary-source verbatim with an access date or carries an explicit could-not-verify note."
+  - "The outline's re-verification TODO checkbox is closed and drafting is unblocked."
+
+metadata:
+  tags: [blog, spark, aqe, research, verification, content]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  last_updated: "2026-07-04T13:30:00"

--- a/_project/TODO/main/planning/spark-aqe-toggle-defects.yaml
+++ b/_project/TODO/main/planning/spark-aqe-toggle-defects.yaml
@@ -1,0 +1,122 @@
+id: spark-aqe-toggle-defects
+title: "Fix Spark adapter AQE toggle: CLI flag cannot disable, run-time config force-re-enables"
+worktree: main
+priority: Medium
+status: Completed
+category: Core Functionality
+
+description: |
+  The Spark adapter cannot actually run with Adaptive Query Execution (AQE)
+  disabled through the standard pipeline, which blocks the AQE on/off comparison
+  planned in the Spark AQE blog post (see
+  _blog/platform-deep-dives/outlines/spark-adaptive-query-execution.md and
+  research file entries B2/B4 in
+  _blog/platform-deep-dives/research/spark-aqe-verification-2026-07-04.md,
+  verified at commit 5fe58367). Three related defects:
+
+    1. CLI flag is enable-only: `--adaptive-enabled` was declared
+       `action="store_true", default=True` (benchbox/platforms/spark.py:300),
+       so passing the flag sets True and omitting it defaults to True. No CLI
+       spelling produces False.
+    2. Session-build disable was a no-op on modern Spark: _get_spark_conf only
+       set the three AQE keys when adaptive_enabled was True and omitted them
+       otherwise (spark.py:439-443). Spark enables AQE by default since 3.2.0,
+       so omission left AQE on even with adaptive_enabled=False.
+    3. Run-time force-re-enable: configure_for_benchmark unconditionally set
+       spark.sql.adaptive.enabled (and the coalesce/skewJoin keys) to "true"
+       for benchmark types olap/analytics/tpch/tpcds/joinorder
+       (spark.py:653-669, called from
+       benchbox/platforms/base/adapter.py:493-494 before query execution),
+       clobbering both adaptive_enabled=False and any spark_config override.
+
+prior_art:
+  - "benchbox/platforms/lakesail.py:207-212 - the same --adaptive-enabled flag already uses argparse.BooleanOptionalAction (--adaptive-enabled / --no-adaptive-enabled) with default=True; reuse this pattern for the Spark adapter."
+  - "benchbox/platforms/spark.py:_get_spark_conf - spark_config merges last (conf.update(self.spark_config)) so explicit user keys win at session build; the fix extends the same precedence to run time."
+  - "tests/unit/platforms/test_lakesail_adapter.py:test_add_cli_arguments_supports_disabling_adaptive - the CLI regression test shape to mirror."
+
+work:
+  - id: w1
+    summary: "Switch --adaptive-enabled to argparse.BooleanOptionalAction"
+    status: done
+    notes: |
+      RESOLVED: benchbox/platforms/spark.py now declares the flag with
+      action=argparse.BooleanOptionalAction, default=True, matching the
+      LakeSail adapter. --no-adaptive-enabled parses to False; the default
+      and the positive spelling stay True, so existing invocations are
+      unchanged.
+
+  - id: w2
+    summary: "Set AQE keys explicitly in both directions in _get_spark_conf"
+    needs: [w1]
+    status: done
+    notes: |
+      RESOLVED: _get_spark_conf sets the three AQE keys (module constant
+      _SPARK_AQE_KEYS) to "true" or "false" per adaptive_enabled, instead of
+      omitting them when disabled. Omission does not disable AQE on Spark
+      3.2.0+ where the upstream default is on. spark_config still merges
+      last, so explicit user overrides continue to win at session build.
+
+  - id: w3
+    summary: "Make configure_for_benchmark honor adaptive_enabled and spark_config"
+    needs: [w2]
+    status: done
+    notes: |
+      RESOLVED: for OLAP benchmark types, configure_for_benchmark now sets
+      each AQE key to spark_config.get(key, computed) where computed follows
+      adaptive_enabled. An explicit spark_config entry is no longer clobbered
+      at run time, and adaptive_enabled=False now survives the full
+      benchbox run pipeline. The CBO settings are unchanged.
+
+  - id: w4
+    summary: "Regression tests for all three defects"
+    needs: [w1, w2, w3]
+    status: done
+    notes: |
+      RESOLVED: tests/unit/platforms/test_spark_adapter.py gains a real-parser
+      CLI test (default/enabled/disabled spellings);
+      tests/unit/platforms/test_spark_coverage.py updates test_aqe_disabled to
+      assert explicit "false" keys (the old assertion encoded defect 2) and
+      adds configure_for_benchmark tests for adaptive_enabled=False and for a
+      spark_config override surviving run time.
+
+deferred:
+  - summary: "Port the same fixes to the sibling Spark-family adapters: lakesail.py (has defect 2 at ~292-295 and defect 3 at ~531-533; its CLI flag is already BooleanOptionalAction so --no-adaptive-enabled currently parses but is silently ineffective at run time) and velox.py (defect 2 at ~266-269), then audit the cloud Spark adapters (CloudSparkConfigMixin, Databricks, EMR/Glue/Dataproc/Synapse/Fabric)"
+    reason: "Different adapters and config surfaces; needs its own pass with per-adapter verification rather than riding along here. Review found the AQE key literals duplicated across spark.py, lakesail.py, velox.py, and pyspark/session.py; consider hoisting _SPARK_AQE_KEYS (and the resolve-then-apply pattern) into _spark_helpers.py as part of that port."
+  - summary: "Update the blog outline section 5 wording once this fix merges (the outline describes the defects in the present tense)"
+    reason: "The outline is redrafted during the drafting TODO anyway; the research file entry is a dated evidence log pinned to commit 5fe58367 and stays as written."
+
+must_preserve:
+  - "Default behavior is unchanged: AQE stays enabled by default (adaptive_enabled defaults True; the three keys are set to 'true')."
+  - "spark_config precedence: an explicit user key wins over adapter-computed values at session build AND at configure_for_benchmark time."
+  - "configure_for_benchmark continues to set spark.sql.cbo.enabled and spark.sql.cbo.joinReorder.enabled for OLAP benchmark types."
+  - "LakeSail adapter behavior untouched."
+
+anti_patterns:
+  - "DO NOT fix by adding a separate --disable-adaptive flag - because two flags for one boolean drift apart - use BooleanOptionalAction like the LakeSail adapter."
+  - "DO NOT drop the AQE keys from _get_spark_conf when disabled - because Spark 3.2.0+ defaults AQE on, so omission silently leaves it enabled - set 'false' explicitly."
+  - "DO NOT remove the configure_for_benchmark AQE block entirely - because plain sessions still benefit from the explicit OLAP settings - make it honor adaptive_enabled and spark_config instead."
+
+verification:
+  - description: "Spark adapter unit tests pass, including the new AQE toggle regressions"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_spark_coverage.py -q"
+    expected_output: "all pass except the pre-existing test_spark_in_platform_list isolation flake (fails identically on a clean tree; passes when run alone)"
+  - description: "--no-adaptive-enabled parses to False through a real ArgumentParser"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_spark_adapter.py -k disabling_adaptive -q"
+    expected_output: "1 passed"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/spark.py"
+    - "tests/unit/platforms/test_spark_adapter.py"
+    - "tests/unit/platforms/test_spark_coverage.py"
+    - "_project/TODO/"
+
+success_metrics:
+  - "benchbox run --platform spark ... --no-adaptive-enabled executes queries with spark.sql.adaptive.enabled=false end to end."
+  - "The AQE on/off comparison in the Spark AQE blog outline (section 6) is runnable without code changes."
+
+metadata:
+  tags: [spark, aqe, cli, configuration, bug]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  last_updated: "2026-07-04T13:30:00"

--- a/_project/TODO/main/planning/spark-aqe-toggle-defects.yaml
+++ b/_project/TODO/main/planning/spark-aqe-toggle-defects.yaml
@@ -79,6 +79,23 @@ work:
       adds configure_for_benchmark tests for adaptive_enabled=False and for a
       spark_config override surviving run time.
 
+  - id: w5
+    summary: "Register adaptive_enabled as a benchbox run platform option for spark"
+    needs: [w1]
+    status: done
+    notes: |
+      RESOLVED (found by Codex review on the PR): the argparse flag lives on a
+      secondary entry point (PlatformRegistry.add_platform_arguments); the
+      primary `benchbox run` CLI parses --platform-option pairs against
+      PlatformHookRegistry's option-spec table, which had no spark rows at
+      all, so even --platform-option adaptive_enabled=false was rejected.
+      Added the spark|adaptive_enabled spec row (parse_bool, default 'true',
+      mirroring the velox row) in benchbox/platforms/__init__.py; the
+      registered spark config builder already maps the field through to
+      SparkAdapter.from_config. Regression test in
+      tests/unit/cli/test_platform_hooks.py asserts the default and that
+      adaptive_enabled=false parses to Python False.
+
 deferred:
   - summary: "Port the same fixes to the sibling Spark-family adapters: lakesail.py (has defect 2 at ~292-295 and defect 3 at ~531-533; its CLI flag is already BooleanOptionalAction so --no-adaptive-enabled currently parses but is silently ineffective at run time) and velox.py (defect 2 at ~266-269), then audit the cloud Spark adapters (CloudSparkConfigMixin, Databricks, EMR/Glue/Dataproc/Synapse/Fabric)"
     reason: "Different adapters and config surfaces; needs its own pass with per-adapter verification rather than riding along here. Review found the AQE key literals duplicated across spark.py, lakesail.py, velox.py, and pyspark/session.py; consider hoisting _SPARK_AQE_KEYS (and the resolve-then-apply pattern) into _spark_helpers.py as part of that port."

--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -787,6 +787,7 @@ datafusion-df|temp_dir|Temporary directory for disk spilling (default: system te
 sqlite|database_path|Path to the SQLite database file (auto-generated from --benchmark/--scale when omitted)|{}
 sqlite|timeout|SQLite connection timeout in seconds|{'parser': 'float', 'default': '30.0'}
 sqlite|check_same_thread|Enforce that connections are used on the creating thread only|{'parser': 'parse_bool', 'default': 'false'}
+spark|adaptive_enabled|Enable or disable Spark Adaptive Query Execution (AQE)|{'parser': 'parse_bool', 'default': 'true'}
 velox|deployment|Deployment mode: 'local' (in-process SparkSession, Linux only) or 'remote' (Spark-Connect server)|{'choices': ('local', 'remote'), 'default': 'local'}
 velox|endpoint|Spark-Connect endpoint for remote mode (e.g., sc://localhost:50051)|{'default': 'sc://localhost:50051'}
 velox|gluten_jar_path|Absolute path to the Gluten Velox bundle jar (required for local mode)|{'aliases': ('jar',)}

--- a/benchbox/platforms/spark.py
+++ b/benchbox/platforms/spark.py
@@ -13,6 +13,7 @@ Licensed under the MIT License. See LICENSE file in the project root for details
 
 from __future__ import annotations
 
+import argparse
 import logging
 import os
 import re
@@ -68,6 +69,11 @@ _MAX_COMPATIBLE_JAVA_VERSION = 22
 
 _logger = logging.getLogger(__name__)
 _SPARK_AUTO_BROADCAST_THRESHOLD = "spark.sql.autoBroadcastJoinThreshold"
+_SPARK_AQE_KEYS = (
+    "spark.sql.adaptive.enabled",
+    "spark.sql.adaptive.coalescePartitions.enabled",
+    "spark.sql.adaptive.skewJoin.enabled",
+)
 
 
 def _get_java_version(java_home: str | None = None) -> int | None:
@@ -297,7 +303,10 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
             "--enable-hive", action="store_true", default=False, help="Enable Hive metastore support"
         )
         spark_group.add_argument(
-            "--adaptive-enabled", action="store_true", default=True, help="Enable Adaptive Query Execution (AQE)"
+            "--adaptive-enabled",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Enable or disable Adaptive Query Execution (AQE)",
         )
 
     @classmethod
@@ -436,11 +445,12 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
             "spark.sql.shuffle.partitions": str(self.shuffle_partitions),
         }
 
-        # Adaptive Query Execution
-        if self.adaptive_enabled:
-            conf["spark.sql.adaptive.enabled"] = "true"
-            conf["spark.sql.adaptive.coalescePartitions.enabled"] = "true"
-            conf["spark.sql.adaptive.skewJoin.enabled"] = "true"
+        # Adaptive Query Execution. Set explicitly in both directions: Spark
+        # enables AQE by default since 3.2.0, so omitting the keys would leave
+        # it on even when adaptive_enabled is False.
+        aqe_value = "true" if self.adaptive_enabled else "false"
+        for aqe_key in _SPARK_AQE_KEYS:
+            conf[aqe_key] = aqe_value
 
         # Broadcast threshold
         if self.broadcast_threshold is not None:
@@ -647,14 +657,17 @@ class SparkAdapter(SparkLikeAdapterMixin, SparkDataLoadMixin, SparkQueryExecutio
 
         try:
             if benchmark_type.lower() in ["olap", "analytics", "tpch", "tpcds", "joinorder"]:
-                # OLAP-specific optimizations via Spark SQL settings
-                spark.conf.set("spark.sql.adaptive.enabled", "true")
-                spark.conf.set("spark.sql.adaptive.coalescePartitions.enabled", "true")
-                spark.conf.set("spark.sql.adaptive.skewJoin.enabled", "true")
+                # OLAP-specific optimizations via Spark SQL settings. Honor the
+                # adapter's AQE setting instead of force-enabling, and let an
+                # explicit spark_config entry win so session-build overrides
+                # are not clobbered at run time.
+                aqe_value = "true" if self.adaptive_enabled else "false"
+                for aqe_key in _SPARK_AQE_KEYS:
+                    spark.conf.set(aqe_key, self.spark_config.get(aqe_key, aqe_value))
 
-                # Cost-based optimization
-                spark.conf.set("spark.sql.cbo.enabled", "true")
-                spark.conf.set("spark.sql.cbo.joinReorder.enabled", "true")
+                # Cost-based optimization, with the same spark_config precedence
+                for cbo_key in ("spark.sql.cbo.enabled", "spark.sql.cbo.joinReorder.enabled"):
+                    spark.conf.set(cbo_key, self.spark_config.get(cbo_key, "true"))
 
                 self.logger.debug("Applied OLAP optimizations for Spark")
 

--- a/tests/unit/cli/test_platform_hooks.py
+++ b/tests/unit/cli/test_platform_hooks.py
@@ -65,6 +65,18 @@ def test_parse_options_unknown_key_raises():
         PlatformHookRegistry.parse_options("clickhouse", [("unknown", "value")])
 
 
+def test_spark_platform_options_adaptive_enabled():
+    # Default is the registered spec-row string "true" (same convention as the
+    # velox row); it only needs to be truthy for the adapter default.
+    parsed = PlatformHookRegistry.parse_options("spark", [])
+    assert parsed["adaptive_enabled"] == "true"
+
+    # Explicit values go through parse_bool, so AQE-off runs are reachable via
+    # --platform-option adaptive_enabled=false.
+    parsed = PlatformHookRegistry.parse_options("spark", [("adaptive_enabled", "false")])
+    assert parsed["adaptive_enabled"] is False
+
+
 @pytest.mark.parametrize(
     ("platform", "expected_defaults"),
     [

--- a/tests/unit/platforms/test_spark_adapter.py
+++ b/tests/unit/platforms/test_spark_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 from unittest.mock import MagicMock, patch
 
@@ -852,6 +853,21 @@ class TestSparkAdapterCliArguments:
         assert any("--executor-cores" in c for c in add_arg_calls)
         assert any("--table-format" in c for c in add_arg_calls)
         assert any("--shuffle-partitions" in c for c in add_arg_calls)
+
+    def test_add_cli_arguments_supports_disabling_adaptive(self, mock_pyspark):
+        """CLI args should allow disabling AQE via --no-adaptive-enabled."""
+        from benchbox.platforms.spark import SparkAdapter
+
+        parser = argparse.ArgumentParser()
+        SparkAdapter.add_cli_arguments(parser)
+
+        default_args = parser.parse_args([])
+        enabled_args = parser.parse_args(["--adaptive-enabled"])
+        disabled_args = parser.parse_args(["--no-adaptive-enabled"])
+
+        assert default_args.adaptive_enabled is True
+        assert enabled_args.adaptive_enabled is True
+        assert disabled_args.adaptive_enabled is False
 
 
 class TestSparkAdapterCreateSession:

--- a/tests/unit/platforms/test_spark_coverage.py
+++ b/tests/unit/platforms/test_spark_coverage.py
@@ -157,7 +157,18 @@ class TestGetSparkConf:
 
         a = SparkAdapter(adaptive_enabled=False)
         conf = a._get_spark_conf()
-        assert "spark.sql.adaptive.enabled" not in conf
+        # Spark enables AQE by default since 3.2.0, so disabling must set the
+        # keys to "false" explicitly rather than omitting them.
+        assert conf["spark.sql.adaptive.enabled"] == "false"
+        assert conf["spark.sql.adaptive.coalescePartitions.enabled"] == "false"
+        assert conf["spark.sql.adaptive.skewJoin.enabled"] == "false"
+
+    def test_aqe_disabled_spark_config_still_wins(self, mock_pyspark):
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(adaptive_enabled=False, spark_config={"spark.sql.adaptive.enabled": "true"})
+        conf = a._get_spark_conf()
+        assert conf["spark.sql.adaptive.enabled"] == "true"
 
     def test_aqe_enabled(self, mock_pyspark):
         from benchbox.platforms.spark import SparkAdapter
@@ -763,6 +774,29 @@ class TestConfigureForBenchmark:
 
         conf_calls = [str(c) for c in mock_session.conf.set.call_args_list]
         assert any("adaptive.enabled" in c for c in conf_calls)
+
+    def test_olap_respects_adaptive_disabled(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(adaptive_enabled=False)
+        a.configure_for_benchmark(mock_session, "tpch")
+
+        mock_session.conf.set.assert_any_call("spark.sql.adaptive.enabled", "false")
+        mock_session.conf.set.assert_any_call("spark.sql.adaptive.coalescePartitions.enabled", "false")
+        mock_session.conf.set.assert_any_call("spark.sql.adaptive.skewJoin.enabled", "false")
+
+    def test_olap_respects_spark_config_aqe_override(self, mock_pyspark):
+        _, mock_session = mock_pyspark
+        from benchbox.platforms.spark import SparkAdapter
+
+        a = SparkAdapter(spark_config={"spark.sql.adaptive.enabled": "false"})
+        a.configure_for_benchmark(mock_session, "olap")
+
+        # The explicit spark_config entry must not be clobbered at run time.
+        mock_session.conf.set.assert_any_call("spark.sql.adaptive.enabled", "false")
+        # Keys without an override still follow adaptive_enabled (default True).
+        mock_session.conf.set.assert_any_call("spark.sql.adaptive.skewJoin.enabled", "true")
 
     def test_tpcds_sets_cbo(self, mock_pyspark):
         _, mock_session = mock_pyspark


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #954 (Spark AQE blog outline). Fixes the three defects that made Adaptive Query Execution impossible to actually disable through the standard `benchbox run` pipeline, which blocks the AQE on/off comparison the blog outline plans (research file entries B2/B4):

1. **CLI flag could only enable** (`benchbox/platforms/spark.py`): `--adaptive-enabled` was `action="store_true", default=True`, so no command-line spelling produced `False`. Now `argparse.BooleanOptionalAction` (adds `--no-adaptive-enabled`), the same pattern the LakeSail adapter already uses.
2. **Session-build disable was a no-op on modern Spark**: `_get_spark_conf` omitted the AQE keys when `adaptive_enabled=False`, but Spark enables AQE by default since 3.2.0, so omission silently left it on. The three keys (new `_SPARK_AQE_KEYS` module constant) are now set explicitly `"true"`/`"false"`; `spark_config` still merges last so user overrides win at session build.
3. **Run-time force-re-enable**: `configure_for_benchmark` hardcoded the AQE keys to `"true"` for OLAP benchmark types on the live session (called from `run_benchmark` right before query execution), clobbering both `adaptive_enabled=False` and any `spark_config` override. It now follows `adaptive_enabled` and lets explicit `spark_config` entries win; the adjacent CBO keys get the same `spark_config` precedence (found in review: the old hardcoding contradicted the new precedence comment two lines above).

Also in this PR:

- Two new TODOs in `_project/TODO/main/planning/`: `spark-aqe-toggle-defects.yaml` (records this fix; defers porting the same fixes to LakeSail/Velox, which review confirmed carry the same patterns, and the cloud Spark adapters, plus hoisting the duplicated AQE key literals into `_spark_helpers.py`) and `spark-aqe-blog-reverify-claims.yaml` (re-verify the search-derived claims in the AQE research file against live primary sources from an unrestricted network before drafting).
- A dated CORRECTION note on research file entry B7, aligning it with the plan-capture clarification from #955: `get_spark_query_plan` runs a fresh `EXPLAIN EXTENDED`, which captures the static pre-adaptive plan, not AQE's executed plan; final-plan capture is follow-up work.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/unit/platforms/test_spark_adapter.py tests/unit/platforms/test_spark_coverage.py tests/unit/platforms/test_lakesail_adapter.py -q`: 221 passed, including new regression tests for all three defects (real-parser `--no-adaptive-enabled` test; explicit `"false"` keys at session build; run-time honor of `adaptive_enabled=False`; `spark_config` override surviving `configure_for_benchmark`).
- One pre-existing coverage test (`test_aqe_disabled`) was updated because its old assertion (`key not in conf`) encoded defect 2.
- `make pr-preflight`: ci-lint, artifact hygiene, and content checks passed. The fast-test stage showed 6 failures out of 23,985; all 6 reproduce identically on the clean tree in this container (pyspark CSV null-semantics integration, delta-scan smoke, two CLI output-dir error tests, changelog tag guard), so they are pre-existing environmental failures unrelated to this diff.
- `uv run _project/scripts/validate_todo.py` on both new TODOs and `todo_cli.py check-graph`: valid, no cycles, no dangling references.
- Review pass (8-angle): confirmed `extra_configs` ordering in `SparkSessionManager` keeps the PySpark SQL adapter path consistent (explicit keys applied last, derived from the same `adaptive_enabled`); no callers depend on the AQE keys being absent when disabled.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (The `--no-adaptive-enabled` spelling is additive; `--adaptive-enabled` and the default are unchanged.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (CLI help text updated in place; blog research file correction noted above.)
- [x] I added regression notes for behavior changes. (Recorded in `spark-aqe-toggle-defects.yaml` work-unit notes.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks. (`ruff check` and `ruff format --check` clean on changed files; full `ci-lint` green.)
- [x] I reviewed impacted modules for backwards compatibility and migration impact. (Defaults unchanged: AQE stays on unless explicitly disabled; subclass `PySparkSQLAdapter` verified.)
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none committed.

## Notes

- LakeSail carries the same defect pattern (its `--no-adaptive-enabled` parses but is silently re-enabled at run time) and Velox the session-build omission; both are explicitly deferred with locations in `spark-aqe-toggle-defects.yaml` rather than widened into this PR.
- The branch reuses `claude/spark-aqe-blog-post-jlcw23`, restarted from the current `develop` tip after #954 merged (force-with-lease over the already-merged history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Dy3NFuPpiRov5Gc9GHyBD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Dy3NFuPpiRov5Gc9GHyBD)_