### PR TITLE
docs: fix governance/architecture doc drift (ADR index, stale evidence, CI descriptions)

### DIFF
--- a/docs/development/adr/README.md
+++ b/docs/development/adr/README.md
@@ -4,3 +4,6 @@ Architecture Decision Records
 - [ADR: Extract ASCII Charting into `textcharts` Standalone Library](adr-textcharts-extraction.md)
 - [ADR: `sql_compat` Phase-Aware Compatibility Pipeline](adr-sql-compat-phase-aware-pipeline.md)
 - [ADR: SQLGlot Use and Non-Use](adr-sqlglot-use-and-non-use.md)
+- [ADR: DuckDB datasketches extension — vendoring vs HLL fallback](adr-duckdb-datasketches-vendoring.md)
+- [ADR: Move Explorer Publishing Out of the BenchBox CLI](adr-explorer-cli-surface.md)
+- [ADR: published-results as a Slim Corpus-Only Branch](adr-published-results-slim-corpus-branch.md)

--- a/docs/development/benchbox-results-platform-strategy.md
+++ b/docs/development/benchbox-results-platform-strategy.md
@@ -477,7 +477,7 @@ if the results platform becomes a core product with sustained community usage.
 | Canonical results already exist as schema-v2 bundles with companion files | `benchbox/core/results/exporter.py` | All downstream paths ingest the real exported bundle, not a second payload |
 | Public site is currently static GitHub Pages assembled from landing + docs + blog | `.github/workflows/docs.yml`, `docs/conf.py` | The public explorer must be a static subsite - no server dependency |
 | BenchBox already hints at a hosted service contract | `_project/_archive/specs/cli/config.md` documents `submit_to_service` and `service_url` (archived) | CLI public submission (`benchbox submit`) is a legitimate future direction, but Phase 1 does not require it |
-| Existing publishing prototype is process-local | `benchbox/core/publishing/artifacts.py`, `benchbox/core/publishing/permalink.py` | The prototype is not the hosted service architecture; it is only a source of reusable concepts |
+| Existing publishing is process-local | `benchbox/core/publishing/bundle_publisher.py`, `benchbox/core/publishing/store.py` (the earlier `artifacts.py`/`permalink.py` prototype was removed in v0.2.1) | The current bundle publisher does local/cloud artifact publication only; it is not the hosted service architecture |
 
 ## Reference Matrix
 

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -56,7 +56,9 @@ Required status checks:
 ```
 
 `ci-required-result` is the umbrella job in `.github/workflows/pr.yml`
-that aggregates `ci-paths`, `content-guard`, `code-lint`, and `code-test`.
+that aggregates the required-lane jobs: `ci-paths`, `content-guard`,
+`code-lint`, `code-test`, `correctness-gate`, `plan-capture-gate`,
+`explorer-tokens`, `audit-sha`, `package-smoke`, and `dependency-audit`.
 Branch protection deliberately keys off the umbrella so the path-aware
 classifier can skip subordinate jobs without making the protected check
 disappear. The classifier fails closed: any path not on the

--- a/docs/operations/results-explorer-token-scan.md
+++ b/docs/operations/results-explorer-token-scan.md
@@ -131,8 +131,8 @@ The post-merge `explorer-tokens` job feeds three downstream consumers in
    merge.
 2. **`metrics`** — the `post_merge_red` shell flag flips true; the
    `develop_red_detected_at` jq filter selects the earliest
-   `completed_at` across `lint`, `fast-test`, and `explorer-tokens` as
-   the red-detection timestamp.
+   `completed_at` across `lint`, `fast-test`, `explorer-tokens`, and
+   `medium-test` as the red-detection timestamp.
 3. The dev-loop metrics row is emitted to the `metrics` artifact under
    `dev-loop-metrics/<sha>.json`.
 

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -20,8 +20,8 @@ static explorer rebuild, and no hosted API is involved.
 
 ### 1.2 Maintainer-run additions (sync from develop)
 
-Maintainer-side corpus changes — the `seed-corpus.yml` workflow's quarterly
-refresh, ad-hoc UAT integrations like PR #164, validator updates — land on
+Maintainer-side corpus changes — the `seed-corpus.yml` workflow's on-demand
+(`workflow_dispatch`) refresh, ad-hoc UAT integrations like PR #164, validator updates — land on
 `develop` first because that is where the project's tooling and tests live.
 The
 [`sync-results-data-to-published.yml`](../../.github/workflows/sync-results-data-to-published.yml)


### PR DESCRIPTION
## Description

Implements the non-colliding parts of TODO `remediate-governance-and-doc-drift` — audit **§2.18b** (grouped Advisory) + the **ADR-index gap** (plan #959). Each drift re-verified against current develop before editing.

## Changes

- **ADR index** (`docs/development/adr/README.md`): added the three Accepted ADRs it omitted — `datasketches-vendoring`, `explorer-cli-surface`, and `published-results-slim-corpus-branch` (the last two have the most operational teeth and were undiscoverable from the index).
- **Strategy doc** (`benchbox-results-platform-strategy.md:480`): the constraints/evidence table cited `publishing/artifacts.py` + `permalink.py` as current evidence; both were deleted in v0.2.1. Now points at the live `bundle_publisher.py`/`store.py` and notes the prototype removal.
- **Token-scan doc** (`:134`): the `develop_red_detected_at` jq filter also selects `medium-test` (`develop-post-merge.yml:515`) — added to the documented job list.
- **repo-admin-settings** (`:59`): `ci-required-result` aggregates **ten** jobs, not the four listed — enumerated the full required lane (`pr.yml:916`).
- **Phase-2 runbook** (`:23`): `seed-corpus.yml` is `workflow_dispatch`-only; described as an on-demand refresh, not "quarterly" (no `schedule`).

## Scope notes

- **§2.16** (QA-plan reusability) landed with the QA-doc-accuracy change (#964) — same file, so it belongs there to avoid a merge collision.
- **§2.22** (relocate the mislabeled `tests/unit/core/explorer_pipeline/` + `test_explorer_build_contract.py`) is deferred as a low-risk cosmetic follow-up: the tests already pass at their current paths, and a `git mv` + import/conftest rewrite isn't worth bundling into a doc PR.

## Type of Change

- [x] Documentation

## Testing

- Each corrected claim re-derived against the live source: `develop-post-merge.yml:515` (medium-test in the jq), `pr.yml:916` (10-job needs list), `git show --stat 0182c955` (artifacts/permalink deleted), `seed-corpus.yml` (workflow_dispatch only), ADR file titles.
- `pre-commit run markdownlint` on all five files → Passed.

## Public Contract Check

- [x] Docs-only; no contract surfaces changed.

## Documentation

- [x] These are the documentation corrections.

## Code Quality

- [x] markdownlint green; no code touched.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Part of the `results-explorer-publication-remediation` batch (plan #959). Auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_