### PR TITLE
docs: canonicalize redirected external links (linkcheck hygiene)

### DIFF
--- a/docs/benchmarks/tsbs-devops.md
+++ b/docs/benchmarks/tsbs-devops.md
@@ -445,5 +445,5 @@ The generator creates realistic data with:
 ## External Resources
 
 - [TSBS GitHub Repository](https://github.com/timescale/tsbs) - Original implementation
-- [TimescaleDB Documentation](https://docs.timescale.com/) - Time-series optimization
-- [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/) - Time-series data format
+- [TimescaleDB Documentation](https://www.tigerdata.com/docs) - Time-series optimization
+- [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/) - Time-series data format

--- a/docs/blog/2026-03-03-duckdb-tpch-extension-vs-benchbox.md
+++ b/docs/blog/2026-03-03-duckdb-tpch-extension-vs-benchbox.md
@@ -55,16 +55,16 @@ CALL dbgen(sf=1);
 PRAGMA tpch(1);
 ```
 
-The `tpch` extension documentation highlights several practical features ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch.html)):
+The `tpch` extension documentation highlights several practical features ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch)):
 
 - `CALL dbgen(sf=<value>)` handles TPC-H data generation in-engine.
 - `sf=0` creates schema without generating data.
 - `children` and `step` allow chunked and parallelized data-generation control.
 - Existing tables are not dropped automatically during regeneration.
 
-For query execution, `PRAGMA tpch(query_id)` provides direct query access with predefined bind behavior ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch.html), [DuckDB benchmarking guide](https://duckdb.org/docs/stable/guides/performance/benchmarks)).
+For query execution, `PRAGMA tpch(query_id)` provides direct query access with predefined bind behavior ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch), [DuckDB benchmarking guide](https://duckdb.org/docs/stable/guides/performance/benchmarks)).
 
-DuckDB also exposes `tpch_answers()`, with documented expected answers currently for SF 0.01, 0.1, and 1 ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch.html)).
+DuckDB also exposes `tpch_answers()`, with documented expected answers currently for SF 0.01, 0.1, and 1 ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch)).
 
 Why this path is strong:
 
@@ -79,7 +79,7 @@ Where this path is narrower:
 - DuckDB's `tpch` extension does not support RF1/RF2 maintenance operations (the TPC-H insert and delete refresh functions that simulate ongoing data maintenance).
 - Workflow metadata and artifact structure are not the primary interface.
 
-Maintenance support note: the documented extension API covers `tpch` (pragma), `tpch_queries`, and `tpch_answers`, with no RF1/RF2 maintenance entry points ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch.html)).
+Maintenance support note: the documented extension API covers `tpch` (pragma), `tpch_queries`, and `tpch_answers`, with no RF1/RF2 maintenance entry points ([DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch)).
 
 ## BenchBox TPC-H mode
 
@@ -320,7 +320,7 @@ We built BenchBox to make workflow guarantees explicit. We would love to hear ho
 
 ## References
 
-1. [DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch.html)
+1. [DuckDB TPC-H extension docs](https://duckdb.org/docs/stable/core_extensions/tpch)
 2. [DuckDB benchmarking guide](https://duckdb.org/docs/stable/guides/performance/benchmarks)
 3. [BenchBox TPC-H benchmark core](https://github.com/joeharris76/BenchBox/blob/main/benchbox/core/tpch/benchmark.py)
 4. [BenchBox TPC-H generator](https://github.com/joeharris76/BenchBox/blob/main/benchbox/core/tpch/generator.py)

--- a/docs/blog/2026-05-18-sketch-functions-databricks-response.md
+++ b/docs/blog/2026-05-18-sketch-functions-databricks-response.md
@@ -249,9 +249,9 @@ The support matrix separates catalog support from live verification. Cloud verif
 
 [^8]: Snowflake, [`APPROX_TOP_K_ACCUMULATE`](https://docs.snowflake.com/en/sql-reference/functions/approx_top_k_accumulate), accessed May 18, 2026.
 
-[^9]: BigQuery, [HyperLogLog++ functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/hll_functions), accessed May 18, 2026.
+[^9]: BigQuery, [HyperLogLog++ functions](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/hll_functions), accessed May 18, 2026.
 
-[^10]: BigQuery, [KLL quantile functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/kll_functions), accessed May 18, 2026.
+[^10]: BigQuery, [KLL quantile functions](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/kll_functions), accessed May 18, 2026.
 
 [^11]: ClickHouse, ["Using Aggregate Combinators in ClickHouse"](https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states), accessed May 18, 2026.
 

--- a/docs/concepts/benchmarking-tools-compared.md
+++ b/docs/concepts/benchmarking-tools-compared.md
@@ -212,7 +212,7 @@ benchbox run --platform duckdb --benchmark tpch --scale 0.1
 - [HammerDB Official Site](https://www.hammerdb.com/)
 - [HammerDB GitHub (TPC Council)](https://github.com/TPC-Council/HammerDB)
 - [BenchBase GitHub (CMU)](https://github.com/cmu-db/benchbase)
-- [LakeBench GitHub](https://github.com/mwc360/LakeBench)
+- [LakeBench GitHub](https://github.com/microsoft/LakeBench)
 
 ## See Also
 

--- a/docs/development/read-primitives-skips-reference.md
+++ b/docs/development/read-primitives-skips-reference.md
@@ -231,7 +231,7 @@ model relies on `UNNEST` + re-aggregation, which changes query structure rather
 than being a drop-in dialect fix.
 
 **Re-enable when**: These functions appear in the
-[BigQuery Standard SQL array functions reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions).
+[BigQuery Standard SQL array functions reference](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/array_functions).
 
 ---
 
@@ -243,7 +243,7 @@ value>>` patterns instead. The queries test map-as-first-class-value semantics
 cannot express equivalently.
 
 **Re-enable when**: A native MAP type or `MAP_FROM_ENTRIES` function appears
-in the [BigQuery data types reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
+in the [BigQuery data types reference](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
 
 ---
 
@@ -253,7 +253,7 @@ in the [BigQuery data types reference](https://cloud.google.com/bigquery/docs/re
 `FILTER(arr, x -> ...)`, or `REDUCE(arr, init, (acc, x) -> ...)`.
 
 **Re-enable when**: Lambda/higher-order array functions appear in the
-[BigQuery array functions reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions).
+[BigQuery array functions reference](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/array_functions).
 
 ---
 
@@ -262,7 +262,7 @@ in the [BigQuery data types reference](https://cloud.google.com/bigquery/docs/re
 **Why skipped**: BigQuery does not support `ASOF JOIN` syntax.
 
 **Re-enable when**: `ASOF JOIN` appears in the
-[BigQuery JOIN reference](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#join_types).
+[BigQuery JOIN reference](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#join_types).
 
 ---
 
@@ -391,7 +391,7 @@ clause syntax. ClickHouse provides `ARRAY JOIN` and conditional aggregation
 query structure that tests different capabilities than `PIVOT`/`UNPIVOT`.
 
 **Re-enable when**: Standard `PIVOT`/`UNPIVOT` clause syntax appears in the
-[ClickHouse SELECT reference](https://clickhouse.com/docs/en/sql-reference/statements/select).
+[ClickHouse SELECT reference](https://clickhouse.com/docs/sql-reference/statements/select).
 
 ---
 
@@ -438,7 +438,7 @@ time this skip was added. Spark's `MERGE ASOF` exists in PySpark but is not
 available as a SQL clause.
 
 **Re-enable when**: `ASOF JOIN` appears in the
-[Databricks SQL reference](https://docs.databricks.com/sql/language-manual/sql-ref-syntax-qry-select-join.html).
+[Databricks SQL reference](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-select-join).
 
 ---
 

--- a/docs/platforms/clickhouse-cloud.md
+++ b/docs/platforms/clickhouse-cloud.md
@@ -34,7 +34,7 @@ benchbox run --platform clickhouse-cloud --benchmark tpch --scale 1.0
 
 ### Getting Your Credentials
 
-1. Sign in to [clickhouse.cloud](https://clickhouse.cloud)
+1. Sign in to [clickhouse.cloud](https://console.clickhouse.cloud/)
 2. Navigate to your service
 3. Click "Connect" to get your connection details:
    - **Host**: `abc123.us-east-2.aws.clickhouse.cloud`

--- a/docs/platforms/databricks-dataframe.md
+++ b/docs/platforms/databricks-dataframe.md
@@ -38,7 +38,7 @@ uv add benchbox --extra cloud-spark-databricks
 The base `databricks` extra covers SQL-mode only; it does **not** pull in
 `databricks-connect`. Use `cloud-spark-databricks` (or the legacy
 `databricks-connect` alias) for DataFrame-mode runs. See
-[Databricks Connect docs](https://docs.databricks.com/dev-tools/databricks-connect.html).
+[Databricks Connect docs](https://docs.databricks.com/aws/en/dev-tools/databricks-connect).
 
 ## Authentication
 

--- a/docs/platforms/datafusion.md
+++ b/docs/platforms/datafusion.md
@@ -599,6 +599,6 @@ DataFusion has some limitations compared to full database systems:
 - [Benchmark Catalog](../benchmarks/index.md) - All available benchmarks
 
 ### External Resources
-- [Apache DataFusion Documentation](https://arrow.apache.org/datafusion/) - Official DataFusion docs
-- [DataFusion Python Bindings](https://arrow.apache.org/datafusion-python/) - Python API reference
+- [Apache DataFusion Documentation](https://datafusion.apache.org/) - Official DataFusion docs
+- [DataFusion Python Bindings](https://datafusion.apache.org/python/) - Python API reference
 - [Apache Arrow](https://arrow.apache.org/) - Arrow columnar format

--- a/docs/platforms/doris.md
+++ b/docs/platforms/doris.md
@@ -351,7 +351,7 @@ Several vendors offer managed Apache Doris cloud services:
 
 | Provider | Service | Description |
 |----------|---------|-------------|
-| **VeloDB Cloud** | [velodb.io](https://velodb.io) | Fully managed Doris by core contributors |
+| **VeloDB Cloud** | [velodb.io](https://www.velodb.io/) | Fully managed Doris by core contributors |
 | **SelectDB Cloud** | [selectdb.com](https://selectdb.com) | Enterprise managed Doris with compute-storage separation |
 | **ApsaraDB for SelectDB** | Alibaba Cloud | Managed Doris on Alibaba Cloud infrastructure |
 

--- a/docs/platforms/singlestore.md
+++ b/docs/platforms/singlestore.md
@@ -145,4 +145,4 @@ SET GLOBAL local_infile = ON;
 
 - [SingleStore Documentation](https://docs.singlestore.com/)
 - [singlestoredb Python SDK](https://github.com/singlestore-labs/singlestoredb-python)
-- [SingleStore Helios](https://www.singlestore.com/cloud/)
+- [SingleStore Helios](https://www.singlestore.com/product-overview/)

--- a/docs/reference/python-api/cloud-storage.rst
+++ b/docs/reference/python-api/cloud-storage.rst
@@ -916,5 +916,5 @@ External Resources
 
 - `cloudpathlib Documentation <https://cloudpathlib.drivendata.org/>`_ - Underlying cloud path library
 - `AWS S3 Documentation <https://docs.aws.amazon.com/s3/>`_ - Amazon S3 object storage
-- `Google Cloud Storage Documentation <https://cloud.google.com/storage/docs>`_ - GCS documentation
-- `Azure Blob Storage Documentation <https://docs.microsoft.com/en-us/azure/storage/blobs/>`_ - Azure storage
+- `Google Cloud Storage Documentation <https://docs.cloud.google.com/storage/docs>`_ - GCS documentation
+- `Azure Blob Storage Documentation <https://learn.microsoft.com/en-us/azure/storage/blobs/>`_ - Azure storage

--- a/docs/reference/python-api/platforms/bigquery.rst
+++ b/docs/reference/python-api/platforms/bigquery.rst
@@ -745,8 +745,8 @@ API Reference
 External Resources
 ~~~~~~~~~~~~~~~~~~
 
-- `BigQuery Documentation <https://cloud.google.com/bigquery/docs>`_ - Official BigQuery docs
-- `BigQuery Best Practices <https://cloud.google.com/bigquery/docs/best-practices>`_ - Performance and cost optimization
-- `Partitioning Guide <https://cloud.google.com/bigquery/docs/partitioned-tables>`_ - Partitioning strategies
-- `Clustering Guide <https://cloud.google.com/bigquery/docs/clustered-tables>`_ - Clustering best practices
-- `Cost Optimization <https://cloud.google.com/bigquery/docs/best-practices-costs>`_ - Reducing query costs
+- `BigQuery Documentation <https://docs.cloud.google.com/bigquery/docs>`_ - Official BigQuery docs
+- `BigQuery Best Practices <https://docs.cloud.google.com/bigquery/docs/best-practices-performance-overview>`_ - Performance and cost optimization
+- `Partitioning Guide <https://docs.cloud.google.com/bigquery/docs/partitioned-tables>`_ - Partitioning strategies
+- `Clustering Guide <https://docs.cloud.google.com/bigquery/docs/clustered-tables>`_ - Clustering best practices
+- `Cost Optimization <https://docs.cloud.google.com/bigquery/docs/best-practices-costs>`_ - Reducing query costs

--- a/docs/reference/python-api/platforms/clickhouse.rst
+++ b/docs/reference/python-api/platforms/clickhouse.rst
@@ -631,6 +631,6 @@ External Resources
 ~~~~~~~~~~~~~~~~~~
 
 - `ClickHouse Documentation <https://clickhouse.com/docs>`_ - Official ClickHouse docs
-- `ClickHouse Performance Guide <https://clickhouse.com/docs/en/operations/optimizing-performance/>`_ - Performance tuning
+- `ClickHouse Performance Guide <https://clickhouse.com/docs/optimize/query-optimization>`_ - Performance tuning
 - `chDB Documentation <https://github.com/chdb-io/chdb>`_ - Local mode library
-- `ClickHouse Table Engines <https://clickhouse.com/docs/en/engines/table-engines/>`_ - Storage engines
+- `ClickHouse Table Engines <https://clickhouse.com/docs/engines/table-engines>`_ - Storage engines

--- a/docs/reference/python-api/platforms/databricks.rst
+++ b/docs/reference/python-api/platforms/databricks.rst
@@ -753,8 +753,8 @@ API Reference
 External Resources
 ~~~~~~~~~~~~~~~~~~
 
-- `Databricks Documentation <https://docs.databricks.com/>`_ - Official Databricks docs
-- `Delta Lake Guide <https://docs.databricks.com/delta/index.html>`_ - Delta Lake reference
-- `Unity Catalog <https://docs.databricks.com/data-governance/unity-catalog/index.html>`_ - Unity Catalog docs
-- `SQL Warehouses <https://docs.databricks.com/sql/admin/sql-endpoints.html>`_ - Warehouse configuration
-- `Photon Engine <https://docs.databricks.com/runtime/photon.html>`_ - Photon performance
+- `Databricks Documentation <https://docs.databricks.com/aws/en>`_ - Official Databricks docs
+- `Delta Lake Guide <https://docs.databricks.com/aws/en/delta>`_ - Delta Lake reference
+- `Unity Catalog <https://docs.databricks.com/aws/en/data-governance/unity-catalog>`_ - Unity Catalog docs
+- `SQL Warehouses <https://docs.databricks.com/aws/en/compute/sql-warehouse/create>`_ - Warehouse configuration
+- `Photon Engine <https://docs.databricks.com/aws/en/compute/photon>`_ - Photon performance

--- a/docs/reference/python-api/platforms/datafusion.rst
+++ b/docs/reference/python-api/platforms/datafusion.rst
@@ -675,6 +675,6 @@ API Reference
 External Resources
 ~~~~~~~~~~~~~~~~~~
 
-- `Apache DataFusion Documentation <https://arrow.apache.org/datafusion/>`_ - Official docs
-- `DataFusion Python Bindings <https://arrow.apache.org/datafusion-python/>`_ - Python API
+- `Apache DataFusion Documentation <https://datafusion.apache.org/>`_ - Official docs
+- `DataFusion Python Bindings <https://datafusion.apache.org/python/>`_ - Python API
 - `Apache Arrow <https://arrow.apache.org/>`_ - Arrow columnar format

--- a/docs/reference/python-api/platforms/snowflake.rst
+++ b/docs/reference/python-api/platforms/snowflake.rst
@@ -772,8 +772,8 @@ API Reference
 External Resources
 ~~~~~~~~~~~~~~~~~~
 
-- `Snowflake Documentation <https://docs.snowflake.com/>`_ - Official Snowflake docs
-- `Warehouse Sizing <https://docs.snowflake.com/en/user-guide/warehouses-considerations.html>`_ - Sizing guidance
-- `Clustering Keys <https://docs.snowflake.com/en/user-guide/tables-clustering-keys.html>`_ - Clustering best practices
-- `Cost Optimization <https://docs.snowflake.com/en/user-guide/cost-understanding.html>`_ - Cost management
-- `Time Travel <https://docs.snowflake.com/en/user-guide/data-time-travel.html>`_ - Time Travel guide
+- `Snowflake Documentation <https://docs.snowflake.com/en/>`_ - Official Snowflake docs
+- `Warehouse Sizing <https://docs.snowflake.com/en/user-guide/warehouses-considerations>`_ - Sizing guidance
+- `Clustering Keys <https://docs.snowflake.com/en/user-guide/tables-clustering-keys>`_ - Clustering best practices
+- `Cost Optimization <https://docs.snowflake.com/en/user-guide/cost-understanding-overall>`_ - Cost management
+- `Time Travel <https://docs.snowflake.com/en/user-guide/data-time-travel>`_ - Time Travel guide

--- a/docs/reference/python-api/tuning.rst
+++ b/docs/reference/python-api/tuning.rst
@@ -754,7 +754,7 @@ See Also
 External Resources
 ~~~~~~~~~~~~~~~~~~
 
-- `Databricks Delta Lake Optimization <https://docs.databricks.com/delta/optimizations/index.html>`_
+- `Databricks Delta Lake Optimization <https://docs.databricks.com/aws/en/optimizations>`_
 - `Snowflake Clustering <https://docs.snowflake.com/en/user-guide/tables-clustering-keys>`_
 - `Redshift Distribution Styles <https://docs.aws.amazon.com/redshift/latest/dg/c_choosing_dist_sort.html>`_
-- `BigQuery Partitioning <https://cloud.google.com/bigquery/docs/partitioned-tables>`_
+- `BigQuery Partitioning <https://docs.cloud.google.com/bigquery/docs/partitioned-tables>`_

--- a/docs/testing/live-integration-tests.md
+++ b/docs/testing/live-integration-tests.md
@@ -352,9 +352,9 @@ uv run -- python -m pytest -m live_databricks -v --log-cli-level=DEBUG
 
 - [BenchBox Documentation](../../README.md)
 - [Platform Setup Guide](../platforms/index.md)
-- [Databricks SQL Warehouse Docs](https://docs.databricks.com/sql/admin/sql-endpoints.html)
-- [Snowflake Connection Docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html)
-- [BigQuery Authentication Docs](https://cloud.google.com/bigquery/docs/authentication)
+- [Databricks SQL Warehouse Docs](https://docs.databricks.com/aws/en/compute/sql-warehouse/create)
+- [Snowflake Connection Docs](https://docs.snowflake.com/en/user-guide/admin-account-identifier)
+- [BigQuery Authentication Docs](https://docs.cloud.google.com/bigquery/docs/authentication)
 
 ## Support
 


### PR DESCRIPTION
## Summary

Follow-up to #1051 (which hardened the Sphinx `linkcheck` job). A clean `make docs-linkcheck` run reported **0 broken / 0 timeouts** but **49 permanent redirects** — external URLs that resolve fine (so CI stays green) but point at stale locations the upstream site 301/302-redirects to a canonical URL. Redirects don't fail the build, so this is pure source-link hygiene: repoint the stale links so readers (and future linkcheck runs) hit the real page directly.

This is **external http/https links only** — the internal repo-relative link baseline is the separate `check_doc_relative_links.py` burn-down tracked in `burn-down-baselined-broken-doc-links`. Implements the `canonicalize-redirected-external-doc-links` TODO.

## Result

| Metric | Before | After |
|---|---|---|
| broken | 0 | 0 |
| timeouts | 0 | 0 |
| redirected | 49 | 9 (intentional residual) |
| working | 117 | 153 |

48 external link references across 18 files repointed. `make lint format typecheck` clean.

## Disposition — REPOINTed (canonical rewrites)

| From -> To | Where |
|---|---|
| `docs.snowflake.com/....html` -> extensionless canonical | snowflake.rst, live-integration-tests.md |
| `cloud.google.com/{bigquery,storage}` -> `docs.cloud.google.com/...` | bigquery.rst, cloud-storage.rst, read-primitives-skips-reference.md, sketch-functions blog |
| `clickhouse.com/docs/en/...` -> `clickhouse.com/docs/...` | clickhouse.rst, read-primitives-skips-reference.md |
| `arrow.apache.org/datafusion*` -> `datafusion.apache.org/*` | datafusion.md, datafusion.rst |
| `docs.databricks.com/....html` -> `docs.databricks.com/aws/en/...` | databricks.rst, databricks-dataframe.md, read-primitives-skips-reference.md |
| `docs.microsoft.com` -> `learn.microsoft.com` | cloud-storage.rst |
| `docs.influxdata.com/.../latest` -> `/v2`; `docs.timescale.com` -> `tigerdata.com/docs` | tsbs-devops.md |
| duckdb `...tpch.html` -> `...tpch` | duckdb-tpch blog |
| `clickhouse.cloud` -> `console.clickhouse.cloud/` | clickhouse-cloud.md |
| `velodb.io` -> `www.velodb.io/`; `singlestore.com/cloud/` -> `/product-overview/` | doris.md, singlestore.md |
| `github.com/mwc360/LakeBench` -> `github.com/microsoft/LakeBench` (repo transfer) | benchmarking-tools-compared.md |

## Disposition — LEFT ALONE (9 residual, intentional)

- **DOI** `doi.org/10.7910/...` -> dataverse — the DOI is the durable citation identifier; the redirect is the point of a DOI.
- **Auth gate** `github.com/.../issues/new` -> `github.com/login?return_to=...` — the source link is correct; the redirect is anonymous-checker auth.
- **Version canonicalization** `rich.readthedocs.io/` -> `/en/stable/` — low value, re-churns each docs release.
- **Scheme/port normalization** `http://tpc.org/...` -> `https://...`, `cs.umb.edu` and `nyc.gov` `:443` — cosmetic.
- **Generic-index collapse** AWS `whats-new?...redshift` and Redshift `dg/r_*.html` -> redirect lands on a generic index page, not a specific successor — repointing would downgrade a specific (if stale) link. Left with this note rather than pointing at a worse target.

## Verification

- `make docs-linkcheck` -> exit 0, 0 broken, 0 timeouts, redirect count 49 -> 9.
- `! rg -n 'docs\.snowflake\.com/[^ )]+\.html' docs/` -> no matches.
- `make lint format typecheck` -> clean.
- Scope: `docs/` source only; no changes to `docs/conf.py`, `docs/linkcheck_ignore.txt`, the relative-link baseline, or workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)