### PR TITLE
fix(qpc-08): make plan history real — attribute fixes, add_run wiring, platform-partitioned flapping

### DIFF
--- a/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
@@ -2,7 +2,8 @@ id: "qpc-08-history-and-plan-metadata-wiring"
 title: "Make plan history real: fix dead attribute reads, wire add_run into the run path, sane ordering"
 worktree: "query-plan-capture"
 priority: "Medium"
-status: "In Progress"
+status: "Completed"
+completed_date: "2026-07-07"
 
 description: |
   benchbox plan-history is dead end-to-end:
@@ -58,15 +59,25 @@ work:
 - id: w4
   summary: "Review: adversarial code review (history dir lifecycle, cache staleness, fingerprint_version interaction with qpc-03)."
   needs: [w3]
-  status: pending
+  notes: >-
+    Opus review: flagged that add_run still used getattr(..., None) for the
+    now-required execution_id/timestamp (spec-forbidden anti-pattern) and that
+    the mixed-offset sort test did not actually distinguish lexicographic from
+    chronological order. Out-of-scope forward-ref noted: flap detection
+    compares raw fingerprints — revisit when qpc-03's fingerprint_version lands.
+  status: done
 - id: w5
   summary: "Fix: address review findings; re-run verification."
   needs: [w4]
-  status: pending
+  notes: >-
+    Changed add_run to direct results.execution_id/results.timestamp access;
+    rewrote the mixed-offset timestamp sort test to genuinely fail under a
+    lexicographic sort. 88 passed, ruff/ty clean.
+  status: done
 - id: w6
   summary: "Submit PR referencing qpc-08."
   needs: [w5]
-  status: pending
+  status: done
 
 must_preserve:
 - "Existing history-file JSON shape stays readable"

--- a/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml
@@ -2,7 +2,7 @@ id: "qpc-08-history-and-plan-metadata-wiring"
 title: "Make plan history real: fix dead attribute reads, wire add_run into the run path, sane ordering"
 worktree: "query-plan-capture"
 priority: "Medium"
-status: "Not Started"
+status: "In Progress"
 
 description: |
   benchbox plan-history is dead end-to-end:
@@ -33,27 +33,28 @@ work:
     Create: fix dead attribute reads in history and plan_metadata_utils;
     make shape drift fail loudly instead of getattr defaults.
   notes: >-
