### PR TITLE
fix(release): restore auto_merge_soundness_paths in validate-base bootstrap; close v0.3.1 recovery

### DIFF
--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -126,11 +126,15 @@ jobs:
           # scripts/ruleset_drift_check.py imports the enforcement helper from
           # _project/scripts, but both the release head and the trusted main
           # base are curated (no _project/) once the release-cut curation
-          # step removes it. Pull the helper from develop, which always has
-          # it, so bootstrap evidence doesn't ModuleNotFoundError.
+          # step removes it. Pull the helper AND its _project/scripts
+          # dependency (auto_merge_soundness_paths) from develop, which always
+          # has them, so bootstrap evidence doesn't ModuleNotFoundError.
+          mkdir -p _project/scripts
           if [ ! -f _project/scripts/ruleset_review_enforcement.py ]; then
-            mkdir -p _project/scripts
             git show origin/develop:_project/scripts/ruleset_review_enforcement.py > _project/scripts/ruleset_review_enforcement.py
+          fi
+          if [ ! -f _project/scripts/auto_merge_soundness_paths.py ]; then
+            git show origin/develop:_project/scripts/auto_merge_soundness_paths.py > _project/scripts/auto_merge_soundness_paths.py
           fi
 
       - name: Bootstrap ruleset drift evidence

--- a/_project/TODO/main/active/release-recovery-v0-3-1.yaml
+++ b/_project/TODO/main/active/release-recovery-v0-3-1.yaml
@@ -2,7 +2,7 @@ id: release-recovery-v0-3-1
 title: "Recover the failed v0.3.0 install smoke with a monotonic v0.3.1 release"
 worktree: main
 priority: Critical
-status: Not Started
+status: Completed
 category: Release Tooling
 
 deps:
@@ -53,7 +53,7 @@ work:
 - id: w3
   summary: "Get explicit maintainer approval and run release-cut VERSION=0.3.1"
   needs: [w2]
-  status: pending
+  status: done
   notes: |
     This is a real public release. Do not proceed without explicit maintainer
     approval after w1/w2 evidence is available.
@@ -64,10 +64,21 @@ work:
     Expected result: a `v0.3.1 -> main` release PR with curated release-tree
     changes, version bumps, and changelog updates.
 
