### PR TITLE
fix(tpch): accept CLI Q-prefixed query ids in power-test subsets

### DIFF
--- a/benchbox/core/tpch/power_test.py
+++ b/benchbox/core/tpch/power_test.py
@@ -21,6 +21,17 @@ from benchbox.core.plan_capture_phase import propagate_plan_capture_fields
 from benchbox.utils.clock import elapsed_seconds, mono_time
 
 
+def _parse_tpch_query_id(qid: object) -> int:
+    """Parse a TPC-H query id that may carry the CLI's Q prefix ("Q1" -> 1)."""
+    text = str(qid).strip()
+    if text[:1] in ("Q", "q"):
+        text = text[1:]
+    try:
+        return int(text)
+    except ValueError as exc:
+        raise ValueError(f"Invalid TPC-H query id: {qid!r} (expected 1-22, optionally Q-prefixed)") from exc
+
+
 @dataclass
 class TPCHPowerTestConfig:
     """Configuration for TPC-H Power Test."""
@@ -232,7 +243,7 @@ class TPCHPowerTest:
         # Determine query execution order
         if self.config.query_subset:
             # User specified specific queries - run in their order
-            query_permutation = [int(qid) for qid in self.config.query_subset]
+            query_permutation = [_parse_tpch_query_id(qid) for qid in self.config.query_subset]
             if self.config.verbose:
                 self.logger.info(f"Using user-specified query subset: {query_permutation}")
             # Warn about TPC-H compliance impact

--- a/tests/unit/core/tpch/test_power_test_query_subset.py
+++ b/tests/unit/core/tpch/test_power_test_query_subset.py
@@ -1,0 +1,31 @@
+"""Regression tests for CLI-style Q-prefixed query ids in the TPC-H power test.
+
+The CLI passes --queries values through verbatim (e.g. "Q1,Q6,Q14"), so the
+power test must accept both bare and Q-prefixed ids (release PR #1043 canary
+found `int("Q1")` crashing every subset run).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchbox.core.tpch.power_test import _parse_tpch_query_id
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("Q1", 1), ("q6", 6), ("14", 14), (22, 22), (" Q7 ", 7)],
+)
+def test_parse_accepts_bare_and_q_prefixed_ids(raw, expected):
+    assert _parse_tpch_query_id(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["", "Q", "Qx", "1.5", "query1"])
+def test_parse_rejects_invalid_ids(raw):
+    with pytest.raises(ValueError, match="Invalid TPC-H query id"):
+        _parse_tpch_query_id(raw)


### PR DESCRIPTION
Found by the v0.3.1 release canary bootstrap (#1043): the CLI passes `--queries Q1,Q6,Q14` through verbatim, but `TPCHPowerTest` parsed the subset with a bare `int()`, so **every TPC-H subset run crashed** with `invalid literal for int() with base 10: 'Q1'` (three e2e failures: DuckDB subset, DuckDB capture-plans, SQLite smoke). The TPC-DS power test already tolerates non-numeric ids.

Fix: `_parse_tpch_query_id()` strips an optional Q/q prefix and raises a clear error for invalid ids. Verified: `benchbox run --platform duckdb --benchmark tpch --scale 0.01 --queries Q1,Q6` now exits 0 with PASSED; 10 new unit tests.

Will be cherry-picked to the v0.3.1 release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)