### PR TITLE
fix(release-admin): wire v* tag ruleset drift into CI; fix doc overstatements

### DIFF
--- a/_project/scripts/ruleset_review_enforcement.py
+++ b/_project/scripts/ruleset_review_enforcement.py
@@ -41,6 +41,7 @@ exercised two ways:
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import sys
 from pathlib import Path
@@ -133,6 +134,20 @@ TAG_RULESET_ENFORCED = False
 TAG_REF_PATTERN = "refs/tags/v*"
 
 
+def _tag_glob_covers(pattern: str) -> bool:
+    """True if a ref-name glob ``pattern`` matches every ``refs/tags/v*`` ref.
+
+    GitHub's ``ref_name`` condition patterns are fnmatch-style globs, so
+    ``refs/tags/*`` covers (or negates, in an ``exclude``) ``refs/tags/v*``
+    just as fully as the literal pattern. Fnmatch-ing ``TAG_REF_PATTERN``
+    itself against ``pattern`` answers that without enumerating concrete tag
+    names: every character in ``refs/tags/v*`` is literal except the trailing
+    ``*``, so a pattern matches it here exactly when that pattern's own
+    wildcard structure would match any real ``refs/tags/vX...`` ref too.
+    """
+    return fnmatch.fnmatchcase(TAG_REF_PATTERN, pattern)
+
+
 def tag_protection_findings(rulesets: list[dict[str, Any]]) -> list[str]:
     """Reasons the live rulesets fail to restrict ``v*`` tag *creation*.
 
@@ -150,17 +165,39 @@ def tag_protection_findings(rulesets: list[dict[str, Any]]) -> list[str]:
     summary-only payload correctly reports the detail as missing rather than
     passing on absent evidence (never green on unverified input). Rulesets
     that target branches (e.g. ``v-release-branches-minimal`` →
-    ``refs/heads/v*``) are ``target != "tag"`` and never count. An ``exclude``
-    that removes ``refs/tags/v*`` negates an otherwise-covering ``include``.
+    ``refs/heads/v*``) are ``target != "tag"`` and never count.
+
+    ``include``/``exclude`` ref-name conditions are GitHub fnmatch-style globs,
+    not exact strings: an ``include`` of ``refs/tags/*`` covers ``refs/tags/v*``
+    just as well as the literal pattern, and an ``exclude`` of ``refs/tags/*``
+    negates that coverage even though it is not byte-identical to
+    ``TAG_REF_PATTERN``. Coverage is therefore tested by fnmatch-ing
+    ``TAG_REF_PATTERN`` itself against each candidate pattern (every character
+    in ``refs/tags/v*`` is literal except the trailing ``*``, so this exactly
+    answers "does this pattern's wildcard structure swallow the whole
+    refs/tags/v* domain" without enumerating concrete tag names). ``~ALL`` is
+    GitHub's literal sentinel for "every ref" and is matched by exact string,
+    not fnmatch.
 
     NOTE on ``bypass_actors``: this predicate deliberately does NOT treat a
     non-empty bypass list as a structural failure. This TODO's must_preserve
     REQUIRES a bypass path (``make release-finalize`` must still create ``v*``
-    tags), so demanding zero bypass actors would brick the release flow. A
-    broad/wrong bypass list is nonetheless a real hole, so it is surfaced via
-    :func:`tag_bypass_advisory` (rendered by ``main`` and required in the
-    runbook's live-state note) for human confirmation before
-    ``TAG_RULESET_ENFORCED`` is flipped — never passed silently.
+    tags), so demanding zero bypass actors would brick the release flow. But an
+    explicitly-empty bypass list (``bypass_actors: []``, as returned by the full
+    ruleset GET when none are configured) is the OTHER failure mode of the same
+    requirement: a structurally-valid ruleset with no exception for the
+    release-finalize identity blocks ``make release-finalize``'s own
+    ``git push origin v$(VERSION)``, bricking releases outright. That case is a
+    finding here, not just an advisory. A MISSING ``bypass_actors`` key (as
+    opposed to a present-but-empty list) is left unasserted — it means the
+    caller didn't populate that field at all (e.g. a partial/synthetic
+    payload), not that GitHub confirmed there are zero bypass actors. A
+    non-empty bypass list is still not a structural failure (must_preserve
+    requires the bypass path to exist) but its actor list is a real hole if
+    too broad, so it is surfaced via :func:`tag_bypass_advisory` (rendered by
+    ``main`` and required in the runbook's live-state note) for human
+    confirmation before ``TAG_RULESET_ENFORCED`` is flipped — never passed
+    silently.
     """
     tag_rulesets = [rs for rs in rulesets if isinstance(rs, dict) and rs.get("target") == "tag"]
     if not tag_rulesets:
