### PR TITLE
fix(test-config): register the filterwarnings marker in pytest-ci.ini

### DIFF
--- a/pytest-ci.ini
+++ b/pytest-ci.ini
@@ -44,6 +44,7 @@ addopts =
 
 # Test markers for categorization and selective execution
 markers =
+    filterwarnings: pytest built-in marker for per-test warning filters (must be registered explicitly for --collect-only -p no:warnings runs under pytest>=9.1)
     # Execution speed markers
     fast: marks tests as fast (< 1 second execution time)
     medium: marks tests as medium speed (1-10 seconds execution time)


### PR DESCRIPTION
## Description

The pytest 9.1.1 bump (#965) requires the built-in `filterwarnings` marker to be **registered explicitly** for `--collect-only -p no:warnings` runs. It was added to `pytest.ini`'s `markers` block but **not** to `pytest-ci.ini`, so the two profiles drifted: `pytest-ci.ini` carries a `filterwarnings =` config key (line 214) with no matching marker registration in its `markers` section.

`test_test_ci_is_maintained_broad_local_profile` (which asserts `pytest.ini` markers ⊆ `pytest-ci.ini` markers) correctly caught the drift. This one-line sync adds the same registration to `pytest-ci.ini` that already exists in `pytest.ini`.

### Why this matters beyond the test

This was the **sole remaining failure** on the `medium-test` job of the real `develop-post-merge` runner (run [28758602267](https://github.com/joeharris76/BenchBox/actions/runs/28758602267), job 85269831183 — `1 failed, 1290 passed, 5 skipped`), everything else in the tier being green. The 44 tpch-extension errors + permission failures seen in the agent sandbox are environment-only and do **not** occur on the runner. Fixing this unblocks the green medium-tier run that `medium-tier-red-disposition-and-promotion`'s w2/w3 promotion (wire `medium-test` into `auto-revert-on-failure`) has been waiting on.

## Type of Change

- [x] Bug fix (test-config drift)

## Testing

- `uv run -- python -m pytest "tests/unit/test_standardized_test_commands.py::TestMakefileCommands::test_test_ci_is_maintained_broad_local_profile" -o addopts=""` → **passed** (was: `AssertionError: Extra items in the left set: 'filterwarnings'`).
- Full module: `tests/unit/test_standardized_test_commands.py` → **38 passed**.
- `uv run -- python -m pytest -c pytest-ci.ini --collect-only -p no:warnings tests/unit/test_standardized_test_commands.py` → no `PytestUnknownMarkWarning` for `filterwarnings`.
- `make lint` → green.

## Public Contract Check

- [x] Test-config only; no public/beta/deprecated/generated/experimental/repo-only contract surfaces changed. No CLI/schema/marker-vocabulary change (the marker already existed in `pytest.ini`; this only syncs the CI profile).

## Documentation

- [x] N/A — the registration line is self-documenting (mirrors `pytest.ini`'s comment).

## Code Quality

- [x] Single-line config sync; verified against the failing runner job and locally.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

No CODEOWNERS soundness path touched — squash auto-merge is being enabled. Once this merges and the next `develop-post-merge` `medium-test` job concludes green, the item-3 w3 promotion PR (drop `continue-on-error`, add `medium-test` to `auto-revert-on-failure`, flip the demotion pin) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_