-    Fix attribute names (execution_id, timestamp) and read plans via the
-    qpc-01 accessor; replace getattr(..., {}) defaults with explicit access;
-    same fixes in plan_metadata_utils.
-  status: pending
+    Fixed add_run to read execution_id/timestamp (not run_id/start_time) and
+    iterate plans via iter_query_results. plan_metadata_utils was already
+    correct (fixed by #967); no change needed there.
+  status: done
 - id: w2
   summary: >-
     Create: wire add_run into the export/post-run path; timestamp-parse
     sorting; partition flap detection by platform.
   notes: >-
-    Single call site, opt-in config for the history dir; parse timestamps
-    with datetime.fromisoformat for sorting; partition flap/version
-    detection by platform.
+    Wired add_run via ResultExporter._record_plan_history (single call site,
+    opt-in plan_history_dir arg + BENCHBOX_PLAN_HISTORY_DIR env, no-op by
+    default, non-fatal on error). Timestamps parsed with datetime.fromisoformat
+    for sorting; flap detection partitioned by platform.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: >-
     Create: end-to-end test — run add_run on a real BenchmarkResults with
     plans, then plan-history CLI via CliRunner shows the entry; flapping test
     with mixed platforms asserts partitioning.
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: "Review: adversarial code review (history dir lifecycle, cache staleness, fingerprint_version interaction with qpc-03)."
   needs: [w3]

--- a/benchbox/core/query_plans/history.py
+++ b/benchbox/core/query_plans/history.py
@@ -99,14 +99,18 @@ class PlanHistory:
         """
         # BenchmarkResults has no `run_id`/`start_time` attributes -- the real
         # fields are `execution_id`/`timestamp` (qpc-08 / F1.2). Reading the
-        # wrong names made this a permanent, silent no-op: `getattr(...,
-        # default)` never raised, it just always returned the default.
-        execution_id = getattr(results, "execution_id", None)
+        # wrong names made this a permanent, silent no-op. Access the required
+        # attributes DIRECTLY rather than via `getattr(..., default)`: the
+        # original bug was silent precisely because getattr never raised on a
+        # missing/renamed attribute, it just returned the default. Direct
+        # access makes a future shape drift fail loudly (AttributeError, caught
+        # and logged by the single caller) instead of silently no-op'ing again.
+        execution_id = results.execution_id
         if not execution_id:
             logger.warning("Cannot add run without execution_id")
             return
 
-        timestamp_value = getattr(results, "timestamp", None)
+        timestamp_value = results.timestamp
         if isinstance(timestamp_value, datetime):
             timestamp = timestamp_value.isoformat()
         elif timestamp_value:

--- a/benchbox/core/query_plans/history.py
+++ b/benchbox/core/query_plans/history.py
@@ -18,6 +18,26 @@ from benchbox.core.results.loader import iter_query_results
 logger = logging.getLogger(__name__)
 
 
+def _parse_history_timestamp(timestamp: str) -> datetime:
+    """Parse a history entry's ISO-8601 timestamp for chronological ordering.
+
+    Naive and timezone-aware timestamps can both appear across history files
+    (e.g. a `datetime.now(timezone.utc).isoformat()` fallback vs. a captured
+    `BenchmarkResults.timestamp` that may be naive); comparing a naive and an
+    aware `datetime` raises `TypeError`, so a naive result is treated as UTC.
+    A malformed/empty timestamp sorts first rather than raising, so one
+    corrupt history entry doesn't break ordering for the rest.
+    """
+    if timestamp:
+        try:
+            parsed = datetime.fromisoformat(timestamp)
+        except ValueError:
+            logger.warning(f"Could not parse history timestamp {timestamp!r}; sorting it first")
+        else:
+            return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+    return datetime.min.replace(tzinfo=timezone.utc)
+
+
 @dataclass
 class PlanHistoryEntry:
     """Single entry in plan history for a query."""
@@ -77,19 +97,30 @@ class PlanHistory:
         Args:
             results: BenchmarkResults instance
         """
-        run_id = getattr(results, "run_id", None)
-        if not run_id:
-            logger.warning("Cannot add run without run_id")
+        # BenchmarkResults has no `run_id`/`start_time` attributes -- the real
+        # fields are `execution_id`/`timestamp` (qpc-08 / F1.2). Reading the
+        # wrong names made this a permanent, silent no-op: `getattr(...,
+        # default)` never raised, it just always returned the default.
+        execution_id = getattr(results, "execution_id", None)
+        if not execution_id:
+            logger.warning("Cannot add run without execution_id")
             return
 
-        timestamp = getattr(results, "start_time", None)
-        if not timestamp:
+        timestamp_value = getattr(results, "timestamp", None)
+        if isinstance(timestamp_value, datetime):
+            timestamp = timestamp_value.isoformat()
+        elif timestamp_value:
+            timestamp = str(timestamp_value)
+        else:
             timestamp = datetime.now(timezone.utc).isoformat()
 
         platform = getattr(results, "platform", "unknown")
 
+        # The on-disk/JSON key stays "run_id" (must_preserve: existing
+        # history-file shape stays readable) even though the value now comes
+        # from the correctly-named `execution_id` attribute.
         history_entry = {
-            "run_id": run_id,
+            "run_id": execution_id,
             "timestamp": timestamp,
             "platform": platform,
             "plan_fingerprints": {},
@@ -107,12 +138,12 @@ class PlanHistory:
                 }
 
         # Write to storage
-        history_file = self.storage_path / f"{run_id}.json"
+        history_file = self.storage_path / f"{execution_id}.json"
         with open(history_file, "w", encoding="utf-8") as f:
             json.dump(history_entry, f, indent=2)
 
         # Update cache
-        self._cache[run_id] = history_entry
+        self._cache[execution_id] = history_entry
 
     def query_plan_history(self, query_id: str) -> list[PlanHistoryEntry]:
         """
@@ -152,8 +183,12 @@ class PlanHistory:
                 logger.warning(f"Error loading history file {entry_file}: {e}")
                 continue
 
-        # Sort by timestamp
-        history.sort(key=lambda x: x.timestamp)
+        # Sort chronologically. Parsing (rather than a lexicographic string
+        # sort) matters once entries mix timestamp representations -- e.g. a
+        # naive local ISO string alongside a "+00:00"/"Z" UTC one sort
+        # incorrectly as plain strings despite being comparable instants
+        # once parsed (qpc-08 / F7.2).
+        history.sort(key=lambda x: _parse_history_timestamp(x.timestamp))
         return history
 
     def detect_plan_flapping(
@@ -168,16 +203,37 @@ class PlanHistory:
         Flapping indicates optimizer instability where the same query gets
         different plans across runs, potentially oscillating between them.
 
+        History is partitioned by platform before checking for flapping: a
+        history directory holding runs from two platforms for the same
+        query_id is NOT one interleaved sequence -- each platform has its own
+        independent plan lineage, and naively alternating between them would
+        report 100% transitions regardless of either platform's actual
+        stability (qpc-08 / F3.4-partial). Flapping is reported if any single
+        platform's own sequence flaps.
+
         Args:
             query_id: Query identifier
-            window_size: Number of recent runs to analyze
+            window_size: Number of recent runs to analyze (per platform)
             transition_threshold: Fraction of transitions that indicates flapping
 
         Returns:
-            True if plan flapping is detected
+            True if plan flapping is detected for any platform
         """
-        history = self.query_plan_history(query_id)[-window_size:]
+        history = self.query_plan_history(query_id)
+        if not history:
+            return False
 
+        by_platform: dict[str, list[PlanHistoryEntry]] = {}
+        for entry in history:
+            by_platform.setdefault(entry.platform, []).append(entry)
+
+        return any(
+            self._series_is_flapping(entries[-window_size:], transition_threshold) for entries in by_platform.values()
+        )
+
+    @staticmethod
+    def _series_is_flapping(history: list[PlanHistoryEntry], transition_threshold: float) -> bool:
+        """Flapping check for a single platform's own chronological series."""
         if len(history) < 3:
             return False
 

--- a/benchbox/core/results/exporter.py
+++ b/benchbox/core/results/exporter.py
@@ -74,6 +74,7 @@ class ResultExporter:
         anonymize: bool = True,
         anonymization_config: AnonymizationConfig | None = None,
         console: Console | None = None,
+        plan_history_dir: str | Path | None = None,
     ):
         """Initialize the result exporter.
 
@@ -82,6 +83,11 @@ class ResultExporter:
             anonymize: Whether to anonymize system information. Defaults to True.
             anonymization_config: Configuration for anonymization.
             console: Rich console for output. Creates new one if not provided.
+            plan_history_dir: Opt-in directory to record this run's plan
+                fingerprints into via ``PlanHistory.add_run`` (see
+                ``benchbox plan-history``). Falls back to the
+                ``BENCHBOX_PLAN_HISTORY_DIR`` env var; unset (the default)
+                means no plan-history recording, matching prior behavior.
         """
         if output_dir is None:
             self.output_dir = resolve_results_dir(env=os.environ)
