### PR TITLE
test: cover the real combined power->maintenance plan-capture checkpoint call site

### DIFF
--- a/_project/DONE/main/test-real-combined-plan-capture-checkpoint.yaml
+++ b/_project/DONE/main/test-real-combined-plan-capture-checkpoint.yaml
@@ -2,7 +2,8 @@ id: test-real-combined-plan-capture-checkpoint
 title: "Cover the real combined power->maintenance plan-capture checkpoint call site"
 worktree: main
 priority: Medium
-status: Not Started
+status: "Completed"
+completed_date: "2026-07-05"
 description: |
   The post-measurement divergence fix depends on `_plan_capture_checkpoint(connection)`
   firing at the top of `_execute_tpch_maintenance_test` (benchbox/platforms/base/execution.py:537)
@@ -36,8 +37,8 @@ impact:
     drops or misorders the checkpoint would ship green.
 
 must_preserve:
-  - "The test must exercise the real _execute_combined_test / _execute_*_maintenance_test path, not hand-built buffers."
-  - "No external services; DuckDB only; keep it in the fast/integration lane if runtime allows, else mark slow."
+- "The test must exercise the real _execute_combined_test / _execute_*_maintenance_test path, not hand-built buffers."
+- "No external services; DuckDB only; keep it in the fast/integration lane if runtime allows, else mark slow."
 
 approach: |
   Build a minimal combined run whose maintenance phase measurably changes a table's
@@ -48,21 +49,22 @@ approach: |
 
 scope_limit:
   only_modify:
-    - "tests/integration/test_plan_capture_combined_divergence.py"
-    - "tests/integration/"
+  - "tests/integration/test_plan_capture_combined_divergence.py"
+  - "tests/integration/"
 
 work:
-  - id: w1
-    summary: "Add a real combined power->maintenance capture test that fails if the checkpoint call site is removed or reordered"
-    status: pending
+- id: w1
+  summary: "Add a real combined power->maintenance capture test that fails if the checkpoint call site is removed or reordered"
+  status: done
 
 verification:
-  - description: "New test passes with the checkpoint in place"
-    command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
-    expected_output: "passed"
-  - description: "New test FAILS when the checkpoint call at execution.py:537 is temporarily removed (manual mutation check during implementation)"
-    command: "# temporarily delete the checkpoint call, run the new test, confirm it fails, then restore"
-    expected_output: "the new test fails"
+- description: "New test passes with the checkpoint in place"
+  command: "uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -n 0 -q"
+  expected_output: "passed"
+- description: "New test FAILS when the checkpoint call at execution.py:537 is temporarily removed (manual mutation check
+    during implementation)"
+  command: "# temporarily delete the checkpoint call, run the new test, confirm it fails, then restore"
+  expected_output: "the new test fails"
 
 deps:
   needs: [fix-multistream-throughput-plan-attachment]

--- a/tests/integration/test_plan_capture_combined_divergence.py
+++ b/tests/integration/test_plan_capture_combined_divergence.py
@@ -34,6 +34,8 @@ They run against a real (file-based) DuckDB so EXPLAIN sees the live row counts.
 
 from __future__ import annotations
 
+import random
+
 import pytest
 
 from benchbox.platforms.base.result_capture import _plan_capture_key
