### PR TITLE
fix(comparator): report all mismatched columns per row; waivers require all-columns-accepted

### DIFF
--- a/_project/DONE/main/validator-report-all-row-mismatches.yaml
+++ b/_project/DONE/main/validator-report-all-row-mismatches.yaml
@@ -2,7 +2,8 @@ id: validator-report-all-row-mismatches
 title: "Close the first-mismatch-per-row comparator blind spot so column-pinned waiver predicates can see a second wrong column"
 worktree: main
 priority: Low
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-05"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -41,7 +42,7 @@ prior_art:
 work:
   - id: w1
     summary: "Make the validator collect and report every mismatched column per divergent row"
-    status: pending
+    status: done
     notes: |
       Shared helper used by both emit sites in validation.py. Keep the
       existing single-column message shape as the degenerate case (one
@@ -54,7 +55,7 @@ work:
   - id: w2
     summary: "Update _VALUE_MISMATCH_RE parsing and enforce the all-columns-accepted waiver contract"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       cross_surface.py: parse the full mismatched-column set; a predicate's
       acceptance now requires every mismatched column to fall in its
@@ -66,7 +67,7 @@ work:
   - id: w3
     summary: "Mutation-probe the closed blind spot and re-run the affected gates"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       New probes: (a) row with column 1 (waived) + column 3 (unwaived) both
       wrong → unclassified; (b) row with only column 1 wrong → still

--- a/benchbox/core/equivalence/cross_surface.py
+++ b/benchbox/core/equivalence/cross_surface.py
@@ -804,18 +804,38 @@ _H2ODB_PERCENTILE_DECIMAL = (
 # of these checks, so Q9 stays guarded against real result regressions instead of the
 # bare key tolerating every Q9 difference.
 #
-# Residual blind spot (validator-imposed, documented): the validator reports only the
-# FIRST positional mismatch, so a SECOND, later Q9 bug behind an accepted p90 residue
-# cannot be seen from the detail string alone. Pinning the accepted cell to the exact
-# p90 column + sub-half-cent + 2-decimal-scale signature minimizes the surface of that
-# blind spot (only the documented cell is ever the "first" accepted mismatch); closing
-# it fully would require the validator to surface ALL mismatches, not one.
+# The former validator-imposed blind spot is now CLOSED: the validator reports every
+# mismatched column per row (validator-report-all-row-mismatches), and this predicate
+# requires the p90 column to be the ONLY mismatched column. A SECOND Q9 bug on the same
+# row as the accepted p90 residue makes the mismatched-column set != {2}, so the
+# divergence is unclassified (gate failure) instead of hidden behind the residue.
 _H2ODB_Q9_P90_COLUMN = 2
 _H2ODB_Q9_RESIDUE_MAX = 0.005 + 1e-6
 _VALUE_MISMATCH_RE = re.compile(
-    r"Value mismatch at row \d+, column (?P<col>\d+)\. Original:\s*(?P<orig>.+?),\s*Variant:\s*(?P<variant>.+)$"
+    r"Value mismatch at row \d+, column (?P<col>\d+)\. "
+    r"Original:\s*(?P<orig>.+?),\s*Variant:\s*(?P<variant>.+?)"
+    r"(?:; also columns \[(?P<also>[\d, ]*)\])?$"
 )
 _NUMBER_RE = re.compile(r"[-+]?\d*\.\d+|[-+]?\d+")
+
+
+def _mismatched_columns(match: re.Match[str]) -> set[int]:
+    """All mismatched column indices from a value-mismatch detail match.
+
+    The validator now reports every mismatched column on a divergent row (the
+    first column's values inline, the rest as a ``; also columns [...]``
+    index suffix - see benchbox/core/tpchavoc/validation.py). A column-pinned
+    waiver may accept a divergence ONLY when EVERY mismatched column is within
+    its accepted set; otherwise a genuinely wrong non-waived column that
+    happened to sort after an accepted one would ride through classified-green
+    (validator-report-all-row-mismatches). This returns that full set so each
+    predicate can enforce the contract with ``columns <= accepted_set``.
+    """
+    columns = {int(match.group("col"))}
+    also = match.group("also")
+    if also:
+        columns.update(int(token) for token in re.findall(r"\d+", also))
+    return columns
 
 
 def _first_number(text: str) -> float | None:
@@ -850,8 +870,10 @@ def _h2odb_q9_decimal_residue(divergence: SurfaceDivergence) -> bool:
     if match is None:
         return False
     # Only the p90 column (index 2) carries the documented residue; a grouping-key
-    # or median mismatch - sub-cent or not - is a real Q9 regression.
-    if int(match.group("col")) != _H2ODB_Q9_P90_COLUMN:
+    # or median mismatch - sub-cent or not - is a real Q9 regression. EVERY
+    # mismatched column on the row must be the p90 column, so a second wrong
+    # column on the same row is unclassified, not hidden behind the residue.
+    if _mismatched_columns(match) != {_H2ODB_Q9_P90_COLUMN}:
         return False
     orig_text = match.group("orig")
     variant_text = match.group("variant")
@@ -931,7 +953,12 @@ def _read_primitives_sketch_residue(divergence: SurfaceDivergence) -> bool:
         (columns for name, columns in _READ_PRIMITIVES_SKETCH_COLUMNS.items() if name in query_id),
         None,
     )
-    if allowed_columns is None or int(match.group("col")) not in allowed_columns:
+    # Every mismatched column must be a documented sketch column; a grouping-key
+    # or other non-sketch column diverging on the same row is unclassified. The
+    # magnitude bound below is checked on the reported (first) column; the live
+    # cells diverge on a single sketch column, so this matches today's behavior
+    # while closing the accepted+unaccepted-both-wrong blind spot.
+    if allowed_columns is None or not (_mismatched_columns(match) <= set(allowed_columns)):
         return False
     orig = _first_number(match.group("orig"))
     variant = _first_number(match.group("variant"))
@@ -982,7 +1009,8 @@ def _read_primitives_decimal_scale_residue(divergence: SurfaceDivergence, *, col
     match = _VALUE_MISMATCH_RE.search(str(divergence.detail))
     if match is None:
         return False
-    if int(match.group("col")) != column:
+    # The pinned column must be the ONLY mismatched column on the row.
+    if _mismatched_columns(match) != {column}:
         return False
     orig_text = match.group("orig")
     orig = _first_number(orig_text)
@@ -1022,13 +1050,12 @@ _READ_PRIMITIVES_ARGMIN_TIE = (
 # may differ. A p_brand (grouping key) or min_price mismatch - even a numerically
 # close one - is a real regression and is rejected.
 #
-# Residual blind spot (validator-imposed, the same shape as h2odb Q9's
-# documented one): the comparator reports only the FIRST positional mismatch per
-# row, so if cheapest_part_name (column 1) differs AND min_price (column 3) is
-# ALSO wrong on the same row, only the accepted column-1 tie-break is visible
-# here. Pinning to columns 1-2 only (never 0 or 3) minimizes, but cannot fully
-# close, that blind spot; closing it fully would require the validator to
-# surface every mismatch per row, not just the first.
+# The former validator-imposed blind spot is now CLOSED: the validator reports
+# every mismatched column per row (validator-report-all-row-mismatches), and
+# _read_primitives_argmin_tie requires EVERY mismatched column to be in {1, 2}.
+# So if cheapest_part_name (column 1) differs AND min_price (column 3) is also
+# wrong on the same row, the divergence is unclassified (gate failure), not
+# hidden behind the accepted tie-break.
 _READ_PRIMITIVES_ARGMIN_TIE_COLUMNS = (1, 2)
 
 
@@ -1037,7 +1064,10 @@ def _read_primitives_argmin_tie(divergence: SurfaceDivergence) -> bool:
     match = _VALUE_MISMATCH_RE.search(str(divergence.detail))
     if match is None:
         return False
-    return int(match.group("col")) in _READ_PRIMITIVES_ARGMIN_TIE_COLUMNS
+    # Every mismatched column must be an ARG_MIN tie-broken column (1 or 2): if
+    # min_price (col 3) or the brand key (col 0) is ALSO wrong on the same row,
+    # the divergence is unclassified, not accepted behind the tie-break.
+    return _mismatched_columns(match) <= set(_READ_PRIMITIVES_ARGMIN_TIE_COLUMNS)
 
 
 _READ_PRIMITIVES_JSON_TEXT = (
@@ -1114,7 +1144,9 @@ def _read_primitives_json_agg_accepts(divergence: SurfaceDivergence) -> bool:
     value_match = _VALUE_MISMATCH_RE.search(detail)
     if value_match is None:
         return False
-    if int(value_match.group("col")) not in (1, 2):
+    # Every mismatched column must be a JSON container column (1 or 2); a third
+    # column diverging on the same row is unclassified.
+    if not (_mismatched_columns(value_match) <= {1, 2}):
         return False
     return _read_primitives_json_equivalent(value_match.group("orig"), value_match.group("variant"))
 

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -508,7 +508,18 @@ class ResultValidator:
         agg = set(aggregation_columns or ())
         mismatched: list[int] = []
         for j, (orig_val, var_val) in enumerate(zip(orig_row, var_row)):
-            equal = self._numeric_values_equal(orig_val, var_val) if j in agg else self._values_equal(orig_val, var_val)
+            if j in agg:
+                try:
+                    equal = self._numeric_values_equal(orig_val, var_val)
+                except (TypeError, ValueError):
+                    # A malformed/non-numeric aggregation cell (e.g. a variant
+                    # returning a string where a number was expected) is itself
+                    # a mismatch, not a crash: scanning every column must never
+                    # raise where the old short-circuiting loop would have
+                    # cleanly reported an earlier column's mismatch first.
+                    equal = False
+            else:
+                equal = self._values_equal(orig_val, var_val)
             if not equal:
                 mismatched.append(j)
         return mismatched

--- a/benchbox/core/tpchavoc/validation.py
+++ b/benchbox/core/tpchavoc/validation.py
@@ -490,6 +490,42 @@ class ResultValidator:
             return _cell_sort_key(None)
         return _cell_sort_key(value)
 
+    def _row_value_mismatch_columns(
+        self,
+        orig_row: tuple[Any, ...],
+        var_row: tuple[Any, ...],
+        aggregation_columns: Optional[Sequence[int]] = None,
+    ) -> list[int]:
+        """Return EVERY mismatched column index in a row (equal-length rows).
+
+        Collects all differing columns, not just the first, so a column-pinned
+        waiver predicate downstream can see a second wrong column on the same
+        row (validator-report-all-row-mismatches). Columns listed in
+        ``aggregation_columns`` use the numeric-tolerance comparison; the rest
+        use strict ``_values_equal`` - identical per-column semantics to the
+        two emit sites this replaces.
+        """
+        agg = set(aggregation_columns or ())
+        mismatched: list[int] = []
+        for j, (orig_val, var_val) in enumerate(zip(orig_row, var_row)):
+            equal = self._numeric_values_equal(orig_val, var_val) if j in agg else self._values_equal(orig_val, var_val)
+            if not equal:
+                mismatched.append(j)
+        return mismatched
+
+    @staticmethod
+    def _also_columns_suffix(mismatched: list[int]) -> str:
+        """Parseable ``"; also columns [j, k]"`` suffix for the extra mismatches.
+
+        Empty when only one column mismatched (keeps the historical
+        single-column message shape as the degenerate case, so log consumers
+        and classified-baseline keys stay stable). Bounded output: indices
+        only for the additional columns - never their values - so a wide-row
+        divergence cannot bloat a committed gate report (anti_pattern).
+        """
+        extra = mismatched[1:]
+        return f"; also columns {extra}" if extra else ""
+
     def _first_positional_mismatch(
         self,
         original_sorted: list[tuple[Any, ...]],
@@ -497,11 +533,13 @@ class ResultValidator:
         query_id: int,
         variant_id: int,
     ) -> str | None:
-        """Return the first row/column mismatch detail, or None if equal.
+        """Return the first row's mismatch detail (all columns), or None if equal.
 
         Assumes the two lists have equal length and are already sorted. Reused by
         both the strict path and the tie-aware deterministic-remainder check so
         the comparison semantics (``_values_equal`` tolerance) stay identical.
+        The detail reports the first mismatched column's values plus a bounded
+        ``"; also columns [...]"`` suffix naming every other mismatched column.
         """
         for i, (orig_row, var_row) in enumerate(zip(original_sorted, variant_sorted)):
             if len(orig_row) != len(var_row):
@@ -509,12 +547,14 @@ class ResultValidator:
                     f"Q{query_id}.{variant_id}: Column count mismatch at row {i}. "
                     f"Original: {len(orig_row)}, Variant: {len(var_row)}"
                 )
-            for j, (orig_val, var_val) in enumerate(zip(orig_row, var_row)):
-                if not self._values_equal(orig_val, var_val):
-                    return (
-                        f"Q{query_id}.{variant_id}: Value mismatch at row {i}, column {j}. "
-                        f"Original: {orig_val}, Variant: {var_val}"
-                    )
+            mismatched = self._row_value_mismatch_columns(orig_row, var_row)
+            if mismatched:
+                j = mismatched[0]
+                return (
+                    f"Q{query_id}.{variant_id}: Value mismatch at row {i}, column {j}. "
+                    f"Original: {orig_row[j]}, Variant: {var_row[j]}"
+                    f"{self._also_columns_suffix(mismatched)}"
+                )
         return None
 
     def _is_boundary_tie_equivalent(
@@ -714,6 +754,7 @@ class ResultValidator:
         original_sorted = sorted(original_results, key=self._row_sort_key)
         variant_sorted = sorted(variant_results, key=self._row_sort_key)
 
+        agg_columns = set(aggregation_columns or ())
         for i, (orig_row, var_row) in enumerate(zip(original_sorted, variant_sorted)):
             if len(orig_row) != len(var_row):
                 raise ValidationError(
@@ -721,20 +762,24 @@ class ResultValidator:
                     f"Original: {len(orig_row)}, Variant: {len(var_row)}"
                 )
 
-            for j, (orig_val, var_val) in enumerate(zip(orig_row, var_row)):
-                # Use tolerance for aggregation columns if specified
-                if aggregation_columns and j in aggregation_columns:
-                    if not self._numeric_values_equal(orig_val, var_val):
-                        raise ValidationError(
-                            f"Q{query_id}.{variant_id}: Aggregation value mismatch at row {i}, column {j}. "
-                            f"Original: {orig_val}, Variant: {var_val}, Tolerance: {self.tolerance}"
-                        )
-                else:
-                    if not self._values_equal(orig_val, var_val):
-                        raise ValidationError(
-                            f"Q{query_id}.{variant_id}: Value mismatch at row {i}, column {j}. "
-                            f"Original: {orig_val}, Variant: {var_val}"
-                        )
+            mismatched = self._row_value_mismatch_columns(orig_row, var_row, aggregation_columns)
+            if not mismatched:
+                continue
+            # Report the first mismatched column's values with its
+            # tolerance/strict label, plus a bounded suffix naming every other
+            # mismatched column on the row (all-columns visibility for the
+            # cross-surface waiver contract).
+            j = mismatched[0]
+            suffix = self._also_columns_suffix(mismatched)
+            if j in agg_columns:
+                raise ValidationError(
+                    f"Q{query_id}.{variant_id}: Aggregation value mismatch at row {i}, column {j}. "
+                    f"Original: {orig_row[j]}, Variant: {var_row[j]}, Tolerance: {self.tolerance}{suffix}"
+                )
+            raise ValidationError(
+                f"Q{query_id}.{variant_id}: Value mismatch at row {i}, column {j}. "
+                f"Original: {orig_row[j]}, Variant: {var_row[j]}{suffix}"
+            )
 
         return True
 

--- a/tests/unit/core/equivalence/test_cross_surface.py
+++ b/tests/unit/core/equivalence/test_cross_surface.py
@@ -1413,3 +1413,84 @@ def test_read_primitives_baseline_report_accepts_documented_cells_rejects_regres
         )
         == 1
     )
+
+
+# ---------------------------------------------------------------------------
+# validator-report-all-row-mismatches: the validator now reports EVERY
+# mismatched column per row, and column-pinned waivers require every
+# mismatched column to fall in their accepted set.
+# ---------------------------------------------------------------------------
+
+
+def _sd(query_id: str, detail: str) -> SurfaceDivergence:
+    return SurfaceDivergence(query_id, "pandas", detail)
+
+
+def test_validator_reports_all_mismatched_columns_in_detail():
+    # A row diverging on two columns must name both: the first inline, the
+    # rest in the "; also columns [...]" suffix (indices only, bounded).
+    validator = ResultValidator()
+    detail = validator._first_positional_mismatch(
+        [("brandX", "nameA", "typeA", 10.0)],
+        [("brandX", "nameB", "typeA", 99.0)],
+        query_id=1,
+        variant_id=1,
+    )
+    assert detail is not None
+    assert "column 1" in detail  # first mismatch inline
+    assert "; also columns [3]" in detail  # min_price (col 3) also wrong
+    # The first column's values are inline; the extra column's value (99.0) is
+    # NOT dumped - the suffix is index-only and bounded.
+    inline = detail.split("; also columns")[0]
+    assert "nameA" in inline and "nameB" in inline  # col-1 values inline
+    assert "99.0" not in detail  # col-3 value never dumped
+    assert detail.endswith("[3]")  # suffix is index-only
+
+
+def test_mismatched_columns_helper_parses_suffix():
+    from benchbox.core.equivalence.cross_surface import _VALUE_MISMATCH_RE, _mismatched_columns
+
+    single = _VALUE_MISMATCH_RE.search("Q1.1: Value mismatch at row 0, column 2. Original: 1.00, Variant: 1.003")
+    assert _mismatched_columns(single) == {2}
+    multi = _VALUE_MISMATCH_RE.search(
+        "Q1.1: Value mismatch at row 0, column 1. Original: a, Variant: b; also columns [3, 5]"
+    )
+    assert _mismatched_columns(multi) == {1, 3, 5}
+
+
+def test_argmin_tie_accepts_single_waived_column_but_not_a_second_wrong_column():
+    from benchbox.core.equivalence.cross_surface import _read_primitives_argmin_tie
+
+    # Only the tie-broken name column (1) diverges -> accepted (unchanged live behavior).
+    accepted = _sd(
+        "min_by_complex_pandas",
+        "Q1.1: Value mismatch at row 0, column 1. Original: nameA, Variant: nameB",
+    )
+    assert _read_primitives_argmin_tie(accepted) is True
+
+    # Headline blind-spot closure: the waived name column (1) AND the non-waived
+    # min_price column (3) are both wrong on the same row -> unclassified.
+    both_wrong = _sd(
+        "min_by_complex_pandas",
+        "Q1.1: Value mismatch at row 0, column 1. Original: nameA, Variant: nameB; also columns [3]",
+    )
+    assert _read_primitives_argmin_tie(both_wrong) is False
+
+
+def test_h2odb_q9_residue_requires_p90_to_be_the_only_mismatched_column():
+    from benchbox.core.equivalence.cross_surface import _h2odb_q9_decimal_residue
+
+    # Sole p90 (col 2) sub-half-cent DECIMAL-scale residue -> accepted.
+    accepted = _sd("Q9_pandas", "Q9.1: Value mismatch at row 0, column 2. Original: 1.00, Variant: 1.003")
+    assert _h2odb_q9_decimal_residue(accepted) is True
+
+    # A second wrong column on the same row (grouping key col 0), whichever
+    # sorts first -> unclassified, both orderings.
+    also_zero = _sd(
+        "Q9_pandas", "Q9.1: Value mismatch at row 0, column 2. Original: 1.00, Variant: 1.003; also columns [0]"
+    )
+    assert _h2odb_q9_decimal_residue(also_zero) is False
+    zero_first = _sd(
+        "Q9_pandas", "Q9.1: Value mismatch at row 0, column 0. Original: gA, Variant: gB; also columns [2]"
+    )
+    assert _h2odb_q9_decimal_residue(zero_first) is False

--- a/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
+++ b/tests/unit/core/tpchavoc/test_tpchavoc_validation_coverage.py
@@ -367,6 +367,32 @@ def test_validate_aggregation_results_uses_tolerance_for_numeric_columns() -> No
     )
 
 
+def test_validate_aggregation_results_reports_clean_key_mismatch_despite_malformed_agg_cell() -> None:
+    """A malformed non-numeric aggregation cell must not crash the all-columns scan.
+
+    Scanning every column (validator-report-all-row-mismatches) means an
+    earlier key-column mismatch no longer short-circuits before a later
+    aggregation column is compared. If that later column holds a
+    non-numeric value (e.g. a variant returning a string where a number was
+    expected), the numeric-tolerance comparison must report it as a mismatch,
+    not raise, so the caller still gets the clean ValidationError the old
+    short-circuiting loop reported for the key-column mismatch alone.
+    """
+    validator = ResultValidator()
+
+    original = [("A", "F", 5)]
+    variant = [("B", "F", "bad")]
+
+    with pytest.raises(ValidationError, match="Value mismatch at row 0, column 0"):
+        validator.validate_aggregation_results(
+            original,
+            variant,
+            query_id=1,
+            variant_id=3,
+            aggregation_columns=[2],
+        )
+
+
 def test_validate_query1_results_delegates_aggregation_columns(monkeypatch: pytest.MonkeyPatch) -> None:
     validator = ResultValidator()
     captured: dict[str, object] = {}


### PR DESCRIPTION
# Pull Request

## Description

**SOUNDNESS PATH — CODEOWNERS-covered (`benchbox/core/tpchavoc/validation.py`, `benchbox/core/equivalence/cross_surface.py`). Auto-merge deliberately NOT enabled; this PR waits for code-owner review.**

Closes the first-mismatch-per-row comparator blind spot: today a real numeric regression can hide behind a legitimate nondeterministic tie-break/residue on the *same row* and pass the cross-surface gate as classified-green, because the validator reported only the FIRST differing column and a column-pinned waiver accepted it.

**w1 (`validation.py`)** — both value-mismatch emit sites (`_first_positional_mismatch` and `validate_aggregation_results`) now use a shared `_row_value_mismatch_columns()` that collects EVERY differing column on a divergent row (numeric-tolerance comparison for `aggregation_columns`, strict `_values_equal` elsewhere — identical per-column semantics to the code it replaces). The detail keeps the historical single-column message shape as the degenerate case and appends a bounded `"; also columns [j, k]"` suffix — **indices only, never the extra columns' values**, so a wide-row divergence cannot bloat a committed gate report.

**w2 (`cross_surface.py`)** — `_VALUE_MISMATCH_RE` parses the new suffix; a shared `_mismatched_columns()` returns the full set. Every column-pinned waiver now requires EVERY mismatched column to fall in its accepted set: `_read_primitives_argmin_tie` (`<= {1,2}`), `_h2odb_q9_decimal_residue` (`== {2}`), `_read_primitives_decimal_scale_residue` (`== {column}`), `_read_primitives_sketch_residue` (`<= allowed_columns`), `_read_primitives_json_agg_accepts` (`<= {1,2}`). So "waived column diverged AND unwaived column diverged on the same row" is unclassified (gate failure), not invisibly green. The two in-code blind-spot disclosures (min_by_complex comment, h2odb Q9 note) are struck as CLOSED.

**w3** — new mutation probes (accepted column alone → classified; accepted + unaccepted both wrong → unclassified, both column orderings) + a detail-format test.

## Type of Change

- [x] Bug fix (comparator blind-spot closure)

## Testing

- `uv run -- python -m pytest tests/unit/core/equivalence/test_cross_surface.py tests/unit/core/tpchavoc/ -q` → 149 passed.
- `make read-primitives-cross-surface-equivalence-report`, `make h2odb-cross-surface-equivalence-report`, `make tpchavoc-equivalence-report` → all exit 0 with the **same** classified-divergence counts as before (the live h2odb Q9 col-2 sub-cent residue and 220/220 tpchavoc variants still classify — today's live cells diverge on a single column).
- `make lint` green.

## Public Contract Check

- [x] No public/beta/deprecated/experimental contract surfaces changed. The mismatch-detail string only GAINS information (`; also columns [...]`); `KNOWN_DIVERGENCES`/baseline keys and reason strings are untouched.
- [x] No result schema / MCP / platform status impact.

## Documentation

- [x] Rationale in the new helper docstrings; the struck blind-spot comments now state the closure; regression notes in the probe docstrings and the DONE TODO.

## Code Quality

- [x] Formatting/lint run.
- [x] `must_preserve` held: all currently-classified live divergences remain classified (same counts before/after); baseline key formats untouched — only the detail string gains information.

## Artifact Hygiene

- [x] No raw artifacts; `benchbox/core/expected_results/` untouched (`do_not_modify`).

## Notes

- **Stacking:** independent of item-6 PR #970 (`calculate-checksum-collision-hardening`), which touches the same `validation.py` but a disjoint function (`calculate_checksum` rendering). #970 **merged** at 18:08; this branch is off fresh `origin/develop` including it — no stacking, no conflict.
- **Code review: no defects found.** A soundness-focused finder pass confirmed: the non-greedy variant regex parses the live h2odb detail as `77.874` (not `77.`); the only theoretical mis-parse (a value literally ending in `"; also columns [N]"`) grows the column set → false-fail, never false-pass; all 5 predicates converted, no leftover `group("col")` call sites (the ClickBench Q18 `"Value mismatch" in detail` classifier is intentionally not column-pinned); validator per-column equality is byte-identical to the old sites; the `Aggregation value mismatch` message (lowercase `value`) still correctly evades the capital-`V` regex.
- **Documented residual:** for a multi-accepted-column predicate (sketch cols `(2,3)`), if BOTH accepted columns mismatch, the value-magnitude bound is checked on the first column's inline values only (the suffix is index-only). Acceptable per `must_preserve` — live cells diverge on a single column — and noted in-code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_