### PR TITLE
fix(throughput): pre-generate query streams outside the timed concurrent window

### DIFF
--- a/_project/DONE/main/planning/throughput-pregenerate-query-streams.yaml
+++ b/_project/DONE/main/planning/throughput-pregenerate-query-streams.yaml
@@ -2,7 +2,37 @@ id: throughput-pregenerate-query-streams
 title: "Pre-generate throughput query streams outside the timed concurrent loop"
 worktree: main
 priority: Critical
-status: Not Started
+status: Completed
+completed_date: "2026-07-09"
+completed_note: |
+  Generation now happens entirely before StreamRunner.execute's timed
+  concurrent window for both TPC-H and TPC-DS, via a new
+  _pregenerate_stream_queries() on each throughput test (instance-attribute
+  cache, read by _execute_stream/_execute_single_query; None when those are
+  called directly, preserving out-of-scope test back-compat). Byte-identity
+  confirmed by diffing old-formula vs new-path SQL for real streams (script
+  output, not committed). New regression tests in
+  test_throughput_corrections.py prove a sleeping get_query() no longer
+  leaks into execution_time_seconds or TTT.
+
+  DEVIATION on w1 (documented, not a scope expansion): did NOT route TPC-H
+  generation through TPCHStreamManager._generate_stream_queries_qgen's
+  native `qgen -p <stream>` batch path. Read qgen.c/rnd.c: that path seeds
+  ONE subprocess call with `rng_seed + stream_id` and lets qgen derive all
+  22 per-query seeds internally from that single Park-Miller LCG chain
+  (Seed[0]=rndm; Seed[i]=NextRand(Seed[i-1]) for i=1..22, indexed by query
+  number) -- a fundamentally different seed scheme than this test's
+  per-*position* formula (`seed + stream_id*1000 + position`, a fresh LCG
+  chain per query). Routing through the batch path would silently change
+  every generated query's substitution parameters, violating this TODO's
+  own must_preserve invariant (byte-identical SQL). Kept per-query
+  generation via the existing benchmark.get_query() path, moved entirely
+  out of the timed loop and parallelized across streams instead; added a
+  complementary fix in queries.py (QGenBinary._ensure_work_dir) that
+  removes the per-call temp-dir + dists.dss copy overhead the TODO also
+  flagged, so per-call subprocess overhead still dropped meaningfully even
+  though subprocess count wasn't collapsed to O(streams). Full analysis in
+  the w1 work-item notes below and in the implementing commit message.
 category: Core Functionality
 
 description: |
@@ -73,7 +103,7 @@ prior_art:
 work:
   - id: w1
     summary: "Pre-generate ordered SQL per stream for TPC-H via the native qgen -p batch path, before the concurrent window"
-    status: pending
+    status: done
     notes: |
       In TPCHThroughputTest.run, before StreamRunner.execute, build a
       {stream_id: [sql, ...]} map. Route generation through the EXISTING native
@@ -83,21 +113,105 @@ work:
       _execute_stream then consumes pre-built SQL; the qgen call leaves the timed
       loop entirely. Preserve the per-position seed (`seed + stream_id*1000 +
       position`) so generated SQL is byte-identical to today.
+
+      IMPLEMENTED WITH A DEVIATION from "route through the native qgen -p
+      path": did not use _generate_stream_queries_qgen. Verified by reading
+      _sources/tpc-h/dbgen/qgen.c main() and rnd.c that the -p path seeds a
+      SINGLE subprocess invocation with `rng_seed + stream_id` and derives
+      all 22 per-query seeds internally from that one Park-Miller LCG chain
+      (Seed[0]=rndm; for i=1..22: Seed[0]=NextRand(Seed[0]); Seed[i]=Seed[0];
+      qsub indexes Seed[qnum] by query NUMBER, not position). This throughput
+      test's seed formula (`seed + stream_id*1000 + position`) instead starts
+      a FRESH LCG chain per query, keyed by position -- a different scheme
+      that produces different SQL for the same nominal seed. Confirmed no
+      accidental convergence anywhere in the codebase (TPCHStreams is never
+      instantiated by TPCHThroughputTest). Routing through the batch path
+      would have silently changed every query's substitution parameters,
+      violating must_preserve. Instead: added TPCHThroughputTest.
+      _pregenerate_stream_queries() (benchbox/core/tpch/throughput_test.py),
+      which calls the EXISTING self.benchmark.get_query() path (same seed
+      formula, same call signature) for all streams via a ThreadPoolExecutor,
+      entirely before StreamRunner.execute; _execute_stream reads the result
+      from an instance-attribute cache (self._pregenerated_queries) so its
+      signature/call-site stayed untouched (required -- out-of-scope tests
+      tests/unit/core/test_tpc_reporting_execution.py and
+      tests/unit/tpch/test_tpch_compliance.py call/monkeypatch _execute_stream
+      with the historical 3-arg signature). Complementary fix in
+      benchbox/core/tpch/queries.py: QGenBinary now lazily creates and reuses
+      ONE working directory across all generate() calls (thread-safe via a
+      lock) instead of a fresh tempfile.TemporaryDirectory() + dists.dss copy
+      per call -- qgen only reads dists.dss and writes to stdout in this
+      mode, so sharing one dir concurrently is safe. This addresses the
+      TODO's stated overhead complaint (per-call temp-dir + copy churn) even
+      though subprocess count remains O(streams x queries) rather than
+      collapsing to O(streams). Byte-identity verified empirically: script
+      generated the same 2 streams x 22 queries via the pre-change inline
+      formula and the new _pregenerate_stream_queries() path at SF 0.01,
+      zero mismatches (not committed -- ad hoc verification script).
   - id: w2
     summary: "Do the same for TPC-DS: reuse/capture the preflight-generated SQL instead of regenerating in _execute_single_query"
     needs: [w1]
