### PR TITLE
fix(cli): don't fail the run when validation never executed (not_run)

### DIFF
--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -65,7 +65,7 @@ from benchbox.core.benchmark_registry import get_benchmark_default_scale
 from benchbox.core.config import DatabaseConfig
 from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.core.results.provenance import FUNDING_SOURCES, RESULT_SOURCES
-from benchbox.core.results.status import result_non_clean_reason
+from benchbox.core.results.status import result_cli_failure_reason, result_non_clean_reason
 from benchbox.core.schemas import ExecutionContext
 from benchbox.platforms import is_dataframe_platform, list_available_dataframe_platforms
 from benchbox.utils.cloud_storage import is_cloud_path
@@ -1543,6 +1543,10 @@ def _direct_handle_result(
 ) -> None:
     """Export results and perform post-run actions for the direct branch."""
     non_clean_reason = result_non_clean_reason(result)
+    # Exit code uses the narrower CLI policy: unvalidated-but-successful runs
+    # (DataFrame mode, --validation disabled) warn and stay non-clean for
+    # publishing, but do not fail the invocation. See status.py.
+    cli_failure_reason = result_cli_failure_reason(result)
     if result.validation_status not in ["FAILED", "INTERRUPTED"]:
         if not s.quiet:
             console.print("\n[bold]Exporting results...[/bold]")
@@ -1605,7 +1609,7 @@ def _direct_handle_result(
             output=s.output,
             additional_options={"table_mode": s.table_mode},
         )
-        if non_clean_reason:
+        if cli_failure_reason:
             s.ctx.exit(1)
     else:
         console.print(f"\n[red]❌ Benchmark failed: {result.validation_status}[/red]")

--- a/benchbox/cli/commands/run.py
+++ b/benchbox/cli/commands/run.py
@@ -1543,10 +1543,6 @@ def _direct_handle_result(
 ) -> None:
     """Export results and perform post-run actions for the direct branch."""
     non_clean_reason = result_non_clean_reason(result)
-    # Exit code uses the narrower CLI policy: unvalidated-but-successful runs
-    # (DataFrame mode, --validation disabled) warn and stay non-clean for
-    # publishing, but do not fail the invocation. See status.py.
-    cli_failure_reason = result_cli_failure_reason(result)
     if result.validation_status not in ["FAILED", "INTERRUPTED"]:
         if not s.quiet:
             console.print("\n[bold]Exporting results...[/bold]")
@@ -1609,7 +1605,7 @@ def _direct_handle_result(
             output=s.output,
             additional_options={"table_mode": s.table_mode},
         )
-        if cli_failure_reason:
+        if result_cli_failure_reason(result):  # narrower than non_clean_reason; see status.py
             s.ctx.exit(1)
     else:
         console.print(f"\n[red]❌ Benchmark failed: {result.validation_status}[/red]")

--- a/benchbox/core/results/status.py
+++ b/benchbox/core/results/status.py
@@ -9,6 +9,12 @@ NON_CLEAN_VALIDATION_STATUSES: frozenset[str] = frozenset(
     {"failed", "interrupted", "partial", "error", "not_run", "not_validated", "uncertain", "unknown"}
 )
 NON_CLEAN_TRANSLATION_STATUSES: frozenset[str] = frozenset({"fallback", "failed"})
+# Statuses that make a run a *CLI-level* failure (non-zero exit). Narrower than
+# NON_CLEAN_VALIDATION_STATUSES: publication must flag unvalidated results
+# (not_run, not_validated, ...), but a completed run whose validation never
+# executed — DataFrame mode, --validation disabled — is not a failed run.
+# Matches the v0.3.0 exit semantics.
+CLI_FAILURE_VALIDATION_STATUSES: frozenset[str] = frozenset({"failed", "interrupted", "partial", "error"})
 
 
 def normalize_validation_status(value: Any) -> str | None:
@@ -76,6 +82,28 @@ def result_non_clean_reason(result: Any) -> str | None:
 def result_is_clean_pass(result: Any) -> bool:
     """Return True when a result has no query failures, non-clean validation, or translation fallback."""
     return result_non_clean_reason(result) is None
