### PR TITLE
docs(todo): SCD2 audit follow-ups (portability claim, doc hygiene, validation hardening)

### DIFF
--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-doc-count-hygiene.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-doc-count-hygiene.yaml
@@ -1,0 +1,157 @@
+id: "scd2-doc-count-hygiene"
+title: "Clear stale post-SCD2 counts and em-dashes in built docs, test comments"
+worktree: "write-primitives-scd2-followup"
+priority: "Low"
+status: "Identified"
+category: "Documentation"
+description: |
+  Post-SCD2 count reconciliation (PR #916 / #923) updated the SOURCE docs to the
+  correct figures (get_all_operations = 112, merge = 23, staging = 18, raw
+  catalog = 136 = 112 baseline + 24 sketch — all verified 2026-07-08). Two
+  residues were missed:
+
+  1. Committed Sphinx BUILD ARTIFACTS under docs/_build/ still show the stale
+     "109 operations" count and are git-tracked (git ls-files docs/_build/ lists
+     them; git check-ignore reports NOT ignored):
+       - docs/_build/html/benchmarks/write-primitives.html:923,1401
+       - docs/_build/html/benchmarks/transaction-primitives.html:1276
+       - docs/_build/html/_sources/benchmarks/write-primitives.md.txt:161,623
+       - docs/_build/html/_sources/benchmarks/transaction-primitives.md.txt:525
+     So the committed/published HTML docs still read "109 operations across 6
+     categories" while the source .md reads 112.
+
+  2. A stale explanatory comment in a live test:
+       tests/integration/test_write_primitives_duckdb.py:512-513
+       "# ... DuckDB doesn't support MERGE (20 ops) ..."
+       "# Expected successes: ~50-60 operations (109 total - 20 MERGE - ...)"
+     The assertion above it (:506, len(results) == 112) is already correct; only
+     the comment is stale. Note the same test (:501) calls
+     execute_operation(op_id, conn) WITHOUT platform_key and reset()s between
+     ops (:499), so it exercises the raw un-gated path (legacy MERGE INTO ops
+     truly FAIL) and does NOT cover the shipped `--platform duckdb` SKIP path
+     (#931) nor the production no-reset cleanup path. Fixing the comment is the
+     required change; adding real coverage for the shipped paths is an optional
+     work unit below.
+
+  3. Pre-existing house-rule em/en-dash violations (PR #922 claimed "no
+     em/en-dashes"):
+       - _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:104
+       - docs/benchmarks/write-primitives.md:130
+
+work:
+  - id: w0
+    summary: >
+      DECISION GATE for docs/_build tracking. (A) Regenerate docs/_build with the
+      Sphinx build so the committed HTML matches the 112-count source. (B) Stop
+      tracking docs/_build entirely (add to .gitignore + git rm --cached) since
+      it is generated output. Recommendation: (B) if the team does not rely on
+      committed HTML; otherwise (A). This gate decides whether w1 regenerates or
+      removes.
+    status: pending
+  - id: w1
+    summary: >
+      Execute the w0 decision: either regenerate docs/_build via the project's
+      Sphinx build and commit the refreshed 112-count HTML, or untrack
+      docs/_build (.gitignore + git rm --cached -r docs/_build) so stale build
+      output stops shipping.
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: >
+      Update the stale comment at tests/integration/test_write_primitives_duckdb.py
+      :512-513 to reflect 112 ops / 23 merge and the fact that this path is
+      un-gated (no platform_key) and resets between ops.
+    status: pending
+  - id: w3
+    summary: >
+      Replace the em/en-dashes at draft:104 and docs/benchmarks/write-primitives.md
+      :130 with house-style punctuation (comma / parenthetical / restructure).
+      Coordinate with scd2-portability-claim-accuracy which also touches
+      draft:104 / docs:134 — land order should avoid a conflict.
+    status: pending
+  - id: w4
+    summary: >
+      OPTIONAL coverage improvement (defer if out of appetite): add a focused
+      DuckDB test that calls execute_operation(op_id, conn, platform_key='duckdb')
+      and asserts the three SCD2 ops return SUCCESS while legacy MERGE INTO ops
+      return status SKIPPED (validates #931), plus a no-reset sequential test
+      asserting the dimension returns to seed after basic->no_change->
+      new_keys_only (validates cleanup on the production path).
+    needs: [w2]
+    status: pending
+
+deferred:
+  - summary: "Broader audit of other benchmarks' docs/_build for stale counts"
+    reason: "Scope is SCD2 follow-up; a repo-wide build-artifact policy is a separate concern."
+
+open_questions:
+  - "Is docs/_build intended to be a committed, browsable artifact, or should it be gitignored build output? (drives w0)"
+
+must_preserve:
+  - "The already-correct 112 / 23 / 18 counts in the source docs/benchmarks/*.md and README — do not regress them."
+  - "tests/integration/test_write_primitives_duckdb.py assertion `len(results) == 112` and the MERGE-failure assertion for the un-gated path."
+
+approach: |
+  Mechanical hygiene. Do the count/build fix (w0->w1) and the comment/dash fixes
+  (w2, w3) as independent small commits. Treat w4 as optional; if the team wants
+  the shipped #931 skip path and no-reset cleanup path under test, it is a genuine
+  coverage gap the current test does not close.
+
+anti_patterns:
+  - "DO NOT hand-edit generated files under docs/_build to patch the number — regenerate or untrack (that is what w0 decides)."
+  - "DO NOT change the test's assertion counts — only the stale prose comment (unless adding the optional w4 tests)."
+
+verification:
+  - description: "No stale 109 count remains in tracked, non-generated files"
+    command: "grep -rniE \"109 operations|109 total\" docs/ tests/ benchbox/ --include=*.md --include=*.py"
+    expected_output: "no matches"
+  - description: "docs/_build either matches 112 or is untracked"
+    command: "git ls-files docs/_build/ | head -1 ; grep -rn \"109 operations\" docs/_build/ 2>/dev/null | head"
+    expected_output: "either docs/_build is no longer tracked (empty ls-files) or grep finds no '109 operations'"
+  - description: "No em/en-dash in the two flagged files"
+    command: "grep -cP \"\\x{2014}|\\x{2013}\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md"
+    expected_output: "0"
+  - description: "SCD2 DuckDB integration tests still pass"
+    command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -k scd2 -q"
+    expected_output: "all selected tests pass"
+
+scope_limit:
+  only_modify:
+    - "docs/_build/"
+    - ".gitignore"
+    - "docs/benchmarks/write-primitives.md"
+    - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+    - "tests/integration/test_write_primitives_duckdb.py"
+  do_not_modify:
+    - "benchbox/core/write_primitives/catalog/operations.yaml"
+    - "benchbox/core/write_primitives/benchmark.py"
+
+files_affected:
+  modified:
+    - "tests/integration/test_write_primitives_duckdb.py"
+    - "docs/benchmarks/write-primitives.md"
+    - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+  removed:
+    - "docs/_build/ (if w0 chooses untrack)"
+
+impact:
+  business_value: |
+    Committed docs that still say "109 operations" undercut the count
+    reconciliation that #923 was supposed to finish.
+  technical_debt: |
+    Removes the last stale-count residue and closes the gap where the DuckDB
+    integration test does not exercise the shipped skip / no-reset paths.
+
+metadata:
+  tags: ["scd2", "write-primitives", "docs", "tests", "hygiene", "counts"]
+  estimated_effort: "Small"
+  created_date: "2026-07-08"
+  last_updated: "2026-07-08T00:00:00"
+
+deps:
+  needs:
+    - "scd2-portability-claim-accuracy"
+
+success_metrics:
+  - "No tracked file reports the stale 109 count; docs/_build is consistent or untracked."
+  - "Stale test comment corrected; both flagged em/en-dashes removed."

--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-doc-count-hygiene.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-doc-count-hygiene.yaml
@@ -40,43 +40,45 @@ description: |
 
 work:
   - id: w0
-    summary: >
-      DECISION GATE for docs/_build tracking. (A) Regenerate docs/_build with the
-      Sphinx build so the committed HTML matches the 112-count source. (B) Stop
-      tracking docs/_build entirely (add to .gitignore + git rm --cached) since
-      it is generated output. Recommendation: (B) if the team does not rely on
-      committed HTML; otherwise (A). This gate decides whether w1 regenerates or
-      removes.
+    summary: "DECISION GATE: regenerate docs/_build (A) or untrack it as generated output (B)."
+    notes: >
+      (A) Regenerate docs/_build with the Sphinx build so the committed HTML
+      matches the 112-count source. (B) Stop tracking docs/_build entirely (add
+      to .gitignore + git rm --cached) since it is generated output.
+      Recommendation: (B) if the team does not rely on committed HTML;
+      otherwise (A). This gate decides whether w1 regenerates or removes.
     status: pending
   - id: w1
-    summary: >
-      Execute the w0 decision: either regenerate docs/_build via the project's
-      Sphinx build and commit the refreshed 112-count HTML, or untrack
-      docs/_build (.gitignore + git rm --cached -r docs/_build) so stale build
-      output stops shipping.
+    summary: "Execute the w0 decision: regenerate docs/_build or untrack it."
+    notes: >
+      Either regenerate docs/_build via the project's Sphinx build and commit
+      the refreshed 112-count HTML, or untrack docs/_build (.gitignore + git rm
+      --cached -r docs/_build) so stale build output stops shipping.
     needs: [w0]
     status: pending
   - id: w2
-    summary: >
-      Update the stale comment at tests/integration/test_write_primitives_duckdb.py
+    summary: "Fix the stale '109 total' comment in test_write_primitives_duckdb.py:512-513."
+    notes: >
+      Update the comment at tests/integration/test_write_primitives_duckdb.py
       :512-513 to reflect 112 ops / 23 merge and the fact that this path is
       un-gated (no platform_key) and resets between ops.
     status: pending
   - id: w3
-    summary: >
-      Replace the em/en-dashes at draft:104 and docs/benchmarks/write-primitives.md
-      :130 with house-style punctuation (comma / parenthetical / restructure).
-      Coordinate with scd2-portability-claim-accuracy which also touches
-      draft:104 / docs:134 — land order should avoid a conflict.
+    summary: "Replace the em/en-dashes at draft:104 and write-primitives.md:130."
+    notes: >
+      Replace with house-style punctuation (comma / parenthetical /
+      restructure). Coordinate with scd2-portability-claim-accuracy which also
+      touches draft:104 / docs:134 - land order should avoid a conflict.
     status: pending
   - id: w4
-    summary: >
-      OPTIONAL coverage improvement (defer if out of appetite): add a focused
-      DuckDB test that calls execute_operation(op_id, conn, platform_key='duckdb')
-      and asserts the three SCD2 ops return SUCCESS while legacy MERGE INTO ops
-      return status SKIPPED (validates #931), plus a no-reset sequential test
-      asserting the dimension returns to seed after basic->no_change->
-      new_keys_only (validates cleanup on the production path).
+    summary: "OPTIONAL: add DuckDB coverage for the #931 skip path and no-reset cleanup."
+    notes: >
+      Add a focused DuckDB test that calls execute_operation(op_id, conn,
+      platform_key='duckdb') and asserts the three SCD2 ops return SUCCESS
+      while legacy MERGE INTO ops return status SKIPPED (validates #931), plus
+      a no-reset sequential test asserting the dimension returns to seed after
+      basic->no_change->new_keys_only (validates cleanup on the production
+      path). Defer if out of appetite.
     needs: [w2]
     status: pending
 

--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-portability-claim-accuracy.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-portability-claim-accuracy.yaml
@@ -1,0 +1,176 @@
+id: "scd2-portability-claim-accuracy"
+title: "Correct the SCD2 'runs unchanged on ClickHouse' portability claim (blog + docs)"
+worktree: "write-primitives-scd2-followup"
+priority: "Medium-High"
+status: "Identified"
+category: "Documentation"
+description: |
+  Adversarial audit of the SCD Type 2 surface (PRs #916 / #922 / #931) found the
+  only material honesty defect in the PORTABILITY CLAIM, not in the SQL mechanics.
+
+  The blog draft
+  `_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md` and the
+  benchmark docs `docs/benchmarks/write-primitives.md` both assert the portable
+  SCD2 operation "runs unchanged" across a named engine set that INCLUDES
+  ClickHouse:
+    - draft:17-18  "portable SQL runs unchanged across DuckDB, PostgreSQL,
+                    Snowflake, BigQuery, and ClickHouse"
+    - draft:103-108 "no engine-specific syntax, so it runs unchanged across the
+                    engines named above (DuckDB, PostgreSQL, Snowflake, BigQuery,
+                    and ClickHouse)"
+    - draft:3 (meta_description) and draft:158 repeat the ClickHouse framing
+    - docs/benchmarks/write-primitives.md:134 "so it runs unchanged across every
+      target engine"
+
+  This is FALSE for two of the three ops. `merge_scd_type2_basic` and
+  `merge_scd_type2_no_change` open with a standard
+  `UPDATE scd2_ops_dim_customer SET is_current = false, valid_to = (SELECT MIN(...))
+  WHERE ... EXISTS(...)`. ClickHouse has NO standard UPDATE statement; row
+  mutation is `ALTER TABLE ... UPDATE` with different semantics and no
+  correlated-subquery-in-SET form. ClickHouse is a wired BenchBox platform
+  (benchbox/platforms/clickhouse/adapter.py) and there is NO UPDATE->mutation
+  rewrite anywhere in benchbox/sql_compat/ (grep for ALTER TABLE ... UPDATE /
+  mutation returns nothing). Only `merge_scd_type2_new_keys_only` (pure
+  INSERT ... SELECT) would actually run unchanged on ClickHouse.
+
+  The draft itself only ever verified DuckDB ("We can show this concretely with
+  one engine", draft:160). So the ClickHouse (and, less severely, the
+  Snowflake/BigQuery) inclusion is an unverified — and for ClickHouse incorrect —
+  claim in published/queued content whose entire thesis is portability-vs-lock-in.
+
+  Secondary, same root cause: the setup population SQL in
+  benchbox/core/write_primitives/benchmark.py:_get_population_sql /
+  _scd2_row_hash_expr uses `||` string concat, `CAST(... AS VARCHAR)`, boolean
+  and DATE literals, executed un-rewritten via connection.execute(); it is also
+  non-portable to ClickHouse. The "portable" claim only ever concerned the
+  operation SQL, so this is a note to keep the corrected wording honest about
+  SETUP portability too, not a separate defect.
+
+  Fix is a documentation/wording change (default), OR — only if the team wants
+  ClickHouse to genuinely execute the ops — a sql_compat UPDATE->mutation rewrite
+  (much larger; out of scope here, capture as its own TODO). See the decision gate.
+
+context_sections:
+  "Audit evidence (verified 2026-07-08)":
+    |
+    - Ran all three ops on real dbgen TPC-H via DuckDB: all SUCCESS, all
+      validations pass. Mechanics are sound; this TODO is wording-only.
+    - Confirmed ClickHouse is a registered platform:
+      `grep -ril clickhouse benchbox/platforms/` -> clickhouse/adapter.py et al.
+    - Confirmed NO UPDATE->mutation rewrite in sql_compat:
+      `grep -rniE "ALTER TABLE.*UPDATE|mutation" benchbox/sql_compat/` -> empty.
+    - Footnotes [^cdc] and [^blog] resolve and quote verbatim-accurately; the
+      Databricks-side facts are NOT in scope for change.
+
+work:
+  - id: w0
+    summary: >
+      DECISION GATE: choose the remediation path. (A) Wording-only — remove
+      ClickHouse from the 'runs unchanged' set and either drop or qualify
+      Snowflake/BigQuery to 'standard-DML engines', keeping the DuckDB proof.
+      (B) Wording + scope note — additionally state that only the insert-only
+      path (new_keys_only) is engine-agnostic and the UPDATE-based ops need
+      standard DML. (C) Engineering — add a sql_compat UPDATE->ALTER TABLE
+      UPDATE rewrite so the claim becomes true (defer to a separate code TODO;
+      do NOT do it here). Recommendation: (A) with a one-line (B) caveat.
+    status: pending
+  - id: w1
+    summary: >
+      Apply the chosen wording to the blog draft
+      _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:
+      meta_description (:3), TL;DR (:17-18), body (:103-108), and the lock-in
+      section (:158) so ClickHouse is no longer claimed to run the UPDATE-based
+      ops unchanged. Preserve the honest 'verified on DuckDB only' framing.
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: >
+      Apply the same correction to docs/benchmarks/write-primitives.md:134
+      ('runs unchanged across every target engine') — qualify to standard-DML
+      engines and note ClickHouse/DataFusion exceptions, consistent with the
+      existing DataFusion caveat already in the draft.
+    needs: [w0]
+    status: pending
+  - id: w3
+    summary: >
+      Add a one-sentence honesty note (draft + docs) that the harness SETUP
+      population SQL (|| concat, CAST AS VARCHAR, boolean/DATE literals) is also
+      standard-SQL, not ClickHouse-portable, so the portability statement is
+      scoped to standard-DML engines end to end.
+    needs: [w1, w2]
+    status: pending
+  - id: w4
+    summary: >
+      Re-run the two source footnote fetches to confirm they still resolve and
+      the corrected paragraph does not disturb any cited quote; strip any
+      em/en-dash introduced by the edit (see sibling TODO scd2-doc-count-hygiene
+      for the pre-existing dash at draft:104 / docs:130).
+    needs: [w3]
+    status: pending
+
+open_questions:
+  - "Do we want ClickHouse to actually execute write_primitives SCD2 (option C, separate code TODO), or is standard-DML-only portability the honest and sufficient claim?"
+  - "Should Snowflake/BigQuery be asserted at all without an execution proof, or softened to 'standard-DML engines' pending a live run?"
+
+must_preserve:
+  - "The DuckDB-only verification framing and the 'we ran no AUTO CDC pipeline / claim no declarative timing' honesty statements in the draft."
+  - "All Databricks-side footnoted facts and their verbatim quotes ([^cdc], [^blog], [^merge], etc.) — these were audited as accurate and must not be reworded."
+  - "The BenchBox measurement tables (SF0.01 / SF0.1) and the scale-independence observation — verified and out of scope."
+
+approach: |
+  This is a wording correction, not a code change. Start from the decision gate
+  (w0). The cleanest fix mirrors how the draft already handles DataFusion: name
+  the exception explicitly rather than deleting the portability argument. Keep
+  the 'portable standard SQL / runs on standard-DML engines, proven on DuckDB'
+  spine; remove ClickHouse from the unqualified 'runs unchanged' set because its
+  lack of standard UPDATE makes the basic/no_change ops non-portable there.
+
+anti_patterns:
+  - "DO NOT silently delete the whole portability section — the portability-vs-lock-in thesis is the point; correct the engine set instead."
+  - "DO NOT edit the Databricks footnote quotes to 'balance' the change — they were verified verbatim and are not the defect."
+  - "DO NOT implement a ClickHouse UPDATE->mutation rewrite inside this TODO — that is option C and belongs in a separate code TODO with its own tests."
+
+verification:
+  - description: "No remaining unqualified 'unchanged ... ClickHouse' claim in blog or docs"
+    command: "grep -rniE \"unchanged.*clickhouse|clickhouse.*unchanged|every target engine\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md"
+    expected_output: "no matches, or only matches inside an explicit exception/caveat sentence"
+  - description: "No em/en-dash introduced by the edit"
+    command: "grep -cP \"\\x{2014}|\\x{2013}\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md"
+    expected_output: "0 for lines this TODO touched (pre-existing dashes handled in scd2-doc-count-hygiene)"
+
+scope_limit:
+  only_modify:
+    - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+    - "_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md"
+    - "docs/benchmarks/write-primitives.md"
+  do_not_modify:
+    - "benchbox/core/write_primitives/"
+    - "benchbox/sql_compat/"
+    - "_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md"
+
+files_affected:
+  modified:
+    - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+    - "docs/benchmarks/write-primitives.md"
+
+impact:
+  business_value: |
+    The blog's credibility rests on evidence discipline; a demonstrably wrong
+    portability claim (ClickHouse cannot run standard UPDATE) in a lock-in
+    argument is the kind of error a Databricks-friendly reader will seize on.
+  user_impact: |
+    A reader who copies the "portable" op to ClickHouse per the promise hits a
+    syntax error on the UPDATE. Correcting the claim prevents that.
+  technical_debt: |
+    Keeps published portability statements bound to what BenchBox actually
+    verified (DuckDB) rather than an aspirational engine list.
+
+metadata:
+  tags: ["scd2", "write-primitives", "blog", "docs", "portability", "honesty"]
+  estimated_effort: "Small"
+  created_date: "2026-07-08"
+  last_updated: "2026-07-08T00:00:00"
+
+success_metrics:
+  - "Blog + docs no longer assert the UPDATE-based SCD2 ops run unchanged on ClickHouse."
+  - "Portability claim scoped to standard-DML engines with DuckDB as the proven case; DataFusion/ClickHouse exceptions named."

--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-portability-claim-accuracy.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-portability-claim-accuracy.yaml
@@ -64,43 +64,46 @@ context_sections:
 
 work:
   - id: w0
-    summary: >
-      DECISION GATE: choose the remediation path. (A) Wording-only — remove
-      ClickHouse from the 'runs unchanged' set and either drop or qualify
-      Snowflake/BigQuery to 'standard-DML engines', keeping the DuckDB proof.
-      (B) Wording + scope note — additionally state that only the insert-only
-      path (new_keys_only) is engine-agnostic and the UPDATE-based ops need
-      standard DML. (C) Engineering — add a sql_compat UPDATE->ALTER TABLE
-      UPDATE rewrite so the claim becomes true (defer to a separate code TODO;
-      do NOT do it here). Recommendation: (A) with a one-line (B) caveat.
+    summary: "DECISION GATE: choose the remediation path (wording-only vs wording+scope vs engineering)."
+    notes: >
+      (A) Wording-only - remove ClickHouse from the 'runs unchanged' set and
+      either drop or qualify Snowflake/BigQuery to 'standard-DML engines',
+      keeping the DuckDB proof. (B) Wording + scope note - additionally state
+      that only the insert-only path (new_keys_only) is engine-agnostic and
+      the UPDATE-based ops need standard DML. (C) Engineering - add a
+      sql_compat UPDATE->ALTER TABLE UPDATE rewrite so the claim becomes true
+      (defer to a separate code TODO; do NOT do it here). Recommendation: (A)
+      with a one-line (B) caveat.
     status: pending
   - id: w1
-    summary: >
-      Apply the chosen wording to the blog draft
-      _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:
+    summary: "Apply the chosen wording to the blog draft so ClickHouse isn't claimed unchanged."
+    notes: >
+      Apply to _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:
       meta_description (:3), TL;DR (:17-18), body (:103-108), and the lock-in
       section (:158) so ClickHouse is no longer claimed to run the UPDATE-based
       ops unchanged. Preserve the honest 'verified on DuckDB only' framing.
     needs: [w0]
     status: pending
   - id: w2
-    summary: >
-      Apply the same correction to docs/benchmarks/write-primitives.md:134
-      ('runs unchanged across every target engine') — qualify to standard-DML
-      engines and note ClickHouse/DataFusion exceptions, consistent with the
-      existing DataFusion caveat already in the draft.
+    summary: "Apply the same correction to docs/benchmarks/write-primitives.md:134."
+    notes: >
+      Correct 'runs unchanged across every target engine' - qualify to
+      standard-DML engines and note ClickHouse/DataFusion exceptions,
+      consistent with the existing DataFusion caveat already in the draft.
     needs: [w0]
     status: pending
   - id: w3
-    summary: >
+    summary: "Add an honesty note that the harness SETUP SQL is also not ClickHouse-portable."
+    notes: >
       Add a one-sentence honesty note (draft + docs) that the harness SETUP
-      population SQL (|| concat, CAST AS VARCHAR, boolean/DATE literals) is also
-      standard-SQL, not ClickHouse-portable, so the portability statement is
-      scoped to standard-DML engines end to end.
+      population SQL (|| concat, CAST AS VARCHAR, boolean/DATE literals) is
+      also standard-SQL, not ClickHouse-portable, so the portability statement
+      is scoped to standard-DML engines end to end.
     needs: [w1, w2]
     status: pending
   - id: w4
-    summary: >
+    summary: "Re-verify footnotes still resolve and strip any em/en-dash introduced by the edit."
+    notes: >
       Re-run the two source footnote fetches to confirm they still resolve and
       the corrected paragraph does not disturb any cited quote; strip any
       em/en-dash introduced by the edit (see sibling TODO scd2-doc-count-hygiene
@@ -131,9 +134,9 @@ anti_patterns:
   - "DO NOT implement a ClickHouse UPDATE->mutation rewrite inside this TODO — that is option C and belongs in a separate code TODO with its own tests."
 
 verification:
-  - description: "No remaining unqualified 'unchanged ... ClickHouse' claim in blog or docs"
-    command: "grep -rniE \"unchanged.*clickhouse|clickhouse.*unchanged|every target engine\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md"
-    expected_output: "no matches, or only matches inside an explicit exception/caveat sentence"
+  - description: "No remaining unqualified 'unchanged ... ClickHouse' claim in blog, outline, or docs"
+    command: "for f in _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md _blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md; do tr '\\n' ' ' < \"$f\" | grep -oiE 'unchanged[^.]*clickhouse|clickhouse[^.]*unchanged|every target engine'; done"
+    expected_output: "no matches, or only matches inside an explicit exception/caveat sentence (tr collapses wrapped lines to one line per file so a claim spanning a line break, e.g. draft:17-18 or :103-104, is still caught; the outline file - in scope_limit.only_modify but previously missing from this check - is now included)"
   - description: "No em/en-dash introduced by the edit"
     command: "grep -cP \"\\x{2014}|\\x{2013}\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md docs/benchmarks/write-primitives.md"
     expected_output: "0 for lines this TODO touched (pre-existing dashes handled in scd2-doc-count-hygiene)"

--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-validation-soundness-hardening.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-validation-soundness-hardening.yaml
@@ -38,39 +38,42 @@ description: |
 
 work:
   - id: w0
-    summary: >
-      DECISION GATE / bug check: confirm both items are non-shipping (they are on
-      current evidence). Re-run the zero-current probe — delete the INSERT half of
+    summary: "DECISION GATE / bug check: confirm both items are non-shipping (hardening-only)."
+    notes: >
+      Re-run the zero-current probe - delete the INSERT half of
       merge_scd_type2_basic in a scratch harness and confirm the op is still
-      failed by the companion positive check (not by one_current_per_business_key).
-      If ANY op lacks a positive backstop for its keys, escalate that op to a
-      real defect and fix the validation. Otherwise proceed as hardening-only.
+      failed by the companion positive check (not by
+      one_current_per_business_key). If ANY op lacks a positive backstop for
+      its keys, escalate that op to a real defect and fix the validation.
+      Otherwise proceed as hardening-only.
     status: pending
   - id: w1
-    summary: >
-      Rename/annotate the invariant honestly: either rename the validation id to
-      at_most_one_current_per_business_key across all three ops in
-      operations.yaml, OR (preferred) strengthen it to also flag zero-current
-      business keys that have a current staged version, so the name holds. Keep
-      expected_rows: 0 semantics. Regenerate any registry-derived count/doc that
-      references validation ids.
+    summary: "Rename or strengthen the one_current_per_business_key invariant so its name holds."
+    notes: >
+      Either rename the validation id to at_most_one_current_per_business_key
+      across all three ops in operations.yaml, OR (preferred) strengthen it to
+      also flag zero-current business keys that have a current staged
+      version. Keep expected_rows: 0 semantics. Regenerate any registry-derived
+      count/doc that references validation ids.
     needs: [w0]
     status: pending
   - id: w2
-    summary: >
-      Add a short code comment at _scd2_row_hash_expr documenting the same-engine
-      comparison guarantee and the '|' delimiter / arbitrary-data assumption, so
-      a future reuse of this fingerprint over non-TPC-H data does not silently
-      inherit a collision risk. Optionally switch the literal '|' to a
-      lower-collision separator or length-prefacing if the team wants defense in
-      depth (guard behind w0 confirming no behavior change on TPC-H).
+    summary: "Document the row_hash same-engine/'|'-delimiter assumption at _scd2_row_hash_expr."
+    notes: >
+      Add a short code comment documenting the same-engine comparison
+      guarantee and the '|' delimiter / arbitrary-data assumption, so a future
+      reuse of this fingerprint over non-TPC-H data does not silently inherit
+      a collision risk. Optionally switch the literal '|' to a lower-collision
+      separator or length-prefacing if the team wants defense in depth (guard
+      behind w0 confirming no behavior change on TPC-H).
     status: pending
   - id: w3
-    summary: >
-      If w1 changed any validation SQL, re-run the SCD2 unit + DuckDB integration
-      tests and confirm all three ops still validate green on real dbgen TPC-H;
-      add/adjust a unit assertion that the strengthened invariant flags a
-      synthetic zero-current row.
+    summary: "Re-run SCD2 tests if w1 changed validation SQL; add a synthetic zero-current assertion."
+    notes: >
+      If w1 changed any validation SQL, re-run the SCD2 unit + DuckDB
+      integration tests and confirm all three ops still validate green on
+      real dbgen TPC-H; add/adjust a unit assertion that the strengthened
+      invariant flags a synthetic zero-current row.
     needs: [w1, w2]
     status: pending
 

--- a/_project/TODO/write-primitives-scd2-followup/planning/scd2-validation-soundness-hardening.yaml
+++ b/_project/TODO/write-primitives-scd2-followup/planning/scd2-validation-soundness-hardening.yaml
@@ -1,0 +1,141 @@
+id: "scd2-validation-soundness-hardening"
+title: "Harden SCD2 validation naming and document row_hash fingerprint limits"
+worktree: "write-primitives-scd2-followup"
+priority: "Low"
+status: "Identified"
+category: "Testing and Quality Assurance"
+description: |
+  Two latent (non-shipping-defect) soundness observations from the SCD2 audit.
+  Both are currently SAFE on the actual benchmark data; this TODO is about making
+  the safety explicit and robust, not fixing a live bug. A real bug gate is in w0.
+
+  OBSERVATION 1 — misnamed / weak invariant.
+  Every SCD2 op includes a validation `one_current_per_business_key`:
+    SELECT c_custkey FROM scd2_ops_dim_customer WHERE is_current = true
+    GROUP BY c_custkey HAVING COUNT(*) <> 1      (expected_rows: 0)
+  This catches DUPLICATE current versions (COUNT > 1) but a business key with
+  ZERO current rows produces no group row and is silently NOT flagged. So the
+  check does not enforce the "exactly one current per key" invariant its name
+  implies; it only enforces "at most one". In each op this is backstopped by a
+  companion positive-existence check
+  (every_changed_key_has_current_staged_version / every_new_key_present_as_current),
+  so a missing-current regression IS caught today. The gap is that the named
+  invariant is weaker than it reads, which is a trap for future edits that lean
+  on it alone.
+
+  OBSERVATION 2 — row_hash fingerprint robustness.
+  benchbox/core/write_primitives/benchmark.py:_scd2_row_hash_expr builds
+    c_name || '|' || c_address || '|' || CAST(acctbal AS VARCHAR) || '|' || c_mktsegment
+  Verified SAFE for TPC-H: SF0.01 customer has 0 pipe chars in name/address/
+  mktsegment and clean decimal acctbal formatting (e.g. '711.56'), and the
+  fingerprint is only ever compared same-engine (dim and stage row_hash computed
+  in the same setup), so CAST-formatting drift across engines cannot cause a
+  false match/miss within a run. The latent risk is a literal '|' delimiter
+  inside an attribute (delimiter injection) or reuse of this fingerprint over
+  arbitrary non-TPC-H data, either of which could make a CHANGED row look
+  unchanged or vice versa. No shipped defect; document the assumption and
+  optionally use a collision-resistant delimiter/encoding.
+
+work:
+  - id: w0
+    summary: >
+      DECISION GATE / bug check: confirm both items are non-shipping (they are on
+      current evidence). Re-run the zero-current probe — delete the INSERT half of
+      merge_scd_type2_basic in a scratch harness and confirm the op is still
+      failed by the companion positive check (not by one_current_per_business_key).
+      If ANY op lacks a positive backstop for its keys, escalate that op to a
+      real defect and fix the validation. Otherwise proceed as hardening-only.
+    status: pending
+  - id: w1
+    summary: >
+      Rename/annotate the invariant honestly: either rename the validation id to
+      at_most_one_current_per_business_key across all three ops in
+      operations.yaml, OR (preferred) strengthen it to also flag zero-current
+      business keys that have a current staged version, so the name holds. Keep
+      expected_rows: 0 semantics. Regenerate any registry-derived count/doc that
+      references validation ids.
+    needs: [w0]
+    status: pending
+  - id: w2
+    summary: >
+      Add a short code comment at _scd2_row_hash_expr documenting the same-engine
+      comparison guarantee and the '|' delimiter / arbitrary-data assumption, so
+      a future reuse of this fingerprint over non-TPC-H data does not silently
+      inherit a collision risk. Optionally switch the literal '|' to a
+      lower-collision separator or length-prefacing if the team wants defense in
+      depth (guard behind w0 confirming no behavior change on TPC-H).
+    status: pending
+  - id: w3
+    summary: >
+      If w1 changed any validation SQL, re-run the SCD2 unit + DuckDB integration
+      tests and confirm all three ops still validate green on real dbgen TPC-H;
+      add/adjust a unit assertion that the strengthened invariant flags a
+      synthetic zero-current row.
+    needs: [w1, w2]
+    status: pending
+
+deferred:
+  - summary: "Generalize row_hash to a real hash function (md5/sha) per engine"
+    reason: "Portability of hash functions across engines is itself non-trivial; the delimiter concat was a deliberate portable choice. Only revisit if the fingerprint is reused outside TPC-H."
+
+open_questions:
+  - "Rename vs strengthen the one_current_per_business_key check — is the extra zero-current predicate worth the added query cost in the benchmark hot path?"
+  - "Is row_hash ever intended to run over user-supplied dimension data (where '|' could appear), or is it forever TPC-H-scoped?"
+
+must_preserve:
+  - "All three SCD2 ops must continue to validate green on real dbgen TPC-H at SF0.01/SF0.1 with identical SCD2 history semantics."
+  - "The portable, single-engine-friendly nature of the fingerprint (no engine-specific hash function) — see the sibling portability TODO."
+  - "expected_rows: 0 offending-row validation style (the harness checks row count only)."
+
+approach: |
+  Hardening, not a fix. Start at w0 to confirm no op is actually unprotected. If
+  confirmed safe, the changes are a validation rename/strengthen plus a code
+  comment. Keep the benchmark hot path cheap — do not add expensive validation
+  that would distort the measured write times the blog reports.
+
+anti_patterns:
+  - "DO NOT swap the portable '|' concat for an engine-specific hash() — that reintroduces the portability problem the design avoided."
+  - "DO NOT add heavy validation SQL to the measured operation path — validations run inside the timed op cycle context; keep them O(scan) like the existing ones."
+  - "DO NOT treat this as a blocker — verified non-shipping on current data."
+
+verification:
+  - description: "All SCD2 ops still green on real TPC-H via DuckDB"
+    command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py tests/integration/test_write_primitives_duckdb.py -k scd2 -q"
+    expected_output: "all selected tests pass"
+  - description: "Strengthened/renamed invariant is consistent across all three ops"
+    command: "grep -oE \"(one|at_most_one)_current_per_business_key\" benchbox/core/write_primitives/catalog/operations.yaml | sort | uniq -c"
+    expected_output: "the chosen id appears for all three SCD2 ops, none of the old id"
+  - description: "row_hash assumption documented"
+    command: "grep -n \"delimiter\\|same-engine\\|collision\" benchbox/core/write_primitives/benchmark.py"
+    expected_output: "comment present at _scd2_row_hash_expr"
+
+scope_limit:
+  only_modify:
+    - "benchbox/core/write_primitives/catalog/operations.yaml"
+    - "benchbox/core/write_primitives/benchmark.py"
+    - "tests/unit/benchmarks/test_write_primitives_core.py"
+  do_not_modify:
+    - "benchbox/core/write_primitives/schema_specs.yaml"
+    - "benchbox/sql_compat/"
+
+files_affected:
+  modified:
+    - "benchbox/core/write_primitives/catalog/operations.yaml"
+    - "benchbox/core/write_primitives/benchmark.py"
+    - "tests/unit/benchmarks/test_write_primitives_core.py"
+
+impact:
+  technical_debt: |
+    Aligns a validation's name with what it actually enforces and records the
+    fingerprint's safety assumptions, preventing a future edit from leaning on a
+    weaker-than-named invariant or reusing the delimiter concat unsafely.
+
+metadata:
+  tags: ["scd2", "write-primitives", "validation", "row-hash", "hardening"]
+  estimated_effort: "Small"
+  created_date: "2026-07-08"
+  last_updated: "2026-07-08T00:00:00"
+
+success_metrics:
+  - "one_current_per_business_key either renamed to its true meaning or strengthened to enforce exactly-one."
+  - "row_hash same-engine + delimiter assumptions documented in code; no behavior change on TPC-H."


### PR DESCRIPTION
## Summary

Adversarial audit of the merged **SCD Type 2** surface (PRs #916 / #922 / #931). This PR lands **planning TODOs only** — no changes to the SCD2 code, docs, or blog (findings, not fixes, per the review protocol). The user asked to capture the audit findings as standard TODOs.

**Audit bottom line:** the SCD2 *mechanics are sound*. All three ops (`merge_scd_type2_basic` / `_no_change` / `_new_keys_only`) execute and validate green on real `dbgen` TPC-H via DuckDB; `cleanup_sql` restores the dimension to seed on the no-reset production path (`run_benchmark` does not reset between ops); surrogate keys stay unique even under pathological double-apply; the #931 DuckDB `MERGE INTO` token gate is exact-match clean (21/21, no whitespace variants, no misfiring overrides); and the Postgres filter is already operation-scoped (does **not** repeat the over-broad merge skip #931 fixed). Footnotes resolve verbatim-accurately.

The genuine defects are documentation/hygiene, captured as three TODOs:

| TODO | Priority | What |
|---|---|---|
| `scd2-portability-claim-accuracy` | Medium-High | Blog + docs claim the ops "run unchanged" on **ClickHouse**, but `basic`/`no_change` use standard `UPDATE` — ClickHouse has none (needs `ALTER TABLE ... UPDATE`), and there is no rewrite in `sql_compat`. Verified only on DuckDB. Only `new_keys_only` (pure INSERT) is truly engine-agnostic. |
| `scd2-doc-count-hygiene` | Low | Committed `docs/_build/**` still shows stale "109 operations"; stale count comment + non-representative path in `test_write_primitives_duckdb.py`; two pre-existing em-dashes despite the "no em/en-dashes" house rule. |
| `scd2-validation-soundness-hardening` | Low | `one_current_per_business_key` catches duplicates but not zero-current keys (backstopped today); `row_hash` `\|`-delimiter/`CAST(... AS VARCHAR)` fingerprint is TPC-H-safe (0 pipe chars at SF0.01) but not injection-safe. |

Each TODO carries decision gates (`w0`), re-runnable `verification` commands, `must_preserve`/`anti_patterns` guardrails, and `scope_limit`. `scd2-doc-count-hygiene` declares a `deps.needs` on `scd2-portability-claim-accuracy` (both touch the same draft/docs region).

## What this PR does NOT do
- Does not modify SCD2 code, catalog, blog, or docs (that is the TODOs' job when scheduled).
- `_project/TODO/_indexes/` is gitignored/generated and not included; regenerate with the project index tool.

## Test plan
- `python -c "import yaml"` parse + work-edge integrity check on all three files: pass.
- All referenced file paths verified to exist on the `develop` base.
- pre-commit (codespell, yaml, whitespace, etc.): pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)