### PR TITLE
test(qpc-11): real-loader companion test per plan CLI + no-mock guardrail

### DIFF
--- a/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
+++ b/_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml
@@ -2,7 +2,8 @@ id: "qpc-11-plan-cli-test-democking"
 title: "De-mock plan CLI/consumer tests: fakes must not define attributes production objects lack"
 worktree: "query-plan-capture"
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-07"
 
 description: |
   All three plan CLI coverage suites monkeypatch load_result_file with
@@ -30,32 +31,40 @@ work:
     Create: replace SimpleNamespace result fakes with real BenchmarkResults
     or spec-constrained mocks; add one real-loader test per CLI.
   notes: >-
-    Real instances are cheap to construct; otherwise
-    create_autospec(BenchmarkResults). Where load_result_file is stubbed for
-    speed, add one companion test per CLI that exercises the real loader on
-    a tmp-file bundle.
-  status: pending
+    The SimpleNamespace .phases fakes were already gone (suites use real
+    make_benchmark_results). Added one real-path test per CLI with NO
+    load_result_file/PlanHistory monkeypatch: show-plan and compare-plans
+    drive real on-disk bundles (build_result_payload + build_plans_payload)
+    through the real loader; plan-history drives a real PlanHistory over
+    real on-disk history JSON.
+  status: done
 - id: w2
   summary: >-
     Create: guardrail preventing load_result_file monkeypatching without a
     sibling real-file test.
   notes: >-
-    Pattern mirror of tests/unit/test_todo_executable_docs.py guardrails, or
-    a lightweight lint in tests/conftest.
+    Added tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py: for each
+    plan CLI suite that stubs its data-load boundary (load_result_file /
+    PlanHistory) it requires a `def test_..real..` companion. Verified it
+    goes red when the real-path test is removed.
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: "Review: adversarial code review (did any test lose coverage in the swap; fake-shape drift actually fails now — mutate a field name and confirm red)."
   needs: [w2]
-  status: pending
+  notes: >-
+    Manual canary confirmed: renaming query_results in iter_query_results
+    turns the new real-loader show-plan/compare-plans tests red; the guardrail
+    goes red when its real-path companion is removed.
+  status: done
 - id: w4
   summary: "Fix: address review findings; re-run verification."
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Submit PR referencing qpc-11."
   needs: [w4]
-  status: pending
+  status: done
 
 must_preserve:
 - "Test suite runtime stays in the fast lane (no benchmark execution; tmp-file bundles only)"

