### PR TITLE
docs: Results Explorer & Publication adversarial review + remediation TODO plan

### DIFF
--- a/_project/TODO/main/planning/remediate-ci-required-gate-integrity.yaml
+++ b/_project/TODO/main/planning/remediate-ci-required-gate-integrity.yaml
@@ -1,0 +1,161 @@
+id: remediate-ci-required-gate-integrity
+title: "Restore the develop-PR required gate: undeclared ci-paths outputs make three jobs no-op"
+worktree: main
+priority: Critical
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.9 (Critical), §2.10 (Required), §2.11
+  (Advisory).
+
+  §2.9 — The `ci-paths` job in `.github/workflows/pr.yml` declares only 7
+  outputs (pr.yml:20-26: safe-content-only, needs-code-ci,
+  content-guard-needed, changed-paths, code-paths, unknown-paths,
+  estimated-runner-minutes-saved). But `package-smoke` (pr.yml:770) and
+  `dependency-audit` (pr.yml:812) gate on
+  `needs.ci-paths.outputs.packaging-needed == 'true'`, and `parity-check`
+  (pr.yml:858) gates on `needs.ci-paths.outputs.viz-needed == 'true'`. The
+  classifier emits these only as STEP outputs
+  (scripts/path_filter_decision.py:196-200), never re-exported at the JOB
+  level, so `needs.ci-paths.outputs.packaging-needed`/`viz-needed` resolve to
+  the empty string and the `== 'true'` conditions are permanently false. All
+  three jobs are always skipped, and `ci-required-result` counts skipped as
+  pass (pr.yml:963-973). This directly defeats the work completed in
+  _project/DONE/main/pr-gate-package-and-audit-promotion.yaml, whose w1 notes
+  claim it emits "a `<group>-needed` GH Actions output" — it added the step
+  output and job gating but not the job-level `outputs:` declaration.
+
+  §2.10 — `_project/scripts/results_explorer_snapshot_invariants.py` enforces
+  12 read-model invariants and its docstring says it exists "so release gates
+  can run it," but nothing invokes it (grep across Makefile/.github/tests
+  returns only its own definition). docs.yml:110-118 builds the snapshot then
+  runs `npm run build` with no validation between, so a malformed snapshot
+  deploys ungated.
+
+  §2.11 — `make validate-imports` runs `scripts/validate_imports.py`, which
+  does not exist (the real gate is `make lint-imports` → `lint-imports`, used
+  by CI). A maintainer running the advertised target gets file-not-found.
+
+work:
+  - id: w0
+    summary: "Re-validate all three defects still reproduce at current develop tip"
+    status: pending
+    notes: |
+      Confirm the audit still holds before changing anything. Capture stdout
+      to /tmp/remediate-ci-gate-w0.log (do not commit) and summarize here:
+        1. Assert packaging-needed/viz-needed are NOT in the ci-paths outputs
+           block: `sed -n '/^  ci-paths:/,/steps:/p' .github/workflows/pr.yml`
+           — expect neither key present.
+        2. Assert the gates reference them:
+           `grep -n "packaging-needed\|viz-needed" .github/workflows/pr.yml`
+           — expect the step-output emit + the three job `if:` lines.
+        3. Assert no snapshot_invariants caller:
+           `grep -rn snapshot_invariants Makefile .github/workflows tests`
+           — expect only the script's own path.
+        4. Assert missing script: `test -f scripts/validate_imports.py` → non-zero.
+
+  - id: w1
+    summary: "Declare packaging-needed/viz-needed (and every extra <group>-needed) in the ci-paths job outputs map"
+    needs: [w0]
+    status: pending
+    notes: |
+      In pr.yml `ci-paths.outputs`, add
+        packaging-needed: ${{ steps.classify.outputs.packaging-needed }}
+        viz-needed: ${{ steps.classify.outputs.viz-needed }}
+      (and any other `<group>-needed` the classifier emits per
+      .github/path-filters.yml extra groups). Keep the generic-classifier
+      idiom from pr-gate-package-and-audit-promotion — do not special-case.
+
+  - id: w2
+    summary: "Add a meta-test asserting every needs.ci-paths.outputs.* referenced in pr.yml is declared in the ci-paths outputs map"
+    needs: [w1]
+    status: pending
+    notes: |
+      New test under tests/unit/scripts/ (e.g. test_pr_workflow_outputs.py):
+      parse .github/workflows/pr.yml, collect every
+      `needs.ci-paths.outputs.<name>` reference and every key declared in the
+      ci-paths `outputs:` map, assert references ⊆ declarations. This backstops
+      the whole `<group>-needed` pattern (also relied on by the planning item
+      explorer-tokens-path-classifier-output.yaml).
+
+  - id: w3
+    summary: "Invoke results_explorer_snapshot_invariants.py in docs.yml after the snapshot build; expose a make target"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add a step in docs.yml between "Build explorer data" (:112) and
+      "Build results-explorer" (:117) that runs the invariants script against
+      results-explorer/public/data/ and fails on violation. Add a matching
+      `make` target (e.g. explorer-snapshot-check) so it is runnable locally.
+      Gate on the same hashFiles('results-explorer/package.json') sentinel the
+      surrounding explorer steps use.
+
+  - id: w4
+    summary: "Repoint make validate-imports at the real import-linter gate (or remove the stale target)"
+    needs: [w0]
+    status: pending
+    notes: |
+      Point `validate-imports` at `lint-imports` (uv run -- lint-imports) or
+      delete the target. Confirm no docs still tell a reader to run
+      `make validate-imports` against the missing script.
+
+deferred:
+  - summary: "§2.7 validate-submission self-green and broader submission-CI hardening"
+    reason: "Tracked in remediate-published-results-submission-ci."
+
+prior_art:
+  - ".github/workflows/pr.yml:audit-sha job — reuse its success-or-skipped ci-required-result pattern (already correct) as the model for w2's declaration contract."
+  - "scripts/path_filter_decision.py:extra_group_keys — extend/verify the existing generic <group>-needed emission; do not add a per-group special case."
+  - "_project/DONE/main/pr-gate-package-and-audit-promotion.yaml — supersede: this item completes the job-output wiring that TODO left latent."
+
+must_preserve:
+  - "ci-required-result's skipped-counts-as-pass semantics for genuinely path-filtered-out jobs (a docs-only PR must still not pay packaging/viz cost)."
+  - "Existing 7 ci-paths outputs and their consumers remain unchanged."
+  - "docs.yml explorer steps remain gated on hashFiles('results-explorer/package.json') so main builds stay a deliberate no-op."
+
+anti_patterns:
+  - "DO NOT make package-smoke/dependency-audit/parity-check unconditionally required - because unrelated PRs would pay the cost - fix the output plumbing so the path filter actually reaches the gate."
+  - "DO NOT hardcode packaging-needed as a bespoke output - because the classifier already derives extra groups generically - re-export whatever <group>-needed keys the classifier emits."
+
+verification:
+  - description: "packaging-needed and viz-needed are declared job outputs"
+    command: "sed -n '/^  ci-paths:/,/^    steps:/p' .github/workflows/pr.yml | grep -E 'packaging-needed:|viz-needed:'"
+    expected_output: "both keys present in the outputs block"
+  - description: "Meta-test catches an undeclared referenced output"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_pr_workflow_outputs.py -q"
+    expected_output: "passes; fails if any needs.ci-paths.outputs.* is undeclared"
+  - description: "Snapshot invariants run in the docs build"
+    command: "grep -n 'results_explorer_snapshot_invariants' .github/workflows/docs.yml"
+    expected_output: "a step invokes the script after the snapshot build"
+  - description: "make validate-imports resolves"
+    command: "make -n validate-imports"
+    expected_output: "resolves to lint-imports (or target removed); no reference to missing scripts/validate_imports.py"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/pr.yml"
+    - ".github/workflows/docs.yml"
+    - ".github/path-filters.yml"
+    - "scripts/path_filter_decision.py"
+    - "Makefile"
+    - "tests/unit/scripts/"
+  do_not_modify:
+    - "benchbox/"
+    - "_project/scripts/results_explorer_snapshot_invariants.py"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "ci"
+    - "critical"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "package-smoke, dependency-audit, and parity-check execute (not skip) on a PR that touches pyproject.toml / a viz fixture."
+  - "A regression that undeclares a referenced ci-paths output fails the new meta-test."
+  - "A malformed explorer snapshot fails the docs build before deploy."

--- a/_project/TODO/main/planning/remediate-explorer-csp-hardening.yaml
+++ b/_project/TODO/main/planning/remediate-explorer-csp-hardening.yaml
@@ -1,0 +1,88 @@
+id: remediate-explorer-csp-hardening
+title: "Add a Content-Security-Policy to the Results Explorer to close the duckdb-wasm remote-fetch channel"
+worktree: main
+priority: Medium
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), finding §2.23 (Advisory).
+
+  results-explorer/index.html sets no CSP meta tag, and duckdb-wasm (1.32.0)
+  can INSTALL httpfs / read_csv('https://...'). The SQL editor text is component
+  state (Query.tsx:115) and is never seeded from URL params, so there is no
+  third-party injection vector — a user would have to paste hostile SQL
+  themselves, and the queried data is public. No XSS sinks exist
+  (dangerouslySetInnerHTML/innerHTML/eval grep is empty) and all app-generated
+  SQL is parameterized with allowlisted columns (queryFilters.ts:33-161). This
+  is a self-inflicted-only exfiltration channel; adding a CSP closes it and
+  hardens defense-in-depth.
+
+  Lower priority than the other items: no reachable exploit today, purely a
+  hardening improvement.
+
+work:
+  - id: w1
+    summary: "Add a restrictive CSP to results-explorer/index.html (and/or the deploy layer) compatible with duckdb-wasm"
+    status: pending
+    notes: |
+      duckdb-wasm needs wasm-eval and its worker/CDN-or-bundled assets; craft a
+      CSP that permits the bundled wasm/worker origins and blocks arbitrary
+      remote fetch (connect-src). Verify the app still loads the snapshot and
+      runs queries. GitHub Pages cannot set response headers, so a <meta
+      http-equiv> CSP (or a documented reverse-proxy header) is the mechanism.
+
+  - id: w2
+    summary: "Optionally disable httpfs/extension autoload in the duckdb-wasm config"
+    needs: [w1]
+    status: pending
+    notes: |
+      If the threat model includes a user pasting attacker-supplied SQL,
+      disable extension install/autoload so INSTALL httpfs cannot fetch. Confirm
+      no app feature (CSV export via COPY TO the virtual FS) depends on it.
+
+deferred:
+  - summary: "COOP/COEP headers for cross-origin isolation"
+    reason: "Separate concern; only needed if SharedArrayBuffer-based duckdb-wasm threading is adopted."
+
+prior_art:
+  - "results-explorer/src/db.ts:262-278 — the existing wasm bundle/attach config is where extension-autoload settings live (w2)."
+  - "results-explorer/index.html — the single entry document that would carry a <meta> CSP (w1)."
+
+must_preserve:
+  - "Snapshot load over HTTP range reads and the read-only ATTACH continue to work."
+  - "In-app CSV export (COPY TO the WASM virtual FS) keeps working."
+  - "The SQL editor keeps running legitimate read queries against bench.*."
+
+anti_patterns:
+  - "DO NOT set a CSP so strict it blocks the wasm worker or the snapshot fetch - because that breaks the app - scope connect-src to the snapshot origin and allow the wasm/worker assets."
+
+verification:
+  - description: "CSP present and app still functions"
+    command: "grep -n 'Content-Security-Policy' results-explorer/index.html && uv run -- npm --prefix results-explorer run build"
+    expected_output: "CSP meta present; build succeeds"
+  - description: "Explorer e2e smoke still passes"
+    command: "npm --prefix results-explorer run test:e2e:fixtures"
+    expected_output: "smoke suite passes with the CSP in place"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/index.html"
+    - "results-explorer/src/db.ts"
+  do_not_modify:
+    - "benchbox/"
+    - ".github/workflows/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "explorer"
+    - "hardening"
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "A CSP blocks arbitrary remote fetch from the explorer while the app still loads and queries the snapshot."

