### PR TITLE
fix(release): stop nested claude stall, make release-cut resumable, check curation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1053,40 +1053,80 @@ run-test:
 
 RELEASE_REQUIRED_CONTEXTS := validate-base release-required-result
 
-.PHONY: release-cut release-finalize
+.PHONY: release-cut release-cut-abort release-finalize
 
 # Cut a release branch from develop in one shot:
 #   1. Create v$(VERSION) branch off develop (develop is not modified).
 #   2. On v$(VERSION): bump version sources (scripts/update_version.py).
 #   3. On v$(VERSION): generate CHANGELOG.md entry from the origin/main patch delta.
-#   4. $EDITOR opens CHANGELOG.md for hand-curation (skipped if EDITOR unset).
-#   5. Curate: git rm dev-only/deferred paths (per A3 in single-repo-migration.md).
-#   6. Commit "Release v$(VERSION)" (bump + changelog + curation in one squash-friendly commit).
-#   7. Merge origin/main with `-s ours` so the PR is mergeable and CI can run.
-#   8. Push, open PR vs main.
-#   9. Sweep stale v* branches on origin (option-c lifecycle).
-# Pre-conditions: on develop, clean tree.
+#   4. $EDITOR opens CHANGELOG.md for hand-curation when interactive.
+#   5. Gate on the changelog curation check (--check-curation).
+#   6. Curate: git rm dev-only/deferred paths (per A3 in single-repo-migration.md).
+#   7. Commit "Release v$(VERSION)" (bump + changelog + curation in one squash-friendly commit).
+#   8. Merge origin/main with `-s ours` so the PR is mergeable and CI can run.
+#   9. Push, open PR vs main.
+#  10. Sweep stale v* branches on origin (option-c lifecycle).
+# Pre-conditions: on develop with a clean tree (new cut), or on v$(VERSION)
+# with no release commit yet (resume).
+#
+# Steps 1-5 are idempotent, so an interrupted cut is resumed by re-running the
+# same command: the branch is reused, the bump and `uv lock` re-apply to the
+# same values, and an existing CHANGELOG.md section is left untouched. The
+# v0.3.1 cut died at step 3 twice and left exactly that half-applied state.
+# `make release-cut-abort VERSION=X.Y.Z` discards it instead.
 # Usage: make release-cut VERSION=X.Y.Z
 release-cut:
 	@test -n "$(VERSION)" || (echo "Usage: make release-cut VERSION=X.Y.Z" && exit 1)
-	@[ "$$(git rev-parse --abbrev-ref HEAD)" = "develop" ] || (echo "Error: must be on develop branch" && exit 1)
-	@[ -z "$$(git status --porcelain)" ] || (echo "Error: working tree must be clean" && exit 1)
+	@# Resume guard. --first-parent matters: the `-s ours` alignment merge below
+	@# puts origin/main's whole release ledger -- which contains commits literally
+	@# titled "Release vX.Y.Z" -- on the merge's second parent. Walking first-parent
+	@# only sees this branch's own commits, so the guard fires for both post-commit
+	@# states: release commit at HEAD, and release commit beneath the alignment merge.
+	@BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$BRANCH" = "v$(VERSION)" ]; then \
+		if git log --first-parent --format=%s develop..HEAD 2>/dev/null | grep -Fxq "Release v$(VERSION)"; then \
+			echo "Error: v$(VERSION) already carries its release commit; nothing left to resume." >&2; \
+			echo "       Finish it by hand (git push -u origin v$(VERSION) && gh pr create --base main ...)," >&2; \
+			echo "       remembering the -s ours alignment merge if it has not run yet, or start over:" >&2; \
+			echo "         make release-cut-abort VERSION=$(VERSION)" >&2; \
+			exit 1; \
+		fi; \
+		echo "==> Resuming interrupted cut on v$(VERSION)"; \
+	elif [ "$$BRANCH" = "develop" ]; then \
+		[ -z "$$(git status --porcelain)" ] || { echo "Error: working tree must be clean" >&2; exit 1; }; \
+		if git rev-parse --verify --quiet refs/heads/v$(VERSION) >/dev/null; then \
+			echo "Error: branch v$(VERSION) already exists but HEAD is develop." >&2; \
+			echo "       Resume it (git checkout v$(VERSION) && make release-cut VERSION=$(VERSION))" >&2; \
+			echo "       or discard it (make release-cut-abort VERSION=$(VERSION))." >&2; \
+			exit 1; \
+		fi; \
+	else \
+		echo "Error: must be on develop (new cut) or v$(VERSION) (resume), not $$BRANCH" >&2; exit 1; \
+	fi
 	git fetch origin
-	git checkout -b v$(VERSION) develop
+	@git rev-parse --verify --quiet refs/heads/v$(VERSION) >/dev/null \
+		&& git checkout v$(VERSION) \
+		|| git checkout -b v$(VERSION) develop
 	uv run -- python scripts/update_version.py --version $(VERSION) --update-pyproject
 	@# Refresh uv.lock now that pyproject.toml carries the new version, so the
 	@# pre-commit uv-lock hook has nothing to regenerate mid-commit (v0.3.1
 	@# aborted because the tracked lock was stale and the hook rewrote it).
 	uv lock
 	uv run -- python scripts/generate_changelog_entry.py --version $(VERSION) --since-ref origin/main
