### PR TITLE
fix(query-plans): repoint plan consumers at real query_results, reattach plans on load

### DIFF
--- a/_project/DONE/main/fix-plan-consumption-phases-and-loader-reattach.yaml
+++ b/_project/DONE/main/fix-plan-consumption-phases-and-loader-reattach.yaml
@@ -2,7 +2,8 @@ id: fix-plan-consumption-phases-and-loader-reattach
 title: "Fix broken plan-consumption surface (BenchmarkResults.phases + loader plan reattachment)"
 worktree: main
 priority: Critical
-status: Not Started
+status: "Completed"
+completed_date: "2026-07-05"
 description: |
   Adversarial review of the query-plan-capture subsystem found the entire
   read/consume side is non-functional on real exported bundles. Two layered
@@ -56,9 +57,9 @@ impact:
     turning a crash into silent data loss.
 
 must_preserve:
-  - "Bundles that legitimately have no plans still load and render without error."
-  - "The .plans.json companion file format is unchanged (loader adapts to it, not vice versa)."
-  - "Non-plan fields of reconstruct_benchmark_results keep their current values."
+- "Bundles that legitimately have no plans still load and render without error."
+- "The .plans.json companion file format is unchanged (loader adapts to it, not vice versa)."
+- "Non-plan fields of reconstruct_benchmark_results keep their current values."
 
 approach: |
   Introduce a single accessor that walks execution over `execution_phases` and/or
@@ -70,43 +71,45 @@ approach: |
   add a real bundle round-trip test.
 
 anti_patterns:
-  - "DO NOT add a `phases` compatibility property that fabricates the old shape - because it hides which real field (execution_phases vs query_results) each consumer needs - repoint consumers explicitly."
-  - "DO NOT rely on getattr(results, 'phases', {}) defaults anywhere - because they convert a hard error into silent empty output."
+- "DO NOT add a `phases` compatibility property that fabricates the old shape - because it hides which real field (execution_phases
+  vs query_results) each consumer needs - repoint consumers explicitly."
+- "DO NOT rely on getattr(results, 'phases', {}) defaults anywhere - because they convert a hard error into silent empty output."
 
 scope_limit:
   only_modify:
-    - "benchbox/core/results/loader.py"
-    - "benchbox/cli/commands/show_plan.py"
-    - "benchbox/cli/commands/compare_plans.py"
-    - "benchbox/cli/commands/compare.py"
-    - "benchbox/core/query_plans/comparison.py"
-    - "benchbox/core/manifest/plan_metadata_utils.py"
-    - "benchbox/core/query_plans/history.py"
-    - "tests/unit/cli/commands/test_show_plan_coverage.py"
-    - "tests/unit/cli/commands/test_compare_plans_coverage.py"
-    - "tests/integration/"
+  - "benchbox/core/results/loader.py"
+  - "benchbox/cli/commands/show_plan.py"
+  - "benchbox/cli/commands/compare_plans.py"
+  - "benchbox/cli/commands/compare.py"
+  - "benchbox/core/query_plans/comparison.py"
+  - "benchbox/core/manifest/plan_metadata_utils.py"
+  - "benchbox/core/query_plans/history.py"
+  - "tests/unit/cli/commands/test_show_plan_coverage.py"
+  - "tests/unit/cli/commands/test_compare_plans_coverage.py"
+  - "tests/integration/"
 
 work:
-  - id: w1
-    summary: "Thread plans_data into _reconstruct_query_results so query_plan/plan_fingerprint are rehydrated on load"
-    status: pending
-  - id: w2
-    summary: "Repoint the 6 results.phases consumers at execution_phases/query_results (no fabricated phases shim)"
-    status: pending
-    needs: [w1]
-  - id: w3
-    summary: "Replace the mocked load_result_file in show/compare coverage tests with the real reconstructed object; add a real DuckDB bundle -> load_result_file -> show-plan/compare-plans round-trip test"
-    status: pending
-    needs: [w2]
+- id: w1
+  summary: "Thread plans_data into _reconstruct_query_results so query_plan/plan_fingerprint are rehydrated on load"
+  status: done
+- id: w2
+  summary: "Repoint the 6 results.phases consumers at execution_phases/query_results (no fabricated phases shim)"
+  status: done
+  needs: [w1]
+- id: w3
+  summary: "Replace the mocked load_result_file in show/compare coverage tests with the real reconstructed object; add a real
+    DuckDB bundle -> load_result_file -> show-plan/compare-plans round-trip test"
+  status: done
+  needs: [w2]
 
 verification:
-  - description: "show-plan renders a plan from a real exported DuckDB bundle (exit 0)"
-    command: "uv run -- python -m pytest tests/integration/ -k 'plan and (show or compare or realpath)' -n 0 -q"
-    expected_output: "passed"
-  - description: "Full plan suites stay green"
-    command: "uv run -- python -m pytest tests/unit/cli/commands/ tests/unit/core/results/ tests/integration/ -k plan -n 0 -q"
-    expected_output: "passed"
+- description: "show-plan renders a plan from a real exported DuckDB bundle (exit 0)"
+  command: "uv run -- python -m pytest tests/integration/ -k 'plan and (show or compare or realpath)' -n 0 -q"
+  expected_output: "passed"
+- description: "Full plan suites stay green"
+  command: "uv run -- python -m pytest tests/unit/cli/commands/ tests/unit/core/results/ tests/integration/ -k plan -n 0 -q"
+  expected_output: "passed"
 
 deferred:
-  - summary: "Reproducing failing tests were captured during review under scratchpad/review-failing-tests/"
-    reason: "Staged locally (uncommitted); fold test_plan_capture_cli_realpath_review.py in as the w3 guard when implementing."
+- summary: "Reproducing failing tests were captured during review under scratchpad/review-failing-tests/"
+  reason: "Staged locally (uncommitted); fold test_plan_capture_cli_realpath_review.py in as the w3 guard when implementing."

--- a/_project/TODO/main/planning/fix-multistream-throughput-plan-attachment.yaml
+++ b/_project/TODO/main/planning/fix-multistream-throughput-plan-attachment.yaml
@@ -1,0 +1,109 @@
+id: fix-multistream-throughput-plan-attachment
+title: "Attach captured plans to multi-stream throughput/combined rows (and reconcile the console count)"
+worktree: main
+priority: High
+status: Not Started
+description: |
+  In any TPC throughput run with >= 2 streams (and in combined mode), every query
+  is captured (EXPLAINed, cost paid, counted) but ZERO plans are attached to result
+  rows.
+
+  Root cause: the inline chokepoint sets `_plan_capture_key` on the recorded dict,
+  but the TPC row converters rebuild rows WITHOUT it:
+    - benchbox/core/tpch/platform_power.py:25  (_power_query_result)
+    - benchbox/platforms/base/execution.py:315-325, 409-419  (throughput converters)
+  Attachment then falls back to the public query_id, and `_attach_captured_plans`
+  (benchbox/platforms/base/execution.py:1311-1314) maps an id to None whenever it has
+  >= 2 captured variants. Throughput streams are seed-varied by spec
+  (`stream_seed = seed + stream_id*1000 + position`, benchbox/core/tpch/throughput_test.py:221),
+  so every query is multi-variant with >= 2 streams -> all dropped. In combined mode
+  this also strips the power-phase plan for any id that later runs in throughput.
+
+  This is currently documented as a limitation (docs/features/query-plan-analysis.md:157)
+  and asserted-as-intended in a test (tests/integration/test_plan_capture_combined_divergence.py:213),
+  but seed variation is the NORMAL multi-stream configuration, not an edge case, and
+  the sibling test `test_standard_path_exact_key_attaches_each_variant` proves the
+  converters COULD carry the key and get per-variant fidelity.
+
+  Secondary reporting defect: the console summary (benchbox/platforms/base/result_capture.py:1744)
+  prints `self.query_plans_captured` (the per-variant counter) e.g. "Query plans: 88/88
+  captured", while the bundle's row-derived count (compute_plan_capture_stats,
+  benchbox/core/results/schema.py:940) is 0 and build_plans_payload writes no
+  .plans.json. The console claims success the artifact contradicts.
+
+  Related serialization defect: build_plans_payload (benchbox/core/results/schema.py:1028,1050)
+  keys plans_by_query by public query_id, so even when attachment succeeds, multiple
+  stream rows for one id collapse to a single last-writer-wins entry - contradicting
+  capture_query_plan's "one plan per (query_id, stream_id)" docstring.
+
+category: Core Functionality
+
+metadata:
+  tags: [query-plans, throughput, combined, tpc, stats]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  source_review: "Query-plan-capture adversarial review (2026-07-04)"
+
+impact:
+  user_impact: |
+    Standard multi-stream TPC-H/TPC-DS throughput and combined runs with
+    --capture-plans produce bundles with no plans, despite paying full EXPLAIN cost,
+    while the console reports a positive capture count.
+
+must_preserve:
+  - "The isolated post-measurement capture contract: no EXPLAIN in the timed loop or a concurrent stream; writes never re-executed."
+  - "Per-variant fidelity for rows that already carry an exact _plan_capture_key (test_standard_path_exact_key_attaches_each_variant must stay green)."
+  - "query_plans_captured and the bundle plans_captured must agree after the fix."
+
+approach: |
+  Propagate `_plan_capture_key` through _power_query_result and the throughput
+  converters (it already exists on the inline-recorded dict), so multi-variant rows
+  attach by exact key instead of falling through the lossy public-id path. Where a row
+  must be keyed for serialization, use the capture key (or (query_id, stream_id)) so
+  per-stream provenance survives build_plans_payload. Reconcile the console summary to
+  the same row-derived count used for the bundle (compute_plan_capture_stats).
+
+anti_patterns:
+  - "DO NOT relax the public-id fallback to 'attach any variant' - because it pairs a row with another stream's plan - carry the exact key instead."
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/tpch/platform_power.py"
+    - "benchbox/platforms/base/execution.py"
+    - "benchbox/platforms/base/result_capture.py"
+    - "benchbox/core/results/schema.py"
+    - "tests/integration/test_plan_capture_combined_divergence.py"
+    - "tests/unit/platforms/"
+    - "docs/features/query-plan-analysis.md"
+
+work:
+  - id: w1
+    summary: "Carry _plan_capture_key through _power_query_result and the TPC-H/TPC-DS throughput converters"
+    status: pending
+  - id: w2
+    summary: "Key build_plans_payload entries so per-stream/per-variant provenance survives (not last-writer-wins on query_id)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Reconcile the console 'Query plans: N/M' summary with the row-derived bundle count"
+    status: pending
+    needs: [w1]
+  - id: w4
+    summary: "Update the divergence test (line 213) and docs so multi-stream rows attach; keep the truly-ambiguous (no-key) case as the only unattached path"
+    status: pending
+    needs: [w1]
+
+verification:
+  - description: "A 2-stream throughput run attaches a plan to every successful row"
+    command: "uv run -- python -m pytest tests/unit/platforms/ tests/integration/ -k 'throughput and plan' -n 0 -q"
+    expected_output: "passed"
+  - description: "Existing exact-key and combined-divergence tests stay green"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
+    expected_output: "passed"
+
+deps:
+  needs: [fix-plan-consumption-phases-and-loader-reattach]
+
+deferred:
+  - summary: "Reproducing failing test captured under scratchpad/review-failing-tests/test_plan_attach_multivariant_review.py"
+    reason: "Staged locally (uncommitted); fold in as a w1 guard when implementing."

