### PR TITLE
fix(datafusion): tolerate trailing-delimiter .tbl chunks (compressed/sharded)

### DIFF
--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -522,6 +522,18 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
         format_type = detect_data_format(path)
 
         if format_type == "tbl":
+            # Raw TPC .tbl/.dat rows use a field-terminating delimiter (every row
+            # ends with `|`), so DataFusion's native CSV reader sees N+1 fields and
+            # errors on the column count ("Expected N columns, got N+1"). That error
+            # is not an extension mismatch, so _read_tbl_via_datafusion would raise
+            # rather than fall back. Detect the trailing delimiter up front and route
+            # such files straight to the tolerant PyArrow path, which appends a dummy
+            # column, projects it away, and transparently decompresses .zst — so
+            # chunked/compressed names like customer.tbl.1.zst load correctly. This
+            # mirrors the pandas/polars adapters. Non-trailing files (e.g. macOS
+            # dbgen output) keep the faster native path unchanged.
+            if has_trailing_delimiter(path, delimiter, column_names):
+                return self._read_tbl_via_pyarrow(path, delimiter=delimiter, column_names=column_names)
             df = self._read_tbl_via_datafusion(
                 path,
                 delimiter=delimiter,

--- a/benchbox/platforms/dataframe/datafusion_df.py
+++ b/benchbox/platforms/dataframe/datafusion_df.py
@@ -533,7 +533,9 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             # mirrors the pandas/polars adapters. Non-trailing files (e.g. macOS
             # dbgen output) keep the faster native path unchanged.
             if has_trailing_delimiter(path, delimiter, column_names):
-                return self._read_tbl_via_pyarrow(path, delimiter=delimiter, column_names=column_names)
+                return self._read_tbl_via_pyarrow(
+                    path, delimiter=delimiter, has_header=has_header, column_names=column_names
+                )
             df = self._read_tbl_via_datafusion(
                 path,
                 delimiter=delimiter,
@@ -542,7 +544,9 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
             )
             if df is not None:
                 return df
-            return self._read_tbl_via_pyarrow(path, delimiter=delimiter, column_names=column_names)
+            return self._read_tbl_via_pyarrow(
+                path, delimiter=delimiter, has_header=has_header, column_names=column_names
+            )
 
         # Build read options
         # Note: DataFusion's read_csv API varies by version
@@ -620,6 +624,7 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
         path: Path,
         *,
         delimiter: str,
+        has_header: bool = False,
         column_names: list[str] | None,
     ) -> DataFusionLazyDF:
         """Read a TBL/DAT file via PyArrow and register in DataFusion.
@@ -643,6 +648,10 @@ class DataFusionDataFrameAdapter(ExpressionFamilyAdapter[DataFusionDF, DataFusio
 
         read_options = pv.ReadOptions(
             column_names=actual_column_names if actual_column_names else None,
+            # When explicit column_names are supplied for a header-bearing file,
+            # drop the header row so it is not registered as data (off-by-one).
+            # Mirrors DataFusionAdapter._convert_and_register_parquet.
+            skip_rows=1 if (column_names and has_header) else 0,
         )
         parse_options = pv.ParseOptions(delimiter=delimiter)
         compression = detect_compression(path)

--- a/benchbox/platforms/datafusion.py
+++ b/benchbox/platforms/datafusion.py
@@ -39,6 +39,7 @@ from benchbox.utils.clock import elapsed_seconds, mono_time
 from benchbox.utils.file_format import (
     TRAILING_DUMMY_COLUMN,
     get_column_names_with_trailing,
+    get_data_extension,
     has_trailing_delimiter,
 )
 
@@ -1406,7 +1407,12 @@ class DataFusionAdapter(NoConstraintEnforcementMixin, PlatformAdapter):
         # `has_trailing_delimiter` uses a raw split() which returns true for any
         # line whose last quoted field happens to contain the delimiter character.
         # Quoted CSVs (non-TPC sources) must use the standard quoted-parsing path.
-        _is_tpc_raw = Path(file_paths[0]).suffix.lower() in {".tbl", ".dat"}
+        # Use the base data extension, not Path.suffix: real dbgen output is
+        # compressed and/or shard-numbered (customer.tbl.zst, customer.tbl.1,
+        # customer.tbl.1.zst), whose Path.suffix is .zst/.1 — a bare Path.suffix
+        # check would wrongly treat those chunks as quoted CSV and fail on the
+        # trailing field.
+        _is_tpc_raw = get_data_extension(file_paths[0]) in {".tbl", ".dat"}
         is_trailing = (
             column_names is not None and _is_tpc_raw and has_trailing_delimiter(file_paths[0], delimiter, column_names)
         )

--- a/tests/unit/platforms/dataframe/test_datafusion_df.py
+++ b/tests/unit/platforms/dataframe/test_datafusion_df.py
@@ -278,11 +278,16 @@ class TestDataFusionDataLoading:
         assert None not in phrases
 
     def test_read_tbl_with_column_names(self, tmp_path):
-        """Test reading TPC-style .tbl with trailing delimiter."""
+        """Test reading TPC-style .tbl with a genuine trailing delimiter.
+
+        Each row ends with a trailing `|`, so it splits into 3 fields for 2
+        columns — the field-terminating framing raw dbgen emits. read_csv must
+        drop the extra field rather than surface it as a third column.
+        """
         adapter = DataFusionDataFrameAdapter()
 
         tbl_path = tmp_path / "test.tbl"
-        tbl_path.write_text("1|Alice\n2|Bob\n")
+        tbl_path.write_text("1|Alice|\n2|Bob|\n")
 
         df = adapter.read_csv(
             tbl_path,

--- a/tests/unit/platforms/test_datafusion_trailing_chunked.py
+++ b/tests/unit/platforms/test_datafusion_trailing_chunked.py
@@ -160,3 +160,30 @@ def test_dataframe_adapter_reads_trailing_delimiter_chunk(tmp_path, filename):
     assert result.num_rows == 2, f"{filename}: expected 2 rows, got {result.num_rows}"
     assert result.column_names == _CUSTOMER_COLUMNS, f"{filename}: wrong columns: {result.column_names}"
     assert TRAILING_DUMMY_COLUMN not in result.column_names, f"{filename}: dummy column leaked"
+
+
+@pytest.mark.skipif(not DATAFUSION_DF_AVAILABLE, reason="DataFusion not installed")
+def test_dataframe_header_bearing_trailing_delimiter_skips_header(tmp_path):
+    """A header-bearing trailing-pipe .tbl must not register its header row as data.
+
+    The PyArrow fallback (now the primary path for trailing files) must honor
+    has_header and skip the header row; otherwise counts are off by one.
+    """
+    data_path = tmp_path / "customer.tbl"
+    header = "|".join(_CUSTOMER_COLUMNS) + "|\n"
+    data_path.write_text(header + _TRAILING_ROWS)
+
+    adapter = DataFusionDataFrameAdapter()
+    df = adapter.read_csv(
+        data_path,
+        delimiter="|",
+        has_header=True,
+        column_names=_CUSTOMER_COLUMNS,
+    )
+    result = adapter.collect(df)
+
+    assert result.num_rows == 2, f"header row leaked into data: got {result.num_rows} rows"
+    assert result.column_names == _CUSTOMER_COLUMNS
+    # The first data row's key is 1, not the header literal "c_custkey"
+    # (had the header leaked, the column would be text-typed and start with it).
+    assert str(result.column("c_custkey").to_pylist()[0]) == "1"

--- a/tests/unit/platforms/test_datafusion_trailing_chunked.py
+++ b/tests/unit/platforms/test_datafusion_trailing_chunked.py
@@ -1,0 +1,162 @@
+"""Regression: DataFusion ingests trailing-delimiter .tbl chunks (compressed/sharded).
+
+Raw TPC-H ``.tbl`` (and TPC-DS ``.dat``) rows use a field-TERMINATING delimiter:
+a row of N values ends with a trailing ``|`` and so splits into N+1 fields. PR #810
+taught the DataFusion adapters to tolerate that by reading with a dummy column and
+projecting it away — but it gated detection on ``Path(...).suffix in {".tbl", ".dat"}``.
+That suffix is only ``.tbl``/``.dat`` for a *bare, uncompressed, single* file. Real
+dbgen output is compressed and/or shard-numbered, so the gate silently failed for:
+
+    customer.tbl.zst      -> Path.suffix == ".zst"
+    customer.tbl.1        -> Path.suffix == ".1"
+    customer.tbl.1.zst    -> Path.suffix == ".zst"
+
+and DataFusion raised ``CSV parse error: Expected 8 columns, got 9`` on those chunks
+while the bare ``customer.tbl`` loaded fine. This bit CI only on Linux, where the
+bundled dbgen emits trailing pipes (the macOS binary happens to be built with
+``-DEOL_HANDLING`` and does not), so the failure did not reproduce on macOS.
+
+The fix resolves the *base* data extension (transparent to compression and shard
+numbers) instead of ``Path.suffix``. These tests use synthetic trailing-pipe fixtures
+— independent of which platform's dbgen is bundled — so the regression reproduces on
+any host. Both the SQL (``DataFusionAdapter``) and DataFrame
+(``DataFusionDataFrameAdapter``) paths are covered across all four naming variants.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+TPC Benchmark(TM) H (TPC-H) - Copyright (C) Transaction Processing Performance Council.
+This implementation is derived from TPC-H.
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from benchbox.utils.compression import CompressionManager
+from benchbox.utils.file_format import TRAILING_DUMMY_COLUMN
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# TPC-H customer has 8 columns; the reported failure is "Expected 8 columns, got 9".
+_CUSTOMER_COLUMNS = [
+    "c_custkey",
+    "c_name",
+    "c_address",
+    "c_nationkey",
+    "c_phone",
+    "c_acctbal",
+    "c_mktsegment",
+    "c_comment",
+]
+# Two rows, each with a TRAILING pipe: 8 values -> 9 fields after split.
+_TRAILING_ROWS = (
+    "1|Customer#000000001|IVhzIApeRb|15|25-989-741-2988|711.56|BUILDING|regular accounts|\n"
+    "2|Customer#000000002|XSTf4NCwDV|13|23-768-687-3665|121.65|AUTOMOBILE|ironic requests|\n"
+)
+
+
+def _write_variant(dir_path: Path, filename: str) -> Path:
+    """Write the trailing-pipe customer rows under ``filename``, zstd-compressing .zst."""
+    path = dir_path / filename
+    if filename.endswith(".zst"):
+        compressor = CompressionManager().get_compressor("zstd")
+        with compressor.open_for_write(path, "wt") as handle:
+            handle.write(_TRAILING_ROWS)
+    else:
+        path.write_text(_TRAILING_ROWS)
+    return path
+
+
+# The four on-disk names real generation produces. Bare .tbl is the #810 control;
+# the other three are the chunked/compressed names that regressed.
+_VARIANTS = [
+    "customer.tbl",
+    "customer.tbl.zst",
+    "customer.tbl.1",
+    "customer.tbl.1.zst",
+]
+
+
+try:
+    import pyarrow as pa  # noqa: F401
+    import pyarrow.parquet as pq
+
+    _PYARROW = True
+except ImportError:  # pragma: no cover - pyarrow is a hard dependency in practice
+    _PYARROW = False
+
+try:
+    import datafusion  # noqa: F401
+
+    from benchbox.platforms.dataframe.datafusion_df import (
+        DATAFUSION_DF_AVAILABLE,
+        DataFusionDataFrameAdapter,
+    )
+except ImportError:
+    DATAFUSION_DF_AVAILABLE = False
+
+
+@pytest.mark.skipif(not _PYARROW, reason="pyarrow not installed")
+@pytest.mark.parametrize("filename", _VARIANTS)
+def test_sql_adapter_loads_trailing_delimiter_chunk(tmp_path, filename):
+    """SQL CSV->Parquet path loads trailing-pipe chunks without the dummy column leaking."""
+    from benchbox.platforms.datafusion import DataFusionAdapter
+
+    data_path = _write_variant(tmp_path, filename)
+
+    mock_benchmark = Mock()
+    mock_benchmark.__class__.__name__ = "TPCHBenchmark"
+    mock_benchmark.get_schema.return_value = {
+        "customer": {
+            "name": "customer",
+            "columns": [{"name": name, "type": "VARCHAR"} for name in _CUSTOMER_COLUMNS],
+        }
+    }
+
+    with patch("benchbox.platforms.datafusion.SessionContext"):
+        adapter = DataFusionAdapter(working_dir=str(tmp_path / "wd"), data_format="parquet")
+        with (
+            patch.object(adapter, "_get_constraint_configuration", return_value=(False, False)),
+            patch.object(adapter, "_log_constraint_configuration"),
+        ):
+            adapter.create_schema(mock_benchmark, Mock())
+
+        # Mock connection: register_parquet is a no-op capture; the real work
+        # (the pyarrow CSV read that used to raise "Expected 8 columns, got 9")
+        # happens inside _convert_and_register_parquet before registration.
+        row_count = adapter._load_table_parquet(Mock(), "customer", [data_path], tmp_path)
+
+    assert row_count == 2, f"{filename}: expected 2 rows, got {row_count}"
+
+    written = adapter.working_dir / "customer.parquet"
+    schema = pq.read_schema(written)
+    assert TRAILING_DUMMY_COLUMN not in schema.names, f"{filename}: dummy column leaked: {schema.names}"
+    assert len(schema.names) == len(_CUSTOMER_COLUMNS), f"{filename}: wrong column count: {schema.names}"
+
+
+@pytest.mark.skipif(not DATAFUSION_DF_AVAILABLE, reason="DataFusion not installed")
+@pytest.mark.parametrize("filename", _VARIANTS)
+def test_dataframe_adapter_reads_trailing_delimiter_chunk(tmp_path, filename):
+    """DataFrame read_csv loads trailing-pipe chunks with correct shape, no dummy column."""
+    data_path = _write_variant(tmp_path, filename)
+
+    adapter = DataFusionDataFrameAdapter()
+    df = adapter.read_csv(
+        data_path,
+        delimiter="|",
+        has_header=False,
+        column_names=_CUSTOMER_COLUMNS,
+    )
+    result = adapter.collect(df)
+
+    assert result.num_rows == 2, f"{filename}: expected 2 rows, got {result.num_rows}"
+    assert result.column_names == _CUSTOMER_COLUMNS, f"{filename}: wrong columns: {result.column_names}"
+    assert TRAILING_DUMMY_COLUMN not in result.column_names, f"{filename}: dummy column leaked"


