### PR TITLE
chore(todo): capture the three re-review follow-ups as tracked TODOs

### DIFF
--- a/_project/TODO/main/planning/explorer-csp-frame-ancestors-meta-cleanup.yaml
+++ b/_project/TODO/main/planning/explorer-csp-frame-ancestors-meta-cleanup.yaml
@@ -1,0 +1,82 @@
+id: explorer-csp-frame-ancestors-meta-cleanup
+title: "Remove the inert frame-ancestors directive from the explorer CSP meta tag"
+worktree: main
+priority: Low
+status: Not Started
+category: Security
+
+description: |
+  Source: results-explorer/publication remediation re-review (2026-07-06),
+  Defect #5 (de-escalated to cosmetic).
+
+  results-explorer/index.html:15 sets the CSP via `<meta http-equiv=
+  "Content-Security-Policy">`, and its content includes `frame-ancestors 'none'`.
+  Per the CSP spec, `frame-ancestors` is IGNORED when the policy is delivered in
+  a <meta> element — it is only honoured as an HTTP response header. So that
+  directive provides no clickjacking protection today; it reads as a control
+  that does not exist.
+
+  This is cosmetic, NOT a security hole: the load-bearing directive
+  `connect-src 'self'` (which confines all network egress and closes the
+  duckdb-wasm remote-fetch/exfil channel) DOES work in a meta CSP, and it is
+  present. The only issue is the misleading inert `frame-ancestors` line.
+
+  Fix: drop the inert directive and replace it with a comment stating that
+  framing/clickjacking protection must be applied as an HTTP response header
+  (`X-Frame-Options: DENY` or a header-delivered `frame-ancestors`) at the
+  hosting/CDN layer (GitHub Pages), because meta CSP cannot express it.
+
+work:
+- id: w1
+  summary: "Drop the inert frame-ancestors from the meta CSP; document the header-layer requirement"
+  status: pending
+  notes: |
+    In results-explorer/index.html: remove `frame-ancestors 'none'` from the
+    `<meta http-equiv="Content-Security-Policy">` content string, leaving every
+    other directive byte-identical (default-src, script-src incl.
+    'wasm-unsafe-eval', worker-src blob:, connect-src 'self', style-src,
+    img-src, font-src, object-src 'none', base-uri 'self'). Add an HTML comment
+    near the tag noting that clickjacking protection needs an HTTP response
+    header at the host/CDN because meta CSP ignores frame-ancestors. If the head
+    comment (index.html:6-7) implies framing is covered, correct it too.
+
+verification:
+- description: "frame-ancestors is gone from the CSP content= directive string (a comment mentioning it is fine)"
+  command: "grep -oE 'content=\"default-src[^\"]*\"' results-explorer/index.html | grep -c 'frame-ancestors'"
+  expected_output: "0 (the directive is removed from the meta content string)"
+- description: "the load-bearing connect-src 'self' directive is preserved"
+  command: "grep -oE 'content=\"default-src[^\"]*\"' results-explorer/index.html | grep -c \"connect-src 'self'\""
+  expected_output: "1 (egress confinement unchanged)"
+- description: "the explorer still builds and the browser e2e suite passes (no CSP regression; connect-src still enforced)"
+  command: "cd results-explorer && npm run test:e2e:chromium 2>&1 | tail -5"
+  expected_output: "all specs pass — removing an inert directive is behaviorally a no-op, so this confirms nothing else broke"
+
+prior_art:
+- "results-explorer/index.html:6-15 — the existing CSP meta + head comment; EDIT in place, preserve all non-frame-ancestors directives."
+- "_project/DONE/main/planning/remediate-explorer-csp-hardening.yaml — the item that added the CSP; SUPERSEDE its noted 'frame-ancestors inert in meta' caveat by actually removing the directive."
+
+scope_limit:
+  only_modify:
+  - "results-explorer/index.html"
+  do_not_modify:
+  - "results-explorer/src/"
+  - "benchbox/"
+
+must_preserve:
+- "connect-src 'self' — the load-bearing egress confinement; must not change."
+- "The duckdb-wasm-compatible directives (script-src 'wasm-unsafe-eval', worker-src blob:) — removing these would break the explorer."
+
+anti_patterns:
+- "DO NOT try to make frame-ancestors work by keeping it in meta — because the CSP spec ignores it there; the fix is a header at the host layer, out of this file's scope."
+
+metadata:
+  tags:
+  - results-explorer
+  - security
+  - csp
+  - remediation-followup
+  estimated_effort: "Small"
+  created_date: "2026-07-06"
+
+success_metrics:
+- "The explorer CSP contains no directive that silently does nothing; framing protection's real home (an HTTP header) is documented."

