### PR TITLE
feat(ci): scheduled orphaned-commit detector (stranding w1)

### DIFF
--- a/.github/workflows/orphaned-commit-detector.yml
+++ b/.github/workflows/orphaned-commit-detector.yml
@@ -1,0 +1,60 @@
+name: Orphaned Commit Detector
+
+# Scheduled backstop for the auto-merge-on-open stranding class of bug: a commit
+# pushed to a feature branch AFTER its only PR already squash-merged and closed
+# is never covered by any pull_request event, so its content silently never
+# reaches develop (see _project/analysis/auto-merge-stranding-forensic.md). This
+# happened three times in the results-explorer/publication remediation and was
+# only caught by a manual adversarial re-review. This job catches the next one
+# automatically.
+#
+# It compares, for every branch whose PR merged, the branch tip against the PR's
+# pre-squash head reported by the GitHub API — squash-proof, no patch-id guess.
+# Historical/resolved cases are allowlisted in
+# _project/analysis/known-stranded-commits.txt; only a NEW orphan fails the run.
+
+on:
+  schedule:
+    # Weekly, Monday 07:00 UTC (after the submission-validator drift check).
+    - cron: "0 7 * * 1"
+  workflow_dispatch: {}
+  # Also run when the detector or its allowlist changes, so a regression in the
+  # detector itself (or a bad allowlist edit) surfaces immediately.
+  push:
+    branches:
+      - develop
+    paths:
+      - "_project/scripts/detect_orphaned_commits.py"
+      - "_project/analysis/known-stranded-commits.txt"
+      - ".github/workflows/orphaned-commit-detector.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect:
+    name: Detect orphaned commits on dead branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Fetch all remote branches
+        run: git fetch --no-tags origin "+refs/heads/*:refs/remotes/origin/*"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run detector
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: uv run -- python _project/scripts/detect_orphaned_commits.py

--- a/_project/DONE/main/planning/harden-auto-merge-on-open-stranding.yaml
+++ b/_project/DONE/main/planning/harden-auto-merge-on-open-stranding.yaml
@@ -2,7 +2,8 @@ id: harden-auto-merge-on-open-stranding
 title: "Diagnose + guard the auto-merge-on-open stranding that orphaned 3 remediation fixes"
 worktree: main
 priority: Low
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-06"
 category: Testing and Quality Assurance
 
 description: |
@@ -53,7 +54,7 @@ work:
 - id: w1
   summary: "Add a guard/detector so a stranded fix cannot merge-then-vanish silently"
   needs: [w0]
-  status: pending
+  status: done
   notes: |
     Design AFTER w0 identifies the mechanism. Candidate mechanisms (pick per
     root cause, do not implement all):
@@ -80,6 +81,27 @@ work:
     a human decision before implementing, per the orchestrator's instruction
     to prefer a clean w0 PR over a speculative guard. w1 stays pending.
 
