### PR TITLE
chore(release): prep release-canary scheduled activation — runbook decision + scheduled-workflow liveness guard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -361,6 +361,151 @@ jobs:
         run: npm test -- --reporter=verbose
         working-directory: results-explorer
 
+  scheduled-workflow-liveness:
+    # Guard for the release-canary-scheduled-activation TODO's failure class:
+    # a workflow that declares `on.schedule` but is not on the DEFAULT branch
+    # never registers and never runs — nothing red appears anywhere (this is
+    # exactly how release-canary.yml sat dead while the repo's safety story
+    # leaned on it). This job scans the DEVELOP tree (where scheduled
+    # workflows are authored) and fails when any of them has no SCHEDULED
+    # run within its cadence-derived window. It executes from main's copy of
+    # nightly.yml, so it takes effect once this file reaches main.
+    # DELIBERATE: a scheduled workflow newly authored on develop goes red
+    # here until it lands on main — that lag is exactly the silent gap this
+    # guard converts to a loud one; land the file (admin/release flow) or
+    # remove the schedule.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout develop (scheduled workflows are authored there first)
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Assert every scheduled workflow in the tree has a recent scheduled run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Bare python3 is intentional: stdlib-only, no uv sync needed for a
+        # pure API check (same precedent as pr.yml's path classifier). The
+        # schedule detection regex is scoped to the `on:` block to stay
+        # stdlib-only without a YAML parser.
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          import time
+          import urllib.error
+          import urllib.request
+          from datetime import datetime, timedelta, timezone
+          from pathlib import Path
+
+          wf_dir = Path(os.environ.get("WORKFLOWS_DIR", ".github/workflows"))
+          repo = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ.get("GITHUB_TOKEN", "")
+          api = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
+          # `on:` block = from a top-level `on:` line to the next top-level key.
+          on_block_re = re.compile(r"(?ms)^(?:\"on\"|'on'|on):[^\n]*\n(.*?)(?=^\S|\Z)")
+          schedule_re = re.compile(r"(?m)^ {1,4}schedule:\s*(#.*)?$")
+          cron_re = re.compile(r"(?m)^\s*-\s*cron:\s*['\"]?([^'\"#\n]+)")
+
+          def cadence_window_days(cron_exprs: list[str]) -> int:
+              """Generous liveness window from the most frequent cron.
+
+              Daily-or-better -> 3 days; weekly (day-of-week bound) -> 9;
+              monthly (day-of-month bound) -> 35; sparser (month bound,
+              e.g. quarterly) -> 100. Coarse on purpose: this guard flags
+              dead schedules, it does not audit punctuality.
+              """
+              windows = []
+              for expr in cron_exprs:
+                  fields = expr.split()
+                  if len(fields) != 5:
+                      continue
+                  _minute, _hour, dom, month, dow = fields
+                  if month != "*":
+                      windows.append(100)
+                  elif dom != "*":
+                      windows.append(35)
+                  elif dow != "*":
+                      windows.append(9)
+                  else:
+                      windows.append(3)
+              return min(windows) if windows else 3
+
+          def latest_scheduled_run(workflow_file: str):
+              """Latest schedule-event run, [] if none, None-sentinel via ValueError."""
+              url = (
+                  f"{api}/repos/{repo}/actions/workflows/{workflow_file}/runs"
+                  "?per_page=1&event=schedule"
+              )
+              headers = {
+                  "Accept": "application/vnd.github+json",
+                  "User-Agent": "benchbox-scheduled-workflow-liveness",
+              }
+              if token:
+                  headers["Authorization"] = f"Bearer {token}"
+              last_err = None
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30) as resp:
+                          return json.load(resp).get("workflow_runs", [])
+                  except urllib.error.HTTPError as err:
+                      if err.code == 404:
+                          # Never registered => never ran (absent from default branch).
+                          return []
+                      if err.code in (401, 403):
+                          print(f"::error::GitHub API auth/rate-limit failure ({err.code}) for {url}; cannot assess liveness.")
+                          sys.exit(1)
+                      last_err = err
+                  except urllib.error.URLError as err:
+                      last_err = err
+                  time.sleep(5 * (attempt + 1))
+              print(f"::error::GitHub API unreachable after retries for {url}: {last_err}")
+              sys.exit(1)
+
+          dead: list[str] = []
+          checked = 0
+          for path in sorted(wf_dir.glob("*.yml")) + sorted(wf_dir.glob("*.yaml")):
+              text = path.read_text(encoding="utf-8")
+              on_block = on_block_re.search(text)
+              if not on_block or not schedule_re.search(on_block.group(1)):
+                  continue
+              checked += 1
+              window_days = cadence_window_days(cron_re.findall(on_block.group(1)))
+              runs = latest_scheduled_run(path.name)
+              if not runs:
+                  dead.append(
+                      f"{path.name}: no scheduled runs at all -- absent from the "
+                      "default branch, or its cron is disabled/never fires"
+                  )
+                  continue
+              created = datetime.fromisoformat(runs[0]["created_at"].replace("Z", "+00:00"))
+              if datetime.now(timezone.utc) - created > timedelta(days=window_days):
+                  dead.append(
+                      f"{path.name}: latest scheduled run {runs[0]['created_at']} is "
+                      f"older than its {window_days}-day cadence window"
+                  )
+          if checked == 0:
+              print("::error::No scheduled workflows found in the checked-out tree; the liveness scan itself is broken.")
+              sys.exit(1)
+          if dead:
+              print(
+                  "::error::Scheduled workflow(s) with no recent scheduled run detected "
+                  "(see TODO release-canary-scheduled-activation and "
+                  "docs/operations/repo-admin-settings.md 'Scheduled activation'):"
+              )
+              for line in dead:
+                  print(f"::error::  {line}")
+              sys.exit(1)
+          print(f"All {checked} scheduled workflow(s) alive within their cadence windows.")
+          PY
+
   pyspark-tests:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/_project/TODO/main/active/release-canary-scheduled-activation.yaml