@@ -178,13 +215,19 @@ def tag_protection_findings(rulesets: list[dict[str, Any]]) -> list[str]:
         ref_name = (ruleset.get("conditions") or {}).get("ref_name") or {}
         include = tuple(ref_name.get("include") or ())
         exclude = tuple(ref_name.get("exclude") or ())
-        if TAG_REF_PATTERN not in include and "~ALL" not in include:
+        if not any(pattern == "~ALL" or _tag_glob_covers(pattern) for pattern in include):
             issues.append(f"ref include={include!r} does not cover {TAG_REF_PATTERN}")
-        elif TAG_REF_PATTERN in exclude or "~ALL" in exclude:
+        elif any(pattern == "~ALL" or _tag_glob_covers(pattern) for pattern in exclude):
             issues.append(f"ref exclude={exclude!r} negates coverage of {TAG_REF_PATTERN}")
         rule_types = {rule.get("type") for rule in ruleset.get("rules") or [] if isinstance(rule, dict)}
         if "creation" not in rule_types:
             issues.append("no 'creation' rule")
+        if ruleset.get("bypass_actors") == []:
+            issues.append(
+                "bypass_actors is empty -- `make release-finalize`'s `git push origin "
+                "v$(VERSION)` would be blocked with no exception for the release-finalize "
+                "identity; add a bypass actor for that identity before enforcing"
+            )
         if not issues:
             return []
         problems.append(f"{name}: " + "; ".join(issues))
@@ -194,11 +237,14 @@ def tag_protection_findings(rulesets: list[dict[str, Any]]) -> list[str]:
 def tag_bypass_advisory(rulesets: list[dict[str, Any]]) -> list[str]:
     """Bypass actors on the covering ``v*`` tag ruleset that a human must confirm.
 
-    Empty list == no protecting tag ruleset (see :func:`tag_protection_findings`)
-    or a protecting one with NO bypass actors. A non-empty result is NOT a
-    failure — it is the list the operator must confirm is release-flow-only
-    before flipping ``TAG_RULESET_ENFORCED`` (must_preserve: the release
-    identity legitimately needs bypass; a broad role in this list is the hole).
+    Empty list == no protecting tag ruleset, a protecting one with an
+    explicitly-empty ``bypass_actors: []`` (both already surfaced as findings
+    by :func:`tag_protection_findings`, so not repeated here), or a protecting
+    one where ``bypass_actors`` is simply absent from the payload. A non-empty
+    result is NOT a failure — it is the list the operator must confirm is
+    release-flow-only before flipping ``TAG_RULESET_ENFORCED`` (must_preserve:
+    the release identity legitimately needs bypass; a broad role in this list
+    is the hole).
     """
     if tag_protection_findings(rulesets):
         return []

--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -105,7 +105,7 @@ uv run -- python scripts/generate_corpus_inventory.py --write
 
 ### 5. Review and merge
 
