### PR TITLE
ci(submission): drift check between develop and published-results validator

### DIFF
--- a/.github/workflows/submission-validator-drift-check.yml
+++ b/.github/workflows/submission-validator-drift-check.yml
@@ -1,0 +1,64 @@
+name: Submission Validator Drift Check
+
+# The submission validator workflow (`validate-submission.yml`) exists on both
+# `develop` (source of truth) and `published-results` (the copy that actually
+# runs for contributor PRs). The corpus sync bot cannot mirror workflow files,
+# so the published-results copy is synced by a hand-opened PR — an easy step to
+# forget. This scheduled check fails loudly when the two copies drift beyond the
+# sanctioned slim-branch invocation difference, so a stale validator surfaces
+# instead of silently running behind.
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+  # Also run when develop's copy or the checker itself changes, so a drift is
+  # flagged the moment the source of truth moves ahead of published-results.
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/validate-submission.yml"
+      - "scripts/check_submission_validator_sync.py"
+      - ".github/workflows/submission-validator-drift-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: Compare develop vs published-results validator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Extract the published-results copy
+        run: |
+          git fetch --no-tags --depth=1 origin published-results
+          # Fail clearly if the branch or file is missing rather than silently
+          # passing an empty comparison.
+          if ! git cat-file -e FETCH_HEAD:.github/workflows/validate-submission.yml 2>/dev/null; then
+            echo "::error::published-results has no .github/workflows/validate-submission.yml"
+            exit 2
+          fi
+          git show FETCH_HEAD:.github/workflows/validate-submission.yml \
+            > /tmp/published-validate-submission.yml
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check for drift
+        run: |
+          uv run -- python scripts/check_submission_validator_sync.py \
+            --develop .github/workflows/validate-submission.yml \
+            --published /tmp/published-validate-submission.yml