--- a/_project/TODO/main/planning/fix-plan-consumption-phases-and-loader-reattach.yaml
+++ b/_project/TODO/main/planning/fix-plan-consumption-phases-and-loader-reattach.yaml
@@ -1,0 +1,112 @@
+id: fix-plan-consumption-phases-and-loader-reattach
+title: "Fix broken plan-consumption surface (BenchmarkResults.phases + loader plan reattachment)"
+worktree: main
+priority: Critical
+status: Not Started
+description: |
+  Adversarial review of the query-plan-capture subsystem found the entire
+  read/consume side is non-functional on real exported bundles. Two layered
+  defects:
+
+  1. `.phases` does not exist. `BenchmarkResults` (benchbox/core/results/models.py:312)
+     exposes `execution_phases: ExecutionPhases` and `query_results: list`, NOT a
+     `phases` dict-of-`.queries`. Six consumers iterate `results.phases`:
+       - benchbox/cli/commands/show_plan.py:89          (crash -> exit 1)
+       - benchbox/cli/commands/compare_plans.py:76,128  (crash)
+       - benchbox/core/query_plans/comparison.py:758    (crash; compare-plans --summary)
+       - benchbox/cli/commands/compare.py:1227          (crash; `compare --include-plans`, the recommended path)
+       - benchbox/core/manifest/plan_metadata_utils.py:50  (getattr default {} -> SILENT empty metadata)
+       - benchbox/core/query_plans/history.py:97           (getattr default {} -> SILENT empty history)
+     The CLI paths raise AttributeError, which the bare `except Exception` swallows
+     into "Error: 'BenchmarkResults' object has no attribute 'phases'" + exit 1, so
+     the plan is never shown/compared. The metadata/history paths silently record
+     nothing.
+
+  2. Plans are never reattached from the `.plans.json` companion. `load_result_file`
+     -> `reconstruct_benchmark_results` (benchbox/core/results/loader.py:208) calls
+     `_reconstruct_query_results(data["queries"], data["errors"])` WITHOUT plans_data;
+     `_extract_plans_info` (loader.py:426) reads only integer counts. So even after
+     fixing #1, every `query_plan` is None after a load.
+
+  Reproduced end-to-end (real DuckDB run -> real ResultExporter bundle -> real
+  load_result_file -> real CLI): `has .phases attr: False`; show-plan and
+  compare-plans exit 1 with the AttributeError; loaded query_results carry no plan.
+
+  Existing coverage tests hide this: tests/unit/cli/commands/test_show_plan_coverage.py:35
+  (and test_compare_plans_coverage.py) monkeypatch `load_result_file` to return a
+  hand-built object with a fabricated `.phases` dict; tests/integration/test_plan_capture_e2e.py
+  deliberately bypasses `load_result_file` and reads `.plans.json` directly via
+  `QueryPlanDAG.from_dict`. Neither exercises the real CLI path.
+
+category: Core Functionality
+
+metadata:
+  tags: [query-plans, results-loader, cli, correctness]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  source_review: "Query-plan-capture adversarial review (2026-07-04)"
+
+impact:
+  user_impact: |
+    `benchbox show-plan`, `compare-plans`, and `compare --include-plans` all fail
+    on any real exported bundle; plan history and cross-run plan-version tracking
+    silently produce nothing. Captured plans are unreadable after a run completes.
+  technical_debt: |
+    Two independent consumers rely on getattr defaults that mask the same bug,
+    turning a crash into silent data loss.
+
+must_preserve:
+  - "Bundles that legitimately have no plans still load and render without error."
+  - "The .plans.json companion file format is unchanged (loader adapts to it, not vice versa)."
+  - "Non-plan fields of reconstruct_benchmark_results keep their current values."
+
+approach: |
+  Introduce a single accessor that walks execution over `execution_phases` and/or
+  `query_results` (whichever the CLI needs), and repoint all six `.phases` consumers
+  at it. In the loader, thread `plans_data` into `_reconstruct_query_results` so each
+  query result is rehydrated with its `query_plan` (QueryPlanDAG.from_dict) and
+  `plan_fingerprint` keyed off the `.plans.json` companion. Re-point the coverage
+  tests at the real reconstructed object (delete the fabricated `.phases` fake) and
+  add a real bundle round-trip test.
+
+anti_patterns:
+  - "DO NOT add a `phases` compatibility property that fabricates the old shape - because it hides which real field (execution_phases vs query_results) each consumer needs - repoint consumers explicitly."
+  - "DO NOT rely on getattr(results, 'phases', {}) defaults anywhere - because they convert a hard error into silent empty output."
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/loader.py"
+    - "benchbox/cli/commands/show_plan.py"
+    - "benchbox/cli/commands/compare_plans.py"
+    - "benchbox/cli/commands/compare.py"
+    - "benchbox/core/query_plans/comparison.py"
+    - "benchbox/core/manifest/plan_metadata_utils.py"
+    - "benchbox/core/query_plans/history.py"
+    - "tests/unit/cli/commands/test_show_plan_coverage.py"
+    - "tests/unit/cli/commands/test_compare_plans_coverage.py"
+    - "tests/integration/"
+
+work:
+  - id: w1
+    summary: "Thread plans_data into _reconstruct_query_results so query_plan/plan_fingerprint are rehydrated on load"
+    status: pending
+  - id: w2
+    summary: "Repoint the 6 results.phases consumers at execution_phases/query_results (no fabricated phases shim)"
+    status: pending
+    needs: [w1]
+  - id: w3
+    summary: "Replace the mocked load_result_file in show/compare coverage tests with the real reconstructed object; add a real DuckDB bundle -> load_result_file -> show-plan/compare-plans round-trip test"
+    status: pending
+    needs: [w2]
+
+verification:
+  - description: "show-plan renders a plan from a real exported DuckDB bundle (exit 0)"
+    command: "uv run -- python -m pytest tests/integration/ -k 'plan and (show or compare or realpath)' -n 0 -q"
+    expected_output: "passed"
+  - description: "Full plan suites stay green"
+    command: "uv run -- python -m pytest tests/unit/cli/commands/ tests/unit/core/results/ tests/integration/ -k plan -n 0 -q"
+    expected_output: "passed"
+
+deferred:
+  - summary: "Reproducing failing tests were captured during review under scratchpad/review-failing-tests/"
+    reason: "Staged locally (uncommitted); fold test_plan_capture_cli_realpath_review.py in as the w3 guard when implementing."

--- a/_project/TODO/main/planning/harden-is-dml-query-replace-upsert.yaml
+++ b/_project/TODO/main/planning/harden-is-dml-query-replace-upsert.yaml
@@ -1,0 +1,56 @@
+id: harden-is-dml-query-replace-upsert
+title: "Defensively cover REPLACE INTO / UPSERT INTO in is_dml_query"
+worktree: main
+priority: Low
+status: Not Started
+description: |
+  `is_dml_query` (benchbox/platforms/base/result_capture.py:196; leading-verb regex
+  `_DML_LEADING_RE` at :82) guards EXPLAIN-ANALYZE plan capture against re-executing a
+  write. It covers INSERT/UPDATE/DELETE/MERGE/COPY (incl. CTE-prefixed), CTAS,
+  CREATE MATERIALIZED VIEW, and SELECT...INTO, but returns False for a bare
+  `REPLACE INTO ...` (MySQL/SingleStore/Doris family) and a bare `UPSERT INTO ...`.
+
+  Not currently exploitable: the three ANALYZE-capturing adapters (DuckDB, MotherDuck,
+  PostgreSQL) do not emit those forms, the MySQL-family adapters use plain non-ANALYZE
+  EXPLAIN, and no workload emits a bare REPLACE/UPSERT (the only occurrence is
+  `INSERT OR REPLACE INTO`, caught via the leading INSERT). This is a latent gap: if a
+  future ANALYZE-capturing engine or workload emits `REPLACE INTO`/`UPSERT INTO`, the
+  statement would be physically re-executed during capture, mutating data twice.
+
+  Add REPLACE and UPSERT to the leading-verb set so the guard is robust by construction.
+
+category: Core Functionality
+
+metadata:
+  tags: [query-plans, dml-guard, defensive, sql-dialects]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  source_review: "Query-plan-capture adversarial review (2026-07-04)"
+
+impact:
+  user_impact: |
+    None today; prevents a future double-mutation-during-capture regression if an
+    ANALYZE engine ever runs REPLACE/UPSERT.
+
+must_preserve:
+  - "No read statement (plain SELECT, CREATE VIEW, plain CREATE TABLE, TRUNCATE) starts returning True."
+  - "All currently-caught write shapes stay caught."
+
+approach: |
+  Extend `_DML_LEADING_RE` to include REPLACE and UPSERT as leading verbs; add both
+  (and lowercase/comment-prefixed variants) to the is_dml_query unit corpus.
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/result_capture.py"
+    - "tests/unit/platforms/"
+
+work:
+  - id: w1
+    summary: "Add REPLACE/UPSERT to _DML_LEADING_RE and extend the is_dml_query test corpus (incl. lowercase + comment-prefixed)"
+    status: pending
+
+verification:
+  - description: "is_dml_query tests pass, including new REPLACE/UPSERT cases and unchanged read/DDL cases"
+    command: "uv run -- python -m pytest tests/unit/platforms/ -k 'dml or plan_capture' -n 0 -q"
+    expected_output: "passed"