@@ -105,6 +111,9 @@ class ResultExporter:
             AnonymizationManager(anonymization_config or AnonymizationConfig()) if anonymize else None
         )
         self._validator = SchemaV2Validator()
+
+        resolved_plan_history_dir = plan_history_dir or os.environ.get("BENCHBOX_PLAN_HISTORY_DIR")
+        self.plan_history_dir = Path(resolved_plan_history_dir) if resolved_plan_history_dir else None
 
     def _write_file(self, file_path: Path, content: str, mode: str = "w") -> None:
         """Write content to file, handling both local and cloud paths."""
@@ -248,6 +257,9 @@ class ResultExporter:
         # Write companion files
         self._write_companion_files(result, filename_base)
 
+        # Opt-in plan-history recording (single call site; see plan_history_dir).
+        self._record_plan_history(result)
+
         return filepath
 
     def _write_companion_files(self, result: ResultLike, filename_base: str) -> None:
@@ -267,6 +279,26 @@ class ResultExporter:
             tuning_path = self._create_file_path(f"{filename_base}.tuning.json")
             self._write_file(tuning_path, canonical_json_text(tuning_payload))
             self.console.print(f"[dim]Exported tuning: {tuning_path}[/dim]")
+
+    def _record_plan_history(self, result: ResultLike) -> None:
+        """Opt-in: append this run's plan fingerprints to a PlanHistory store.
+
+        No-op unless ``plan_history_dir`` was configured (constructor arg or
+        ``BENCHBOX_PLAN_HISTORY_DIR``) -- this is the wiring `add_run` never
+        had (qpc-08 / F1.2): it existed with zero production callers, so the
+        `benchbox plan-history` CLI could only ever read an empty store.
+        Recording failures are logged, never fatal to the export -- plan
+        history is a secondary observability feature, not part of the
+        result's correctness contract.
+        """
+        if not self.plan_history_dir:
+            return
+        try:
+            from benchbox.core.query_plans.history import PlanHistory
+
+            PlanHistory(self.plan_history_dir).add_run(result)
+        except Exception as exc:
+            logger.warning(f"Failed to record plan history: {exc}")
 
     def _apply_anonymization(self, payload: dict[str, Any]) -> None:
         """Apply public-export anonymization to environment, platform, config, and execution metadata."""

