### PR TITLE
fix(qpc-10): truncate deep plans with a marker; configurable plan_max_depth

### DIFF
--- a/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
+++ b/_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml
@@ -2,7 +2,8 @@ id: "qpc-10-concurrency-and-depth-limits"
 title: "Thread-safe capture stats under throughput mode; explicit depth-limit truncation"
 worktree: "query-plan-capture"
 priority: "Low"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-06"
 
 description: |
   Concurrency: throughput streams run on a ThreadPoolExecutor
@@ -37,37 +38,49 @@ work:
     Create: one threading.Lock in the capture mixin around the three mutation
     sites (rare, contention-free); make plan_first_n check-and-increment
     atomic under the lock.
-  status: pending
+  notes: >-
+    Already landed on develop prior to this PR: _plan_capture_lock guards the
+    capture-stat mutation sites (the per-iteration/per-stream plan_first_n
+    sampling machinery was retired by the canonical capture-once-per-query
+    model, so there is no counter left to make atomic). No change in this PR.
+  status: done
 - id: w2
   summary: >-
     Create: define and implement strict-mode semantics under throughput
     (recommended: abort the run — propagate PlanCaptureError distinctly from
     generic stream failure); document the choice.
+  notes: >-
+    Already landed prior to this PR (strict-mode PlanCaptureError propagation).
+    No change in this PR.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: >-
     Create: deep plans serialize with a truncated_at_depth marker instead of
     being dropped; make plan_max_depth configurable.
   notes: >-
-    Fingerprint computed over the full in-memory tree with the fingerprint
-    marked partial-safe; expose plan_max_depth in adapter config next to
-    plan_capture_timeout_seconds; remove the dangling "external plan
-    storage" hint.
+    Implemented here: LogicalOperator.to_dict emits a truncated_at_depth marker
+    (with children_omitted) beyond max_depth instead of raising
+    SerializationError; QueryPlanDAG.to_dict/to_json/estimate_serialized_size
+    default to DEFAULT_PLAN_MAX_DEPTH (50). plan_max_depth is exposed in adapter
+    config next to plan_capture_timeout_seconds and threaded into the
+    capture-time size guard. The plan_fingerprint is computed over the full
+    in-memory tree, so truncation never changes fingerprint equality. Removed
+    the dangling "external plan storage" hint.
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Review: adversarial code review (lock scope vs EXPLAIN duration — never hold the lock across I/O; truncation-marker round-trip)."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Fix: address review findings; re-run verification."
   needs: [w4]
-  status: pending
+  status: done
 - id: w6
   summary: "Submit PR referencing qpc-10."
   needs: [w5]
-  status: pending
+  status: done
 
 must_preserve:
 - "compute_plan_capture_stats iteration-stable semantics"

--- a/benchbox/core/results/query_plan_models.py
+++ b/benchbox/core/results/query_plan_models.py
@@ -113,8 +113,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from benchbox.core.errors import SerializationError
-
 # Literal-masking patterns for normalize_literals fingerprints. Numeric literals
 # (including decimals, and a tightly-adjacent sign like ``-5``) collapse to a
 # placeholder and single-quoted string literals to another, so that structurally