+++ b/_project/TODO/main/active/release-canary-scheduled-activation.yaml
@@ -2,7 +2,7 @@ id: release-canary-scheduled-activation
 title: "Get release-canary.yml actually firing: the workflow is not on the default branch, so its daily schedule has never run"
 worktree: main
 priority: High
-status: "Not Started"
+status: "In Progress"
 category: "Release Tooling"
 
 description: |
@@ -53,7 +53,7 @@ prior_art:
 work:
   - id: w0
     summary: "Re-validate the finding: release-canary.yml still absent from origin/main and unregistered"
-    status: pending
+    status: done
     notes: |
       Run `git fetch origin main && git ls-tree origin/main --name-only
       .github/workflows/` (expect: no release-canary.yml) and
@@ -62,11 +62,15 @@ work:
       one-line results in the PR/TODO notes. If either now shows the
       workflow, re-scope this TODO against the new live state instead of
       proceeding blind.
+      DONE 2026-07-05: `git ls-tree origin/main --name-only .github/workflows/`
+      -> 14 files, NO release-canary.yml; Actions list-workflows API -> 19
+      workflows, release-canary absent. Finding re-validated; recorded in
+      docs/operations/repo-admin-settings.md "Scheduled activation" section.
 
   - id: w1
     summary: "Decide the activation mechanism with the maintainer"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Options, with the trade-off each carries:
         (a) Admin cherry-picks/pushes the current release-canary.yml to main
@@ -84,6 +88,13 @@ work:
       Recommendation: (a) + (c) together — land the shell form on main once,
       keep logic on develop. Record the decision in
       docs/operations/repo-admin-settings.md.
+      DONE 2026-07-05: options + recommendation (a)+(c) recorded in the
+      runbook's new "Scheduled activation of release-canary.yml" section.
+      Key observation: the current release-canary.yml ALREADY IS the (c)
+      shell (test/drift jobs check out develop via RELEASE_CANARY_REF;
+      pypi job needs no checkout), so (a) = cherry-pick the current file
+      verbatim. Final sign-off on the mechanism rests with the maintainer
+      at execution time (w2).
 
   - id: w2
     summary: "Land the chosen form on main (admin/release-flow action) and confirm registration"
@@ -96,6 +107,11 @@ work:
       canary RED with pypi-latest-installability failing on 0.3.0's broken
       import — record that run URL as proof-of-life, and cross-link it in
       release-recovery-v0-3-1 as live pressure for the recovery release.