--- a/_project/TODO/main/planning/harden-normalized-plan-fingerprint.yaml
+++ b/_project/TODO/main/planning/harden-normalized-plan-fingerprint.yaml
@@ -1,0 +1,89 @@
+id: harden-normalized-plan-fingerprint
+title: "Harden normalized plan fingerprint: literal-masking gaps + cross-mode mixing marker"
+worktree: main
+priority: Medium
+status: Not Started
+description: |
+  The opt-in literal-normalized fingerprint (masks numeric/string literals for
+  seed-independent comparison) has correctness gaps. It is currently API-only - the
+  `--normalize-plan-literals` CLI flag is NOT shipped (docs correctly call it
+  "planned", docs/features/query-plan-analysis.md:661) - so impact is limited to API
+  callers, but these must be fixed before the flag ships.
+
+  1. Literal masking is wrong for several literal forms (benchbox/core/results/query_plan_models.py):
+     - `_LITERAL_NUM_RE = \b\d+(?:\.\d+)?\b` (line 123) misses scientific (1e5),
+       hex (0xFF), leading/trailing-dot (.5, 5.), underscore (1_000), and CORRUPTS
+       1.2E-3 into `<NUM>.2E-<NUM>`.  -> false "plan changed" when a seed emits 1e2
+       vs 100, or any hex/scientific threshold.
+     - `_LITERAL_STR_RE = '[^']*'` (line 124) does not understand SQL '' escaping, so
+       `'O''Brien'` masks to `<STR><STR>` (two tokens) instead of one. -> false "changed",
+       latent collision risk.
+     Verified clean and must stay so: digit-bearing identifiers (col_5, revenue_2024,
+     t1.col_5) are NOT masked; NULL/TRUE/FALSE/DATE literals behave correctly.
+
+  2. Cross-run mode mixing (reproduced). `update_plan_versions`
+     (benchbox/core/manifest/plan_metadata_utils.py:64) and `PlanMetadata.plan_fingerprints`
+     carry NO normalized-vs-literal marker. A run recorded with normalize_literals=False
+     compared to one with True yields different fingerprints for the same plan ->
+     false "version changed" on EVERY query; merge_plan_metadata silently mixes schemes.
+     The docstring's "never silently mixes" (plan_metadata_utils.py:44-48) holds only
+     within a single create_plan_metadata_from_results call, not across runs.
+
+category: Core Functionality
+
+metadata:
+  tags: [query-plans, fingerprint, normalization, manifest]
+  estimated_effort: "Medium"
+  created_date: "2026-07-04"
+  source_review: "Query-plan-capture adversarial review (2026-07-04)"
+
+impact:
+  user_impact: |
+    API users of normalized fingerprints (and any future --normalize-plan-literals
+    run) get spurious plan-version regressions from scientific/hex/escaped-quote
+    literals and from toggling the normalization mode between runs.
+
+must_preserve:
+  - "The default literal-sensitive plan_fingerprint is unchanged (normalization stays opt-in)."
+  - "Digit-bearing identifiers and NULL/boolean/DATE handling stay correct."
+  - "The structural fingerprint continues to exclude cost/cardinality/timing."
+
+approach: |
+  Broaden the numeric mask to a single well-formed SQL-numeric-literal regex
+  (integer/decimal/scientific/hex, with sign) that masks the whole token atomically;
+  make the string mask escaped-quote aware ('' inside a literal). Tag PlanMetadata
+  with the normalization mode (a scheme field) and make update_plan_versions /
+  merge_plan_metadata refuse or flag a cross-mode comparison instead of blindly
+  diffing fingerprints.
+
+anti_patterns:
+  - "DO NOT mask digit runs adjacent to identifier characters - because it corrupts columns like col_5 - keep the identifier-boundary guard."
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/query_plan_models.py"
+    - "benchbox/core/manifest/plan_metadata_utils.py"
+    - "benchbox/core/manifest/models.py"
+    - "tests/unit/core/query_plans/test_fingerprint_normalization.py"
+    - "tests/unit/core/manifest/"
+
+work:
+  - id: w1
+    summary: "Rewrite _LITERAL_NUM_RE/_LITERAL_STR_RE to atomically mask scientific/hex/dotted/underscore numerics and escaped-quote strings"
+    status: pending
+  - id: w2
+    summary: "Add a normalization-mode marker to PlanMetadata; make update_plan_versions/merge_plan_metadata reject or flag cross-mode comparison"
+    status: pending
+  - id: w3
+    summary: "Extend test_fingerprint_normalization.py with the adversarial literal corpus and a cross-mode-mixing regression"
+    status: pending
+    needs: [w1, w2]
+
+verification:
+  - description: "Normalization + manifest suites green with the new adversarial corpus"
+    command: "uv run -- python -m pytest tests/unit/core/query_plans/test_fingerprint_normalization.py tests/unit/core/manifest/ -n 0 -q"
+    expected_output: "passed"
+
+deferred:
+  - summary: "Shipping the --normalize-plan-literals CLI flag and surfacing the normalized fingerprint in the bundle"
+    reason: "Separate feature work; this TODO only hardens the underlying API so the flag is safe to ship."

--- a/_project/TODO/main/planning/test-real-combined-plan-capture-checkpoint.yaml
+++ b/_project/TODO/main/planning/test-real-combined-plan-capture-checkpoint.yaml
@@ -1,0 +1,68 @@
+id: test-real-combined-plan-capture-checkpoint
+title: "Cover the real combined power->maintenance plan-capture checkpoint call site"
+worktree: main
+priority: Medium
+status: Not Started
+description: |
+  The post-measurement divergence fix depends on `_plan_capture_checkpoint(connection)`
+  firing at the top of `_execute_tpch_maintenance_test` (benchbox/platforms/base/execution.py:537)
+  and `_execute_tpcds_maintenance_test` (:445), so read-phase plans are captured against
+  pre-mutation data state. But tests/integration/test_plan_capture_combined_divergence.py
+  drives `_plan_capture_checkpoint` / `_capture_plans_post_measurement` BY HAND and never
+  routes through the production call site.
+
+  Proof of the blind spot: deleting the checkpoint call at execution.py:537 - i.e. fully
+  reverting the fix - leaves all of that file's tests green, because no test runs a real
+  `_execute_combined_test` -> `_execute_tpch_maintenance_test` lifecycle under
+  capture_plans=True. The slow regression guard (`test_real_tpch_power_capture_attaches_plans`)
+  runs power-only with a read-only query_subset and never reaches the checkpoint.
+
+  Add a real (DuckDB, in-memory or file-based, no external services) combined
+  power->maintenance run with --capture-plans that asserts a read-phase plan reflects
+  PRE-mutation cardinality (i.e. the checkpoint fired before the maintenance mutation),
+  so removing/reordering the checkpoint call actually fails a test.
+
+category: Testing & Quality
+
+metadata:
+  tags: [query-plans, testing, combined, maintenance, false-pass]
+  estimated_effort: "Small"
+  created_date: "2026-07-04"
+  source_review: "Query-plan-capture adversarial review (2026-07-04)"
+
+impact:
+  maintainer_impact: |
+    The divergence fix's production wiring is currently untested; a regression that
+    drops or misorders the checkpoint would ship green.
+
+must_preserve:
+  - "The test must exercise the real _execute_combined_test / _execute_*_maintenance_test path, not hand-built buffers."
+  - "No external services; DuckDB only; keep it in the fast/integration lane if runtime allows, else mark slow."
+
+approach: |
+  Build a minimal combined run whose maintenance phase measurably changes a table's
+  cardinality, capture a read query in the power/throughput phase, and assert the
+  captured plan (or a proxy such as an estimate visible only pre-mutation) reflects the
+  pre-mutation state. Use the existing spy pattern from the divergence test but wire it
+  through the real driver entry point rather than calling the checkpoint directly.
+
+scope_limit:
+  only_modify:
+    - "tests/integration/test_plan_capture_combined_divergence.py"
+    - "tests/integration/"
+
+work:
+  - id: w1
+    summary: "Add a real combined power->maintenance capture test that fails if the checkpoint call site is removed or reordered"
+    status: pending
+
+verification:
+  - description: "New test passes with the checkpoint in place"
+    command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
+    expected_output: "passed"
+  - description: "New test FAILS when the checkpoint call at execution.py:537 is temporarily removed (manual mutation check during implementation)"
+    command: "# temporarily delete the checkpoint call, run the new test, confirm it fails, then restore"
+    expected_output: "the new test fails"
+
+deps:
+  needs: [fix-multistream-throughput-plan-attachment]

--- a/benchbox/cli/commands/compare.py
+++ b/benchbox/cli/commands/compare.py
@@ -32,6 +32,7 @@ from benchbox.core.results.exporter import ResultExporter
 from benchbox.core.results.loader import (
     ResultLoadError,
     UnsupportedSchemaError,
+    iter_query_results,
     load_result_file,
 )
 
