### PR TITLE
feat(mcp): expose the statistics-phase opt-in through run_benchmark

### DIFF
--- a/_project/DONE/main/planning/mcp-statistics-phase-opt-in.yaml
+++ b/_project/DONE/main/planning/mcp-statistics-phase-opt-in.yaml
@@ -2,7 +2,7 @@ id: mcp-statistics-phase-opt-in
 title: "feat(mcp): expose the statistics-phase opt-in through the MCP run_benchmark tool"
 worktree: main
 priority: Low
-status: Not Started
+status: Completed
 category: Core Functionality
 
 description: |
@@ -38,7 +38,7 @@ deps:
 work:
   - id: w1
     summary: "Thread a gather_statistics flag from MCP run_benchmark into run_with_platform"
-    status: pending
+    status: done
     notes: |
       Detect `statistics` in the tool's `phases` argument (independently of
       `_map_phases_to_test_execution_type`, which intentionally ignores it)
@@ -49,10 +49,22 @@ work:
       so no adapter change is needed. Preserve the existing per-benchmark
       registry gate (`supports_statistics_phase`) so non-opted-in benchmarks
       still skip the phase and the response is unchanged for them.
+
+      Implementation note (found while implementing, not in the original
+      notes): `run_statistics_phase(benchmark, connection, benchmark_name=...)`
+      looks up the registry gate via `get_benchmark_metadata(run_config.get
+      ("benchmark_name", ""))`. Since MCP never populated `benchmark_name` in
+      run_config, the slug was always empty and the gate would treat every
+      benchmark as "not opted in" -- gather_statistics=True alone is
+      insufficient. Fixed by also forwarding `benchmark_name=benchmark_lower`
+      in the same conditional block (only when `statistics` is requested, so
+      must_preserve #1 -- byte-identical responses when it isn't -- still
+      holds). Verified against a real duckdb TPC-H SF=0.01 run: phases.
+      statistics only appears with this pairing.
   - id: w2
     summary: "Confirm phases.statistics surfaces in the MCP response payload"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       The MCP result payload is built from the same exporter path as the CLI
       (`_export_and_build_payload`), so phases.statistics should already
@@ -60,6 +72,18 @@ work:
       `run_benchmark` call with `phases` including `statistics` on an
       opted-in benchmark yields `phases.statistics` with a `stats_mode`, and
       that a non-opted-in benchmark omits the block.
