### PR TITLE
fix: normalize string option-spec defaults through their declared parser

### DIFF
--- a/benchbox/core/hooks/platform_hooks.py
+++ b/benchbox/core/hooks/platform_hooks.py
@@ -42,6 +42,16 @@ class PlatformOptionSpec:
     choices: Iterable[Any] | None = None
     aliases: tuple[str, ...] = field(default_factory=tuple)
 
+    def __post_init__(self) -> None:
+        # Defaults declared as raw strings (e.g. 'true', '8192') must carry the
+        # same type as parsed user input: get_default_options() feeds them into
+        # database_config.options and, since #1062, straight into DataFrame
+        # adapter constructors, where a str 'true' breaks bool consumers
+        # (polars scan_parquet rejects rechunk='true') and a str 'false' is
+        # truthy — silently inverting the default.
+        if isinstance(self.default, str) and self.parser is not _identity:
+            object.__setattr__(self, "default", self.parse(self.default))
+
     def parse(self, raw: str) -> Any:
         value = self.parser(raw)
         if self.choices and value not in self.choices:

--- a/tests/unit/cli/test_platform_hooks.py
+++ b/tests/unit/cli/test_platform_hooks.py
@@ -66,15 +66,38 @@ def test_parse_options_unknown_key_raises():
 
 
 def test_spark_platform_options_adaptive_enabled():
-    # Default is the registered spec-row string "true" (same convention as the
-    # velox row); it only needs to be truthy for the adapter default.
+    # Spec-row string defaults are normalized through the declared parser, so
+    # the default arrives with the same type as parsed user input.
     parsed = PlatformHookRegistry.parse_options("spark", [])
-    assert parsed["adaptive_enabled"] == "true"
+    assert parsed["adaptive_enabled"] is True
 
     # Explicit values go through parse_bool, so AQE-off runs are reachable via
     # --platform-option adaptive_enabled=false.
     parsed = PlatformHookRegistry.parse_options("spark", [("adaptive_enabled", "false")])
     assert parsed["adaptive_enabled"] is False
+
+
+@pytest.mark.parametrize(
+    ("platform", "option", "expected"),
+    [
+        # str 'true' reaching polars scan_parquet(rechunk=...) raised
+        # "failed to extract field Extract.rechunk" once #1062 started
+        # forwarding options into DataFrame adapter constructors.
+        ("polars", "rechunk", True),
+        # str 'false' defaults are truthy — without parser normalization the
+        # effective default inverts wherever consumers rely on truthiness.
+        ("polars", "streaming", False),
+        ("sqlite", "check_same_thread", False),
+        ("datafusion", "batch_size", 8192),
+        ("sqlite", "timeout", 30.0),
+        ("cudf", "device_id", 0),
+        ("velox", "shuffle_partitions", 200),
+    ],
+)
+def test_spec_row_string_defaults_are_parser_typed(platform, option, expected):
+    defaults = PlatformHookRegistry.get_default_options(platform)
+    assert defaults[option] == expected
+    assert type(defaults[option]) is type(expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/platforms/test_dataframe_factory.py
+++ b/tests/unit/platforms/test_dataframe_factory.py
@@ -179,8 +179,8 @@ class TestPlatformHookRegistration:
 
         defaults = PlatformHookRegistry.get_default_options("polars")
 
-        assert defaults["streaming"] == "false"
-        assert defaults["rechunk"] == "true"
+        assert defaults["streaming"] is False
+        assert defaults["rechunk"] is True
         assert defaults["n_rows"] is None
 
     def test_pandas_df_option_defaults(self):


### PR DESCRIPTION
get_default_options() returned spec-row defaults verbatim, so options
declared as {'parser': 'parse_bool', 'default': 'true'} produced the
string 'true' instead of True. Harmless while defaults never left
database_config.options, but #1062 began forwarding them into DataFrame
adapter constructors: polars-df received rechunk='true' and every table
load failed with "failed to extract field Extract.rechunk" (the three
polars-df e2e failures in the 2026-07-09 release canary). String 'false'
defaults (polars streaming, sqlite check_same_thread) were also truthy,
silently inverting the intended default for truthiness consumers.

PlatformOptionSpec now parses string defaults through the declared
parser at construction, so defaults always carry the same type as
parsed user input. Identity/str-parser specs are unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