--- a/tests/unit/core/query_plans/test_plan_history.py
+++ b/tests/unit/core/query_plans/test_plan_history.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from benchbox.cli.commands.plan_history import plan_history
 from benchbox.core.query_plans.history import (
     PlanHistory,
     PlanHistoryEntry,
@@ -86,7 +89,15 @@ class TestPlanHistoryEntry:
 
 
 class TestPlanHistory:
-    """Tests for PlanHistory class."""
+    """Tests for PlanHistory class.
+
+    Constructs real ``BenchmarkResults`` via ``make_benchmark_results`` using
+    its REAL attribute names (``execution_id``/``timestamp``), not the
+    ``run_id``/``start_time`` names ``PlanHistory.add_run`` used to read
+    (qpc-08 / F1.2): those attributes don't exist on ``BenchmarkResults``, so
+    a fixture that bolted them on as loose attributes masked `add_run` being
+    permanently unreachable from any real caller.
+    """
 
     def test_add_run(self) -> None:
         """Test adding a benchmark run to history."""
@@ -95,7 +106,7 @@ class TestPlanHistory:
 
             plan = _create_plan_with_fingerprint("q1", "a" * 64)
             results = make_benchmark_results(
-                run_id="run1",
+                execution_id="run1",
                 query_results=[_qr("q1", 100.0, plan)],
             )
 
@@ -111,6 +122,21 @@ class TestPlanHistory:
             assert "q1" in data["plan_fingerprints"]
             assert data["plan_fingerprints"]["q1"]["fingerprint"] == "a" * 64
 
+    def test_add_run_without_execution_id_is_a_noop(self) -> None:
+        """A result with no execution_id cannot be filed under any run name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = PlanHistory(Path(tmpdir))
+
+            plan = _create_plan_with_fingerprint("q1", "a" * 64)
+            results = make_benchmark_results(
+                execution_id="",
+                query_results=[_qr("q1", 100.0, plan)],
+            )
+
+            history.add_run(results)
+
+            assert history.get_run_count() == 0
+
     def test_query_plan_history(self) -> None:
         """Test retrieving history for a query."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -120,8 +146,8 @@ class TestPlanHistory:
             for i in range(3):
                 plan = _create_plan_with_fingerprint("q1", "a" * 64)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0 + i * 10, plan)],
                 )
                 history.add_run(results)
@@ -131,6 +157,48 @@ class TestPlanHistory:
             assert len(entries) == 3
             assert entries[0].run_id == "run0"  # Sorted by timestamp
             assert entries[2].run_id == "run2"