@@ -427,11 +429,30 @@ def test_real_combined_power_maintenance_checkpoint_captures_pre_mutation_plan(t
         baseline_lineitem_count = conn.execute("SELECT COUNT(*) FROM lineitem").fetchone()[0]
         # RF2 (delete) targets the single oldest order at scale factor 0.01 (see
         # TPCHMaintenanceTest._identify_old_orders / num_to_delete). Recording its
-        # key now, before the run, gives a deterministic post-run check that the
-        # mutation actually happened - unlike a net lineitem-row-count delta, which
-        # can coincidentally net to zero (RF1's random insert count happening to
-        # match RF2's delete count for that specific order).
+        # key AND its current lineitem count now, before the run, lets the mutation
+        # below be made deterministic (see the random.randint patch): RF1's insert
+        # count is otherwise `random.randint(1, 7)`, which could coincidentally
+        # equal the oldest order's own lineitem count, netting the total lineitem
+        # row count back to the baseline regardless of whether the checkpoint fired.
         oldest_order_key = conn.execute("SELECT O_ORDERKEY FROM orders ORDER BY O_ORDERDATE ASC LIMIT 1").fetchone()[0]
+        oldest_order_lineitem_count = conn.execute(
+            "SELECT COUNT(*) FROM lineitem WHERE L_ORDERKEY = ?", [oldest_order_key]
+        ).fetchone()[0]
+
+        # Force RF1's insert count to be provably different from what RF2 is about
+        # to delete, so the net lineitem row count is guaranteed to move (not just
+        # usually move) - only the maintenance test's own num_items roll (its one
+        # `randint(1, 7)` call site) is intercepted; every other random call in the
+        # maintenance test (order dates, keys, prices, ...) is untouched.
+        forced_insert_count = oldest_order_lineitem_count + 1
+        original_randint = random.randint
+
+        def _deterministic_randint(a, b):
+            if (a, b) == (1, 7):
+                return forced_insert_count
+            return original_randint(a, b)
+
+        monkeypatch.setattr(random, "randint", _deterministic_randint)
 
         # Record the lineitem row count visible at the instant Q1's SELECT plan is
         # captured. RF1's own INSERT statements never match this filter (not a
@@ -473,6 +494,13 @@ def test_real_combined_power_maintenance_checkpoint_captures_pre_mutation_plan(t
         assert remaining == 0, "RF2 did not delete the identified oldest order - test setup invalid"
 
         post_run_lineitem_count = conn.execute("SELECT COUNT(*) FROM lineitem").fetchone()[0]
+        # Guaranteed by the forced insert count above, not a probabilistic hope -
+        # this is the invariant the whole test depends on to distinguish a
+        # pre-mutation capture from a post-mutation one.
+        assert post_run_lineitem_count != baseline_lineitem_count, (
+            "lineitem row count did not change net of the mutation - test setup invalid"
+        )
+
         assert captured_counts == [baseline_lineitem_count], (
             f"expected Q1's plan captured exactly once, at the pre-mutation row count "
             f"{baseline_lineitem_count}, but got {captured_counts} (post-mutation count is "

--- a/tests/integration/test_plan_capture_combined_divergence.py
+++ b/tests/integration/test_plan_capture_combined_divergence.py
@@ -387,3 +387,97 @@ def test_combined_power_then_throughput_same_public_id_different_sql(tmp_path):
             assert "_plan_capture_key" not in row, "the internal key must be consumed, not leaked to the caller"
     finally:
         conn.close()
+
+
+@pytest.mark.slow
+def test_real_combined_power_maintenance_checkpoint_captures_pre_mutation_plan(tmp_path, monkeypatch):
+    """Regression for the real production checkpoint call site.
+
+    The hand-driven tests above (``test_combined_maintenance_mutation_captures_read_plan_before_mutation``
+    etc.) exercise ``_plan_capture_checkpoint``/``_capture_plans_post_measurement`` by
+    calling them directly, never through the real
+    ``_execute_combined_test`` -> ``_execute_tpch_maintenance_test`` lifecycle. Proof of
+    the blind spot: deleting the checkpoint call at the top of
+    ``_execute_tpch_maintenance_test`` (``self._plan_capture_checkpoint(connection)``) -
+    i.e. fully reverting the divergence fix - leaves every test in this file green,
+    because none of them drives a real combined power->maintenance run under
+    ``capture_plans=True``.
+
+    This test does: a real (file-based) DuckDB TPC-H combined run, power phase then
+    maintenance phase, through the actual ``_execute_queries_by_type`` entry point.
+    RF1 inserts new rows into ``lineitem`` (and ``orders``); Q1 (a plain lineitem scan)
+    is the power-phase query. A spy on ``capture_query_plan`` records the ``lineitem``
+    row count visible at the instant Q1's plan is EXPLAINed. If the checkpoint fires
+    where it should - before RF1's mutation - that count equals the PRE-mutation
+    (post-load) row count. If the checkpoint call is removed or reordered, Q1's plan
+    is instead captured in the final post-measurement pass, AFTER RF1 has already
+    mutated the table, and this assertion fails.
+    """
+    from benchbox.core.tpch.benchmark import TPCHBenchmark
+
+    db_path = str(tmp_path / "combined_maintenance.duckdb")
+    adapter = DuckDBAdapter(database_path=db_path, capture_plans=True)
+    conn = adapter.create_connection()
+    try:
+        bench = TPCHBenchmark(scale_factor=0.01, output_dir=str(tmp_path / "data"))
+        bench.generate_data()
+        adapter.create_schema(bench, conn)
+        adapter.load_data(bench, conn, str(tmp_path / "data"))
+
+        baseline_lineitem_count = conn.execute("SELECT COUNT(*) FROM lineitem").fetchone()[0]
+        # RF2 (delete) targets the single oldest order at scale factor 0.01 (see
+        # TPCHMaintenanceTest._identify_old_orders / num_to_delete). Recording its
+        # key now, before the run, gives a deterministic post-run check that the
+        # mutation actually happened - unlike a net lineitem-row-count delta, which
+        # can coincidentally net to zero (RF1's random insert count happening to
+        # match RF2's delete count for that specific order).
+        oldest_order_key = conn.execute("SELECT O_ORDERKEY FROM orders ORDER BY O_ORDERDATE ASC LIMIT 1").fetchone()[0]
+
+        # Record the lineitem row count visible at the instant Q1's SELECT plan is
+        # captured. RF1's own INSERT statements never match this filter (not a
+        # SELECT), so a non-empty list unambiguously means Q1's plan.
+        captured_counts: list[int] = []
+        original_capture_query_plan = adapter.capture_query_plan
+
+        def _spy(connection, sql, capture_key):
+            if sql.strip().upper().startswith("SELECT") and "lineitem" in sql.lower():
+                captured_counts.append(connection.execute("SELECT COUNT(*) FROM lineitem").fetchone()[0])
+            return original_capture_query_plan(connection, sql, capture_key)
+
+        monkeypatch.setattr(adapter, "capture_query_plan", _spy)
+
+        run_config = {
+            "benchmark_name": "tpch",
+            "test_execution_type": "combined",
+            "scale_factor": 0.01,
+            "iterations": 1,
+            "warm_up_iterations": 0,
+            "query_subset": [1],  # Q1: a plain lineitem scan, no seed-varied predicates needed
+            "maintenance_pairs": 1,
+            "rf1_interval": 0.0,
+            "rf2_interval": 0.0,
+            "validate_integrity": False,
+            "output_dir": str(tmp_path / "maintenance_output"),
+            "options": {"requested_phases": ["power", "maintenance"]},
+        }
+        results = adapter._execute_queries_by_type(bench, conn, run_config)
+
+        power_rows = [r for r in results if r.get("test_type") == "power" and r.get("status") == "SUCCESS"]
+        assert power_rows, "combined run produced no successful power rows"
+        assert power_rows[0].get("plan_fingerprint"), "Q1's power-phase plan was never captured"
+
+        # RF2 must have actually deleted the pre-identified oldest order, or the
+        # pre/post comparison below would be vacuously true regardless of whether
+        # the checkpoint fired.
+        remaining = conn.execute("SELECT COUNT(*) FROM orders WHERE O_ORDERKEY = ?", [oldest_order_key]).fetchone()[0]
+        assert remaining == 0, "RF2 did not delete the identified oldest order - test setup invalid"
+
+        post_run_lineitem_count = conn.execute("SELECT COUNT(*) FROM lineitem").fetchone()[0]
+        assert captured_counts == [baseline_lineitem_count], (
+            f"expected Q1's plan captured exactly once, at the pre-mutation row count "
+            f"{baseline_lineitem_count}, but got {captured_counts} (post-mutation count is "
+            f"{post_run_lineitem_count}) - the pre-maintenance checkpoint did not fire "
+            "before RF1's mutation"
+        )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Description

Fixes TODO `test-real-combined-plan-capture-checkpoint` (Medium, from the query-plan-capture adversarial review; depended on `fix-multistream-throughput-plan-attachment`, now merged via #976/#979/#989).

The post-measurement divergence fix depends on `_plan_capture_checkpoint(connection)` firing at the top of `_execute_tpch_maintenance_test`/`_execute_tpcds_maintenance_test`, so read-phase plans are captured against pre-mutation data state rather than the state after the maintenance phase mutates it. But `tests/integration/test_plan_capture_combined_divergence.py` drove `_plan_capture_checkpoint`/`_capture_plans_post_measurement` **by hand**, never through the real production call site.

Proof of the blind spot (verified during implementation): deleting the checkpoint call at `execution.py`'s `_execute_tpch_maintenance_test` — i.e. fully reverting the divergence fix — left every existing test in that file green, because none of them drives a real `_execute_combined_test` → `_execute_tpch_maintenance_test` lifecycle under `capture_plans=True`.

## Fix

Added `test_real_combined_power_maintenance_checkpoint_captures_pre_mutation_plan` to `tests/integration/test_plan_capture_combined_divergence.py`:

- Real (file-based) DuckDB TPC-H combined run — power phase then maintenance phase — through the actual `_execute_queries_by_type` production entry point (`test_execution_type: "combined"`, `requested_phases: ["power", "maintenance"]`).
- A spy on `capture_query_plan` records the `lineitem` row count visible at the instant Q1's plan (a plain lineitem scan) is EXPLAINed.
- RF1 inserts new rows into `lineitem`; if the checkpoint fires where it should, the recorded count equals the pre-mutation (post-load) baseline. If the checkpoint is removed or reordered, Q1's plan is instead captured in the final post-measurement pass, after RF1 has already mutated the table, and the assertion fails.
- A deterministic sanity check (not a flaky row-count-delta comparison — `maintenance_pairs=1`'s RF1 insert count and RF2 delete count can coincidentally net to zero) confirms the mutation actually happened: the pre-identified oldest order (RF2's deterministic delete target at this scale factor) is gone after the run.

**Manually verified per the TODO's second verification step**: temporarily deleted the checkpoint call in `execution.py`, ran the new test, confirmed it failed (`captured lineitem count 60176 != baseline 60175` — captured the post-RF1-insert count instead of pre-mutation), then restored the checkpoint call (`git diff` confirmed a clean revert before committing).

## Type of Change

- [x] Test coverage (no production code changed)

## Testing

- `uv run -- python -m pytest tests/integration/test_plan_capture_combined_divergence.py -m "slow or not slow" -n 0 -q` → 10 passed (the TODO's literal verification command selects only 7 — it undercounts because the new test, like the file's other real-DuckDB regression guards, is `@pytest.mark.slow`, excluded by `pytest.ini`'s default marker filter; same discrepancy noted on the TODO2 PRs).
- `uv run -- python -m pytest tests/integration/ -k 'plan or combined or maintenance' -m "slow or not slow" -n 0 -q` → 136 passed, 18 skipped (no live Postgres/Velox/DuckLake/maintenance-stress-matrix opt-ins), no casualties.
- `uv run ruff check` / `uv run ruff format --check` on the touched file → clean.

## Public Contract Check

- [x] Test-only change; no public/beta/deprecated/generated/experimental/repo-only contract surfaces touched.

## Documentation

- [x] N/A — test coverage only.

## Code Quality

- [x] Ran formatting/lint checks.
- [x] Manually confirmed the new test fails without the fix it guards (see above).

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

Only touches `tests/integration/test_plan_capture_combined_divergence.py`; not CODEOWNERS-gated, so enabling squash auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_018Dfk9EwmhZns8ttQFuVg34)_