--- a/_project/TODO/main/planning/remediate-explorer-deploy-path-reconciliation.yaml
+++ b/_project/TODO/main/planning/remediate-explorer-deploy-path-reconciliation.yaml
@@ -1,0 +1,130 @@
+id: remediate-explorer-deploy-path-reconciliation
+title: "Reconcile the 'explorer is built/served from main' docs with the release curation that strips it"
+worktree: main
+priority: High
+status: Not Started
+category: Documentation
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.13 (Required) and §2.14 (Required).
+
+  §2.13 — results-phase-2-runbook.md:41-47 says the explorer "is built from
+  main via docs.yml … publishes from main's view of results-data/," and
+  contributing-results.md:108 promises an automatic explorer rebuild after a
+  merge. But: docs.yml has no trigger on published-results and its deploy job
+  requires push to main (:193), so §6's `gh workflow run docs.yml`
+  (workflow_dispatch) builds but never deploys; Makefile:1070-1072 (release-cut)
+  `git rm -rf results-data results-explorer` from every release branch, so those
+  paths can never reach main; and docs.yml:79-84 documents that on main the
+  explorer steps are a deliberate no-op (hashFiles empty). Net: a merged
+  submission never reaches the public explorer via any automated path, and there
+  is no automated flow from published-results back to develop/main.
+
+  §2.14 — On the default branch (main), docs/operations/results-explorer-qa.md,
+  adr-explorer-cli-surface.md, and a Makefile audit-sha-check target reference
+  results-explorer/, _project/scripts/, _project/audits/ — all stripped from
+  main by release-cut — and README.md:66 links benchbox.dev/results/. A reader
+  landing on the default branch follows docs pointing at absent infrastructure.
+  (CONTRIBUTING.md:44 does correctly say develop is the dev branch — the one
+  mitigation that passes.)
+
+  This item is decision-first: the fix depends on where the explorer is actually
+  intended to build and deploy from. It cannot be a mechanical doc edit until
+  that is settled (see open_questions).
+
+work:
+  - id: w0
+    summary: "Re-derive the current deploy reality and settle the intended source-of-truth branch for the explorer"
+    status: pending
+    notes: |
+      Confirm: (1) results-explorer/ has never existed on main
+      (`git log origin/main -- results-explorer/` empty); (2) docs.yml deploy is
+      main-push-only; (3) release-cut strips the paths. Then get the maintainer
+      decision recorded in this item (open_questions) before any doc/workflow
+      edit. Capture findings to /tmp and summarize.
+
+  - id: w1
+    summary: "Make the runbook + contributing-results describe the real trigger and deploy path"
+    needs: [w0]
+    status: pending
+    notes: |
+      Rewrite results-phase-2-runbook.md §1.3/§6 and
+      contributing-results.md:108 to match the decided reality: state which
+      branch builds and deploys the explorer, that workflow_dispatch builds but
+      does not deploy, and how (or whether) a merged submission reaches the site.
+
+  - id: w2
+    summary: "Fix the wiring so the documented path is actually achievable (if the decision requires it)"
+    needs: [w0]
+    status: pending
+    notes: |
+      Depending on w0's decision: either (a) stop stripping
+      results-data/results-explorer in release-cut and let docs.yml deploy from
+      main, or (b) add a deploy trigger/source for the branch that genuinely
+      holds the explorer, or (c) document explicitly that the explorer is
+      pre-launch / served out-of-band. Only one of these lands.
+
+  - id: w3
+    summary: "Stop the default branch from shipping docs that reference stripped paths"
+    needs: [w0]
+    status: pending
+    notes: |
+      Either exclude the develop-only operations/QA docs and the
+      audit-sha-check Make target from release-cut curation (as
+      results-explorer/ and _project/ already are), or add a prominent
+      "describes develop-only tooling" banner, or gate the README results link
+      until the site is live. Keep only docs whose referenced paths survive
+      release-cut.
+
+prior_art:
+  - "Makefile:1070-1072 release-cut curation list — extend the exclusion set (or stop excluding) per the decision, rather than adding a parallel curation mechanism."
+  - "docs.yml:79-84 — the inline dormancy comment is the accurate description; align the runbook to it (or change the wiring), not vice versa."
+  - "docs/operations/release-guide.md + _project/decisions/single-repo-migration.md — the authoritative curation rationale; reconcile the docs against these."
+
+must_preserve:
+  - "The single-repo migration model (develop is authoritative, main is release-only)."
+  - "Whatever the decision, CONTRIBUTING.md's correct 'develop is the dev branch' statement stays."
+
+anti_patterns:
+  - "DO NOT edit the runbook to a new happy-path story without fixing the wiring - because the contradiction is between docs AND pipeline - reconcile both or the drift returns."
+  - "DO NOT unconditionally ship all operations docs on main - because they reference develop-only paths - curate or banner them."
+
+verification:
+  - description: "No doc claims an automated explorer rebuild that the wiring cannot perform"
+    command: "grep -n 'automatically rebuilds\\|built from .main.' docs/operations/results-phase-2-runbook.md docs/contributing-results.md"
+    expected_output: "remaining statements match the decided, wired reality"
+  - description: "Default-branch docs do not reference paths stripped by release-cut"
+    command: "review release-cut output vs docs references (results-explorer/, _project/scripts/, _project/audits/)"
+    expected_output: "no unexecutable references, or an explicit develop-only banner"
+
+scope_limit:
+  only_modify:
+    - "docs/operations/results-phase-2-runbook.md"
+    - "docs/contributing-results.md"
+    - "docs/operations/results-explorer-qa.md"
+    - "Makefile"
+    - ".github/workflows/docs.yml"
+  do_not_modify:
+    - "benchbox/"
+    - "results-explorer/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "docs"
+    - "release"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+open_questions:
+  - question: "From which branch is benchbox.dev/results/ intended to build and deploy, and is it live today?"
+    gating: true
+    affects: ["w1", "w2", "w3"]
+    default: "Assume main is the intended source but the explorer is pre-launch (never yet deployed); document that state and fix the auto-rebuild promise, deferring any release-cut change to an explicit maintainer decision."
+
+success_metrics:
+  - "The runbook and contributor guide describe a deploy path that the workflows can actually perform."
+  - "A reader on the default branch is not sent to paths that do not exist there."

--- a/_project/TODO/main/planning/remediate-explorer-deploy-path-reconciliation.yaml
+++ b/_project/TODO/main/planning/remediate-explorer-deploy-path-reconciliation.yaml
@@ -94,9 +94,12 @@ verification:
   - description: "No doc claims an automated explorer rebuild that the wiring cannot perform"
     command: "grep -n 'automatically rebuilds\\|built from .main.' docs/operations/results-phase-2-runbook.md docs/contributing-results.md"
     expected_output: "remaining statements match the decided, wired reality"
-  - description: "Default-branch docs do not reference paths stripped by release-cut"
-    command: "review release-cut output vs docs references (results-explorer/, _project/scripts/, _project/audits/)"
-    expected_output: "no unexecutable references, or an explicit develop-only banner"
+  - description: "release-cut still strips the explorer/results paths (confirms the constraint the docs must respect)"
+    command: "make -n release-cut | grep -nE 'git rm .*results-(data|explorer)'"
+    expected_output: "the strip line is present (or, if the decision changed the wiring, it is intentionally gone)"
+  - description: "Default-branch docs do not send readers to paths absent on main"
+    command: "git show origin/main:docs/operations/results-explorer-qa.md | grep -cE 'results-explorer/|_project/scripts/|_project/audits/'"
+    expected_output: "0 (references removed or gated behind an explicit develop-only banner)"
 
 scope_limit:
   only_modify:

--- a/_project/TODO/main/planning/remediate-explorer-trust-label-vocabulary.yaml
+++ b/_project/TODO/main/planning/remediate-explorer-trust-label-vocabulary.yaml
@@ -1,0 +1,103 @@
+id: remediate-explorer-trust-label-vocabulary
+title: "Unify trust-label vocabulary across publisher and explorer; stop hiding the badge on empty labels"
+worktree: main
+priority: Medium-High
+status: Not Started
+category: Documentation
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.20 (Advisory) and §2.21 (Advisory).
+
+  §2.20 — The publisher's canonical set is
+  benchbox/core/publishing/bundle_publisher.py:30
+  VALID_LABELS = (maintainer-run, community-submission, ci, local,
+  unofficial-research). But the explorer's TrustBadge config keys are
+  ci-verified, ci-validated, local-run
+  (results-explorer/src/components/TrustBadge.tsx:19-43) and ranking
+  eligibility is {maintainer-run, ci-verified} (models.py:82-89). So a bundle
+  labeled `ci` or `local` by the publisher renders under the "unrecognised —
+  contact maintainers" fallback and (for `ci`) is not ranking-eligible despite
+  the publisher treating it as first-class; `unofficial-research` has no
+  explorer badge at all. The two halves of the platform disagree on the label
+  vocabulary.
+
+  §2.21 — TrustBadge.tsx:64 `if (!trustLabel) return null;` hides the badge
+  entirely on an empty label instead of showing an explicit "unknown" (moot
+  today because the snapshot schema makes trust_label NOT NULL, but the
+  component contract is hide-on-missing).
+
+work:
+  - id: w1
+    summary: "Define one canonical trust-label vocabulary shared by the publisher, pipeline, and explorer"
+    status: pending
+    notes: |
+      Pick the single source of truth (publisher VALID_LABELS vs explorer
+      TRUST_CONFIG) and reconcile ci↔ci-verified and local↔local-run
+      explicitly. Ensure unofficial-research has an explorer badge. Document the
+      canonical list where both sides reference it.
+
+  - id: w2
+    summary: "Map every publisher label to an explorer badge (no silent 'unrecognised' for a valid label)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Update results-explorer/src/components/TrustBadge.tsx TRUST_CONFIG so
+      every VALID_LABELS value renders a curated badge; keep the fallback only
+      for genuinely unknown strings.
+
+  - id: w3
+    summary: "Render an explicit 'unknown' badge on empty trust label instead of returning null"
+    needs: [w1]
+    status: pending
+    notes: |
+      TrustBadge.tsx:64 — render DEFAULT_CONFIG/'unknown' on empty rather than
+      hiding the trust dimension. Update the pinning tests
+      (results-explorer/src/components/__tests__/).
+
+deps:
+  needs:
+    - remediate-submission-trust-label-enforcement
+
+prior_art:
+  - "benchbox/core/publishing/bundle_publisher.py:30 VALID_LABELS — reuse as (or reconcile toward) the canonical vocabulary."
+  - "results-explorer/src/components/TrustBadge.tsx:TRUST_CONFIG — extend to cover every canonical label."
+  - "results-explorer/src/lib/displayLabels.ts:formatTrustLabel — reuse the existing 'unknown' rendering for the empty-state fix."
+
+must_preserve:
+  - "is_ranking_eligible semantics: community-submission and local stay excluded from official rankings."
+  - "Existing curated badge tones for maintainer-run and ci-verified."
+
+anti_patterns:
+  - "DO NOT add a third divergent label set - because there are already two - collapse to one canonical vocabulary referenced by both sides."
+
+verification:
+  - description: "Every publisher VALID_LABELS value has a non-fallback explorer badge"
+    command: "uv run -- npm --prefix results-explorer test -- TrustBadge"
+    expected_output: "no valid label falls through to the 'unrecognised' path; empty → 'unknown'"
+  - description: "Label vocabulary is single-sourced"
+    command: "grep -rn 'ci-verified\\|VALID_LABELS' benchbox/core/publishing results-explorer/src _project/scripts/explorer_pipeline"
+    expected_output: "one canonical definition, referenced (not re-declared divergently)"
+
+scope_limit:
+  only_modify:
+    - "results-explorer/src/components/TrustBadge.tsx"
+    - "results-explorer/src/components/__tests__/"
+    - "results-explorer/src/lib/displayLabels.ts"
+    - "benchbox/core/publishing/bundle_publisher.py"
+    - "_project/scripts/explorer_pipeline/models.py"
+  do_not_modify:
+    - "benchbox/validation/bundle.py"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "explorer"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "A bundle published with any VALID_LABELS value renders a meaningful, correctly-ranked badge in the explorer."
+  - "An empty trust label shows 'unknown', never nothing."

--- a/_project/TODO/main/planning/remediate-explorer-trust-label-vocabulary.yaml
+++ b/_project/TODO/main/planning/remediate-explorer-trust-label-vocabulary.yaml
@@ -72,12 +72,12 @@ anti_patterns:
   - "DO NOT add a third divergent label set - because there are already two - collapse to one canonical vocabulary referenced by both sides."
 
 verification:
-  - description: "Every publisher VALID_LABELS value has a non-fallback explorer badge"
-    command: "uv run -- npm --prefix results-explorer test -- TrustBadge"
-    expected_output: "no valid label falls through to the 'unrecognised' path; empty → 'unknown'"
-  - description: "Label vocabulary is single-sourced"
-    command: "grep -rn 'ci-verified\\|VALID_LABELS' benchbox/core/publishing results-explorer/src _project/scripts/explorer_pipeline"
-    expected_output: "one canonical definition, referenced (not re-declared divergently)"
+  - description: "Every publisher VALID_LABELS value renders a non-fallback badge; empty renders 'unknown'"
+    command: "npm --prefix results-explorer test -- TrustBadge"
+    expected_output: "new/updated test asserts each VALID_LABELS value maps to a curated badge (not the 'unrecognised' fallback) and empty → 'unknown'; suite passes"
+  - description: "The ci↔ci-verified / local↔local-run mappings are covered by a test, not just a grep"
+    command: "npm --prefix results-explorer test -- TrustBadge -t 'vocabulary'"
+    expected_output: "a test enumerates the canonical labels and asserts each resolves; fails if a VALID_LABELS value is unmapped"
 
 scope_limit:
   only_modify:

