### PR TITLE
chore(todo): add DuckLake platform TODOs (core adapter + catalog/storage backends)

### DIFF
--- a/_project/TODO/ducklake-platform/planning/ducklake-catalog-storage-backends.yaml
+++ b/_project/TODO/ducklake-platform/planning/ducklake-catalog-storage-backends.yaml
@@ -1,0 +1,165 @@
+id: "ducklake-catalog-storage-backends"
+title: "DuckLake platform: SQLite + PostgreSQL catalogs and S3/cloud data storage"
+worktree: "ducklake-platform"
+priority: "Medium-High"
+status: "Not Started"
+description: |
+  Extend the DuckLake platform adapter (see ducklake-platform-adapter) beyond the
+  default DuckDB-file catalog + local storage to the full v1 scope:
+
+    - Catalog metadata backends: SQLite and PostgreSQL (in addition to DuckDB).
+    - Data storage: S3 / cloud object storage for DATA_PATH (in addition to local).
+
+  DuckLake's catalog backend is chosen by the ATTACH connection string, each
+  needing a DuckDB extension:
+    duckdb  : ATTACH 'ducklake:meta.ducklake'          (default; done in base item)
+    sqlite  : INSTALL sqlite;   ATTACH 'ducklake:sqlite:meta.sqlite'   (DATA_PATH ...)
+    postgres: INSTALL postgres; ATTACH 'ducklake:postgres:dbname=... host=...' (DATA_PATH ...)
+  (MySQL is explicitly excluded — DuckLake docs flag it as not recommended.)
+
+  Cloud storage is orthogonal to the catalog: DATA_PATH can be 's3://bucket/prefix/'
+  with httpfs + a DuckDB secret:
+    INSTALL httpfs;
+    CREATE SECRET (TYPE s3, PROVIDER credential_chain);  -- or KEY_ID/SECRET/REGION
+    ATTACH 'ducklake:...' AS lake (DATA_PATH 's3://bucket/bench/');
+
+  Selection is surfaced via --platform-option catalog=duckdb|sqlite|postgres and
+  --platform-option data_path=<local|s3://...>.
+
+  Sources: https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database ,
+  https://duckdb.org/docs/lts/core_extensions/ducklake
+
+category: "Platform Expansion"
+
+prior_art:
+  - "benchbox/platforms/base/config_utils.py POSTGRES_FAMILY_PLATFORM_FIELDS/POSTGRES_FAMILY_BASE_OPTIONS + make_platform_config_builder — REUSE for the postgres-catalog connection params (pg_duckdb.py:419 shows usage)"
+  - "benchbox/utils/cloud_storage.py is_cloud_path/get_cloud_path_info (used in duckdb.py:844-848) — REUSE to detect and route s3:// DATA_PATH"
+  - "benchbox/platforms/duckdb.py extension-install idiom (_try_delta_scan:136, _try_iceberg_scan:153) — REUSE for INSTALL/LOAD sqlite|postgres|httpfs"
+  - "benchbox/platforms/__init__.py _OPTION_SPEC_ROWS:604 + register_config_builder:826 — EXTEND: add catalog/data_path/PG/S3 option specs and (if creds persistence needed) a config builder"
+  - "benchbox/core/platform_registry.py DeploymentCapability:210 (requires_cloud_storage, requires_network, auth_methods) — EXTEND the ducklake metadata deployment_modes for self-hosted-PG and cloud-S3"
+  - "tests/integration/test_open_table_formats.py:715-733 TestDuckLakeFormatSmoke extension-availability guard — REUSE the skip-guard pattern for extension/credential gating"
+
+work:
+  - id: w1
+    summary: "Add catalog-backend selection (--platform-option catalog=duckdb|sqlite|postgres) + SQLite backend"
+    status: pending
+    notes: |
+      Generalize create_connection to build the ATTACH string per catalog; validate
+      catalog in {duckdb,sqlite,postgres}. SQLite: INSTALL sqlite; ATTACH
+      'ducklake:sqlite:<meta>.sqlite' AS lake (DATA_PATH '<dir>').
+
+  - id: w2
+    summary: "Add PostgreSQL catalog backend, reusing PG-family option/credential machinery"
+    needs: [w1]
+    status: pending
+    notes: |
+      INSTALL postgres; ATTACH 'ducklake:postgres:dbname=<db> host=<host> user=... password=...'
+      AS lake (DATA_PATH '<dir>'). Pull PG connection params from platform options/env via
+      the POSTGRES_FAMILY_* helpers. Catalog DB must be pre-created (document this).
+
+  - id: w3
+    summary: "Add S3/cloud DATA_PATH support (httpfs + DuckDB secret + cloud_storage routing)"
+    status: pending
+    notes: |
+      When data_path is a cloud URI (is_cloud_path): INSTALL httpfs; create an S3 secret
+      (credential_chain by default, or explicit KEY_ID/SECRET/REGION from options) before
+      ATTACH with DATA_PATH 's3://...'. Extend ducklake metadata deployment_modes with a
+      cloud mode (requires_cloud_storage/requires_network).
+
+  - id: w4
+    summary: "Integration tests for sqlite/postgres catalogs and s3 storage (extension/creds-gated)"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      tests/integration/test_ducklake_integration.py: add a SQLite-catalog TPC-H SF 0.01
+      case; a PostgreSQL-catalog case behind the existing PG fixtures/marker; an S3 case
+      skipped when creds absent. Guard on ducklake/sqlite/postgres/httpfs extension
+      availability like TestDuckLakeFormatSmoke.
+
+  - id: w5
+    summary: "Update docs: catalog-backend + storage options in ducklake.md, comparison-matrix, support-status"
+    needs: [w1, w2, w3]
+    status: pending
+    notes: |
+      Document the three catalog backends, local vs S3 DATA_PATH, required extensions,
+      and the pre-created-PG-database prerequisite. Update deployment-mode columns.
+
+deferred:
+  - summary: "MySQL catalog backend"
+    reason: "DuckLake docs explicitly flag MySQL as not recommended (compatibility issues)"
+  - summary: "GCS / Azure object storage backends for DATA_PATH"
+    reason: "S3 first; other object stores are a follow-on once the secret/httpfs path is proven"
+  - summary: "Multi-client / concurrent-writer benchmark scenarios (the 'multiplayer DuckDB' story)"
+    reason: "Single-process benchmarking parity first; concurrency benchmarks are a separate research item"
+
+must_preserve:
+  - "The default DuckDB-file catalog + local storage path from ducklake-platform-adapter keeps working unchanged when no catalog/data_path option is given"
+  - "No new hard dependency: sqlite/postgres/httpfs are DuckDB runtime extensions, not Python packages; the global pyproject `duckdb` pin is untouched"
+  - "Existing PostgreSQL-family platforms (postgresql, pg_duckdb, timescaledb) and their option plumbing are unaffected"
+
+approach: |
+  Build on the base adapter. create_connection already ATTACHes a catalog after
+  INSTALL/LOAD ducklake; generalize it to switch the ATTACH string on a `catalog`
+  option and to prepend INSTALL sqlite / INSTALL postgres / INSTALL httpfs as
+  needed. Reuse POSTGRES_FAMILY_* option helpers for PG params and cloud_storage
+  helpers to detect s3:// DATA_PATH. Keep S3 secret creation optional and
+  credential-chain-first so no creds are needed for local runs. Gate all live
+  extended-backend tests behind availability/credential skips.
+
+anti_patterns:
+  - "DO NOT connect to the PostgreSQL catalog via psycopg — because DuckLake reads the catalog through DuckDB's own `postgres` extension — use the ATTACH 'ducklake:postgres:...' connection string"
+  - "DO NOT require S3 credentials for the default path — because most benchmark runs are local — only create the S3 secret when data_path is a cloud URI"
+  - "DO NOT duplicate PG connection-arg parsing — because POSTGRES_FAMILY_* helpers already exist — reuse them"
+
+verification:
+  - description: "SQLite catalog runs TPC-H"
+    command: "uv run -- python -m benchbox run --platform ducklake --benchmark tpch --scale 0.01 --platform-option catalog=sqlite"
+    expected_output: "queries succeed; metadata.sqlite + Parquet written"
+  - description: "PostgreSQL catalog runs TPC-H (with a reachable PG server + pre-created catalog DB)"
+    command: "uv run -- python -m benchbox run --platform ducklake --benchmark tpch --scale 0.01 --platform-option catalog=postgres --platform-option pg_host=localhost"
+    expected_output: "queries succeed; catalog rows in the Postgres ducklake_catalog DB"
+  - description: "S3 DATA_PATH (with creds present) writes Parquet to the bucket"
+    command: "uv run -- python -m benchbox run --platform ducklake --benchmark tpch --scale 0.01 --platform-option data_path=s3://<bucket>/bench/"
+    expected_output: "queries succeed; Parquet objects appear under s3://<bucket>/bench/"
+  - description: "Extended-backend integration tests pass or skip cleanly"
+    command: "uv run -- python -m pytest tests/integration/test_ducklake_integration.py -q"
+    expected_output: "sqlite case passes; postgres/s3 cases pass or skip when unavailable"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/ducklake.py"
+    - "benchbox/platforms/__init__.py"
+    - "benchbox/core/platform_registry.py"
+    - "tests/integration/test_ducklake_integration.py"
+    - "tests/unit/platforms/test_ducklake_adapter.py"
+    - "docs/platforms/ducklake.md"
+    - "docs/platforms/comparison-matrix.md"
+    - "docs/platforms/support-status.md"
+  do_not_modify:
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/platforms/postgresql.py"
+    - "benchbox/platforms/pg_duckdb.py"
+    - "benchbox/utils/cloud_storage.py"
+
+success_metrics:
+  - "TPC-H runs on all three catalog backends (duckdb, sqlite, postgres) at SF 0.01"
+  - "TPC-H runs with an s3:// DATA_PATH when credentials are available"
+  - "PostgreSQL/S3 tests skip cleanly (not fail) when the server/credentials are absent"
+
+deps:
+  needs:
+    - "ducklake-platform-adapter"
+
+metadata:
+  tags:
+    - "platform"
+    - "ducklake"
+    - "postgres"
+    - "s3"
+    - "lakehouse"
+  estimated_effort: "Medium"
+  created_date: "2026-07-07"
+
+open_questions:
+  - "Should the PG catalog reuse an existing BenchBox-managed Postgres instance/fixtures, or require an externally provisioned server? (affects CI gating)"
+  - "Credential-chain vs explicit-key default for the S3 secret — default to credential_chain to match the aws-extension convention."

