### PR TITLE
fix(query-plans): disambiguate cross-phase plan-key collisions in .plans.json

### DIFF
--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -456,7 +456,11 @@ def _reconstruct_query_results(
     changing the on-disk ``.plans.json`` format. A query ID that ran in more than
     one stream is written under ``"{query_id}#{stream_id}"`` composite keys (see
     ``build_plans_payload``); ``_index_plan_entries``/``_lookup_plan_entry`` below
-    resolve those back to the exact stream's entry.
+    resolve those back to the exact stream's entry. A combined run (e.g. power
+    then throughput) can have a power row and a throughput row share the same
+    query_id AND stream_id (each phase's stream counter starts at its own 0);
+    those are disambiguated with a further ``"{query_id}#{stream_id}:{test_type}"``
+    key, resolved via the row's own compact ``test_type`` field.
     """
     plan_entries = _index_plan_entries(plans_data)
     results: list[dict[str, Any]] = []
@@ -474,7 +478,12 @@ def _reconstruct_query_results(
             result["iteration"] = q["iter"]
         if q.get("stream"):
             result["stream_id"] = q["stream"]
-        _attach_plan(result, _lookup_plan_entry(plan_entries, query_id, q.get("stream", 0)))
+        if q.get("test_type"):
+            result["test_type"] = q["test_type"]
+        _attach_plan(
+            result,
+            _lookup_plan_entry(plan_entries, query_id, q.get("stream", 0), q.get("test_type")),
+        )
         results.append(result)
 
     # Add failed queries from errors
@@ -531,13 +540,20 @@ def _index_plan_entries(plans_data: dict[str, Any] | None) -> dict[str, Any]:
     return indexed
 
 
-def _lookup_plan_entry(plan_entries: dict[str, Any], query_id: Any, stream_id: Any) -> dict[str, Any] | None:
-    """Resolve the plan entry for ``query_id``, disambiguating by ``stream_id`` when needed."""
+def _lookup_plan_entry(
+    plan_entries: dict[str, Any], query_id: Any, stream_id: Any, test_type: Any = None
+) -> dict[str, Any] | None:
+    """Resolve the plan entry for ``query_id``, disambiguating by ``stream_id`` (and,
+    for a cross-phase collision, ``test_type``) when needed."""
     if query_id is None:
         return None
     entry = plan_entries.get(normalize_query_id(query_id))
     if entry is None or "plan" in entry:
         return entry
+    if test_type:
+        qualified = entry.get(f"{stream_id}:{test_type}")
+        if qualified is not None:
+            return qualified
     return entry.get(str(stream_id))
 
 

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -365,6 +365,16 @@ def _build_query_results_section(
         entry["stream"] = stream_id
         entry["run_type"] = run_type
         entry["status"] = status
+        # Additive, present only for phased runs (power/throughput/maintenance):
+        # a combined run executes the same public query_id in more than one
+        # phase, each with its own independent stream_id counter, so stream_id
+        # alone cannot always disambiguate which phase's .plans.json entry a
+        # reconstructed row belongs to (see build_plans_payload). Standard
+        # single-phase runs never set this, so their compact entries are
+        # unchanged.
+        test_type = qr.get("test_type")
+        if test_type:
+            entry["test_type"] = test_type
         # Gate-only value-digest oracle (BENCHBOX_EMIT_RESULT_DIGEST): present only
         # when the runner emitted a full-result digest, so a normal run's payload
         # shape is unchanged. Explicit None checks (not `or`) so a digest is never
@@ -1056,6 +1066,15 @@ def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
         ``query_id`` key (the common single-stream case, unchanged format), and
         a group with more than one row uses a ``"{query_id}#{stream_id}"``
         composite key per row so every stream's plan survives.
+
+        A combined run (e.g. power then throughput) executes the same public
+        query id in BOTH phases, and each phase's stream_id counter starts at
+        its own 0 - so a power row and a throughput row for the same query_id
+        can share the exact same stream_id too. When stream_id alone does not
+        disambiguate every row in a group, ``test_type`` (already carried on
+        every row - see ``_build_query_results_section``) is appended to the
+        composite key so cross-phase collisions never silently overwrite each
+        other, on top of the same-phase multi-stream case above.
     """
     if not result.query_plans_captured or result.query_plans_captured == 0:
         return None
@@ -1072,8 +1091,18 @@ def build_plans_payload(result: BenchmarkResults) -> dict[str, Any] | None:
 
     for query_id, rows in rows_by_query_id.items():
         multi_stream = len(rows) > 1
+        stream_ids = [qr.get("stream_id", 0) for qr in rows]
+        # stream_id alone disambiguates the group only if every row's stream_id
+        # is distinct; a cross-phase collision (same query_id AND stream_id from
+        # two different test_types) needs test_type appended too.
+        stream_id_disambiguates = len(set(stream_ids)) == len(stream_ids)
         for qr in rows:
-            key = f"{query_id}#{qr.get('stream_id', 0)}" if multi_stream else query_id
+            if not multi_stream:
+                key = query_id
+            elif stream_id_disambiguates:
+                key = f"{query_id}#{qr.get('stream_id', 0)}"
+            else:
+                key = f"{query_id}#{qr.get('stream_id', 0)}:{qr.get('test_type', '')}"
             plans_by_query[key] = _build_plan_entry(qr)
 
     # Add plan capture errors

--- a/benchbox/core/results/schema_specs.yaml
+++ b/benchbox/core/results/schema_specs.yaml
@@ -23,6 +23,7 @@ query_key_order:
 - iter
 - stream
 - run_type
+- test_type
 - status
 - digest
 - dataframe_skip_summary

--- a/tests/unit/core/results/test_loader.py
+++ b/tests/unit/core/results/test_loader.py
@@ -578,6 +578,53 @@ class TestReconstructBenchmarkResults:
         assert result.query_results[1]["stream_id"] == 2
         assert result.query_results[1]["plan_fingerprint"] == "b" * 64
 
+    def test_reconstruct_query_results_cross_phase_same_stream_id_reattach(self):
+        """A power row and a throughput row sharing the same query_id AND
+        stream_id (independent per-phase stream counters) are keyed in
+        .plans.json as "{query_id}#{stream_id}:{test_type}"; the loader must
+        resolve each row to its OWN phase's plan using the compact entry's
+        test_type field, not the other phase's.
+        """
+        data = make_v2_result_dict(
+            version="2.0",
+            benchmark_id="test",
+            benchmark_name="Test",
+            platform="Test",
+            scale_factor=1.0,
+            execution_id="test",
+            timestamp="2025-01-01T10:00:00",
+            query_time_ms=200,
+            streams=2,
+            total_queries=2,
+            passed_queries=2,
+            failed_queries=0,
+            total_ms=200,
+            queries=[
+                {"id": "6", "ms": 100.0, "rows": 4, "stream": 0, "test_type": "power"},
+                {"id": "6", "ms": 90.0, "rows": 4, "stream": 0, "test_type": "throughput"},
+            ],
+        )
+        plans_data = {
+            "queries": {
+                "6#0:power": {
+                    "fingerprint": "a" * 64,
+                    "plan": {"query_id": "6", "platform": "duckdb", "logical_root": None},
+                },
+                "6#0:throughput": {
+                    "fingerprint": "b" * 64,
+                    "plan": {"query_id": "6", "platform": "duckdb", "logical_root": None},
+                },
+            }
+        }
+
+        result = reconstruct_benchmark_results(data, plans_data=plans_data)
+
+        assert len(result.query_results) == 2
+        assert result.query_results[0]["test_type"] == "power"
+        assert result.query_results[0]["plan_fingerprint"] == "a" * 64
+        assert result.query_results[1]["test_type"] == "throughput"
+        assert result.query_results[1]["plan_fingerprint"] == "b" * 64
+
     def test_reconstruct_query_results_single_stream_bare_key_still_works(self):
         """A query_id captured in exactly one stream is keyed bare (no "#stream"
         suffix); this must keep working unchanged (the common case)."""

--- a/tests/unit/core/results/test_query_plan_serialization.py
+++ b/tests/unit/core/results/test_query_plan_serialization.py
@@ -325,6 +325,60 @@ class TestSchemaV2ExportWithPlans:
         assert queries["q06#0"]["fingerprint"] == "a" * 64
         assert queries["q06#1"]["fingerprint"] == "b" * 64
 
+    def test_schema_v2_plans_companion_cross_phase_same_stream_id_disambiguated(self) -> None:
+        """A power row and a throughput row can share the SAME query_id AND
+        stream_id (each phase's stream counter independently starts at 0). The
+        stream_id-only composite key from the multi-stream fix would then
+        collide again (both rows landing on "q06#0"), so a cross-phase
+        collision must fall back to a further test_type-qualified key.
+        """
+
+        def _plan(fingerprint: str) -> QueryPlanDAG:
+            root = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_1", table_name="lineitem")
+            return QueryPlanDAG(query_id="q06", platform="duckdb", logical_root=root, plan_fingerprint=fingerprint)
+
+        power_plan = _plan("a" * 64)
+        throughput_plan = _plan("b" * 64)
+
+        results = make_benchmark_results(
+            benchmark_id="tpch",
+            benchmark_name="tpch",
+            platform="duckdb",
+            scale_factor=1.0,
+            execution_id="test_cross_phase",
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            total_queries=2,
+            successful_queries=2,
+            query_plans_captured=2,
+            query_results=[
+                {
+                    "query_id": "q06",
+                    "status": "SUCCESS",
+                    "stream_id": 0,
+                    "test_type": "power",
+                    "query_plan": power_plan,
+                    "plan_fingerprint": power_plan.plan_fingerprint,
+                },
+                {
+                    "query_id": "q06",
+                    "status": "SUCCESS",
+                    "stream_id": 0,
+                    "test_type": "throughput",
+                    "query_plan": throughput_plan,
+                    "plan_fingerprint": throughput_plan.plan_fingerprint,
+                },
+            ],
+        )
+
+        plans_payload = build_plans_payload(results)
+
+        assert plans_payload is not None
+        assert plans_payload["plans_captured"] == 1
+        queries = plans_payload["queries"]
+        assert "q06#0" not in queries, "bare stream_id key must not be used once ambiguous across phases too"
+        assert queries["q06#0:power"]["fingerprint"] == "a" * 64
+        assert queries["q06#0:throughput"]["fingerprint"] == "b" * 64
+
     def test_schema_v2_export_complex_plan(self) -> None:
         """Test schema v2.0 export with complex query plan tree."""
         # Build: Join(orders, lineitem) -> [Scan(orders), Scan(lineitem)]


### PR DESCRIPTION
# Pull Request

## Description

Late-landing follow-up to #976 (merged): a `chatgpt-codex-connector` review comment posted after merge flagged a real remaining collision in `build_plans_payload`'s new `"{query_id}#{stream_id}"` composite key.

In a combined run (power then throughput), each phase's `stream_id` counter independently starts at `0` (power measurement streams are `warm_up_iterations + i`; throughput streams are `0..num_streams-1`). So a power row and a throughput row for the **same** `query_id` can share the **same** `stream_id` too. The `#976` fix only disambiguated same-phase multi-stream rows — a cross-phase collision on `query_id` + `stream_id` still silently overwrites one captured plan with the other in `plans_by_query`.

## Fix

- `build_plans_payload` (schema.py): when `stream_id` alone doesn't disambiguate every row in a `query_id` group, appends `test_type` (`"power"`/`"throughput"`/etc — already carried on every row via `execution.py`) to the composite key: `"{query_id}#{stream_id}:{test_type}"`. The common single-stream and same-phase-multi-stream cases are unchanged (still bare `query_id` / `"{query_id}#{stream_id}"`).
- `_build_query_results_section` (schema.py): threads `test_type` into the compact per-query entry, **additive and only present for phased runs** — standard single-phase runs' entries are byte-for-byte unchanged.
- `loader.py`: `_reconstruct_query_results`/`_lookup_plan_entry` read the compact entry's `test_type` and try the qualified key first, falling back to the bare-stream_id key for existing bundles.

## Type of Change

- [x] Bug fix

## Testing

- New tests confirmed to **fail against the pre-fix code** (real regressions, not tautologies) and pass after:
  - `test_schema_v2_plans_companion_cross_phase_same_stream_id_disambiguated` (write side)
  - `test_reconstruct_query_results_cross_phase_same_stream_id_reattach` (read side round-trip)
- `uv run -- python -m pytest tests/unit/core/results/ tests/unit/platforms/base/test_result_capture.py -q` → 648 passed, 3 skipped (pre-existing, unrelated).
- `uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -m "slow or not slow" -n 0 -q` → 9 passed, including `test_combined_power_then_throughput_same_public_id_different_sql`.
- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` on touched files → clean.

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces changed. `.plans.json` is an internal companion file; the new compact `test_type` field is additive and absent for standard single-phase runs.

## Documentation

- [x] N/A — the multi-stream keying mechanism is already documented in `build_plans_payload`'s docstring, extended in this PR to cover the cross-phase case.

## Code Quality

- [x] Ran formatting/lint/type checks.
- [x] Backwards compatible: existing bundles with only bare/stream-suffixed `.plans.json` keys (no `test_type`) still resolve via the existing fallback path.
- [x] Added regression tests for both the write-side collision and the read-side round-trip.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Addresses a `chatgpt-codex-connector` review comment left on #976 after it had already merged (https://github.com/joeharris76/BenchBox/pull/976#discussion_r3524995614).

None of the changed files (`benchbox/core/results/schema.py`, `benchbox/core/results/loader.py`, `benchbox/core/results/schema_specs.yaml`) touch a `.github/CODEOWNERS` soundness path, so squash auto-merge is being enabled.

---
_Generated by Claude Code_


---
_Generated by [Claude Code](https://claude.ai/code/session_01D5cPJRHok7vur6jxL3NBdZ)_