### PR TITLE
Track branching-strategy work as TODO items (default→develop, main→release)

### DIFF
--- a/_project/TODO/main/active/release-canary-scheduled-activation.yaml
+++ b/_project/TODO/main/active/release-canary-scheduled-activation.yaml
@@ -95,6 +95,15 @@ work:
       pypi job needs no checkout), so (a) = cherry-pick the current file
       verbatim. Final sign-off on the mechanism rests with the maintainer
       at execution time (w2).
+      ADDENDUM 2026-07-06 (option d, from the PR #993 branching-strategy
+      review): a fourth option supersedes (a)/(b)/(c) — make `develop` the
+      GitHub DEFAULT branch (see branch-default-switch-to-develop). GitHub
+      runs on.schedule workflows from the default branch's copy; since
+      release-canary.yml already lives on develop, flipping the default
+      registers and fires it with ZERO per-release re-landing on main. If
+      that item lands, w2 (land on main) becomes moot and w3 (liveness guard)
+      still applies. Recommended resolution; sequence behind Decision A. Soft
+      cross-link, not a hard dep — do not block this item on it.
 
   - id: w2
     summary: "Land the chosen form on main (admin/release-flow action) and confirm registration"
@@ -112,6 +121,9 @@ work:
       in docs/operations/repo-admin-settings.md "Scheduled activation of
       release-canary.yml (pending admin action)" — land the file, confirm
       registration, dispatch, record the (expected-RED) run URL.
+      NOTE 2026-07-06: if branch-default-switch-to-develop lands first, this
+      unit is MOOT (develop-as-default registers the canary directly). Prefer
+      that path; keep this only as the fallback if Decision A is declined.
 
   - id: w3
     summary: "Add a scheduled-workflow liveness guard so this class of gap cannot recur silently"