+
+    def test_query_plan_history_sorts_mixed_offset_timestamps_chronologically(self) -> None:
+        """qpc-08 / F7.2: a lexicographic string sort misorders timestamps that
+        mix representations (naive vs. explicit UTC offset) even when they are
+        chronologically unambiguous once parsed.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = PlanHistory(Path(tmpdir))
+
+            # Naive-looking "Z" timestamp that sorts AFTER an explicit "+00:00"
+            # offset lexicographically ('Z' > '+') despite being the earlier
+            # instant once parsed.
+            plan_a = _create_plan_with_fingerprint("q1", "a" * 64)
+            plan_b = _create_plan_with_fingerprint("q1", "b" * 64)
+            history.add_run(
+                make_benchmark_results(
+                    execution_id="early",
+                    timestamp=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                    query_results=[_qr("q1", 100.0, plan_a)],
+                )
+            )
+            history.add_run(
+                make_benchmark_results(
+                    execution_id="late",
+                    timestamp=datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+                    query_results=[_qr("q1", 100.0, plan_b)],
+                )
+            )
+            # Directly corrupt "early"'s stored timestamp representation to a
+            # lexicographically-larger-but-chronologically-earlier string, the
+            # way a naive-vs-aware mix would in practice.
+            early_file = Path(tmpdir) / "early.json"
+            with open(early_file, encoding="utf-8") as f:
+                data = json.load(f)
+            data["timestamp"] = "2024-01-01T00:00:00Z"
+            with open(early_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+            history._cache.clear()
+
+            entries = history.query_plan_history("q1")
+
+            assert [e.run_id for e in entries] == ["early", "late"]
 
     def test_query_plan_history_empty(self) -> None:
         """Test history for non-existent query."""
@@ -148,8 +216,8 @@ class TestPlanHistory:
             for i in range(5):
                 plan = _create_plan_with_fingerprint("q1", "a" * 64)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
@@ -166,8 +234,8 @@ class TestPlanHistory:
             for i, fp in enumerate(fingerprints):
                 plan = _create_plan_with_fingerprint("q1", fp)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
@@ -185,8 +253,8 @@ class TestPlanHistory:
             for i, fp in enumerate(fingerprints):
                 plan = _create_plan_with_fingerprint("q1", fp)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
@@ -204,13 +272,70 @@ class TestPlanHistory:
                 fp = "a" * 64 if i == 0 else "b" * 64
                 plan = _create_plan_with_fingerprint("q1", fp)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
 
             assert history.detect_plan_flapping("q1") is False
+
+    def test_detect_plan_flapping_ignores_cross_platform_alternation(self) -> None:
+        """qpc-08 / F3.4-partial: two platforms alternating for the same
+        query_id is NOT one flapping sequence -- each platform has its own
+        independent, stable plan lineage. Naive interleaved comparison would
+        report 100% transitions; partitioned by platform, neither platform
+        actually flaps.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = PlanHistory(Path(tmpdir))
+
+            # duckdb: always "a". postgres: always "b". Interleaved by
+            # timestamp they alternate a/b/a/b/a -- 100% naive transition rate.
+            for i in range(5):
+                platform = "duckdb" if i % 2 == 0 else "postgres"
+                fingerprint = "a" * 64 if platform == "duckdb" else "b" * 64
+                plan = _create_plan_with_fingerprint("q1", fingerprint)
+                results = make_benchmark_results(
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
+                    platform=platform,
+                    query_results=[_qr("q1", 100.0, plan)],
+                )
+                history.add_run(results)
+
+            assert history.detect_plan_flapping("q1") is False
+
+    def test_detect_plan_flapping_detects_real_flap_within_one_platform(self) -> None:
+        """A genuine flap on ONE platform is still detected even when a
+        second, stable platform's runs are interleaved in the same history."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history = PlanHistory(Path(tmpdir))
+
+            duckdb_fingerprints = ["a" * 64, "c" * 64, "a" * 64, "c" * 64, "a" * 64]
+            for i, fp in enumerate(duckdb_fingerprints):
+                plan = _create_plan_with_fingerprint("q1", fp)
+                history.add_run(
+                    make_benchmark_results(
+                        execution_id=f"duckdb-run{i}",
+                        timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
+                        platform="duckdb",
+                        query_results=[_qr("q1", 100.0, plan)],
+                    )
+                )
+            # A stable postgres lineage interleaved in the same history dir.
+            for i in range(5):
+                plan = _create_plan_with_fingerprint("q1", "b" * 64)
+                history.add_run(
+                    make_benchmark_results(
+                        execution_id=f"postgres-run{i}",
+                        timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
+                        platform="postgres",
+                        query_results=[_qr("q1", 100.0, plan)],
+                    )
+                )
+
+            assert history.detect_plan_flapping("q1") is True
 
     def test_get_plan_version_history(self) -> None:
         """Test version history tracking."""
@@ -221,8 +346,8 @@ class TestPlanHistory:
             for i, fp in enumerate(fingerprints):
                 plan = _create_plan_with_fingerprint("q1", fp)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
-                    start_time=f"2024-01-0{i + 1}T00:00:00Z",
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
@@ -246,7 +371,7 @@ class TestPlanHistory:
             plan1 = _create_plan_with_fingerprint("q1", "a" * 64)
             plan2 = _create_plan_with_fingerprint("q2", "b" * 64)
             results = make_benchmark_results(
-                run_id="run1",
+                execution_id="run1",
                 query_results=[
                     _qr("q1", 100.0, plan1),
                     _qr("q2", 200.0, plan2),
@@ -268,7 +393,7 @@ class TestPlanHistory:
             for i in range(3):
                 plan = _create_plan_with_fingerprint("q1", "a" * 64)
                 results = make_benchmark_results(
-                    run_id=f"run{i}",
+                    execution_id=f"run{i}",
                     query_results=[_qr("q1", 100.0, plan)],
                 )
                 history.add_run(results)
@@ -282,7 +407,7 @@ class TestPlanHistory:
 
             plan = _create_plan_with_fingerprint("q1", "a" * 64)
             results = make_benchmark_results(
-                run_id="run1",
+                execution_id="run1",
                 query_results=[_qr("q1", 100.0, plan)],
             )
             history.add_run(results)
@@ -309,3 +434,37 @@ class TestCreatePlanHistory:
             new_dir = Path(tmpdir) / "subdir" / "history"
             create_plan_history(new_dir)
             assert new_dir.exists()
+
+
+class TestAddRunEndToEndViaCLI:
+    """qpc-08 w3: exercise the real (un-mocked) `add_run` -> `PlanHistory` ->
+    `benchbox plan-history` CLI path end to end, proving the wiring actually
+    reaches a real ``BenchmarkResults`` rather than only a fixture that
+    happens to define the attributes `add_run` reads.
+    """
+
+    def test_real_benchmark_results_recorded_and_shown_by_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            history_dir = Path(tmpdir)
+            history = PlanHistory(history_dir)
+
+            for i, fp in enumerate(["a" * 64, "a" * 64, "b" * 64]):
+                plan = _create_plan_with_fingerprint("1", fp)
+                results = make_benchmark_results(
+                    execution_id=f"run{i}",
+                    timestamp=datetime(2024, 1, i + 1, tzinfo=timezone.utc),
+                    platform="duckdb",
+                    query_results=[_qr("1", 100.0 + i, plan)],
+                )
+                history.add_run(results)
+
+            result = CliRunner().invoke(
+                plan_history,
+                ["--query-id", "1", "--history-dir", str(history_dir)],
+            )
+
+            assert result.exit_code == 0, result.output
+            assert "Plan History for 1" in result.output
+            assert "run0" in result.output
+            assert "run2" in result.output
+            assert "Unique plans: 2" in result.output

--- a/tests/unit/core/query_plans/test_plan_history.py
+++ b/tests/unit/core/query_plans/test_plan_history.py
@@ -159,46 +159,52 @@ class TestPlanHistory:
             assert entries[2].run_id == "run2"
 
     def test_query_plan_history_sorts_mixed_offset_timestamps_chronologically(self) -> None:
-        """qpc-08 / F7.2: a lexicographic string sort misorders timestamps that
-        mix representations (naive vs. explicit UTC offset) even when they are
-        chronologically unambiguous once parsed.
+        """qpc-08 / F7.2: mixed-offset timestamps must be ordered by the instant
+        they denote, not by lexicographic string comparison.
+
+        The earlier instant here is deliberately arranged to sort LATER by both
+        of the axes a naive implementation might rely on -- filename/glob order
+        and raw-string order -- so only a parse-based sort recovers the true
+        chronological order. A regression to ``history.sort(key=lambda x:
+        x.timestamp)`` (lexicographic) turns this test red.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             history = PlanHistory(Path(tmpdir))
 
-            # Naive-looking "Z" timestamp that sorts AFTER an explicit "+00:00"
-            # offset lexicographically ('Z' > '+') despite being the earlier
-            # instant once parsed.
-            plan_a = _create_plan_with_fingerprint("q1", "a" * 64)
-            plan_b = _create_plan_with_fingerprint("q1", "b" * 64)
-            history.add_run(
-                make_benchmark_results(
-                    execution_id="early",
-                    timestamp=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
-                    query_results=[_qr("q1", 100.0, plan_a)],
-                )
+            # run-a: 2024-03-10 02:30 UTC.
+            # run-b: 2024-03-10 06:30 +08:00 == 2024-03-09 22:30 UTC -- the
+            # EARLIER instant. Yet its filename ("run-b" > "run-a") AND its raw
+            # timestamp string ("06:30" > "02:30") both sort it AFTER run-a, so
+            # a lexicographic (or glob-order) sort yields the wrong [run-a,
+            # run-b]; only parsing yields the correct [run-b, run-a]. Explicit
+            # offsets (not "Z") keep this valid on every supported Python,
+            # including 3.10 where ``fromisoformat`` rejects a trailing "Z".
+            stored_timestamps = (
+                ("run-a", "2024-03-10T02:30:00+00:00"),
+                ("run-b", "2024-03-10T06:30:00+08:00"),
             )
-            history.add_run(
-                make_benchmark_results(
-                    execution_id="late",
-                    timestamp=datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
-                    query_results=[_qr("q1", 100.0, plan_b)],
+            for exec_id, iso_timestamp in stored_timestamps:
+                plan = _create_plan_with_fingerprint("q1", "a" * 64)
+                history.add_run(
+                    make_benchmark_results(
+                        execution_id=exec_id,
+                        query_results=[_qr("q1", 100.0, plan)],
+                    )
                 )
-            )
-            # Directly corrupt "early"'s stored timestamp representation to a
-            # lexicographically-larger-but-chronologically-earlier string, the
-            # way a naive-vs-aware mix would in practice.
-            early_file = Path(tmpdir) / "early.json"
-            with open(early_file, encoding="utf-8") as f:
-                data = json.load(f)
-            data["timestamp"] = "2024-01-01T00:00:00Z"
-            with open(early_file, "w", encoding="utf-8") as f:
-                json.dump(data, f)
+                # Overwrite the stored timestamp with the exact mixed-offset
+                # representation under test (add_run would otherwise write the
+                # fixture's naive now()).
+                entry_file = Path(tmpdir) / f"{exec_id}.json"
+                with open(entry_file, encoding="utf-8") as f:
+                    data = json.load(f)
+                data["timestamp"] = iso_timestamp
+                with open(entry_file, "w", encoding="utf-8") as f:
+                    json.dump(data, f)
             history._cache.clear()
 
             entries = history.query_plan_history("q1")
 
-            assert [e.run_id for e in entries] == ["early", "late"]
+            assert [e.run_id for e in entries] == ["run-b", "run-a"]
 
     def test_query_plan_history_empty(self) -> None:
         """Test history for non-existent query."""

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -279,6 +279,8 @@ def test_canonical_bundle_export_keeps_plans_raw_explain_output_when_not_anonymi
         plans_data = json.load(handle)
 
     assert plans_data["queries"]["1"]["plan"]["raw_explain_output"] == "SEQ_SCAN /Users/alice/data/lineitem.parquet"
+
+
 def test_exporter_records_plan_history_when_dir_configured(tmp_path):
     """qpc-08 w2: `add_run` had zero production callers -- `_export_json_v2`
     is now the single wired call site, gated behind an opt-in

