### PR TITLE
feat(uat): add Apple container cleanup mode to uat-docker-cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,21 @@ query). NOT validated: 3+ service stacks -- databend stays healthy on docker but
 minio exits on mocker, so use docker for multi-service (doris/starrocks are
 all-in-one single containers).
 
+## Apple container cleanup
+
+The Apple `container` store (`~/Library/Application Support/com.apple.container`)
+grows unbounded -- image snapshots, mocker compose leftovers, the buildkit
+builder's writable cache. Reclaim it via the container mode of the UAT cleanup
+flow: `make uat-docker-cleanup ENGINE=container [MODE=owned|images|max]
+[APPLY=1]`. Dry-run (no `APPLY`) prints `container system df` footprint + the
+plan; it speaks the native `container` CLI (mocker can't inventory). Mode ladder,
+widest last: `owned` (default; `benchbox/*` + `local/benchbox*` images and
+UAT-prefixed compose leftovers) < `images` (+ shared pull-through bases:
+postgres/ubuntu/uv/questdb) < `max` (+ stopped-container/volume prune + builder
+delete, ~all reclaimable). Never removes the store dir or stops `container
+system`. `owned` is safe anytime; `max` also clears non-BenchBox containers, so
+run it only when the engine is idle.
+
 ## Output Discipline
 
 Broad commands are final gates. Long output is an artifact, not chat, and

--- a/Makefile
+++ b/Makefile
@@ -2087,9 +2087,14 @@ uat-bring-up:
 		$(if $(BENCHMARK_RUNS_DIR),--benchmark-runs-dir "$(BENCHMARK_RUNS_DIR)",) \
 		$(if $(DRY_RUN),--dry-run,)
 
-# make uat-docker-cleanup [APPLY=1] [PREFIX=benchbox-uat]
+# make uat-docker-cleanup [ENGINE=docker|container] [MODE=owned|images|max] [APPLY=1] [PREFIX=benchbox-uat]
+# ENGINE=container reclaims the Apple `container` store (~/Library/Application
+# Support/com.apple.container); MODE widens breadth owned<images<max. See
+# AGENTS.md "Apple container cleanup".
 uat-docker-cleanup:
 	@uv run --no-sync -- python -m tests.uat._cli docker-cleanup \
+		$(if $(ENGINE),--engine "$(ENGINE)",) \
+		$(if $(MODE),--mode "$(MODE)",) \
 		$(if $(PREFIX),--prefix "$(PREFIX)",) \
 		$(if $(APPLY),--apply,)
 
@@ -2203,6 +2208,7 @@ help:
 	@echo "UAT Operations:"
 	@echo "  make uat-docker-cleanup        Report abandoned UAT Docker resources and non-UAT cleanup commands"
 	@echo "  make uat-docker-cleanup APPLY=1 Remove only UAT-owned Docker leftovers"
+	@echo "  make uat-docker-cleanup ENGINE=container [MODE=owned|images|max] Reclaim the Apple container store"
 	@echo ""
 	@echo "Coverage:"
 	@echo "  make coverage-fast   Run fast-marked tests with coverage (quick feedback)"

--- a/tests/uat/_cli.py
+++ b/tests/uat/_cli.py
@@ -442,7 +442,10 @@ def _handle_execute(args: argparse.Namespace) -> int:
 
 
 def _handle_docker_cleanup(args: argparse.Namespace) -> int:
-    """Implements `make uat-docker-cleanup [APPLY=1]`."""
+    """Implements `make uat-docker-cleanup [ENGINE=] [MODE=] [APPLY=1]`."""
+    if args.engine == "container":
+        return _handle_container_cleanup(args)
+
     from tests.uat import docker_cleanup
 
     try:
@@ -454,6 +457,23 @@ def _handle_docker_cleanup(args: argparse.Namespace) -> int:
         print(f"[uat-docker-cleanup] ERROR: {exc}", file=sys.stderr)
         return 2
     print(docker_cleanup.format_cleanup_report(report))
+    return 0
+
+
+def _handle_container_cleanup(args: argparse.Namespace) -> int:
+    """Apple `container` mode of `make uat-docker-cleanup ENGINE=container`."""
+    from tests.uat import container_cleanup
+
+    try:
+        report = container_cleanup.reclaim_container_usage(
+            project_prefix=args.prefix,
+            mode=args.mode,
+            apply=args.apply,
+        )
+    except container_cleanup.ContainerCleanupError as exc:
+        print(f"[uat-docker-cleanup] ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(container_cleanup.format_container_cleanup_report(report))
     return 0
 
 
@@ -546,18 +566,32 @@ def _build_parser() -> argparse.ArgumentParser:
     execute.add_argument("--resume", default=None, help="Path to a prior execute/sweep resume.json manifest")
     _set_handler(execute, _handle_execute)
 
-    docker = subparsers.add_parser("docker-cleanup", help="report or remove abandoned UAT-owned Docker resources")
-    from tests.uat import docker_cleanup
+    docker = subparsers.add_parser(
+        "docker-cleanup", help="report or remove abandoned UAT-owned Docker / Apple container resources"
+    )
+    from tests.uat import container_cleanup, docker_cleanup
 
+    docker.add_argument(
+        "--engine",
+        choices=("docker", "container"),
+        default="docker",
+        help="Cleanup engine: 'docker' (default) or 'container' (Apple container store).",
+    )
+    docker.add_argument(
+        "--mode",
+        choices=container_cleanup.CONTAINER_CLEANUP_MODES,
+        default="owned",
+        help="Apple-container breadth ladder: owned (default) < images < max. Ignored for --engine docker.",
+    )
     docker.add_argument(
         "--prefix",
         default=docker_cleanup.DEFAULT_UAT_PROJECT_PREFIX,
-        help="Docker compose project prefix that marks UAT-owned resources",
+        help="Compose project prefix that marks UAT-owned resources",
     )
     docker.add_argument(
         "--apply",
         action="store_true",
-        help="Remove UAT-owned resources. Without this flag the command only reports the plan.",
+        help="Remove owned resources. Without this flag the command only reports the plan.",
     )
     _set_handler(docker, _handle_docker_cleanup)
 

--- a/tests/uat/container_cleanup.py
+++ b/tests/uat/container_cleanup.py
@@ -1,0 +1,472 @@
+"""Reclaim disk used by BenchBox on the Apple ``container`` engine.
+
+This is the Apple-``container`` mode of the UAT cleanup flow (the Docker mode
+lives in :mod:`tests.uat.docker_cleanup`). Apple ``container`` backs the
+``make ci-linux`` CI-parity machine and the ``CONTAINER_ENGINE=mocker`` local
+test-docker stacks, and its store under
+``~/Library/Application Support/com.apple.container`` grows without bound: image
+snapshots, mocker compose leftovers, and the buildkit builder's writable cache.
+
+``mocker`` is a Docker-compatible CLI but does NOT faithfully implement the JSON
+inventory verbs the Docker flow relies on (``image ls --format json`` echoes the
+format string; ``volume ls -q`` is empty), so this mode speaks the native
+``container`` CLI whose JSON is structured differently (image name under
+``configuration.name``; compose labels under ``configuration.labels``; the
+builder tagged ``com.apple.container.resource.role=builder``).
+
+Ownership + breadth are controlled by a three-rung mode ladder, widest last:
+
+* ``owned``  -- BenchBox-owned only: ``benchbox/*`` / ``local/benchbox*`` images
+  and mocker compose leftovers tagged with the UAT project prefix.
+* ``images`` -- ``owned`` plus every other non-system image (re-pullable shared
+  bases: postgres, ubuntu, uv, questdb, ...). The image store, minus the builder.
+* ``max``    -- ``images`` plus stopped-container prune, volume prune, and a
+  builder-cache reclaim (``container builder delete``; the builder is recreated
+  on the next build). The full reclaim.
+
+The system builder container/image are never removed except by the explicit
+``max`` builder reclaim, and truly destructive host commands (``rm -rf`` of the
+store, ``container system stop``) are refused outright.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Literal
+
+from tests.uat import docker_assets
+from tests.uat.docker_cleanup import COMPOSE_PROJECT_LABEL, DEFAULT_UAT_PROJECT_PREFIX
+
+ContainerResourceKind = Literal["image", "container", "volume"]
+ContainerCategory = Literal["owned", "shared", "system"]
+ContainerRunner = Callable[..., docker_assets.DockerCommandResult]
+
+CONTAINER_BIN = "container"
+CONTAINER_CLEANUP_MODES: tuple[str, ...] = ("owned", "images", "max")
+
+# On-disk store the engine manages. Reported for context; never removed directly
+# (resources are reclaimed through the CLI, which keeps the store consistent).
+CONTAINER_STORAGE_PATH = Path("~/Library/Application Support/com.apple.container")
+
+# Image name prefixes that mark a BenchBox-built image regardless of compose
+# labels (native images carry no compose project label).
+_OWNED_IMAGE_PREFIXES: tuple[str, ...] = ("benchbox/", "benchbox-", "local/benchbox")
+
+# The buildkit builder identifies itself with this role label; its image repo is
+# the container-builder-shim. Both are engine infrastructure, not workload.
+_BUILDER_ROLE_LABEL = "com.apple.container.resource.role"
+_BUILDER_IMAGE_MARKER = "container-builder-shim"
+
+
+class ContainerCleanupError(RuntimeError):
+    """Raised when Apple ``container`` inventory or cleanup commands fail."""
+
+
+@dataclass(frozen=True)
+class ContainerResource:
+    """One Apple ``container`` resource discovered by the inventory."""
+
+    kind: ContainerResourceKind
+    identifier: str
+    name: str
+    category: ContainerCategory
+    created_at: str = ""
+    status: str = ""
+
+    @property
+    def display_name(self) -> str:
+        return self.name or self.identifier
+
+    def cleanup_command(self) -> tuple[str, ...]:
+        """Return the native command that removes this single resource."""
+        if self.kind == "image":
+            return (CONTAINER_BIN, "image", "rm", self.display_name)
+        if self.kind == "container":
+            return (CONTAINER_BIN, "rm", "-f", self.identifier)
+        return (CONTAINER_BIN, "volume", "rm", self.display_name)
+
+    def cleanup_command_text(self) -> str:
+        return shlex.join(self.cleanup_command())
+
+
+@dataclass(frozen=True)
+class ContainerFootprint:
+    """Parsed ``container system df`` totals (human-unit strings, as reported)."""
+
+    rows: tuple[tuple[str, str, str], ...] = ()  # (type, size, reclaimable)
+
+    def as_lines(self) -> list[str]:
+        if not self.rows:
+            return ["  (disk usage unavailable)"]
+        return [f"  {kind}: size={size} reclaimable={reclaimable}" for kind, size, reclaimable in self.rows]
+
+
+@dataclass(frozen=True)
+class ContainerCommandResult:
+    """A planned/executed cleanup command and its result."""
+
+    argv: tuple[str, ...]
+    result: docker_assets.DockerCommandResult | None = None
+
+    @property
+    def command(self) -> str:
+        return shlex.join(self.argv)
+
+    @property
+    def status(self) -> str:
+        if self.result is None:
+            return "planned"
+        return "ok" if self.result.succeeded else "failed"
+
+
+@dataclass(frozen=True)
+class ContainerCleanupReport:
+    """Inventory, ownership split, and the planned/executed cleanup commands."""
+
+    project_prefix: str
+    mode: str
+    apply: bool
+    targets: tuple[ContainerResource, ...]
+    retained: tuple[ContainerResource, ...]
+    commands: tuple[ContainerCommandResult, ...]
+    footprint_before: ContainerFootprint = field(default_factory=ContainerFootprint)
+    footprint_after: ContainerFootprint | None = None
+
+
+def reclaim_container_usage(
+    *,
+    project_prefix: str = DEFAULT_UAT_PROJECT_PREFIX,
+    mode: str = "owned",
+    apply: bool = False,
+    runner: ContainerRunner | None = None,
+) -> ContainerCleanupReport:
+    """Inventory Apple ``container`` resources and reclaim them per ``mode``.
+
+    Non-``apply`` runs mutate nothing; they return the plan. ``apply`` executes
+    the plan and re-reads the disk footprint so the caller can show before/after.
+    """
+    if mode not in CONTAINER_CLEANUP_MODES:
+        raise ContainerCleanupError(
+            f"Unknown container cleanup mode {mode!r}; valid: {', '.join(CONTAINER_CLEANUP_MODES)}"
+        )
+    run = runner or docker_assets.run_docker_command
+
+    resources = _inventory_resources(run)
+    targets, retained = _partition_targets(resources, mode)
+    planned = _plan_commands(targets, mode)
+    footprint_before = _read_footprint(run)
+
+    executed: list[ContainerCommandResult] = []
+    footprint_after: ContainerFootprint | None = None
+    if apply:
+        for argv in planned:
+            if _is_forbidden(argv):
+                raise ContainerCleanupError(f"Refusing to run destructive container command: {shlex.join(argv)}")
+            result = run(list(argv))
+            executed.append(ContainerCommandResult(argv=argv, result=result))
+            if not result.succeeded:
+                raise ContainerCleanupError(f"Container cleanup failed: {shlex.join(argv)}: {_result_detail(result)}")
+        footprint_after = _read_footprint(run)
+    else:
+        executed = [ContainerCommandResult(argv=argv) for argv in planned]
+
+    return ContainerCleanupReport(
+        project_prefix=project_prefix,
+        mode=mode,
+        apply=apply,
+        targets=targets,
+        retained=retained,
+        commands=tuple(executed),
+        footprint_before=footprint_before,
+        footprint_after=footprint_after,
+    )
+
+
+def format_container_cleanup_report(report: ContainerCleanupReport) -> str:
+    """Render a human-readable Apple ``container`` cleanup summary."""
+    lines = [
+        "Apple container cleanup report",
+        f"engine store: {CONTAINER_STORAGE_PATH}",
+        f"project_prefix: {report.project_prefix}",
+        f"mode: {report.mode} ({'apply' if report.apply else 'dry-run'})",
+        "",
+        "Disk footprint (container system df)" + (" before:" if report.apply else ":"),
+    ]
+    lines.extend(report.footprint_before.as_lines())
+    if report.apply and report.footprint_after is not None:
+        lines.append("Disk footprint after:")
+        lines.extend(report.footprint_after.as_lines())
+    lines.append("")
+
+    if report.targets:
+        verb = "Reclaimed" if report.apply else "Would reclaim"
+        lines.append(f"{verb} ({report.mode}):")
+        lines.extend(_format_resource_lines(report.targets))
+        lines.append("")
+    else:
+        lines.append(f"No reclaimable resources for mode {report.mode!r}.")
+        lines.append("")
+
+    if report.commands:
+        lines.append("Cleanup commands:")
+        for cmd in report.commands:
+            suffix = f" [{cmd.status}]" if report.apply else ""
+            lines.append(f"  - {cmd.command}{suffix}")
+        lines.append("")
+
+    if report.retained:
+        lines.append("Retained (widen --mode to reclaim):")
+        lines.extend(_format_resource_lines(report.retained, include_cleanup=True))
+    else:
+        lines.append("Nothing retained.")
+    return "\n".join(lines)
+
+
+def _format_resource_lines(resources: tuple[ContainerResource, ...], *, include_cleanup: bool = False) -> list[str]:
+    lines: list[str] = []
+    for item in sorted(resources, key=lambda r: (r.kind, r.category, r.display_name)):
+        created = f" created={item.created_at}" if item.created_at else ""
+        status = f" status={item.status}" if item.status else ""
+        lines.append(f"  - {item.kind} {item.display_name} [{item.category}]{created}{status}")
+        if include_cleanup:
+            lines.append(f"    cleanup: {item.cleanup_command_text()}")
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Ownership classification and mode -> command planning
+# --------------------------------------------------------------------------
+
+
+def _is_owned_image_name(name: str, project_prefix: str) -> bool:
+    lowered = name.lower()
+    if lowered.startswith(project_prefix.lower()):
+        return True
+    return any(lowered.startswith(prefix) for prefix in _OWNED_IMAGE_PREFIXES)
+
+
+def _partition_targets(
+    resources: tuple[ContainerResource, ...], mode: str
+) -> tuple[tuple[ContainerResource, ...], tuple[ContainerResource, ...]]:
+    """Split resources into (targets to remove, retained) for ``mode``.
+
+    Widening is asymmetric by kind:
+
+    * ``system`` resources are never per-resource targets (the builder is handled
+      by an explicit ``max`` reclaim command, not resource removal).
+    * ``owned`` resources are targets in every mode.
+    * ``shared`` images widen in at ``images`` (and ``max``); ``shared``
+      containers/volumes widen in only at ``max``, where the prune sweep clears
+      them.
+    """
+    targets: list[ContainerResource] = []
+    retained: list[ContainerResource] = []
+    for resource in resources:
+        if resource.category == "system":
+            retained.append(resource)
+        elif resource.category == "owned" or resource.kind == "image" and mode in {"images", "max"} or mode == "max":
+            targets.append(resource)
+        else:
+            retained.append(resource)
+    return tuple(targets), tuple(retained)
+
+
+def _plan_commands(targets: tuple[ContainerResource, ...], mode: str) -> list[tuple[str, ...]]:
+    """Build the ordered cleanup command plan for the selected targets/mode."""
+    commands: list[tuple[str, ...]] = []
+    # Remove containers before their images so image removal is not blocked.
+    commands.extend(_grouped_removals(targets, "container", (CONTAINER_BIN, "rm", "-f"), key=lambda r: r.identifier))
+    commands.extend(_grouped_removals(targets, "volume", (CONTAINER_BIN, "volume", "rm"), key=lambda r: r.display_name))
+    commands.extend(_grouped_removals(targets, "image", (CONTAINER_BIN, "image", "rm"), key=lambda r: r.display_name))
+    if mode == "max":
+        # Widest reclaim: stopped-container + volume prune sweep any non-system
+        # leftovers, then drop the builder's writable cache (recreated on build).
+        commands.append((CONTAINER_BIN, "prune"))
+        commands.append((CONTAINER_BIN, "volume", "prune"))
+        commands.append((CONTAINER_BIN, "builder", "delete", "--force"))
+    return commands
+
+
+def _grouped_removals(
+    targets: tuple[ContainerResource, ...],
+    kind: ContainerResourceKind,
+    base: tuple[str, ...],
+    *,
+    key: Callable[[ContainerResource], str],
+) -> list[tuple[str, ...]]:
+    seen: set[str] = set()
+    ids: list[str] = []
+    for resource in targets:
+        if resource.kind != kind:
+            continue
+        value = key(resource)
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ids.append(value)
+    return [(*base, *ids)] if ids else []
+
+
+def _is_forbidden(argv: tuple[str, ...]) -> bool:
+    """Refuse host-destructive commands even if a caller constructs them."""
+    joined = " ".join(argv)
+    return "rm -rf" in joined or "system stop" in joined or "system kill" in joined
+
+
+# --------------------------------------------------------------------------
+# Native `container` CLI inventory (JSON schema differs from Docker's)
+# --------------------------------------------------------------------------
+
+
+def _inventory_resources(run: ContainerRunner) -> tuple[ContainerResource, ...]:
+    resources: list[ContainerResource] = []
+    resources.extend(_list_images(run))
+    resources.extend(_list_containers(run))
+    resources.extend(_list_volumes(run))
+    return tuple(resources)
+
+
+def _list_images(run: ContainerRunner) -> list[ContainerResource]:
+    rows = _run_json_array(run, [CONTAINER_BIN, "image", "ls", "--format", "json"])
+    out: list[ContainerResource] = []
+    for row in rows:
+        config = row.get("configuration") if isinstance(row, dict) else None
+        config = config if isinstance(config, dict) else {}
+        name = str(config.get("name") or "")
+        identifier = str(row.get("id") or "")
+        created_at = str(config.get("creationDate") or "")
+        category: ContainerCategory
+        if _BUILDER_IMAGE_MARKER in name:
+            category = "system"
+        elif _is_owned_image_name(name, DEFAULT_UAT_PROJECT_PREFIX):
+            category = "owned"
+        else:
+            category = "shared"
+        out.append(
+            ContainerResource(
+                kind="image",
+                identifier=identifier,
+                name=name,
+                category=category,
+                created_at=created_at,
+            )
+        )
+    return out
+
+
+def _list_containers(run: ContainerRunner) -> list[ContainerResource]:
+    rows = _run_json_array(run, [CONTAINER_BIN, "ls", "-a", "--format", "json"])
+    out: list[ContainerResource] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        config = row.get("configuration") if isinstance(row.get("configuration"), dict) else {}
+        labels = config.get("labels") if isinstance(config.get("labels"), dict) else {}
+        identifier = str(row.get("id") or config.get("id") or "")
+        image_ref = ""
+        image = config.get("image")
+        if isinstance(image, dict):
+            image_ref = str(image.get("reference") or "")
+        status = row.get("status") if isinstance(row.get("status"), dict) else {}
+        state = str(status.get("state") or "")
+        project = labels.get(COMPOSE_PROJECT_LABEL)
+
+        if labels.get(_BUILDER_ROLE_LABEL) == "builder" or _BUILDER_IMAGE_MARKER in image_ref:
+            category = "system"
+        elif _is_owned(project, DEFAULT_UAT_PROJECT_PREFIX) or _is_owned_image_name(
+            image_ref, DEFAULT_UAT_PROJECT_PREFIX
+        ):
+            category = "owned"
+        else:
+            category = "shared"
+        out.append(
+            ContainerResource(
+                kind="container",
+                identifier=identifier,
+                name=identifier or image_ref,
+                category=category,
+                created_at=str(config.get("creationDate") or ""),
+                status=state,
+            )
+        )
+    return out
+
+
+def _list_volumes(run: ContainerRunner) -> list[ContainerResource]:
+    rows = _run_json_array(run, [CONTAINER_BIN, "volume", "ls", "--format", "json"])
+    out: list[ContainerResource] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or row.get("Name") or "")
+        if not name:
+            continue
+        category: ContainerCategory = "owned" if _is_owned(name, DEFAULT_UAT_PROJECT_PREFIX) else "shared"
+        out.append(
+            ContainerResource(
+                kind="volume",
+                identifier=name,
+                name=name,
+                category=category,
+                status=str(row.get("driver") or row.get("Driver") or ""),
+            )
+        )
+    return out
+
+
+def _read_footprint(run: ContainerRunner) -> ContainerFootprint:
+    """Parse ``container system df`` into (type, size, reclaimable) rows.
+
+    Best-effort: a missing/failed command yields an empty footprint rather than
+    aborting the whole cleanup.
+    """
+    result = run([CONTAINER_BIN, "system", "df"])
+    if not result.succeeded or not result.stdout.strip():
+        return ContainerFootprint()
+    rows: list[tuple[str, str, str]] = []
+    lines = result.stdout.splitlines()
+    for line in lines[1:]:  # skip header
+        # Columns: TYPE(1-2 words) TOTAL ACTIVE SIZE <unit> RECLAIMABLE <unit> [(pct)]
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+        # Find the first purely-numeric field: that is TOTAL; everything before is TYPE.
+        num_idx = next((i for i, tok in enumerate(parts) if tok.isdigit()), None)
+        if num_idx is None or num_idx == 0 or len(parts) < num_idx + 6:
+            continue
+        kind = " ".join(parts[:num_idx])
+        size = " ".join(parts[num_idx + 2 : num_idx + 4])
+        reclaimable = " ".join(parts[num_idx + 4 : num_idx + 6])
+        rows.append((kind, size, reclaimable))
+    return ContainerFootprint(rows=tuple(rows))
+
+
+def _is_owned(project: str | None, project_prefix: str) -> bool:
+    if not project:
+        return False
+    return (
+        project == project_prefix
+        or project.startswith(f"{project_prefix}-")
+        or project.startswith(f"{project_prefix}_")
+    )
+
+
+def _run_json_array(run: ContainerRunner, argv: list[str]) -> list[object]:
+    result = run(argv)
+    if not result.succeeded:
+        raise ContainerCleanupError(f"Container inventory command failed: {shlex.join(argv)}: {_result_detail(result)}")
+    stdout = result.stdout.strip()
+    if not stdout:
+        return []
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise ContainerCleanupError(f"Could not parse container JSON from {shlex.join(argv)}: {exc}") from exc
+    return list(parsed) if isinstance(parsed, list) else []
+
+
+def _result_detail(result: docker_assets.DockerCommandResult) -> str:
+    return result.error or result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"

--- a/tests/uat/test_container_cleanup.py
+++ b/tests/uat/test_container_cleanup.py
@@ -1,0 +1,185 @@
+"""Fast-test coverage for the Apple `container` cleanup mode."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.uat import container_cleanup, docker_assets
+
+pytestmark = pytest.mark.fast
+
+
+_IMAGES = [
+    {
+        "id": "img-owned",
+        "configuration": {"name": "benchbox/tpc-h-linux-arm64:latest", "creationDate": "2026-07-08T17:47:31Z"},
+    },
+    {
+        "id": "img-agent",
+        "configuration": {"name": "local/benchbox-agent:latest", "creationDate": "2026-07-01T00:00:00Z"},
+    },
+    {"id": "img-shared", "configuration": {"name": "postgres:18", "creationDate": "2026-06-01T00:00:00Z"}},
+    {"id": "img-shared2", "configuration": {"name": "ubuntu:24.04", "creationDate": "2026-06-02T00:00:00Z"}},
+    {
+        "id": "img-builder",
+        "configuration": {
+            "name": "ghcr.io/apple/container-builder-shim/builder:0.12.0",
+            "creationDate": "2026-06-30T00:00:00Z",
+        },
+    },
+]
+
+_CONTAINERS = [
+    {
+        "id": "buildkit",
+        "configuration": {
+            "id": "buildkit",
+            "image": {"reference": "ghcr.io/apple/container-builder-shim/builder:0.12.0"},
+            "labels": {"com.apple.container.resource.role": "builder"},
+        },
+        "status": {"state": "running"},
+    },
+    {
+        "id": "uat-leftover",
+        "configuration": {
+            "id": "uat-leftover",
+            "image": {"reference": "postgres:18"},
+            "labels": {"com.docker.compose.project": "benchbox-uat-smoke-postgresql"},
+        },
+        "status": {"state": "stopped"},
+    },
+    {
+        "id": "external-ctr",
+        "configuration": {"id": "external-ctr", "image": {"reference": "redis:7"}, "labels": {}},
+        "status": {"state": "running"},
+    },
+]
+
+_VOLUMES = [
+    {"name": "benchbox-uat-smoke-postgresql_pgdata", "driver": "local"},
+    {"name": "developer_scratch", "driver": "local"},
+]
+
+_SYSTEM_DF = (
+    "TYPE           TOTAL  ACTIVE  SIZE      RECLAIMABLE\n"
+    "Images         5      1       11.65 GB  11.22 GB (96%)\n"
+    "Containers     3      2       14.01 GB  0 B (0%)\n"
+    "Local Volumes  2      0       120 MB    120 MB (100%)\n"
+)
+
+
+def _runner(calls: list[tuple[str, ...]], *, df_fails: bool = False):
+    def fake(argv, **kwargs):
+        argv_tuple = tuple(argv)
+        calls.append(argv_tuple)
+        if argv_tuple[:4] == ("container", "image", "ls", "--format"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_IMAGES), "")
+        if argv_tuple[:3] == ("container", "ls", "-a"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_CONTAINERS), "")
+        if argv_tuple[:4] == ("container", "volume", "ls", "--format"):
+            return docker_assets.DockerCommandResult(argv_tuple, 0, json.dumps(_VOLUMES), "")
+        if argv_tuple == ("container", "system", "df"):
+            if df_fails:
+                return docker_assets.DockerCommandResult(argv_tuple, 1, "", "boom", error="unavailable")
+            return docker_assets.DockerCommandResult(argv_tuple, 0, _SYSTEM_DF, "")
+        # Mutating commands succeed.
+        return docker_assets.DockerCommandResult(argv_tuple, 0, "", "")
+
+    return fake
+
+
+def _targets_by_kind(report):
+    out: dict[str, set[str]] = {}
+    for r in report.targets:
+        out.setdefault(r.kind, set()).add(r.display_name)
+    return out
+
+
+def test_owned_mode_targets_only_benchbox_owned():
+    report = container_cleanup.reclaim_container_usage(mode="owned", apply=False, runner=_runner([]))
+    assert _targets_by_kind(report) == {
+        "image": {"benchbox/tpc-h-linux-arm64:latest", "local/benchbox-agent:latest"},
+        "container": {"uat-leftover"},
+        "volume": {"benchbox-uat-smoke-postgresql_pgdata"},
+    }
+    # Shared + system are retained; builder is never a target.
+    retained = {r.display_name for r in report.retained}
+    assert {"postgres:18", "ubuntu:24.04", "ghcr.io/apple/container-builder-shim/builder:0.12.0"} <= retained
+    assert "buildkit" in retained
+
+
+def test_images_mode_adds_shared_images_but_not_builder():
+    report = container_cleanup.reclaim_container_usage(mode="images", apply=False, runner=_runner([]))
+    assert _targets_by_kind(report)["image"] == {
+        "benchbox/tpc-h-linux-arm64:latest",
+        "local/benchbox-agent:latest",
+        "postgres:18",
+        "ubuntu:24.04",
+    }
+    # The builder image + builder container stay retained (system category).
+    retained = {r.display_name for r in report.retained}
+    assert "ghcr.io/apple/container-builder-shim/builder:0.12.0" in retained
+    assert "buildkit" in retained
+    # The external non-owned container is only reclaimed at max.
+    assert "external-ctr" not in {r.display_name for r in report.targets}
+
+
+def test_apply_runs_grouped_removals_in_dependency_order():
+    calls: list[tuple[str, ...]] = []
+    report = container_cleanup.reclaim_container_usage(mode="owned", apply=True, runner=_runner(calls))
+    mutations = [
+        c
+        for c in calls
+        if c[:3] not in {("container", "image", "ls"), ("container", "volume", "ls")}
+        and c[:3] != ("container", "ls", "-a")
+        and c != ("container", "system", "df")
+    ]
+    # Containers removed before images so image removal is not blocked.
+    assert mutations == [
+        ("container", "rm", "-f", "uat-leftover"),
+        ("container", "volume", "rm", "benchbox-uat-smoke-postgresql_pgdata"),
+        ("container", "image", "rm", "benchbox/tpc-h-linux-arm64:latest", "local/benchbox-agent:latest"),
+    ]
+    assert all(c.status == "ok" for c in report.commands)
+    assert report.footprint_after is not None
+
+
+def test_max_mode_appends_prune_and_builder_reclaim():
+    calls: list[tuple[str, ...]] = []
+    container_cleanup.reclaim_container_usage(mode="max", apply=True, runner=_runner(calls))
+    assert ("container", "prune") in calls
+    assert ("container", "volume", "prune") in calls
+    assert ("container", "builder", "delete", "--force") in calls
+
+
+def test_max_mode_reclaims_external_container():
+    report = container_cleanup.reclaim_container_usage(mode="max", apply=False, runner=_runner([]))
+    assert "external-ctr" in {r.display_name for r in report.targets if r.kind == "container"}
+
+
+def test_footprint_parses_system_df_rows():
+    report = container_cleanup.reclaim_container_usage(mode="owned", apply=False, runner=_runner([]))
+    rows = {kind: (size, recl) for kind, size, recl in report.footprint_before.rows}
+    assert rows["Images"] == ("11.65 GB", "11.22 GB")
+    assert rows["Local Volumes"] == ("120 MB", "120 MB")
+
+
+def test_footprint_unavailable_is_non_fatal():
+    report = container_cleanup.reclaim_container_usage(mode="owned", apply=False, runner=_runner([], df_fails=True))
+    assert report.footprint_before.rows == ()
+    assert "disk usage unavailable" in container_cleanup.format_container_cleanup_report(report)
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(container_cleanup.ContainerCleanupError):
+        container_cleanup.reclaim_container_usage(mode="everything", apply=False, runner=_runner([]))
+
+
+def test_report_renders_mode_and_store_path():
+    report = container_cleanup.reclaim_container_usage(mode="owned", apply=False, runner=_runner([]))
+    rendered = container_cleanup.format_container_cleanup_report(report)
+    assert "mode: owned (dry-run)" in rendered
+    assert "com.apple.container" in rendered
+    assert "Retained (widen --mode to reclaim):" in rendered


### PR DESCRIPTION
The Apple `container` store (~/Library/Application Support/com.apple.container)
grows unbounded from image snapshots, mocker compose leftovers, and the buildkit
builder's writable cache (~24 GB observed). Add an ENGINE=container mode to the
existing UAT cleanup flow that reclaims it.

mocker is not engine-swappable for inventory (`image ls --format json` echoes the
format; `volume ls -q` is empty), so the mode speaks the native `container` CLI
(image name under configuration.name, compose labels under configuration.labels,
builder tagged com.apple.container.resource.role=builder).

Breadth is a three-rung ladder, widest last:
- owned  (default): benchbox/* + local/benchbox* images, UAT-prefixed leftovers
- images: + shared pull-through bases (postgres/ubuntu/uv/questdb)
- max:    + stopped-container/volume prune + builder-cache delete

Dry-run by default; prints `container system df` footprint + the plan. Never
removes the store dir or stops `container system`. Reuses docker_cleanup
constants and the docker_assets subprocess executor.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
