### PR TITLE
fix(qpc-09): exclude plan-capture time from DataFrame execution_time_ms

### DIFF
--- a/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
+++ b/_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml
@@ -2,7 +2,8 @@ id: "qpc-09-df-timing-semantics"
 title: "Exclude plan-capture time from DataFrame execution_time_ms (align with SQL semantics)"
 worktree: "query-plan-capture"
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-06"
 
 description: |
   QueryProfileContext.get_profile computes execution_time_ms wall-to-wall
@@ -28,32 +29,38 @@ work:
     Create: add a plan_capture timed phase to QueryProfileContext and define
     execution_time_ms to exclude capture time.
   notes: >-
-    Either sum-of-measured-phases minus capture, or collect-time as the
-    canonical query time. Document which segments count in the profile
-    docstring.
-  status: pending
+    Chose measure-and-subtract: QueryProfileContext gains
+    start_plan_capture/end_plan_capture; get_profile computes execution_time_ms
+    as wall minus the MEASURED capture time (clamped at 0). Capture time
+    surfaced as plan_capture_time_ms on QueryExecutionProfile. planning_time_ms
+    / collect_time_ms meaning preserved. Timing semantics documented in the
+    profile docstring. expression_family and the profile_query_execution helper
+    both wrap capture_query_plan in the timed phase; benchmark_mixin surfaces
+    plan_capture_time_ms on the result row.
+  status: done
 - id: w2
   summary: >-
     Create: timing contract test — capture on/off must report equal
     execution_time_ms; capture time gets its own field.
   notes: >-
-    Same fake query profiled with and without capture_plan must report
-    execution_time_ms within tolerance; capture time surfaced as
-    plan_capture_time_ms matching the SQL-side field name.
+    tests/unit/platforms/dataframe/test_df_timing_contract.py: same fake query
+    profiled with capture on/off; a slow (40ms) fake capture must NOT appear in
+    execution_time_ms while plan_capture_time_ms carries it. Also unit-level
+    QueryProfileContext and profile_query_execution coverage.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Review: adversarial code review (timing-policy check compliance, downstream consumers of execution_time_ms/planning/collect fields)."
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Fix: address review findings; re-run verification."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Submit PR referencing qpc-09."
   needs: [w4]
-  status: pending
+  status: done
 
 must_preserve:
 - "planning_time_ms / collect_time_ms fields and their meaning"