--- a/_project/TODO/main/planning/branch-default-switch-to-develop.yaml
+++ b/_project/TODO/main/planning/branch-default-switch-to-develop.yaml
@@ -1,0 +1,109 @@
+id: branch-default-switch-to-develop
+title: "Make develop the GitHub default branch (Decision A of the branching-strategy review)"
+worktree: main
+priority: High
+status: "Not Started"
+category: "Release Tooling"
+
+description: |
+  BRANCHING-STRATEGY REVIEW (2026-07-06, session on PR #993). The repo already
+  treats `develop` as the integration branch — all PRs target it, the
+  develop-squash-only ruleset and develop-post-merge auto-revert live there —
+  but GitHub's default_branch is still `main` (confirmed via
+  `gh api repos/joeharris76/BenchBox --jq .default_branch` -> "main"). This
+  item flips the default to `develop`.
+
+  Decision A is deliberately separated from the main->release rename
+  (Decision B, see rename-release-branch-main-to-release): A is a low-risk,
+  reversible, one-call admin change and captures most of the value on its own.
+
+  KEY INTERACTION — this resolves an open High/In-Progress TODO. GitHub runs
+  on.schedule workflows ONLY from the default branch's copy of the file.
+  release-canary.yml lives on develop, not main, so its daily cron has never
+  fired (see release-canary-scheduled-activation, whose w1 menu proposes
+  landing the file on main as options (a)/(b)/(c)). Making develop the default
+  dissolves that problem: the canary — and any future scheduled workflow
+  authored on develop — registers and fires with no per-release re-landing.
+  Cross-link and re-scope that item when this lands.
+
+  Verified safe (documented in the session's branch-rename runbook draft):
+  PyPI trusted publishing is branch-independent (keyed on repo + workflow
+  filename release.yml + environment pypi, never a branch), and GitHub Pages
+  deploys via deploy-pages (source = "GitHub Actions", not a branch). Neither
+  is affected by changing the default branch.
+
+prior_art:
+  - "_project/TODO/main/active/release-canary-scheduled-activation.yaml — the open item this resolves; its w1 option menu (a/b/c) predates and omits the develop-as-default option. Re-scope its w2/w3 once this lands."
+  - ".github/workflows/nightly.yml — the scheduled workflow currently on main that DOES fire; after the default flips, scheduled workflows fire from develop instead, so confirm nightly still triggers as expected."
+  - "docs/operations/repo-admin-settings.md — the admin-state runbook; its 'Scheduled activation' section is written under the main-as-default premise and must be updated to reflect develop-as-default."
+
+work:
+  - id: w1
+    summary: "ADMIN: set default_branch=develop"
+    status: pending
+    notes: |
+      `gh api -X PATCH repos/joeharris76/BenchBox -f default_branch=develop`.
+      Admin-only. Reversible: re-run with default_branch=main to roll back.
+      Record the dated before/after in repo-admin-settings.md.
+  - id: w2
+    summary: "Verify scheduled workflows now register and fire from develop"
+    needs: [w1]
+    status: pending
+    notes: |
+      After the flip, confirm release-canary.yml is registered:
+      `gh api repos/joeharris76/BenchBox/actions/workflows --jq '.workflows[].path'`
+      now includes .github/workflows/release-canary.yml, and
+      `gh api .../actions/workflows/release-canary.yml/runs` no longer 404s.
+      Dispatch once (workflow_dispatch) to prove liveness; expected first
+      result is RED on 0.3.0's broken import (that is the canary working —
+      see release-recovery-v0-3-1). Confirm nightly.yml still fires from the
+      new default.
+  - id: w3
+    summary: "Update repo-admin-settings.md: the default-branch premise inverts"
+    needs: [w1]
+    status: pending
+    notes: |
+      The 'Scheduled activation of release-canary.yml' section and any text
+      asserting 'the default branch is main' become stale. Rewrite to reflect
+      develop-as-default; several (a)/(b)/(c) workarounds for the canary
+      become unnecessary. Record the new live state with a date.
+
+must_preserve:
+  - "main stays release-only and push-restricted regardless of the default-branch setting — the default flip changes clone/PR/UI defaults and scheduled-workflow source, not the release gating."
+  - "PyPI trusted publishing and GitHub Pages config — both branch-independent; do not touch them as part of this change."
+
+anti_patterns:
+  - "DO NOT bundle the main->release rename into this item - because Decision B has real functional blast radius (verify-tag-on-main, test.yml base_ref gates) and Decision A's value plus low risk should not wait on it - keep them separate PRs/items."
+
+verification:
+  - description: "Default branch is develop"
+    command: "gh api repos/joeharris76/BenchBox --jq .default_branch"
+    expected_output: "develop"
+  - description: "Scheduled canary now registered"
+    command: "gh api repos/joeharris76/BenchBox/actions/workflows --jq '.workflows[].path' | grep release-canary"
+    expected_output: ".github/workflows/release-canary.yml present"
+
+scope_limit:
+  only_modify:
+    - "docs/operations/repo-admin-settings.md"
+  do_not_modify:
+    - ".github/workflows/release.yml"
+    - ".github/workflows/docs.yml"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "release"
+    - "governance"
+    - "admin-action"
+    - "branching-strategy"
+  estimated_effort: "Tiny (one admin API call + doc update)"
+  created_date: "2026-07-06"
+
+impact:
+  business_value: |
+    Aligns the repo's front door (clone/PR/UI defaults) with how work actually
+    flows, and — more concretely — activates the daily release canary and
+    ruleset-drift checks that have never run because they live on develop
+    while the default is main. Low risk, reversible in one call.

