### PR TITLE
docs(todo): enforce stats-control gate in joinorder prototype deps (#1011 review)

### DIFF
--- a/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
+++ b/_project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml
@@ -18,6 +18,7 @@ deps:
   needs:
     - joinorder-scale-stress-decision-framework
     - track2-joinorder-stats-phase
+    - track2-joinorder-stats-phase-controls
 
 context_sections:
   "Why start with replication": |


### PR DESCRIPTION
## Description

Late-landing bot review follow-up for merged PR #1011. `joinorder-replicated-imdb-scale-prototype.yaml`'s `deps.needs` only listed `track2-joinorder-stats-phase` (mechanics, DONE), not `track2-joinorder-stats-phase-controls` (reset/persist control, DONE) — even though the item's own w1 notes explicitly say publication-quality stale-stats conclusions require BOTH. The machine-checked gate (`todo_cli ready`/`next`) could treat this item as unblocked after the mechanics seed alone, exactly the false-ready signal the notes were written to prevent.

Added `track2-joinorder-stats-phase-controls` to `deps.needs` so the graph matches the documented requirement. Both dependencies are already `done`, so this is a documentation/graph-correctness fix, not a behavior change.

## Type of Change

- [x] Documentation

## Testing

- `uv run --project _project/scripts -- python _project/scripts/validate_todo.py _project/TODO/main/planning/joinorder-replicated-imdb-scale-prototype.yaml` — valid.
- `uv run --project _project/scripts -- python _project/scripts/todo_cli.py check-graph` — passed, 124 items checked, no dangling references.

## Public Contract Check

- [x] No contract-surface impact (planning TODO metadata only).

## Documentation

- [x] N/A — this PR only edits a planning TODO file.

## Code Quality

- [x] N/A — no code changed.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs, benchmark outputs, or temporary binary artifacts.

## Notes

Closes out the outstanding P2 bot review thread on merged PR #1011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKw2UhgHuzYPo3y5MfarD6)_