--- a/tests/unit/test_results_exporter.py
+++ b/tests/unit/test_results_exporter.py
@@ -279,6 +279,47 @@ def test_canonical_bundle_export_keeps_plans_raw_explain_output_when_not_anonymi
         plans_data = json.load(handle)
 
     assert plans_data["queries"]["1"]["plan"]["raw_explain_output"] == "SEQ_SCAN /Users/alice/data/lineitem.parquet"
+def test_exporter_records_plan_history_when_dir_configured(tmp_path):
+    """qpc-08 w2: `add_run` had zero production callers -- `_export_json_v2`
+    is now the single wired call site, gated behind an opt-in
+    `plan_history_dir` so default export behavior (no history recording) is
+    unchanged.
+    """
+    history_dir = tmp_path / "history"
+    result = _minimal_result("duckdb")
+
+    ResultExporter(output_dir=tmp_path / "results", anonymize=False, plan_history_dir=history_dir).export_result(
+        result, formats=["json"]
+    )
+
+    history_file = history_dir / f"{result.execution_id}.json"
+    assert history_file.exists()
+    with open(history_file, encoding="utf-8") as handle:
+        entry = json.load(handle)
+    assert entry["run_id"] == result.execution_id
+
+
+def test_exporter_records_plan_history_from_env_var(tmp_path, monkeypatch):
+    """The BENCHBOX_PLAN_HISTORY_DIR env var is an equivalent opt-in to the
+    constructor arg, for callers that can't easily thread a new parameter
+    through (e.g. existing CLI entry points)."""
+    history_dir = tmp_path / "history"
+    monkeypatch.setenv("BENCHBOX_PLAN_HISTORY_DIR", str(history_dir))
+    result = _minimal_result("duckdb")
+
+    ResultExporter(output_dir=tmp_path / "results", anonymize=False).export_result(result, formats=["json"])
+
+    assert (history_dir / f"{result.execution_id}.json").exists()
+
+
+def test_exporter_does_not_record_plan_history_by_default(tmp_path):
+    """No plan_history_dir configured (the default) -- no history directory
+    should be created at all."""
+    result = _minimal_result("duckdb")
+
+    ResultExporter(output_dir=tmp_path / "results", anonymize=False).export_result(result, formats=["json"])
+
+    assert not (tmp_path / "history").exists()
 
 
 def test_exporter_omits_direct_total_for_unavailable_normalized_cost(tmp_path):


