### PR TITLE
ci(medium-tier): promote medium-test to a blocking auto-revert lane

### DIFF
--- a/.github/workflows/develop-post-merge.yml
+++ b/.github/workflows/develop-post-merge.yml
@@ -79,22 +79,19 @@ jobs:
     # the develop-PR-blocking lane, so it lands here for visibility/metrics.
     # See _project/TODO/main/planning/medium-tier-ci-home.yaml.
     #
-    # VISIBILITY-ONLY FOR NOW (continue-on-error: true, deliberately EXCLUDED
-    # from auto-revert-on-failure's trigger): the tier has at least one
-    # known-red test on clean develop
-    # (tests/unit/test_cross_surface_applicability.py::test_committed_artifact_is_current,
-    # stale committed artifact) plus 14 failures / 44 errors observed under a
-    # contended sandbox measurement that have not been dispositioned. Wiring
-    # this into auto-revert now would open a revert PR against the first
-    # innocent merge. Promotion criterion: a full clean (green) run of the
-    # medium tier - prerequisites are (1) regenerating the stale
-    # cross-surface-applicability artifact and (2) a clean-environment
-    # re-measurement to disposition the other observed failures/errors. When
-    # promoting, drop continue-on-error and add medium-test to
-    # auto-revert-on-failure's needs + if, mirroring lint/fast-test.
+    # PROMOTED 2026-07-06 (medium-tier-red-disposition-and-promotion): the
+    # tier ran clean (green) on the real runner - develop-post-merge run
+    # 28763663703, job 85283671051, "Run medium speed tier" success - once
+    # its dispositioned failures were fixed: timeout markers for the 6 slow
+    # data-gen/cross-surface tests (#977) and the pytest-ci.ini
+    # filterwarnings marker sync (#994, the last remaining runner failure).
+    # It is now a blocking post-merge lane wired into auto-revert-on-failure's
+    # trigger, same as lint/fast-test/explorer-tokens (continue-on-error
+    # dropped). The 44 tpch-extension "errors" reported earlier were
+    # sandbox-only (egress proxy 403 on the extension download) and do not
+    # occur on the runner.
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -234,12 +231,12 @@ jobs:
   auto-revert-on-failure:
     name: auto-revert-on-failure
     runs-on: ubuntu-latest
-    # medium-test is deliberately absent from this needs/if while the medium
-    # tier has known-red tests (see the medium-test job's promotion criterion)
-    # - an auto-revert must never fire against an innocent merge because of a
-    # pre-existing tier failure.
-    needs: [lint, fast-test, explorer-tokens]
-    if: ${{ always() && (needs.lint.result == 'failure' || needs.fast-test.result == 'failure' || needs.explorer-tokens.result == 'failure') }}
+    # medium-test promoted into this trigger 2026-07-06 (see the medium-test
+    # job's promotion note): the tier ran clean on the real runner after its
+    # dispositioned failures were fixed (#977, #994), so a medium-test failure
+    # now opens a (reviewable) revert PR, same as lint/fast-test/explorer-tokens.
+    needs: [lint, fast-test, explorer-tokens, medium-test]
+    if: ${{ always() && (needs.lint.result == 'failure' || needs.fast-test.result == 'failure' || needs.explorer-tokens.result == 'failure' || needs.medium-test.result == 'failure') }}
     outputs:
       auto-revert-pr-opened-at: ${{ steps.open-revert.outputs.auto-revert-pr-opened-at }}
       auto-revert-pr-url: ${{ steps.open-revert.outputs.auto-revert-pr-url }}

--- a/_project/DONE/main/medium-tier-red-disposition-and-promotion.yaml
+++ b/_project/DONE/main/medium-tier-red-disposition-and-promotion.yaml
@@ -2,7 +2,8 @@ id: medium-tier-red-disposition-and-promotion
 title: "Disposition the medium tier's live failures on develop, get medium-test green, then wire it into auto-revert per its recorded criterion"
 worktree: main
 priority: Medium-High
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-06"
 category: "Testing and Quality Assurance"
 
 description: |