### PR DESCRIPTION
## Problem

The v0.3.1 release canary bootstrap (validate-base job on ubuntu) fails `TestDataFusionE2E::test_tpch_full_execution` and `TestDataFusionDataFrameE2E::test_tpch_full_execution` with:

```
Failed to process CSV file .../customer.tbl.1.zst: CSV parse error: Expected 8 columns, got 9
```

The offending row ends with a trailing `|`. Raw TPC `.tbl`/`.dat` rows use a **field-terminating** delimiter, so a row of N values splits into N+1 fields.

## Root cause

Two layers:

1. **Generation divergence (not fixed here — see follow-up).** The bundled **Linux** `dbgen` binaries were compiled *without* `-DEOL_HANDLING` → every row carries a trailing `|`. The **macOS arm64** binary was compiled *with* it → no trailing pipe. The datagen pipeline passes raw dbgen bytes through untouched (shard via `-S/-C`, then per-chunk zstd), so the difference lands verbatim on disk. That is why the failure reproduces only on Linux CI.

2. **DataFusion intolerance (fixed here).** PR #810 taught both DataFusion adapters to tolerate the trailing delimiter (read with a dummy column, project it away). But detection was gated on `Path(...).suffix in {".tbl",".dat"}`, which is only true for a **bare, uncompressed, single** file. Real dbgen output is compressed and/or shard-numbered — `customer.tbl.zst`, `customer.tbl.1`, `customer.tbl.1.zst` — whose `Path.suffix` is `.zst`/`.1`, so the workaround was skipped and the exact-column read failed. The DataFrame adapter had the mirror bug: its native `read_csv` path only falls back to the tolerant PyArrow reader on an *extension* error, not a column-count error.

