### PR TITLE
chore(todo): close qa-doc-accuracy (false positive) + published-results-ci

### DIFF
--- a/_project/DONE/main/planning/remediate-published-results-submission-ci.yaml
+++ b/_project/DONE/main/planning/remediate-published-results-submission-ci.yaml
@@ -2,7 +2,8 @@ id: remediate-published-results-submission-ci
 title: "Harden published-results submission CI: on-branch drift, self-green, fork-PR comments, ADR allowlist"
 worktree: main
 priority: High
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-06"
 category: Testing and Quality Assurance
 
 description: |
@@ -72,19 +73,21 @@ work:
 - id: w2
   summary: "Fix fork-PR comment posting so a passing validation never shows red for external contributors"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
     If §2.8 confirmed: move commenting to a workflow_run/pull_request_target
     companion running with the base token, or skip commenting gracefully when
     the token is read-only. Do not weaken the read-only posture for fork code.
 
-    2026-07-06 status: IMPLEMENTED, landing. develop PR #1000 adds the
-    workflow_run companion (validate-submission-comment.yml) + artifact upload
-    + continue-on-error on the inline post; published-results mirror is PR
-    #1001. NOTE: the companion only fires from the DEFAULT branch, so it stays
-    inert until the develop default-switch (#993) lands; and the repo has 0
-    forks, so §2.8 could not be verified against a real fork-PR run. Close this
-    unit once #1000/#1001 merge; leave the item open on w5 until then.
+    2026-07-06 DONE: develop PR #1000 (merged) adds the workflow_run companion
+    (validate-submission-comment.yml) + artifact upload + continue-on-error on
+    the inline post; published-results mirror #1001 (merged) carries the
+    artifact-upload + continue-on-error half. NOTE (documented, not blocking):
+    the companion only fires from the DEFAULT branch, so it stays inert until
+    the develop default-switch (#993) lands; and the repo has 0 forks, so §2.8
+    could not be verified against a real fork-PR run — built to the documented
+    GitHub mechanism. The continue-on-error change already removes the red-X
+    harm on published-results now.
 
 - id: w3
   summary: "Neutralize the self-green vector (§2.7)"
@@ -107,7 +110,7 @@ work:
 - id: w5
   summary: "Post-merge: merge the resulting mirror PR into published-results and confirm the branch is live"
   needs: [w1, w3, w4]
-  status: pending
+  status: done
   notes: |
     This TODO's develop-side PR only prepares the fix; it does not put it on
     published-results by itself. After it merges to develop,

--- a/_project/DONE/main/planning/remediate-qa-and-browser-test-doc-accuracy.yaml
+++ b/_project/DONE/main/planning/remediate-qa-and-browser-test-doc-accuracy.yaml
@@ -2,7 +2,8 @@ id: remediate-qa-and-browser-test-doc-accuracy
 title: "Fix Results Explorer QA doc: false S7.6 security claim, non-existent sample IDs, stale URL-sync notes"
 worktree: main
 priority: Medium
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-06"
 category: Documentation
 
 description: |
@@ -41,19 +42,23 @@ work:
 
 - id: w2
   summary: "Regenerate the §S5 sample result IDs and the corpus-surface description from the actual fixtures"
-  status: pending
+  status: done
   notes: |
     Derive real IDs from results-explorer/test-fixtures/source/bundles/;
     drop the non-existent sqlite surface (or add a fixture if it is intended);
     correct the result count.
 
-    2026-07-06 re-review verification: the sqlite surface and platforms were
-    corrected, but all 4 current §S5 sample IDs carry WRONG hash suffixes and
-    fail to resolve against the committed fixtures — doc `…-010ee756` /
-    `…-a6bb8a70` / `…-a62d0d72` / `…-3cdeede0` vs fixtures `…-7fe93365`
-    (duckdb) / `…-c0d4f3d9` (datafusion) / `…-39bb1a7b` (polars) /
-    `…-ac3ed9a9` (star_schema-duckdb). Regenerate the four IDs from the actual
-    fixture filenames; the verification `command:` above then passes.
+    2026-07-06 RESOLVED (no doc change needed): the four §S5 IDs are CORRECT.
+    They are the pipeline's recomputed result_ids (sha256 of the normalized
+    corpus bundle bytes), NOT the source-bundle filename hashes — the doc body
+    (:240-247) says so explicitly. A fresh `npm run test:e2e:fixtures` produces
+    exactly 010ee756 (duckdb) / a6bb8a70 (datafusion) / a62d0d72 (polars) /
+    3cdeede0 (star_schema-duckdb) in the generated results.duckdb, matching the
+    doc verbatim. The earlier "wrong hash" report was a FALSE POSITIVE from the
+    stale verification command below, which grepped source-bundle FILENAMES (the
+    pre-normalization hashes 7fe93365/c0d4f3d9/39bb1a7b/ac3ed9a9) instead of the
+    normalized result_ids. Verification command corrected to query the generated
+    corpus; w1 and w3 already landed. Item complete.
 
 - id: w3
   summary: "Delete the stale 'not URL-synced' notes (§S3.1, §S3.4) and fix the browser-testing trigger claim"
@@ -79,10 +84,10 @@ verification:
 - description: "S7.6 no longer claims a view"
   command: "grep -n 'is a view' docs/operations/results-explorer-qa.md"
   expected_output: "no match; wording describes READ_ONLY attach"
-- description: "Every §S5 sample ID exists in the fixtures"
+- description: "Every §S5 sample ID is a normalized result_id in the generated corpus (NOT a source-bundle filename)"
   command: |
-    for id in $(grep -oE '[a-z0-9-]+-sf[0-9.]+-[0-9]{8}-[0-9a-f]{8}' docs/operations/results-explorer-qa.md); do ls results-explorer/test-fixtures/source/bundles/ | grep -q "$id" || echo MISSING:$id; done
-  expected_output: "no MISSING lines"
+    cd results-explorer && npm run test:e2e:fixtures >/dev/null 2>&1 && uv run --project .. -- python -c "import duckdb,re,pathlib; ids=set(re.findall(r'[a-z_]+-[a-z-]+-sf[0-9.]+-[0-9]{8}-[0-9a-f]{8}', pathlib.Path('../docs/operations/results-explorer-qa.md').read_text())); con=duckdb.connect('test-fixtures/.generated/data/results.duckdb', read_only=True); real={r[0] for r in con.execute('select distinct result_id from benchmark_matrix_cells').fetchall()}; missing=sorted(i for i in ids if i not in real); print('MISSING:', missing) if missing else print('all resolve')"
+  expected_output: "all resolve — the IDs are recomputed result_ids in results.duckdb; do NOT grep source-bundle filenames (those are pre-normalization hashes and will always mismatch)"
 
 scope_limit:
   only_modify:


### PR DESCRIPTION
## Description

Follow-up to #1002 after **verifying** the two items it had kept open. Both are now complete — leaving just one remediation TODO open.

### `remediate-qa-and-browser-test-doc-accuracy` → DONE (the flagged defect was a false positive)

The re-review flagged the §S5 sample IDs as "wrong hash suffixes." **Verified false positive:** the four IDs are the pipeline's **recomputed `result_id`s** (`sha256` of the *normalized* corpus bundle bytes), not source-bundle filename hashes — the doc body (`:240-247`) states this explicitly. A fresh `npm run test:e2e:fixtures` reproduces exactly `010ee756` / `a6bb8a70` / `a62d0d72` / `3cdeede0` in the generated `results.duckdb`, matching the doc verbatim.

- **The doc needs no change** — it's accurate.
- The item's own `verification:` command was the wrong artifact (it grepped source-bundle *filenames*, which are pre-normalization hashes and never equal the result_ids). Corrected to query the generated corpus so it can't raise this false alarm again.

### `remediate-published-results-submission-ci` → DONE

w2 (§2.8 fork-PR comment) and w5 (mirror live on `published-results`) landed via **#1000** (develop) + **#1001** (published-results mirror), both merged; #985 (fork gate) and #998 (drift-check) complete the rest. Activation caveats (companion inert until the default-branch switch #993; 0 forks to verify against) are documented, not blocking.

## Type of Change

- [x] Refactor / chore (governance bookkeeping)

## Testing

- `todo_cli validate` → **1248/1248 valid**; `check-graph` → clean, 101 items.
- Confirmed the doc IDs by regenerating fixtures and querying `results.duckdb`.

## Notes

**One remediation item remains open:** `remediate-explorer-deploy-path-reconciliation` (w3) — the default-branch (`main`) copy of `results-explorer-qa.md` still references `release-cut`-stripped paths. That's a genuine design choice (develop-only banner vs. adding the QA doc to `release-cut`'s strip list, which touches release infra) and I've left it for a direction call rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_