--- a/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
+++ b/_project/TODO/main/planning/external-contributor-submission-dry-run.yaml
@@ -135,8 +135,39 @@ work:
       - `base_branch: published-results`
       - `merged_at: <ISO timestamp>`
       - `trust_label: community-submission`
+      - `s28_fork_comment_verified: true | blocked-on-#993`   # see w6
     The existing 2026-04-28 and 2026-04-29 agent-proxy retrospectives are
     useful prior evidence but must not satisfy this TODO's verification.
+
+- id: w6
+  summary: "Verify the §2.8 fork-PR validation-comment path on the real fork PR"
+  needs: [w4]
+  status: pending
+  notes: |
+    The dry-run PR is (by design) a FORK PR to published-results — the only way
+    to exercise the §2.8 fork-PR comment fix against reality. Every
+    maintainer/mirror PR is same-repo, and the repo has 0 forks today, so §2.8
+    was implemented (PRs #1000 develop + #1001 published-results) but NEVER
+    verified end-to-end. This unit closes that gap using w4's real external
+    fork PR.
+
+    HARD PRECONDITION: only meaningful once the repo default_branch is
+    `develop` (PR #993 + the manual default switch in
+    docs/operations/branch-rename-runbook.md). A `workflow_run` companion fires
+    only from the DEFAULT branch, so validate-submission-comment.yml does not
+    run until develop is the default. If the dry-run runs before that switch,
+    record w6 as blocked-on-#993 in the retrospective, do not mark it done.
+
+    Observe and record in the retrospective evidence block:
+      - The fork PR's `Validate Submission` check is GREEN when the bundle
+        validates (the read-only-token 403 on the inline "Post PR comment
+        (same-repo fast path)" step did NOT redden it — continue-on-error held).
+      - The `Submission Validation Comment` workflow_run companion ran and the
+        comment (marker `## Submission Validation`) is present, posted by
+        github-actions[bot], with NO duplicate.
+      - `s28_fork_comment_verified: true | blocked-on-#993`
+    If the companion did not post but the artifact uploaded, capture the
+    workflow_run logs URL for follow-up debugging.
 
 verification:
 - description: "Human-specific retrospective exists and lists at least 3 captured friction items"
@@ -147,6 +178,10 @@ verification:
   command: |
     pr="$(rg -o 'https://github.com/joeharris76/BenchBox/pull/[0-9]+' _project/handoffs/external-human-dry-run-retrospective-*.md | tail -1 | sed 's#.*/##')"; test -n "$pr"; gh pr view "$pr" --repo joeharris76/BenchBox --json baseRefName,mergedAt,labels --jq 'select(.baseRefName == "published-results" and .mergedAt != null and ([.labels[].name] | index("community-submission"))) | "ok"'
   expected_output: "ok"
+- description: "w6: the §2.8 fork-PR comment path was exercised (verified, or explicitly blocked-on-#993) in the retrospective"
+  command: |
+    rg -n 's28_fork_comment_verified:\s*(true|blocked-on-#993)' _project/handoffs/external-human-dry-run-retrospective-*.md
+  expected_output: "one match — true once the default-branch switch (#993) is live and the companion posted; blocked-on-#993 if the dry-run ran before the switch"
 
 prior_art:
 - "_project/handoffs/external-dry-run-retrospective-2026-04-28.md — agent-proxy retrospective format; REUSE the compact friction-summary style but do not count this file as human evidence"

--- a/_project/TODO/main/planning/harden-auto-merge-on-open-stranding.yaml
+++ b/_project/TODO/main/planning/harden-auto-merge-on-open-stranding.yaml
@@ -1,0 +1,109 @@
+id: harden-auto-merge-on-open-stranding
+title: "Diagnose + guard the auto-merge-on-open stranding that orphaned 3 remediation fixes"
+worktree: main
+priority: Low
+status: Not Started
+category: Testing and Quality Assurance
+
+description: |
+  Source: results-explorer/publication remediation re-review (2026-07-06).
+
+  Symptom (confirmed, not hypothesised): three separate fixes were committed on
+  feature branches and their PRs treated as landed, yet the fix content never
+  reached merged `origin/develop` and had to be re-landed:
+    - §2.7 submission self-green guard — re-landed via #986.
+    - §2.16 QA-plan reusability (stranded commit cf394466) — re-landed via #996.
+    - §2.22 explorer-test relocation (stranded commits 4865a2f2 + 33687637) —
+      re-landed via #997.
+  The common factor is the `auto-merge-on-open.yml` flow, which auto-enables
+  squash auto-merge the moment a PR opens. The re-review found each fix ABSENT
+  from develop despite the originating session believing it merged. The exact
+  mechanism was never established — this item is diagnose-first, guard-second.
+
+  Risk if left alone: silent recurrence. A future PR can be reported "merged"
+  while a subset of its intended changes is orphaned, so a closed/DONE item is
+  not actually live — the most dangerous class of drift because nothing flags it.
+
+  NOTE: `.github/workflows/auto-merge-on-open.yml` is CODEOWNERS-gated
+  (@joeharris76). Any workflow change in w1 waits for Code Owner review — do not
+  expect squash auto-merge on this item's own PR for that path.
+
+work:
+- id: w0
+  summary: "Forensically reconstruct why each of the 3 stranded fixes did not reach develop"
+  status: pending
+  notes: |
+    For each of §2.7 (#986), §2.16 (#996, stranded cf394466), §2.22 (#997,
+    stranded 4865a2f2/33687637), reconstruct from git + GitHub history: the
+    original PR number, the SHA auto-merge actually merged, the branch's head
+    SHA at merge time, and whether the fix commit predated or postdated the
+    merged snapshot. Test the concrete hypotheses:
+      (a) auto-merge merged a base/snapshot that predated the fix commit
+          (commits pushed after auto-merge was enabled but merged from an
+          earlier point);
+      (b) the PR was closed (not merged) with the branch's commits abandoned;
+      (c) a rebase/force-push or a superseding PR dropped the commit;
+      (d) the squash captured only a subset of the branch's commits.
+    Write a compact committed summary to
+    `_project/analysis/auto-merge-stranding-forensic.md` — one block per case
+    (§2.7/#986, §2.16/#996, §2.22/#997) with: original PR#, the SHA auto-merge
+    merged, the branch head SHA at merge, and the verdict (which hypothesis).
+    Raw logs go to an ignored local path, not a committed transcript.
+
+- id: w1
+  summary: "Add a guard/detector so a stranded fix cannot merge-then-vanish silently"
+  needs: [w0]
+  status: pending
+  notes: |
+    Design AFTER w0 identifies the mechanism. Candidate mechanisms (pick per
+    root cause, do not implement all):
+      - a `develop-post-merge.yml` assertion that the merged commit's tree
+        actually contains the merged PR head's diff (fail loudly on mismatch);
+      - an `auto-merge-on-open.yml` guard that only enables auto-merge when the
+        PR head is the branch tip AND refuses if the base is stale;
+      - a scheduled "orphaned fix-commit" detector that flags closed PR branches
+        whose unique commits never appear on develop.
+    Keep it minimal and targeted at the confirmed cause; add a test.
+
+prior_art:
+- ".github/workflows/auto-merge-on-open.yml — the flow under investigation; the guard in w1 extends or gates this (CODEOWNERS-protected)."
+- ".github/workflows/develop-post-merge.yml — existing post-merge hook; the natural home for a merged-tree-vs-PR-head assertion (w1 option a)."
+- "PRs #986 / #996 / #997 — the three re-landings; their diffs are the ground truth for what was stranded (w0 forensic input)."
+
+verification:
+- description: "w0: a committed forensic file records a per-case merged-vs-head verdict for all 3 stranded fixes"
+  command: "test -f _project/analysis/auto-merge-stranding-forensic.md && grep -cE '#986|#996|#997' _project/analysis/auto-merge-stranding-forensic.md"
+  expected_output: ">= 3 (the file exists with a verdict block per case; absent until w0 is done, so this fails-closed before then)"
+- description: "w1: a guard/detector plus a test exists for the confirmed mechanism"
+  command: "git grep -lE 'stranded|orphan|merged.*head|head.*merged' -- .github/workflows/ _project/scripts/ tests/ 2>/dev/null"
+  expected_output: "at least one guard/detector implementation + test (once w1 lands)"
+
+scope_limit:
+  only_modify:
+  - ".github/workflows/auto-merge-on-open.yml"
+  - ".github/workflows/develop-post-merge.yml"
+  - "_project/scripts/"
+  - "_project/analysis/"  # w0 forensic summary
+  - "tests/unit/workflows/"
+  do_not_modify:
+  - "benchbox/"
+  - "results-explorer/"
+
+must_preserve:
+- "The one-PR-per-fix squash-auto-merge dev flow (do not disable auto-merge wholesale to fix a detection gap)."
+- "CODEOWNERS review on soundness/self-protection workflow paths."
+
+anti_patterns:
+- "DO NOT disable auto-merge-on-open to 'fix' this — because the flow is high-value; add detection, not a process regression."
+- "DO NOT guess the mechanism and build a guard for it — because 4 distinct causes are plausible; w0's forensic verdict gates w1."
+
+metadata:
+  tags:
+  - ci
+  - dev-experience
+  - remediation-followup
+  estimated_effort: "Small"
+  created_date: "2026-07-06"
+
+success_metrics:
+- "The mechanism that stranded §2.7/§2.16/§2.22 is documented, and a fix landing without its content is detected automatically rather than by a later adversarial re-review."


### PR DESCRIPTION
## Description

Closes the three documentation gaps found when auditing the results-explorer / publication remediation for un-tracked follow-ups (they previously lived only in closed-TODO notes or nowhere). Tracker-only — no code/doc behavior change.

### 1. UPDATE `external-contributor-submission-dry-run` — §2.8 verification
New work unit **w6**: verify the §2.8 fork-PR → validation-comment path against the dry-run's **real external fork PR**. This is the only way to exercise §2.8 — every maintainer/mirror PR is same-repo, the repo has **0 forks**, and §2.8 (PRs #1000/#1001) was implemented but never verified end-to-end. Records the **hard #993 precondition** (a `workflow_run` companion fires only from the default branch, so `validate-submission-comment.yml` is inert until `develop` is the default) and adds an `s28_fork_comment_verified: true | blocked-on-#993` evidence field + a matching verification entry.

### 2. NEW `harden-auto-merge-on-open-stranding` (Low)
Diagnose + guard the stranding that orphaned **three** fixes (§2.7/§2.16/§2.22, re-landed via #986/#996/#997) so their content never reached merged `develop`. Diagnose-first (**w0** writes a committed per-case forensic summary to `_project/analysis/`), guard-second (**w1** adds a detector once the mechanism is known). Notes the CODEOWNERS gate on `auto-merge-on-open.yml`. Risk it addresses: a "merged" fix silently vanishing — the most dangerous drift because nothing flags it.

### 3. NEW `explorer-csp-frame-ancestors-meta-cleanup` (Low)
Remove the inert `frame-ancestors 'none'` from the explorer's `<meta>` CSP (the directive is ignored outside an HTTP response header) and document that framing/clickjacking protection belongs at the host/CDN layer. **Cosmetic** — the load-bearing `connect-src 'self'` (which closes the duckdb-wasm egress channel) is unaffected.

## Type of Change

- [x] Refactor / chore (governance / TODO tracking)

## Testing

- `todo_cli validate` → **1250/1250 valid**; `check-graph` → no cycles/dangling, 100 items.
- **Verification commands exercised** against the current tree: CSP checks return 1/1 today (frame-ancestors present, connect-src present) and will flip to 0/1 after the fix; the stranding w0 check correctly fails-closed (`_project/analysis/auto-merge-stranding-forensic.md` absent until the work is done).
- Applied the todo review rubric (clarity / completeness / actionability / freshness / guardrails / work-breakdown / prior_art) and fixed two findings before submitting: a self-referential w0 verification (now keyed on a committed artifact) and a shaky CSP e2e command (now the real `test:e2e:chromium` gate).

## Notes

`_indexes/` are generated/gitignored — not committed. These three items are the complete set of follow-ups surfaced by the re-review; everything else from that program is merged and closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_