@@ -1224,9 +1225,10 @@ def _check_regression_threshold(comparison: dict[str, Any], regression_threshold
 def _build_execution_map(results: Any) -> dict[str, Any]:
     """Collect the first execution per query ID across all phases."""
     execution_map: dict[str, Any] = {}
-    for phase_results in results.phases.values():
-        for execution in phase_results.queries:
-            execution_map.setdefault(execution.query_id, execution)
+    for execution in iter_query_results(results):
+        query_id = execution.get("query_id")
+        if query_id is not None:
+            execution_map.setdefault(query_id, execution)
     return execution_map
 
 
@@ -1280,8 +1282,8 @@ def _compare_plans(
         baseline_exec = baseline_map[query_id]
         current_exec = current_map[query_id]
 
-        baseline_plan = getattr(baseline_exec, "query_plan", None)
-        current_plan = getattr(current_exec, "query_plan", None)
+        baseline_plan = baseline_exec.get("query_plan")
+        current_plan = current_exec.get("query_plan")
 
         if not baseline_plan or not current_plan:
             continue
@@ -1295,8 +1297,8 @@ def _compare_plans(
             continue
 
         # Get performance change for this query
-        baseline_time = getattr(baseline_exec, "execution_time_ms", 0.0) or 0.0
-        current_time = getattr(current_exec, "execution_time_ms", 0.0) or 0.0
+        baseline_time = baseline_exec.get("execution_time_ms", 0.0) or 0.0
+        current_time = current_exec.get("execution_time_ms", 0.0) or 0.0
         perf_change_pct = 0.0
         if baseline_time > 0:
             perf_change_pct = ((current_time - baseline_time) / baseline_time) * 100

--- a/benchbox/cli/commands/compare_plans.py
+++ b/benchbox/cli/commands/compare_plans.py
@@ -9,6 +9,7 @@ from benchbox.cli.shared import console
 from benchbox.core.query_plans.comparison import compare_query_plans, generate_plan_comparison_summary
 from benchbox.core.query_plans.visualization import render_comparison
 from benchbox.core.results.loader import iter_query_results, load_result_file
+from benchbox.core.results.query_normalizer import normalize_query_id
 
 
 @click.command("compare-plans", hidden=True, deprecated=True)
@@ -125,7 +126,18 @@ def _emit_comparisons(comparisons, output_format, output_file, explicit_query_id
 
 
 def _find_query_execution(results, query_id: str):
-    return next((qr for qr in iter_query_results(results) if qr.get("query_id") == query_id), None)
+    """Find a query result whose ID matches after normalization.
+
+    ``load_result_file`` returns already-normalized IDs from a real bundle's
+    compact ``queries[].id`` field (e.g. ``q05``/``Q05`` -> ``05``), so a raw
+    string comparison against the CLI's documented ``--query-id q05`` input
+    would report "not found" even when the plan is present.
+    """
+    normalized_target = normalize_query_id(query_id)
+    return next(
+        (qr for qr in iter_query_results(results) if normalize_query_id(qr.get("query_id", "")) == normalized_target),
+        None,
+    )
 
 
 def _output_text(comparisons: list, single_query: bool, return_string: bool = False) -> str | None:

--- a/benchbox/cli/commands/compare_plans.py
+++ b/benchbox/cli/commands/compare_plans.py
@@ -8,7 +8,7 @@ import click
 from benchbox.cli.shared import console
 from benchbox.core.query_plans.comparison import compare_query_plans, generate_plan_comparison_summary
 from benchbox.core.query_plans.visualization import render_comparison
-from benchbox.core.results.loader import load_result_file
+from benchbox.core.results.loader import iter_query_results, load_result_file
 
 
 @click.command("compare-plans", hidden=True, deprecated=True)
@@ -73,7 +73,7 @@ def _run_summary_mode(
 
 
 def _collect_query_ids(results) -> set[str]:
-    return {execution.query_id for phase in results.phases.values() for execution in phase.queries}
+    return {str(qr["query_id"]) for qr in iter_query_results(results) if qr.get("query_id") is not None}
 
 
 def _resolve_query_ids(query_id: str | None, results1, results2, ctx) -> list[str]:
@@ -96,8 +96,8 @@ def _build_comparisons(
         if not exec1 or not exec2:
             _warn_if_explicit(explicit_query_id, f"Query '{qid}' not found in both runs")
             continue
-        plan1 = getattr(exec1, "query_plan", None)
-        plan2 = getattr(exec2, "query_plan", None)
+        plan1 = exec1.get("query_plan")
+        plan2 = exec2.get("query_plan")
         if not plan1 or not plan2:
             _warn_if_explicit(explicit_query_id, f"Query '{qid}' missing plan in one or both runs")
             continue
@@ -125,7 +125,7 @@ def _emit_comparisons(comparisons, output_format, output_file, explicit_query_id
 
 
 def _find_query_execution(results, query_id: str):
-    return next((e for phase in results.phases.values() for e in phase.queries if e.query_id == query_id), None)
+    return next((qr for qr in iter_query_results(results) if qr.get("query_id") == query_id), None)
 
 
 def _output_text(comparisons: list, single_query: bool, return_string: bool = False) -> str | None:

--- a/benchbox/cli/commands/show_plan.py
+++ b/benchbox/cli/commands/show_plan.py
@@ -14,7 +14,7 @@ from benchbox.core.query_plans.visualization import (
     render_plan,
     render_summary,
 )
-from benchbox.core.results.loader import load_result_file
+from benchbox.core.results.loader import iter_query_results, load_result_file
 
 
 @click.command("show-plan")
@@ -85,26 +85,22 @@ def show_plan(
         results, _ = load_result_file(run_path)
 
         # Find query execution
-        query_exec = None
-        for phase_name, phase_results in results.phases.items():
-            for exec_result in phase_results.queries:
-                if exec_result.query_id == query_id:
-                    query_exec = exec_result
-                    break
-            if query_exec:
-                break
+        query_exec = next(
+            (qr for qr in iter_query_results(results) if qr.get("query_id") == query_id),
+            None,
+        )
 
         if not query_exec:
             console.print(f"[red]Error:[/red] Query '{query_id}' not found in results")
             ctx.exit(1)
 
         # Check if plan was captured
-        if not hasattr(query_exec, "query_plan") or query_exec.query_plan is None:
+        if query_exec.get("query_plan") is None:
             console.print(f"[yellow]Warning:[/yellow] No query plan captured for query '{query_id}'")
             console.print("Run benchmark with --capture-plans flag to capture query plans")
             ctx.exit(1)
 
-        plan = query_exec.query_plan
+        plan = query_exec["query_plan"]
 
         # Handle different output formats
         if output_format == "json":

--- a/benchbox/cli/commands/show_plan.py
+++ b/benchbox/cli/commands/show_plan.py
@@ -15,6 +15,22 @@ from benchbox.core.query_plans.visualization import (
     render_summary,
 )
 from benchbox.core.results.loader import iter_query_results, load_result_file
+from benchbox.core.results.query_normalizer import normalize_query_id
+
+
+def _find_query(results, query_id: str):
+    """Find a query result whose ID matches after normalization.
+
+    ``load_result_file`` returns already-normalized IDs from a real bundle's
+    compact ``queries[].id`` field (e.g. ``q05``/``Q05`` -> ``05``), so a raw
+    string comparison against the CLI's documented ``--query-id q05`` input
+    would report "not found" even when the plan is present.
+    """
+    normalized_target = normalize_query_id(query_id)
+    return next(
+        (qr for qr in iter_query_results(results) if normalize_query_id(qr.get("query_id", "")) == normalized_target),
+        None,
+    )
 
 
 @click.command("show-plan")
@@ -85,10 +101,7 @@ def show_plan(
         results, _ = load_result_file(run_path)
 
         # Find query execution
-        query_exec = next(
-            (qr for qr in iter_query_results(results) if qr.get("query_id") == query_id),
-            None,
-        )
+        query_exec = _find_query(results, query_id)
 
         if not query_exec:
             console.print(f"[red]Error:[/red] Query '{query_id}' not found in results")

--- a/benchbox/core/manifest/plan_metadata_utils.py
+++ b/benchbox/core/manifest/plan_metadata_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from benchbox.core.manifest.models import PlanMetadata
+from benchbox.core.results.loader import iter_query_results
 
 
 def create_plan_metadata_from_results(
@@ -47,16 +48,15 @@ def create_plan_metadata_from_results(
     # comparison this option exists for (a plan lacking the normalized property is
     # skipped rather than recorded under the wrong scheme).
     attr = "normalized_fingerprint" if normalize_literals else "plan_fingerprint"
-    for phase_results in getattr(results, "phases", {}).values():
-        for execution in phase_results.queries:
-            plan = getattr(execution, "query_plan", None)
-            fingerprint = getattr(plan, attr, None) if plan is not None else None
-            if fingerprint:
-                query_id = execution.query_id
-                if query_id not in metadata.plan_fingerprints:
-                    metadata.plan_fingerprints[query_id] = fingerprint
-                    metadata.plan_capture_timestamp[query_id] = timestamp
-                    metadata.plan_versions[query_id] = 1  # Default to version 1
+    for execution in iter_query_results(results):
+        plan = execution.get("query_plan")
+        fingerprint = getattr(plan, attr, None) if plan is not None else None
+        if fingerprint:
+            query_id = execution.get("query_id")
+            if query_id not in metadata.plan_fingerprints:
+                metadata.plan_fingerprints[query_id] = fingerprint
+                metadata.plan_capture_timestamp[query_id] = timestamp
+                metadata.plan_versions[query_id] = 1  # Default to version 1
 
     return metadata
 

--- a/benchbox/core/query_plans/comparison.py
+++ b/benchbox/core/query_plans/comparison.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from benchbox.core.results.loader import iter_query_results
 from benchbox.core.results.query_plan_models import (
     LogicalOperator,
     LogicalOperatorType,
@@ -755,9 +756,10 @@ class PlanComparisonSummary:
 def _build_execution_map(results: Any) -> dict[str, Any]:
     """Collect the first execution per query ID across all phases."""
     execution_map: dict[str, Any] = {}
-    for phase_results in results.phases.values():
-        for execution in phase_results.queries:
-            execution_map.setdefault(execution.query_id, execution)
+    for execution in iter_query_results(results):
+        query_id = execution.get("query_id")
+        if query_id is not None:
+            execution_map.setdefault(query_id, execution)
     return execution_map
 
 
@@ -800,8 +802,8 @@ def generate_plan_comparison_summary(
         baseline_exec = baseline_map[query_id]
         current_exec = current_map[query_id]
 
-        baseline_plan = getattr(baseline_exec, "query_plan", None)
-        current_plan = getattr(current_exec, "query_plan", None)
+        baseline_plan = baseline_exec.get("query_plan")
+        current_plan = current_exec.get("query_plan")
 
         # Skip if either run doesn't have a plan
         if not baseline_plan or not current_plan:
@@ -847,8 +849,8 @@ def generate_plan_comparison_summary(
         structural_differences.append(change)
 
         # Calculate performance correlation
-        baseline_time = getattr(baseline_exec, "execution_time_ms", 0.0) or 0.0
-        current_time = getattr(current_exec, "execution_time_ms", 0.0) or 0.0
+        baseline_time = baseline_exec.get("execution_time_ms", 0.0) or 0.0
+        current_time = current_exec.get("execution_time_ms", 0.0) or 0.0
 
         if baseline_time > 0:
             perf_change_pct = ((current_time - baseline_time) / baseline_time) * 100

--- a/benchbox/core/query_plans/history.py
+++ b/benchbox/core/query_plans/history.py
@@ -13,6 +13,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from benchbox.core.results.loader import iter_query_results
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,16 +96,15 @@ class PlanHistory:
         }
 
         # Extract plan fingerprints from all phases
-        for phase_results in getattr(results, "phases", {}).values():
-            for execution in phase_results.queries:
-                plan = getattr(execution, "query_plan", None)
-                if plan and hasattr(plan, "plan_fingerprint") and plan.plan_fingerprint:
-                    query_id = execution.query_id
-                    history_entry["plan_fingerprints"][query_id] = {
-                        "fingerprint": plan.plan_fingerprint,
-                        "estimated_cost": getattr(plan, "estimated_cost", None),
-                        "execution_time_ms": getattr(execution, "execution_time_ms", 0.0) or 0.0,
-                    }
+        for execution in iter_query_results(results):
+            plan = execution.get("query_plan")
+            if plan and hasattr(plan, "plan_fingerprint") and plan.plan_fingerprint:
+                query_id = execution.get("query_id")
+                history_entry["plan_fingerprints"][query_id] = {
+                    "fingerprint": plan.plan_fingerprint,
+                    "estimated_cost": getattr(plan, "estimated_cost", None),
+                    "execution_time_ms": execution.get("execution_time_ms", 0.0) or 0.0,
+                }
 
         # Write to storage
         history_file = self.storage_path / f"{run_id}.json"

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -23,6 +23,8 @@ from benchbox.core.results.models import (
     NativeComparisonEntry,
     SetupPhase,
 )
+from benchbox.core.results.query_normalizer import normalize_query_id
+from benchbox.core.results.query_plan_models import QueryPlanDAG
 from benchbox.core.results.schema_policy import LOADER_SCHEMA_POLICY, is_loader_supported_result_schema
 
 logger = logging.getLogger(__name__)
@@ -205,7 +207,7 @@ def reconstruct_benchmark_results(
     execution_section = data.get("execution", {})
 
     timestamp = _parse_timestamp(run_section.get("timestamp", ""))
-    query_results = _reconstruct_query_results(data.get("queries", []), data.get("errors", []))
+    query_results = _reconstruct_query_results(data.get("queries", []), data.get("errors", []), plans_data)
 
     timing = _extract_timing_metrics(summary_section)
     tpc = _extract_tpc_metrics(summary_section)
@@ -433,6 +435,7 @@ def _extract_plans_info(plans_data: dict[str, Any] | None) -> tuple[int, int]:
 def _reconstruct_query_results(
     queries_list: list[dict[str, Any]],
     errors_list: list[dict[str, Any]],
+    plans_data: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Reconstruct query results from compact v2.0 format.
 
@@ -441,13 +444,26 @@ def _reconstruct_query_results(
 
     To internal format:
         {"query_id": "Q1", "execution_time_ms": 632.9, "rows_returned": 100, "status": "SUCCESS"}
+
+    When ``plans_data`` (the loaded ``.plans.json`` companion) carries an entry for a
+    query ID, rehydrate ``query_plan`` as a real ``QueryPlanDAG`` plus its fingerprint
+    fields, so plans survive a load -> show-plan/compare-plans round-trip.
+
+    ``build_plans_payload`` keys its ``queries`` map by the raw, pre-normalization
+    query ID (e.g. ``"q1"``), while the compact ``queries`` list here carries the
+    already-normalized ID (e.g. ``"1"``) written by ``_build_query_results_section``.
+    Normalize both sides for the lookup so the two companion files agree without
+    changing the on-disk ``.plans.json`` format.
     """
+    raw_plan_entries: dict[str, Any] = (plans_data or {}).get("queries") or {}
+    plan_entries: dict[str, Any] = {normalize_query_id(k): v for k, v in raw_plan_entries.items()}
     results: list[dict[str, Any]] = []
 
     # Process successful queries
     for q in queries_list:
+        query_id = q.get("id")
         result: dict[str, Any] = {
-            "query_id": q.get("id"),
+            "query_id": query_id,
             "execution_time_ms": q.get("ms"),
             "rows_returned": q.get("rows"),
             "status": "SUCCESS",
@@ -456,6 +472,7 @@ def _reconstruct_query_results(
             result["iteration"] = q["iter"]
         if q.get("stream"):
             result["stream_id"] = q["stream"]
+        _attach_plan(result, plan_entries.get(normalize_query_id(query_id)) if query_id is not None else None)
         results.append(result)
 
     # Add failed queries from errors
@@ -471,6 +488,37 @@ def _reconstruct_query_results(
             )
 
     return results
+
+
+def _attach_plan(result: dict[str, Any], plan_entry: dict[str, Any] | None) -> None:
+    """Rehydrate a ``.plans.json`` entry onto a reconstructed query result dict."""
+    if not plan_entry:
+        return
+
+    plan_dict = plan_entry.get("plan")
+    if plan_dict is not None:
+        result["query_plan"] = QueryPlanDAG.from_dict(plan_dict)
+    if plan_entry.get("fingerprint"):
+        result["plan_fingerprint"] = plan_entry["fingerprint"]
+    if plan_entry.get("fingerprint_normalized"):
+        result["plan_fingerprint_normalized"] = plan_entry["fingerprint_normalized"]
+    if plan_entry.get("capture_time_ms") is not None:
+        result["plan_capture_time_ms"] = plan_entry["capture_time_ms"]
+
+
+def iter_query_results(results: Any) -> list[dict[str, Any]]:
+    """Return the flattened per-query result dicts for a ``BenchmarkResults`` instance.
+
+    ``query_results`` is the canonical per-query source: ``ResultBuilder`` populates it
+    identically for freshly executed results and ``reconstruct_benchmark_results``
+    populates it the same way for bundles reloaded from disk (including rehydrated
+    ``query_plan``/``plan_fingerprint`` values from the ``.plans.json`` companion).
+    ``execution_phases`` is not a reliable per-query source once reconstructed from a
+    bundle - only phase-level summaries survive that round-trip - so consumers that
+    need per-query plan/fingerprint data should use this accessor instead of walking
+    ``execution_phases``.
+    """
+    return list(getattr(results, "query_results", None) or [])
 
 
 def _reconstruct_execution_phases(phases_section: dict[str, Any]) -> ExecutionPhases | None:
@@ -543,6 +591,7 @@ def _reconstruct_native_comparison(comparisons_section: dict[str, Any]) -> Nativ
 
 __all__ = [
     "find_latest_result",
+    "iter_query_results",
     "load_result_file",
     "reconstruct_benchmark_results",
     "ResultLoadError",

--- a/tests/integration/test_plan_capture_cli_realpath_review.py
+++ b/tests/integration/test_plan_capture_cli_realpath_review.py
@@ -1,0 +1,165 @@
+"""Real CLI round-trip for the plan-consumption surface (query-plan-capture review).
+
+Covers the gap the mocked coverage tests (``test_show_plan_coverage.py``,
+``test_compare_plans_coverage.py``) and the direct-``QueryPlanDAG.from_dict``
+integration test (``test_plan_capture_e2e.py``) both leave open: neither drives
+a real exported bundle through the real ``load_result_file`` -> CLI command path.
+
+This test runs a real DuckDB workload with ``capture_plans=True``, exports it
+through the production ``ResultExporter`` (``<run>.json`` + ``<run>.plans.json``),
+and invokes the real ``show-plan``, ``compare-plans``, and ``compare
+--include-plans`` Click commands against the on-disk bundle with no mocking of
+``load_result_file``. Before the fix, all three commands crash with
+``AttributeError: 'BenchmarkResults' object has no attribute 'phases'``
+(swallowed by a bare ``except Exception`` into exit code 1).
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.fast,
+    pytest.mark.duckdb,
+]
+
+_QUERIES = [
+    ("1", "SELECT i FROM range(5) t(i) WHERE i > 2"),
+    ("2", "SELECT count(*) AS c FROM range(5) t(i)"),
+]
+# Query IDs are bare numerals (not "q1"/"q2"): the compact export format normalizes
+# IDs (query_normalizer.normalize_query_id strips a leading "Q"/"q"), so a bare
+# numeral round-trips unchanged and keeps this test focused on plan reattachment
+# rather than the separate, pre-existing query-ID-format lookup behavior.
+
+
+def _run_queries(capture_plans: bool) -> dict[str, dict]:
+    """Run _QUERIES through a fresh DuckDB in-memory adapter; return results keyed by query_id."""
+    from benchbox.platforms.duckdb import DuckDBAdapter
+
+    adapter = DuckDBAdapter(capture_plans=capture_plans)
+    conn = adapter.create_connection()
+    results: dict[str, dict] = {}
+    try:
+        for query_id, query in _QUERIES:
+            results[query_id] = adapter.execute_query(
+                connection=conn,
+                query=query,
+                query_id=query_id,
+                validate_row_count=False,
+            )
+    finally:
+        adapter.close_connection(conn)
+    return results
+
+
+def _export_bundle(output_dir, execution_id: str):
+    """Run the trivial workload with capture, export a real result bundle, return its main JSON path."""
+    from benchbox.core.results.exporter import ResultExporter
+    from tests.fixtures.result_dict_fixtures import make_benchmark_results
+
+    captured = _run_queries(capture_plans=True)
+    query_results = []
+    for order, (query_id, _sql) in enumerate(_QUERIES, start=1):
+        row = captured[query_id]
+        assert row["status"] == "SUCCESS", f"{query_id} did not succeed: {row}"
+        query_results.append(
+            {
+                "query_id": query_id,
+                "status": "SUCCESS",
+                "execution_order": order,
+                "execution_time_ms": (row.get("execution_time_seconds") or 0.0) * 1000.0,
+                "rows_returned": row.get("rows_returned", 0),
+                "query_plan": row.get("query_plan"),
+                "plan_fingerprint": row.get("plan_fingerprint"),
+            }
+        )
+
+    results = make_benchmark_results(
+        benchmark_id="plan-cli-realpath",
+        benchmark_name="plan-cli-realpath",
+        platform="duckdb",
+        scale_factor=0.01,
+        execution_id=execution_id,
+        duration_seconds=0.0,
+        total_queries=len(_QUERIES),
+        successful_queries=len(_QUERIES),
+        query_plans_captured=len(_QUERIES),
+        query_results=query_results,
+    )
+
+    exporter = ResultExporter(output_dir=output_dir)
+    exported = exporter.export_result(results, ["json"])
+    return exported["json"]
+
+
+class TestPlanCaptureCLIRealpath:
+    """Drive show-plan / compare-plans / compare --include-plans through real bundles."""
+
+    def test_show_plan_renders_from_real_bundle(self, tmp_path):
+        """`benchbox show-plan --run <real bundle>` must exit 0 and render a plan."""
+        from benchbox.cli.commands.show_plan import show_plan
+
+        main_json = _export_bundle(tmp_path / "run1", "run1")
+        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "1"])
+
+        assert result.exit_code == 0, result.output
+        assert "no attribute" not in result.output.lower()
+        assert "Query Plan" in result.output
+
+    def test_show_plan_json_format_from_real_bundle(self, tmp_path):
+        """`--format json` must emit the real rehydrated plan, not an error."""
+        from benchbox.cli.commands.show_plan import show_plan
+
+        main_json = _export_bundle(tmp_path / "run1", "run1")
+        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "2", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert '"query_id": "2"' in result.output
+
+    def test_compare_plans_summary_from_real_bundles(self, tmp_path):
+        """The deprecated `compare-plans --summary` path must work against real bundles."""
+        from benchbox.cli.commands.compare_plans import compare_plans
+
+        run1 = _export_bundle(tmp_path / "run1", "run1")
+        run2 = _export_bundle(tmp_path / "run2", "run2")
+
+        result = CliRunner().invoke(
+            compare_plans,
+            ["--run1", str(run1), "--run2", str(run2), "--summary"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "no attribute" not in result.output.lower()
+
+    def test_compare_include_plans_from_real_bundles(self, tmp_path):
+        """`benchbox compare <run1> <run2> --include-plans` - the recommended path - must exit 0."""
+        from benchbox.cli.commands.compare import compare
+
+        run1 = _export_bundle(tmp_path / "run1", "run1")
+        run2 = _export_bundle(tmp_path / "run2", "run2")
+
+        result = CliRunner().invoke(
+            compare,
+            [str(run1), str(run2), "--include-plans", "--non-interactive"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "no attribute" not in result.output.lower()
+
+    def test_loaded_query_results_carry_rehydrated_plans(self, tmp_path):
+        """load_result_file must reattach query_plan/plan_fingerprint from the .plans.json companion."""
+        from benchbox.core.results.loader import iter_query_results, load_result_file
+        from benchbox.core.results.query_plan_models import QueryPlanDAG
+
+        main_json = _export_bundle(tmp_path / "run1", "run1")
+        loaded, _raw = load_result_file(main_json)
+
+        query_results = iter_query_results(loaded)
+        assert len(query_results) == len(_QUERIES)
+        for qr in query_results:
+            plan = qr.get("query_plan")
+            assert isinstance(plan, QueryPlanDAG), f"{qr.get('query_id')}: query_plan not rehydrated: {plan!r}"
+            assert qr.get("plan_fingerprint"), f"{qr.get('query_id')}: plan_fingerprint missing after reload"

--- a/tests/integration/test_plan_capture_cli_realpath_review.py
+++ b/tests/integration/test_plan_capture_cli_realpath_review.py
@@ -26,13 +26,13 @@ pytestmark = [
 ]
 
 _QUERIES = [
-    ("1", "SELECT i FROM range(5) t(i) WHERE i > 2"),
-    ("2", "SELECT count(*) AS c FROM range(5) t(i)"),
+    ("q1", "SELECT i FROM range(5) t(i) WHERE i > 2"),
+    ("q2", "SELECT count(*) AS c FROM range(5) t(i)"),
 ]
-# Query IDs are bare numerals (not "q1"/"q2"): the compact export format normalizes
-# IDs (query_normalizer.normalize_query_id strips a leading "Q"/"q"), so a bare
-# numeral round-trips unchanged and keeps this test focused on plan reattachment
-# rather than the separate, pre-existing query-ID-format lookup behavior.
+# Query IDs use the documented "q1"/"q2" style deliberately: the compact export
+# format normalizes IDs (query_normalizer.normalize_query_id strips a leading
+# "Q"/"q", so "q1" round-trips through a bundle as "1"), which exercises the
+# --query-id normalization fix in show_plan.py/compare_plans.py below.
 
 
 def _run_queries(capture_plans: bool) -> dict[str, dict]:
@@ -103,7 +103,7 @@ class TestPlanCaptureCLIRealpath:
         from benchbox.cli.commands.show_plan import show_plan
 
         main_json = _export_bundle(tmp_path / "run1", "run1")
-        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "1"])
+        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "q1"])
 
         assert result.exit_code == 0, result.output
         assert "no attribute" not in result.output.lower()
@@ -114,10 +114,24 @@ class TestPlanCaptureCLIRealpath:
         from benchbox.cli.commands.show_plan import show_plan
 
         main_json = _export_bundle(tmp_path / "run1", "run1")
-        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "2", "--format", "json"])
+        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", "q2", "--format", "json"])
 
         assert result.exit_code == 0, result.output
-        assert '"query_id": "2"' in result.output
+        # The emitted plan is the QueryPlanDAG captured at execution time, whose own
+        # query_id field retains the original "q2" (not the reconstructed result
+        # dict's separately-normalized "query_id" of "2").
+        assert '"query_id": "q2"' in result.output
+
+    @pytest.mark.parametrize("requested_id", ["q1", "Q1", "1"])
+    def test_show_plan_query_id_normalization(self, tmp_path, requested_id):
+        """--query-id accepts any documented format (q1/Q1/1) against a normalized real bundle."""
+        from benchbox.cli.commands.show_plan import show_plan
+
+        main_json = _export_bundle(tmp_path / "run1", "run1")
+        result = CliRunner().invoke(show_plan, ["--run", str(main_json), "--query-id", requested_id])
+
+        assert result.exit_code == 0, result.output
+        assert "not found" not in result.output.lower()
 
     def test_compare_plans_summary_from_real_bundles(self, tmp_path):
         """The deprecated `compare-plans --summary` path must work against real bundles."""
@@ -133,6 +147,21 @@ class TestPlanCaptureCLIRealpath:
 
         assert result.exit_code == 0, result.output
         assert "no attribute" not in result.output.lower()
+
+    def test_compare_plans_explicit_query_id_normalization(self, tmp_path):
+        """`compare-plans --query-id q1` must match a bundle whose reloaded ID normalized to "1"."""
+        from benchbox.cli.commands.compare_plans import compare_plans
+
+        run1 = _export_bundle(tmp_path / "run1", "run1")
+        run2 = _export_bundle(tmp_path / "run2", "run2")
+
+        result = CliRunner().invoke(
+            compare_plans,
+            ["--run1", str(run1), "--run2", str(run2), "--query-id", "q1"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "missing plan" not in result.output.lower()
 
     def test_compare_include_plans_from_real_bundles(self, tmp_path):
         """`benchbox compare <run1> <run2> --include-plans` - the recommended path - must exit 0."""

--- a/tests/uat/test_no_cli_surface_drift.py
+++ b/tests/uat/test_no_cli_surface_drift.py
@@ -23,6 +23,11 @@ ALLOWED_INTERNAL_CLI_FILES = {
     "benchbox/cli/commands/calculate_qphh.py",
     "benchbox/cli/commands/compare_dataframes.py",
     "benchbox/cli/commands/compare_plans.py",
+    # fix-plan-consumption-phases-and-loader-reattach: internal-only fix repointing
+    # the broken `results.phases` walk at the real `query_results` accessor; no
+    # command/option/argument surface changed.
+    "benchbox/cli/commands/compare.py",
+    "benchbox/cli/commands/show_plan.py",
     "benchbox/cli/commands/convert.py",
     "benchbox/cli/commands/df_tuning.py",
     "benchbox/cli/commands/run.py",

--- a/tests/unit/cli/commands/test_compare_plans_coverage.py
+++ b/tests/unit/cli/commands/test_compare_plans_coverage.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import importlib
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
+
+from tests.fixtures.result_dict_fixtures import make_benchmark_results
 
 cp = importlib.import_module("benchbox.cli.commands.compare_plans")
 
@@ -68,21 +70,15 @@ class _Summary:
         return {"baseline": self.baseline_run_id, "current": self.current_run_id}
 
 
-@dataclass
-class _Exec:
-    query_id: str
-    query_plan: object | None = field(default_factory=object)
-
-
-class _Phase:
-    def __init__(self, queries):
-        self.queries = queries
-
-
-class _Results:
-    def __init__(self, ids=("q1",), with_plans=True):
-        qp = object() if with_plans else None
-        self.phases = {"power": _Phase([_Exec(qid, qp) for qid in ids])}
+def _Results(ids=("q1",), with_plans=True):
+    """Build a real BenchmarkResults instance (not a fabricated `.phases` fake)."""
+    query_results = []
+    for qid in ids:
+        entry: dict = {"query_id": qid}
+        if with_plans:
+            entry["query_plan"] = object()
+        query_results.append(entry)
+    return make_benchmark_results(query_results=query_results)
 
 
 def _write_json(path: Path) -> None:

--- a/tests/unit/cli/commands/test_show_plan_coverage.py
+++ b/tests/unit/cli/commands/test_show_plan_coverage.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import importlib
-import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
+
+from tests.fixtures.result_dict_fixtures import make_benchmark_results
 
 mod = importlib.import_module("benchbox.cli.commands.show_plan")
 
@@ -18,24 +19,16 @@ pytestmark = [
 ]
 
 
-class _Exec:
-    def __init__(self, qid: str, plan=None):
-        self.query_id = qid
-        self.query_plan = plan
+def _make_results(query_id: str = "q1", has_plan: bool = True):
+    """Build a real BenchmarkResults instance (not a fabricated `.phases` fake)."""
+    plan = SimpleNamespace(to_dict=lambda: {"node": "scan"}) if has_plan else None
+    query_result: dict = {"query_id": query_id}
+    if plan is not None:
+        query_result["query_plan"] = plan
+    return make_benchmark_results(query_results=[query_result])
 
 
-class _Phase:
-    def __init__(self, queries):
-        self.queries = queries
-
-
-class _Results:
-    def __init__(self, query_id="q1", has_plan=True):
-        plan = SimpleNamespace(to_dict=lambda: {"node": "scan"}) if has_plan else None
-        self.phases = {"power": _Phase([_Exec(query_id, plan)])}
-
-
-def _make_load(results: _Results):
+def _make_load(results):
     """Return a load_result_file stub yielding (results, {})."""
     return lambda _p: (results, {})
 
@@ -47,7 +40,7 @@ def _write(path: Path, payload: str = "{}") -> None:
 def test_show_plan_tree_summary_and_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     p = tmp_path / "r.json"
     _write(p)
-    monkeypatch.setattr(mod, "load_result_file", _make_load(_Results()))
+    monkeypatch.setattr(mod, "load_result_file", _make_load(_make_results()))
     monkeypatch.setattr(mod, "render_plan", lambda *_a, **_k: "TREE")
     monkeypatch.setattr(mod, "render_summary", lambda *_a, **_k: "SUMMARY")
 
@@ -68,7 +61,7 @@ def test_show_plan_uses_load_result_file(monkeypatch: pytest.MonkeyPatch, tmp_pa
 
     def _spy(path):
         calls.append(path)
-        return (_Results(), {})
+        return (_make_results(), {})
 
     monkeypatch.setattr(mod, "load_result_file", _spy)
     monkeypatch.setattr(mod, "render_plan", lambda *_a, **_k: "TREE")
@@ -80,11 +73,11 @@ def test_show_plan_missing_query_and_plan(monkeypatch: pytest.MonkeyPatch, tmp_p
     p = tmp_path / "r.json"
     _write(p)
 
-    monkeypatch.setattr(mod, "load_result_file", _make_load(_Results(query_id="q2", has_plan=True)))
+    monkeypatch.setattr(mod, "load_result_file", _make_load(_make_results(query_id="q2", has_plan=True)))
     miss_q = CliRunner().invoke(mod.show_plan, ["--run", str(p), "--query-id", "q1"])
     assert miss_q.exit_code == 1
 
-    monkeypatch.setattr(mod, "load_result_file", _make_load(_Results(query_id="q1", has_plan=False)))
+    monkeypatch.setattr(mod, "load_result_file", _make_load(_make_results(query_id="q1", has_plan=False)))
     miss_p = CliRunner().invoke(mod.show_plan, ["--run", str(p), "--query-id", "q1"])
     assert miss_p.exit_code == 1
 
@@ -98,7 +91,7 @@ def test_show_plan_load_error_and_verbose_exception(monkeypatch: pytest.MonkeyPa
 
     p = tmp_path / "ok.json"
     _write(p)
-    monkeypatch.setattr(mod, "load_result_file", _make_load(_Results(query_id="q1", has_plan=True)))
+    monkeypatch.setattr(mod, "load_result_file", _make_load(_make_results(query_id="q1", has_plan=True)))
     monkeypatch.setattr(mod, "render_plan", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")))
     res = CliRunner().invoke(mod.show_plan, ["--run", str(p), "--query-id", "q1"], obj={"verbose": True})
     assert res.exit_code == 1

--- a/tests/unit/cli/test_compare_command_behavioral.py
+++ b/tests/unit/cli/test_compare_command_behavioral.py
@@ -550,26 +550,20 @@ class TestCompareHelperFunctions:
         from benchbox.cli.commands.compare import _build_execution_map
 
         results = SimpleNamespace(
-            phases={
-                "power": SimpleNamespace(
-                    queries=[
-                        SimpleNamespace(query_id="Q1", execution_time_ms=10.0),
-                        SimpleNamespace(query_id="Q2", execution_time_ms=20.0),
-                    ]
-                ),
-                "throughput": SimpleNamespace(
-                    queries=[
-                        SimpleNamespace(query_id="Q1", execution_time_ms=99.0),
-                        SimpleNamespace(query_id="Q3", execution_time_ms=30.0),
-                    ]
-                ),
-            }
+            query_results=[
+                # "power" phase
+                {"query_id": "Q1", "execution_time_ms": 10.0},
+                {"query_id": "Q2", "execution_time_ms": 20.0},
+                # "throughput" phase
+                {"query_id": "Q1", "execution_time_ms": 99.0},
+                {"query_id": "Q3", "execution_time_ms": 30.0},
+            ]
         )
 
         execution_map = _build_execution_map(results)
 
         assert set(execution_map) == {"Q1", "Q2", "Q3"}
-        assert execution_map["Q1"].execution_time_ms == 10.0
+        assert execution_map["Q1"]["execution_time_ms"] == 10.0
 
     @patch("benchbox.core.query_plans.comparison.QueryPlanComparator")
     @patch("benchbox.core.query_plans.comparison.generate_plan_comparison_summary")
@@ -577,24 +571,16 @@ class TestCompareHelperFunctions:
         from benchbox.cli.commands.compare import _compare_plans
 
         baseline = SimpleNamespace(
-            phases={
-                "power": SimpleNamespace(
-                    queries=[
-                        SimpleNamespace(query_id="Q1", query_plan={"a": 1}, execution_time_ms=100.0),
-                        SimpleNamespace(query_id="Q2", query_plan={"b": 2}, execution_time_ms=50.0),
-                    ]
-                )
-            }
+            query_results=[
+                {"query_id": "Q1", "query_plan": {"a": 1}, "execution_time_ms": 100.0},
+                {"query_id": "Q2", "query_plan": {"b": 2}, "execution_time_ms": 50.0},
+            ]
         )
         current = SimpleNamespace(
-            phases={
-                "power": SimpleNamespace(
-                    queries=[
-                        SimpleNamespace(query_id="Q1", query_plan={"a": 2}, execution_time_ms=150.0),
-                        SimpleNamespace(query_id="Q2", query_plan={"b": 3}, execution_time_ms=55.0),
-                    ]
-                )
-            }
+            query_results=[
+                {"query_id": "Q1", "query_plan": {"a": 2}, "execution_time_ms": 150.0},
+                {"query_id": "Q2", "query_plan": {"b": 3}, "execution_time_ms": 55.0},
+            ]
         )
 
         mock_summary_fn.return_value = SimpleNamespace(plans_compared=2, plans_unchanged=0, plans_changed=2)

--- a/tests/unit/core/manifest/test_plan_metadata.py
+++ b/tests/unit/core/manifest/test_plan_metadata.py
@@ -31,30 +31,19 @@ pytestmark = [
 ]
 
 
-@dataclass
-class MockQueryExecution:
-    """Mock query execution for testing."""
-
-    query_id: str
-    execution_time_ms: float = 100.0
-    query_plan: QueryPlanDAG | None = None
-
-
-@dataclass
-class MockPhaseResults:
-    """Mock phase results for testing."""
-
-    queries: list[MockQueryExecution] = field(default_factory=list)
+def _mock_query_result(query_id: str, execution_time_ms: float = 100.0, query_plan: QueryPlanDAG | None = None) -> dict:
+    """Build a query_results dict matching the real BenchmarkResults.query_results shape."""
+    return {"query_id": query_id, "execution_time_ms": execution_time_ms, "query_plan": query_plan}
 
 
 @dataclass
 class MockBenchmarkResults:
-    """Mock benchmark results for testing."""
+    """Mock benchmark results for testing (matches the real query_results flattened list)."""
 
     run_id: str = "test_run"
     platform: str = "duckdb"
     platform_version: str = "0.9.0"
-    phases: dict[str, MockPhaseResults] = field(default_factory=dict)
+    query_results: list[dict] = field(default_factory=list)
 
 
 def _create_plan_with_fingerprint(query_id: str, fingerprint: str) -> QueryPlanDAG:
@@ -231,14 +220,10 @@ class TestCreatePlanMetadataFromResults:
         results = MockBenchmarkResults(
             platform="duckdb",
             platform_version="0.9.0",
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan1),
-                        MockQueryExecution("q2", 200.0, plan2),
-                    ]
-                )
-            },
+            query_results=[
+                _mock_query_result("q1", 100.0, plan1),
+                _mock_query_result("q2", 200.0, plan2),
+            ],
         )
 
         metadata = create_plan_metadata_from_results(results)
@@ -255,14 +240,10 @@ class TestCreatePlanMetadataFromResults:
         plan1 = _create_plan_with_fingerprint("q1", "a" * 64)
 
         results = MockBenchmarkResults(
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan1),
-                        MockQueryExecution("q2", 200.0, None),  # No plan
-                    ]
-                )
-            },
+            query_results=[
+                _mock_query_result("q1", 100.0, plan1),
+                _mock_query_result("q2", 200.0, None),  # No plan
+            ],
         )
 
         metadata = create_plan_metadata_from_results(results)
@@ -272,7 +253,7 @@ class TestCreatePlanMetadataFromResults:
 
     def test_handles_empty_results(self) -> None:
         """Test handling results with no executions."""
-        results = MockBenchmarkResults(phases={})
+        results = MockBenchmarkResults(query_results=[])
 
         metadata = create_plan_metadata_from_results(results)
 

--- a/tests/unit/core/query_plans/test_comparison_summary.py
+++ b/tests/unit/core/query_plans/test_comparison_summary.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-
 import pytest
 
 from benchbox.core.query_plans.comparison import (
@@ -25,20 +23,9 @@ pytestmark = [
 ]
 
 
-@dataclass
-class MockQueryExecution:
-    """Mock query execution for testing."""
-
-    query_id: str
-    execution_time_ms: float = 100.0
-    query_plan: QueryPlanDAG | None = None
-
-
-@dataclass
-class MockPhaseResults:
-    """Mock phase results for testing."""
-
-    queries: list[MockQueryExecution] = field(default_factory=list)
+def _qr(query_id: str, execution_time_ms: float = 100.0, query_plan: QueryPlanDAG | None = None) -> dict:
+    """Build a query_results dict matching the real BenchmarkResults.query_results shape."""
+    return {"query_id": query_id, "execution_time_ms": execution_time_ms, "query_plan": query_plan}
 
 
 def _create_simple_plan(query_id: str, table_name: str = "orders") -> QueryPlanDAG:
@@ -162,11 +149,11 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan2)])},
+            query_results=[_qr("q1", 100.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)
@@ -184,11 +171,11 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan2)])},
+            query_results=[_qr("q1", 100.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)
@@ -209,25 +196,11 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan1a),
-                        MockQueryExecution("q2", 200.0, plan2a),
-                    ]
-                )
-            },
+            query_results=[_qr("q1", 100.0, plan1a), _qr("q2", 200.0, plan2a)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan1b),
-                        MockQueryExecution("q2", 200.0, plan2b),
-                    ]
-                )
-            },
+            query_results=[_qr("q1", 100.0, plan1b), _qr("q2", 200.0, plan2b)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)
@@ -243,16 +216,12 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "power": MockPhaseResults(
-                    # 150% slower (from 100ms to 250ms)
-                    queries=[MockQueryExecution("q1", 250.0, plan2)]
-                )
-            },
+            # 150% slower (from 100ms to 250ms)
+            query_results=[_qr("q1", 250.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current, regression_threshold_pct=20.0)
@@ -274,16 +243,12 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "power": MockPhaseResults(
-                    # Slower but plan unchanged
-                    queries=[MockQueryExecution("q1", 200.0, plan2)]
-                )
-            },
+            # Slower but plan unchanged
+            query_results=[_qr("q1", 200.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current, regression_threshold_pct=20.0)
@@ -301,16 +266,12 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "power": MockPhaseResults(
-                    # 15% slower - below 20% threshold but above 10%
-                    queries=[MockQueryExecution("q1", 115.0, plan2)]
-                )
-            },
+            # 15% slower - below 20% threshold but above 10%
+            query_results=[_qr("q1", 115.0, plan2)],
         )
 
         # With 20% threshold - not a regression