-A maintainer reviews the submission for quality and environment consistency. Once approved and merged into `published-results`, the bundle enters the public corpus. The results explorer rebuilds when the corpus reaches `main` through the develop → main release flow (the explorer builds and deploys from `main` via the docs CI workflow, not from `published-results` directly), so a merged submission appears on the site at the next release rather than immediately.
+A maintainer reviews the submission for quality and environment consistency. Once approved and merged into `published-results`, the bundle enters the public corpus. The results explorer is designed to build and deploy from `main` (not from `published-results` directly) via the docs CI workflow, so once that deploy path is live, a merged submission would appear on the site at the next release rather than immediately. **Pre-launch caveat:** `release-cut` currently strips `results-explorer/` and `results-data/` out of every release branch, so the `main`-deployed site is not live yet — see [`docs/operations/results-phase-2-runbook.md`](operations/results-phase-2-runbook.md#13-explorer-publish-path) for the current state. Until that changes, treat `benchbox.dev/results/` as a develop-built preview rather than a guarantee that your merged submission will appear there.
 
 ## What Makes a Good Submission
 

--- a/docs/development/adr/adr-published-results-slim-corpus-branch.md
+++ b/docs/development/adr/adr-published-results-slim-corpus-branch.md
@@ -104,10 +104,16 @@ in the slim-down.
 is a thin wrapper that imports the shared implementation from
 `benchbox/validation/bundle.py` (mirrored onto this branch), with an
 `importlib` file-loader fallback if `benchbox` is not importable; that shared
-module is itself stdlib-only (`hashlib`, `json`, `sys`, `argparse`, `pathlib`,
-`decimal`, `collections`, `datetime` — it does not import the rest of
-`benchbox.*`). CI invokes them with `uv run --no-project --python 3.11`, so
-neither needs project metadata or an installed BenchBox to run.
+module's own dependencies are stdlib-only (`hashlib`, `json`, `sys`,
+`argparse`, `pathlib`, `decimal`, `collections`, `datetime`), but it also
+*tries* one `benchbox.*` import — `benchbox.core.results.schema_policy` — and
+falls back to a standalone policy check when that import fails (as it will on
+this slim branch, which has no installed BenchBox). That is an optional
+BenchBox import, not an absence of one: develop intentionally uses the
+central schema policy when `benchbox` is importable there, while
+`published-results` always takes the standalone fallback path. CI invokes
+both scripts with `uv run --no-project --python 3.11`, so neither needs
+project metadata or an installed BenchBox to run.
 
 The current `validate-submission.yml` invokes them via
 `uv run -- python scripts/<script>.py`, which expects a `pyproject.toml`

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -335,19 +335,31 @@ for id in $ids; do gh api repos/joeharris76/BenchBox/rulesets/$id; done \
 While `TAG_RULESET_ENFORCED` is `False` (until the POST above lands), a
 missing/incomplete `v*`-tag ruleset prints as `WARNING (non-blocking):` and
 exits 0 — the check ships before the admin acts without going red. The
-predicate flags a ruleset that is not `active`, whose `ref_name.include`
-does not cover `refs/tags/v*` (or `~ALL`), whose `exclude` negates that
-coverage, or that lacks a `creation` rule. It does NOT fail on a non-empty
-`bypass_actors` list — a bypass path is REQUIRED so `make release-finalize`
-can still tag — but it prints a `CONFIRM before enforcing:` line listing the
-bypass actors; verify that list is the release identity only (not a broad
-Write/Admin role) before flipping the flag. After applying the ruleset and
-confirming the bypass list, flip `TAG_RULESET_ENFORCED = True` (a one-line
-change, tested by `test_ruleset_drift_review_coverage.py`) so the gap becomes
-blocking. NOTE: this predicate is not yet wired into the live
-`release-canary.yml` run — that wiring is a follow-up and also depends on
-`release-canary-scheduled-activation` making the canary run at all; the
-predicate + tests land first per this TODO's scope.
+predicate flags a ruleset that is not `active`; whose `ref_name.include`
+does not cover `refs/tags/v*` (or `~ALL`) under GitHub's fnmatch ref-glob
+semantics (an `include`/`exclude` of `refs/tags/*` counts the same as the
+literal `refs/tags/v*`, not just a byte-identical string); that lacks a
+`creation` rule; or whose `bypass_actors` is explicitly `[]` (a
+structurally-valid ruleset with zero bypass actors would itself block
+`make release-finalize`'s `git push origin v$(VERSION)`, bricking releases —
+that is a finding, not just an advisory). A NON-empty `bypass_actors` list is
+not a structural failure (a bypass path is REQUIRED so `make release-finalize`
+can still tag) — instead it prints a `CONFIRM before enforcing:` line listing
+the bypass actors; verify that list is the release identity only (not a
+broad Write/Admin role) before flipping the flag. After applying the
+ruleset and confirming the bypass list, flip `TAG_RULESET_ENFORCED = True`
+(a one-line change, tested by `test_ruleset_drift_review_coverage.py`) so
+the gap becomes blocking.
+
+Wired into CI (landed alongside the fnmatch/bypass-empty hardening above):
+`scripts/ruleset_drift_check.py`'s `tag_creation_findings()` calls
+`tag_protection_findings()`/`tag_bypass_advisory()` against every ruleset
+`release-canary.yml`'s `ruleset-drift` job already fetches (the same
+`RULESET_DRIFT_TOKEN`-authenticated full-ruleset listing used for the
+`develop-squash-only`/`main-release-only` checks — no second API call), so
+the daily canary run itself surfaces tag-ruleset drift under the same
+WARN-until-applied gating as the develop review rule, with no dependency on
+`release-canary-scheduled-activation` beyond the canary running at all.
 
 Live-state note (fill in after applying — do not leave blank):
 