--- a/tests/unit/cli/commands/test_compare_plans_coverage.py
+++ b/tests/unit/cli/commands/test_compare_plans_coverage.py
@@ -136,16 +136,34 @@ def _write_real_bundle(path: Path, *, execution_id: str, query_id: str, table_na
 def test_compare_plans_real_loader_compares_bundles(tmp_path: Path) -> None:
     """End-to-end through the REAL loader for BOTH runs: no load_result_file
     monkeypatch. Two bundles share query id "1" but scan different tables, so
-    the loader rehydrates real QueryPlanDAGs and the comparator reports a
-    structural difference (qpc-11 w1: one real-loader test per CLI)."""
+    the loader rehydrates real QueryPlanDAGs and the comparator must report the
+    property difference (qpc-11 w1: one real-loader test per CLI).
+
+    Asserts on the emitted comparison, not just exit code: with only
+    ``exit_code == 0`` this would be a false green, because ``--threshold 0.0``
+    plus an explicit ``--query-id`` filters every comparison out of the result
+    list, so the command exits 0 having printed "No plans available for
+    comparison" without ever rehydrating or comparing a plan. ``--threshold
+    1.0`` admits the (non-identical) comparison so the real compare path runs,
+    and the JSON assertions below fail unless both plans were genuinely
+    rehydrated and the differing table was detected.
+    """
     p1 = tmp_path / "r1.json"
     p2 = tmp_path / "r2.json"
     _write_real_bundle(p1, execution_id="run1", query_id="1", table_name="lineitem")
     _write_real_bundle(p2, execution_id="run2", query_id="1", table_name="orders")
 
-    result = CliRunner().invoke(cp.compare_plans, ["--run1", str(p1), "--run2", str(p2), "--query-id", "1"])
+    result = CliRunner().invoke(
+        cp.compare_plans,
+        ["--run1", str(p1), "--run2", str(p2), "--query-id", "1", "--threshold", "1.0", "--output", "json"],
+    )
 
     assert result.exit_code == 0, result.output
+    assert '"query_id": "1"' in result.output
+    assert '"plans_identical": false' in result.output
+    # The one property difference is the differing scanned table (lineitem vs
+    # orders) -- proves both plans were rehydrated and structurally compared.
+    assert '"property_mismatches": 1' in result.output
 
 
 def test_compare_plans_uses_load_result_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/cli/commands/test_compare_plans_coverage.py
+++ b/tests/unit/cli/commands/test_compare_plans_coverage.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import importlib
 import json
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
 
+from benchbox.core.results.canonical_json import canonical_json_text
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType, QueryPlanDAG
+from benchbox.core.results.schema import build_plans_payload, build_result_payload
 from tests.fixtures.result_dict_fixtures import make_benchmark_results
 
 cp = importlib.import_module("benchbox.cli.commands.compare_plans")
@@ -93,6 +97,55 @@ def _make_load_seq(*results_list):
         return (seq.pop(0), {})
 
     return _load
+
+
+def _write_real_bundle(path: Path, *, execution_id: str, query_id: str, table_name: str) -> None:
+    """Write a REAL on-disk v2 bundle (main file + .plans.json companion) with a
+    genuine QueryPlanDAG, for the no-monkeypatch real-loader test (qpc-11 w1)."""
+    root = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_1", table_name=table_name)
+    plan = QueryPlanDAG(query_id=query_id, platform="duckdb", logical_root=root)
+    results = make_benchmark_results(
+        benchmark_id="tpch",
+        benchmark_name="tpch",
+        platform="duckdb",
+        scale_factor=1.0,
+        execution_id=execution_id,
+        timestamp=datetime(2025, 1, 1, 12, 0, 0),
+        duration_seconds=1.0,
+        total_queries=1,
+        successful_queries=1,
+        query_plans_captured=1,
+        query_results=[
+            {
+                "query_id": query_id,
+                "status": "SUCCESS",
+                "execution_time_ms": 100.0,
+                "rows_returned": 4,
+                "query_plan": plan,
+                "plan_fingerprint": plan.plan_fingerprint,
+            }
+        ],
+    )
+    path.write_text(canonical_json_text(build_result_payload(results)), encoding="utf-8")
+    plans_payload = build_plans_payload(results)
+    assert plans_payload is not None
+    companion = path.with_name(path.name[: -len(".json")] + ".plans.json")
+    companion.write_text(canonical_json_text(plans_payload), encoding="utf-8")
+
+
+def test_compare_plans_real_loader_compares_bundles(tmp_path: Path) -> None:
+    """End-to-end through the REAL loader for BOTH runs: no load_result_file
+    monkeypatch. Two bundles share query id "1" but scan different tables, so
+    the loader rehydrates real QueryPlanDAGs and the comparator reports a
+    structural difference (qpc-11 w1: one real-loader test per CLI)."""
+    p1 = tmp_path / "r1.json"
+    p2 = tmp_path / "r2.json"
+    _write_real_bundle(p1, execution_id="run1", query_id="1", table_name="lineitem")
+    _write_real_bundle(p2, execution_id="run2", query_id="1", table_name="orders")
+
+    result = CliRunner().invoke(cp.compare_plans, ["--run1", str(p1), "--run2", str(p2), "--query-id", "1"])
+
+    assert result.exit_code == 0, result.output
 
 
 def test_compare_plans_uses_load_result_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py
+++ b/tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py
@@ -1,0 +1,75 @@
+"""Guardrail: plan CLI coverage suites that stub the real data-load path must
+keep a sibling test that exercises the REAL path (qpc-11 w2 / finding F8.1).
+
+The masking bug this prevents: all three plan CLI coverage suites used to
+monkeypatch ``load_result_file`` (or ``PlanHistory``) with hand-built fakes
+that DEFINED attributes the production objects lack (notably ``.phases``), so
+the suites stayed green while every real invocation crashed. Fast fakes for
+flag/option coverage are fine, but each such suite must ALSO contain at least
+one test that drives the CLI through the real loader / real store with no
+monkeypatch, so attribute drift is actually caught.
+
+This is a lightweight text-level lint (mirrors the guardrail style in
+tests/unit/test_todo_executable_docs.py) rather than an AST analysis: it keys
+off the presence of a ``*real*`` test function in any suite that stubs the
+data-load boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_COMMANDS_DIR = Path(__file__).resolve().parent
+
+# The plan CLI coverage suites guarded here, with the data-load symbol each one
+# stubs for its fast flag/option tests. Any suite that monkeypatches that
+# symbol must keep a real-path companion test.
+_GUARDED_SUITES = {
+    "test_show_plan_coverage.py": "load_result_file",
+    "test_compare_plans_coverage.py": "load_result_file",
+    "test_plan_history_coverage.py": "PlanHistory",
+}
+
+
+def _stubs_symbol(text: str, symbol: str) -> bool:
+    """True if the suite monkeypatches ``symbol`` (the data-load boundary)."""
+    return f'"{symbol}"' in text and "monkeypatch.setattr" in text
+
+
+# A real-path companion test is identified by a ``real`` token in its OWN
+# function name (e.g. ``test_show_plan_real_loader_...``,
+# ``test_..._real_history_store_...``). Matching the function name -- not just
+# any "real" appearing in a comment/docstring/helper -- is what makes deleting
+# the companion test actually trip this guardrail.
+_REAL_PATH_TEST_RE = re.compile(r"^def (test_\w*real\w*)\(", re.MULTILINE)
+
+
+def _has_real_path_test(text: str) -> bool:
+    """True if the suite defines at least one real-path test function."""
+    return bool(_REAL_PATH_TEST_RE.search(text))
+
+
+@pytest.mark.parametrize(("filename", "stubbed_symbol"), sorted(_GUARDED_SUITES.items()))
+def test_plan_cli_suite_that_stubs_loader_has_real_path_test(filename: str, stubbed_symbol: str) -> None:
+    suite_path = _COMMANDS_DIR / filename
+    assert suite_path.exists(), f"guarded plan CLI suite missing: {filename}"
+    text = suite_path.read_text(encoding="utf-8")
+
+    if not _stubs_symbol(text, stubbed_symbol):
+        # Suite no longer stubs the data-load boundary at all -> nothing to guard.
+        return
+
+    assert _has_real_path_test(text), (
+        f"{filename} monkeypatches {stubbed_symbol!r} for fast coverage but has no "
+        f"real-path (no-monkeypatch) companion test. Add one that drives the CLI "
+        f"through the real loader/store on a tmp-file bundle so fake-shape drift "
+        f"(e.g. a fabricated '.phases' attribute) is actually caught. See qpc-11 / F8.1."
+    )

--- a/tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py
+++ b/tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py
@@ -44,12 +44,14 @@ def _stubs_symbol(text: str, symbol: str) -> bool:
     return f'"{symbol}"' in text and "monkeypatch.setattr" in text
 
 
-# A real-path companion test is identified by a ``real`` token in its OWN
-# function name (e.g. ``test_show_plan_real_loader_...``,
+# A real-path companion test is identified by a ``real`` token, delimited by
+# underscores, in its OWN function name (e.g. ``test_show_plan_real_loader_...``,
 # ``test_..._real_history_store_...``). Matching the function name -- not just
 # any "real" appearing in a comment/docstring/helper -- is what makes deleting
-# the companion test actually trip this guardrail.
-_REAL_PATH_TEST_RE = re.compile(r"^def (test_\w*real\w*)\(", re.MULTILINE)
+# the companion test actually trip this guardrail. Requiring the ``_real_``
+# delimiters (rather than a bare "real" substring) stops an unrelated future
+# test such as ``test_really_fast_flag`` from silently satisfying the guardrail.
+_REAL_PATH_TEST_RE = re.compile(r"^def (test_\w*_real_\w*)\(", re.MULTILINE)
 
 
 def _has_real_path_test(text: str) -> bool:

--- a/tests/unit/cli/commands/test_plan_history_coverage.py
+++ b/tests/unit/cli/commands/test_plan_history_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -123,3 +124,46 @@ def test_plan_history_reraises_exception_in_verbose_mode(monkeypatch: pytest.Mon
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, RuntimeError)
+
+
+def _write_history_file(history_dir: Path, run_id: str, timestamp: str, fingerprint: str) -> None:
+    """Write a real on-disk PlanHistory JSON file (the format PlanHistory reads)."""
+    (history_dir / f"{run_id}.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "timestamp": timestamp,
+                "platform": "duckdb",
+                "plan_fingerprints": {
+                    "1": {"fingerprint": fingerprint, "estimated_cost": None, "execution_time_ms": 100.0}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_plan_history_real_history_store_end_to_end(tmp_path: Path) -> None:
+    """End-to-end through the REAL PlanHistory (no monkeypatch): the CLI reads
+    genuine on-disk history files, sorts + versions + renders them via the real
+    query_plan_history/get_plan_version_history path (qpc-11 w1: one real-path
+    test per CLI).
+
+    Writes files directly rather than via ``PlanHistory.add_run`` so the test
+    is independent of the add_run wiring (exercised separately by qpc-08's
+    suite); it pins the CLI's real *read* path against a real store.
+    """
+    history_dir = tmp_path / "history"
+    history_dir.mkdir()
+    _write_history_file(history_dir, "run0", "2024-01-01T00:00:00", "a" * 64)
+    _write_history_file(history_dir, "run1", "2024-01-02T00:00:00", "a" * 64)
+    _write_history_file(history_dir, "run2", "2024-01-03T00:00:00", "b" * 64)
+
+    result = CliRunner().invoke(ph.plan_history, ["--query-id", "1", "--history-dir", str(history_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "Plan History for 1" in result.output
+    assert "run0" in result.output
+    assert "run2" in result.output
+    # Two distinct fingerprints across the three runs.
+    assert "Unique plans: 2" in result.output

--- a/tests/unit/cli/commands/test_show_plan_coverage.py
+++ b/tests/unit/cli/commands/test_show_plan_coverage.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import importlib
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
 
+from benchbox.core.results.canonical_json import canonical_json_text
+from benchbox.core.results.query_plan_models import LogicalOperator, LogicalOperatorType, QueryPlanDAG
+from benchbox.core.results.schema import build_plans_payload, build_result_payload
 from tests.fixtures.result_dict_fixtures import make_benchmark_results
 
 mod = importlib.import_module("benchbox.cli.commands.show_plan")
@@ -26,6 +30,44 @@ def _make_results(query_id: str = "q1", has_plan: bool = True):
     if plan is not None:
         query_result["query_plan"] = plan
     return make_benchmark_results(query_results=[query_result])
+
+
+def _write_real_bundle(tmp_path: Path, query_id: str = "1") -> Path:
+    """Write a REAL on-disk v2 bundle (main file + .plans.json companion) with a
+    genuine QueryPlanDAG, so a test can drive show-plan through the actual
+    ``load_result_file`` -> reconstruct -> companion-rehydrate path with NO
+    monkeypatching (qpc-11 w1: one real-loader test per CLI).
+    """
+    root = LogicalOperator(operator_type=LogicalOperatorType.SCAN, operator_id="scan_1", table_name="lineitem")
+    plan = QueryPlanDAG(query_id=query_id, platform="duckdb", logical_root=root)
+    results = make_benchmark_results(
+        benchmark_id="tpch",
+        benchmark_name="tpch",
+        platform="duckdb",
+        scale_factor=1.0,
+        execution_id="show-plan-real",
+        timestamp=datetime(2025, 1, 1, 12, 0, 0),
+        duration_seconds=1.0,
+        total_queries=1,
+        successful_queries=1,
+        query_plans_captured=1,
+        query_results=[
+            {
+                "query_id": query_id,
+                "status": "SUCCESS",
+                "execution_time_ms": 100.0,
+                "rows_returned": 4,
+                "query_plan": plan,
+                "plan_fingerprint": plan.plan_fingerprint,
+            }
+        ],
+    )
+    main_path = tmp_path / "r.json"
+    main_path.write_text(canonical_json_text(build_result_payload(results)), encoding="utf-8")
+    plans_payload = build_plans_payload(results)
+    assert plans_payload is not None
+    (tmp_path / "r.plans.json").write_text(canonical_json_text(plans_payload), encoding="utf-8")
+    return main_path
 
 
 def _make_load(results):
@@ -80,6 +122,24 @@ def test_show_plan_missing_query_and_plan(monkeypatch: pytest.MonkeyPatch, tmp_p
     monkeypatch.setattr(mod, "load_result_file", _make_load(_make_results(query_id="q1", has_plan=False)))
     miss_p = CliRunner().invoke(mod.show_plan, ["--run", str(p), "--query-id", "q1"])
     assert miss_p.exit_code == 1
+
+
+def test_show_plan_real_loader_renders_plan_from_bundle(tmp_path: Path) -> None:
+    """End-to-end through the REAL loader: no load_result_file monkeypatch.
+
+    Proves the CLI works against an actual on-disk bundle -- the companion
+    .plans.json is discovered, the plan is rehydrated into a real QueryPlanDAG,
+    and JSON output carries its structure. A fabricated fake that merely
+    defined the attributes the CLI reads would pass its other tests while this
+    real path stayed broken (the exact F8.1 masking this item targets).
+    """
+    main_path = _write_real_bundle(tmp_path, query_id="1")
+
+    result = CliRunner().invoke(mod.show_plan, ["--run", str(main_path), "--query-id", "1", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"logical_root"' in result.output
+    assert '"lineitem"' in result.output
 
 
 def test_show_plan_load_error_and_verbose_exception(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

The plan CLI coverage suites stub the data-load boundary (`load_result_file` / `PlanHistory`) with fast fakes for flag/option coverage. Historically those fakes DEFINED attributes the real production objects lack (notably `.phases`), so the suites stayed green while every real CLI invocation crashed (finding F8.1). The `.phases` fakes were already removed in prior work; this item is the sweep — add the missing real-path coverage and a guardrail so the masking cannot silently return.

Tests-only change (scope_limit: `tests/`):
- **show-plan** and **compare-plans**: one real-path test each that writes a genuine on-disk v2 bundle (`build_result_payload` + `build_plans_payload` companion) and drives the CLI through the REAL `load_result_file` → reconstruct → companion-rehydrate path with no monkeypatch.
- **plan-history**: one real-path test driving the REAL `PlanHistory` over real on-disk history JSON (independent of the `add_run` wiring, which qpc-08/#1025 covers — so this test is valid on develop today).
- **`test_plan_cli_no_mock_guardrail.py`** (new): for each suite that stubs its data-load boundary, requires a `def test_..real..` companion test; verified it goes red when the companion is removed.

## Type of Change

- [x] Refactor / chore (test hardening)

## Testing

- `uv run -- python -m pytest tests/unit/cli/commands/test_show_plan_coverage.py tests/unit/cli/commands/test_compare_plans_coverage.py tests/unit/cli/commands/test_plan_history_coverage.py tests/unit/cli/commands/test_plan_cli_no_mock_guardrail.py -q` — 22 passed.
- `ruff check` / `ruff format --check` / `ty check` on the four files — all clean.
- Manual shape-drift canary (per the item's verification): renaming `query_results` in `iter_query_results` turns the new real-loader show-plan/compare-plans tests red; the guardrail goes red when its real-path companion is removed.
- Adversarial Opus review caught a false-green: the compare-plans real-loader test originally asserted only `exit_code == 0` and passed via a "No plans available" exit-0 quirk without comparing anything. Rewrote it to assert real comparison content (`--threshold 1.0 --output json`, asserting `query_id` / `plans_identical` / `property_mismatches`), and tightened the guardrail regex to require a `_real_` token in the test name.

## Public Contract Check

- [x] This PR does not change public, beta-public, deprecated, generated, experimental, or repo-only contract surfaces. (Tests only.)
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] N/A — tests only; no user-facing docs or behavior change.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

- Marks `_project/TODO/query-plan-capture/planning/11-plan-cli-test-democking.yaml` Completed.
- No CODEOWNERS-gated paths touched (tests only) — auto-merge enabled.
- **Out-of-scope product observation** (deliberately NOT fixed here — tests-only scope; worth a future TODO): `compare_plans._build_comparisons` drops an explicitly-requested query at `--threshold 0.0`, so single-query output is unreachable at the default threshold.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_