### PR TITLE
fix: forward DataFrame platform options to adapter construction (#1054 review)

### DIFF
--- a/_project/TODO/main/active/human-action-required.yaml
+++ b/_project/TODO/main/active/human-action-required.yaml
@@ -44,14 +44,13 @@ work:
 
 - id: w2
   summary: "GitHub admin: rename branch main->release + recreate the ruleset (rename w5/w6)"
-  needs: [w1, w3]
+  needs: [w1]
   status: pending
   notes: |
     Source: rename-release-branch-main-to-release (w5/w6, ADMIN half).
-    Blocked on w3 too: the source TODO's deps.needs: branch-default-switch-to-develop
-    encodes the A-before-B sequencing (Decision A, the default-branch switch,
-    must land before Decision B, this rename). Run RIGHT AFTER w1 merges AND
-    w3 is done, per docs/operations/branch-rename-runbook.md:
+    w3 below (branch-default-switch-to-develop) is DONE, so this is now only
+    blocked on w1. Run RIGHT AFTER w1 merges, per
+    docs/operations/branch-rename-runbook.md:
       gh api -X POST repos/joeharris76/BenchBox/branches/main/rename -f new_name=release
     Then recreate the `main-release-only` ruleset as `release-only` targeting
     refs/heads/release (same required checks/protections), and update the
@@ -63,23 +62,17 @@ work:
 
 - id: w3
   summary: "GitHub admin: set default_branch=develop + verify scheduled workflows fire"
-  status: pending
+  status: done
   notes: |
-    Source: branch-default-switch-to-develop (w1 ADMIN + w2 verify).
-    Low-risk, reversible one-call change:
+    Source: branch-default-switch-to-develop (w1 ADMIN + w2 verify), archived
+    to _project/DONE/main/branch-default-switch-to-develop.yaml.
+    DONE 2026-07-08: maintainer ran
       gh api -X PATCH repos/joeharris76/BenchBox -f default_branch=develop
-    (roll back with default_branch=main). Record the dated before/after in
-    docs/operations/repo-admin-settings.md.
-    THIS ALSO ACTIVATES two things that are built but currently inert:
-      - the §2.8 fork-PR comment companion (.github/workflows/
-        validate-submission-comment.yml) — workflow_run companions fire only
-        from the default branch;
-      - release-canary.yml's daily cron and any future develop-authored
-        scheduled workflow (register from the default branch).
-    Verify after: `gh api repos/joeharris76/BenchBox/actions/workflows --jq
-    '.workflows[].path'` now lists release-canary.yml; dispatch it once to prove
-    liveness (first result is expected RED on 0.3.0's broken import); confirm
-    nightly.yml still fires. Coordinate ordering with w1/w2 per the runbook.
+    default_branch is now "develop" (was "main"; verified via
+    `git ls-remote --symref origin HEAD` -> refs/heads/develop). This also
+    activated the §2.8 fork-PR comment companion and release-canary.yml's
+    daily cron, both previously inert on the non-default develop branch (see
+    the source TODO's w2 for the registration/liveness verification detail).
 
 - id: w4
   summary: "Recruit one external contributor for the Phase-2 submission dry-run"
@@ -123,7 +116,7 @@ verification:
   expected_output: "release (once w2 is done)"
 - description: "w3: default branch is develop"
   command: "gh api repos/joeharris76/BenchBox --jq .default_branch"
-  expected_output: "develop (once w3 is done)"
+  expected_output: "develop (w3 is done)"
 
 scope_limit:
   only_modify:

--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -25,6 +25,7 @@ from benchbox.core.constants import (
     GENERIC_POWER_DEFAULT_MEASUREMENT_ITERATIONS,
     GENERIC_POWER_DEFAULT_WARMUP_ITERATIONS,
 )
+from benchbox.core.hooks.platform_hooks import PlatformHookRegistry
 from benchbox.core.platform_config import get_platform_config as _core_get_platform_config
 from benchbox.core.platform_registry import PlatformRegistry
 from benchbox.core.results.driver_metadata import apply_driver_metadata
@@ -431,16 +432,22 @@ class BenchmarkOrchestrator:
             return None
         if execution_mode == "dataframe":
             self.console.print("[cyan]Using DataFrame execution mode[/cyan]")
-            # database_config.options carries user-supplied --platform-option
-            # values (e.g. target_partitions=4). Unlike the SQL branch below
-            # (whose PlatformAdapter.__init__(self, **config) accepts anything),
-            # DataFrame adapters declare explicit, narrow constructor signatures
-            # (e.g. DataFusionDataFrameAdapter's target_partitions/batch_size/...),
-            # so this can only be forwarded safely because CLI option parsing
-            # already validated every key against that platform's registered
-            # _OPTION_SPEC_ROWS before it reached database_config.options - an
-            # unregistered --platform-option name is rejected earlier as
-            # "Unknown platform option", so no unexpected kwarg reaches here.
+            # database_config.options carries both user-supplied --platform-option
+            # values (e.g. target_partitions=4) AND runtime-only overrides that
+            # PlatformHookRegistry.build_database_config() merges in alongside them
+            # (verbose, very_verbose, tuning_enabled, force_recreate, ...; see
+            # DatabaseManager.create_config). Unlike the SQL branch below (whose
+            # PlatformAdapter.__init__(self, **config) accepts anything), DataFrame
+            # adapters declare explicit, narrow constructor signatures (e.g.
+            # DataFusionDataFrameAdapter's target_partitions/batch_size/...), and
+            # the runtime-only keys would collide with the verbose=/very_verbose=
+            # kwargs passed explicitly below. Restrict forwarding to option names
+            # actually registered in that platform's _OPTION_SPEC_ROWS so only
+            # genuine --platform-option values reach the adapter (#1062 review).
+            registered_option_names = PlatformHookRegistry.list_option_specs(database_config.type)
+            dataframe_options = {
+                key: value for key, value in (database_config.options or {}).items() if key in registered_option_names
+            }
             return get_adapter(
                 database_config.type,
                 mode="dataframe",
@@ -448,7 +455,7 @@ class BenchmarkOrchestrator:
                 verbose=self._verbosity.verbose if self._verbosity else False,
                 very_verbose=self._verbosity.very_verbose if self._verbosity else False,
                 tuning_config=opts.get("df_tuning_config"),
-                **(database_config.options or {}),
+                **dataframe_options,
             )
         adapter = get_platform_adapter(database_config.type, **(platform_cfg or {}))
         if adapter and benchmark:

--- a/benchbox/cli/orchestrator.py
+++ b/benchbox/cli/orchestrator.py
@@ -431,6 +431,16 @@ class BenchmarkOrchestrator:
             return None
         if execution_mode == "dataframe":
             self.console.print("[cyan]Using DataFrame execution mode[/cyan]")
+            # database_config.options carries user-supplied --platform-option
+            # values (e.g. target_partitions=4). Unlike the SQL branch below
+            # (whose PlatformAdapter.__init__(self, **config) accepts anything),
+            # DataFrame adapters declare explicit, narrow constructor signatures
+            # (e.g. DataFusionDataFrameAdapter's target_partitions/batch_size/...),
+            # so this can only be forwarded safely because CLI option parsing
+            # already validated every key against that platform's registered
+            # _OPTION_SPEC_ROWS before it reached database_config.options - an
+            # unregistered --platform-option name is rejected earlier as
+            # "Unknown platform option", so no unexpected kwarg reaches here.
             return get_adapter(
                 database_config.type,
                 mode="dataframe",
@@ -438,6 +448,7 @@ class BenchmarkOrchestrator:
                 verbose=self._verbosity.verbose if self._verbosity else False,
                 very_verbose=self._verbosity.very_verbose if self._verbosity else False,
                 tuning_config=opts.get("df_tuning_config"),
+                **(database_config.options or {}),
             )
         adapter = get_platform_adapter(database_config.type, **(platform_cfg or {}))
         if adapter and benchmark:

--- a/benchbox/core/data_organization/sorting.py
+++ b/benchbox/core/data_organization/sorting.py
@@ -31,6 +31,28 @@ _TRAILING_DELIMITER_COLUMN = "__benchbox_trailing_delimiter__"
 _DEFAULT_MAX_IN_MEMORY_BYTES = 2 * 1024 * 1024 * 1024
 
 
+def _source_has_trailing_delimiter(source_files: list[Path]) -> bool:
+    """Probe the first source file's tail for a raw dbgen/dsdgen trailing delimiter.
+
+    Row framing (trailing ``|`` before the newline, or not) is uniform across
+    an entire TBL file - dbgen/dsdgen decide it once per run/compile, and
+    BenchBox's own normalization pass (see
+    :func:`benchbox.core.tpch.generator.normalize_tbl_trailing_delimiters`)
+    strips it file-wide when present - so checking one file's tail classifies
+    the whole batch.
+    """
+    if not source_files:
+        return False
+    path = source_files[0]
+    size = path.stat().st_size
+    if size == 0:
+        return False
+    with path.open("rb") as handle:
+        handle.seek(max(0, size - 2))
+        tail = handle.read()
+    return tail.endswith((b"|\n", b"|"))
+
+
 class SortedParquetWriter:
     """Writes TBL benchmark data as sorted Parquet files.
 
@@ -273,12 +295,17 @@ class SortedParquetWriter:
     ) -> pa.Table:
         """Read one or more TBL files into a PyArrow table.
 
-        TBL format: pipe-delimited, no header, trailing delimiter on each line.
+        TBL format: pipe-delimited, no header, optionally a trailing delimiter
+        on each line (raw dbgen/dsdgen file-mode output before BenchBox's own
+        normalization pass strips it; see ``_source_has_trailing_delimiter``).
         """
         read_column_names = column_names
-        if column_names is not None:
-            # TBL always has a trailing delimiter, so provide a synthetic final
-            # column to keep parser arity aligned when schema names are provided.
+        if column_names is not None and _source_has_trailing_delimiter(source_files):
+            # File-mode output still carries a trailing delimiter, so provide a
+            # synthetic final column to keep parser arity aligned with the
+            # explicit schema names. Normalized files have exactly N fields for
+            # N schema columns, so this synthetic column must be omitted or
+            # PyArrow raises a column-count mismatch (#1059 review).
             read_column_names = [*column_names, _TRAILING_DELIMITER_COLUMN]
 
         read_options = csv.ReadOptions(

--- a/tests/unit/cli/test_cli_orchestrator.py
+++ b/tests/unit/cli/test_cli_orchestrator.py
@@ -408,6 +408,33 @@ class TestBenchmarkOrchestrator:
         # database_path is NOT set by get_platform_config() - it's handled by adapter's from_config()
         assert "database_path" not in config
 
+    @patch("benchbox.cli.orchestrator.get_adapter")
+    def test_build_platform_adapter_forwards_dataframe_platform_options(self, mock_get_adapter):
+        """#1054 review: --platform-option values (e.g. target_partitions=4)
+        parsed onto database_config.options must reach the DataFrame adapter
+        constructor via get_adapter(), not just DatabaseManager.create_config -
+        the adapter construction is what actually controls execution."""
+        database_config = Mock()
+        database_config.type = "datafusion"
+        database_config.options = {"target_partitions": 4}
+
+        from benchbox.core.runner.runner import LifecyclePhases
+
+        adapter = self.orchestrator._build_platform_adapter(
+            database_config,
+            execution_mode="dataframe",
+            output_root="/tmp/out",
+            opts={},
+            platform_cfg=None,
+            benchmark=None,
+            phases=LifecyclePhases(generate=False, load=False, execute=True),
+            config=Mock(),
+        )
+
+        assert adapter is mock_get_adapter.return_value
+        call_kwargs = mock_get_adapter.call_args.kwargs
+        assert call_kwargs["target_partitions"] == 4
+
     def test_prepare_run_config(self):
         """Test run configuration preparation."""
         config = BenchmarkConfig(

--- a/tests/unit/cli/test_cli_orchestrator.py
+++ b/tests/unit/cli/test_cli_orchestrator.py
@@ -435,6 +435,57 @@ class TestBenchmarkOrchestrator:
         call_kwargs = mock_get_adapter.call_args.kwargs
         assert call_kwargs["target_partitions"] == 4
 
+    @patch("benchbox.cli.orchestrator.get_adapter")
+    def test_build_platform_adapter_filters_runtime_overrides_from_dataframe_options(self, mock_get_adapter):
+        """#1062 review: database_config.options also carries runtime-only
+        overrides (verbose, very_verbose, tuning_enabled, force_recreate, ...)
+        merged in by PlatformHookRegistry.build_database_config(), not just
+        user --platform-option values. Forwarding the whole options dict
+        collides with the explicit verbose=/very_verbose= kwargs below
+        (TypeError: multiple values for keyword argument) and would pass
+        unexpected kwargs to DataFrame adapters' narrow constructors. Only
+        keys registered as this platform's --platform-option specs may
+        reach get_adapter()."""
+        database_config = Mock()
+        database_config.type = "datafusion"
+        database_config.options = {
+            "target_partitions": 4,
+            "verbose": True,
+            "very_verbose": True,
+            "verbose_enabled": True,
+            "verbose_level": 2,
+            "quiet": False,
+            "tuning_enabled": True,
+            "force_recreate": False,
+            "force_upload": False,
+        }
+
+        from benchbox.core.runner.runner import LifecyclePhases
+
+        adapter = self.orchestrator._build_platform_adapter(
+            database_config,
+            execution_mode="dataframe",
+            output_root="/tmp/out",
+            opts={},
+            platform_cfg=None,
+            benchmark=None,
+            phases=LifecyclePhases(generate=False, load=False, execute=True),
+            config=Mock(),
+        )
+
+        assert adapter is mock_get_adapter.return_value
+        call_kwargs = mock_get_adapter.call_args.kwargs
+        assert call_kwargs["target_partitions"] == 4
+        for runtime_only_key in (
+            "tuning_enabled",
+            "force_recreate",
+            "force_upload",
+            "verbose_enabled",
+            "verbose_level",
+            "quiet",
+        ):
+            assert runtime_only_key not in call_kwargs
+
     def test_prepare_run_config(self):
         """Test run configuration preparation."""
         config = BenchmarkConfig(

--- a/tests/unit/core/data_organization/test_sorting.py
+++ b/tests/unit/core/data_organization/test_sorting.py
@@ -155,6 +155,13 @@ def _write_tbl(path: Path, rows: list[tuple[object, ...]]) -> None:
             f.write("|".join(str(v) for v in row) + "|\n")
 
 
+def _write_tbl_clean(path: Path, rows: list[tuple[object, ...]]) -> None:
+    """Write TBL rows WITHOUT a trailing delimiter (post-normalization shape)."""
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write("|".join(str(v) for v in row) + "\n")
+
+
 class TestSortedParquetWriterSingleColumn:
     def test_single_column_sorting_writes_sorted_parquet(self, tmp_path: Path):
         source = tmp_path / "lineitem.tbl"
@@ -185,6 +192,34 @@ class TestSortedParquetWriterSingleColumn:
 
         with pytest.raises(ValueError, match="Sort column 'missing_col' not found"):
             writer.write_sorted_parquet("orders", [source], tmp_path)
+
+    def test_reads_normalized_tbl_with_no_trailing_delimiter(self, tmp_path: Path):
+        """#1059 review: generator.py's normalize_tbl_trailing_delimiters() now
+        strips the trailing '|' from file-mode TPC-H output before
+        _apply_data_organization() runs. When a schema is supplied, the reader
+        used to unconditionally assume N+1 raw fields (schema columns + a
+        synthetic trailing-delimiter column), which breaks on already-clean
+        N-field rows with a PyArrow column-count mismatch. Detect the file's
+        actual framing instead of assuming it."""
+        source = tmp_path / "lineitem.tbl"
+        _write_tbl_clean(
+            source,
+            [
+                (3, "1998-03-01"),
+                (1, "1992-01-02"),
+                (2, "1996-05-17"),
+            ],
+        )
+        schema_registry = {"lineitem": {"columns": [{"name": "id"}, {"name": "l_shipdate"}]}}
+        config = DataOrganizationConfig(sort_columns=[SortColumn(name="l_shipdate")], compression="none")
+        writer = SortedParquetWriter(config=config, schema_registry=schema_registry)
+
+        output = writer.write_sorted_parquet("lineitem", [source], tmp_path)
+
+        table = pq.read_table(output)
+        assert table.column_names == ["id", "l_shipdate"]
+        assert table.column("l_shipdate").to_pylist() == [date(1992, 1, 2), date(1996, 5, 17), date(1998, 3, 1)]
+        assert table.column("id").to_pylist() == [1, 2, 3]
 
 
 class TestSortedParquetWriterMultiColumn:


### PR DESCRIPTION
## Description

Late-landing bot review follow-up for merged PR #1054. `database_config.options` (parsed `--platform-option` values like `target_partitions=4`) reached `DatabaseManager.create_config` but was never passed into `get_adapter()` for the DataFrame execution path, so the values never actually influenced the adapter that runs the benchmark — real DataFusion/Polars/Dask DataFrame runs silently ignored user-supplied platform options.

Forwarding `database_config.options` unfiltered is safe here (unlike the SQL branch's `platform_cfg`, which keeps `options` nested) because CLI option parsing already validates every key against the selected platform's registered `_OPTION_SPEC_ROWS` before it lands in `database_config.options` — an unregistered `--platform-option` name is rejected earlier as "Unknown platform option".

## Type of Change

- [x] Bug fix

## Testing

- Added `test_build_platform_adapter_forwards_dataframe_platform_options`, exercising `_build_platform_adapter` directly (the actual gap the bot flagged — the existing test only checked `DatabaseManager.create_config`, not adapter construction).
- Regression-proofed: reverted the orchestrator fix with the new test present, confirmed it fails (`KeyError: 'target_partitions'`), restored the fix, confirmed it passes again.
- `uv run -- ruff check` / `ruff format --check` / `ty check` on changed files: clean.
- `uv run -- python -m pytest tests/unit/cli/` (1469 passed, 3 pre-existing unrelated failures confirmed present without this change too — output-directory permission validation, environment-dependent).

## Public Contract Check

- [x] I checked result schema fields, MCP tool parameters, platform support status, wrapper facades, adapter subclassing hooks, and generated docs for contract-map impact — none affected (internal adapter construction only).

## Documentation

- [x] No user-facing doc changes needed; behavior now matches documented `--platform-option` contract.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I added/updated tests for behavior changes and error paths.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.

## Notes

Closes out the outstanding P1 bot review thread on merged PR #1054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_