### PR DESCRIPTION
## Description

`benchbox plan-history` was dead end-to-end (qpc-08 / findings F1.2, F7.2, F3.4-partial):

- `PlanHistory.add_run` read `results.run_id` / `results.start_time` — attributes that do not exist on `BenchmarkResults` (the real fields are `execution_id` / `timestamp`). Because it used `getattr(..., None)`, it silently no-op'd on every real object; the old test suite masked this with fixtures that bolted the wrong attribute names on. Fixed to read `execution_id`/`timestamp` via **direct attribute access** (not `getattr`-with-default — the spec's anti-pattern is exactly "converting a wiring bug into permanently-empty output"). The on-disk JSON key stays `"run_id"` for backward-compatible history files.
- `add_run` had **zero production callers**. It is now wired into `ResultExporter._export_json_v2` via `_record_plan_history`, gated behind an opt-in `plan_history_dir` constructor arg (or `BENCHBOX_PLAN_HISTORY_DIR` env var). Unset = no recording (default behavior unchanged). Recording failures are logged, never fatal to the export.
- `query_plan_history` sorted timestamps as raw ISO **strings** (lexicographic), which misorders mixed-representation timestamps. Now parsed via `datetime.fromisoformat` (naive treated as UTC; malformed sorts first rather than raising).
- `detect_plan_flapping` ignored platform: a history dir holding two platforms for one query_id reported 100% flapping from the interleaved sequence. Now partitions by platform and reports flapping if any single platform's own series flaps.

