### PR TITLE
ci(parity): promote parity-check to the required develop-PR lane

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -854,22 +854,23 @@ jobs:
     name: parity-check
     needs: ci-paths
     # Path-filtered on results-explorer/viz source changes (see
-    # _project/TODO/main/planning/parity-check-develop-ring.yaml). `make
-    # parity-check` is Python-only (no npm/vitest install), measured at well
-    # under a second locally, so it is cheap enough to block develop PRs.
+    # _project/DONE/main/parity-check-develop-ring.yaml). `make parity-check`
+    # is Python-only (no npm/vitest install), measured at well under a second
+    # locally, so it is cheap enough to block develop PRs.
     #
-    # NON-BLOCKING FOR NOW (continue-on-error: true, deliberately NOT in
-    # ci-required-result.needs): `make parity-check` currently fails in at
-    # least one local environment with an unexplained 2e-13 last-bit float
-    # drift in tests/parity/fixtures/geomean_ms.json (likely libm
-    # transcendental-precision variance across environments). Promotion
-    # criterion to the required lane: (1) one green run of this job on a
-    # real GitHub runner, AND (2) a decision on the geomean_ms.json float
-    # drift (comparison tolerance vs fixture regen). Until both hold, a
-    # failure here shows red in the PR checks list but does not block merge.
+    # PROMOTED TO THE REQUIRED LANE 2026-07-05 (parity-check-promotion): the
+    # job is now observed by ci-required-result via PARITY_CHECK_RESULT with
+    # the package-smoke skipped-counts-as-pass rule, and continue-on-error is
+    # dropped. Both promotion criteria met: (1) one green run on a real
+    # GitHub runner (PR #973, run 28742318825 job 85227174150 - the runner's
+    # `make parity-check` printed "fixtures match Python source"); (2) the
+    # geomean_ms 2e-13 last-bit drift seen locally did NOT reproduce on the
+    # runner, so it is a local libm transcendental-precision artifact, not a
+    # fixture error - exact comparison is kept and the drift is documented in
+    # tests/parity/README.md. Path-filtering stays: a non-viz PR skips this
+    # job and passes via skipped-counts-as-pass.
     if: ${{ needs.ci-paths.outputs.viz-needed == 'true' }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -923,9 +924,7 @@ jobs:
 
   ci-required-result:
     name: ci-required-result
-    # parity-check is deliberately absent from this needs list while it is
-    # demoted to non-blocking (see the parity-check job's promotion criterion).
-    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, explorer-tokens, audit-sha, package-smoke, dependency-audit]
+    needs: [ci-paths, content-guard, code-lint, code-test, correctness-gate, plan-capture-gate, explorer-tokens, audit-sha, package-smoke, dependency-audit, parity-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -941,6 +940,7 @@ jobs:
           AUDIT_SHA_RESULT: ${{ needs.audit-sha.result }}
           PACKAGE_SMOKE_RESULT: ${{ needs.package-smoke.result }}
           DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency-audit.result }}
+          PARITY_CHECK_RESULT: ${{ needs.parity-check.result }}
           CONTENT_GUARD_NEEDED: ${{ needs.ci-paths.outputs.content-guard-needed }}
           NEEDS_CODE_CI: ${{ needs.ci-paths.outputs.needs-code-ci }}
           SAFE_CONTENT_ONLY: ${{ needs.ci-paths.outputs.safe-content-only }}
@@ -969,9 +969,6 @@ jobs:
           # pass. A PR that DID touch those paths gets a real success/failure
           # result from the job itself, so this cannot silently green a
           # packaging regression (pr-gate-package-and-audit-promotion.yaml).
-          # parity-check (viz filter) is intentionally NOT checked here while
-          # demoted to non-blocking; see its job comment for the promotion
-          # criterion (parity-check-develop-ring.yaml).
           if [ "$PACKAGE_SMOKE_RESULT" != "success" ] \
               && [ "$PACKAGE_SMOKE_RESULT" != "skipped" ]; then
             echo "package-smoke=$PACKAGE_SMOKE_RESULT"
