### PR TITLE
chore(todo): log deferred statistics-phase design questions from #980

### DIFF
--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -45,7 +45,11 @@ work:
           hosted derived-data workflow;
         - any required first-class stats/analyze phase TODO is completed or this
           prototype is explicitly narrowed to a measurement smoke that does not
-          claim stats-maintenance conclusions;
+          claim stats-maintenance conclusions; NOTE "completed" for
+          publication-quality stale-stats conclusions means BOTH
+          track2-joinorder-stats-phase (phase mechanics, DONE) AND
+          track2-joinorder-stats-phase-controls (the reset/persist control) --
+          the mechanics seed alone only supports the measurement-smoke path;
         - the scale-stress decision note contains exactly one `Stats phase gate:
           completed`, `Stats phase gate: smoke-only`, or `Stats phase gate:
           dependency:track2-joinorder-stats-phase` line; if the

--- a/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-scaling-strategy.yaml
@@ -33,6 +33,7 @@ description: |
 deps:
   needs:
     - track2-joinorder-stats-phase
+    - track2-joinorder-stats-phase-controls
 
 work:
   - id: w1
@@ -55,8 +56,12 @@ work:
       derived archive. Non-empty checks are insufficient.
 
       This is the scaled prototype starting: per must_preserve, do not begin until