`plan_metadata_utils.py` was in the original scope but was already correct (fixed by prior work #967) — no change needed there.

## Type of Change

- [x] Bug fix

## Testing

- `uv run -- python -m pytest tests/unit/core/query_plans/test_plan_history.py tests/unit/test_results_exporter.py -q` — 30 passed. Includes: real-`BenchmarkResults` `add_run` → `benchbox plan-history` CLI end-to-end (CliRunner); cross-platform-alternation-is-not-flapping; genuine-flap-within-one-platform-still-detected; mixed-offset timestamps sort chronologically; opt-in wiring (constructor arg, env var, and off-by-default).
- Full query_plans + manifest + CLI-coverage suites pass.
- `ruff check` / `ruff format --check` / `ty check` on touched files — all clean.
- Adversarial Opus review: changed the two now-required reads from `getattr(..., None)` to direct attribute access, and rewrote the mixed-offset sort test so it genuinely fails under a lexicographic sort (the original didn't distinguish the two orders). 88 passed after fixes.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (`plan_history_dir` is a new optional constructor arg / env opt-in; default behavior unchanged.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] I updated the relevant user-facing docs. (N/A — opt-in observability wiring; no user-facing schema change.)
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

- Marks `_project/TODO/query-plan-capture/planning/08-history-and-plan-metadata-wiring.yaml` Completed.
- No CODEOWNERS-gated paths touched (`history.py` / `exporter.py` are not soundness-comparator/plan-parser paths) — auto-merge enabled.
- **Out-of-scope forward-reference** (deliberately not addressed here): `detect_plan_flapping` compares raw fingerprint strings within a platform. This is correct today, but should be revisited to also partition/guard by `fingerprint_version` once qpc-03's fingerprint-versioning lands, so a v1↔v2 fingerprint change is never counted as a plan flap.
- Shares `exporter.py` (different regions) with the still-open #1024 (qpc-07); will rebase on develop if GitHub flags a conflict after that merges.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_