### PR TITLE
plan: results provenance labels + funding disclosure work items

### DIFF
--- a/_project/TODO/results-labels-funding/README.md
+++ b/_project/TODO/results-labels-funding/README.md
@@ -1,0 +1,81 @@
+# Results provenance labels + funding disclosure
+
+**Worktree:** `results-labels-funding`
+**Branch:** `claude/results-labels-funding-r030xb`
+**Created:** 2026-07-06
+**Status:** Planning
+
+## Goal
+
+Give every result in the results explorer two provenance signals it lacks today:
+
+1. **A source/provenance label** that distinguishes **vendor-supplied** results
+   from **internal (maintainer)** and **community-submitted** results. Today the
+   explorer only derives two trust labels (`maintainer-run` vs
+   `community-submission`) from the *presence of a submission-manifest sidecar*
+   (`scripts/generate_corpus_inventory.py:41`, explorer pipeline). A vendor
+   running its own product has a conflict of interest and is neither category.
+2. **A funding disclosure** — who/how the run was paid for (employer, personal,
+   free trial, vendor-sponsored, grant, unspecified). Nothing records this today.
+
+## Resolved decisions (locked with the requester, 2026-07-06)
+
+| # | Decision | Outcome |
+|---|---|---|
+| D1 | How `vendor-supplied` relates to trust labels | **New trust-label value** `vendor-supplied` (visibility state `public-vendor-reported`), not a separate orthogonal flag. |
+| D2 | Ranking eligibility of vendor-supplied results | **Ranked, clearly badged** — `is_ranking_eligible = true`, with a distinct badge + legend note (disclose the conflict of interest without demoting to browse-only). |
+| D3 | Funding vocabulary | `employer` · `personal` · `free-trial` · `vendor-sponsored` · `grant` · `unspecified`. |
+
+## Open decision gates (resolved inside the owning work item)
+
+| Gate | Work item | Question |
+|---|---|---|
+| G-VENDOR-SIGNAL | `submit-manifest-and-validator` | Exact maintainer-controlled mechanism that applies `vendor-supplied` at merge so it cannot be self-asserted in a community PR. |
+| G-FUNDING-PRIVACY | `corpus-inventory-and-read-model` | Whether `funding` is a public, non-redactable field (proposed: yes — it is a disclosure) and whether `unspecified` is allowed on curated results. |
+| G-READMODEL-COORD | `explorer-pipeline-frontend-handoff` | How the `read_model_version` bump + private `explorer_pipeline`/`results-explorer` edits are coordinated, since that source is not in this checkout. |
+
+## Design in one paragraph
+
+Two **orthogonal** fields. `result_source` extends the existing trust-label
+spectrum: `internal → maintainer-run`, `community → community-submission`,
+`vendor → vendor-supplied` (new). `funding` is a new independent axis (a vendor
+result may be employer-funded; a community result may be free-trial-funded). Both
+are **declared, not inferred**: `funding` is captured at run time (`--funding`)
+and carried in an optional `provenance` block in the schema-v2 bundle; the vendor
+label is applied by maintainers at merge (never self-asserted). Canonical
+vocabulary lives in one module so the CLI, submit path, corpus inventory,
+validator, and read model agree.
+
+## Sequenced work items (each shipped via the delivery loop below)
+
+| Order | Item | Depends on | In-repo? |
+|---|---|---|---|
+| 1 | `provenance-vocabulary-and-labels` | — | Yes |
+| 2 | `bundle-schema-and-run-cli` | 1 | Yes |
+| 3 | `submit-manifest-and-validator` | 1 | Yes |
+| 4 | `corpus-inventory-and-read-model` | 1, 2, 3 | Yes (DDL + inventory) |
+| 5 | `explorer-pipeline-frontend-handoff` | 4 | **No** — spec only; `_project/scripts/explorer_pipeline/` and `results-explorer/` are gitignored and absent from this checkout. |
+
+Items 1–3 are independent of each other after item 1 lands and can proceed in
+parallel. Item 4 integrates them into the explorer ingest. Item 5 is a
+hand-off spec because the code it changes lives in maintainer-private trees.
+
+## Standard delivery loop (per work item)
+
+Every work item is delivered with the same **create → review → fix → submit-pr**
+loop:
+
+1. **create** — implement the item strictly within its `scope_limit`; keep the
+   change back-compatible (absent fields ⇒ today's behavior).
+2. **review** — run `/code-review` (and `/security-review` for the validator
+   item, which parses attacker-controlled PR JSON); run the item's
+   `verification` commands and `make pr-preflight`.
+3. **fix** — address review findings and any failing gate; re-run verification.
+4. **submit-pr** — open a PR against `main` using
+   `.github/PULL_REQUEST_TEMPLATE.md`, linking this work item; on merge move the
+   item's YAML from `_project/TODO/results-labels-funding/planning/` to
+   `_project/DONE/results-labels-funding/planning/` and set
+   `status: Completed` + `completed_date`.
+
+A work item does not start until its `deps.needs` are merged and any blocking
+decision gate is resolved.

--- a/_project/TODO/results-labels-funding/README.md
+++ b/_project/TODO/results-labels-funding/README.md
@@ -71,7 +71,7 @@ loop:
    item, which parses attacker-controlled PR JSON); run the item's
    `verification` commands and `make pr-preflight`.
 3. **fix** — address review findings and any failing gate; re-run verification.
-4. **submit-pr** — open a PR against `main` using
+4. **submit-pr** — open a PR against `develop` using
    `.github/PULL_REQUEST_TEMPLATE.md`, linking this work item; on merge move the
    item's YAML from `_project/TODO/results-labels-funding/planning/` to
    `_project/DONE/results-labels-funding/planning/` and set