+    Outcome (2026-07-09): maintainer approval granted; cut from
+    `develop@99db4caf3`; release PR #1072 opened. Two mechanical snags:
+      - a stale local `v0.3.1` branch + worktree from prior aborted cuts
+        (#711/#712/#1029/#1043) blocked `git checkout -b v0.3.1` and had to be
+        removed first;
+      - `scripts/generate_changelog_entry.py` shells out to a nested `claude`
+        CLI (`CLAUDE_TIMEOUT_SECONDS = 120`) which stalls when release-cut is
+        driven from inside a Claude Code session. Worked around with a
+        fail-fast `claude` shim on PATH so it fell back to the raw changelog,
+        which was then hand-curated before the commit was pushed.
+
 - id: w4
   summary: "Review the v0.3.1 release PR and required release context"
   needs: [w3]
-  status: pending
+  status: done
   notes: |
     Confirm the release PR diff is only the expected release curation,
     version, changelog, docs, and landing marker changes. Confirm
@@ -75,10 +86,29 @@ work:
     finalization. Do not use post-merge push-to-main checks as pre-publish
     evidence.
 
+    Outcome (2026-07-09): PR #1072 verified — release tree carries
+    `__version__ = "0.3.1"`, the hand-curated `[0.3.1]` CHANGELOG section, zero
+    dev-only paths, and the rebuilt Linux dbgen binaries. Required contexts
+    `validate-base` and `release-required-result` both green before finalize.
+
+    Two release-infrastructure gaps surfaced here (both fixed, see w7):
+      - a clean cut from `develop` CONFLICTS with `main`: the two diverge by
+        design (the 2026-04-27 amendment removed the develop-rebase), so
+        GitHub could not compute a merge ref and no CI ran at all. Needs
+        `git merge -s ours --allow-unrelated-histories origin/main` on the
+        release branch ("align release histories") -- tree-preserving, and
+        what every prior aborted cut had done by hand. `release-cut` does not
+        do this.
+      - `validate-base` bootstrap restored `ruleset_review_enforcement.py`
+        from develop but not its sibling import `auto_merge_soundness_paths`,
+        so the ruleset-drift step died with ModuleNotFoundError. Prior cuts
+        never reached that step (they failed earlier on the non-fast suite),
+        which is why it stayed latent.
+
 - id: w5
   summary: "Run release-finalize VERSION=0.3.1 after required checks pass"
   needs: [w4]
-  status: pending
+  status: done
   notes: |
     Command:
       make release-finalize VERSION=0.3.1
@@ -86,10 +116,22 @@ work:
     Expected result: release PR squash-merged to `main`, tag `v0.3.1` pushed,
     and release.yml triggered for the immutable `v0.3.1` artifact.
 
+    Outcome (2026-07-09): PR #1072 squash-merged to `main` as the single
+    commit `7550c423d` ("Release v0.3.1 (#1072)"); tag `v0.3.1` points at it;
+    `release.yml` run 29055922350 triggered and concluded success.
+
+    Snag: `release-finalize`'s `git push origin v$(VERSION)` fails with
+    "src refspec v0.3.1 matches more than one" because a `v0.3.1` branch and a
+    `v0.3.1` tag both exist at that point. Pushed explicitly with
+    `git push origin refs/tags/v0.3.1`. Also, `release-finalize` (and the
+    release-branch push) trip the local pre-commit pre-push hook, since
+    curation removes `.pre-commit-config.yaml` from the release tree; run with
+    `PRE_COMMIT_ALLOW_NO_CONFIG=1` (do NOT disable hooks wholesale).
+
 - id: w6
   summary: "Verify v0.3.1 publishes and clean install/import passes"
   needs: [w5]
-  status: pending
+  status: done
   notes: |
     Required checks:
       - release.yml for tag `v0.3.1` concludes success;
@@ -98,10 +140,30 @@ work:
         `uv run --isolated --no-project --with 'benchbox==0.3.1' -- python -c 'import benchbox; print(benchbox.__version__)'`;
       - wheel contents remain clean of maintainer scaffolding.
 
+    Outcome (2026-07-09): all four pass.
+      - `release.yml` run 29055922350 concluded `success` (verify-tag-on-main,
+        dependency-bounds, build, publish, github-release, and
+        test-installation on ubuntu/macos/windows x 3.10/3.12/3.13).
+      - `pip index versions benchbox` lists `0.3.1` as the available/latest
+        version, ahead of the broken `0.3.0`.
+      - Clean isolated import prints `0.3.1`; the install resolves 29 packages
+        and pandas is NOT among them, so the exact `ModuleNotFoundError: No
+        module named 'pandas'` that broke `v0.3.0` is repaired.
+      - `pip show -f benchbox` yields zero hits for `_project`,
+        `automate_release`, `benchbox/release/`, `.claude`, `AGENTS.md`,
+        `CLAUDE.md`, `_blog`, `results-explorer`, or `skill-sync`.
+
+    The emergency override variables were never set: `validate-base` takes the
+    trusted-base bootstrap path while `main` lacks
+    `scripts/release_readiness_check.py`, and that path never consults
+    `RELEASE_READINESS_OVERRIDE_SHA/REASON`. The circular
+    `pypi-latest-installability` canary failure therefore never gated this
+    release. Nothing to remove.
+
 - id: w7
   summary: "Close migration bookkeeping from the recovery evidence"
   needs: [w6]
-  status: pending
+  status: done
   notes: |
     After v0.3.1 is verified, update Phase 4 w8 with the recovery-release
     evidence and move Phase 4 to DONE if the maintainer accepts the monotonic
@@ -110,6 +172,25 @@ work:
     Then make an explicit Phase 8 decision: either retire Phase 8 as
     satisfied by the v0.3.1 recovery release, or keep Phase 8 as a separate
     later post-migration release. Do not let that decision remain implicit.
+
+    Outcome (2026-07-09), maintainer-approved:
+      - Phase 4 w8 recorded the recovery evidence and Phase 4 moved to
+        `Completed`. The monotonic v0.3.1 release is accepted as terminal for
+        the failed v0.3.0 installability gate; immutable `0.3.0` was never
+        re-tagged or re-uploaded.
+      - Phase 8 is RETIRED as satisfied by this recovery release. Rationale:
+        `_project/decisions/single-repo-migration.md` already scopes Phase 8 as
+        "exercises the full flow end-to-end on `v0.3.1`", and v0.3.1 did
+        exactly that -- cut from `develop` with `release-cut`, curated,
+        squash-merged to `main`, tagged, and published via `release.yml`, with
+        the old `automate_release.py` long gone. A second post-migration
+        release would re-run an already-passed exercise.
+      - The two release-infrastructure gaps this release exposed (the
+        `-s ours` history alignment that `release-cut` does not perform, and
+        the missing `auto_merge_soundness_paths` restore in the `validate-base`
+        bootstrap) are recorded in the decision-doc amendment. The bootstrap
+        restore is fixed and regression-tested in this PR; the alignment merge
+        remains a documented manual step.
 
 verification:
 - description: "Recovery release workflow succeeded"

--- a/_project/TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
+++ b/_project/TODO/main/active/single-repo-migration-phase-4-test-release-with-new-flow.yaml
@@ -2,7 +2,7 @@ id: single-repo-migration-phase-4-test-release-with-new-flow
 title: "Single-repo migration phase 4: final sync, _project/** history merge, first release on public (v0.3.0)"
 worktree: main
 priority: High
-status: Blocked
+status: Completed
 category: Release Tooling
 
 deps:
@@ -229,8 +229,22 @@ work:
 - id: w8
   summary: "Verify the release published to PyPI and is installable"
   needs: [w7]
-  status: pending
+  status: done
   notes: |
+    CLOSED 2026-07-09 as recovery-complete via `release-recovery-v0-3-1`.
+    Immutable `0.3.0` was never re-tagged or re-uploaded; the installability
+    gate is satisfied by the later monotonic `v0.3.1`:
+      - `release.yml` run 29055922350 (tag `v0.3.1`) concluded `success`,
+        including every `test-installation` job across ubuntu/macos/windows.
+      - `pip index versions benchbox` lists `0.3.1` as available/latest.
+      - `uv run --isolated --no-project --with 'benchbox==0.3.1' -- python -c 'import benchbox; print(benchbox.__version__)'`
+        prints `0.3.1`; pandas is absent from the 29 resolved packages.
+      - `pip show -f benchbox` shows zero maintainer-scaffolding entries.
+    `0.3.0` remains permanently broken on PyPI by design; it is superseded,
+    not repaired.
+
+    ---- original blocker record (2026-05-25) ----
+
     Blocked as of 2026-05-25. The publish half succeeded, but the
     installability half failed and cannot be repaired in-place because
     PyPI rejects replacement uploads for an existing version.

--- a/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
+++ b/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
@@ -2,7 +2,7 @@ id: single-repo-migration-phase-8-first-post-migration-release
 title: "Single-repo migration phase 8: cut the first release after deletion and docs cleanup"
 worktree: main
 priority: Medium-High
-status: Blocked
+status: Completed
 category: Release Tooling
 
 deps:
@@ -50,7 +50,7 @@ description: |
 work:
 - id: w0
   summary: "Decide: is Phase 8 satisfied by the v0.3.1 recovery release, or is a separate release needed?"
-  status: pending
+  status: done
   notes: |
     release-recovery-v0-3-1 cuts and verifies v0.3.1 as the first real
     release on the new flow with no fallback — the exact exercise this phase
@@ -63,6 +63,27 @@ work:
         proceed to w1-w7 using v0.3.2+ (v0.3.1 is consumed by recovery).
     Mirrors the decision required by release-recovery-v0-3-1 w7; do not leave
     it implicit in the dependency graph.
+
+    DECISION 2026-07-09 (maintainer-approved): RETIRE — Phase 8 is satisfied
+    by the v0.3.1 recovery release. w1-w7 are deliberately skipped, not
+    forgotten.
+
+    Rationale: this phase exists to prove the new flow works end-to-end in the
+    canonical single-repo state with no fallback. v0.3.1 did precisely that —
+    `make release-cut VERSION=0.3.1` off `develop`, curation, squash-merge to
+    `main` (`7550c423d`), tag, and `release.yml` run 29055922350 publishing to
+    PyPI with green cross-platform install smoke — with `automate_release.py`
+    already deleted (Phase 6) and docs aligned (Phase 7). Phase 4 closed the
+    same day as recovery-complete. Cutting a v0.3.2 solely to re-run a passed
+    exercise would add a public release with no user-facing content.
+
+    The exercise did surface two real gaps, both recorded in
+    _project/decisions/single-repo-migration.md (2026-07-09 amendment):
+    `release-cut` does not perform the `-s ours` history alignment that a
+    `vX.Y.Z -> main` PR needs, and the `validate-base` bootstrap failed to
+    restore `auto_merge_soundness_paths`. The latter is fixed and
+    regression-tested; the former remains a documented manual step.
+    Recorded in _project/decisions/single-repo-migration.md, not left implicit.
 
 - id: w1
   summary: "Confirm main is green and all migration phases are merged"

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -250,3 +250,77 @@ extension above because they are not part of the v0.3.0 release tree.
 `scripts/check_release_curation.py` now pins these required removals in
 addition to the top-level split, so the drift guard fails if a future edit
 accidentally reclassifies the results explorer as shipping content.
+
+## Amendment 2026-07-09 — v0.3.1 recovery release; Phase 4 closed, Phase 8 retired
+
+The `v0.3.1` recovery release published successfully (tag `v0.3.1`,
+`release.yml` run 29055922350, squash commit `7550c423d` on `main`). A clean
+isolated install of `benchbox==0.3.1` imports without pandas, resolving the
+`v0.3.0` installability failure. `0.3.0` was neither re-tagged nor re-uploaded;
+it remains permanently broken on PyPI and is superseded, not repaired.
+
+Bookkeeping consequences, decided explicitly rather than left implicit:
+
+- **Phase 4 is `Completed`** — its w8 installability gate is closed as
+  recovery-complete on the `v0.3.1` evidence.
+- **Phase 8 is `Completed` (RETIRED), satisfied by `v0.3.1`.** Phase 8 exists
+  to exercise the new flow end-to-end in the canonical single-repo state with
+  no fallback; `v0.3.1` did exactly that, with `automate_release.py` already
+  deleted (Phase 6) and docs aligned (Phase 7). Its w1-w7 are deliberately
+  skipped. A `v0.3.2` cut solely to re-run a passed exercise would be a public
+  release with no user-facing content.
+
+### Two release-flow gaps this release exposed
+
+1. **`release-cut` does not align release histories.** Because the 2026-04-27
+   amendment removed A4 step 6 (`rebase develop onto main`), `main` and
+   `develop` diverge permanently — `main` carries one squash commit per release
+   that `develop` never sees, and the two have unrelated roots since the Phase 4
+   filter-merge. A `vX.Y.Z` branch cut cleanly from `develop` is therefore
+   *not mergeable* into `main`: GitHub cannot compute a merge ref, so **no CI
+   runs at all** and the release PR sits at `CONFLICTING`. The fix, applied by
+   hand on `v0.3.1` (and, in hindsight, by every prior aborted cut):
+
+   ```bash
+   git merge -s ours --allow-unrelated-histories origin/main \
+     -m "Merge main into vX.Y.Z (strategy: ours) to align release histories"
+   ```
+
+   `-s ours` preserves the curated release tree byte-for-byte and only records
+   `main` as a second parent. `release-finalize`'s squash-merge then collapses
+   the branch into a single commit on `main`, so this merge never pollutes
+   `main`'s release-only ledger. **This remains a manual step**; folding it into
+   `release-cut` is the obvious follow-up.
+
+2. **`validate-base` bootstrap under-restored its helpers.** The trusted-base
+   bootstrap path (taken while `main` lacks `scripts/release_readiness_check.py`)
+   restored `_project/scripts/ruleset_review_enforcement.py` from `develop` but
+   not its sibling import `auto_merge_soundness_paths`, so the ruleset-drift
+   step died with `ModuleNotFoundError`. Prior cuts never reached that step —
+   they failed earlier on the non-fast suite — which is why it stayed latent.
+   Fixed in `.github/workflows/validate-main-pr.yml` and pinned by
+   `tests/unit/test_release_infrastructure.py::TestReleaseInfrastructure::test_validate_main_pr_restores_ruleset_helper_before_drift_check`.
+
+### Operational notes for the next release
+
+- The **emergency override variables were never set.** While `main` lacks
+  `scripts/release_readiness_check.py`, `validate-base` short-circuits into the
+  trusted-base bootstrap *before* `release_readiness_check.py` runs, so
+  `RELEASE_READINESS_OVERRIDE_SHA`/`_REASON` are not consulted and the circular
+  `pypi-latest-installability` canary failure does not gate the release. The
+  real gates on that path are the inline non-fast suite and the inline ruleset
+  drift check (which requires the `RULESET_DRIFT_TOKEN` repo secret). Once
+  `v0.3.1` lands the readiness script on `main`, later releases return to the
+  canary-consuming path and the override becomes meaningful again.
+- Release-branch pushes and `release-finalize`'s tag push trip the local
+  pre-commit **pre-push** hook, because curation removes
+  `.pre-commit-config.yaml` from the release tree. Use
+  `PRE_COMMIT_ALLOW_NO_CONFIG=1`; do not disable hooks wholesale.
+- `release-finalize`'s `git push origin v$(VERSION)` is ambiguous once both a
+  `vX.Y.Z` branch and tag exist (`src refspec ... matches more than one`). Push
+  the tag explicitly: `git push origin refs/tags/vX.Y.Z`.
+- `scripts/generate_changelog_entry.py` shells out to a nested `claude` CLI
+  (`CLAUDE_TIMEOUT_SECONDS = 120`) to summarize commits. That stalls when
+  `release-cut` is driven from inside a Claude Code session; the generated
+  section is raw commit subjects anyway and needs hand-curation, so the
+  changelog should be curated deliberately rather than accepted as generated.

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -431,6 +431,10 @@ class TestReleaseInfrastructure:
         base. The restore-from-develop step must run, and must run before
         the ruleset drift check, or bootstrap evidence would ModuleNotFoundError
         on every real release PR.
+
+        The helper itself imports auto_merge_soundness_paths from the same
+        curated-out directory, so restoring only the helper still fails
+        (v0.3.1 release PR #1072). Both modules must be restored.
         """
         job = _workflow("validate-main-pr.yml")["jobs"]["validate-base"]
         step_names = [step.get("name") for step in job["steps"]]
@@ -441,6 +445,7 @@ class TestReleaseInfrastructure:
         restore_step = job["steps"][restore_index]
         assert restore_step["if"] == "steps.release-readiness.outputs.bootstrap_required == 'true'"
         assert "_project/scripts/ruleset_review_enforcement.py" in restore_step["run"]
+        assert "_project/scripts/auto_merge_soundness_paths.py" in restore_step["run"]
         assert "origin/develop" in restore_step["run"]
 
     def test_release_docs_name_canary_and_ruleset_drift(self):


### PR DESCRIPTION
The trusted-base bootstrap step restored ruleset_review_enforcement.py from
develop but not its sibling import auto_merge_soundness_paths, so
ruleset_drift_check.py failed with ModuleNotFoundError on the v0.3.1 release
PR (#1072). Prior cuts never reached that step, so it stayed latent. Restore
both helpers and pin it with a regression assertion.

Bookkeeping from the now-published v0.3.1 recovery release:
- release-recovery-v0-3-1: w3-w7 done, status Completed.
- Phase 4: w8 closed as recovery-complete on the v0.3.1 evidence; Completed.
- Phase 8: explicitly RETIRED as satisfied by v0.3.1 (w1-w7 skipped).
- Decision doc: 2026-07-09 amendment recording the recovery, the two
  release-flow gaps it exposed (release-cut does not perform the -s ours
  history alignment; the bootstrap helper restore), and operational notes.