-    status: pending
+    status: done
     notes: |
       _preflight_validate_generation already generates every query; capture its
       output keyed by (stream_id, position) and feed _execute_single_query from
       that cache. Keep preflight's fail-fast behavior.
+
+      IMPLEMENTED AS A NEW METHOD rather than repurposing
+      _preflight_validate_generation in place: that method is called
+      directly by out-of-scope tests (tests/unit/core/
+      test_tpc_reporting_execution.py, tests/unit/core/tpcds/
+      test_throughput_test_coverage.py) and had to keep its exact behavior
+      (including a latent quirk -- it iterates query IDs 1..99 in natural
+      order with `stream_seed = config.base_seed + stream_id*1000 +
+      position`, missing the `+ stream_id` seed offset real execution
+      applies via `seed = config.base_seed + stream_id`, and never resolves
+      variants/permutation -- so it was already only an approximate
+      pre-check, not a faithful capture of what a stream actually runs).
+      Added TPCDSThroughputTest._pregenerate_stream_queries()
+      (benchbox/core/tpcds/throughput_test.py), which for each stream calls
+      the existing _build_stream_queries() (untouched -- TPC-DS stream/
+      permutation logic in streams.py is out of scope and unmodified) to
+      resolve the real per-stream ordering/variant subset, then generates
+      each entry's SQL via the existing _get_stream_query_text() using the
+      EXACT per-position seed formula _execute_single_query already used
+      (`seed + stream_id*1000 + position`, seed = base_seed + stream_id).
+      Raises immediately on any failure (fail-fast, matching the historical
+      preflight contract) and is only invoked when config.enable_preflight
+      is True -- when False, self._pregenerated_queries stays None and
+      _execute_stream/_execute_single_query fall back to on-the-fly
+      generation exactly as before (required for back-compat: several
+      out-of-scope tests pass benchmark doubles without a real
+      query_manager and rely on enable_preflight=False to avoid touching
+      generation at all during run()). _execute_stream also reuses the
+      pregenerated StreamQuery ordering instead of calling
+      _build_stream_queries() again inside the timed region, which
+      incidentally removes a latent race: create_standard_streams's
+      permutation generator calls Python's global random.seed() per stream,
+      which the OLD code invoked concurrently (once per thread) inside
+      StreamRunner.execute's ThreadPoolExecutor; pre-generation now resolves
+      every stream's ordering sequentially, single-threaded, before any
+      concurrency starts. Byte-identity verified empirically the same way as
+      w1 (old-formula vs new-path SQL for 2 streams x 10 queries at SF 1.0,
+      zero mismatches).
   - id: w3
     summary: "Assert the timed region excludes generation; add a regression test that generation time is not in execution_time_seconds"
     needs: [w2]
-    status: pending
+    status: done
     notes: |
       Test with an instrumented get_query that sleeps; confirm per-query
       execution_time_seconds and TTT do not include the sleep.