--- a/_project/TODO/results-labels-funding/planning/bundle-schema-and-run-cli.yaml
+++ b/_project/TODO/results-labels-funding/planning/bundle-schema-and-run-cli.yaml
@@ -1,0 +1,137 @@
+id: "bundle-schema-and-run-cli"
+title: "Emit a provenance block (funding) in schema-v2 bundles and add run --funding"
+worktree: "results-labels-funding"
+priority: "High"
+status: "Blocked"
+description: |
+  Make funding a declared property of a run, captured where the run happens.
+  Today the schema-v2 bundle (benchbox/core/results/schema.py, CANONICAL_KEY_ORDER
+  ~lines 40-58, payload build ~lines 311-353) has no provenance/funding/source
+  fields, and BenchmarkResults (benchbox/core/results/models.py:268-383) carries
+  no funding attribute. The run command (benchbox/cli/commands/run.py) has no way
+  to declare who paid for the run.
+
+  This item adds an OPTIONAL top-level "provenance" block to the bundle
+  ({ "funding": <enum>, "source": <declared source or omitted> }), threads a
+  funding field through BenchmarkResults, and adds `benchbox run --funding
+  <value>` (plus a maintainer-only `--result-source` that only annotates intent;
+  the authoritative vendor label is still applied at merge in item 3). Absent
+  provenance block == today's behavior, so every existing bundle and test stays
+  valid.
+
+category: "Feature"
+
+decision_gates:
+  - id: G-source-on-producer
+    gate: >-
+      Should `benchbox run --result-source vendor` be able to *set* the vendor
+      label directly in the bundle? Risk: a producer-set source would let a
+      vendor self-assert the vendor-supplied (ranking-eligible) label, which
+      G-VENDOR-SIGNAL (item 3) exists to prevent.
+    blocks: [w3]
+    outcome: >-
+      PROPOSED: --result-source writes only an ADVISORY producer hint into
+      provenance.source; it is NOT trusted as the trust label. The trust label is
+      resolved downstream (item 4) from the maintainer-controlled signal, and the
+      validator (item 3) rejects a self-asserted 'vendor' hint on a community PR.
+      Confirm during item-3 gate resolution before trusting provenance.source
+      anywhere.
+
+prior_art:
+  - "benchbox/core/results/schema.py:40-58 CANONICAL_KEY_ORDER + :311-353 payload build — extend (add 'provenance' as an optional, canonically-ordered section like 'environment')"
+  - "benchbox/core/results/models.py:268-383 BenchmarkResults — extend (add funding + optional result_source fields, defaulted so no call site breaks)"
+  - "benchbox/cli/commands/run.py:2655-2666 --publish-target/--publish-label options — reference (mirror option style; --funding lives next to these run-scoped options)"
+  - "benchbox/core/results/provenance.py (item 1) — reference (funding enum + normalize; the ONLY source of valid values)"
+  - "tests/unit/core/explorer_pipeline/conftest.py:15-84 MINIMAL_BUNDLE — reference (must still validate with no provenance block)"
+
+work:
+  - id: w1
+    summary: >-
+      Add funding: str | None (default None) and result_source: str | None to
+      BenchmarkResults; ensure result_factory/aggregation paths pass them through
+      without requiring them.
+    status: todo
+  - id: w2
+    summary: >-
+      In schema.py, emit an optional 'provenance' section only when funding or
+      source is present; normalize funding via provenance.normalize_funding();
+      add 'provenance' to CANONICAL_KEY_ORDER; keep bundle byte-identical when
+      absent.
+    needs: [w1]
+    status: todo
+  - id: w3
+    summary: >-
+      Add `benchbox run --funding` (Choice from FUNDING_SOURCES, default
+      'unspecified' -> emitted only if explicitly set) and maintainer-only
+      `--result-source` advisory hint; plumb into the result. Update run --help.
+    needs: [w1, w2]
+    status: todo
+
+must_preserve:
+  - "MINIMAL_BUNDLE and all existing schema-v2 fixtures validate unchanged (no provenance block required)."
+  - "Canonical JSON bytes for a run without --funding are identical to pre-change output (no empty provenance block emitted)."
+  - "SchemaV2Validator required-key set is unchanged; provenance is optional."
+
+approach: |
+  Follow the exact pattern schema.py already uses for optional sections
+  ('environment', 'tables', 'errors' are only added when non-empty). Gate the
+  provenance block on `if funding or source:`. Normalize funding through the
+  item-1 helper so an unknown CLI value can never reach the bundle (Click Choice
+  already constrains it, but normalize defends the python-API path). Keep
+  result_source purely advisory in the bundle; label resolution is item 4's job.
+
+anti_patterns:
+  - "DO NOT add provenance to REQUIRED keys or emit an empty provenance:{} block — that would change canonical bytes for every existing run."
+  - "DO NOT trust provenance.source as the trust label anywhere in this item (see G-source-on-producer)."
+  - "DO NOT hardcode funding strings in run.py — use FUNDING_SOURCES from item 1."
+  - "DO NOT bump SCHEMA_VERSION for a purely additive optional block unless the schema policy requires it; if it does, update the accepted-prefix set and note it."
+
+verification:
+  - description: "Run without --funding produces a bundle with no provenance block"
+    command: "uv run -- benchbox run --platform duckdb --benchmark tpch --scale 0.01 --phases power && uv run -- python -c \"import json,glob; b=json.load(open(sorted(glob.glob('benchmark_runs/results/*duckdb*.json'))[-1])); assert 'provenance' not in b, b.get('provenance')\""
+    expected_output: "no assertion error"
+  - description: "Run WITH --funding personal emits a valid provenance block"
+    command: "uv run -- benchbox run --platform duckdb --benchmark tpch --scale 0.01 --phases power --funding personal && uv run -- python -c \"import json,glob; b=json.load(open(sorted(glob.glob('benchmark_runs/results/*duckdb*.json'))[-1])); assert b['provenance']['funding']=='personal'\""
+    expected_output: "no assertion error"
+  - description: "Existing schema + explorer fixtures still validate"
+    command: "uv run -- python -m pytest tests/unit/core/results/ tests/unit/core/explorer_pipeline/test_transformer.py -q"
+    expected_output: "all pass"
+  - description: "run --help lists --funding"
+    command: "uv run -- benchbox run --help | grep -- --funding"
+    expected_output: "--funding option shown with the enum values"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/models.py"
+    - "benchbox/core/results/schema.py"
+    - "benchbox/core/results/result_factory.py"
+    - "benchbox/cli/commands/run.py"
+    - "tests/unit/core/results/"
+  do_not_modify:
+    - "scripts/generate_corpus_inventory.py"
+    - "scripts/validate_submission.py"
+    - "docs/development/browser-duckdb-schema.sql"
+    - "benchbox/cli/commands/submit.py"
+
+impact:
+  technical_debt: |
+    Introduces the first real provenance surface on the producer side; keeps it
+    additive/optional so it carries zero migration cost for existing corpora.
+
+success_metrics:
+  - "A run with --funding round-trips funding into the bundle; a run without it is byte-identical to before."
+  - "No existing result fixture required editing to accommodate the new optional block."
+
+deps:
+  needs: ["provenance-vocabulary-and-labels"]
+
+delivery_loop:
+  create: "Implement w1-w3 within scope_limit; additive optional block only."
+  review: "/code-review; run verification + make pr-preflight; confirm canonical-byte stability."
+  fix: "Resolve findings; re-run verification."
+  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature)."
+
+metadata:
+  tags: ["explorer", "provenance", "funding", "schema-v2", "cli"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-06"

--- a/_project/TODO/results-labels-funding/planning/bundle-schema-and-run-cli.yaml
+++ b/_project/TODO/results-labels-funding/planning/bundle-schema-and-run-cli.yaml
@@ -50,22 +50,25 @@ work:
       Add funding: str | None (default None) and result_source: str | None to
       BenchmarkResults; ensure result_factory/aggregation paths pass them through
       without requiring them.
-    status: todo
+    status: pending
   - id: w2
     summary: >-
-      In schema.py, emit an optional 'provenance' section only when funding or
-      source is present; normalize funding via provenance.normalize_funding();
-      add 'provenance' to CANONICAL_KEY_ORDER; keep bundle byte-identical when
-      absent.
+      In schema.py, emit an optional 'provenance' section only when funding
+      or source is present; keep the bundle byte-identical when absent.
+    notes: >-
+      Normalize funding via provenance.normalize_funding(); add 'provenance'
+      to CANONICAL_KEY_ORDER.
     needs: [w1]
-    status: todo
+    status: pending
   - id: w3
     summary: >-
-      Add `benchbox run --funding` (Choice from FUNDING_SOURCES, default
-      'unspecified' -> emitted only if explicitly set) and maintainer-only
-      `--result-source` advisory hint; plumb into the result. Update run --help.
+      Add `benchbox run --funding` (Choice from FUNDING_SOURCES) and a
+      maintainer-only `--result-source` advisory hint; update run --help.
+    notes: >-
+      Default 'unspecified' -> emitted only if explicitly set; plumb into
+      the result.
     needs: [w1, w2]
-    status: todo
+    status: pending
 
 must_preserve:
   - "MINIMAL_BUNDLE and all existing schema-v2 fixtures validate unchanged (no provenance block required)."
@@ -129,7 +132,7 @@ delivery_loop:
   create: "Implement w1-w3 within scope_limit; additive optional block only."
   review: "/code-review; run verification + make pr-preflight; confirm canonical-byte stability."
   fix: "Resolve findings; re-run verification."
-  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature)."
+  submit_pr: "PR vs develop using PULL_REQUEST_TEMPLATE.md (Type: New feature)."
 
 metadata:
   tags: ["explorer", "provenance", "funding", "schema-v2", "cli"]