--- a/_project/TODO/main/planning/remediate-governance-and-doc-drift.yaml
+++ b/_project/TODO/main/planning/remediate-governance-and-doc-drift.yaml
@@ -1,0 +1,151 @@
+id: remediate-governance-and-doc-drift
+title: "Retire the stale prune-publishing doc and fix governance/doc drift that misdirects maintainers"
+worktree: main
+priority: High
+status: Not Started
+category: Documentation
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.12 (Critical), §2.16 (Required), §2.18b
+  (Advisory, grouped), plus the ADR-index gap and §2.22 test-dir relocation.
+
+  §2.12 (Critical) — docs/design/future-state/prune-publishing-subsystem/README.md
+  :31-33 says the publishing module has "zero consumers … no CLI integration"
+  and is "High priority (dead code removal)" (docs/design/future-state/index.md:43,
+  in the Sphinx toctree). Reality: benchbox/cli/commands/__init__.py:33 registers
+  `publish`, publish.py imports benchbox.core.publishing, run --publish uses it,
+  and 33 tests cover it. The doc was written 2026-04-01 about the OLD generic
+  layer, which was deleted in 0182c955 (2026-04-27) — the same commit that added
+  the current bundle_publisher.py/store.py at the same path. Following the doc
+  today deletes live, shipped code.
+
+  §2.16 (Required) — results-explorer-qa.md is billed as the maintained,
+  reusable QA plan (:7-10) but hardcodes saving findings to the sealed
+  pass-2 file (:95,:392), says to update the completed pass-1 TODO (:369,:392),
+  and points screenshots at a non-existent _project/audits/screenshots/ (:114).
+
+  §2.18b (Advisory, grouped) — benchbox-results-platform-strategy.md:480 cites
+  publishing/artifacts.py + permalink.py (deleted 2026-04-27) as current
+  evidence; adr-explorer-cli-surface.md:38-41 and
+  results-explorer-browser-testing.md:70-72 misstate the docs.yml / browser
+  workflow triggers; results-explorer-token-scan.md:135-137 omits medium-test
+  from the jq filter; repo-admin-settings.md:58-59 says ci-required-result
+  aggregates 4 jobs (it needs 10, pr.yml:916); results-phase-2-runbook.md:29-30
+  says the sync watches "two vendored validators" (three code files) and calls
+  seed-corpus.yml a "quarterly refresh" (it is workflow_dispatch only).
+
+  Also: docs/development/adr/README.md indexes only 4 of the ADRs, omitting the
+  three Accepted ADRs with the most operational teeth (datasketches-vendoring,
+  explorer-cli-surface, published-results-slim-corpus-branch). And §2.22: the
+  explorer tests live under misleading paths (tests/unit/core/explorer_pipeline/
+  imports _project.scripts.explorer_pipeline; tests/unit/cli/test_explorer_build_contract.py
+  tests no CLI command) — a naming residue from the completed migration.
+
+work:
+  - id: w1
+    summary: "Retire / correct the prune-publishing future-state doc (Critical hazard)"
+    status: pending
+    notes: |
+      Move docs/design/future-state/prune-publishing-subsystem/ to an _archive
+      (or rewrite it to state the prune completed in v0.2.1), remove it from
+      docs/design/future-state/index.md and the toctree, and note that the path
+      now hosts the live bundle-publish subsystem. This is the highest-urgency
+      unit: the current text is an instruction to delete shipped code.
+
+  - id: w2
+    summary: "Make the QA plan reusable: parameterize the pass number, drop the closed pass-1 TODO reference, fix the screenshots path"
+    status: pending
+    notes: |
+      results-explorer-qa.md — replace the hardcoded pass-2 file with
+      "results-explorer-qa-pass<N>-findings.md, next unused N"; remove the
+      pass-1 TODO update instruction; either create _project/audits/screenshots/
+      or change the retention line to match the "not retained in git" reality
+      the pass-2 findings already record.
+
+  - id: w3
+    summary: "Fix the grouped §2.18b doc drifts against current YAML/tree"
+    status: pending
+    notes: |
+      Strategy doc deleted-file evidence row (:480); ADR/browser-testing trigger
+      claims; token-scan jq (add medium-test); repo-admin-settings aggregator
+      count (4→10); runbook §1.2 validator count + seed-corpus cadence.
+
+  - id: w4
+    summary: "Add the three missing Accepted ADRs to docs/development/adr/README.md"
+    status: pending
+    notes: |
+      Index adr-duckdb-datasketches-vendoring, adr-explorer-cli-surface,
+      adr-published-results-slim-corpus-branch so they are discoverable.
+
+  - id: w5
+    summary: "Relocate the mislabeled explorer tests to mirror the migrated source layout"
+    status: pending
+    notes: |
+      git mv tests/unit/core/explorer_pipeline/ → tests/unit/scripts/explorer_pipeline/
+      and tests/unit/cli/test_explorer_build_contract.py →
+      tests/unit/scripts/. Update any import/collection config. Behavior
+      unchanged (260 tests already pass); this is a naming fix only.
+
+deferred:
+  - summary: "§2.17/§2.18 QA-doc S7.6 wording and fixture/route accuracy"
+    reason: "Content-accuracy of the QA doc body; tracked in remediate-qa-and-browser-test-doc-accuracy."
+
+prior_art:
+  - "docs/design/future-state/ existing _archive convention — reuse for w1 rather than deleting outright."
+  - "docs/development/adr/README.md existing table format — extend with the three missing rows (w4)."
+  - "_project/DONE/main/ completed-item conventions — model for how a superseded future-state doc is annotated."
+
+must_preserve:
+  - "The live benchbox/core/publishing/ subsystem and its tests remain untouched (this item only edits docs and moves tests)."
+  - "The 260 explorer_pipeline tests keep passing after the git mv (imports resolve via namespace packages)."
+  - "audit-sha frontmatter contract on _project/audits/ files."
+
+anti_patterns:
+  - "DO NOT delete benchbox/core/publishing/ - because the prune doc is stale, not correct - retire the doc instead."
+  - "DO NOT hand-edit generated _project/TODO/_indexes/ - regenerate via the todo CLI / make todo-reindex."
+
+verification:
+  - description: "Prune doc no longer presents live code as removable dead code"
+    command: "grep -rn 'zero consumers\\|dead code removal' docs/design/future-state/prune-publishing-subsystem/ docs/design/future-state/index.md"
+    expected_output: "removed or reworded to 'completed in v0.2.1'"
+  - description: "QA plan has no hardcoded pass-2/pass-1 references"
+    command: "grep -n 'pass2-findings\\|pass-1 TODO' docs/operations/results-explorer-qa.md"
+    expected_output: "pass number parameterized; closed-TODO reference gone"
+  - description: "ADR index lists all Accepted ADRs"
+    command: "grep -c 'adr-' docs/development/adr/README.md"
+    expected_output: ">= 7 ADR entries"
+  - description: "Relocated tests still pass"
+    command: "uv run -- python -m pytest tests/unit/scripts/explorer_pipeline/ -q"
+    expected_output: "all pass at the new path"
+
+scope_limit:
+  only_modify:
+    - "docs/design/future-state/"
+    - "docs/operations/results-explorer-qa.md"
+    - "docs/development/benchbox-results-platform-strategy.md"
+    - "docs/development/adr/"
+    - "docs/development/results-explorer-browser-testing.md"
+    - "docs/operations/results-explorer-token-scan.md"
+    - "docs/operations/repo-admin-settings.md"
+    - "docs/operations/results-phase-2-runbook.md"
+    - "tests/unit/core/explorer_pipeline/"
+    - "tests/unit/scripts/"
+    - "tests/unit/cli/test_explorer_build_contract.py"
+  do_not_modify:
+    - "benchbox/core/publishing/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "governance"
+    - "docs"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "No published doc instructs deletion of the live publishing subsystem."
+  - "A future QA pass writes to its own findings file, not a sealed one."
+  - "All Accepted ADRs are discoverable from the ADR index."

--- a/_project/TODO/main/planning/remediate-governance-and-doc-drift.yaml
+++ b/_project/TODO/main/planning/remediate-governance-and-doc-drift.yaml
@@ -1,5 +1,5 @@
 id: remediate-governance-and-doc-drift
-title: "Retire the stale prune-publishing doc and fix governance/doc drift that misdirects maintainers"
+title: "Fix governance/doc drift: QA plan overwrite hazard, stale evidence, ADR index, test relocation"
 worktree: main
 priority: High
 status: Not Started
@@ -7,18 +7,11 @@ category: Documentation
 
 description: |
   Source: _project/audits/results-explorer-publication-adversarial-review.md
-  (develop_sha fddedf26), findings §2.12 (Critical), §2.16 (Required), §2.18b
-  (Advisory, grouped), plus the ADR-index gap and §2.22 test-dir relocation.
+  (develop_sha fddedf26), findings §2.16 (Required), §2.18b (Advisory, grouped),
+  plus the ADR-index gap and §2.22 test-dir relocation.
 
-  §2.12 (Critical) — docs/design/future-state/prune-publishing-subsystem/README.md
-  :31-33 says the publishing module has "zero consumers … no CLI integration"
-  and is "High priority (dead code removal)" (docs/design/future-state/index.md:43,
-  in the Sphinx toctree). Reality: benchbox/cli/commands/__init__.py:33 registers
-  `publish`, publish.py imports benchbox.core.publishing, run --publish uses it,
-  and 33 tests cover it. The doc was written 2026-04-01 about the OLD generic
-  layer, which was deleted in 0182c955 (2026-04-27) — the same commit that added
-  the current bundle_publisher.py/store.py at the same path. Following the doc
-  today deletes live, shipped code.
+  (§2.12 Critical — the prune-publishing doc hazard — was split into its own
+  Critical item remediate-prune-publishing-doc-hazard; it is NOT covered here.)
 
   §2.16 (Required) — results-explorer-qa.md is billed as the maintained,
   reusable QA plan (:7-10) but hardcodes saving findings to the sealed
@@ -43,16 +36,6 @@ description: |
   tests no CLI command) — a naming residue from the completed migration.
 
 work:
-  - id: w1
-    summary: "Retire / correct the prune-publishing future-state doc (Critical hazard)"
-    status: pending
-    notes: |
-      Move docs/design/future-state/prune-publishing-subsystem/ to an _archive
-      (or rewrite it to state the prune completed in v0.2.1), remove it from
-      docs/design/future-state/index.md and the toctree, and note that the path
-      now hosts the live bundle-publish subsystem. This is the highest-urgency
-      unit: the current text is an instruction to delete shipped code.
-
   - id: w2
     summary: "Make the QA plan reusable: parameterize the pass number, drop the closed pass-1 TODO reference, fix the screenshots path"
     status: pending
@@ -90,25 +73,27 @@ work:
 deferred:
   - summary: "§2.17/§2.18 QA-doc S7.6 wording and fixture/route accuracy"
     reason: "Content-accuracy of the QA doc body; tracked in remediate-qa-and-browser-test-doc-accuracy."
+  - summary: "§2.19 optional 'publish disambiguation' note in AGENTS.md / CLI docs"
+    reason: "Advisory nicety; the substantive publish-naming hazard is remediate-prune-publishing-doc-hazard. Left as a small follow-up so the audit item is not silently dropped."
+
+deps:
+  needs:
+    - remediate-submission-trust-label-enforcement
 
 prior_art:
-  - "docs/design/future-state/ existing _archive convention — reuse for w1 rather than deleting outright."
   - "docs/development/adr/README.md existing table format — extend with the three missing rows (w4)."
-  - "_project/DONE/main/ completed-item conventions — model for how a superseded future-state doc is annotated."
+  - "_project/DONE/main/ completed-item conventions — model for how a relocated/annotated item is recorded."
 
 must_preserve:
-  - "The live benchbox/core/publishing/ subsystem and its tests remain untouched (this item only edits docs and moves tests)."
   - "The 260 explorer_pipeline tests keep passing after the git mv (imports resolve via namespace packages)."
   - "audit-sha frontmatter contract on _project/audits/ files."
+  - "Any trust tests added by remediate-submission-trust-label-enforcement (which lands first) are moved along with the rest of tests/unit/core/explorer_pipeline/."
 
 anti_patterns:
-  - "DO NOT delete benchbox/core/publishing/ - because the prune doc is stale, not correct - retire the doc instead."
   - "DO NOT hand-edit generated _project/TODO/_indexes/ - regenerate via the todo CLI / make todo-reindex."
+  - "DO NOT run w5 before remediate-submission-trust-label-enforcement merges - because that item adds tests under tests/unit/core/explorer_pipeline/ - the deps.needs edge enforces ordering so the move captures those tests too."
 
 verification:
-  - description: "Prune doc no longer presents live code as removable dead code"
-    command: "grep -rn 'zero consumers\\|dead code removal' docs/design/future-state/prune-publishing-subsystem/ docs/design/future-state/index.md"
-    expected_output: "removed or reworded to 'completed in v0.2.1'"
   - description: "QA plan has no hardcoded pass-2/pass-1 references"
     command: "grep -n 'pass2-findings\\|pass-1 TODO' docs/operations/results-explorer-qa.md"
     expected_output: "pass number parameterized; closed-TODO reference gone"
@@ -121,7 +106,6 @@ verification:
 
 scope_limit:
   only_modify:
-    - "docs/design/future-state/"
     - "docs/operations/results-explorer-qa.md"
     - "docs/development/benchbox-results-platform-strategy.md"
     - "docs/development/adr/"
@@ -134,6 +118,7 @@ scope_limit:
     - "tests/unit/cli/test_explorer_build_contract.py"
   do_not_modify:
     - "benchbox/core/publishing/"
+    - "docs/design/future-state/"
 
 metadata:
   owners:
@@ -146,6 +131,6 @@ metadata:
   created_date: "2026-07-04"
 
 success_metrics:
-  - "No published doc instructs deletion of the live publishing subsystem."
   - "A future QA pass writes to its own findings file, not a sealed one."
   - "All Accepted ADRs are discoverable from the ADR index."
+  - "The mislabeled explorer tests live under a path that matches their imported source."

