### PR TITLE
Add query-plan capture remediation plan as executable TODOs

### DIFF
--- a/_project/TODO/query-plan-capture/README.md
+++ b/_project/TODO/query-plan-capture/README.md
@@ -1,0 +1,45 @@
+# Query-Plan Capture Subsystem Remediation
+
+Source: adversarial review of the query-plan capture pipeline (capture → parse →
+model/fingerprint → serialize → load → consume) conducted 2026-07-04 on branch
+`claude/query-plan-capture-review-hjwlm2`. Findings are referenced below by the
+review's numbering (e.g. F1.1 = finding 1.1 "loader discards plans").
+
+Each YAML item in `planning/` is one PR-sized work package and carries the
+standard delivery loop as explicit work steps:
+
+1. **create** — implement the change with tests
+2. **review** — adversarial code review of the diff
+3. **fix** — address review findings, re-run verification
+4. **submit PR** — push branch, open PR referencing the TODO item id
+
+## Sequencing (dependency order)
+
+| # | Item | Priority | Findings | Depends on |
+|---|------|----------|----------|------------|
+| 01 | plan-rehydration-and-phases-view | Critical | F1.1, F1.3, F7.1, F8.1 (keystone test) | — |
+| 02 | loader-roundtrip-fidelity | High | F1.4 | 01 |
+| 03 | fingerprint-signature-v2 | High | F2.1, F2.2 | — |
+| 04 | capture-timeout-and-analyze-default | High | F4.1, F5.2 | — |
+| 05 | silent-failure-surfacing | Medium | F4.2, F4.3, F4.4, F2.3 | 01 |
+| 06 | cross-platform-capture-wiring | High (large) | F3.1, F3.2, F3.3, F3.4 | 01, 03 |
+| 07 | plans-companion-hardening | Medium | F1.5, F1.6, F1.7 | 01 |
+| 08 | history-and-plan-metadata-wiring | Medium | F1.2, F7.2 | 01 |
+| 09 | df-timing-semantics | Medium | F5.1 | — |
+| 10 | concurrency-and-depth-limits | Low | F6.1, F5.3 | — |
+| 11 | plan-cli-test-democking | Medium | F8.1 (sweep) | 01 |
+
+Items 01–02 restore basic end-to-end function; 03–05 make the data trustworthy;
+06 extends the pipeline beyond DuckDB; 07–11 harden the tail. Items without
+dependencies (03, 04, 09, 10) can proceed in parallel with 01/02.
+
+## Ground rules for every item
+
+- No new plan feature ships without a no-mock round-trip test
+  (export → load → consume on real files).
+- Fingerprint changes must bump `fingerprint_version`; never compare
+  fingerprints across versions.
+- Failures must be distinguishable by users: "not captured" vs "capture
+  failed: <reason>" vs "captured but file failed to load: <reason>".
+- Review-stage repro scripts exist as a starting point for regression tests
+  (export→load→show-plan, fingerprint collisions, timeout ineffectiveness).

--- a/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
+++ b/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
@@ -1,0 +1,103 @@
+id: "qpc-01-plan-rehydration-and-phases-view"
+title: "Rehydrate .plans.json in the loader and give consumers a real phases/plan accessor"
+worktree: "query-plan-capture"
+priority: "Critical"
+status: "Not Started"
+
+description: |
+  The loader parses the .plans.json companion but uses only the two count
+  fields; per-query plan payloads are discarded (loader.py:153,221,
+  _extract_plans_info). BenchmarkResults has no `phases` attribute, yet every
+  plan consumer iterates `results.phases` — show-plan and compare-plans crash
+  on every real exported bundle ("'BenchmarkResults' object has no attribute
+  'phases'", reproduced), and history/plan_metadata_utils silently produce
+  empty output via getattr(results, "phases", {}).
+
+  Compounding key mismatch: builder stamps query_results with "Q1"
+  (builder.py:949 format_query_id) so companion keys are "Q1"
+  (schema.py:1061) while main-file query ids are normalized to "1"
+  (schema.py:378) — any join by id misses every plan.
+
+  Findings: F1.1, F1.3, F7.1, plus the keystone integration test from F8.1.
+
+category: "Bug Fix / Data Pipeline"
+
+prior_art:
+- "benchbox/core/results/loader.py:153-221 — companion loaded, only counts extracted"
+- "benchbox/cli/commands/show_plan.py:89, compare_plans.py:181,255, compare.py:1236, core/query_plans/comparison.py:579 — .phases consumers"
+- "benchbox/core/results/query_normalizer.py:normalize_query_id — the canonical id form"
+- "scratchpad repro repro_e2e.py from the 2026-07-04 review — 90% of the keystone test"
+
+work:
+- id: w1
+  summary: >-
+    Create: rehydrate plans in reconstruct_benchmark_results — walk
+    plans_data["queries"], QueryPlanDAG.from_dict(entry["plan"],
+    verify_fingerprint=True), attach query_plan/plan_fingerprint/
+    plan_capture_time_ms to matching query_results keyed by
+    normalize_query_id. Normalize companion keys in build_plans_payload
+    (schema.py:1061). Add a `phases` property on BenchmarkResults returning
+    {phase_name: view-with-.queries} derived from query_results (or migrate
+    the four consumers to read query_results directly — decide in-diff,
+    smaller change wins). Normalize --query-id lookups in show_plan.py and
+    compare_plans.py with normalize_query_id on both sides.
+  status: pending
+- id: w2
+  summary: >-
+    Create: keystone no-mock integration test
+    (tests/integration/test_plan_capture_e2e.py): build BenchmarkResults with
+    a parser-produced QueryPlanDAG, export_result to tmp, load_result_file,
+    run show-plan and compare-plans via CliRunner asserting rendered plan
+    output — zero monkeypatching.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review of the diff (id normalization edge cases, multi-iteration attach semantics, .phases contract)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix: address review findings; re-run full verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-01; include repro-before/after in the PR body."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "Companion schema stays readable for already-exported bundles (accept both 'Q1' and '1' keys on load)"
+- "load_result_file signature and (BenchmarkResults, raw dict) return contract"
+- "Existing 453 plan-related unit tests keep passing"
+
+anti_patterns:
+- "DO NOT satisfy the CLI by teaching tests to fake .phases — the CLIs must work against load_result_file output on disk."
+- "DO NOT key rehydration on raw query_id strings — normalize both sides."
+
+verification:
+- description: "Keystone round-trip passes without mocks"
+  command: "uv run -- python -m pytest tests/integration/test_plan_capture_e2e.py -q"
+  expected_output: "all pass"
+- description: "show-plan works on a real bundle (manual or scripted)"
+  command: "uv run -- python -m pytest tests/unit/cli/commands -q -k 'show_plan or compare_plans'"
+  expected_output: "all pass"
+- description: "Companion keys match main-file ids on a fresh export"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_query_plan_serialization.py -q"
+  expected_output: "all pass, including new key-contract test"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/loader.py"
+  - "benchbox/core/results/models.py"
+  - "benchbox/core/results/schema.py"
+  - "benchbox/cli/commands/show_plan.py"
+  - "benchbox/cli/commands/compare_plans.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "loader", "cli", "round-trip"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F1.1", "F1.3", "F7.1", "F8.1-keystone"]