--- a/_project/TODO/results-labels-funding/planning/corpus-inventory-and-read-model.yaml
+++ b/_project/TODO/results-labels-funding/planning/corpus-inventory-and-read-model.yaml
@@ -1,0 +1,157 @@
+id: "corpus-inventory-and-read-model"
+title: "Surface vendor-supplied label + funding in the corpus inventory and DuckDB read model"
+worktree: "results-labels-funding"
+priority: "High"
+status: "Blocked"
+description: |
+  Integrate the two new signals into the explorer's ingest layer so they reach
+  the browser. Two in-repo surfaces change: (1) scripts/generate_corpus_inventory.py,
+  which today derives trust_label from submission-manifest-sidecar presence
+  (_bundle_trust_label, :41-52) and emits per-bundle metadata + a
+  by_trust_label summary; (2) docs/development/browser-duckdb-schema.sql, the
+  frozen read-model DDL that already defines trust_label, visibility, and
+  is_ranking_eligible on the `results` table and carries trust_label into
+  benchmark_rankings and cohort_metadata.
+
+  This item teaches the inventory to recognize the maintainer-controlled vendor
+  signal (from item 3) and the funding value (from item 2's provenance block /
+  item 3's manifest), adds a `funding` column to the read-model DDL and the
+  ranking/cohort projections, and sets is_ranking_eligible = true for
+  vendor-supplied per decision D2. It records the required read_model_version
+  bump as a hand-off obligation for item 5 (the pipeline that writes the DB is
+  not in this checkout).
+
+category: "Feature"
+
+decision_gates:
+  - id: G-FUNDING-PRIVACY
+    gate: >-
+      Is funding a public, non-redactable field, and is 'unspecified' acceptable
+      on public-curated (maintainer) results?
+    blocks: [w2]
+    outcome: >-
+      PROPOSED: funding is PUBLIC and non-redactable (it is a disclosure, and the
+      contract's redactable set is about PII/host details, not provenance);
+      'unspecified' is allowed on any result. Add funding to the §4.1 public-field
+      list in item 1's contract edit if not already. CONFIRM before adding the
+      column to public read model.
+  - id: G-vendor-ranking
+    gate: >-
+      Confirm vendor-supplied rows are is_ranking_eligible = true (D2) rather than
+      browse-only.
+    blocks: [w2]
+    outcome: >-
+      RESOLVED (D2): true — vendor-supplied is ranking-eligible with a distinct
+      badge. visibility 'public-vendor-reported' joins curated/verified as
+      ranking-eligible; 'public-self-reported' remains ineligible.
+
+prior_art:
+  - "scripts/generate_corpus_inventory.py:41-52 _bundle_trust_label + :63-140 extract_metadata/generate_inventory — extend (add vendor detection, funding extraction, by_funding summary)"
+  - "docs/development/browser-duckdb-schema.sql results table (trust_label/visibility/is_ranking_eligible) + benchmark_rankings + cohort_metadata — extend (add funding column; wire vendor visibility into ranking eligibility)"
+  - "tests/unit/core/explorer_pipeline/test_pipeline.py:279-465 trust-label sidecar override tests — extend (add vendor + funding cases)"
+  - "tests/unit/core/explorer_pipeline/test_read_model_contract.py + tests/unit/cli/test_explorer_build_contract.py — extend (read_model_version + column set)"
+  - "benchbox/core/results/provenance.py (item 1) — reference (mapping + funding enum, imported not duplicated)"
+
+work:
+  - id: w1
+    summary: >-
+      In generate_corpus_inventory.py, resolve trust_label via the item-1 mapping
+      and the item-3 vendor signal (not just community-vs-default); extract
+      funding from the bundle provenance block / manifest; add funding to each
+      entry and a by_funding counter to the summary. Import constants from
+      provenance.py (retire the local COMMUNITY/DEFAULT literals).
+    status: todo
+  - id: w2
+    summary: >-
+      Add `funding VARCHAR NOT NULL` to the `results` table in
+      browser-duckdb-schema.sql and propagate it into benchmark_rankings and
+      cohort_metadata where trust_label already travels; ensure the vendor
+      visibility state is treated as ranking-eligible in the is_ranking_eligible
+      derivation (computed in Python per the G-11 views-are-bare-columns rule).
+    needs: [w1]
+    status: todo
+  - id: w3
+    summary: >-
+      Update the read-model contract tests + corpus-inventory tests for the new
+      column/summary and the vendor/funding cases; record the required
+      read_model_version bump as an explicit obligation passed to item 5.
+    needs: [w2]
+    status: todo
+
+must_preserve:
+  - "corpus-inventory.json remains deterministic (sorted, timestamp-normalized in --check)."
+  - "Bundles with no provenance/funding default to funding='unspecified' and today's trust_label derivation is unchanged for internal/community."
+  - "DuckDB views keep projecting only bare columns (no arithmetic/CASE/window in views); all derivation stays in the pipeline (Python)."
+  - "corpus-inventory schema_version is bumped if the entry shape changes (currently '2.2')."
+
+approach: |
+  Keep the inventory's sidecar-presence inference for internal vs community, and
+  layer the vendor signal on top exactly as the item-3 gate resolves it (e.g.
+  bundle under results-data/bundles/vendor/ -> vendor-supplied). Read funding
+  from the bundle's provenance.funding first, then the manifest, defaulting to
+  'unspecified'. For the DDL, funding is a plain column; is_ranking_eligible is
+  already a precomputed boolean, so the only change is which visibility states
+  map to true — encode that from provenance.py's mapping so the DDL, inventory,
+  and pipeline agree. Because the pipeline that POPULATES the DB is gitignored,
+  this item changes the SCHEMA + tests + inventory only and hands the populate
+  logic + read_model_version bump to item 5.
+
+anti_patterns:
+  - "DO NOT put the vendor/funding derivation logic in a DuckDB view (violates the bare-column G-11 rule) — it belongs in the pipeline/Python."
+  - "DO NOT bump read_model_version in the DDL comment without the matching pipeline change — record it as an item-5 obligation to avoid a half-applied version."
+  - "DO NOT re-derive label->visibility here; import the mapping from provenance.py."
+  - "DO NOT make funding NULLable in the read model — default 'unspecified' keeps the badge/chip logic total."
+
+verification:
+  - description: "Inventory includes funding + by_funding and vendor labels"
+    command: "uv run -- python scripts/generate_corpus_inventory.py --write && uv run -- python -c \"import json; inv=json.load(open('results-data/corpus-inventory.json')); assert 'by_funding' in inv['summary']; assert all('funding' in b for b in inv['bundles'])\""
+    expected_output: "no assertion error"
+  - description: "Inventory --check is stable after --write"
+    command: "uv run -- python scripts/generate_corpus_inventory.py --check"
+    expected_output: "OK: corpus-inventory.json is up-to-date"
+  - description: "Read-model + explorer pipeline contract tests pass with the new column"
+    command: "uv run -- python -m pytest tests/unit/core/explorer_pipeline/ tests/unit/explorer/ -q"
+    expected_output: "all pass (or documented xfails pending item 5 pipeline change)"
+  - description: "DDL parses"
+    command: "uv run -- python -c \"import duckdb; con=duckdb.connect(); con.execute(open('docs/development/browser-duckdb-schema.sql').read())\""
+    expected_output: "no error"
+
+scope_limit:
+  only_modify:
+    - "scripts/generate_corpus_inventory.py"
+    - "docs/development/browser-duckdb-schema.sql"
+    - "results-data/corpus-inventory.json (regenerated)"
+    - "tests/unit/core/explorer_pipeline/"
+    - "tests/unit/explorer/"
+    - "tests/unit/scripts/ (corpus inventory tests)"
+  do_not_modify:
+    - "_project/scripts/explorer_pipeline/ (not in checkout; item 5)"
+    - "results-explorer/ (not in checkout; item 5)"
+    - "benchbox/cli/commands/submit.py"
+
+impact:
+  technical_debt: |
+    Brings the read-model schema and the public inventory in line with the new
+    provenance model, and makes explicit the one cross-tree coupling
+    (read_model_version) so it cannot be silently half-applied.
+
+success_metrics:
+  - "corpus-inventory.json shows vendor-supplied bundles and a funding breakdown."
+  - "The read-model DDL carries funding and marks vendor rows ranking-eligible; contract tests pin it."
+
+deps:
+  needs:
+    - "provenance-vocabulary-and-labels"
+    - "bundle-schema-and-run-cli"
+    - "submit-manifest-and-validator"
+
+delivery_loop:
+  create: "Resolve G-FUNDING-PRIVACY; implement w1-w3 within scope_limit."
+  review: "/code-review; run verification + make pr-preflight; verify inventory determinism."
+  fix: "Resolve findings; re-run verification and --check."
+  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature); flag the read_model_version obligation for item 5 in Notes."
+
+metadata:
+  tags: ["explorer", "read-model", "duckdb", "corpus-inventory", "provenance", "funding", "ranking"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-06"

--- a/_project/TODO/results-labels-funding/planning/corpus-inventory-and-read-model.yaml
+++ b/_project/TODO/results-labels-funding/planning/corpus-inventory-and-read-model.yaml
@@ -55,28 +55,35 @@ prior_art:
 work:
   - id: w1
     summary: >-
-      In generate_corpus_inventory.py, resolve trust_label via the item-1 mapping
-      and the item-3 vendor signal (not just community-vs-default); extract
-      funding from the bundle provenance block / manifest; add funding to each
-      entry and a by_funding counter to the summary. Import constants from
-      provenance.py (retire the local COMMUNITY/DEFAULT literals).
-    status: todo
+      In generate_corpus_inventory.py, resolve trust_label via the item-1
+      mapping and the item-3 vendor signal, and extract funding from the
+      bundle. Import constants from provenance.py.
+    notes: >-
+      Resolve via item-1 mapping + item-3 vendor signal (not just
+      community-vs-default); extract funding from the bundle provenance
+      block/manifest; add funding to each entry and a by_funding counter to
+      the summary; retire the local COMMUNITY/DEFAULT literals.
+    status: pending
   - id: w2
     summary: >-
       Add `funding VARCHAR NOT NULL` to the `results` table in
-      browser-duckdb-schema.sql and propagate it into benchmark_rankings and
-      cohort_metadata where trust_label already travels; ensure the vendor
-      visibility state is treated as ranking-eligible in the is_ranking_eligible
-      derivation (computed in Python per the G-11 views-are-bare-columns rule).
+      browser-duckdb-schema.sql and propagate it where trust_label travels.
+    notes: >-
+      Propagate into benchmark_rankings and cohort_metadata; ensure the
+      vendor visibility state is treated as ranking-eligible in the
+      is_ranking_eligible derivation (computed in Python per the G-11
+      views-are-bare-columns rule).
     needs: [w1]
-    status: todo
+    status: pending
   - id: w3
     summary: >-
-      Update the read-model contract tests + corpus-inventory tests for the new
-      column/summary and the vendor/funding cases; record the required
-      read_model_version bump as an explicit obligation passed to item 5.
+      Update the read-model contract tests + corpus-inventory tests for the
+      new column/summary and the vendor/funding cases.
+    notes: >-
+      Record the required read_model_version bump as an explicit obligation
+      passed to item 5.
     needs: [w2]
-    status: todo
+    status: pending
 
 must_preserve:
   - "corpus-inventory.json remains deterministic (sorted, timestamp-normalized in --check)."
@@ -149,7 +156,7 @@ delivery_loop:
   create: "Resolve G-FUNDING-PRIVACY; implement w1-w3 within scope_limit."
   review: "/code-review; run verification + make pr-preflight; verify inventory determinism."
   fix: "Resolve findings; re-run verification and --check."
-  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature); flag the read_model_version obligation for item 5 in Notes."
+  submit_pr: "PR vs develop using PULL_REQUEST_TEMPLATE.md (Type: New feature); flag the read_model_version obligation for item 5 in Notes."
 
 metadata:
   tags: ["explorer", "read-model", "duckdb", "corpus-inventory", "provenance", "funding", "ranking"]

--- a/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
+++ b/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
@@ -42,27 +42,32 @@ prior_art:
 work:
   - id: w1
     summary: >-
-      PIPELINE (private): BundleTransformer/ExplorerPipeline read provenance.funding
-      + the maintainer vendor signal, write funding + vendor-supplied trust_label +
-      public-vendor-reported visibility + is_ranking_eligible=true into the
-      results/benchmark_rankings/cohort_metadata tables. Bump
-      EXPLORER_READ_MODEL_VERSION in contract.py.
-    status: todo
+      PIPELINE (private): BundleTransformer/ExplorerPipeline write funding +
+      vendor-supplied trust_label + visibility + ranking-eligibility into
+      the read-model tables; bump EXPLORER_READ_MODEL_VERSION.
+    notes: >-
+      Read provenance.funding + the maintainer vendor signal; write funding +
+      vendor-supplied trust_label + public-vendor-reported visibility +
+      is_ranking_eligible=true into the results/benchmark_rankings/
+      cohort_metadata tables. Bump EXPLORER_READ_MODEL_VERSION in contract.py.
+    status: pending
   - id: w2
     summary: >-
-      FRONTEND (private): render the vendor badge in a distinct approved accent
-      token (separate from curated primary + self-reported muted), a funding chip
-      on result cards/detail, a legend row for both, and keep per-row badges in
-      mixed compare views. Vendor rows appear in ranked tables with the badge.
+      FRONTEND (private): render the vendor badge in a distinct accent token,
+      a funding chip on result cards/detail, and a legend row for both.
+    notes: >-
+      Separate from curated primary + self-reported muted; keep per-row
+      badges in mixed compare views. Vendor rows appear in ranked tables
+      with the badge.
     needs: [w1]
-    status: todo
+    status: pending
   - id: w3
     summary: >-
       Add/adjust e2e coverage (results-explorer/e2e/) for the vendor badge +
       funding chip + legend; update any Playwright smoke that asserts the legend
       set.
     needs: [w2]
-    status: todo
+    status: pending
 
 must_preserve:
   - "test_explorer_build_contract.py stays green: version bump + declared outputs move together."

--- a/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
+++ b/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
@@ -1,0 +1,132 @@
+id: "explorer-pipeline-frontend-handoff"
+title: "Hand-off spec: populate funding + vendor label in the pipeline and render them in the frontend"
+worktree: "results-labels-funding"
+priority: "High"
+status: "Blocked"
+description: |
+  The remaining changes live in two trees that are gitignored and NOT present in
+  this checkout: the build pipeline `_project/scripts/explorer_pipeline/`
+  (BundleTransformer, ExplorerPipeline, contract.py with EXPLORER_READ_MODEL_VERSION)
+  and the Vite/TypeScript frontend `results-explorer/`. This item is a precise
+  hand-off spec + patch checklist to be executed wherever that source is
+  maintained (e.g. a separate branch such as published-results, or maintainer-
+  local tooling), plus the read_model_version coordination. It is intentionally a
+  spec, not code, in this repo.
+
+  Its own tests, however, ARE in this repo (tests/unit/core/explorer_pipeline/,
+  tests/unit/cli/test_explorer_build_contract.py) and pin the contract, so the
+  spec is exact and the change is verifiable once applied.
+
+category: "Documentation"
+
+decision_gates:
+  - id: G-READMODEL-COORD
+    gate: >-
+      How is the read_model_version bump + private-tree edit coordinated so the
+      DDL (item 4), the pipeline contract.py, and the deployed DB never disagree?
+    blocks: [w1, w2, w3]
+    outcome: >-
+      PROPOSED: bump EXPLORER_READ_MODEL_VERSION and the DDL comment in the SAME
+      change that adds the pipeline populate logic; the build-contract test
+      (test_explorer_build_contract.py) is the tripwire that fails if version and
+      outputs drift. Land pipeline+frontend together behind that version bump.
+      CONFIRM the location/branch of the private trees before starting.
+
+prior_art:
+  - "tests/unit/core/explorer_pipeline/test_pipeline.py + test_transformer.py — reference (define the exact ExplorerPipeline.run/BundleTransformer.to_manifest_entry surface the populate change must satisfy)"
+  - "tests/unit/cli/test_explorer_build_contract.py:EXPLORER_BUILD_CONTRACT / read_model_version — reference (version + outputs tripwire)"
+  - "docs/reference/hosted-results-contract.md:601-616 trust-label rendering rules — extend (add vendor badge color + funding chip + legend row)"
+  - "docs/development/browser-duckdb-schema.sql (item 4) — reference (the funding column + vendor ranking eligibility the pipeline must populate)"
+  - "docs/development/results-explorer-brand-ownership.md + results-explorer-token-scan.md — reference (badge color must use an approved design token; token scan gate)"
+
+work:
+  - id: w1
+    summary: >-
+      PIPELINE (private): BundleTransformer/ExplorerPipeline read provenance.funding
+      + the maintainer vendor signal, write funding + vendor-supplied trust_label +
+      public-vendor-reported visibility + is_ranking_eligible=true into the
+      results/benchmark_rankings/cohort_metadata tables. Bump
+      EXPLORER_READ_MODEL_VERSION in contract.py.
+    status: todo
+  - id: w2
+    summary: >-
+      FRONTEND (private): render the vendor badge in a distinct approved accent
+      token (separate from curated primary + self-reported muted), a funding chip
+      on result cards/detail, a legend row for both, and keep per-row badges in
+      mixed compare views. Vendor rows appear in ranked tables with the badge.
+    needs: [w1]
+    status: todo
+  - id: w3
+    summary: >-
+      Add/adjust e2e coverage (results-explorer/e2e/) for the vendor badge +
+      funding chip + legend; update any Playwright smoke that asserts the legend
+      set.
+    needs: [w2]
+    status: todo
+
+must_preserve:
+  - "test_explorer_build_contract.py stays green: version bump + declared outputs move together."
+  - "Existing trust-badge rendering (curated primary, self-reported muted) is unchanged."
+  - "The DuckDB-in-browser read-only attach + bare-column view rule is unchanged."
+  - "Design-token / stale-theme scans (results-explorer-token-scan.md) pass — no ad-hoc badge colors."
+
+approach: |
+  Treat this repo's explorer_pipeline + explorer build-contract tests as the
+  executable specification. Apply w1 in the private pipeline tree so those tests
+  (which are runnable here) pass, then w2/w3 in results-explorer/. Because the
+  DDL and contract tests live in-repo, the private change is fully verifiable
+  from this repo's test suite even though the source edited is elsewhere.
+
+anti_patterns:
+  - "DO NOT bump read_model_version without the populate logic (or vice versa) — the tripwire test exists to stop exactly that."
+  - "DO NOT introduce a new badge color outside the approved design tokens (token scan will fail)."
+  - "DO NOT collapse vendor into the self-reported muted badge — D1/D2 require a distinct, ranking-eligible treatment."
+  - "DO NOT re-implement label->visibility mapping in TS — mirror provenance.py's table (kept in sync via the contract doc)."
+
+verification:
+  - description: "Explorer build-contract + pipeline tests pass with the version bump"
+    command: "uv run -- python -m pytest tests/unit/cli/test_explorer_build_contract.py tests/unit/core/explorer_pipeline/ -q"
+    expected_output: "all pass; read_model_version matches contract"
+  - description: "Built DB exposes funding + vendor rows"
+    command: "<in private tree> run ExplorerPipeline build on a corpus containing a vendor bundle; query results.funding + trust_label"
+    expected_output: "vendor-supplied rows present with funding populated and is_ranking_eligible=true"
+  - description: "Frontend e2e shows vendor badge + funding chip + legend"
+    command: "<in results-explorer/> npm run test:e2e -- --grep 'vendor|funding'"
+    expected_output: "badge, chip, and legend entries render; vendor row shown in ranked table"
+  - description: "Design-token scan passes"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_scan_explorer_tokens.py -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "_project/scripts/explorer_pipeline/ (private, not in this checkout)"
+    - "results-explorer/ (private, not in this checkout)"
+    - "docs/reference/hosted-results-contract.md (rendering-rules subsection only, if not already covered by item 1)"
+  do_not_modify:
+    - "benchbox/ (producer + CLI are items 1-3)"
+    - "scripts/generate_corpus_inventory.py (item 4)"
+    - "docs/development/browser-duckdb-schema.sql (item 4)"
+
+impact:
+  technical_debt: |
+    Completes the feature end-to-end and makes the one unavoidable cross-repo
+    coupling (read_model_version) explicit and test-guarded, instead of an
+    undocumented tribal step.
+
+success_metrics:
+  - "A vendor-supplied result renders with its distinct badge in a ranked table and shows its funding chip."
+  - "read_model_version, the DDL, and the deployed DB agree; the contract test proves it."
+
+deps:
+  needs: ["corpus-inventory-and-read-model"]
+
+delivery_loop:
+  create: "Confirm G-READMODEL-COORD + private-tree location; apply w1-w3 there behind the version bump."
+  review: "/code-review on the pipeline diff; visual/e2e review of badge + chip; token scan."
+  fix: "Resolve findings; re-run explorer contract + e2e."
+  submit_pr: "PR(s) in the tree(s) that host the private source; cross-link this work item and item 4's PR."
+
+metadata:
+  tags: ["explorer", "pipeline", "frontend", "read-model-version", "handoff", "vendor", "funding"]
+  estimated_effort: "Medium-High"
+  created_date: "2026-07-06"

--- a/_project/TODO/results-labels-funding/planning/provenance-vocabulary-and-labels.yaml
+++ b/_project/TODO/results-labels-funding/planning/provenance-vocabulary-and-labels.yaml
@@ -1,0 +1,155 @@
+id: "provenance-vocabulary-and-labels"
+title: "Canonical result-source + funding vocabulary and the vendor-supplied trust label"
+worktree: "results-labels-funding"
+priority: "High"
+status: "Ready"
+description: |
+  Establish a single source of truth for two provenance concepts before any
+  producer, submit, inventory, or read-model code references them. Today the
+  trust-label vocabulary is split and partial: VALID_LABELS lives in
+  benchbox/core/publishing/bundle_publisher.py:26
+  ("maintainer-run", "community-submission", "ci", "local",
+  "unofficial-research") but the explorer only ever distinguishes two labels,
+  inferred from submission-manifest-sidecar presence
+  (scripts/generate_corpus_inventory.py:41 _bundle_trust_label). There is no
+  "vendor-supplied" tier and no funding concept anywhere.
+
+  This item introduces one module that defines: the result_source enum and its
+  source -> trust_label -> visibility -> ranking-eligibility mapping, and the
+  funding enum, with normalize/validate helpers. It adds "vendor-supplied" to
+  VALID_LABELS and updates the governance contract of record. No behavior
+  changes for existing bundles yet (nothing emits the new fields until the
+  bundle/run item lands); this item is the vocabulary + docs foundation every
+  later item imports.
+
+category: "Architecture"
+
+decision_gates:
+  - id: G1-vendor-modeling
+    gate: >-
+      DECISION (RESOLVED 2026-07-06): vendor-supplied is a new *trust-label
+      value*, not a separate orthogonal flag. It maps to a new visibility state
+      "public-vendor-reported" and is ranking-eligible with a distinct badge.
+    blocks: []
+    outcome: >-
+      RESOLVED. RESULT_SOURCE = {internal, community, vendor}; source->label:
+      internal->maintainer-run, community->community-submission,
+      vendor->vendor-supplied. label->visibility: maintainer-run->public-curated,
+      community-submission->public-self-reported,
+      vendor-supplied->public-vendor-reported. Ranking-eligible: curated,
+      verified (reserved), AND vendor-reported = true; self-reported = false.
+  - id: G2-funding-enum
+    gate: >-
+      DECISION (RESOLVED 2026-07-06): funding vocabulary.
+    blocks: []
+    outcome: >-
+      RESOLVED. FUNDING_SOURCES = ("employer", "personal", "free-trial",
+      "vendor-sponsored", "grant", "unspecified"). "unspecified" is the default
+      when a producer does not declare funding.
+
+prior_art:
+  - "benchbox/core/publishing/bundle_publisher.py:26 VALID_LABELS — extend (add 'vendor-supplied'; keep ci/local/unofficial-research untouched)"
+  - "scripts/generate_corpus_inventory.py:21-22 COMMUNITY_TRUST_LABEL/DEFAULT_TRUST_LABEL — reference (these constants must be re-sourced from the new module in item 4, not redefined)"
+  - "docs/reference/hosted-results-contract.md:181-233 Trust Labels / visibility / ranking eligibility — extend (this doc is the contract of record; the new module must match it exactly)"
+  - "benchbox/core/results/status.py — reference (existing small result-vocabulary module; mirror its style/placement)"
+
+work:
+  - id: w1
+    summary: >-
+      Add benchbox/core/results/provenance.py defining RESULT_SOURCE, the
+      source->trust_label->visibility->ranking_eligible mapping, FUNDING_SOURCES,
+      and normalize_funding()/is_valid_funding()/trust_label_for_source()/
+      visibility_for_label() helpers. Pure data + functions, no I/O, no
+      CLI/platform imports (avoid cycles, same rule as models.py).
+    status: todo
+  - id: w2
+    summary: >-
+      Add 'vendor-supplied' to VALID_LABELS in bundle_publisher.py and re-source
+      the community/default label constants from the new module where trivially
+      safe. Do NOT change publish default (stays 'maintainer-run').
+    needs: [w1]
+    status: todo
+  - id: w3
+    summary: >-
+      Update the governance contract of record (hosted-results-contract.md) and
+      contributing-results.md + strategy doc: add the vendor-supplied label row,
+      the public-vendor-reported visibility state, ranking-eligibility change,
+      and a Funding disclosure subsection listing the enum. Add CHANGELOG entry.
+    needs: [w1]
+    status: todo
+
+must_preserve:
+  - "Existing VALID_LABELS entries (ci, local, unofficial-research) keep working; publish --label default stays 'maintainer-run'."
+  - "The new module imports nothing from benchbox.cli or benchbox.platforms (no import cycle)."
+  - "hosted-results-contract.md remains internally consistent: every label has a visibility state and a ranking-eligibility rule."
+
+approach: |
+  Model result_source and funding as plain string enums (tuples + frozenset)
+  plus a dict-backed mapping, mirroring status.py's lightweight style rather
+  than introducing Enum classes the rest of the result layer does not use.
+  Expose the mapping as data so item 4's DuckDB DDL and item 5's frontend can be
+  derived from the same table rather than re-deriving label->visibility in three
+  places. Keep helpers total: unknown/empty source -> 'internal'; unknown/empty
+  funding -> 'unspecified' (never raise in the producer path; strict rejection
+  is the validator's job in item 3).
+
+anti_patterns:
+  - "DO NOT redefine label/funding string literals in generate_corpus_inventory.py, submit.py, or the DDL — import from the one module."
+  - "DO NOT wire vendor-supplied into inference-by-sidecar — vendor is maintainer-applied (item 3 gate G-VENDOR-SIGNAL), never inferred here."
+  - "DO NOT bump read_model_version in this item — no read-model column changes here (that is item 4)."
+  - "DO NOT introduce Enum classes if tuples/frozensets match the surrounding result-layer style."
+
+verification:
+  - description: "New module imports cleanly with only core deps and has no cycle"
+    command: "uv run -- python -c 'import benchbox.core.results.provenance as p; print(sorted(p.FUNDING_SOURCES)); print(p.trust_label_for_source(\"vendor\"))'"
+    expected_output: "funding list printed; prints 'vendor-supplied'"
+  - description: "vendor-supplied is a valid publish label"
+    command: "uv run -- python -c 'from benchbox.core.publishing.bundle_publisher import VALID_LABELS; assert \"vendor-supplied\" in VALID_LABELS'"
+    expected_output: "no assertion error"
+  - description: "Unit tests for the vocabulary + mapping pass"
+    command: "uv run -- python -m pytest tests/unit/core/results/test_provenance.py -q"
+    expected_output: "all pass"
+  - description: "Contract doc still parses / links check (repo doc lint)"
+    command: "make docs-check || true"
+    expected_output: "no new failures attributable to this change"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/results/provenance.py (new)"
+    - "benchbox/core/publishing/bundle_publisher.py"
+    - "tests/unit/core/results/test_provenance.py (new)"
+    - "docs/reference/hosted-results-contract.md"
+    - "docs/contributing-results.md"
+    - "docs/development/benchbox-results-platform-strategy.md"
+    - "CHANGELOG.md"
+  do_not_modify:
+    - "benchbox/core/results/schema.py"
+    - "benchbox/cli/"
+    - "scripts/generate_corpus_inventory.py"
+    - "scripts/validate_submission.py"
+    - "docs/development/browser-duckdb-schema.sql"
+
+impact:
+  technical_debt: |
+    Removes the split-brain trust-label vocabulary (constants duplicated between
+    bundle_publisher.py and generate_corpus_inventory.py) by giving downstream
+    items one module to import, and closes the gap between the shipped labels and
+    the governance contract.
+
+success_metrics:
+  - "Every later work item imports label/funding constants from provenance.py; grep finds no new duplicated literals."
+  - "hosted-results-contract.md documents vendor-supplied + funding and matches the module exactly."
+
+deps:
+  needs: []
+
+delivery_loop:
+  create: "Implement w1-w3 within scope_limit; no emitters change yet."
+  review: "/code-review; run verification + make pr-preflight."
+  fix: "Resolve findings; re-run verification."
+  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature + Documentation)."
+
+metadata:
+  tags: ["explorer", "provenance", "trust-labels", "funding", "governance"]
+  estimated_effort: "Small-Medium"
+  created_date: "2026-07-06"

--- a/_project/TODO/results-labels-funding/planning/provenance-vocabulary-and-labels.yaml
+++ b/_project/TODO/results-labels-funding/planning/provenance-vocabulary-and-labels.yaml
@@ -2,7 +2,7 @@ id: "provenance-vocabulary-and-labels"
 title: "Canonical result-source + funding vocabulary and the vendor-supplied trust label"
 worktree: "results-labels-funding"
 priority: "High"
-status: "Ready"
+status: "Not Started"
 description: |
   Establish a single source of truth for two provenance concepts before any
   producer, submit, inventory, or read-model code references them. Today the
@@ -56,27 +56,33 @@ prior_art:
 work:
   - id: w1
     summary: >-
-      Add benchbox/core/results/provenance.py defining RESULT_SOURCE, the
-      source->trust_label->visibility->ranking_eligible mapping, FUNDING_SOURCES,
-      and normalize_funding()/is_valid_funding()/trust_label_for_source()/
-      visibility_for_label() helpers. Pure data + functions, no I/O, no
-      CLI/platform imports (avoid cycles, same rule as models.py).
-    status: todo
+      Add benchbox/core/results/provenance.py: RESULT_SOURCE, the
+      source->trust_label->visibility->ranking_eligible mapping,
+      FUNDING_SOURCES, and normalize/validate/lookup helper functions.
+    notes: >-
+      Helpers: normalize_funding()/is_valid_funding()/trust_label_for_source()/
+      visibility_for_label(). Pure data + functions, no I/O, no CLI/platform
+      imports (avoid cycles, same rule as models.py).
+    status: pending
   - id: w2
     summary: >-
-      Add 'vendor-supplied' to VALID_LABELS in bundle_publisher.py and re-source
-      the community/default label constants from the new module where trivially
-      safe. Do NOT change publish default (stays 'maintainer-run').
+      Add 'vendor-supplied' to VALID_LABELS in bundle_publisher.py and
+      re-source the community/default label constants from the new module.
+    notes: >-
+      Re-source community/default label constants from the new module where
+      trivially safe. Do NOT change publish default (stays 'maintainer-run').
     needs: [w1]
-    status: todo
+    status: pending
   - id: w3
     summary: >-
-      Update the governance contract of record (hosted-results-contract.md) and
-      contributing-results.md + strategy doc: add the vendor-supplied label row,
-      the public-vendor-reported visibility state, ranking-eligibility change,
-      and a Funding disclosure subsection listing the enum. Add CHANGELOG entry.
+      Update the governance contract of record (hosted-results-contract.md),
+      contributing-results.md, and the strategy doc for the new vocabulary.
+    notes: >-
+      Add the vendor-supplied label row, the public-vendor-reported visibility
+      state, ranking-eligibility change, and a Funding disclosure subsection
+      listing the enum. Add CHANGELOG entry.
     needs: [w1]
-    status: todo
+    status: pending
 
 must_preserve:
   - "Existing VALID_LABELS entries (ci, local, unofficial-research) keep working; publish --label default stays 'maintainer-run'."
@@ -147,7 +153,7 @@ delivery_loop:
   create: "Implement w1-w3 within scope_limit; no emitters change yet."
   review: "/code-review; run verification + make pr-preflight."
   fix: "Resolve findings; re-run verification."
-  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature + Documentation)."
+  submit_pr: "PR vs develop using PULL_REQUEST_TEMPLATE.md (Type: New feature + Documentation)."
 
 metadata:
   tags: ["explorer", "provenance", "trust-labels", "funding", "governance"]