--- a/_project/TODO/main/planning/remediate-prune-publishing-doc-hazard.yaml
+++ b/_project/TODO/main/planning/remediate-prune-publishing-doc-hazard.yaml
@@ -1,0 +1,101 @@
+id: remediate-prune-publishing-doc-hazard
+title: "Retire the stale prune-publishing future-state doc that instructs deletion of the live benchbox publish subsystem"
+worktree: main
+priority: Critical
+status: Not Started
+category: Documentation
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), finding §2.12 (Critical). Split out of
+  remediate-governance-and-doc-drift so the Critical severity surfaces on the
+  priority/ready queue (the rest of that item is High doc cleanup).
+
+  docs/design/future-state/prune-publishing-subsystem/README.md:31-33 says the
+  publishing module has "zero consumers … no CLI integration" and is
+  "High priority (dead code removal)" (docs/design/future-state/index.md:43, in
+  the Sphinx toctree, so it renders on the published docs site). Reality:
+  benchbox/cli/commands/__init__.py:33 registers `publish`, publish.py imports
+  benchbox.core.publishing, `benchbox run --publish` uses it, and
+  tests/unit/core/publishing/ (33 tests) + tests/integration/test_publish_cli.py
+  cover it. The doc was authored 2026-04-01 (90a2fd08) about the OLD generic
+  layer, which was deleted in 0182c955 (2026-04-27) — the SAME commit that added
+  the current bundle_publisher.py/store.py at the same package path. Following
+  the doc today deletes live, shipped code. Its "Related TODO:
+  prune-publishing-subsystem" no longer exists.
+
+work:
+  - id: w0
+    summary: "Re-confirm the publishing subsystem is live and the doc still presents it as removable"
+    status: pending
+    notes: |
+      Capture to /tmp/remediate-prune-w0.log (do not commit); summarize:
+        - `grep -n 'publish' benchbox/cli/commands/__init__.py` shows the
+          registered publish command.
+        - `grep -rn 'core.publishing' benchbox/cli/commands/` shows live imports.
+        - `uv run -- python -m pytest tests/unit/core/publishing -q` passes.
+        - `grep -rn 'zero consumers\|dead code removal'
+          docs/design/future-state/prune-publishing-subsystem/ docs/design/future-state/index.md`
+          still returns the stale claims.
+
+  - id: w1
+    summary: "Retire or rewrite the prune-publishing future-state doc so it no longer targets live code"
+    needs: [w0]
+    status: pending
+    notes: |
+      Preferred: move docs/design/future-state/prune-publishing-subsystem/ to a
+      future-state archive location and add a short header noting the prune
+      completed in v0.2.1 and that benchbox/core/publishing/ is now the live
+      bundle-publish subsystem. Alternative: rewrite README.md in place to the
+      same effect. Either way the "zero consumers / dead code removal" framing
+      must be gone.
+
+  - id: w2
+    summary: "Remove the doc from the active future-state index and Sphinx toctree"
+    needs: [w1]
+    status: pending
+    notes: |
+      docs/design/future-state/index.md:43 and the toctree entry — drop or
+      relocate so the retired doc no longer renders as an active High-priority
+      proposal on the published docs site.
+
+prior_art:
+  - "docs/design/future-state/index.md — the active proposals index this doc must be removed from (extend the index conventions)."
+  - "_project/DONE/ completed-item annotation style — model for how a superseded/completed plan is marked; there is no existing docs/design/future-state/_archive/ dir, so w1 either introduces that archive convention (supersede) or rewrites in place."
+
+must_preserve:
+  - "The live benchbox/core/publishing/ subsystem, its CLI registration, and its 33 tests remain untouched — this item edits docs only."
+  - "Other future-state proposals in docs/design/future-state/index.md stay listed."
+
+anti_patterns:
+  - "DO NOT delete benchbox/core/publishing/ - because the prune doc is stale, not correct - the old generic layer it described was already removed in v0.2.1; retire the DOC."
+  - "DO NOT leave the doc in the active toctree with only a footnote - because it still renders as a High-priority 'dead code removal' proposal - remove or archive it."
+
+verification:
+  - description: "Prune doc no longer presents live code as removable dead code"
+    command: "grep -rn 'zero consumers\\|dead code removal' docs/design/future-state/prune-publishing-subsystem/ docs/design/future-state/index.md"
+    expected_output: "no match (removed or reworded to 'completed in v0.2.1')"
+  - description: "The live publish subsystem is intact"
+    command: "uv run -- python -m pytest tests/unit/core/publishing -q && benchbox publish --help"
+    expected_output: "tests pass; publish command still registered"
+
+scope_limit:
+  only_modify:
+    - "docs/design/future-state/"
+  do_not_modify:
+    - "benchbox/core/publishing/"
+    - "benchbox/cli/commands/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "governance"
+    - "critical"
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "No published doc instructs deletion of the live publishing subsystem."
+  - "docs.benchbox.dev no longer lists prune-publishing as an active High-priority proposal."

--- a/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
+++ b/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
@@ -105,11 +105,11 @@ anti_patterns:
 
 verification:
   - description: "published-results validate-submission covers manifest-only PRs"
-    command: "git show <mirror-branch>:.github/workflows/validate-submission.yml | grep -c CHANGED_MANIFESTS"
-    expected_output: ">= 1 (guard present on the branch that runs it)"
-  - description: "A validator-modifying submission PR cannot self-green"
-    command: "review the workflow: validation runs from a trusted ref or errors on validator edits"
-    expected_output: "self-green vector closed"
+    command: "git show origin/published-results:.github/workflows/validate-submission.yml | grep -c CHANGED_MANIFESTS"
+    expected_output: ">= 1 (guard present on the branch that actually runs the workflow for contributor PRs)"
+  - description: "Validation runs from a trusted ref (closes the self-green vector), or errors on validator edits"
+    command: "grep -nE 'pull_request_target|base\\.sha|base\\.ref|actions/checkout' .github/workflows/validate-submission.yml"
+    expected_output: "validator runs from the base ref (not the PR head), OR a step fails the job when the PR modifies scripts/validate_submission.py / benchbox/validation/bundle.py"
   - description: "ADR allowlist includes the vendored validator"
     command: "grep -n 'benchbox/validation/bundle.py' docs/development/adr/adr-published-results-slim-corpus-branch.md"
     expected_output: "listed in the allowlist; stdlib-only claim corrected"

