### PR TITLE
docs(future-state): mark prune-publishing proposal completed (stop targeting live code)

### DIFF
--- a/docs/design/future-state/index.md
+++ b/docs/design/future-state/index.md
@@ -17,7 +17,10 @@ established the following priority tiers based on coupling analysis, effort, and
 evidence of need:
 
 **Tier 1: Act now (small effort, clear value):**
-- **artifactlinks**: Dead code with zero consumers. Prune.
+- **artifactlinks**: Completed in v0.2.1 — the old generic publishing layer was
+  pruned. `benchbox/core/publishing/` now hosts the live, CLI-integrated
+  bundle-publish subsystem; do not prune it. See
+  [Prune publishing](prune-publishing-subsystem/README.md).
 - **benchbox-maintainer**: Near-zero coupling. Remove entry point and exclude from wheel.
 - **benchbox-experimental**: Namespace hygiene for 5 misplaced subsystems.
 
@@ -40,7 +43,7 @@ Two proposals were discarded during adversarial review:
   index for public-contract and future-state decisions
 - [Benchmark family plugin seam](benchmark-family-plugin-seam/README.md) -
   **Medium** priority, gated by API classification and one pilot family
-- [Prune publishing](prune-publishing-subsystem/README.md) - **High** priority (dead code removal)
+- [Prune publishing](prune-publishing-subsystem/README.md) - **Completed (v0.2.1)**; retained as a historical record (the path now hosts the live bundle-publish subsystem)
 - [Remove release tooling from wheel](remove-release-tooling-from-wheel/README.md) - **High** priority
 - [Isolate experimental subsystems](isolate-experimental-core-subsystems/README.md) - **High** priority
 - [Gate monitoring behind optional extra](gate-monitoring-behind-optional-extra/README.md) - **Medium** priority

--- a/docs/design/future-state/prune-publishing-subsystem/README.md
+++ b/docs/design/future-state/prune-publishing-subsystem/README.md
@@ -1,53 +1,44 @@
 <!-- Copyright 2026 Joe Harris / BenchBox Project. Licensed under the MIT License. -->
 
-# artifactlinks Future State
+# Prune publishing subsystem — COMPLETED (v0.2.1)
 
 ```{tags} contributor, architecture
 ```
 
-Related TODO: `prune-publishing-subsystem`
+> **Status: Completed / superseded. Do not act on the original proposal.**
+>
+> This proposal targeted an *older* generic publishing layer (the
+> `ArtifactManager` — `artifacts.py`, `config.py`, `permalink.py`,
+> `publisher.py`) whose coupling analysis found no active consumers. That layer
+> was **pruned in v0.2.1** (commit `0182c955`, 2026-04-27): the four files above
+> were deleted, and the **same commit** introduced a new, different subsystem at
+> the same package path — the schema-v2 result-bundle publisher
+> (`benchbox/core/publishing/bundle_publisher.py`, `store.py`).
+>
+> `benchbox/core/publishing/` today is **live, CLI-integrated code**, not dead
+> code: it backs the registered `benchbox publish` command
+> (`benchbox/cli/commands/__init__.py`) and `benchbox run --publish`, and is
+> covered by `tests/unit/core/publishing/` and
+> `tests/integration/test_publish_cli.py`. **Do not delete it.**
 
-## Future State
+## History
 
-This subsystem ends in one of two explicit states:
+The original future-state analysis (below, for the record) concluded that the
+generic artifact/permalink layer had no active supported use and should be
+pruned rather than extracted. That conclusion was correct for the code as it
+existed then, and the prune was executed in v0.2.1. Because a new bundle-publish
+subsystem was subsequently built at the same path, this proposal is retained only
+as a completed record.
 
-1. If the audit shows real reuse potential, generic artifact publishing and
-   permalink creation move into `artifactlinks`.
-2. If the audit shows no active supported use, BenchBox deletes the subsystem
-   instead of carrying an unowned generic layer.
+The original "unused generic layer, safe to remove" framing describes code that
+no longer exists; nothing currently under `benchbox/core/publishing/` is
+removable dead code.
 
