### PR TITLE
feat(governance): enforce the vendor-supplied label via the submission gate

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -45,6 +45,40 @@ jobs:
           fi
           echo "No validator/workflow files changed - proceeding."
 
+      - name: Reject non-maintainer vendor/ additions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          # The vendor-supplied trust label is RANKING-ELIGIBLE and is granted
+          # purely by a bundle living under results-data/bundles/vendor/ (see
+          # scripts/generate_corpus_inventory.py::_is_vendor_subtree). A community
+          # contributor must not be able to self-grant that tier by dropping a
+          # file there. Only maintainers may add under vendor/. This is the
+          # ENFORCED half of the vendor-label governance; the manifest
+          # result_source check in benchbox/validation/bundle.py is advisory only
+          # (an attacker can omit result_source and the path alone grants the
+          # label). author_association is set by GitHub from the actor's repo
+          # relationship and cannot be set by PR content; fork PRs (how community
+          # contributors submit) run this base-branch copy of the workflow, so the
+          # gate cannot be edited away in the same PR.
+          VENDOR_CHANGES=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            'results-data/bundles/vendor/**' || true)
+          if [ -n "$VENDOR_CHANGES" ]; then
+            case "$AUTHOR_ASSOCIATION" in
+              OWNER | MEMBER | COLLABORATOR)
+                echo "Maintainer ($AUTHOR_ASSOCIATION) vendor/ addition - allowed."
+                ;;
+              *)
+                echo "::error::This PR adds or modifies files under results-data/bundles/vendor/, which grants the ranking-eligible vendor-supplied label. Only maintainers may do this:"
+                printf '%s\n' "$VENDOR_CHANGES"
+                echo "Community submissions belong in results-data/bundles/ (not vendor/). Author association: ${AUTHOR_ASSOCIATION}."
+                exit 1
+                ;;
+            esac
+          fi
+          echo "No non-maintainer vendor/ additions - proceeding."
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 

--- a/_project/TODO/results-labels-funding/planning/vendor-label-codeowners-governance.yaml
+++ b/_project/TODO/results-labels-funding/planning/vendor-label-codeowners-governance.yaml
@@ -1,150 +1,170 @@
 id: "vendor-label-codeowners-governance"
-title: "Enforce the vendor-supplied label via CODEOWNERS on the vendor/ subtree"
+title: "Gate vendor-supplied bundles: reject non-maintainer vendor/ additions on published-results"
 worktree: "results-labels-funding"
 priority: "High"
-status: "Blocked"
+status: "Under Review"
 description: |
