### PR TITLE
fix: address late-landing bot review findings across pass-12 merged PRs (sweep 12)

### DIFF
--- a/.github/workflows/phase3-promotion-review.yml
+++ b/.github/workflows/phase3-promotion-review.yml
@@ -26,6 +26,15 @@ concurrency:
   group: phase3-promotion-review
   cancel-in-progress: false
 
+env:
+  # If this workflow file ever lands on `main` (scheduled workflows only run
+  # from the default branch), a scheduled run's implicit checkout ref is
+  # `main`, not `develop` -- and `scripts/phase2_metrics.py` /
+  # `_project/analysis/phase-3-promotion-metrics.md` only exist on `develop`
+  # (release-cut strips `_project/` and dev-tooling scripts from `main`).
+  # Same pattern as release-canary.yml's RELEASE_CANARY_REF.
+  PHASE3_REVIEW_REF: develop
+
 jobs:
   # First-Monday guard. Scheduled runs proceed only on Monday; manual
   # dispatch always proceeds.
@@ -57,6 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ env.PHASE3_REVIEW_REF }}
           fetch-depth: 0  # full history so we can branch and push
 
       - name: Set up Python

--- a/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
+++ b/_project/TODO/main/planning/remediate-published-results-submission-ci.yaml
@@ -62,6 +62,13 @@ work:
       a documented mirror mechanism. Whichever is chosen, the manifest-only
       bypass must be closed on published-results.
 
+      Propagation note: `sync-results-data-to-published.yml` opens a DRAFT PR
+      against `published-results` on a develop push -- it never auto-merges
+      (maintainers flip it ready by hand). So merging THIS TODO's PR into
+      develop does not, by itself, make `origin/published-results` reflect
+      the fix; a maintainer must still review and merge the resulting mirror
+      PR. Do not treat "merged into develop" as "live on published-results".
+
   - id: w2
     summary: "Fix fork-PR comment posting so a passing validation never shows red for external contributors"
     needs: [w0]
@@ -89,6 +96,18 @@ work:
       "stdlib-only / no benchbox.*" statement to describe the shared
       implementation + importlib fallback; fix the DONE TODO path reference.
 
+  - id: w5
+    summary: "Post-merge: merge the resulting mirror PR into published-results and confirm the branch is live"
+    needs: [w1, w3, w4]
+    status: pending
+    notes: |
+      This TODO's develop-side PR only prepares the fix; it does not put it on
+      published-results by itself. After it merges to develop,
+      sync-results-data-to-published.yml opens (or updates) a draft PR against
+      published-results -- review and merge that PR, then re-run the
+      published-results-branch verification command below against the
+      now-current branch.
+
 prior_art:
   - ".github/workflows/validate-main-pr.yml — reuse its trusted-policy checkout pattern for w1 option (a)."
   - ".github/workflows/sync-results-data-to-published.yml — extend its allowlist for w1 option (b)."
@@ -104,9 +123,15 @@ anti_patterns:
   - "DO NOT run fork-PR code with pull_request_target checked out at the PR head - because that executes untrusted code with a writable token - check out the base's validator only."
 
 verification:
-  - description: "published-results validate-submission covers manifest-only PRs"
+  - description: "The checked-out (develop-side) validate-submission.yml covers manifest-only PRs -- run this on the PR that implements w1, BEFORE it merges"
+    command: "grep -c CHANGED_MANIFESTS .github/workflows/validate-submission.yml"
+    expected_output: ">= 1"
+  - description: "The sync workflow's allowlist will carry the fixed workflow file to published-results on the next mirror PR (if w1 chose option b)"
+    command: "grep -n 'validate-submission.yml' .github/workflows/sync-results-data-to-published.yml"
+    expected_output: "present in the trigger paths, so a develop push after this PR opens/updates a mirror PR carrying the fix"
+  - description: "POST-MERGE ONLY (w5): published-results validate-submission covers manifest-only PRs, once the mirror PR has been reviewed and merged"
     command: "git show origin/published-results:.github/workflows/validate-submission.yml | grep -c CHANGED_MANIFESTS"
