### PR TITLE
fix(release-ci): tag-claim guard honors GITHUB_HEAD_REF on detached PR checkouts

### DIFF
--- a/scripts/generate_changelog_entry.py
+++ b/scripts/generate_changelog_entry.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -265,7 +266,12 @@ def find_untagged_changelog_versions(
 def _current_branch(source: Path) -> str | None:
     result = _run_git(source, "rev-parse", "--abbrev-ref", "HEAD")
     branch = result.stdout.strip()
-    return branch if result.returncode == 0 and branch and branch != "HEAD" else None
+    if result.returncode == 0 and branch and branch != "HEAD":
+        return branch
+    # PR CI checks out a detached merge ref; fall back to the PR head ref so
+    # the release-branch exemption in the tag-claim guard still applies.
+    env_branch = os.environ.get("GITHUB_HEAD_REF", "").strip()
+    return env_branch or None
 
 
 def check_tag_claims(source: Path) -> tuple[bool, list[str]]:

--- a/tests/unit/release/test_changelog_tag_guard.py
+++ b/tests/unit/release/test_changelog_tag_guard.py
@@ -118,3 +118,29 @@ def test_repo_changelog_has_no_untagged_released_section_on_this_branch():
     from an in-progress release branch for that exact version."""
     ok, untagged = gce.check_tag_claims(REPO_ROOT)
     assert ok, f"CHANGELOG.md claims untagged version(s): {untagged}"
+
+
+def test_current_branch_falls_back_to_github_head_ref(tmp_path, monkeypatch):
+    """On a detached-HEAD PR checkout, the release-branch exemption must come
+    from GITHUB_HEAD_REF (set by Actions for pull_request events)."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-q", "--allow-empty", "-m", "x"],
+        check=True,
+        env={
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    subprocess.run(["git", "-C", str(tmp_path), "checkout", "-q", "--detach"], check=True)
+
+    monkeypatch.setenv("GITHUB_HEAD_REF", "v9.9.9")
+    assert gce._current_branch(tmp_path) == "v9.9.9"
+
+    monkeypatch.delenv("GITHUB_HEAD_REF")
+    assert gce._current_branch(tmp_path) is None


### PR DESCRIPTION
Found on release PR #1029: the changelog tag-claim guard's release-branch exemption keys off `git rev-parse --abbrev-ref HEAD`, which returns `HEAD` in Actions pull_request checkouts (detached merge ref). The guard therefore failed the release PR for its own in-progress version (`CHANGELOG.md claims untagged version(s): ['0.3.1']`) even though it passes locally on the named branch.

Fix: fall back to `GITHUB_HEAD_REF` (set by Actions for pull_request events) when git reports a detached HEAD. Covered by a new unit test with a detached tmp repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)