### PR TITLE
docs(scd2): address bot review on ClickHouse portability framing (#1057 follow-up)

### DIFF
--- a/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
+++ b/_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md
@@ -107,8 +107,11 @@ Two documented exceptions apply. DataFusion is marked unsupported for this exact
 operation in BenchBox's Write Primitives catalog
 (`platform_overrides: {"datafusion": null}`)[^op], so it is skipped. ClickHouse has no
 standard UPDATE statement (row changes go through `ALTER TABLE ... UPDATE` mutations),
-so only the insert-only path (`merge_scd_type2_new_keys_only`) runs there unchanged; the
-close-old step would need a mutation rewrite. The same standard-DML scoping applies to
+so only the insert-only path (`merge_scd_type2_new_keys_only`) is portable there; the
+close-old step would need a mutation rewrite. Note the catalog currently marks only
+DataFusion unsupported, so BenchBox does not yet special-case ClickHouse: a ClickHouse
+run attempts the close-old ops (and errors on the UPDATE) rather than automatically
+restricting to the insert-only path. The same standard-DML scoping applies to
 the harness setup that seeds the dimension and change batch (it also uses string
 concatenation and CAST), so the portability claim is about standard-DML engines end to
 end, not just the operation.
@@ -265,15 +268,18 @@ and the declarative form absorbs that complexity for you.
 
 The more useful way to read the comparison is convenience versus portability. AUTO CDC
 buys you concise, correct-by-construction SCD Type 2 on Databricks. Portable SQL buys you
-the same history-tracking workload on every engine, including ones that reject `MERGE
-INTO`. Both are legitimate choices; the right one depends on whether your constraint is
+the same history-tracking workload on any standard-DML engine, including ones that reject
+`MERGE INTO` (like DuckDB); engines without a standard UPDATE (such as ClickHouse) run
+the insert-only path unchanged and need a mutation rewrite for the close-old step. Both
+are legitimate choices; the right one depends on whether your constraint is
 maintainability inside one platform or portability across many.
 
 ## Next steps
 
 The portable operation lives in BenchBox's Write Primitives benchmark[^op], and the full
 evidence behind every number here is in our verification log[^log]. We would love for
-others to run the portable form on PostgreSQL, Snowflake, BigQuery, or ClickHouse and
+others to run the portable form on other standard-DML engines like PostgreSQL, Snowflake,
+or BigQuery (and to try the insert-only path or a mutation rewrite on ClickHouse) and
 compare. Open an issue to share results or to discuss the methodology.
 
 ---

--- a/docs/benchmarks/write-primitives.md
+++ b/docs/benchmarks/write-primitives.md
@@ -131,8 +131,9 @@ The benchmark includes **112 write operations** across 6 categories:
   current version of a changed business key and opens a new one, expressed as
   portable UPDATE + INSERT against the dedicated `scd2_ops_*` dimension tables
   (no `APPLY CHANGES INTO` / declarative-pipeline syntax, so it runs unchanged on
-  standard-DML engines; ClickHouse lacks a standard UPDATE so it runs only the
-  insert-only path, and DataFusion is skipped)
+  standard-DML engines). The catalog marks only DataFusion unsupported; ClickHouse
+  has no standard UPDATE, so only the insert-only op is portable there and the
+  close-old ops would need a mutation rewrite (they are not auto-skipped today)
 
 **Purpose**: Test UPSERT/MERGE operations for CDC, ETL, slowly-changing
 dimension maintenance, and incremental data loading scenarios.


### PR DESCRIPTION
## Summary

Follow-up to the merged #1057, addressing both **P2** bot review comments from `chatgpt-codex-connector`:

1. **[docs:135] "Don't say ClickHouse runs only insert-only SCD2."** Correct — the harness does **not** filter SCD2 ops to insert-only on ClickHouse. The catalog marks only DataFusion unsupported, so `_get_effective_write_sql(platform_key="clickhouse")` falls through to the default `UPDATE` SQL, and `merge_scd_type2_basic`/`_no_change` are **attempted** (and error), not skipped. Reworded the docs bullet and the blog body: only the insert-only op is *portable* there, the close-old ops need a mutation rewrite, and BenchBox does **not yet special-case ClickHouse** (they are not auto-skipped).
2. **[draft:111] "Scope the remaining blog portability claims."** Correct — the qualification wasn't carried through. Scoped the **conclusion** ("the same workload on every engine" → "any standard-DML engine", with the ClickHouse insert-only/mutation caveat) and the **Next steps** invite (standard-DML engines; ClickHouse via the insert-only path or a mutation rewrite).

## Scope
Doc-accuracy only; no catalog or execution-filter change. Both files remain em/en-dash-free; `markdownlint` passes.

## Deferred (possible future TODO)
The bot noted the alternative: make the catalog/execution-filter actually skip the close-old SCD2 ops on ClickHouse (mirroring the DataFusion `platform_overrides: null`) so behavior matches the doc. That's a soundness/behavior change worth its own TODO; this PR takes the honest-doc route instead.

Resolves the two review comments on #1057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)