### PR TITLE
fix(release): release-cut curation survives untracked paths; refresh uv.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1073,6 +1073,10 @@ release-cut:
 	git fetch origin
 	git checkout -b v$(VERSION) develop
 	uv run -- python scripts/update_version.py --version $(VERSION) --update-pyproject
+	@# Refresh uv.lock now that pyproject.toml carries the new version, so the
+	@# pre-commit uv-lock hook has nothing to regenerate mid-commit (v0.3.1
+	@# aborted because the tracked lock was stale and the hook rewrote it).
+	uv lock
 	uv run -- python scripts/generate_changelog_entry.py --version $(VERSION) --since-ref origin/main
 	@if [ -n "$$EDITOR" ]; then \
 		echo "==> Opening CHANGELOG.md in $$EDITOR for hand-curation"; \
@@ -1086,12 +1090,25 @@ release-cut:
 	@# before git add ensures untracked files inside _project/ etc. don't end up
 	@# staged-for-add by a later git add.
 	@# Curation list: A3 of _project/decisions/single-repo-migration.md.
-	-git rm -rf _project _blog results-data results-explorer .claude .codex .gemini
-	-git rm -f .pre-commit-config.yaml .importlinter todo.config.yaml skill-sync.yaml skill-sync.lock .gitattributes .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
-	-git rm -f .github/workflows/results-explorer-browser.yml .github/workflows/seed-corpus.yml .github/workflows/sync-results-data-to-published.yml .github/workflows/validate-submission.yml
-	@# Stage only the files update_version.py + generate_changelog_entry.py write.
-	@# Explicit list (not `git add -A`) to avoid staging build/cache artifacts.
-	git add pyproject.toml benchbox/__init__.py landing/index.html README.md docs/README.md benchbox/utils/VERSION_MANAGEMENT.md CHANGELOG.md
+	@# --ignore-unmatch: git rm aborts the ENTIRE command when any one pathspec
+	@# is untracked, and a leading `-` would hide that, silently skipping all
+	@# curation on that line (v0.3.1 shipped uncurated because of this). With
+	@# --ignore-unmatch, unmatched paths are a no-op and any remaining failure
+	@# is real, so no `-` prefix: real failures must abort the cut.
+	git rm -rf --ignore-unmatch _project _blog results-data results-explorer .claude .codex .gemini
+	git rm -f --ignore-unmatch .pre-commit-config.yaml .importlinter todo.config.yaml skill-sync.yaml skill-sync.lock .gitattributes .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md
+	git rm -f --ignore-unmatch .github/workflows/results-explorer-browser.yml .github/workflows/seed-corpus.yml .github/workflows/sync-results-data-to-published.yml .github/workflows/validate-submission.yml
+	@# Post-curation guard: every curated path must be gone from the index.
+	@LEFTOVER=$$(git ls-files _project _blog results-data results-explorer .claude .codex .gemini .pre-commit-config.yaml .importlinter todo.config.yaml skill-sync.yaml skill-sync.lock .gitattributes .coveragerc_core .dockerignore .env.example .mcp.json AGENTS.md CLAUDE.md GEMINI.md ANTIGRAVITY.md .github/workflows/results-explorer-browser.yml .github/workflows/seed-corpus.yml .github/workflows/sync-results-data-to-published.yml .github/workflows/validate-submission.yml); \
+	if [ -n "$$LEFTOVER" ]; then \
+		echo "ERROR: release curation incomplete; dev-only paths still tracked:" >&2; \
+		echo "$$LEFTOVER" | sed 's/^/  /' >&2; \
+		exit 1; \
+	fi
+	@# Stage only the files update_version.py + generate_changelog_entry.py +
+	@# uv lock write. Explicit list (not `git add -A`) to avoid staging
+	@# build/cache artifacts.
+	git add pyproject.toml uv.lock benchbox/__init__.py landing/index.html README.md docs/README.md benchbox/utils/VERSION_MANAGEMENT.md CHANGELOG.md
 	git commit -m "Release v$(VERSION)"
 	git push -u origin v$(VERSION)
 	gh pr create --base main --head v$(VERSION) --title "Release v$(VERSION)" --body-file .github/RELEASE_PR_TEMPLATE.md

--- a/scripts/check_release_curation.py
+++ b/scripts/check_release_curation.py
@@ -79,9 +79,10 @@ def parse_curation_list(makefile: Path) -> set[str]:
     body = match.group(1)
     paths: set[str] = set()
     for line in body.splitlines():
