### PR TITLE
fix(submission-ci): gate manifest waiver on unforgeable head.repo.fork (Defect #1)

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -115,12 +115,26 @@ jobs:
           # submission, which must include the manifest sidecar (its presence is
           # the community-submission trust signal). Require the sidecar unless
           # this is a maintainer mirror PR.
+          #
+          # The waiver gates on TWO signals, and `head.repo.fork` is the load-bearing
+          # one: `github.head_ref` is attacker-controlled on fork PRs, so a branch
+          # name alone (`auto/results-mirror-*`) is spoofable — anyone could open a
+          # fork PR from a branch so named and drop `--require-manifest`, laundering
+          # a community bundle into a maintainer-run (ranking-eligible) stamp. The
+          # branch pattern only narrows *which* same-repo PRs qualify; the
+          # `head.repo.fork == false` check (unforgeable — a fork PR cannot present
+          # itself as same-repo) is what actually confines the waiver to the trusted
+          # sync bot, whose mirror branches live on this repo. If both aren't
+          # satisfied we fail closed and require the sidecar.
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
           REQUIRE_MANIFEST="--require-manifest"
-          case "$HEAD_REF" in
-            auto/results-mirror-*) REQUIRE_MANIFEST="" ;;
-          esac
+          if [ "$IS_FORK" = "false" ]; then
+            case "$HEAD_REF" in
+              auto/results-mirror-*) REQUIRE_MANIFEST="" ;;
+            esac
+          fi
           # Validate and generate PR comment in a single invocation.
           # --pr-comment writes the Markdown file; exit code reflects validation result.
           xargs -d '\n' uv run -- python scripts/validate_submission.py $REQUIRE_MANIFEST --pr-comment /tmp/pr_comment.md < /tmp/changed_bundles.txt \

--- a/tests/unit/scripts/test_submission_workflow_waiver.py
+++ b/tests/unit/scripts/test_submission_workflow_waiver.py
@@ -1,0 +1,77 @@
+"""Regression guard for the submission-manifest waiver's spoof resistance.
+
+`validate-submission.yml` waives the `--require-manifest` requirement for
+maintainer corpus-mirror PRs (they legitimately carry maintainer-run bundles
+with no sidecar). The waiver MUST gate on an unforgeable signal.
+
+`github.head_ref` is attacker-controlled on fork PRs, so a branch-name-only
+waiver (`case $HEAD_REF in auto/results-mirror-*`) is spoofable: anyone could
+open a fork PR from a branch so named and drop the sidecar requirement,
+laundering a community bundle into a maintainer-run (ranking-eligible) stamp.
+The load-bearing check is `github.event.pull_request.head.repo.fork == false`,
+which a fork PR cannot forge. This test fails closed if the fork gate is ever
+dropped from the waiver.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "validate-submission.yml"
+
+
+def _validate_step() -> dict:
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = data["jobs"]["validate"]["steps"]
+    for step in steps:
+        if step.get("id") == "validate":
+            return step
+    raise AssertionError("validate-submission.yml has no step with id: validate")
+
+
+def test_waiver_env_binds_unforgeable_fork_signal() -> None:
+    env = _validate_step().get("env") or {}
+    fork_bindings = {k: v for k, v in env.items() if "head.repo.fork" in str(v)}
+    assert fork_bindings, (
+        "The 'Validate bundles' step must bind github.event.pull_request."
+        "head.repo.fork into the env so the manifest waiver can gate on it. "
+        "github.head_ref alone is attacker-controlled on fork PRs and spoofable."
+    )
+
+
+def test_waiver_gates_manifest_skip_on_fork_check() -> None:
+    step = _validate_step()
+    env = step.get("env") or {}
+    run = step["run"]
+
+    fork_var = next(
+        (k for k, v in env.items() if "head.repo.fork" in str(v)),
+        None,
+    )
+    assert fork_var is not None, "no env var bound to head.repo.fork"
+
+    # The block that clears REQUIRE_MANIFEST (the sidecar waiver) must be
+    # guarded by the fork variable resolving to the same-repo ("false") case.
+    # We require the fork guard and the branch pattern to co-occur with the
+    # empty-string assignment that drops --require-manifest.
+    assert re.search(rf'\[\s*"\${fork_var}"\s*=\s*"false"\s*\]', run), (
+        "The manifest waiver must be nested under an "
+        f'[ "${fork_var}" = "false" ] guard; a fork PR must never reach the '
+        "REQUIRE_MANIFEST='' branch."
+    )
+    assert "auto/results-mirror-*" in run, "The waiver should still narrow to the mirror branch pattern."
+
+
+def test_default_requires_manifest() -> None:
+    # Fail-closed default: the sidecar is required unless explicitly waived.
+    run = _validate_step()["run"]
+    assert 'REQUIRE_MANIFEST="--require-manifest"' in run, (
+        "REQUIRE_MANIFEST must default to --require-manifest (fail closed); "
+        "the waiver only clears it inside the fork+branch guard."
+    )


### PR DESCRIPTION
## Description

Closes the adversarial-review Defect #1 (spoofable corpus-mirror waiver). The `--require-manifest` waiver in `validate-submission.yml` keyed **only** on `github.head_ref`, which is attacker-controlled on fork PRs. Anyone could open a fork PR from a branch named `auto/results-mirror-anything` and drop the community-submission sidecar requirement — laundering a community bundle into a **maintainer-run (ranking-eligible)** trust stamp, defeating the exact provenance boundary the submission validator exists to defend.

**Fix:** nest the waiver under `[ "$IS_FORK" = "false" ]`, binding `github.event.pull_request.head.repo.fork` — a signal a fork PR cannot forge. The `auto/results-mirror-*` branch pattern now only *narrows which same-repo PRs* qualify; the fork check is what actually confines the waiver to the trusted sync bot (whose mirror branches live on this repo). Fails closed (requires the sidecar) unless **both** signals hold.

## Type of Change

- [x] Bug fix (security / provenance)

## Testing

- `uv run -- python -m pytest tests/unit/scripts/test_submission_workflow_waiver.py -n 0 -q` → **3 passed**.
- New fail-closed meta-test `test_submission_workflow_waiver.py` (mirrors the `test_pr_workflow_outputs.py` pattern): asserts the validate step binds `head.repo.fork`, that the manifest waiver is nested under the `[ "$IS_FORK" = "false" ]` guard, and that `REQUIRE_MANIFEST` defaults to `--require-manifest` (fail closed). Manually confirmed the test **fails** if the fork guard is removed.
- `python -c "import yaml; yaml.safe_load(...)"` → parses.

## Public Contract Check

- [x] No public/beta/deprecated/experimental contract surfaces changed — CI-only workflow logic plus a new test.

## Documentation

- [x] Rationale documented inline in the workflow env comment and the test module docstring.

## Code Quality

- [x] Formatting/lint run (formatter hook clean); new regression test added.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

- The companion published-results copy of this workflow (PR #985) carries the **same** spoofable waiver; the identical fork gate is applied there in that PR.
- Follow-up (separate PRs): §2.8 fork-PR comment `workflow_run` companion, and a drift-detection meta-test to keep the develop and published-results copies in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_