--- a/scripts/ruleset_drift_check.py
+++ b/scripts/ruleset_drift_check.py
@@ -20,7 +20,13 @@ DEFAULT_RUNBOOK = REPO_ROOT / "docs" / "operations" / "repo-admin-settings.md"
 # how this module is loaded (script, package import, or out-of-tree test).
 sys.path.insert(0, str(REPO_ROOT / "_project" / "scripts"))
 
-from ruleset_review_enforcement import extract_rules, review_enforcement_findings  # noqa: E402
+from ruleset_review_enforcement import (  # noqa: E402
+    TAG_RULESET_ENFORCED,
+    extract_rules,
+    review_enforcement_findings,
+    tag_bypass_advisory,
+    tag_protection_findings,
+)
 
 # Findings with this prefix are surfaced (rendered, included in the JSON
 # `findings` list) exactly like any other drift finding, but do NOT flip the
@@ -227,6 +233,42 @@ def compare_ruleset(
     return findings
 
 
+def tag_creation_findings(
+    all_live_rulesets: list[dict[str, Any]],
+    *,
+    enforce_tag_rule: bool = TAG_RULESET_ENFORCED,
+) -> list[str]:
+    """Findings for the ``v*`` tag-creation ruleset (release-flow hardening).
+
+    Delegates entirely to ``ruleset_review_enforcement.tag_protection_findings``/
+    ``tag_bypass_advisory`` (single source of truth, shared with the standalone
+    ``--rulesets-file`` CLI documented in ``docs/operations/repo-admin-settings.md``).
+    Unlike the per-name ``compare_ruleset`` checks above, this scans ALL fetched
+    rulesets (not one by expected name) because the tag-creation ruleset has no
+    fixed expected name — any ruleset with ``target: "tag"`` that covers
+    ``refs/tags/v*`` with a ``creation`` rule counts.
+
+    Mirrors the ``DEVELOP_REVIEW_RULE_ENFORCED`` WARN-until-applied pattern:
+    while ``enforce_tag_rule`` is ``False`` (the default, driven by
+    ``TAG_RULESET_ENFORCED``), a missing/incomplete tag ruleset is a
+    ``WARNING_PREFIX``-prefixed finding — visible, non-blocking — until the
+    admin POST lands and the flag is flipped.
+    """
+    findings: list[str] = []
+    protection_findings = tag_protection_findings(all_live_rulesets)
+    if protection_findings:
+        if enforce_tag_rule:
+            findings.extend(protection_findings)
+        else:
+            findings.extend(f"{WARNING_PREFIX}{finding}" for finding in protection_findings)
+    else:
+        findings.extend(
+            f"{WARNING_PREFIX}CONFIRM before enforcing: {advisory}"
+            for advisory in tag_bypass_advisory(all_live_rulesets)
+        )
+    return findings
+
+
 def _override_active(env: dict[str, str]) -> tuple[bool, str]:
     sha = env.get("RELEASE_READINESS_OVERRIDE_SHA", "").strip()
     reason = env.get("RELEASE_READINESS_OVERRIDE_REASON", "").strip()
@@ -320,6 +362,7 @@ def main(argv: list[str] | None = None) -> int:
                 require_bypass_actor_visibility=args.require_bypass_actor_visibility,
             )
         )
+    findings.extend(tag_creation_findings(list(live_by_name.values())))
 
     blocking = blocking_findings(findings)
     summary = render_summary(findings, expected)

--- a/tests/unit/release/test_ruleset_drift_review_coverage.py
+++ b/tests/unit/release/test_ruleset_drift_review_coverage.py
@@ -35,6 +35,7 @@ from scripts.ruleset_drift_check import (
     blocking_findings,
     compare_ruleset,
     parse_expected_rulesets,
+    tag_creation_findings,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.fast]
@@ -292,3 +293,98 @@ def test_tag_check_main_prints_bypass_confirmation_on_ok(tmp_path, capsys):
     assert rc == 0
     assert "Tag-creation ruleset - OK" in out
     assert "CONFIRM before enforcing:" in out