-        # Match both `-git rm -rf <paths>` and `-git rm -f <paths>` (leading
-        # `-` is the Make convention for "ignore exit code").
-        rm_match = re.search(r"git rm (?:-rf|-f) (.+?)$", line.strip())
+        # Match `git rm -rf <paths>` and `git rm -f <paths>`, with or without
+        # `--ignore-unmatch` and with or without a leading `-` (the Make
+        # "ignore exit code" prefix used before --ignore-unmatch was added).
+        rm_match = re.search(r"git rm (?:-rf|-f)(?: --ignore-unmatch)? (.+?)$", line.strip())
         if not rm_match:
             continue
         paths.update(rm_match.group(1).split())

--- a/tests/unit/scripts/test_check_release_curation.py
+++ b/tests/unit/scripts/test_check_release_curation.py
@@ -1,0 +1,77 @@
+"""Tests for the release curation-drift guard's Makefile parsing."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_release_curation.py"
+
+spec = importlib.util.spec_from_file_location("check_release_curation", SCRIPT_PATH)
+check_release_curation = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check_release_curation)
+
+
+def _write_makefile(tmp_path: Path, recipe_lines: list[str]) -> Path:
+    makefile = tmp_path / "Makefile"
+    body = "\n".join(f"\t{line}" for line in recipe_lines)
+    makefile.write_text(f"release-cut:\n{body}\n\nother-target:\n\techo hi\n", encoding="utf-8")
+    return makefile
+
+
+def test_parse_curation_list_handles_ignore_unmatch(tmp_path):
+    """--ignore-unmatch must not be swallowed into the parsed path set."""
+    makefile = _write_makefile(
+        tmp_path,
+        [
+            "git rm -rf --ignore-unmatch _project _blog",
+            "git rm -f --ignore-unmatch .mcp.json todo.config.yaml",
+            "git add pyproject.toml",
+        ],
+    )
+    paths = check_release_curation.parse_curation_list(makefile)
+    assert paths == {"_project", "_blog", ".mcp.json", "todo.config.yaml"}
+
+
+def test_parse_curation_list_handles_legacy_prefixed_lines(tmp_path):
+    """Pre---ignore-unmatch form (`-git rm -rf <paths>`) still parses."""
+    makefile = _write_makefile(
+        tmp_path,
+        [
+            "-git rm -rf _project",
+            "-git rm -f .mcp.json",
+        ],
+    )
+    paths = check_release_curation.parse_curation_list(makefile)
+    assert paths == {"_project", ".mcp.json"}
+
+
+def test_parse_curation_list_ignores_non_rm_lines(tmp_path):
+    """git ls-files guard lines and other commands contribute no paths."""
+    makefile = _write_makefile(
+        tmp_path,
+        [
+            "git rm -rf --ignore-unmatch _project",
+            "@LEFTOVER=$$(git ls-files _project _blog); \\",
+            'if [ -n "$$LEFTOVER" ]; then exit 1; fi',
+        ],
+    )
+    paths = check_release_curation.parse_curation_list(makefile)
+    assert paths == {"_project"}
+
+
+def test_real_makefile_curation_list_parses_to_paths_only():
+    """Against the repo Makefile: every parsed entry is a path, never a flag."""
+    paths = check_release_curation.parse_curation_list(REPO_ROOT / "Makefile")
+    assert paths, "expected a non-empty curation list from the repo Makefile"
+    flags = {p for p in paths if p.startswith("-")}
+    assert not flags, f"parser leaked flags into the curation list: {sorted(flags)}"

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -519,6 +519,54 @@ class TestReleaseInfrastructure:
         assert "origin/main" in release_guide
         assert "intentionally does not replay release commits onto" in release_guide
 
+    def test_release_cut_curation_survives_untracked_paths(self):
+        """Curation `git rm` lines must use --ignore-unmatch and abort on real failures.
+
+        Without --ignore-unmatch, one untracked pathspec aborts the entire
+        `git rm`, and the old `-` prefix hid that — the v0.3.1 cut shipped an
+        uncurated release branch because .codex/.gemini/todo.config.yaml were
+        untracked at cut time.
+        """
+        recipe = _make_target_recipe("release-cut")
+        rm_lines = [line.strip() for line in recipe.splitlines() if re.search(r"git rm (?:-rf|-f) ", line)]
+        assert rm_lines, "expected git rm curation lines in release-cut"
+        for line in rm_lines:
+            assert "--ignore-unmatch" in line, f"curation line missing --ignore-unmatch: {line}"
+            assert not line.startswith("-"), f"real git rm failures must abort the cut (drop `-` prefix): {line}"
+
+    def test_release_cut_post_curation_guard_covers_every_curated_path(self):
+        """The git ls-files guard must re-check every path the git rm lines curate."""
+        recipe = _make_target_recipe("release-cut")
+        rm_paths: set[str] = set()
+        for line in recipe.splitlines():
+            rm_match = re.search(r"git rm (?:-rf|-f) --ignore-unmatch (.+?)$", line.strip())
+            if rm_match:
+                rm_paths.update(rm_match.group(1).split())
+        assert rm_paths, "expected git rm curation paths in release-cut"
+        guard_match = re.search(r"git ls-files (.+?)\)", recipe)
+        assert guard_match, "expected a `git ls-files <curated paths>` post-curation guard in release-cut"
+        guard_paths = set(guard_match.group(1).split())
+        assert rm_paths == guard_paths, (
+            f"post-curation guard out of sync with git rm lines; "
+            f"missing from guard: {sorted(rm_paths - guard_paths)}, "
+            f"extra in guard: {sorted(guard_paths - rm_paths)}"
+        )
+
+    def test_release_cut_refreshes_and_stages_uv_lock(self):
+        """release-cut must regenerate uv.lock after the version bump and stage it.
+
+        The v0.3.1 cut aborted mid-commit because the tracked uv.lock was stale
+        and the pre-commit uv-lock hook rewrote it during `git commit`.
+        """
+        recipe = _make_target_recipe("release-cut")
+        lock_match = re.search(r"^\tuv lock\s*$", recipe, re.MULTILINE)
+        assert lock_match, "release-cut must run `uv lock` to refresh the lockfile"
+        bump_idx = recipe.index("scripts/update_version.py")
+        assert bump_idx < lock_match.start(), "`uv lock` must run after the pyproject version bump"
+        add_match = re.search(r"^\tgit add (.+?)$", recipe, re.MULTILINE)
+        assert add_match, "expected explicit git add line in release-cut"
+        assert "uv.lock" in add_match.group(1).split(), "uv.lock must be staged with the release commit"
+
     def test_issue_templates_exist(self):
         """Test that GitHub issue templates exist."""
         templates_dir = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"


### PR DESCRIPTION
## Summary

Fixes two latent `release-cut` bugs discovered during the v0.3.1 cut (2026-07-07):

**1. Curation silently skipped when any pathspec is untracked.** `git rm` aborts the *entire* command when a single pathspec matches nothing, and the leading `-` (make's ignore-exit-code prefix) hid the failure. At v0.3.1 cut time `.codex`, `.gemini`, `todo.config.yaml`, and `.mcp.json` were untracked, so the first two curation lines were no-ops and the release branch shipped uncurated (only the workflow-file line succeeded).

- Added `--ignore-unmatch` to all three curation `git rm` lines — unmatched pathspecs become no-ops.
- Dropped the `-` prefix — with `--ignore-unmatch`, any remaining failure is real and must abort the cut.
- Added a post-curation guard: `git ls-files <every curated path>` must return nothing, else the cut fails loudly with the leftover paths.
- Updated `scripts/check_release_curation.py`'s Makefile parser to recognize the `--ignore-unmatch` form (it previously would have captured the flag as a "path"); paths stay listed literally on the `git rm` lines so the drift guard keeps working.

**2. Stale `uv.lock` aborted the release commit.** The tracked lock still said 0.2.1; pre-commit's uv-lock hook regenerated it mid-commit, aborting the release commit. `release-cut` now runs `uv lock` right after the version bump and stages `uv.lock` explicitly alongside `pyproject.toml`.

## Tests

- `tests/unit/test_release_infrastructure.py`: three new Makefile contract tests — curation lines use `--ignore-unmatch` and abort on real failures; the `git ls-files` guard covers exactly the `git rm` path set (kills list-drift); `uv lock` runs after the bump and `uv.lock` is staged.
- `tests/unit/scripts/test_check_release_curation.py` (new): parser unit tests for the `--ignore-unmatch` form, the legacy `-git rm` form, non-`git rm` lines, and a flag-leak check against the real Makefile.
- Verified end-to-end in a scratch repo: old form exits 128 removing nothing when one pathspec is untracked; new form curates cleanly and the guard passes.
- `uv run -- python scripts/check_release_curation.py` → OK (46 paths accounted for, 25 curated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
