### PR TITLE
chore(todo): reconcile qpc-01 (landed) and correct qpc-03 (still open) tracker state

### DIFF
--- a/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
+++ b/_project/TODO/query-plan-capture/planning/01-plan-rehydration-and-phases-view.yaml
@@ -2,9 +2,19 @@ id: "qpc-01-plan-rehydration-and-phases-view"
 title: "Rehydrate .plans.json in the loader and give consumers a real phases/plan accessor"
 worktree: "query-plan-capture"
 priority: "Critical"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-06"
 
 description: |
+  RECONCILED 2026-07-06: landed via PR #967 (fix-plan-consumption-phases-and-
+  loader-reattach), verified on develop. The loader now rehydrates .plans.json
+  via `iter_query_results` + `_attach_plan`/`QueryPlanDAG.from_dict`; the six
+  plan consumers read `iter_query_results(results)` instead of a non-existent
+  `.phases`; companion/main query IDs are normalized on both sides; and the
+  keystone no-mock e2e test exists (tests/integration/test_plan_capture_e2e.py,
+  11 passed). This item was filed before #967 landed and was never closed.
+
+
   The loader parses the .plans.json companion but uses only the two count
   fields; per-query plan payloads are discarded (loader.py:153,221,
   _extract_plans_info). BenchmarkResults has no `phases` attribute, yet every
@@ -43,7 +53,7 @@ work:
     the four consumers to read query_results directly — decide in-diff,
     smaller change wins. Normalize --query-id lookups in show_plan.py and
     compare_plans.py with normalize_query_id on both sides.
-  status: pending
+  status: done
 - id: w2
   summary: >-
     Create: keystone no-mock integration test covering export -> load ->
@@ -54,19 +64,19 @@ work:
     run show-plan and compare-plans via CliRunner asserting rendered plan
     output — zero monkeypatching.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Review: adversarial code review of the diff (id normalization edge cases, multi-iteration attach semantics, .phases contract)."
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Fix: address review findings; re-run full verification."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Submit PR referencing qpc-01; include repro-before/after in the PR body."
   needs: [w4]
-  status: pending
+  status: done
 
 must_preserve:
 - "Companion schema stays readable for already-exported bundles (accept both 'Q1' and '1' keys on load)"

--- a/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
+++ b/_project/TODO/query-plan-capture/planning/03-fingerprint-signature-v2.yaml
@@ -5,6 +5,22 @@ priority: "High"
 status: "Not Started"
 
 description: |
+  PARTIAL as of 2026-07-06 (still OPEN): the ADJACENT literal-normalization work
+  landed via #987 (harden-normalized-plan-fingerprint) + #1008 (ordinal
+  protection) — atomic numeric grammar, `#` ordinal preservation, and a
+  `normalization_scheme` + PlanFingerprintSchemeMismatchError guard. But this
+  item's TWO CORE findings are STILL REPRODUCIBLE on develop and remain open:
+    - F2.1 tree-shape collision: `Join[Scan(t1),Scan(t2)]` (two children) and
+      `Join[Scan(t1)->Scan(t2)]` (nested chain) both yield the signature
+      `Join|Scan|table:t1|Scan|table:t2` and hash identically — children are
+      still joined flat with `|`, so tree shape is NOT encoded. Verified
+      2026-07-06.
+    - F2.2 trust laundering: a plan with its stored fingerprint field removed is
+      recomputed and marked VERIFIED/trusted in __post_init__, so dropping the
+      field bypasses STALE tamper-detection. Verified 2026-07-06.
+  The tree-shape re-encoding (`op(child1,...)`), field escaping, fingerprint_version,
+  and the integrity-trust fix below are the remaining work.
+
   get_structural_signature flattens children with the same '|' separator as
   scalar fields, so tree shape is not encoded: Join[Scan(t1), Scan(t2)] and
   Join[Scan(t1) -> Scan(t2)] produce identical SHA256 fingerprints


### PR DESCRIPTION
## Description

Tracker-only reconciliation of two query-plan-capture TODO items whose status had drifted from the code on `develop`. No source changes.

- **qpc-01** (`01-plan-rehydration-and-phases-view.yaml`) → **Completed**. Its work (loader `.plans.json` reattach via `iter_query_results`/`_attach_plan`, the six plan consumers reading `iter_query_results` instead of a non-existent `.phases`, normalized companion/main query IDs, and the keystone no-mock e2e test) landed via PR #967 but the item was never closed. Verified on develop: `tests/integration/test_plan_capture_e2e.py` → **11 passed**.
- **qpc-03** (`03-fingerprint-signature-v2.yaml`) → **left OPEN**, with a corrected `PARTIAL` note. Its *adjacent* literal-normalization work landed via #987 + #1008, but I verified on develop that its **two core findings are still reproducible**, so it must not be closed:
  - **F2.1 tree-shape collision:** `Join[Scan(t1),Scan(t2)]` (two children) and `Join[Scan(t1)→Scan(t2)]` (nested chain) both produce `Join|Scan|table:t1|Scan|table:t2` and hash identically — children are still flat-joined with `|`, so tree shape isn't encoded.
  - **F2.2 trust laundering:** a plan with its stored fingerprint field removed is recomputed and marked `VERIFIED`/trusted in `__post_init__`, bypassing STALE tamper-detection.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <each file>` → both valid.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` → no cycles, no dangling references, 108 items.
- Evidence for the closures/non-closures (qpc-01 e2e pass; qpc-03 F2.1/F2.2 still reproducing) captured via `uv run` on develop.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none — two TODO YAML edits only.

## Notes

- Not a soundness-gated path (TODO YAML only) — eligible for squash auto-merge.
- **Consequence for planning:** qpc-06 (cross-platform capture wiring) depends on both qpc-01 and qpc-03; with qpc-03 still open, qpc-06 remains blocked. qpc-01's other dependents (qpc-02/05/07/08/11) are now unblocked pending a separate open-vs-landed assessment (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_