--- a/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
+++ b/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
@@ -1,0 +1,149 @@
+id: remediate-published-results-submission-ci
+title: "Harden published-results submission CI: on-branch drift, self-green, fork-PR comments, ADR allowlist"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.6 (Required), §2.8 (Required, verify
+  first), §2.7 (Advisory), §2.15 (Required).
+
+  §2.6 — Contributor PRs target `published-results`, so the workflow that runs
+  is the ON-BRANCH copy of validate-submission.yml, which has drifted behind
+  develop: `git show origin/published-results:.github/workflows/validate-submission.yml
+  | grep -c CHANGED_MANIFESTS` → 0 vs 3 on develop. The develop fix that closed
+  the manifest-only-PR hash bypass is absent exactly where untrusted PRs land,
+  and the sync workflow's allowlist (sync-results-data-to-published.yml:21-30)
+  does not include .github/workflows/**, so nothing detects/mirrors the drift.
+
+  §2.8 — validate-submission.yml uses plain `pull_request` with
+  `pull-requests: write` (:3-12); for fork PRs GitHub caps GITHUB_TOKEN
+  read-only, so the always()-gated "Post PR comment" step (:97-132) should 403
+  and turn even a passing validation red for external contributors. VERIFY
+  against a real historical fork-PR run before implementing (a repo setting
+  could change this).
+
+  §2.7 — The trigger path filter (results-data/bundles/**) matches any-of, and
+  validator scripts run from the PR merge commit, so a PR touching a bundle plus
+  scripts/validate_submission.py or benchbox/validation/bundle.py runs its own
+  doctored validator and self-greens the check (no privilege escalation; token
+  is read-only for forks, but check-spoofing).
+
+  §2.15 — adr-published-results-slim-corpus-branch.md claims validators are
+  "stdlib-only … no benchbox.* imports" (:100-103) and excludes benchbox/ from
+  the allowlist (:84-86), but scripts/validate_submission.py:23 imports
+  benchbox.validation.bundle, the sync workflow mirrors
+  benchbox/validation/bundle.py, and that file is present on published-results
+  (landed via mirror PR #555). The ADR's own maintenance trigger fired and was
+  never actioned; it also cites a TODO path now under _project/DONE/.
+
+work:
+  - id: w0
+    summary: "Verify §2.8 against a real fork-PR run and re-confirm §2.6 branch drift"
+    status: pending
+    notes: |
+      Gate: §2.8 remediation only proceeds if a historical fork PR to
+      published-results actually 403s on the comment step (check Actions
+      history). Re-confirm §2.6 drift:
+      `git show origin/published-results:.github/workflows/validate-submission.yml`
+      lacks the CHANGED_MANIFESTS block. Capture to /tmp and summarize.
+
+  - id: w1
+    summary: "Establish a maintained update path for the on-branch validate-submission.yml and restore the manifest-only guard"
+    needs: [w0]
+    status: pending
+    notes: |
+      Options (decide in review): (a) run validation from a trusted branch via
+      pull_request_target checking out the base's validator, so the up-to-date
+      workflow always runs and self-green (§2.7) is closed at once; or (b) add
+      .github/workflows/validate-submission.yml to the slim-branch allowlist +
+      a documented mirror mechanism. Whichever is chosen, the manifest-only
+      bypass must be closed on published-results.
+
+  - id: w2
+    summary: "Fix fork-PR comment posting so a passing validation never shows red for external contributors"
+    needs: [w0]
+    status: pending
+    notes: |
+      If §2.8 confirmed: move commenting to a workflow_run/pull_request_target
+      companion running with the base token, or skip commenting gracefully when
+      the token is read-only. Do not weaken the read-only posture for fork code.
+
+  - id: w3
+    summary: "Neutralize the self-green vector (§2.7)"
+    needs: [w1]
+    status: pending
+    notes: |
+      Run validation from a trusted ref, OR fail the job when the PR modifies
+      validator files, OR narrow the trigger so validator edits route to
+      develop only. May be subsumed by w1 option (a).
+
+  - id: w4
+    summary: "Update adr-published-results-slim-corpus-branch.md to match reality"
+    needs: [w0]
+    status: pending
+    notes: |
+      Add benchbox/validation/bundle.py to the allowlist; correct the
+      "stdlib-only / no benchbox.*" statement to describe the shared
+      implementation + importlib fallback; fix the DONE TODO path reference.
+
+prior_art:
+  - ".github/workflows/validate-main-pr.yml — reuse its trusted-policy checkout pattern for w1 option (a)."
+  - ".github/workflows/sync-results-data-to-published.yml — extend its allowlist for w1 option (b)."
+  - "docs/development/adr/adr-published-results-slim-corpus-branch.md:maintenance-protocol — the ADR itself prescribes the update in w4."
+
+must_preserve:
+  - "The slim, corpus-only shape of published-results (no pyproject.toml/uv.lock added)."
+  - "The uv run --no-project invocation contract on published-results."
+  - "Read-only token posture for fork-supplied code (no elevation)."
+
+anti_patterns:
+  - "DO NOT verbatim-mirror develop's validate-submission.yml onto the branch - because the copies intentionally differ in the --no-project invocation - use an explicit, documented update mechanism."
+  - "DO NOT run fork-PR code with pull_request_target checked out at the PR head - because that executes untrusted code with a writable token - check out the base's validator only."
+
+verification:
+  - description: "published-results validate-submission covers manifest-only PRs"
+    command: "git show <mirror-branch>:.github/workflows/validate-submission.yml | grep -c CHANGED_MANIFESTS"
+    expected_output: ">= 1 (guard present on the branch that runs it)"
+  - description: "A validator-modifying submission PR cannot self-green"
+    command: "review the workflow: validation runs from a trusted ref or errors on validator edits"
+    expected_output: "self-green vector closed"
+  - description: "ADR allowlist includes the vendored validator"
+    command: "grep -n 'benchbox/validation/bundle.py' docs/development/adr/adr-published-results-slim-corpus-branch.md"
+    expected_output: "listed in the allowlist; stdlib-only claim corrected"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/validate-submission.yml"
+    - ".github/workflows/sync-results-data-to-published.yml"
+    - "docs/development/adr/adr-published-results-slim-corpus-branch.md"
+  do_not_modify:
+    - "benchbox/"
+    - "results-data/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "security"
+    - "published-results"
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+
+open_questions:
+  - question: "Does a historical fork PR to published-results actually 403 on the comment step?"
+    gating: true
+    affects: ["w2"]
+    default: "If unconfirmed, keep §2.8 as a documented risk and implement only w1/w3/w4."
+  - question: "pull_request_target-from-trusted-branch (closes drift+self-green together) vs allowlist-mirror of the workflow file — which model does the maintainer prefer?"
+    gating: true
+    affects: ["w1", "w3"]
+    default: "Prefer pull_request_target from a trusted branch; it closes §2.6 and §2.7 with one mechanism."
+
+success_metrics:
+  - "The workflow that actually runs for contributor PRs verifies bundle hashes, including manifest-only PRs."
+  - "A validator-modifying PR cannot report its own validation as passing."
+  - "External-contributor PRs get a truthful pass/fail check status."

--- a/_project/TODO/main/planning/remediate-qa-and-browser-test-doc-accuracy.yaml
+++ b/_project/TODO/main/planning/remediate-qa-and-browser-test-doc-accuracy.yaml
@@ -1,0 +1,96 @@
+id: remediate-qa-and-browser-test-doc-accuracy
+title: "Fix Results Explorer QA doc: false S7.6 security claim, non-existent sample IDs, stale URL-sync notes"
+worktree: main
+priority: Medium
+status: Not Started
+category: Documentation
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.17 (Advisory) and §2.18 (Advisory; the
+  sample-ID part borders on Required — the section is unusable as written).
+
+  §2.17 — results-explorer-qa.md:331 tells the tester to "confirm bench.results
+  is a view." It is a TABLE (duckdb_builder.py:371,:282); the real protection is
+  the read-only attach (results-explorer/src/db.ts:278
+  `ATTACH 'results.duckdb' AS bench (READ_ONLY)`), and there is no SQL statement
+  filtering (Query.tsx:608-617 passes raw SQL). DDL/DML against bench.* is
+  rejected because the attach is read-only, but CREATE/SET against the in-memory
+  catalog succeed transiently — so "no-op" is the wrong word. The security
+  property holds; the doc's stated mechanism does not exist.
+
+  §2.18 — results-explorer-qa.md:5 claims the fixture corpus spans
+  duckdb/sqlite/datafusion/polars with 12 results, but there is no sqlite
+  fixture anywhere and 5 of 6 sample result IDs in §S5 do not exist in the tree
+  (only tpch-duckdb-sf0.01-20260403-7fe93365 is real). §S3.1 ("view mode not
+  URL-synced") and §S3.4 ("trust filter not URL-synced") are both stale —
+  BenchmarkIndex.tsx:211 and the facet URL-state hook show both ARE URL-synced.
+  results-explorer-browser-testing.md:70-72 overstates the push trigger as
+  "every push" (it is branches:[main] only).
+
+work:
+  - id: w1
+    summary: "Reword S7.6 to describe the real read-only-attach protection"
+    status: pending
+    notes: |
+      Replace the "is it a view?" check with: "the bench database is attached
+      READ_ONLY (db.ts:278); writes to bench.* error; writes to the in-memory
+      catalog succeed but are tab-local and transient and cannot alter the
+      published snapshot." Reference the pinning e2e test
+      (results-explorer/e2e/routes/query.spec.ts:153-168).
+
+  - id: w2
+    summary: "Regenerate the §S5 sample result IDs and the corpus-surface description from the actual fixtures"
+    status: pending
+    notes: |
+      Derive real IDs from results-explorer/test-fixtures/source/bundles/;
+      drop the non-existent sqlite surface (or add a fixture if it is intended);
+      correct the result count.
+
+  - id: w3
+    summary: "Delete the stale 'not URL-synced' notes (§S3.1, §S3.4) and fix the browser-testing trigger claim"
+    status: pending
+    notes: |
+      Update results-explorer-qa.md §S3.1/§S3.4 to reflect that view mode and
+      trust filter are URL-synced; correct
+      results-explorer-browser-testing.md:70-72 push trigger to branches:[main].
+
+prior_art:
+  - "results-explorer/e2e/routes/query.spec.ts:153-168 — cite this existing test as the evidence for the reworded S7.6 claim."
+  - "results-explorer/test-fixtures/source/bundles/ — the source of truth for real sample IDs (w2)."
+
+must_preserve:
+  - "The QA plan's overall structure and section numbering (only the inaccurate content changes)."
+
+anti_patterns:
+  - "DO NOT assert bench.results is a view to make the doc 'true' - because it is a table - describe the read-only attach that actually provides the property."
+  - "DO NOT invent sample IDs - because that recreates the current defect - derive them from the committed fixtures."
+
+verification:
+  - description: "S7.6 no longer claims a view"
+    command: "grep -n 'is a view' docs/operations/results-explorer-qa.md"
+    expected_output: "no match; wording describes READ_ONLY attach"
+  - description: "Every §S5 sample ID exists in the fixtures"
+    command: "for id in $(grep -oE '[a-z0-9-]+-sf[0-9.]+-[0-9]{8}-[0-9a-f]{8}' docs/operations/results-explorer-qa.md); do ls results-explorer/test-fixtures/source/bundles/ | grep -q \"$id\" || echo MISSING:$id; done"
+    expected_output: "no MISSING lines"
+
+scope_limit:
+  only_modify:
+    - "docs/operations/results-explorer-qa.md"
+    - "docs/development/results-explorer-browser-testing.md"
+  do_not_modify:
+    - "results-explorer/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "docs"
+    - "qa"
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "A tester following S7.6 checks a property that actually exists."
+  - "Every documented sample ID and corpus surface resolves in the fixtures."

--- a/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
+++ b/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
@@ -90,7 +90,9 @@ work:
 
 deferred:
   - summary: "§2.20 label-vocabulary unification and §2.21 TrustBadge empty-state"
-    reason: "Explorer-render concerns; tracked in remediate-explorer-trust-label-vocabulary (depends on the canonical enum defined here)."
+    reason: "Explorer-render concerns; tracked in remediate-explorer-trust-label-vocabulary, whose w1 defines the canonical vocabulary (that item deps.needs this one so the fail-closed trust derivation lands first)."
+  - summary: "§2.5 optional dedup-string normalization and 0.0-republish scale_factor nit"
+    reason: "Audit rates §2.5 'verified — no defect'; optional robustness only. Recorded here so the audit item is not silently dropped; fix opportunistically if touching store.py."
 
 prior_art:
   - "benchbox/validation/bundle.py:_is_safe_bundle_filename / symlink guard — reuse the existing attacker-facing hardening; extend, do not replace."
@@ -123,7 +125,10 @@ scope_limit:
     - "benchbox/core/publishing/bundle_publisher.py"
     - "_project/scripts/explorer_pipeline/"
     - "scripts/generate_corpus_inventory.py"
-    - "tests/unit/"
+    - "tests/unit/validation/"
+    - "tests/unit/core/publishing/"
+    - "tests/unit/core/explorer_pipeline/"
+    - "tests/unit/scripts/"
   do_not_modify:
     - "results-explorer/src/"
     - ".github/workflows/"

--- a/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
+++ b/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
@@ -1,0 +1,144 @@
+id: remediate-submission-trust-label-enforcement
+title: "Close the trust-provenance gap: unmanifested / mislabeled bundles must not be promoted to maintainer-run"
+worktree: main
+priority: High
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Source: _project/audits/results-explorer-publication-adversarial-review.md
+  (develop_sha fddedf26), findings §2.1, §2.2, §2.3, §2.4 (all Required).
+
+  The community-vs-maintainer trust label is derived solely from the presence
+  of a `.manifest.json` sidecar and defaults to the most-trusted tier when the
+  sidecar is absent, and nothing in CI requires the sidecar:
+    - _project/scripts/explorer_pipeline/pipeline.py:458-460 — trust stays the
+      build default unless a manifest sidecar exists.
+    - _project/scripts/explorer_publish.py:45-46 defaults --trust-label to
+      "maintainer-run"; docs.yml:112 runs the build with no --trust-label.
+    - scripts/generate_corpus_inventory.py:41-52 — same sidecar-or-default rule.
+    - benchbox/validation/bundle.py:718-726 validates the manifest hash only
+      `if manifest_path is not None`; a bundle with no sidecar yields no error.
+    - models.py:82-89 — RANKING_ELIGIBLE_TRUST_LABELS = {maintainer-run,
+      ci-verified}, so a mislabel flips a result from "displayed" to "ranked".
+  §2.1: a community bundle submitted without a sidecar is badged maintainer-run
+  and made ranking-eligible. §2.2: the explorer build discards the publish-time
+  label entirely (an `unofficial-research` bundle — required by
+  publish.py:97-110 for non-compliant TPC results — is re-badged maintainer-run;
+  the pipeline never reads a per-bundle label). §2.3: bundle_publisher.py:88
+  silently coerces an unknown label to maintainer-run for programmatic callers.
+  §2.4: a present-but-empty manifest emits only `vr.warn` and returns
+  (bundle.py:594-602); ValidationResult.ok ignores warnings (bundle.py:170-172),
+  so the sidecar grants the community label without the hash ever being verified.
+
+work:
+  - id: w0
+    summary: "Reproduce the four trust-label failures with fixtures before changing code"
+    status: pending
+    notes: |
+      Capture to /tmp/remediate-trust-w0.log (do not commit); summarize here:
+        - A bundle with no sidecar → validate_submission.py exits 0 AND the
+          pipeline/inventory assign the build-default (maintainer-run).
+        - A bundle published `--label unofficial-research` → its explorer
+          trust_label comes out maintainer-run (label discarded).
+        - BundlePublisher(label="bogus") → stored label == "maintainer-run".
+        - A `<stem>.manifest.json` missing bundle_hash → validate_bundles
+          returns ok (warning only), pipeline assigns community-submission.
+
+  - id: w1
+    summary: "Require a complete, verifying manifest sidecar for every primary bundle under results-data/bundles/"
+    needs: [w0]
+    status: pending
+    notes: |
+      In benchbox/validation/bundle.py: when a primary bundle has no paired
+      manifest, emit an ERROR (not silent pass) for the submission-corpus path;
+      and promote the "manifest present but missing bundle_file/bundle_hash"
+      case (594-602) from warn to error. Keep the existing traversal/symlink
+      hardening. Ensure validate-submission.yml surfaces the new error.
+
+  - id: w2
+    summary: "Carry per-bundle provenance into the explorer pipeline instead of stamping one build-wide label"
+    needs: [w0]
+    status: pending
+    notes: |
+      _project/scripts/explorer_pipeline/{pipeline,transformer}.py and
+      scripts/generate_corpus_inventory.py: derive trust from the bundle's own
+      provenance (compliance_class and/or a label field carried in the manifest)
+      so an unofficial-research/community bundle cannot inherit maintainer-run.
+      Fail closed: a submission-path bundle with missing provenance is treated
+      as community-submission, never maintainer-run.
+
+  - id: w3
+    summary: "Make BundlePublisher raise on an out-of-vocabulary label instead of coercing to maintainer-run"
+    needs: [w0]
+    status: pending
+    notes: |
+      benchbox/core/publishing/bundle_publisher.py:88 — raise ValueError for a
+      label not in VALID_LABELS; only default when the caller passed None. The
+      CLI is already guarded by click.Choice; this protects publish_bundle /
+      run --publish / API callers.
+
+  - id: w4
+    summary: "Add regression tests pinning each corrected behavior"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      tests/unit/validation + tests/unit/core/publishing +
+      tests/unit/core/explorer_pipeline: no-sidecar → validation error;
+      unofficial-research bundle → non-maintainer trust in the built snapshot;
+      invalid label → ValueError; empty manifest → validation error.
+
+deferred:
+  - summary: "§2.20 label-vocabulary unification and §2.21 TrustBadge empty-state"
+    reason: "Explorer-render concerns; tracked in remediate-explorer-trust-label-vocabulary (depends on the canonical enum defined here)."
+
+prior_art:
+  - "benchbox/validation/bundle.py:_is_safe_bundle_filename / symlink guard — reuse the existing attacker-facing hardening; extend, do not replace."
+  - "benchbox/cli/commands/publish.py:97-110 — reuse the existing compliance_class guardrail as the provenance source of truth for w2."
+  - "_project/scripts/explorer_pipeline/pipeline.py:_find_submission_manifest — extend: keep sidecar detection but stop treating absence as maintainer-run."
+
+must_preserve:
+  - "Existing manifest-hash traversal and symlink defenses in bundle.py."
+  - "Already-merged community bundles keep their community-submission label (legacy singleton submission-manifest.json still honored)."
+  - "The maintainer-run local publish flow (benchbox publish with a valid label) is unaffected."
+
+anti_patterns:
+  - "DO NOT infer trust from build-time CLI defaults - because a missing sidecar then silently means maintainer-run - fail closed to community-submission on the submission path."
+  - "DO NOT keep manifest-missing as a warning - because ValidationResult.ok ignores warnings and the bundle merges unverified - make it an error on the corpus path."
+
+verification:
+  - description: "A bundle with no sidecar fails submission validation"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_validate_submission.py -q"
+    expected_output: "new test: missing/empty manifest → FAIL (non-zero validator exit)"
+  - description: "An unofficial-research bundle is not maintainer-run in the built snapshot"
+    command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline/ -k trust -q"
+    expected_output: "trust reflects per-bundle provenance, not the build default"
+  - description: "Invalid publisher label raises"
+    command: "uv run -- python -m pytest tests/unit/core/publishing/ -k label -q"
+    expected_output: "BundlePublisher(label='bogus') raises ValueError"
+
+scope_limit:
+  only_modify:
+    - "benchbox/validation/bundle.py"
+    - "benchbox/core/publishing/bundle_publisher.py"
+    - "_project/scripts/explorer_pipeline/"
+    - "scripts/generate_corpus_inventory.py"
+    - "tests/unit/"
+  do_not_modify:
+    - "results-explorer/src/"
+    - ".github/workflows/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "results-explorer-publication-remediation"
+    - "security"
+    - "provenance"
+  estimated_effort: "Large"
+  created_date: "2026-07-04"
+
+success_metrics:
+  - "No corpus path can produce a maintainer-run badge for a bundle lacking a complete, verifying manifest."
+  - "unofficial-research provenance survives into the explorer trust label."
+  - "Programmatic publish callers cannot store an unknown label as maintainer-run."

--- a/_project/audits/results-explorer-publication-adversarial-review.md
+++ b/_project/audits/results-explorer-publication-adversarial-review.md
@@ -1,0 +1,603 @@
+---
+develop_sha: fddedf261b2446d62d6c51114c8b31c059c5a420
+---
+
+<!--
+Base branch: this repo has both `main` and `develop`. `develop` (tip
+fddedf261b2446d62d6c51114c8b31c059c5a420) is the live development branch and
+the subject of this review; `main` (2d3295c7) is the release-only branch, 2419
+commits behind develop. All "reality" claims below were re-derived against a
+read-only worktree of origin/develop unless a finding explicitly names main or
+the published-results branch. Review conducted per docs/development/review-protocol.md
+(read-only + local capture; no commit/push/PR).
+-->
+
+# Results Explorer & Publication — Adversarial Review
+
+## 1. Executive summary
+
+I reviewed the two "publish"-shaped subsystems and every doc/ADR/workflow/test
+that asserts something about them: (a) the **Results Publication** path
+(`benchbox publish` → `benchbox/core/publishing/`, `benchbox submit`, the
+`published-results` corpus branch and its `sync`/`validate-submission`
+workflows), and (b) the **Results Explorer** (the Vite/Preact + DuckDB-WASM app
+under `results-explorer/` and the static-snapshot pipeline under
+`_project/scripts/explorer_pipeline/` + `explorer_publish.py`). Contrary to two
+of the seeded leads, `results-explorer/` **does** exist (on `develop`, not
+`main`), the `adr-explorer-cli-surface.md` migration **did** fully land, the
+`explorer_pipeline` tests are **not** orphaned (260 collect and pass against the
+migrated `_project` location), and the audit-SHA governance contract **is**
+wired into `pr.yml`. What I could not verify from this checkout: live runtime
+behavior of the deployed explorer and the live state of `benchbox.dev/results/`
+(outbound HTTPS to that host is proxy-blocked). The headline risks are three:
+(1) a **Critical** CI hole where `package-smoke`, `dependency-audit`, and
+`parity-check` are permanently skipped yet counted as passing; (2) a
+**Critical** published future-state doc that instructs maintainers to delete the
+live `benchbox publish` subsystem as "dead code"; and (3) a **Required** trust
+provenance gap where a community result missing its manifest sidecar is silently
+badged `maintainer-run` and promoted into official rankings. A recurring theme
+across the corpus is that the prose (ADRs, runbooks, QA plans, future-state
+docs) is voluminous and has drifted from the code faster than it has been
+maintained — several "Accepted"/"maintained" documents describe a prior world.
+
+Findings by severity: **2 Critical, 11 Required, 11 Advisory.**
+
+---
+
+## 2. Findings
+
+### Publication Path — Correctness & Security
+
+#### 2.1 Community results without a manifest sidecar are silently promoted to `maintainer-run` and made ranking-eligible
+
+- Evidence: The community-vs-maintainer trust label is derived **solely** from
+  the presence of a `.manifest.json` sidecar, defaulting to the most-trusted
+  tier when absent:
+  - `_project/scripts/explorer_pipeline/pipeline.py:458-460` — `effective_trust = trust_label` (the build default) and only becomes `COMMUNITY_TRUST_LABEL` "if `_find_submission_manifest(bundle_path) is not None`".
+  - `_project/scripts/explorer_publish.py:45-46` — `--trust-label` defaults to `"maintainer-run"`, and `.github/workflows/docs.yml:112` invokes the build with **no** `--trust-label`, so every unmanifested bundle inherits `maintainer-run`.
+  - `scripts/generate_corpus_inventory.py:41-52` — the same "sidecar present → community, else `DEFAULT_TRUST_LABEL`" rule.
+  - The gate is never enforced: `benchbox/validation/bundle.py:718-726` validates the manifest hash only `if manifest_path is not None`; a bundle with no sidecar produces no error and no warning. `validate-submission.yml` runs only `validate_submission.py` + `generate_corpus_inventory.py --check`, neither of which requires a sidecar.
+  - Consequence for ranking: `_project/scripts/explorer_pipeline/models.py:82-89` — `RANKING_ELIGIBLE_TRUST_LABELS = {"maintainer-run", "ci-verified"}`; `is_ranking_eligible` (`models.py:343-349`) admits `maintainer-run`. `community-submission` is intentionally excluded — so mislabeling flips a result from "displayed, not ranked" to "officially ranked."
+- Impact: A contributor who omits (or deliberately withholds) the sidecar has
+  their result badged as maintainer-verified and placed in the official
+  leaderboard. This defeats the provenance model the trust labels exist to
+  enforce. The only backstop is human review, and the maintainer review
+  checklist (`results-phase-2-runbook.md:49-55`) never tells the reviewer to
+  confirm sidecar presence.
+- Severity: Required (provenance integrity / maintainer trust; the escalation
+  criteria in `results-phase-2-runbook.md:166` — "a trust-label or visibility
+  bug would publish misleading provenance" — describe exactly this).
+- Remediation: Make the sidecar mandatory for any bundle under
+  `results-data/bundles/` in `validate_submission.py`/`validate-submission.yml`
+  (hard error when a primary bundle has no paired `.manifest.json`), OR have the
+  explorer/inventory trust derivation treat a missing sidecar on the
+  community-submission path as `community-submission` (fail-closed) rather than
+  inheriting the build default. Add the sidecar check to the runbook review
+  checklist.
+
+#### 2.2 The explorer build discards the publisher's trust label entirely, including the `unofficial-research` compliance guardrail
+
+- Evidence: The publish CLI *requires* `--label unofficial-research` for
+  non-compliant TPC results (`benchbox/cli/commands/publish.py:97-110`,
+  `run.py` `--publish-label`). But the explorer pipeline never reads any
+  publish-time label from the bundle or the `~/.benchbox/published.json` store —
+  it stamps a single CLI/`--trust-label` value on every result
+  (`pipeline.py:377` `trust_label: str = "maintainer-run"`), overridable only by
+  sidecar presence (§2.1). A bundle published as `unofficial-research` is
+  re-badged `maintainer-run` by the explorer build. (Confirmed: no trust
+  extraction in `transformer.py`; the `.manifest.json` carries no label field.)
+- Impact: The compliance guardrail that `unofficial-research` exists to satisfy
+  is silently voided the moment the result enters the explorer corpus — an
+  unofficial/subscale TPC-DS result can appear maintainer-verified and ranked.
+- Severity: Required.
+- Remediation: Carry per-bundle provenance from the bundle/manifest into the
+  pipeline (read `compliance_class` / a label field and map to the correct trust
+  tier), instead of stamping one build-wide label.
+
+#### 2.3 `BundlePublisher` silently coerces an unknown trust label to `maintainer-run`
+
+- Evidence: `benchbox/core/publishing/bundle_publisher.py:88` —
+  `self.label = label if label in VALID_LABELS else "maintainer-run"`. The CLI
+  path is guarded by `click.Choice` (`publish.py:74`), but programmatic callers
+  (`publish_bundle`, `run --publish`, any API user) get their invalid label
+  upgraded to the **most** trusted tier rather than an error.
+- Impact: A typo'd or attacker-influenced label (`"communtiy-submission"`,
+  `"unofficial"`) is stored and referenced as `maintainer-run` in the durable
+  publication record — a truthful-looking but wrong provenance stamp.
+- Severity: Required.
+- Remediation: Raise `ValueError` on an out-of-vocabulary label instead of
+  coercing; only fall back to a default when the caller passed `None`.
+
+#### 2.4 A present-but-empty manifest grants the community label without ever verifying the bundle hash
+
+- Evidence: When a manifest is present but missing `bundle_file`/`bundle_hash`,
+  `_validate_manifest_hash` emits `vr.warn(...)` and returns
+  (`benchbox/validation/bundle.py:594-602`). `ValidationResult.ok` is
+  `len(self.errors) == 0` (`bundle.py:170-172`), so warnings do **not** fail the
+  check. Meanwhile sidecar *presence* alone flips the trust label to
+  `community-submission` (§2.1) and inventory (`generate_corpus_inventory.py:50`).
+- Impact: A submission can ship a contentless `.manifest.json`, pass
+  `Validate Submission` green, receive a `community-submission` badge, and have
+  its bundle bytes never actually hash-checked — the integrity contract the
+  manifest represents is unenforced in this path.
+- Severity: Required.
+- Remediation: Promote the "manifest present but missing `bundle_file`/
+  `bundle_hash`" case from `warn` to `error` (a sidecar that exists must be
+  complete and must verify).
+
+#### 2.5 The publisher's URI/dedup/companion handling is sound (verified — no defect)
+
+- Evidence: `build_reference` (`store.py:266-286`) uses `is_cloud_path`
+  (`cloud_storage.py:344-361`, schemes `s3/gs/gcs/az/abfss/azure/dbfs`) and
+  otherwise `Path(destination).resolve()/filename` → `as_uri()`; the appended
+  filename is always a basename (`source.name`), so no traversal via label/path.
+  `_copy_bundle` (`bundle_publisher.py:251-271`) copies by `file.name` basename.
+  The attacker-facing validator path is well-hardened:
+  `_is_safe_bundle_filename` (`bundle.py:551-564`) rejects `/`, `\`, NUL, `..`,
+  absolute and multi-segment names, and `_validate_manifest_hash` rejects
+  symlinks before `is_file()` (`bundle.py:615-617`). Dedup key is
+  `(resolved source_path, destination)` (`store.py:246-253`).
+- Impact: None — recorded so a reader knows the traversal/spoofing surface was
+  checked and passed. (Minor nit, Advisory-adjacent: dedup compares
+  `destination` as a raw string, so `/x` vs `/x/` yield duplicate records; and
+  `existing.scale_factor = scale_factor or existing.scale_factor` drops a
+  legitimate `0.0` republish. Neither is a security issue.)
+- Severity: Advisory (nits only).
+- Remediation: Optionally normalize `destination` before the dedup compare.
+
+#### 2.6 The operative `validate-submission.yml` on `published-results` still lets manifest-only PRs bypass hash validation
+
+- Evidence: Contributor PRs target `published-results`, so the workflow that
+  runs is the **on-branch** copy. That copy lacks the `CHANGED_MANIFESTS` block
+  present on develop: `git show origin/published-results:.github/workflows/validate-submission.yml | grep -c CHANGED_MANIFESTS` → `0`; develop's copy → `3`. The
+  develop block's own comment states the risk it closes: "A manifest-only PR
+  skips both validate_submission.py and the corpus inventory check … so a bad
+  manifest edit can merge without verifying the hash." The `sync` workflow's
+  path allowlist (`sync-results-data-to-published.yml:21-30`) does not include
+  `.github/workflows/**`, and its `GITHUB_TOKEN` could not push workflow files
+  anyway — so nothing detects or mirrors this drift.
+- Impact: On the exact branch where external, untrusted PRs land, a PR that
+  edits only a `.manifest.json` (e.g. swapping in an attacker-chosen hash for an
+  already-merged bundle) runs neither the validator nor the inventory drift
+  check and can merge unverified.
+- Severity: Required.
+- Remediation: Add `.github/workflows/validate-submission.yml` to the slim-branch
+  allowlist and document (in the ADR/runbook) how the on-branch workflow is kept
+  current; or trigger `validate-submission` with `pull_request_target` from a
+  trusted branch so the up-to-date workflow always runs. (Note the copies must
+  differ in the `--no-project` invocation per the ADR, so verbatim mirroring is
+  not correct — the update mechanism needs to be explicit.)
+
+#### 2.7 `validate-submission.yml` executes PR-controlled validator code (self-green risk)
+
+- Evidence: The trigger path filter is `results-data/bundles/**` (any-of match).
+  The validator scripts run from the PR merge commit, so a PR that touches a
+  bundle **and** `scripts/validate_submission.py` or
+  `benchbox/validation/bundle.py` runs its own doctored validator and can
+  self-report PASS. (Token is `contents: read` and downgraded for forks, so this
+  is not privilege escalation — but it is trivial check-spoofing.) Neither
+  `contributing-results.md` nor the runbook calls this out; the only backstop is
+  the runbook's instruction to redirect out-of-allowlist PRs
+  (`results-phase-2-runbook.md:134-135`).
+- Impact: A green "Submission Validation" check is not trustworthy if the PR
+  altered the validator; a reviewer relying on the check can be misled.
+- Severity: Advisory (mitigated by review, no elevated permissions).
+- Remediation: Run validation from a trusted ref (`pull_request_target` +
+  checkout of base's validator), or fail the job if the PR modifies validator
+  files, or narrow the trigger so validator edits route to `develop` only.
+
+#### 2.8 Fork-PR validation comment likely 403s under the default token
+
+- Evidence: `validate-submission.yml:3-12` uses plain `pull_request` with
+  `permissions: pull-requests: write`. For fork PRs GitHub caps `GITHUB_TOKEN`
+  read-only regardless of the `permissions:` block, so the always()-gated
+  "Post PR comment" github-script step (`:97-132`) should 403 — turning even a
+  passing validation red for the external-contributor audience the flow is for.
+- Impact: External contributors (the whole point of Phase 2) see a red/failed
+  check even when their bundle is valid.
+- Severity: Required — but verify against a real historical fork-PR run first
+  (a repo setting granting fork PRs write tokens would change this; I could not
+  observe a live run).
+- Remediation: Move commenting to a `workflow_run`/`pull_request_target`
+  companion workflow that runs with the base repo's token, or gracefully skip
+  commenting when the token is read-only.
+
+---
+
+### CI / Pipeline Integrity
+
+#### 2.9 Three PR gates (`package-smoke`, `dependency-audit`, `parity-check`) are permanently skipped yet counted as passing
+
+- Evidence: The gating jobs read outputs that the `ci-paths` job never exports.
+  `ci-paths` declares only 7 outputs (`.github/workflows/pr.yml:20-26`:
+  `safe-content-only, needs-code-ci, content-guard-needed, changed-paths,
+  code-paths, unknown-paths, estimated-runner-minutes-saved`). But:
+  - `pr.yml:770` and `:812` gate on `needs.ci-paths.outputs.packaging-needed == 'true'`.
+  - `pr.yml:858` gates on `needs.ci-paths.outputs.viz-needed == 'true'`.
+  The classifier emits these as **step** outputs
+  (`scripts/path_filter_decision.py:196-200`; `.github/path-filters.yml:93-98`),
+  but in GitHub Actions `needs.<job>.outputs.X` exists only if re-declared in the
+  job's `outputs:` map. Undeclared → empty string → `== 'true'` always false →
+  jobs always skipped. `ci-required-result` explicitly treats `skipped` as pass
+  (`pr.yml:963-973`), and its comment claims this "cannot silently green a
+  packaging regression" — which is exactly what happens. Shipped in HEAD
+  (`fddedf26`, PR #952); the outputs map was never extended.
+- Impact: Packaging regressions (the class `pr.yml:803` says "let v0.3.0 ship a
+  broken clean install"), `pip-audit` findings, and CLI↔explorer visualization
+  parity breaks all pass PR CI silently; `parity-check` never earns the green run
+  its promotion criterion needs.
+- Severity: Critical.
+- Remediation: Add `packaging-needed: ${{ steps.classify.outputs.packaging-needed }}`
+  and `viz-needed: ${{ steps.classify.outputs.viz-needed }}` (plus any other
+  `<group>-needed` gate consumed downstream) to the `ci-paths` `outputs:` map.
+  Add a CI meta-test asserting every `needs.ci-paths.outputs.*` referenced in
+  `pr.yml` is declared.
+
+#### 2.10 The snapshot-invariants gate exists but nothing runs it — the deploy ships an unvalidated read model
+
+- Evidence: `_project/scripts/results_explorer_snapshot_invariants.py` enforces
+  12 eligibility invariants; its docstring says it exists "so release gates can
+  run it." There is no such caller: `grep -rn "snapshot_invariants" Makefile
+  .github/workflows/ tests/ results-explorer/ _project/scripts/*.py` returns only
+  the script's own definition (and historical audit prose). `docs.yml:110-118`
+  builds the snapshot and immediately runs `npm run build` with no validation
+  step in between.
+- Impact: A malformed snapshot (missing required columns, ranked rows with no
+  primary metric, compare-eligible rows without enough timings) deploys to the
+  public explorer with no gate catching it.
+- Severity: Required.
+- Remediation: Invoke `results_explorer_snapshot_invariants.py` against
+  `results-explorer/public/data/` in `docs.yml` right after the build step (and
+  expose it as a `make` target), failing the build on violation.
+
+#### 2.11 `make validate-imports` references a script that does not exist
+
+- Evidence: `Makefile` `validate-imports` runs
+  `uv run -- python scripts/validate_imports.py`, but that file does not exist
+  (the real gate is `make lint-imports` → `uv run -- lint-imports`, the
+  import-linter console script, which is what `pr.yml` uses). This was the only
+  missing script among ~44 script references checked across the Makefile.
+- Impact: A maintainer running the advertised `make validate-imports` gets a
+  file-not-found; CI is unaffected.
+- Severity: Advisory.
+- Remediation: Point `validate-imports` at `lint-imports` (or delete the stale
+  target).
+
+---
+
+### Doc / Reality Drift
+
+#### 2.12 The `prune-publishing-subsystem` future-state doc instructs deletion of the live `benchbox publish` subsystem
+
+- Evidence: `docs/design/future-state/prune-publishing-subsystem/README.md:31-33`
+  — "Coupling analysis found zero consumers of the publishing module: no CLI
+  integration, no runtime imports, no result-export coupling. The expected
+  outcome is pruning." Listed as active, **High priority (dead code removal)** in
+  `docs/design/future-state/index.md:43` and in the Sphinx toctree (renders on the
+  published docs site). Reality: `benchbox/cli/commands/__init__.py:33` registers
+  `publish`; `benchbox/cli/commands/publish.py:23-24` imports
+  `benchbox.core.publishing.bundle_publisher`/`store`; `run.py` `--publish` calls
+  `publish_bundle`; `tests/unit/core/publishing/` (33 tests) and
+  `tests/integration/test_publish_cli.py` cover it. Timeline: the doc was written
+  2026-04-01 (`90a2fd08`, v0.2.0) about the *old* generic layer, which was
+  **deleted** in `0182c955` (2026-04-27) — the same commit that added the current
+  `bundle_publisher.py`/`store.py` at the same path. The doc's "Related TODO:
+  `prune-publishing-subsystem`" no longer exists.
+- Impact: A maintainer or agent working the future-state backlog reads
+  "High priority, zero consumers, no CLI integration" and deletes
+  `benchbox/core/publishing/`, breaking the shipped `benchbox publish` command
+  and `benchbox run --publish`. This is the single concrete instance where the
+  "publish" naming collision (§2.19) causes real damage.
+- Severity: Critical (a published instruction to delete live, shipped code).
+- Remediation: Archive the doc (move under `docs/design/future-state/_archive/`
+  or mark `Status: Completed in v0.2.1`), remove it from the active index/toctree,
+  and note that the path now hosts the live bundle-publish subsystem.
+
+#### 2.13 The "explorer is built and published from `main`" story contradicts the release curation and the workflow wiring
+
+- Evidence: `results-phase-2-runbook.md:41-47` states the explorer "is built
+  from `main` via docs.yml … The explorer publishes from `main`'s view of
+  `results-data/`," and `contributing-results.md:108` promises "the docs CI
+  workflow automatically rebuilds the results explorer with the new data" after a
+  merge. But:
+  - `docs.yml` has no trigger on `published-results` (`:3-36`; push=main,
+    PR=main/develop); the `deploy` job requires `github.event_name == 'push' &&
+    github.ref == 'refs/heads/main'` (`:193`), so §6's `gh workflow run docs.yml`
+    (`workflow_dispatch`) builds but never deploys.
+  - `Makefile:1070-1072` (`release-cut`) runs
+    `git rm -rf … results-data results-explorer …` and deletes the four results
+    workflows from every release branch, so `results-data/`/`results-explorer/`
+    can never reach `main` under current curation.
+  - `docs.yml:79-84` itself documents that on `main` the explorer steps are a
+    "deliberate no-op" because `hashFiles('results-explorer/package.json')` is
+    empty; `git ls-tree origin/main` confirms none of `results-explorer/`,
+    `results-data/`, `_project/scripts/explorer_publish.py` exist on main
+    (`results-explorer/` has never existed on main).
+- Impact: A merged community submission never appears in the public explorer via
+  any automated path, and there is no automated flow back from `published-results`
+  into develop/main. A maintainer following the runbook waits for a rebuild that
+  cannot occur; a contributor reading `contributing-results.md` is promised an
+  auto-rebuild that never runs.
+- Severity: Required.
+- Remediation: Reconcile the docs with the actual pipeline: either (a) document
+  that the explorer is served from `develop`/a dedicated build and fix the deploy
+  trigger accordingly, or (b) if `main` is genuinely the source, stop stripping
+  `results-data`/`results-explorer` in `release-cut`. Update
+  `contributing-results.md:108` and `results-phase-2-runbook.md §1.3/§6` to
+  describe the real trigger and the fact that `workflow_dispatch` does not deploy.
+
+#### 2.14 The default branch (`main`) ships QA/ADR/runbook docs and a Make target that reference paths absent on `main`
+
+- Evidence (all via `git show origin/main:…` / `git ls-tree origin/main`): main
+  **lacks** `results-explorer/`, `_project/scripts/`, `_project/audits/`, and any
+  explorer publisher (neither `benchbox/cli/commands/explorer.py` nor
+  `_project/scripts/explorer_publish.py`). main **has**
+  `docs/operations/results-explorer-qa.md` (7 references to
+  `results-explorer/`/`_project/`/`results-data/`; e.g. `cd results-explorer`,
+  the `_project/audits/*.md` contract, `_project/scripts/audit_sha_backfill.py`),
+  `adr-explorer-cli-surface.md` (mandates a script path absent on main), and a
+  `Makefile` `audit-sha-check` target invoking `_project/scripts/audit_sha_check.py`
+  which is absent on main (so the target fails). main's `README.md:66` links
+  "Browse results online: benchbox.dev/results/". Mitigation that passes:
+  `CONTRIBUTING.md:44` states "`develop` is the long-lived development branch; …
+  `main` is release-only."
+- Impact: Anyone landing on the default GitHub branch reads QA runbooks, an ADR,
+  and a Make target that reference infrastructure existing only on develop, plus a
+  README link to a results site the current main pipeline cannot have deployed.
+- Severity: Required (default-branch reader experience).
+- Remediation: Exclude these dev-only docs from the release curation (as
+  `results-explorer/`/`_project/` already are), OR add a prominent "this page
+  describes develop-only tooling" banner, OR keep only docs whose referenced
+  paths survive `release-cut`.
+
+#### 2.15 `adr-published-results-slim-corpus-branch.md` (Accepted) contradicts the branch it governs
+
+- Evidence: ADR `:100-103` claims the validators are "stdlib-only … no
+  `benchbox.*` imports," and the allowlist table `:84-86` **excludes** `benchbox/`.
+  Reality: `scripts/validate_submission.py:23` imports
+  `from benchbox.validation.bundle import …` (with an importlib fallback);
+  `sync-results-data-to-published.yml` watches/mirrors
+  `benchbox/validation/bundle.py` (`:29,:83,:127,:160`); and
+  `git ls-tree -r origin/published-results | grep ^benchbox/` shows
+  `benchbox/validation/bundle.py` present on the branch (landed via mirror PR
+  #555, 2026-05-21). The ADR's own maintenance trigger ("a new validator …
+  becomes load-bearing … and would need to be vendored") fired but the ADR
+  (last touched 2026-05-03) was never updated. Minor: the ADR references a TODO
+  path now under `_project/DONE/`.
+- Impact: The allowlist is the governance contract for a public, force-pushed
+  branch. An auditor comparing the branch to the ADR would flag
+  `benchbox/validation/bundle.py` as contamination and could "clean" it, breaking
+  submission CI; the stdlib-only claim misleads anyone re-deriving the
+  `uv run --no-project` invocation contract.
+- Severity: Required.
+- Remediation: Update the ADR allowlist to include `benchbox/validation/bundle.py`
+  and correct the "stdlib-only / no `benchbox.*`" statement to describe the
+  shared-implementation + importlib-fallback reality; fix the DONE TODO path.
+
+#### 2.16 The "maintained" Results Explorer QA plan points future testers at a sealed audit and a closed TODO
+
+- Evidence: `results-explorer-qa.md:7-10` says the plan "should be reused for
+  future … passes," yet `:95` and `:392` hardcode saving findings to
+  `_project/audits/results-explorer-qa-pass2-findings.md` — a completed,
+  `develop_sha`-stamped audit (pass 3 already happened;
+  `results-explorer-qa-pass3-findings.md` exists). `:392` also says to "update the
+  existing pass-1 TODO" and `:369` references the `results-explorer-qa-pass1-fixes`
+  TODO — completed at `_project/DONE/main/active/results-explorer-qa-pass1-fixes.yaml`.
+  `:114` directs screenshots to `_project/audits/screenshots/`, which does not
+  exist. (Also noted per the seed: there is no `*pass1*findings*` file — pass-1
+  evidence lives only in the QA doc's S11 list and the DONE TODO, so the audit
+  trail is asymmetric.)
+- Impact: A pass-4 tester following the doc appends to a sealed pass-2 audit,
+  corrupting a record whose `develop_sha` stamp then misdescribes its contents,
+  and tries to update a TODO that no longer exists.
+- Severity: Required.
+- Remediation: Parameterize the pass number (e.g. "save to
+  `results-explorer-qa-pass<N>-findings.md`, next unused N"), drop the hardcoded
+  pass-1 TODO reference, and either create `_project/audits/screenshots/` or
+  update the retention instruction to match the "not retained in git" reality the
+  pass-2 findings already record.
+
+#### 2.17 QA doc §S7.6 security check asserts a mechanism that does not exist ("`bench.results` is a view")
+
+- Evidence: `results-explorer-qa.md:331` — "confirm `bench.results` is a view,
+  not the bare table — or that DDL … is rejected or a no-op." Reality: the
+  builder creates `results` as a **table**
+  (`_project/scripts/explorer_pipeline/duckdb_builder.py:371,:282`; the file's
+  views are `result_detail_metrics` and `platform_index_rows`). The real
+  protection is the read-only attach: `results-explorer/src/db.ts:278` —
+  `ATTACH 'results.duckdb' AS bench (READ_ONLY)` (and `:275` registers the file
+  HTTP-backed/unwritable). There is **no** SQL statement filtering in the editor
+  path (`src/pages/Query.tsx:608-617` passes raw SQL to `queryRows`). So DDL/DML
+  against `bench.*` is rejected (catalog is read-only), but `CREATE TABLE …`/`SET`
+  against the in-memory catalog succeed (transient, tab-local) — "no-op" is the
+  wrong word. An e2e test pins the rejection: `results-explorer/e2e/routes/query.spec.ts:153-168`.
+- Impact: A QA tester who checks "is it a view?" files a false failure; a
+  reviewer citing S7.6 claims a protection in a form that doesn't exist. The
+  underlying security property (published data cannot be mutated) does hold.
+- Severity: Advisory (doc-wording defect; the property itself is satisfied).
+- Remediation: Reword S7.6 to "the `bench` database is attached `READ_ONLY`;
+  writes to `bench.*` error; writes to the in-memory catalog succeed but are
+  tab-local and transient and cannot alter the published snapshot."
+
+#### 2.18 QA-doc fixture/route drift (sample IDs, corpus surfaces, URL-sync claims)
+
+- Evidence: `results-explorer-qa.md:5` claims the fixture corpus spans
+  `duckdb, sqlite, datafusion, polars` with 12 results, but there is **no sqlite
+  fixture anywhere** (`find results-explorer -name "*sqlite*"` → empty), and 5 of
+  6 sample result IDs in §S5 do not exist in the tree (only
+  `tpch-duckdb-sf0.01-20260403-7fe93365` is real). `:S3.1` says view mode "is not
+  currently URL-synced" — stale: `BenchmarkIndex.tsx:211` uses
+  `useUrlState("view", …)`. `:S3.4` says the trust filter is "not URL-synced" —
+  stale: it flows through `useFacetUrlState`. Browser-testing doc overstates the
+  push trigger as "every push … that touches results-explorer/" — push is
+  `branches: [main]` only (`results-explorer-browser.yml:5-6`).
+- Impact: Testers waste time on non-existent sample IDs / a non-existent sqlite
+  surface and file false findings against already-fixed URL-sync behavior.
+- Severity: Advisory (the sample-ID section borders on Required — it is unusable
+  as written).
+- Remediation: Regenerate the sample-ID list and corpus-surface description from
+  the actual `test-fixtures/`, and delete the stale "not URL-synced" notes.
+
+#### 2.18b Assorted smaller doc drifts (grouped)
+
+- Evidence:
+  - Strategy doc cites deleted files as current evidence:
+    `benchbox-results-platform-strategy.md:480` points at
+    `benchbox/core/publishing/artifacts.py` / `permalink.py`, both deleted in
+    `0182c955` (2026-04-27).
+  - `adr-explorer-cli-surface.md:38-41` and `results-explorer-browser-testing.md:70-72`
+    say docs.yml / browser workflow "trigger only on `main`" and run on "every
+    push and pull request" — both now also run on PRs to develop, and the browser
+    push trigger is main-only.
+  - `results-explorer-token-scan.md:135-137` omits `medium-test` from the jq
+    filter it describes (`develop-post-merge.yml:515` includes it).
+  - `repo-admin-settings.md:58-59` says `ci-required-result` "aggregates 4 jobs";
+    the real `needs` list has 10 (`pr.yml:916`).
+  - `results-phase-2-runbook.md:29-30` says the sync watches "two vendored
+    validators" (it watches three code files incl. `benchbox/validation/bundle.py`)
+    and calls `seed-corpus.yml` a "quarterly refresh" (it is `workflow_dispatch`
+    only, no `schedule`).
+- Impact: Each misleads a maintainer re-deriving CI behavior or the release
+  surface from the docs.
+- Severity: Advisory.
+- Remediation: Correct each cited line against the current YAML/tree.
+
+---
+
+### Architectural Boundary & Naming Collisions
+
+#### 2.19 Five overlapping "publish" senses; the collision is mostly disambiguated but has one live hazard
+
+- Evidence: The token "publish" spans (1) `benchbox publish` — copy a bundle to
+  storage + track (`benchbox/cli/commands/publish.py`); (2) `benchbox submit` —
+  community corpus PR; (3) `explorer_publish.py build` — build the static snapshot
+  (`_project/scripts/explorer_publish.py`, click group `explorer_publish`); (4)
+  the `published-results` corpus branch; (5) the stale "generic publishing /
+  artifactlinks" concept in the prune doc. The strategy doc explicitly splits
+  publish vs submit (`benchbox-results-platform-strategy.md:14-20`), the CLI ref
+  disambiguates publish vs export (`CLI_REFERENCE.md:75-88`), `submit.md:123-133`
+  has a "submit vs publish" table, and `db.ts:192` no longer names a command — so
+  most surfaces are safe. The one place a reader acts on the wrong "publish" is
+  §2.12 (the prune doc / future-state index treating the live `benchbox publish`
+  backend as the dead generic layer).
+- Impact: Bounded — the concrete damage is captured as §2.12; the rest is
+  cognitive overhead.
+- Severity: Advisory.
+- Remediation: Fix §2.12; optionally add a one-line "publish disambiguation" note
+  to `AGENTS.md`/CLI docs naming all five senses.
+
+#### 2.20 Trust-label vocabulary diverges between the publisher and the explorer
+
+- Evidence: `bundle_publisher.py:30` — `VALID_LABELS = ("maintainer-run",
+  "community-submission", "ci", "local", "unofficial-research")`. The explorer's
+  `TrustBadge` config keys are `ci-verified`, `ci-validated`, `local-run`
+  (`results-explorer/src/components/TrustBadge.tsx:19-43`), and ranking eligibility
+  is `{"maintainer-run", "ci-verified"}` (`models.py:82-89`). So a bundle labeled
+  `ci` or `local` by the publisher renders under the explorer's "unrecognised —
+  contact maintainers" fallback and (for `ci`) is **not** ranking-eligible despite
+  the publisher treating `ci` as a first-class trusted label; `unofficial-research`
+  has no explorer badge at all.
+- Impact: Cross-subsystem inconsistency: the two halves of the platform disagree
+  on the label vocabulary, so publisher-set labels can silently degrade to
+  "unrecognised" / non-ranked in the UI.
+- Severity: Advisory.
+- Remediation: Define one canonical trust-label enum shared by
+  `benchbox/core/publishing/` and `_project/scripts/explorer_pipeline/` +
+  `TrustBadge`, and map `ci`↔`ci-verified` / `local`↔`local-run` explicitly.
+
+#### 2.21 `TrustBadge` hides entirely on an empty label instead of showing "unknown"
+
+- Evidence: `results-explorer/src/components/TrustBadge.tsx:64` —
+  `if (!trustLabel) return null;`. (Moot in the current pipeline because
+  `trust_label` is `NOT NULL` in the snapshot schema, `duckdb_builder.py:392`, but
+  the component contract is hide-on-missing.)
+- Impact: If a future schema/path yields an empty label, the trust dimension is
+  silently hidden rather than flagged.
+- Severity: Advisory.
+- Remediation: Render the `DEFAULT_CONFIG`/"unknown" badge on empty rather than
+  returning null.
+
+#### 2.22 Explorer-related tests live under misleading directory paths
+
+- Evidence: `tests/unit/core/explorer_pipeline/*` all import
+  `_project.scripts.explorer_pipeline.*` (the module moved out of
+  `benchbox.core` per `adr-explorer-cli-surface.md`), and
+  `tests/unit/cli/test_explorer_build_contract.py` imports
+  `_project.scripts.explorer_publish` while testing no `benchbox.cli` command.
+  The tests pass (verified, see §3-preface), so this is a naming residue, not a
+  breakage.
+- Impact: A reader navigating by directory believes the explorer pipeline still
+  lives under `benchbox/core` / that a CLI contract test covers a CLI command.
+- Severity: Advisory.
+- Remediation: Relocate to `tests/unit/scripts/explorer_pipeline/` and
+  `tests/unit/scripts/` to mirror the migrated source layout.
+
+---
+
+### Explorer Runtime Surface (static-analysis only)
+
+#### 2.23 No CSP on the explorer, combined with duckdb-wasm remote-fetch capability
+
+- Evidence: `results-explorer/index.html` sets no CSP meta tag; duckdb-wasm
+  (1.32.0 per `package-lock.json`) can `INSTALL httpfs`/`read_csv('https://…')`.
+  The SQL editor's text is component state (`Query.tsx:115`), never seeded from
+  URL params, so there is no injection vector — a user would have to paste hostile
+  SQL themselves, and the queried data is public.
+- Impact: A self-inflicted-only exfiltration channel; no third-party injection
+  path found. No XSS sinks exist (`grep dangerouslySetInnerHTML|innerHTML|
+  document.write|eval` over `src` → zero), and all app-generated SQL is
+  parameterized with allowlisted columns (`queryFilters.ts:33-161`).
+- Severity: Advisory.
+- Remediation: Add a restrictive CSP (and consider disabling
+  `autoload`/`httpfs` in the wasm config) if the threat model includes a user
+  pasting attacker-supplied SQL.
+
+---
+
+## 3. L2 — what this review's method did not cover
+
+These are gaps in the review approach itself, not defects (all defects above are
+owned in §2). Preface: I confirmed the `explorer_pipeline`/publishing tests pass
+(260 + 33 green) and the ADR migration/audit-SHA wiring landed, so the
+"orphaned tests / unexecuted migration" class was checked and came back clean.
+
+- **No runtime observation of the explorer or the deployed site.** The review is
+  entirely static. I verified the read-only DuckDB attach and the absence of SQL
+  filtering from source, but did not run the app, the Playwright suite, or a real
+  snapshot build — so I cannot confirm the *actual* error text on rejected DDL,
+  whether duckdb-wasm in the shipped bundle really can fetch `httpfs`, or that the
+  built `.duckdb` matches the schema at runtime. Outbound HTTPS to
+  `benchbox.dev/results/` is proxy-blocked, so the live deployment state
+  (Finding 2.13/2.14) is inferred from workflow gating + branch content, never
+  observed. A reviewer with Actions history / a live browser could confirm or
+  refute whether the explorer has *ever* deployed.
+- **No adversarial modeling of the hosted submission service.** `benchbox submit`
+  has an entire hosted path (`submit_auth.py`, `submit_service.py`, token refresh,
+  visibility choices) that ships to end users on `main`/PyPI. This review scoped to
+  the PR-based Phase-2 flow; the hosted API's auth/token/replay surface was not
+  examined.
+- **No performance-budget evaluation.** The explorer has documented range-read /
+  snapshot-size budgets (`e2e/capability/range-read-budget.spec.ts`) and the
+  pipeline does per-bundle I/O; I did not assess whether the snapshot build or the
+  browser read model meets any latency/size budget, or how it scales past the
+  current ~525-result corpus.
+- **Docs read opportunistically, not exhaustively.** The `docs/` +
+  `_project/` prose corpus is very large (dozens of ADRs, handoffs, decisions,
+  specs). I verified the documents named in the seeds and those they cross-link,
+  but there are whole doc trees (`_project/decisions/`, `_project/planning/`,
+  `_project/research/`, `_project/specs/`) whose claims about these subsystems I
+  did not re-derive. The drift rate observed (§2.12–2.18b) suggests more of the
+  same class exists unexamined.
+- **Concurrency/ordering of the sync + release pipelines not modeled.** I read the
+  `sync`/`release-cut`/`docs` workflows for content correctness but did not reason
+  about interleavings (e.g. a mirror PR racing a release cut, or a
+  `published-results` force-push landing between a contributor PR's checks and its
+  merge) — a class of bug the static read cannot surface.
+
+---
+
+<!--
+Per docs/development/review-protocol.md §1 & §4, this capture is local-only.
+No commit, push, PR, or remediation was performed. Remediation of any finding
+above requires explicit user authorization in a separate turn.
+-->


### PR DESCRIPTION
## Description

Read-only adversarial review of the **Results Explorer** and **Results
Publication** subsystems (per `docs/development/review-protocol.md`, against
`develop@fddedf26`), plus the remediation **plan** captured as TODO items.

**This PR is the plan, not the fixes.** No product code changes — it adds the
audit findings and a validated set of planning TODOs that the standard
`create > review > fix > submit PR` loop can then implement one PR at a time.

- `_project/audits/results-explorer-publication-adversarial-review.md` — the
  audit: **2 Critical, 11 Required, 11 Advisory** findings, each with
  evidence (file:line / reproduced commands), impact, severity, and remediation.
- `_project/TODO/main/planning/remediate-*.yaml` — **9 planning TODOs** (tagged
  `results-explorer-publication-remediation`), each scoped to one PR, covering
  every Critical/Required finding (coverage verified: none orphaned):
  - `remediate-ci-required-gate-integrity` — **Critical**: undeclared `ci-paths`
    job outputs make `package-smoke`/`dependency-audit`/`parity-check` permanent
    no-ops that count as passing.
  - `remediate-prune-publishing-doc-hazard` — **Critical**: a published
    future-state doc instructs deleting the live `benchbox publish` subsystem.
  - `remediate-submission-trust-label-enforcement` — provenance: unmanifested /
    mislabeled community bundles get promoted to `maintainer-run` and ranked.
  - `remediate-explorer-trust-label-vocabulary` (deps: enforcement)
  - `remediate-published-results-submission-ci` — on-branch validator drift,
    self-green, fork-PR comment 403, ADR allowlist.
  - `remediate-explorer-deploy-path-reconciliation` — docs claim the explorer
    builds/serves from `main`; release-cut strips it (has gating open questions).
  - `remediate-governance-and-doc-drift`, `remediate-qa-and-browser-test-doc-accuracy`,
    `remediate-explorer-csp-hardening`.

The plan itself went through the loop: an independent `todo review` pass
confirmed full coverage and raised 4 Required + 6 Advisory findings, all applied
(split the Critical prune-doc into its own item, added dependency edges to avoid
a test-dir collision, replaced non-runnable verification commands, narrowed
scope). Branch re-based onto `develop` (the base for remediation work; the TODO
system and target code live there).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor / chore

## Testing

- `make pr-content-guard` (path-aware): `check-yaml` passed; all 9 TODOs pass
  `validate_todo.py`; `todo_cli.py check-graph` — no cycles/dangling refs
  (91 items).
- `todo_cli.py reindex` regenerates the gitignored `_indexes/` cleanly.
- Independent `todo review` (six-axis rubric): all Critical/Required findings
  actioned; findings applied and re-validated.
- No product code changed, so no `pytest` behavior suites were relevant to run.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated,
      experimental, or repo-only contract surfaces (audit + planning docs only).
- [x] No result-schema / MCP-tool / platform-support / facade / adapter-hook /
      generated-doc impact.
- [x] No platform/benchmark count claims added.

## Documentation

- [x] The audit and TODOs are the documentation this PR adds; each TODO pins its
      evidence to the audit path + `develop_sha fddedf26`.
- [x] No behavior changes (planning only), so no regression notes needed.
- [x] No API contract wording changed.

## Code Quality

- [x] Content-guard lint (`check-yaml`, TODO schema/graph) run and green.
- [x] No product modules changed; nothing to review for backward compatibility.
- [x] No behavior changes, so no tests added here — each TODO specifies the
      tests its future implementation PR must add.
- [x] No public contracts or release checklists affected.

## Artifact Hygiene

- [x] No raw screenshots, browser reports, generated logs, benchmark outputs, or
      temporary binaries committed. Generated `_project/TODO/_indexes/` are
      gitignored and not included.
- [x] No committed binary/raw evidence files.

## Notes

- **The two Critical items are the ones to land first.** `ci-required-gate-integrity`
  is a live CI hole (regression from the merged `pr-gate-package-and-audit-promotion`
  work, which added the step output and job gating but never the job-level
  `outputs:` declaration).
- **Two items carry gating open questions** for a maintainer before their fix is
  mechanical: where `benchbox.dev/results/` actually deploys from
  (deploy-path reconciliation), and whether a historical fork PR truly 403s on
  the validation comment (submission-CI).
- Implementing the TODOs (the code fixes) is a **separate** effort — run the
  `todo` batch over the `results-explorer-publication-remediation` set.
- Auto-merge intentionally not enabled; this is a plan for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_