### PR TITLE
feat(explorer): add Content-Security-Policy (close duckdb-wasm remote-fetch channel)

### DIFF
--- a/results-explorer/index.html
+++ b/results-explorer/index.html
@@ -2,6 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      Content-Security-Policy: the explorer is a fully static, self-contained
+      SPA. `connect-src 'self'` is the load-bearing directive — it confines all
+      network access (including anything duckdb-wasm's httpfs could attempt) to
+      the app's own origin, closing the remote-fetch/exfil channel. wasm-unsafe-eval
+      + worker-src blob: are required for the duckdb-wasm module and its worker.
+      GitHub Pages cannot set response headers, so this ships as a <meta> tag.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; worker-src 'self' blob:; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+    />
     <link rel="icon" type="image/svg+xml" href="/results/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="BenchBox Results Explorer - browse, compare, and analyze public benchmark results across platforms." />


### PR DESCRIPTION
## Description

Implements TODO `remediate-explorer-csp-hardening` — audit **§2.23** (plan #959). The explorer shipped with **no CSP**, leaving duckdb-wasm's `httpfs`/remote-read capability as an (only self-inflicted) exfiltration channel.

Adds a `<meta http-equiv="Content-Security-Policy">` to `results-explorer/index.html` (GitHub Pages can't set response headers). The load-bearing directive is **`connect-src 'self'`** — all network access, including anything duckdb-wasm attempts, is confined to the app's own origin. `script-src 'wasm-unsafe-eval'` + `worker-src 'self' blob:` keep the wasm module and its worker functional; `object-src 'none'` / `base-uri 'self'` / `frame-ancestors 'none'` harden the rest.

## Testing (verified against the built app, not just static reasoning)

- `npm run typecheck` + `npm run build` → pass; CSP present in `dist/index.html`.
- **17 DuckDB-loading e2e specs pass with the CSP in place** (`home.spec.ts`, `query.spec.ts` — including the read-only-write error path and CSV/JSON downloads — and `result-detail.spec.ts`), run against the built `dist/` via the project's Playwright web server. This confirms the CSP does **not** break wasm instantiation, the worker, queries, or downloads.

## Type of Change

- [x] New feature (security hardening)

## Public Contract Check

- [x] No public API/schema/contract change — a client-side security header on the static explorer.

## Documentation

- [x] No doc change needed; the CSP is self-documenting via an inline comment explaining each directive.

## Code Quality

- [x] Single-file change; verified end-to-end via the browser suite.

## Artifact Hygiene

- [x] No raw artifacts committed. (A temporary, env-gated `executablePath` tweak was used to run Playwright against the environment's pre-installed Chromium and was **not** committed.)

## Notes

Part of the `results-explorer-publication-remediation` batch (#959). If you later add a same-origin CDN or analytics endpoint, extend `connect-src`/`script-src` accordingly. Auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_