--- a/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
+++ b/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
@@ -31,21 +31,25 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: rehydrate plans in reconstruct_benchmark_results — walk
-    plans_data["queries"], QueryPlanDAG.from_dict(entry["plan"],
+    Create: rehydrate companion plans in the loader, normalize companion
+    keys, and add a phases accessor (or migrate consumers to query_results).
+  notes: >-
+    Walk plans_data["queries"], QueryPlanDAG.from_dict(entry["plan"],
     verify_fingerprint=True), attach query_plan/plan_fingerprint/
     plan_capture_time_ms to matching query_results keyed by
     normalize_query_id. Normalize companion keys in build_plans_payload
     (schema.py:1061). Add a `phases` property on BenchmarkResults returning
-    {phase_name: view-with-.queries} derived from query_results (or migrate
+    {phase_name: view-with-.queries} derived from query_results, or migrate
     the four consumers to read query_results directly — decide in-diff,
-    smaller change wins). Normalize --query-id lookups in show_plan.py and
+    smaller change wins. Normalize --query-id lookups in show_plan.py and
     compare_plans.py with normalize_query_id on both sides.
   status: pending
 - id: w2
   summary: >-
-    Create: keystone no-mock integration test
-    (tests/integration/test_plan_capture_e2e.py): build BenchmarkResults with
+    Create: keystone no-mock integration test covering export -> load ->
+    show-plan/compare-plans on real files.
+  notes: >-
+    tests/integration/test_plan_capture_e2e.py: build BenchmarkResults with
     a parser-produced QueryPlanDAG, export_result to tmp, load_result_file,
     run show-plan and compare-plans via CliRunner asserting rendered plan
     output — zero monkeypatching.

--- a/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
+++ b/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
@@ -30,18 +30,20 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: in _reconstruct_query_results honor q["status"] and q["run_type"];
-    use `is not None` checks for iter/stream; reconstruct FAILED rows from
+    Create: fix _reconstruct_query_results to honor status/run_type, keep
+    iter/stream 0, dedupe errors[], and carry plan fields through.
+  notes: >-
+    Use `is not None` checks for iter/stream; reconstruct FAILED rows from
     queries[] alone and use errors[] only for legacy bundles whose queries[]
-    lack status; carry plan fields through. In build_plans_payload use
-    `if capture_time is not None:`.
+    lack status. In build_plans_payload use `if capture_time is not None:`.
   status: pending
 - id: w2
   summary: >-
-    Create: round-trip property test — export, load, export again; assert the
-    two main files are byte-identical via canonical_json_text and the two
-    .plans.json companions are byte-identical. Include warmup (iter 0),
-    FAILED, and stream>0 rows in the fixture.
+    Create: round-trip property test — export, load, re-export must be
+    byte-identical for both main file and plans companion.
+  notes: >-
+    Compare via canonical_json_text. Include warmup (iter 0), FAILED, and
+    stream>0 rows in the fixture.
   needs: [w1]
   status: pending
 - id: w3

--- a/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
+++ b/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
@@ -1,0 +1,89 @@
+id: "qpc-02-loader-roundtrip-fidelity"
+title: "Make export -> load -> export lossless: stop corrupting status/iteration/run_type and destroying plans"
+worktree: "query-plan-capture"
+priority: "High"
+status: "Not Started"
+
+description: |
+  A load/re-export cycle corrupts bundles (all reproduced):
+  1. Plans destroyed: loaded results carry counts but no plan payloads, so
+     re-export writes no .plans.json (partially fixed by qpc-01; this item
+     asserts the property end-to-end).
+  2. Warmup rows become measurement rows: exporter writes iter: 0, loader
+     keeps iteration only `if q.get("iter"):` (loader.py:448) — 0 is falsy —
+     so re-export defaults iteration=1/run_type=measurement and warmup times
+     pollute summary stats.
+  3. FAILED queries duplicate as phantom successes: loader hardcodes
+     "status": "SUCCESS" for every queries[] entry (loader.py:446) and also
+     appends a FAILED row from errors[].
+  Loader also drops run_type, stream 0, plan_fingerprint, plan_capture_time_ms.
+
+  Findings: F1.4 (and the `if capture_time:` 0.0-drop from F1.5).
+
+category: "Bug Fix / Data Pipeline"
+
+prior_art:
+- "benchbox/core/results/loader.py:426-466 _reconstruct_query_results"
+- "benchbox/core/results/schema.py:376-423 _build_queries (writes iter/stream/run_type/status unconditionally)"
+- "benchbox/core/results/canonical_json.py — byte-stable form enables byte-equality round-trip test"
+
+work:
+- id: w1
+  summary: >-
+    Create: in _reconstruct_query_results honor q["status"] and q["run_type"];
+    use `is not None` checks for iter/stream; reconstruct FAILED rows from
+    queries[] alone and use errors[] only for legacy bundles whose queries[]
+    lack status; carry plan fields through. In build_plans_payload use
+    `if capture_time is not None:`.
+  status: pending
+- id: w2
+  summary: >-
+    Create: round-trip property test — export, load, export again; assert the
+    two main files are byte-identical via canonical_json_text and the two
+    .plans.json companions are byte-identical. Include warmup (iter 0),
+    FAILED, and stream>0 rows in the fixture.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review (legacy-bundle branch, errors[] dedup rules, summary-stat recomputation)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-02."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "Legacy bundles (queries[] without status/run_type keys) still load without error"
+- "compute_plan_capture_stats measurement-only semantics"
+
+anti_patterns:
+- "DO NOT drop errors[] from the export format — it is the legacy-load fallback; dedup on load instead."
+- "DO NOT 'fix' by making the exporter omit warmup rows — warmup data is part of the record."
+
+verification:
+- description: "Byte-equality round trip"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_loader.py -q -k roundtrip"
+  expected_output: "all pass"
+- description: "No phantom SUCCESS rows for failed queries"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_loader.py -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/loader.py"
+  - "benchbox/core/results/schema.py"
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view"]
+
+metadata:
+  tags: ["query-plans", "loader", "round-trip", "data-integrity"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F1.4", "F1.5-capture-time-zero"]

--- a/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
+++ b/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
@@ -1,0 +1,98 @@
+id: "qpc-03-fingerprint-signature-v2"
+title: "Fingerprint v2: encode tree shape, escape separators, honest integrity states"
+worktree: "query-plan-capture"
+priority: "High"
+status: "Not Started"
+
+description: |
+  get_structural_signature flattens children with the same '|' separator as
+  scalar fields, so tree shape is not encoded: Join[Scan(t1), Scan(t2)] and
+  Join[Scan(t1) -> Scan(t2)] produce identical SHA256 fingerprints
+  (reproduced). Separator injection also collides: filters ["a","b"] ==
+  ["a,b"]; table_name "x|filters:y" == table x + filter y. The comparator's
+  trusted fast path (comparison.py:181) then declares structurally different
+  plans identical — masking exactly the plan-regression class the tool exists
+  to catch.
+
+  Integrity: a plan whose stored fingerprint is missing gets recomputed and
+  marked VERIFIED in __post_init__ (query_plan_models.py:345-349), so
+  deleting the fingerprint field bypasses STALE tamper-detection;
+  refresh_on_mismatch launders tampered plans into trusted RECOMPUTED.
+
+  Findings: F2.1, F2.2.
+
+category: "Correctness / Data Integrity"
+
+prior_art:
+- "benchbox/core/results/query_plan_models.py:250-308 get_structural_signature"
+- "benchbox/core/results/query_plan_models.py:311-317 FingerprintIntegrity"
+- "benchbox/core/query_plans/comparison.py:167-182 trusted fast path"
+- "scratchpad repro repro_fingerprint.py — collision and trust repros to convert into tests"
+
+work:
+- id: w1
+  summary: >-
+    Create: rewrite the signature to be unambiguous — recursive form
+    op(child1,child2,...) with scalar fields JSON-encoded (json.dumps of the
+    parts list is simplest). Add fingerprint_version field to QueryPlanDAG,
+    to_dict/from_dict, and the companion payload; version bump to 2.
+  status: pending
+- id: w2
+  summary: >-
+    Create: integrity semantics — from_dict with absent stored fingerprint
+    sets RECOMPUTED (not VERIFIED); comparison fast path requires matching
+    fingerprint_version AND trusted integrity, else full tree walk; document
+    that integrity states verify internal consistency, not provenance.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: regression tests from the review repros — sibling-vs-nested
+    collision, separator injection, deleted-fingerprint trust, version
+    mismatch falls back to tree walk.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (hash stability across Python versions, unicode expressions, empty-list vs None fields)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-03; call out the fingerprint-version break loudly in the PR body."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "Old bundles (no fingerprint_version / v1 fingerprints) still load; they compare via tree walk, never via cross-version fingerprint equality"
+- "Fingerprints remain structure-only (no costs/rows/operator ids)"
+
+anti_patterns:
+- "DO NOT keep '|'/',' joining with ad-hoc escaping — use a canonical encoder (JSON) so the next field added cannot re-introduce injection."
+- "DO NOT compare v1 and v2 fingerprints for equality anywhere, including history flap detection."
+
+verification:
+- description: "Collision repros now produce distinct fingerprints"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_query_plan_models.py -q"
+  expected_output: "all pass, including new collision tests"
+- description: "Comparator falls back to tree walk on version mismatch and untrusted integrity"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/test_query_plans_comparison.py -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/query_plan_models.py"
+  - "benchbox/core/query_plans/comparison.py"
+  - "benchbox/core/results/schema.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "fingerprint", "integrity", "versioning"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F2.1", "F2.2"]

--- a/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
+++ b/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
@@ -32,17 +32,22 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: rewrite the signature to be unambiguous — recursive form
-    op(child1,child2,...) with scalar fields JSON-encoded (json.dumps of the
-    parts list is simplest). Add fingerprint_version field to QueryPlanDAG,
-    to_dict/from_dict, and the companion payload; version bump to 2.
+    Create: rewrite the structural signature to encode tree shape and escape
+    fields; add fingerprint_version=2 to model and companion payload.
+  notes: >-
+    Recursive form op(child1,child2,...) with scalar fields JSON-encoded
+    (json.dumps of the parts list is simplest). Add fingerprint_version to
+    QueryPlanDAG, to_dict/from_dict, and the companion payload.
   status: pending
 - id: w2
   summary: >-
-    Create: integrity semantics — from_dict with absent stored fingerprint
-    sets RECOMPUTED (not VERIFIED); comparison fast path requires matching
-    fingerprint_version AND trusted integrity, else full tree walk; document
-    that integrity states verify internal consistency, not provenance.
+    Create: honest integrity semantics — missing stored fingerprint yields
+    RECOMPUTED; comparator fast path requires version match + trust.
+  notes: >-
+    from_dict with absent stored fingerprint sets RECOMPUTED (not VERIFIED);
+    comparison fast path requires matching fingerprint_version AND trusted
+    integrity, else full tree walk; document that integrity states verify
+    internal consistency, not provenance.
   needs: [w1]
   status: pending
 - id: w3

--- a/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
+++ b/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
@@ -1,0 +1,98 @@
+id: "qpc-04-capture-timeout-and-analyze-default"
+title: "Make the plan-capture timeout real; default DuckDB capture to estimated plans (no re-execution)"
+worktree: "query-plan-capture"
+priority: "High"
+status: "Not Started"
+
+description: |
+  The capture timeout does not bound wall-clock time: capture_query_plan
+  wraps get_query_plan in `with ThreadPoolExecutor(...)`, and after
+  future.result(timeout=...) raises, the context exit calls
+  shutdown(wait=True) which blocks until the hung EXPLAIN finishes.
+  Reproduced: timeout=1s, EXPLAIN sleeping 5s, call returned after 5.0s.
+  A hung EXPLAIN stalls the whole benchmark; recorded capture_time_ms
+  (~timeout) understates the real stall.
+
+  Separately, DuckDB capture defaults to EXPLAIN (ANALYZE, FORMAT JSON)
+  (analyze_plans=True at adapter.py:128) which re-executes every measured
+  query: ~2x wall-clock and perturbed cache state, with no CLI-level notice.
+  Fingerprints are structure-only, so estimated plans lose nothing downstream.
+
+  Findings: F4.1, F5.2.
+
+category: "Reliability / Performance"
+
+prior_art:
+- "benchbox/platforms/base/result_capture.py:601-633 capture_query_plan timeout block"
+- "benchbox/platforms/base/adapter.py:128-130 analyze_plans / plan_capture_timeout_seconds defaults"
+- "benchbox/platforms/duckdb.py:1038-1067 get_query_plan EXPLAIN options"
+- "scratchpad repro repro_timeout_parsers.py — 1s-timeout/5s-hang repro"
+
+work:
+- id: w1
+  summary: >-
+    Create: on timeout, executor.shutdown(wait=False) and mark the connection
+    for recycling (the leaked thread may still be using it); where the engine
+    supports it prefer a server-side bound (DuckDB interrupt API /
+    SET statement_timeout for PG-family) over the thread dance. Log the true
+    elapsed time if the straggler eventually completes.
+  status: pending
+- id: w2
+  summary: >-
+    Create: flip analyze_plans default to False (estimated plans); emit a
+    one-line run-level notice when ANALYZE capture is explicitly enabled
+    ("plan capture re-executes each query; timings are not comparable to
+    non-capture runs").
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: tests — timeout actually bounds capture_query_plan wall-clock
+    (hang 5s, timeout 1s, assert return < 2s); default EXPLAIN options
+    contain no ANALYZE; notice printed when enabled.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (connection-recycle path per platform, orphan-thread lifecycle, strict-mode interaction)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-04; document the analyze_plans default change in release notes."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "analyze_plans=True still available and functional for users who want actual cardinalities"
+- "Per-query timing continues to exclude capture time on SQL platforms (capture after measurement)"
+
+anti_patterns:
+- "DO NOT keep using the abandoned connection after a timeout — the worker thread may still be executing on it."
+- "DO NOT cancel via daemon-thread tricks that hide the hung EXPLAIN; record it as a capture failure with reason=timeout and the real elapsed time."
+
+verification:
+- description: "Timeout bounds wall-clock"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_plan_capture_errors.py -q -k timeout"
+  expected_output: "all pass, including new wall-clock bound test"
+- description: "Default capture issues plain EXPLAIN (FORMAT JSON)"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_duckdb_plan_capture.py -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/base/result_capture.py"
+  - "benchbox/platforms/base/adapter.py"
+  - "benchbox/platforms/duckdb.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "timeout", "explain-analyze", "overhead"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F4.1", "F5.2"]

--- a/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
+++ b/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
@@ -31,18 +31,22 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: on timeout, executor.shutdown(wait=False) and mark the connection
-    for recycling (the leaked thread may still be using it); where the engine
+    Create: make the capture timeout bound wall-clock — non-blocking executor
+    shutdown, connection recycling, server-side bounds where supported.
+  notes: >-
+    On timeout, executor.shutdown(wait=False) and mark the connection for
+    recycling (the leaked thread may still be using it); where the engine
     supports it prefer a server-side bound (DuckDB interrupt API /
     SET statement_timeout for PG-family) over the thread dance. Log the true
     elapsed time if the straggler eventually completes.
   status: pending
 - id: w2
   summary: >-
-    Create: flip analyze_plans default to False (estimated plans); emit a
-    one-line run-level notice when ANALYZE capture is explicitly enabled
-    ("plan capture re-executes each query; timings are not comparable to
-    non-capture runs").
+    Create: flip analyze_plans default to False; print a run-level notice
+    when ANALYZE capture is explicitly enabled.
+  notes: >-
+    Notice wording: plan capture re-executes each query; timings are not
+    comparable to non-capture runs.
   needs: [w1]
   status: pending
 - id: w3

--- a/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
+++ b/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
@@ -39,10 +39,12 @@ work:
   status: pending
 - id: w2
   summary: >-
-    Create: _load_companion_file logs WARNING with path+error and load_result_file
-    surfaces a plans_load_error field; show-plan/compare-plans print
-    "plans file exists but failed to load: <reason>" instead of
-    "no plans captured".
+    Create: corrupt companion files surface as warnings and a
+    plans_load_error field; CLIs report load failure, not "no plans".
+  notes: >-
+    _load_companion_file logs WARNING with path+error; load_result_file
+    surfaces plans_load_error; show-plan/compare-plans print "plans file
+    exists but failed to load: <reason>" instead of "no plans captured".
   needs: [w1]
   status: pending
 - id: w3
@@ -54,9 +56,12 @@ work:
   status: pending
 - id: w4
   summary: >-
-    Create: DuckDB text parser joins box continuation lines (unbalanced-paren
-    heuristic) before splitting expressions; regression test with the
-    DUCKDB_0_9_FILTER_SCAN fixture asserting one filter expression.
+    Create: DuckDB text parser joins box continuation lines before splitting
+    expressions, with a wrapped-filter regression test.
+  notes: >-
+    Use an unbalanced-paren heuristic to detect continuations; regression
+    test with the DUCKDB_0_9_FILTER_SCAN fixture asserting one filter
+    expression.
   needs: [w3]
   status: pending
 - id: w5

--- a/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
+++ b/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
@@ -1,0 +1,111 @@
+id: "qpc-05-silent-failure-surfacing"
+title: "Surface capture/load failures: no more errors converted into absence"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  Four places convert failures into silent absence or garbage:
+  1. get_query_plan_from_cursor returns "Could not get query plan: <exc>" AS
+     the plan text (sql_execution.py:29-30) — displayed as a plan; would be
+     parsed as one if those platforms ever join capture.
+  2. Corrupt .plans.json logged at DEBUG (loader.py:172-179) — user is told
+     "no plans captured, re-run with --capture-plans" for a file problem.
+  3. DataFrame capture exceptions logged at debug with no error record
+     (expression_family.py:1433-1437) — companion errors show generic
+     "Query plan not captured" instead of the real cause.
+  4. DuckDB text-format (pre-0.10 fallback) splits box-wrapped expressions
+     mid-token into separate filter expressions (reproduced:
+     "filters:'1998-12-01' AS DATE)),(l_shipdate <= CAST(") making
+     fingerprints depend on line-wrap width.
+
+  Findings: F4.2, F4.3, F4.4, F2.3.
+
+category: "Error Handling / Observability"
+
+prior_art:
+- "benchbox/platforms/base/sql_execution.py:11-32 get_query_plan_from_cursor"
+- "benchbox/core/results/loader.py:165-179 _load_companion_file"
+- "benchbox/platforms/dataframe/expression_family.py:1431-1437 capture swallow"
+- "benchbox/platforms/base/result_capture.py:524-558 _record_plan_capture_failure — the pattern to mirror"
+- "benchbox/core/query_plans/parsers/duckdb.py text/box parser"
+
+work:
+- id: w1
+  summary: >-
+    Create: get_query_plan_from_cursor returns None on failure and logs the
+    exception; callers (trino/presto/athena/firebolt/azure_synapse display
+    paths) handle None.
+  status: pending
+- id: w2
+  summary: >-
+    Create: _load_companion_file logs WARNING with path+error and load_result_file
+    surfaces a plans_load_error field; show-plan/compare-plans print
+    "plans file exists but failed to load: <reason>" instead of
+    "no plans captured".
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: DataFrame capture failures recorded into a per-run capture-error
+    list (mirroring _record_plan_capture_failure) so companion errors carry
+    the real exception; warn once per run.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: >-
+    Create: DuckDB text parser joins box continuation lines (unbalanced-paren
+    heuristic) before splitting expressions; regression test with the
+    DUCKDB_0_9_FILTER_SCAN fixture asserting one filter expression.
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Review: adversarial code review (message wording reachable from CLIs, no new crash paths on None plans)."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w5]
+  status: pending
+- id: w7
+  summary: "Submit PR referencing qpc-05."
+  needs: [w6]
+  status: pending
+
+must_preserve:
+- "Display path (show_query_plans) stays best-effort: failures never abort query execution"
+- "strict_plan_capture still raises PlanCaptureError on capture failure"
+
+anti_patterns:
+- "DO NOT encode errors in the data channel (error strings returned as plan text)."
+- "DO NOT log user-actionable failures at DEBUG."
+
+verification:
+- description: "Cursor helper returns None on EXPLAIN failure"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_plan_capture_errors.py -q"
+  expected_output: "all pass"
+- description: "Corrupt companion produces distinguishable CLI message"
+  command: "uv run -- python -m pytest tests/unit/cli/commands/test_show_plan_coverage.py tests/unit/core/results/test_loader.py -q"
+  expected_output: "all pass, including corrupt-companion test"
+- description: "Wrapped filter parses as one expression"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/parsers -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/base/sql_execution.py"
+  - "benchbox/core/results/loader.py"
+  - "benchbox/platforms/dataframe/expression_family.py"
+  - "benchbox/core/query_plans/parsers/duckdb.py"
+  - "benchbox/cli/commands/show_plan.py"
+  - "benchbox/cli/commands/compare_plans.py"
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view"]
+
+metadata:
+  tags: ["query-plans", "error-handling", "parser", "observability"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F4.2", "F4.3", "F4.4", "F2.3"]

--- a/_project/TODO/query-plan-capture/planning/06-cross-platform-capture-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/06-cross-platform-capture-wiring.yaml
@@ -1,0 +1,114 @@
+id: "qpc-06-cross-platform-capture-wiring"
+title: "Wire structured plan capture beyond DuckDB: shared SQL path, PG JSON format, DataFrame DAGs"
+worktree: "query-plan-capture"
+priority: "High"
+status: "Not Started"
+
+description: |
+  The structured capture pipeline is DuckDB-only: capture_query_plan is
+  called solely from duckdb.py:969 and only DuckDB overrides
+  get_query_plan_parser. The PostgreSQL/Redshift/DataFusion/SQLite parsers
+  are complete, tested, and unreachable. --capture-plans on any other SQL
+  platform silently does nothing.
+
+  Contract breaks to fix on the way:
+  - postgresql.py emits EXPLAIN ... FORMAT TEXT (line 722) but the PG parser
+    accepts only JSON (reproduced: "Invalid JSON in EXPLAIN output").
+  - DataFrame platforms store profiling.QueryPlan (text+hints, no DAG, no
+    fingerprint) into the same query_plan slot (benchmark_mixin.py:1035),
+    silently forking the companion schema by platform family.
+  - Fingerprints are platform-scoped by construction; document that and keep
+    cross-platform comparison at the operator-type tree level.
+
+  Findings: F3.1, F3.2, F3.3, F3.4.
+
+category: "Feature Completion / Architecture"
+
+prior_art:
+- "benchbox/platforms/base/execution.py:_execute_single_query — the choke point for shared wiring"
+- "benchbox/platforms/duckdb.py:915-1075 — the one working reference implementation"
+- "benchbox/core/query_plans/parsers/{postgresql,redshift,datafusion,sqlite}.py + registry.py"
+- "benchbox/core/dataframe/profiling.py:70-85 QueryPlan (text-only model)"
+
+work:
+- id: w1
+  summary: >-
+    Create: move the capture invocation into the shared SQL execute path so
+    every adapter with a parser captures structured plans; platforms without
+    a parser emit ONE prominent run-level warning ("plan capture not
+    supported on X") instead of silence.
+  status: pending
+- id: w2
+  summary: >-
+    Create: PostgreSQL — capture-path EXPLAIN uses FORMAT JSON (display path
+    keeps TEXT); add get_query_plan_parser override; same for any platform
+    whose parser exists (redshift, sqlite where applicable).
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: per-platform contract tests — the adapter's own EXPLAIN output
+    (fixture) fed to the platform's registered parser must produce a
+    QueryPlanDAG; add plan_format discriminator to companion entries.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: >-
+    Create: DataFrame family — route captured plan text through the
+    registered parsers (DataFusion first) to produce QueryPlanDAG with
+    plan_text preserved as raw_explain_output; keep text-only QueryPlan as
+    fallback with explicit plan_format so consumers fail informatively.
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: >-
+    Create: docs — fingerprints are platform-scoped; cross-platform
+    comparison uses tree comparison, never fingerprint equality.
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Review: adversarial code review (per-platform EXPLAIN dialects, DML/refresh paths must NOT be captured with ANALYZE, connection reuse)."
+  needs: [w5]
+  status: pending
+- id: w7
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w6]
+  status: pending
+- id: w8
+  summary: "Submit PR referencing qpc-06 (consider splitting SQL wiring and DataFrame wiring into two PRs if the diff exceeds review size)."
+  needs: [w7]
+  status: pending
+
+must_preserve:
+- "DuckDB capture behavior and its existing tests"
+- "Refresh/maintenance operations (OperationExecutor path) are never re-executed by plan capture"
+- "Platforms without parsers keep working with a warning, not a failure (unless strict_plan_capture)"
+
+anti_patterns:
+- "DO NOT copy the capture block into each adapter — wire it once in the shared path."
+- "DO NOT let two platform families write differently-shaped 'plan' objects without a discriminator field."
+
+verification:
+- description: "Adapter-output -> parser contract per platform"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/parsers tests/unit/platforms -q -k 'plan'"
+  expected_output: "all pass, including new contract tests"
+- description: "PG capture produces a DAG from FORMAT JSON fixture"
+  command: "uv run -- python -m pytest tests/unit/platforms -q -k 'postgres and plan'"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/"
+  - "benchbox/core/query_plans/"
+  - "benchbox/core/results/schema.py"
+  - "docs/"
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view", "qpc-03-fingerprint-signature-v2"]
+
+metadata:
+  tags: ["query-plans", "cross-platform", "parsers", "dataframe"]
+  estimated_effort: "Large"
+  created_date: "2026-07-04"
+  review_findings: ["F3.1", "F3.2", "F3.3", "F3.4"]

--- a/_project/TODO/query-plan-capture/planning/06-cross-platform-capture-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/06-cross-platform-capture-wiring.yaml
@@ -33,10 +33,12 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: move the capture invocation into the shared SQL execute path so
-    every adapter with a parser captures structured plans; platforms without
+    Create: move capture invocation into the shared SQL execute path;
+    parserless platforms warn once per run instead of staying silent.
+  notes: >-
+    Every adapter with a parser captures structured plans; platforms without
     a parser emit ONE prominent run-level warning ("plan capture not
-    supported on X") instead of silence.
+    supported on X").
   status: pending
 - id: w2
   summary: >-
@@ -47,17 +49,22 @@ work:
   status: pending
 - id: w3
   summary: >-
-    Create: per-platform contract tests — the adapter's own EXPLAIN output
-    (fixture) fed to the platform's registered parser must produce a
-    QueryPlanDAG; add plan_format discriminator to companion entries.
+    Create: per-platform adapter-EXPLAIN -> parser contract tests; add a
+    plan_format discriminator to companion entries.
+  notes: >-
+    The adapter's own EXPLAIN output (fixture) fed to the platform's
+    registered parser must produce a QueryPlanDAG.
   needs: [w2]
   status: pending
 - id: w4
   summary: >-
-    Create: DataFrame family — route captured plan text through the
-    registered parsers (DataFusion first) to produce QueryPlanDAG with
-    plan_text preserved as raw_explain_output; keep text-only QueryPlan as
-    fallback with explicit plan_format so consumers fail informatively.
+    Create: DataFrame plans become QueryPlanDAGs via registered parsers,
+    with text-only fallback tagged by plan_format.
+  notes: >-
+    Route captured plan text through the registered parsers (DataFusion
+    first); preserve plan_text as raw_explain_output; keep text-only
+    QueryPlan as fallback with explicit plan_format so consumers fail
+    informatively.
   needs: [w3]
   status: pending
 - id: w5

--- a/_project/TODO/query-plan-capture/planning/07-plans-companion-hardening.yaml
+++ b/_project/TODO/query-plan-capture/planning/07-plans-companion-hardening.yaml
@@ -1,0 +1,109 @@
+id: "qpc-07-plans-companion-hardening"
+title: "Harden .plans.json: to_dict serialization, multi-iteration retention, anonymization, path arithmetic"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  Four companion-file defects:
+  1. build_plans_payload checks is_dataclass BEFORE hasattr(to_dict)
+     (schema.py:1074-1083), so QueryPlanDAG always serializes via asdict —
+     bypassing the depth-guarded to_dict, leaking the internal
+     fingerprint_integrity field (reproduced), and drifting from the designed
+     serialization.
+  2. plans_by_query[query_id] = plan_entry is last-writer-wins: with multiple
+     iterations/streams only one plan per query survives, silently — plan
+     flapping across iterations is unobservable from a bundle.
+  3. The companion bypasses anonymization: raw_explain_output is exported
+     verbatim even when anonymize=True (exporter.py:224 vs 253) — absolute
+     paths/usernames leak from "anonymized" bundles.
+  4. _load_companion_file path arithmetic breaks on filenames with extra dots
+     (sf0.1) and the fallback str.replace(".json", ...) hits the first
+     occurrence anywhere in the path.
+
+  Findings: F1.5, F1.6, F1.7.
+
+category: "Data Integrity / Privacy"
+
+prior_art:
+- "benchbox/core/results/schema.py:1043-1104 build_plans_payload"
+- "benchbox/core/results/exporter.py:218-267 _export_json_v2 / _write_companion_files"
+- "benchbox/core/results/loader.py:165-179 _load_companion_file"
+- "benchbox/core/results/anonymization.py AnonymizationManager"
+
+work:
+- id: w1
+  summary: >-
+    Create: reorder serialization branches (to_dict first, asdict fallback);
+    assert fingerprint_integrity is absent from exported payloads.
+  status: pending
+- id: w2
+  summary: >-
+    Create: retain plans per (query_id, iteration, stream) — companion
+    entries become a list under each normalized query id with a
+    schema-version bump, or (minimum) keep first + emit plans_dropped count;
+    prefer the list. Loader accepts both shapes.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: route the plans payload through AnonymizationManager when
+    anonymize=True (scrub paths/hostnames in raw_explain_output and operator
+    properties, or omit raw_explain_output for anonymized exports).
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: >-
+    Create: fix companion path arithmetic — exact basename suffix
+    replacement (name[:-len('.json')] + suffix); regression test with sf0.1
+    style filenames.
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Review: adversarial code review (companion schema-version handling on load, anonymization completeness)."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w5]
+  status: pending
+- id: w7
+  summary: "Submit PR referencing qpc-07."
+  needs: [w6]
+  status: pending
+
+must_preserve:
+- "Existing single-plan companions still load (backward-compatible reader)"
+- "canonical_json_text byte-stability"
+
+anti_patterns:
+- "DO NOT silently drop plans for repeated query ids — either retain or count what was dropped."
+- "DO NOT anonymize by mutating the in-memory result object — anonymize the payload copy only (mirror the main-file pattern)."
+
+verification:
+- description: "No internal fields leak; to_dict branch used"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_query_plan_serialization.py -q"
+  expected_output: "all pass, including fingerprint_integrity-absent assertion"
+- description: "Multi-iteration plans retained"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_query_plan_serialization.py -q -k iteration"
+  expected_output: "all pass"
+- description: "Anonymized export contains no absolute paths in companion"
+  command: "uv run -- python -m pytest tests/unit/core/results -q -k anonym"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/schema.py"
+  - "benchbox/core/results/exporter.py"
+  - "benchbox/core/results/loader.py"
+  - "benchbox/core/results/anonymization.py"
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view"]
+
+metadata:
+  tags: ["query-plans", "companion-file", "anonymization", "serialization"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F1.5", "F1.6", "F1.7"]

--- a/_project/TODO/query-plan-capture/planning/07-plans-companion-hardening.yaml
+++ b/_project/TODO/query-plan-capture/planning/07-plans-companion-hardening.yaml
@@ -39,17 +39,21 @@ work:
   status: pending
 - id: w2
   summary: >-
-    Create: retain plans per (query_id, iteration, stream) — companion
-    entries become a list under each normalized query id with a
+    Create: retain plans per (query_id, iteration, stream) in the companion
+    instead of last-writer-wins; loader accepts both shapes.
+  notes: >-
+    Companion entries become a list under each normalized query id with a
     schema-version bump, or (minimum) keep first + emit plans_dropped count;
-    prefer the list. Loader accepts both shapes.
+    prefer the list.
   needs: [w1]
   status: pending
 - id: w3
   summary: >-
-    Create: route the plans payload through AnonymizationManager when
-    anonymize=True (scrub paths/hostnames in raw_explain_output and operator
-    properties, or omit raw_explain_output for anonymized exports).
+    Create: anonymize the plans payload when anonymize=True (paths/hostnames
+    in raw_explain_output and operator properties).
+  notes: >-
+    Route through AnonymizationManager, or omit raw_explain_output entirely
+    for anonymized exports.
   needs: [w2]
   status: pending
 - id: w4

--- a/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
@@ -1,0 +1,96 @@
+id: "qpc-08-history-and-plan-metadata-wiring"
+title: "Make plan history real: fix dead attribute reads, wire add_run into the run path, sane ordering"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  benchbox plan-history is dead end-to-end:
+  - PlanHistoryStorage.add_run reads results.run_id / results.start_time /
+    results.phases — none exist on BenchmarkResults (fields are execution_id
+    / timestamp; phases arrives with qpc-01) — so it warns and no-ops
+    (history.py:78-97). Same silent-empty pattern in
+    core/manifest/plan_metadata_utils.py:38.
+  - add_run has zero production callers; the CLI reads a store nothing
+    populates.
+  - query_plan_history sorts ISO timestamp strings lexicographically
+    (history.py:155) — mixed-offset timestamps misorder flap detection.
+  - detect_plan_flapping ignores platform: a history dir with two platforms
+    for one query id reports 100% flapping.
+
+  Findings: F1.2, F7.2, plus the platform-partitioning slice of F3.4.
+
+category: "Feature Completion"
+
+prior_art:
+- "benchbox/core/query_plans/history.py:71-156"
+- "benchbox/core/manifest/plan_metadata_utils.py:25-46"
+- "benchbox/cli/commands/plan_history.py"
+
+work:
+- id: w1
+  summary: >-
+    Create: fix attribute names (execution_id, timestamp) and read plans via
+    the qpc-01 accessor; replace getattr(..., {}) defaults with explicit
+    access so shape drift fails loudly; same fixes in plan_metadata_utils.
+  status: pending
+- id: w2
+  summary: >-
+    Create: wire add_run into the export/post-run path (single call site,
+    opt-in config for the history dir); parse timestamps with
+    datetime.fromisoformat for sorting; partition flap/version detection by
+    platform.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: end-to-end test — run add_run on a real BenchmarkResults with
+    plans, then plan-history CLI via CliRunner shows the entry; flapping test
+    with mixed platforms asserts partitioning.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (history dir lifecycle, cache staleness, fingerprint_version interaction with qpc-03)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-08."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "Existing history-file JSON shape stays readable"
+- "plan-history CLI flags and output format"
+
+anti_patterns:
+- "DO NOT keep defensive getattr(..., default) for required attributes — it converted a wiring bug into permanently-empty output."
+- "DO NOT compare fingerprints across fingerprint_version or across platforms in flap detection."
+
+verification:
+- description: "add_run stores fingerprints from a real BenchmarkResults"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/test_plan_history.py -q"
+  expected_output: "all pass, including real-object add_run test"
+- description: "plan-history CLI end-to-end"
+  command: "uv run -- python -m pytest tests/unit/cli/commands/test_plan_history_coverage.py -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/query_plans/history.py"
+  - "benchbox/core/manifest/plan_metadata_utils.py"
+  - "benchbox/cli/commands/plan_history.py"
+  - "benchbox/core/results/exporter.py"
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view"]
+
+metadata:
+  tags: ["query-plans", "history", "manifest", "cli"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F1.2", "F7.2", "F3.4-partial"]

--- a/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
@@ -30,16 +30,21 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: fix attribute names (execution_id, timestamp) and read plans via
-    the qpc-01 accessor; replace getattr(..., {}) defaults with explicit
-    access so shape drift fails loudly; same fixes in plan_metadata_utils.
+    Create: fix dead attribute reads in history and plan_metadata_utils;
+    make shape drift fail loudly instead of getattr defaults.
+  notes: >-
+    Fix attribute names (execution_id, timestamp) and read plans via the
+    qpc-01 accessor; replace getattr(..., {}) defaults with explicit access;
+    same fixes in plan_metadata_utils.
   status: pending
 - id: w2
   summary: >-
-    Create: wire add_run into the export/post-run path (single call site,
-    opt-in config for the history dir); parse timestamps with
-    datetime.fromisoformat for sorting; partition flap/version detection by
-    platform.
+    Create: wire add_run into the export/post-run path; timestamp-parse
+    sorting; partition flap detection by platform.
+  notes: >-
+    Single call site, opt-in config for the history dir; parse timestamps
+    with datetime.fromisoformat for sorting; partition flap/version
+    detection by platform.
   needs: [w1]
   status: pending
 - id: w3

--- a/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
+++ b/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
@@ -25,18 +25,21 @@ prior_art:
 work:
 - id: w1
   summary: >-
-    Create: add a plan_capture timed phase to QueryProfileContext (like
-    planning/collect); define execution_time_ms to exclude capture time —
-    either sum-of-measured-phases minus capture, or collect-time as the
+    Create: add a plan_capture timed phase to QueryProfileContext and define
+    execution_time_ms to exclude capture time.
+  notes: >-
+    Either sum-of-measured-phases minus capture, or collect-time as the
     canonical query time. Document which segments count in the profile
     docstring.
   status: pending
 - id: w2
   summary: >-
-    Create: timing contract test — same fake query profiled with and without
-    capture_plan must report execution_time_ms within tolerance; capture time
-    surfaced as its own field (plan_capture_time_ms) matching the SQL-side
-    field name.
+    Create: timing contract test — capture on/off must report equal
+    execution_time_ms; capture time gets its own field.
+  notes: >-
+    Same fake query profiled with and without capture_plan must report
+    execution_time_ms within tolerance; capture time surfaced as
+    plan_capture_time_ms matching the SQL-side field name.
   needs: [w1]
   status: pending
 - id: w3

--- a/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
+++ b/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
@@ -1,0 +1,84 @@
+id: "qpc-09-df-timing-semantics"
+title: "Exclude plan-capture time from DataFrame execution_time_ms (align with SQL semantics)"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  QueryProfileContext.get_profile computes execution_time_ms wall-to-wall
+  from context creation (profiling.py:187), and plan capture runs inside that
+  window (expression_family.py:1431-1437). So enabling --capture-plans
+  changes reported per-query times on DataFrame platforms, while SQL
+  platforms capture after timing (duckdb.py:957 vs :969). A/B comparisons
+  where one side had capture enabled are skewed; cross-family comparisons
+  embed inconsistent timing semantics within a single run.
+
+  Finding: F5.1.
+
+category: "Correctness / Timing"
+
+prior_art:
+- "benchbox/core/dataframe/profiling.py:139-200 QueryProfileContext"
+- "benchbox/platforms/dataframe/expression_family.py:1421-1445 capture-inside-window"
+- "tests/unit/core/results/test_schema_timing_contract.py / test_exporter_timing_contract.py — the repo's timing-policy pattern"
+
+work:
+- id: w1
+  summary: >-
+    Create: add a plan_capture timed phase to QueryProfileContext (like
+    planning/collect); define execution_time_ms to exclude capture time —
+    either sum-of-measured-phases minus capture, or collect-time as the
+    canonical query time. Document which segments count in the profile
+    docstring.
+  status: pending
+- id: w2
+  summary: >-
+    Create: timing contract test — same fake query profiled with and without
+    capture_plan must report execution_time_ms within tolerance; capture time
+    surfaced as its own field (plan_capture_time_ms) matching the SQL-side
+    field name.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review (timing-policy check compliance, downstream consumers of execution_time_ms/planning/collect fields)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-09."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "planning_time_ms / collect_time_ms fields and their meaning"
+- "Timing policy checks (_project/scripts/timing_policy_check.py) pass"
+
+anti_patterns:
+- "DO NOT subtract an estimated capture cost — measure the capture phase explicitly."
+
+verification:
+- description: "Capture on/off produces equal execution_time_ms for identical work"
+  command: "uv run -- python -m pytest tests/unit/platforms/dataframe -q -k 'profil or timing'"
+  expected_output: "all pass, including new contract test"
+- description: "Timing policy gate"
+  command: "uv run -- python scripts/validate_todo_indexes.py"
+  expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/dataframe/profiling.py"
+  - "benchbox/platforms/dataframe/expression_family.py"
+  - "benchbox/platforms/dataframe/benchmark_mixin.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "dataframe", "timing"]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  review_findings: ["F5.1"]

--- a/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
+++ b/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
@@ -1,0 +1,102 @@
+id: "qpc-10-concurrency-and-depth-limits"
+title: "Thread-safe capture stats under throughput mode; explicit depth-limit truncation"
+worktree: "query-plan-capture"
+priority: "Low"
+status: "Not Started"
+
+description: |
+  Concurrency: throughput streams run on a ThreadPoolExecutor
+  (tpc_patterns.py:664) against one shared adapter; capture mutates
+  plan_capture_failures += 1, plan_capture_errors.append,
+  _plan_capture_iteration_counts, query_plans_captured += 1 with no lock
+  (result_capture.py:541-542,591-592,700). Exported headline stats are
+  recomputed iteration-stably (builder.py:498) so main-file numbers are
+  mostly immune; the damage is live progress logs, plan_capture_errors
+  ordering/loss, and plan_first_n over/under-capture. Strict-mode
+  PlanCaptureError raised in a stream thread surfaces as a generic stream
+  failure instead of aborting the run.
+
+  Depth limits: plans deeper than 50 are dropped whole (to_dict raises,
+  estimate_serialized_size -> serialization_error failure); the 50-depth and
+  100KB thresholds are hardcoded; the "consider external plan storage" hint
+  references a feature that does not exist.
+
+  Findings: F6.1, F5.3.
+
+category: "Reliability / Concurrency"
+
+prior_art:
+- "benchbox/platforms/base/result_capture.py:541-542,591-592,682-700"
+- "benchbox/core/tpc_patterns.py:655-690 stream executor"
+- "benchbox/core/results/query_plan_models.py:155-158,406-418 depth guard"
+- "benchbox/core/results/builder.py:498 stats recomputation"
+
+work:
+- id: w1
+  summary: >-
+    Create: one threading.Lock in the capture mixin around the three mutation
+    sites (rare, contention-free); make plan_first_n check-and-increment
+    atomic under the lock.
+  status: pending
+- id: w2
+  summary: >-
+    Create: define and implement strict-mode semantics under throughput
+    (recommended: abort the run — propagate PlanCaptureError distinctly from
+    generic stream failure); document the choice.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: >-
+    Create: depth handling — serialize to max_depth with a
+    truncated_at_depth marker instead of dropping the plan; fingerprint
+    computed over the full in-memory tree with the fingerprint marked
+    partial-safe; expose plan_max_depth in adapter config next to
+    plan_capture_timeout_seconds; remove the dangling "external plan storage"
+    hint.
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (lock scope vs EXPLAIN duration — never hold the lock across I/O; truncation-marker round-trip)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-10."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "compute_plan_capture_stats iteration-stable semantics"
+- "No lock held during get_query_plan (EXPLAIN I/O)"
+
+anti_patterns:
+- "DO NOT serialize captures globally — lock only the counter/list mutations."
+- "DO NOT fingerprint a truncated tree as if complete — mark it."
+
+verification:
+- description: "Concurrent capture stress test keeps counts exact"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_plan_capture_stats.py tests/unit/platforms/test_plan_capture_errors.py -q"
+  expected_output: "all pass, including new concurrency test"
+- description: "Deep plan exports with truncation marker instead of disappearing"
+  command: "uv run -- python -m pytest tests/unit/core/results/test_query_plan_models.py -q -k depth"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/base/result_capture.py"
+  - "benchbox/platforms/base/adapter.py"
+  - "benchbox/core/results/query_plan_models.py"
+  - "benchbox/core/tpc_patterns.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "concurrency", "throughput", "limits"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  review_findings: ["F6.1", "F5.3"]

--- a/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
+++ b/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
@@ -47,12 +47,13 @@ work:
   status: pending
 - id: w3
   summary: >-
-    Create: depth handling — serialize to max_depth with a
-    truncated_at_depth marker instead of dropping the plan; fingerprint
-    computed over the full in-memory tree with the fingerprint marked
-    partial-safe; expose plan_max_depth in adapter config next to
-    plan_capture_timeout_seconds; remove the dangling "external plan storage"
-    hint.
+    Create: deep plans serialize with a truncated_at_depth marker instead of
+    being dropped; make plan_max_depth configurable.
+  notes: >-
+    Fingerprint computed over the full in-memory tree with the fingerprint
+    marked partial-safe; expose plan_max_depth in adapter config next to
+    plan_capture_timeout_seconds; remove the dangling "external plan
+    storage" hint.
   needs: [w2]
   status: pending
 - id: w4

--- a/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
+++ b/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
@@ -1,0 +1,84 @@
+id: "qpc-11-plan-cli-test-democking"
+title: "De-mock plan CLI/consumer tests: fakes must not define attributes production objects lack"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  All three plan CLI coverage suites monkeypatch load_result_file with
+  SimpleNamespace fakes that DEFINE .phases (test_show_plan_coverage.py:34-35,
+  test_compare_plans_coverage.py:85, test_plan_history_coverage.py) — the
+  suite stayed green while every real invocation crashed. The keystone
+  no-mock integration test lands with qpc-01; this item is the sweep: keep
+  fast fakes for flag/option coverage but derive their shape from the real
+  classes so attribute drift fails, and add the missing contract tests the
+  review identified (export->load->export byte equality lives in qpc-02;
+  adapter->parser contracts live in qpc-06).
+
+  Finding: F8.1 (sweep portion).
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- "tests/unit/cli/commands/test_show_plan_coverage.py:8-51 — the masking pattern"
+- "tests/unit/cli/commands/test_compare_plans_coverage.py, test_plan_history_coverage.py"
+- "benchbox/core/runner/dataframe_runner.py:66,98 — repo precedent for rejecting synthetic MagicMock attributes"
+
+work:
+- id: w1
+  summary: >-
+    Create: replace SimpleNamespace result fakes with real BenchmarkResults
+    instances (cheap to construct) or spec-constrained mocks
+    (create_autospec(BenchmarkResults)); where load_result_file is stubbed
+    for speed, add one companion test per CLI that exercises the real loader
+    on a tmp-file bundle.
+  status: pending
+- id: w2
+  summary: >-
+    Create: a guardrail test asserting plan CLI test modules do not
+    monkeypatch load_result_file without a sibling real-file test (pattern
+    mirror of tests/unit/test_todo_executable_docs.py guardrails), or a
+    lightweight lint in tests/conftest.
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review (did any test lose coverage in the swap; fake-shape drift actually fails now — mutate a field name and confirm red)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix: address review findings; re-run verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-11."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "Test suite runtime stays in the fast lane (no benchmark execution; tmp-file bundles only)"
+- "Existing coverage of CLI flags/options"
+
+anti_patterns:
+- "DO NOT hand fakes attributes the production class lacks — that is the exact mechanism that masked the .phases crash."
+- "DO NOT convert everything to slow integration tests — one real-path test per CLI plus spec'd fakes is the target."
+
+verification:
+- description: "CLI suites pass against real loader output"
+  command: "uv run -- python -m pytest tests/unit/cli/commands/test_show_plan_coverage.py tests/unit/cli/commands/test_compare_plans_coverage.py tests/unit/cli/commands/test_plan_history_coverage.py -q"
+  expected_output: "all pass"
+- description: "Shape-drift canary: renaming a BenchmarkResults field used by CLIs breaks a test"
+  command: "manual: temporarily rename query_results locally, run the suites, restore"
+  expected_output: "at least one test fails"
+
+scope_limit:
+  only_modify:
+  - "tests/"
+
+deps:
+  needs: ["qpc-01-plan-rehydration-and-phases-view"]
+
+metadata:
+  tags: ["query-plans", "testing", "mocking", "guardrail"]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  review_findings: ["F8.1-sweep"]

--- a/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
+++ b/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
@@ -28,17 +28,20 @@ work:
 - id: w1
   summary: >-
     Create: replace SimpleNamespace result fakes with real BenchmarkResults
-    instances (cheap to construct) or spec-constrained mocks
-    (create_autospec(BenchmarkResults)); where load_result_file is stubbed
-    for speed, add one companion test per CLI that exercises the real loader
-    on a tmp-file bundle.
+    or spec-constrained mocks; add one real-loader test per CLI.
+  notes: >-
+    Real instances are cheap to construct; otherwise
+    create_autospec(BenchmarkResults). Where load_result_file is stubbed for
+    speed, add one companion test per CLI that exercises the real loader on
+    a tmp-file bundle.
   status: pending
 - id: w2
   summary: >-
-    Create: a guardrail test asserting plan CLI test modules do not
-    monkeypatch load_result_file without a sibling real-file test (pattern
-    mirror of tests/unit/test_todo_executable_docs.py guardrails), or a
-    lightweight lint in tests/conftest.
+    Create: guardrail preventing load_result_file monkeypatching without a
+    sibling real-file test.
+  notes: >-
+    Pattern mirror of tests/unit/test_todo_executable_docs.py guardrails, or
+    a lightweight lint in tests/conftest.
   needs: [w1]
   status: pending
 - id: w3


### PR DESCRIPTION
# Pull Request

## Description

Adds a comprehensive remediation plan for the query-plan capture subsystem as executable TODO documentation under `_project/TODO/query-plan-capture/`, following the existing `_project/TODO`/`_project/DONE` YAML convention.

The plan is derived from a deep adversarial review (2026-07-04) of the full pipeline — capture → parse → model/fingerprint → serialize → load → consume. Key confirmed defects driving the plan:

- The loader parses `.plans.json` but discards the plan payloads (only counts survive), and every plan consumer iterates a `results.phases` attribute that `BenchmarkResults` does not have — `show-plan`/`compare-plans` fail on every real exported bundle (reproduced end-to-end).
- Companion files are keyed `"Q1"` while main-file query ids are normalized to `"1"`, so no id join can succeed.
- An export → load → export cycle corrupts bundles: warmup rows become measurement rows, failed queries duplicate as phantom successes, and the plans companion is destroyed.
- Plan fingerprints do not encode tree shape and are separator-injectable — structurally different plans collide (reproduced), and the comparator's trusted fast path then reports them identical.
- The plan-capture timeout does not bound wall-clock time (executor context exit blocks on the hung EXPLAIN; reproduced 1s timeout / 5s actual).
- Structured capture is wired for DuckDB only; the PostgreSQL/Redshift/DataFusion/SQLite parsers are unreachable, and the PG adapter emits `FORMAT TEXT` while its parser accepts only JSON.

Contents: a README (findings → item map, sequencing table, ground rules) plus 11 PR-sized work packages (`01`–`11`), each carrying the standard delivery loop — create → review → fix → submit PR — as explicit dependency-ordered work steps, with runnable verification commands, `must_preserve`/`anti_patterns` guardrails, and file-scope limits. Items 01→02 restore end-to-end function; 03/04/09/10 are parallelizable; 06 (cross-platform wiring) depends on 01+03.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

- Validated all 11 YAML files parse and satisfy the item schema (id/title/work present; every `work[].needs` reference resolves): `uv run -- python -c "<yaml.safe_load + needs-graph check>"` — all OK.
- `uv run -- python -m pytest tests/unit/test_todo_executable_docs.py -q` — 4 pre-existing failures unrelated to this change (they assert on artifacts from a different worktree not present in this checkout); this PR adds no assertions to that suite and does not modify any file it inspects.
- Review evidence behind the plan: three repro scripts (export→load→CLI crash, fingerprint collisions, timeout ineffectiveness) were run against this branch; their observed outputs are quoted in the item descriptions. Repro scripts intentionally not committed (scratchpad artifacts).

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size: none — text/YAML documentation only (12 files, ~1,100 lines).

## Notes

- Documentation-only: no runtime code paths are touched.
- Reviewers should sanity-check the sequencing choices in `README.md` (esp. that fingerprint v2 (`03`) gates cross-platform wiring (`06`)) and the `scope_limit` lists on items 01/02, which constrain the first two implementation PRs.
- Each item ends with its own "submit PR" step, so remediation lands as a series of small reviewable PRs; this PR only establishes the plan of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_