@@ -95,8 +96,17 @@ work:
   - id: w2
     summary: "Demonstrate a green medium-test run on a real runner"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
+      DONE 2026-07-06: medium-test concluded GREEN on the real runner —
+      develop-post-merge run 28763663703, job 85283671051, "Run medium speed
+      tier" success (26m, on develop 382311b6 which includes both the w1
+      dispositions #977 and the #994 filterwarnings-marker fix). Trajectory
+      across the three post-merge runs: 8 failures (pre-w1) -> 1 (the
+      Makefile-pin, which turned out to be a real pytest-ci.ini config-drift,
+      not "pre-existing/unrelated" as the w1 note assumed — fixed in #994) ->
+      0. The 44 tpch-extension "errors" were confirmed sandbox-only.
+    notes_original: |
       Evidence = a develop-post-merge run URL whose medium-test job
       concludes success (or `make test-medium` green in CI-equivalent
       conditions if timing a post-merge run is impractical — say which).
@@ -117,8 +127,19 @@ work:
   - id: w3
     summary: "Promote: wire medium-test into auto-revert-on-failure and update the pinned tests"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
+      DONE 2026-07-06 (this PR): dropped continue-on-error from the
+      medium-test job, added medium-test to auto-revert-on-failure's needs +
+      if:failure trigger (alongside lint/fast-test/explorer-tokens), updated
+      both job comments, and flipped the pinning test
+      test_medium_test_is_visibility_only_not_auto_revert_trigger ->
+      test_medium_test_is_promoted_to_auto_revert_trigger (asserts no
+      continue-on-error, medium-test in needs + if). 11 workflow pin tests
+      pass; YAML parses; make lint green. auto-revert opens a REVIEWABLE
+      revert PR (not a silent revert), so a future tier flake surfaces as a
+      dismissable PR rather than a forced revert.
+    notes_original: |
       Per the job comment: drop continue-on-error, add medium-test to
       auto-revert-on-failure's needs and if-expression alongside
       lint/fast-test, update the workflow comments, and flip any pinning

--- a/tests/unit/workflows/test_develop_post_merge_metrics.py
+++ b/tests/unit/workflows/test_develop_post_merge_metrics.py
@@ -191,25 +191,26 @@ def test_auto_revert_triggers_on_explorer_tokens_failure() -> None:
     assert "needs.explorer-tokens.result == 'failure'" in auto_revert["if"]
 
 
-def test_medium_test_is_visibility_only_not_auto_revert_trigger() -> None:
-    # The medium tier has known-red tests on clean develop (stale
-    # cross-surface-applicability artifact, plus undispositioned failures
-    # observed under a contended sandbox measurement — see
-    # medium-tier-ci-home.yaml). Until a full clean run of the tier is
-    # green, medium-test must be visibility-only: continue-on-error and
-    # EXCLUDED from the auto-revert-on-failure trigger, so an innocent
-    # merge can never be auto-reverted for a pre-existing tier failure.
-    # When promoting, flip these assertions to the explorer-tokens pattern
-    # (needs + if:failure trigger, no continue-on-error).
+def test_medium_test_is_promoted_to_auto_revert_trigger() -> None:
+    # PROMOTED 2026-07-06 (medium-tier-red-disposition-and-promotion): after
+    # the medium tier ran clean (green) on the real runner - develop-post-merge
+    # run 28763663703, job 85283671051 - once its dispositioned failures were
+    # fixed (#977 timeout markers, #994 pytest-ci.ini filterwarnings marker
+    # sync), medium-test was promoted to a blocking post-merge lane on the
+    # explorer-tokens pattern: no continue-on-error, present in
+    # auto-revert-on-failure's needs + if:failure trigger. This is the inverse
+    # of the former visibility-only pin; a regression here means the promotion
+    # was silently undone and a medium-test failure would no longer open a
+    # revert PR.
     workflow_yaml = yaml.safe_load(
         (REPO_ROOT / ".github" / "workflows" / "develop-post-merge.yml").read_text(encoding="utf-8")
     )
     medium_test = workflow_yaml["jobs"]["medium-test"]
     auto_revert = workflow_yaml["jobs"]["auto-revert-on-failure"]
 
-    assert medium_test.get("continue-on-error") is True
-    assert "medium-test" not in auto_revert["needs"]
-    assert "needs.medium-test.result" not in auto_revert["if"]
+    assert "continue-on-error" not in medium_test
+    assert "medium-test" in auto_revert["needs"]
+    assert "needs.medium-test.result == 'failure'" in auto_revert["if"]
 
 
 def test_close_orphaned_prs_waits_for_post_merge_validation_success() -> None:


### PR DESCRIPTION
## Description

Completes `medium-tier-red-disposition-and-promotion` **w2 + w3** — the promotion that was deferred pending a real-runner green observation.

The medium tier ran **clean (green) on the real runner**: develop-post-merge run [28763663703](https://github.com/joeharris76/BenchBox/actions/runs/28763663703), job 85283671051, `Run medium speed tier` = **success** (26 min, on develop `382311b6`), once its dispositioned failures were fixed. Failure trajectory across the three post-merge runs:

| Run | Commit | medium-test result |
|---|---|---|
| 28706929881 | pre-disposition | 8 failed |
| 28758602267 | after #977 (w1 dispositions) | 1 failed — the `filterwarnings` Makefile-pin |
| 28763663703 | after #994 (marker sync) | **0 failed — green** |

Note: the one failure #977 called "pre-existing / unrelated" turned out to be a **real `pytest-ci.ini` config drift** (the pytest 9.1.1 `filterwarnings` marker was registered in `pytest.ini` but not `pytest-ci.ini`), fixed in #994. The 44 `tpch`-extension "errors" seen in the agent sandbox were egress-proxy 403s that do not occur on the runner.

## Changes (per the recorded promotion criterion in the job comment)

- **`develop-post-merge.yml`**: drop `continue-on-error: true` from the `medium-test` job; add `medium-test` to `auto-revert-on-failure`'s `needs` + `if:failure` trigger (alongside lint/fast-test/explorer-tokens); rewrite both job comments to record the promotion + evidence.
- **`test_develop_post_merge_metrics.py`**: flip `test_medium_test_is_visibility_only_not_auto_revert_trigger` → `test_medium_test_is_promoted_to_auto_revert_trigger` (asserts no `continue-on-error`, `medium-test` in `needs` + `if`).
- **TODO → DONE** with w2/w3 marked done and the run evidence recorded.

## Safety note

`auto-revert-on-failure` opens a **reviewable revert PR** (it has an `auto-revert-pr-url` output) — not a silent/forced revert. So if the medium tier ever flakes on a future innocent merge, it surfaces as a dismissable PR, not a forced revert of develop. This satisfies the TODO's anti-pattern guard ("an auto-revert lane that reverts innocent merges is worse than none") while honoring the documented "one clean green run" criterion.

## Type of Change

- [x] CI/infra change (gate promotion)

## Testing

- `uv run -- python -m pytest tests/unit/workflows/test_develop_post_merge_metrics.py -o addopts=""` → **11 passed** (including the flipped promotion pin; the `post_merge_red` / `red_at` medium-test pins still hold).
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/develop-post-merge.yml'))"` → parses.
- `make lint` → green.
- `validate_todo.py` + `todo_cli.py check-graph` → valid, 100 items, no cycles/dangling.

## Public Contract Check

- [x] CI workflow + workflow-pin test + TODO bookkeeping only; no public/beta/deprecated/generated/experimental/repo-only contract surfaces changed.

## Documentation

- [x] The job comments and the flipped pin test document the promotion + evidence; DONE TODO carries the full trajectory.

## Code Quality

- [x] Minimal diff matching the pre-recorded promotion recipe; verified end-to-end against the green runner job.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

No CODEOWNERS soundness path touched — squash auto-merge is being enabled. Closes the last non-admin remainder of the verification-review follow-up batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_