### PR TITLE
fix(qpc-04): default plan capture to estimated EXPLAIN; notice on ANALYZE opt-in

### DIFF
--- a/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
+++ b/_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml
@@ -2,7 +2,8 @@ id: "qpc-04-capture-timeout-and-analyze-default"
 title: "Make the plan-capture timeout real; default DuckDB capture to estimated plans (no re-execution)"
 worktree: "query-plan-capture"
 priority: "High"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-06"
 
 description: |
   The capture timeout does not bound wall-clock time: capture_query_plan
@@ -34,40 +35,47 @@ work:
     Create: make the capture timeout bound wall-clock — non-blocking executor
     shutdown, connection recycling, server-side bounds where supported.
   notes: >-
-    On timeout, executor.shutdown(wait=False) and mark the connection for
-    recycling (the leaked thread may still be using it); where the engine
-    supports it prefer a server-side bound (DuckDB interrupt API /
-    SET statement_timeout for PG-family) over the thread dance. Log the true
-    elapsed time if the straggler eventually completes.
-  status: pending
+    Already landed on develop prior to this PR: capture_query_plan uses
+    run_with_timeout (daemon thread + join(timeout)), which returns promptly
+    on timeout instead of blocking in shutdown(wait=True); connection
+    recycling after a timeout is handled in the isolated capture phase
+    (benchbox/core/plan_capture_phase.py). Verified via
+    test_capture_timeout_returns_promptly and
+    test_capture_phase_replaces_owned_connection_after_timeout.
+  status: done
 - id: w2
   summary: >-
     Create: flip analyze_plans default to False; print a run-level notice
     when ANALYZE capture is explicitly enabled.
   notes: >-
     Notice wording: plan capture re-executes each query; timings are not
-    comparable to non-capture runs.
+    comparable to non-capture runs. Implemented in adapter.py (default flip)
+    and result_capture.py capture_query_plan (one-time per-run notice via
+    quiet_console, guarded by _analyze_plans_notice_printed, reset in
+    _reset_plan_capture_stats). CLI help text in cli/commands/run.py still
+    describes the old default and is a documented follow-up outside this
+    item's scope_limit.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: >-
     Create: tests — timeout actually bounds capture_query_plan wall-clock
     (hang 5s, timeout 1s, assert return < 2s); default EXPLAIN options
     contain no ANALYZE; notice printed when enabled.
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Review: adversarial code review (connection-recycle path per platform, orphan-thread lifecycle, strict-mode interaction)."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Fix: address review findings; re-run verification."
   needs: [w4]
-  status: pending
+  status: done
 - id: w6
   summary: "Submit PR referencing qpc-04; document the analyze_plans default change in release notes."
   needs: [w5]
-  status: pending
+  status: done
 
 must_preserve:
 - "analyze_plans=True still available and functional for users who want actual cardinalities"

