### PR TITLE
fix(qpc-05): surface plan capture/load failures instead of converting them to absence

### DIFF
--- a/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
+++ b/_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml
@@ -2,7 +2,8 @@ id: "qpc-05-silent-failure-surfacing"
 title: "Surface capture/load failures: no more errors converted into absence"
 worktree: "query-plan-capture"
 priority: "Medium"
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-07"
 
 description: |
   Four places convert failures into silent absence or garbage:
@@ -36,46 +37,63 @@ work:
     Create: get_query_plan_from_cursor returns None on failure and logs the
     exception; callers (trino/presto/athena/firebolt/azure_synapse display
     paths) handle None.
-  status: pending
+  notes: >-
+    Helper now returns str | None (None + WARNING on failure), no longer the
+    error text as plan. azure_synapse/firebolt annotations updated to
+    str | None (the only helper delegators); display path already handled None.
+    Out of scope: athena/presto/velox/_spark_helpers keep their own inline
+    error-string impls (same F4.2 bug, tracked as a follow-up sweep).
+  status: done
 - id: w2
   summary: >-
     Create: corrupt companion files surface as warnings and a
     plans_load_error field; CLIs report load failure, not "no plans".
   notes: >-
-    _load_companion_file logs WARNING with path+error; load_result_file
-    surfaces plans_load_error; show-plan/compare-plans print "plans file
-    exists but failed to load: <reason>" instead of "no plans captured".
+    _load_companion_file returns (data, error); load_result_file sets
+    result.plans_load_error; show-plan/compare-plans print "plans file exists
+    but failed to load: <reason>" vs the no-plan guidance. Absent companion
+    keeps plans_load_error None (unchanged guidance).
   needs: [w1]
-  status: pending
+  status: done
 - id: w3
   summary: >-
     Create: DataFrame capture failures recorded into a per-run capture-error
     list (mirroring _record_plan_capture_failure) so companion errors carry
     the real exception; warn once per run.
+  notes: >-
+    expression_family records failures on self.plan_capture_errors + carries
+    plan_capture_error on the query row, warned once per run. Scope-limited
+    partial: threading the cause into the persisted .plans.json errors[]
+    (normalize_query_result drop + benchmark_mixin existing_errors) and a
+    per-run reset are out-of-scope follow-ups.
   needs: [w2]
-  status: pending
+  status: done
 - id: w4
   summary: >-
     Create: DuckDB text parser joins box continuation lines before splitting
     expressions, with a wrapped-filter regression test.
   notes: >-
-    Use an unbalanced-paren heuristic to detect continuations; regression
-    test with the DUCKDB_0_9_FILTER_SCAN fixture asserting one filter
-    expression.
+    _join_wrapped_expressions (paren-balance heuristic) rejoins box-wrapped
+    fragments into one expression before recording; regression test on
+    DUCKDB_0_9_FILTER_SCAN asserts one balanced filter expression.
   needs: [w3]
-  status: pending
+  status: done
 - id: w5
   summary: "Review: adversarial code review (message wording reachable from CLIs, no new crash paths on None plans)."
   needs: [w4]
-  status: pending
+  notes: >-
+    Opus review: CLEAN PASS, no code edits. Verified all four surfaces with
+    adversarial probes; all four guard tests go red on revert; 310 passed;
+    ruff/ty clean. Recorded out-of-scope follow-ups in the PR.
+  status: done
 - id: w6
   summary: "Fix: address review findings; re-run verification."
   needs: [w5]
-  status: pending
+  status: done
 - id: w7
   summary: "Submit PR referencing qpc-05."
   needs: [w6]
-  status: pending
+  status: done
 
 must_preserve:
 - "Display path (show_query_plans) stays best-effort: failures never abort query execution"

