### PR TITLE
fix(tpch): normalize trailing delimiters in file-mode datagen fallback

### DIFF
--- a/benchbox/core/tpch/generator.py
+++ b/benchbox/core/tpch/generator.py
@@ -45,6 +45,84 @@ _GENERATOR_SPECS = _load_generator_specs()
 _TPCH_TABLE_CODES = dict(_GENERATOR_SPECS["table_codes"])
 _TPCH_BASE_ROW_COUNTS = dict(_GENERATOR_SPECS["base_row_counts"])
 
+# Chunk size for the streaming trailing-delimiter rewrite (bytes).
+_NORMALIZE_CHUNK_SIZE = 1 << 20
+
+
+def _has_trailing_delimiter(path: Path) -> bool:
+    """Probe the last bytes of ``path`` for a classic dbgen trailing delimiter.
+
+    dbgen row framing is decided at compile time (EOL_HANDLING), so every row
+    in a file shares the same framing; inspecting the file tail is sufficient
+    to classify the whole file.
+    """
+    size = path.stat().st_size
+    if size == 0:
+        return False
+    with path.open("rb") as handle:
+        handle.seek(max(0, size - 2))
+        tail = handle.read()
+    return tail.endswith((b"|\n", b"|"))
+
+
+def normalize_tbl_trailing_delimiters(path: Path) -> bool:
+    """Strip exactly one trailing ``|`` before each newline, rewriting in place.
+
+    Classic dbgen file mode (binaries without the BenchBox stdout-streaming
+    patch, e.g. the bundled Linux dbgen) terminates every row with a field
+    delimiter (``...|BUILDING|comment.|``), while the patched ``-z`` streaming
+    mode does not. Normalizing file-mode output keeps generated data identical
+    across platforms.
+
+    Only the delimiter immediately before the line terminator is removed;
+    interior empty fields are preserved. In ``.tbl`` format a trailing empty
+    field is a delimiter artifact, not a NULL (see
+    :func:`benchbox.utils.file_format.get_data_extension`).
+
+    The rewrite streams fixed-size chunks through a temporary file, so large
+    scale-factor outputs are never loaded into memory. Files that are already
+    clean are detected with an O(1) tail probe and left untouched, which also
+    makes the operation idempotent.
+
+    Args:
+        path: Uncompressed ``.tbl`` (or ``.tbl.N`` chunk) file to normalize.
+
+    Returns:
+        True if the file was rewritten, False if it was already clean.
+    """
+    if not _has_trailing_delimiter(path):
+        return False
+
+    tmp_path = path.with_name(path.name + ".normalize.tmp")
+    try:
+        with path.open("rb") as src, tmp_path.open("wb") as dst:
+            carry = b""
+            while True:
+                chunk = src.read(_NORMALIZE_CHUNK_SIZE)
+                if not chunk:
+                    break
+                data = carry + chunk
+                # Hold back a chunk-final "|": it may be followed by "\n" in
+                # the next chunk and must be stripped together with it.
+                if data.endswith(b"|"):
+                    carry = b"|"
+                    data = data[:-1]
+                else:
+                    carry = b""
+                # "\n" only occurs at row boundaries, so "|\n" is always the
+                # trailing delimiter; str.replace removes exactly one "|" per
+                # newline and never touches interior empty fields.
+                dst.write(data.replace(b"|\n", b"\n"))
+            # A held-back "|" at EOF means the final row is unterminated but
+            # still carries the trailing delimiter; drop it.
+        with contextlib.suppress(OSError):
+            shutil.copystat(path, tmp_path)
+        os.replace(tmp_path, path)
+    finally:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+    return True
+
 
 class TPCHDataGenerator(CompressionMixin, CloudStorageGeneratorMixin, VerbosityMixin):
     """TPC-H data generator.
@@ -974,6 +1052,13 @@ class TPCHDataGenerator(CompressionMixin, CloudStorageGeneratorMixin, VerbosityM
         """
         table_paths, precompressed_tables = self._gather_generated_table_paths(target_dir)
 
+        # Classic (non -z) dbgen writes a trailing field delimiter on every
+        # row. Normalize file-mode output before any compression or data
+        # organization so results match the streaming path byte-for-byte
+        # (release PR #1043 canary: the bundled Linux dbgen lacks the stdout
+        # patch, falls back to file mode, and emitted trailing pipes).
+        self._normalize_table_delimiters(table_paths, precompressed_tables)
+
         # Data organization is a post-generation output mode. When configured,
         # prefer organized outputs over raw compression artifacts.
         if self._data_organization_config is not None:
