### PR TITLE
fix(plan-fingerprint): protect ordinal column refs on the filter/join/projection normalization surface

### DIFF
--- a/_project/TODO/query-plan-capture/planning/12-fingerprint-ordinal-protection-all-surfaces.yaml
+++ b/_project/TODO/query-plan-capture/planning/12-fingerprint-ordinal-protection-all-surfaces.yaml
@@ -1,0 +1,70 @@
+id: qpc-12-fingerprint-ordinal-protection-all-surfaces
+title: "Apply ordinal-column (#0/#1) fingerprint protection to filter/join/projection too"
+worktree: query-plan-capture
+priority: Medium
+status: "Completed"
+completed_date: "2026-07-06"
+description: |
+  Follow-up to qpc-03 / #987. That change hardened the numeric-literal grammar
+  for normalized plan fingerprints and added a ``#`` boundary exclusion so DuckDB
+  ordinal column references (``#0``/``#1``) stay structural instead of masking to
+  an indistinguishable placeholder - but the exclusion was applied to only ONE of
+  two divergent regexes. ``_normalize_literal_text`` (aggregation/group/sort
+  expressions) excluded ``#``; ``_mask_literals`` (join/filter/projection
+  expressions) did not. Result: two plans referencing GENUINELY DIFFERENT
+  positional columns collapsed to the same normalized fingerprint on the
+  filter/join/projection surface - a false "plan unchanged" - while the
+  agg/group/sort surface reported them correctly.
+
+  Reproduced on the real signature path before the fix:
+    proj #0,#1 -> Project|proj:#<NUM>,#<NUM>
+    proj #0,#2 -> Project|proj:#<NUM>,#<NUM>   COLLIDE: True
+    group #0,#1 vs #0,#2                        COLLIDE: False (already correct)
+
+  Since ``--normalize-plan-literals`` is API-only / unshipped, this was not live,
+  but it would have produced false negatives on real DuckDB plans that use
+  positional projection/filter references. Found during sign-off review of the
+  five query-plan-capture remediation PRs.
+
+category: "Bug Fix / Correctness"
+
+prior_art:
+- "benchbox/core/results/query_plan_models.py:_mask_literals / _normalize_literal_text - the two divergent maskers"
+- "#987 (qpc-03) - added # exclusion to _NUMERIC_LITERAL_RE only"
+- "tests/unit/core/query_plans/test_fingerprint_normalization.py:test_ordinal_column_references_survive_normalization_in_group_by - the sibling test for the already-protected surface"
+
+work:
+- id: w1
+  summary: "Consolidate to one canonical #-protected _NUMERIC_LITERAL_RE shared by both maskers; delete the divergent un-protected pattern"
+  status: done
+- id: w2
+  summary: "Add a regression test asserting projection/filter ordinals #0,#1 vs #0,#2 do not collapse, while literal thresholds still normalize"
+  needs: [w1]
+  status: done
+
+must_preserve:
+- "Literal normalization still collapses genuine value differences (x>5 vs x>99 share a normalized fingerprint)"
+- "Default (literal-sensitive) fingerprint unchanged"
+- "Identifiers with trailing digits (l_orderkey1, t1) and signed/hex/underscore/scientific literals behave as before"
+
+anti_patterns:
+- "DO NOT keep two separately-compiled numeric patterns - a single source of truth prevents the boundary set from drifting again."
+
+verification:
+- description: "Fingerprint normalization + plan model suites pass, incl. the new projection/filter ordinal regression"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/ tests/unit/query_plans/ tests/unit/core/results/test_query_plan_models.py -q -n 0"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/query_plan_models.py"
+  - "tests/unit/core/query_plans/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "fingerprint", "normalization", "ordinal"]
+  estimated_effort: "Small"
+  created_date: "2026-07-06"
+  review_findings: ["F2.1-followup"]

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -116,11 +116,11 @@ from typing import Any
 from benchbox.core.errors import SerializationError
 
 # Literal-masking patterns for normalize_literals fingerprints. Numeric literals
-# (including decimals, and a tightly-adjacent sign like ``-5``) collapse to <NUM>
-# and single-quoted string literals to <STR> so that structurally identical plans
-# whose only difference is a data-driven parameter value (e.g. a seed-varied filter
-# threshold) hash the same. Numbers are masked first so digits inside a quoted
-# literal are folded into the <STR> token.
+# (including decimals, and a tightly-adjacent sign like ``-5``) collapse to a
+# placeholder and single-quoted string literals to another, so that structurally
+# identical plans whose only difference is a data-driven parameter value (e.g. a
+# seed-varied filter threshold) hash the same. Numbers are masked first so digits
+# inside a quoted literal are folded into the string token.
 #
 # The numeric pattern uses a negative lookbehind (rather than \b on both ends) so
 # it can also absorb a leading sign: \b requires a word/non-word transition