-	@if [ -n "$$EDITOR" ]; then \
+	@# The generated section is raw commit subjects across the whole
+	@# origin/main..HEAD delta (main lags develop by many releases), so it always
+	@# needs hand-curation. Open $$EDITOR when there is a terminal to open it in;
+	@# either way the --check-curation gate below decides, on the section's own
+	@# text, whether curation actually happened. The old gate tested only whether
+	@# EDITOR was set and stdin was a TTY, which `EDITOR=true` defeated.
+	@if [ -n "$$EDITOR" ] && [ -t 0 ]; then \
 		echo "==> Opening CHANGELOG.md in $$EDITOR for hand-curation"; \
 		$$EDITOR CHANGELOG.md; \
-	elif [ -t 0 ]; then \
-		echo "==> EDITOR unset; skipping interactive CHANGELOG curation"; \
 	else \
-		echo "ERROR: EDITOR unset and no TTY — refusing to skip changelog curation in headless mode." >&2; exit 1; \
+		echo "==> Non-interactive: CHANGELOG.md holds the raw generated draft."; \
+		echo "    Hand-curate the [$(VERSION)] section, then re-run: make release-cut VERSION=$(VERSION)"; \
 	fi
+	uv run -- python scripts/generate_changelog_entry.py --check-curation --version $(VERSION)
 	@# Curation FIRST so dev-only paths are never staged. Order matters: git rm
 	@# before git add ensures untracked files inside _project/ etc. don't end up
 	@# staged-for-add by a later git add.
@@ -1167,6 +1207,33 @@ release-cut:
 	@echo "  1. Review the PR diff; confirm CHANGELOG and curation are correct."
 	@echo "  2. Wait for the required release contexts: $(RELEASE_REQUIRED_CONTEXTS)."
 	@echo "  3. make release-finalize VERSION=$(VERSION)"
+
+# Discard a local, unpushed release cut: reset the working tree, return to
+# develop, delete the v$(VERSION) branch. Use when a cut died partway through
+# (bumped versions, rewritten uv.lock, curated-away paths, no commit) and you
+# want to start over rather than resume with `make release-cut VERSION=X.Y.Z`.
+# Refuses once the branch exists on origin — deleting a pushed release branch
+# is release-finalize's or the option-c sweep's job, not this target's.
+# Usage: make release-cut-abort VERSION=X.Y.Z
+release-cut-abort:
+	@test -n "$(VERSION)" || (echo "Usage: make release-cut-abort VERSION=X.Y.Z" && exit 1)
+	@git rev-parse --verify --quiet refs/heads/v$(VERSION) >/dev/null \
+		|| (echo "Nothing to abort: no local v$(VERSION) branch" >&2 && exit 1)
+	@if git ls-remote --exit-code --heads origin "v$(VERSION)" >/dev/null 2>&1; then \
+		echo "Error: v$(VERSION) exists on origin; aborting would discard a pushed branch." >&2; \
+		echo "       Close its release PR and delete the remote branch first." >&2; \
+		exit 1; \
+	fi
+	@BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
+	if [ "$$BRANCH" = "v$(VERSION)" ]; then \
+		echo "==> Discarding uncommitted cut state on v$(VERSION)"; \
+		git reset --hard HEAD; \
+		git checkout develop; \
+	elif [ "$$BRANCH" != "develop" ]; then \
+		echo "Error: expected to be on v$(VERSION) or develop, not $$BRANCH" >&2; exit 1; \
+	fi; \
+	git branch -D v$(VERSION)
+	@echo "==> Aborted: v$(VERSION) deleted; develop untouched."
 
 # After release-cut's PR is approved and all required release contexts are
 # green: squash-merge it, tag main, push the tag (fires release.yml), and
@@ -2302,7 +2369,8 @@ help:
 	@echo "  make blind-spots-sweep  Alias for blind-spots-report"
 	@echo ""
 	@echo "Release Workflow (2-command flow; see docs/operations/release-guide.md):"
-	@echo "  make release-cut VERSION=X.Y.Z      Cut v\$$VERSION off develop, bump + changelog + curate, push, open PR vs main"
+	@echo "  make release-cut VERSION=X.Y.Z      Cut v\$$VERSION off develop, bump + changelog + curate, push, open PR vs main (re-run to resume)"
+	@echo "  make release-cut-abort VERSION=X.Y.Z  Discard an unpushed v\$$VERSION cut and return to develop"
 	@echo "  make release-finalize VERSION=X.Y.Z Verify validate-base and release-required-result, squash-merge the release PR, tag main, push tag"
 	@echo ""
 	@echo "  make help            Show this help message"

