### PR TITLE
chore(todo): file 5 query-plan-capture review follow-ups (qpc-13..17)

### DIFF
--- a/_project/TODO/query-plan-capture/planning/13-explain-error-string-inline-impls-sweep.yaml
+++ b/_project/TODO/query-plan-capture/planning/13-explain-error-string-inline-impls-sweep.yaml
@@ -1,0 +1,85 @@
+id: "qpc-13-explain-error-string-inline-impls-sweep"
+title: "Stop returning EXPLAIN error strings as plan text in the inline get_query_plan impls"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  Follow-up from the qpc-05 (#1032) review. qpc-05 fixed the SHARED helper
+  benchbox/platforms/base/sql_execution.py::get_query_plan_from_cursor to return
+  None (not an error string) on EXPLAIN failure, and updated its two delegators
+  (azure_synapse, firebolt). But four adapters have their OWN inline
+  get_query_plan implementations that still `return f"Could not get query plan:
+  {e}"` as the plan text — so a failed EXPLAIN is handed to a parser as if it
+  were plan output, or displayed as a plan:
+    - benchbox/platforms/velox.py:520
+    - benchbox/platforms/dataframe/_spark_helpers.py:132
+    - benchbox/platforms/athena.py:1319
+    - benchbox/platforms/presto_trino_adapter_base.py:649
+  (redshift.py / snowflake.py log at DEBUG — a separate lower-priority smell.)
+
+  CRITICAL COUPLING: several parsers deliberately sniff the
+  "Could not get query plan" prefix as a sentinel — doris, singlestore, spark,
+  databend, questdb. Any cleanup of the inline returners MUST update those
+  parsers in lockstep (remove the prefix-sniffing branch, handle None instead),
+  or captured-failure detection regresses on those engines.
+
+category: "Error Handling / Consistency"
+
+prior_art:
+- "benchbox/platforms/base/sql_execution.py::get_query_plan_from_cursor — the fixed shared helper (qpc-05, returns None + WARNING)"
+- "benchbox/platforms/{velox.py:520, athena.py:1319, presto_trino_adapter_base.py:649}, benchbox/platforms/dataframe/_spark_helpers.py:132 — inline error-string returners"
+- "parsers doris/singlestore/spark/databend/questdb — sniff the 'Could not get query plan' prefix"
+
+work:
+- id: w1
+  summary: "Make the four inline get_query_plan impls return None + log WARNING on EXPLAIN failure, matching the shared helper."
+  status: pending
+- id: w2
+  summary: "Update the prefix-sniffing parsers (doris/singlestore/spark/databend/questdb) to handle None instead of the sentinel string; add a test per changed impl."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review (no engine loses capture-failure detection; display path still best-effort)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix review findings; re-run verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-13."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "strict_plan_capture still raises on capture failure"
+- "Display path stays best-effort (failure never aborts query execution)"
+- "No engine's capture-failure accounting regresses when the sentinel string is removed"
+
+anti_patterns:
+- "DO NOT remove an inline error-string return without also updating every parser that sniffs its prefix — grep 'Could not get query plan' first."
+- "DO NOT encode errors in the data channel; return None and log."
+
+verification:
+- description: "Inline impls return None on failure; sniffing parsers handle None"
+  command: "uv run -- python -m pytest tests/unit/platforms -q -k 'plan and (velox or spark or athena or presto or trino)'"
+  expected_output: "all pass, including new None-return tests"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/velox.py"
+  - "benchbox/platforms/athena.py"
+  - "benchbox/platforms/presto_trino_adapter_base.py"
+  - "benchbox/platforms/dataframe/_spark_helpers.py"
+  - "benchbox/core/query_plans/parsers/"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "error-handling", "parsers"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-07"
+  review_findings: ["F4.2-inline"]

--- a/_project/TODO/query-plan-capture/planning/14-history-fingerprint-version-guard.yaml
+++ b/_project/TODO/query-plan-capture/planning/14-history-fingerprint-version-guard.yaml
@@ -1,0 +1,80 @@
+id: "qpc-14-history-fingerprint-version-guard"
+title: "Make plan-history flap/version detection fingerprint_version-aware"
+worktree: "query-plan-capture"
+priority: "Medium"
+status: "Not Started"
+
+description: |
+  Follow-up flagged by BOTH the qpc-08 (#1025) and qpc-03 (#1028) reviews. Now
+  that qpc-03 shipped fingerprint v2 (FINGERPRINT_VERSION=2) and the loader/
+  comparator gate fingerprint-equality on matching fingerprint_version,
+  benchbox/core/query_plans/history.py is the one remaining place that compares
+  raw fingerprint strings with `!=` and ZERO version awareness:
+    - detect_plan_flapping (~history.py:192) counts transitions on raw fingerprints
+    - get_plan_version_history (~history.py:218) bumps a version on each raw != change
+    - PlanHistoryEntry (~history.py:27) does not store fingerprint_version at all —
+      it is dropped in add_run/to_dict/from_dict
+  A single history directory that spans a v1->v2 tool upgrade will contain
+  mixed-version fingerprints, so the v1->v2 encoding boundary registers as a
+  spurious plan transition / version bump — exactly the "never compare v1 vs v2
+  for equality, including history flap detection" anti-pattern qpc-03 calls out.
+  Low severity (a single boundary transition rarely breaches the flapping
+  threshold alone) but a genuine correctness gap.
+
+category: "Correctness / Data Integrity"
+
+prior_art:
+- "benchbox/core/query_plans/history.py:27 PlanHistoryEntry (drops fingerprint_version), :192 detect_plan_flapping, :218 get_plan_version_history"
+- "benchbox/core/results/query_plan_models.py FINGERPRINT_VERSION / fingerprint_version (from qpc-03 #1028)"
+
+work:
+- id: w1
+  summary: "Persist fingerprint_version on PlanHistoryEntry (add_run/record/to_dict/from_dict); default missing to 1 for legacy history files."
+  status: pending
+- id: w2
+  summary: "In detect_plan_flapping / get_plan_version_history, segment by fingerprint_version: a version boundary is neither a flap transition nor counted as a plan change."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Test: a v1->v2 boundary in one query's history is not reported as flapping or a version bump; within-version flaps still detected."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (legacy history files without the field still load; sort/order unaffected)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-14."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "Legacy history JSON without fingerprint_version still loads (default to 1)"
+- "Within-a-single-version genuine flapping is still detected"
+
+anti_patterns:
+- "DO NOT compare fingerprints across fingerprint_version for equality anywhere."
+- "DO NOT drop pre-existing history entries that lack the field — treat them as v1."
+
+verification:
+- description: "Version boundary is not a spurious flap/version bump"
+  command: "uv run -- python -m pytest tests/unit/core/query_plans/test_plan_history.py -q"
+  expected_output: "all pass, including new version-boundary tests"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/query_plans/history.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "history", "fingerprint", "versioning"]
+  estimated_effort: "Small"
+  created_date: "2026-07-07"
+  review_findings: ["F3.4-history-followup", "qpc-03-forward-ref"]

--- a/_project/TODO/query-plan-capture/planning/15-dataframe-capture-error-persistence.yaml
+++ b/_project/TODO/query-plan-capture/planning/15-dataframe-capture-error-persistence.yaml
@@ -1,0 +1,91 @@
+id: "qpc-15-dataframe-capture-error-persistence"
+title: "Persist DataFrame plan-capture error cause to the bundle; reset capture state per run"
+worktree: "query-plan-capture"
+priority: "Low"
+status: "Not Started"
+
+description: |
+  Follow-up from the qpc-05 (#1032) review, F4.4. qpc-05 stopped the DataFrame
+  plan-capture path from swallowing exceptions at DEBUG — it now records the
+  real cause on the query row (plan_capture_error) and a per-run adapter list
+  (self.plan_capture_errors) and warns once per run. But two gaps remain, both
+  out of qpc-05's scope_limit:
+
+  1. The cause never reaches the persisted files. run_benchmark calls
+     compute_plan_capture_stats(query_results, capture_plans) WITHOUT
+     existing_errors= (benchbox/platforms/dataframe/benchmark_mixin.py:~397), so
+     schema.py emits the generic {"error": "Query plan not captured"} instead of
+     the real cause. And row["plan_capture_error"] is dropped by
+     normalize_query_result / QueryResultInput (not in its field set), so it
+     isn't in the main results file either. Durable improvement today = the
+     warn-once log only.
+  2. ExpressionFamilyAdapter does not inherit the SQL mixin's
+     _reset_plan_capture_stats, so neither plan_capture_errors nor
+     _plan_capture_warning_emitted is reset per run. A reused DF adapter
+     instance accumulates errors and permanently suppresses warn-once from run 2
+     on. Low impact today (module entrypoints construct a fresh adapter per run).
+
+category: "Observability / Data Integrity"
+
+prior_art:
+- "benchbox/platforms/dataframe/benchmark_mixin.py:~397 compute_plan_capture_stats call (missing existing_errors=)"
+- "benchbox/core/results/query_normalizer.py QueryResultInput (drops plan_capture_error)"
+- "benchbox/platforms/base/result_capture.py::_reset_plan_capture_stats — the SQL-side per-run reset the DF adapter lacks"
+
+work:
+- id: w1
+  summary: "Thread existing_errors=self.plan_capture_errors into the DF compute_plan_capture_stats call so the real cause reaches the .plans.json errors list."
+  status: pending
+- id: w2
+  summary: "Persist plan_capture_error on the main-file row and add a per-run reset of the DF adapter's capture-error/warn-once state."
+  notes: >-
+    Allow plan_capture_error through normalize_query_result/QueryResultInput
+    (currently dropped); add a per-run reset of plan_capture_errors and
+    _plan_capture_warning_emitted for ExpressionFamilyAdapter (it doesn't
+    inherit the SQL mixin's _reset_plan_capture_stats).
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Test: a DF capture failure's real cause appears in the companion errors + row; warn-once resets across two runs on a reused adapter."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (SQL path unaffected; no schema break)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-15."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "SQL-path plan-capture stats/errors behavior unchanged"
+- "compute_plan_capture_stats iteration-stable semantics"
+
+anti_patterns:
+- "DO NOT reset capture state per-query (breaks warn-once/accumulation within a run) — reset once per run."
+
+verification:
+- description: "DF capture cause persists to companion + row; warn-once resets per run"
+  command: "uv run -- python -m pytest tests/unit/platforms/dataframe -q -k 'capture or plan'"
+  expected_output: "all pass, including new persistence/reset tests"
+
+scope_limit:
+  only_modify:
+  - "benchbox/platforms/dataframe/benchmark_mixin.py"
+  - "benchbox/core/results/query_normalizer.py"
+  - "benchbox/platforms/dataframe/expression_family.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "dataframe", "error-handling"]
+  estimated_effort: "Small"
+  created_date: "2026-07-07"
+  review_findings: ["F4.4-persistence", "F4.4-reset"]

--- a/_project/TODO/query-plan-capture/planning/16-plan-max-depth-cli-wiring.yaml
+++ b/_project/TODO/query-plan-capture/planning/16-plan-max-depth-cli-wiring.yaml
@@ -1,0 +1,87 @@
+id: "qpc-16-plan-max-depth-cli-wiring"
+title: "Expose plan_max_depth via --platform-option (and bound the persisted companion)"
+worktree: "query-plan-capture"
+priority: "Low"
+status: "Not Started"
+
+description: |
+  Follow-up from the qpc-10 (#1018) review. qpc-10 added a configurable
+  plan_max_depth adapter-config knob and a truncated_at_depth serialization
+  marker, but two loose ends remain:
+
+  1. plan_max_depth is reachable only via direct adapter config= construction /
+     an arbitrary-key config path — it is NOT registered in
+     benchbox/core/results/platform_options.py and has no CLI flag, so
+     `--platform-option plan_max_depth=N` is rejected. (Its sibling
+     plan_capture_timeout_seconds has the same gap.)
+  2. The truncated_at_depth marker does not reach the persisted .plans.json:
+     schema.py::_build_plan_entry serializes a QueryPlanDAG via
+     asdict(...)/to_dict() at full depth for the companion, so plan_max_depth
+     today only affects the capture-time size-guard estimate and
+     `show-plan --format json`, not the on-disk bundle. The size-guard hint
+     "use a smaller plan_max_depth" therefore overstates its effect.
+
+  Decide whether bounding the persisted companion is desired (it would shrink
+  pathologically deep bundles) or whether full-depth persistence is preferred
+  (deep plans are no longer dropped — a strict improvement over pre-qpc-10);
+  at minimum, register the option so it is settable and correct the hint.
+
+category: "Usability / Config"
+
+prior_art:
+- "benchbox/core/results/query_plan_models.py DEFAULT_PLAN_MAX_DEPTH / to_dict(max_depth) / truncated_at_depth (qpc-10 #1018)"
+- "benchbox/core/results/platform_options.py — the --platform-option allowlist (plan_max_depth + plan_capture_timeout_seconds not registered)"
+- "benchbox/core/results/schema.py::_build_plan_entry — companion serialization (full depth)"
+
+work:
+- id: w1
+  summary: "Register plan_max_depth (and plan_capture_timeout_seconds) as PlatformOptionSpecs so --platform-option accepts them; add CLI/help coverage."
+  status: pending
+- id: w2
+  summary: "Decide + implement persisted-companion depth policy: either thread plan_max_depth into _build_plan_entry serialization, or correct the size-guard hint to say it does not bound the bundle."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Test: --platform-option plan_max_depth=N is accepted and takes effect; companion depth behavior matches the chosen policy."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Review: adversarial code review (option validation, no schema regression)."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Fix review findings; re-run verification."
+  needs: [w4]
+  status: pending
+- id: w6
+  summary: "Submit PR referencing qpc-16."
+  needs: [w5]
+  status: pending
+
+must_preserve:
+- "Deep plans are never dropped (qpc-10 truncation-marker behavior)"
+- "Default plan_max_depth (50) unchanged when the option is not set"
+
+anti_patterns:
+- "DO NOT leave the size-guard hint claiming plan_max_depth shrinks the bundle if it does not."
+
+verification:
+- description: "plan_max_depth settable via --platform-option and effective"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_base_adapter_database_management.py tests/unit/core/results/test_query_plan_models.py -q -k depth"
+  expected_output: "all pass, including new --platform-option test"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/results/platform_options.py"
+  - "benchbox/core/results/schema.py"
+  - "benchbox/cli/"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "config", "cli", "limits"]
+  estimated_effort: "Small"
+  created_date: "2026-07-07"
+  review_findings: ["F5.3-cli", "qpc-10-followup"]

--- a/_project/TODO/query-plan-capture/planning/17-compare-plans-threshold-zero-query-drop.yaml
+++ b/_project/TODO/query-plan-capture/planning/17-compare-plans-threshold-zero-query-drop.yaml
@@ -1,0 +1,74 @@
+id: "qpc-17-compare-plans-threshold-zero-query-drop"
+title: "compare-plans drops an explicitly-requested query at --threshold 0.0"
+worktree: "query-plan-capture"
+priority: "Low"
+status: "Not Started"
+
+description: |
+  Follow-up from the qpc-11 (#1026) review. In
+  benchbox/cli/commands/compare_plans.py::_build_comparisons the append
+  condition is roughly:
+    overall_similarity < threshold or (not explicit_query_id and threshold == 0.0)
+  With BOTH an explicit --query-id AND --threshold 0.0, the first clause is
+  `similarity < 0.0` (always False) and the second is
+  `(not True and ...)` (always False), so the requested query is never appended;
+  the command then prints "No plans available for comparison" and exits 0. Net:
+  single-query comparison output is unreachable at the default threshold — a
+  confusing product quirk (surfaced because a test vacuously passed on this
+  exit-0 path before qpc-11 hardened it).
+
+  Fix: when a query_id is explicitly requested, always include that query's
+  comparison regardless of threshold (threshold should filter the multi-query
+  sweep, not suppress an explicit single-query request).
+
+category: "Usability / CLI"
+
+prior_art:
+- "benchbox/cli/commands/compare_plans.py::_build_comparisons — the append condition"
+- "tests/unit/cli/commands/test_compare_plans_coverage.py — qpc-11 real-loader test now asserts real comparison content"
+
+work:
+- id: w1
+  summary: "Make _build_comparisons always include an explicitly-requested --query-id's comparison regardless of --threshold; threshold filters only the unfiltered sweep."
+  status: pending
+- id: w2
+  summary: "Test: --query-id X --threshold 0.0 emits X's comparison (not 'No plans available'); the multi-query threshold sweep is unchanged."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Review: adversarial code review (default multi-query behavior preserved; no double-count)."
+  needs: [w2]
+  status: pending
+- id: w4
+  summary: "Fix review findings; re-run verification."
+  needs: [w3]
+  status: pending
+- id: w5
+  summary: "Submit PR referencing qpc-17."
+  needs: [w4]
+  status: pending
+
+must_preserve:
+- "Default (no --query-id) threshold-sweep behavior unchanged"
+
+anti_patterns:
+- "DO NOT change the threshold default; fix the explicit-query interaction only."
+
+verification:
+- description: "Explicit query at threshold 0.0 produces output"
+  command: "uv run -- python -m pytest tests/unit/cli/commands/test_compare_plans_coverage.py -q"
+  expected_output: "all pass, including the explicit-query-at-0.0 test"
+
+scope_limit:
+  only_modify:
+  - "benchbox/cli/commands/compare_plans.py"
+  - "tests/"
+
+deps:
+  needs: []
+
+metadata:
+  tags: ["query-plans", "cli", "compare-plans"]
+  estimated_effort: "Small"
+  created_date: "2026-07-07"
+  review_findings: ["qpc-11-threshold-quirk"]


### PR DESCRIPTION
## Description

Files the out-of-scope findings surfaced during the query-plan-capture remediation batch's adversarial reviews as scoped TODO items, so they're tracked rather than living only in merged-PR notes. Tracker-only — no source changes.

| Item | Priority | Source review | Gist |
|------|----------|---------------|------|
| **qpc-13** | Medium | qpc-05 (#1032) | Error-string-as-plan (F4.2) still in the inline `get_query_plan` of `velox`/`_spark_helpers`/`athena`/`presto_trino_adapter_base`; the fix must update the 5 parsers that sniff the `"Could not get query plan"` prefix in lockstep. |
| **qpc-14** | Medium | qpc-03 (#1028) + qpc-08 (#1025) | `history.py` flap/version detection compares raw fingerprints with no `fingerprint_version` awareness; a v1→v2 history boundary reads as a spurious flap. `PlanHistoryEntry` doesn't persist the version. |
| **qpc-15** | Low | qpc-05 (#1032) | DataFrame plan-capture cause reaches only the warn-once log, not the persisted `.plans.json`/main file (dropped by `normalize_query_result`; `existing_errors` not threaded); DF adapter has no per-run capture-state reset. |
| **qpc-16** | Low | qpc-10 (#1018) | `plan_max_depth` isn't settable via `--platform-option`; the `truncated_at_depth` marker doesn't reach the persisted companion, so the size-guard hint overstates its effect. |
| **qpc-17** | Low | qpc-11 (#1026) | `compare-plans` drops an explicitly-requested `--query-id` at `--threshold 0.0` (the append condition zeroes it out), so single-query output is unreachable at the default threshold. |

Each carries the standard create → review → fix → submit work loop, `scope_limit`, `must_preserve`/`anti_patterns`, and a runnable `verification` command. qpc-13 and qpc-14 are the two with real correctness weight; the rest are usability/observability polish.

## Type of Change

- [x] Refactor / chore (TODO tracking)

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py <each>` → all 5 valid.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` → no cycles, no dangling references, 116 items.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is justified here with its consumer and size: none — five TODO YAMLs only.

## Notes

- Not a soundness-gated path (TODO YAML only) — squash auto-merge enabled.
- These close out the query-plan-capture review thread: the 12 original remediation items are merged or in-flight (qpc-05 #1032 awaits Code Owner review; qpc-06 #1036 auto-merges), and these five capture the residual follow-ups those reviews deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyFvQN68nhFLT1ktMB2pc9)_