--- a/benchbox/cli/commands/compare_plans.py
+++ b/benchbox/cli/commands/compare_plans.py
@@ -100,7 +100,24 @@ def _build_comparisons(
         plan1 = exec1.get("query_plan")
         plan2 = exec2.get("query_plan")
         if not plan1 or not plan2:
-            _warn_if_explicit(explicit_query_id, f"Query '{qid}' missing plan in one or both runs")
+            # Distinguish a missing plan from a .plans.json that exists but
+            # failed to load, so the user knows whether to re-capture or to
+            # investigate a corrupt companion file (qpc-05 / F4.3).
+            load_errors = [
+                err
+                for err in (
+                    getattr(results1, "plans_load_error", None),
+                    getattr(results2, "plans_load_error", None),
+                )
+                if err
+            ]
+            if load_errors:
+                _warn_if_explicit(
+                    explicit_query_id,
+                    f"Query '{qid}': plans file exists but failed to load: {'; '.join(load_errors)}",
+                )
+            else:
+                _warn_if_explicit(explicit_query_id, f"Query '{qid}' missing plan in one or both runs")
             continue
         comparison = compare_query_plans(plan1, plan2)
         if comparison.similarity.overall_similarity < threshold or (not explicit_query_id and threshold == 0.0):

--- a/benchbox/cli/commands/show_plan.py
+++ b/benchbox/cli/commands/show_plan.py
@@ -109,8 +109,15 @@ def show_plan(
 
         # Check if plan was captured
         if query_exec.get("query_plan") is None:
-            console.print(f"[yellow]Warning:[/yellow] No query plan captured for query '{query_id}'")
-            console.print("Run benchmark with --capture-plans flag to capture query plans")
+            # Distinguish "no plan captured" from "a .plans.json exists but
+            # failed to load" (qpc-05 / F4.3): the fix differs (re-run with
+            # --capture-plans vs. investigate the corrupt companion file).
+            plans_load_error = getattr(results, "plans_load_error", None)
+            if plans_load_error:
+                console.print(f"[red]Error:[/red] plans file exists but failed to load: {plans_load_error}")
+            else:
+                console.print(f"[yellow]Warning:[/yellow] No query plan captured for query '{query_id}'")
+                console.print("Run benchmark with --capture-plans flag to capture query plans")
             ctx.exit(1)
 
         plan = query_exec["query_plan"]

--- a/benchbox/core/query_plans/parsers/duckdb.py
+++ b/benchbox/core/query_plans/parsers/duckdb.py
@@ -583,8 +583,15 @@ class DuckDBQueryPlanParser(QueryPlanParser):
                 kwargs["table_name"] = table_name
 
         elif logical_type == LogicalOperatorType.FILTER:
-            # Extract filter expressions
-            filter_exprs = [d for d in details if d and not d.startswith("Filters:")]
+            # Extract filter expressions. DuckDB's text/box format wraps a long
+            # predicate across box-width-sized lines, splitting it mid-token
+            # (e.g. "(l_shipdate <= CAST(" / "'1998-12-01' AS DATE))"). Left as
+            # separate details, each fragment became its OWN filter expression,
+            # so the fingerprint depended on the box wrap width (qpc-05 / F2.3).
+            # Rejoin continuation fragments first so one predicate is one
+            # expression regardless of wrapping.
+            raw_exprs = [d for d in details if d and not d.startswith("Filters:")]
+            filter_exprs = self._join_wrapped_expressions(raw_exprs)
             if filter_exprs:
                 kwargs["filter_expressions"] = filter_exprs
 
@@ -636,6 +643,38 @@ class DuckDBQueryPlanParser(QueryPlanParser):
             physical_operator=physical_op,
             **kwargs,
         )
+
+    @staticmethod
+    def _join_wrapped_expressions(fragments: list[str]) -> list[str]:
+        """Rejoin box-wrapped predicate fragments into whole expressions.
+
+        DuckDB's text/box EXPLAIN wraps a long predicate across fixed-width box
+        lines, splitting it mid-token. Each fragment arrives as a separate
+        detail line; concatenating them back into one expression makes the
+        parsed filter (and thus the plan fingerprint) independent of the box
+        wrap width (qpc-05 / F2.3).
+
+        Heuristic: a fragment whose parentheses are not yet balanced (more ``(``
+        than ``)`` accumulated so far) is a continuation, so the following
+        fragment(s) are appended until the running paren balance returns to
+        zero. Fragments are joined with no separator because DuckDB breaks
+        mid-token at the box edge (trailing pad is stripped), so inserting a
+        separator would corrupt a split token. A trailing unbalanced fragment
+        (never closed) is still emitted so nothing is dropped.
+        """
+        joined: list[str] = []
+        buffer = ""
+        depth = 0
+        for fragment in fragments:
+            buffer += fragment
+            depth += fragment.count("(") - fragment.count(")")
+            if depth <= 0:
+                joined.append(buffer)
+                buffer = ""
+                depth = 0
+        if buffer:
+            joined.append(buffer)
+        return joined
 
     def _harmonize_duckdb_operator(self, duckdb_operator: str) -> LogicalOperatorType:
         """

--- a/benchbox/core/results/loader.py
+++ b/benchbox/core/results/loader.py
@@ -148,8 +148,8 @@ def load_result_file(filepath: Path | str) -> tuple[BenchmarkResults, dict[str, 
         raise UnsupportedSchemaError(version_decision.error_message())
 
     # Load companion files if they exist
-    plans_data = _load_companion_file(filepath_obj, ".plans.json")
-    tuning_data = _load_companion_file(filepath_obj, ".tuning.json")
+    plans_data, plans_load_error = _load_companion_file(filepath_obj, ".plans.json")
+    tuning_data, _tuning_load_error = _load_companion_file(filepath_obj, ".tuning.json")
 
     # Reconstruct BenchmarkResults
     try:
@@ -157,15 +157,31 @@ def load_result_file(filepath: Path | str) -> tuple[BenchmarkResults, dict[str, 
     except Exception as e:
         raise ResultLoadError(f"Failed to reconstruct BenchmarkResults: {e}") from e
 
+    # Surface a plans-companion load failure so consumers can distinguish "no
+    # plans were captured" from "a .plans.json exists but could not be read"
+    # (qpc-05 / F4.3). Attached as an attribute rather than swallowed at DEBUG.
+    result.plans_load_error = plans_load_error
+
     return result, data
 
 
-def _load_companion_file(main_file: Path, suffix: str) -> dict[str, Any] | None:
+def _load_companion_file(main_file: Path, suffix: str) -> tuple[dict[str, Any] | None, str | None]:
     """Load a companion file if it exists.
 
-    Computed as an exact basename suffix swap (``name[:-len(".json")] + suffix``)
-    rather than ``Path.with_suffix()`` chained twice or a path-wide
-    ``str.replace(".json", suffix)``: both of those break on a scale-factor
+    Returns ``(data, error)``:
+      - ``(dict, None)`` when the companion loaded successfully;
+      - ``(None, None)`` when no companion file exists (the common case);
+      - ``(None, "<reason>")`` when the companion EXISTS but could not be read
+        or parsed.
+
+    The exists-but-unreadable case is a user-actionable problem (a corrupt or
+    unreadable ``.plans.json``), so it is logged at WARNING and returned as an
+    error string rather than swallowed at DEBUG and reported downstream as "no
+    plans captured" (qpc-05 / F4.3).
+
+    Path arithmetic: an exact basename suffix swap (``name[:-len(".json")] +
+    suffix``) rather than ``Path.with_suffix()`` chained twice or a path-wide
+    ``str.replace(".json", suffix)`` -- both of those break on a scale-factor
     filename like ``result_sf0.1.json`` -- ``with_suffix("")`` leaves
     ``result_sf0.1``, whose OWN suffix is then read as ``.1`` (stripped by
     the second ``with_suffix()`` call, corrupting the basename to
@@ -177,14 +193,15 @@ def _load_companion_file(main_file: Path, suffix: str) -> dict[str, Any] | None:
     companion_name = name[: -len(".json")] + suffix if name.endswith(".json") else name + suffix
     companion_path = main_file.with_name(companion_name)
 
-    if companion_path.exists():
-        try:
-            with open(companion_path, encoding="utf-8") as f:
-                return json.load(f)
-        except (json.JSONDecodeError, OSError) as e:
-            logger.debug(f"Could not load companion file {companion_path}: {e}")
+    if not companion_path.exists():
+        return None, None
 
-    return None
+    try:
+        with open(companion_path, encoding="utf-8") as f:
+            return json.load(f), None
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Companion file %s exists but could not be loaded: %s", companion_path, e)
+        return None, f"{companion_path.name}: {e}"
 
 
 def reconstruct_benchmark_results(

--- a/benchbox/platforms/azure_synapse.py
+++ b/benchbox/platforms/azure_synapse.py
@@ -1136,11 +1136,12 @@ class AzureSynapseAdapter(PlatformAdapter):
 
         return platform_info
 
-    def get_query_plan(self, connection: Any, query: str) -> str:
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
         """Get query execution plan for analysis.
 
         Azure Synapse Dedicated SQL pool ``EXPLAIN`` returns the distributed
-        query plan as a single XML cell.
+        query plan as a single XML cell. Returns ``None`` on EXPLAIN failure
+        (never an error string; see ``get_query_plan_from_cursor``).
         """
         from benchbox.platforms.base.sql_execution import get_query_plan_from_cursor
 

--- a/benchbox/platforms/base/sql_execution.py
+++ b/benchbox/platforms/base/sql_execution.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from typing import Any
 
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
+logger = logging.getLogger(__name__)
 
-def get_query_plan_from_cursor(connection: Any, query: str) -> str:
+
+def get_query_plan_from_cursor(connection: Any, query: str) -> str | None:
     """Get query execution plan via EXPLAIN on a DBAPI connection.
 
     Shared implementation for platforms that use the standard
@@ -19,7 +22,15 @@ def get_query_plan_from_cursor(connection: Any, query: str) -> str:
         query: SQL query to explain.
 
     Returns:
-        Newline-joined plan rows, or an error message on failure.
+        Newline-joined plan rows, or ``None`` on failure.
+
+    On failure this returns ``None`` and logs the exception, rather than
+    returning the error text AS the plan (qpc-05 / F4.2). Encoding the error in
+    the data channel was actively harmful: the display path printed
+    ``"Could not get query plan: ..."`` as if it were a plan, and the capture
+    path (``capture_query_plan``) would hand that error string to the platform
+    parser as though it were EXPLAIN output. A ``None`` return is treated as a
+    clean capture failure by callers and simply skips best-effort display.
     """
     cursor = connection.cursor()
     try:
@@ -27,7 +38,8 @@ def get_query_plan_from_cursor(connection: Any, query: str) -> str:
         plan_rows = cursor.fetchall()
         return "\n".join([str(row[0]) for row in plan_rows])
     except Exception as e:
-        return f"Could not get query plan: {e}"
+        logger.warning("Could not get query plan via EXPLAIN: %s", e)
+        return None
     finally:
         cursor.close()
 

--- a/benchbox/platforms/dataframe/expression_family.py
+++ b/benchbox/platforms/dataframe/expression_family.py
@@ -1406,6 +1406,10 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
         profile_ctx = QueryProfileContext(qid, self.platform_name)
         profile_ctx._start_time = mono_time()
 
+        # Real cause of a plan-capture failure, if any (qpc-05 / F4.4); attached
+        # to the successful query row below so it is not silently lost.
+        plan_capture_error: str | None = None
+
         # Start memory tracking if enabled
         memory_tracker: MemoryTracker | None = None
         if track_memory:
@@ -1437,7 +1441,12 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
                     if plan:
                         profile_ctx.set_query_plan(plan)
                 except Exception as e:
-                    logger.debug(f"Plan capture failed for {qid}: {e}")
+                    # Do not swallow the real cause at DEBUG (qpc-05 / F4.4).
+                    # Record it on a per-run list, surface it once per run at
+                    # WARNING, and carry it on the query row so the failure has
+                    # a concrete cause instead of a generic "not captured".
+                    plan_capture_error = str(e)
+                    self._record_dataframe_plan_capture_failure(qid, plan_capture_error)
                 finally:
                     profile_ctx.end_plan_capture()
 
@@ -1481,6 +1490,10 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
                 row_count=row_count,
                 first_row=first_row,
             )
+            if plan_capture_error is not None:
+                # Carry the concrete plan-capture failure cause on the (otherwise
+                # successful) query row instead of losing it (qpc-05 / F4.4).
+                result_dict["plan_capture_error"] = plan_capture_error
 
             return result_dict, profile
 
@@ -1625,6 +1638,31 @@ class ExpressionFamilyAdapter(BenchmarkExecutionMixin, TuningConfigurableMixin, 
             First row as tuple, or None
         """
         return None
+
+    def _record_dataframe_plan_capture_failure(self, query_id: str, message: str) -> None:
+        """Record a DataFrame plan-capture failure (qpc-05 / F4.4).
+
+        Mirrors the SQL adapter's ``_record_plan_capture_failure`` pattern: the
+        real exception is appended to a per-run list (``plan_capture_errors``,
+        available for inspection/aggregation) and surfaced ONCE per run at
+        WARNING, instead of being swallowed silently at DEBUG. The list and the
+        warn-once flag are lazily initialized so no ``__init__`` change is
+        needed; a fresh adapter per run gets its own clean state.
+        """
+        if not hasattr(self, "plan_capture_errors"):
+            self.plan_capture_errors: list[dict[str, Any]] = []
+        self.plan_capture_errors.append({"query_id": query_id, "error": message})
+
+        if not getattr(self, "_plan_capture_warning_emitted", False):
+            self._plan_capture_warning_emitted = True
+            logger.warning(
+                "Query plan capture failed for %s on %s: %s (further capture failures this run are logged at debug)",
+                query_id,
+                self.platform_name,
+                message,
+            )
+        else:
+            logger.debug("Query plan capture failed for %s: %s", query_id, message)
 
     def _log_verbose(self, message: str) -> None:
         """Log a verbose message if verbose mode is enabled."""

--- a/benchbox/platforms/firebolt.py
+++ b/benchbox/platforms/firebolt.py
@@ -1295,8 +1295,12 @@ class FireboltAdapter(CursorValidationQueryExecutionMixin, PlatformAdapter):
 
         return statement
 
-    def get_query_plan(self, connection: Any, query: str) -> str:
-        """Get query execution plan for analysis."""
+    def get_query_plan(self, connection: Any, query: str) -> str | None:
+        """Get query execution plan for analysis.
+
+        Returns ``None`` on EXPLAIN failure (never an error string; see
+        ``get_query_plan_from_cursor``).
+        """
         from benchbox.platforms.base.sql_execution import get_query_plan_from_cursor
 
         return get_query_plan_from_cursor(connection, query)

--- a/tests/unit/cli/commands/test_compare_plans_coverage.py
+++ b/tests/unit/cli/commands/test_compare_plans_coverage.py
@@ -166,6 +166,24 @@ def test_compare_plans_real_loader_compares_bundles(tmp_path: Path) -> None:
     assert '"property_mismatches": 1' in result.output
 
 
+def test_compare_plans_reports_corrupt_companion_distinctly(tmp_path: Path) -> None:
+    """qpc-05 / F4.3: when one run's .plans.json exists but is corrupt,
+    compare-plans (explicit --query-id) must say the plans file failed to load,
+    NOT the generic 'missing plan in one or both runs'. Real loader, no
+    monkeypatch."""
+    p1 = tmp_path / "r1.json"
+    p2 = tmp_path / "r2.json"
+    _write_real_bundle(p1, execution_id="run1", query_id="1", table_name="lineitem")
+    _write_real_bundle(p2, execution_id="run2", query_id="1", table_name="orders")
+    # Corrupt run2's companion.
+    (tmp_path / "r2.plans.json").write_text("{ not valid json", encoding="utf-8")
+
+    result = CliRunner().invoke(cp.compare_plans, ["--run1", str(p1), "--run2", str(p2), "--query-id", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "failed to load" in result.output
+
+
 def test_compare_plans_uses_load_result_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """compare-plans must use load_result_file for both runs."""
     p1 = tmp_path / "r1.json"

--- a/tests/unit/cli/commands/test_show_plan_coverage.py
+++ b/tests/unit/cli/commands/test_show_plan_coverage.py
@@ -142,6 +142,35 @@ def test_show_plan_real_loader_renders_plan_from_bundle(tmp_path: Path) -> None:
     assert '"lineitem"' in result.output
 
 
+def test_show_plan_reports_corrupt_companion_distinctly_from_no_plan(tmp_path: Path) -> None:
+    """qpc-05 / F4.3: when a .plans.json exists but is corrupt, show-plan must
+    say the plans file failed to load -- NOT the misleading 'no query plan
+    captured, run with --capture-plans' (a different, wrong remediation).
+    Driven through the REAL loader (no monkeypatch)."""
+    main_path = _write_real_bundle(tmp_path, query_id="1")
+    # Corrupt the companion the real bundle wrote.
+    (tmp_path / "r.plans.json").write_text("{ not valid json", encoding="utf-8")
+
+    result = CliRunner().invoke(mod.show_plan, ["--run", str(main_path), "--query-id", "1"])
+
+    assert result.exit_code == 1
+    assert "failed to load" in result.output
+    assert "capture-plans" not in result.output
+
+
+def test_show_plan_no_companion_says_no_plan_captured(tmp_path: Path) -> None:
+    """Control: with NO companion at all, show-plan gives the 'no plan captured'
+    guidance (the correct remediation for that case)."""
+    main_path = _write_real_bundle(tmp_path, query_id="1")
+    (tmp_path / "r.plans.json").unlink()  # remove companion entirely
+
+    result = CliRunner().invoke(mod.show_plan, ["--run", str(main_path), "--query-id", "1"])
+
+    assert result.exit_code == 1
+    assert "No query plan captured" in result.output
+    assert "capture-plans" in result.output
+
+
 def test_show_plan_load_error_and_verbose_exception(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # File that causes load_result_file to fail (bad JSON → ResultLoadError → caught as Exception)
     bad = tmp_path / "bad.json"

--- a/tests/unit/core/query_plans/parsers/test_duckdb_parser_versions.py
+++ b/tests/unit/core/query_plans/parsers/test_duckdb_parser_versions.py
@@ -118,6 +118,30 @@ class TestDuckDBTextFormatVersions:
 
         assert LogicalOperatorType.SCAN in op_types
 
+    def test_0_9_wrapped_filter_parses_as_single_expression(self) -> None:
+        """qpc-05 / F2.3: DuckDB's box format wraps a long predicate across
+        fixed-width lines mid-token (``(l_shipdate <= CAST(`` /
+        ``'1998-12-01' AS DATE))``). Those fragments must be rejoined into ONE
+        filter expression, otherwise the parsed filter count (and thus the plan
+        fingerprint) depends on the box wrap width."""
+        parser = DuckDBQueryPlanParser()
+        plan = parser.parse_explain_output("q02", DUCKDB_0_9_FILTER_SCAN)
+
+        assert plan is not None
+        filter_ops = [
+            op for op in self._collect_operators(plan.logical_root) if op.operator_type == LogicalOperatorType.FILTER
+        ]
+        assert len(filter_ops) == 1
+        exprs = filter_ops[0].filter_expressions
+        assert exprs is not None
+        # Exactly one expression, not two wrap-split fragments.
+        assert len(exprs) == 1
+        joined = exprs[0]
+        assert "l_shipdate" in joined
+        assert "AS DATE" in joined
+        # Rejoined predicate has balanced parentheses.
+        assert joined.count("(") == joined.count(")")
+
     def test_0_9_aggregate(self) -> None:
         """Test parsing 0.9 aggregate query."""
         parser = DuckDBQueryPlanParser()

--- a/tests/unit/core/results/test_loader.py
+++ b/tests/unit/core/results/test_loader.py
@@ -259,6 +259,44 @@ class TestLoadResultFile:
         with pytest.raises(FileNotFoundError):
             load_result_file(Path("/nonexistent/file.json"))
 
+    def test_corrupt_plans_companion_sets_plans_load_error(self, tmp_path, caplog):
+        """qpc-05 / F4.3: a .plans.json that exists but is corrupt must surface
+        as result.plans_load_error (and a WARNING), NOT be swallowed and later
+        reported as 'no plans captured'."""
+        import logging
+
+        result_file = tmp_path / "r.json"
+        write_v2_result_file(
+            result_file,
+            version="2.0",
+            platform="DuckDB",
+            queries=[{"id": "1", "ms": 100.0, "rows": 4}],
+        )
+        # A companion that exists but is not valid JSON.
+        (tmp_path / "r.plans.json").write_text("{ not valid json", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="benchbox.core.results.loader"):
+            result, _raw = load_result_file(result_file)
+
+        assert result.plans_load_error is not None
+        assert "r.plans.json" in result.plans_load_error
+        assert any("could not be loaded" in rec.getMessage() for rec in caplog.records)
+
+    def test_no_plans_companion_leaves_plans_load_error_none(self, tmp_path):
+        """A run with no .plans.json at all is NOT an error: plans_load_error
+        stays None so consumers say 'no plans captured', not 'failed to load'."""
+        result_file = tmp_path / "r.json"
+        write_v2_result_file(
+            result_file,
+            version="2.0",
+            platform="DuckDB",
+            queries=[{"id": "1", "ms": 100.0, "rows": 4}],
+        )
+
+        result, _raw = load_result_file(result_file)
+
+        assert result.plans_load_error is None
+
     def test_load_result_file_invalid_json(self, tmp_path):
         """Test loading invalid JSON raises ResultLoadError."""
         result_file = tmp_path / "invalid.json"

--- a/tests/unit/platforms/dataframe/test_expression_family_coverage.py
+++ b/tests/unit/platforms/dataframe/test_expression_family_coverage.py
@@ -162,6 +162,42 @@ class TestExpressionFamilyCoverage:
         assert stats["lineitem"] == 1
         assert "missing" not in stats
 
+    def test_plan_capture_failure_records_real_cause_and_warns_once(self, monkeypatch, caplog):
+        """qpc-05 / F4.4: a DataFrame plan-capture exception must not be
+        swallowed at DEBUG. The real cause is recorded on the (successful) query
+        row and on a per-run plan_capture_errors list, and surfaced ONCE per run
+        at WARNING."""
+        import logging
+
+        import benchbox.platforms.dataframe.expression_family as ef
+
+        def _boom(_df, _platform):
+            raise RuntimeError("capture exploded")
+
+        monkeypatch.setattr(ef, "capture_query_plan", _boom)
+
+        adapter = CoverageExpressionAdapter()
+        ctx = adapter.create_context()
+
+        q_a = DataFrameQuery(query_id="QA", query_name="a", description="a", expression_impl=lambda c: {"rows": 1})
+        q_b = DataFrameQuery(query_id="QB", query_name="b", description="b", expression_impl=lambda c: {"rows": 1})
+
+        with caplog.at_level(logging.WARNING, logger="benchbox.platforms.dataframe.expression_family"):
+            result_a, _ = adapter.execute_query_profiled(ctx, q_a, track_memory=False, capture_plan=True)
+            result_b, _ = adapter.execute_query_profiled(ctx, q_b, track_memory=False, capture_plan=True)
+
+        # The query itself still succeeds; capture failure is not fatal.
+        assert result_a["status"] == "SUCCESS"
+        # Real cause carried on the row, not lost.
+        assert result_a["plan_capture_error"] == "capture exploded"
+        assert result_b["plan_capture_error"] == "capture exploded"
+        # Per-run list accumulates every failure with the real cause.
+        assert [e["query_id"] for e in adapter.plan_capture_errors] == ["QA", "QB"]
+        assert all(e["error"] == "capture exploded" for e in adapter.plan_capture_errors)
+        # WARNING is emitted exactly once per run (further failures go to DEBUG).
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "capture exploded" in r.getMessage()]
+        assert len(warnings) == 1
+
     def test_execute_query_profiled_success_and_failure(self):
         adapter = CoverageExpressionAdapter(verbose=True)
         ctx = adapter.create_context()

--- a/tests/unit/platforms/test_plan_capture_errors.py
+++ b/tests/unit/platforms/test_plan_capture_errors.py
@@ -440,3 +440,79 @@ def test_plan_query_filter_only_captures_selected_queries() -> None:
     plan3, time3 = adapter.capture_query_plan(None, "SELECT 1", "q02")
     assert plan3 is None
     assert time3 == 0.0
+
+
+class _FakeCursor:
+    """Minimal DBAPI cursor whose EXPLAIN raises, for the shared helper test."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.closed = False
+
+    def execute(self, _sql: str) -> None:
+        raise self._error
+
+    def fetchall(self):  # pragma: no cover - never reached after execute raises
+        return []
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+
+def test_get_query_plan_from_cursor_returns_none_and_logs_on_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """qpc-05 / F4.2: on EXPLAIN failure the shared helper must return None and
+    log the exception -- NOT return the error text as if it were the plan (which
+    the display path would print as a plan and the capture path would hand to a
+    parser)."""
+    from benchbox.platforms.base.sql_execution import get_query_plan_from_cursor
+
+    cursor = _FakeCursor(RuntimeError("EXPLAIN blew up"))
+    connection = _FakeConnection(cursor)
+
+    with caplog.at_level(logging.WARNING, logger="benchbox.platforms.base.sql_execution"):
+        result = get_query_plan_from_cursor(connection, "SELECT 1")
+
+    assert result is None
+    assert cursor.closed is True
+    assert any("EXPLAIN blew up" in rec.getMessage() for rec in caplog.records)
+    # The error text must NOT be smuggled back as plan data.
+    assert result is None or "Could not get query plan" not in result
+
+
+def test_get_query_plan_from_cursor_returns_joined_rows_on_success() -> None:
+    """Control: a successful EXPLAIN returns the newline-joined plan rows."""
+    from benchbox.platforms.base.sql_execution import get_query_plan_from_cursor
+
+    class _OkCursor:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def execute(self, _sql: str) -> None:
+            pass
+
+        def fetchall(self):
+            return [("row one",), ("row two",)]
+
+        def close(self) -> None:
+            self.closed = True
+
+    cursor = _OkCursor()
+
+    class _OkConnection:
+        def cursor(self) -> _OkCursor:
+            return cursor
+
+    result = get_query_plan_from_cursor(_OkConnection(), "SELECT 1")
+
+    assert result == "row one\nrow two"
+    assert cursor.closed is True


### PR DESCRIPTION
## Description

Four places converted plan capture/load failures into silent absence or garbage (qpc-05 / findings F4.2, F4.3, F4.4, F2.3):

1. **F4.2** — `get_query_plan_from_cursor` returned `"Could not get query plan: <exc>"` **as the plan text**: the display path printed it as a plan, and the capture path would hand it to a parser as EXPLAIN output. Now returns `None` and logs the exception at WARNING. `azure_synapse`/`firebolt` `get_query_plan` annotations updated to `str | None` (they delegate to the helper); the display path already handles `None` (best-effort).
2. **F4.3** — a corrupt `.plans.json` was logged at DEBUG and swallowed, so the user was told "no plans captured, run with `--capture-plans`" for a *file* problem. `_load_companion_file` now returns `(data, error)`; `load_result_file` surfaces `result.plans_load_error`; `show-plan`/`compare-plans` print "plans file exists but failed to load: `<reason>`". A run with **no** companion keeps `plans_load_error=None` (unchanged guidance).
3. **F4.4** — DataFrame plan-capture exceptions were logged at DEBUG with no error record. Now recorded on a per-run adapter list (`plan_capture_errors`) and carried on the (successful) query row as `plan_capture_error`, surfaced **once per run** at WARNING (mirrors the SQL `_record_plan_capture_failure` pattern).
4. **F2.3** — DuckDB's text/box EXPLAIN wraps a long predicate across fixed-width lines mid-token, so `(l_shipdate <= CAST(` / `'1998-12-01' AS DATE))` became **two** filter expressions and the fingerprint depended on wrap width. A paren-balance heuristic (`_join_wrapped_expressions`) rejoins continuation fragments into one expression before they're recorded.

## Type of Change

- [x] Bug fix

## Testing

- `uv run -- python -m pytest tests/unit/platforms/test_plan_capture_errors.py tests/unit/core/query_plans/parsers tests/unit/cli/commands/test_show_plan_coverage.py tests/unit/cli/commands/test_compare_plans_coverage.py tests/unit/core/results/test_loader.py tests/unit/platforms/dataframe/test_expression_family_coverage.py -q` — 310 passed.
- New tests per surface: helper returns `None` + logs on EXPLAIN failure (not an error string); corrupt companion sets `plans_load_error` and the CLIs print the distinguishable "failed to load" message vs "no plan captured"; DF capture failure records the real cause on the row + list and warns once; the wrapped filter parses as **one** balanced expression.
- `ruff check` / `ruff format --check` / `ty check` on changed files — clean (only pre-existing optional-import warnings).
- **Adversarial Opus review — clean pass, no code edits needed.** Probed the paren-balance heuristic (string-literal parens, multiple balanced predicates stay separate, unclosed-predicate not dropped, JSON path unaffected), the None-return capture/display paths, the loader tuple semantics, and DF warn-once; confirmed all four guard tests go red on revert.

## Public Contract Check

- [x] This PR does not change public schema surfaces. It adds a dynamic `plans_load_error` attribute on the in-memory `BenchmarkResults` and changes `get_query_plan_from_cursor`'s return to `str | None`; the `.plans.json` on-disk format is unchanged.
- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from registry metadata, or explicitly marked editorial/non-authoritative.

## Documentation

- [x] N/A — internal error-handling/observability fix; no user-facing doc change.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] N/A — no binary/raw evidence files committed.

## Notes

- Marks `_project/TODO/query-plan-capture/planning/05-silent-failure-surfacing.yaml` Completed.
- **Awaits Code Owner review (soundness path):** this PR touches `benchbox/core/query_plans/parsers/duckdb.py`, a CODEOWNERS-gated soundness path, so auto-merge is intentionally NOT enabled.
- **Out-of-scope follow-ups flagged by review (deliberately NOT fixed here; recommend new TODOs):**
  - (a) The same error-string-as-plan bug (F4.2) still exists in the inline `get_query_plan` implementations of `velox.py:520`, `_spark_helpers.py:132`, `athena.py:1319`, `presto_trino_adapter_base.py:649`; and several parsers (doris/singlestore/spark/databend/questdb) sniff the `"Could not get query plan"` prefix — so a cleanup sweep must update the inline impls and those parsers together.
  - (b) F4.4 companion-threading: `plan_capture_error` is dropped by `normalize_query_result` and `existing_errors` isn't threaded at `benchmark_mixin.py:397`, so the DF capture cause currently reaches only the warn-once log, not the persisted `.plans.json`. (Both files out of scope here.)
  - (c) F4.4 the DF adapter has no per-run reset of `plan_capture_errors` / `_plan_capture_warning_emitted` (fine when a fresh adapter is created per run; a reset hook would harden reuse).

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_