### PR TITLE
ci(submission): re-land the self-green guard on develop (§2.7)

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -21,6 +21,30 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for diff
 
+      - name: Reject validator or workflow changes in a submission PR
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Self-green defense: a corpus submission PR must only touch corpus
+          # data. If it also modifies the validator, its shared implementation,
+          # the inventory generator, or this workflow, it could run its OWN
+          # doctored validator and pass itself. Validator/workflow changes belong
+          # on develop (they reach this branch only via a maintainer-reviewed
+          # mirror), never in a contributor submission PR.
+          CHANGED_GUARD=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            scripts/validate_submission.py \
+            benchbox/validation/bundle.py \
+            scripts/generate_corpus_inventory.py \
+            .github/workflows/validate-submission.yml \
+            || true)
+          if [ -n "$CHANGED_GUARD" ]; then
+            echo "::error::This submission PR modifies validator/workflow files, which is not allowed:"
+            printf '%s\n' "$CHANGED_GUARD"
+            echo "Revert these files and open a separate develop PR for validator/workflow changes."
+            exit 1
+          fi
+          echo "No validator/workflow files changed - proceeding."
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 


### PR DESCRIPTION
## Description

Re-lands the §2.7 self-green guard on `develop`. It was authored on #966's branch but the repo's auto-merge-on-open landed #966 on an earlier commit, so the guard commit was stranded on the (now-closed) branch and never reached `develop`. This restores `develop`'s copy as the correct source of truth. (The same guard is applied to the running branch copy in #985 against `published-results`.)

## Change

A single early step in `validate-submission.yml`: a corpus submission PR that also modifies `scripts/validate_submission.py`, `benchbox/validation/bundle.py`, `scripts/generate_corpus_inventory.py`, or this workflow **fails fast** — otherwise it could run its own doctored validator and pass itself. Validator/workflow changes belong on `develop`.

It's a read-only `git diff` check — no `pull_request_target`, no execution of PR code.

## Type of Change

- [x] Bug fix

## Testing

- Cherry-picked cleanly onto current `develop`; workflow YAML parses.
- The guard is a pure diff check; it fires only when a submission PR touches validator/workflow files.

## Public Contract Check / Documentation / Code Quality / Artifact Hygiene

- [x] CI-only change; no contract/doc/code-surface impact; no artifacts.

## Notes

Companion to **#985** (the one-time sync of this workflow onto `published-results`, the branch that actually runs it). Auto-merge fine for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_