### PR TITLE
fix(cli): key DataFrame platform options by base name so run can reach them

### DIFF
--- a/benchbox/platforms/__init__.py
+++ b/benchbox/platforms/__init__.py
@@ -601,6 +601,12 @@ try:
             *(_spec(spec[0], spec[1], **(spec[2] if len(spec) > 2 else {})) for spec in specs),
         )
 
+    # Rows are "platform|name|help|kwargs". `platform` is the BASE platform key
+    # (e.g. `datafusion`, `polars`) — NOT the `-df` CLI alias. `benchbox run`
+    # normalizes `--platform datafusion-df` to `datafusion` via PLATFORM_ALIASES
+    # before calling PlatformHookRegistry.parse_options(), and the DataFrame
+    # adapters take these as base-name constructor kwargs, so DataFrame options
+    # must be keyed by the base name to be reachable from the CLI.
     _OPTION_SPEC_ROWS = """\
 databricks|uc_catalog|Unity Catalog catalog name for staging data|{}
 databricks|uc_schema|Unity Catalog schema name for staging data|{}
@@ -765,25 +771,25 @@ singlestore|port|SingleStore MySQL protocol port|{'default': '3306'}
 singlestore|database|SingleStore database name (auto-generated if not specified)|{}
 singlestore|username|SingleStore username|{'default': 'root'}
 singlestore|password|SingleStore password|{}
-polars-df|streaming|Enable streaming mode for large datasets|{'parser': 'parse_bool', 'default': 'false'}
-polars-df|rechunk|Rechunk data for better memory layout|{'parser': 'parse_bool', 'default': 'true'}
-polars-df|n_rows|Limit number of rows to read (for testing)|{'parser': 'int'}
-pandas-df|dtype_backend|Backend for nullable dtypes|{'choices': ('numpy', 'numpy_nullable', 'pyarrow'), 'default': 'numpy_nullable'}
-modin-df|engine|Modin execution engine|{'choices': ('ray', 'dask'), 'default': 'ray'}
-cudf-df|device_id|CUDA device ID to use|{'parser': 'int', 'default': '0'}
-cudf-df|spill_to_host|Enable GPU memory spilling to host RAM|{'parser': 'parse_bool', 'default': 'true'}
-dask-df|n_workers|Number of worker processes|{'parser': 'int'}
-dask-df|threads_per_worker|Threads per worker process|{'parser': 'int'}
-dask-df|use_distributed|Use distributed scheduler (enables dashboard)|{'parser': 'parse_bool', 'default': True}
-dask-df|scheduler_address|Connect to existing scheduler (e.g., 'tcp://...')|{}
-dask-df|memory_limit|Memory limit per local Dask worker (e.g., '4GB')|{}
-dask-df|spill_directory|Directory for Dask spill files; explicit directories are not deleted by close()|{}
-datafusion-df|target_partitions|Number of target partitions for parallelism (default: CPU count)|{'parser': 'int'}
-datafusion-df|repartition_joins|Enable automatic repartitioning for joins|{'parser': 'parse_bool', 'default': 'true'}
-datafusion-df|parquet_pushdown|Enable predicate/projection pushdown for Parquet files|{'parser': 'parse_bool', 'default': 'true'}
-datafusion-df|batch_size|Batch size for query execution|{'parser': 'int', 'default': '8192'}
-datafusion-df|memory_limit|Memory limit for fair spill pool (e.g., '8G', '16GB')|{}
-datafusion-df|temp_dir|Temporary directory for disk spilling (default: system temp)|{}
+polars|streaming|Enable streaming mode for large datasets|{'parser': 'parse_bool', 'default': 'false'}
+polars|rechunk|Rechunk data for better memory layout|{'parser': 'parse_bool', 'default': 'true'}
+polars|n_rows|Limit number of rows to read (for testing)|{'parser': 'int'}
+pandas|dtype_backend|Backend for nullable dtypes|{'choices': ('numpy', 'numpy_nullable', 'pyarrow'), 'default': 'numpy_nullable'}
+modin|engine|Modin execution engine|{'choices': ('ray', 'dask'), 'default': 'ray'}
+cudf|device_id|CUDA device ID to use|{'parser': 'int', 'default': '0'}
+cudf|spill_to_host|Enable GPU memory spilling to host RAM|{'parser': 'parse_bool', 'default': 'true'}
+dask|n_workers|Number of worker processes|{'parser': 'int'}
+dask|threads_per_worker|Threads per worker process|{'parser': 'int'}
+dask|use_distributed|Use distributed scheduler (enables dashboard)|{'parser': 'parse_bool', 'default': True}
+dask|scheduler_address|Connect to existing scheduler (e.g., 'tcp://...')|{}
+dask|memory_limit|Memory limit per local Dask worker (e.g., '4GB')|{}
+dask|spill_directory|Directory for Dask spill files; explicit directories are not deleted by close()|{}
+datafusion|target_partitions|Number of target partitions for parallelism (default: CPU count)|{'parser': 'int'}
+datafusion|repartition_joins|Enable automatic repartitioning for joins|{'parser': 'parse_bool', 'default': 'true'}
+datafusion|parquet_pushdown|Enable predicate/projection pushdown for Parquet files|{'parser': 'parse_bool', 'default': 'true'}
+datafusion|batch_size|Batch size for query execution|{'parser': 'int', 'default': '8192'}
+datafusion|memory_limit|Memory limit for fair spill pool (e.g., '8G', '16GB')|{}
+datafusion|temp_dir|Temporary directory for disk spilling (default: system temp)|{}
 sqlite|database_path|Path to the SQLite database file (auto-generated from --benchmark/--scale when omitted)|{}
 sqlite|timeout|SQLite connection timeout in seconds|{'parser': 'float', 'default': '30.0'}
 sqlite|check_same_thread|Enforce that connections are used on the creating thread only|{'parser': 'parse_bool', 'default': 'false'}

--- a/tests/unit/cli/test_run_dataframe_platform_options.py
+++ b/tests/unit/cli/test_run_dataframe_platform_options.py
@@ -1,0 +1,171 @@
+"""Regression tests: DataFrame platform options are reachable from `benchbox run`.
+
+DataFrame platforms are selected on the CLI via a ``-df`` alias
+(``--platform datafusion-df``), which ``PLATFORM_ALIASES`` normalizes to the
+base platform key (``datafusion``) before any option parsing happens.  The
+option specs for those platforms must therefore be registered under the *base*
+key, not the ``-df`` alias, or every DataFrame-specific option
+(``target_partitions``, ``streaming``, ``dtype_backend``, ...) becomes
+unreachable and ``benchbox run`` rejects it as an unknown option.
+
+See benchbox/platforms/__init__.py ``_OPTION_SPEC_ROWS``.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+import sys as _sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from benchbox.cli.main import cli
+from benchbox.cli.platform import normalize_platform_name
+from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
+from benchbox.core.schemas import DatabaseConfig
+
+# See test_run_driver_version_announcement.py for why this indirection is needed
+# to patch DatabaseManager on the run submodule across Python versions.
+__import__("benchbox.cli.commands.run")
+_run_module = _sys.modules["benchbox.cli.commands.run"]
+
+# Import for its spec-registration side effects so the registry is populated
+# regardless of test collection order.
+import benchbox.cli.platform_defaults  # noqa: E402,F401
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# (CLI ``-df`` alias, one representative option, a value, its parsed form).
+_DATAFRAME_OPTION_CASES = [
+    ("datafusion-df", "target_partitions", "4", 4),
+    ("polars-df", "streaming", "true", True),
+    ("pandas-df", "dtype_backend", "pyarrow", "pyarrow"),
+    ("modin-df", "engine", "dask", "dask"),
+    ("cudf-df", "device_id", "1", 1),
+    ("dask-df", "n_workers", "8", 8),
+]
+
+
+class TestDataFrameOptionSpecKeying:
+    """Option specs live under the normalized base key, not the -df alias."""
+
+    @pytest.mark.parametrize("df_alias,option,raw,expected", _DATAFRAME_OPTION_CASES)
+    def test_option_reachable_under_normalized_key(self, df_alias, option, raw, expected):
+        base_key = normalize_platform_name(df_alias)
+        # The alias must actually normalize to a distinct base key, otherwise
+        # this regression would be vacuous.
+        assert base_key != df_alias
+
+        # Parsing with the key the run CLI actually uses must succeed...
+        parsed = PlatformHookRegistry.parse_options(base_key, [(option, raw)])
+        assert parsed[option] == expected
+
+        # ...and the spec must be registered under the base key.
+        assert option in PlatformHookRegistry.list_option_specs(base_key)
+
+    @pytest.mark.parametrize("df_alias,option,raw,expected", _DATAFRAME_OPTION_CASES)
+    def test_option_not_orphaned_under_df_alias(self, df_alias, option, raw, expected):
+        # The -df alias key must NOT carry the specs; if it did, the run CLI —
+        # which only ever sees the normalized base key — could never reach them.
+        assert option not in PlatformHookRegistry.list_option_specs(df_alias)
+
+
+def _datafusion_df_available() -> bool:
+    try:
+        from benchbox.platforms import list_available_dataframe_platforms
+
+        avail = list_available_dataframe_platforms()
+    except Exception:
+        return False
+    return bool(avail.get("datafusion-df") or avail.get("datafusion"))
+
+
+@pytest.mark.skipif(not _datafusion_df_available(), reason="DataFusion DataFrame backend not installed")
+class TestDataFrameOptionReachesConfig:
+    """`benchbox run --platform <x>-df --platform-option ...` reaches create_config."""
+
+    def _invoke_run(self, platform, option_pairs):
+        """Drive `benchbox run` through the non-interactive power path.
+
+        Managers/orchestration are mocked so no benchmark actually executes; we
+        only care that _run_direct hands the parsed platform options to
+        DatabaseManager.create_config under the normalized base platform key.
+        """
+        mock_db_manager = MagicMock()
+        mock_db_manager.create_config.return_value = DatabaseConfig(type="datafusion", name="DataFusion")
+
+        mock_result = Mock()
+        mock_result.validation_status = "PASSED"
+        mock_result.execution_id = "test-exec-id"
+
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.execute_benchmark.return_value = mock_result
+        mock_orchestrator.directory_manager.get_result_path.return_value = "/tmp/test.json"
+        mock_orchestrator.directory_manager.results_dir = "/tmp"
+
+        mock_bench_manager = MagicMock()
+        mock_bench_manager.benchmarks = {
+            "tpch": {
+                "display_name": "TPC-H",
+                "class": Mock(),
+                "description": "TPC-H",
+                "estimated_time_range": (2, 10),
+            }
+        }
+        mock_bench_manager.validate_scale_factor = Mock()
+
+        args = [
+            "run",
+            "--platform",
+            platform,
+            "--benchmark",
+            "tpch",
+            "--scale",
+            "0.01",
+            "--non-interactive",
+            "--phases",
+            "power",
+        ]
+        for name, value in option_pairs:
+            args += ["--platform-option", f"{name}={value}"]
+
+        runner = CliRunner()
+        with (
+            patch.object(_run_module, "DatabaseManager", return_value=mock_db_manager),
+            patch.object(_run_module, "BenchmarkManager", return_value=mock_bench_manager),
+            patch.object(_run_module, "BenchmarkOrchestrator", return_value=mock_orchestrator),
+            patch.object(_run_module, "SystemProfiler") as mock_profiler_cls,
+            patch("benchbox.cli.main.get_config_manager") as mock_cfg,
+            patch.object(_run_module, "_execute_orchestrated_run", return_value=mock_result),
+            patch.object(_run_module, "_export_orchestrated_result", return_value={"json": "/tmp/t.json"}),
+            patch.object(_run_module, "_render_post_run_charts"),
+            patch("benchbox.cli.preferences.save_last_run_config"),
+        ):
+            mock_profiler_cls.return_value.get_system_profile.return_value = Mock()
+            # Behave like an empty config manager: return the caller's default
+            # rather than None, so downstream config.get(key, default) lookups
+            # (e.g. compression settings) resolve to their real defaults.
+            mock_cfg.return_value.get.side_effect = lambda *a, **k: a[1] if len(a) > 1 else k.get("default")
+            result = runner.invoke(cli, args)
+        return result, mock_db_manager
+
+    def test_datafusion_df_target_partitions_reaches_create_config(self):
+        result, mock_db_manager = self._invoke_run("datafusion-df", [("target_partitions", "4")])
+
+        # The bug manifested as a non-zero exit with "Unknown platform option".
+        assert "Unknown platform option" not in result.output
+        assert result.exit_code == 0, result.output
+
+        # create_config is called with the normalized base key and the parsed
+        # option threaded into the options dict.
+        assert mock_db_manager.create_config.called
+        call = mock_db_manager.create_config.call_args
+        platform_key = call.args[0]
+        options = call.args[1]
+        assert platform_key == "datafusion"
+        assert options.get("target_partitions") == 4