--- a/benchbox/core/dataframe/profiling.py
+++ b/benchbox/core/dataframe/profiling.py
@@ -93,11 +93,27 @@ class QueryPlan:
 class QueryExecutionProfile:
     """Profile of a single query execution.
 
+    Timing semantics:
+        ``execution_time_ms`` is the query's own work time and EXCLUDES the plan
+        capture phase, so enabling ``--capture-plans`` does not change the reported
+        per-query time. It covers the segments that make up executing the query
+        itself -- planning (building the lazy query), collect/materialize, and the
+        surrounding result-shaping overhead (row count, first-row fetch, memory
+        tracker stop) -- but not the ``capture_query_plan`` call, whose measured
+        duration is reported separately as ``plan_capture_time_ms``. This aligns
+        DataFrame timing with the SQL platforms, which capture plans after the timed
+        block and likewise surface capture cost as ``plan_capture_time_ms``. The
+        capture time is measured explicitly (a timed phase in QueryProfileContext),
+        never estimated and subtracted.
+
     Attributes:
         query_id: Query identifier
-        execution_time_ms: Total execution time in milliseconds
+        execution_time_ms: Query execution time in milliseconds, EXCLUDING plan
+            capture time (see Timing semantics above)
         planning_time_ms: Time spent in query planning (lazy platforms)
         collect_time_ms: Time spent in collect/materialize phase
+        plan_capture_time_ms: Time spent capturing the query plan (0.0 when capture
+            was disabled or no plan was captured); excluded from execution_time_ms
         rows_processed: Number of rows in result
         peak_memory_mb: Peak memory usage in MB
         query_plan: Captured query plan if available
@@ -110,6 +126,7 @@ class QueryExecutionProfile:
     execution_time_ms: float
     planning_time_ms: float = 0.0
     collect_time_ms: float = 0.0
+    plan_capture_time_ms: float = 0.0
     rows_processed: int = 0
     peak_memory_mb: float = 0.0
     query_plan: QueryPlan | None = None
@@ -141,6 +158,8 @@ class QueryProfileContext:
         self._planning_time: float = 0.0
         self._collect_start: float = 0.0
         self._collect_time: float = 0.0
+        self._plan_capture_start: float = 0.0
+        self._plan_capture_time: float = 0.0
         self._rows: int = 0
         self._query_plan: QueryPlan | None = None
         self._peak_memory: float = 0.0
@@ -166,6 +185,22 @@ class QueryProfileContext:
         if self._collect_start > 0:
             self._collect_time = (time.perf_counter() - self._collect_start) * 1000
 
+    def start_plan_capture(self) -> None:
+        """Mark start of the plan-capture phase (excluded from execution_time_ms)."""
+        self._plan_capture_start = time.perf_counter()
+
+    def end_plan_capture(self) -> None:
+        """Mark end of the plan-capture phase.
+
+        The measured duration is accumulated into ``plan_capture_time_ms`` and
+        subtracted from ``execution_time_ms`` in :meth:`get_profile`, so plan
+        capture never inflates the reported query time. Accumulates across calls in
+        case capture happens in more than one segment.
+        """
+        if self._plan_capture_start > 0:
+            self._plan_capture_time += (time.perf_counter() - self._plan_capture_start) * 1000
+            self._plan_capture_start = 0.0
+
     def set_rows(self, rows: int) -> None:
         """Set number of rows processed."""
         self._rows = rows
@@ -183,14 +218,23 @@ class QueryProfileContext:
         self._metrics[name] = value
 
     def get_profile(self) -> QueryExecutionProfile:
-        """Get the execution profile."""
-        execution_time = (time.perf_counter() - self._start_time) * 1000
+        """Get the execution profile.
+
+        ``execution_time_ms`` is the wall-clock span since the context started with
+        the measured plan-capture phase subtracted out, so capture on/off report the
+        same query time. The subtracted amount is the value measured by
+        ``start_plan_capture``/``end_plan_capture`` -- never an estimate. Clamped at
+        0.0 to defend against clock noise if capture somehow exceeds the window.
+        """
+        wall_ms = (time.perf_counter() - self._start_time) * 1000
+        execution_time = max(0.0, wall_ms - self._plan_capture_time)
 
         return QueryExecutionProfile(
             query_id=self.query_id,
             execution_time_ms=execution_time,
             planning_time_ms=self._planning_time,
             collect_time_ms=self._collect_time,
+            plan_capture_time_ms=self._plan_capture_time,
             rows_processed=self._rows,
             peak_memory_mb=self._peak_memory,
             query_plan=self._query_plan,
@@ -872,15 +916,19 @@ def profile_query_execution(
         lazy_result = query_fn()
         ctx.end_planning()
 
-        # Capture query plan before collect if possible
+        # Capture query plan before collect if possible. Timed as its own phase so
+        # it is excluded from execution_time_ms (see QueryProfileContext timing).
         query_plan = None
         if plan_capture_fn is not None:
+            ctx.start_plan_capture()
             try:
                 query_plan = plan_capture_fn(lazy_result)
                 if query_plan:
                     ctx.set_query_plan(query_plan)
             except Exception as e:
                 logger.debug(f"Plan capture failed: {e}")
+            finally:
+                ctx.end_plan_capture()
 
         # Phase 2: Collect/materialize results
         if collect_fn is not None:

--- a/benchbox/platforms/dataframe/benchmark_mixin.py
+++ b/benchbox/platforms/dataframe/benchmark_mixin.py
@@ -1129,6 +1129,10 @@ class BenchmarkExecutionMixin:
                     raw_result = dict(raw_result)
                     if profile.query_plan is not None:
                         raw_result["query_plan"] = profile.query_plan
+                    # Surface capture cost separately (excluded from execution time),
+                    # matching the SQL platforms' plan_capture_time_ms field.
+                    if profile.plan_capture_time_ms:
+                        raw_result["plan_capture_time_ms"] = profile.plan_capture_time_ms
                 else:
                     raw_result = self.execute_query(ctx, query)
                     raw_result = dict(raw_result)

--- a/benchbox/platforms/dataframe/expression_family.py
+++ b/benchbox/platforms/dataframe/expression_family.py
@@ -1427,14 +1427,19 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
             if isinstance(lazy_result, UnifiedLazyFrame):
                 lazy_result = lazy_result.native
 
-            # Capture query plan before collect if enabled
+            # Capture query plan before collect if enabled. Timed as its own phase
+            # so capture cost is excluded from execution_time_ms and reported
+            # separately as plan_capture_time_ms (matching the SQL platforms).
             if capture_plan:
+                profile_ctx.start_plan_capture()
                 try:
                     plan = capture_query_plan(lazy_result, self.platform_name)
                     if plan:
                         profile_ctx.set_query_plan(plan)
                 except Exception as e:
                     logger.debug(f"Plan capture failed for {qid}: {e}")
+                finally:
+                    profile_ctx.end_plan_capture()
 
             # Phase 2: Collection (materialize results)
             profile_ctx.start_collect()

--- a/tests/unit/platforms/dataframe/test_benchmark_mixin.py
+++ b/tests/unit/platforms/dataframe/test_benchmark_mixin.py
@@ -74,7 +74,7 @@ class DummyPandasProfiledAdapter(DummyAdapter):
             "execution_time_seconds": 0.01,
             "rows_returned": 1,
         }
-        profile = SimpleNamespace(query_plan=self._query_plan)
+        profile = SimpleNamespace(query_plan=self._query_plan, plan_capture_time_ms=0.0)
         return result, profile
 
 

--- a/tests/unit/platforms/dataframe/test_df_timing_contract.py
+++ b/tests/unit/platforms/dataframe/test_df_timing_contract.py
@@ -1,0 +1,214 @@
+"""Timing contract: plan capture must not inflate DataFrame execution_time_ms.
+
+qpc-09 regression tests. Enabling ``--capture-plans`` on DataFrame platforms must
+NOT change the reported per-query ``execution_time_ms``: the capture phase is timed
+as its own segment and excluded from execution time (mirroring the SQL platforms,
+which capture after the timed block). The capture cost is surfaced separately as
+``plan_capture_time_ms``.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchbox.core.dataframe.profiling import (
+    QueryExecutionProfile,
+    QueryPlan,
+    QueryProfileContext,
+    profile_query_execution,
+)
+from benchbox.core.dataframe.query import DataFrameQuery
+from benchbox.platforms.dataframe import expression_family
+from benchbox.platforms.dataframe.expression_family import ExpressionFamilyAdapter
+from benchbox.platforms.dataframe.unified_frame import UnifiedExpr
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Capture-phase sleep, chosen large relative to the trivial fake query so the
+# "excluded from execution time" contract is unambiguous even with clock noise.
+_CAPTURE_SLEEP_MS = 40.0
+
+
+class _TimingAdapter(ExpressionFamilyAdapter[dict, dict, str]):
+    """Minimal expression-family adapter with a trivial (near-zero-time) query."""
+
+    table_mode = "native"
+    config = None
+
+    @property
+    def platform_name(self) -> str:
+        return "Polars"
+
+    def col(self, name: str) -> str:
+        return f"col({name})"
+
+    def lit(self, value: Any) -> str:
+        return f"lit({value})"
+
+    def date_sub(self, column: str, days: int) -> str:
+        return f"date_sub({column},{days})"
+
+    def date_add(self, column: str, days: int) -> str:
+        return f"date_add({column},{days})"
+
+    def cast_date(self, column: str) -> str:
+        return f"cast_date({column})"
+
+    def cast_string(self, column: str) -> str:
+        return f"cast_string({column})"
+
+    def read_csv(
+        self,
+        path: Path,
+        *,
+        delimiter: str = ",",
+        has_header: bool = True,
+        column_names: list[str] | None = None,
+        null_marker: str | None = None,
+    ) -> dict:
+        return {"kind": "csv", "path": str(path)}
+
+    def read_parquet(self, path: Path) -> dict:
+        return {"kind": "parquet", "path": str(path)}
+
+    def collect(self, df: dict) -> dict:
+        return df
+
+    def get_row_count(self, df: dict) -> int:
+        return int(df.get("rows", 1))
+
+    def scalar(self, df: dict, column: str | None = None) -> Any:
+        return df.get("value", 1)
+
+    def scalar_to_df(self, data: dict[str, Any]) -> dict:
+        return {"rows": 1, "first": tuple(data.values())}
+
+    def window_rank(self, order_by, partition_by=None):
+        return "window_rank"
+
+    def window_row_number(self, order_by, partition_by=None):
+        return "window_row_number"
+
+    def window_dense_rank(self, order_by, partition_by=None):
+        return "window_dense_rank"
+
+    def window_sum(self, column, partition_by=None, order_by=None):
+        return "window_sum"
+
+    def window_avg(self, column, partition_by=None, order_by=None):
+        return "window_avg"
+
+    def window_count(self, column=None, partition_by=None, order_by=None):
+        return "window_count"
+
+    def window_min(self, column, partition_by=None):
+        return "window_min"
+
+    def window_max(self, column, partition_by=None):
+        return "window_max"
+
+    def union_all(self, *dataframes):
+        return {"union": list(dataframes)}
+
+    def rename_columns(self, df, mapping):
+        return {"df": df, "mapping": mapping}
+
+
+def _slow_capture(_lazy: Any, _platform: str) -> QueryPlan:
+    """Stand-in plan capture that costs a measurable, fixed amount of time."""
+    time.sleep(_CAPTURE_SLEEP_MS / 1000.0)
+    return QueryPlan(platform="polars", plan_type="optimized", plan_text="PLAN")
+
+
+class TestQueryProfileContextTiming:
+    def test_execution_time_excludes_measured_plan_capture(self) -> None:
+        ctx = QueryProfileContext("Q1", "polars")
+        ctx._start_time = time.perf_counter()
+
+        # A measurable "capture" phase inside the profiling window.
+        ctx.start_plan_capture()
+        time.sleep(_CAPTURE_SLEEP_MS / 1000.0)
+        ctx.end_plan_capture()
+
+        profile = ctx.get_profile()
+
+        # Capture time is recorded, and execution_time_ms excludes it.
+        assert profile.plan_capture_time_ms >= _CAPTURE_SLEEP_MS * 0.5
+        assert profile.execution_time_ms < profile.plan_capture_time_ms, (
+            "execution_time_ms must exclude the measured plan-capture phase"
+        )
+
+    def test_no_capture_leaves_zero_capture_time(self) -> None:
+        ctx = QueryProfileContext("Q2", "polars")
+        ctx._start_time = time.perf_counter()
+        time.sleep(0.005)
+        profile = ctx.get_profile()
+
+        assert profile.plan_capture_time_ms == 0.0
+        # With no capture phase, execution_time_ms is the full window.
+        assert profile.execution_time_ms >= 5.0 * 0.5
+
+    def test_profile_default_capture_time_is_zero(self) -> None:
+        # Field default keeps existing callers / serialized rows unchanged.
+        profile = QueryExecutionProfile(query_id="Q", execution_time_ms=1.0)
+        assert profile.plan_capture_time_ms == 0.0
+
+
+class TestProfileQueryExecutionTiming:
+    def test_helper_excludes_capture_from_execution_time(self) -> None:
+        _, profile = profile_query_execution(
+            query_id="Q1",
+            platform="polars",
+            query_fn=lambda: {"rows": 3},
+            collect_fn=lambda df: df,
+            row_count_fn=lambda df: 3,
+            plan_capture_fn=lambda _df: _slow_capture(_df, "polars"),
+            track_memory=False,
+        )
+
+        assert profile.query_plan is not None
+        assert profile.plan_capture_time_ms >= _CAPTURE_SLEEP_MS * 0.5
+        # The capture sleep must not appear in execution time.
+        assert profile.execution_time_ms < _CAPTURE_SLEEP_MS * 0.5
+
+
+class TestExpressionFamilyCaptureTimingContract:
+    def test_capture_on_off_report_equal_execution_time(self, monkeypatch) -> None:
+        """Same query profiled with capture on/off reports equal execution_time.
+
+        With capture ON the (slow) capture phase must be excluded, so the two runs'
+        execution_time_ms agree within tolerance while capture ON reports a
+        non-trivial plan_capture_time_ms.
+        """
+        monkeypatch.setattr(expression_family, "capture_query_plan", _slow_capture)
+
+        adapter = _TimingAdapter()
+        ctx = adapter.create_context()
+        ctx.register_table("orders", {"rows": 3, "first": (1,)})
+        query = DataFrameQuery(
+            query_id="Q1",
+            query_name="q",
+            description="q",
+            expression_impl=lambda c: {"rows": 3},
+        )
+
+        result_off, profile_off = adapter.execute_query_profiled(ctx, query, track_memory=False, capture_plan=False)
+        result_on, profile_on = adapter.execute_query_profiled(ctx, query, track_memory=False, capture_plan=True)
+
+        assert profile_on.query_plan is not None
+        assert profile_on.plan_capture_time_ms >= _CAPTURE_SLEEP_MS * 0.5
+        assert profile_off.plan_capture_time_ms == 0.0
+
+        # The capture sleep (>=20ms of a 40ms budget) must not leak into the timed
+        # query; if it did, capture-on would exceed capture-off by ~the sleep.
+        assert profile_on.execution_time_ms < _CAPTURE_SLEEP_MS * 0.5, "plan capture time leaked into execution_time_ms"
+        # execution_time_seconds in the result row mirrors the excluded value.
+        assert result_on["execution_time_seconds"] < _CAPTURE_SLEEP_MS * 0.5 / 1000.0
+        assert result_off["status"] == "SUCCESS" and result_on["status"] == "SUCCESS"