+
+      Added TestGenerationExcludedFromTiming in
+      tests/integration/test_throughput_corrections.py with one test per
+      benchmark: get_query sleeps 0.3s per call (22 calls for TPC-H, 3 for
+      TPC-DS with queries_per_stream=3 + enable_preflight=True), then
+      asserts result.total_time (TTT) is under the total sleep budget and
+      every query_results[i]["execution_time_seconds"] is under a single
+      sleep. Verified the tests are not vacuous by stashing the w1/w2
+      source changes (keeping only this test file) and re-running: both
+      failed against pre-change code (TTT included the full 6.6s/0.9s of
+      generation sleep), confirming they exercise the actual fix.
 
 must_preserve:
   - "Per-stream, per-position seeds remain `seed + stream_id*1000 + position` so generated SQL is byte-identical to today (only WHEN it is generated changes)."

--- a/benchbox/core/tpcds/throughput_test.py
+++ b/benchbox/core/tpcds/throughput_test.py
@@ -104,6 +104,16 @@ class TPCDSThroughputTest:
             self.logger.setLevel(logging.INFO)
         # Captured SQL items for dry-run preview: (label, sql)
         self.captured_items: list[tuple[str, str]] = []
+
+        # Populated by run() via _pregenerate_stream_queries() before the
+        # timed concurrent window starts: {stream_id: [(stream_query, sql_or_
+        # exception), ...]} aligned by position. When set, _execute_single_
+        # query() consumes the cached SQL instead of regenerating inline.
+        # Left as None when _execute_stream()/_execute_single_query() are
+        # invoked directly (bypassing run()), preserving the historical
+        # inline-generation behavior for direct/unit callers.
+        self._pregenerated_queries: Optional[dict[int, list[tuple[Any, Any]]]] = None
+
         # Lock for concurrent stream capture
         import threading
 
@@ -170,9 +180,15 @@ class TPCDSThroughputTest:
             # Reraise any logging/prep errors
             raise
 
-        # Run preflight outside of try so failures raise
+        # Pre-generate every stream's ordered SQL before the timed concurrent
+        # window starts (outside try, so failures raise -- matching the
+        # historical fail-fast preflight contract). This removes dsqgen
+        # subprocess cost from execution_time_seconds and TTT. Left disabled
+        # (falls back to inline per-query generation in _execute_single_query)
+        # when enable_preflight=False, matching today's behavior for callers
+        # that explicitly opt out of upfront validation/generation.
         if config.enable_preflight:
-            self._preflight_validate_generation(config)
+            self._pregenerated_queries = self._pregenerate_stream_queries(config)
 
         try:
             # Execute concurrent streams
@@ -246,6 +262,64 @@ class TPCDSThroughputTest:
             )
             raise RuntimeError(msg)
 
+    def _pregenerate_stream_queries(self, config: TPCDSThroughputTestConfig) -> dict[int, list[tuple[Any, str]]]:
+        """Pre-generate every stream's ordered (StreamQuery, SQL) pairs before
+        the timed concurrent window starts.
+
+        This is the real generation cache that ``_execute_single_query``
+        consumes, keyed by (stream_id, position): for each stream,
+        ``_build_stream_queries`` resolves the ordering/variant subset exactly
+        as it does today (TPC-DS stream/permutation logic --
+        ``create_standard_streams`` / ``streams.py`` -- is untouched and out
+        of scope for this TODO), then each entry is generated with the
+        *exact* per-position seed formula ``seed + stream_id * 1000 +
+        position`` (``seed = config.base_seed + stream_id``, matching
+        ``StreamRunner.execute``'s per-stream seed) via
+        ``_get_stream_query_text``, so generated SQL is byte-identical to
+        before -- only *when* it is generated changes.
+
+        This supersedes ``_preflight_validate_generation`` as the source of
+        truth for what actually runs: that legacy sweep iterated query IDs
+        1..99 in natural order with ``stream_seed = config.base_seed +
+        stream_id * 1000 + position`` -- no permutation, no variant
+        selection, and (notably) missing the ``+ stream_id`` seed offset
+        that real execution applies -- so it never matched the queries a
+        stream actually executes. It is kept unchanged (unused by ``run()``)
+        purely for API/test back-compat.
+
+        Only called when ``config.enable_preflight`` is True; any generation
+        failure raises immediately (matching the historical fail-fast
+        preflight contract) before the timed window starts.
+        """
+        stream_queries: dict[int, list[tuple[Any, str]]] = {}
+        failures: list[str] = []
+
+        for stream_id in range(config.num_streams):
+            seed = config.base_seed + stream_id
+            query_subset = self._build_stream_queries(stream_id, seed, config)
+            entries: list[tuple[Any, str]] = []
+
+            for position, stream_query in enumerate(query_subset):
+                stream_seed = seed + stream_id * 1000 + position
+                try:
+                    sql_text = self._get_stream_query_text(
+                        stream_query.query_id, stream_query.variant, stream_seed, config.scale_factor
+                    )
+                    entries.append((stream_query, sql_text))
+                except Exception as e:
+                    failures.append(f"stream {stream_id} q{stream_query.query_id} pos {position + 1}: {e}")
+
+            stream_queries[stream_id] = entries
+
+        if failures:
+            msg = (
+                f"TPC-DS ThroughputTest preflight failed for {len(failures)} queries. "
+                f"Examples: {', '.join(failures[:3])}"
+            )
+            raise RuntimeError(msg)
+
+        return stream_queries
+
     def _resolve_available_query_ids(self) -> list[int]:
         try:
             all_queries = self.benchmark.get_queries()