@@ -129,14 +129,19 @@ from benchbox.core.errors import SerializationError
 # the sign at all. Excluding identifier characters (letters, digits, ``_``,
 # ``.``, ``$``) keeps ``l_orderkey1``/``t1`` intact (the digit is preceded by a
 # letter) while still matching a tightly-adjacent sign (``col > -5``) as PART of
-# the same token. Absorbing the sign matters because without it, ``-5`` and
-# ``5`` (thresholds that cross zero across seeds) mask to ``-<NUM>`` and
-# ``<NUM>`` respectively - still distinct - instead of collapsing to the same
-# placeholder. A sign separated from its digit by whitespace (``a - b``, a
-# binary operator) is NOT absorbed: the pattern requires the sign and digit to
-# be adjacent with nothing in between. The trailing negative lookahead mirrors
-# the leading lookbehind (rather than a trailing \b) so a number is not matched
-# when immediately glued to more identifier-continuation characters either.
+# the same token. ``#`` is excluded on both boundaries too, so ordinal column
+# references (``#0``/``#1``, emitted by DuckDB and others for projected/grouped
+# columns) stay structural instead of collapsing to an indistinguishable masked
+# token - otherwise two plans that reference GENUINELY DIFFERENT positional
+# columns (``proj:#0,#1`` vs ``proj:#0,#2``) would hash the same, hiding a real
+# structural change behind what looks like a literal. Absorbing the sign matters
+# because without it, ``-5`` and ``5`` (thresholds that cross zero across seeds)
+# mask to distinct signed/unsigned placeholders instead of collapsing to the
+# same one. A sign separated from its digit by whitespace (``a - b``, a binary
+# operator) is NOT absorbed: the pattern requires the sign and digit to be
+# adjacent with nothing in between. The trailing negative lookahead mirrors the
+# leading lookbehind (rather than a trailing \b) so a number is not matched when
+# immediately glued to more identifier-continuation characters either.
 #
 # The alternation covers every SQL numeric literal form atomically (a single
 # match spans the whole literal, never leaving a residual value-dependent
@@ -147,18 +152,27 @@ from benchbox.core.errors import SerializationError
 #   - plain integer (``123``) or scientific integer (``1e5``, ``1E-3``)
 #   - ``_`` digit-group separators anywhere in the integer/exponent part
 #     (``1_000``, DuckDB/PostgreSQL numeric-literal syntax)
+#
+# ONE canonical numeric pattern is shared by BOTH maskers below. They previously
+# used two separately-compiled patterns that drifted: only the normalized-text
+# masker excluded ``#``, so the ordinal-collision protection above applied to
+# aggregation/group/sort expressions but NOT to join/filter/projection ones.
+# A single source of truth keeps every surface consistent.
 _HEX_LITERAL = r"0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*"
 _DECIMAL_LITERAL = (
     r"(?:\d(?:_?\d)*(?:\.(?:\d(?:_?\d)*)?)?|\.\d(?:_?\d)*)"  # 123 | 123. | 123.456 | .456
     r"(?:[eE][+-]?\d(?:_?\d)*)?"  # optional exponent: e5, E-3, e+10
 )
-_LITERAL_NUM_RE = re.compile(rf"(?<![A-Za-z0-9_.$])[+-]?(?:{_HEX_LITERAL}|{_DECIMAL_LITERAL})(?![A-Za-z0-9_.$])")
+_NUMERIC_LITERAL_RE = re.compile(rf"(?<![A-Za-z0-9_.$#])[+-]?(?:{_HEX_LITERAL}|{_DECIMAL_LITERAL})(?![A-Za-z0-9_.$#])")
 # ``(?:[^']|'')*`` (rather than ``[^']*``) treats a doubled single quote as an
 # escaped apostrophe INSIDE the literal rather than the end of the string, so
-# ``'O''Brien'`` masks to one <STR> token instead of splitting into two
-# (``'O'`` + ``'Brien'`` -> ``<STR><STR>``, which would leave the split itself
-# as residual value-dependent syntax in the "normalized" signature).
-_LITERAL_STR_RE = re.compile(r"'(?:[^']|'')*'")
+# ``'O''Brien'`` masks to one token instead of splitting into two (``'O'`` +
+# ``'Brien'``, which would leave the split itself as residual value-dependent
+# syntax in the "normalized" signature).
+_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
+_LITERAL_PLACEHOLDER = "?"
+
+logger = logging.getLogger(__name__)
 
 
 def _mask_literals(expression: str) -> str:
@@ -166,32 +180,13 @@ def _mask_literals(expression: str) -> str:
 
     Masks only concrete values, never identifiers: a leading identifier character
     immediately before a digit (a column or alias like ``l_orderkey1``, ``t1``)
