### PR TITLE
docs(scd2): scope portability claim to standard-DML engines (drop ClickHouse overclaim)

### DIFF
--- a/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
@@ -14,9 +14,10 @@ date: 2026-06-30
 **TL;DR**: Databricks' AUTO CDC (formerly APPLY CHANGES INTO) genuinely removes
 boilerplate and a class of Slowly Changing Dimension bugs, and that convenience is
 real. But it runs only on Databricks declarative pipelines, while the equivalent
-portable SQL runs unchanged across DuckDB, PostgreSQL, Snowflake, BigQuery, and
-ClickHouse. For a basic Type 2, that portable SQL is about 18 lines, not 200. The
-honest trade-off is convenience versus portability, not lines of code.
+portable SQL runs unchanged across standard-DML engines such as DuckDB,
+PostgreSQL, Snowflake, and BigQuery (verified here on DuckDB). For a basic Type 2,
+that portable SQL is about 18 lines, not 200. The honest trade-off is convenience
+versus portability, not lines of code.
 
 ---
 
@@ -99,13 +100,18 @@ WHERE s.change_type = 'new'
 
 This is portable standard SQL. It uses a business key (`c_custkey`), a current-version
 flag (`is_current`), validity timestamps (`valid_from` and `valid_to`), and a
-change-detection fingerprint (`row_hash`) to decide what changed. There is no
-engine-specific syntax, so it runs unchanged across the engines named above
-(DuckDB, PostgreSQL, Snowflake, BigQuery, and ClickHouse) — not every engine
-BenchBox targets. DataFusion is a documented exception: BenchBox's Write
-Primitives catalog marks this exact operation unsupported there
-(`platform_overrides: {"datafusion": null}`)[^op], so it is skipped rather than
-run on that engine.
+change-detection fingerprint (`row_hash`) to decide what changed. The close-and-insert
+uses standard DML (UPDATE plus INSERT), so it runs unchanged on engines that support a
+standard UPDATE: DuckDB (which we verify below), PostgreSQL, Snowflake, and BigQuery.
+Two documented exceptions apply. DataFusion is marked unsupported for this exact
+operation in BenchBox's Write Primitives catalog
+(`platform_overrides: {"datafusion": null}`)[^op], so it is skipped. ClickHouse has no
+standard UPDATE statement (row changes go through `ALTER TABLE ... UPDATE` mutations),
+so only the insert-only path (`merge_scd_type2_new_keys_only`) runs there unchanged; the
+close-old step would need a mutation rewrite. The same standard-DML scoping applies to
+the harness setup that seeds the dimension and change batch (it also uses string
+concatenation and CAST), so the portability claim is about standard-DML engines end to
+end, not just the operation.
 
 ### The honest line count
 
@@ -157,8 +163,10 @@ pipeline, not on warehouse compute, and not on any other engine. It is not a sta
 statement you can run against an ordinary table, and it does not run on DuckDB,
 PostgreSQL, Snowflake, BigQuery, or ClickHouse.
 
-The portable form runs on all of them. We can show this concretely with one engine. The
-bundled DuckDB 1.3.2 rejects `MERGE INTO` outright, so BenchBox's standard run skips its
+The portable form runs on the standard-DML engines in that list (ClickHouse, lacking a
+standard UPDATE, needs the insert-only path or a mutation rewrite, as noted above). We
+can show the portable form concretely on one engine. The bundled DuckDB 1.3.2 rejects
+`MERGE INTO` outright, so BenchBox's standard run skips its
 entire MERGE category on DuckDB[^skip]. Yet the portable SCD Type 2 operation, built
 from UPDATE and INSERT rather than `MERGE INTO`, runs on DuckDB and passes its
 correctness checks. The same SQL that an engine refuses in `MERGE INTO` form runs fine