--- a/tests/unit/platforms/dataframe/test_pandas_family_adapters.py
+++ b/tests/unit/platforms/dataframe/test_pandas_family_adapters.py
@@ -153,7 +153,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if MODIN_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("modin-df")
+            specs = PlatformHookRegistry.list_option_specs("modin")
             assert "engine" in specs
         else:
             # If modin not available, verify platform exists but may have no options
@@ -164,7 +164,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if MODIN_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("modin-df")
+            specs = PlatformHookRegistry.list_option_specs("modin")
             engine_spec = specs.get("engine")
             if engine_spec and hasattr(engine_spec, "choices"):
                 assert "ray" in engine_spec.choices
@@ -175,7 +175,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if CUDF_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("cudf-df")
+            specs = PlatformHookRegistry.list_option_specs("cudf")
             assert "device_id" in specs
 
     def test_cudf_df_spill_to_host_option_registered(self):
@@ -183,7 +183,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if CUDF_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("cudf-df")
+            specs = PlatformHookRegistry.list_option_specs("cudf")
             assert "spill_to_host" in specs
 
     def test_dask_df_n_workers_option_registered(self):
@@ -191,7 +191,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if DASK_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("dask-df")
+            specs = PlatformHookRegistry.list_option_specs("dask")
             assert "n_workers" in specs
 
     def test_dask_df_threads_per_worker_option_registered(self):