@@ -981,6 +978,18 @@ jobs:
           if [ "$DEPENDENCY_AUDIT_RESULT" != "success" ] \
               && [ "$DEPENDENCY_AUDIT_RESULT" != "skipped" ]; then
             echo "dependency-audit=$DEPENDENCY_AUDIT_RESULT"
+            exit 1
+          fi
+
+          # parity-check is gated on the viz path filter with the same
+          # skipped-counts-as-pass rule (promoted 2026-07-05,
+          # parity-check-promotion): a non-viz PR skips it and passes, a
+          # viz-touching PR gets a real success/failure so a CLI-vs-explorer
+          # numeric parity regression now blocks merge instead of showing
+          # red-but-mergeable.
+          if [ "$PARITY_CHECK_RESULT" != "success" ] \
+              && [ "$PARITY_CHECK_RESULT" != "skipped" ]; then
+            echo "parity-check=$PARITY_CHECK_RESULT"
             exit 1
           fi
 

--- a/_project/DONE/main/parity-check-promotion.yaml
+++ b/_project/DONE/main/parity-check-promotion.yaml
@@ -2,7 +2,8 @@ id: parity-check-promotion
 title: "Promote parity-check from non-blocking to the required develop-PR lane once its two recorded criteria hold"
 worktree: main
 priority: Medium
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-05"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -36,7 +37,7 @@ prior_art:
 work:
   - id: w0
     summary: "Observe (or force) the first real parity-check run on a GitHub runner and record the result"
-    status: pending
+    status: done
     notes: |
       Watch for the next viz-touching PR post-#955, or open a trivial
       viz-path-touching draft PR to trigger one. Record the run URL and
@@ -47,7 +48,7 @@ work:
   - id: w1
     summary: "Disposition the geomean_ms.json 2e-13 float drift: tolerance vs fixture regen"
     needs: [w0]
-    status: pending
+    status: done
     notes: |
       Decide with evidence: if the runner reproduces the drift, prefer a
       bounded relative-tolerance comparison in the parity fixture check
@@ -57,11 +58,17 @@ work:
       the fixture README/comment and keep exact comparison. Regen the
       fixture only if the Python source is established as the intended
       truth.
