### PR TITLE
chore(ci): promote parity-check to the required develop-PR lane (draft: w0 runner observation)

### DIFF
--- a/tests/parity/README.md
+++ b/tests/parity/README.md
@@ -1,0 +1,22 @@
+# CLI ↔ Explorer visualization parity fixtures
+
+`generate_visualization_fixtures.py` writes one JSON fixture per chart-math
+helper into `fixtures/`. Each fixture is the checked-in contract between the
+Python reference implementations (this directory) and the TypeScript helpers
+in `results-explorer/src/lib/chartMath.ts`, asserted byte-identically by the
+Vitest parity suite (`chartMath.parity.test.ts`).
+
+- `make parity-fixtures` — regenerate and overwrite the committed fixtures.
+- `make parity-check` — regenerate into a tmpdir and fail on any diff
+  (the CI `parity-check` job in `.github/workflows/pr.yml`, path-filtered to
+  viz changes).
+
+## Environment note: `geomean_ms` last-bit drift
+
+`geomean_ms` is a transcendental computation (`exp`/`log`); its final bits
+can vary across libm builds, so a regenerated `fixtures/geomean_ms.json` may
+differ from the committed one by ~1 ulp depending on the environment
+(observed: `237.9081547062432` committed vs `...34` in at least one Linux
+container). `make parity-check` compares byte-exactly. The
+`parity-check-promotion` TODO owns the disposition (tolerance vs fixture
+regeneration) based on what real GitHub runners produce.


### PR DESCRIPTION
# Pull Request

## Description

DRAFT — first stage of TODO `parity-check-promotion` (w0): force the first real `parity-check` job run on a GitHub runner since PR #955 fixed the `viz-needed` output wiring (before #955 the job silently skipped on every PR, so promotion criterion 1 — "one green run on a real runner" — was unmeetable).

This commit touches `tests/parity/**` (a `viz` path-filter group path) with a durable README documenting the fixtures contract and the `geomean_ms` last-bit libm drift that promotion criterion 2 dispositions. The parity-check job on THIS PR is the w0 observation.

Next stages on this branch (before marking ready for review):
- w1: disposition the geomean_ms drift based on the runner result (tolerance vs fixture regen vs document-local-artifact).
- w2: promotion — add parity-check to `ci-required-result.needs` with the package-smoke skip-counts-as-pass pattern, drop `continue-on-error`, flip `test_parity_check_is_demoted_to_non_blocking` to the promoted-shape assertions.

## Type of Change

- [ ] Bug fix
- [x] Documentation (this commit) — promotion workflow change follows on this branch

## Testing

The PR run itself is the test: parity-check must execute (not skip) because tests/parity/** changed. Local `make parity-check` currently FAILS with the 2-ulp geomean drift (fixture `237.9081547062432` vs local `...34`) — the runner result decides w1.

## Public Contract Check

- [x] No contract surfaces changed.

## Documentation

- [x] The README is the documentation.

## Code Quality

- [x] Markdown only (this commit).

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

Draft until the promotion commits land. Do not merge as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_