### PR TITLE
docs(explorer-qa): re-land stranded §2.16 QA-plan reusability fix

### DIFF
--- a/docs/operations/results-explorer-qa.md
+++ b/docs/operations/results-explorer-qa.md
@@ -92,7 +92,7 @@ If a step's "expected" behavior is unclear or seems wrong on its face, mark it `
 
 ## Reporting format
 
-After the required `develop_sha:` frontmatter, append one block per finding to a new file at `_project/audits/results-explorer-qa-pass2-findings.md`. **One finding per block, no prose between them.** Use this exact template — I parse it:
+After the required `develop_sha:` frontmatter, append one block per finding to a **new** findings file for this pass at `_project/audits/results-explorer-qa-pass<N>-findings.md`, where `<N>` is the next unused pass number (pass-2 and pass-3 files already exist — do **not** append to a sealed prior-pass file; its `develop_sha` stamp describes that pass only). **One finding per block, no prose between them.** Use this exact template — I parse it:
 
 ```yaml
 - id: <STABLE_ID from this plan, e.g. S2.3, U1, F4>
@@ -111,7 +111,7 @@ After the required `develop_sha:` frontmatter, append one block per finding to a
       <paste any console output, or "none">
     network: |
       <paste any non-2xx responses with URL + status, or "none">
-    screenshot: <relative path under _project/audits/screenshots/, or "none">
+    screenshot: "none"   # screenshots are not retained in git; keep them locally and reference "none" here unless a durable path is agreed
   severity: <blocker | major | minor | nit>   # only for F and Q; omit for P
   notes: |
     <anything else — repro flakiness, only-on-cold-load, etc.>
@@ -374,7 +374,7 @@ For every URL-synced control found in S2–S7:
 
 ## S11 — Pass-1 confirmed bugs (must re-test)
 
-Re-run these verbatim and report status. They drive the `results-explorer-qa-pass1-fixes` TODO.
+Re-run these verbatim and report status. (The original `results-explorer-qa-pass1-fixes` TODO is complete — file any new regressions as fresh findings in this pass's findings file.)
 
 - **B1** — PlatformIndex `<th>` headers don't sort. Confirm on every platform page.
 - **B2** — `/results/p/duckdb/` and `/results/p/polars/` render empty. Hard refresh + warm reload + 30s wait.
@@ -397,4 +397,4 @@ Do not file findings for these — they're tracked separately:
 
 ## When you're done
 
-Save findings at `_project/audits/results-explorer-qa-pass2-findings.md` and reply with just: "pass-2 findings ready, N=<count>". I'll read the file, triage, and either patch directly or update the existing pass-1 TODO.
+Save findings at `_project/audits/results-explorer-qa-pass<N>-findings.md` (next unused pass number) and reply with just: "pass-<N> findings ready, N=<count>". I'll read the file and triage.


### PR DESCRIPTION
## Description

Re-lands audit **§2.16**, which was fixed once (commit `cf394466`) but never reached merged `develop` — the fix commit was stranded on a branch closed by the auto-merge-on-open bot landing its PR on an earlier commit (same failure mode as the §2.7 guard, re-landed in #986). The re-review confirmed the stranding; this restores the fix.

`docs/operations/results-explorer-qa.md` is a reusable QA plan, but it hardcoded pass-2 specifics:

- **Reporting format / S11 / "When you're done"** wrote findings to the sealed `results-explorer-qa-pass2-findings.md` and drove the completed `results-explorer-qa-pass1-fixes` TODO. Now they target `results-explorer-qa-pass<N>-findings.md` (next unused pass) and note not to append to a sealed prior-pass file whose `develop_sha` describes that pass only.
- **Screenshot field** pointed at a non-existent `_project/audits/screenshots/` path; now defaults to `"none"` (screenshots aren't retained in git).

**Conflict note:** the stranded commit also rewrote S2.1's stat-card counts, but `develop` has since gained a *superior* independent fix there (verified `11 results / 2 benchmarks / 7 platforms` from `npm run test:e2e:fixtures`). I kept develop's version and dropped the stranded S2.1 hunk — so this PR lands 4 of the original 5 line changes.

## Type of Change

- [x] Documentation

## Testing

- `grep` sweep: 0 residual hardcoded `pass2-findings` targets, 0 `_project/audits/screenshots/` references, 0 stale "update the existing pass-1 TODO" directives; the `pass<N>` reusable references are present at the reporting-format, screenshot, S11, and "When you're done" sites.
- No conflict markers remain.

## Public Contract Check

- [x] Docs-only; no contract surfaces changed.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

One of three confirmed stranded fixes from the re-review. §2.7 was already re-landed (#986); §2.22 (test relocation) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_