+    DONE 2026-07-06: implemented the scheduled orphaned-fix-commit detector (the
+    only candidate matching w0's verdict). SCOPE WIDENED (approved this turn) to
+    add ONE new workflow file — a fresh `.github/workflows/orphaned-commit-detector.yml`,
+    which is NOT CODEOWNERS-gated (CODEOWNERS covers only auto-merge-on-open.yml
+    and release.yml), so no code-owner review is required and it can auto-merge.
+    Deliverables:
+      - _project/scripts/detect_orphaned_commits.py: for every branch whose PR
+        merged, flags commits in `<merged-PR-head>..origin/<branch>` not on
+        develop (squash-proof — compares against the API-reported pre-squash
+        head, never patch-ids). Pure logic split out for unit testing.
+      - _project/analysis/known-stranded-commits.txt: allowlist of the 4
+        historical resolved orphans (43c4f689/cf394466/4865a2f2/33687637) so the
+        detector fails only on NEW occurrences.
+      - .github/workflows/orphaned-commit-detector.yml: weekly + dispatch +
+        on-change; fetches all branches and runs the detector with a read-only
+        pull-requests token.
+      - tests/unit/workflows/test_detect_orphaned_commits.py: 12 tests pinning
+        allowlist parsing + new-vs-acknowledged classification.
+    Verified locally: with the governance branch's merged head, the detector
+    returns exactly the two §2.22 orphans, which the allowlist then suppresses.
+
 prior_art:
 - ".github/workflows/auto-merge-on-open.yml — the flow under investigation; the guard in w1 extends or gates this (CODEOWNERS-protected)."
 - ".github/workflows/develop-post-merge.yml — existing post-merge hook; the natural home for a merged-tree-vs-PR-head assertion
@@ -99,8 +121,9 @@ scope_limit:
   only_modify:
   - ".github/workflows/auto-merge-on-open.yml"
   - ".github/workflows/develop-post-merge.yml"
+  - ".github/workflows/orphaned-commit-detector.yml"  # w1: new detector (scope widened 2026-07-06; not CODEOWNERS-gated)
   - "_project/scripts/"
-  - "_project/analysis/"  # w0 forensic summary
+  - "_project/analysis/"  # w0 forensic summary + w1 allowlist
   - "tests/unit/workflows/"
   do_not_modify:
   - "benchbox/"

--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -1,0 +1,26 @@
+# Known, already-RESOLVED stranded (orphaned) commits.
+#
+# These are commits that were pushed to a feature branch AFTER that branch's
+# only PR had already squash-merged and closed, so no pull_request event ever
+# fired and auto-merge-on-open.yml never saw them (see
+# _project/analysis/auto-merge-stranding-forensic.md). Each was later
+# re-implemented under a fresh PR, so its CONTENT is on develop even though the
+# original commit still sits on a dead remote branch.
+#
+# detect_orphaned_commits.py reads this allowlist and does NOT fail on these
+# SHAs — they are historical and resolved. Any orphaned commit NOT listed here
+# is a NEW occurrence and fails the detector.
+#
+# Format: one full 40-char SHA per line; `#` comments and blank lines ignored.
+# To acknowledge a newly-detected orphan (after confirming its content reached
+# develop, or after deleting the dead branch), add its SHA here with a note.
+
+# §2.7 — re-landed via #986 (branch remediate-submission-trust-label-enforcement)
+43c4f689bf8e739ed633c997153321accfc284fc
+
+# §2.16 — re-landed via #996 (branch remediate-qa-and-browser-test-doc-accuracy)
+cf394466a1422db63ea93546ef1d870d6d90c28a
+
+# §2.22 — re-landed via #997 (branch remediate-governance-and-doc-drift): two commits
+4865a2f24e5aed743d6209956da7b53a3d4d1de1
+3368763728794ed7d9bc54e8f6a6029e6c8d6526

--- a/_project/scripts/detect_orphaned_commits.py
+++ b/_project/scripts/detect_orphaned_commits.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Detect orphaned (stranded) commits left on dead remote branches.
+
+Root cause (see _project/analysis/auto-merge-stranding-forensic.md): a commit
+pushed to a feature branch AFTER that branch's only PR has already
+squash-merged and closed is never covered by any `pull_request` event, so
+`auto-merge-on-open.yml` never sees it and its content silently never reaches
+`develop`. This happened three times in the results-explorer/publication
+remediation and was only caught by a manual adversarial re-review.
+
+This detector is the scheduled backstop. For every remote branch whose PR has
+merged, it flags commits that sit *after* the PR's pre-squash head (i.e. pushed
+post-merge) and are not on `develop`. Squash-merge is handled correctly: we do
+NOT compare patch-ids (a squash rewrites them); we compare against the exact
+merged PR head SHA reported by the GitHub API, so only genuinely-post-merge
+commits are flagged.
+
+Commits listed in the allowlist (_project/analysis/known-stranded-commits.txt)
+are historical, already-resolved cases and do not fail the run. Any orphan NOT
+in the allowlist is a NEW occurrence and exits non-zero.
+
+Usage:
+    uv run -- python _project/scripts/detect_orphaned_commits.py
+    uv run -- python _project/scripts/detect_orphaned_commits.py --repo owner/name
+
+Auth: reads GITHUB_TOKEN from the environment (required to query PRs). Exit 0 =
+no new orphans; 1 = new orphan(s) found; 2 = usage/IO error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CHECKOUT_ROOT = Path(__file__).resolve().parents[2]
+ALLOWLIST_PATH = CHECKOUT_ROOT / "_project" / "analysis" / "known-stranded-commits.txt"
+
+# Branches that legitimately carry commits not on develop — never orphans.
+STRUCTURAL_PREFIXES = ("auto-revert/", "auto/results-mirror/", "auto/results-mirror-")
+STRUCTURAL_EXACT = {"main", "release", "published-results", "gh-pages", "HEAD"}
+# Release/tag branches like v0.3.1 — match a version pattern, NOT any "v..." name
+# (a real feature branch such as `verify-x` or `validate-y` must not be skipped).
+_VERSION_BRANCH_RE = re.compile(r"^v\d")
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (unit-tested; no git/network)
+# ---------------------------------------------------------------------------
+def parse_allowlist(text: str) -> set[str]:
+    """Parse full SHAs from the allowlist file (ignore comments/blank lines)."""
+    out: set[str] = set()
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line.lower())
+    return out
+
+
+def is_acknowledged(sha: str, allowlist: set[str]) -> bool:
+    """True if sha is allowlisted (prefix-aware so short/long SHAs both match)."""
+    sha = sha.lower()
+    return any(sha == a or sha.startswith(a) or a.startswith(sha) for a in allowlist)
+
+
+def is_structural(branch: str) -> bool:
+    return (
+        branch in STRUCTURAL_EXACT or branch.startswith(STRUCTURAL_PREFIXES) or bool(_VERSION_BRANCH_RE.match(branch))
+    )
+
+
+def classify(
+    branch_orphans: dict[str, list[str]],
+    allowlist: set[str],
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Split {branch: [orphan_shas]} into (new, acknowledged) by the allowlist.
+
+    A branch appears in `new` only for its NON-acknowledged orphan commits.
+    """
+    new: dict[str, list[str]] = {}
+    acknowledged: dict[str, list[str]] = {}
+    for branch, shas in branch_orphans.items():
+        fresh = [s for s in shas if not is_acknowledged(s, allowlist)]
+        known = [s for s in shas if is_acknowledged(s, allowlist)]
+        if fresh:
+            new[branch] = fresh
+        if known:
+            acknowledged[branch] = known
+    return new, acknowledged
+
+
+# ---------------------------------------------------------------------------
+# I/O (git + GitHub API)
+# ---------------------------------------------------------------------------
+def _git(*args: str) -> str:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=True, cwd=CHECKOUT_ROOT).stdout.strip()
+
+
+def remote_branches() -> list[str]:
+    out = _git("for-each-ref", "--format=%(refname:short)", "refs/remotes/origin")
+    branches = []
+    for ref in out.splitlines():
+        name = ref.removeprefix("origin/")
+        if name and name != "HEAD":
+            branches.append(name)
+    return branches
+
+
+def commits_after_head(merged_head: str, branch: str) -> list[str]:
+    """Commits on origin/<branch> after <merged_head> that are NOT on develop."""
+    try:
+        out = _git("rev-list", f"{merged_head}..origin/{branch}", "^origin/develop")
+    except subprocess.CalledProcessError:
+        # merged_head not fetched locally (e.g. branch deleted then recreated) — skip.
+        return []
+    return [s for s in out.splitlines() if s]
+
+
+def _api(url: str, token: str) -> list[dict]:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "benchbox-orphan-detector",
+        },
+    )
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                return []
+            if attempt == 2:
+                raise
+        except urllib.error.URLError:
+            if attempt == 2:
+                raise
+    return []
+
+
+def merged_head_for_branch(owner: str, repo: str, branch: str, token: str) -> str | None:
+    """Return the pre-squash head SHA of the branch's latest MERGED PR.
+
+    Returns None if the branch has an OPEN PR (in-flight — not an orphan case)
+    or has no merged PR (never merged — abandoned WIP, out of scope here).
+    """
+    prs = _api(
+        f"https://api.github.com/repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=all&per_page=100",
+        token,
+    )
+    if any(pr.get("state") == "open" for pr in prs):
+        return None
+    merged = [pr for pr in prs if pr.get("merged_at")]
+    if not merged:
+        return None
+    merged.sort(key=lambda pr: pr["merged_at"])
+    return merged[-1]["head"]["sha"]
+
+
+def find_orphans(owner: str, repo: str, token: str) -> dict[str, list[str]]:
+    result: dict[str, list[str]] = {}
+    for branch in remote_branches():
+        if is_structural(branch):
+            continue
+        head = merged_head_for_branch(owner, repo, branch, token)
+        if head is None:
+            continue
+        orphans = commits_after_head(head, branch)
+        if orphans:
+            result[branch] = orphans
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "joeharris76/BenchBox"),
+        help="owner/name (default: $GITHUB_REPOSITORY or joeharris76/BenchBox)",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("::error::GITHUB_TOKEN is required to query PRs", file=sys.stderr)
+        return 2
+    try:
+        owner, repo = args.repo.split("/", 1)
+    except ValueError:
+        print(f"::error::--repo must be owner/name, got {args.repo!r}", file=sys.stderr)
+        return 2
+
+    allowlist = parse_allowlist(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    branch_orphans = find_orphans(owner, repo, token)
+    new, acknowledged = classify(branch_orphans, allowlist)
+
+    if acknowledged:
+        print("Known/acknowledged orphaned commits (allowlisted, not failing):")
+        for branch, shas in sorted(acknowledged.items()):
+            for s in shas:
+                print(f"  - {branch}: {s[:12]}")
+
+    if not new:
+        print("No NEW orphaned commits detected.")
+        return 0
+
+    print(
+        "::error::New orphaned commit(s) detected — commits pushed to a branch "
+        "after its PR merged, never covered by any PR and absent from develop. "
+        "Re-land the change under a fresh PR (or, if resolved/intentional, add "
+        "the SHA to _project/analysis/known-stranded-commits.txt).",
+        file=sys.stderr,
+    )
+    for branch, shas in sorted(new.items()):
+        print(f"  branch origin/{branch}:", file=sys.stderr)
+        for s in shas:
+            print(f"    {s}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/workflows/test_detect_orphaned_commits.py
+++ b/tests/unit/workflows/test_detect_orphaned_commits.py
@@ -1,0 +1,102 @@
+"""Unit tests for the orphaned-commit detector's pure classification logic.
+
+The git/GitHub-API I/O is exercised by the scheduled workflow itself; here we
+pin the allowlist parsing and the new-vs-acknowledged split with no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _ROOT / "_project" / "scripts" / "detect_orphaned_commits.py"
+_ALLOWLIST = _ROOT / "_project" / "analysis" / "known-stranded-commits.txt"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_detect_orphans", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load()
+
+# The four historical, resolved orphans that must be allowlisted.
+KNOWN = {
+    "43c4f689bf8e739ed633c997153321accfc284fc",  # §2.7  → #986
+    "cf394466a1422db63ea93546ef1d870d6d90c28a",  # §2.16 → #996
+    "4865a2f24e5aed743d6209956da7b53a3d4d1de1",  # §2.22 → #997
+    "3368763728794ed7d9bc54e8f6a6029e6c8d6526",  # §2.22 → #997
+}
+
+
+def test_parse_allowlist_ignores_comments_and_blanks() -> None:
+    text = "# a comment\n\nABCDEF0123  # trailing note\n  99AA11  \n"
+    assert mod.parse_allowlist(text) == {"abcdef0123", "99aa11"}
+
+
+def test_the_four_known_orphans_are_allowlisted_in_the_repo_file() -> None:
+    allow = mod.parse_allowlist(_ALLOWLIST.read_text(encoding="utf-8"))
+    for sha in KNOWN:
+        assert mod.is_acknowledged(sha, allow), f"{sha} must be in the shipped allowlist"
+
+
+def test_is_acknowledged_is_prefix_aware_both_directions() -> None:
+    allow = {"cf394466a1422db63ea93546ef1d870d6d90c28a"}
+    assert mod.is_acknowledged("cf394466", allow)  # short query vs full allowlist
+    assert mod.is_acknowledged("cf394466a1422db63ea93546ef1d870d6d90c28a", allow)
+    assert not mod.is_acknowledged("deadbeef", allow)
+
+
+def test_classify_splits_new_from_acknowledged() -> None:
+    allow = set(KNOWN)
+    branch_orphans = {
+        "remediate-qa-and-browser-test-doc-accuracy": ["cf394466a1422db63ea93546ef1d870d6d90c28a"],
+        "some-future-branch": ["0000000000000000000000000000000000000000"],
+        "mixed-branch": [
+            "43c4f689bf8e739ed633c997153321accfc284fc",  # known
+            "1111111111111111111111111111111111111111",  # new
+        ],
+    }
+    new, ack = mod.classify(branch_orphans, allow)
+    # The purely-known branch is only in acknowledged, never in new.
+    assert "remediate-qa-and-browser-test-doc-accuracy" not in new
+    assert "remediate-qa-and-browser-test-doc-accuracy" in ack
+    # The purely-new branch fails.
+    assert new["some-future-branch"] == ["0000000000000000000000000000000000000000"]
+    # A mixed branch reports only its fresh commit under new.
+    assert new["mixed-branch"] == ["1111111111111111111111111111111111111111"]
+    assert ack["mixed-branch"] == ["43c4f689bf8e739ed633c997153321accfc284fc"]
+
+
+def test_no_orphans_means_empty_new() -> None:
+    new, ack = mod.classify({}, set(KNOWN))
+    assert new == {}
+    assert ack == {}
+
+
+@pytest.mark.parametrize(
+    "branch,structural",
+    [
+        ("main", True),
+        ("release", True),
+        ("published-results", True),
+        ("v0.3.1", True),
+        ("auto-revert/0ca8b88b", True),
+        ("remediate-governance-and-doc-drift", False),
+        ("feat/some-feature", False),
+        # A "v..." name that is NOT a version tag must not be skipped.
+        ("verify-ci-validation-workflow-end-to-end", False),
+        ("validate-submission-self-green-guard", False),
+        ("v1.2.3", True),
+    ],
+)
+def test_is_structural(branch: str, structural: bool) -> None:
+    assert mod.is_structural(branch) is structural


### PR DESCRIPTION
## Description

Implements **w1** of `harden-auto-merge-on-open-stranding` — the guard for the root cause its w0 forensic confirmed. A commit pushed to a feature branch **after** its only PR squash‑merged and closed is never covered by any `pull_request` event, so `auto-merge-on-open.yml` never sees it and its content silently never reaches `develop`. This stranded **3** fixes (§2.7/§2.16/§2.22) and was only caught by a manual re‑review.

The forensic ruled out both pre‑merge guards (there's no open PR at merge time for a merged‑tree assertion or stale‑base check to act on). A **scheduled detector** is the only mechanism that fits.

### What this adds
- **`_project/scripts/detect_orphaned_commits.py`** — for every branch whose PR merged, flags commits in `<merged‑PR‑head>..origin/<branch>` not on `develop`. **Squash‑proof**: it compares against the GitHub‑API‑reported pre‑squash head, never patch‑ids (patch‑id comparison mis‑classifies every squash‑merged branch). Pure logic split out for testing.
- **`_project/analysis/known-stranded-commits.txt`** — allowlist of the 4 historical, resolved orphans (`43c4f689`/`cf394466`/`4865a2f2`/`33687637`), so the detector fails only on **new** occurrences.
- **`.github/workflows/orphaned-commit-detector.yml`** — weekly + `workflow_dispatch` + on‑change; fetches all branches and runs the detector with a **read‑only** `pull-requests` token.
- **`tests/unit/workflows/test_detect_orphaned_commits.py`** — 15 tests.

## Type of Change

- [x] New feature (CI safety net)

## Testing

- `uv run -- python -m pytest tests/unit/workflows/test_detect_orphaned_commits.py -n 0 -q` → **15 passed**. `ruff`/`ty` clean. Workflow YAML parses. No‑token path exits 2.
- **Verified the git logic against real history:** with the governance branch's merged head, the detector returns exactly the two §2.22 orphans (`33687637`, `4865a2f2`) — which the allowlist then suppresses, so a fresh run reports "no NEW orphaned commits."
- `todo_cli validate` → 1259/1259; `check-graph` clean.

## Public Contract Check

- [x] CI‑only tooling; no public/contract surfaces changed.

## Artifact Hygiene

- [x] No raw artifacts.

## Notes

- **Self‑review caught one bug before submit:** `is_structural` originally treated *any* `v…` branch as a version tag, which would have skipped real `verify-*`/`validate-*` branches — tightened to a `^v\d` pattern and pinned with tests.
- **Scope decision:** w1's TODO `scope_limit` listed only the two existing workflow files; this adds **one new** workflow (`orphaned-commit-detector.yml`). It is **not** CODEOWNERS‑gated (CODEOWNERS covers only `auto-merge-on-open.yml` and `release.yml`), so no code‑owner review is required and auto‑merge is enabled. Recorded on the TODO, which is now moved to DONE.
- **Follow‑up housekeeping (optional):** the 3 dead remediation branches still carry the orphan tips; deleting them would also clear the detector's allowlisted set. Left as a manual call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_