### PR TITLE
sync(published-results): make the vendor/ submission gate live

### DIFF
--- a/.github/workflows/validate-submission.yml
+++ b/.github/workflows/validate-submission.yml
@@ -45,6 +45,62 @@ jobs:
           fi
           echo "No validator/workflow files changed - proceeding."
 
+      - name: Reject non-maintainer vendor/ additions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          # Same two-signal trust check as the "Validate bundles" step below
+          # (see its comment for the full reasoning): a maintainer adding a
+          # vendor bundle on develop is published through a same-repo
+          # auto/results-mirror-* PR opened by sync-results-data-to-published.yml
+          # with secrets.GITHUB_TOKEN, so its author is github-actions[bot] -
+          # never OWNER/MEMBER/COLLABORATOR. Without this, that trusted mirror
+          # PR falls through to the else branch and blocks legitimate
+          # maintainer vendor bundles. head.repo.fork is the load-bearing
+          # signal (unforgeable from a fork); the branch-name pattern alone
+          # would be spoofable.
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # The vendor-supplied trust label is RANKING-ELIGIBLE and is granted
+          # purely by a bundle living under results-data/bundles/vendor/ (see
+          # scripts/generate_corpus_inventory.py::_is_vendor_subtree). A community
+          # contributor must not be able to self-grant that tier by dropping a
+          # file there. Only maintainers may add under vendor/. This is the
+          # ENFORCED half of the vendor-label governance; the manifest
+          # result_source check in benchbox/validation/bundle.py is advisory only
+          # (an attacker can omit result_source and the path alone grants the
+          # label). author_association is set by GitHub from the actor's repo
+          # relationship and cannot be set by PR content; fork PRs (how community
+          # contributors submit) run this base-branch copy of the workflow, so the
+          # gate cannot be edited away in the same PR.
+          VENDOR_CHANGES=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            'results-data/bundles/vendor/**' || true)
+          if [ -n "$VENDOR_CHANGES" ]; then
+            TRUSTED_MIRROR="false"
+            if [ "$IS_FORK" = "false" ]; then
+              case "$HEAD_REF" in
+                auto/results-mirror-*) TRUSTED_MIRROR="true" ;;
+              esac
+            fi
+            case "$AUTHOR_ASSOCIATION" in
+              OWNER | MEMBER | COLLABORATOR)
+                echo "Maintainer ($AUTHOR_ASSOCIATION) vendor/ addition - allowed."
+                ;;
+              *)
+                if [ "$TRUSTED_MIRROR" = "true" ]; then
+                  echo "Trusted same-repo mirror PR ($HEAD_REF) vendor/ addition - allowed."
+                else
+                  echo "::error::This PR adds or modifies files under results-data/bundles/vendor/, which grants the ranking-eligible vendor-supplied label. Only maintainers may do this:"
+                  printf '%s\n' "$VENDOR_CHANGES"
+                  echo "Community submissions belong in results-data/bundles/ (not vendor/). Author association: ${AUTHOR_ASSOCIATION}."
+                  exit 1
+                fi
+                ;;
+            esac
+          fi
+          echo "No non-maintainer vendor/ additions - proceeding."
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 


### PR DESCRIPTION
## Description

Mirrors the vendor-label enforcement step (landed on `develop` in #1041) to the `published-results` copy of `validate-submission.yml`. **This is the branch where the gate actually enforces** — for fork PRs GitHub runs the `published-results` copy of the workflow, so until this merges the develop change protected nothing.

The step rejects any submission PR that adds/modifies files under `results-data/bundles/vendor/` unless `github.event.pull_request.author_association` is `OWNER`/`MEMBER`/`COLLABORATOR`. `author_association` is set by GitHub and not settable by PR content; fork PRs run this base-branch copy, so the gate can't be edited away in the same PR. The step is **byte-identical to develop's** (no `uv` invocation), so it carries no slim-branch spelling difference and the `submission-validator-drift-check` sees the two vendor steps as matching.

This is the **w5 "REQUIRED to go live"** step from the `vendor-label-codeowners-governance` TODO.

## Type of Change

- [x] New feature (security governance)

## Testing

Workflow YAML parses; the step is byte-identical to the develop copy verified in #1041 (which carries the pinning unit test). This workflow only triggers on `results-data/bundles/**` changes, so this workflow-only PR does not self-trigger.

## Notes

**Scope:** this PR adds *only* the vendor gate. There is a separate, pre-existing drift between `develop` and `published-results` — `develop` removed a `pr_number.txt` artifact line as part of the comment-companion security hardening, which `published-results` still has. I intentionally did **not** touch that here: it belongs to a separate `validate-submission-comment` sync, and changing it piecemeal risks the published-results comment companion. So `submission-validator-drift-check` may still report that one line until it's synced separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY)_