@@ -327,25 +288,11 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan),
-                        MockQueryExecution("q2", 100.0, None),  # No plan
-                    ]
-                )
-            },
+            query_results=[_qr("q1", 100.0, plan), _qr("q2", 100.0, None)],  # q2: no plan
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "power": MockPhaseResults(
-                    queries=[
-                        MockQueryExecution("q1", 100.0, plan),
-                        MockQueryExecution("q2", 100.0, None),
-                    ]
-                )
-            },
+            query_results=[_qr("q1", 100.0, plan), _qr("q2", 100.0, None)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)
@@ -359,11 +306,11 @@ class TestGeneratePlanComparisonSummary:
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)])},
+            query_results=[_qr("q1", 100.0, plan1)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={"power": MockPhaseResults(queries=[MockQueryExecution("q2", 100.0, plan2)])},
+            query_results=[_qr("q2", 100.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)
@@ -371,23 +318,17 @@ class TestGeneratePlanComparisonSummary:
         assert summary.plans_compared == 0  # No common queries
 
     def test_multiple_phases(self) -> None:
-        """Test that queries from multiple phases are collected."""
+        """Test that all queries in query_results are collected regardless of phase."""
         plan1 = _create_simple_plan("q1", "orders")
         plan2 = _create_simple_plan("q2", "customers")
 
         baseline = make_benchmark_results(
             run_id="baseline",
-            phases={
-                "warmup": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)]),
-                "power": MockPhaseResults(queries=[MockQueryExecution("q2", 200.0, plan2)]),
-            },
+            query_results=[_qr("q1", 100.0, plan1), _qr("q2", 200.0, plan2)],
         )
         current = make_benchmark_results(
             run_id="current",
-            phases={
-                "warmup": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan1)]),
-                "power": MockPhaseResults(queries=[MockQueryExecution("q2", 200.0, plan2)]),
-            },
+            query_results=[_qr("q1", 100.0, plan1), _qr("q2", 200.0, plan2)],
         )
 
         summary = generate_plan_comparison_summary(baseline, current)

