### PR TITLE
fix(explorer): remove inert frame-ancestors from CSP meta tag

### DIFF
--- a/_project/DONE/main/planning/explorer-csp-frame-ancestors-meta-cleanup.yaml
+++ b/_project/DONE/main/planning/explorer-csp-frame-ancestors-meta-cleanup.yaml
@@ -2,7 +2,8 @@ id: explorer-csp-frame-ancestors-meta-cleanup
 title: "Remove the inert frame-ancestors directive from the explorer CSP meta tag"
 worktree: main
 priority: Low
-status: Not Started
+status: "Completed"
+completed_date: "2026-07-06"
 category: Security
 
 description: |
@@ -29,7 +30,7 @@ description: |
 work:
 - id: w1
   summary: "Drop the inert frame-ancestors from the meta CSP; document the header-layer requirement"
-  status: pending
+  status: done
   notes: |
     In results-explorer/index.html: remove `frame-ancestors 'none'` from the
     `<meta http-equiv="Content-Security-Policy">` content string, leaving every
@@ -52,8 +53,10 @@ verification:
   expected_output: "all specs pass — removing an inert directive is behaviorally a no-op, so this confirms nothing else broke"
 
 prior_art:
-- "results-explorer/index.html:6-15 — the existing CSP meta + head comment; EDIT in place, preserve all non-frame-ancestors directives."
-- "_project/DONE/main/planning/remediate-explorer-csp-hardening.yaml — the item that added the CSP; SUPERSEDE its noted 'frame-ancestors inert in meta' caveat by actually removing the directive."
+- "results-explorer/index.html:6-15 — the existing CSP meta + head comment; EDIT in place, preserve all non-frame-ancestors
+  directives."
+- "_project/DONE/main/planning/remediate-explorer-csp-hardening.yaml — the item that added the CSP; SUPERSEDE its noted 'frame-ancestors
+  inert in meta' caveat by actually removing the directive."
 
 scope_limit:
   only_modify:
@@ -64,10 +67,12 @@ scope_limit:
 
 must_preserve:
 - "connect-src 'self' — the load-bearing egress confinement; must not change."
-- "The duckdb-wasm-compatible directives (script-src 'wasm-unsafe-eval', worker-src blob:) — removing these would break the explorer."
+- "The duckdb-wasm-compatible directives (script-src 'wasm-unsafe-eval', worker-src blob:) — removing these would break the
+  explorer."
 
 anti_patterns:
-- "DO NOT try to make frame-ancestors work by keeping it in meta — because the CSP spec ignores it there; the fix is a header at the host layer, out of this file's scope."
+- "DO NOT try to make frame-ancestors work by keeping it in meta — because the CSP spec ignores it there; the fix is a header
+  at the host layer, out of this file's scope."
 
 metadata:
   tags:

--- a/results-explorer/index.html
+++ b/results-explorer/index.html
@@ -9,10 +9,15 @@
       the app's own origin, closing the remote-fetch/exfil channel. wasm-unsafe-eval
       + worker-src blob: are required for the duckdb-wasm module and its worker.
       GitHub Pages cannot set response headers, so this ships as a <meta> tag.
+      NOTE: `frame-ancestors` is intentionally NOT set here — per the CSP spec it
+      is ignored when delivered via <meta>, so it would provide no clickjacking
+      protection. Framing protection must be applied as an HTTP response header
+      (X-Frame-Options: DENY or a header-delivered frame-ancestors) at the
+      hosting/CDN layer; it cannot be expressed in this file.
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; worker-src 'self' blob:; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; worker-src 'self' blob:; connect-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; object-src 'none'; base-uri 'self'"
     />
     <link rel="icon" type="image/svg+xml" href="/results/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Description

Closes TODO `explorer-csp-frame-ancestors-meta-cleanup` (w1). Source: results-explorer/publication remediation re-review (2026-07-06), Defect #5 (cosmetic).

`results-explorer/index.html` set its CSP via a `<meta http-equiv="Content-Security-Policy">` tag whose content included `frame-ancestors 'none'`. Per the CSP spec, `frame-ancestors` is **ignored** when delivered via `<meta>` — it only takes effect as an HTTP response header. So the directive provided no actual clickjacking protection; it read as a control that didn't exist.

This is cosmetic, not a security hole: the load-bearing directive `connect-src 'self'` (which confines all network egress, closing the duckdb-wasm remote-fetch/exfil channel) *does* work in a meta CSP and is unchanged.

## Change

- Removed `frame-ancestors 'none'` from the CSP `content=` string. Every other directive (`default-src`, `script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'`, `worker-src 'self' blob:`, `connect-src 'self'`, `style-src`, `img-src`, `font-src`, `object-src 'none'`, `base-uri 'self'`) is byte-identical to before.
- Added a note to the existing head comment stating that framing/clickjacking protection must be applied as an HTTP response header (`X-Frame-Options: DENY` or a header-delivered `frame-ancestors`) at the hosting/CDN layer, because meta CSP cannot express `frame-ancestors`.

## Type of Change

- [x] Bug fix

## Testing

- `grep -oE 'content="default-src[^"]*"' results-explorer/index.html | grep -c 'frame-ancestors'` → `0` (expected `0`)
- `grep -oE 'content="default-src[^"]*"' results-explorer/index.html | grep -c "connect-src 'self'"` → `1` (expected `1`)
- `cd results-explorer && npm run test:e2e:chromium` — infeasible in this remote environment: the pinned Playwright version resolves to `chromium_headless_shell-1217`, but the environment's pre-installed browser cache only has `chromium_headless_shell-1194` / `chromium-1194` (`Error: browserType.launch: Executable doesn't exist at /opt/pw-browsers/chromium_headless_shell-1217/...`), a pre-existing environment/version mismatch unrelated to this change. As the fallback specified by the TODO, ran `npm run build` instead: builds cleanly (`✓ 222 modules transformed`, `✓ built in 4.96s`), and the built `dist/index.html` was inspected to confirm the CSP `content=` string carries the fix (no `frame-ancestors`, `connect-src 'self'` present).

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs (inline CSP comment in `index.html`).
- [x] I added regression notes for behavior changes (none needed — removing an inert directive is a behavioral no-op).
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks (n/a — HTML-only edit).
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths (n/a — no test coverage gap introduced; removing an inert directive needs no new test).
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] No committed binary/raw evidence files.

## Notes

**Opus 4.8 review outcome:** No findings (Required or Nit). Confirmed: `frame-ancestors` fully removed, all other directives byte-identical, scope limited to `results-explorer/index.html` + the TODO YAML move, `must_preserve` directives intact, no anti-pattern triggered. Verdict: ready to land, no fixes needed.

TODO item `explorer-csp-frame-ancestors-meta-cleanup` moved to `_project/DONE/main/planning/` with `status: Completed`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_