+      DONE 2026-07-05: the runner MATCHED the committed fixtures exactly (the
+      2e-13 geomean_ms drift seen locally did NOT reproduce). Per this unit's
+      own rule, the drift is therefore a local-environment libm artifact -
+      exact comparison KEPT, and the drift is documented in the new
+      tests/parity/README.md (merged via #973). No tolerance widened, no
+      fixture regenerated.
 
   - id: w2
     summary: "Promote: aggregator wiring + test flip in one change"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       In .github/workflows/pr.yml: add parity-check to
       ci-required-result.needs, add PARITY_CHECK_RESULT env + the
@@ -71,6 +78,13 @@ work:
       replace test_parity_check_is_demoted_to_non_blocking with the
       promoted-shape assertions per its own comment. Run the aggregator
       bash-matrix tests to cover the new env var.
+      DONE 2026-07-05: pr.yml - parity-check added to ci-required-result.needs,
+      PARITY_CHECK_RESULT env + skipped-counts-as-pass check added, and
+      continue-on-error dropped; job comment records the promotion date +
+      evidence. test_pr_workflow_path_classifier.py - the demotion pin
+      replaced by test_parity_check_is_promoted_to_the_required_lane, plus
+      two aggregator bash-matrix tests (parity failure -> gate fails; parity
+      skipped -> gate passes). 15 classifier tests green; pr.yml parses.
 
 must_preserve:
   - "Path-filtering stays: parity-check keeps its viz-needed gate; promotion must not make every PR pay for it."

--- a/tests/unit/workflows/test_pr_workflow_path_classifier.py
+++ b/tests/unit/workflows/test_pr_workflow_path_classifier.py
@@ -69,6 +69,7 @@ def _run_ci_required_result(**env_overrides: str) -> subprocess.CompletedProcess
         "AUDIT_SHA_RESULT": "skipped",
         "PACKAGE_SMOKE_RESULT": "skipped",
         "DEPENDENCY_AUDIT_RESULT": "skipped",
+        "PARITY_CHECK_RESULT": "skipped",
         "CONTENT_GUARD_NEEDED": "false",
         "NEEDS_CODE_CI": "false",
         "SAFE_CONTENT_ONLY": "true",
@@ -288,24 +289,32 @@ def test_ci_paths_output_reference_regex_matches_fully_bracketed_form() -> None:
     assert matches == {"new-needed"}
 
 
-def test_parity_check_is_demoted_to_non_blocking() -> None:
-    # parity-check is deliberately non-blocking for now: `make parity-check`
-    # fails locally with an unexplained 2e-13 float drift in
-    # tests/parity/fixtures/geomean_ms.json, so wiring it into
-    # ci-required-result would risk hard-blocking every viz-touching PR on
-    # arrival. Promotion criterion (parity-check-develop-ring.yaml): one
-    # green run on a real GitHub runner + a decision on the float drift
-    # (tolerance vs fixture regen). When promoting, flip this test to the
-    # package-smoke pattern: add parity-check to ci-required-result.needs,
-    # drop continue-on-error, and assert the aggregator observes
-    # PARITY_CHECK_RESULT.
-    workflow_yaml = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8"))
+def test_parity_check_is_promoted_to_the_required_lane() -> None:
+    # parity-check was promoted from non-blocking to required (2026-07-05,
+    # parity-check-promotion) once both criteria held: (1) one green run on a
+    # real GitHub runner (PR #973), and (2) the 2e-13 geomean_ms drift did NOT
+    # reproduce on the runner (a local libm artifact, not a fixture error), so
+    # exact comparison is kept. This is the package-smoke pattern: the job
+    # keeps its viz path-filter, drops continue-on-error, is in
+    # ci-required-result.needs, and the aggregator observes PARITY_CHECK_RESULT
+    # with skipped-counts-as-pass.
+    workflow_text = (REPO_ROOT / ".github" / "workflows" / "pr.yml").read_text(encoding="utf-8")
+    workflow_yaml = yaml.safe_load(workflow_text)
     parity_job = workflow_yaml["jobs"]["parity-check"]
-    needs = workflow_yaml["jobs"]["ci-required-result"]["needs"]
+    aggregator = workflow_yaml["jobs"]["ci-required-result"]
+    needs = aggregator["needs"]
 
-    assert parity_job.get("continue-on-error") is True
-    assert "viz-needed == 'true'" in parity_job["if"]
-    assert "parity-check" not in needs
+    # Promoted shape: blocking, observed, still path-filtered.
+    assert parity_job.get("continue-on-error") is None, "continue-on-error must be dropped on promotion"
+    assert "viz-needed == 'true'" in parity_job["if"], "path-filtering must stay (non-viz PRs skip)"
+    assert "parity-check" in needs, "aggregator must depend on parity-check to observe its result"
+
+    # The aggregator must read PARITY_CHECK_RESULT and apply skipped-counts-as-pass.
+    agg_step = next(s for s in aggregator["steps"] if s.get("name") == "Aggregate required result")
+    assert agg_step["env"].get("PARITY_CHECK_RESULT") == "${{ needs.parity-check.result }}"
+    run = agg_step["run"]
+    assert 'PARITY_CHECK_RESULT" != "success"' in run
+    assert 'PARITY_CHECK_RESULT" != "skipped"' in run
 
 
 def test_ci_required_result_fails_on_packaging_job_failure() -> None:
@@ -337,5 +346,37 @@ def test_ci_required_result_passes_when_packaging_jobs_skip() -> None:
         CORRECTNESS_RESULT="success",
         PLAN_CAPTURE_RESULT="success",
         EXPLORER_TOKENS_RESULT="success",
+    )
+    assert result.returncode == 0
+
+
+def test_ci_required_result_fails_on_parity_check_failure() -> None:
+    # Promotion (parity-check-promotion): a viz-touching PR whose parity-check
+    # job fails must now fail the required gate (was non-blocking before).
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+        PARITY_CHECK_RESULT="failure",
+    )
+    assert result.returncode == 1
+
+
+def test_ci_required_result_passes_when_parity_check_skips() -> None:
+    # A non-viz PR skips parity-check (path-filtered) and must still pass -
+    # the skipped-counts-as-pass contract the promotion preserves.
+    result = _run_ci_required_result(
+        NEEDS_CODE_CI="true",
+        SAFE_CONTENT_ONLY="false",
+        LINT_RESULT="success",
+        TEST_RESULT="success",
+        CORRECTNESS_RESULT="success",
+        PLAN_CAPTURE_RESULT="success",
+        EXPLORER_TOKENS_RESULT="success",
+        PARITY_CHECK_RESULT="skipped",
     )
     assert result.returncode == 0


