### PR TITLE
feat(explorer): project funding into the result_detail_metrics view

### DIFF
--- a/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
+++ b/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
@@ -61,23 +61,37 @@ work:
       (bare-column projection, G-11 rule), and add funding to the matching
       EXPECTED_VIEWS set in test_duckdb_browser_contract.py. No new base-table
       column, so no read_model_version bump.
+    notes: >-
+      DONE in PR #1080: r.funding added to result_detail_metrics in
+      duckdb_builder.py + browser-duckdb-schema.sql; EXPECTED_VIEWS guards it.
     needs: [w1]
-    status: pending
+    status: done
   - id: w3
     summary: >-
-      Render a funding chip on result cards + the detail page, reading funding
-      from the projected view; add a legend row explaining chip + vendor badge.
+      Render a funding chip on the detail page (ResultDetail.tsx), reading funding
+      from result_detail_metrics; add a legend row explaining chip + vendor badge.
     notes: >-
-      Reuse the StatusBadge/chip pattern and an approved design token (token scan
-      gate). Label/tooltip text from provenance.py display strings; do not
-      re-list the funding enum in TS. 'unspecified' should render muted or be
-      omitted per design review.
+      REQUIRES a node env (tsc/vitest not available in the develop checkout).
+      Integration points: (1) results-explorer/src/db.ts - add `funding` to the
+      result_detail_metrics SELECT/row type; (2) new
+      results-explorer/src/components/FundingChip.tsx mirroring
+      StatusBadge.tsx/TrustBadge.tsx (StatusTone: info/success/warning/danger/
+      neutral); (3) render it in results-explorer/src/pages/ResultDetail.tsx next
+      to the TrustBadge; (4) add a legend row wherever the trust-label legend
+      lives. Label/tooltip text from provenance.py display strings; do NOT re-list
+      the funding enum in TS. 'unspecified' renders muted or omitted per design.
+      Use an approved design token (tests/unit/scripts/test_scan_explorer_tokens.py
+      gate). Consider whether the index/leaderboard pages (BenchmarkIndex.tsx,
+      PlatformIndex.tsx, MetaLeaderboard.tsx, Compare.tsx) also show the chip -
+      those query different views (platform_index_rows / benchmark_rankings) that
+      do NOT yet project funding, so a card-level chip needs its own view
+      projection first (scope decision).
     needs: [w2]
     status: pending
   - id: w4
     summary: >-
-      Add results-explorer e2e for the funding chip + legend (the vendor badge is
-      already covered by TrustBadge unit tests); update any legend-set smoke.
+      Add results-explorer e2e (results-explorer/e2e/) for the funding chip +
+      legend; update any legend-set smoke. Needs a node env.
     needs: [w3]
     status: pending
 

--- a/_project/scripts/explorer_pipeline/duckdb_builder.py
+++ b/_project/scripts/explorer_pipeline/duckdb_builder.py
@@ -450,6 +450,7 @@ class DuckDBSnapshotBuilder:
                 r.ranking_exclusion_reason,
                 r.trust_label,
                 r.visibility,
+                r.funding,
                 r.platform_version,
                 r.execution_mode,
                 r.tuning_mode,

--- a/docs/development/browser-duckdb-schema.sql
+++ b/docs/development/browser-duckdb-schema.sql
@@ -167,6 +167,7 @@ SELECT
     r.ranking_exclusion_reason,
     r.trust_label,
     r.visibility,
+    r.funding,
     r.platform_version,
     r.execution_mode,
     r.tuning_mode,

--- a/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
+++ b/tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py
@@ -226,6 +226,7 @@ class TestG1SchemaContract:
             "ranking_exclusion_reason",
             "trust_label",
             "visibility",
+            "funding",
             "platform_version",
             "execution_mode",
             "tuning_mode",


### PR DESCRIPTION
## Description

The `funding` column landed on the base `results` table in #1021 but was **not projected into `result_detail_metrics`** — the view the explorer detail page queries — so the frontend can't read it. This adds `r.funding` to that view (bare-column projection, per the G-11 views-are-bare-columns rule) in both the `duckdb_builder` DDL and the `browser-duckdb-schema.sql` doc, and adds `funding` to the `EXPECTED_VIEWS` contract set so a future drop is caught (the results-table set already guards it).

This is **w2** of `explorer-pipeline-frontend-handoff` and unblocks the frontend funding chip (w3).

## Type of Change

- [x] New feature (read model)

## Testing

`tests/unit/scripts/explorer_pipeline/` — 269 pass, including the browser-contract test now asserting `funding` in `result_detail_metrics`. No base-table column added, so no `read_model_version` bump.

## Notes

The frontend chip + legend + e2e (w3/w4) are **not** in this PR: they're React/TS across `db.ts`, `ResultDetail.tsx`, a new `FundingChip` component, and a legend row, and need a node environment (`tsc`/`vitest`/`playwright`) that isn't available in this checkout — writing them blind would be unverifiable. Exact integration points are captured in the TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvGemBr6T34NC53aevntpY)_