@@ -994,6 +1079,25 @@ class TPCHDataGenerator(CompressionMixin, CloudStorageGeneratorMixin, VerbosityM
 
         self._write_manifest(target_dir, table_paths)
         return table_paths
+
+    def _normalize_table_delimiters(
+        self,
+        table_paths: dict[str, Path | list[Path]],
+        precompressed_tables: set[str],
+    ) -> None:
+        """Strip classic dbgen trailing row delimiters from uncompressed outputs.
+
+        Covers both single-file mode (``customer.tbl``) and parallel chunked
+        mode (``customer.tbl.1`` ... ``customer.tbl.N``). Pre-compressed
+        tables are skipped: they come from the streaming (-z) path or a
+        previous run and are already normalized.
+        """
+        for table_name, paths in table_paths.items():
+            if table_name in precompressed_tables:
+                continue
+            for file_path in paths if isinstance(paths, list) else [paths]:
+                if normalize_tbl_trailing_delimiters(file_path):
+                    self.log_verbose(f"Stripped trailing row delimiters from {file_path.name}")
 
     def _apply_data_organization(
         self,

--- a/tests/unit/core/tpch/test_tpch_trailing_delimiters.py
+++ b/tests/unit/core/tpch/test_tpch_trailing_delimiters.py
@@ -1,0 +1,194 @@
+"""Tests for TPC-H file-mode trailing-delimiter normalization.
+
+Classic dbgen file mode (binaries without the BenchBox stdout-streaming
+patch, e.g. the bundled Linux dbgen) terminates every row with a field
+delimiter, while the patched -z streaming mode does not. The generator
+normalizes file-mode output so generated data is identical across platforms
+(release PR #1043 canary caught the Linux divergence).
+
+These tests exercise the post-processing directly with synthetic .tbl files
+so the behavior is verified on every platform, including macOS where the
+streaming path normally hides the bug.
+
+Copyright 2026 Joe Harris / BenchBox Project
+
+Licensed under the MIT License. See LICENSE file in the project root for details.
+"""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+import benchbox.core.tpch.generator as generator_module
+from benchbox.core.tpch.generator import TPCHDataGenerator, normalize_tbl_trailing_delimiters
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.fast,
+    pytest.mark.tpch,
+]
+
+DIRTY_CUSTOMER = (
+    b"1|Customer#000000001|IVhzIApeRb|15|25-989-741-2988|711.56|BUILDING|to the even, regular platelets|\n"
+    b"2|Customer#000000002|XSTf4,NCwDVaW|13|23-768-687-3665|121.65|AUTOMOBILE|l accounts. blithely|\n"
+)
+CLEAN_CUSTOMER = (
+    b"1|Customer#000000001|IVhzIApeRb|15|25-989-741-2988|711.56|BUILDING|to the even, regular platelets\n"
+    b"2|Customer#000000002|XSTf4,NCwDVaW|13|23-768-687-3665|121.65|AUTOMOBILE|l accounts. blithely\n"
+)
+
+
+class TestNormalizeTblTrailingDelimiters:
+    """Unit tests for the streaming normalization function."""
+
+    def test_strips_exactly_one_trailing_pipe_per_line(self, tmp_path: Path):
+        tbl = tmp_path / "customer.tbl"
+        tbl.write_bytes(DIRTY_CUSTOMER)
+
+        assert normalize_tbl_trailing_delimiters(tbl) is True
+        assert tbl.read_bytes() == CLEAN_CUSTOMER
+
+    def test_preserves_interior_and_trailing_empty_fields(self, tmp_path: Path):
+        # In .tbl format the trailing empty field is a delimiter artifact, not
+        # a NULL; only the final delimiter may be removed.
+        tbl = tmp_path / "table.tbl"
+        tbl.write_bytes(b"1|a||b|\n2|||\n")
+
+        assert normalize_tbl_trailing_delimiters(tbl) is True
+        assert tbl.read_bytes() == b"1|a||b\n2||\n"
+
+    def test_clean_file_left_untouched(self, tmp_path: Path):
+        tbl = tmp_path / "customer.tbl"
+        tbl.write_bytes(CLEAN_CUSTOMER)
+
+        assert normalize_tbl_trailing_delimiters(tbl) is False
+        assert tbl.read_bytes() == CLEAN_CUSTOMER
+
+    def test_empty_file_left_untouched(self, tmp_path: Path):
+        tbl = tmp_path / "empty.tbl"
+        tbl.write_bytes(b"")
+
+        assert normalize_tbl_trailing_delimiters(tbl) is False
+        assert tbl.read_bytes() == b""
+
+    def test_final_line_without_newline(self, tmp_path: Path):
+        tbl = tmp_path / "table.tbl"
+        tbl.write_bytes(b"1|a|\n2|b|")
+
+        assert normalize_tbl_trailing_delimiters(tbl) is True
+        assert tbl.read_bytes() == b"1|a\n2|b"
+
+    def test_idempotent(self, tmp_path: Path):
+        tbl = tmp_path / "customer.tbl"
+        tbl.write_bytes(DIRTY_CUSTOMER)
+
+        assert normalize_tbl_trailing_delimiters(tbl) is True
+        assert normalize_tbl_trailing_delimiters(tbl) is False
+        assert tbl.read_bytes() == CLEAN_CUSTOMER
+
+    @pytest.mark.parametrize("chunk_size", [1, 2, 3, 7, 64])
+    def test_chunk_boundary_carry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, chunk_size: int):
+        # Force the "|" / "\n" pair to straddle read-chunk boundaries so the
+        # carry-byte logic is exercised.
+        monkeypatch.setattr(generator_module, "_NORMALIZE_CHUNK_SIZE", chunk_size)
+        tbl = tmp_path / "table.tbl"
+        tbl.write_bytes(b"1|aa||\n22|b|\n|\n")
+
+        assert normalize_tbl_trailing_delimiters(tbl) is True
+        assert tbl.read_bytes() == b"1|aa|\n22|b\n\n"
+
+    def test_no_temp_file_left_behind(self, tmp_path: Path):
+        tbl = tmp_path / "customer.tbl"
+        tbl.write_bytes(DIRTY_CUSTOMER)
+
+        normalize_tbl_trailing_delimiters(tbl)
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["customer.tbl"]
+
+
+TPCH_TABLES = ["customer", "lineitem", "nation", "orders", "part", "partsupp", "region", "supplier"]
+
+
+class TestFinalizeGenerationNormalization:
+    """The file-mode fallback pipeline must normalize before returning/compressing."""
+
+    def _write_all_tables(self, target_dir: Path, payload: bytes, chunked: tuple[str, int] | None = None) -> None:
+        """Write synthetic .tbl files for all 8 tables (avoids dbgen fallback lookups)."""
+        for table in TPCH_TABLES:
+            if chunked and table == chunked[0]:
+                for chunk_id in range(1, chunked[1] + 1):
+                    (target_dir / f"{table}.tbl.{chunk_id}").write_bytes(payload)
+            else:
+                (target_dir / f"{table}.tbl").write_bytes(payload)
+
+    def test_file_mode_single_tables_normalized(self, tmp_path: Path):
+        generator = TPCHDataGenerator(scale_factor=0.01, output_dir=tmp_path, compress_data=False)
+        self._write_all_tables(tmp_path, DIRTY_CUSTOMER)
+
+        result = generator._finalize_generation(tmp_path)
+
+        assert set(result) == set(TPCH_TABLES)
+        for table in TPCH_TABLES:
+            path = result[table]
+            assert isinstance(path, Path)
+            assert path.read_bytes() == CLEAN_CUSTOMER
+
+    def test_file_mode_chunked_tables_normalized(self, tmp_path: Path):
+        generator = TPCHDataGenerator(scale_factor=0.01, output_dir=tmp_path, compress_data=False, parallel=2)
+        self._write_all_tables(tmp_path, DIRTY_CUSTOMER, chunked=("customer", 2))
+
+        result = generator._finalize_generation(tmp_path)
+
+        chunks = result["customer"]
+        assert isinstance(chunks, list)
+        assert len(chunks) == 2
+        for chunk in chunks:
+            assert chunk.read_bytes() == CLEAN_CUSTOMER
+
+    def test_normalization_happens_before_compression(self, tmp_path: Path):
+        generator = TPCHDataGenerator(
+            scale_factor=0.01,
+            output_dir=tmp_path,
+            compress_data=True,
+            compression_type="gzip",
+        )
+        self._write_all_tables(tmp_path, DIRTY_CUSTOMER)
+
+        result = generator._finalize_generation(tmp_path)
+
+        compressed = result["customer"]
+        assert isinstance(compressed, Path)
+        assert compressed.name == "customer.tbl.gz"
+        assert gzip.decompress(compressed.read_bytes()) == CLEAN_CUSTOMER
+
+    def test_chunked_compression_normalized_before_compressing(self, tmp_path: Path):
+        generator = TPCHDataGenerator(
+            scale_factor=0.01,
+            output_dir=tmp_path,
+            compress_data=True,
+            compression_type="gzip",
+            parallel=2,
+        )
+        self._write_all_tables(tmp_path, DIRTY_CUSTOMER, chunked=("customer", 2))
+
+        result = generator._finalize_generation(tmp_path)
+
+        chunks = result["customer"]
+        assert isinstance(chunks, list)
+        assert [c.name for c in chunks] == ["customer.tbl.1.gz", "customer.tbl.2.gz"]
+        for chunk in chunks:
+            assert gzip.decompress(chunk.read_bytes()) == CLEAN_CUSTOMER
+
+    def test_clean_file_mode_output_unchanged(self, tmp_path: Path):
+        # macOS patched dbgen already emits clean rows in file mode; the
+        # normalization pass must not alter them.
+        generator = TPCHDataGenerator(scale_factor=0.01, output_dir=tmp_path, compress_data=False)
+        self._write_all_tables(tmp_path, CLEAN_CUSTOMER)
+
+        result = generator._finalize_generation(tmp_path)
+
+        customer = result["customer"]
+        assert isinstance(customer, Path)
+        assert customer.read_bytes() == CLEAN_CUSTOMER