@@ -199,7 +199,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if DASK_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("dask-df")
+            specs = PlatformHookRegistry.list_option_specs("dask")
             assert "threads_per_worker" in specs
 
     def test_dask_df_use_distributed_option_registered(self):
@@ -207,7 +207,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if DASK_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("dask-df")
+            specs = PlatformHookRegistry.list_option_specs("dask")
             assert "use_distributed" in specs
 
     def test_dask_df_scheduler_address_option_registered(self):
@@ -215,7 +215,7 @@ class TestPandasFamilyPlatformHooks:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         if DASK_AVAILABLE:
-            specs = PlatformHookRegistry.list_option_specs("dask-df")
+            specs = PlatformHookRegistry.list_option_specs("dask")
             assert "scheduler_address" in specs
 
 

--- a/tests/unit/platforms/test_dataframe_factory.py
+++ b/tests/unit/platforms/test_dataframe_factory.py
@@ -157,7 +157,9 @@ class TestPlatformHookRegistration:
         """Test that polars-df platform options are registered."""
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
-        specs = PlatformHookRegistry.list_option_specs("polars-df")
+        # Options are keyed by the base platform name (`polars`), not the `-df`
+        # CLI alias, so they are reachable via the normalized run platform key.
+        specs = PlatformHookRegistry.list_option_specs("polars")
 
         assert "streaming" in specs
         assert "rechunk" in specs