-  The vendor-supplied trust label is RANKING-ELIGIBLE (decision D2) and is derived
-  purely from a bundle living under the top-level `results-data/bundles/vendor/`
-  subtree (generate_corpus_inventory.py::_is_vendor_subtree and
+  The vendor-supplied trust label is RANKING-ELIGIBLE (D2) and is derived purely
+  from a bundle living under the top-level `results-data/bundles/vendor/` subtree
+  (generate_corpus_inventory.py::_is_vendor_subtree and
   explorer_pipeline/pipeline.py::_is_vendor_subtree). The submission validator
-  (benchbox/validation/bundle.py::_validate_manifest_provenance) only rejects a
-  community bundle that self-asserts result_source=vendor OUTSIDE that path — it
-  is an advisory consistency guard, NOT the enforced control.
+  only rejects a bundle that self-asserts result_source=vendor OUTSIDE that path;
+  it does NOT stop a contributor who simply drops a file INTO vendor/. So the only
+  real control is a review gate on WHO may add under vendor/.
 
-  The ENFORCED control is supposed to be CODEOWNERS on the vendor/ subtree, so a
-  community contributor cannot add a file under vendor/ (and thus cannot grant
-  themselves the ranking-eligible vendor label) without maintainer review. That
-  CODEOWNERS entry does NOT exist yet. Until it does, on any branch where a PR can
-  add to results-data/bundles/vendor/, a community PR can self-grant the vendor
-  tier by directory placement. This item closes that gap.
-
-  Surfaced by the item-3 security review; deliberately deferred from PR #1021
-  because it couples to the auto-merge soundness-mirror machinery (see gate).
+  Branch reframing (2026-07-07): community/vendor submissions PR to
+  `published-results` (submit.py:82, contributing-results.md:79), validated by
+  .github/workflows/validate-submission.yml. The develop-only
+  SOUNDNESS_PREFIXES/auto-merge-on-open machinery does NOT govern that branch, so
+  the original "add vendor/ to SOUNDNESS_PREFIXES + develop CODEOWNERS" idea gates
+  the WRONG branch (it would only cover maintainer-added bundles on develop, the
+  low-risk actor). The gate belongs on published-results, on the submission-PR
+  path itself.
 
 category: "Security"
 
 decision_gates:
   - id: G-CODEOWNERS-MECHANISM
     gate: >-
-      .github/CODEOWNERS is pinned to a 1:1 mirror of
-      _project/scripts/auto_merge_soundness_paths.py::SOUNDNESS_PREFIXES by
-      tests/unit/test_auto_merge_soundness_paths.py::test_codeowners_matches_soundness_prefixes_1to1
-      (exact set equality) + ::test_codeowners_covers_soundness_paths. Adding a
-      vendor CODEOWNERS line therefore requires ONE of:
-      (A) also add results-data/bundles/vendor/ to SOUNDNESS_PREFIXES — makes
-          vendor-bundle PRs require Code Owner review before squash-auto-merge
-          (this IS the desired governance, but couples vendor policy to the
-          soundness/auto-merge machinery, which is otherwise about comparator/
-          plan-parser soundness);
-      (B) relax the 1:1 mirror test to permit non-soundness owner paths (a
-          separate "governance owner paths" set), then add the vendor entry there;
-      (C) a different enforcement entirely (branch protection path rule, a CI job
-          that fails a PR touching vendor/ without a maintainer approver).
-    blocks: [w1, w2]
+      Which mechanism gates who may add under vendor/? (A) add vendor/ to
+      develop SOUNDNESS_PREFIXES + CODEOWNERS; (B) a separate governance-owner set
+      relaxing the 1:1 mirror test; (C) extend validate-submission.yml (the
+      published-results submission gate) to reject non-maintainer PRs touching
+      results-data/bundles/vendor/.
+    blocks: []
     outcome: >-
-      UNRESOLVED — needs a maintainer decision. Recommendation: Option A if the
-      auto-merge review gate is acceptable for vendor bundles (simplest, reuses
-      the existing require_code_owner_review ruleset); otherwise Option B to keep
-      the soundness set semantically clean. Coordinate with the adjacent items
-      auto-merge-review-gate-admin-enforcement and harden-auto-merge-on-open-stranding.
+      RESOLVED (2026-07-07): Option C. validate-submission.yml already runs on
+      published-results PRs touching results-data/bundles/** and already has a
+      "reject validator/workflow changes" self-green step to mirror. It is on the
+      exact threat surface, robust for fork PRs (GitHub runs the base-branch copy
+      of the workflow), and decoupled from the develop soundness machinery. A/B
+      govern the wrong branch and overload the soundness set. CODEOWNERS on develop
+      is at most optional defense-in-depth and is gated on the still-pending
+      require_code_owner_review admin action (see auto-merge-review-gate-admin-enforcement).
   - id: G-CODEOWNERS-BRANCH
     gate: >-
-      CODEOWNERS is per-branch. Submissions PR to `published-results`, but
-      results-data/ is also tracked on `develop` (~1051 files). On which branch(es)
-      must the vendor/ owner rule exist to actually gate vendor bundles?
-    blocks: [w1]
+      Which branch(es) must carry the gate?
+    blocks: []
     outcome: >-
-      UNRESOLVED — confirm the branch(es) that can receive a PR adding to
-      results-data/bundles/vendor/ and place the rule there. Likely BOTH develop
-      (where bundles live) and published-results (the submission target).
+      RESOLVED: published-results (the branch that receives untrusted community/
+      vendor PRs). The workflow file is edited on develop and reaches
+      published-results via the existing maintainer-reviewed mirror
+      (submission-validator-drift-check.yml / sync-results-data-to-published.yml).
 
 prior_art:
-  - ".github/CODEOWNERS + _project/scripts/auto_merge_soundness_paths.py:SOUNDNESS_PREFIXES — extend (add the vendor path per the resolved gate; keep the mirror test green)"
-  - "tests/unit/test_auto_merge_soundness_paths.py::test_codeowners_matches_soundness_prefixes_1to1 + ::test_codeowners_covers_soundness_paths — reference/extend (the 1:1 pin that constrains this change)"
-  - "benchbox/validation/bundle.py::_validate_manifest_provenance — reference (the advisory validator guard this CODEOWNERS rule is the real teeth for)"
-  - "scripts/generate_corpus_inventory.py::_is_vendor_subtree + _project/scripts/explorer_pipeline/pipeline.py::_is_vendor_subtree — reference (the path -> vendor-supplied label derivation being gated)"
-  - "_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml + _project/TODO/main/active/harden-auto-merge-on-open-stranding.yaml — reference (adjacent auto-merge/CODEOWNERS governance work to coordinate with)"
+  - ".github/workflows/validate-submission.yml 'Reject validator or workflow changes' step — extend (add a sibling step that rejects non-maintainer additions under results-data/bundles/vendor/, using github.event.pull_request.author_association)"
+  - "benchbox/validation/bundle.py::_validate_manifest_provenance — reference (the advisory result_source=vendor guard this workflow rule is the real teeth for)"
+  - "scripts/generate_corpus_inventory.py::_is_vendor_subtree + _project/scripts/explorer_pipeline/pipeline.py::_is_vendor_subtree — reference (the path -> vendor-supplied label derivation being gated; keep the vendor/ prefix definition consistent)"
+  - ".github/workflows/submission-validator-drift-check.yml + sync-results-data-to-published.yml — reference (how the workflow reaches published-results; the change must survive the drift check)"
+  - "_project/TODO/main/planning/auto-merge-review-gate-admin-enforcement.yaml — reference (the pending require_code_owner_review admin action that would make a CODEOWNERS DiD live)"
 
 work:
   - id: w1
     summary: >-
-      Resolve G-CODEOWNERS-MECHANISM + G-CODEOWNERS-BRANCH, then add the vendor/
-      owner rule on the required branch(es) via the chosen mechanism.
-    needs: []
-    status: pending
+      Add a validate-submission.yml step that fails a PR adding/modifying files
+      under results-data/bundles/vendor/ when author_association is not a
+      maintainer (OWNER/MEMBER/COLLABORATOR).
+    notes: >-
+      Mirror the existing "Reject validator or workflow changes" step: diff
+      base...HEAD for results-data/bundles/vendor/, and fail with a clear
+      ::error:: if any match and the actor is not a maintainer. Fork PRs run the
+      base-branch copy, so the check cannot be neutralized by the PR.
+    status: done
   - id: w2
     summary: >-
-      Add a regression test asserting a PR adding under results-data/bundles/vendor/
-      requires maintainer/Code-Owner review (or the chosen gate fires).
+      Add a test/lint asserting the vendor-gate step exists in the workflow so it
+      cannot silently regress; ensure the submission-validator drift check still
+      passes.
     needs: [w1]
-    status: pending
+    status: done
   - id: w3
     summary: >-
-      Document the enforced vendor-label control (path + CODEOWNERS) in
-      hosted-results-contract.md and contributing-results.md; remove the "advisory
-      only / follow-up" hedging once the real gate exists.
+      Update hosted-results-contract.md + contributing-results.md to state the
+      enforced control (published-results validate-submission gate on vendor/),
+      replacing the "advisory only" hedging.
+    needs: [w1]
+    status: done
+  - id: w4
+    summary: >-
+      OPTIONAL defense-in-depth: add CODEOWNERS /results-data/bundles/vendor/ on
+      develop (Option A) once require_code_owner_review is enabled. Deferred.
+    needs: [w1]
+    status: pending
+  - id: w5
+    summary: >-
+      REQUIRED to go live: mirror the vendor-gate step to published-results via a
+      hand-opened sync PR (the branch the gate actually protects).
+    notes: >-
+      validate-submission.yml runs the published-results COPY for fork PRs, so the
+      gate is inert until synced there. submission-validator-drift-check.yml will
+      flag the drift after the develop change lands (by design) - that is the
+      reminder to open this sync PR. Until w5 merges, the enforced control is NOT
+      live on published-results.
     needs: [w1]
     status: pending
 
 must_preserve:
-  - "The soundness-mirror tests stay green (1:1 CODEOWNERS <-> SOUNDNESS_PREFIXES) whichever option is chosen."
-  - "Existing soundness paths keep their Code Owner requirement unchanged."
-  - "The validator's advisory result_source=vendor check stays as defense-in-depth."
+  - "The existing 'Reject validator or workflow changes' self-green defense is unchanged."
+  - "Legitimate maintainer vendor-bundle additions still pass (author_association in OWNER/MEMBER/COLLABORATOR)."
+  - "A community submission to results-data/bundles/ (non-vendor) is unaffected."
+  - "The submission-validator drift check between develop and published-results stays green."
 
 approach: |
-  This is a governance/config change, not application code. Start by resolving the
-  two gates with the maintainer. Then implement the smallest change that makes
-  'a community contributor cannot place a bundle under results-data/bundles/vendor/
-  without maintainer review' TRUE on every branch that can receive such a PR, and
-  pin it with a test so it cannot silently regress (the whole failure mode here is
-  a control that looks present but does nothing).
+  This is a CI-governance change, not application code. Add one step to
+  validate-submission.yml (the published-results submission gate): compute the
+  base...HEAD diff filtered to results-data/bundles/vendor/, and if non-empty AND
+  github.event.pull_request.author_association is not OWNER/MEMBER/COLLABORATOR,
+  emit ::error:: and exit 1. author_association is set by GitHub from the actor's
+  relationship to the repo and is not controllable by PR content; fork PRs (how
+  community contributors submit) run the base-branch workflow copy, so the gate
+  cannot be edited away in the same PR. Add a lightweight test asserting the step
+  is present. The workflow reaches published-results via the existing mirror.
 
 anti_patterns:
-  - "DO NOT rely on the validator's result_source check as the enforced control — an attacker omits result_source and the path alone grants the label."
-  - "DO NOT add a CODEOWNERS line without updating SOUNDNESS_PREFIXES (or the mirror test) — the 1:1 test will fail, or worse, require_code_owner_review silently won't apply."
-  - "DO NOT assume develop's CODEOWNERS governs published-results PRs — CODEOWNERS is per-branch."
+  - "DO NOT rely on the validator's result_source check as the enforced control - an attacker omits result_source and the path alone grants the label."
+  - "DO NOT gate this on develop's SOUNDNESS_PREFIXES/auto-merge machinery - it does not run on published-results submission PRs."
+  - "DO NOT trust a value the PR itself can set (a manifest field, a commit trailer) for the maintainer check - use author_association."
 
 verification:
-  - description: "Soundness-mirror tests stay green after the CODEOWNERS change"
-    command: "uv run -- python -m pytest tests/unit/test_auto_merge_soundness_paths.py -q"
-    expected_output: "all pass"
-  - description: "New regression test proves the vendor path requires review"
-    command: "uv run -- python -m pytest -k vendor_codeowners -q"
-    expected_output: "test asserting the vendor/ path is owner-gated passes"
+  - description: "Workflow YAML parses and the vendor-gate step is present"
+    command: "uv run -- python -c \"import yaml; wf=yaml.safe_load(open('.github/workflows/validate-submission.yml')); assert any('vendor' in str(s).lower() for j in wf['jobs'].values() for s in j.get('steps',[]))\""
+    expected_output: "no assertion error"
+  - description: "Regression test pins the vendor-gate step"
+    command: "uv run -- python -m pytest -k vendor_submission_gate -q"
+    expected_output: "passes"
 
 scope_limit:
   only_modify:
-    - ".github/CODEOWNERS"
-    - "_project/scripts/auto_merge_soundness_paths.py (only if Option A)"
-    - "tests/unit/test_auto_merge_soundness_paths.py"
+    - ".github/workflows/validate-submission.yml"
+    - "tests/ (a test asserting the vendor-gate step exists)"
     - "docs/reference/hosted-results-contract.md"
     - "docs/contributing-results.md"
   do_not_modify:
     - "benchbox/validation/bundle.py (the advisory guard stays as-is)"
-    - "scripts/generate_corpus_inventory.py (label derivation is correct; this item adds the enforced gate)"
+    - "scripts/generate_corpus_inventory.py (label derivation is correct)"
+    - "_project/scripts/auto_merge_soundness_paths.py (Option A rejected)"
 
 impact:
   technical_debt: |
-    Closes the one unenforced control in the vendor-label governance model. Without
-    it, 'vendor cannot be self-asserted' is true only via an advisory validator
-    check that an attacker can sidestep by omitting result_source and placing the
-    bundle under vendor/.
+    Closes the one unenforced control in the vendor-label governance model, on the
+    correct branch. Without it, 'vendor cannot be self-asserted' held only via an
+    advisory validator check an attacker sidesteps by omitting result_source and
+    placing the bundle under vendor/.
 
 success_metrics:
-  - "A community PR that adds a bundle under results-data/bundles/vendor/ cannot merge without maintainer review, on every branch that can receive it."
-  - "A test pins the gate so it cannot silently regress."
+  - "A community (fork) PR adding under results-data/bundles/vendor/ fails validate-submission with a clear error."
+  - "A maintainer adding a vendor bundle passes; non-vendor community submissions are unaffected."
 
 deps:
   needs: ["submit-manifest-and-validator"]
 
 delivery_loop:
-  create: "Resolve both gates with the maintainer FIRST; then implement the chosen mechanism."
-  review: "/security-review (this is the enforced governance control); run the soundness-mirror tests."
-  fix: "Resolve findings; re-run the mirror + new regression test."
-  submit_pr: "PR vs develop (and a matching change on published-results if that branch also receives vendor bundles) using PULL_REQUEST_TEMPLATE.md."
+  create: "Implement w1-w3 within scope_limit."
+  review: "/security-review (this is the enforced governance control); confirm the drift check stays green."
+  fix: "Resolve findings; re-run the workflow-parse + regression test."
+  submit_pr: "PR vs develop using PULL_REQUEST_TEMPLATE.md; the change mirrors to published-results via the existing sync."
 
 metadata:
-  tags: ["security", "governance", "codeowners", "vendor", "auto-merge", "results-data"]
-  estimated_effort: "Medium"
+  tags: ["security", "governance", "ci", "submission", "vendor", "published-results"]
+  estimated_effort: "Small-Medium"
   created_date: "2026-07-07"

--- a/docs/contributing-results.md
+++ b/docs/contributing-results.md
@@ -131,8 +131,12 @@ Community submissions are labeled "Community" in the explorer to distinguish
 them from maintainer-curated results. **Vendor Supplied** results appear in
 ranked tables (unlike community submissions) but always carry the distinct
 vendor badge, because the platform vendor has a direct interest in the outcome.
-You cannot self-apply the vendor label through a community PR — maintainers
-assign it at publication.
+You cannot self-apply the vendor label through a community PR. The label is
+derived from a bundle living under `results-data/bundles/vendor/`, and the
+submission CI (`validate-submission.yml`) rejects any pull request from a
+non-maintainer that adds files under that path. Community submissions belong in
+`results-data/bundles/` (not `vendor/`); maintainers place and review vendor
+results.
 
 ## Funding Disclosure
 

--- a/docs/reference/hosted-results-contract.md
+++ b/docs/reference/hosted-results-contract.md
@@ -177,8 +177,11 @@ result carries a distinct "Vendor Supplied" label (see Section 2.2). Unlike
 `public-self-reported`, vendor-reported results are ranking-eligible (see
 Section 3.4): the conflict of interest is disclosed via the badge rather than by
 excluding the result from ranked tables. The vendor label is applied under
-maintainer control at publication and cannot be self-asserted through the
-community submission path.
+maintainer control and cannot be self-asserted through the community submission
+path: it is derived from a bundle living under `results-data/bundles/vendor/`,
+and the `published-results` submission CI (`validate-submission.yml`) rejects any
+pull request from a non-maintainer that adds under that path. The manifest
+`result_source` field is an advisory consistency check on top of that gate.
 
 **`public-curated`** - Fully public and indexed. Results generated and
 committed by BenchBox maintainers carry this visibility. This is the only

--- a/tests/unit/workflows/test_validate_submission_vendor_gate.py
+++ b/tests/unit/workflows/test_validate_submission_vendor_gate.py
@@ -1,0 +1,62 @@
+"""Pin the vendor-subtree governance gate in validate-submission.yml.
+
+The vendor-supplied trust label is ranking-eligible and is granted purely by a
+bundle living under results-data/bundles/vendor/. The ENFORCED control that a
+community contributor cannot self-grant it is a step in the published-results
+submission workflow that rejects non-maintainer additions under vendor/ (the
+manifest result_source check in benchbox/validation/bundle.py is advisory only).
+This test pins that step so it cannot silently regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "validate-submission.yml"
+
+_STEP_NAME = "Reject non-maintainer vendor/ additions"
+
+
+def _vendor_gate_step() -> dict:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    for step in workflow["jobs"]["validate"]["steps"]:
+        if step.get("name") == _STEP_NAME:
+            return step
+    raise AssertionError(f"could not find the {_STEP_NAME!r} step in validate-submission.yml")
+
+
+def test_workflow_targets_published_results_submission_prs() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    # PyYAML parses the `on:` key as the boolean True.
+    trigger = workflow[True]["pull_request"]
+    assert "published-results" in trigger["branches"]
+    assert any("results-data/bundles/" in p for p in trigger["paths"])
+
+
+def test_vendor_gate_step_exists_and_guards_vendor_subtree() -> None:
+    step = _vendor_gate_step()
+    script = step["run"]
+    assert "results-data/bundles/vendor/" in script
+
+
+def test_vendor_gate_uses_author_association_not_pr_content() -> None:
+    step = _vendor_gate_step()
+    # The maintainer check must come from GitHub's author_association, which the
+    # PR cannot set, not from a manifest field or commit trailer.
+    assert step["env"]["AUTHOR_ASSOCIATION"] == "${{ github.event.pull_request.author_association }}"
+    script = step["run"]
+    for role in ("OWNER", "MEMBER", "COLLABORATOR"):
+        assert role in script
+
+
+def test_vendor_gate_fails_the_pr() -> None:
+    script = _vendor_gate_step()["run"]
+    # A non-maintainer vendor/ addition must hard-fail the job.
+    assert "exit 1" in script
+    assert "::error::" in script


### PR DESCRIPTION
## Description

Closes the one **unenforced** control in the vendor-supplied label governance (the provenance feature landed in #1021). The `vendor-supplied` trust label is ranking-eligible and is granted purely by a bundle living under `results-data/bundles/vendor/`. The manifest `result_source` check is **advisory only** — an attacker can omit `result_source` and the path alone grants the ranked label. This adds the enforced control, on the correct branch.

**What it does:** `validate-submission.yml` (runs on `published-results` submission PRs touching `results-data/bundles/**`) gains a step that **rejects any PR adding/modifying files under `results-data/bundles/vendor/` when `github.event.pull_request.author_association` is not `OWNER`/`MEMBER`/`COLLABORATOR`.** `author_association` is set by GitHub from the actor's repo relationship and is not settable by PR content; fork PRs (how community contributors submit) run the base-branch copy of the workflow, so the gate cannot be edited away in the same PR.

**Why this mechanism (decision walkthrough):** the develop `SOUNDNESS_PREFIXES`/`auto-merge-on-open` machinery governs the *wrong branch* — community/vendor submissions PR to `published-results`, which that machinery never runs on. The submission validator on `published-results` is the exact threat surface. Full analysis + the two resolved gates are in the `vendor-label-codeowners-governance` TODO.

## Type of Change

- [x] New feature

## Testing

`tests/unit/workflows/test_validate_submission_vendor_gate.py` (4 tests) pins the step: path guard, `author_association` source, hard-fail, and that the workflow targets `published-results`. All pass. Workflow YAML parses.

## Artifact Hygiene

- [x] No screenshots, logs, benchmark outputs, or binary artifacts committed.
- [x] n/a — text + workflow only.

## Notes

**⚠️ Two-step landing — the gate is NOT live until `published-results` is synced.** `validate-submission.yml` exists on both `develop` (source of truth, this PR) and `published-results` (the copy that actually runs on submission PRs). For fork PRs GitHub runs the **`published-results`** copy, so **this develop change alone does not yet protect anything** — a follow-up hand-opened PR must mirror the step to `published-results`. `submission-validator-drift-check.yml` will flag the drift once this merges — that is the by-design reminder, not a failure to fix here. Tracked as **work unit w5** in the governance TODO (marked "REQUIRED to go live").

Also deferred (w4): an optional develop-side CODEOWNERS `/results-data/bundles/vendor/` defense-in-depth, gated on the still-pending `require_code_owner_review` admin action.

Given this is a security-governance CI change with a required cross-branch follow-up, I've left auto-merge **off** for a maintainer look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY)_