--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -134,10 +134,16 @@ class PlatformAdapter(
         self.force_recreate = config.get("force_recreate", False)
         self.show_query_plans = config.get("show_query_plans", False)
         self.capture_plans = config.get("capture_plans", False)
-        # When True (default), plan capture uses EXPLAIN (ANALYZE, FORMAT JSON) to include actual
-        # per-operator timing and cardinality. Set to False to use plain EXPLAIN (FORMAT JSON) for
-        # estimated-plan-only capture with no re-execution overhead.
-        self.analyze_plans: bool = config.get("analyze_plans", True)
+        # When False (default), plan capture uses plain EXPLAIN (FORMAT JSON) for
+        # estimated-plan-only capture with no re-execution overhead: fingerprints are
+        # structure-only, so estimated plans lose nothing for structural comparison.
+        # Set to True to opt into EXPLAIN (ANALYZE, FORMAT JSON), which re-executes
+        # every captured SELECT once to include actual per-operator timing and
+        # cardinality -- roughly 2x wall-clock for a --capture-plans run and
+        # perturbed cache state. A one-time run-level notice is printed the first
+        # time a plan is actually captured with this enabled (see
+        # ResultCaptureMixin.capture_query_plan).
+        self.analyze_plans: bool = config.get("analyze_plans", False)
         self.strict_plan_capture = config.get("strict_plan_capture", False)
         # When True, also record a literal-normalized plan fingerprint alongside
         # the default fingerprint during plan capture (see --normalize-plan-literals).

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -508,6 +508,9 @@ class ResultCaptureMixin:
         # recorded queries can never leak into the next.
         self._plan_capture_phase_active = False
         self._phase_recorded_queries: dict[str, str] = {}
+        # Guards the one-time analyze_plans=True re-execution notice in
+        # capture_query_plan; reset per run so each run gets its own notice.
+        self._analyze_plans_notice_printed = False
         # The lock is created in PlatformAdapter.__init__; create it defensively
         # for hosts that reset stats without going through __init__ (e.g. tests
         # that mix in this class directly). Reset runs before any worker threads
@@ -788,10 +791,14 @@ class ResultCaptureMixin:
         Calls get_query_plan() to obtain EXPLAIN output and parses it into a QueryPlanDAG.
         Returns timing information for observability of capture overhead.
 
-        By default (analyze_plans=True), DuckDB uses EXPLAIN (ANALYZE, FORMAT JSON) which
-        re-executes the query to capture actual per-operator timing and cardinality.
-        Set analyze_plans=False in the adapter config to use plain EXPLAIN (FORMAT JSON)
-        for estimated-plan-only capture with no re-execution overhead.
+        By default (analyze_plans=False), DuckDB uses plain EXPLAIN (FORMAT JSON), which
+        captures the estimated plan without re-executing the query. Set
+        analyze_plans=True in the adapter config to opt into EXPLAIN (ANALYZE, FORMAT
+        JSON), which re-executes every captured SELECT once to include actual
+        per-operator timing and cardinality -- roughly 2x wall-clock cost for a
+        --capture-plans run and perturbed cache state. The first time this method
+        actually captures a plan with analyze_plans enabled for a run, it prints a
+        one-time notice (see the ``_analyze_plans_notice_printed`` guard below).
 
         Plan fingerprints exclude timing/cardinality by design - structural comparisons
         are unaffected by this setting. See the plan fingerprint stability contract in
@@ -802,9 +809,9 @@ class ResultCaptureMixin:
             All adapters capture the plan AFTER the timed execution block (the
             "post-execution" plan). This is intentional and is the supported
             default:
-              - With ``analyze_plans=True`` it yields the *actual* plan that ran,
-                including real per-operator timing/cardinality (EXPLAIN ANALYZE) —
-                the most useful artifact for profiling.
+              - With ``analyze_plans=True`` (opt-in) it yields the *actual* plan that
+                ran, including real per-operator timing/cardinality (EXPLAIN ANALYZE) —
+                the most useful artifact for profiling, at the cost of re-execution.
               - The structural fingerprint is unaffected by post- vs. pre-execution
                 timing, because it excludes costs and row estimates. A plan captured
                 before vs. after execution hashes to the same fingerprint as long as
@@ -860,6 +867,19 @@ class ResultCaptureMixin:
             query_id not in self.plan_query_filter and _plan_capture_public_id(query_id) not in self.plan_query_filter
         ):
             return None, 0.0
+
+        # ANALYZE re-execution is an explicit opt-in (analyze_plans defaults to
+        # False): print a one-time run-level notice the first time this path is
+        # about to actually capture a plan with it enabled, so a user who set
+        # analyze_plans=True is not surprised that --capture-plans runs now cost
+        # ~2x wall-clock and perturb cache state. Guarded by a per-run flag reset
+        # in _reset_plan_capture_stats so a fresh run gets its own notice.
+        if self.analyze_plans and not getattr(self, "_analyze_plans_notice_printed", False):
+            self._analyze_plans_notice_printed = True
+            quiet_console.print(
+                "[bold yellow]Notice:[/bold yellow] plan capture re-executes each query "
+                "(analyze_plans=True); timings are not comparable to non-capture runs."
+            )
 
         start_time = time.perf_counter()
 

--- a/benchbox/platforms/duckdb.py
+++ b/benchbox/platforms/duckdb.py
@@ -1036,17 +1036,20 @@ class DuckDBAdapter(PlatformAdapter):
                 connection.execute("PRAGMA disable_profiling")
 
     def get_query_plan(self, connection: Any, query: str) -> str | None:
-        """Get DuckDB query execution plan using EXPLAIN (ANALYZE, FORMAT JSON).
+        """Get DuckDB query execution plan using EXPLAIN (FORMAT JSON).
 
-        Uses EXPLAIN (ANALYZE, FORMAT JSON) by default (PostgreSQL-style combined syntax)
-        to capture actual per-operator timing and cardinality from real query execution.
-        The ANALYZE format uses different field names than plain EXPLAIN (FORMAT JSON):
-        operator_timing/operator_cardinality/operator_name vs timing/cardinality/name.
-        DuckDBQueryPlanParser handles both schemas transparently.
+        Uses plain EXPLAIN (FORMAT JSON) by default (self.analyze_plans=False) to
+        capture the estimated plan with no re-execution overhead: plan fingerprints
+        are structure-only, so estimated plans lose nothing for structural comparison.
 