### PR DESCRIPTION
## Description

Implements TODO item **qpc-09** (`_project/TODO/query-plan-capture/planning/09-df-timing-semantics.yaml`).

`QueryProfileContext.get_profile` computed `execution_time_ms` wall-to-wall from context creation, and plan capture ran *inside* that window (`expression_family.execute_query_profiled`). So enabling `--capture-plans` **changed reported per-query times** on DataFrame platforms, while SQL platforms capture *after* timing. A/B comparisons where one side had capture enabled were skewed, and cross-family comparisons embedded inconsistent timing semantics within a single run (Finding F5.1).

Fix — measure the capture phase explicitly and exclude it (never estimate/subtract):

- `benchbox/core/dataframe/profiling.py`: `QueryProfileContext` gains `start_plan_capture()` / `end_plan_capture()`, accumulating the **measured** capture duration into `_plan_capture_time`. `get_profile()` now returns `execution_time_ms = max(0.0, wall_ms - _plan_capture_time)` (the `max` is a clock-noise guard — capture always sits inside the wall window) and a new `plan_capture_time_ms` field on `QueryExecutionProfile` (default `0.0`). `planning_time_ms` / `collect_time_ms` are untouched. The standalone `profile_query_execution` helper wraps its `plan_capture_fn` in the timed phase too. Timing semantics documented in the profile docstring.
- `benchbox/platforms/dataframe/expression_family.py`: wraps the `capture_query_plan(...)` call in `execute_query_profiled` with the timed phase (try/finally).
- `benchbox/platforms/dataframe/benchmark_mixin.py`: surfaces `plan_capture_time_ms` on the result row alongside `query_plan`, matching the SQL-side field name.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

