### PR TITLE
fix(qpc-02): stop corrupting status/iteration/run_type on load, fix capture_time 0.0 drop

### DIFF
--- a/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
+++ b/_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml
@@ -2,7 +2,8 @@ id: "qpc-02-loader-roundtrip-fidelity"
 title: "Make export -> load -> export lossless: stop corrupting status/iteration/run_type and destroying plans"
 worktree: "query-plan-capture"
 priority: "High"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-07"
 
 description: |
   A load/re-export cycle corrupts bundles (all reproduced):
@@ -33,31 +34,34 @@ work:
     Create: fix _reconstruct_query_results to honor status/run_type, keep
     iter/stream 0, dedupe errors[], and carry plan fields through.
   notes: >-
-    Use `is not None` checks for iter/stream; reconstruct FAILED rows from
-    queries[] alone and use errors[] only for legacy bundles whose queries[]
-    lack status. In build_plans_payload use `if capture_time is not None:`.
-  status: pending
+    Rewrote loader with is-not-None checks for iter/stream/run_type; status
+    now read per-entry (default SUCCESS for legacy); errors[] merges detail
+    onto non-success rows and only synthesizes a standalone row when the
+    query_id is absent from queries[] (legacy shape). Fixed schema.py
+    capture_time falsy-check to `is not None`.
+  status: done
 - id: w2
   summary: >-
     Create: round-trip property test — export, load, re-export must be
     byte-identical for both main file and plans companion.
   notes: >-
-    Compare via canonical_json_text. Include warmup (iter 0), FAILED, and
-    stream>0 rows in the fixture.
+    Added byte-equality roundtrip test (warmup iter0/stream0, FAILED dup,
+    stream1+plan w/ capture_time_ms=0.0) plus two targeted loader tests
+    (no phantom-dup for current-format failures; iter0/stream0 preserved).
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Review: adversarial code review (legacy-bundle branch, errors[] dedup rules, summary-stat recomputation)."
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Fix: address review findings; re-run verification."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Submit PR referencing qpc-02."
   needs: [w4]
