### PR TITLE
chore(ci): acknowledge two resolved stranded commits in the orphan allowlist

### DIFF
--- a/_project/analysis/known-stranded-commits.txt
+++ b/_project/analysis/known-stranded-commits.txt
@@ -24,3 +24,16 @@ cf394466a1422db63ea93546ef1d870d6d90c28a
 # §2.22 — re-landed via #997 (branch remediate-governance-and-doc-drift): two commits
 4865a2f24e5aed743d6209956da7b53a3d4d1de1
 3368763728794ed7d9bc54e8f6a6029e6c8d6526
+
+# Content already on develop (branch fix/joinorder-trino-primary-key-ddl):
+# one-line DONE-path repoint of the item's own validate command; develop's
+# _project/DONE/main/planning/joinorder-trino-primary-key-ddl.yaml already
+# carries the identical line.
+4345f18cbbe9860511ef489557b39fd3079d6b98
+
+# Superseded on develop (branch fix/multistream-throughput-plan-attachment):
+# keyed .plans.json cross-phase collisions as "{query_id}#{test_type}#{stream_id}";
+# develop resolves the same power/throughput stream-0 collision via the
+# "{query_id}#{stream_id}:{test_type}" scheme landed through #976/#979/#989,
+# with a regression test in tests/unit/core/results/test_loader.py.
+ee072b2c98c62671229876c075039a723732c3ea


### PR DESCRIPTION
The scheduled orphaned-commit detector (#1020) flags two commits pushed to
feature branches after their PRs had squash-merged:

- 4345f18c on fix/joinorder-trino-primary-key-ddl: one-line repoint of the
  DONE item's validate command path. Develop's copy of
  joinorder-trino-primary-key-ddl.yaml already carries the identical line,
  so the content is on develop.

- ee072b2c on fix/multistream-throughput-plan-attachment: keyed .plans.json
  cross-phase collisions as "{query_id}#{test_type}#{stream_id}". Develop
  resolves the same power/throughput stream-0 collision via the
  "{query_id}#{stream_id}:{test_type}" scheme (#976/#979/#989), verified by
  comparing _lookup_plan_entry/_index_plan_entries on develop against the
  stranded commit and by the regression test in
  tests/unit/core/results/test_loader.py covering the exact collision.

Detector re-run with the updated allowlist: both SHAs acknowledged, exit 0,
"No NEW orphaned commits detected."

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
