### PR TITLE
Fix incomplete Decision A closeout (missed content edits from #1049)

### DIFF
--- a/_project/DONE/main/branch-default-switch-to-develop.yaml
+++ b/_project/DONE/main/branch-default-switch-to-develop.yaml
@@ -2,7 +2,8 @@ id: branch-default-switch-to-develop
 title: "Make develop the GitHub default branch (Decision A of the branching-strategy review)"
 worktree: main
 priority: High
-status: "Not Started"
+status: "Completed"
+completed_date: "2026-07-08"
 category: "Release Tooling"
 
 description: |
@@ -40,15 +41,17 @@ prior_art:
 work:
   - id: w1
     summary: "ADMIN: set default_branch=develop"
-    status: pending
+    status: done
     notes: |
       `gh api -X PATCH repos/joeharris76/BenchBox -f default_branch=develop`.
       Admin-only. Reversible: re-run with default_branch=main to roll back.
       Record the dated before/after in repo-admin-settings.md.
+      DONE 2026-07-08: maintainer ran the PATCH. Verified via MCP
+      search_repositories -> default_branch="develop" (was "main").
   - id: w2
     summary: "Verify scheduled workflows now register and fire from develop"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       After the flip, confirm release-canary.yml is registered:
       `gh api repos/joeharris76/BenchBox/actions/workflows --jq '.workflows[].path'`
@@ -58,15 +61,29 @@ work:
       result is RED on 0.3.0's broken import (that is the canary working —
       see release-recovery-v0-3-1). Confirm nightly.yml still fires from the
       new default.
+      DONE 2026-07-08: Actions list-workflows API now returns 26 registered
+      workflows (was 19); Release Canary (id 309070628) is present and active,
+      as are phase3-promotion-review and orphaned-commit-detector — all
+      previously unregistered develop-only scheduled workflows. Registration
+      (the blocker) is confirmed. Immediate workflow_dispatch was NOT run to
+      avoid an unprompted CI run; the daily 08:00 UTC cron now fires on its
+      own (expected first result RED on broken 0.3.0 — cross-link into
+      release-recovery-v0-3-1 when it lands). Maintainer may dispatch for
+      instant proof if desired.
   - id: w3
     summary: "Update repo-admin-settings.md: the default-branch premise inverts"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       The 'Scheduled activation of release-canary.yml' section and any text
       asserting 'the default branch is main' become stale. Rewrite to reflect
       develop-as-default; several (a)/(b)/(c) workarounds for the canary
       become unnecessary. Record the new live state with a date.
+      DONE 2026-07-08: added a dated RESOLVED banner to the 'Scheduled
+      activation' section and corrected the 'default branch (main)' assertion
+      to note develop-as-default. Conservative edit — historical analysis and
+      still-live code-path descriptions (bootstrap, RELEASE_CANARY_REF shell,
+      liveness guard) preserved rather than rewritten.
 
 must_preserve:
   - "main stays release-only and push-restricted regardless of the default-branch setting — the default flip changes clone/PR/UI defaults and scheduled-workflow source, not the release gating."

--- a/_project/TODO/main/active/release-canary-scheduled-activation.yaml
+++ b/_project/TODO/main/active/release-canary-scheduled-activation.yaml
@@ -124,6 +124,14 @@ work:
       NOTE 2026-07-06: if branch-default-switch-to-develop lands first, this
       unit is MOOT (develop-as-default registers the canary directly). Prefer
       that path; keep this only as the fallback if Decision A is declined.
+      UPDATE 2026-07-08: Decision A LANDED (default_branch=develop; see
+      _project/DONE/main/branch-default-switch-to-develop.yaml). release-canary
+      is now registered (Actions list-workflows: 26 workflows, Release Canary
+      id 309070628) with no per-release re-landing on main. This w2 is now
+      MOOT — no admin land-on-main action is needed. Remaining to fully close
+      this TODO: confirm the first scheduled cron run (expected RED on broken
+      0.3.0) and cross-link it into release-recovery-v0-3-1, then w3 (the
+      liveness guard) which already exists in nightly.yml.
 
   - id: w3
     summary: "Add a scheduled-workflow liveness guard so this class of gap cannot recur silently"

--- a/_project/TODO/main/planning/rename-release-branch-main-to-release.yaml
+++ b/_project/TODO/main/planning/rename-release-branch-main-to-release.yaml
@@ -99,9 +99,9 @@ work:
       -release window; the release branch only receives pushes via
       release-finalize, which is maintainer-controlled, so no real CI gap).
 
