### PR TITLE
test(ci): pin ci-paths job outputs to path-filter groups in lockstep

### DIFF
--- a/_project/DONE/main/pr-gate-path-filter-output-lockstep-test.yaml
+++ b/_project/DONE/main/pr-gate-path-filter-output-lockstep-test.yaml
@@ -2,7 +2,8 @@ id: pr-gate-path-filter-output-lockstep-test
 title: "Pin ci-paths job-level outputs to the path-filter groups so a missing output mapping can never silently disable a gate again"
 worktree: main
 priority: Medium-High
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-05"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -38,18 +39,21 @@ prior_art:
 work:
   - id: w0
     summary: "Re-validate the #955 fix is present on develop before pinning it"
-    status: pending
+    status: done
     notes: |
       `grep -n 'packaging-needed\|viz-needed' .github/workflows/pr.yml` —
       expect the two job-level `outputs:` mappings (currently pr.yml:27-28)
       plus the three `if:` references. Record the line numbers in the test's
       docstring-adjacent comment or PR body. If absent (revert/refactor),
       restore the mapping first in the same change.
+      DONE 2026-07-05: mappings present at pr.yml:27-28; `if:` references
+      at pr.yml:772 (package-smoke), :814 (dependency-audit), :865
+      (parity-check). Fix confirmed present on origin/develop 7c59f574.
 
   - id: w1
     summary: "Add the lockstep test: every referenced <group>-needed output is declared on the ci-paths job"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       In tests/unit/workflows/test_pr_workflow_path_classifier.py: load
       .github/path-filters.yml groups via the same logic as