--- a/_project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml
+++ b/_project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml
@@ -1,0 +1,67 @@
+id: "scd2-portability-claim-accuracy"
+title: "Correct the SCD2 'runs unchanged on ClickHouse' portability claim (blog + docs)"
+worktree: "write-primitives-scd2-followup"
+priority: "Medium-High"
+status: "Completed"
+completed_date: "2026-07-08"
+category: "Documentation"
+description: |
+  SCD2 audit finding #1. The blog draft and docs/benchmarks/write-primitives.md
+  claimed the portable SCD2 op "runs unchanged" on ClickHouse (and "every target
+  engine"). False for merge_scd_type2_basic / _no_change: they use standard
+  UPDATE, which ClickHouse lacks (row changes go through ALTER TABLE ... UPDATE
+  mutations); no UPDATE->mutation rewrite exists in benchbox/sql_compat/. Only
+  merge_scd_type2_new_keys_only (pure INSERT) runs there unchanged. Verified only
+  on DuckDB. Decision (w0): Option A + one-line B caveat - scope the claim to
+  standard-DML engines, name ClickHouse (and DataFusion) as exceptions, keep the
+  DuckDB proof.
+
+work:
+  - id: w0
+    summary: "Decision gate: chose Option A + caveat (scope to standard-DML engines; ClickHouse/DataFusion named as exceptions; DuckDB proof retained)."
+    status: done
+  - id: w1
+    summary: "Corrected blog draft: TL;DR (:16), portability body (:102), and lock-in section (:166) no longer claim ClickHouse runs the UPDATE-based ops unchanged."
+    status: done
+  - id: w2
+    summary: "Corrected docs/benchmarks/write-primitives.md SCD2 bullet: 'every target engine' -> standard-DML engines, with ClickHouse insert-only / DataFusion-skipped caveat."
+    status: done
+  - id: w3
+    summary: "Added end-to-end honesty note: the harness setup population SQL (concat/CAST) is also standard-SQL, so the standard-DML scoping covers setup, not just the op."
+    status: done
+  - id: w4
+    summary: "Verified no em/en-dash remains in either edited file (incidentally fixed the pre-existing draft:104 and docs:130 dashes); footnotes untouched and previously confirmed resolving."
+    needs: [w1, w2, w3]
+    status: done
+
+sections:
+  "Implementation Summary": |
+    Wording-only change across two files. ClickHouse removed from the unqualified
+    "runs unchanged" set in the blog TL;DR, portability body, and lock-in
+    paragraph; recast as an explicit exception (no standard UPDATE -> only the
+    insert-only path runs unchanged; close-old needs a mutation rewrite).
+    docs/benchmarks/write-primitives.md:134 changed from "runs unchanged across
+    every target engine" to standard-DML engines with the ClickHouse/DataFusion
+    caveat. Both edits incidentally removed the pre-existing em-dashes at
+    draft:104 and docs:130, so the sibling scd2-doc-count-hygiene TODO no longer
+    needs to touch those lines (only the test comment and docs/_build remain).
+  "Verification": |
+    grep confirms 0 em/en-dashes in both files and no remaining "every target
+    engine" / unqualified "unchanged ... ClickHouse" claim. Databricks footnotes
+    [^cdc] and [^blog] were confirmed to resolve verbatim during the audit and
+    were not modified.
+
+metadata:
+  tags: ["scd2", "write-primitives", "blog", "docs", "portability", "honesty"]
+  estimated_effort: "Small"
+  created_date: "2026-07-08"
+  last_updated: "2026-07-08T00:00:00"
+
+files_affected:
+  modified:
+    - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+    - "docs/benchmarks/write-primitives.md"
+
+success_metrics:
+  - "Blog + docs no longer assert the UPDATE-based SCD2 ops run unchanged on ClickHouse."
+  - "Portability claim scoped to standard-DML engines; DuckDB proof retained; ClickHouse/DataFusion exceptions named."

--- a/docs/benchmarks/write-primitives.md
+++ b/docs/benchmarks/write-primitives.md
@@ -127,11 +127,12 @@ The benchmark includes **112 write operations** across 6 categories:
 - ETL aggregation with running totals
 - Window function deduplication (ROW_NUMBER pattern)
 - SCD Type 2 dimension maintenance (`merge_scd_type2_basic`,
-  `merge_scd_type2_no_change`, `merge_scd_type2_new_keys_only`) — close the
-  current version of a changed business key and open a new one, expressed as
+  `merge_scd_type2_no_change`, `merge_scd_type2_new_keys_only`), which closes the
+  current version of a changed business key and opens a new one, expressed as
   portable UPDATE + INSERT against the dedicated `scd2_ops_*` dimension tables
-  (no `APPLY CHANGES INTO` / declarative-pipeline syntax, so it runs unchanged
-  across every target engine)
+  (no `APPLY CHANGES INTO` / declarative-pipeline syntax, so it runs unchanged on
+  standard-DML engines; ClickHouse lacks a standard UPDATE so it runs only the
+  insert-only path, and DataFusion is skipped)
 
 **Purpose**: Test UPSERT/MERGE operations for CDC, ETL, slowly-changing
 dimension maintenance, and incremental data loading scenarios.


### PR DESCRIPTION
## Summary

SCD2 audit **finding #1** (blog + docs honesty). The blog draft and `docs/benchmarks/write-primitives.md` claimed the portable SCD Type 2 op "runs unchanged" on **ClickHouse** / "every target engine". That is false for `merge_scd_type2_basic` and `merge_scd_type2_no_change`: they open with a standard `UPDATE ... SET ...`, which **ClickHouse has no equivalent for** (row changes go through `ALTER TABLE ... UPDATE` mutations), and there is **no `UPDATE`→mutation rewrite** in `benchbox/sql_compat/`. Only the insert-only `merge_scd_type2_new_keys_only` runs there unchanged. The claim was verified on DuckDB only.

**Decision gate (w0):** Option A + one-line caveat — scope the claim to standard-DML engines, name ClickHouse and DataFusion as exceptions, keep the DuckDB proof.

## Changes
- **Blog draft**: TL;DR, portability body, and lock-in paragraph no longer claim ClickHouse runs the `UPDATE`-based ops unchanged; recast as a documented exception (insert-only path runs; close-old needs a mutation rewrite).
- **`write-primitives.md:134`**: "runs unchanged across every target engine" → standard-DML engines, with the ClickHouse/DataFusion caveat.
- **End-to-end honesty note**: the harness setup population SQL is also standard-SQL, so the scoping covers setup, not just the operation.
- Incidentally removed the pre-existing em-dashes at `draft:104` / `docs:130` (a house-rule cleanup the sibling hygiene TODO no longer needs to do).
- Recorded the completed TODO under `_project/DONE/write-primitives-scd2-followup/`.

## Verification
- `grep`: **0** em/en-dashes in both files; no remaining "every target engine" / unqualified "unchanged … ClickHouse" claim.
- `markdownlint`: pass. TODO validator on the DONE file: valid.
- Databricks footnotes `[^cdc]` / `[^blog]` confirmed resolving verbatim during the audit; untouched here.

Part of the SCD2 audit follow-up batch. Supersedes the planning-only PR #1055. `scd2-doc-count-hygiene` depends on this (shares the same files) and lands after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)