### PR DESCRIPTION
## Root cause

The v0.3.1 release canary (PR #1043, ubuntu runner) found TPC-H data generated on Linux carries a trailing pipe delimiter on every row (`1|Customer#000000001|...|BUILDING|to the even...|` — 9 fields for the 8-column `customer` table), while macOS-generated data does not. `benchbox/core/tpch/generator.py` prefers dbgen's patched `-z` stdout-streaming mode, which yields clean output; the bundled Linux dbgen lacks the patch, so generation falls back to classic file mode, which wrote raw dbgen output with trailing field delimiters and no post-processing. Two slow-marked contract tests in `tests/unit/test_fractional_scale_factors.py` pin the intended behavior and failed on Linux.

## Fix

- New `normalize_tbl_trailing_delimiters()` in `benchbox/core/tpch/generator.py`: a streaming, chunked (1 MiB), in-place rewrite that strips exactly one trailing `|` immediately before each newline. Interior empty fields are untouched — in `.tbl` format a trailing empty field is a delimiter artifact, not a NULL (see `benchbox/utils/file_format.py`). Already-clean files are detected with an O(1) tail probe and left untouched (dbgen row framing is compile-time uniform), so the streaming path and macOS file-mode output pay effectively zero cost, and the operation is idempotent.
- `_finalize_generation()` now calls `_normalize_table_delimiters()` on all uncompressed file-mode outputs — single `customer.tbl` and parallel chunked `customer.tbl.1..N` — **before** any compression or data-organization step, so `.tbl.zst`/`.tbl.gz` artifacts and chunked shards are built from normalized bytes. Pre-compressed tables (streaming `-z` output) are skipped.
- No changes to dbgen binaries, contract tests, or DataFusion readers (reader tolerance landed separately in #1053).

## Verification

- New `tests/unit/core/tpch/test_tpch_trailing_delimiters.py` (fast/unit, runs in PR CI): 17 tests covering exact-one-pipe stripping, interior/trailing empty-field preservation, clean-file no-op, missing final newline, idempotency, chunk-boundary carry (chunk sizes 1–64), chunked shards, and strip-before-compression ordering (gzip round-trip) — all passing.
- `uv run -- python -m pytest tests/unit/test_fractional_scale_factors.py -q -m "slow or resource_heavy"` — 8 passed (macOS, no regression).
- `uv run -- python -m pytest tests/unit/core/tpch -q -m fast` — 299 passed.
- `uv run -- ruff check benchbox/core/tpch tests` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
