### PR TITLE
fix(explorer): unify trust-label vocabulary; render Unknown on empty (§2.20/§2.21)

### DIFF
--- a/results-explorer/src/components/TrustBadge.tsx
+++ b/results-explorer/src/components/TrustBadge.tsx
@@ -4,9 +4,16 @@
 // Tone semantics:
 //   maintainer-run       → success  (verified by project maintainers)
 //   community-submission → info     (user-submitted, explicitly disclosed)
-//   ci-verified          → neutral  (automated pipeline, no human review)
-//   local-run            → neutral  (developer machine, no CI validation)
-//   unknown              → neutral  (fallback for unrecognised values)
+//   ci / ci-verified     → neutral  (automated pipeline, no human review)
+//   local / local-run    → neutral  (developer machine, no CI validation)
+//   unofficial-research  → warning  (non-standard config, not comparable)
+//   unknown / empty      → neutral  (fallback for unrecognised / missing values)
+//
+// The keys below cover BOTH the explorer pipeline's trust labels
+// (ci-verified, local-run) AND the publisher vocabulary in
+// benchbox/core/publishing/bundle_publisher.py:VALID_LABELS
+// (ci, local, unofficial-research), so a valid label never falls through to the
+// "unrecognised" fallback. Keep the two in sync.
 //
 // Tones meet WCAG AA contrast (light background + dark text in each tier).
 // Do NOT de-emphasise community results - show them prominently with their
@@ -36,10 +43,25 @@ const TRUST_CONFIG: Record<string, { label: string; tone: StatusTone; title: str
     tone: "neutral",
     title: "Validated by automated CI pipeline",
   },
+  ci: {
+    label: "CI",
+    tone: "neutral",
+    title: "Validated by automated CI pipeline",
+  },
   "local-run": {
     label: "Local",
     tone: "neutral",
     title: "Run on a developer machine - environment may vary",
+  },
+  local: {
+    label: "Local",
+    tone: "neutral",
+    title: "Run on a developer machine - environment may vary",
+  },
+  "unofficial-research": {
+    label: "Unofficial",
+    tone: "warning",
+    title: "Unofficial / non-standard configuration - not comparable and excluded from official rankings",
   },
 };
 
@@ -61,13 +83,20 @@ interface ValidationBadgeProps {
 }
 
 export function TrustBadge({ trustLabel, compact = false }: TrustBadgeProps) {
-  if (!trustLabel) return null;
-  const known = TRUST_CONFIG[trustLabel];
-  const config = known ?? {
-    ...DEFAULT_CONFIG,
-    label: trustLabel,
-    title: `Trust tier: ${trustLabel} (unrecognised - contact maintainers)`,
-  };
+  // Render an explicit "Unknown" badge for a missing label rather than hiding
+  // the trust dimension entirely: a silently-absent badge reads as "no opinion"
+  // instead of "provenance not recorded". (trust_label is NOT NULL in the
+  // snapshot schema today, so this is a defensive contract, not a hot path.)
+  const known = trustLabel ? TRUST_CONFIG[trustLabel] : undefined;
+  const config =
+    known ??
+    (trustLabel
+      ? {
+          ...DEFAULT_CONFIG,
+          label: trustLabel,
+          title: `Trust tier: ${trustLabel} (unrecognised - contact maintainers)`,
+        }
+      : DEFAULT_CONFIG);
   const text = compact ? (config.label.split(" ")[0] ?? config.label) : config.label;
   return (
     <StatusBadge role="trust" tone={config.tone} title={config.title}>

--- a/results-explorer/src/components/__tests__/TrustBadge.test.tsx
+++ b/results-explorer/src/components/__tests__/TrustBadge.test.tsx
@@ -93,9 +93,37 @@ describe("TrustBadge", () => {
     expect(title).toContain("unrecognised");
   });
 
-  it("empty trustLabel renders nothing", () => {
+  it("empty trustLabel renders an explicit Unknown badge (not nothing)", () => {
     const { container } = render(<TrustBadge trustLabel="" />);
-    expect(container.querySelector(".badge")).toBeNull();
+    const badge = container.querySelector(".badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe("Unknown");
+    expect(badge?.getAttribute("data-tone")).toBe("neutral");
+  });
+
+  // Mirror of bundle_publisher.py VALID_LABELS; keep in sync.
+  const PUBLISHER_VALID_LABELS = [
+    "maintainer-run",
+    "community-submission",
+    "ci",
+    "local",
+    "unofficial-research",
+  ] as const;
+
+  it.each(PUBLISHER_VALID_LABELS)("publisher label %s renders a curated (non-unrecognised) badge", (label) => {
+    const { container } = render(<TrustBadge trustLabel={label} />);
+    const badge = container.querySelector(".badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("title") ?? "").not.toContain("unrecognised");
+    // Curated labels never echo the raw slug back as their visible text.
+    expect(badge?.textContent).not.toBe(label);
+  });
+
+  it("unofficial-research uses a cautionary warning tone", () => {
+    const { container } = render(<TrustBadge trustLabel="unofficial-research" />);
+    const badge = container.querySelector(".badge");
+    expect(badge?.getAttribute("data-tone")).toBe("warning");
+    expect(badge?.textContent).toBe("Unofficial");
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Implements TODO `remediate-explorer-trust-label-vocabulary` — audit **§2.20 / §2.21** (plan #959).

- **§2.20 (vocabulary parity):** `TrustBadge` mapped `ci-verified`/`ci-validated`/`local-run` but not the publisher vocabulary (`bundle_publisher.py:VALID_LABELS` = `maintainer-run, community-submission, ci, local, unofficial-research`). A bundle labeled `ci`, `local`, or `unofficial-research` rendered under the "unrecognised — contact maintainers" fallback. Added curated badges for all three (`unofficial-research` gets a cautionary **warning** tone, since it's not comparable). A parity test enumerates `VALID_LABELS` and asserts each resolves to a non-fallback badge.
- **§2.21 (empty-state):** `TrustBadge` returned `null` on an empty label, silently hiding the trust dimension. It now renders the explicit **"Unknown"** badge (defensive — `trust_label` is `NOT NULL` in the snapshot schema).

## Testing

- `npm run typecheck` → pass.
- **Full vitest suite: 717 passed (65 files)**, including 25 in `TrustBadge.test.tsx` — the new `VALID_LABELS` parity cases (`it.each`), the empty→"Unknown" case, and the `unofficial-research` warning-tone case. The 3 callers (`QueryHeatmap` ×2, `MetaLeaderboard`) all pass NOT-NULL snapshot fields, so the empty-state change is inert in practice.

## Type of Change

- [x] Bug fix

## Public Contract Check

- [x] No public API/schema change — client-side badge rendering only.

## Documentation

- [x] The component comment documents the tone semantics and the VALID_LABELS sync requirement.

## Code Quality

- [x] typecheck + full vitest green; parity test guards against future divergence.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

This makes `TrustBadge` the single rendering authority that must cover the publisher vocabulary; a follow-up could hoist a shared canonical label list, but that's a larger cross-language change than this fix needs. Part of the `results-explorer-publication-remediation` batch (#959). Auto-merge not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_