-  status: pending
+  status: done
 
 must_preserve:
 - "Legacy bundles (queries[] without status/run_type keys) still load without error"

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -461,42 +461,81 @@ def _reconstruct_query_results(
     query_id AND stream_id (each phase's stream counter starts at its own 0);
     those are disambiguated with a further ``"{query_id}#{stream_id}:{test_type}"``
     key, resolved via the row's own compact ``test_type`` field.
+
+    Current-format bundles write ``status``/``run_type`` on every compact entry
+    (including failures, which are ALSO duplicated into ``errors[]`` for the
+    legacy fallback below) and use ``iter``/``stream`` 0 for warmup rows / the
+    first stream. Legacy bundles predate those per-entry fields entirely: their
+    ``queries[]`` entries carry only successful queries (no ``status`` key at
+    all) and failures live solely in ``errors[]``. Both shapes must round-trip:
+    an entry's own ``status`` (when present) is authoritative; ``errors[]`` is
+    only used to (a) attach ``error_type``/``error_message`` detail onto a
+    compact entry that already reports non-SUCCESS, and (b) synthesize a
+    standalone FAILED row for a query_id that never appears in ``queries[]``
+    at all (the legacy shape).
     """
     plan_entries = _index_plan_entries(plans_data)
     results: list[dict[str, Any]] = []
 
-    # Process successful queries
+    query_error_by_id: dict[str, dict[str, Any]] = {}
+    for error in errors_list:
+        if error.get("phase") != "query":
+            continue
+        qid = error.get("query_id")
+        if qid is None:
+            continue
+        query_error_by_id.setdefault(normalize_query_id(qid), error)
+
+    ids_in_queries_list: set[str] = {normalize_query_id(q["id"]) for q in queries_list if q.get("id") is not None}
+
     for q in queries_list:
         query_id = q.get("id")
+        status = q.get("status", "SUCCESS")
         result: dict[str, Any] = {
             "query_id": query_id,
             "execution_time_ms": q.get("ms"),
             "rows_returned": q.get("rows"),
-            "status": "SUCCESS",
+            "status": status,
         }
-        if q.get("iter"):
+        if q.get("iter") is not None:
             result["iteration"] = q["iter"]
-        if q.get("stream"):
+        if q.get("stream") is not None:
             result["stream_id"] = q["stream"]
+        if q.get("run_type") is not None:
+            result["run_type"] = q["run_type"]
         if q.get("test_type"):
             result["test_type"] = q["test_type"]
+
+        if status not in ("SUCCESS", "SKIPPED") and query_id is not None:
+            error = query_error_by_id.get(normalize_query_id(query_id))
+            if error is not None:
+                result["error_type"] = error.get("type")
+                result["error_message"] = error.get("message")
+
         _attach_plan(
             result,
             _lookup_plan_entry(plan_entries, query_id, q.get("stream", 0), q.get("test_type")),
         )
         results.append(result)
 
-    # Add failed queries from errors
+    # Legacy fallback: synthesize a FAILED row only for query_ids that never
+    # appear in queries[] at all. Current-format bundles duplicate every
+    # failure into queries[] too (handled above); re-adding it here would
+    # produce a phantom second row for the same failure.
     for error in errors_list:
-        if error.get("phase") == "query":
-            results.append(
-                {
-                    "query_id": error.get("query_id"),
-                    "status": "FAILED",
-                    "error_type": error.get("type"),
-                    "error_message": error.get("message"),
-                }
-            )
+        if error.get("phase") != "query":
+            continue
+        qid = error.get("query_id")
+        if qid is not None and normalize_query_id(qid) in ids_in_queries_list:
+            continue
+        results.append(
+            {
+                "query_id": qid,
+                "status": "FAILED",
+                "error_type": error.get("type"),
+                "error_message": error.get("message"),
+            }
+        )
 
     return results
 

--- a/benchbox/core/results/schema.py
+++ b/benchbox/core/results/schema.py
@@ -1042,7 +1042,7 @@ def _build_plan_entry(qr: dict[str, Any]) -> dict[str, Any]:
         plan_entry["fingerprint"] = plan_fingerprint
     if plan_fingerprint_normalized:
         plan_entry["fingerprint_normalized"] = plan_fingerprint_normalized
-    if capture_time:
+    if capture_time is not None:
         plan_entry["capture_time_ms"] = round(capture_time, 1)
 
     if is_dataclass(query_plan):

--- a/tests/unit/core/results/test_loader.py
+++ b/tests/unit/core/results/test_loader.py
@@ -850,6 +850,14 @@ class TestExportLoadReexportRoundtrip:
         plans_payload = build_plans_payload(original)
         assert plans_payload is not None
 
+        # Guard the schema.py `if capture_time is not None:` fix (F1.5): a
+        # capture time of exactly 0.0 is falsy, so a truthy check would drop
+        # it from the plans payload entirely. Byte-equality alone cannot catch
+        # that regression -- both the export and re-export would omit the field
+        # symmetrically and still compare equal -- so assert the 0.0 actually
+        # survives the initial export here.
+        assert plans_payload["queries"]["2"]["capture_time_ms"] == 0.0
+
         reimported = reconstruct_benchmark_results(exported, plans_data=plans_payload)
         re_exported = build_result_payload(reimported)
         re_plans_payload = build_plans_payload(reimported)

--- a/tests/unit/core/results/test_loader.py
+++ b/tests/unit/core/results/test_loader.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from benchbox.core.results.canonical_json import canonical_json_text
 from benchbox.core.results.loader import (
     ResultLoadError,
     UnsupportedSchemaError,
@@ -16,8 +17,9 @@ from benchbox.core.results.loader import (
     reconstruct_benchmark_results,
 )
 from benchbox.core.results.models import BenchmarkResults
-from benchbox.core.results.schema import build_result_payload
-from tests.fixtures.result_dict_fixtures import make_v2_result_dict, write_v2_result_file
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType, QueryPlanDAG
+from benchbox.core.results.schema import build_plans_payload, build_result_payload
+from tests.fixtures.result_dict_fixtures import make_benchmark_results, make_v2_result_dict, write_v2_result_file
 
 pytestmark = [
     pytest.mark.unit,
@@ -684,3 +686,174 @@ class TestReconstructBenchmarkResults:
         assert len(failed_query) == 1
         assert failed_query[0]["query_id"] == "2"
         assert failed_query[0]["error_type"] == "QueryError"
+
+    def test_reconstruct_does_not_duplicate_current_format_failure(self):
+        """A current-format bundle duplicates a failure into BOTH queries[]
+        (status="FAILED") and errors[] (see schema.py _build_query_results_section).
+        The loader must reconstruct exactly one row for it, not a phantom
+        second row synthesized from errors[] (qpc-02 / F1.4).
+        """
+        data = make_v2_result_dict(
+            version="2.1",
+            benchmark_id="test",
+            benchmark_name="Test",
+            platform="Test",
+            scale_factor=1.0,
+            execution_id="test",
+            timestamp="2025-01-01T10:00:00",
+            query_time_ms=100,
+            total_queries=2,
+            passed_queries=1,
+            failed_queries=1,
+            total_ms=100,
+            queries=[
+                {
+                    "id": "1",
+                    "ms": 100.0,
+                    "rows": 4,
+                    "iter": 1,
+                    "stream": 0,
+                    "run_type": "measurement",
+                    "status": "SUCCESS",
+                },
+                {"id": "2", "iter": 1, "stream": 0, "run_type": "measurement", "status": "FAILED"},
+            ],
+            errors=[
+                {"phase": "query", "query_id": "2", "type": "QueryError", "message": "Syntax error"},
+            ],
+        )
+
+        result = reconstruct_benchmark_results(data)
+
+        failed_rows = [q for q in result.query_results if q.get("status") == "FAILED"]
+        assert len(result.query_results) == 2
+        assert len(failed_rows) == 1
+        assert failed_rows[0]["query_id"] == "2"
+        assert failed_rows[0]["error_type"] == "QueryError"
+        assert failed_rows[0]["error_message"] == "Syntax error"
+
+    def test_reconstruct_preserves_warmup_iteration_zero_and_stream_zero(self):
+        """iter/stream of 0 are falsy and must not be dropped by a truthy `if`
+        check (qpc-02 / F1.4): warmup rows (iter=0) and the first stream
+        (stream=0) must survive reconstruction.
+        """
+        data = make_v2_result_dict(
+            version="2.1",
+            benchmark_id="test",
+            benchmark_name="Test",
+            platform="Test",
+            scale_factor=1.0,
+            execution_id="test",
+            timestamp="2025-01-01T10:00:00",
+            query_time_ms=100,
+            total_queries=1,
+            passed_queries=1,
+            failed_queries=0,
+            total_ms=100,
+            queries=[
+                {
+                    "id": "1",
+                    "ms": 90.0,
+                    "rows": 4,
+                    "iter": 0,
+                    "stream": 0,
+                    "run_type": "warmup",
+                    "status": "SUCCESS",
+                },
+            ],
+        )
+
+        result = reconstruct_benchmark_results(data)
+
+        assert len(result.query_results) == 1
+        row = result.query_results[0]
+        assert row["iteration"] == 0
+        assert row["stream_id"] == 0
+        assert row["run_type"] == "warmup"
+
+
+class TestExportLoadReexportRoundtrip:
+    """Byte-equality property test (qpc-02): export -> load -> re-export must
+    reproduce both the main result file and the .plans.json companion
+    exactly, for a fixture spanning warmup rows (iter 0), a failure, and a
+    stream > 0 row.
+    """
+
+    def test_export_load_reexport_roundtrip_byte_identical(self):
+        root = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_1", table_name="lineitem")
+        plan = QueryPlanDAG(query_id="2", platform="duckdb", logical_root=root)
+
+        query_results = [
+            # Warmup row: iteration 0 and stream 0 are both falsy -- must not
+            # be dropped by the loader.
+            {
+                "query_id": "1",
+                "status": "SUCCESS",
+                "execution_time_ms": 120.0,
+                "rows_returned": 4,
+                "iteration": 0,
+                "stream_id": 0,
+                "run_type": "warmup",
+            },
+            {
+                "query_id": "1",
+                "status": "SUCCESS",
+                "execution_time_ms": 100.0,
+                "rows_returned": 4,
+                "iteration": 1,
+                "stream_id": 0,
+                "run_type": "measurement",
+            },
+            # Second stream, with a captured plan whose capture_time_ms is
+            # exactly 0.0 (also falsy -- must not be dropped either).
+            {
+                "query_id": "2",
+                "status": "SUCCESS",
+                "execution_time_ms": 200.0,
+                "rows_returned": 8,
+                "iteration": 1,
+                "stream_id": 1,
+                "run_type": "measurement",
+                "query_plan": plan,
+                "plan_fingerprint": plan.plan_fingerprint,
+                "plan_capture_time_ms": 0.0,
+            },
+            # A FAILED query, duplicated into errors[] the way
+            # build_result_payload's _build_query_results_section does.
+            {
+                "query_id": "3",
+                "status": "FAILED",
+                "iteration": 1,
+                "stream_id": 0,
+                "run_type": "measurement",
+                "error_type": "QueryError",
+                "error_message": "Syntax error",
+            },
+        ]
+
+        original = make_benchmark_results(
+            benchmark_id="tpch",
+            benchmark_name="tpch",
+            platform="duckdb",
+            scale_factor=1.0,
+            execution_id="roundtrip-001",
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            duration_seconds=10.0,
+            total_queries=4,
+            successful_queries=3,
+            failed_queries=1,
+            query_plans_captured=1,
+            query_results=query_results,
+        )
+
+        exported = build_result_payload(original)
+        plans_payload = build_plans_payload(original)
+        assert plans_payload is not None
+
+        reimported = reconstruct_benchmark_results(exported, plans_data=plans_payload)
+        re_exported = build_result_payload(reimported)
+        re_plans_payload = build_plans_payload(reimported)
+
+        assert canonical_json_text(exported) == canonical_json_text(re_exported)
+        assert re_plans_payload is not None
+        assert canonical_json_text(plans_payload) == canonical_json_text(re_plans_payload)


### PR DESCRIPTION
## Description

A load/re-export cycle corrupted bundles: `_reconstruct_query_results` hardcoded `status="SUCCESS"` for every `queries[]` entry and separately appended FAILED rows from `errors[]`, so a failed query in a current-format bundle (which duplicates the failure into both arrays) became a phantom extra row. `iter`/`stream` were only kept `if q.get(...)`, so warmup rows (iter 0) and the first stream (stream 0) silently reverted to iteration=1/measurement on re-export. `run_type` was dropped entirely. `build_plans_payload`'s `if capture_time:` also dropped a captured plan's `capture_time_ms` when it was exactly `0.0`.

Fixes (per `_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml`):
- Each compact `queries[]` entry's own `status`/`iter`/`stream`/`run_type` is now honored (`status` falls back to `SUCCESS` only when the key is absent, preserving legacy-bundle loading).
- `errors[]` is now used only to (a) merge `error_type`/`error_message` onto a row whose own status is already non-SUCCESS/non-SKIPPED, or (b) synthesize a standalone row for a `query_id` that never appears in `queries[]` at all (the legacy shape) — eliminating the phantom-duplicate-FAILED-row bug.
- `capture_time_ms == 0.0` now round-trips correctly (`is not None` check).

## Type of Change

- [x] Bug fix

## Testing

- `uv run -- python -m pytest tests/unit/core/results/test_loader.py -q -k roundtrip` — new byte-equality export→load→re-export round-trip test (main file + `.plans.json` companion), covering a warmup row (iter=0/stream=0), a stream>0 row with a captured plan (`capture_time_ms=0.0`), and a FAILED row duplicated into `errors[]`.
- `uv run -- python -m pytest tests/unit/core/results/test_loader.py -q` — 32 passed (includes two new targeted regression tests: no phantom-duplicate for current-format failures, iter/stream-zero preserved).
- `uv run -- python -m pytest tests/unit/core/results/ tests/unit/test_results_exporter.py -q` — 657 passed, 3 skipped.
- `uv run -- ruff check` / `ruff format --check` / `ty check` on touched files — all pass.
- Adversarially reviewed by a second pass (Opus): confirmed the status/error-merge logic, `None` guards, and legacy fallback are all correct against the spec's `must_preserve`/`anti_patterns`; strengthened the round-trip test to assert `capture_time_ms == 0.0` explicitly (it was previously unprotected — reverting the schema.py fix left the test green because both sides dropped the field symmetrically).

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (N/A — internal bug fix, no public-facing schema field change.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

Marks `_project/TODO/query-plan-capture/planning/02-loader-roundtrip-fidelity.yaml` Completed. No CODEOWNERS-gated paths touched (`loader.py`/`schema.py` are not soundness-comparator/plan-parser paths) — auto-merge enabled.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_