--- a/scripts/check_submission_validator_sync.py
+++ b/scripts/check_submission_validator_sync.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Detect drift between the two copies of the submission validator workflow.
+
+`validate-submission.yml` lives on both `develop` (the maintained source of
+truth) and `published-results` (the branch copy that actually runs for
+contributor PRs). The corpus sync bot cannot mirror workflow files
+(`GITHUB_TOKEN` lacks `workflows: write`), so the published-results copy is
+kept in sync by a hand-opened PR. That manual step is easy to forget, and a
+drifted copy silently runs stale validation logic (this is exactly how the
+§2.6/§2.7/§2.1 hardening and the Defect #1 fork gate came to lag behind).
+
+The two copies are intended to be byte-identical **except** for the uv
+invocation: `develop` runs inside the project (`uv run -- python ...`), while
+`published-results` is a slim branch with no `pyproject.toml`/`uv.lock` and
+must run `uv run --no-project --python 3.11 -- python ...`. This tool
+normalizes that one sanctioned difference away and reports any remaining
+divergence as drift.
+
+Usage:
+    uv run -- python scripts/check_submission_validator_sync.py \
+        --develop .github/workflows/validate-submission.yml \
+        --published /tmp/published-results-validate-submission.yml
+
+Exit code 0 when the copies match (after normalization), 1 on drift, 2 on a
+usage/IO error. The scheduled `submission-validator-drift-check.yml` workflow
+wires the two real branch copies into this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from pathlib import Path
+
+# The published-results (slim-branch) invocation and the develop (in-project)
+# invocation are the only sanctioned difference between the two copies. Collapse
+# both spellings to a single canonical token before comparing so the diff
+# surfaces *substantive* drift only.
+_SLIM_INVOCATION = re.compile(r"uv run --no-project --python 3\.11 -- python")
+_PROJECT_INVOCATION = re.compile(r"uv run -- python")
+_CANONICAL = "uv run <INVOCATION> python"
+
+
+def normalize(text: str) -> str:
+    """Collapse the sanctioned uv-invocation difference to a canonical token."""
+    # Order matters: the slim spelling is a superset of the project spelling's
+    # prefix, so replace it first.
+    text = _SLIM_INVOCATION.sub(_CANONICAL, text)
+    text = _PROJECT_INVOCATION.sub(_CANONICAL, text)
+    return text
+
+
+def diff(develop_text: str, published_text: str) -> list[str]:
+    """Return a unified diff of the two copies after normalization (empty if in sync)."""
+    dev = normalize(develop_text).splitlines(keepends=True)
+    pub = normalize(published_text).splitlines(keepends=True)
+    if dev == pub:
+        return []
+    return list(
+        difflib.unified_diff(
+            dev,
+            pub,
+            fromfile="develop:validate-submission.yml (normalized)",
+            tofile="published-results:validate-submission.yml (normalized)",
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--develop",
+        required=True,
+        type=Path,
+        help="Path to develop's copy of validate-submission.yml.",
+    )
+    parser.add_argument(
+        "--published",
+        required=True,
+        type=Path,
+        help="Path to published-results' copy of validate-submission.yml.",
+    )
+    args = parser.parse_args(argv)
+
+    for label, path in (("develop", args.develop), ("published-results", args.published)):
+        if not path.is_file():
+            print(f"::error::{label} copy not found at {path}", file=sys.stderr)
+            return 2
+
+    drift = diff(
+        args.develop.read_text(encoding="utf-8"),
+        args.published.read_text(encoding="utf-8"),
+    )
+    if not drift:
+        print("Submission validator copies are in sync (after invocation normalization).")
+        return 0
+
+    print(
+        "::error::validate-submission.yml has drifted between develop and "
+        "published-results. Open a sync PR against published-results, preserving "
+        "the slim-branch `uv run --no-project --python 3.11` invocation (see "
+        "docs/development/adr/adr-published-results-slim-corpus-branch.md). "
+        "Normalized diff:",
+        file=sys.stderr,
+    )
+    sys.stderr.writelines(drift)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_submission_validator_sync.py
+++ b/tests/unit/scripts/test_check_submission_validator_sync.py
@@ -1,0 +1,91 @@
+"""Unit tests for the submission-validator drift-check comparison logic.
+
+The scheduled workflow feeds this script the two real branch copies; these
+tests pin the normalization contract (the sanctioned uv-invocation difference
+is ignored, everything else is drift) without any network or branch access.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check_submission_validator_sync.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_check_sync", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+# Minimal representative develop / published-results copies that differ ONLY in
+# the sanctioned invocation.
+DEVELOP = """      - name: Validate bundles
+        run: |
+          xargs -d '\\n' uv run -- python scripts/validate_submission.py $REQUIRE_MANIFEST
+      - name: Check corpus inventory
+        run: uv run -- python scripts/generate_corpus_inventory.py --check
+"""
+
+PUBLISHED_IN_SYNC = """      - name: Validate bundles
+        run: |
+          xargs -d '\\n' uv run --no-project --python 3.11 -- python scripts/validate_submission.py $REQUIRE_MANIFEST
+      - name: Check corpus inventory
+        run: uv run --no-project --python 3.11 -- python scripts/generate_corpus_inventory.py --check
+"""
+
+
+def test_invocation_only_difference_is_in_sync() -> None:
+    # The develop and published-results copies differ only by the slim-branch
+    # invocation; the drift check must treat them as in sync.
+    assert mod.diff(DEVELOP, PUBLISHED_IN_SYNC) == []
+
+
+def test_identical_text_is_in_sync() -> None:
+    assert mod.diff(DEVELOP, DEVELOP) == []
+
+
+def test_substantive_drift_is_detected() -> None:
+    # published-results dropped the fork gate / a guard line -> real drift.
+    drifted = PUBLISHED_IN_SYNC.replace("$REQUIRE_MANIFEST", "")
+    result = mod.diff(DEVELOP, drifted)
+    assert result, "substantive divergence must be reported as drift"
+    assert any("REQUIRE_MANIFEST" in line for line in result)
+
+
+def test_normalize_collapses_both_spellings_identically() -> None:
+    slim = "run: uv run --no-project --python 3.11 -- python x.py"
+    proj = "run: uv run -- python x.py"
+    assert mod.normalize(slim) == mod.normalize(proj)
+
+
+def test_main_returns_1_on_drift(tmp_path) -> None:
+    dev = tmp_path / "develop.yml"
+    pub = tmp_path / "published.yml"
+    dev.write_text(DEVELOP, encoding="utf-8")
+    pub.write_text(PUBLISHED_IN_SYNC.replace("$REQUIRE_MANIFEST", ""), encoding="utf-8")
+    assert mod.main(["--develop", str(dev), "--published", str(pub)]) == 1
+
+
+def test_main_returns_0_when_in_sync(tmp_path) -> None:
+    dev = tmp_path / "develop.yml"
+    pub = tmp_path / "published.yml"
+    dev.write_text(DEVELOP, encoding="utf-8")
+    pub.write_text(PUBLISHED_IN_SYNC, encoding="utf-8")
+    assert mod.main(["--develop", str(dev), "--published", str(pub)]) == 0
+
+
+def test_main_returns_2_on_missing_file(tmp_path) -> None:
+    dev = tmp_path / "develop.yml"
+    dev.write_text(DEVELOP, encoding="utf-8")
+    missing = tmp_path / "nope.yml"
+    assert mod.main(["--develop", str(dev), "--published", str(missing)]) == 2


### PR DESCRIPTION
## Description

Implements the durable half of the re-review's sync decision (**#3: "manual periodic copy + a drift-detection meta-test"**). `validate-submission.yml` lives on both `develop` (source of truth) and `published-results` (the copy that actually runs for contributor PRs). The corpus sync bot **cannot** mirror workflow files (`GITHUB_TOKEN` lacks `workflows: write`), so the published-results copy is synced by a hand-opened PR — an easy step to forget. A drifted copy silently runs stale validation logic; this is exactly how the §2.6/§2.7/§2.1 hardening (and the Defect #1 fork gate) came to lag behind on that branch.

### What this adds

- **`scripts/check_submission_validator_sync.py`** — normalizes away the *one* sanctioned difference (the slim-branch `uv run --no-project --python 3.11` invocation vs develop's in-project `uv run -- python`) and reports any remaining divergence as a unified diff. Exit 0 in sync / 1 on drift / 2 on IO error.
- **`.github/workflows/submission-validator-drift-check.yml`** — scheduled (weekly) + `workflow_dispatch` + on push to develop touching the validator; checks out develop, extracts the live `published-results` copy via `git show`, and runs the checker. Fails loudly on drift.
- **`tests/unit/scripts/test_check_submission_validator_sync.py`** — 7 unit tests pinning the normalization contract (invocation-only difference = in sync; substantive change = drift) with **no network or branch access**.

## Type of Change

- [x] New feature (CI safety net)

## Testing

- `uv run -- python -m pytest tests/unit/scripts/test_check_submission_validator_sync.py -n 0 -q` → **7 passed**.
- `ruff check` / `ruff format --check` / `ty check` clean.
- **Ran the checker against the real branch copies**: after #985 merged, `develop` (pre-#995) vs live `published-results` differs by *exactly* the Defect #1 fork gate — which `develop` gains when **#995** merges, bringing them back in sync. (The earlier pre-#985 state differed by the entire self-green guard + `CHANGED_MANIFESTS` block + the whole `--require-manifest` waiver — confirming the drift risk is real and severe.)

## Public Contract Check

- [x] CI-only tooling; no public contract surfaces changed.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

- **Ordering:** until **#995** merges (adding the fork gate to develop), the checker correctly reports the transient fork-gate drift — that is the checker doing its job, and it self-corrects the moment #995 lands. If this PR merges first, its initial develop-push run may be red until #995 lands.
- Scope is intentionally the workflow file (the copy the sync bot can't touch and the one that actually drifted). The script is trivially extensible to other mirrored files if that need arises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_