--- a/tests/unit/core/query_plans/test_fingerprint_normalization.py
+++ b/tests/unit/core/query_plans/test_fingerprint_normalization.py
@@ -235,9 +235,8 @@ class TestComputePlanFingerprint:
 class TestPlanMetadataNormalization:
     @staticmethod
     def _results(query_plan: QueryPlanDAG) -> SimpleNamespace:
-        execution = SimpleNamespace(query_id=query_plan.query_id, query_plan=query_plan)
-        phase = SimpleNamespace(queries=[execution])
-        return SimpleNamespace(platform="duckdb", platform_version="1.0", phases={"power": phase})
+        query_result = {"query_id": query_plan.query_id, "query_plan": query_plan}
+        return SimpleNamespace(platform="duckdb", platform_version="1.0", query_results=[query_result])
 
     def test_metadata_default_uses_literal_sensitive_fingerprint(self):
         """Without the flag, two seeds record different fingerprints (the bug)."""

--- a/tests/unit/core/query_plans/test_plan_history.py
+++ b/tests/unit/core/query_plans/test_plan_history.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import tempfile
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
@@ -27,20 +26,9 @@ pytestmark = [
 ]
 
 
-@dataclass
-class MockQueryExecution:
-    """Mock query execution for testing."""
-
-    query_id: str
-    execution_time_ms: float = 100.0
-    query_plan: QueryPlanDAG | None = None
-
-
-@dataclass
-class MockPhaseResults:
-    """Mock phase results for testing."""
-
-    queries: list[MockQueryExecution] = field(default_factory=list)
+def _qr(query_id: str, execution_time_ms: float = 100.0, query_plan: QueryPlanDAG | None = None) -> dict:
+    """Build a query_results dict matching the real BenchmarkResults.query_results shape."""
+    return {"query_id": query_id, "execution_time_ms": execution_time_ms, "query_plan": query_plan}
 
 
 def _create_plan_with_fingerprint(query_id: str, fingerprint: str) -> QueryPlanDAG:
@@ -108,7 +96,7 @@ class TestPlanHistory:
             plan = _create_plan_with_fingerprint("q1", "a" * 64)
             results = make_benchmark_results(
                 run_id="run1",
-                phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                query_results=[_qr("q1", 100.0, plan)],
             )
 
             history.add_run(results)
@@ -134,7 +122,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0 + i * 10, plan)])},
+                    query_results=[_qr("q1", 100.0 + i * 10, plan)],
                 )
                 history.add_run(results)
 
@@ -162,7 +150,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -180,7 +168,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -199,7 +187,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -218,7 +206,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -235,7 +223,7 @@ class TestPlanHistory:
                 results = make_benchmark_results(
                     run_id=f"run{i}",
                     start_time=f"2024-01-0{i + 1}T00:00:00Z",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -259,14 +247,10 @@ class TestPlanHistory:
             plan2 = _create_plan_with_fingerprint("q2", "b" * 64)
             results = make_benchmark_results(
                 run_id="run1",
-                phases={
-                    "power": MockPhaseResults(
-                        queries=[
-                            MockQueryExecution("q1", 100.0, plan1),
-                            MockQueryExecution("q2", 200.0, plan2),
-                        ]
-                    )
-                },
+                query_results=[
+                    _qr("q1", 100.0, plan1),
+                    _qr("q2", 200.0, plan2),
+                ],
             )
             history.add_run(results)
 
@@ -285,7 +269,7 @@ class TestPlanHistory:
                 plan = _create_plan_with_fingerprint("q1", "a" * 64)
                 results = make_benchmark_results(
                     run_id=f"run{i}",
-                    phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                    query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
@@ -299,7 +283,7 @@ class TestPlanHistory:
             plan = _create_plan_with_fingerprint("q1", "a" * 64)
             results = make_benchmark_results(
                 run_id="run1",
-                phases={"power": MockPhaseResults(queries=[MockQueryExecution("q1", 100.0, plan)])},
+                query_results=[_qr("q1", 100.0, plan)],
             )
             history.add_run(results)
 


### PR DESCRIPTION
## Description

`BenchmarkResults` has no `.phases` attribute — it exposes `execution_phases`
and `query_results` — so `show-plan`, `compare-plans`, and
`compare --include-plans` all crashed with `AttributeError: 'BenchmarkResults'
object has no attribute 'phases'` on any real exported bundle (swallowed by a
bare `except Exception` into exit 1). `plan_metadata_utils.py` and
`history.py` masked the same defect behind `getattr(results, "phases", {})`
defaults, silently recording no metadata/history instead of crashing.

Separately, `load_result_file` never threaded the `.plans.json` companion into
`_reconstruct_query_results`, so every `query_plan` was `None` after a load
even once the AttributeError was fixed.

TODO: `_project/DONE/main/fix-plan-consumption-phases-and-loader-reattach.yaml`
(Critical, from the query-plan-capture adversarial review).

### Fix

- Added `iter_query_results()` in `loader.py` as the single per-query
  accessor. `query_results` is populated identically by `ResultBuilder` for
  live results and by `reconstruct_benchmark_results` for disk-reloaded
  results; `execution_phases` loses per-query detail once reconstructed from a
  bundle, so it isn't a reliable source. Repointed all six `.phases`
  consumers (`show_plan.py`, `compare_plans.py`, `compare.py`,
  `comparison.py`, `plan_metadata_utils.py`, `history.py`) at it.
- Threaded the `.plans.json` companion into `_reconstruct_query_results` so
  `query_plan` (`QueryPlanDAG.from_dict`), `plan_fingerprint`,
  `plan_fingerprint_normalized`, and `plan_capture_time_ms` are rehydrated on
  load.
- Found and fixed a related bug while wiring the round-trip: `build_plans_payload`
  keys `.plans.json` by the *raw* query ID (e.g. `"q1"`) while the compact
  `queries` list in the main JSON carries the *normalized* ID (e.g. `"1"`).
  Normalized both sides of the lookup in the loader (not the `.plans.json`
  format, which must stay unchanged per the TODO's `must_preserve`).
- Replaced the fabricated `.phases`/`getattr(..., "phases", {})` test doubles
  in the two named coverage tests, plus several casualty test files that used
  the identical fake shape and broke once the production code stopped reading
  it (`tests/unit/core/manifest/test_plan_metadata.py`,
  `tests/unit/core/query_plans/test_comparison_summary.py`,
  `tests/unit/core/query_plans/test_fingerprint_normalization.py`,
  `tests/unit/core/query_plans/test_plan_history.py`,
  `tests/unit/cli/test_compare_command_behavioral.py`) with the real
  `BenchmarkResults`/`query_results` shape.
- Added `tests/integration/test_plan_capture_cli_realpath_review.py`: a real
  DuckDB run → `ResultExporter` bundle → `load_result_file` → `show-plan` /
  `compare-plans` / `compare --include-plans` round-trip, so a regression here
  fails loudly instead of being hidden by a mock.
- Added the two touched CLI files to `tests/uat/test_no_cli_surface_drift.py`'s
  internal-only allowlist (no command/option/argument surface changed).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

```
uv run -- python -m pytest tests/integration/ -k 'plan and (show or compare or realpath)' -n 0 -q
uv run -- python -m pytest tests/unit/cli/commands/ tests/unit/core/results/ tests/integration/ -k plan -n 0 -q
uv run -- python -m pytest tests/unit/core/manifest/ tests/unit/core/query_plans/ tests/unit/cli/ -n 0 -q
uv run ruff check . && uv run ruff format --check . && uv run ty check
uv run -- python -m pytest -m "fast and not (slow or stress or resource_heavy or live_integration)" -q
make pr-preflight
```

The full fast suite has 5 pre-existing failures unrelated to this change
(confirmed zero diff overlap): two `pyspark` CSV-loading tests (`Unable to
determine Java version` — no JRE in this sandbox), one Delta Lake smoke test
(DuckDB extension download blocked, `HTTP 403` from the sandbox's egress
proxy), and two CLI output-dir error-handling tests that assert `OSError`/
`FileNotFoundError` on a permission-denied path — this sandbox runs as root,
which bypasses the permission check the test relies on.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not
      change public, beta-public, deprecated, generated, experimental, or
      repo-only contract surfaces. (No CLI option/command signatures changed;
      internal bug fix only.)
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs
      for contract-map impact.
- [ ] N/A — no platform/benchmark count claims touched.

## Documentation

- [ ] N/A — no user-facing doc changes needed; this restores documented
      behavior (show-plan/compare-plans were supposed to work on real bundles).
- [x] I added regression notes for behavior changes (see Description).
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration
      impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

Part of a 5-item batch from the query-plan-capture adversarial review
(Critical item, no dependencies — landing first). Two downstream items
(`fix-multistream-throughput-plan-attachment`,
`test-real-combined-plan-capture-checkpoint`) depend on this merging first.

None of the changed files touch a `.github/CODEOWNERS` soundness path
(`benchbox/platforms/base/result_capture.py`, `benchbox/core/**/validation.py`,
`benchbox/core/equivalence/**`, `benchbox/core/query_plans/parsers/**`), so
squash auto-merge is being enabled.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Dfk9EwmhZns8ttQFuVg34)_