### PR TITLE
fix/uat artifact hygiene local growth

### DIFF
--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -146,7 +146,13 @@ def run_cell(
     # external root (runs_dir resolves outside cwd), the worktree-local
     # benchmark_runs/ must not grow — see tests.uat.artifact_hygiene and the
     # 2026-06-01 datagen-leak incident. Default local runs leave this None.
-    external_root = configured_external_root(output=runs_dir)
+    # NB: pass the raw `benchmark_runs_dir` (None unless the caller explicitly
+    # set it), not the already-defaulted `runs_dir` — configured_external_root
+    # falls back to checking BENCHBOX_OUTPUT_DIR itself when output is None, so
+    # passing the resolved default here would make every unconfigured run look
+    # "externally configured" (the home-directory fallback always resolves
+    # outside cwd) and spuriously arm the guard against the real local tree.
+    external_root = configured_external_root(output=benchmark_runs_dir)
     local_snapshot = snapshot_local_runs() if external_root is not None else None
     argv = benchbox_run_argv(
         platform,

--- a/tests/uat/runner.py
+++ b/tests/uat/runner.py
@@ -146,13 +146,7 @@ def run_cell(
     # external root (runs_dir resolves outside cwd), the worktree-local
     # benchmark_runs/ must not grow — see tests.uat.artifact_hygiene and the
     # 2026-06-01 datagen-leak incident. Default local runs leave this None.
-    # NB: pass the raw `benchmark_runs_dir` (None unless the caller explicitly
-    # set it), not the already-defaulted `runs_dir` — configured_external_root
-    # falls back to checking BENCHBOX_OUTPUT_DIR itself when output is None, so
-    # passing the resolved default here would make every unconfigured run look
-    # "externally configured" (the home-directory fallback always resolves
-    # outside cwd) and spuriously arm the guard against the real local tree.
-    external_root = configured_external_root(output=benchmark_runs_dir)
+    external_root = configured_external_root(output=runs_dir)
     local_snapshot = snapshot_local_runs() if external_root is not None else None
     argv = benchbox_run_argv(
         platform,

--- a/tests/uat/test_runner.py
+++ b/tests/uat/test_runner.py
@@ -17,6 +17,21 @@ from tests.uat.timeouts import TimeoutResult
 pytestmark = pytest.mark.fast
 
 
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch):
+    """Keep run_cell's hygiene snapshot off the real repo tree.
+
+    run_cell() defaults benchmark_runs_dir to a home-directory root outside
+    any worktree (see runner._default_benchmark_runs_dir), so the artifact
+    hygiene guard is armed for every call and snapshots cwd/benchmark_runs.
+    Without isolating cwd here, that snapshot targets the real, shared
+    worktree directory, which concurrent pytest-xdist workers or leftover
+    manual runs can mutate mid-test, causing spurious LocalArtifactGrowthError
+    failures unrelated to what the test is exercising.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 def _write_result_json(path: Path, *, failed: int = 0, compliance_class: str | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     passed = 1 if failed == 0 else 0


### PR DESCRIPTION
- **fix(uat): stop treating default output root as externally configured**
- **fix(uat): isolate test cwd instead of weakening the hygiene guard**
