### PR TITLE
ci(submission): deliver validation comment to fork PRs (§2.8 workflow_run companion)

### DIFF
--- a/.github/workflows/validate-submission-comment.yml
+++ b/.github/workflows/validate-submission-comment.yml
@@ -1,0 +1,99 @@
+name: Submission Validation Comment
+
+# Companion to `validate-submission.yml`. Fork PRs run that workflow with a
+# read-only GITHUB_TOKEN (GitHub caps the token for PRs from forks), so its
+# inline "Post PR comment" step 403s and cannot post the validation result to
+# an external contributor's PR. This workflow runs on `workflow_run` completion
+# in the TRUSTED base-repository context with a writable `pull-requests` token,
+# downloads the comment artifact the validation run uploaded, and posts (or
+# updates) the comment. It never checks out or executes any PR-supplied code —
+# it only reads the artifact and calls the issue-comment API — so granting the
+# write permission here is safe.
+#
+# ACTIVATION PREREQUISITES (this workflow is inert until both hold):
+#   1. A `workflow_run` companion only fires when its file is on the repository's
+#      DEFAULT branch. The default branch is being moved from the release branch
+#      to `develop` (see docs/operations/branch-rename-runbook.md / PR #993);
+#      until that switch lands, GitHub will not trigger this workflow.
+#   2. The artifact-upload half lives in `validate-submission.yml`, which runs on
+#      the `published-results` branch. That branch's copy must be synced from
+#      develop (the sync bot cannot mirror workflow files; see
+#      submission-validator-drift-check.yml) before a real contributor PR uploads
+#      the artifact this workflow consumes.
+
+on:
+  workflow_run:
+    workflows: ["Validate Submission"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post validation comment from trusted context
+    runs-on: ubuntu-latest
+    # Only PR-triggered validation runs carry a comment artifact.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download validation comment artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: submission-validation-comment
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update the comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // The validation run only uploads this artifact when bundles changed.
+            // If it is absent or malformed there is nothing to post — exit cleanly.
+            if (!fs.existsSync('artifact/pr_comment.md') || !fs.existsSync('artifact/pr_number.txt')) {
+              core.info('No submission-validation comment artifact; nothing to post.');
+              return;
+            }
+
+            const prNumber = parseInt(fs.readFileSync('artifact/pr_number.txt', 'utf8').trim(), 10);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number in artifact: ${prNumber}`);
+              return;
+            }
+
+            const body = fs.readFileSync('artifact/pr_comment.md', 'utf8');
+            const marker = '## Submission Validation';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c =>
+              c.body.trimStart().startsWith(marker) &&
+              (c.user.type === 'Bot' || c.user.login === 'github-actions[bot]')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }

--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -144,8 +144,39 @@ jobs:
         if: steps.validate.outcome == 'success'
         run: uv run -- python scripts/generate_corpus_inventory.py --check
 
-      - name: Post PR comment
+      # Stage the validation comment as an artifact so the workflow_run companion
+      # (validate-submission-comment.yml) can post it from the trusted base
+      # context. Fork PRs run this workflow with a read-only GITHUB_TOKEN, so the
+      # inline "Post PR comment" step below 403s for them — the companion is the
+      # path that actually delivers the comment for external contributors.
+      # workflow_run's github.event.workflow_run.pull_requests is empty for fork
+      # PRs, so we persist the PR number in the artifact for the companion to read.
+      - name: Stage validation comment artifact
+        if: steps.changed.outputs.has_bundles == 'true' && always()
+        run: |
+          mkdir -p /tmp/pr-comment-artifact
+          if [ -f /tmp/pr_comment.md ]; then
+            cp /tmp/pr_comment.md /tmp/pr-comment-artifact/pr_comment.md
+          fi
+          echo "${{ github.event.pull_request.number }}" > /tmp/pr-comment-artifact/pr_number.txt
+
+      - name: Upload validation comment artifact
+        if: steps.changed.outputs.has_bundles == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-validation-comment
+          path: /tmp/pr-comment-artifact/
+          if-no-files-found: warn
+          retention-days: 3
+
+      # Same-repo fast path: post the comment inline with the writable token.
+      # continue-on-error so a fork PR's read-only-token 403 here never turns a
+      # passing validation red — the companion delivers the comment instead. On
+      # same-repo PRs the companion later finds this comment by marker and updates
+      # it in place (idempotent), so there is no duplicate.
+      - name: Post PR comment (same-repo fast path)
         if: steps.validate.outcome != 'skipped' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Description

Implements audit **§2.8** (re-review decision #2). Fork PRs run `validate-submission.yml` with a read-only `GITHUB_TOKEN`, so its inline "Post PR comment" step 403s — a *passing* validation could show **red** for an external contributor purely because the bot couldn't comment.

Two-part fix:

1. **`validate-submission.yml`** — uploads the rendered comment (plus the PR number, since `github.event.workflow_run.pull_requests` is empty for fork PRs) as an artifact, and marks the inline post `continue-on-error`. The same-repo fast path still posts immediately; a fork's read-only-token 403 no longer fails the job.
2. **New `validate-submission-comment.yml`** — runs on `workflow_run` completion in the **trusted base context** with `pull-requests: write`, downloads the artifact, and posts/updates the comment. It **never checks out or runs PR-supplied code** (only reads the artifact and calls the issue-comment API), so the write permission is safe. On same-repo PRs it finds the inline comment by marker and updates it in place — idempotent, no duplicate.

## Type of Change

- [x] Bug fix / CI hardening

## Testing

- Both workflows parse (`yaml.safe_load`).
- `uv run -- python -m pytest tests/unit/scripts/test_submission_workflow_waiver.py -n 0 -q` → 3 passed (the fork-gate meta-test is unaffected; I did not touch the `validate` step).
- `test_release_infrastructure.py` only asserts a fixed required-workflow allowlist, so the new file is fine.

## Public Contract Check

- [x] CI-only; no public contract surfaces changed.

## Artifact Hygiene

- [x] No raw artifacts committed (the workflow uploads an ephemeral CI artifact, retention 3 days).

## Notes — activation prerequisites (documented in the companion header)

- **Two caveats I discovered while implementing (worth your awareness):**
  1. A `workflow_run` companion only fires when its file is on the repository's **default branch**. Default is still the release branch; it becomes active once the **develop default switch (#993)** lands.
  2. The artifact-upload half runs on `published-results`; that branch's copy must be **synced from develop** (I'll open the mirror PR, same as #985) before a real contributor PR uploads the artifact.
  3. This repo currently has **0 forks**, so §2.8 cannot be verified against a real historical fork-PR run — the fix is built to the documented mechanism rather than an observed failure.
- **Until those prerequisites hold, the `continue-on-error` change alone already removes the red-X harm** — that part is effective the moment it reaches published-results.
- **Expected drift:** these `validate-submission.yml` changes put develop ahead of published-results, so the drift-check (#998) will flag it until the mirror sync PR lands — that is the drift-check working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_