### PR TITLE
fix(tpch): standardize dbgen row framing on -DEOL_HANDLING across platforms

### DIFF
--- a/_sources/compilation/scripts/compile-all-platforms.sh
+++ b/_sources/compilation/scripts/compile-all-platforms.sh
@@ -35,6 +35,22 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
+# Resolve a Docker-compatible container engine for the Linux/Windows builds.
+# `mocker` (Apple Containerization, macOS) and `docker` (Linux CI) share a
+# CLI, so the same `build`/`run -v` invocations work with either. Preference
+# order puts `mocker` first because CI Linux runners ship `docker` but not
+# `mocker`, so this resolves correctly in both environments; override with
+# BENCHBOX_CONTAINER_ENGINE when needed.
+CONTAINER_ENGINE="${BENCHBOX_CONTAINER_ENGINE:-}"
+if [ -z "$CONTAINER_ENGINE" ]; then
+    for _engine in mocker docker podman; do
+        if command -v "$_engine" >/dev/null 2>&1; then
+            CONTAINER_ENGINE="$_engine"
+            break
+        fi
+    done
+fi
+
 # Platform configurations for all supported targets
 PLATFORMS=(
     "darwin:arm64:native"
@@ -56,7 +72,9 @@ compile_tpch_macos_native() {
     mkdir -p "$temp_build"
     cp -r "$PROJECT_ROOT/_sources/tpc-h/dbgen"/* "$temp_build/"
 
-    # Build using native macOS clang
+    # Build using native macOS clang.
+    # EOL_HANDLING (no trailing field separator) comes from makefile.suite's
+    # default CFLAGS -- BenchBox's canonical framing convention.
     cd "$temp_build"
     make -f makefile.suite clean || true
     make -f makefile.suite CC=clang MACHINE=LINUX DATABASE=ORACLE WORKLOAD=TPCH
@@ -191,7 +209,7 @@ compile_tpch_macos_cross() {
         MACHINE=LINUX \
         DATABASE=ORACLE \
         WORKLOAD=TPCH \
-        CFLAGS="-g -DDBNAME=\\\"dss\\\" -DLINUX -DORACLE -DTPCH -DRNG_TEST -D_FILE_OFFSET_BITS=64" \
+        CFLAGS="-g -DDBNAME=\\\"dss\\\" -DLINUX -DORACLE -DTPCH -DRNG_TEST -D_FILE_OFFSET_BITS=64 -DEOL_HANDLING" \
         LDFLAGS="$cross_flags -O" \
         || {
             log_error "TPC-H cross-compilation failed for macOS ${target_arch}"
@@ -291,14 +309,14 @@ compile_with_docker() {
     local benchmark=$3  # tpc-h or tpc-ds
 
     local benchmark_upper=$(echo "$benchmark" | tr '[:lower:]' '[:upper:]')
-    log_info "Compiling ${benchmark_upper} for ${platform}-${arch} using Docker..."
+    log_info "Compiling ${benchmark_upper} for ${platform}-${arch} using ${CONTAINER_ENGINE}..."
 
     local platform_dir="$PROJECT_ROOT/_binaries/${benchmark}/${platform}-${arch}"
     local docker_platform="linux/${arch}"
 
-    # Build Docker image
+    # Build the container image
     local image_name="benchbox/${benchmark}-${platform}-${arch}"
-    docker build -f "$PROJECT_ROOT/_sources/compilation/docker/Dockerfile.${platform}-${arch}" \
+    "$CONTAINER_ENGINE" build -f "$PROJECT_ROOT/_sources/compilation/docker/Dockerfile.${platform}-${arch}" \
                  -t "$image_name" \
                  "$PROJECT_ROOT/_sources/compilation/docker/"
 
@@ -318,7 +336,7 @@ compile_tpch_docker() {
     local image_name=$3
     local platform_dir=$4
 
-    docker run --rm \
+    "$CONTAINER_ENGINE" run --rm \
         -v "$PROJECT_ROOT/_sources/tpc-h/dbgen:/build/source" \
         -v "$platform_dir:/build/output" \
         "$image_name" \
@@ -326,6 +344,10 @@ compile_tpch_docker() {
             cd /build/source
             make -f makefile.suite clean || true
 
+            # Framing note: these builds do NOT override CFLAGS, so they inherit
+            # makefile.suite's default -DEOL_HANDLING (no trailing field
+            # separator) -- BenchBox's canonical convention. Keep it that way so
+            # Linux/Windows .tbl framing matches macOS.
             # Set compilation parameters based on platform
             if [ '$platform' = 'windows' ]; then
                 # Fix MinGW integer literal compatibility in config.h
@@ -355,7 +377,7 @@ compile_tpcds_docker() {
     local image_name=$3
     local platform_dir=$4
 
-    docker run --rm \
+    "$CONTAINER_ENGINE" run --rm \
         -v "$PROJECT_ROOT/_sources/tpc-ds/tools:/build/source" \
         -v "$PROJECT_ROOT/_sources/tpc-ds/query_templates:/build/query_templates" \
         -v "$platform_dir:/build/output" \
@@ -588,12 +610,14 @@ main() {
     # Change to project root
     cd "$PROJECT_ROOT"
 
-    # Check Docker availability for Docker-based platforms
-    if ! command -v docker &> /dev/null; then
-        log_error "Docker is not installed or not available"
-        log_info "Tip: run with --native to compile for the current platform only (no Docker needed)"
+    # Check container-engine availability for the Linux/Windows builds.
+    if [ -z "$CONTAINER_ENGINE" ]; then
+        log_error "No container engine found (looked for: mocker, docker, podman)"
+        log_info "Install one, set BENCHBOX_CONTAINER_ENGINE=<engine>, or run with"
+        log_info "--native to compile for the current platform only (no engine needed)"
         exit 1
     fi
+    log_info "Using container engine: ${CONTAINER_ENGINE}"
 
     compile_all_platforms
     verify_all_binaries

--- a/_sources/tpc-h/PATCHES.md
+++ b/_sources/tpc-h/PATCHES.md
@@ -130,6 +130,65 @@ diff /tmp/stdout.tbl customer.tbl
 
 ---
 
+## Patch: EOL_HANDLING default (consistent row framing across platforms)
+
+**Date Applied:** 2026-07-08
+**Reference:** BenchBox `fix/tpch-dbgen-eol-consistency`; upstream `config.h`
+documents `EOL_HANDLING -- flat files don't need final column separator`.
+
+### Problem
+
+Upstream `makefile.suite` does **not** define `EOL_HANDLING`, so `dbgen`
+emits a trailing field separator (`|`) at the end of every row (see the
+`#ifdef EOL_HANDLING` guard in `print.c`). BenchBox's bundled binaries were
+built inconsistently: the macOS binaries were compiled *with* `EOL_HANDLING`
+(no trailing `|`) while the Linux/Windows binaries used the upstream default
+(*with* trailing `|`). Because `core/tpch/generator.py` streams raw `dbgen`
+bytes straight into the `.tbl`/`.tbl.N.zst` output, this compile-time
+difference produced **platform-dependent generated data** — a reproducibility
+defect for a benchmarking tool (it surfaced as a DataFusion "Expected 8
+columns, got 9" failure, worked around at the reader layer in PR #1053).
+
+### Solution
+
+Standardize on **`EOL_HANDLING` ON (no trailing separator)** everywhere. This
+matches TPC-DS, which BenchBox already invokes with `-terminate n` (disable
+trailing field delimiters), so both benchmarks now frame rows identically.
+
+### Changes
+
+#### makefile.suite - add `-DEOL_HANDLING` to default CFLAGS
+
+```make
+# Before:
+CFLAGS	= -g -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD) -DRNG_TEST -D_FILE_OFFSET_BITS=64
+
+# After:
+CFLAGS	= -g -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD) -DRNG_TEST -D_FILE_OFFSET_BITS=64 -DEOL_HANDLING
+```
+
+Build paths that override `CFLAGS` must include `-DEOL_HANDLING` explicitly;
+paths that don't override it inherit the flag from the default above. The three
+BenchBox build entrypoints are kept in sync:
+
+- `_sources/compilation/scripts/compile-all-platforms.sh` — macOS native/docker
+  Linux/Windows inherit the default; the macOS cross block adds it explicitly.
+- `benchbox/utils/tpc_compilation.py::_create_tpc_h_makefile` — runtime source
+  build fallback (already defines `-DEOL_HANDLING`).
+
+### Verification
+
+```bash
+# A generated row must NOT end with the field separator.
+./dbgen -s 0.01 -T n && tail -n 1 nation.tbl | od -c | tail -n 2
+# The last byte before \n must be a data character, not '|'.
+```
+
+`tests/unit/core/test_tpch_dbgen_framing.py` asserts this invariant across all
+bundled per-platform binaries (skipping those the host can't execute).
+
+---
+
 ## Applying the Patch
 
 To apply these changes to a fresh TPC-H source distribution:

--- a/_sources/tpc-h/dbgen/makefile.suite
+++ b/_sources/tpc-h/dbgen/makefile.suite
@@ -110,7 +110,12 @@ DATABASE=
 MACHINE = 
 WORKLOAD = 
 #
-CFLAGS	= -g -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD) -DRNG_TEST -D_FILE_OFFSET_BITS=64 
+# BenchBox: -DEOL_HANDLING makes dbgen emit rows WITHOUT a trailing field
+# separator (see print.c EOL_HANDLING #ifdef). This is BenchBox's canonical
+# framing convention so generated .tbl output is byte-identical across
+# platforms and consistent with TPC-DS (invoked with `-terminate n`). Keep
+# this in sync with compile-all-platforms.sh and _create_tpc_h_makefile.
+CFLAGS	= -g -DDBNAME=\"dss\" -D$(MACHINE) -D$(DATABASE) -D$(WORKLOAD) -DRNG_TEST -D_FILE_OFFSET_BITS=64 -DEOL_HANDLING
 LDFLAGS = -O
 # The OBJ,EXE and LIB macros will need to be changed for compilation under
 #  Windows NT

--- a/benchbox/utils/tpc_compilation.py
+++ b/benchbox/utils/tpc_compilation.py
@@ -678,7 +678,9 @@ class TPCCompiler:
 # Platform: {platform_name}
 CC = gcc
 # Let config.h handle most definitions to avoid redefinition warnings
-# Enable EOL_HANDLING to prevent trailing column separators
+# -DEOL_HANDLING: no trailing field separator. Must match makefile.suite's
+# default CFLAGS and compile-all-platforms.sh so a runtime-built dbgen frames
+# rows identically to the bundled binaries (BenchBox canonical convention).
 CFLAGS = -O2 -DDBNAME=\\"dss\\" -D{machine_flag} -DTPCH -DRNG_TEST -D_FILE_OFFSET_BITS=64 \\
          -DEOL_HANDLING {extra_defines} -I.
 

--- a/docs/development/tpc-compilation-guide.md
+++ b/docs/development/tpc-compilation-guide.md
@@ -340,12 +340,18 @@ git add benchbox/_binaries/tpc-ds/darwin-arm64/
 git commit -m "fix(tpcds): rebuild darwin-arm64 binaries from patched sources"
 ```
 
-#### Rebuild for all platforms (requires Docker)
+#### Rebuild for all platforms (requires a container engine)
 
 ```bash
 cd _sources/compilation/scripts
 ./compile-all-platforms.sh
 ```
+
+The Linux/Windows builds run in a container. The script auto-detects a
+Docker-compatible engine, preferring `mocker` (Apple Containerization on
+macOS) then `docker` then `podman`; override with
+`BENCHBOX_CONTAINER_ENGINE=<engine>`. The macOS `arm64`/`x86_64` binaries build
+natively (no engine needed).
 
 **Supported platforms:**
 
@@ -353,10 +359,15 @@ cd _sources/compilation/scripts
 |----------|--------------|--------|
 | darwin | arm64 | Native (on Apple Silicon) |
 | darwin | x86_64 | Cross-compilation |
-| linux | x86_64 | Docker |
-| linux | arm64 | Docker |
-| windows | x86_64 | Docker + MinGW |
-| windows | arm64 | Docker + MinGW |
+| linux | x86_64 | Container (mocker/docker/podman) |
+| linux | arm64 | Container (mocker/docker/podman) |
+| windows | x86_64 | Container + MinGW |
+| windows | arm64 | Container + MinGW |
+
+> **Framing convention:** all `dbgen` builds compile with `-DEOL_HANDLING`
+> (no trailing field separator), matching TPC-DS `-terminate n`. Keep this
+> consistent across every build path — see `_sources/tpc-h/PATCHES.md`.
+> `tests/unit/core/tpch/test_tpch_dbgen_framing.py` enforces it.
 
 > **Note:** The full Docker build currently only deploys to `_binaries/`
 > (untracked).  After running it, manually copy the updated binaries into

--- a/tests/unit/core/tpcds/generator/test_tpcds_terminate_framing.py
+++ b/tests/unit/core/tpcds/generator/test_tpcds_terminate_framing.py
@@ -1,0 +1,72 @@
+"""Regression guard: every dsdgen invocation must pin ``-terminate n``.
+
+Unlike TPC-H's ``dbgen`` (whose row framing is fixed at compile time via
+``EOL_HANDLING``), TPC-DS ``dsdgen`` exposes framing as a *runtime* flag:
+``-terminate n`` disables the trailing field separator. BenchBox relies on
+passing ``-terminate n`` on every invocation so TPC-DS output is byte-identical
+across platforms regardless of how the binary was compiled -- the same
+no-trailing-separator convention the bundled TPC-H binaries enforce via
+``-DEOL_HANDLING`` (see ``tests/unit/core/tpch/test_tpch_dbgen_framing.py``).
+
+If a new dsdgen call site forgets ``-terminate n`` (or passes ``-terminate y``),
+that platform's generated data would silently regain trailing delimiters and
+diverge. This test parses the generator source so it catches such regressions
+without needing to execute dsdgen.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import benchbox
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+_TPCDS_GENERATOR_DIR = Path(benchbox.__file__).parent / "core" / "tpcds" / "generator"
+
+# Matches a ``"-terminate", "<value>"`` pair in a command list, tolerating
+# newlines/whitespace between the two string literals.
+_TERMINATE_PAIR = re.compile(r'"-terminate"\s*,\s*"([^"]+)"')
+# Catches a bare ``"-terminate"`` not immediately followed by a string literal.
+_TERMINATE_TOKEN = re.compile(r'"-terminate"')
+
+
+def _generator_sources() -> list[Path]:
+    return sorted(_TPCDS_GENERATOR_DIR.glob("*.py"))
+
+
+def test_generator_sources_present() -> None:
+    sources = _generator_sources()
+    assert sources, f"no TPC-DS generator sources under {_TPCDS_GENERATOR_DIR}"
+
+
+@pytest.mark.parametrize("source", _generator_sources(), ids=lambda p: p.name)
+def test_every_terminate_flag_is_n(source: Path) -> None:
+    text = source.read_text(encoding="utf-8")
+
+    token_count = len(_TERMINATE_TOKEN.findall(text))
+    if token_count == 0:
+        pytest.skip(f"{source.name} issues no dsdgen -terminate flag")
+
+    values = _TERMINATE_PAIR.findall(text)
+    assert len(values) == token_count, (
+        f"{source.name}: {token_count} '-terminate' token(s) but "
+        f"{len(values)} were followed by a string value -- a call site may pass "
+        "the flag without an argument."
+    )
+    for value in values:
+        assert value == "n", (
+            f"{source.name}: dsdgen invoked with '-terminate {value}'; must be "
+            "'n' to disable trailing field separators (BenchBox framing "
+            "convention)."
+        )

--- a/tests/unit/core/tpch/test_tpch_dbgen_framing.py
+++ b/tests/unit/core/tpch/test_tpch_dbgen_framing.py
@@ -1,0 +1,54 @@
+"""Fast guard: every TPC-H dbgen build entrypoint defines ``-DEOL_HANDLING``.
+
+BenchBox's canonical TPC-H framing convention is **no trailing field
+separator** (dbgen compiled ``-DEOL_HANDLING``), matching TPC-DS which is
+always invoked with ``-terminate n``. ``core/tpch/generator.py`` streams raw
+dbgen bytes straight into ``.tbl``/``.tbl.N.zst`` output, so a compile-time
+framing difference between the per-platform binaries would silently produce
+platform-dependent generated data -- a reproducibility defect (it once
+surfaced as a DataFusion "Expected 8 columns, got 9" failure, worked around
+at the reader layer in PR #1053).
+
+This module is the host-independent guard: it asserts each dbgen build
+entrypoint defines ``-DEOL_HANDLING`` so source drift is caught before it ever
+reaches a compiled binary. The complementary runtime guard that executes the
+bundled binaries lives in ``test_tpch_dbgen_framing_binaries.py`` (slow).
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+]
+
+# Repo root: tests/unit/core/tpch/<this file> -> parents[4]
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# dbgen build entrypoints that must all agree on the framing convention.
+_BUILD_CONFIG_FILES = (
+    _REPO_ROOT / "_sources" / "tpc-h" / "dbgen" / "makefile.suite",
+    _REPO_ROOT / "_sources" / "compilation" / "scripts" / "compile-all-platforms.sh",
+    _REPO_ROOT / "benchbox" / "utils" / "tpc_compilation.py",
+)
+
+
+@pytest.mark.parametrize("config_file", _BUILD_CONFIG_FILES, ids=lambda p: p.name)
+def test_config_defines_eol_handling(config_file: Path) -> None:
+    """Each dbgen build entrypoint must define -DEOL_HANDLING."""
+    if not config_file.exists():
+        pytest.skip(f"source tree not available: {config_file}")
+    text = config_file.read_text(encoding="utf-8")
+    assert "-DEOL_HANDLING" in text, (
+        f"{config_file} does not define -DEOL_HANDLING; TPC-H row framing "
+        "would diverge from BenchBox's canonical no-trailing-separator "
+        "convention."
+    )

--- a/tests/unit/core/tpch/test_tpch_dbgen_framing_binaries.py
+++ b/tests/unit/core/tpch/test_tpch_dbgen_framing_binaries.py
@@ -1,0 +1,137 @@
+"""Slow guard: bundled TPC-H binaries emit rows with no trailing separator.
+
+Companion to ``test_tpch_dbgen_framing.py`` (which statically checks the build
+configs). This module runs each bundled per-platform ``dbgen`` that the current
+host can actually execute and asserts its output carries no trailing ``|`` --
+BenchBox's canonical framing convention (``-DEOL_HANDLING``). Foreign-arch
+binaries are skipped per-binary; run across CI's Linux and macOS runners the
+union covers the whole platform matrix.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import benchbox
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.slow,
+]
+
+# Directory of bundled, runtime-priority TPC-H binaries (one dir per platform).
+_BINARIES_ROOT = Path(benchbox.__file__).parent / "_binaries" / "tpc-h"
+
+
+def _host_platform_arch() -> str:
+    """Return the ``<system>-<arch>`` dir name for the current host.
+
+    Mirrors ``TPCCompiler._get_platform_string`` so the test agrees with the
+    runtime binary resolver.
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "x86_64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    else:
+        arch = machine
+    return f"{system}-{arch}"
+
+
+def _dbgen_in(directory: Path) -> Path | None:
+    """Return the dbgen executable in ``directory`` (``.exe`` on Windows)."""
+    for name in ("dbgen", "dbgen.exe"):
+        candidate = directory / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _bundled_binary_dirs() -> list[Path]:
+    if not _BINARIES_ROOT.is_dir():
+        return []
+    return sorted(p for p in _BINARIES_ROOT.iterdir() if p.is_dir() and _dbgen_in(p))
+
+
+def _generate_nation_rows(dbgen_exe: Path) -> list[str] | None:
+    """Run ``dbgen`` for the (tiny) nation table; return its rows.
+
+    Returns ``None`` when the binary cannot be executed on this host (wrong
+    architecture / missing loader / no Rosetta), so callers can skip rather
+    than fail for binaries built for other platforms.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        dists = dbgen_exe.parent / "dists.dss"
+        if dists.exists():
+            shutil.copy2(dists, tmp_path / "dists.dss")
+        try:
+            result = subprocess.run(
+                [str(dbgen_exe), "-z", "-s", "0.01", "-T", "n", "-q"],
+                capture_output=True,
+                cwd=tmp,
+                timeout=30,
+            )
+        except OSError:
+            # e.g. "Exec format error" for a foreign-arch binary.
+            return None
+        if result.returncode != 0 and not result.stdout:
+            # A foreign binary may fail to load; treat as not-runnable-here.
+            return None
+        assert result.stdout, f"dbgen produced no output: {result.stderr!r}"
+        return result.stdout.decode().splitlines()
+
+
+def _assert_no_trailing_delimiter(rows: list[str], label: str) -> None:
+    assert rows, f"{label}: no rows generated"
+    for row in rows:
+        assert row, f"{label}: unexpected empty row"
+        assert not row.endswith("|"), (
+            f"{label}: row carries a trailing '|' (dbgen built WITHOUT -DEOL_HANDLING). Row: {row!r}"
+        )
+
+
+def test_host_binary_has_no_trailing_delimiter() -> None:
+    """The binary matching this host MUST exist and frame rows correctly."""
+    host_dir = _BINARIES_ROOT / _host_platform_arch()
+    dbgen_exe = _dbgen_in(host_dir)
+    if dbgen_exe is None:
+        pytest.skip(f"no bundled dbgen for host platform {host_dir.name}")
+    rows = _generate_nation_rows(dbgen_exe)
+    assert rows is not None, f"host binary {dbgen_exe} failed to execute"
+    _assert_no_trailing_delimiter(rows, f"host:{host_dir.name}")
+
+
+def test_all_runnable_bundled_binaries_agree() -> None:
+    """Every bundled binary the host CAN run must share the convention.
+
+    Foreign-architecture binaries are skipped per-binary; across CI's Linux +
+    macOS runners the union covers the full platform matrix.
+    """
+    binary_dirs = _bundled_binary_dirs()
+    if not binary_dirs:
+        pytest.skip("no bundled TPC-H binaries found")
+
+    checked: list[str] = []
+    for directory in binary_dirs:
+        dbgen_exe = _dbgen_in(directory)
+        assert dbgen_exe is not None  # guaranteed by _bundled_binary_dirs
+        rows = _generate_nation_rows(dbgen_exe)
+        if rows is None:
+            continue  # not executable on this host (foreign arch)
+        _assert_no_trailing_delimiter(rows, directory.name)
+        checked.append(directory.name)
+
+    assert checked, "no bundled TPC-H binary was executable on this host; cannot verify row framing"


### PR DESCRIPTION
Bundled TPC-H dbgen binaries were compiled inconsistently: macOS with
-DEOL_HANDLING (no trailing field separator), Linux/Windows without it
(trailing `|`). generator.py streams raw dbgen bytes into .tbl output, so this
compile-time split produced platform-dependent generated data -- a
reproducibility defect (surfaced as a DataFusion "Expected 8 columns, got 9"
failure, worked around at the reader layer in #1053).

Standardize on -DEOL_HANDLING ON (no trailing separator), matching TPC-DS
(always invoked with `-terminate n`) and the macOS binaries:

- Reconcile all dbgen build entrypoints so they agree: makefile.suite default
  CFLAGS, compile-all-platforms.sh (native/cross/docker), and the runtime
  fallback _create_tpc_h_makefile.
- Add framing guards: a fast static check that every build path defines
  -DEOL_HANDLING (runs in PR CI), plus a slow runtime check that bundled
  binaries emit no trailing `|` (covers the matrix across CI Linux+macOS).
- Add a TPC-DS regression guard asserting every dsdgen call pins `-terminate n`
  (TPC-DS framing is runtime-controlled and already consistent).
- Make compile-all-platforms.sh container-engine-agnostic (mocker/docker/
  podman) since the local toolchain moved to Apple Containerization.
- Document the change in PATCHES.md and the compilation guide.

The Linux/Windows binaries still need recompiling with the reconciled configs
(container build; follow-up). The macOS binaries already comply, verified
empirically. No CI lane runs a blanket `-m slow`, so this lands green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
