### PR TITLE
docs: reconcile explorer deploy-path claims with release curation (§2.13/§2.14)

### DIFF
--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -105,7 +105,7 @@ uv run -- python scripts/generate_corpus_inventory.py --write
 
 ### 5. Review and merge
 
-A maintainer reviews the submission for quality and environment consistency. Once approved and merged, the docs CI workflow automatically rebuilds the results explorer with the new data.
+A maintainer reviews the submission for quality and environment consistency. Once approved and merged into `published-results`, the bundle enters the public corpus. The results explorer rebuilds when the corpus reaches `main` through the develop → main release flow (the explorer builds and deploys from `main` via the docs CI workflow, not from `published-results` directly), so a merged submission appears on the site at the next release rather than immediately.
 
 ## What Makes a Good Submission
 

--- a/docs/operations/results-phase-2-runbook.md
+++ b/docs/operations/results-phase-2-runbook.md
@@ -38,13 +38,23 @@ needed outside the trigger conditions), trigger it manually via
 
 ### 1.3 Explorer publish path
 
-The static explorer at `benchbox.dev/results/` is built from `main` via
-[`docs.yml`](../../.github/workflows/docs.yml) on every push and pull
-request to that branch. `published-results` is **not** the explorer's
-build source — it is the corpus-archive branch that contributor PRs
-target and that mirrors develop's `results-data/`. The explorer
-publishes from `main`'s view of `results-data/`, which is what eventually
-reaches `main` via the develop → main release flow.
+The static explorer at `benchbox.dev/results/` is intended to build and
+deploy from `main` via [`docs.yml`](../../.github/workflows/docs.yml): the
+`build` job runs on pushes and PRs to `main`, and the `deploy` job (Pages)
+runs only on pushes to `main`. `published-results` is **not** the explorer's
+build source — it is the corpus-archive branch that contributor PRs target
+and that mirrors develop's `results-data/`.
+
+> **Current state (pre-launch):** the explorer steps in `docs.yml` are gated
+> on `hashFiles('results-explorer/package.json')`, and `release-cut`
+> (`Makefile`) currently `git rm`s `results-explorer/` and `results-data/`
+> from the release branch, so those paths are **not on `main`** and the
+> explorer build/deploy steps are a deliberate no-op there today. The site is
+> therefore not yet published from `main`. For the explorer to go live from
+> `main`, the develop → main release flow must stop curating
+> `results-explorer/`/`results-data/` out of the release branch — a maintainer
+> decision tracked separately. Until then, treat `benchbox.dev/results/` as a
+> develop-built preview, not a main-deployed site.
 
 ## 2. Maintainer Review Checklist
 
@@ -113,7 +123,12 @@ gh workflow run docs.yml --repo joeharris76/BenchBox
 gh run watch --repo joeharris76/BenchBox
 ```
 
-Use `workflow_dispatch` only after confirming there is no newer push already rebuilding the site.
+Use `workflow_dispatch` only after confirming there is no newer push already
+rebuilding the site. Note that `workflow_dispatch` runs the `build` job but
+**not** the `deploy` job — the Pages deploy is gated on
+`github.event_name == 'push' && github.ref == 'refs/heads/main'` — so a manual
+run validates the build without publishing. A publish requires a push to
+`main` (and, per §1.3, the explorer paths actually being present on `main`).
 
 ## 7. Data Locations
 


### PR DESCRIPTION
## Description

Implements TODO `remediate-explorer-deploy-path-reconciliation` — audit **§2.13/§2.14** (plan #959) — using the conservative default from the TODO's gating open question (the actual "where does it deploy from" decision is yours; this makes the docs honest about the *current* state without prejudging it).

The docs claimed the explorer "is built from `main`… publishes from `main`'s view of `results-data/`" and that a merged submission triggers an automatic rebuild. In reality `release-cut` (`Makefile`) `git rm`s `results-explorer/` and `results-data/` from the release branch, and `docs.yml`'s explorer steps are gated on `hashFiles('results-explorer/package.json')` — so on `main` they no-op and the site is not actually published from `main` today.

## Changes

- **runbook §1.3:** keep the design intent, add a **Current state (pre-launch)** note explaining the `hashFiles` gate + `release-cut` curation, that the site isn't yet published from `main`, and that going live requires a maintainer decision to stop curating those paths out of the release branch.
- **runbook §6:** note `workflow_dispatch` runs `build` but **not** `deploy` (deploy is push-to-`main` only), so a manual run validates without publishing.
- **contributing-results.md:** correct the "automatically rebuilds once merged" promise — a merged submission surfaces when the corpus reaches `main` via the release flow, not immediately on merge to `published-results`.

## Type of Change

- [x] Documentation

## Testing

- Re-derived against `docs.yml` (`deploy` job `if:`), `Makefile` `release-cut` strip list, and the current `main` tree (`results-explorer/` absent).
- `pre-commit run markdownlint` → Passed.

## Public Contract Check

- [x] Docs-only; no contract surfaces changed.

## Documentation / Code Quality / Artifact Hygiene

- [x] Docs are the change; markdownlint green; no code; no artifacts.

## Notes

This documents the current reality; the underlying **decision** — whether `main` should carry the explorer/corpus so the site deploys from it, or whether the explorer should deploy from elsewhere — remains yours (the TODO's gating open question). Part of the `results-explorer-publication-remediation` batch (#959). Auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_