### PR TITLE
docs(runbook): make the review-enforcement flag flip's ordering explicit

### DIFF
--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -184,6 +184,26 @@ gh api -X PUT repos/joeharris76/BenchBox/rulesets/15611785 --input /tmp/develop-
 After applying, re-run the Verify command (expect exit 0) and confirm a zero-approval
 soundness-path PR can no longer be squash-merged.
 
+**Order of operations (the flag flip is coupled to this PUT — do it second, never first):**
+
+1. Apply the PUT above so the live `develop-squash-only` ruleset actually carries
+   `require_code_owner_review: true`, and update this section's "Live state" line to `true`.
+2. Only then flip the one-line constant in `scripts/ruleset_drift_check.py:47`:
+
+   ```diff
+   -DEVELOP_REVIEW_RULE_ENFORCED = False
+   +DEVELOP_REVIEW_RULE_ENFORCED = True
+   ```
+
+Flipping the constant **before** step 1 turns the (still-live) missing-review gap from a
+`WARNING (non-blocking):` finding into a blocking one, which reddens **both** the daily
+`release-canary.yml` run **and** `validate-main-pr.yml`'s drift-check on every real develop
+PR until the PUT lands. Done in the correct order, the flip's own CI is green (the live
+ruleset already satisfies the rule). No test changes are required: `compare_ruleset`'s
+`enforce_review_rule` parameter is exercised in both `False`/`True` modes by
+`tests/unit/release/test_ruleset_drift_review_coverage.py`, so the constant's value does
+not itself make any unit test pass or fail.
+
 History:
 
 - Switched required status check from


### PR DESCRIPTION
## Description

Adds an explicit "Order of operations" note to the **Soundness-path review enforcement** section of `docs/operations/repo-admin-settings.md`, capturing at the point of use the coupling between the admin ruleset PUT and the `DEVELOP_REVIEW_RULE_ENFORCED` code flip.

The section already said the constant "must be flipped to `True` once the Live state is updated," but did not spell out the **ordering hazard** or give the literal diff. This adds:

1. A numbered sequence — **PUT first, flip second, never before**.
2. The exact one-line diff (`scripts/ruleset_drift_check.py:47`, `False` → `True`).
3. The consequence of getting it wrong: flipping early turns the missing-review gap from a `WARNING (non-blocking):` finding into a blocking one, which reddens **both** `release-canary.yml` **and** `validate-main-pr.yml`'s drift-check on every real develop PR until the PUT lands.
4. That **no test change is needed** — `compare_ruleset`'s `enforce_review_rule` parameter is exercised in both modes by `tests/unit/release/test_ruleset_drift_review_coverage.py`.

Context: this is the code-side half of the deferred `auto-merge-review-gate-admin-enforcement` admin action. Documenting the coupling here means the maintainer close-out for that step is unambiguous — do the PUT, then flip one character.

## Type of Change

- [x] Documentation

## Testing

- `pre-commit run markdownlint --files docs/operations/repo-admin-settings.md` → **Passed**.
- Content re-derived against the live code: the flag is at `scripts/ruleset_drift_check.py:47`; the WARN-until-enforced behavior and `enforce_review_rule` parametrization are in `compare_ruleset` and `tests/unit/release/test_ruleset_drift_review_coverage.py` as cited.

## Public Contract Check

- [x] Docs-only; no public/beta/deprecated/generated/experimental/repo-only contract surfaces changed.

## Documentation

- [x] This is the documentation change (ops runbook clarification); no behavior change.

## Code Quality

- [x] markdownlint green; no code touched.

## Artifact Hygiene

- [x] No raw artifacts committed.

## Notes

No CODEOWNERS soundness path touched (ops doc only) — squash auto-merge is being enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd5wWCAiBnKLjuqTv6Ej6p)_