+
+
+# ---------------------------------------------------------------------------
+# Review-followup hardening: empty bypass_actors + fnmatch ref-glob matching
+# ---------------------------------------------------------------------------
+
+
+def test_tag_protection_flags_explicitly_empty_bypass_actors():
+    # A structurally-valid ruleset with bypass_actors: [] (GitHub's shape for
+    # "none configured") would itself block make release-finalize's own tag
+    # push, so it must NOT read as protected.
+    ruleset = _tag_ruleset() | {"bypass_actors": []}
+    findings = _rre.tag_protection_findings([ruleset])
+    assert findings and "bypass_actors is empty" in findings[0]
+    assert not _rre.is_tag_creation_protected([ruleset])
+    # No redundant advisory: the empty-bypass gap is already a finding above.
+    assert _rre.tag_bypass_advisory([ruleset]) == []
+
+
+def test_tag_protection_does_not_flag_missing_bypass_actors_key():
+    # A caller that never populated bypass_actors at all (vs. GitHub
+    # confirming zero via an explicit []) is left unasserted -- unlike a
+    # confirmed-empty list, absence isn't evidence of anything.
+    ruleset = _tag_ruleset()
+    assert "bypass_actors" not in ruleset
+    assert _rre.tag_protection_findings([ruleset]) == []
+
+
+def test_tag_protection_include_covers_via_broader_fnmatch_glob():
+    # refs/tags/* is a broader GitHub fnmatch glob that covers refs/tags/v*
+    # just as fully as the literal pattern -- not just an exact string match.
+    findings = _rre.tag_protection_findings([_tag_ruleset(include=("refs/tags/*",))])
+    assert findings == []
+
+
+def test_tag_protection_flags_exclude_that_negates_v_coverage_via_broader_glob():
+    # The bug this regression pins: a prior exact-string exclude check missed
+    # a broader-but-still-covering exclude glob like refs/tags/* (as opposed
+    # to the byte-identical refs/tags/v* already covered by the older test
+    # above), so an admin who wrote refs/tags/* saw a false "protected" OK.
+    negated = _rre.tag_protection_findings(
+        [
+            _tag_ruleset(include=("~ALL",))
+            | {"conditions": {"ref_name": {"include": ["~ALL"], "exclude": ["refs/tags/*"]}}}
+        ]
+    )
+    assert negated and "negates coverage" in negated[0]
+
+
+def test_tag_protection_narrower_exclude_does_not_negate_coverage():
+    # refs/tags/rc* (a disjoint, narrower glob) does not overlap refs/tags/v*
+    # at all, so it must not be treated as a negating exclude.
+    findings = _rre.tag_protection_findings(
+        [_tag_ruleset() | {"conditions": {"ref_name": {"include": ["refs/tags/v*"], "exclude": ["refs/tags/rc*"]}}}]
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# scripts/ruleset_drift_check.py wiring (release-canary.yml's ruleset-drift
+# job) -- the tag predicate must actually run in CI, not just via the
+# standalone --rulesets-file CLI documented in the runbook.
+# ---------------------------------------------------------------------------
+
+
+def test_tag_creation_findings_warns_non_blocking_when_no_tag_ruleset_exists():
+    # Live state: only develop/main-release rulesets exist, no target='tag'
+    # ruleset yet -- must surface as a non-blocking warning by default
+    # (TAG_RULESET_ENFORCED is False), same WARN-until-applied pattern as the
+    # develop review rule.
+    all_live = [
+        _live_develop_ruleset(review_count=0, code_owner_review=False),
+    ]
+    findings = tag_creation_findings(all_live)
+    assert findings and all(f.startswith(WARNING_PREFIX) for f in findings)
+    assert blocking_findings(findings) == []
+    assert any("target='tag'" in f for f in findings)
+
+
+def test_tag_creation_findings_empty_when_ruleset_present_and_no_bypass_gap():
+    all_live = [
+        _tag_ruleset() | {"bypass_actors": [{"actor_type": "Integration", "actor_id": 1, "bypass_mode": "always"}]}
+    ]
+    findings = tag_creation_findings(all_live)
+    # A non-empty bypass list is an advisory, not a failure -- still non-blocking.
+    assert blocking_findings(findings) == []
+
+
+def test_tag_creation_findings_can_be_switched_to_blocking_explicitly():
+    # The one-line enforce switch: TAG_RULESET_ENFORCED=True would make this
+    # call with enforce_tag_rule=True instead, turning the same gap blocking.
+    findings = tag_creation_findings([], enforce_tag_rule=True)
+    assert findings, "expected a blocking finding once tag-rule enforcement is on"
+    assert not any(f.startswith(WARNING_PREFIX) for f in findings)
+    assert blocking_findings(findings) == findings


### PR DESCRIPTION
## Description

Consolidated review-followup sweep addressing late-landing `chatgpt-codex-connector` findings on three already-merged PRs: #981 (v* tag-creation ruleset drift check), #975 (ADR wording), #971 (contributing-results.md overstatement).

## Type of Change

- [x] Bug fix
- [x] Documentation

## Testing

**#981 — v* tag ruleset drift wiring/hardening:**
- `scripts/ruleset_drift_check.py`: added `tag_creation_findings()`, wiring `ruleset_review_enforcement.tag_protection_findings()`/`tag_bypass_advisory()` into `main()` using the same live-ruleset fetch already used for `develop-squash-only`/`main-release-only` (no extra API call). `release-canary.yml`'s `ruleset-drift` job now actually evaluates the v* tag ruleset, gated by the existing WARN-until-applied `TAG_RULESET_ENFORCED` flag — previously the predicate existed but was never invoked from CI.
- `_project/scripts/ruleset_review_enforcement.py`: `ref_name` include/exclude matching now uses `fnmatch` (GitHub's actual glob semantics) instead of exact-string membership — a broader-but-still-covering exclude like `refs/tags/*` is now correctly treated as negating `refs/tags/v*` coverage (previously only the byte-identical string was caught). An explicitly-empty `bypass_actors: []` on an otherwise-valid ruleset is now a finding, not silently OK — that shape would itself block `make release-finalize`'s own tag push with no exception for the release-finalize identity. A *missing* `bypass_actors` key (as opposed to a confirmed-empty one) stays unasserted, since that just means the field wasn't populated in the payload.
- `docs/operations/repo-admin-settings.md`: replaced the "not yet wired into `release-canary.yml`" note with the actual wiring description, and documented the fnmatch/empty-bypass hardening.
- `tests/unit/release/test_ruleset_drift_review_coverage.py`: added regression tests for fnmatch include/exclude matching (including a case that reproduces the exact gap the reviewer flagged), the empty-bypass finding, the missing-key non-finding, and `tag_creation_findings`' WARN-until-applied wiring. Verified new tests fail without the fix via `git stash`.
- `uv run -- python -m pytest tests/unit/release/ tests/unit/test_ruleset_drift.py tests/unit/scripts/ -n 0 -q` → 386 passed.
- `uv run ruff check` / `ruff format --check` / `ty check` on touched files → clean (no new diagnostics).

**#975 — ADR wording:** `benchbox/validation/bundle.py` does try one `benchbox.*` import (`benchbox.core.results.schema_policy`) before falling back standalone. Reworded the ADR to describe this as an optional import rather than an absence of one.

**#971 — contributing-results.md overstatement:** `release-cut` currently strips `results-explorer/` and `results-data/` from every release branch (`Makefile`), so the `main`-deployed site is not live yet, per `docs/operations/results-phase-2-runbook.md`'s own documented pre-launch state. Reworded to stop promising release-time publication and link to the runbook's current-state note.

**#972 — investigated, not included in this PR.** The finding claims the CSP `<meta>` tag doesn't cover the DuckDB worker. I verified empirically with a real Chromium + Playwright test that a same-origin classic `Worker` *does* inherit the page's meta-delivered CSP and enforces `connect-src 'self'` against cross-origin fetches issued from inside the worker — and confirmed the app has no code path where user input reaches a DuckDB URL fetch (all queries are parameterized/hardcoded; `LOCAL_DUCKDB_BUNDLES` and the one `results.duckdb` URL are same-origin constants). I also attempted the standard cross-browser-safe hardening (instantiating the worker from a `blob:` URL, which always inherits CSP per spec regardless of browser quirks), but confirmed via the repo's own e2e harness (`e2e/smoke/harness.spec.ts`) that this breaks DuckDB-WASM's COI bundle, which spawns its nested pthread worker using a path resolved against `self.location` — meaningless under a `blob:` base. Left a detailed reply on the PR thread with this evidence rather than merging a broken workaround; flagged as a possible follow-up TODO (WebKit-specific — already a smoke-only, non-blocking tier in this repo — rather than a live Chromium gap).

## Public Contract Check

- [x] No public/beta/deprecated/experimental contract surfaces changed — these are CI predicate/doc-only changes.

## Documentation

- [x] Updated the two doc-accuracy issues described above.

## Code Quality

- [x] Ran formatting/lint/type checks.
- [x] Added/updated tests for behavior changes (fnmatch matching, empty-bypass finding, CI wiring).

## Artifact Hygiene

- [x] No raw screenshots, logs, or binary artifacts committed.

## Notes

Does not touch any CODEOWNERS soundness path; enabling squash auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_