+      MAINTAINER HANDOFF (2026-07-05): this unit is admin-only (main is
+      push-restricted; agents never push main). Exact steps are enumerated
+      in docs/operations/repo-admin-settings.md "Scheduled activation of
+      release-canary.yml (pending admin action)" — land the file, confirm
+      registration, dispatch, record the (expected-RED) run URL.
 
   - id: w3
     summary: "Add a scheduled-workflow liveness guard so this class of gap cannot recur silently"

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -398,6 +398,68 @@ stale/red canary evidence instead of silently trusting comments.
 script with the identical token, so the same review-rule coverage is reachable
 from both CI call sites without a separate code path.
 
+### Scheduled activation of `release-canary.yml` (pending admin action)
+
+Live state observed 2026-07-05 (release-canary-scheduled-activation TODO, w0):
+
+- `git ls-tree origin/main --name-only .github/workflows/` does **not**
+  contain `release-canary.yml` — the file exists only on `develop`.
+- The Actions list-workflows API returns 19 registered workflows and
+  release-canary is not among them (a workflow absent from the default
+  branch with zero historical runs is never registered), so its
+  `on.schedule` cron has **never fired** and none of its jobs
+  (pypi-latest-installability, ruleset-drift, credential-free-non-fast,
+  plus the release-canary-result aggregator) has ever executed.
+- Same class, second instance: `phase3-promotion-review.yml` (quarterly
+  cron `0 9 1-7 1,4,7,10 *`) is also on `develop` but absent from
+  `origin/main`, so its schedule has never fired either. The liveness
+  guard below will name it alongside release-canary; the admin should
+  land it on `main` in the same pass (or deliberately remove its
+  schedule and record that decision here).
+
+GitHub runs `on.schedule` workflows only from the default branch (`main`).
+Activation options considered (w1):
+
+- **(a) Admin lands the current `release-canary.yml` on `main` out-of-band**
+  (cherry-pick/push through the documented admin flow; `main` is
+  push-restricted, so admin-only). Fastest path; content on `main` then
+  goes stale between release-cuts unless (c) also holds.
+- **(b) Wait for the next release-cut to carry it.** Zero extra action, but
+  the canary stays dead until v0.3.1 ships — the exact window it guards.
+- **(c) Keep `main`'s copy a minimal stable scheduled shell that checks out
+  `develop` for current logic.** The file already follows this shape: the
+  test and drift jobs check out `develop` via `RELEASE_CANARY_REF`, and
+  pypi-latest-installability needs no checkout at all. Only future
+  *workflow-structure* edits (job graph, permissions, schedule) need
+  re-landing on `main`; test/drift *content* tracks `develop` automatically.
+
+**Recommendation (recorded 2026-07-05): (a) + (c) together** — land the
+current `develop` copy of `release-canary.yml` on `main` once (it already is
+the (c) shell), keep logic on `develop`.
+
+Admin steps (w2 — maintainer action, never an agent push):
+
+1. Land `develop`'s `.github/workflows/release-canary.yml` on `main` via the
+   admin/release flow.
+2. Confirm registration: the workflow appears in
+   `gh api repos/joeharris76/BenchBox/actions/workflows --jq '.workflows[].path'`.
+3. Trigger `workflow_dispatch` (or wait for the next 08:00 UTC cron) and
+   record the run URL here as proof-of-life.
+4. **Expected first result: RED** — pypi-latest-installability correctly
+   fails on the broken 0.3.0 PyPI release (`ModuleNotFoundError: pandas` on
+   clean install). That is the canary working; cross-link the red run in
+   `release-recovery-v0-3-1` as live pressure for the recovery release. Do
+   not weaken the canary to get a green first run.
+
+Once the canary is live, the `scheduled-workflow-liveness` job in
+`nightly.yml` (added 2026-07-05, executes once its copy reaches `main`)
+asserts daily that every workflow in the `develop` tree declaring
+`on.schedule` has a recent run of `event=schedule` within a
+cadence-derived window (3 days for daily crons, up to 100 days for
+quarterly ones), so this dead-scheduled-workflow class cannot recur
+silently. Deliberate consequence: a scheduled workflow newly authored on
+`develop` reads red in that guard until its file lands on `main`.
+
 Emergency override is intentionally explicit and SHA-scoped. Admins may set
 both repository variables below, then remove them after the release:
 