@@ -240,6 +238,15 @@ RAW_OUTPUT_POLICIES = frozenset({RAW_OUTPUT_FULL, RAW_OUTPUT_TRUNCATED, RAW_OUTP
 # useful for debugging.
 DEFAULT_RAW_OUTPUT_POLICY = RAW_OUTPUT_TRUNCATED
 DEFAULT_RAW_OUTPUT_MAX_BYTES = 16 * 1024
+
+# Default maximum logical-tree depth serialized by ``QueryPlanDAG.to_dict`` /
+# ``to_json`` / ``estimate_serialized_size``. Nodes deeper than this are replaced by
+# a truncation marker (``truncated_at_depth``) in the serialized output rather than
+# dropping the whole plan, so a pathologically deep plan still round-trips its upper
+# levels instead of failing capture outright. The in-memory tree and the structural
+# ``plan_fingerprint`` are computed over the FULL tree and are unaffected by this
+# serialization cap. Configurable per-adapter via ``plan_max_depth``.
+DEFAULT_PLAN_MAX_DEPTH = 50
 
 
 def normalize_raw_output_policy(policy: str | None) -> str:
@@ -391,14 +398,35 @@ class LogicalOperator:
     offset_count: int | None = None
 
     def to_dict(self, max_depth: int | None = None, current_depth: int = 0) -> dict[str, Any]:
-        """Convert to JSON-serializable dictionary with optional depth guard."""
-        if max_depth is not None and current_depth > max_depth:
-            raise SerializationError(f"Max depth {max_depth} exceeded")
+        """Convert to JSON-serializable dictionary with optional depth guard.
 
+        When ``max_depth`` is set and this node sits beyond it, the node is
+        serialized as a shallow truncation marker (carrying ``truncated_at_depth``
+        and the count of omitted children) instead of raising and discarding the
+        whole plan. This bounds the serialized size of a pathologically deep tree
+        while preserving everything down to the limit. The in-memory tree and the
+        structural ``plan_fingerprint`` are computed over the FULL tree, so this
+        serialization-only truncation never changes fingerprint equality — a
+        truncated serialized plan is explicitly marked rather than silently passed
+        off as complete.
+        """
         # Handle enum conversion
         operator_type_value = (
             self.operator_type.value if isinstance(self.operator_type, LogicalOperatorType) else self.operator_type
         )
+
+        if max_depth is not None and current_depth > max_depth:
+            # Depth guard: emit a marker node instead of dropping the plan. Keep the
+            # operator identity so the truncation point is legible; omit children and
+            # the value-bearing fields (they are what the depth cap is protecting
+            # against). ``from_dict`` reconstructs this as a childless leaf.
+            return {
+                "operator_type": operator_type_value,
+                "operator_id": self.operator_id,
+                "truncated_at_depth": current_depth,
+                "children_omitted": len(self.children),
+            }
+
         join_type_value = self.join_type.value if isinstance(self.join_type, JoinType) else self.join_type
 
         return {
@@ -750,8 +778,13 @@ class QueryPlanDAG:
             f"of {original_bytes} bytes under '{RAW_OUTPUT_TRUNCATED}' policy]"
         )
 
-    def to_dict(self, max_depth: int | None = 50) -> dict[str, Any]:
-        """Convert to JSON-serializable dictionary with depth protection."""
+    def to_dict(self, max_depth: int | None = DEFAULT_PLAN_MAX_DEPTH) -> dict[str, Any]:
+        """Convert to JSON-serializable dictionary with depth protection.
+
+        Nodes deeper than ``max_depth`` are replaced by a ``truncated_at_depth``
+        marker (see ``LogicalOperator.to_dict``) rather than raising; the stored
+        ``plan_fingerprint`` reflects the full in-memory tree regardless.
+        """
         return {
             "query_id": self.query_id,
             "platform": self.platform,
@@ -813,12 +846,12 @@ class QueryPlanDAG:
 
         return plan
 
-    def to_json(self, indent: int | None = 2, *, max_depth: int | None = 50) -> str:
+    def to_json(self, indent: int | None = 2, *, max_depth: int | None = DEFAULT_PLAN_MAX_DEPTH) -> str:
         """Serialize to JSON string."""
         return json.dumps(self.to_dict(max_depth=max_depth), indent=indent)
 
-    def estimate_serialized_size(self, *, max_depth: int | None = 50) -> int:
-        """Estimate JSON serialized size in bytes."""
+    def estimate_serialized_size(self, *, max_depth: int | None = DEFAULT_PLAN_MAX_DEPTH) -> int:
+        """Estimate JSON serialized size in bytes (deep nodes truncated, not dropped)."""
         return len(json.dumps(self.to_dict(max_depth=max_depth), indent=None))
 
     @classmethod

--- a/benchbox/platforms/base/adapter.py
+++ b/benchbox/platforms/base/adapter.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+from benchbox.core.results.query_plan_models import DEFAULT_PLAN_MAX_DEPTH
 from benchbox.core.results.schema import compute_plan_capture_stats
 from benchbox.platforms.base.connection_lifecycle import ConnectionLifecycleMixin
 from benchbox.platforms.base.connection_wrappers import (
@@ -143,6 +144,12 @@ class PlatformAdapter(
         # the default fingerprint during plan capture (see --normalize-plan-literals).
         self.normalize_plan_literals = config.get("normalize_plan_literals", False)
         self.plan_capture_timeout_seconds = int(config.get("plan_capture_timeout_seconds", 30))
+        # Maximum logical-tree depth serialized when a captured plan is written to
+        # the results bundle / size-checked. Nodes deeper than this become a
+        # truncation marker instead of dropping the whole plan (see
+        # query_plan_models.DEFAULT_PLAN_MAX_DEPTH). The structural fingerprint is
+        # computed over the full in-memory tree, so it is unaffected by this cap.
+        self.plan_max_depth = int(config.get("plan_max_depth", DEFAULT_PLAN_MAX_DEPTH))
         # Plan capture query selection. plan_query_filter restricts capture to an
         # explicit set of query ids; it is orthogonal to the retired per-iteration /
         # per-stream sampling machinery (plan_first_n / plan_sampling_rate), which the

--- a/benchbox/platforms/base/result_capture.py
+++ b/benchbox/platforms/base/result_capture.py
@@ -49,6 +49,7 @@ from benchbox.core.results.builder import (
 )
 from benchbox.core.results.models import QUERY_RUN_TYPE_MEASUREMENT
 from benchbox.core.results.query_plan_models import (
+    DEFAULT_PLAN_MAX_DEPTH,
     DEFAULT_RAW_OUTPUT_MAX_BYTES,
     DEFAULT_RAW_OUTPUT_POLICY,
 )
@@ -964,14 +965,18 @@ class ResultCaptureMixin:
         plan.apply_raw_output_policy(raw_output_policy, raw_output_max_bytes)
 
         try:
-            size_kb = plan.estimate_serialized_size() / 1024
+            # Size the plan as it will actually be serialized: deep nodes past
+            # plan_max_depth become a truncation marker rather than dropping the plan.
+            size_kb = plan.estimate_serialized_size(max_depth=getattr(self, "plan_max_depth", DEFAULT_PLAN_MAX_DEPTH))
+            size_kb /= 1024
             if size_kb > 100:
                 # Only suggest a stricter raw-output policy when raw text is still
-                # retained; if it is already dropped the bloat is the structured DAG.
+                # retained; if it is already dropped the bloat is the structured DAG,
+                # which a smaller plan_max_depth bounds.
                 hint = (
-                    " Consider a stricter plan_raw_output policy (full|truncated|none) or external plan storage."
+                    " Consider a stricter plan_raw_output policy (full|truncated|none)."
                     if plan.raw_explain_output
-                    else " The structured plan tree itself is large; consider external plan storage."
+                    else " The structured plan tree itself is large; consider a smaller plan_max_depth."
                 )
                 self.logger.warning("Large query plan for %s: %.1f KB.%s", query_id, size_kb, hint)
         except SerializationError as exc:

--- a/tests/unit/core/results/test_query_plan_models.py
+++ b/tests/unit/core/results/test_query_plan_models.py
@@ -1699,3 +1699,105 @@ class TestUnknownTypeWarnings:
         assert result is False
         # Should not trigger warnings during comparison
         assert "Unknown operator type" not in caplog.text
+
+
+class TestPlanDepthTruncation:
+    """qpc-10: deep plans serialize with a truncated_at_depth marker, not dropped."""
+
+    @staticmethod
+    def _linear_chain(depth: int) -> LogicalOperator:
+        """Build a linear operator chain ``depth`` levels below a SCAN leaf.
+
+        Returns the root; the chain is root -> child -> ... -> scan, so the deepest
+        node sits at ``current_depth == depth``.
+        """
+        node = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_leaf", table_name="t")
+        for level in range(depth):
+            node = LogicalOperator(
+                operator_type=LogicalOperatorType.FILTER,
+                operator_id=f"filter_{level}",
+                filter_expressions=[f"c > {level}"],
+                children=[node],
+            )
+        return node
+
+    def test_to_dict_emits_truncation_marker_beyond_max_depth(self) -> None:
+        root = self._linear_chain(6)
+
+        serialized = root.to_dict(max_depth=3)
+
+        # Walk down; at depth 4 (first node with current_depth > max_depth=3) we
+        # must hit a truncation marker instead of a raise or a dropped plan.
+        node = serialized
+        depth = 0
+        while "truncated_at_depth" not in node:
+            assert node["children"], f"reached a leaf at depth {depth} before truncation"
+            node = node["children"][0]
+            depth += 1
+        assert node["truncated_at_depth"] == 4
+        assert node["children_omitted"] >= 1
+        # The marker node carries operator identity but no recursed children key.
+        assert node["operator_id"].startswith(("filter_", "scan_"))
+        assert "children" not in node
+
+    def test_to_dict_no_truncation_when_within_max_depth(self) -> None:
+        root = self._linear_chain(3)
+        serialized = root.to_dict(max_depth=50)
+
+        # Full tree present, no marker anywhere.
+        node = serialized
+        while node.get("children"):
+            assert "truncated_at_depth" not in node
+            node = node["children"][0]
+        assert node["operator_id"] == "scan_leaf"
+
+    def test_deep_plan_serializes_instead_of_raising(self) -> None:
+        # A plan deeper than the default cap must NOT raise / disappear; it must
+        # produce a bounded serialization carrying the marker.
+        root = self._linear_chain(60)
+        plan = QueryPlanDAG(query_id="deep_q", platform="duckdb", logical_root=root)
+
+        size = plan.estimate_serialized_size()  # default max_depth
+        assert size > 0
+        payload = plan.to_json()
+        assert "truncated_at_depth" in payload
+
+    def test_truncation_marker_round_trips_as_leaf(self) -> None:
+        root = self._linear_chain(5)
+        serialized = root.to_dict(max_depth=2)
+        restored = LogicalOperator.from_dict(serialized)
+
+        # Traverse to the deepest restored node: it is a childless leaf (the
+        # marker's omitted children are not reconstructed).
+        node = restored
+        while node.children:
+            node = node.children[0]
+        assert node.children == []
+
+    def test_fingerprint_unaffected_by_serialization_truncation(self) -> None:
+        # The fingerprint is computed over the FULL in-memory tree, so shrinking
+        # the serialization depth must not change it (anti-pattern: never
+        # fingerprint a truncated tree as complete).
+        root = self._linear_chain(60)
+        plan = QueryPlanDAG(query_id="fp_q", platform="duckdb", logical_root=root)
+
+        fp = plan.plan_fingerprint
+        # Recompute after a shallow serialization round-trip of the size guard.
+        plan.estimate_serialized_size(max_depth=3)
+        assert plan.plan_fingerprint == fp
+        # And equals a fresh full-tree fingerprint (depth cap plays no role).
+        assert plan.compute_plan_fingerprint() == fp
+
+    def test_configurable_max_depth_changes_truncation_point(self) -> None:
+        root = self._linear_chain(10)
+
+        def _first_truncated_depth(md: int) -> int:
+            node = root.to_dict(max_depth=md)
+            depth = 0
+            while "truncated_at_depth" not in node:
+                node = node["children"][0]
+                depth += 1
+            return depth
+
+        assert _first_truncated_depth(2) == 3
+        assert _first_truncated_depth(5) == 6

--- a/tests/unit/core/results/test_serialization_limits.py
+++ b/tests/unit/core/results/test_serialization_limits.py
@@ -6,7 +6,6 @@ import json
 
 import pytest
 
-from benchbox.core.errors import SerializationError
 from benchbox.core.results.query_plan_models import (
     LogicalOperator,
     LogicalOperatorType,
@@ -32,12 +31,29 @@ def _build_linear_plan(depth: int) -> QueryPlanDAG:
     return QueryPlanDAG(query_id="q_linear", platform="duckdb", logical_root=child)
 
 
-def test_depth_limit_enforced() -> None:
-    """Deep trees exceeding max_depth should raise SerializationError."""
-    plan = _build_linear_plan(depth=60)
+def test_depth_limit_truncates_with_marker_instead_of_dropping() -> None:
+    """Deep trees exceeding max_depth serialize with a truncation marker (qpc-10).
 
-    with pytest.raises(SerializationError):
-        plan.to_dict(max_depth=50)
+    The whole plan must NOT be dropped or raise: it serializes down to the limit,
+    then a ``truncated_at_depth`` marker replaces the deeper subtree. The stored
+    fingerprint still reflects the full in-memory tree.
+    """
+    plan = _build_linear_plan(depth=60)
+    fingerprint_before = plan.plan_fingerprint
+
+    serialized = plan.to_dict(max_depth=50)  # no exception
+
+    # Walk to the marker node.
+    node = serialized["logical_root"]
+    while "truncated_at_depth" not in node:
+        assert node["children"], "reached a leaf before hitting the truncation marker"
+        node = node["children"][0]
+    assert node["truncated_at_depth"] == 51
+    assert node["children_omitted"] >= 1
+
+    # Fingerprint is computed over the full tree and is unchanged by truncation.
+    assert plan.plan_fingerprint == fingerprint_before
+    assert plan.compute_plan_fingerprint() == fingerprint_before
 
 
 def test_depth_limit_at_boundary_succeeds() -> None:

--- a/tests/unit/platforms/test_base_adapter_database_management.py
+++ b/tests/unit/platforms/test_base_adapter_database_management.py
@@ -519,6 +519,29 @@ class TestAdapterPlanCaptureGaps:
 
         assert plan == mock_plan
         assert "Large query plan" in caplog.text
+        # No dangling "external plan storage" advice (that feature does not exist).
+        assert "external plan storage" not in caplog.text
+
+    def test_plan_max_depth_defaults_and_is_configurable(self):
+        from benchbox.core.results.query_plan_models import DEFAULT_PLAN_MAX_DEPTH
+
+        assert _TrackingAdapter().plan_max_depth == DEFAULT_PLAN_MAX_DEPTH
+        assert _TrackingAdapter(plan_max_depth=12).plan_max_depth == 12
+
+    def test_capture_query_plan_sizes_with_configured_plan_max_depth(self):
+        adapter = _TrackingAdapter(plan_max_depth=7)
+        adapter.capture_plans = True
+        adapter.get_query_plan = Mock(return_value="SOME PLAN")
+        mock_parser = Mock()
+        mock_plan = Mock()
+        mock_plan.estimate_serialized_size.return_value = 1024
+        mock_parser.parse_explain_output.return_value = mock_plan
+        adapter.get_query_plan_parser = Mock(return_value=mock_parser)
+
+        adapter.capture_query_plan(Mock(), "SELECT 1", "Q1")
+
+        # The configured plan_max_depth is threaded into the size estimate.
+        mock_plan.estimate_serialized_size.assert_called_once_with(max_depth=7)
 
 
 class TestAdapterValidationGaps:


### PR DESCRIPTION
## Description

Implements the **depth-limit remainder** of TODO item **qpc-10** (`_project/TODO/query-plan-capture/planning/10-concurrency-and-depth-limits.yaml`). The concurrency work (w1 `_plan_capture_lock`, w2 strict-mode propagation) had already landed on `develop`; this PR completes **w3** only.

Previously, query plans deeper than 50 levels were **dropped whole**: `LogicalOperator.to_dict` raised `SerializationError` past the depth guard, so `estimate_serialized_size` turned a deep plan into a `serialization_error` capture failure. The thresholds were hardcoded, and the "consider external plan storage" warning hint referenced a feature that does not exist (Finding F5.3).

Fix:
- `benchbox/core/results/query_plan_models.py`: new module constant `DEFAULT_PLAN_MAX_DEPTH = 50`. `LogicalOperator.to_dict` now emits a shallow **truncation marker** (`{"operator_type", "operator_id", "truncated_at_depth", "children_omitted"}`) beyond `max_depth` instead of raising, so the plan serializes down to the limit and its upper levels survive. `QueryPlanDAG.to_dict` / `to_json` / `estimate_serialized_size` default `max_depth` to the constant. The `plan_fingerprint` is computed via `get_structural_signature` over the **full in-memory tree**, so serialization truncation never changes fingerprint equality — the serialized tree is explicitly marked, never passed off as complete.
- `benchbox/platforms/base/adapter.py`: `plan_max_depth` is exposed as adapter config (`int(config.get("plan_max_depth", DEFAULT_PLAN_MAX_DEPTH))`) next to `plan_capture_timeout_seconds`.
- `benchbox/platforms/base/result_capture.py`: the capture-time size guard threads `plan_max_depth` into `estimate_serialized_size(...)`; the dangling "external plan storage" hints are removed (one now suggests a smaller `plan_max_depth`). The `except SerializationError` block is deliberately kept (defensive; a Mock-based test relies on it).
- Tests: new `TestPlanDepthTruncation` in `test_query_plan_models.py`; updated `test_serialization_limits.py::test_depth_limit_enforced` (which encoded the old raise) to assert the truncation-marker contract; added `plan_max_depth` config + size-guard tests in `test_base_adapter_database_management.py`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

All via `uv run --`:
- `uv run -- python -m pytest tests/unit/core/results/test_plan_capture_stats.py tests/unit/platforms/test_plan_capture_errors.py -q` → 15 passed (concurrency stats unaffected)
- `uv run -- python -m pytest tests/unit/core/results/test_query_plan_models.py -q -k depth` → 6 passed (deep plan exports with a marker instead of disappearing)
- `uv run -- python -m pytest tests/unit/core/results/test_serialization_limits.py tests/unit/platforms/test_base_adapter_database_management.py -q` → 68 passed
- Broad regression `uv run -- python -m pytest tests/unit/core/results tests/unit/platforms/test_duckdb_plan_capture.py tests/integration/test_plan_capture_phase.py -q` → all pass (no consumer relied on the old raise)
- `uv run -- ruff check` / `ruff format --check` on touched files → clean
- `uv run -- ty check` on the source files → clean (query_plan_models.py, adapter.py); result_capture.py shows only the 3 pre-existing psutil `possibly-missing-attribute` warnings, unrelated

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Serialized-plan shape gains an additive `truncated_at_depth`/`children_omitted` marker only for pathologically deep subtrees that previously did not serialize at all; the fingerprint contract is unchanged.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [ ] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: n/a.

## Notes

- **Soundness path — awaits Code Owner review.** This PR modifies `benchbox/platforms/base/result_capture.py` (CODEOWNERS-gated, `@joeharris76`). Auto-merge is intentionally **not** enabled; it awaits Code Owner review.
- An adversarial (Opus) review found no in-scope defects: the off-by-one is correct (depth 50 boundary still serializes fully; depth 51 is the first marker), `from_dict` round-trips a marker as a childless leaf without crashing, and no consumer of `to_dict()` output depended on the removed raise.
- Out-of-scope follow-up (deliberately not changed — outside `scope_limit.only_modify`): `plan_max_depth` is reachable via direct adapter `config=` construction but is not yet allowlisted in `benchbox/core/results/platform_options.py` or wired to a CLI flag, so it cannot yet be set via `--platform-option`. Threading it through the CLI is a small future follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_