### PR TITLE
fix(comparator): escape temporal cell payloads in calculate_checksum

### DIFF
--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -64,7 +64,7 @@ def _render_cell(value: Any) -> str:
     if isinstance(value, Decimal):
         return f"d:{value}"
     if isinstance(value, (datetime.date, datetime.time)):  # datetime.datetime subclasses date
-        return f"t:{value}"
+        return f"t:{_escape_cell_text(str(value))}"
     # Escape the typename too, including its ':' delimiter: a dynamically
     # created type can carry an arbitrary __name__, and an unescaped '|',
     # '\n', or boundary-shifting ':' inside it would re-open exactly the

--- a/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
+++ b/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
@@ -229,6 +229,34 @@ def test_calculate_checksum_distinguishes_numeric_and_temporal_dtypes() -> None:
     assert calculate_checksum([(True,)]) != calculate_checksum([(1,)])
 
 
+def test_calculate_checksum_escapes_temporal_payloads() -> None:
+    """Temporal cells (``t:`` tag) must be escaped like every other cell type.
+
+    A date/time subclass with a forged ``__str__`` containing a row separator
+    would otherwise render byte-identical to two separate temporal rows,
+    reopening the exact separator-forgery false-pass this hardening closes for
+    every other dtype (str, the ``o:`` fallback, etc.).
+    """
+    from datetime import date
+
+    class ForgedDate(date):
+        def __str__(self) -> str:
+            return "a\nt:b"
+
+    forged = calculate_checksum([(ForgedDate(2026, 1, 1),)])
+
+    class LiteralA(date):
+        def __str__(self) -> str:
+            return "a"
+
+    class LiteralB(date):
+        def __str__(self) -> str:
+            return "b"
+
+    two_rows = calculate_checksum([(LiteralA(2026, 1, 1),), (LiteralB(2026, 1, 2),)])
+    assert forged != two_rows
+
+
 def test_tie_aware_constant_column_is_not_a_boundary_key() -> None:
     """A constant/literal column must not qualify as the tie-boundary key.
 


### PR DESCRIPTION
# Pull Request

## Description

**SOUNDNESS PATH — CODEOWNERS-covered (`benchbox/core/tpchavoc/validation.py`, `benchbox/core/expected_results/**`). Auto-merge deliberately NOT enabled; this PR waits for code-owner review.**

Late-landing follow-up to #970 (merged): a `chatgpt-codex-connector` review comment posted after merge flagged that `_render_cell`'s `t:` tag for `date`/`time`/`datetime` cells rendered the value **unescaped**, unlike every other cell type `#970` hardened in the same pass. A temporal value whose `str()` contains the row separator (e.g. a driver-provided subclass with a custom `__str__`) can therefore alias two separate rows in the digest — reopening the exact separator-forgery false-pass `#970` closed for `str`/`o:`/etc.

## Fix

`_render_cell` now wraps the temporal payload with the same `_escape_cell_text` helper used by every other branch:

```python
if isinstance(value, (datetime.date, datetime.time)):
    return f"t:{_escape_cell_text(str(value))}"
```

## Type of Change

- [x] Bug fix

## Testing

- New regression test `test_calculate_checksum_escapes_temporal_payloads`: a `date` subclass forging `__str__() == "a\nt:b"` in one row must not collide with two separate rows rendering `"a"` and `"b"`. Confirmed it **fails** against the pre-fix renderer (`AssertionError: 'd83f43...' != 'd83f43...'`) and passes after the fix.
- `uv run -- python -m pytest tests/unit/core/tpchavoc/ -q` → 90 passed.
- `make correctness-gate-digests-regen && git diff --exit-code` → no-op (standard ISO date/time renderings never contain `|` or `\n`, so no committed digest changes).
- `uv run ruff check .` / `uv run ruff format --check .` on touched files → clean.

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces changed. Internal comparator hardening only; the committed reference digests are unchanged (verified via regen).

## Documentation

- [x] N/A — no user-facing docs affected; internal comparator hardening, already documented in `_render_cell`'s docstring.

## Code Quality

- [x] Ran formatting and lint checks.
- [x] Added a regression test that fails pre-fix and passes post-fix.
- [x] Backwards compatibility: digest values are unaffected for any real temporal rendering (verified via the digest regen no-op); only a forged/adversarial `__str__` changes.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Addresses a `chatgpt-codex-connector` review comment left on #970 after it had already merged (https://github.com/joeharris76/BenchBox/pull/970#discussion_r3524964994).

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_01D5cPJRHok7vur6jxL3NBdZ)_