@@ -167,7 +169,7 @@ class TestPlatformHookRegistration:
         """Test that pandas-df platform options are registered."""
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
-        specs = PlatformHookRegistry.list_option_specs("pandas-df")
+        specs = PlatformHookRegistry.list_option_specs("pandas")
 
         assert "dtype_backend" in specs
 
@@ -175,7 +177,7 @@ class TestPlatformHookRegistration:
         """Test polars-df option defaults."""
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
-        defaults = PlatformHookRegistry.get_default_options("polars-df")
+        defaults = PlatformHookRegistry.get_default_options("polars")
 
         assert defaults["streaming"] == "false"
         assert defaults["rechunk"] == "true"
@@ -185,7 +187,7 @@ class TestPlatformHookRegistration:
         """Test pandas-df option defaults."""
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
-        defaults = PlatformHookRegistry.get_default_options("pandas-df")
+        defaults = PlatformHookRegistry.get_default_options("pandas")
 
         assert defaults["dtype_backend"] == "numpy_nullable"
 
@@ -194,7 +196,7 @@ class TestPlatformHookRegistration:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         parsed = PlatformHookRegistry.parse_options(
-            "polars-df",
+            "polars",
             [("streaming", "true"), ("rechunk", "false"), ("n_rows", "1000")],
         )
 
@@ -207,7 +209,7 @@ class TestPlatformHookRegistration:
         from benchbox.cli.platform_hooks import PlatformHookRegistry
 
         parsed = PlatformHookRegistry.parse_options(
-            "pandas-df",
+            "pandas",
             [("dtype_backend", "pyarrow")],
         )
 
@@ -219,7 +221,7 @@ class TestPlatformHookRegistration:
 
         with pytest.raises(PlatformOptionError, match="Invalid value"):
             PlatformHookRegistry.parse_options(
-                "pandas-df",
+                "pandas",
                 [("dtype_backend", "invalid_backend")],
             )
 


### PR DESCRIPTION
DataFrame platform option specs (target_partitions, streaming, dtype_backend,
engine, device_id, n_workers, ...) were registered under -df-suffixed keys
(datafusion-df, polars-df, ...). But `benchbox run` normalizes the platform via
PLATFORM_ALIASES (datafusion-df -> datafusion) before calling
PlatformHookRegistry.parse_options(s.platform_key, ...), so lookups used the
base key and every DataFrame option was unreachable:

    benchbox run --platform datafusion-df --platform-option target_partitions=4
    -> "Unknown platform option 'target_partitions' for platform 'datafusion'"

Everything downstream keys off the base name (the metadata registry, the
universal driver_version specs, get_default_options/list_option_specs, and the
DataFrame adapter constructors, which take base-name kwargs), so re-key the
specs to base names to match. Pure-DataFrame platforms have no SQL adapter;
dual-mode datafusion's SQL adapter takes **config and these map to DataFusion
SessionConfig, so accepting them in SQL mode is harmless.

Regression tests cover parse_options under the normalized key for all six
DataFrame platforms and an end-to-end `benchbox run --platform datafusion-df
--platform-option target_partitions=4` reaching DatabaseManager.create_config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