--- a/_project/TODO/main/planning/rename-release-branch-main-to-release.yaml
+++ b/_project/TODO/main/planning/rename-release-branch-main-to-release.yaml
@@ -1,0 +1,154 @@
+id: rename-release-branch-main-to-release
+title: "Rename the release branch main->release (Decision B of the branching-strategy review)"
+worktree: main
+priority: Medium
+status: "Not Started"
+category: "Release Tooling"
+
+description: |
+  BRANCHING-STRATEGY REVIEW (2026-07-06, session on PR #993). `main` is already
+  release-only: validate-main-pr.yml rejects any PR whose head is not a vX.Y.Z
+  branch, release-finalize fast-forwards+tags it, and its HEAD is always the
+  exact latest-release commit. `release` is the accurate name.
+
+  This is Decision B — deliberately separated from the low-risk default-branch
+  switch (Decision A, branch-default-switch-to-develop). Unlike A, B has real
+  functional blast radius: it touches the release-publish gate, so it is its
+  own change, sequenced AFTER A (per the session's branch-rename runbook draft,
+  saved outside the tree).
+
+  This item captures the full surface discovered on develop, which is larger
+  than the curated main branch shows. NO behavioral gain — this is naming
+  clarity — so priority is Medium.
+
+  Verified safe / unchanged (do not touch): PyPI trusted publishing (keyed on
+  repo + workflow filename release.yml + environment pypi, never a branch);
+  GitHub Pages (deploy-pages, source = GitHub Actions). README badges pin no
+  branch.
+
+prior_art:
+  - "docs/operations/branch-rename-runbook.md — DRAFTED in the PR #993 session and saved to the session scratchpad (not yet committed); enumerates the full admin sequence, ordering/no-gap reasoning, verification, and rollback. Land it with w4/w6 or recreate from the scratchpad patch."
+  - "_project/TODO/main/active/tag-and-pypi-environment-admin-hardening.yaml — reuse the agent-does-code/docs plus admin-does-GitHub-action split for w6 (the branch rename + ruleset recreate are admin-only)."
+  - "_project/decisions/single-repo-migration.md — the architecture record for the two-branch flow; the branching-strategy decision (A+B) should be recorded here or as a sibling decision doc (w5)."
+
+work:
+  - id: w1
+    summary: "Rename in-repo across workflows (incl. the functional publish gate)"
+    status: pending
+    notes: |
+      Triggers main->release: lint.yml, test.yml, perf-smoke.yml, docs.yml
+      (incl. Pages deploy gate refs/heads/main). Dev-only
+      results-explorer-browser.yml (branches [main] / [main, develop]).
+      FUNCTIONAL: release.yml verify-tag-on-main job — rename job +
+      refs/heads/main ancestor check to release (this gates PyPI publish;
+      keep the tag-shaped-ref publish condition intact). test.yml
+      base_ref == 'main' / != 'main' release-gating conditionals (~6:
+      compat-test, integration-smoke, integration-table-formats,
+      check-test-patterns, security, plus the credential-free lanes near
+      lines 238/263/344/414). Rename validate-main-pr.yml ->
+      validate-release-pr.yml and its strings.
+  - id: w2
+    summary: "Rename in-repo across Makefile"
+    status: pending
+    notes: |
+      release-cut / release-finalize base branch (--base main), checkout/pull
+      release, generate_changelog_entry --since-ref origin/main,
+      RELEASE_REQUIRED_CONTEXTS / ruleset-name references, help text, and the
+      branch-protection guards (pr-open develop|main; worktree sweep/refresh
+      develop|main|""; pool-release and force-clean develop|main). Leave the
+      MAIN_CLONE / "main clone" worktree-pool concept untouched (unrelated).
+  - id: w3
+    summary: "Rename in docs/templates + pin external URLs"
+    status: pending
+    notes: |
+      release-guide.md, RELEASE_PR_TEMPLATE.md, CONTRIBUTING.md, and — CAREFUL,
+      NON-MECHANICAL — repo-admin-settings.md (its scheduling section logic
+      depends on which branch is default; coordinate with Decision A's w3).
+      landing/index.html footer blob/main -> blob/release. Blog blob/main
+      links -> pin to the matching release TAG (duckdb-tpch 2026-03-03 ->
+      v0.1.4; the two v0.2.1 posts -> v0.2.1) — verified to resolve with
+      `git cat-file -e <tag>:<path>`.
+  - id: w4
+    summary: "Add the migration runbook doc"
+    status: pending
+    notes: |
+      Land docs/operations/branch-rename-runbook.md (recreate from the session
+      scratchpad patch): default-branch switch, branch rename, ruleset
+      recreate, ordering/no-real-gap reasoning, verification, rollback, and the
+      verified-safe notes (PyPI/Pages branch-independence).
+  - id: w5
+    summary: "Record the branching-strategy decision (A+B)"
+    status: pending
+    notes: |
+      Capture the decision + rationale in _project/decisions/ (new sibling to
+      single-repo-migration.md, or an amendment): why release is the accurate
+      name, the A-before-B sequencing, and the verified-safe publish/Pages
+      facts.
+  - id: w6
+    summary: "ADMIN: rename branch + recreate ruleset"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      `gh api -X POST repos/joeharris76/BenchBox/branches/main/rename
+      -f new_name=release` (GitHub redirects old URLs, retargets open PRs).
+      Recreate the main-release-only ruleset as release-only on
+      refs/heads/release, preserving required checks (lint + the release test
+      contexts), linear history, non-fast-forward, no direct push, deletion
+      blocked, no bypass_actors. Update ruleset-id references in
+      repo-admin-settings.md. Do this together with merging w1-w5 (no orphaned
+      -release window; the release branch only receives pushes via
+      release-finalize, which is maintainer-controlled, so no real CI gap).
+
+deps:
+  needs:
+    - branch-default-switch-to-develop
+
+must_preserve:
+  - "release.yml verify-tag-on-* gate and the tag-shaped-ref publish condition — the rename must not loosen the publish gate; only retarget main->release."
+  - "The legitimate release flow (release-cut / release-finalize) keeps working end-to-end after the rename — every main reference in those targets moves atomically."
+  - "PyPI trusted publishing, the pypi/test-pypi/github-pages environments, and the release.yml filename — all branch-independent; unchanged."
+
+anti_patterns:
+  - "DO NOT sed main->release blindly across repo-admin-settings.md - because its scheduling/default-branch section encodes GitHub mechanics (scheduled workflows run from the DEFAULT branch) whose truth changes with Decision A - a token swap there produces wrong docs."
+  - "DO NOT rename the branch (w6) before w1-w5 merge - because a half-applied state leaves release-cut opening PRs against a release branch that does not exist - land the in-repo edits and the branch rename in one coordinated step."
+  - "DO NOT touch the MAIN_CLONE / 'main clone' worktree-pool concept in the Makefile - it is the primary-checkout notion, unrelated to the branch name."
+
+verification:
+  - description: "No residual main-branch trigger/gate references after w1-w3"
+    command: "grep -rn 'refs/heads/main' .github/workflows; grep -rn -- '--base main' Makefile"
+    expected_output: "no output (all release)"
+  - description: "Release flow targets release"
+    command: "grep -n 'base release' Makefile"
+    expected_output: "release-cut and release-finalize both present"
+  - description: "Renamed branch exists, ruleset targets it"
+    command: "gh api repos/joeharris76/BenchBox/rulesets --jq '.[] | {name, target}'"
+    expected_output: "a ruleset targeting refs/heads/release; none targeting refs/heads/main"
+
+scope_limit:
+  only_modify:
+    - ".github/workflows/"
+    - "Makefile"
+    - ".github/RELEASE_PR_TEMPLATE.md"
+    - "docs/operations/"
+    - "CONTRIBUTING.md"
+    - "landing/index.html"
+    - "docs/blog/"
+    - "_project/decisions/"
+
+metadata:
+  owners:
+    - "joeharris76"
+  tags:
+    - "release"
+    - "governance"
+    - "admin-action"
+    - "branching-strategy"
+  estimated_effort: "Medium (in-repo edits across ~12 files) + admin rename/ruleset"
+  created_date: "2026-07-06"
+
+impact:
+  business_value: |
+    Names the branches for what they are: develop is the integration branch,
+    release is the curated release branch. Removes the standing trap where
+    `main` reads as primary but is the most restricted branch. No behavioral
+    change — pure clarity — hence Medium priority, sequenced after Decision A.


### PR DESCRIPTION
## Description

Captures the concerns from the branching-strategy review as **tracked TODO items** rather than one high-risk PR, and **rebases this branch onto `develop`** (it was mistakenly cut from `main`, which produced a 9,500-file cross-branch diff — now corrected; the diff is just the three YAML files below).

The actual `main→release` rename is **not** executed here — it's a functional change touching the release-publish gate and is scheduled against its own TODO.

## What this PR adds

- **`branch-default-switch-to-develop`** (planning, **High**) — Decision A: make `develop` the GitHub default branch. Low-risk, reversible one-call admin change. **Resolves the open `release-canary-scheduled-activation` item**: GitHub runs `on.schedule` workflows only from the default branch, and `release-canary.yml` already lives on `develop`, so flipping the default registers/fires it with zero per-release re-landing.
- **`rename-release-branch-main-to-release`** (planning, **Medium**) — Decision B: the full functional rename surface discovered on `develop` (the `verify-tag-on-main` publish gate, `test.yml` `base_ref` release-gating conditionals, dev-only `results-explorer-browser.yml`, Makefile release targets, ops docs). `deps.needs: branch-default-switch-to-develop`. No behavioral gain → Medium.
- **`release-canary-scheduled-activation`** (edited) — cross-linked: added option **(d)** (develop-as-default dissolves the problem) to `w1`, and a "moot if Decision A lands" note to `w2`. Soft link only — the item stays unblocked.

## Type of Change

- [x] Refactor / chore
- [x] Documentation

## Testing

- `validate_todo.py` (non-strict, matching repo convention — the committed items use `prior_art`, which only `--strict` rejects): all three files **valid**.
- `todo_cli.py check-graph`: **passed** — no cycles, no dangling refs, 102 items (the new `deps.needs` edge resolves).
- Generated indexes are gitignored, so nothing to commit there.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or temporary binaries committed.
- [x] No binary/raw evidence files added.

## Notes

- The in-repo rename edits I drafted earlier (workflows/Makefile/docs) and the `branch-rename-runbook.md` are preserved in the session scratchpad and referenced as `prior_art` in the Decision B TODO — they'll be recreated when that item is executed.
- Both new items sit in `_project/TODO/main/planning/`; promote to `active/` when work starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPPPtRSp95b8JkUJcLEUcn