### PR TITLE
chore(todo): seed verification-review follow-up TODOs (canary activation, CI-gate pins, tier promotions, comparator hardening)

### DIFF
--- a/_project/TODO/main/planning/calculate-checksum-collision-hardening.yaml
+++ b/_project/TODO/main/planning/calculate-checksum-collision-hardening.yaml
@@ -1,0 +1,122 @@
+id: calculate-checksum-collision-hardening
+title: "Fix (not just pin) calculate_checksum's separator/dtype collisions with an escaped, type-tagged rendering plus same-change digest regen"
+worktree: main
+priority: Low
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  SOUNDNESS-CRITICAL COMPARATOR SURFACE: benchbox/core/tpchavoc/validation.py
+  is CODEOWNERS-covered; this TODO's PR requires code-owner review.
+
+  value-digest-collision-pinning (DONE, PR #952) took the deliberate
+  pin-only half of its "pin (or fix)" mandate: three verified collisions in
+  `calculate_checksum`'s raw str-join digest are now pinned as accepted
+  properties in tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py:144-193:
+    1. cell-separator aliasing: [("a|b","c")] == [("a","b|c")]
+    2. row-separator aliasing:  [("a\nb",)]  == [("a",),("b",)]
+    3. dtype aliasing:          [("1",)]     == [(1,)]
+  plus the pre-existing NULL-vs-"NULL" pin (same file, :133-141). The pins
+  make the weakness conscious; they do not remove it. The digest backs BOTH
+  TPC-Havoc's validate_results_checksum comparator AND the bounded
+  correctness gate's value-digest oracle (one shared definition, per
+  validation.py's module docstring), so a colliding regression on either
+  path is invisible today. The DONE notes' stated reason for not fixing was
+  scope, not design: any rendering change invalidates the committed
+  reference benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json,
+  and regeneration machinery discipline was the riskier part at the time.
+  That machinery now exists and is contract-tested
+  (`make correctness-gate-digests-regen`, Makefile:147-160, idempotent on a
+  clean tree), which is what makes the real fix cheap now.
+
+  Fix shape: render each cell with a type tag and escape the separator
+  characters (e.g. escape `\`, `|`, `\n` in string payloads; prefix a
+  one-byte type marker for str/int/float/Decimal/date/NULL), keeping
+  _row_sort_key's None-safe ordering untouched. Every pinned collision then
+  becomes a distinctness assertion.
+
+prior_art:
+  - "benchbox/core/results/result_digest.py:_normalize_cell — the gate-side cell renderer with its own documented int-vs-float rendering asymmetry (pinned in tests/unit/test_correctness_gate_value_oracle.py::test_digest_couples_value_with_numeric_type); align the two renderers' type-tagging decisions or document divergence explicitly."
+  - "Makefile:correctness-gate-digests-regen (147-160) — reuse: the exact same-change regen mechanism this fix's reference-invalidation depends on; its idempotency contract is the post-fix verification."
+  - "tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py:133-193 — supersede: the four collision pins flip from equality-asserts to inequality-asserts with their docstrings rewritten from 'accepted property' to 'fixed, distinctness guaranteed'."
+
+work:
+  - id: w1
+    summary: "Implement escaped, type-tagged cell rendering in calculate_checksum"
+    status: pending
+    notes: |
+      Keep the digest definition in exactly one place. Decide the NULL
+      handling consciously: the NULL-vs-"NULL" pin can be fixed by the same
+      type tag (NULL marker vs str tag) — fixing it is preferred; if kept,
+      re-justify in the pin's docstring why it survives a fix that makes
+      the other three distinct.
+
+  - id: w2
+    summary: "Flip the collision pins to distinctness tests; extend with escape-char round-trip cases"
+    needs: [w1]
+    status: pending
+    notes: |
+      Each former collision asserts digests now differ; add cases where the
+      escape character itself appears in payloads (backslash-containing
+      strings) so the escaping is exercised, not just the happy path.
+
+  - id: w3
+    summary: "Regenerate the committed reference digests in the SAME change and prove gate + idempotency"
+    needs: [w1]
+    status: pending
+    notes: |
+      `make correctness-gate-digests-regen` then
+      `git diff --exit-code benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json`
+      must be dirty exactly once (the regen) and clean on a second regen.
+      Then `make test-correctness-gate` green. Check whether
+      result_digest.py's oracle path shares the changed renderer — if the
+      two renderers are independent, say so in the PR body and leave
+      result_digest's asymmetry to its own pin (deferred below).
+
+deferred:
+  - summary: "Reworking result_digest.py's int-vs-float/Decimal rendering asymmetry"
+    reason: "Separately pinned accepted property with its own DuckDB-pinned-oracle rationale; only touch it here if w3 shows the renderers are actually shared."
+
+must_preserve:
+  - "make test-correctness-gate passes on a correct tree after the same-change regen (Makefile:150-160 idempotency contract: regen && git diff --exit-code is clean)."
+  - "validate_results_checksum and the correctness gate's value-digest oracle keep sharing exactly one digest definition — no forked renderer."
+  - "_row_sort_key's None-safe row ordering semantics are unchanged (ordering is not part of this fix)."
+
+anti_patterns:
+  - "DO NOT hand-edit tpch_value_digests_sf1.json - because the file is generated with provenance from a live gate run - only correctness-gate-digests-regen writes it."
+  - "DO NOT ship the renderer change and the reference regen in separate PRs - because the window between them is a red gate on a correct tree - same change, per the Makefile's documented contract."
+
+verification:
+  - description: "Former collisions now distinct"
+    command: "uv run -- python -m pytest tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py -q"
+    expected_output: "all pass with the flipped distinctness assertions"
+  - description: "Gate green with regenerated reference, regen idempotent"
+    command: "make correctness-gate-digests-regen && git diff --exit-code benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json && make test-correctness-gate"
+    expected_output: "second regen produces no diff; gate exits 0 with ran=1 skipped=0"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/validation.py"
+    - "tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py"
+    - "benchbox/core/expected_results/reference_digests/tpch_value_digests_sf1.json"
+  do_not_modify:
+    - "benchbox/core/results/result_digest.py"
+    - "Makefile"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "soundness"
+    - "comparator"
+    - "verification-review-followup"
+  estimated_effort: "Small-Medium"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    Removes a comparator blind spot where a dtype regression or a
+    separator-containing value can hash identically to a genuinely different
+    result. Low priority because the collisions are contrived in TPC-shaped
+    data — but this is the layer everything else trusts, and the fix is now
+    cheap because the regen machinery it was blocked on exists.

--- a/_project/TODO/main/planning/medium-tier-red-disposition-and-promotion.yaml
+++ b/_project/TODO/main/planning/medium-tier-red-disposition-and-promotion.yaml
@@ -1,0 +1,116 @@
+id: medium-tier-red-disposition-and-promotion
+title: "Disposition the medium tier's live failures on develop, get medium-test green, then wire it into auto-revert per its recorded criterion"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  medium-tier-ci-home (DONE, PR #952) gave the ~81-file medium speed tier its
+  first CI consumer: the `medium-test` job in
+  .github/workflows/develop-post-merge.yml (lines ~74-113), deliberately
+  visibility-only (`continue-on-error: true`, excluded from
+  auto-revert-on-failure's needs/if) because the tier was known-red. The
+  recorded promotion criterion: a full clean green run of `make test-medium`,
+  with two named prerequisites — (1) regenerate the stale
+  cross-surface-applicability artifact (DONE: PR #952 commit 3d64c58e
+  regenerated it, so tests/unit/test_cross_surface_applicability.py::
+  test_committed_artifact_is_current may already pass), and (2) a
+  clean-environment re-measurement to disposition the "14 failures / 44
+  errors" previously observed only under a contended sandbox.
+
+  LIVE EVIDENCE the tier is still red on clean develop: on the #952 squash
+  itself (fddedf26, develop-post-merge run 28706929881, 2026-07-04), the
+  medium-test job FAILED on a real GitHub runner (job 85134046869-series,
+  "Run medium speed tier" step failure at 13:07 UTC) while lint and
+  fast-test passed. The job behaved exactly as designed (no block, no
+  auto-revert), but the promotion criterion is now measurably unmet on
+  uncontended hardware — so the remaining work is real failure disposition,
+  not just re-measurement.
+
+prior_art:
+  - ".github/workflows/develop-post-merge.yml:medium-test job comment — reuse: it prescribes the exact promotion mechanics (drop continue-on-error, add medium-test to auto-revert-on-failure's needs + if, mirroring lint/fast-test)."
+  - "_project/DONE/main/medium-tier-ci-home.yaml — the measurement history and known-red inventory this TODO dispositions; extend its accounting rather than re-deriving it."
+  - "tests/unit/workflows/test_develop_post_merge_metrics.py — extend: the pinned tests for develop-post-merge wiring; promotion must update whichever assertions pin medium-test's exclusion from auto-revert."
+
+work:
+  - id: w0
+    summary: "Pull the authoritative failure list from the live red run (not a contended local run)"
+    status: pending
+    notes: |
+      Fetch the failing-test list from develop-post-merge run 28706929881's
+      medium-test job logs (gh api / MCP get_job_logs), or trigger a fresh
+      run's logs if expired. Summarize: N failures / M errors, grouped by
+      module, with the one-line error per group, into this TODO's notes.
+      This replaces the stale "14 failures / 44 errors under contention"
+      figure with clean-runner truth.
+
+  - id: w1
+    summary: "Disposition every failure: real bug, stale test, environment-dependency, or marker misplacement"
+    needs: [w0]
+    status: pending
+    notes: |
+      For each failure group decide and act: fix small real bugs in-scope
+      here; file separate TODOs for large ones (link them in deps of the
+      promotion unit); re-tier tests that genuinely need resources the
+      runner lacks (marker change, with justification); delete/repair stale
+      assertions. Confirm whether test_committed_artifact_is_current now
+      passes post-3d64c58e and strike prerequisite (1) if so.
+
+  - id: w2
+    summary: "Demonstrate a green medium-test run on a real runner"
+    needs: [w1]
+    status: pending
+    notes: |
+      Evidence = a develop-post-merge run URL whose medium-test job
+      concludes success (or `make test-medium` green in CI-equivalent
+      conditions if timing a post-merge run is impractical — say which).
+
+  - id: w3
+    summary: "Promote: wire medium-test into auto-revert-on-failure and update the pinned tests"
+    needs: [w2]
+    status: pending
+    notes: |
+      Per the job comment: drop continue-on-error, add medium-test to
+      auto-revert-on-failure's needs and if-expression alongside
+      lint/fast-test, update the workflow comments, and flip any pinning
+      assertions (grep tests/unit/workflows/ for medium-test). An
+      auto-revert lane that reverts innocent merges is worse than none —
+      w2's green run is a hard gate for this unit.
+
+must_preserve:
+  - "auto-revert-on-failure's current behavior for lint/fast-test/explorer-tokens (including its outputs consumed by metrics) — promotion adds a trigger, it must not restructure the job."
+  - "The medium tier's ~18-minute runtime envelope: dispositions must not quietly move slow tests INTO the fast (PR-blocking) tier as a shortcut."
+
+anti_patterns:
+  - "DO NOT promote with continue-on-error still set 'to be safe' - because a non-blocking auto-revert trigger is a contradiction (the if-expression would never see failure) - the two flips go together or not at all."
+  - "DO NOT disposition failures by blanket-adding skip markers - because that converts known-red into invisible-red - every skip/re-tier needs a one-line justification naming what would make it runnable."
+
+scope_limit:
+  do_not_modify:
+    - "Makefile"
+    - "pytest.ini"
+
+verification:
+  - description: "Medium tier green"
+    command: "make test-medium"
+    expected_output: "exit 0, no failures/errors"
+  - description: "Promotion wiring pinned"
+    command: "uv run -- python -m pytest tests/unit/workflows/ -q"
+    expected_output: "all pass with medium-test asserted inside auto-revert-on-failure's needs/if"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "ci"
+    - "medium-tier"
+    - "verification-review-followup"
+  estimated_effort: "Medium (disposition volume unknown until w0)"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    ~81 test files currently run nowhere that anyone must look. Green +
+    auto-revert makes the medium tier a real regression net for develop
+    instead of a red badge everyone has learned to scroll past.

--- a/_project/TODO/main/planning/parity-check-promotion.yaml
+++ b/_project/TODO/main/planning/parity-check-promotion.yaml
@@ -1,0 +1,114 @@
+id: parity-check-promotion
+title: "Promote parity-check from non-blocking to the required develop-PR lane once its two recorded criteria hold"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  parity-check-develop-ring (DONE, PR #952) landed the parity-check job in
+  pr.yml deliberately demoted: `continue-on-error: true` and absent from
+  `ci-required-result.needs`, with the promotion criteria recorded in the
+  job comment (pr.yml, parity-check job), in the DONE TODO, and pinned by
+  tests/unit/workflows/test_pr_workflow_path_classifier.py::
+  test_parity_check_is_demoted_to_non_blocking. The criteria:
+
+    1. One green run of the job on a real GitHub runner. NOTE: until PR #955
+       (merged 2026-07-04) this was unmeetable — the viz-needed job output
+       was never declared on the ci-paths job, so parity-check skipped on
+       every PR including viz-touching ones (see
+       pr-gate-path-filter-output-lockstep-test for the incident). With the
+       wiring fixed, the next PR that touches results-explorer/**,
+       tests/parity/**, or _project/scripts/explorer_pipeline/** should
+       produce the first real run.
+    2. A disposition for the unexplained ~2e-13 last-bit float drift seen
+       locally in tests/parity/fixtures/geomean_ms.json (likely libm
+       transcendental-precision variance across environments): comparison
+       tolerance vs fixture regeneration.
+
+  This TODO is the promotion itself, so the criteria do not silently rot as
+  a comment nobody owns.
+
+prior_art:
+  - ".github/workflows/pr.yml:package-smoke + ci-required-result — reuse: the recorded promotion pattern ('flip this test to the package-smoke pattern') — path-filtered job observed by the aggregator with skip-counts-as-pass."
+  - "tests/unit/workflows/test_pr_workflow_path_classifier.py::test_parity_check_is_demoted_to_non_blocking — supersede: its own comment prescribes exactly how to invert it on promotion (add to needs, drop continue-on-error, assert PARITY_CHECK_RESULT observed)."
+
+work:
+  - id: w0
+    summary: "Observe (or force) the first real parity-check run on a GitHub runner and record the result"
+    status: pending
+    notes: |
+      Watch for the next viz-touching PR post-#955, or open a trivial
+      viz-path-touching draft PR to trigger one. Record the run URL and
+      conclusion. If it fails with the geomean_ms.json drift, that is w1's
+      input, not a blocker. If it fails some other way, triage before
+      promotion — do not promote a red lane.
+
+  - id: w1
+    summary: "Disposition the geomean_ms.json 2e-13 float drift: tolerance vs fixture regen"
+    needs: [w0]
+    status: pending
+    notes: |
+      Decide with evidence: if the runner reproduces the drift, prefer a
+      bounded relative-tolerance comparison in the parity fixture check
+      (document the bound's derivation, mirroring the read_primitives
+      predicate-bound style from PR #952); if the runner matches fixtures
+      exactly, the drift is a local-environment artifact — document that in
+      the fixture README/comment and keep exact comparison. Regen the
+      fixture only if the Python source is established as the intended
+      truth.
+
+  - id: w2
+    summary: "Promote: aggregator wiring + test flip in one change"
+    needs: [w1]
+    status: pending
+    notes: |
+      In .github/workflows/pr.yml: add parity-check to
+      ci-required-result.needs, add PARITY_CHECK_RESULT env + the
+      skipped-counts-as-pass check (package-smoke pattern), drop
+      `continue-on-error: true`, and update the job comment to record the
+      promotion date/evidence. In test_pr_workflow_path_classifier.py:
+      replace test_parity_check_is_demoted_to_non_blocking with the
+      promoted-shape assertions per its own comment. Run the aggregator
+      bash-matrix tests to cover the new env var.
+
+must_preserve:
+  - "Path-filtering stays: parity-check keeps its viz-needed gate; promotion must not make every PR pay for it."
+  - "ci-required-result's skip-counts-as-pass contract for path-filtered jobs (a non-viz PR with parity-check skipped still passes)."
+
+anti_patterns:
+  - "DO NOT promote on the strength of local runs - because criterion 1 exists precisely due to an unexplained local/runner divergence - a real runner run is the evidence."
+  - "DO NOT widen a tolerance to make an unexplained failure pass - because that converts a parity gate into a parity suggestion - derive and document any bound from the observed drift magnitude."
+
+verification:
+  - description: "Promoted wiring pinned by tests"
+    command: "uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q"
+    expected_output: "all pass; demotion pin replaced by promotion assertions (parity-check in needs, no continue-on-error, PARITY_CHECK_RESULT observed)"
+  - description: "make parity-check green in the environment the disposition chose as truth"
+    command: "make parity-check"
+    expected_output: "exit 0"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/pr.yml"
+    - "tests/unit/workflows/test_pr_workflow_path_classifier.py"
+    - "tests/parity/"
+    - "_project/scripts/explorer_pipeline/"
+  do_not_modify:
+    - "results-explorer/src/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "ci"
+    - "parity"
+    - "verification-review-followup"
+  estimated_effort: "Small-Medium"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    Closes the loop on a deliberately-demoted correctness lane: CLI-vs-explorer
+    numeric parity regressions currently show red-but-mergeable, which decays
+    into ignored red. Promotion makes the lane mean something again.

--- a/_project/TODO/main/planning/pr-gate-path-filter-output-lockstep-test.yaml
+++ b/_project/TODO/main/planning/pr-gate-path-filter-output-lockstep-test.yaml
@@ -1,0 +1,118 @@
+id: pr-gate-path-filter-output-lockstep-test
+title: "Pin ci-paths job-level outputs to the path-filter groups so a missing output mapping can never silently disable a gate again"
+worktree: main
+priority: Medium-High
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  INDEPENDENT-VERIFICATION FINDING (2026-07-04 review of PR #952): the
+  "package-smoke + dependency-audit now BLOCK develop PRs" remediation
+  shipped inert. The classify step wrote `packaging-needed`/`viz-needed` to
+  GITHUB_OUTPUT (scripts/path_filter_decision.py:186-199), and the gated
+  jobs' `if:` conditions referenced `needs.ci-paths.outputs.<group>-needed`,
+  but the `ci-paths` JOB's `outputs:` block never mapped those step outputs.
+  GitHub Actions only exposes job outputs that are explicitly declared, so
+  the `if:` expressions always saw an empty string and package-smoke,
+  dependency-audit, and parity-check skipped on EVERY PR — with
+  ci-required-result's skip-counts-as-pass rule rendering that green.
+  Empirical proof: PR #952's own CI skipped both packaging jobs while the PR
+  changed pyproject.toml, uv.lock, and benchbox/__init__.py.
+
+  The wiring itself was fixed in PR #955 (commit 8652d135: `packaging-needed`
+  and `viz-needed` added to the ci-paths outputs block, pr.yml:27-28 on
+  current develop). What is STILL missing is the regression pin: #955 added
+  no workflow test for the mapping, and the existing pinned tests
+  (tests/unit/workflows/test_pr_workflow_path_classifier.py:160-233) check
+  the aggregator env plumbing and the `if:` STRINGS but never that the
+  referenced outputs are actually declared — exactly the blind spot the bug
+  lived in. path-filters.yml is designed to grow new groups ("Add a new
+  group by adding a key here — no script changes required"), so the same
+  bug re-arms every time a group is added unless the lockstep is pinned.
+
+prior_art:
+  - "tests/unit/test_auto_merge_soundness_paths.py::test_codeowners_covers_soundness_paths — reuse: the repo's established two-files-in-lockstep pinning pattern (SOUNDNESS_PREFIXES vs CODEOWNERS), applied here to path-filters.yml groups vs pr.yml job outputs."
+  - "tests/unit/workflows/test_pr_workflow_path_classifier.py:160-193 — extend: already yaml.safe_load's pr.yml and asserts needs-list/if-string wiring; add the missing outputs-declaration axis to this same file rather than creating a new test module."
+  - "scripts/path_filter_decision.py:extra_group_keys — reuse: derive the expected group list from the same function/rules file the classifier uses, so the test tracks path-filters.yml automatically instead of hardcoding today's two groups."
+
+work:
+  - id: w0
+    summary: "Re-validate the #955 fix is present on develop before pinning it"
+    status: pending
+    notes: |
+      `grep -n 'packaging-needed\|viz-needed' .github/workflows/pr.yml` —
+      expect the two job-level `outputs:` mappings (currently pr.yml:27-28)
+      plus the three `if:` references. Record the line numbers in the test's
+      docstring-adjacent comment or PR body. If absent (revert/refactor),
+      restore the mapping first in the same change.
+
+  - id: w1
+    summary: "Add the lockstep test: every referenced <group>-needed output is declared on the ci-paths job"
+    needs: [w0]
+    status: pending
+    notes: |
+      In tests/unit/workflows/test_pr_workflow_path_classifier.py: load
+      .github/path-filters.yml groups via the same logic as
+      scripts/path_filter_decision.py (import extra_group_keys if cleanly
+      importable; otherwise parse the YAML with the same core-bucket
+      exclusions). Assert BOTH directions:
+        (1) for every extra group `<g>`, `jobs.ci-paths.outputs` contains
+            key `<g>-needed` mapped to `steps.classify.outputs.<g>-needed`;
+        (2) every `needs.ci-paths.outputs.*` reference found in any job's
+            `if:` string names an output key that ci-paths declares (catches
+            a future job referencing a never-declared output even outside
+            the extra-group convention).
+      Include a comment naming the #952/#955 incident so the test's reason
+      survives.
+
+  - id: w2
+    summary: "Mutation-probe the new test"
+    needs: [w1]
+    status: pending
+    notes: |
+      Locally (uncommitted): delete the `packaging-needed:` mapping line from
+      pr.yml, run the new test, confirm it FAILS with a message naming the
+      missing key; restore the file (`git checkout -- .github/workflows/pr.yml`)
+      and confirm green. Record the probe result in the PR body — a lockstep
+      test that cannot go red is the same bug one level up.
+
+must_preserve:
+  - "Existing assertions in test_pr_workflow_path_classifier.py (aggregator needs-list, parity-check demotion pin, skip-counts-as-pass semantics) keep passing unchanged."
+  - "The 'add a new group with no script changes' contract of path-filters.yml: the new test must derive groups from the rules file, not freeze today's {packaging, viz} set."
+
+anti_patterns:
+  - "DO NOT hardcode ['packaging', 'viz'] in the test - because the whole point is catching the NEXT group's missing mapping - derive the list from path-filters.yml/extra_group_keys."
+  - "DO NOT assert on raw YAML text/regex for the outputs block - because formatting drift would false-positive - use yaml.safe_load structure like the neighboring tests do."
+
+verification:
+  - description: "New lockstep test passes on the fixed tree"
+    command: "uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q"
+    expected_output: "all tests pass, including the new outputs-lockstep test"
+  - description: "Mutation probe goes red"
+    command: "sed -i '/packaging-needed: \\${{ steps.classify.outputs.packaging-needed }}/d' .github/workflows/pr.yml && uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q; git checkout -- .github/workflows/pr.yml"
+    expected_output: "test run fails naming packaging-needed while the mapping is deleted; tree restored afterward"
+
+scope_limit:
+  only_modify:
+    - "tests/unit/workflows/test_pr_workflow_path_classifier.py"
+    - ".github/workflows/pr.yml"
+  do_not_modify:
+    - "scripts/path_filter_decision.py"
+    - ".github/path-filters.yml"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "ci"
+    - "workflow-tests"
+    - "verification-review-followup"
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    The #952 incident showed a one-line missing output mapping can turn a
+    "blocking" gate into a permanent no-op that reads as green. This pin
+    converts that failure mode from silent to test-red for every current and
+    future path-filter group.

--- a/_project/TODO/main/planning/release-canary-scheduled-activation.yaml
+++ b/_project/TODO/main/planning/release-canary-scheduled-activation.yaml
@@ -1,0 +1,162 @@
+id: release-canary-scheduled-activation
+title: "Get release-canary.yml actually firing: the workflow is not on the default branch, so its daily schedule has never run"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Release Tooling"
+
+description: |
+  INDEPENDENT-VERIFICATION FINDING (2026-07-04 review of PR #952): the entire
+  scheduled release-canary lattice is inert. `.github/workflows/release-canary.yml`
+  declares `on.schedule: cron "0 8 * * *"` (line 5-7) and now carries three
+  jobs the repo's safety story leans on:
+
+    1. `pypi-latest-installability` — the daily PyPI-latest install/import
+       canary added by pypi-installability-canary-and-rollback (PR #952),
+       whose DONE notes claim it "would have caught broken 0.3.0 in a day";
+    2. `ruleset-drift` — the daily check that pins the develop ruleset's
+       required-check wiring and (since PR #952) reports the
+       require_code_owner_review gap via
+       _project/scripts/ruleset_review_enforcement.py;
+    3. `credential-free-non-fast` — the scheduled non-fast test sweep.
+
+  None of them has ever executed. GitHub runs `on.schedule` workflows ONLY
+  from the DEFAULT branch's copy of the workflow file. The default branch is
+  `main` (`git remote show origin` → "HEAD branch: main"), and
+  `git ls-tree origin/main .github/workflows/` does NOT contain
+  release-canary.yml — it exists only on `develop`. Corroborating live
+  evidence gathered 2026-07-04:
+    - the Actions "list workflows" API returns 19 workflows and
+      release-canary is not among them (a workflow absent from the default
+      branch with zero historical runs is never registered);
+    - `GET /actions/workflows/release-canary.yml/runs` returns 404.
+
+  Consequence: the PyPI-latest canary cannot alert on the currently-broken
+  0.3.0 release (reconfirmed broken 2026-07-04: clean isolated install fails
+  with `ModuleNotFoundError: No module named 'pandas'`), and the daily
+  ruleset-drift check that several governance TODOs treat as the live
+  detection layer (e.g. auto-merge-review-gate-admin-enforcement w2) is not
+  actually running. In this repo's flow, files reach `main` only at
+  release-cut, so without deliberate action the canary stays dead until the
+  next release — the exact window it is supposed to guard.
+
+  IMPORTANT EXPECTED STATE once activated: `pypi-latest-installability` will
+  correctly go RED every day until release-recovery-v0-3-1 ships a fixed
+  release. That is the desired signal, not a defect — do not "fix" the red
+  by weakening the canary.
+
+prior_art:
+  - ".github/workflows/nightly.yml — the one scheduled workflow that IS on main and does fire; reuse: its main-branch copy is the proof that schedule-from-default-branch works here, and it is the natural home for a scheduled-workflow liveness guard once one exists on main."
+  - ".github/workflows/release-canary.yml:credential-free-non-fast — already checks out develop explicitly for its test sweep; extend: the same 'scheduled shell runs, then checks out develop for current logic' pattern is the candidate design for keeping the canary current between release-cuts."
+  - "docs/operations/repo-admin-settings.md — the runbook that records deferred admin actions and live-state notes; extend it with the outcome here (main is push-restricted, so landing a file on main is an admin/release-flow action of the same class)."
+
+work:
+  - id: w0
+    summary: "Re-validate the finding: release-canary.yml still absent from origin/main and unregistered"
+    status: pending
+    notes: |
+      Run `git fetch origin main && git ls-tree origin/main --name-only
+      .github/workflows/` (expect: no release-canary.yml) and
+      `gh api repos/joeharris76/BenchBox/actions/workflows --jq
+      '.workflows[].path'` (expect: no release-canary.yml). Record both
+      one-line results in the PR/TODO notes. If either now shows the
+      workflow, re-scope this TODO against the new live state instead of
+      proceeding blind.
+
+  - id: w1
+    summary: "Decide the activation mechanism with the maintainer"
+    needs: [w0]
+    status: pending
+    notes: |
+      Options, with the trade-off each carries:
+        (a) Admin cherry-picks/pushes the current release-canary.yml to main
+            out-of-band (fastest; main is push-restricted, so admin-only;
+            content then goes stale on main between release-cuts unless (c)
+            is also adopted);
+        (b) Wait for the next release-cut to carry it (zero extra action,
+            but the canary stays dead until v0.3.1 — the exact gap it
+            guards);
+        (c) Restructure so main carries a minimal stable scheduled SHELL
+            that checks out develop and invokes the canary logic living on
+            develop (one-time admin landing, then develop-side edits take
+            effect without touching main; credential-free-non-fast already
+            half-follows this pattern).
+      Recommendation: (a) + (c) together — land the shell form on main once,
+      keep logic on develop. Record the decision in
+      docs/operations/repo-admin-settings.md.
+
+  - id: w2
+    summary: "Land the chosen form on main (admin/release-flow action) and confirm registration"
+    needs: [w1]
+    status: pending
+    notes: |
+      After landing, confirm: the workflow appears in the Actions
+      list-workflows API, and a manual `workflow_dispatch` (or the next
+      08:00 UTC cron) produces a real run. Expected first result: overall
+      canary RED with pypi-latest-installability failing on 0.3.0's broken
+      import — record that run URL as proof-of-life, and cross-link it in
+      release-recovery-v0-3-1 as live pressure for the recovery release.
+
+  - id: w3
+    summary: "Add a scheduled-workflow liveness guard so this class of gap cannot recur silently"
+    needs: [w2]
+    status: pending
+    notes: |
+      A repo-tree workflow with `on.schedule` that is not on the default
+      branch fails silently forever — nothing red appears anywhere. Add a
+      guard in a place that provably executes: e.g. a step in the (now
+      live) canary's result job or in nightly.yml that uses the Actions API
+      (GITHUB_TOKEN) to assert every `.github/workflows/*.yml` in the
+      CHECKED-OUT TREE that declares `on.schedule` has at least one run in
+      the last N days, failing with a message naming this TODO. Keep the
+      threshold generous (e.g. 3 days) to tolerate outages.
+
+deferred:
+  - summary: "Making the PyPI-latest canary green"
+    reason: "That is release-recovery-v0-3-1's outcome (ship a fixed 0.3.1). This TODO only makes the canary RUN; a red result on a broken PyPI-latest is the canary working."
+  - summary: "Auto-syncing all of main's workflow copies from develop"
+    reason: "Broader release-flow design question; only the scheduled-shell decision in w1 is needed here."
+
+must_preserve:
+  - "release-canary.yml's existing job semantics on develop (credential-free-non-fast checkout target, ruleset-drift WARN-until-enforced behavior, pypi-latest-installability blocking within release-canary-result) — activation must not weaken any of them."
+  - "main remains release-only: whatever lands there goes through the documented admin/release flow, never a direct agent push (CLAUDE.md: git push * main is never auto-allowed)."
+
+anti_patterns:
+  - "DO NOT mark the canary 'activated' because a workflow_dispatch run from develop succeeds - scheduled firing only ever uses the default branch's copy - verify registration and a run on main's copy specifically."
+  - "DO NOT silence or down-scope pypi-latest-installability to get a green first run - PyPI-latest 0.3.0 is genuinely broken and red is the correct reading - link the red run to release-recovery-v0-3-1 instead."
+
+verification:
+  - description: "Workflow registered and scheduled runs occurring"
+    command: "gh api repos/joeharris76/BenchBox/actions/workflows --jq '.workflows[] | select(.path | contains(\"release-canary\")) | {path, state}'"
+    expected_output: "release-canary path present with state=active; a subsequent runs query returns at least one scheduled run"
+  - description: "Liveness guard fails when a scheduled workflow has no recent runs"
+    command: "(mutation probe) point the guard at a fake workflow name in a scratch run"
+    expected_output: "guard step exits non-zero naming the dead workflow"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/release-canary.yml"
+    - ".github/workflows/nightly.yml"
+    - "docs/operations/repo-admin-settings.md"
+    - "_project/TODO/main/active/release-recovery-v0-3-1.yaml"
+  do_not_modify:
+    - ".github/workflows/release.yml"
+    - ".github/workflows/pr.yml"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "release"
+    - "ci"
+    - "canary"
+    - "verification-review-followup"
+  estimated_effort: "Small (agent side); one admin action"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    The repo's post-#952 safety narrative (daily PyPI installability signal,
+    daily ruleset-drift detection) is currently fictional — every consumer of
+    that narrative is over-trusting. Activation makes three shipped guards
+    real at the cost of one admin action.

--- a/_project/TODO/main/planning/tag-and-pypi-environment-admin-hardening.yaml
+++ b/_project/TODO/main/planning/tag-and-pypi-environment-admin-hardening.yaml
@@ -1,0 +1,129 @@
+id: tag-and-pypi-environment-admin-hardening
+title: "Apply the two remaining publish-path admin protections: v* tag-creation ruleset and pypi environment required reviewers"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Release Tooling"
+
+description: |
+  release-tag-publish-hardening (DONE, PR #952) closed the workflow-level
+  half of the stray-publish problem: release.yml's verify-tag-on-main job
+  refuses refs that are not main/ancestor-of-main, and the real-PyPI publish
+  step additionally requires a refs/tags/v* ref. The repo-admin half was
+  explicitly deferred and is documented with live-state notes in
+  docs/operations/repo-admin-settings.md ("Tag creation and
+  release-environment protections", ~lines 260-340):
+
+    (a) TAG-CREATION RULESET — live state 2026-07-03: no ruleset with
+        target "tag" exists (the similarly-named v-release-branches-minimal
+        ruleset targets refs/heads/v*, not tags). Residual risk left open:
+        any collaborator with push access can create a v* tag ON an
+        existing main commit out of band (re-tag an old main commit, or tag
+        a version out of sequence); verify-tag-on-main passes such a tag
+        (it IS an ancestor of main) and release.yml proceeds toward
+        publish. The runbook has a draft `gh api -X POST .../rulesets`
+        payload; bypass_actors needs finalizing with the admin.
+
+    (b) PYPI ENVIRONMENT REQUIRED REVIEWERS — release.yml already scopes
+        publish to `environment: pypi`, but whether that environment has
+        `required_reviewers` protection configured was NOT verifiable from
+        the sandbox (no admin-scope API access) and no prior record exists
+        in _project/decisions/. Treat as absent until verified. Residual
+        risk: no human approval gate at the actual publish step.
+
+  Both are the same class of deferred admin action as
+  auto-merge-review-gate-admin-enforcement's ruleset PUT (the develop-PR
+  GITHUB_TOKEN has no administration scope), so this TODO follows that
+  item's shape: agent-side work is verification, runbook recording, and
+  drift-check coverage; the PUT/POST themselves are maintainer actions.
+
+prior_art:
+  - "docs/operations/repo-admin-settings.md:260-340 — the runbook sections with verify commands, live-state notes, and the draft ruleset payload; this TODO executes and then updates them (single source of truth, per that doc's convention)."
+  - "_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml — reuse: the established pattern for admin-blocked work (agent verifies + records + adds CI detection; admin applies)."
+  - "_project/scripts/ruleset_review_enforcement.py — extend: the existing ruleset-drift checker that already reads live rulesets in release-canary; add tag-ruleset presence to its findings rather than writing a second checker."
+
+work:
+  - id: w1
+    summary: "ADMIN: create the v* tag-creation ruleset; record the applied payload and resulting ruleset id in the runbook"
+    status: pending
+    notes: |
+      Start from the runbook's draft POST (target=tag, enforcement=active,
+      include refs/tags/v*, rules[type]=creation); finalize bypass_actors
+      with the admin (who may legitimately tag: release automation identity
+      and/or the maintainer). Verify with
+      `gh api repos/joeharris76/BenchBox/rulesets --jq '.[] | select(.target=="tag")'`
+      and paste the id + conditions into repo-admin-settings.md's live-state
+      note with a date.
+
+  - id: w2
+    summary: "ADMIN: verify (and if absent, configure) required_reviewers on the pypi environment; record the live state"
+    status: pending
+    notes: |
+      `gh api repos/joeharris76/BenchBox/environments/pypi` — inspect
+      protection_rules for type=required_reviewers with a non-empty
+      reviewers list. If absent, configure via the environments API/UI with
+      the maintainer as reviewer. Either way, replace the runbook's
+      "not independently re-verified" caveat with the dated observed state.
+      Consider the same check for the test-pypi environment and record the
+      decision (it is deliberately lower-friction; documenting "no gate,
+      intentional" is an acceptable outcome there).
+
+  - id: w3
+    summary: "Extend the ruleset-drift check to flag a missing v*-tag ruleset (WARN-until-applied, then enforce)"
+    needs: [w1]
+    status: pending
+    notes: |
+      In _project/scripts/ruleset_review_enforcement.py (or a sibling
+      function it calls), assert a target="tag" ruleset covering
+      refs/tags/v* with a creation rule exists; mirror the existing
+      DEVELOP_REVIEW_RULE_ENFORCED warn-until-enforced flag pattern so the
+      check lands before the admin acts without going red. Extend
+      tests/unit/release/test_ruleset_drift_review_coverage.py for the new
+      finding. NOTE: this check only executes when release-canary actually
+      runs — see release-canary-scheduled-activation; that TODO is a hard
+      dependency for the check being live, though the code change itself
+      can land first.
+
+must_preserve:
+  - "release.yml's existing verify-tag-on-main and tag-shaped-ref publish conditions — the admin layers are additive; do not loosen the workflow-level checks because the ruleset now exists."
+  - "The legitimate release flow (make release-cut / release-finalize) can still create v* tags after the ruleset applies — bypass_actors must cover whichever identity release-finalize tags with, verified before enforcement."
+
+anti_patterns:
+  - "DO NOT apply the draft POST payload verbatim without settling bypass_actors - because a creation ruleset with no bypass path bricks the release flow itself - dry-run the actor list against how release-finalize actually pushes tags."
+  - "DO NOT record 'likely configured' in the runbook - because unverified-optimistic notes are how the pypi-environment question got here - only dated, observed API output goes in the live-state sections."
+
+verification:
+  - description: "Tag ruleset live"
+    command: "gh api repos/joeharris76/BenchBox/rulesets --jq '.[] | select(.target==\"tag\") | {id, enforcement, conditions}'"
+    expected_output: "one active ruleset including refs/tags/v* with a creation rule"
+  - description: "pypi environment protection observed"
+    command: "gh api repos/joeharris76/BenchBox/environments/pypi --jq '.protection_rules'"
+    expected_output: "contains type=required_reviewers with non-empty reviewers (or a dated runbook entry documenting the accepted alternative)"
+  - description: "Drift check covers the tag ruleset"
+    command: "uv run -- python -m pytest tests/unit/release/test_ruleset_drift_review_coverage.py -q"
+    expected_output: "all pass including the new tag-ruleset finding coverage"
+
+scope_limit:
+  only_modify:
+    - "docs/operations/repo-admin-settings.md"
+    - "_project/scripts/ruleset_review_enforcement.py"
+    - "tests/unit/release/test_ruleset_drift_review_coverage.py"
+  do_not_modify:
+    - ".github/workflows/release.yml"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "release"
+    - "governance"
+    - "admin-action"
+    - "verification-review-followup"
+  estimated_effort: "Small (agent side); two admin actions"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    Today a stray-but-on-main v* tag reaches the real-PyPI publish step with
+    no human in the loop. These two admin layers close the last zero-human
+    path from push access to a public release.

--- a/_project/TODO/main/planning/validator-report-all-row-mismatches.yaml
+++ b/_project/TODO/main/planning/validator-report-all-row-mismatches.yaml
@@ -1,0 +1,121 @@
+id: validator-report-all-row-mismatches
+title: "Close the first-mismatch-per-row comparator blind spot so column-pinned waiver predicates can see a second wrong column"
+worktree: main
+priority: Low
+status: "Not Started"
+category: "Testing and Quality Assurance"
+
+description: |
+  SOUNDNESS-CRITICAL COMPARATOR SURFACE: benchbox/core/tpchavoc/validation.py
+  and benchbox/core/equivalence/cross_surface.py are CODEOWNERS-covered;
+  this TODO's PR requires code-owner review.
+
+  The comparator behind the cross-surface gates reports only the FIRST
+  positional mismatch per row: both "Value mismatch at row {i}, column {j}"
+  emit sites in benchbox/core/tpchavoc/validation.py (:454 and :674) break
+  out after the first differing column. PR #952's waiver-tightening work
+  (read-primitives-waivers-classified-divergence) made every waiver a
+  column-pinned predicate and, in doing so, documented the residual limit
+  honestly (cross_surface.py, min_by_complex waiver comment): if an ACCEPTED
+  column (e.g. the ARG_MIN tie-broken cheapest_part_name, column 1) differs
+  on the same row where a NON-waived column (min_price, column 3) is ALSO
+  wrong, only the accepted column-1 mismatch is visible, the predicate
+  accepts it, and the real regression rides through classified-green. The
+  h2odb Q9 waiver carries the same shape ("validator-imposed" blind spot).
+  Column-pinning minimized but structurally cannot close this; the fix is in
+  the validator's reporting, not in more predicate work.
+
+  Fix shape: when a row diverges, collect ALL mismatched column indices for
+  that row (bounded output — indices always, per-column values capped) and
+  surface them in the divergence detail. Then tighten the waiver contract:
+  a ClassifiedDivergence predicate accepts only if EVERY mismatched column
+  on the row is within its accepted set, so "waived column diverged AND
+  unwaived column diverged" is unclassified (gate failure) instead of
+  invisibly green.
+
+prior_art:
+  - "benchbox/core/tpchavoc/validation.py:454,674 — the two first-mismatch emit sites; extend both identically (shared helper) so SQL-variant and gate paths keep one comparator behavior."
+  - "benchbox/core/equivalence/cross_surface.py:_VALUE_MISMATCH_RE (:794) and the column-pinned predicates (_read_primitives_argmin_tie, _h2odb_q9_decimal_residue) — these parse the detail string; they must be updated in lockstep with the new multi-column detail format, and their probe tests extended with the two-columns-wrong case."
+  - "tests/unit/core/equivalence/test_cross_surface.py:789-836 — reuse: the established accept/reject mutation-probe style; the new headline probe is 'accepted column AND unaccepted column both wrong on one row → unclassified'."
+
+work:
+  - id: w1
+    summary: "Make the validator collect and report every mismatched column per divergent row"
+    status: pending
+    notes: |
+      Shared helper used by both emit sites in validation.py. Keep the
+      existing single-column message shape as the degenerate case (one
+      mismatch) so unrelated log consumers and the classified-baseline
+      keys stay stable; append the additional columns in a parseable
+      suffix (e.g. "; also columns [3]"). Bound value payloads (first
+      mismatch keeps values; additional columns report indices, values
+      truncated) so a wide-row divergence cannot bloat reports.
+
+  - id: w2
+    summary: "Update _VALUE_MISMATCH_RE parsing and enforce the all-columns-accepted waiver contract"
+    needs: [w1]
+    status: pending
+    notes: |
+      cross_surface.py: parse the full mismatched-column set; a predicate's
+      acceptance now requires every mismatched column to fall in its
+      accepted set. Audit each existing ClassifiedDivergence for the
+      contract change (argmin cols {1,2}; h2odb/percentile/round single
+      columns; sketch column maps) — behavior on today's observed
+      single-column divergences must be unchanged.
+
+  - id: w3
+    summary: "Mutation-probe the closed blind spot and re-run the affected gates"
+    needs: [w2]
+    status: pending
+    notes: |
+      New probes: (a) row with column 1 (waived) + column 3 (unwaived) both
+      wrong → unclassified; (b) row with only column 1 wrong → still
+      classified. Then re-run `make read-primitives-cross-surface-equivalence-report`
+      and `make h2odb-cross-surface-equivalence-report` (expect exit 0,
+      identical classification counts — the live cells diverge on single
+      columns today) and `make tpchavoc-equivalence-report` for the
+      validation.py-shared path. Strike the two in-code blind-spot
+      disclosures (min_by_complex comment, h2odb Q9 note) as part of the
+      same change so the docs match the new reality.
+
+must_preserve:
+  - "All currently-classified live divergences remain classified: the three gate reports above exit 0 before and after with the same classified counts (the fix must not reclassify today's single-column residues)."
+  - "KNOWN_DIVERGENCES/baseline key formats are untouched — only the detail string gains information; keys and reason strings stay stable."
+
+anti_patterns:
+  - "DO NOT fix this by widening waiver predicates to accept more columns - because the blind spot is under-reporting, not under-waiving - the validator must surface the columns first."
+  - "DO NOT dump full row contents for every extra mismatched column - because gate reports are committed/quoted artifacts - indices always, values bounded."
+
+verification:
+  - description: "Blind-spot probe: waived+unwaived columns on one row is unclassified"
+    command: "uv run -- python -m pytest tests/unit/core/equivalence/test_cross_surface.py tests/unit/core/tpchavoc/ -q"
+    expected_output: "all pass, including the new two-column probes"
+  - description: "Live gates unchanged"
+    command: "make read-primitives-cross-surface-equivalence-report && make h2odb-cross-surface-equivalence-report && make tpchavoc-equivalence-report"
+    expected_output: "all exit 0 with the same classified-divergence counts as before the change"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpchavoc/validation.py"
+    - "benchbox/core/equivalence/cross_surface.py"
+    - "tests/unit/core/tpchavoc/"
+    - "tests/unit/core/equivalence/"
+  do_not_modify:
+    - "benchbox/core/expected_results/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "soundness"
+    - "comparator"
+    - "verification-review-followup"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+impact:
+  business_value: |
+    Today a real numeric regression can hide behind a legitimate
+    nondeterministic tie-break on the same row and pass the gate as
+    classified-green. This closes the last documented structural gap in the
+    cross-surface waiver system rather than leaving it as a comment.


### PR DESCRIPTION
# Pull Request

## Description

Seeds **7 planning TODOs** in `_project/TODO/main/planning/` covering everything actionable from the 2026-07-04 independent verification review of the architecture-review remediation batch (PR #952) and its follow-up sweep (PR #955). TODO-only change — no code touched.

**High**
- `release-canary-scheduled-activation` — `release-canary.yml` is not on the default branch (`main`), so its daily cron has **never fired**: the PyPI-latest installability canary (PR #952) and the ruleset-drift check are inert (workflow unregistered in the Actions API; runs endpoint 404s). Activation mechanism decision + admin landing + a scheduled-workflow liveness guard so the failure class can't recur silently. Expected first result is a *red* canary (PyPI 0.3.0 is genuinely broken) — documented as the desired signal, cross-linked to `release-recovery-v0-3-1`.

**Medium-High**
- `pr-gate-path-filter-output-lockstep-test` — regression-pin the `ci-paths` job-level `outputs:` ↔ path-filter-group lockstep whose absence silently disabled package-smoke/dependency-audit/parity-check on every PR until #955; derived from `path-filters.yml` so future groups are covered, with a mutation probe.
- `medium-tier-red-disposition-and-promotion` — medium-test failed on the #952 squash's own post-merge run (28706929881) on a clean runner; pull the authoritative failure list, disposition, get green, then wire into auto-revert per the recorded criterion.

**Medium**
- `parity-check-promotion` — execute the two recorded promotion criteria (first real runner run — now possible post-#955 — and the geomean_ms.json 2e-13 drift disposition), then promote via the package-smoke pattern.
- `tag-and-pypi-environment-admin-hardening` — the two remaining publish-path admin actions deferred by `release-tag-publish-hardening`: `v*` tag-creation ruleset and `pypi` environment required reviewers, plus ruleset-drift-check coverage for the tag ruleset (warn-until-applied).

**Low (soundness-path implementation TODOs; their PRs will need code-owner review)**
- `calculate-checksum-collision-hardening` — fix (not just pin) the three digest collisions via escaped, type-tagged cell rendering + same-change `correctness-gate-digests-regen`.
- `validator-report-all-row-mismatches` — close the documented first-mismatch-per-row comparator blind spot so a column-pinned waiver can't mask a co-located real regression.

Deliberately **not** duplicated: `release-recovery-v0-3-1` (active, Critical), `auto-merge-review-gate-admin-enforcement` (develop ruleset review-rule PUT), `github-token-approval-capability-followup` — all already open and covering their findings.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <file>` — ✅ valid for all 7 items
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` — 91 items, no cycles, no dangling references
- `uv run _project/scripts/generate_indexes.py` — regenerated locally (indexes are gitignored, nothing committed)
- Self-review pass applied (todo-review rubric): added missing `scope_limit`s, removed an empty `deps` block, added a do-not-redefine-the-tier guard to the medium-tier item

## Public Contract Check

- [x] TODO YAML only; no public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces changed; no count claims changed.

## Documentation

- [x] N/A — planning artifacts only; each item carries its own description, prior_art, guardrails, and verification commands.

## Code Quality

- [x] All items follow `_project/TODO_ENTRY_TEMPLATE.yaml` (flat `work[]` with `needs` edges, `prior_art`, `must_preserve`, `anti_patterns`, `verification`, `scope_limit` where applicable; `w0` re-validation units wherever a description cites live external state).

## Artifact Hygiene

- [x] No logs, binaries, or generated indexes committed.

## Notes

- Content-only PR (`_project/TODO/**` is in the `safe-content` path filter), so it takes the content-guard CI lane.
- Two items (`release-canary-scheduled-activation`, `tag-and-pypi-environment-admin-hardening`) contain maintainer-only admin steps, following the `github-token-approval-capability-followup` pattern: agent-side work is verification, runbook recording, and CI detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_