### PR TITLE
fix(query-plans): key .plans.json by stream for multi-stream rows, fix console count

### DIFF
--- a/_project/DONE/main/fix-multistream-throughput-plan-attachment.yaml
+++ b/_project/DONE/main/fix-multistream-throughput-plan-attachment.yaml
@@ -2,7 +2,22 @@ id: fix-multistream-throughput-plan-attachment
 title: "Attach captured plans to multi-stream throughput/combined rows (and reconcile the console count)"
 worktree: main
 priority: High
-status: Not Started
+status: "Completed"
+completed_date: "2026-07-05"
+completion_note: |
+  Freshness re-validation at implementation time (develop had moved ~75 commits
+  since this TODO was filed): w1 (carry _plan_capture_key through the TPC-H/
+  TPC-DS power+throughput converters) and w4 (update the divergence test +
+  docs) were ALREADY implemented by unrelated prior work (the
+  query-plan-capture-canonical-isolation effort) - confirmed via
+  test_combined_power_then_throughput_same_public_id_different_sql, which
+  already existed, passed, and documents "production TPC power/throughput rows
+  DO carry the key today". Only w2 (build_plans_payload last-writer-wins on
+  query_id for multi-stream rows) and w3 (console summary using the per-variant
+  counter instead of the row-derived count) were still real, live defects; this
+  PR implements those two. w2's fix required also touching loader.py (out of
+  the original scope_limit) to keep the .plans.json reattachment TODO1 fixed
+  working for the new composite-keyed multi-stream case.
 description: |
   In any TPC throughput run with >= 2 streams (and in combined mode), every query
   is captured (EXPLAINed, cost paid, counted) but ZERO plans are attached to result
@@ -51,9 +66,10 @@ impact:
     while the console reports a positive capture count.
 
 must_preserve:
-  - "The isolated post-measurement capture contract: no EXPLAIN in the timed loop or a concurrent stream; writes never re-executed."
-  - "Per-variant fidelity for rows that already carry an exact _plan_capture_key (test_standard_path_exact_key_attaches_each_variant must stay green)."
-  - "query_plans_captured and the bundle plans_captured must agree after the fix."
+- "The isolated post-measurement capture contract: no EXPLAIN in the timed loop or a concurrent stream; writes never re-executed."
+- "Per-variant fidelity for rows that already carry an exact _plan_capture_key (test_standard_path_exact_key_attaches_each_variant
+  must stay green)."
+- "query_plans_captured and the bundle plans_captured must agree after the fix."
 
 approach: |
   Propagate `_plan_capture_key` through _power_query_result and the throughput
@@ -64,46 +80,48 @@ approach: |
   the same row-derived count used for the bundle (compute_plan_capture_stats).
 
 anti_patterns:
-  - "DO NOT relax the public-id fallback to 'attach any variant' - because it pairs a row with another stream's plan - carry the exact key instead."
+- "DO NOT relax the public-id fallback to 'attach any variant' - because it pairs a row with another stream's plan - carry
+  the exact key instead."
 
 scope_limit:
   only_modify:
-    - "benchbox/core/tpch/platform_power.py"
-    - "benchbox/platforms/base/execution.py"
-    - "benchbox/platforms/base/result_capture.py"
-    - "benchbox/core/results/schema.py"
-    - "tests/integration/test_plan_capture_combined_divergence.py"
-    - "tests/unit/platforms/"
-    - "docs/features/query-plan-analysis.md"
+  - "benchbox/core/tpch/platform_power.py"
+  - "benchbox/platforms/base/execution.py"
+  - "benchbox/platforms/base/result_capture.py"
+  - "benchbox/core/results/schema.py"
+  - "tests/integration/test_plan_capture_combined_divergence.py"
+  - "tests/unit/platforms/"
+  - "docs/features/query-plan-analysis.md"
 
 work:
-  - id: w1
-    summary: "Carry _plan_capture_key through _power_query_result and the TPC-H/TPC-DS throughput converters"
-    status: pending
-  - id: w2
-    summary: "Key build_plans_payload entries so per-stream/per-variant provenance survives (not last-writer-wins on query_id)"
-    status: pending
-    needs: [w1]
-  - id: w3
-    summary: "Reconcile the console 'Query plans: N/M' summary with the row-derived bundle count"
-    status: pending
-    needs: [w1]
-  - id: w4
-    summary: "Update the divergence test (line 213) and docs so multi-stream rows attach; keep the truly-ambiguous (no-key) case as the only unattached path"
-    status: pending
-    needs: [w1]
+- id: w1
+  summary: "Carry _plan_capture_key through _power_query_result and the TPC-H/TPC-DS throughput converters"
+  status: done
+- id: w2
+  summary: "Key build_plans_payload entries so per-stream/per-variant provenance survives (not last-writer-wins on query_id)"
+  status: done
+  needs: [w1]
+- id: w3
+  summary: "Reconcile the console 'Query plans: N/M' summary with the row-derived bundle count"
+  status: done
+  needs: [w1]
+- id: w4
+  summary: "Update the divergence test (line 213) and docs so multi-stream rows attach; keep the truly-ambiguous (no-key)
+    case as the only unattached path"
+  status: done
+  needs: [w1]
 
 verification:
-  - description: "A 2-stream throughput run attaches a plan to every successful row"
-    command: "uv run -- python -m pytest tests/unit/platforms/ tests/integration/ -k 'throughput and plan' -n 0 -q"
-    expected_output: "passed"
-  - description: "Existing exact-key and combined-divergence tests stay green"
-    command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
-    expected_output: "passed"
+- description: "A 2-stream throughput run attaches a plan to every successful row"
+  command: "uv run -- python -m pytest tests/unit/platforms/ tests/integration/ -k 'throughput and plan' -n 0 -q"
+  expected_output: "passed"
+- description: "Existing exact-key and combined-divergence tests stay green"
+  command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
+  expected_output: "passed"
 
 deps:
   needs: [fix-plan-consumption-phases-and-loader-reattach]
 
 deferred:
-  - summary: "Reproducing failing test captured under scratchpad/review-failing-tests/test_plan_attach_multivariant_review.py"
-    reason: "Staged locally (uncommitted); fold in as a w1 guard when implementing."
+- summary: "Reproducing failing test captured under scratchpad/review-failing-tests/test_plan_attach_multivariant_review.py"
+  reason: "Staged locally (uncommitted); fold in as a w1 guard when implementing."

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -453,10 +453,12 @@ def _reconstruct_query_results(
     query ID (e.g. ``"q1"``), while the compact ``queries`` list here carries the
     already-normalized ID (e.g. ``"1"``) written by ``_build_query_results_section``.
     Normalize both sides for the lookup so the two companion files agree without
-    changing the on-disk ``.plans.json`` format.
+    changing the on-disk ``.plans.json`` format. A query ID that ran in more than
+    one stream is written under ``"{query_id}#{stream_id}"`` composite keys (see
+    ``build_plans_payload``); ``_index_plan_entries``/``_lookup_plan_entry`` below
+    resolve those back to the exact stream's entry.
     """
-    raw_plan_entries: dict[str, Any] = (plans_data or {}).get("queries") or {}
-    plan_entries: dict[str, Any] = {normalize_query_id(k): v for k, v in raw_plan_entries.items()}
+    plan_entries = _index_plan_entries(plans_data)
     results: list[dict[str, Any]] = []
 
     # Process successful queries
@@ -472,7 +474,7 @@ def _reconstruct_query_results(
             result["iteration"] = q["iter"]
         if q.get("stream"):
             result["stream_id"] = q["stream"]
-        _attach_plan(result, plan_entries.get(normalize_query_id(query_id)) if query_id is not None else None)
+        _attach_plan(result, _lookup_plan_entry(plan_entries, query_id, q.get("stream", 0)))
         results.append(result)
 
     # Add failed queries from errors
@@ -504,6 +506,39 @@ def _attach_plan(result: dict[str, Any], plan_entry: dict[str, Any] | None) -> N
         result["plan_fingerprint_normalized"] = plan_entry["fingerprint_normalized"]
     if plan_entry.get("capture_time_ms") is not None:
         result["plan_capture_time_ms"] = plan_entry["capture_time_ms"]
+
+
+def _index_plan_entries(plans_data: dict[str, Any] | None) -> dict[str, Any]:
+    """Index a ``.plans.json`` ``queries`` map for lookup by normalized query ID.
+
+    A query ID that ran in more than one stream is written under
+    ``"{query_id}#{stream_id}"`` composite keys (see ``build_plans_payload``); this
+    splits those apart so the reader doesn't need to know the writer's key format.
+    Each normalized query ID maps to either a single entry dict (the common
+    bare-key, single-stream case) or a ``{stream_id_str: entry}`` dict (the
+    multi-stream case) - distinguished in ``_lookup_plan_entry`` by the presence
+    of a ``"plan"`` key, which a stream-keyed bucket never has.
+    """
+    raw_entries: dict[str, Any] = (plans_data or {}).get("queries") or {}
+    indexed: dict[str, Any] = {}
+    for key, entry in raw_entries.items():
+        if "#" in key:
+            base_id, _, stream_id = key.rpartition("#")
+            bucket = indexed.setdefault(normalize_query_id(base_id), {})
+            bucket[stream_id] = entry
+        else:
+            indexed[normalize_query_id(key)] = entry
+    return indexed
+
+
+def _lookup_plan_entry(plan_entries: dict[str, Any], query_id: Any, stream_id: Any) -> dict[str, Any] | None:
+    """Resolve the plan entry for ``query_id``, disambiguating by ``stream_id`` when needed."""
+    if query_id is None:
+        return None
+    entry = plan_entries.get(normalize_query_id(query_id))
+    if entry is None or "plan" in entry:
+        return entry
+    return entry.get(str(stream_id))
 
 
 def iter_query_results(results: Any) -> list[dict[str, Any]]:

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -1008,6 +1008,33 @@ def compute_plan_capture_stats(
     return plans_captured, len(failed_ids), capture_errors
 
 
+def _build_plan_entry(qr: dict[str, Any]) -> dict[str, Any]:
+    """Serialize a single query result's captured plan into a `.plans.json` entry."""
+    query_plan = qr.get("query_plan")
+    plan_fingerprint = qr.get("plan_fingerprint")
+    plan_fingerprint_normalized = qr.get("plan_fingerprint_normalized")
+    capture_time = qr.get("plan_capture_time_ms")
+
+    plan_entry: dict[str, Any] = {}
+    if plan_fingerprint:
+        plan_entry["fingerprint"] = plan_fingerprint
+    if plan_fingerprint_normalized:
+        plan_entry["fingerprint_normalized"] = plan_fingerprint_normalized
+    if capture_time:
+        plan_entry["capture_time_ms"] = round(capture_time, 1)
+
+    if is_dataclass(query_plan):
+        plan_entry["plan"] = asdict(query_plan)
+    elif isinstance(query_plan, dict):
+        plan_entry["plan"] = query_plan
+    elif hasattr(query_plan, "to_dict"):
+        plan_entry["plan"] = query_plan.to_dict()
+    else:
+        plan_entry["plan"] = str(query_plan)
+
+    return plan_entry
+
+
 def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
     """Build companion plans file payload.
 
@@ -1018,40 +1045,36 @@ def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
 
     Returns:
         Dictionary for plans companion file, or None if no plans.
+
+    Multi-stream keying:
+        ``capture_query_plan``'s documented contract is one plan record per
+        ``(query_id, stream_id)`` - streams are NOT deduplicated, so a query_id
+        that ran in more than one stream has more than one captured-plan row.
+        Keying this payload by bare ``query_id`` alone would collapse those rows
+        to a single last-writer-wins entry. Rows are grouped by ``query_id``
+        first; a group with exactly one plan-bearing row keeps the simple bare
+        ``query_id`` key (the common single-stream case, unchanged format), and
+        a group with more than one row uses a ``"{query_id}#{stream_id}"``
+        composite key per row so every stream's plan survives.
     """
     if not result.query_plans_captured or result.query_plans_captured == 0:
         return None
 
+    rows_by_query_id: dict[str, list[dict[str, Any]]] = {}
+    for qr in result.query_results or []:
+        if qr.get("query_plan") is None:
+            continue
+        query_id = str(qr.get("query_id", qr.get("id", "")))
+        rows_by_query_id.setdefault(query_id, []).append(qr)
+
     plans_by_query: dict[str, Any] = {}
     errors_list: list[dict[str, Any]] = []
 
-    for qr in result.query_results or []:
-        query_id = str(qr.get("query_id", qr.get("id", "")))
-        query_plan = qr.get("query_plan")
-        plan_fingerprint = qr.get("plan_fingerprint")
-        plan_fingerprint_normalized = qr.get("plan_fingerprint_normalized")
-        capture_time = qr.get("plan_capture_time_ms")
-
-        if query_plan is not None:
-            plan_entry: dict[str, Any] = {}
-            if plan_fingerprint:
-                plan_entry["fingerprint"] = plan_fingerprint
-            if plan_fingerprint_normalized:
-                plan_entry["fingerprint_normalized"] = plan_fingerprint_normalized
-            if capture_time:
-                plan_entry["capture_time_ms"] = round(capture_time, 1)
-
-            # Serialize the plan
-            if is_dataclass(query_plan):
-                plan_entry["plan"] = asdict(query_plan)
-            elif isinstance(query_plan, dict):
-                plan_entry["plan"] = query_plan
-            elif hasattr(query_plan, "to_dict"):
-                plan_entry["plan"] = query_plan.to_dict()
-            else:
-                plan_entry["plan"] = str(query_plan)
-
-            plans_by_query[query_id] = plan_entry
+    for query_id, rows in rows_by_query_id.items():
+        multi_stream = len(rows) > 1
+        for qr in rows:
+            key = f"{query_id}#{qr.get('stream_id', 0)}" if multi_stream else query_id
+            plans_by_query[key] = _build_plan_entry(qr)
 
     # Add plan capture errors
     for error in result.plan_capture_errors or []:
@@ -1068,7 +1091,7 @@ def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
     return {
         "version": SCHEMA_VERSION,
         "run_id": result.execution_id,
-        "plans_captured": len(plans_by_query),
+        "plans_captured": len(rows_by_query_id),
         "capture_failures": result.plan_capture_failures or 0,
         "queries": plans_by_query,
         "errors": errors_list if errors_list else None,

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -1731,6 +1731,29 @@ class ResultCaptureMixin:
             return True
         return False
 
+    def _log_plan_capture_summary(self, query_results: list[dict[str, Any]]) -> None:
+        """Log a "Query plans: N/M captured" summary using the same row-derived,
+        unique-query-id stat that ends up in ``BenchmarkResults.query_plans_captured``
+        and the ``.plans.json`` companion (see ``adapter.py``'s canonical
+        ``compute_plan_capture_stats`` call site).
+
+        ``self.query_plans_captured`` is a per-variant counter (one increment per
+        distinct captured SQL text, e.g. once per seed-varied stream), so it
+        legitimately exceeds the unique-query-id count on any multi-stream run;
+        printing it here would contradict what the bundle actually contains.
+        """
+        from benchbox.core.results.schema import compute_plan_capture_stats
+
+        plans_captured, capture_failures, _errors = compute_plan_capture_stats(
+            query_results, self.capture_plans, existing_errors=list(self.plan_capture_errors)
+        )
+        total_queries = plans_captured + capture_failures
+        summary_message = f"Query plans: {plans_captured}/{total_queries} captured"
+        if capture_failures:
+            summary_message = f"{summary_message}, {capture_failures} failed"
+        log_fn = self.logger.warning if capture_failures else self.logger.info
+        log_fn(summary_message)
+
     def _build_execution_phases(self, query_results, query_executions, run_config, setup_phase) -> tuple:
         """Build power/throughput test phases and return execution phases with metrics.
 
@@ -1744,12 +1767,7 @@ class ResultCaptureMixin:
         avg_time = total_exec_time / max(successful_queries, 1)
 
         if self.capture_plans:
-            total_queries_executed = len(query_results)
-            summary_message = f"Query plans: {self.query_plans_captured}/{total_queries_executed} captured"
-            if self.plan_capture_failures:
-                summary_message = f"{summary_message}, {self.plan_capture_failures} failed"
-            log_fn = self.logger.warning if self.plan_capture_failures else self.logger.info
-            log_fn(summary_message)
+            self._log_plan_capture_summary(query_results)
 
         # When a fallback occurred (e.g. throughput requested but unsupported),
         # _effective_execution_type reflects the actual execution shape.

--- a/docs/features/query-plan-analysis.md
+++ b/docs/features/query-plan-analysis.md
@@ -150,19 +150,20 @@ and plans are attached to result rows once, at the end. The checkpoint runs stri
 never inside a timed query or a concurrent throughput stream — so measured timings are unaffected.
 
 Capture is driven by the recorded-query buffer (every distinct query that succeeded during the timed
-run), and each captured plan is attached to its result row by the exact recorded query, or — for the
-TPC power/throughput drivers, whose result rows carry only the query id — by that query id when it
-maps to a single executed SQL variant.
+run), and each captured plan is attached to its result row by the exact recorded query - including the
+TPC power/throughput drivers, which carry the recorded query's key through their result rows, so each
+seed-varied stream attaches its own plan rather than falling back to an id-only match. A row that
+somehow lacks the key (a bespoke driver that cannot supply one) falls back to matching by bare query id,
+which only succeeds when that id maps to a single executed SQL variant.
 
-> **Seed-varied throughput streams and bespoke DML query sets.** When one query id runs as *several*
-> distinct SQL variants in the same run (e.g. throughput streams rendered with different seeds), a
-> result row that carries only the query id cannot be matched to the specific variant it ran, so its
-> plan is left unattached rather than risk pairing it with another variant's plan (literal-normalized
-> fingerprints, tracked separately, make these variants structurally equal). Likewise, a *bespoke*
-> query set that runs an `INSERT`/`UPDATE`/`DELETE` partway through and then more `SELECT`s has no
-> maintenance phase boundary, so the isolated model captures those later reads against the end-of-run
-> state. Keep data-mutating steps in a maintenance phase (or a separate run) when you need read-query
-> fingerprints to reflect their measured data state.
+Multi-stream runs persist one plan record per `(query_id, stream_id)` in the `.plans.json` companion -
+streams are never deduplicated or last-writer-wins collapsed, so every stream's plan and fingerprint
+survive a result-file round trip (`show-plan`, `compare-plans`).
+
+> **Bespoke DML query sets.** A *bespoke* query set that runs an `INSERT`/`UPDATE`/`DELETE` partway
+> through and then more `SELECT`s has no maintenance phase boundary, so the isolated model captures
+> those later reads against the end-of-run state. Keep data-mutating steps in a maintenance phase (or a
+> separate run) when you need read-query fingerprints to reflect their measured data state.
 
 ### Captured Fields
 

--- a/tests/unit/core/results/test_loader.py
+++ b/tests/unit/core/results/test_loader.py
@@ -539,6 +539,74 @@ class TestReconstructBenchmarkResults:
         assert result.query_results[0]["stream_id"] == 1
         assert result.query_results[1]["stream_id"] == 2
 
+    def test_reconstruct_query_results_multi_stream_plans_reattach_per_stream(self):
+        """A query_id captured in multiple streams is keyed in .plans.json as
+        "{query_id}#{stream_id}" (build_plans_payload); the loader must resolve
+        each row to its OWN stream's plan, not the other stream's or none at all.
+        """
+        data = make_v2_result_dict(
+            version="2.0",
+            benchmark_id="test",
+            benchmark_name="Test",
+            platform="Test",
+            scale_factor=1.0,
+            execution_id="test",
+            timestamp="2025-01-01T10:00:00",
+            query_time_ms=200,
+            streams=2,
+            total_queries=2,
+            passed_queries=2,
+            failed_queries=0,
+            total_ms=200,
+            queries=[
+                {"id": "1", "ms": 100.0, "rows": 4, "stream": 1},
+                {"id": "1", "ms": 90.0, "rows": 4, "stream": 2},
+            ],
+        )
+        plans_data = {
+            "queries": {
+                "1#1": {"fingerprint": "a" * 64, "plan": {"query_id": "1", "platform": "duckdb", "logical_root": None}},
+                "1#2": {"fingerprint": "b" * 64, "plan": {"query_id": "1", "platform": "duckdb", "logical_root": None}},
+            }
+        }
+
+        result = reconstruct_benchmark_results(data, plans_data=plans_data)
+
+        assert len(result.query_results) == 2
+        assert result.query_results[0]["stream_id"] == 1
+        assert result.query_results[0]["plan_fingerprint"] == "a" * 64
+        assert result.query_results[1]["stream_id"] == 2
+        assert result.query_results[1]["plan_fingerprint"] == "b" * 64
+
+    def test_reconstruct_query_results_single_stream_bare_key_still_works(self):
+        """A query_id captured in exactly one stream is keyed bare (no "#stream"
+        suffix); this must keep working unchanged (the common case)."""
+        data = make_v2_result_dict(
+            version="2.0",
+            benchmark_id="test",
+            benchmark_name="Test",
+            platform="Test",
+            scale_factor=1.0,
+            execution_id="test",
+            timestamp="2025-01-01T10:00:00",
+            query_time_ms=100,
+            total_queries=1,
+            passed_queries=1,
+            failed_queries=0,
+            total_ms=100,
+            queries=[{"id": "1", "ms": 100.0, "rows": 4}],
+        )
+        plans_data = {
+            "queries": {
+                "1": {"fingerprint": "c" * 64, "plan": {"query_id": "1", "platform": "duckdb", "logical_root": None}},
+            }
+        }
+
+        result = reconstruct_benchmark_results(data, plans_data=plans_data)
+
+        assert len(result.query_results) == 1
+        assert result.query_results[0]["plan_fingerprint"] == "c" * 64
+
     def test_reconstruct_with_errors(self):
         """Test that errors array is properly reconstructed."""
         data = make_v2_result_dict(

--- a/tests/unit/core/results/test_query_plan_serialization.py
+++ b/tests/unit/core/results/test_query_plan_serialization.py
@@ -273,6 +273,58 @@ class TestSchemaV2ExportWithPlans:
         assert plans_payload["plans_captured"] == 1
         assert "q01" in plans_payload["queries"]
 
+    def test_schema_v2_plans_companion_multi_stream_keys_per_stream(self) -> None:
+        """A query_id captured in more than one stream must not collapse to one
+        last-writer-wins entry: capture_query_plan's contract is one plan record
+        per (query_id, stream_id), so each stream's plan must survive under its
+        own key.
+        """
+
+        def _plan(fingerprint: str) -> QueryPlanDAG:
+            root = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_1", table_name="lineitem")
+            return QueryPlanDAG(query_id="q06", platform="duckdb", logical_root=root, plan_fingerprint=fingerprint)
+
+        plan_stream0 = _plan("a" * 64)
+        plan_stream1 = _plan("b" * 64)
+
+        results = make_benchmark_results(
+            benchmark_id="tpch",
+            benchmark_name="tpch",
+            platform="duckdb",
+            scale_factor=1.0,
+            execution_id="test_multi_stream",
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            total_queries=2,
+            successful_queries=2,
+            query_plans_captured=2,
+            query_results=[
+                {
+                    "query_id": "q06",
+                    "status": "SUCCESS",
+                    "stream_id": 0,
+                    "query_plan": plan_stream0,
+                    "plan_fingerprint": plan_stream0.plan_fingerprint,
+                },
+                {
+                    "query_id": "q06",
+                    "status": "SUCCESS",
+                    "stream_id": 1,
+                    "query_plan": plan_stream1,
+                    "plan_fingerprint": plan_stream1.plan_fingerprint,
+                },
+            ],
+        )
+
+        plans_payload = build_plans_payload(results)
+
+        assert plans_payload is not None
+        # Top-level count is unique query IDs, not per-stream row count.
+        assert plans_payload["plans_captured"] == 1
+        queries = plans_payload["queries"]
+        assert "q06" not in queries, "bare query_id key must not be used once ambiguous across streams"
+        assert queries["q06#0"]["fingerprint"] == "a" * 64
+        assert queries["q06#1"]["fingerprint"] == "b" * 64
+
     def test_schema_v2_export_complex_plan(self) -> None:
         """Test schema v2.0 export with complex query plan tree."""
         # Build: Join(orders, lineitem) -> [Scan(orders), Scan(lineitem)]

--- a/tests/unit/platforms/base/test_result_capture.py
+++ b/tests/unit/platforms/base/test_result_capture.py
@@ -89,3 +89,54 @@ class TestMergePlanCaptureIntoResult:
         result = {"status": "SUCCESS"}
         ret = host._merge_plan_capture_into_result(result, "conn", "SELECT 1", "q1")
         assert ret is None, "helper mutates in place and must not return the dict"
+
+
+class _SummaryHost(ResultCaptureMixin):
+    """Minimal ResultCaptureMixin host for _log_plan_capture_summary."""
+
+    def __init__(self, capture_plans=True):
+        self.capture_plans = capture_plans
+        self.plan_capture_errors = []
+        self.logger = MagicMock()
+
+
+def _qr(query_id, status="SUCCESS", run_type="measurement", query_plan=None, stream_id=0):
+    row = {"query_id": query_id, "status": status, "run_type": run_type, "stream_id": stream_id}
+    if query_plan is not None:
+        row["query_plan"] = query_plan
+    return row
+
+
+class TestLogPlanCaptureSummary:
+    """The console summary must match the row-derived, unique-query-id count that
+    ends up in BenchmarkResults.query_plans_captured / the .plans.json companion -
+    not the per-variant self.query_plans_captured counter, which legitimately
+    exceeds it on any multi-stream run.
+    """
+
+    def test_single_stream_all_captured_logs_info_with_matching_counts(self):
+        host = _SummaryHost()
+        query_results = [_qr("q1", query_plan=_make_plan()), _qr("q2", query_plan=_make_plan())]
+        host._log_plan_capture_summary(query_results)
+        host.logger.info.assert_called_once_with("Query plans: 2/2 captured")
+        host.logger.warning.assert_not_called()
+
+    def test_multi_stream_same_query_id_not_double_counted(self):
+        """2 streams of the same query_id must report 1/1, not 1/2 or 2/2 -
+        the per-variant capture count must not leak into this unique-id summary.
+        """
+        host = _SummaryHost()
+        plan = _make_plan()
+        query_results = [
+            _qr("q1", query_plan=plan, stream_id=0),
+            _qr("q1", query_plan=plan, stream_id=1),
+        ]
+        host._log_plan_capture_summary(query_results)
+        host.logger.info.assert_called_once_with("Query plans: 1/1 captured")
+
+    def test_capture_failure_logs_warning_with_failed_suffix(self):
+        host = _SummaryHost()
+        query_results = [_qr("q1", query_plan=_make_plan()), _qr("q2", query_plan=None)]
+        host._log_plan_capture_summary(query_results)
+        host.logger.warning.assert_called_once_with("Query plans: 1/2 captured, 1 failed")
+        host.logger.info.assert_not_called()


### PR DESCRIPTION
## Description

TODO: `_project/DONE/main/fix-multistream-throughput-plan-attachment.yaml`
(High, from the query-plan-capture adversarial review). Part 2 of a 5-item
batch; depends on #967 (merged).

**Freshness re-check at implementation time:** `develop` had moved ~75 commits
since this TODO was filed. Two of its four work units turned out to already be
implemented by unrelated prior work (the query-plan-capture-canonical-isolation
effort):

- **w1** (carry `_plan_capture_key` through the TPC-H/TPC-DS power+throughput
  converters) — already done (`platform_power.py`, `execution.py` already call
  `propagate_plan_capture_fields`).
- **w4** (update the divergence test + docs so multi-stream rows attach) —
  already done: `test_combined_power_then_throughput_same_public_id_different_sql`
  already exists, already passes, and its docstring documents "production TPC
  power/throughput rows DO carry the key today."

I verified both directly (ran the real regression test, read the current
`_attach_captured_plans`/`_power_query_result` code) before touching anything,
per the review protocol's freshness guidance — implementing already-fixed work
units would have been wasted/misleading effort.

Two real, still-live defects remained, which this PR fixes:

### w2 — `build_plans_payload` last-writer-wins on `query_id`

`capture_query_plan`'s documented contract (`result_capture.py`) is one plan
record per `(query_id, stream_id)` — streams are never deduplicated. But
`build_plans_payload` keyed its `.plans.json` `queries` map by bare `query_id`,
so a query_id captured in more than one stream silently collapsed to a single
last-writer-wins entry.

Fix: query_ids with more than one plan-bearing row now get a
`"{query_id}#{stream_id}"` composite key per row; a query_id with exactly one
row keeps the simple bare `query_id` key (the common single-stream case,
unchanged on-disk format).

Reattaching these on load required extending `loader.py`'s lookup (added in
#967) to resolve composite keys back to the right stream — this is outside
this TODO's original `scope_limit`, but necessary: without it, the multi-stream
fix here would silently regress the reload path #967 just fixed.

### w3 — console summary used the wrong counter

`"Query plans: N/M captured"` printed `self.query_plans_captured`, a
per-variant counter (one increment per distinct captured SQL text — e.g. once
per seed-varied stream), against total row count. On any multi-stream run this
number is structurally different from what ends up in the bundle
(`BenchmarkResults.query_plans_captured`, a row-derived unique-query-id count).

Fix: extracted the summary into `_log_plan_capture_summary()` and reconciled it
with `compute_plan_capture_stats` — the same row-derived stat `adapter.py`
already uses to set `BenchmarkResults.query_plans_captured`, so the console
message and the bundle now always agree.

### Docs

Updated `docs/features/query-plan-analysis.md` to reflect current (already-w1/w4-fixed)
behavior — TPC drivers carry the capture key, so seed-varied streams attach
correctly — and to document the new per-stream `.plans.json` persistence.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

```
uv run -- python -m pytest tests/unit/platforms/ tests/integration/ -k 'throughput and plan' -m "slow or not slow" -n 0 -q
uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -m "slow or not slow" -n 0 -q
uv run -- python -m pytest tests/unit/platforms/ tests/unit/core/results/ tests/unit/core/tpch/ tests/integration/ -k plan -m "slow or not slow" -n 0 -q
uv run ruff check . && uv run ruff format --check . && uv run ty check
uv run -- python -m pytest -m "fast and not (slow or stress or resource_heavy or live_integration)" -q
```

Note: the TODO's own verification command (`-k 'throughput and plan' -n 0 -q`,
no marker override) selects **zero tests** — the one real regression test
(`test_combined_power_then_throughput_same_public_id_different_sql`) is marked
`@pytest.mark.slow`, which `pytest.ini`'s default `addopts` excludes. Ran with
`-m "slow or not slow"` to actually exercise it (1 passed).

The full fast suite has the same 5 pre-existing, environment-only failures as
#967 (no JRE for pyspark, DuckDB extension download blocked by the sandbox's
egress proxy, root-user bypasses permission-check tests) — zero diff overlap.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not
      change public, beta-public, deprecated, generated, experimental, or
      repo-only contract surfaces. (`.plans.json` is an internal companion
      file, not a documented public contract; no CLI surface changed.)
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs
      for contract-map impact.

## Documentation

- [x] I updated the relevant user-facing docs (`docs/features/query-plan-analysis.md`).
- [x] I added regression notes for behavior changes (see Description).
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

This PR touches `benchbox/platforms/base/result_capture.py`, which is a
`.github/CODEOWNERS` soundness path (`@joeharris76`). Per project policy,
**auto-merge is intentionally left disabled** pending Code Owner review.

Downstream: `test-real-combined-plan-capture-checkpoint` (TODO #4 in the batch)
depends on this merging first.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Dfk9EwmhZns8ttQFuVg34)_