### PR TITLE
ci(published-results): sync §2.8 fork-PR comment plumbing from develop

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -144,8 +144,39 @@ jobs:
         if: steps.validate.outcome == 'success'
         run: uv run --no-project --python 3.11 -- python scripts/generate_corpus_inventory.py --check
 
-      - name: Post PR comment
+      # Stage the validation comment as an artifact so the workflow_run companion
+      # (validate-submission-comment.yml) can post it from the trusted base
+      # context. Fork PRs run this workflow with a read-only GITHUB_TOKEN, so the
+      # inline "Post PR comment" step below 403s for them — the companion is the
+      # path that actually delivers the comment for external contributors.
+      # workflow_run's github.event.workflow_run.pull_requests is empty for fork
+      # PRs, so we persist the PR number in the artifact for the companion to read.
+      - name: Stage validation comment artifact
+        if: steps.changed.outputs.has_bundles == 'true' && always()
+        run: |
+          mkdir -p /tmp/pr-comment-artifact
+          if [ -f /tmp/pr_comment.md ]; then
+            cp /tmp/pr_comment.md /tmp/pr-comment-artifact/pr_comment.md
+          fi
+          echo "${{ github.event.pull_request.number }}" > /tmp/pr-comment-artifact/pr_number.txt
+
+      - name: Upload validation comment artifact
+        if: steps.changed.outputs.has_bundles == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-validation-comment
+          path: /tmp/pr-comment-artifact/
+          if-no-files-found: warn
+          retention-days: 3
+
+      # Same-repo fast path: post the comment inline with the writable token.
+      # continue-on-error so a fork PR's read-only-token 403 here never turns a
+      # passing validation red — the companion delivers the comment instead. On
+      # same-repo PRs the companion later finds this comment by marker and updates
+      # it in place (idempotent), so there is no duplicate.
+      - name: Post PR comment (same-repo fast path)
         if: steps.validate.outcome != 'skipped' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Description

Mirrors the `validate-submission.yml` half of the §2.8 fork-PR-comment fix (develop PR **#1000**) onto `published-results` — the branch copy that actually runs for contributor PRs. The corpus sync bot can't mirror workflow files, so this is a hand-opened PR (same as #985).

## What this lands on `published-results`

- Uploads the rendered validation comment (+ the PR number) as an artifact.
- Marks the inline "Post PR comment" step `continue-on-error`, so a fork PR's read-only-token 403 no longer turns a **passing** validation red.
- Preserves the slim-branch `uv run --no-project --python 3.11` invocation.

## Not included here (by design)

- The `workflow_run` companion (`validate-submission-comment.yml`) is **not** mirrored — a `workflow_run` companion only fires from the **default branch**, so it lives only on develop. This branch just needs to *produce* the artifact the companion consumes.

## Testing

- `yaml.safe_load` → parses; 2 `--no-project --python 3.11` invocations preserved, 0 develop-style.
- **Verified byte-identical to develop's copy** (modulo the uv invocation) with `scripts/check_submission_validator_sync.py` → "in sync", so the drift-check (#998) stays green after both land.
- Touches only `.github/workflows/**`; the `Validate Submission` workflow does not run on this PR — review the diff and merge.

## Notes

Merge after #1000 lands on develop. Together with #985 (fork gate) this brings the on-branch validator fully current with develop's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_