All via `uv run --`:
- `uv run -- python -m pytest tests/unit/platforms/dataframe -q -k 'profil or timing'` → 19 passed (new `tests/unit/platforms/dataframe/test_df_timing_contract.py`: a slow 40ms fake capture must NOT appear in `execution_time_ms` while `plan_capture_time_ms` carries it; plus unit coverage of `QueryProfileContext` and `profile_query_execution`)
- `uv run -- python scripts/validate_todo_indexes.py` → exit 0 (timing-policy gate: Violations: 0, Fast lane policy violations: 0)
- Broader `uv run -- python -m pytest tests/unit/platforms/dataframe tests/unit/core/dataframe -q` → 1872 passed, 66 skipped (Java/pyspark unavailable), no regressions
- `uv run -- ruff check` / `ruff format --check` on touched files → clean
- `uv run -- ty check` on the three source files → All checks passed

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Adds an additive `plan_capture_time_ms` field defaulting to `0.0`; changes the internal DataFrame timing semantics to match the existing SQL contract.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [ ] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: n/a.

## Notes

- Not a soundness-gated (CODEOWNERS) path — this touches only DataFrame profiling. Squash auto-merge enabled.
- An adversarial (Opus) review found no in-scope defects. Timing arithmetic confirmed correct (measured, not estimated; `mono_time() == perf_counter()` so no clock mismatch; no double-count — `end_plan_capture` guards and resets `_plan_capture_start`). Confirmed the pandas-family `execute_query_profiled` path is genuinely unaffected (it never captures a plan inside its timing window, so there is nothing to exclude — not a follow-up).
- Minor consistency nit (left as-is, non-defect): `benchmark_mixin` surfaces the field with a truthy check (`if profile.plan_capture_time_ms:`), so it omits the field when capture cost is exactly `0.0`, whereas the SQL side uses `is not None`. Harmless — when capture actually runs the value is positive; downstream readers treat absence as "no capture cost."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_