@@ -291,6 +365,21 @@ class TPCDSThroughputTest:
                 f"Stream {stream_id} using TPC-DS permutation with {len(all_queries)} queries (full query set)"
             )
         return all_queries
+
+    def _cached_query_text(self, stream_id: int, position: int) -> Optional[str]:
+        """Return pre-generated SQL for (stream_id, position), if available.
+
+        Returns None when no pre-generation cache exists (enable_preflight is
+        False, or _execute_stream/_execute_single_query were invoked directly
+        without going through run()), signalling the caller should generate
+        the query text inline instead -- exactly as it always has.
+        """
+        if self._pregenerated_queries is None:
+            return None
+        entries = self._pregenerated_queries.get(stream_id)
+        if entries is None or position >= len(entries):
+            return None
+        return entries[position][1]
 
     def _get_stream_query_text(self, query_id: int, variant, stream_seed: int, scale_factor) -> str:
         if variant is not None:
@@ -342,8 +431,12 @@ class TPCDSThroughputTest:
         }
 
         try:
-            stream_seed = seed + stream_id * 1000 + position
-            query_text = self._get_stream_query_text(query_id, variant, stream_seed, config.scale_factor)
+            cached_text = self._cached_query_text(stream_id, position)
+            if cached_text is not None:
+                query_text = cached_text
+            else:
+                stream_seed = seed + stream_id * 1000 + position
+                query_text = self._get_stream_query_text(query_id, variant, stream_seed, config.scale_factor)
             label = f"Stream_{stream_id}_Position_{position + 1}_Query_{query_display_id}"
             try:
                 platform_result = self._run_single_stream_query(connection, query_text, query_display_id, stream_id)
@@ -429,7 +522,19 @@ class TPCDSThroughputTest:
                 self.logger.info(f"Starting stream {stream_id} with seed {seed}")
 
             connection = self.connection_factory()
-            query_subset = self._build_stream_queries(stream_id, seed, config)
+
+            # When run() pre-generated this stream (the normal path with
+            # enable_preflight=True), reuse its already-resolved ordering
+            # instead of calling _build_stream_queries() again inside the
+            # timed window -- that call also (re-)invokes stream permutation
+            # generation, which this avoids repeating here entirely.
+            cached_entries = (
+                self._pregenerated_queries.get(stream_id) if self._pregenerated_queries is not None else None
+            )
+            if cached_entries is not None:
+                query_subset = [stream_query for stream_query, _sql in cached_entries]
+            else:
+                query_subset = self._build_stream_queries(stream_id, seed, config)
 
             for position, stream_query in enumerate(query_subset):
                 self._execute_single_query(connection, stream_id, position, stream_query, seed, config, stream_result)

--- a/benchbox/core/tpch/queries.py
+++ b/benchbox/core/tpch/queries.py
@@ -10,7 +10,9 @@ This implementation is based on the TPC-H specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import atexit
 import subprocess
+import threading
 from pathlib import Path
 from typing import Optional, Union
 
@@ -24,6 +26,41 @@ class QGenBinary:
         """Find qgen or fail immediately."""
         self.qgen_path = self._find_qgen_or_fail()
         self.templates_dir = self._find_templates_dir()