### PR DESCRIPTION
# Pull Request

## Description

Agent-side units of TODO `release-canary-scheduled-activation` (High). The entire scheduled release-canary lattice is inert: `release-canary.yml` exists only on `develop`, and GitHub runs `on.schedule` only from the default branch.

- **w0 (re-validated 2026-07-05)**: `git ls-tree origin/main .github/workflows/` has no release-canary.yml; Actions list-workflows API returns 19 workflows without it → the daily cron has never fired. Also found a **second instance of the same class**: `phase3-promotion-review.yml` (quarterly cron) is on develop, absent from main — recorded in the runbook for the same admin pass.
- **w1**: activation options + recommendation recorded in `docs/operations/repo-admin-settings.md` (new "Scheduled activation of release-canary.yml (pending admin action)" section). Recommendation: (a)+(c) — admin lands the current file on main once; it already follows the develop-checkout shell pattern, so canary logic keeps landing on develop.
- **w2 = maintainer handoff** (main is push-restricted; agents never push main): exact steps in the runbook. First live run is **expected RED** on pypi-latest 0.3.0's broken install — that is the canary working; cross-link the run in release-recovery-v0-3-1. Do not weaken the canary for a green first run.
- **w3 prepared**: new `nightly.yml` job `scheduled-workflow-liveness` — checks out develop's tree, finds every workflow declaring `on.schedule` (regex scoped to the `on:` block), and fails when any lacks a run of `event=schedule` within a cadence-derived window (daily 3d / weekly 9d / monthly 35d / quarterly 100d). Stdlib-only inline python, retries on URLError, fails loud on auth/rate-limit. Executes once nightly.yml's copy reaches main, closing this dead-scheduled-workflow class permanently.

TODO stays in `_project/TODO/main/active/` with w2 pending as the admin handoff (per batch policy: PR ships agent-side work; admin/wait units keep the TODO active).

## Type of Change

- [x] Bug fix (inert safety lattice → documented activation path + recurrence guard)
- [x] Documentation (runbook)

## Testing

- Guard mutation-probed against a local stub API (proxy blocks unauthenticated api.github.com here): no-scheduled-runs → exit 1 naming the workflow; fresh run → exit 0; stale-vs-window → exit 1; 90-day-old quarterly-cron run → correctly alive; a job literally named `schedule` → correctly ignored; real-repo scan finds exactly the 5 scheduled workflows.
- `yaml.safe_load` parse of nightly.yml green; `tests/unit/test_standardized_test_commands.py` (pins nightly.yml content) green; `make lint` green.
- TODO validated (`validate_todo.py`) and `todo_cli.py check-graph` clean.

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental contract surfaces changed (CI workflow + ops runbook + TODO bookkeeping).
- [x] No result schema / MCP / platform status impact.
- [x] No count claims touched.

## Documentation

- [x] Runbook updated (the user-facing ops doc for this change).
- [x] Regression rationale recorded in the job comment and runbook.

## Code Quality

- [x] Formatting and lint checks run (`make lint`).
- [x] Backwards compatible: purely additive job; release-canary.yml semantics untouched (must_preserve).
- [x] Guard behavior exercised via stub-API probes (inline workflow python is not unit-testable in-repo without new modules, which scope_limit forbids).

## Artifact Hygiene

- [x] No raw artifacts committed; probe logs stayed in the local scratchpad.

## Notes

**Maintainer handoff (w2, admin-only)**: land develop's `release-canary.yml` (and decide `phase3-promotion-review.yml`) on `main` via the admin/release flow, confirm Actions registration, dispatch, and record the expected-RED run URL in the runbook. Steps enumerated in the new runbook section.

Review findings applied: cadence-derived windows (quarterly cron would have false-red under a flat 3-day window), `event=schedule` filter (push/dispatch runs can't mask a dead cron), `on:`-block-scoped schedule detection, URLError/429 retry-then-fail-loud, runbook job-count correction, phase3-promotion-review.yml documented as a second dead-schedule instance. Logged-not-applied (Consider): bare `python3` in the guard step — deliberate stdlib-only exception with in-file rationale, same precedent as pr.yml's path classifier; develop→main lag red for newly authored scheduled workflows — deliberate, documented in the job comment and runbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_