### PR DESCRIPTION
# Pull Request

## Description

Promotes the `parity-check` CI job from non-blocking to the required develop-PR lane — the w2 completion of TODO `parity-check-promotion`. Both recorded criteria are met:

1. **One green run on a real GitHub runner** (criterion 1, unmeetable before #955 fixed the `viz-needed` wiring): draft PR #973 (touching `tests/parity/**`, a viz path) produced run 28742318825 job 85227174150 — the runner's `make parity-check` printed `fixtures match Python source` (confirmed from the job log, not the continue-on-error-masked job conclusion).
2. **Disposition of the geomean_ms drift** (criterion 2): the 2e-13 last-bit drift seen locally did **not** reproduce on the runner, so it is a local libm transcendental-precision artifact, not a fixture error. Exact comparison is **kept**; the drift is documented in `tests/parity/README.md` (already merged via #973). No tolerance widened, no fixture regenerated.

Promotion follows the package-smoke pattern:
- `pr.yml`: `parity-check` added to `ci-required-result.needs`; the aggregator gains `PARITY_CHECK_RESULT` env + a skipped-counts-as-pass check (placed before the needs-code-ci early-exit, mirroring package-smoke); `continue-on-error` dropped; job comment records the promotion date + evidence. **Path-filtering stays** (`if: viz-needed == 'true'`), so a non-viz PR skips parity-check and still passes.
- `test_pr_workflow_path_classifier.py`: the demotion pin (`test_parity_check_is_demoted_to_non_blocking`) is replaced by `test_parity_check_is_promoted_to_the_required_lane` (asserts blocking + observed + still path-filtered + aggregator reads `PARITY_CHECK_RESULT` with skipped-counts-as-pass), plus two aggregator bash-matrix tests (parity failure → gate fails; parity skipped → gate passes).

## Type of Change

- [x] CI/infra change (gate promotion)

## Testing

- `uv run -- python -m pytest tests/unit/workflows/test_pr_workflow_path_classifier.py -q` → 15 passed.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` → parses.
- `make lint` green.

## Public Contract Check

- [x] No public/beta/deprecated/experimental contract surfaces changed (CI workflow + workflow tests + TODO bookkeeping).

## Documentation

- [x] The geomean drift disposition is documented in `tests/parity/README.md` (merged via #973); the promotion evidence is in the job comment and the DONE TODO.

## Code Quality

- [x] Formatting/lint run.
- [x] `must_preserve` held: path-filtering kept (non-viz PRs skip and pass); `ci-required-result`'s skip-counts-as-pass contract intact; `results-explorer/src/` untouched (`do_not_modify`).

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

Code review (soundness of the aggregator bash under `set -euo pipefail`): the parity block sits before the `needs-code-ci=false` early-exit like package-smoke (belt-and-suspenders — the three viz paths are all in `code-ci`, so a viz PR is needs-code-ci=true anyway); `PARITY_CHECK_RESULT` is always defined in both the workflow env and the test harness (no `set -u` trap); the promoted-shape test would catch either a `continue-on-error` regression or a dropped skipped-counts-as-pass. No findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_