+
+
+def result_cli_failure_reason(result: Any) -> str | None:
+    """Return a reason when a completed run should exit non-zero at the CLI.
+
+    Narrower than :func:`result_non_clean_reason`: validation that never
+    executed (``not_run``/``not_validated``/...) keeps the bundle non-clean for
+    publication, but does not fail the run itself.
+    """
+    failed = result_failed_query_count(result)
+    if failed:
+        noun = "query" if failed == 1 else "queries"
+        return f"{failed} failed {noun}"
+
+    status = normalize_validation_status(getattr(result, "validation_status", None))
+    if status in CLI_FAILURE_VALIDATION_STATUSES:
+        return f"validation_status={status}"
+
+    translation_status = _result_translation_status(result)
+    if translation_status in NON_CLEAN_TRANSLATION_STATUSES:
+        return f"translation_status={translation_status}"
+    return None
 
 
 def bundle_failed_query_count(data: dict[str, Any]) -> int:

--- a/tests/unit/core/results/test_status.py
+++ b/tests/unit/core/results/test_status.py
@@ -9,6 +9,7 @@ import pytest
 from benchbox.core.results.status import (
     bundle_failed_query_count,
     bundle_is_clean_pass,
+    result_cli_failure_reason,
     result_failed_query_count,
     result_is_clean_pass,
 )
@@ -77,3 +78,34 @@ def test_result_non_clean_translation_statuses_are_not_clean(status: str) -> Non
     )
 
     assert result_is_clean_pass(result) is False
+
+
+@pytest.mark.parametrize("status", ["not_run", "NOT_RUN", "not_validated", "uncertain", "unknown"])
+def test_unexecuted_validation_is_not_a_cli_failure(status: str) -> None:
+    """Validation that never ran keeps the result non-clean for publication
+    but must not fail the CLI invocation (v0.3.0 exit semantics)."""
+    result = SimpleNamespace(total_queries=1, successful_queries=1, failed_queries=0, validation_status=status)
+    assert not result_is_clean_pass(result)
+    assert result_cli_failure_reason(result) is None
+
+
+@pytest.mark.parametrize("status", ["failed", "interrupted", "partial", "error"])
+def test_executed_validation_failures_are_cli_failures(status: str) -> None:
+    result = SimpleNamespace(total_queries=1, successful_queries=1, failed_queries=0, validation_status=status)
+    assert result_cli_failure_reason(result) == f"validation_status={status}"
+
+
+def test_failed_queries_are_cli_failures_regardless_of_validation() -> None:
+    result = SimpleNamespace(total_queries=2, successful_queries=1, failed_queries=1, validation_status="not_run")
+    assert result_cli_failure_reason(result) == "1 failed query"
+
+
+def test_translation_fallback_is_a_cli_failure() -> None:
+    result = SimpleNamespace(
+        total_queries=1,
+        successful_queries=1,
+        failed_queries=0,
+        validation_status="passed",
+        execution_metadata={"translation": {"status": "fallback"}},
+    )
+    assert result_cli_failure_reason(result) == "translation_status=fallback"


### PR DESCRIPTION
Regression vs v0.3.0, caught by the v0.3.1 release gate's first-ever bootstrap canary run on #1029.

The soundness sweeps added `not_run`/`not_validated`/`uncertain`/`unknown` to `NON_CLEAN_VALIDATION_STATUSES`, and the run command exits 1 on any non-clean result — so every DataFrame-mode run (no validation support) and every `--validation disabled` run exited 1 despite full success. SQL-mode runs (which validate) were unaffected.

**Fix**: split the policy. New `result_cli_failure_reason()` fails the invocation only on failed queries, executed-validation failures (`failed`/`interrupted`/`partial`/`error`), or translation fallback — the v0.3.0 exit semantics. Publication and submit gating keep the strict `result_non_clean_reason()`, so unvalidated bundles remain non-clean for trust labels and ranking; the CLI still prints the non-clean warning, it just doesn't fail the run.

Verified: `tests/e2e/test_dataframe_platforms.py` TPC-H full-execution tests (pandas, polars) go red→green; 25 status-policy unit tests and 1,414 CLI unit tests pass.

Will be cherry-picked to the `v0.3.1` release branch once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)