### PR TITLE
fix(query-plans): propagate test_type through the real result-building pipeline

### DIFF
--- a/benchbox/core/results/builder.py
+++ b/benchbox/core/results/builder.py
@@ -977,6 +977,8 @@ class ResultBuilder:
                 result_dict["plan_capture_time_ms"] = result.plan_capture_time_ms
             if result.result_digest is not None:
                 result_dict["result_digest"] = result.result_digest
+            if result.test_type:
+                result_dict["test_type"] = result.test_type
 
             results.append(result_dict)
 

--- a/benchbox/core/results/query_normalizer.py
+++ b/benchbox/core/results/query_normalizer.py
@@ -115,6 +115,12 @@ class QueryResultInput:
     # Gate-only value-digest oracle (BENCHBOX_EMIT_RESULT_DIGEST): full-result
     # digest of a stream-0 query. None on a normal run (no payload change).
     result_digest: str | None = None
+    # Phase discriminator ("power"/"throughput"/"maintenance") for combined runs,
+    # where the same query_id executes in more than one phase and each phase's
+    # stream_id counter independently starts at 0 - stream_id alone can't
+    # disambiguate a cross-phase collision in the .plans.json companion (see
+    # build_plans_payload). None for standard single-phase runs.
+    test_type: str | None = None
 
 
 def normalize_query_result(
@@ -200,6 +206,7 @@ def normalize_query_result(
         plan_fingerprint_normalized=raw_result.get("plan_fingerprint_normalized"),
         plan_capture_time_ms=raw_result.get("plan_capture_time_ms"),
         result_digest=raw_result.get("result_digest"),
+        test_type=raw_result.get("test_type"),
     )
 
 

--- a/tests/unit/core/results/test_builder.py
+++ b/tests/unit/core/results/test_builder.py
@@ -14,7 +14,7 @@ from benchbox.core.results.builder import (
     normalize_benchmark_id,
 )
 from benchbox.core.results.platform_info import PlatformInfoInput
-from benchbox.core.results.query_normalizer import QueryResultInput
+from benchbox.core.results.query_normalizer import QueryResultInput, normalize_query_result
 
 pytestmark = [
     pytest.mark.unit,
@@ -389,6 +389,43 @@ class TestResultBuilder:
         assert result.platform_info["execution_mode"] == "sql"
         assert result.platform_info["connection_mode"] == "in-memory"
         assert result.platform_info["configuration"] == {"threads": 4}
+
+    def test_build_preserves_test_type_through_real_pipeline(self) -> None:
+        """test_type must survive the REAL production pipeline: raw platform-adapter
+        dict -> normalize_query_result -> ResultBuilder.add_query_result -> build()
+        -> BenchmarkResults.query_results. This is the phase discriminator
+        build_plans_payload uses to disambiguate a power row and a throughput row
+        sharing the same query_id/stream_id in a combined run; a synthetic
+        QueryResultInput built directly (bypassing normalize_query_result) would
+        hide a regression where the raw dict's "test_type" key gets silently
+        dropped at the normalization boundary."""
+        power_raw = {
+            "query_id": "Q6",
+            "execution_time_seconds": 1.0,
+            "rows_returned": 10,
+            "status": "SUCCESS",
+            "stream_id": 0,
+            "test_type": "power",
+        }
+        throughput_raw = {
+            "query_id": "Q6",
+            "execution_time_seconds": 2.0,
+            "rows_returned": 10,
+            "status": "SUCCESS",
+            "stream_id": 0,
+            "test_type": "throughput",
+        }
+
+        builder = self.create_builder()
+        builder.add_query_result(normalize_query_result(power_raw))
+        builder.add_query_result(normalize_query_result(throughput_raw))
+
+        result = builder.build()
+
+        assert len(result.query_results) == 2
+        power_row, throughput_row = result.query_results
+        assert power_row["test_type"] == "power"
+        assert throughput_row["test_type"] == "throughput"
 
 
 class TestBuildBenchmarkResults:

--- a/tests/unit/core/results/test_query_normalizer.py
+++ b/tests/unit/core/results/test_query_normalizer.py
@@ -306,6 +306,35 @@ class TestNormalizeQueryResult:
         assert result.iteration == 5
         assert result.stream_id == 2
 
+    def test_normalize_preserves_test_type(self) -> None:
+        """test_type (the combined-run phase discriminator stamped by platform
+        adapters, e.g. benchbox/platforms/base/execution.py) must survive
+        normalization - it's how build_plans_payload disambiguates a power row
+        and a throughput row for the same query_id/stream_id in a combined run."""
+        raw = {
+            "query_id": "Q1",
+            "execution_time_seconds": 1.5,
+            "rows_returned": 100,
+            "status": "SUCCESS",
+            "test_type": "throughput",
+        }
+        result = normalize_query_result(raw)
+
+        assert result.test_type == "throughput"
+
+    def test_normalize_test_type_defaults_to_none(self) -> None:
+        """Standard single-phase runs never set test_type; normalization must not
+        invent a value."""
+        raw = {
+            "query_id": "Q1",
+            "execution_time_seconds": 1.5,
+            "rows_returned": 100,
+            "status": "SUCCESS",
+        }
+        result = normalize_query_result(raw)
+
+        assert result.test_type is None
+
 
 class TestNormalizeQueryResults:
     """Tests for normalize_query_results function."""


### PR DESCRIPTION
## Description

Follow-up to #979 (merged), which added `test_type` as the cross-phase discriminator for `.plans.json`'s composite key — a power row and a throughput row in a combined run can share the same `query_id`/`stream_id`, so `test_type` is needed to tell them apart.

`test_type` is stamped on raw per-query dicts in `benchbox/platforms/base/execution.py` (e.g. `"test_type": "throughput"`), but `normalize_query_result`/`QueryResultInput` had no `test_type` field. Since `ResultBuilder.add_query_result`/`add_query_results` only accept `QueryResultInput` instances, every real production caller must go through `normalize_query_result` first — which silently dropped `test_type` before it ever reached `BenchmarkResults.query_results`. #979's own regression tests (`test_schema_v2_plans_companion_cross_phase_same_stream_id_disambiguated`, `test_reconstruct_query_results_cross_phase_same_stream_id_reattach`) construct `query_results` dicts directly via `make_benchmark_results`, bypassing the normalizer entirely, so this gap wasn't caught.

Net effect before this fix: the cross-phase collision #979 set out to fix was still live for every real (non-test-constructed) combined run.

## Fix

- `benchbox/core/results/query_normalizer.py`: added `test_type: str | None = None` to `QueryResultInput`; `normalize_query_result()` sets it from `raw_result.get("test_type")`.
- `benchbox/core/results/builder.py`: `ResultBuilder._format_query_results()` copies `result.test_type` into the compact per-query dict when set (additive, absent for standard single-phase runs — unchanged output for existing callers).

## Type of Change

- [x] Bug fix

## Testing

- Added `test_build_preserves_test_type_through_real_pipeline` (`tests/unit/core/results/test_builder.py`): raw dict → `normalize_query_result` → `ResultBuilder.add_query_result` → `build()` → asserts both power/throughput rows keep distinct `test_type` in `BenchmarkResults.query_results`.
- Added `test_normalize_preserves_test_type` / `test_normalize_test_type_defaults_to_none` (`tests/unit/core/results/test_query_normalizer.py`).
- `uv run -- python -m pytest tests/unit/core/results/test_query_normalizer.py tests/unit/core/results/test_builder.py -n 0 -q` → 104 passed
- `uv run -- python -m pytest tests/unit/core/ tests/integration/ -k 'plan or normali or builder or result_capture' -n 0 -q` → 1076 passed, 3 skipped (no live PostgreSQL), no casualties
- `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` on touched files → clean

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surfaces changed. `test_type` is an additive, optional field on the internal `QueryResultInput`/compact query dict, mirroring what #979 already added to the compact export and `.plans.json` companion.

## Documentation

- [x] N/A — no user-facing behavior change; completes the internal mechanism #979 documented.

## Code Quality

- [x] Ran formatting/lint/type checks.
- [x] Added regression tests exercising the real pipeline (not just synthetic `query_results` dicts).
- [x] Backwards compatible: `test_type` defaults to `None`/absent for standard single-phase runs.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Does not touch `benchbox/platforms/base/result_capture.py` or any other CODEOWNERS-gated path, so enabling squash auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Dfk9EwmhZns8ttQFuVg34)_