-        When self.analyze_plans is False, falls back to EXPLAIN (FORMAT JSON) which
-        captures estimated plans only (timing/cardinality fields absent). Use this
-        opt-out when plan capture overhead must be minimised.
+        When self.analyze_plans is True (opt-in), uses EXPLAIN (ANALYZE, FORMAT JSON)
+        (PostgreSQL-style combined syntax) to capture actual per-operator timing and
+        cardinality from real query execution. The ANALYZE format uses different field
+        names than plain EXPLAIN (FORMAT JSON): operator_timing/operator_cardinality/
+        operator_name vs timing/cardinality/name. DuckDBQueryPlanParser handles both
+        schemas transparently. capture_query_plan() prints a one-time run-level notice
+        the first time this opt-in actually captures a plan, since it roughly doubles
+        wall-clock cost for a --capture-plans run and perturbs cache state.
 
         Note: EXPLAIN (ANALYZE, ...) re-executes the query, adding ~1× query cost to the
         capture step. Plan fingerprints are unaffected - compute_plan_fingerprint()

--- a/tests/integration/test_plan_capture_phase.py
+++ b/tests/integration/test_plan_capture_phase.py
@@ -214,7 +214,8 @@ class TestIntegratedCapturePhase:
         timing. It must now honour the adapter's analyze_plans.
         """
         _seed_table(file_adapter)
-        assert file_adapter.analyze_plans is True  # DuckDB default
+        # analyze_plans defaults to False; opt in explicitly for this regression test.
+        file_adapter.analyze_plans = True
         conn = file_adapter.create_connection()
         try:
             benchmark = _FakeBenchmark({"q": "SELECT id, SUM(val) FROM t GROUP BY id"})

--- a/tests/unit/platforms/test_adapter_lifecycle.py
+++ b/tests/unit/platforms/test_adapter_lifecycle.py
@@ -198,17 +198,17 @@ def test_run_benchmark_applies_and_restores_analyze_plans(tmp_path: Path) -> Non
     for the run and restored afterwards, exactly like capture_plans."""
     adapter = _LifecycleAdapter(existing_databases=[False])
     benchmark = _LifecycleBenchmark(tmp_path)
-    assert adapter.analyze_plans is True  # adapter default
+    assert adapter.analyze_plans is False  # adapter default
 
     adapter.run_benchmark(
         benchmark,
         benchmark_name="tpch",
         capture_plans=True,
-        analyze_plans=False,
+        analyze_plans=True,
     )
 
     # Restored to the adapter default after the run (saved/restored in run_benchmark).
-    assert adapter.analyze_plans is True
+    assert adapter.analyze_plans is False
 
 
 def test_run_benchmark_leaves_analyze_plans_default_when_run_config_omits_it(tmp_path: Path) -> None:
@@ -218,4 +218,4 @@ def test_run_benchmark_leaves_analyze_plans_default_when_run_config_omits_it(tmp
 
     adapter.run_benchmark(benchmark, benchmark_name="tpch", capture_plans=True, analyze_plans=None)
 
-    assert adapter.analyze_plans is True
+    assert adapter.analyze_plans is False

--- a/tests/unit/platforms/test_duckdb_adapter.py
+++ b/tests/unit/platforms/test_duckdb_adapter.py
@@ -930,25 +930,25 @@ class TestDuckDBAdapter:
         mock_connection = Mock()
         mock_duckdb.connect.return_value = mock_connection
 
-        # Default (analyze_plans=True): uses EXPLAIN (ANALYZE, FORMAT JSON)
+        # Default (analyze_plans=False): uses EXPLAIN (FORMAT JSON) - estimated plan only
+        estimated_payload = '{"name": "SEQ_SCAN", "timing": null}'
+        mock_connection.execute.return_value.fetchall.return_value = [("explain_key", estimated_payload)]
+        adapter_default = DuckDBAdapter()
+        plan = adapter_default.get_query_plan(mock_connection, "SELECT * FROM test")
+        assert plan == estimated_payload
+        call_sql = mock_connection.execute.call_args[0][0]
+        assert "ANALYZE" not in call_sql
+        assert "FORMAT JSON" in call_sql
+
+        # analyze_plans=True (opt-in): uses EXPLAIN (ANALYZE, FORMAT JSON)
+        mock_connection.execute.reset_mock()
         json_payload = '{"operator_type": "SEQ_SCAN", "operator_timing": 0.001}'
         mock_connection.execute.return_value.fetchall.return_value = [("explain_key", json_payload)]
-        adapter = DuckDBAdapter()
+        adapter = DuckDBAdapter(analyze_plans=True)
         plan = adapter.get_query_plan(mock_connection, "SELECT * FROM test")
         assert plan == json_payload
         call_sql = mock_connection.execute.call_args[0][0]
         assert "ANALYZE" in call_sql
-        assert "FORMAT JSON" in call_sql
-
-        # analyze_plans=False: uses EXPLAIN (FORMAT JSON) - estimated plan only
-        mock_connection.execute.reset_mock()
-        estimated_payload = '{"name": "SEQ_SCAN", "timing": null}'
-        mock_connection.execute.return_value.fetchall.return_value = [("explain_key", estimated_payload)]
-        adapter_no_analyze = DuckDBAdapter(analyze_plans=False)
-        plan = adapter_no_analyze.get_query_plan(mock_connection, "SELECT * FROM test")
-        assert plan == estimated_payload
-        call_sql = mock_connection.execute.call_args[0][0]
-        assert "ANALYZE" not in call_sql
         assert "FORMAT JSON" in call_sql
 
         # Exception during EXPLAIN → returns None

--- a/tests/unit/platforms/test_duckdb_plan_capture.py
+++ b/tests/unit/platforms/test_duckdb_plan_capture.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from benchbox.platforms.duckdb import DuckDBAdapter
+from benchbox.utils.printing import set_quiet
 
 pytestmark = [
     pytest.mark.unit,
@@ -295,10 +296,10 @@ class TestDuckDBPlanCapture:
         assert parser.platform_name == "duckdb"
 
     def test_plan_capture_when_enabled(self, adapter_with_capture):
-        """Test that plan is captured with actual timing when capture_plans=True.
+        """Test that a plan is captured when capture_plans=True.
 
-        Default behavior uses EXPLAIN (ANALYZE, FORMAT JSON) so captured plans include
-        actual per-operator timing and cardinality from real execution.
+        Default behavior (analyze_plans=False) uses plain EXPLAIN (FORMAT JSON), so
+        captured plans are estimated-only: no re-execution, no per-operator timing.
         """
         connection = adapter_with_capture.create_connection()
 
@@ -316,14 +317,41 @@ class TestDuckDBPlanCapture:
             plan = result["query_plan"]
             assert plan is not None
             assert plan.logical_root is not None
-            # Default capture uses EXPLAIN (ANALYZE, FORMAT JSON) - physical operator must carry timing
+            # Default capture uses plain EXPLAIN (FORMAT JSON) - no ANALYZE timing.
+            phys = plan.logical_root.physical_operator
+            assert phys is not None, "physical_operator should always be present"
+            timing = phys.properties.get("timing")
+            assert timing is None or timing == 0, f"Expected no timing with default analyze_plans=False, got {timing}"
+
+        finally:
+            adapter_with_capture.close_connection(connection)
+
+    def test_plan_capture_analyze_plans_true_populates_timing(self):
+        """With analyze_plans=True (opt-in), captured plans carry actual timing.
+
+        Regression guard for the default flip: EXPLAIN ANALYZE is still fully
+        functional and available for users who explicitly opt in.
+        """
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        connection = adapter.create_connection()
+
+        try:
+            result = adapter.execute_query(
+                connection=connection,
+                query="SELECT 1 as test_column",
+                query_id="test_q1_analyze",
+                validate_row_count=False,
+            )
+
+            plan = result["query_plan"]
+            assert plan is not None
             phys = plan.logical_root.physical_operator
             assert phys is not None, "physical_operator should always be present"
             assert phys.properties.get("timing") is not None, "EXPLAIN ANALYZE should populate timing"
             assert phys.properties["timing"] >= 0, "timing should be non-negative"
 
         finally:
-            adapter_with_capture.close_connection(connection)
+            adapter.close_connection(connection)
 
     def test_plan_not_captured_when_disabled(self, adapter_without_capture):
         """Test that plan is not captured when capture_plans=False."""
@@ -399,8 +427,8 @@ class TestDuckDBPlanCapture:
         """get_query_plan must use EXPLAIN (ANALYZE, FORMAT JSON), not the text/box format.
 
         The text-box parser rejects branching structures (JOINs) and would
-        produce incorrect fingerprints. JSON format handles all query shapes.
-        EXPLAIN ANALYZE adds actual timing and cardinality data to the captured plan.
+        produce incorrect fingerprints. JSON format handles all query shapes,
+        regardless of whether ANALYZE (opt-in) is used.
         """
         connection = adapter_with_capture.create_connection()
         try:
@@ -510,6 +538,76 @@ class TestDuckDBPlanCapture:
 
         finally:
             adapter.close_connection(connection)
+
+    def test_default_adapter_analyze_plans_is_false(self):
+        """analyze_plans defaults to False on a fresh adapter (no explicit override)."""
+        adapter = DuckDBAdapter(capture_plans=True)
+        assert adapter.analyze_plans is False
+
+    def test_default_get_query_plan_issues_plain_explain_no_analyze(self):
+        """Default capture (no analyze_plans override) must not run EXPLAIN ANALYZE.
+
+        Verifies the executed SQL directly rather than inferring it from parsed
+        timing fields, so the assertion holds even if the parser's timing
+        extraction changes.
+        """
+        adapter = DuckDBAdapter(capture_plans=True)
+        connection = MagicMock()
+        connection.execute.return_value.fetchall.return_value = [("physical_plan", "{}")]
+
+        adapter.get_query_plan(connection, "SELECT 1")
+
+        called_sql = connection.execute.call_args[0][0].upper()
+        assert "ANALYZE" not in called_sql, f"Default capture must not run EXPLAIN ANALYZE: {called_sql}"
+        assert "FORMAT JSON" in called_sql
+
+    def test_analyze_plans_notice_printed_once_per_run(self, capsys):
+        """A one-time notice is printed the first time analyze_plans=True actually captures.
+
+        The notice must not repeat on subsequent captures within the same run, and
+        must not appear at all when analyze_plans is left at its False default.
+        """
+        set_quiet(False)
+        adapter = DuckDBAdapter(capture_plans=True, analyze_plans=True)
+        connection = adapter.create_connection()
+
+        try:
+            connection.execute("CREATE TABLE notice_test (id INTEGER)")
+            connection.execute("INSERT INTO notice_test VALUES (1)")
+
+            adapter.capture_query_plan(connection, "SELECT * FROM notice_test", "notice_q1")
+            first_output = capsys.readouterr().out
+            assert "re-executes each query" in first_output, "Expected the analyze_plans notice on first capture"
+
+            adapter.capture_query_plan(connection, "SELECT * FROM notice_test", "notice_q2")
+            second_output = capsys.readouterr().out
+            assert "re-executes each query" not in second_output, "Notice must print only once per run"
+
+            # A fresh run (stats reset) gets its own notice.
+            adapter._reset_plan_capture_stats()
+            adapter.capture_query_plan(connection, "SELECT * FROM notice_test", "notice_q3")
+            third_output = capsys.readouterr().out
+            assert "re-executes each query" in third_output, "Notice must reprint after a stats reset (new run)"
+        finally:
+            adapter.close_connection(connection)
+            set_quiet(False)
+
+    def test_no_notice_when_analyze_plans_default(self, capsys):
+        """No re-execution notice is printed when analyze_plans stays at its False default."""
+        set_quiet(False)
+        adapter = DuckDBAdapter(capture_plans=True)
+        connection = adapter.create_connection()
+
+        try:
+            connection.execute("CREATE TABLE no_notice_test (id INTEGER)")
+            connection.execute("INSERT INTO no_notice_test VALUES (1)")
+
+            adapter.capture_query_plan(connection, "SELECT * FROM no_notice_test", "no_notice_q1")
+            output = capsys.readouterr().out
+            assert "re-executes each query" not in output
+        finally:
+            adapter.close_connection(connection)
+            set_quiet(False)
 
 
 class TestDuckDBFingerprintIntegration:

--- a/tests/unit/platforms/test_postgresql_plan_capture.py
+++ b/tests/unit/platforms/test_postgresql_plan_capture.py
@@ -183,8 +183,10 @@ class TestPostgreSQLPlanCapture:
         assert "ANALYZE" not in call_args.upper(), f"EXPLAIN ANALYZE must not be used for write DDL: {write_ddl!r}"
         assert "FORMAT JSON" in call_args.upper()
 
-    def test_get_query_plan_select_uses_analyze(self, adapter):
-        """SELECT queries must still use EXPLAIN ANALYZE for actual timing data."""
+    def test_get_query_plan_select_uses_analyze(self, monkeypatch):
+        """SELECT queries use EXPLAIN ANALYZE for actual timing data when opted in (analyze_plans=True)."""
+        monkeypatch.setattr("benchbox.platforms.postgresql.psycopg", MagicMock())
+        adapter = PostgreSQLAdapter(capture_plans=True, analyze_plans=True)
         cursor = MagicMock()
         cursor.fetchall.return_value = [('{"Plan":{}}',)]
         conn = MagicMock()


### PR DESCRIPTION
## Description

Implements TODO item **qpc-04** (`_project/TODO/query-plan-capture/planning/04-capture-timeout-and-analyze-default.yaml`).

DuckDB plan capture previously defaulted to `EXPLAIN (ANALYZE, FORMAT JSON)` (`analyze_plans=True`), which **re-executes every measured query** during capture — roughly 2x wall-clock for a `--capture-plans` run and perturbed cache state, with no user-facing notice. Since plan fingerprints are structure-only, estimated plans lose nothing downstream. This flips the default:

- `benchbox/platforms/base/adapter.py`: `analyze_plans` config default `True` → `False`, so capture defaults to plain `EXPLAIN (FORMAT JSON)` (no re-execution). `analyze_plans=True` remains a fully-functional explicit opt-in.
- `benchbox/platforms/base/result_capture.py`: `capture_query_plan` prints a one-time per-run notice ("plan capture re-executes each query (analyze_plans=True); timings are not comparable to non-capture runs.") the first time it actually captures a plan with ANALYZE enabled. Guarded by a new `_analyze_plans_notice_printed` flag reset per-run in `_reset_plan_capture_stats`. The notice fires after the query-filter selection check and outside the capture-timing block, so per-query timing exclusion is unaffected.
- `benchbox/platforms/duckdb.py`: docstrings updated to describe the new default.
- Tests updated/added across the plan-capture suites (see Testing).

The **capture-timeout wall-clock fix** (work unit w1) was already landed on `develop` prior to this change — `capture_query_plan` uses `run_with_timeout` (daemon thread + `join(timeout)`), which returns promptly on timeout instead of blocking in `shutdown(wait=True)`. Verified via the existing timeout regression tests; no further change needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

All via `uv run --`:
- `uv run -- python -m pytest tests/unit/platforms/test_plan_capture_errors.py -q -k timeout` → 6 passed (timeout bounds wall-clock)
- `uv run -- python -m pytest tests/unit/platforms/test_duckdb_plan_capture.py -q` → 93 passed (default EXPLAIN has no ANALYZE; notice printed once per run when opted in; not printed at default)
- Related touched suites (`test_duckdb_adapter.py`, `test_postgresql_plan_capture.py`, `test_adapter_lifecycle.py`, `test_plan_capture_phase.py`, `test_motherduck_plan_capture.py`, `test_duckdb_operations.py`) → all passing
- `uv run -- ruff check` / `ruff format --check` on the three source files → clean
- `uv run -- ty check` on the three source files → only 3 pre-existing psutil `possibly-missing-attribute` warnings (unrelated to this change)

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Default value of an internal adapter config knob; the `analyze_plans` CLI/config surface is unchanged — only its default.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [ ] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes. (See Notes — CLI help text follow-up is out of scope.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: n/a.

## Notes

- **Soundness path — awaits Code Owner review.** This PR modifies `benchbox/platforms/base/result_capture.py`, which is CODEOWNERS-gated (`@joeharris76`). Auto-merge is intentionally **not** enabled; it waits for Code Owner review before merge.
- An adversarial (Opus) review found no in-scope defects. It flagged two **out-of-scope** follow-ups, deliberately left untouched because they fall outside qpc-04's `scope_limit.only_modify`:
  1. `benchbox/core/plan_capture_phase.py:155` still uses `getattr(adapter, "analyze_plans", True)` as its save-fallback default — now inconsistent with the new `False` default, but latent only (real adapters always set the attribute in `__init__`, so the fallback never triggers).
  2. `benchbox/cli/commands/run.py` `--analyze-plans` help text still describes the old ANALYZE-by-default behavior.
- Minor: the one-time notice flag check-then-set is not under `_plan_capture_lock`; worst case is a duplicate cosmetic one-line notice under concurrent inline capture with `analyze_plans=True`. No counter/soundness/timing invariant is affected, so it was intentionally left unlocked to avoid gold-plating the soundness-gated lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_