### PR TITLE
docs(todo): add a standing human/maintainer action queue

### DIFF
--- a/_project/TODO/main/active/human-action-required.yaml
+++ b/_project/TODO/main/active/human-action-required.yaml
@@ -1,0 +1,148 @@
+id: human-action-required
+title: "Human/maintainer action queue: steps agents cannot perform"
+worktree: main
+priority: High
+status: "In Progress"
+category: "Release Tooling"
+
+description: |
+  A running QUEUE of actions that only the human maintainer can perform —
+  GitHub repository-admin/settings changes, Code-Owner PR reviews, and
+  real-human tasks (e.g. recruiting an external contributor). Agents in this
+  project cannot do these: the sandbox git remote rejects branch
+  create/delete/rename and default-branch changes, GitHub admin/settings APIs
+  are out of scope, CODEOWNERS review must be a human, and human recruitment is
+  by definition not automatable.
+
+  This item is an INDEX, not the source of truth for each task's design — each
+  work unit cross-references the authoritative TODO and gives the exact command
+  to run. Append new maintainer/human actions here as they arise so there is a
+  single place to see "what's waiting on me". Mark a work unit done when the
+  action is performed; close the item only when the queue is empty (or keep it
+  open indefinitely as the standing queue — maintainer's choice).
+
+  As of 2026-07-07 every AGENT-completable item across the results-explorer/
+  publication re-review and the branching-strategy work is merged or open as a
+  reviewed PR; the actions below are the only things left, and they are all
+  yours.
+
+work:
+- id: w1
+  summary: "Code-Owner review + merge PR #1027 (in-repo main->release rename)"
+  status: pending
+  notes: |
+    Source: rename-release-branch-main-to-release (w1-w4, in-repo half).
+    PR #1027 renames the release branch main->release across workflows/Makefile/
+    docs and adds docs/operations/branch-rename-runbook.md. It touches
+    release.yml, so it is CODEOWNERS-gated (@joeharris76) and auto-merge is
+    intentionally OFF — it needs your review. An Opus 4.8 review already
+    verified the PyPI publish gate (tag-shaped-ref condition) is untouched and
+    all six test.yml base_ref conditionals renamed consistently; re-confirm the
+    two flagged maintainer notes in the PR body (pyproject blob/main URL;
+    seed-corpus.yml --base main) are acceptable, then squash-merge.
+    Do NOT merge until you are ready to run w2 right after (ordering matters).
+
+- id: w2
+  summary: "GitHub admin: rename branch main->release + recreate the ruleset (rename w5/w6)"
+  needs: [w1]
+  status: pending
+  notes: |
+    Source: rename-release-branch-main-to-release (w5/w6, ADMIN half).
+    Run RIGHT AFTER w1 merges, per docs/operations/branch-rename-runbook.md:
+      gh api -X POST repos/joeharris76/BenchBox/branches/main/rename -f new_name=release
+    Then recreate the `main-release-only` ruleset as `release-only` targeting
+    refs/heads/release (same required checks/protections), and update the
+    ruleset-id reference in docs/operations/repo-admin-settings.md.
+    No real coverage gap exists because the release branch only receives pushes
+    via release-cut/release-finalize (both maintainer-controlled); if
+    `make release-cut` is run before the rename it fails fast (base does not
+    exist) rather than mis-cutting.
+
+- id: w3
+  summary: "GitHub admin: set default_branch=develop + verify scheduled workflows fire"
+  status: pending
+  notes: |
+    Source: branch-default-switch-to-develop (w1 ADMIN + w2 verify).
+    Low-risk, reversible one-call change:
+      gh api -X PATCH repos/joeharris76/BenchBox -f default_branch=develop
+    (roll back with default_branch=main). Record the dated before/after in
+    docs/operations/repo-admin-settings.md.
+    THIS ALSO ACTIVATES two things that are built but currently inert:
+      - the §2.8 fork-PR comment companion (.github/workflows/
+        validate-submission-comment.yml) — workflow_run companions fire only
+        from the default branch;
+      - release-canary.yml's daily cron and any future develop-authored
+        scheduled workflow (register from the default branch).
+    Verify after: `gh api repos/joeharris76/BenchBox/actions/workflows --jq
+    '.workflows[].path'` now lists release-canary.yml; dispatch it once to prove
+    liveness (first result is expected RED on 0.3.0's broken import); confirm
+    nightly.yml still fires. Coordinate ordering with w1/w2 per the runbook.
+
+- id: w4
+  summary: "Recruit one external contributor for the Phase-2 submission dry-run"
+  status: pending
+  notes: |
+    Source: external-contributor-submission-dry-run (w1). A genuinely human
+    task — recruit one trusted external user (not a maintainer, not an agent)
+    to attempt a real submission cold from docs/contributing-results.md. Its w6
+    (verify the §2.8 fork-PR validation-comment path) is only meaningful AFTER
+    w3 above lands (the companion is inert until develop is the default). Recruit
+    can begin anytime; run the §2.8 verification during the dry-run once w3 done.
+
+- id: w5
+  summary: "OPTIONAL cleanup: delete the 5 dead orphan branches"
+  status: pending
+  notes: |
+    The agent could not delete remote branches (the sandbox git remote rejects
+    deletion; no delete-branch MCP tool). Harmless to leave — they are
+    allowlisted in _project/analysis/known-stranded-commits.txt so the
+    orphaned-commit detector ignores them — but if you want a tidy branch list:
+      git push origin --delete \
+        remediate-submission-trust-label-enforcement \
+        remediate-qa-and-browser-test-doc-accuracy \
+        remediate-governance-and-doc-drift \
+        fix/joinorder-trino-primary-key-ddl \
+        fix/multistream-throughput-plan-attachment
+    Their SHAs are preserved in the allowlist if ever needed back.
+
+prior_art:
+- "rename-release-branch-main-to-release.yaml — authoritative source for w1/w2; this item only indexes its human halves (Code-Owner review + w5/w6 admin)."
+- "branch-default-switch-to-develop.yaml — authoritative source for w3 (its w1 admin + w2 verify)."
+- "external-contributor-submission-dry-run.yaml — authoritative source for w4 (its w1 recruit + w6 §2.8 verification)."
+- "_project/analysis/known-stranded-commits.txt — the allowlist referenced by w5; the branches are safe to delete because their content is on develop."
+
+verification:
+- description: "w1: PR #1027 is merged"
+  command: "gh pr view 1027 --repo joeharris76/BenchBox --json state,mergedAt --jq '.state + \" \" + (.mergedAt // \"unmerged\")'"
+  expected_output: "MERGED <timestamp> (once you review + merge it)"
+- description: "w2: the release branch is renamed"
+  command: "gh api repos/joeharris76/BenchBox/branches/release --jq .name 2>/dev/null || echo 'not renamed yet'"
+  expected_output: "release (once w2 is done)"
+- description: "w3: default branch is develop"
+  command: "gh api repos/joeharris76/BenchBox --jq .default_branch"
+  expected_output: "develop (once w3 is done)"
+
+scope_limit:
+  only_modify:
+  - "_project/TODO/main/active/human-action-required.yaml"
+  do_not_modify:
+  - "benchbox/"
+
+must_preserve:
+- "This item never performs the actions — it only records them. Agents update status/notes; the human executes the GitHub-admin/review/recruit steps."
+
+anti_patterns:
+- "DO NOT have an agent attempt the GitHub-admin actions (default-branch change, branch rename, ruleset recreate) — the sandbox cannot, and they are hard-to-reverse maintainer decisions with ordering constraints."
+- "DO NOT duplicate each task's full design here — cross-reference the source TODO and give only the exact command + why, so this stays a scannable queue."
+
+metadata:
+  tags:
+  - maintainer-action
+  - human-action
+  - release
+  - queue
+  estimated_effort: "Small"
+  created_date: "2026-07-07"
+
+success_metrics:
+- "At any moment, this item shows exactly what is waiting on the human maintainer, with the precise command for each, and nothing agent-completable is parked here."


### PR DESCRIPTION
## Description

Creates **`_project/TODO/main/active/human-action-required.yaml`** — a single running index of the actions only the human maintainer can perform (GitHub repo‑admin/settings changes, Code‑Owner reviews, human recruitment). Agents in this project cannot do these (the sandbox git remote rejects branch/default‑branch changes, admin APIs are out of scope, CODEOWNERS review must be human), so this gives one scannable place to see "what's waiting on me." New such actions get appended here.

### Seeded queue
| Unit | Action | Source TODO |
|------|--------|-------------|
| w1 | Code‑Owner review + merge **PR #1027** (in‑repo `main`→`release` rename) | rename‑release‑branch |
| w2 *(needs w1)* | GitHub‑side branch rename `main`→`release` + ruleset recreate | rename‑release‑branch w5/w6 |
| w3 | `PATCH default_branch=develop` + verify scheduled workflows — **also activates the §2.8 companion + release‑canary cron** | branch‑default‑switch |
| w4 | Recruit one external contributor for the Phase‑2 submission dry‑run | external‑contributor‑dry‑run |
| w5 *(optional)* | Delete the 5 dead orphan branches (agent couldn't; harmless — they're allowlisted) | known‑stranded‑commits |

Each unit cross‑references its authoritative source TODO and gives the **exact command**; `verification:` entries check whether each admin action has been applied (`gh pr view 1027`, `branches/release`, `.default_branch`).

## Type of Change

- [x] Documentation / governance (TODO tracking)

## Testing

- `todo_cli validate` → **1260/1260 valid**; `check-graph` → clean (108 items). New file only; `_indexes/` not committed (generated/gitignored).

## Notes

This is an index, not a re‑design — it deliberately does not duplicate each task's full spec, and it never performs the actions (agents update status/notes; the human executes). It's the standing home for future maintainer/human actions too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFdZAbavgrKaNLe4YZa3zf)_