--- a/_project/decisions/single-repo-migration.md
+++ b/_project/decisions/single-repo-migration.md
@@ -332,3 +332,41 @@ Bookkeeping consequences, decided explicitly rather than left implicit:
   `release-cut` is driven from inside a Claude Code session; the generated
   section is raw commit subjects anyway and needs hand-curation, so the
   changelog should be curated deliberately rather than accepted as generated.
+  **Resolved** — see "Changelog and cut recovery" below.
+
+### Changelog and cut recovery (resolves the nested-`claude` stall)
+
+Three changes, pinned by `tests/unit/scripts/test_generate_changelog_entry.py`
+and `tests/unit/test_release_infrastructure.py`:
+
+1. **Summarization is off inside a Claude Code session.** `summarize_skip_reason()`
+   checks `CLAUDECODE` / `CLAUDE_CODE_ENTRYPOINT` / `CLAUDE_CODE_SESSION_ID` and
+   falls straight through to `_build_raw_changelog` instead of blocking for 120s.
+   `BENCHBOX_CHANGELOG_SUMMARIZE` overrides in both directions. The CLI now also
+   runs with `stdin=DEVNULL` in its own process group, so the timeout path kills
+   every pipe holder. `subprocess.run(timeout=...)` killed only the direct child
+   and then re-waited on a stdout pipe a surviving grandchild still held open —
+   that is what produced the orphaned `make`/`uv`/python tree, and it is why the
+   120s timeout never actually fired.
+
+2. **`release-cut` is resumable; `release-cut-abort` discards.** Branch creation,
+   the version bump and `uv lock` were already idempotent; changelog generation
+   now leaves an existing `## [X.Y.Z]` section untouched rather than inserting a
+   second one. Re-running `make release-cut VERSION=X.Y.Z` from the release branch
+   therefore picks up where it stopped, preserving a section curated in between.
+   `make release-cut-abort VERSION=X.Y.Z` resets the tree, returns to `develop`
+   and deletes the branch; it refuses once the branch exists on origin, and
+   `release-cut` refuses to resume a branch that already carries its release commit.
+
+3. **Curation is an explicit, checked step.** The old gate refused to skip curation
+   only when `EDITOR` was unset *and* stdin was not a TTY — `EDITOR=true` defeated
+   it. `--check-curation` now judges the drafted section's own text: verbatim commit
+   subjects (trailing `(#NNNN)`), the manual-edit placeholder, or more than
+   `MAX_CURATED_BULLETS` bullets fail the cut. The ceiling is 60, set from evidence
+   rather than the summarizer prompt's 10-25 target: the largest hand-curated
+   section shipped is `0.2.1` at 39 bullets, while the raw `origin/main..HEAD` delta
+   at `v0.3.1` was 231 conventional commits. `RELEASE_ALLOW_RAW_CHANGELOG=1` accepts
+   a raw draft deliberately.
+
+With gap 1 (history alignment via `-s ours`) folded into `release-cut` by #1089,
+both gaps this release exposed are now closed in the target itself.

--- a/docs/operations/release-guide.md
+++ b/docs/operations/release-guide.md
@@ -87,9 +87,15 @@ must not be bypassed with an undocumented local change.
    delta against `main`, not `git log origin/main..HEAD` ancestry and not the
    latest tag reachable from `develop`, because `release-finalize`
    intentionally does not replay release commits onto `develop`.