-The important future state is that ambiguity disappears: the code is either a
-real, owned library or it is gone.
+## Original proposal (historical)
 
-## Why This Is Valuable
-
-- BenchBox stops carrying generic infrastructure without clear ownership.
-- If extraction is justified, the publishing surface becomes reusable and easier
-  to maintain independently.
-- If extraction is not justified, BenchBox gets simpler with minimal user cost.
-
-## How The End State Is Used
-
-Coupling analysis found zero consumers of the publishing module: no CLI
-integration, no runtime imports, no result-export coupling. The expected outcome
-is pruning rather than extraction.
-
-If pruning is selected (expected), there is no replacement package. BenchBox
-keeps only the result-export and artifact behavior that is part of supported
-workflows. The result-export system (`benchbox/core/results/exporter.py`) is
-completely independent and unaffected.
-
-If future evidence of reuse emerges, extraction to a standalone package remains
-possible because the module is self-contained.
-
-## BenchBox After The Refactor
-
-- Result export stays user-focused rather than carrying a generic publishing
-  layer by default.
-- Any retained publishing API has an explicit owner and documented consumer set.
-- The package boundary reflects evidence rather than guesswork.
-
-## Non-Goals
-
-- Extracting a package just because the code looks reusable
-- Preserving dead internal APIs with no supported user or maintainer
+The original generic layer was to end in one of two explicit states: extract a
+reusable `artifactlinks` library if the audit showed real reuse potential, or
+delete the subsystem if it showed no active supported use. The audit found zero
+consumers (no CLI integration, no runtime imports, no result-export coupling),
+so deletion was selected. `benchbox/core/results/exporter.py` was and remains
+independent and unaffected.


### PR DESCRIPTION
## Description

Implements TODO `remediate-prune-publishing-doc-hazard` — audit finding **§2.12 (Critical)** from PR #959's plan.

`docs/design/future-state/prune-publishing-subsystem/README.md` (and the future-state index) framed `benchbox/core/publishing/` as "dead code, zero consumers, **High** priority (dead code removal)". That was true of an **older** generic layer (`ArtifactManager`: `artifacts.py`, `config.py`, `permalink.py`, `publisher.py`), which was pruned in v0.2.1 (`0182c955`, 2026-04-27). The **same commit** added a new subsystem at the same path — the live schema-v2 bundle publisher (`bundle_publisher.py`, `store.py`) backing the registered `benchbox publish` command and `benchbox run --publish`. A maintainer following the future-state backlog could therefore have deleted shipped code.

## Changes

- Rewrote the proposal README as a **Completed (v0.2.1)** record with a do-not-delete banner and accurate history (verified against `git show --stat 0182c955`: −1385 lines old layer, +490 lines new subsystem in one commit).
- `future-state/index.md`: marked the proposal Completed in the Proposals list and corrected the stale Tier‑1 "artifactlinks: dead code, prune" line.

## Type of Change

- [x] Documentation

## Testing

- `grep -rn 'zero consumers\|dead code removal' docs/design/future-state/prune-publishing-subsystem/ docs/design/future-state/index.md` → no matches (stale framing gone).
- `pre-commit run markdownlint` on both files → Passed.
- `pytest tests/unit/core/publishing -q` → 28 passed; `benchbox publish` still registered — confirms the "do not delete" subject is live.

## Public Contract Check

- [x] Docs-only; no public/beta/deprecated/generated/experimental/repo-only contract surfaces changed.

## Documentation

- [x] This is the documentation change; no behavior change, no API wording change.

## Code Quality

- [x] markdownlint green; no code touched.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Doc-only, no gating questions. Part of the `results-explorer-publication-remediation` batch (plan: #959). Auto-merge not enabled — left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_