+
+      Implemented in tests/unit/mcp/test_mcp_statistics_phase.py using the
+      existing mocked run_with_platform pattern (real duckdb runs take
+      ~3-12s each -- too slow for the "fast" lane, which `make test-fast`
+      documents as sub-second per test). Covers: gather_statistics/
+      benchmark_name forwarded when `statistics` is requested and omitted
+      otherwise (call_kwargs-level), test_execution_type unaffected, and
+      phases.statistics pass-through in the response for both the
+      present and gate-skipped (absent) cases. The registry gate itself
+      (supports_statistics_phase true/false) is exercised at the adapter
+      level in tests/unit/platforms/test_base_adapter.py (PR #980); this
+      file only locks down that MCP doesn't bypass it.
 
 must_preserve:
   - "MCP callers that do NOT request the statistics phase get byte-identical responses to today (no statistics block)."

--- a/benchbox/mcp/tools/benchmark.py
+++ b/benchbox/mcp/tools/benchmark.py
@@ -383,12 +383,36 @@ def _run_benchmark_impl(
 
         test_execution_type = _map_phases_to_test_execution_type(phases_list)
 
+        # Opt-in statistics phase (`statistics` in `phases`): threaded independently
+        # of `_map_phases_to_test_execution_type`, which intentionally ignores the
+        # token for execution-type derivation. `benchmark_name` is required here so
+        # the base-adapter's `run_statistics_phase` can resolve the per-benchmark
+        # `supports_statistics_phase` registry gate; omitting it would make the gate
+        # look up an empty slug and always skip. Only set when requested, so callers
+        # that don't ask for statistics keep byte-identical `run_config` and responses.
+        #
+        # Coupling note: `benchmark_name` is not gate-only downstream. In
+        # `run_enhanced_benchmark` it also seeds query dialect-family selection
+        # (`_get_dialect_queries` -> `get_tpc_base_dialect`, currently uniform across
+        # families) and the query-level `benchmark_type` that gates row-count
+        # validation (only when `enable_validation` is set, which the MCP adapter
+        # leaves False). Both are inert today, so setting `benchmark_name` only in
+        # this branch changes no observable behavior; but if a family-aware base
+        # dialect or MCP-side validation ever lands, requesting `statistics` would
+        # then also shift query SQL / validation. Revisit this conditional (pass the
+        # slug unconditionally) if either consumer becomes active.
+        statistics_run_config: dict[str, Any] = {}
+        if "statistics" in phases_list:
+            statistics_run_config["gather_statistics"] = True
+            statistics_run_config["benchmark_name"] = benchmark_lower
+
         with silence_output(enabled=True):
             result = benchmark_instance.run_with_platform(
                 adapter,
                 query_subset=query_subset,
                 test_execution_type=test_execution_type,
                 capture_plans=capture_plans,
+                **statistics_run_config,
             )
 
         if result is not None:

--- a/tests/unit/mcp/test_mcp_statistics_phase.py
+++ b/tests/unit/mcp/test_mcp_statistics_phase.py
@@ -1,0 +1,161 @@
+"""Tests for the opt-in statistics phase exposed through the MCP run_benchmark tool.
+
+Covers benchbox/mcp/tools/benchmark.py's handling of `statistics` in the
+`phases` argument: threading `gather_statistics`/`benchmark_name` into
+`run_with_platform`, and pass-through of the resulting `phases.statistics`
+block in the MCP response.
+
+The per-benchmark `supports_statistics_phase` registry gate itself is
+exercised at the adapter level in tests/unit/platforms/test_base_adapter.py
+(added with PR #980, e.g. test_run_statistics_phase_skips_benchmark_without_opt_in
+and test_run_statistics_phase_completed_for_opted_in_benchmark). This file
+locks down that the MCP layer forwards the flag correctly (without
+bypassing that gate) and leaves non-statistics requests byte-identical.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.fixtures.result_dict_fixtures import write_v2_result_file
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+    pytest.mark.skipif(sys.version_info < (3, 10), reason="MCP server requires Python 3.10+"),
+]
+
+
+def _get_tool_functions() -> dict[str, Any]:
+    """Create a fresh MCP server and extract registered tool functions."""
+    from benchbox.mcp import create_server
+
+    server = create_server()
+    tools: dict[str, Any] = {}
+    if hasattr(server, "_tool_manager"):
+        tool_dict = getattr(server._tool_manager, "_tools", {})
+        for name, tool in tool_dict.items():
+            tools[name] = tool.fn
+    return tools
+
+
+@pytest.fixture(scope="module")
+def tool_functions() -> dict[str, Any]:
+    """Module-scoped fixture for tool function lookup."""
+    return _get_tool_functions()
+
+
+def _mock_run(
+    tool_functions: dict[str, Any],
+    tmp_path: Path,
+    *,
+    phases: str,
+    extra_result_kwargs: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Call run_benchmark with run_with_platform mocked; return (response, call_kwargs)."""
+    fn = tool_functions["run_benchmark"]
+
+    mock_result = MagicMock()
+    mock_result.query_results = []
+
+    mock_instance = MagicMock()
+    mock_instance.run_with_platform.return_value = mock_result
+
+    mock_bm_class = MagicMock(return_value=mock_instance)
+
+    result_path = tmp_path / "result.json"
+    write_v2_result_file(
+        result_path,
+        execution_id="mcp_test",
+        timestamp="2026-01-01T00:00:00",
+        **(extra_result_kwargs or {}),
+    )
+
+    mock_exporter = MagicMock()
+    mock_exporter.export_result.return_value = {"json": result_path}
+
+    with (
+        patch("benchbox.mcp.tools.benchmark._get_platform_adapter"),
+        patch("benchbox.mcp.tools.benchmark.get_public_benchmark_class", return_value=mock_bm_class),
+        patch("benchbox.mcp.tools.benchmark.ResultExporter", return_value=mock_exporter),
+    ):
+        result = fn(platform="duckdb", benchmark="tpch", scale_factor=0.01, phases=phases)
+
+    call_kwargs = mock_instance.run_with_platform.call_args[1]
+    return result, call_kwargs
+
+
+class TestStatisticsPhaseFlagThreading:
+    """gather_statistics/benchmark_name threading into run_with_platform."""
+
+    def test_statistics_in_phases_forwards_gather_statistics_flag(self, tool_functions, tmp_path):
+        """`statistics` in phases sets gather_statistics=True and benchmark_name for the registry gate."""
+        _, call_kwargs = _mock_run(tool_functions, tmp_path, phases="load,statistics,power")
+
+        assert call_kwargs.get("gather_statistics") is True
+        assert call_kwargs.get("benchmark_name") == "tpch"
+
+    def test_statistics_absent_from_phases_omits_the_flag(self, tool_functions, tmp_path):
+        """Callers that don't request statistics get an unchanged run_config (must_preserve)."""
+        _, call_kwargs = _mock_run(tool_functions, tmp_path, phases="load,power")
+
+        assert "gather_statistics" not in call_kwargs
+        assert "benchmark_name" not in call_kwargs
+
+    def test_statistics_does_not_change_test_execution_type(self, tool_functions, tmp_path):
+        """statistics is not a query phase; test_execution_type mapping is unaffected."""
+        _, call_kwargs = _mock_run(tool_functions, tmp_path, phases="load,statistics,power")
+
+        assert call_kwargs.get("test_execution_type") == "power"
+
+
+class TestStatisticsPhaseResponsePassThrough:
+    """phases.statistics pass-through from the exported result into the MCP response.
+
+    These are deliberately shallow pass-through checks: ``run_with_platform`` is
+    mocked and the exported result file is hand-written, so they only prove the MCP
+    response carries through whatever ``phases`` the exporter produced. They do NOT
+    exercise the ``supports_statistics_phase`` registry gate or ``run_statistics_phase``
+    (those run inside the real adapter and are covered in
+    tests/unit/platforms/test_base_adapter.py). Their value is guarding against the
+    MCP layer dropping or mangling the phases block on the way to the response.
+    """
+
+    def test_response_carries_through_a_statistics_block_when_present(self, tool_functions, tmp_path):
+        """A result whose exported phases include statistics surfaces it in the response."""
+        result, _ = _mock_run(
+            tool_functions,
+            tmp_path,
+            phases="load,statistics,power",
+            extra_result_kwargs={
+                "phases": {
+                    "statistics": {"status": "COMPLETED", "stats_mode": "explicit", "tables_analyzed": 8},
+                }
+            },
+        )
+
+        assert result["phases"]["statistics"]["stats_mode"] == "explicit"
+
+    def test_response_has_no_statistics_block_when_result_omits_it(self, tool_functions, tmp_path):
+        """A result without a statistics phase (e.g. the phase never ran) yields no phases.statistics."""
+        result, _ = _mock_run(
+            tool_functions,
+            tmp_path,
+            phases="load,statistics,power",
+            extra_result_kwargs={
+                "phases": {
+                    "power_test": {"status": "COMPLETED"},
+                }
+            },
+        )
+
+        assert "statistics" not in result["phases"]


### PR DESCRIPTION
# Pull Request

## Description

Implements `mcp-statistics-phase-opt-in` — the follow-up deferred from the statistics-as-a-phase work (#980). The MCP `run_benchmark` tool collapsed its requested phases to a single `test_execution_type` (`_map_phases_to_test_execution_type`) and called `run_with_platform` **without** a `gather_statistics` flag, so an MCP caller that listed `statistics` in `phases` had it silently dropped.

- Detect `statistics` in the phases list (independently of `_map_phases_to_test_execution_type`, which correctly ignores it for execution-type derivation) and thread `gather_statistics=True` + `benchmark_name` into `run_with_platform`. That method forwards `**run_config` into `run_enhanced_benchmark`, whose statistics call site already reads `run_config.get("gather_statistics")` (landed in #980) and enforces the per-benchmark `supports_statistics_phase` registry gate — **MCP does not bypass it**. Callers that don't request statistics keep byte-identical `run_config` and responses.
- Tests under `tests/unit/mcp/`: flag-threading (`gather_statistics` + `benchmark_name` forwarded when requested, absent otherwise, `test_execution_type` unaffected) and honest exporter→response pass-through checks for the `phases.statistics` block.

## Type of Change

- [ ] Bug fix
- [x] New feature (opt-in; off by default)
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/unit/mcp/test_mcp_statistics_phase.py -q` → 5 passed
- `uv run -- python -m pytest tests/unit/mcp/ -q` → 495 passed (no regression)
- Seed verification (mapper routing unchanged): `_map_phases_to_test_execution_type(['load','statistics'])=='load_only'`, `(['generate','load','statistics','power'])=='power'` ✅
- `make format` / `make lint` / `make typecheck` → all clean
- `validate_todo.py` + `todo_cli.py check-graph` → valid, 109 items, no cycles/dangling refs

## Public Contract Check

- [x] No public/beta/deprecated/generated/experimental/repo-only contract surface changed. This adds an MCP-side opt-in that reuses the existing `RunConfig.gather_statistics` path; the `run_benchmark` tool's parameter set is unchanged (the `phases` string already accepted arbitrary tokens).
- [x] No result-schema / wrapper / adapter-hook / generated-doc impact. The `phases.statistics` block itself is the #980 contract; this only lets MCP trigger it.
- [x] No platform/benchmark count claim added to shipped docs.

## Documentation

- [x] No user-facing docs changed (the `--phases` vocabulary docs updated in #980 cover the token).
- [x] No behavior change for MCP callers that don't request the statistics phase.
- [x] API contract wording unaffected.

## Code Quality

- [x] Ran format, lint, and typecheck.
- [x] Backwards-compat: non-statistics MCP requests keep byte-identical `run_config`/response; the registry gate still governs whether the phase runs.
- [x] Tests added for flag-threading and response pass-through.
- [x] Public contracts / release checklists still valid.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or binaries — source, one test file, and the seed moved to DONE.

## Notes

- **Model split (as requested):** implemented on Sonnet 5; code review performed by an Opus 4.8 subagent. It returned 3 findings (all minor/nit, no blockers), all addressed before this PR:
  1. Documented the latent `benchmark_name` coupling — it also feeds query dialect-family selection (currently uniform) and query-level `benchmark_type`/validation (only when `enable_validation`, which the MCP adapter leaves False); inert today, called out in a code comment with a "revisit if either consumer becomes active" note.
  2. Relabeled the response-surface tests to state plainly they exercise MCP exporter→response pass-through, not the registry gate (the gate is covered at the adapter level in `test_base_adapter.py`), and fixed the overclaiming docstring.
  3. Case-sensitivity of the `statistics` token is left as-is — consistent with the existing (unvalidated, case-sensitive) MCP phases handling.
- Depends on #980 (merged): the runtime statistics-phase capability it triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh)_