-3. Opens `$EDITOR` on `CHANGELOG.md` for hand-curation. (Headless mode:
-   refuses to skip the curation step rather than silently committing
-   raw output.)
+3. Opens `$EDITOR` on `CHANGELOG.md` for hand-curation when a terminal is
+   attached, then gates on `generate_changelog_entry.py --check-curation`,
+   which inspects the drafted section's text: it rejects verbatim commit
+   subjects (trailing `(#NNNN)`), the manual-edit placeholder, and more than
+   60 bullets. Curation is always required — the draft is the raw
+   `origin/main..HEAD` delta, hundreds of commits whenever `main` lags
+   `develop`. Headless runs stop here: hand-curate the section, then re-run
+   `make release-cut` (see "Resuming or aborting a cut" below).
+   `RELEASE_ALLOW_RAW_CHANGELOG=1` accepts the raw draft deliberately.
 4. Curates the release branch — `git rm`'s the dev-only and deferred
    release paths (`_project/`, `_blog/`, results explorer/data, agent
    configs, dev-tooling root files; full list in the `release-cut:`
@@ -108,6 +114,34 @@ must not be bypassed with an undocumented local change.
 7. Pushes and opens a PR against `main`.
 8. Sweeps prior `v*` branches on origin (option-c lifecycle: keep until
    superseded, then auto-delete on the next `release-cut`).
+
+### Resuming or aborting a cut
+
+Steps 1-3 are idempotent, so an interrupted cut is resumed by re-running the
+same command from the `vX.Y.Z` branch:
+
+```bash
+make release-cut VERSION=X.Y.Z      # reuses the branch, keeps the CHANGELOG section
+```
+
+The branch is reused rather than recreated, the version bump and `uv lock`
+re-apply to the same values, and an existing `## [X.Y.Z]` section is left
+untouched — so a section you curated between runs survives. To throw the cut
+away instead:
+
+```bash
+make release-cut-abort VERSION=X.Y.Z   # reset, return to develop, delete the branch
+```
+
+`release-cut-abort` refuses once `vX.Y.Z` exists on origin, and refuses to run
+from any branch other than `vX.Y.Z` or `develop`. `release-cut` likewise
+refuses to resume a branch that already carries its `Release vX.Y.Z` commit.
+
+Changelog summarization shells out to the `claude` CLI. It is skipped
+automatically inside a Claude Code session (where the nested call blocks until
+its 120s timeout) and whenever `BENCHBOX_CHANGELOG_SUMMARIZE=0`; set
+`BENCHBOX_CHANGELOG_SUMMARIZE=1` to force it. Skipping only means the draft is
+raw commit subjects, which step 3 requires you to curate anyway.
 
 ### What `release-finalize` does
 

--- a/scripts/generate_changelog_entry.py
+++ b/scripts/generate_changelog_entry.py
@@ -16,9 +16,13 @@ _summarize_changelog_with_claude, and generate_changelog_entry helpers:
   non-conventional commits.
 - If the Claude CLI is available, summarises the raw bullets into a
   compact, themed section (10-25 user-facing bullets). Falls back to
-  raw commit messages otherwise.
+  raw commit messages otherwise. Summarization is skipped inside a
+  Claude Code session unless BENCHBOX_CHANGELOG_SUMMARIZE=1, because the
+  nested CLI call blocks (see the 2026-07-09 amendment of
+  _project/decisions/single-repo-migration.md).
 - Inserts the new section into CHANGELOG.md before the first existing
-  `## [` entry.
+  `## [` entry, or leaves an existing section for that version alone so
+  an interrupted `make release-cut` can be re-run.
 
 Usage:
     uv run python scripts/generate_changelog_entry.py --version 0.3.0
@@ -26,6 +30,8 @@ Usage:
         --release-date 2026-04-30 --since-tag v0.2.1
     uv run python scripts/generate_changelog_entry.py --version 0.3.1 \
         --since-ref origin/main
+    uv run python scripts/generate_changelog_entry.py --version 0.3.1 \
+        --check-curation
 """
 
 from __future__ import annotations
@@ -33,12 +39,35 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import signal
 import subprocess
 import sys
 from datetime import date
 from pathlib import Path
 
 CLAUDE_TIMEOUT_SECONDS = 120
+
+# Set by the Claude Code CLI in every session it spawns. Shelling out to a
+# nested `claude` from inside one stalls (the v0.3.1 cut hung here twice), so
+# summarization defaults off when any of these are present.
+_NESTED_CLAUDE_ENV_VARS = ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_CODE_SESSION_ID")
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+# Curation gate. `_build_raw_changelog` emits verbatim commit subjects, which
+# keep their squash-merge PR suffix (e.g. "... (#1086)"); the Claude summary
+# and any hand-curated section do not. That suffix is the precise signal; the
+# bullet ceiling is a backstop for drafts written by other means.
+#
+# The ceiling is set from evidence, not the prompt's 10-25 target: the largest
+# genuinely hand-curated section shipped so far is 0.2.1 at 39 bullets, while
+# the raw origin/main..HEAD delta at v0.3.1 was 231 conventional commits. 60
+# separates the two with room to spare.
+MAX_CURATED_BULLETS = 60
+RAW_PLACEHOLDER = "(no user-facing changes detected -- please edit manually)"
+_PR_SUFFIX_RE = re.compile(r"\(#\d+\)\s*$")
+_BULLET_RE = re.compile(r"^\s*- \S")
 
 # Matches a dated released-version CHANGELOG.md header, e.g. "## [0.3.0] - 2026-05-16".
 # Deliberately does not match "## [Unreleased]" (no version number) or an
@@ -93,15 +122,78 @@ def _build_raw_changelog(
     return "\n".join(lines)
 
 
+def summarize_skip_reason(env: dict[str, str] | None = None) -> str | None:
+    """Return why Claude summarization is skipped, or None to run it.
+
+    `BENCHBOX_CHANGELOG_SUMMARIZE` decides explicitly in both directions. With
+    it unset, summarization runs only outside a Claude Code session: a nested
+    `claude --print` blocks until the timeout, which is how `make release-cut`
+    stalled during the v0.3.1 cut.
+    """
+    env = os.environ if env is None else env
+    flag = env.get("BENCHBOX_CHANGELOG_SUMMARIZE", "").strip().lower()
+    if flag in _FALSE_VALUES:
+        return "BENCHBOX_CHANGELOG_SUMMARIZE opts out"
+    if flag in _TRUE_VALUES:
+        return None
+    nested = next((name for name in _NESTED_CLAUDE_ENV_VARS if env.get(name)), None)
+    if nested:
+        return f"already inside a Claude Code session ({nested} set); set BENCHBOX_CHANGELOG_SUMMARIZE=1 to force"
+    return None
+
+
+def _kill_process_tree(proc: subprocess.Popen[str]) -> None:
+    """SIGKILL the child's whole process group, falling back to the child alone."""
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        else:  # pragma: no cover - Windows
+            proc.kill()
+    except (ProcessLookupError, PermissionError):  # pragma: no cover - already reaped
+        proc.kill()
+
+
+def _run_claude_cli(prompt: str) -> subprocess.CompletedProcess[str]:
+    """Run `claude --print` under a timeout that reaps the entire child tree.
+
+    `subprocess.run(timeout=...)` kills only the direct child, then re-waits on
+    the captured pipes; a surviving grandchild holding stdout open blocks that
+    wait forever, which is what left an orphaned `claude` tree behind the
+    stalled v0.3.1 cut. Running the child in its own process group lets the
+    timeout path kill every pipe holder. stdin is closed so the CLI can never
+    block waiting for input it will not get.
+    """
+    with subprocess.Popen(
+        ["claude", "--print", "--model", "sonnet", "-p", prompt],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    ) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=CLAUDE_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            _kill_process_tree(proc)
+            proc.communicate()
+            raise
+    return subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
+
+
 def _summarize_changelog_with_claude(
     version: str, release_date: str, added: list[str], fixed: list[str], changed: list[str]
 ) -> str | None:
     """Use Claude Code CLI to summarize raw commits into a compact changelog.
 
-    Returns the summarized changelog section, or None if claude is unavailable
-    or the summarization fails.
+    Returns the summarized changelog section, or None if summarization is
+    skipped, claude is unavailable, or the summarization fails.
     """
     if not added and not fixed and not changed:
+        return None
+
+    skip_reason = summarize_skip_reason()
+    if skip_reason is not None:
+        print(f"  Skipping Claude summarization: {skip_reason}")
         return None
 
     raw_parts: list[str] = []
@@ -141,12 +233,7 @@ Now summarize the following raw commits:
 {raw_input}"""
 
     try:
-        result = subprocess.run(
-            ["claude", "--print", "--model", "sonnet", "-p", prompt],
-            capture_output=True,
-            text=True,
-            timeout=CLAUDE_TIMEOUT_SECONDS,
-        )
+        result = _run_claude_cli(prompt)
     except FileNotFoundError:
         print("  Claude CLI not found, falling back to raw changelog")
         return None
@@ -203,6 +290,58 @@ def released_versions_in_changelog(changelog_text: str) -> list[str]:
     Excludes '## [Unreleased]', which is not a released-version claim.
     """
     return [m.group("version") for m in _CHANGELOG_VERSION_HEADER_RE.finditer(changelog_text)]
+
+
+def section_body(changelog_text: str, version: str) -> str | None:
+    """Return the body of `## [version] - <date>`, or None when absent."""
+    header = re.search(rf"^## \[{re.escape(version)}\] - .*$", changelog_text, re.MULTILINE)
+    if header is None:
+        return None
+    rest = changelog_text[header.end() :]
+    following = re.search(r"^## \[", rest, re.MULTILINE)
+    return rest[: following.start()] if following else rest
+
+
+def has_changelog_section(source: Path, version: str) -> bool:
+    """True when CHANGELOG.md carries a dated section for `version`."""
+    changelog = source / "CHANGELOG.md"
+    if not changelog.exists():
+        return False
+    return section_body(changelog.read_text(encoding="utf-8"), version) is not None
+
+
+def check_changelog_curation(source: Path, version: str) -> tuple[bool, list[str]]:
+    """Return (ok, problems) for the drafted `version` section.
+
+    `release-cut` generates a section from every conventional commit in the
+    `origin/main..HEAD` patch delta, which for a `main` that lags `develop` is
+    a raw dump of hundreds of commit subjects. The old gate only refused to
+    skip curation when `EDITOR` was unset *and* stdin was not a TTY, so
+    `EDITOR=true` waved the raw dump through. This checks the text instead.
+    """
+    changelog = source / "CHANGELOG.md"
+    if not changelog.exists():
+        return False, [f"{changelog} not found"]
+
+    body = section_body(changelog.read_text(encoding="utf-8"), version)
+    if body is None:
+        return False, [f"no '## [{version}] - <date>' section found in CHANGELOG.md"]
+
+    bullets = [line.strip() for line in body.splitlines() if _BULLET_RE.match(line)]
+    problems: list[str] = []
+    if not bullets:
+        problems.append("section contains no bullets")
+    if RAW_PLACEHOLDER in body:
+        problems.append("section still carries the generator's manual-edit placeholder")
+    raw_bullets = [b for b in bullets if _PR_SUFFIX_RE.search(b)]
+    if raw_bullets:
+        problems.append(
+            f"{len(raw_bullets)} bullet(s) are verbatim commit subjects "
+            f"(trailing PR number), e.g. {raw_bullets[0][:70]!r}"
+        )
+    if len(bullets) > MAX_CURATED_BULLETS:
+        problems.append(f"{len(bullets)} bullets exceeds the {MAX_CURATED_BULLETS}-bullet curated ceiling")
+    return (not problems), problems
 
 
 def existing_tags(source: Path) -> set[str]:
@@ -432,6 +571,19 @@ def generate_changelog_entry(
         True if changelog was updated, False otherwise.
     """
     print(f"\n  Auto-generating changelog entry for v{version}...")
+
+    changelog = source / "CHANGELOG.md"
+    if not changelog.exists():
+        print(f"  Error: {changelog} not found")
+        return False
+
+    # An interrupted `make release-cut` leaves the drafted section in place.
+    # Re-running the cut must not append a second one, and must not discard a
+    # hand-curated section the operator wrote between the two runs.
+    if section_body(changelog.read_text(encoding="utf-8"), version) is not None:
+        print(f"  CHANGELOG.md already has a [{version}] section; leaving it untouched")
+        return True
+
     if since_ref is not None:
         print(f"  Since ref: {since_ref} (patch delta)")
         commits = _patch_delta_commit_subjects(source, since_ref)
@@ -485,11 +637,6 @@ def generate_changelog_entry(
     if new_section is None:
         new_section = _build_raw_changelog(version, release_date, added, fixed, changed)
 
-    changelog = source / "CHANGELOG.md"
-    if not changelog.exists():
-        print(f"  Error: {changelog} not found")
-        return False
-
     content = changelog.read_text()
     insertion_marker = "\n## ["
     idx = content.find(insertion_marker)
@@ -513,6 +660,16 @@ def main() -> int:
         help=(
             "Check CHANGELOG.md for dated released-version sections with no matching "
             "vX.Y.Z git tag, then exit (skips entry generation; --version not required)."
+        ),
+    )
+    parser.add_argument(
+        "--check-curation",
+        action="store_true",
+        help=(
+            "Check that the '## [VERSION]' section has been hand-curated (no raw commit "
+            "subjects, no placeholder, at most "
+            f"{MAX_CURATED_BULLETS} bullets), then exit. Requires --version. "
+            "Override with RELEASE_ALLOW_RAW_CHANGELOG=1."
         ),
     )
     parser.add_argument(
@@ -559,6 +716,27 @@ def main() -> int:
 
     if not args.version:
         parser.error("--version is required unless --check-tag-claims is set")
+
+    if args.check_curation:
+        ok, problems = check_changelog_curation(args.source, args.version)
+        if ok:
+            print(f"  CHANGELOG.md curation guard: OK ([{args.version}] section looks hand-curated)")
+            return 0
+        print(f"  CHANGELOG.md section [{args.version}] does not look hand-curated:")
+        for problem in problems:
+            print(f"    - {problem}")
+        # The override forgives an uncurated section, not a missing one: with no
+        # section at all there is nothing to accept, and the cut would fail later.
+        if has_changelog_section(args.source, args.version) and (
+            os.environ.get("RELEASE_ALLOW_RAW_CHANGELOG", "").strip().lower() in _TRUE_VALUES
+        ):
+            print("  RELEASE_ALLOW_RAW_CHANGELOG is set; accepting the section as-is")
+            return 0
+        print()
+        print(f"  Edit the [{args.version}] section in CHANGELOG.md, then re-run the cut:")
+        print(f"    make release-cut VERSION={args.version}")
+        print("  To accept the raw draft deliberately: RELEASE_ALLOW_RAW_CHANGELOG=1 make release-cut ...")
+        return 1
 
     success = generate_changelog_entry(
         source=args.source,

--- a/tests/unit/scripts/test_generate_changelog_entry.py
+++ b/tests/unit/scripts/test_generate_changelog_entry.py
@@ -190,3 +190,164 @@ def test_since_ref_ignores_intermediate_squashed_same_file_commits(
     assert "- add next same-file patch" in changelog
     assert "already released same-file feature" not in changelog
     assert "already released same-file fix" not in changelog
+
+
+class TestSummarizeSkipReason:
+    """`claude --print` must never be spawned from inside a Claude Code session.
+
+    The v0.3.1 cut hung twice on the nested CLI call, leaving an orphaned
+    make/uv/python tree and a half-applied cut.
+    """
+
+    def test_nested_session_skips_summarization(self) -> None:
+        for var in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_CODE_SESSION_ID"):
+            reason = generate_changelog_entry.summarize_skip_reason({var: "1"})
+            assert reason is not None and var in reason
+
+    def test_outside_session_runs_summarization(self) -> None:
+        assert generate_changelog_entry.summarize_skip_reason({}) is None
+
+    def test_explicit_opt_in_overrides_nesting(self) -> None:
+        env = {"CLAUDECODE": "1", "BENCHBOX_CHANGELOG_SUMMARIZE": "1"}
+        assert generate_changelog_entry.summarize_skip_reason(env) is None
+
+    def test_explicit_opt_out_wins_outside_session(self) -> None:
+        env = {"BENCHBOX_CHANGELOG_SUMMARIZE": "0"}
+        assert generate_changelog_entry.summarize_skip_reason(env) is not None
+
+    def test_skipped_summarization_never_spawns_a_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.delenv("BENCHBOX_CHANGELOG_SUMMARIZE", raising=False)
+
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise AssertionError("nested claude CLI must not be spawned")
+
+        monkeypatch.setattr(generate_changelog_entry.subprocess, "Popen", _explode)
+        assert generate_changelog_entry._summarize_changelog_with_claude("0.3.1", "2026-07-09", ["a"], [], []) is None
+
+    def test_claude_cli_runs_in_its_own_process_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A timeout must be able to kill grandchildren holding the stdout pipe."""
+        captured: dict[str, object] = {}
+
+        class _FakeProc:
+            args = ["claude"]
+            returncode = 0
+
+            def __enter__(self) -> _FakeProc:
+                return self
+
+            def __exit__(self, *exc: object) -> None:
+                return None
+
+            def communicate(self, timeout: float | None = None) -> tuple[str, str]:
+                return ("### Added\n- x\n", "")
+
+        def _fake_popen(cmd: list[str], **kwargs: object) -> _FakeProc:
+            captured.update(kwargs)
+            return _FakeProc()
+
+        monkeypatch.setattr(generate_changelog_entry.subprocess, "Popen", _fake_popen)
+        generate_changelog_entry._run_claude_cli("prompt")
+        assert captured["start_new_session"] is True
+        assert captured["stdin"] is generate_changelog_entry.subprocess.DEVNULL
+
+
+class TestChangelogCurationGuard:
+    """`EDITOR=true` used to wave a raw commit dump straight into a release."""
+
+    def _write(self, repo: Path, body: str) -> None:
+        (repo / "CHANGELOG.md").write_text(body, encoding="utf-8")
+
+    def test_raw_commit_subjects_are_rejected(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "## [0.3.1] - 2026-07-09\n\n### Fixed\n\n- restore auto_merge_soundness_paths (#1086)\n",
+        )
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok
+        assert any("verbatim commit subjects" in p for p in problems)
+
+    def test_manual_edit_placeholder_is_rejected(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            f"## [0.3.1] - 2026-07-09\n\n### Added\n\n- {generate_changelog_entry.RAW_PLACEHOLDER}\n",
+        )
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok
+        assert any("placeholder" in p for p in problems)
+
+    def test_bullet_ceiling_is_enforced(self, tmp_path: Path) -> None:
+        bullets = "\n".join(f"- change number {i}" for i in range(generate_changelog_entry.MAX_CURATED_BULLETS + 1))
+        self._write(tmp_path, f"## [0.3.1] - 2026-07-09\n\n### Added\n\n{bullets}\n")
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok
+        assert any("ceiling" in p for p in problems)
+
+    def test_missing_section_is_rejected(self, tmp_path: Path) -> None:
+        self._write(tmp_path, "## [0.3.0] - 2026-05-16\n\n### Added\n\n- **Thing** - does things.\n")
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok
+        assert "no '## [0.3.1] - <date>' section found" in problems[0]
+
+    def test_curated_section_passes(self, tmp_path: Path) -> None:
+        self._write(
+            tmp_path,
+            "## [0.3.1] - 2026-07-09\n\n### Fixed\n\n"
+            "- **Release bootstrap** - validate-base now restores its helper module.\n\n"
+            "## [0.3.0] - 2026-05-16\n\n### Added\n\n- Older entry (#1) still ignored.\n",
+        )
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert ok, problems
+
+    def test_every_shipped_changelog_section_passes_the_guard(self) -> None:
+        """The ceiling is calibrated on real releases, not on the prompt's target.
+
+        0.2.1 shipped 39 hand-curated bullets; a tighter ceiling would reject it.
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+        text = (repo_root / "CHANGELOG.md").read_text(encoding="utf-8")
+        for version in generate_changelog_entry.released_versions_in_changelog(text):
+            ok, problems = generate_changelog_entry.check_changelog_curation(repo_root, version)
+            assert ok, f"shipped section [{version}] fails the curation guard: {problems}"
+
+
+class TestChangelogGenerationIsIdempotent:
+    """Re-running an interrupted `make release-cut` must not double-insert."""
+
+    def test_existing_section_is_left_untouched(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@example.com")
+        _git(repo, "config", "user.name", "Test User")
+        _commit(repo, "feat: a new feature", "f.txt", "A\n")
+
+        curated = "## [0.3.1] - 2026-07-09\n\n### Added\n\n- **Curated** - written by hand.\n"
+        (repo / "CHANGELOG.md").write_text(curated, encoding="utf-8")
+
+        monkeypatch.setattr(generate_changelog_entry, "_summarize_changelog_with_claude", lambda *args: None)
+        assert generate_changelog_entry.generate_changelog_entry(repo, version="0.3.1", release_date="2026-07-09")
+
+        text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+        assert text == curated
+        assert text.count("## [0.3.1]") == 1
+
+
+class TestCurationOverrideScope:
+    """RELEASE_ALLOW_RAW_CHANGELOG forgives an uncurated section, not a missing one."""
+
+    def test_missing_changelog_reports_cleanly(self, tmp_path: Path) -> None:
+        ok, problems = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok
+        assert "not found" in problems[0]
+
+    def test_override_does_not_apply_without_a_section(self, tmp_path: Path) -> None:
+        (tmp_path / "CHANGELOG.md").write_text("## [0.3.0] - 2026-05-16\n\n- **X** - y.\n", encoding="utf-8")
+        assert not generate_changelog_entry.has_changelog_section(tmp_path, "0.3.1")
+        assert generate_changelog_entry.has_changelog_section(tmp_path, "0.3.0")
+
+    def test_override_applies_to_a_raw_section(self, tmp_path: Path) -> None:
+        (tmp_path / "CHANGELOG.md").write_text("## [0.3.1] - 2026-07-09\n\n- raw subject (#1086)\n", encoding="utf-8")
+        assert generate_changelog_entry.has_changelog_section(tmp_path, "0.3.1")
+        ok, _ = generate_changelog_entry.check_changelog_curation(tmp_path, "0.3.1")
+        assert not ok

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -543,6 +543,50 @@ class TestReleaseInfrastructure:
         assert "origin/main" in release_guide
         assert "intentionally does not replay release commits onto" in release_guide
 
+    def test_release_cut_gates_on_changelog_curation_not_on_editor(self):
+        """`EDITOR=true` must not wave a raw commit dump into a release.
+
+        The old gate refused to skip curation only when EDITOR was unset AND
+        there was no TTY, so setting EDITOR to any no-op binary defeated it.
+        The gate is now the drafted section's own text.
+        """
+        recipe = _make_target_recipe("release-cut")
+
+        assert "scripts/generate_changelog_entry.py --check-curation --version $(VERSION)" in recipe
+        assert "refusing to skip changelog curation" not in recipe
+        gen_idx = recipe.index("--version $(VERSION) --since-ref origin/main")
+        check_idx = recipe.index("--check-curation")
+        rm_idx = recipe.index("git rm")
+        assert gen_idx < check_idx < rm_idx, "curation check must gate between changelog draft and `git rm`"
+
+    def test_release_cut_is_resumable_and_has_an_abort_target(self):
+        """An interrupted cut must be resumable or discardable, not a manual cleanup.
+
+        The v0.3.1 cut died at the changelog step twice, each time leaving the
+        vX.Y.Z branch created, versions bumped and uv.lock rewritten with no
+        commit.
+        """
+        recipe = _make_target_recipe("release-cut")
+        assert "Resuming interrupted cut" in recipe
+        assert "already carries its release commit" in recipe
+        assert "git checkout -b v$(VERSION) develop" in recipe
+        assert "git rev-parse --verify --quiet refs/heads/v$(VERSION)" in recipe
+
+        assert "--first-parent" in recipe, (
+            "the resume guard must walk first-parent: the `-s ours` alignment merge puts "
+            "origin/main's release ledger (full of 'Release vX.Y.Z' subjects) on the second parent, "
+            "and a plain `git log -1` misses a release commit sitting beneath that merge"
+        )
+
+        abort = _make_target_recipe("release-cut-abort")
+        assert "git reset --hard HEAD" in abort
+        assert "git checkout develop" in abort
+        assert "git branch -D v$(VERSION)" in abort
+        assert "git ls-remote --exit-code --heads origin" in abort, (
+            "abort must refuse to discard a release branch that already exists on origin"
+        )
+        assert ".PHONY: release-cut release-cut-abort release-finalize" in _makefile_text()
+
     def test_release_cut_curation_survives_untracked_paths(self):
         """Curation `git rm` lines must use --ignore-unmatch and abort on real failures.
 


### PR DESCRIPTION
`make release-cut` hung twice during the v0.3.1 cut when driven from inside a
Claude Code session: generate_changelog_entry.py shells out to `claude --print`
to summarize commits, and the nested CLI never returned. The 120s timeout could
not save it either — subprocess.run(timeout=...) kills only the direct child and
then re-waits on the captured stdout pipe, which a surviving grandchild still
held open. The cut died mid-flight, leaving the vX.Y.Z branch created, versions
bumped and uv.lock rewritten with no commit.

- Skip summarization inside a Claude Code session (CLAUDECODE /
  CLAUDE_CODE_ENTRYPOINT / CLAUDE_CODE_SESSION_ID), falling straight through to
  _build_raw_changelog. BENCHBOX_CHANGELOG_SUMMARIZE overrides both ways. Run the
  CLI with stdin=DEVNULL in its own process group so the timeout reaps the tree.
- Make release-cut resumable: changelog generation now leaves an existing
  [X.Y.Z] section untouched, so re-running the cut resumes it and preserves a
  section curated in between. Add release-cut-abort to discard a cut instead; it
  refuses once the branch exists on origin.
- Make curation an explicit, checked step. The old gate refused to skip curation
  only when EDITOR was unset AND there was no TTY, which `EDITOR=true` defeated.
  --check-curation now judges the section's own text: verbatim commit subjects
  (trailing PR number), the manual-edit placeholder, or >60 bullets fail the cut.
  The ceiling is calibrated on shipped releases (0.2.1 has 39 curated bullets;
  the raw v0.3.1 delta had 231). RELEASE_ALLOW_RAW_CHANGELOG=1 accepts a raw draft.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