@@ -68,7 +72,7 @@ work:
   - id: w2
     summary: "Mutation-probe the new test"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       Locally (uncommitted): delete the `packaging-needed:` mapping line from
       pr.yml, run the new test, confirm it FAILS with a message naming the

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -15,6 +17,22 @@ pytestmark = [
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_path_filter_decision():
+    """Load scripts/path_filter_decision.py the way the workflow uses it.
+
+    tests/unit/scripts/ has a conftest sys.path shim; here we load by file
+    path so the lockstep test derives group names from the same
+    `load_rules` + `extra_group_keys` logic the classify step runs (output
+    naming additionally mirrors write_github_output's `_`→`-` mapping).
+    """
+    script = REPO_ROOT / "scripts" / "path_filter_decision.py"
+    spec = importlib.util.spec_from_file_location("path_filter_decision_lockstep", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _ci_required_result_script() -> str:
@@ -171,6 +189,85 @@ def test_ci_required_result_required_jobs_in_needs() -> None:
     # result silently disappears from the gate.
     assert "package-smoke" in needs
     assert "dependency-audit" in needs
+
+
+def test_ci_paths_job_outputs_declare_every_path_filter_group() -> None:
+    # Incident pin (PR #952 → fixed in PR #955 commit 8652d135): the classify
+    # step wrote `packaging-needed`/`viz-needed` to GITHUB_OUTPUT and the
+    # gated jobs' `if:` referenced `needs.ci-paths.outputs.<group>-needed`,
+    # but the ci-paths JOB `outputs:` block never mapped those step outputs.
+    # GitHub Actions only exposes job outputs that are explicitly declared,
+    # so every `if:` saw "" and package-smoke / dependency-audit /
+    # parity-check silently skipped on EVERY PR — reading green via the
+    # aggregator's skip-counts-as-pass rule. path-filters.yml is designed to
+    # grow new groups without script changes, so this lockstep must be
+    # derived from the rules file, never a hardcoded group list.
+    # (Mapping currently lives at pr.yml jobs.ci-paths.outputs, lines ~27-28.)
+    pfd = _load_path_filter_decision()
+    groups = pfd.extra_group_keys(pfd.load_rules(REPO_ROOT / ".github" / "path-filters.yml"))
+    assert groups, "expected at least one extra path-filter group (e.g. packaging, viz)"
+
+    workflow_yaml = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8"))
+    declared_outputs = workflow_yaml["jobs"]["ci-paths"]["outputs"]
+
+    # Direction 1 (both ways): the set of `*-needed` outputs declared on the
+    # ci-paths job must equal the classify step's `*-needed` emissions —
+    # one per extra group (write_github_output normalizes the rules key
+    # `_`→`-`) plus the always-emitted core `content-guard-needed`. A
+    # missing declaration silently disables a gate (the #952 incident); a
+    # stale declaration after a group is removed/renamed feeds "" to the
+    # gated job's `if:` — the same silent skip from the other side.
+    expected_needed = {f"{group.replace('_', '-')}-needed" for group in groups}
+    expected_needed.add("content-guard-needed")
+    declared_needed = {key for key in declared_outputs if key.endswith("-needed")}
+    assert declared_needed == expected_needed, (
+        "jobs.ci-paths.outputs `*-needed` keys must stay in lockstep with "
+        "path-filters.yml groups (plus core content-guard-needed). "
+        f"Missing declarations: {sorted(expected_needed - declared_needed)}; "
+        f"stale declarations (no classify emission behind them): "
+        f"{sorted(declared_needed - expected_needed)}. Either way the gated "
+        "job's `if:` sees an empty string and silently skips (PR #952)."
+    )
+
+    for key in sorted(expected_needed):
+        # Whitespace-insensitive: `${{steps.classify.outputs.x}}` and
+        # `${{ steps.classify.outputs.x }}` behave identically in Actions.
+        actual = re.sub(r"\s+", "", str(declared_outputs[key]))
+        assert actual == f"${{{{steps.classify.outputs.{key}}}}}", (
+            f"jobs.ci-paths.outputs.{key} must map steps.classify.outputs.{key}"
+        )
+
+
+def test_every_referenced_ci_paths_output_is_declared() -> None:
+    # Direction 2 of the lockstep: any `needs.ci-paths.outputs.<key>`
+    # reference anywhere in pr.yml (job `if:`, step `if:`, env, run) must
+    # name an output the ci-paths job actually declares. Catches a future
+    # job referencing a never-declared output even outside the extra-group
+    # `<group>-needed` convention.
+    # Scanning the raw text (rather than walking parsed YAML) deliberately
+    # covers every usage site — job/step `if:`, env, run blocks. Trade-off:
+    # a comment naming a dropped output would fail this test too; that is a
+    # loud false-fail, preferred over a silent skip.
+    workflow_text = (REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8")
+    workflow_yaml = yaml.safe_load(workflow_text)
+    declared_outputs = set(workflow_yaml["jobs"]["ci-paths"]["outputs"])
+
+    # Match dot and bracket reference forms: needs.ci-paths.outputs.x,
+    # needs['ci-paths'].outputs.x, needs.ci-paths.outputs['x'], and the
+    # fully bracketed combination (single or double quotes).
+    reference_re = (
+        r"needs(?:\.ci-paths|\[['\"]ci-paths['\"]\])"
+        r"\.outputs(?:\.([A-Za-z0-9_-]+)|\[['\"]([A-Za-z0-9_-]+)['\"]\])"
+    )
+    referenced = {dot or bracket for dot, bracket in re.findall(reference_re, workflow_text)}
+    assert referenced, "expected pr.yml to reference ci-paths outputs"
+
+    undeclared = referenced - declared_outputs
+    assert not undeclared, (
+        f"pr.yml references undeclared ci-paths outputs {sorted(undeclared)}; "
+        "declare them in jobs.ci-paths.outputs or the referencing `if:` "
+        "silently evaluates against an empty string (the PR #952 incident)."
+    )
 
 
 def test_parity_check_is_demoted_to_non_blocking() -> None:


### PR DESCRIPTION
# Pull Request

## Description

Regression pin for the PR #952 incident (fixed in #955 commit 8652d135): the classify step's `<group>-needed` step outputs were referenced by gated jobs' `if:` expressions but never declared on the `ci-paths` job's `outputs:` block, so package-smoke / dependency-audit / parity-check silently skipped on every PR and read green via the aggregator's skip-counts-as-pass rule.

Two new tests in `tests/unit/workflows/test_pr_workflow_path_classifier.py`:

- **Direction 1 (set equality, both ways)**: the `*-needed` outputs declared on `ci-paths` must equal the classify step's emissions — one per extra path-filter group (derived from `scripts/path_filter_decision.py`'s `load_rules`/`extra_group_keys` over `.github/path-filters.yml`, mirroring `write_github_output`'s `_`→`-` naming; no hardcoded group list) plus core `content-guard-needed`. Catches both a missing declaration (the #952 incident) and a stale declaration left behind after a group is removed/renamed. Mapping values are checked whitespace-insensitively against `steps.classify.outputs.<key>`.
- **Direction 2**: every `needs.ci-paths.outputs.*` reference anywhere in pr.yml (dot and bracket forms) must name a declared output — catches a future job referencing a never-declared output even outside the extra-group convention.

w0 re-validation recorded: mappings present at pr.yml:27-28; `if:` references at pr.yml:772/814/865 on develop 7c59f574.

Closes TODO `pr-gate-path-filter-output-lockstep-test` (moved to `_project/DONE/main/`).

## Type of Change

- [x] Bug fix (regression pin for a CI-gate soundness gap)

## Testing

- `uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q` → 12 passed.
- Mutation probe (TODO w2): deleted the `packaging-needed:` mapping line from pr.yml → both new tests FAIL naming `packaging-needed`; restored tree → green again.
- `make lint` green.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces (tests + TODO bookkeeping only).
- [x] No result schema / MCP / platform status / wrapper / adapter impact.
- [x] No count claims touched.

## Documentation

- [x] No user-facing docs impact; the incident rationale is recorded in the test comments and the DONE TODO.

## Code Quality

- [x] I ran formatting and lint/type checks (`ruff check` + `ruff format --check` on the changed file, `make lint`).
- [x] No backwards-compatibility impact (additive tests).
- [x] Tests added for the behavior (the tests ARE the change), with a mutation probe proving they can go red.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Code review (2 finder agents, correctness + cleanup/conventions) findings applied: underscore-group output-name normalization, stale-declaration direction added, bracket-form reference regex, whitespace-insensitive mapping compare. One Consider logged as accepted trade-off instead of applied: Direction 2 scans raw pr.yml text, so a *comment* naming a dropped output would fail the test — a loud false-fail, deliberately preferred over the silent-skip failure mode this pin exists for (documented in the test comment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_