-      track2-joinorder-stats-phase (see deps.needs) is satisfied or explicitly
-      scoped out.
+      the statistics-phase requirement is satisfied or explicitly scoped out.
+      NOTE: track2-joinorder-stats-phase (DONE, PR #980) delivered only the phase
+      mechanics; the stale-stats axis this study needs requires the reset/persist
+      control in track2-joinorder-stats-phase-controls (see deps.needs). Treat the
+      stats requirement as satisfied only when BOTH are done, or explicitly scope
+      the stale-stats axis out.
 
   - id: w3
     summary: "Define derived workload labels and result-bundle metadata"
@@ -70,7 +75,7 @@ work:
 must_preserve:
   - "Canonical joinorder remains fixed to canonical_imdb SF=1 and is never replaced by a derived scale mode."
   - "Any derived workload reports its data-generation strategy, dataset version, generator version, seed, and stats protocol."
-  - "The scaled prototype must not start until the statistics-phase requirement is satisfied or explicitly scoped out (see track2-joinorder-stats-phase)."
+  - "The scaled prototype must not start until the statistics-phase requirement is satisfied or explicitly scoped out. This means BOTH track2-joinorder-stats-phase (phase mechanics, DONE) AND track2-joinorder-stats-phase-controls (the reset/persist control the stale-stats axis depends on) -- not the mechanics seed alone."
 
 approach: |
   Plan-deepening is already done in the groundwork design doc. At kickoff, lock

--- a/_project/TODO/main/planning/track2-joinorder-stats-phase-controls.yaml
+++ b/_project/TODO/main/planning/track2-joinorder-stats-phase-controls.yaml
@@ -1,0 +1,138 @@
+id: track2-joinorder-stats-phase-controls
+title: "Track-2: statistics-phase reset/persist control, per-table breakdown, and idempotence check"
+worktree: main
+priority: Medium
+status: Not Started
+category: Benchmark Development
+
+description: |
+  Follow-up captured from the statistics-as-a-phase work (track2-joinorder-stats-phase,
+  landed via PR #980). That work delivered the first-class statistics phase
+  (load -> statistics -> query): the StatisticsGatheringPhase dataclass
+  (benchbox/core/results/models.py:131), the per-engine ANALYZE knob
+  (benchbox/platforms/base/adapter.py:384 gather_statistics / :405
+  run_statistics_phase, with the Redshift auto-on-load override), phases.statistics
+  serialization, and the per-benchmark supports_statistics_phase opt-in.
+
+  It resolved exactly ONE of the four "Open design questions" in
+  _project/design/track2-joinorder-stats-as-phase.md (detect-and-disable vs
+  document auto-analyze -> "document", via stats_mode: auto-on-load). The
+  other three were NOT implemented and were not recorded as deferred on the
+  now-DONE seed, so this seed logs them:
+
+    1. (REQUIRED for Track 2) Cold-stats vs warm-stats reset/persist control.
+       The design doc states Track 2 needs BOTH fresh-stats and
+       stale-stats-after-additional-load modes to study statistics maintenance,
+       "so the phase must support an explicit reset/persist control". PR #980's
+       phase only runs ANALYZE once after load; there is no way to reset stats,
+       or to load more data and re-measure with deliberately stale stats. Without
+       this, the replicated/sampled scale-stress work cannot exercise the
+       stale-statistics axis at all.
+    2. (OPTIONAL) Per-table stats-build breakdown. PR #980 reports an aggregate
+       phase duration_ms plus a tables_analyzed count; the design doc's lean was
+       "aggregate phase total with optional per-table breakdown in
+       timing_breakdown". The optional per-table breakdown was not added.
+    3. (SANITY CHECK) Idempotence. Re-running ANALYZE on already-analyzed data
+       should produce the same plan -- the check that the phase measures stats
+       build, not incidental cache warmth. No such assertion exists.
+
+  Consequence being corrected here: track2-joinorder-scaling-strategy's
+  deps.needs and must_preserve treat track2-joinorder-stats-phase (now DONE) as
+  "the statistics-phase requirement satisfied". That is only true for the phase
+  mechanics; the reset/persist control the stale-stats study depends on lives in
+  THIS seed. track2-joinorder-scaling-strategy is updated to also depend on this
+  item so the stats-axis-ready signal is honest.
+
+deps:
+  needs:
+    - track2-joinorder-stats-phase
+
+work:
+  - id: w1
+    summary: "Add an explicit reset/persist control to the statistics phase (cold vs warm stats)"
+    status: pending
+    notes: |
+      Give the statistics phase a mode/knob controlling whether optimizer
+      statistics are reset (dropped/recomputed for a cold-stats measurement) or
+      persisted across runs so a subsequent additional load leaves stats stale.
+      Add a per-adapter reset hook (sibling of gather_statistics at
+      benchbox/platforms/base/adapter.py:384) with a safe default for engines
+      that cannot drop stats, surfaced through the same LifecyclePhases/RunConfig
+      path that PR #980 used for gather_statistics, and recorded in the
+      phases.statistics payload (e.g. a stats_lifecycle / reset field) so a bundle
+      says which mode produced it. Do NOT change default behavior: absent the
+      knob, the phase behaves exactly as PR #980 shipped.
+  - id: w2
+    summary: "Optional per-table stats-build breakdown in the statistics phase payload"
+    needs: [w1]
+    status: pending
+    notes: |
+      Extend StatisticsGatheringPhase (benchbox/core/results/models.py:131) and
+      its serializer with an OPTIONAL per-table timing breakdown (the design
+      doc's timing_breakdown lean), omitted when not collected so existing
+      bundles stay byte-identical. Aggregate duration_ms/tables_analyzed remain
+      the primary fields.
+  - id: w3
+    summary: "Idempotence sanity check: re-ANALYZE yields the same plan"
+    needs: [w1]
+    status: pending
+    notes: |
+      Add a test (opt-in / local engine, e.g. DuckDB or PostgreSQL) asserting
+      that running the statistics phase twice on unchanged data produces the same
+      plan shape / cardinality estimates, so the phase is measuring stats build
+      rather than incidental cache warmth. Mirrors the design doc's idempotence
+      sanity check.
+
+must_preserve:
+  - "Default behavior is unchanged from PR #980: without the new reset/persist knob, the statistics phase runs ANALYZE once after load exactly as shipped, and bundles that don't use the control stay byte-identical."
+  - "The per-benchmark supports_statistics_phase opt-in gate still governs whether any statistics phase runs; this seed does not make it run by default."
+  - "Any new phases.statistics field is additive and omitted-when-empty (the schema-v2 omit-empty rule)."
+
+prior_art:
+  - "_project/design/track2-joinorder-stats-as-phase.md 'Open design questions' -- the source list; item 1 (auto-analyze) is done, items 2-4 are this seed's w1-w3."
+  - "benchbox/platforms/base/adapter.py:384 gather_statistics / :405 run_statistics_phase (PR #980) -- extend alongside these; the reset hook is their sibling."
+  - "benchbox/core/results/models.py:131 StatisticsGatheringPhase (PR #980) -- extend additively for the reset-mode marker (w1) and optional per-table breakdown (w2)."
+  - "benchbox/core/runner/runner.py + benchbox/core/schemas.py (PR #980, LifecyclePhases.statistics / RunConfig.gather_statistics) -- the flag-threading precedent for the new reset/persist knob."
+
+anti_patterns:
+  - "DO NOT change the default statistics-phase behavior -- the reset/persist control is opt-in; a bare `--phases ...,statistics` run must stay identical to PR #980."
+  - "DO NOT force-drop statistics on engines that cannot reset them -- provide a safe no-op/documented fallback and record it in stats_mode/payload rather than failing the run."
+  - "DO NOT block on the joinorder data archive -- this is runner/adapter mechanics testable on any opted-in benchmark (tpch/tpcds); it is NOT archive-gated."
+
+verification:
+  - description: "Default statistics run is unchanged when the reset/persist control is not requested"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_base_adapter.py -k statistics -q"
+    expected_output: "existing statistics-phase tests still pass"
+  - description: "Reset/persist control is exercised and recorded in the payload"
+    command: "uv run -- python -m pytest tests/ -k 'statistics and (reset or persist or stale)' -q"
+    expected_output: "new reset/persist tests pass"
+  - description: "This item keeps the TODO graph valid"
+    command: "uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph"
+    expected_output: "Graph validation passed"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/base/"
+    - "benchbox/platforms/"
+    - "benchbox/core/runner/"
+    - "benchbox/core/schemas.py"
+    - "benchbox/core/results/models.py"
+    - "benchbox/core/results/schema.py"
+    - "benchbox/core/results/schema_specs.yaml"
+    - "benchbox/cli/"
+    - "tests/"
+    - "docs/reference/public-contracts.md"
+    - "_project/TODO/main/planning/track2-joinorder-stats-phase-controls.yaml"
+  do_not_modify:
+    - "benchbox/core/joinorder/"
+    - "benchbox/core/benchmark_registry.yaml"
+
+metadata:
+  tags:
+    - joinorder
+    - track-2
+    - statistics-phase
+    - stale-stats
+    - follow-up
+  estimated_effort: "Medium"
+  created_date: "2026-07-06"


### PR DESCRIPTION
# Pull Request

## Description

Follow-up-capture audit after the statistics-as-a-phase work landed. `track2-joinorder-stats-phase` (DONE via #980) resolved only **1 of the 4** "Open design questions" in `_project/design/track2-joinorder-stats-as-phase.md` (document-vs-disable auto-analyze → `stats_mode: auto-on-load`). The other three were implemented as **neither code nor a recorded deferral** on the now-DONE seed, so they had no open home:

1. **(REQUIRED for Track 2)** cold-stats vs warm-stats **reset/persist control** — the design doc states Track 2 needs both fresh-stats and stale-stats-after-additional-load modes, "so the phase must support an explicit reset/persist control." #980's phase only runs ANALYZE once after load; there is no way to reset stats or re-measure with deliberately stale stats. Without it the scale-stress study cannot exercise the stale-statistics axis at all.
2. **(optional)** per-table stats-build breakdown in the phase payload (the doc's `timing_breakdown` lean; #980 reports only the aggregate).
3. **(sanity check)** idempotence — re-ANALYZE on unchanged data should yield the same plan.

New seed **`track2-joinorder-stats-phase-controls`** (Medium) captures these as w1–w3. It is **not** archive-gated (runner/adapter mechanics, testable on tpch/tpcds).

**Corrects a now-false readiness signal:** `track2-joinorder-scaling-strategy`'s `deps.needs` + `must_preserve` treated the DONE mechanics seed as "the statistics-phase requirement satisfied" — but the reset/persist control the stale-stats axis depends on lives in the new seed, so that dependency read as satisfied while the capability didn't exist. Added the new seed to `scaling-strategy`'s `deps.needs` and clarified both that seed's and the (deferred) `replicated-imdb` prototype's gating so "stats phase satisfied" means **both** seeds, not the mechanics alone.

## Type of Change

- [x] Documentation (planning TODO seeds)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore

## Testing

- `validate_todo.py` → ✅ valid on all three touched seeds
- `todo_cli.py check-graph` → passed, 102 items, no cycles/dangling refs (the new `track2-joinorder-stats-phase-controls` dependency resolves)
- New seed's file:line citations verified against develop's post-#980 code (`models.py:131` StatisticsGatheringPhase, `adapter.py:384` gather_statistics, `:405` run_statistics_phase).

## Public Contract Check

- [x] Planning YAML only — no public/beta/deprecated/generated/experimental/repo-only contract surface changed.
- [x] No result-schema / MCP-parameter / platform-support / wrapper / adapter-hook / generated-doc impact.
- [x] No platform/benchmark count claim added to shipped docs.

## Documentation

- [x] No user-facing docs changed (planning artifacts only).
- [x] No behavior change.
- [x] API contract wording unaffected.

## Code Quality

- [x] Seeds validated with `validate_todo.py` + `check-graph`.
- [x] No backwards-compat/migration impact.
- [x] N/A — no behavior change (the new seed schedules its own tests at implementation time).
- [x] Public contracts / release checklists unaffected.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or binaries — one new + two edited text YAML files.

## Notes

- Deliberately **not** turned into a TODO: the `benchmark_name` coupling flagged in #999's review is conditional and inert (it only bites if a family-aware base dialect or MCP-side validation ever lands), and is already captured in-code at the exact site that would change, with a "revisit if either consumer becomes active" note. That is the right home for a latent conditional concern — a standalone TODO would be an untriggerable backlog item. Called out here for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1fC6krx3GUzuEb6DxFfhh)_