+        # Lazily-created, reused working directory for qgen invocations (see
+        # _ensure_work_dir). Guards concurrent first-creation from multiple
+        # threads (e.g. throughput-test pre-generation, which fans out
+        # per-stream generation across a ThreadPoolExecutor).
+        self._work_dir: Optional[str] = None
+        self._work_dir_lock = threading.Lock()
+
+    def _ensure_work_dir(self) -> str:
+        """Return a writable working directory for qgen, creating it once.
+
+        qgen only *reads* ``dists.dss`` from its cwd and writes generated SQL
+        to stdout (no other files are written into the working directory in
+        this mode), so a single directory can safely be shared across every
+        ``generate()`` call -- including concurrent calls from multiple
+        threads -- instead of paying a fresh ``mkdtemp`` + ``dists.dss`` copy
+        on every single query generation. The directory is removed at
+        process exit via ``atexit`` since it is no longer a context-managed
+        ``TemporaryDirectory``.
+        """
+        if self._work_dir is not None:
+            return self._work_dir
+
+        with self._work_dir_lock:
+            if self._work_dir is None:
+                import shutil
+                import tempfile
+
+                work_dir = tempfile.mkdtemp(prefix="benchbox_qgen_")
+                dists_src = self.templates_dir / "dists.dss"
+                if dists_src.exists():
+                    shutil.copy2(dists_src, Path(work_dir) / "dists.dss")
+                atexit.register(shutil.rmtree, work_dir, ignore_errors=True)
+                self._work_dir = work_dir
+
+        return self._work_dir
 
     def generate(self, query_id: int, *, seed: Optional[int] = None, scale_factor: float = 1.0) -> str:
         """Generate query using qgen. Returns clean SQL.
@@ -56,26 +93,20 @@ class QGenBinary:
         env = os.environ.copy()
         env["DSS_QUERY"] = str(self.templates_dir / query_dir)
 
-        # Run qgen from a writable directory (temp dir) but point to source templates
-        import shutil
-        import tempfile
+        # Run qgen from a writable directory, reused across calls (see
+        # _ensure_work_dir), but point to source templates via DSS_QUERY above.
+        work_dir = self._ensure_work_dir()
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Copy required dists.dss file to temp directory
-            dists_src = self.templates_dir / "dists.dss"
-            if dists_src.exists():
-                shutil.copy2(dists_src, Path(temp_dir) / "dists.dss")
-
-            result = subprocess.run(
-                cmd,
-                cwd=temp_dir,  # Use temp dir as writable working directory
-                env=env,
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=10,
-            )
-            return self._clean_sql(result.stdout)
+        result = subprocess.run(
+            cmd,
+            cwd=work_dir,  # Use the shared work dir as writable working directory
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        return self._clean_sql(result.stdout)
 
     def _find_qgen_or_fail(self) -> str:
         """Find qgen executable or attempt compilation if missing."""

--- a/benchbox/core/tpch/throughput_test.py
+++ b/benchbox/core/tpch/throughput_test.py
@@ -12,6 +12,7 @@ This implementation is based on the TPC-H specification.
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import concurrent.futures
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -85,6 +86,14 @@ class TPCHThroughputTest:
         # Initialize captured items for dry-run SQL preview
         self.captured_items: list[tuple[str, str]] = []
 
+        # Populated by run() via _pregenerate_stream_queries() before the timed
+        # concurrent window starts. When set, _execute_stream() consumes this
+        # pre-built SQL instead of generating inline. Left as None when
+        # _execute_stream() is invoked directly (bypassing run()), which
+        # preserves the historical inline-generation behavior for direct/unit
+        # callers and test doubles.
+        self._pregenerated_queries: Optional[dict[int, list[Any]]] = None
+
     def run(self, config: Optional[TPCHThroughputTestConfig] = None) -> TPCHThroughputTestResult:
         """Execute the TPC-H Throughput Test.
 
@@ -124,6 +133,12 @@ class TPCHThroughputTest:
                 self.logger.info(f"Number of streams: {config.num_streams}")
                 self.logger.info(f"Scale factor: {config.scale_factor}")
 
+            # Pre-generate every stream's ordered SQL text BEFORE the timed
+            # concurrent window starts. This removes qgen subprocess/tempdir
+            # cost from execution_time_seconds and TTT -- _execute_stream()
+            # only performs connection use and DB execution once this is set.
+            self._pregenerated_queries = self._pregenerate_stream_queries(config)
+
             # Execute concurrent streams
             StreamRunner.execute(self._execute_stream, config, result, self.logger)
 
@@ -161,6 +176,101 @@ class TPCHThroughputTest:
                 self.logger.error(f"Throughput Test failed: {e}")
 
             return result