--- a/_project/TODO/results-labels-funding/planning/submit-manifest-and-validator.yaml
+++ b/_project/TODO/results-labels-funding/planning/submit-manifest-and-validator.yaml
@@ -1,0 +1,151 @@
+id: "submit-manifest-and-validator"
+title: "Carry funding + result_source in the submission manifest; enforce vendor label governance"
+worktree: "results-labels-funding"
+priority: "High"
+status: "Blocked"
+description: |
+  Extend the submission path so contributors disclose funding and so the
+  authoritative vendor-supplied label can only be applied under maintainer
+  control. Today _build_submission_manifest (benchbox/cli/commands/submit.py:153-175)
+  writes submission_tool_version, submitted_at, bundle/companion hashes,
+  benchmark, platform, scale_factor, phase, submission_path, submitted_by — no
+  funding, no source, and (a pre-existing drift) no submission_notes even though
+  the contract (hosted-results-contract.md:5.1) lists it.
+
+  scripts/validate_submission.py runs in CI on attacker-controlled PR JSON. It
+  must strictly validate the new enum fields and, critically, refuse a
+  self-asserted vendor-supplied label so a vendor cannot open a community PR that
+  lands in the ranking-eligible vendor tier without maintainer sign-off.
+
+category: "Feature"
+
+decision_gates:
+  - id: G-VENDOR-SIGNAL
+    gate: >-
+      What maintainer-controlled mechanism assigns the vendor-supplied trust
+      label, such that it cannot be self-asserted in a community PR? Options:
+      (A) a dedicated results-data/bundles/vendor/ subtree that only maintainers
+      can add to (enforced via CODEOWNERS on that path); (B) a manifest field
+      result_source: vendor that the validator accepts ONLY when the PR is
+      authored/approved by a maintainer (checked in CI against an allowlist);
+      (C) a separate maintainer-only sidecar (e.g. <stem>.provenance.json) not
+      writable by the submit CLI.
+    blocks: [w3, w4]
+    outcome: >-
+      PROPOSED default: Option A (vendor subtree + CODEOWNERS) — simplest,
+      git-native, matches the existing "trust derived from where the bundle
+      lives / which sidecar is present" model, and needs no identity check in the
+      validator. The validator treats a vendor hint in a normal community bundle
+      as an ERROR. CONFIRM before implementing w3/w4.
+
+prior_art:
+  - "benchbox/cli/commands/submit.py:153-175 _build_submission_manifest — extend (add funding, result_source, submission_notes)"
+  - "benchbox/cli/commands/submit.py:455-523 submit options — extend (add --funding, --notes; reuse existing --submitted-by/--visibility style)"
+  - "scripts/validate_submission.py:33-37 REQUIRED_* key sets + :517-603 _validate_manifest_hash — extend (add manifest field validation; the hash/path-traversal defenses are the security baseline to preserve)"
+  - "docs/reference/hosted-results-contract.md:5.1 submission manifest schema — reference (add funding/result_source; submission_notes already specified there)"
+  - "benchbox/core/results/provenance.py (item 1) — reference (FUNDING_SOURCES / validators)"
+
+work:
+  - id: w1
+    summary: >-
+      Add --funding (Choice from FUNDING_SOURCES) and --notes (<=500 chars) to
+      benchbox submit; thread into _build_submission_manifest. Default funding
+      inherits from the bundle's provenance.funding when present, else
+      'unspecified'.
+    status: todo
+  - id: w2
+    summary: >-
+      Add funding, result_source (default 'community' for the submit path), and
+      submission_notes to the manifest envelope; keep field order deterministic
+      (canonical JSON).
+    needs: [w1]
+    status: todo
+  - id: w3
+    summary: >-
+      In validate_submission.py, strictly validate funding in FUNDING_SOURCES and
+      result_source in {internal, community, vendor}; reject unknown values.
+    needs: [w2]
+    status: todo
+  - id: w4
+    summary: >-
+      Enforce G-VENDOR-SIGNAL: a bundle claiming vendor provenance is only valid
+      via the maintainer-controlled path (per the resolved gate); a self-asserted
+      vendor label in an ordinary community submission is a hard validation error
+      with a clear message.
+    needs: [w3]
+    status: todo
+
+must_preserve:
+  - "The bundle_hash / companion_hashes contract and path-traversal + symlink defenses in _validate_manifest_hash are unchanged."
+  - "Existing manifests (no funding/result_source/submission_notes) still validate — new fields are optional except where the vendor gate requires them."
+  - "The pinned submit checklist regression test (tests/unit/cli/commands/test_submit.py) keeps its four required tokens."
+  - "Unofficial-compliance and non-clean-run refusals in submit.py stay in force."
+
+approach: |
+  Reuse the item-1 validators so the validator and CLI share one allowlist.
+  Default the submit path's result_source to 'community' (that is what the submit
+  CLI is for); the vendor label never originates from the public submit CLI.
+  For the vendor gate, implement the resolved option (default A): detect vendor
+  provenance by bundle location/sidecar, and have the validator ERROR if a
+  community-located bundle asserts vendor. Add targeted unit tests that feed the
+  validator hostile manifests (unknown funding, injected vendor label,
+  oversized notes) and assert rejection.
+
+anti_patterns:
+  - "DO NOT let the public submit CLI or a community PR self-assert vendor-supplied — that defeats the whole governance point."
+  - "DO NOT weaken or reorder the existing hash/path-traversal validation to slot in new checks."
+  - "DO NOT make funding REQUIRED for community submissions (default 'unspecified'); DO require an explicit funding on the maintainer vendor path if the gate resolution says so."
+  - "DO NOT duplicate the enum in validate_submission.py — import from provenance.py."
+
+verification:
+  - description: "Submit dry-run emits a manifest with funding + result_source"
+    command: "uv run -- benchbox submit --last --funding free-trial --dry-run"
+    expected_output: "dry-run preview shows funding=free-trial; no bytes sent"
+  - description: "Validator accepts a valid community manifest with funding"
+    command: "uv run -- python scripts/validate_submission.py <fixture-bundle-with-manifest>"
+    expected_output: "validation passes"
+  - description: "Validator REJECTS a self-asserted vendor label in a community bundle"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_validate_submission.py -k vendor -q"
+    expected_output: "test asserting hard rejection passes"
+  - description: "Validator rejects unknown funding + oversized notes"
+    command: "uv run -- python -m pytest tests/unit/scripts/test_validate_submission.py -k 'funding or notes' -q"
+    expected_output: "all pass"
+  - description: "Submit contract + hash tests still pass"
+    command: "uv run -- python -m pytest tests/unit/cli/commands/test_submit.py -q"
+    expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+    - "benchbox/cli/commands/submit.py"
+    - "scripts/validate_submission.py"
+    - "tests/unit/cli/commands/test_submit.py"
+    - "tests/unit/scripts/test_validate_submission.py"
+    - ".github/CODEOWNERS (only if resolved gate = Option A)"
+  do_not_modify:
+    - "benchbox/core/results/schema.py"
+    - "scripts/generate_corpus_inventory.py"
+    - "docs/development/browser-duckdb-schema.sql"
+
+impact:
+  technical_debt: |
+    Closes the manifest/contract drift (submission_notes) and gives the corpus a
+    trustworthy, non-self-assertable vendor signal — the precondition for putting
+    vendor results into ranking-eligible tables (item 4).
+
+success_metrics:
+  - "A community PR cannot produce a vendor-supplied result; CI errors clearly if it tries."
+  - "Funding disclosure round-trips from submit CLI into the manifest and passes CI validation."
+
+deps:
+  needs: ["provenance-vocabulary-and-labels"]
+
+delivery_loop:
+  create: "Resolve G-VENDOR-SIGNAL first, then implement w1-w4 within scope_limit."
+  review: "/code-review AND /security-review (validator parses hostile PR JSON); run verification + make pr-preflight."
+  fix: "Resolve findings; add regression tests for any bypass found."
+  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature); call out the governance rule in Notes."
+
+metadata:
+  tags: ["explorer", "provenance", "funding", "submission", "validation", "security", "governance"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-06"

--- a/_project/TODO/results-labels-funding/planning/submit-manifest-and-validator.yaml
+++ b/_project/TODO/results-labels-funding/planning/submit-manifest-and-validator.yaml
@@ -48,32 +48,35 @@ prior_art:
 work:
   - id: w1
     summary: >-
-      Add --funding (Choice from FUNDING_SOURCES) and --notes (<=500 chars) to
-      benchbox submit; thread into _build_submission_manifest. Default funding
-      inherits from the bundle's provenance.funding when present, else
-      'unspecified'.
-    status: todo
+      Add --funding (Choice from FUNDING_SOURCES) and --notes (<=500 chars)
+      to benchbox submit; thread into _build_submission_manifest.
+    notes: >-
+      Default funding inherits from the bundle's provenance.funding when
+      present, else 'unspecified'.
+    status: pending
   - id: w2
     summary: >-
       Add funding, result_source (default 'community' for the submit path), and
       submission_notes to the manifest envelope; keep field order deterministic
       (canonical JSON).
     needs: [w1]
-    status: todo
+    status: pending
   - id: w3
     summary: >-
       In validate_submission.py, strictly validate funding in FUNDING_SOURCES and
       result_source in {internal, community, vendor}; reject unknown values.
     needs: [w2]
-    status: todo
+    status: pending
   - id: w4
     summary: >-
-      Enforce G-VENDOR-SIGNAL: a bundle claiming vendor provenance is only valid
-      via the maintainer-controlled path (per the resolved gate); a self-asserted
-      vendor label in an ordinary community submission is a hard validation error
-      with a clear message.
+      Enforce G-VENDOR-SIGNAL: vendor provenance is only valid via the
+      maintainer-controlled path; a self-asserted vendor label is a hard
+      validation error.
+    notes: >-
+      Per the resolved gate: a self-asserted vendor label in an ordinary
+      community submission is a hard validation error with a clear message.
     needs: [w3]
-    status: todo
+    status: pending
 
 must_preserve:
   - "The bundle_hash / companion_hashes contract and path-traversal + symlink defenses in _validate_manifest_hash are unchanged."
@@ -143,7 +146,7 @@ delivery_loop:
   create: "Resolve G-VENDOR-SIGNAL first, then implement w1-w4 within scope_limit."
   review: "/code-review AND /security-review (validator parses hostile PR JSON); run verification + make pr-preflight."
   fix: "Resolve findings; add regression tests for any bypass found."
-  submit_pr: "PR vs main using PULL_REQUEST_TEMPLATE.md (Type: New feature); call out the governance rule in Notes."
+  submit_pr: "PR vs develop using PULL_REQUEST_TEMPLATE.md (Type: New feature); call out the governance rule in Notes."
 
 metadata:
   tags: ["explorer", "provenance", "funding", "submission", "validation", "security", "governance"]


### PR DESCRIPTION
## Description

Adds a sequenced set of planning-YAML work items (the repo's `_project/<worktree>/planning/` convention) for introducing two provenance signals the results explorer lacks today:

1. **A vendor-supplied trust label** distinct from internal (`maintainer-run`) and community (`community-submission`). Today the explorer only derives those two labels from submission-manifest-sidecar presence; a vendor running its own product has a conflict of interest and fits neither.
2. **A funding disclosure axis** — who/how a run was paid for (`employer` · `personal` · `free-trial` · `vendor-sponsored` · `grant` · `unspecified`). Nothing records this today.

**Locked decisions** (with the requester): vendor-supplied is a *new trust-label value* (visibility `public-vendor-reported`), **ranking-eligible with a distinct badge**; funding is an orthogonal enum.

No product code changes here — this PR is the plan of record. Five items under `_project/TODO/results-labels-funding/`, each with decision gates, runnable verification commands, scope limits, and the create→review→fix→submit-pr delivery loop:

1. `provenance-vocabulary-and-labels` — canonical enums + `vendor-supplied` in `VALID_LABELS` + contract docs (foundation, unblocked)
2. `bundle-schema-and-run-cli` — optional `provenance` block + `run --funding`
3. `submit-manifest-and-validator` — manifest fields + **vendor-label governance** (not self-assertable)
4. `corpus-inventory-and-read-model` — inventory + `browser-duckdb-schema.sql` funding column + read_model_version
5. `explorer-pipeline-frontend-handoff` — spec for the gitignored `_project/scripts/explorer_pipeline/` + `results-explorer/` trees

## Type of Change

- [x] Documentation

## Testing

Docs/planning only — no runtime surface. Verified: all five YAMLs parse (`yaml.safe_load`), and every codebase reference cited in the items (`VALID_LABELS` at `bundle_publisher.py:26`, `_bundle_trust_label` at `generate_corpus_inventory.py:41`, `_build_submission_manifest` at `submit.py:153`, inventory `schema_version`) was spot-checked against the tree.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: n/a — text planning files only.

## Notes

- Three **open decision gates** are flagged in the items with proposed defaults and "CONFIRM before implementing" markers on the specific `work` steps they block. The highest-leverage one is **G-VENDOR-SIGNAL** (item 3): the maintainer-controlled mechanism that applies `vendor-supplied` at merge so it can't be self-asserted in a community PR (proposed default: a `results-data/bundles/vendor/` subtree guarded by CODEOWNERS).
- Item 5 is intentionally a **hand-off spec**, not code: it edits `_project/scripts/explorer_pipeline/` and `results-explorer/`, which are gitignored and absent from the checkout. Its contract tests, however, are in-repo, so the change stays verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY)_