-    expected_output: ">= 1 (guard present on the branch that actually runs the workflow for contributor PRs)"
+    expected_output: ">= 1 -- run this ONLY after w5's mirror-PR merge, not as a gate on this TODO's own develop-side PR (the branch cannot reflect the fix until that separate merge happens)"
   - description: "Validation runs from a trusted ref (closes the self-green vector), or errors on validator edits"
     command: "grep -nE 'pull_request_target|base\\.sha|base\\.ref|actions/checkout' .github/workflows/validate-submission.yml"
     expected_output: "validator runs from the base ref (not the PR head), OR a step fails the job when the PR modifies scripts/validate_submission.py / benchbox/validation/bundle.py"

--- a/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
+++ b/_project/TODO/main/planning/remediate-submission-trust-label-enforcement.yaml
@@ -56,6 +56,16 @@ work:
       case (594-602) from warn to error. Keep the existing traversal/symlink
       hardening. Ensure validate-submission.yml surfaces the new error.
 
+      Do NOT make this a blanket rule inside validate_bundles() itself:
+      `benchbox submit --dry-run` calls that same shared validator on the
+      SOURCE bundle before its `<bundle>.manifest.json` sidecar is generated,
+      so a valid local dry-run would start failing the no-sidecar check too.
+      Scope the new hard error to the submission-corpus CI entrypoint
+      (scripts/validate_submission.py, now in scope_limit below) — e.g. an
+      explicit flag/mode passed into validate_bundles(), or a corpus-only
+      wrapper check in validate_submission.py itself — so `benchbox submit
+      --dry-run` keeps working on a bundle whose sidecar doesn't exist yet.
+
   - id: w2
     summary: "Carry per-bundle provenance into the explorer pipeline instead of stamping one build-wide label"
     needs: [w0]
@@ -103,6 +113,7 @@ must_preserve:
   - "Existing manifest-hash traversal and symlink defenses in bundle.py."
   - "Already-merged community bundles keep their community-submission label (legacy singleton submission-manifest.json still honored)."
   - "The maintainer-run local publish flow (benchbox publish with a valid label) is unaffected."
+  - "`benchbox submit --dry-run` still succeeds against a source bundle whose `<bundle>.manifest.json` sidecar does not exist yet -- the new missing-sidecar hard error is scoped to the submission-corpus CI path, not validate_bundles() unconditionally."
 
 anti_patterns:
   - "DO NOT infer trust from build-time CLI defaults - because a missing sidecar then silently means maintainer-run - fail closed to community-submission on the submission path."
@@ -125,6 +136,7 @@ scope_limit:
     - "benchbox/core/publishing/bundle_publisher.py"
     - "_project/scripts/explorer_pipeline/"
     - "scripts/generate_corpus_inventory.py"
+    - "scripts/validate_submission.py"
     - "tests/unit/validation/"
     - "tests/unit/core/publishing/"
     - "tests/unit/core/explorer_pipeline/"

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -417,7 +417,11 @@ Live state observed 2026-07-05 (release-canary-scheduled-activation TODO, w0):
   `origin/main`, so its schedule has never fired either. The liveness
   guard below will name it alongside release-canary; the admin should
   land it on `main` in the same pass (or deliberately remove its
-  schedule and record that decision here).
+  schedule and record that decision here). Its `review` job now checks out
+  `develop` explicitly via a `PHASE3_REVIEW_REF` env var (the same
+  `RELEASE_CANARY_REF` shell pattern release-canary.yml uses), so landing
+  the file on `main` does not leave a scheduled run checking out `main`'s
+  stripped tree (no `_project/` or `scripts/phase2_metrics.py`) by default.
 
 GitHub runs `on.schedule` workflows only from the default branch (`main`).
 Activation options considered (w1):