## Why fix the reader, not the generator

The trailing pipe is **legitimate, spec-standard dbgen output** — every other reader (pandas, polars, dask, cudf, DuckDB) already tolerates it, and users pointing BenchBox at externally-generated official TPC-H data will always have trailing pipes. Stripping at generation would add overhead to the perf-critical datagen path and only mask the reader's intolerance. Rebuilding the bundled binaries for cross-platform framing consistency is a separate, larger concern that should not block the release gate (tracked as a follow-up).

## Fix

- `datafusion.py`: resolve the **base** data extension via `get_data_extension()` (transparent to compression and shard numbers) instead of `Path.suffix`.
- `datafusion_df.py`: detect the trailing delimiter up front and route such files straight to the tolerant PyArrow path (matching pandas/polars). Non-trailing files keep the faster native path unchanged.

## Tests

- **New** `tests/unit/platforms/test_datafusion_trailing_chunked.py` — synthetic trailing-pipe fixtures across `.tbl` / `.tbl.zst` / `.tbl.1` / `.tbl.1.zst` for **both** SQL and DataFrame adapters. Platform-independent, so it reproduces the failure on any host (no dependence on which dbgen binary is bundled). Verified failing without the fix (exact `Expected 8 columns, got 9`) and passing with it.
- Fixed the mislabeled `test_read_tbl_with_column_names`, whose data had no trailing pipe despite its docstring — part of why this slipped past #810.
- Full DataFusion unit + #810 integration suites pass (156 unit, 2 integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)