-deps:
-  needs:
-    - branch-default-switch-to-develop
+# deps.needs on branch-default-switch-to-develop cleared 2026-07-08: Decision A
+# COMPLETED (see _project/DONE/main/branch-default-switch-to-develop.yaml), so the
+# sequencing prerequisite is satisfied. B remains independently schedulable.
 
 must_preserve:
   - "release.yml verify-tag-on-* gate and the tag-shaped-ref publish condition — the rename must not loosen the publish gate; only retarget main->release."

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -453,9 +453,25 @@ stale/red canary evidence instead of silently trusting comments.
 script with the identical token, so the same review-rule coverage is reachable
 from both CI call sites without a separate code path.
 
-### Scheduled activation of `release-canary.yml` (pending admin action)
+### Scheduled activation of `release-canary.yml` (RESOLVED 2026-07-08)
 
-Live state observed 2026-07-05 (release-canary-scheduled-activation TODO, w0):
+> **RESOLVED 2026-07-08 by the default-branch switch (Decision A,
+> `branch-default-switch-to-develop`).** The GitHub default branch is now
+> `develop` (`gh api repos/joeharris76/BenchBox --jq .default_branch` →
+> `develop`). GitHub runs `on.schedule` workflows from the **default** branch's
+> copy, so every develop-authored scheduled workflow now registers and fires
+> directly — the "land it on `main`" problem below no longer exists. Verified
+> 2026-07-08 via the Actions list-workflows API: `release-canary.yml`
+> (id 309070628), `phase3-promotion-review.yml`, and
+> `orphaned-commit-detector.yml` are now registered (26 workflows, up from 19).
+> Activation options (a)/(b)/(c) and the "Admin steps (w2)" below are
+> **superseded** and retained only as history. The `nightly.yml`
+> `scheduled-workflow-liveness` guard now runs from `develop` directly (no
+> "until its file lands on `main`" caveat). The canary's first scheduled run is
+> expected **RED** on the broken 0.3.0 PyPI release (see
+> `release-recovery-v0-3-1`) — that is the canary working, not a regression.
+
+Historical live state observed 2026-07-05 (release-canary-scheduled-activation TODO, w0):
 
 - `git ls-tree origin/main --name-only .github/workflows/` does **not**
   contain `release-canary.yml` — the file exists only on `develop`.
@@ -485,7 +501,9 @@ Live state observed 2026-07-05 (release-canary-scheduled-activation TODO, w0):
   `main` as-is whenever the admin does the next pass for this class of fix —
   no `main`-relative edits needed first.
 
-GitHub runs `on.schedule` workflows only from the default branch (`main`).
+GitHub runs `on.schedule` workflows only from the default branch (historically
+`main`; **now `develop` as of 2026-07-08** — see the RESOLVED note above, which
+makes the options below historical).
 Activation options considered (w1):
 
 - **(a) Admin lands the current `release-canary.yml` on `main` out-of-band**


### PR DESCRIPTION
## Description

Follow-up to **#1049**, which merged with only 1 file changed. A failed `git add` pathspec in that PR's prep meant only the `git mv` rename got committed — the actual **content edits were never staged**, so `develop` ended up with Decision A half-closed:

- `_project/DONE/main/branch-default-switch-to-develop.yaml` was archived but still read `status: "Not Started"` with pending work units;
- `repo-admin-settings.md` was missing the RESOLVED banner + corrected default-branch assertion;
- `rename-release-branch-main-to-release.yaml` still carried a `deps.needs` edge on an item that had moved to DONE (a transient **dangling reference**);
- `release-canary-scheduled-activation.yaml` was missing the "Decision A landed, w2 moot" note.

This PR applies those four content edits (cherry-picked onto latest `develop`), completing the Decision A closeout.

## What changed

- **`branch-default-switch-to-develop`** → `status: "Completed"` + `completed_date`, all three work units marked `done` with dated verification notes.
- **`repo-admin-settings.md`** → RESOLVED (2026-07-08) banner on the "Scheduled activation" section + corrected the `default branch (main)` assertion (conservative edit; history + live code-path notes preserved).
- **`rename-release-branch-main-to-release`** → cleared the `deps.needs` edge (Decision A satisfied), fixing the dangling reference.
- **`release-canary-scheduled-activation`** → dated "A landed, land-on-main step moot" note.

## Type of Change

- [x] Bug fix (incomplete prior merge)
- [x] Documentation

## Testing

- `validate_todo.py` (non-strict): all three changed items **valid**.
- `todo_cli.py check-graph`: **passed** — 113 items, **no dangling references** (repairs the transient dangling edge #1049 introduced).
- Verified content: A `status: "Completed"`, RESOLVED banner present, B `deps:` block gone.

## Artifact Hygiene

- [x] No raw screenshots, logs, benchmark outputs, or temporary binaries committed.
- [x] No binary/raw evidence files added.

## Notes

- Decision A's actual outcome (default branch flipped, canary registered) was already correct and verified in #1049's description; this only fixes the **tracking/doc records** that failed to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPPPtRSp95b8JkUJcLEUcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPPtRSp95b8JkUJcLEUcn)_