+
+    def _pregenerate_stream_queries(self, config: TPCHThroughputTestConfig) -> dict[int, list[Any]]:
+        """Pre-generate ordered SQL text for every stream before the timed window.
+
+        Builds a ``{stream_id: [sql_or_exception, ...]}`` map (one entry per
+        permutation position) using the *exact* per-stream, per-position seed
+        formula ``seed + stream_id * 1000 + position`` that ``_execute_stream``
+        has always used, so generated SQL is byte-identical to before -- only
+        *when* it is generated changes.
+
+        Deviation from the TODO's literal instruction: the native
+        ``qgen -p <stream>`` batch path (``TPCHStreamManager.
+        _generate_stream_queries_qgen``) seeds its single subprocess call with
+        ``rng_seed + stream_id`` and lets qgen derive all 22 per-query seeds
+        internally from that ONE value (see ``qgen.c`` main(): ``Seed[0] =
+        rndm; Seed[i] = NextRand(Seed[i-1])`` for i=1..22, indexed by query
+        number). That is a fundamentally different Park-Miller LCG seed chain
+        than this throughput test's per-*position* seed convention. Routing
+        through the batch path would silently change every generated query's
+        substitution parameters -- a correctness regression the TODO's own
+        ``must_preserve`` explicitly forbids. So per-query generation is kept
+        (via the existing ``self.benchmark.get_query`` path), but moved
+        entirely out of the timed loop and parallelized across streams here;
+        see ``QGenBinary._ensure_work_dir`` (queries.py) for the complementary
+        fix that removes the per-call temp-dir + dists.dss copy overhead this
+        TODO also flagged.
+
+        Generation failures are captured per-position (not raised) so a
+        single bad query still only fails that one query during execution,
+        matching today's per-query fault isolation in ``_execute_stream``.
+        """
+        from benchbox.core.tpch.streams import TPCHStreams
+
+        def _generate_one_stream(stream_id: int) -> tuple[int, list[Any]]:
+            seed = config.base_seed + stream_id
+            query_permutation = TPCHStreams.PERMUTATION_MATRIX[stream_id % len(TPCHStreams.PERMUTATION_MATRIX)]
+            sql_list: list[Any] = []
+            for position, query_id in enumerate(query_permutation):
+                stream_seed = seed + stream_id * 1000 + position
+                try:
+                    sql_list.append(
+                        self.benchmark.get_query(
+                            query_id,
+                            seed=stream_seed,
+                            stream_id=stream_id,
+                            scale_factor=config.scale_factor,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001 - deferred to per-query fault isolation
+                    sql_list.append(exc)
+            return stream_id, sql_list
+
+        stream_queries: dict[int, list[Any]] = {}
+        if config.num_streams <= 0:
+            return stream_queries
+
+        max_workers = max(1, config.max_workers or config.num_streams)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_generate_one_stream, sid) for sid in range(config.num_streams)]
+            for future in concurrent.futures.as_completed(futures):
+                stream_id, sql_list = future.result()
+                stream_queries[stream_id] = sql_list
+
+        return stream_queries
+
+    def _resolve_query_text(
+        self,
+        pregenerated: Optional[list[Any]],
+        position: int,
+        stream_id: int,
+        seed: int,
+        query_id: int,
+        config: TPCHThroughputTestConfig,
+    ) -> str:
+        """Return this position's SQL: pre-generated if available, else inline.
+
+        Re-raises a cached generation failure so it still only fails this one
+        query, matching the per-query fault isolation _execute_stream has
+        always had.
+        """
+        if pregenerated is not None:
+            pre = pregenerated[position]
+            if isinstance(pre, BaseException):
+                raise pre
+            return pre
+
+        # Fall back to inline generation (_execute_stream called directly,
+        # bypassing run()'s pre-generation pass).
+        stream_seed = seed + stream_id * 1000 + position
+        return self.benchmark.get_query(
+            query_id,
+            seed=stream_seed,
+            stream_id=stream_id,
+            scale_factor=config.scale_factor,
+        )
 
     def _execute_stream(
         self, stream_id: int, seed: int, config: TPCHThroughputTestConfig
@@ -204,6 +314,11 @@ class TPCHThroughputTest:
             if config.verbose:
                 self.logger.info(f"Stream {stream_id} using TPC-H permutation: {query_permutation}")
 
+            # If run() pre-generated this stream's SQL (the normal path), use
+            # it; otherwise (e.g. _execute_stream() called directly, bypassing
+            # run()) fall back to inline generation exactly as before.
+            pregenerated = self._pregenerated_queries.get(stream_id) if self._pregenerated_queries is not None else None
+
             for position, query_id in enumerate(query_permutation):
                 query_start = mono_time()
                 query_result = {
@@ -217,15 +332,7 @@ class TPCHThroughputTest:
                 }
 
                 try:
-                    # Get the query with stream-specific parameters
-                    # Use stream and position-specific seed as per TPC-H specification
-                    stream_seed = seed + stream_id * 1000 + position
-                    query_text = self.benchmark.get_query(
-                        query_id,
-                        seed=stream_seed,
-                        stream_id=stream_id,
-                        scale_factor=config.scale_factor,
-                    )
+                    query_text = self._resolve_query_text(pregenerated, position, stream_id, seed, query_id, config)
 
                     # Execute the actual query against the database
                     label = f"Stream_{stream_id}_Position_{position + 1}_Query_{query_id}"

--- a/tests/integration/test_throughput_corrections.py
+++ b/tests/integration/test_throughput_corrections.py
@@ -185,6 +185,130 @@ class TestTimingMeasurementAccuracy:
             assert abs(measured_ttt - max_stream_duration) < 0.5
 
 
+class TestGenerationExcludedFromTiming:
+    """Validate that query GENERATION cost is excluded from the timed window.
+
+    Query generation (qgen/dsqgen subprocess calls) used to run INSIDE the
+    per-query timed region, contaminating both ``execution_time_seconds`` and
+    TTT with generation cost. These tests instrument ``get_query`` to sleep
+    for a known duration and assert neither the per-query timing nor TTT
+    include it, proving generation now happens entirely before the timed
+    concurrent window (see ``_pregenerate_stream_queries`` in both
+    ``tpch/throughput_test.py`` and ``tpcds/throughput_test.py``).
+    """
+
+    GENERATION_SLEEP = 0.3
+
+    def test_tpch_generation_time_excluded_from_timing(self):
+        """22 queries x 0.3s sleep = 6.6s of generation cost must not land
+        inside TTT or any single query's execution_time_seconds."""
+
+        def slow_get_query(*args, **kwargs):
+            time.sleep(self.GENERATION_SLEEP)
+            return "SELECT 1"
+
+        benchmark = Mock()
+        benchmark.get_query = slow_get_query
+
+        def connection_factory():
+            conn = Mock()
+            cursor = Mock()
+            cursor.fetchall.return_value = []
+            conn.execute.return_value = cursor
+            conn.close.return_value = None
+            return conn
+
+        config = TPCHThroughputTestConfig(
+            scale_factor=0.01,
+            num_streams=1,
+            stream_timeout=30,
+            verbose=False,
+        )
+
+        test = TPCHThroughputTest(
+            benchmark=benchmark,
+            connection_factory=connection_factory,
+            scale_factor=config.scale_factor,
+            num_streams=config.num_streams,
+            verbose=config.verbose,
+        )
+
+        result = test.run(config)
+
+        assert result.success
+        assert result.stream_results[0].queries_executed == 22
+
+        total_generation_time = 22 * self.GENERATION_SLEEP
+        # TTT excludes generation entirely -- it happens before the timed
+        # window starts, so it should be nowhere near the 6.6s of sleeping
+        # that 22 in-loop get_query() calls would have added.
+        assert result.total_time < total_generation_time
+        for query_result in result.stream_results[0].query_results:
+            assert query_result["execution_time_seconds"] < self.GENERATION_SLEEP
+
+    def test_tpcds_generation_time_excluded_from_timing(self):
+        """3 queries x 0.3s sleep = 0.9s of generation cost must not land
+        inside TTT or any single query's execution_time_seconds."""
+
+        def slow_get_query(*args, **kwargs):
+            time.sleep(self.GENERATION_SLEEP)
+            return "SELECT 1"
+
+        def connection_factory():
+            conn = Mock()
+            cursor = Mock()
+            cursor.fetchall.return_value = []
+            conn.execute.return_value = cursor
+            conn.close.return_value = None
+            conn.commit.return_value = None
+            return conn
+
+        benchmark = Mock()
+        benchmark.get_query = slow_get_query
+        benchmark.get_queries.return_value = {"1": "SELECT 1", "2": "SELECT 2", "3": "SELECT 3"}
+        benchmark.query_manager = Mock()
+
+        config = TPCDSThroughputTestConfig(
+            scale_factor=1.0,
+            num_streams=1,
+            stream_timeout=30,
+            verbose=False,
+            queries_per_stream=3,
+            enable_preflight=True,  # pre-generation only runs when preflight is enabled
+        )
+
+        test = TPCDSThroughputTest(
+            benchmark=benchmark,
+            connection_factory=connection_factory,
+            scale_factor=config.scale_factor,
+            num_streams=config.num_streams,
+            verbose=config.verbose,
+        )
+
+        from unittest.mock import patch
+
+        with patch("benchbox.core.tpcds.streams.create_standard_streams") as mock_create:
+            mock_manager = Mock()
+            mock_manager.generate_streams.return_value = {
+                0: [
+                    Mock(stream_id=0, query_id=1, position=0, variant=None, sql="SELECT 1"),
+                    Mock(stream_id=0, query_id=2, position=1, variant=None, sql="SELECT 2"),
+                    Mock(stream_id=0, query_id=3, position=2, variant=None, sql="SELECT 3"),
+                ]
+            }
+            mock_create.return_value = mock_manager
+
+            result = test.run(config)
+
+        assert result.success
+        assert result.stream_results[0].queries_executed == 3
+
+        total_generation_time = 3 * self.GENERATION_SLEEP
+        assert result.total_time < total_generation_time
+        for query_result in result.stream_results[0].query_results:
+            assert query_result["execution_time_seconds"] < self.GENERATION_SLEEP
+
+
 class TestConnectionCleanup:
     """Validate connection cleanup on failures."""
 


### PR DESCRIPTION
## Summary

Pre-generate throughput query streams **outside** the timed concurrent window so `execution_time_seconds`/TTT measure only connection use + DB execution — not query-generation subprocess/temp-dir cost. Both TPC-H and TPC-DS now build all per-stream SQL in a new `_pregenerate_stream_queries()` step before `StreamRunner.execute()`'s ThreadPoolExecutor starts; `_execute_stream`/`_execute_single_query` consume pre-built SQL from a per-run `(stream_id, position)` cache.

Implements TODO `throughput-pregenerate-query-streams`. **Soundness-critical** (throughput driver) — auto-merge intentionally left disabled pending Code Owner review.

## Changes
- `benchbox/core/tpch/throughput_test.py`, `benchbox/core/tpcds/throughput_test.py`: pre-generation step; timed region now DB-execution only.
- `benchbox/core/tpch/queries.py`: `QGenBinary._ensure_work_dir` reuses one working dir across `generate()` calls instead of a fresh tempdir + `dists.dss` copy per call (removes per-query FS churn).
- `tests/integration/test_throughput_corrections.py`: new timing tests proving generation time is excluded from `execution_time_seconds` and TTT (verified non-vacuous — fails against pre-change code).

## Deviation from TODO w1 (reviewed & verified justified)
The TODO's w1 / an anti_pattern asked to route TPC-H generation through the native `qgen -p <stream>` batch path (O(streams×queries) → O(streams) subprocesses). This was **not** done, because it conflicts with the byte-identity `must_preserve`:

- `qgen` (see `_sources/tpc-h/dbgen/qgen.c:432-437`) builds one LCG chain `Seed[i]=NextRand(Seed[i-1])` from a single `-r` value and uses `Seed[qnum]` per query.
- The native `-p` path seeds that one chain with `rng_seed + stream_id` for the whole stream; the current throughput path seeds a **fresh** chain per query with `base_seed + stream_id*1000 + position`.
- These produce different substitution parameters → different SQL bytes. Routing through `qgen -p` would break byte-identity, which is soundness-critical.

Opus 4.8 review confirmed this against the binary source (`DEVIATION_VERDICT: justified`). The **primary** goal — no generation inside the measured concurrent window — is fully met for both benchmarks; the per-query subprocess count is unchanged but now runs entirely before the timed window (and with the FS-churn fix). Byte-identity confirmed by the implementer's ad-hoc old-vs-new diff (TPC-H 2×22, TPC-DS 2×10; zero mismatches).

## Verification
- `pytest test_tpch_throughput_test.py test_tpcds_throughput_test.py tests/unit/core/throughput/ -m 'integration or slow'` → 19 passed.
- `pytest test_throughput_corrections.py -m 'integration or slow'` → 6 passed (incl. new generation-excluded-from-timing tests).
- Combined run incl. adjacent suites → 97 passed. ruff/ty clean.

## Guardrails
Cache is a fresh per-`run()` instance attribute keyed by `(stream_id, position)` at the run's fixed `base_seed` (not global across seeds); PERMUTATION_MATRIX / StreamQuery ordering unchanged; dry-run `captured_items` still records labeled SQL per stream/position; DB execution stays in the timed region. `streams.py` (in scope) correctly left untouched.

## Skipped review observations (non-blocking; not fixed here)
- **[Consider]** TPC-DS pre-generation is gated on `enable_preflight` (default `True`); the `enable_preflight=False` opt-out path still generates inline in the timed window (pre-existing opt-out, not a regression). A doc note would help but `docs/` is outside this TODO's `scope_limit` — deferring to `concurrency-docs-alignment` / `throughput-result-handling-and-metrics`.
- **[Consider]** TPC-DS pre-generation runs streams serially vs TPC-H's parallel fan-out — outside the timed window, no measurement impact; optional symmetry.
- **[Nit]** The TTT-level timing assertion is loose; non-vacuity is carried by the tight per-query assertion (`execution_time_seconds < generation_sleep`). Adequate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
