### PR TITLE
fix(packaging): ship JoinOrder data_manifest.toml; tolerate Python 3.10 tomllib absence

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include LICENSE
 include pyproject.toml
 include MANIFEST.in
 
-recursive-include benchbox *.py *.sql *.yaml *.json *.jinja2 *.md *.csv
+recursive-include benchbox *.py *.sql *.yaml *.json *.jinja2 *.md *.csv *.toml
 
 # Include _sources/ for sdist (patches, EULAs, compilation infra, templates)
 # Note: Runtime templates are ALSO bundled inside benchbox/_binaries/*/templates/

--- a/benchbox/core/data_fetch/manifest.py
+++ b/benchbox/core/data_fetch/manifest.py
@@ -52,7 +52,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10: stdlib tomllib is 3.11+
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from .errors import ManifestValidationError
 


### PR DESCRIPTION
Both flagged by Codex on release PR #1043:

1. **MANIFEST.in missed `*.toml`** — `benchbox/core/joinorder/data_manifest.toml` is loaded at runtime by `JoinOrderBenchmark`, and `include-package-data = true` means MANIFEST.in governs wheel contents, so installed users hit a missing-manifest failure instantiating `joinorder`. Verified: wheel now contains the file.
2. **Unconditional `import tomllib`** — 3.11-only stdlib module, but `requires-python >= 3.10` and `tomli` is already declared for `<3.11`; added the standard fallback.

486 joinorder/data_fetch unit tests pass. Will be cherry-picked to the v0.3.1 release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)