--- a/_project/TODO/ducklake-platform/planning/ducklake-platform-adapter.yaml
+++ b/_project/TODO/ducklake-platform/planning/ducklake-platform-adapter.yaml
@@ -1,0 +1,216 @@
+id: "ducklake-platform-adapter"
+title: "Add DuckLake as a first-class benchmark platform (core adapter)"
+worktree: "ducklake-platform"
+priority: "High"
+status: "Not Started"
+description: |
+  Add DuckLake as a runnable BenchBox platform so it can be benchmarked on
+  TPC-H/TPC-DS/etc. alongside the other 45 SQL engines.
+
+  DuckLake (GA v1.0, April 2026 — https://ducklake.select) is an open lakehouse
+  format: table DATA is Parquet on local disk or object storage, and all catalog
+  METADATA (schemas, snapshots, stats, file lists) lives in a standard SQL
+  database (DuckDB / SQLite / PostgreSQL) instead of Iceberg manifests or Delta
+  JSON logs. It ships as a DuckDB extension and uses DuckDB's engine + SQL
+  dialect unchanged:
+    INSTALL ducklake;
+    ATTACH 'ducklake:<catalog>' AS lake (DATA_PATH '<parquet_dir_or_s3>');
+    USE lake;  -- then normal CREATE TABLE / COPY / SELECT
+
+  Current state: DuckLake already exists in BenchBox as a table *format*
+  (converter benchbox/utils/format_converters/ducklake_converter.py,
+  DUCKLAKE_CAPABILITY in benchbox/platforms/base/format_capabilities.py:180,
+  DataFrame maintenance ops in
+  benchbox/platforms/dataframe/ducklake_maintenance.py) but NOT as a *platform*.
+  There is no DuckLakeAdapter and no `ducklake` entry in PlatformRegistry. This
+  TODO adds the adapter and wires it in.
+
+  This item = the MVP: DuckLakeAdapter subclassing DuckDBAdapter, with a
+  DuckDB-file catalog + local Parquet storage, full registry wiring, docs, and
+  live TPC-H/TPC-DS validation. SQLite/PostgreSQL catalogs and S3 storage are a
+  follow-on (see ducklake-catalog-storage-backends).
+
+  Evidence (pinned): the worktree venv resolves duckdb==1.3.2; the `ducklake`
+  extension requires DuckDB >= 1.3 (spec 0.1/0.2; 1.4 for 0.3). The global
+  `duckdb` pin in pyproject.toml is intentionally `>=1.0.0,<2.0.0` (kept at 1.0
+  floor for duckdb-wasm on-disk-format compatibility — see the comment at
+  pyproject.toml:90-94). Do NOT raise that floor; enforce the >=1.3 requirement
+  at runtime in the adapter instead.
+
+category: "Platform Expansion"
+
+prior_art:
+  - "benchbox/platforms/pg_duckdb.py: PgDuckDBAdapter(PostgreSQLAdapter) overrides create_connection to install/configure an extension — EXTEND: primary structural template for DuckLakeAdapter(DuckDBAdapter)"
+  - "benchbox/platforms/duckdb.py: create_connection:709, create_schema:775, load_data:838, execute_query:917, plan capture:1038, extension-install idiom _try_delta_scan:136 — REUSE/INHERIT unchanged; override only create_connection + catalog targeting"
+  - "benchbox/platforms/dataframe/ducklake_maintenance.py:168-189: proven INSTALL/LOAD ducklake + ATTACH 'ducklake:...' (DATA_PATH ...) SQL — REUSE the exact statements"
+  - "benchbox/platforms/motherduck.py: platform_family/inherits_from='duckdb' metadata + get_target_dialect via resolve_dialect_for_query_translation — REUSE the family-inheritance pattern for dialect + benchmark compatibility"
+  - "benchbox/platforms/base/format_capabilities.py:180 DUCKLAKE_CAPABILITY + utils/format_converters/ducklake_converter.py — LEAVE AS-IS (orthogonal format-conversion pipeline; native adapter load writes DuckLake via the attached catalog, not the converter)"
+
+work:
+  - id: w1
+    summary: "Re-validate DuckLake extension loads on the pinned DuckDB (>=1.3.2) and commit a compact summary"
+    status: pending
+    notes: |
+      uv run -- python -c "import duckdb; c=duckdb.connect(); c.execute('INSTALL ducklake'); c.execute('LOAD ducklake'); print(duckdb.__version__)"
+      Record duckdb version + PASS in the PR body / commit message. Confirms the
+      pinned-evidence version and that the extension is fetchable in CI.
+
+  - id: w2
+    summary: "Create benchbox/platforms/ducklake.py — DuckLakeAdapter(DuckDBAdapter), DuckDB-file catalog + local DATA_PATH"
+    needs: [w1]
+    status: pending
+    notes: |
+      Model on pg_duckdb.py. Implement: platform_name -> 'DuckLake';
+      get_target_dialect -> 'duckdb'; add_cli_arguments (--ducklake-metadata-path,
+      --ducklake-data-path); from_config (resolve metadata_path default under
+      benchmark_runs/databases, data_path default sibling ducklake_data/);
+      __init__; create_connection = super().create_connection() then INSTALL/LOAD
+      ducklake, ATTACH 'ducklake:<meta>' AS lake (DATA_PATH '<dir>'), USE lake,
+      with an actionable RuntimeError if the extension fails (point to DuckDB>=1.3);
+      get_platform_info adds catalog_backend/data_path/ducklake extension version.
+
+  - id: w3
+    summary: "Confirm inherited create_schema/load_data write into the attached catalog; override to qualify if not"
+    needs: [w2]
+    status: pending
+    notes: |
+      Read benchbox/platforms/base/data_loading.py DataLoader/handler SQL. If it
+      issues unqualified DDL/COPY it flows into `lake` after USE — no override.
+      If it hard-qualifies `main.` or opens its own connection, override
+      create_schema/load_data to qualify with the catalog name (lake.main.<table>).
+
+  - id: w4
+    summary: "Register in benchbox/core/platform_registry.py (3 places, family=duckdb)"
+    needs: [w2]
+    status: pending
+    notes: |
+      _OPTIONAL_ADAPTERS (:1234) add ('ducklake','benchbox.platforms.ducklake','DuckLakeAdapter');
+      _PLATFORM_SUPPORT_STATUS (:44) add 'ducklake':'experimental';
+      _PLATFORM_METADATA_JSON (:121) add a block modeled on motherduck with
+      capabilities supports_sql:true, supports_dataframe:false, default_mode:'sql',
+      platform_family:'duckdb', inherits_from:'duckdb', empty unsupported_benchmarks,
+      and requirements noting DuckDB>=1.3. Registry validation cross-checks all three.
+
+  - id: w5
+    summary: "Wire lazy import/export + option specs in benchbox/platforms/__init__.py"
+    needs: [w4]
+    status: pending
+    notes: |
+      _LAZY_ADAPTER_ROWS (:68) add 'DuckLakeAdapter|.ducklake';
+      _EXPORT_NAMES (:276) add 'DuckLakeAdapter';
+      _OPTION_SPEC_ROWS (:604) add ducklake|metadata_path|... and ducklake|data_path|...
+
+  - id: w6
+    summary: "Unit tests: tests/unit/platforms/test_ducklake_adapter.py + run ABC-conformance suite"
+    needs: [w3, w5]
+    status: pending
+    notes: |
+      from_config resolution, catalog-string construction, get_target_dialect=='duckdb',
+      platform appears in registry. ABC conformance (test_abc_conformance.py) and
+      adapter-validation suites parametrize over the registry automatically. Add a
+      module-level pytestmark marker (CI enforces via test_marker_strategy.py).
+
+  - id: w7
+    summary: "Docs: ducklake.md + index toctree, comparison-matrix, support-status, README, CHANGELOG"
+    needs: [w4]
+    status: pending
+    notes: |
+      New docs/platforms/ducklake.md (model on motherduck.md); add to
+      docs/platforms/index.md list + {toctree} (:183-225); add rows to
+      comparison-matrix.md and support-status.md; add to README.md SQL Platforms
+      list (:60); add a CHANGELOG.md entry.
+
+  - id: w8
+    summary: "Live validation: TPC-H + TPC-DS at SF 0.01 then SF 1 (duckdb catalog, local); cross-check vs duckdb platform"
+    needs: [w6]
+    status: pending
+    notes: |
+      uv run -- python -m benchbox run --platform ducklake --benchmark tpch --scale 0.01
+      (then tpcds, then SF 1). Confirm all queries pass, Parquet + .ducklake catalog
+      appear on disk, results validate, and TPC-H power results/row-counts match the
+      `duckdb` platform at the same SF (same engine).
+
+deferred:
+  - summary: "SQLite and PostgreSQL catalog backends; S3/cloud object storage for DATA_PATH"
+    reason: "Tracked in ducklake-catalog-storage-backends (depends on this item)"
+  - summary: "DuckLake-specific benchmarks (time travel, schema evolution, snapshot/maintenance workloads)"
+    reason: "Adapter parity first; lakehouse-feature benchmarks are a separate research item"
+  - summary: "Vector search / any benchmark DuckDB itself does not support"
+    reason: "Inherits DuckDB's unsupported_benchmarks set unchanged"
+
+must_preserve:
+  - "DuckDBAdapter behavior is unchanged — DuckLakeAdapter only overrides create_connection (+ catalog targeting if w3 requires it); all existing tests/integration/*duckdb* keep passing"
+  - "The global pyproject.toml `duckdb` pin stays >=1.0.0,<2.0.0 (duckdb-wasm on-disk-format compat)"
+  - "The existing DuckLake table-FORMAT path (ducklake_converter.py, DUCKLAKE_CAPABILITY) is untouched"
+  - "PlatformRegistry metadata/support-status validation continues to pass for all platforms"
+
+approach: |
+  Subclass, don't rebuild. DuckLake is DuckDB + a catalog ATTACH, so
+  DuckLakeAdapter(DuckDBAdapter) mirrors PgDuckDBAdapter(PostgreSQLAdapter):
+  super().create_connection() yields a DuckDB connection; INSTALL/LOAD ducklake;
+  ATTACH the DuckLake catalog; USE it so it becomes the default catalog. Inherited
+  create_schema + load_data (via DataLoader) then write into DuckLake with no
+  override — verify this in w3 before assuming it. Declare platform_family/
+  inherits_from='duckdb' so dialect translation and benchmark compatibility are
+  inherited (motherduck pattern). Reuse the exact ATTACH SQL from
+  ducklake_maintenance.py:186.
+
+anti_patterns:
+  - "DO NOT raise the global pyproject `duckdb` floor to >=1.3 — because the 1.0 floor is deliberate for duckdb-wasm on-disk-format compat (pyproject.toml:90-94) — enforce >=1.3 at runtime in create_connection with a clear error instead"
+  - "DO NOT route load through the ducklake_converter format pipeline — because native platform load should CREATE/COPY into the attached catalog directly — let inherited DuckDB load_data write into `lake` after USE"
+  - "DO NOT add a new SQL dialect or query driver — because DuckLake IS DuckDB — return 'duckdb' from get_target_dialect and inherit execution"
+  - "DO NOT hardcode argparse platform choices — because CLI choices come from PlatformRegistry.get_available_platforms() — registration in _OPTIONAL_ADAPTERS is sufficient"
+
+verification:
+  - description: "Platform is discoverable"
+    command: "uv run -- python -m benchbox platform list"
+    expected_output: "output includes 'ducklake'"
+  - description: "Registry metadata/support-status validation + ABC conformance pass with ducklake registered"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_abc_conformance.py tests/unit/platforms/test_adapter_validation_consistency.py -q"
+    expected_output: "all pass; PlatformRegistry validates ducklake metadata against its support_status without error"
+  - description: "Adapter unit tests pass"
+    command: "uv run -- python -m pytest tests/unit/platforms/test_ducklake_adapter.py -q"
+    expected_output: "all pass, 0 failures"
+  - description: "Live TPC-H at SF 0.01 (duckdb catalog, local storage)"
+    command: "uv run -- python -m benchbox run --platform ducklake --benchmark tpch --scale 0.01"
+    expected_output: "all 22 queries succeed; Parquet data + .ducklake catalog written under benchmark_runs/"
+  - description: "Live TPC-DS at SF 0.01"
+    command: "uv run -- python -m benchbox run --platform ducklake --benchmark tpcds --scale 0.01"
+    expected_output: "queries succeed; results validate"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/ducklake.py"
+    - "benchbox/platforms/__init__.py"
+    - "benchbox/core/platform_registry.py"
+    - "tests/unit/platforms/test_ducklake_adapter.py"
+    - "tests/integration/test_ducklake_integration.py"
+    - "docs/platforms/ducklake.md"
+    - "docs/platforms/index.md"
+    - "docs/platforms/comparison-matrix.md"
+    - "docs/platforms/support-status.md"
+    - "README.md"
+    - "CHANGELOG.md"
+  do_not_modify:
+    - "benchbox/platforms/duckdb.py"
+    - "benchbox/utils/format_converters/ducklake_converter.py"
+    - "benchbox/platforms/dataframe/ducklake_maintenance.py"
+    - "benchbox/core/runner/"
+
+success_metrics:
+  - "`ducklake` platform runs TPC-H and TPC-DS end-to-end at SF 0.01 and SF 1 with all queries passing"
+  - "TPC-H power results match the `duckdb` platform at the same scale factor (same engine, different storage)"
+  - "Zero regressions in existing DuckDB platform tests and registry validation"
+
+metadata:
+  tags:
+    - "platform"
+    - "ducklake"
+    - "duckdb"
+    - "lakehouse"
+  estimated_effort: "Medium"
+  created_date: "2026-07-07"
+
+open_questions:
+  - "Does DataLoader honor the current DuckDB catalog after USE, or does it hard-qualify `main.`? (resolved in w3)"
+  - "Should support_status debut as 'experimental' or 'beta'? Defaulting to 'experimental' for the first release."


### PR DESCRIPTION
Converts the DuckLake platform research plan into two dependency-linked TODO items under `_project/TODO/ducklake-platform/planning/`. **Planning artifacts only — no code changes.**

## What DuckLake is
DuckLake (GA v1.0, Apr 2026) is an open lakehouse format: table data is Parquet on local disk or object storage; all catalog metadata lives in a standard SQL DB (DuckDB/SQLite/Postgres). It ships as a DuckDB extension and reuses DuckDB's engine + SQL dialect unchanged.

## Key finding
DuckLake already exists in BenchBox as a table *format* (converter, `DUCKLAKE_CAPABILITY`, DataFrame maintenance ops) but **not** as a runnable *platform* — there is no `DuckLakeAdapter` and no `ducklake` registry entry. These TODOs add that.

## The two items
- **`ducklake-platform-adapter`** (High) — MVP: `DuckLakeAdapter(DuckDBAdapter)` with a DuckDB-file catalog + local Parquet storage, full `PlatformRegistry` wiring (3 places + lazy import/export + option specs), docs, and live TPC-H/TPC-DS validation at SF 0.01–1. Models on `pg_duckdb.py`; reuses the ATTACH SQL from `dataframe/ducklake_maintenance.py`; inherits DuckDB dialect + benchmark compatibility via `platform_family='duckdb'`.
- **`ducklake-catalog-storage-backends`** (Medium-High, `deps.needs: [ducklake-platform-adapter]`) — SQLite + PostgreSQL catalog backends and S3/cloud `DATA_PATH`.

## Constraint captured
The `ducklake` extension needs **DuckDB ≥ 1.3** (venv resolves 1.3.2), but the global pyproject `duckdb` pin stays `>=1.0.0,<2.0.0` for duckdb-wasm on-disk-format compat — so the requirement is enforced **at runtime** in the adapter, not by bumping the pin.

## Validation
Both files pass schema validation and `todo check-graph` (no cycles, dependency edge resolves). Scope decisions (embedded + PostgreSQL catalogs, local + S3 storage, live TPC-H/TPC-DS validation) confirmed with the requester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