--- a/docs/operations/results-explorer-qa.md
+++ b/docs/operations/results-explorer-qa.md
@@ -139,7 +139,7 @@ Test on at least Home and one ResultDetail.
 ## S2 — Home (`/results/`)
 
 ### S2.1 Stat cards
-- Three cards: Results / Benchmarks / Platforms. Numbers match the corpus (12 results, 2 benchmarks, 4 platforms expected).
+- Three cards: Results / Benchmarks / Platforms. Numbers match the corpus (11 results, 2 benchmarks, 7 platforms expected — confirmed by running `npm run test:e2e:fixtures` and querying the generated `results.duckdb`; re-verify if the generator's variant list changes).
 
 ### S2.2 MetaLeaderboard mode toggle (`?mode=`)
 - Three modes: **times** (default), **ranks**, **speedup**. Click each.
@@ -161,7 +161,7 @@ Test on at least Home and one ResultDetail.
 - Reload preserves selection.
 
 ### S2.5 Filter combinations
-- Apply 2+ filters that produce an empty set (e.g. `tpch` + sqlite-only by date window). Verify a clear "no results" empty state, not a blank page or stack trace.
+- Apply 2+ filters that produce an empty set (e.g. `star_schema` + Polars, since `star_schema` in this corpus only has a `duckdb` result). Verify a clear "no results" empty state, not a blank page or stack trace.
 - Apply filters that match exactly one cohort. Verify the table shrinks correctly and platform avg-rank recalculates.
 
 ### S2.6 Cohort and platform links
@@ -211,7 +211,7 @@ Test against `/results/tpch/` and `/results/star_schema/`.
 
 ## S4 — PlatformIndex (`/results/p/:platform/`)
 
-Test all four platforms: `duckdb`, `sqlite`, `datafusion`, `polars`. **Pass-1 found duckdb + polars rendered empty** — verify status on this branch.
+Test all three source platforms: `duckdb`, `datafusion`, `polars` (there is no `sqlite` bundle in this corpus — see the Corpus note at the top of this doc). The generator's variant platforms (`datafusion-partial`, `fixture-aws-sql`, `fixture-gcp-serverless`, `fixture-container-sql`) are additional single-result platforms worth spot-checking too, but the three source platforms are the priority. **Pass-1 found duckdb + polars rendered empty** — verify status on this branch.
 
 ### S4.1 Page renders for each platform
 - Title, breadcrumb, results table, charts.
@@ -237,14 +237,18 @@ Test all four platforms: `duckdb`, `sqlite`, `datafusion`, `polars`. **Pass-1 fo
 Result IDs embed a content hash and change whenever the fixtures regenerate, so
 **pick current IDs from the Browse view** (`/results/`) rather than pasting a
 stale one. Cover at least one `tpch` and one `star_schema`, and at least two
-platforms. The four base source-bundle IDs below exist in a freshly generated
-fixture corpus and are safe concrete starting points; the generator also
-produces derived records (SF 0.1 scale, community, tuned) whose IDs you should
-read off the Browse view:
-- `tpch-duckdb-sf0.01-20260403-7fe93365`
-- `tpch-datafusion-sf0.01-20260403-c0d4f3d9`
-- `tpch-polars-sf0.01-20260403-39bb1a7b`
-- `star_schema-duckdb-sf0.01-20260403-ac3ed9a9`
+platforms. Note: the pipeline recomputes `result_id` from the copied/normalized
+bundle JSON — it is **not** the source bundle's filename hash — so do not
+reuse the filenames under `results-explorer/test-fixtures/source/bundles/`
+verbatim. The four base-result IDs below were read from a freshly generated
+fixture corpus's `results.duckdb` (via `npm run test:e2e:fixtures`) and are
+safe concrete starting points as of this writing; the generator also produces
+derived records (SF 0.1 scale, community, tuned, environment variants) whose
+IDs you should read off the Browse view:
+- `tpch-duckdb-sf0.01-20260403-010ee756`
+- `tpch-datafusion-sf0.01-20260403-a6bb8a70`
+- `tpch-polars-sf0.01-20260403-a62d0d72`
+- `star_schema-duckdb-sf0.01-20260403-3cdeede0`
 
 ### S5.1 Header & badges
 - Trust badge and Tuning badge render with the right label/color for the bundle's metadata.

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -26,7 +26,9 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 # its own regex-behavior regression test below so they cannot drift apart.
 _CI_PATHS_SEG = r"(?:\.ci-paths|\[['\"]ci-paths['\"]\])"
 _OUTPUTS_SEG = r"(?:\.outputs|\[['\"]outputs['\"]\])"
-CI_PATHS_OUTPUT_REFERENCE_RE = r"needs" + _CI_PATHS_SEG + _OUTPUTS_SEG + r"(?:\.([A-Za-z0-9_-]+)|\[['\"]([A-Za-z0-9_-]+)['\"]\])"
+CI_PATHS_OUTPUT_REFERENCE_RE = (
+    r"needs" + _CI_PATHS_SEG + _OUTPUTS_SEG + r"(?:\.([A-Za-z0-9_-]+)|\[['\"]([A-Za-z0-9_-]+)['\"]\])"
+)
 
 
 def _load_path_filter_decision():

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -18,6 +18,16 @@ pytestmark = [
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
+# Matches dot and bracket reference forms for every segment of the chain
+# independently: needs.ci-paths.outputs.x, needs['ci-paths'].outputs.x,
+# needs.ci-paths.outputs['x'], needs['ci-paths']['outputs']['x'] (the fully
+# bracketed form GitHub Actions also accepts for hyphenated keys), and any
+# dot/bracket mix across the three segments. Shared by the lockstep test and
+# its own regex-behavior regression test below so they cannot drift apart.
+_CI_PATHS_SEG = r"(?:\.ci-paths|\[['\"]ci-paths['\"]\])"
+_OUTPUTS_SEG = r"(?:\.outputs|\[['\"]outputs['\"]\])"
+CI_PATHS_OUTPUT_REFERENCE_RE = r"needs" + _CI_PATHS_SEG + _OUTPUTS_SEG + r"(?:\.([A-Za-z0-9_-]+)|\[['\"]([A-Za-z0-9_-]+)['\"]\])"
+
 
 def _load_path_filter_decision():
     """Load scripts/path_filter_decision.py the way the workflow uses it.
@@ -252,14 +262,7 @@ def test_every_referenced_ci_paths_output_is_declared() -> None:
     workflow_yaml = yaml.safe_load(workflow_text)
     declared_outputs = set(workflow_yaml["jobs"]["ci-paths"]["outputs"])
 
-    # Match dot and bracket reference forms: needs.ci-paths.outputs.x,
-    # needs['ci-paths'].outputs.x, needs.ci-paths.outputs['x'], and the
-    # fully bracketed combination (single or double quotes).
-    reference_re = (
-        r"needs(?:\.ci-paths|\[['\"]ci-paths['\"]\])"
-        r"\.outputs(?:\.([A-Za-z0-9_-]+)|\[['\"]([A-Za-z0-9_-]+)['\"]\])"
-    )
-    referenced = {dot or bracket for dot, bracket in re.findall(reference_re, workflow_text)}
+    referenced = {dot or bracket for dot, bracket in re.findall(CI_PATHS_OUTPUT_REFERENCE_RE, workflow_text)}
     assert referenced, "expected pr.yml to reference ci-paths outputs"
 
     undeclared = referenced - declared_outputs
@@ -268,6 +271,19 @@ def test_every_referenced_ci_paths_output_is_declared() -> None:
         "declare them in jobs.ci-paths.outputs or the referencing `if:` "
         "silently evaluates against an empty string (the PR #952 incident)."
     )
+
+
+def test_ci_paths_output_reference_regex_matches_fully_bracketed_form() -> None:
+    # Regression pin: the regex previously hardcoded a literal `.outputs`, so
+    # `needs['ci-paths']['outputs']['new-needed']` (GitHub Actions' fully
+    # bracketed index syntax, a common way to reference hyphenated keys) was
+    # invisible to Direction 2 -- an undeclared output referenced only in that
+    # form would silently bypass this lockstep guard. Exercised against
+    # synthetic text so this stays green even if pr.yml itself never happens
+    # to use the bracketed form.
+    synthetic = "if: ${{ needs['ci-paths']['outputs']['new-needed'] == 'true' }}"
+    matches = {dot or bracket for dot, bracket in re.findall(CI_PATHS_OUTPUT_REFERENCE_RE, synthetic)}
+    assert matches == {"new-needed"}
 
 
 def test_parity_check_is_demoted_to_non_blocking() -> None:


### PR DESCRIPTION
## Description

Consolidated fix for late-landing `chatgpt-codex-connector` review comments posted after merge on #959, #964, #960, #963. This is sweep pass 12 of the ongoing review-followup process. #712 is intentionally excluded per standing instruction (release PR).

Separately (not in this PR): fixed one finding directly on open PR #962's own branch (`remediate-ci-required-gate-integrity`, commit 7332aa1a) — a missing docs.yml path filter entry. Also reviewed #967, #966, #935 (open) and #956/#957/#958/#961/#965/#968 (merged) — no unresolved bot threads found there this pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <file>` for both touched TODO YAMLs
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` — 111 items, no cycles/dangling refs
- `uv run -- ruff check tests/unit/workflows/test_pr_workflow_path_classifier.py` — clean
- `uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q` — 13 passed
- New regression test (`test_ci_paths_output_reference_regex_matches_fully_bracketed_form`) confirmed to fail against the pre-fix regex via `git stash`
- `python -c "import yaml; yaml.safe_load(...)"` on both touched workflow files — valid
- Ran the actual `npm run test:e2e:fixtures` fixture generator + queried the generated `results.duckdb` directly to get real corpus counts/IDs for the QA doc fix, rather than guessing

## Summary of fixes

- **remediate-submission-trust-label-enforcement TODO (#959)** — brought `scripts/validate_submission.py` into `scope_limit` and noted that the new missing-sidecar hard error must be scoped to the submission-corpus CI path, not `validate_bundles()` unconditionally — `benchbox submit --dry-run` calls the same shared validator against a source bundle before its sidecar exists, so a blanket rule would break local dry-runs.
- **remediate-published-results-submission-ci TODO (#959)** — the develop-side PR that implements w1–w4 does not itself update `origin/published-results`; `sync-results-data-to-published.yml` only opens a draft mirror PR a maintainer must review and merge. Reworded the verification section to check the develop-side wiring first and moved the published-results branch check to an explicit new post-merge work item (w5).
- **results-explorer-qa.md (#964)** — corrected the stat-card counts (11 results, 2 benchmarks, 7 platforms, not the stale 12/2/4), replaced a sqlite-based empty-filter example and "test all four platforms" instruction (there is no sqlite bundle in this corpus), and replaced the stale source-bundle-filename result IDs with the actual regenerated `result_id`s read from a fresh fixture build — all reconfirmed by actually running the generator and querying the generated DuckDB.
- **test_pr_workflow_path_classifier.py (#960)** — the ci-paths output lockstep regression test's regex only matched `.outputs` (dot form), missing GitHub Actions' fully bracketed `needs['ci-paths']['outputs']['x']` index syntax. Extended the regex to cover all dot/bracket combinations across every segment and added a dedicated regression test exercising the bracketed form directly.
- **phase3-promotion-review.yml (#963)** — added a `PHASE3_REVIEW_REF=develop` env var and used it in the review job's checkout, mirroring `release-canary.yml`'s `RELEASE_CANARY_REF` pattern — without it, landing this workflow on `main` (required for its schedule to ever fire) would make a scheduled run check out `main`'s stripped tree (no `_project/` or `phase2_metrics.py`) by default instead of `develop`'s. Documented the fix in the admin runbook.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files added.

## Notes

Reply-and-resolve on each source PR's review thread follows this PR being opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_