-    excludes the match, so it is left intact. Used for the opt-in
-    literal-normalized structural signature; the default fingerprint keeps
-    literals verbatim.
+    excludes the match, and ordinal column references (``#0``/``#1``) are likewise
+    preserved via the shared ``#`` boundary exclusion, so they are left intact.
+    Used for the opt-in literal-normalized structural signature
+    (join/filter/projection expressions); the default fingerprint keeps literals
+    verbatim.
     """
-    return _LITERAL_STR_RE.sub("<STR>", _LITERAL_NUM_RE.sub("<NUM>", expression))
-
-
-logger = logging.getLogger(__name__)
-
-# Literal-normalization patterns for normalized plan fingerprints.
-# A normalized fingerprint collapses queries that differ only in literal
-# constants (e.g. TPC-H parameter substitutions) to the same hash by replacing
-# string/date literals and standalone numeric literals with a placeholder.
-_STRING_LITERAL_RE = re.compile(r"'(?:[^']|'')*'")
-# Shares _HEX_LITERAL/_DECIMAL_LITERAL with _LITERAL_NUM_RE (see _mask_literals)
-# so aggregation/group/sort expressions get the same atomic scientific/hex/
-# underscore/dotted numeric masking as join/filter/projection expressions -
-# without it, a seed-varying literal buried in e.g. an aggregation_functions
-# entry (``sum(x + 0xFF)`` vs ``sum(x + 0x1A)``) would still produce a
-# different normalized_fingerprint. ``#`` is additionally excluded from both
-# boundaries: DuckDB (and others) emit ordinal column references like
-# ``#0``/``#1`` for projected/grouped columns, and without this exclusion every
-# ordinal collapses to the same ``#?`` placeholder, hiding a genuine structural
-# change (a different column referenced) behind what looks like a literal.
-_NUMERIC_LITERAL_RE = re.compile(rf"(?<![A-Za-z0-9_.$#])[+-]?(?:{_HEX_LITERAL}|{_DECIMAL_LITERAL})(?![A-Za-z0-9_.$#])")
-_LITERAL_PLACEHOLDER = "?"
+    return _STRING_LITERAL_RE.sub("<STR>", _NUMERIC_LITERAL_RE.sub("<NUM>", expression))
 
 
 def _normalize_literal_text(text: str) -> str:
@@ -200,8 +195,8 @@ def _normalize_literal_text(text: str) -> str:
     Used to compute literal-normalized plan fingerprints so that queries which
     differ only in constant values share a fingerprint. String/date literals are
     replaced first, then standalone numeric literals. Identifiers containing
-    digits are preserved because the numeric pattern only matches digits not
-    immediately preceded by an identifier character.
+    digits and ordinal column references (``#0``/``#1``) are preserved because the
+    shared numeric pattern excludes those boundary characters.
     """
     if not text:
         return text

--- a/tests/unit/core/query_plans/test_fingerprint_normalization.py
+++ b/tests/unit/core/query_plans/test_fingerprint_normalization.py
@@ -129,11 +129,11 @@ class TestStructuralSignatureNormalization:
         assert "group:o_orderstatus" in normalized
 
     def test_aggregation_hex_literal_collapses_when_normalized(self):
-        """aggregation_functions/group_by_keys/sort_keys go through _normalize_literal_text,
-        a separate normalizer from _mask_literals (used by filter/join/projection). It must
-        share the same hardened numeric grammar - otherwise a hex/underscore/dotted literal
-        buried in an aggregate call masks in filter expressions but not here, and two
-        seed-varied hex constants still produce different normalized signatures."""
+        """aggregation_functions/group_by_keys/sort_keys and filter/join/projection now share
+        ONE canonical numeric pattern (_NUMERIC_LITERAL_RE), applied via _normalize_literal_text
+        and _mask_literals respectively. A hex/underscore/dotted literal buried in an aggregate
+        call must mask exactly as it does in a filter expression, so two seed-varied hex
+        constants produce the same normalized signature on every surface."""
         a = LogicalOperator(
             operator_type=LogicalOperatorType.AGGREGATE,
             operator_id="agg_1",
@@ -163,6 +163,37 @@ class TestStructuralSignatureNormalization:
         normalized = op.get_structural_signature(normalize_literals=True)
         assert "#0" in normalized
         assert "#1" in normalized
+
+    def test_ordinal_column_references_survive_normalization_in_projection_and_filter(self):
+        """DuckDB ordinal refs (#0/#1) in projection/filter expressions (the _mask_literals
+        surface) must not be masked either: two plans that project or filter on GENUINELY
+        DIFFERENT positional columns are a real structural change, not a literal difference,
+        and must NOT collapse to the same normalized signature. Regression for the gap where
+        only the aggregation/group/sort surface excluded '#' from the numeric boundary, so
+        projection ordinals '#0,#1' and '#0,#2' hashed identically under normalization."""
+        proj_a = LogicalOperator(
+            operator_type=LogicalOperatorType.PROJECT,
+            operator_id="proj_1",
+            projection_expressions=["#0", "#1"],
+        )
+        proj_b = LogicalOperator(
+            operator_type=LogicalOperatorType.PROJECT,
+            operator_id="proj_1",
+            projection_expressions=["#0", "#2"],
+        )
+        norm_a = proj_a.get_structural_signature(normalize_literals=True)
+        assert "#0" in norm_a and "#1" in norm_a
+        assert norm_a != proj_b.get_structural_signature(normalize_literals=True), (
+            "genuinely different projection ordinals must not collapse under normalization"
+        )
+
+        # Same protection on the filter surface, while an actual literal still normalizes.
+        filt_a = _scan("#0 > 5")
+        filt_b = _scan("#1 > 5")
+        assert filt_a.get_structural_signature(normalize_literals=True) != filt_b.get_structural_signature(
+            normalize_literals=True
+        )
+        assert "> <NUM>" in filt_a.get_structural_signature(normalize_literals=True)
 
     def test_escaped_apostrophe_string_literal_masks_as_one_token(self):
         """A doubled single quote is an escaped apostrophe INSIDE the literal, not the


### PR DESCRIPTION
## Description

Follow-up to the normalized-plan-fingerprint hardening in #987 (`harden-normalized-plan-fingerprint`). That change added a `#` boundary exclusion so DuckDB ordinal column references (`#0`/`#1`) stay structural instead of masking to an indistinguishable placeholder — but applied it to only **one** of two divergent numeric regexes:

- `_normalize_literal_text` (aggregation/group/sort expressions) → `_NUMERIC_LITERAL_RE`, which excluded `#`.
- `_mask_literals` (join/filter/**projection** expressions) → `_LITERAL_NUM_RE`, which did **not**.

So two plans referencing genuinely different positional columns collapsed to the same normalized fingerprint on the filter/join/projection surface — a false "plan unchanged" — while the aggregation/group/sort surface reported them correctly. Reproduced on the real signature path before the fix:

```
proj  #0,#1  ->  Project|proj:#<NUM>,#<NUM>
proj  #0,#2  ->  Project|proj:#<NUM>,#<NUM>     COLLIDE: True   ← genuinely different columns
group #0,#1 vs #0,#2                            COLLIDE: False  ← already correct
```

Not currently live: `--normalize-plan-literals` is API-only / unshipped, so no exported fingerprint uses this path yet. This closes the gap before the flag ships. Found during sign-off review of the five query-plan-capture remediation PRs (#967, #989, #987, #992, #990).

## Changes

- `benchbox/core/results/query_plan_models.py`: consolidate the two divergent numeric-literal patterns into **one** canonical `#`-protected `_NUMERIC_LITERAL_RE`, shared by both `_mask_literals` and `_normalize_literal_text`. Single source of truth so the boundary set cannot drift again. Comments and docstrings updated to reflect the shared pattern.
- `tests/unit/core/query_plans/test_fingerprint_normalization.py`: add `test_ordinal_column_references_survive_normalization_in_projection_and_filter` (mirrors the existing `group_by` ordinal test) asserting `#0,#1` vs `#0,#2` do not collapse and filter ordinals `#0`/`#1` stay distinct, while a literal threshold still normalizes. Refresh the now-stale docstring on `test_aggregation_hex_literal_collapses_when_normalized` that described the two normalizers as separate.
- `_project/TODO/query-plan-capture/planning/12-...yaml`: the completed follow-up TODO item.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

- `uv run -- python -m pytest tests/unit/core/query_plans/ tests/unit/query_plans/ tests/unit/cli/test_normalize_plan_literals_flag.py tests/unit/core/results/test_query_plan_models.py -q -n 0` — 488 passed.
- Empirically confirmed post-fix: `proj #0,#1` vs `#0,#2` no longer collide; `#0` preserved by both maskers; `x>5` ≡ `x>99` still normalize equal; `1.2E-3`/`0xFF`/`1_000`/`.5`/`5.`/`'O''Brien'`/`col > -5` mask correctly; `l_orderkey1`/`t1` identifiers preserved.
- `uv run ruff check` / `ruff format --check` / `ty check` on touched files — clean.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none — source, test, and one TODO YAML only.

## Notes

- `benchbox/core/results/query_plan_models.py` is **not** in `.github/CODEOWNERS` (the gated plan path is `benchbox/core/query_plans/parsers/**`), so this is eligible for squash auto-merge once CI passes.
- Default (literal-sensitive) fingerprints are unchanged; only the opt-in normalized path is affected, and only to make it more correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_