### PR TITLE
feat/explorer funding chip

### DIFF
--- a/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
+++ b/_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml
@@ -71,28 +71,52 @@ work:
       Render a funding chip on the detail page (ResultDetail.tsx), reading funding
       from result_detail_metrics; add a legend row explaining chip + vendor badge.
     notes: >-
-      REQUIRES a node env (tsc/vitest not available in the develop checkout).
-      Integration points: (1) results-explorer/src/db.ts - add `funding` to the
-      result_detail_metrics SELECT/row type; (2) new
-      results-explorer/src/components/FundingChip.tsx mirroring
-      StatusBadge.tsx/TrustBadge.tsx (StatusTone: info/success/warning/danger/
-      neutral); (3) render it in results-explorer/src/pages/ResultDetail.tsx next
-      to the TrustBadge; (4) add a legend row wherever the trust-label legend
-      lives. Label/tooltip text from provenance.py display strings; do NOT re-list
-      the funding enum in TS. 'unspecified' renders muted or omitted per design.
-      Use an approved design token (tests/unit/scripts/test_scan_explorer_tokens.py
-      gate). Consider whether the index/leaderboard pages (BenchmarkIndex.tsx,
-      PlatformIndex.tsx, MetaLeaderboard.tsx, Compare.tsx) also show the chip -
-      those query different views (platform_index_rows / benchmark_rankings) that
-      do NOT yet project funding, so a card-level chip needs its own view
-      projection first (scope decision).
+      DONE: funding threaded through duckdbQueries.ts
+      (RESULT_DETAIL_METRICS_COLUMNS + ResultDetailMetricsRow + the DetailResult
+      mapping) and types.ts; new FundingChip.tsx renders via the StatusBadge
+      primitive with a new StatusRole "funding" and a uniform `neutral` tone (a
+      tone gradient would re-encode funding as a trust signal); 'unspecified'
+      renders NO chip; formatFunding() added to displayLabels.ts. New
+      ProvenanceLegend.tsx satisfies the hosted-results-contract legend rule and
+      pulls its prose from trustLabelDescription()/fundingDescription() so it
+      cannot drift from the badges. SCOPE: detail page only - see w5 for the
+      card-level chip.
     needs: [w2]
-    status: pending
+    status: done
   - id: w4
     summary: >-
       Add results-explorer e2e (results-explorer/e2e/) for the funding chip +
       legend; update any legend-set smoke. Needs a node env.
+    notes: >-
+      DONE: results-explorer/e2e/routes/funding-disclosure.spec.ts covers chip
+      render, chip omission on 'unspecified', neutral tone, trust/funding
+      orthogonality, and the legend (reachable + expands to explain both axes).
+      The browser fixture corpus gained its first funding-disclosing bundle: the
+      `community` variant in scripts/generate-browser-fixtures.mjs now declares
+      provenance.funding=employer, so community-submission + employer-funded
+      proves the two axes are independent. Unit coverage in
+      FundingChip.test.tsx, ProvenanceLegend.test.tsx, ResultDetail.test.tsx.
     needs: [w3]
+    status: done
+  - id: w5
+    summary: >-
+      Project funding into the card-level views and render the chip on the
+      index/leaderboard/compare surfaces.
+    notes: >-
+      Deferred out of the w3/w4 PR (detail page only). The cards read
+      platform_index_rows / benchmark_rankings / benchmark_matrix_cells, none of
+      which project funding. Steps, mirroring exactly what PR #1080 did for
+      result_detail_metrics: (1) add a BARE `r.funding` column reference to the
+      relevant view DDL in _project/scripts/explorer_pipeline/duckdb_builder.py
+      (no computed expression - G-11); (2) mirror it in
+      docs/development/browser-duckdb-schema.sql; (3) add "funding" to the
+      matching EXPECTED_VIEWS entry in
+      tests/unit/scripts/explorer_pipeline/test_duckdb_browser_contract.py. No
+      read_model_version bump - the base `results` table already has the column.
+      Then render <FundingChip> in the card components and extend
+      ProvenanceLegend to those pages (the hosted-results-contract legend rule
+      applies to every page that shows the badges).
+    needs: [w4]
     status: pending
 
 must_preserve:

--- a/results-explorer/e2e/routes/funding-disclosure.spec.ts
+++ b/results-explorer/e2e/routes/funding-disclosure.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from "@playwright/test";
+import { waitForDataLoaded, waitForShell } from "../support/fixtures";
+
+/**
+ * Funding-disclosure surface on the result detail page: the funding chip and
+ * the provenance legend that explains it.
+ *
+ * Corpus facts these tests rely on (see scripts/generate-browser-fixtures.mjs):
+ *   - the `community` variant is the ONLY bundle declaring `provenance.funding`
+ *     (employer), and it is simultaneously `trust_label=community-submission`
+ *   - every other fixture leaves funding at the `unspecified` default
+ */
+
+// Community-submission + employer-funded. The pairing is the point: it shows
+// the funding axis is independent of the trust axis.
+const FUNDED_ID = "tpch-duckdb-sf0.01-20260403-b92a4ffb";
+// Maintainer-run, funding left `unspecified` -> no chip.
+const UNSPECIFIED_ID = "tpch-duckdb-sf0.01-20260403-010ee756";
+
+// Scope header assertions to the summary region: the expanded legend renders
+// its own sample chips, so an unscoped [data-role="funding"] would match those
+// too and make the "no chip" assertion depend on legend state.
+const summary = (page: Page) => page.getByRole("region", { name: "Result summary" });
+const fundingChip = (page: Page) => summary(page).locator('[data-role="funding"]');
+const trustBadge = (page: Page) => summary(page).locator('[data-role="trust"]');
+
+test.describe("Funding chip", () => {
+  test("@smoke a funded result renders its funding chip beside the trust badge", async ({ page }) => {
+    await page.goto(`/results/r/${FUNDED_ID}`);
+    await waitForShell(page);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    const chip = fundingChip(page).first();
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveText("Employer funded");
+    await expect(chip).toHaveAttribute("title", /employer/i);
+  });
+
+  test("funding is orthogonal to trust: a community result can be employer-funded", async ({ page }) => {
+    await page.goto(`/results/r/${FUNDED_ID}`);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    // Both badges render, independently, in the same header row.
+    await expect(trustBadge(page).first()).toHaveText("Community");
+    await expect(fundingChip(page).first()).toHaveText("Employer funded");
+  });
+
+  test("funding chip is neutral-toned, never a trust-style warning", async ({ page }) => {
+    await page.goto(`/results/r/${FUNDED_ID}`);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    // A tone gradient would re-encode "who paid" as "how much to trust this".
+    await expect(fundingChip(page).first()).toHaveAttribute("data-tone", "neutral");
+  });
+
+  test("a result with unspecified funding renders no chip, and its trust badge is untouched", async ({
+    page,
+  }) => {
+    await page.goto(`/results/r/${UNSPECIFIED_ID}`);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    // The trust badge still renders - proving the page loaded and that omitting
+    // the funding chip did not suppress the orthogonal trust surface.
+    await expect(trustBadge(page).first()).toBeVisible();
+    await expect(fundingChip(page)).toHaveCount(0);
+  });
+});
+
+test.describe("Provenance legend", () => {
+  test("@smoke the legend is reachable from a page that shows the badges", async ({ page }) => {
+    await page.goto(`/results/r/${FUNDED_ID}`);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    // hosted-results-contract.md requires a legend accessible from every page
+    // displaying trust labels.
+    const toggle = page.getByRole("button", { name: /What do these labels mean\?/i });
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("expanding the legend explains both the trust and funding axes", async ({ page }) => {
+    await page.goto(`/results/r/${FUNDED_ID}`);
+    await waitForDataLoaded(page, /TPC-H\s+-\s+DuckDB/);
+
+    const toggle = page.getByRole("button", { name: /What do these labels mean\?/i });
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    const legend = page.getByTestId("provenance-legend");
+    await expect(legend.getByRole("heading", { name: "Trust label" })).toBeVisible();
+    await expect(legend.getByRole("heading", { name: "Funding" })).toBeVisible();
+
+    // Every disclosed funding source gets a row, and the omitted `unspecified`
+    // case is explained rather than left as a silent absence.
+    for (const label of ["Employer funded", "Personally funded", "Free trial", "Vendor sponsored", "Grant funded"]) {
+      await expect(legend.getByText(label, { exact: true })).toBeVisible();
+    }
+    await expect(legend.getByText(/Funding was not disclosed for this run/i)).toBeVisible();
+
+    // The legend states the orthogonality explicitly.
+    await expect(legend.getByText(/disclosure, not a trust signal/i)).toBeVisible();
+  });
+});

--- a/results-explorer/scripts/generate-browser-fixtures.mjs
+++ b/results-explorer/scripts/generate-browser-fixtures.mjs
@@ -55,6 +55,12 @@ const VARIANTS = [
     // `submission-manifest.json` sidecar to `trust_label=community-submission`,
     // so the derived file must land in its own subdirectory to avoid
     // tainting the adjacent maintainer-run bundles.
+    //
+    // This is also the corpus's only funding-disclosing bundle
+    // (`provenance.funding`), which is what gives the funding-chip e2e a row to
+    // assert on. Community + employer-funded is a deliberate pairing: it proves
+    // the two axes are independent, since every other fixture leaves funding at
+    // the `unspecified` producer default and therefore renders no chip.
     source: "tpch-duckdb-sf0.01-20260403-7fe93365.json",
     subdir: "community",
     derived: "tpch-duckdb-sf0.01-20260403-community.json",
@@ -76,6 +82,9 @@ const VARIANTS = [
       if (mutated.run) {
         mutated.run.id = `${mutated.run.id ?? "run"}-community`;
       }
+      // Declare a funding source so the read model carries a non-default
+      // `funding` value. See transformer.py::_funding.
+      mutated.provenance = { ...(mutated.provenance ?? {}), funding: "employer" };
       return mutated;
     },
   },

--- a/results-explorer/src/components/FundingChip.tsx
+++ b/results-explorer/src/components/FundingChip.tsx
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------
+// FundingChip - renders the `funding` disclosure as a StatusBadge with
+// role="funding".
+//
+// Funding is ORTHOGONAL to the trust label: a vendor-supplied result can be
+// employer-funded, and a community submission can be vendor-sponsored. The chip
+// is therefore ADDITIVE to TrustBadge, never a replacement for it.
+//
+// Every value renders with the SAME `neutral` tone. This is deliberate: a tone
+// gradient (e.g. vendor-sponsored → warning) would re-encode funding as a trust
+// signal and invite readers to rank results by who paid for them. Funding is a
+// disclosure, not a verdict. The chip text carries the meaning; the color does
+// not.
+//
+// `unspecified` (the producer default, and the value for every bundle that
+// predates the funding axis) renders NOTHING. An "Unspecified" chip on the
+// overwhelming majority of results would be pure noise, and unlike trust_label
+// there is no misreading to guard against: absent disclosure is the baseline
+// expectation, not a silent claim of neutrality.
+//
+// Vocabulary source of truth: benchbox/core/results/provenance.py::FUNDING_SOURCES.
+// ---------------------------------------------------------------------------
+
+import { StatusBadge } from "./StatusBadge";
+
+const FUNDING_CONFIG: Record<string, { label: string; title: string }> = {
+  employer: {
+    label: "Employer funded",
+    title: "Run paid for by the submitter's employer",
+  },
+  personal: {
+    label: "Personally funded",
+    title: "Run paid for by the submitter personally",
+  },
+  "free-trial": {
+    label: "Free trial",
+    title: "Run executed on a free trial or promotional credit from the platform",
+  },
+  "vendor-sponsored": {
+    label: "Vendor sponsored",
+    title:
+      "Compute or credits for this run were provided by the platform vendor - disclosed separately from who produced the result",
+  },
+  grant: {
+    label: "Grant funded",
+    title: "Run paid for by a research grant or similar award",
+  },
+};
+
+/** The producer default; carries no information, so the chip is omitted. */
+export const UNSPECIFIED_FUNDING = "unspecified";
+
+/**
+ * An unrecognised token is still a disclosure the producer chose to make - show
+ * it verbatim rather than dropping it, so vocabulary drift between
+ * provenance.py and this map surfaces in the UI instead of hiding a claim.
+ */
+function configFor(funding: string): { label: string; title: string } {
+  return (
+    FUNDING_CONFIG[funding] ?? {
+      label: funding,
+      title: `Funding source: ${funding} (unrecognised - contact maintainers)`,
+    }
+  );
+}
+
+/** Tooltip/legend prose for a funding value. Single source for both surfaces. */
+export function fundingDescription(funding: string): string {
+  return configFor(funding).title;
+}
+
+interface FundingChipProps {
+  funding: string | null | undefined;
+}
+
+export function FundingChip({ funding }: FundingChipProps) {
+  if (!funding || funding === UNSPECIFIED_FUNDING) return null;
+
+  const config = configFor(funding);
+  return (
+    <StatusBadge role="funding" tone="neutral" title={config.title}>
+      {config.label}
+    </StatusBadge>
+  );
+}
+
+export default FundingChip;

--- a/results-explorer/src/components/ProvenanceLegend.tsx
+++ b/results-explorer/src/components/ProvenanceLegend.tsx
@@ -1,0 +1,131 @@
+import type { ComponentChildren } from "preact";
+import { useState } from "preact/hooks";
+import { FundingChip, fundingDescription, UNSPECIFIED_FUNDING } from "@/components/FundingChip";
+import { TrustBadge, trustLabelDescription } from "@/components/TrustBadge";
+
+// ---------------------------------------------------------------------------
+// ProvenanceLegend - collapsible "What do these labels mean?" panel.
+//
+// docs/reference/hosted-results-contract.md (§ Trust label rendering rules)
+// requires that "a legend explaining all trust labels is accessible from every
+// page that displays them". This is that legend, extended with the orthogonal
+// funding axis.
+//
+// Rows render the REAL TrustBadge / FundingChip components and pull their prose
+// from the components' own config via trustLabelDescription() /
+// fundingDescription(). The legend therefore cannot drift from the badges it
+// explains - there is one source for each string.
+//
+// Today this renders on ResultDetail only. The index, leaderboard, and compare
+// surfaces also show trust badges and still need it; that is tracked alongside
+// the card-level funding chip, which needs its own read-model view projection
+// first (platform_index_rows / benchmark_rankings do not project funding).
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical trust labels, one row each. TRUST_CONFIG additionally carries
+ * alias keys (`ci`/`ci-verified`/`ci-validated`, `local`/`local-run`) that map
+ * onto the same badge; listing every alias would show the reader duplicate
+ * rows, so the legend names the canonical spelling only.
+ */
+const LEGEND_TRUST_LABELS = [
+  "maintainer-run",
+  "community-submission",
+  "vendor-supplied",
+  "ci-verified",
+  "local-run",
+  "unofficial-research",
+] as const;
+
+/**
+ * Mirror of benchbox/core/results/provenance.py::FUNDING_SOURCES minus
+ * `unspecified`, which is covered by its own explanatory row below because it
+ * renders no chip at all.
+ */
+const LEGEND_FUNDING_SOURCES = [
+  "employer",
+  "personal",
+  "free-trial",
+  "vendor-sponsored",
+  "grant",
+] as const;
+
+export function ProvenanceLegend() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <section class="card" data-testid="provenance-legend">
+      <button
+        class="flex w-full items-center justify-between text-left"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-controls="provenance-legend-body"
+      >
+        <h2 class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
+          What do these labels mean?
+        </h2>
+        <span class="text-sm text-[var(--bb-data-fg-subtle)]">{expanded ? "↑ Hide" : "↓ Show"}</span>
+      </button>
+
+      {expanded && (
+        <div id="provenance-legend-body" class="mt-4 space-y-6 text-sm">
+          <div>
+            <h3 class="mb-1 font-semibold text-[var(--bb-data-fg-primary)]">Trust label</h3>
+            <p class="mb-3 text-[var(--bb-data-fg-muted)]">
+              Who produced this result, and under what review. Every result carries exactly one.
+            </p>
+            <dl class="space-y-2">
+              {LEGEND_TRUST_LABELS.map((label) => (
+                <LegendRow
+                  key={label}
+                  badge={<TrustBadge trustLabel={label} />}
+                  description={trustLabelDescription(label)}
+                />
+              ))}
+            </dl>
+          </div>
+
+          <div>
+            <h3 class="mb-1 font-semibold text-[var(--bb-data-fg-primary)]">Funding</h3>
+            <p class="mb-3 text-[var(--bb-data-fg-muted)]">
+              Who paid for the run. This is a disclosure, not a trust signal, and it is independent
+              of the trust label - a vendor-supplied result can be employer-funded, and a community
+              submission can be vendor-sponsored. All funding chips share one neutral color so that
+              no funding source reads as better or worse than another.
+            </p>
+            <dl class="space-y-2">
+              {LEGEND_FUNDING_SOURCES.map((funding) => (
+                <LegendRow
+                  key={funding}
+                  badge={<FundingChip funding={funding} />}
+                  description={fundingDescription(funding)}
+                />
+              ))}
+              <LegendRow
+                key={UNSPECIFIED_FUNDING}
+                badge={<span class="text-[var(--bb-data-fg-subtle)]">(no chip)</span>}
+                description="Funding was not disclosed for this run. No chip is shown."
+              />
+            </dl>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface LegendRowProps {
+  badge: ComponentChildren;
+  description: string;
+}
+
+function LegendRow({ badge, description }: LegendRowProps) {
+  return (
+    <div class="flex flex-col gap-1 sm:flex-row sm:gap-3">
+      <dt class="w-40 flex-shrink-0">{badge}</dt>
+      <dd class="text-[var(--bb-data-fg-muted)]">{description}</dd>
+    </div>
+  );
+}
+
+export default ProvenanceLegend;

--- a/results-explorer/src/components/ProvenanceLegend.tsx
+++ b/results-explorer/src/components/ProvenanceLegend.tsx
@@ -59,7 +59,6 @@ export function ProvenanceLegend() {
         class="flex w-full items-center justify-between text-left"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        aria-controls="provenance-legend-body"
       >
         <h2 class="text-base font-semibold text-[var(--bb-data-fg-primary)]">
           What do these labels mean?
@@ -68,7 +67,7 @@ export function ProvenanceLegend() {
       </button>
 
       {expanded && (
-        <div id="provenance-legend-body" class="mt-4 space-y-6 text-sm">
+        <div class="mt-4 space-y-6 text-sm">
           <div>
             <h3 class="mb-1 font-semibold text-[var(--bb-data-fg-primary)]">Trust label</h3>
             <p class="mb-3 text-[var(--bb-data-fg-muted)]">

--- a/results-explorer/src/components/RunReceipt.tsx
+++ b/results-explorer/src/components/RunReceipt.tsx
@@ -3,7 +3,12 @@ import type { ComponentChildren } from "preact";
 import type { DetailResult } from "@/types";
 import { humanizeBenchmark } from "@/utils";
 import { costModelSummary, costScopeSummary, normalizedCostLabel } from "@/lib/costDisplay";
-import { formatTrustLabel, formatValidationStatus, formatVisibility } from "@/lib/displayLabels";
+import {
+  formatFunding,
+  formatTrustLabel,
+  formatValidationStatus,
+  formatVisibility,
+} from "@/lib/displayLabels";
 import { StatusBadge } from "@/components/StatusBadge";
 
 interface RunReceiptProps {
@@ -93,6 +98,10 @@ export function RunReceipt({
       title: "Integrity",
       rows: [
         rowFromString("Trust", detail.trust_label, formatTrustLabel),
+        // The receipt states funding even when it is "unspecified". The chip
+        // stays silent in that case to avoid noise, but a provenance receipt
+        // should record that no disclosure was made rather than omit the row.
+        rowFromString("Funding", detail.funding, formatFunding),
         rowFromString("Visibility", detail.visibility, formatVisibility),
         rowFromString("Validation", detail.validation_status, formatValidationStatus),
         rowFromString("Compliance", detail.compliance_class),

--- a/results-explorer/src/components/StatusBadge.tsx
+++ b/results-explorer/src/components/StatusBadge.tsx
@@ -3,6 +3,7 @@ import type { ComponentChildren } from "preact";
 export type StatusTone = "info" | "success" | "warning" | "danger" | "neutral";
 export type StatusRole =
   | "trust"
+  | "funding"
   | "validation"
   | "visibility"
   | "computed"

--- a/results-explorer/src/components/TrustBadge.tsx
+++ b/results-explorer/src/components/TrustBadge.tsx
@@ -78,6 +78,11 @@ const DEFAULT_CONFIG = {
   title: "Trust level not recorded",
 };
 
+/** Tooltip/legend prose for a trust label. Single source for both surfaces. */
+export function trustLabelDescription(trustLabel: string): string {
+  return TRUST_CONFIG[trustLabel]?.title ?? DEFAULT_CONFIG.title;
+}
+
 interface TrustBadgeProps {
   trustLabel: string;
   /** When true, show only the first word of the label. */

--- a/results-explorer/src/components/__tests__/ChartPanel.test.tsx
+++ b/results-explorer/src/components/__tests__/ChartPanel.test.tsx
@@ -159,6 +159,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: overrides.bundle_download_url ?? "/bundle.json",
     trust_label: overrides.trust_label ?? "maintainer-run",
     visibility: overrides.visibility ?? "public-curated",
+    funding: overrides.funding ?? "unspecified",
     platform_version: overrides.platform_version ?? null,
     execution_mode: overrides.execution_mode ?? "sql",
     tuning_mode: overrides.tuning_mode ?? "default",

--- a/results-explorer/src/components/__tests__/ComparabilityReceipt.a11y.test.tsx
+++ b/results-explorer/src/components/__tests__/ComparabilityReceipt.a11y.test.tsx
@@ -35,6 +35,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: "0.10",
     execution_mode: "sql",
     tuning_mode: "default",

--- a/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/ComparabilityReceipt.test.tsx
@@ -39,6 +39,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: "0.10",
     execution_mode: "sql",
     tuning_mode: "default",

--- a/results-explorer/src/components/__tests__/CompareSummary.test.tsx
+++ b/results-explorer/src/components/__tests__/CompareSummary.test.tsx
@@ -37,6 +37,7 @@ function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: null,
     execution_mode: null,
     tuning_mode: null,

--- a/results-explorer/src/components/__tests__/FundingChip.test.tsx
+++ b/results-explorer/src/components/__tests__/FundingChip.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Tests for FundingChip component.
+ *
+ * Cases:
+ *   (a) Every FUNDING_SOURCES value except `unspecified` renders a curated chip
+ *   (b) `unspecified` / empty / null render nothing (chip omitted)
+ *   (c) Unrecognised values render verbatim rather than being dropped
+ *   (d) Tone is uniformly neutral - funding is a disclosure, not a trust signal
+ *   (e) data-role="funding" so pages and e2e can target funding chips
+ *       independently of the orthogonal trust badge
+ */
+
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { FundingChip } from "@/components/FundingChip";
+
+// Mirror of benchbox/core/results/provenance.py::FUNDING_SOURCES; keep in sync.
+const FUNDING_SOURCES = [
+  "employer",
+  "personal",
+  "free-trial",
+  "vendor-sponsored",
+  "grant",
+  "unspecified",
+] as const;
+
+const DISCLOSED_SOURCES = FUNDING_SOURCES.filter((value) => value !== "unspecified");
+
+describe("FundingChip", () => {
+  // -----------------------------------------------------------------------
+  // (a) Known funding values
+  // -----------------------------------------------------------------------
+
+  it.each(DISCLOSED_SOURCES)("%s renders a curated (non-unrecognised) chip", (funding) => {
+    const { container } = render(<FundingChip funding={funding} />);
+    const chip = container.querySelector(".badge");
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("title") ?? "").not.toContain("unrecognised");
+    // Curated values never echo the raw slug back as their visible text.
+    expect(chip?.textContent).not.toBe(funding);
+  });
+
+  it("employer renders its human label", () => {
+    render(<FundingChip funding="employer" />);
+    expect(screen.getByText("Employer funded")).toBeTruthy();
+  });
+
+  it("vendor-sponsored renders its human label", () => {
+    render(<FundingChip funding="vendor-sponsored" />);
+    expect(screen.getByText("Vendor sponsored")).toBeTruthy();
+  });
+
+  it.each(DISCLOSED_SOURCES)("%s has a descriptive title tooltip", (funding) => {
+    const { container } = render(<FundingChip funding={funding} />);
+    const title = container.querySelector(".badge")?.getAttribute("title") ?? "";
+    expect(title.length).toBeGreaterThan(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // (b) `unspecified` and missing values render nothing
+  // -----------------------------------------------------------------------
+
+  it("unspecified renders no chip", () => {
+    const { container } = render(<FundingChip funding="unspecified" />);
+    expect(container.querySelector(".badge")).toBeNull();
+  });
+
+  it("empty string renders no chip", () => {
+    const { container } = render(<FundingChip funding="" />);
+    expect(container.querySelector(".badge")).toBeNull();
+  });
+
+  it("null renders no chip", () => {
+    const { container } = render(<FundingChip funding={null} />);
+    expect(container.querySelector(".badge")).toBeNull();
+  });
+
+  it("undefined renders no chip", () => {
+    const { container } = render(<FundingChip funding={undefined} />);
+    expect(container.querySelector(".badge")).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // (c) Unrecognised values surface rather than disappear
+  // -----------------------------------------------------------------------
+
+  it("unrecognised value renders verbatim with an explanatory tooltip", () => {
+    const { container } = render(<FundingChip funding="crowdfunded" />);
+    const chip = container.querySelector(".badge");
+    expect(chip?.textContent).toBe("crowdfunded");
+    const title = chip?.getAttribute("title") ?? "";
+    expect(title).toContain("crowdfunded");
+    expect(title).toContain("unrecognised");
+  });
+
+  // -----------------------------------------------------------------------
+  // (d) Tone is uniformly neutral (no trust gradient)
+  // -----------------------------------------------------------------------
+
+  it.each(DISCLOSED_SOURCES)("%s uses the neutral tone", (funding) => {
+    const { container } = render(<FundingChip funding={funding} />);
+    const chip = container.querySelector(".badge");
+    expect(chip?.getAttribute("data-tone")).toBe("neutral");
+    expect(chip?.className).toContain("tone-neutral");
+  });
+
+  it("vendor-sponsored is not styled as a warning (funding is not a trust signal)", () => {
+    const { container } = render(<FundingChip funding="vendor-sponsored" />);
+    const chip = container.querySelector(".badge");
+    expect(chip?.getAttribute("data-tone")).toBe("neutral");
+    expect(chip?.className).not.toContain("tone-warning");
+  });
+
+  // -----------------------------------------------------------------------
+  // (e) role wiring
+  // -----------------------------------------------------------------------
+
+  it('sets data-role="funding" so it is targetable apart from the trust badge', () => {
+    const { container } = render(<FundingChip funding="grant" />);
+    expect(container.querySelector(".badge")?.getAttribute("data-role")).toBe("funding");
+  });
+});

--- a/results-explorer/src/components/__tests__/ProvenanceLegend.test.tsx
+++ b/results-explorer/src/components/__tests__/ProvenanceLegend.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for ProvenanceLegend.
+ *
+ * The legend satisfies docs/reference/hosted-results-contract.md
+ * (§ Trust label rendering rules): "a legend explaining all trust labels is
+ * accessible from every page that displays them". These tests pin:
+ *   (a) it starts collapsed and toggles
+ *   (b) it explains both axes, including the chip-less `unspecified` case
+ *   (c) its prose comes from the badge components, so it cannot drift
+ */
+
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { ProvenanceLegend } from "@/components/ProvenanceLegend";
+import { fundingDescription } from "@/components/FundingChip";
+import { trustLabelDescription } from "@/components/TrustBadge";
+
+const toggle = () => screen.getByRole("button", { name: /What do these labels mean\?/i });
+
+describe("ProvenanceLegend", () => {
+  // -----------------------------------------------------------------------
+  // (a) collapsed by default, expandable
+  // -----------------------------------------------------------------------
+
+  it("renders collapsed with an accessible toggle", () => {
+    render(<ProvenanceLegend />);
+    expect(toggle().getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("heading", { name: "Funding" })).toBeNull();
+  });
+
+  it("expands to show both axes", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    expect(toggle().getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("heading", { name: "Trust label" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Funding" })).toBeTruthy();
+  });
+
+  // -----------------------------------------------------------------------
+  // (b) content
+  // -----------------------------------------------------------------------
+
+  it("lists every disclosed funding source", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    for (const label of [
+      "Employer funded",
+      "Personally funded",
+      "Free trial",
+      "Vendor sponsored",
+      "Grant funded",
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("explains the omitted `unspecified` case rather than leaving a silent gap", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    expect(screen.getByText("(no chip)")).toBeTruthy();
+    expect(screen.getByText(/Funding was not disclosed for this run/i)).toBeTruthy();
+  });
+
+  it("states that funding is orthogonal to trust", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    expect(screen.getByText(/disclosure, not a trust signal/i)).toBeTruthy();
+  });
+
+  it("lists canonical trust labels without duplicating their alias spellings", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    // `ci`/`ci-verified`/`ci-validated` all render the badge text "CI"; the
+    // legend must name it once, not three times.
+    expect(screen.getAllByText("CI")).toHaveLength(1);
+    expect(screen.getAllByText("Local")).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // (c) single source for prose
+  // -----------------------------------------------------------------------
+
+  it("uses the badge components' own descriptions", () => {
+    render(<ProvenanceLegend />);
+    fireEvent.click(toggle());
+    expect(screen.getByText(trustLabelDescription("vendor-supplied"))).toBeTruthy();
+    expect(screen.getByText(fundingDescription("vendor-sponsored"))).toBeTruthy();
+  });
+});

--- a/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
+++ b/results-explorer/src/components/__tests__/QueryDiffTable.test.tsx
@@ -35,6 +35,7 @@ function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: null,
     execution_mode: null,
     tuning_mode: null,

--- a/results-explorer/src/components/__tests__/RunReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/RunReceipt.test.tsx
@@ -93,6 +93,10 @@ describe("RunReceipt", () => {
     expect(within(receipt).getByText("maintainer run")).toBeTruthy();
     expect(within(receipt).getByText("public (curated)")).toBeTruthy();
     expect(within(receipt).getByText("exact")).toBeTruthy();
+    // Funding is recorded on the receipt even when undisclosed. The chip is
+    // omitted for "unspecified"; the receipt states it.
+    expect(within(receipt).getByText("Funding")).toBeTruthy();
+    expect(within(receipt).getByText("unspecified")).toBeTruthy();
     expect(within(receipt).getByText("Eligible")).toBeTruthy();
     expect(within(receipt).getByText("abc12345")).toBeTruthy();
     expect(within(receipt).getByText("Plans not published")).toBeTruthy();
@@ -298,5 +302,10 @@ describe("RunReceipt", () => {
         makeDetail({ has_plans: true, plans_published: true, bundle_download_url: "" }),
       ),
     ).toBeNull();
+  });
+
+  it("humanizes a disclosed funding source on the receipt", () => {
+    render(<RunReceipt detail={makeDetail({ funding: "vendor-sponsored" })} />);
+    expect(screen.getByText("vendor sponsored")).toBeTruthy();
   });
 });

--- a/results-explorer/src/components/__tests__/RunReceipt.test.tsx
+++ b/results-explorer/src/components/__tests__/RunReceipt.test.tsx
@@ -46,6 +46,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "https://example.test/bundles/abcdef1234567890.json",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: "1.2.0",
     execution_mode: "sql",
     tuning_mode: "tuned",

--- a/results-explorer/src/lib/__tests__/compareSummary.test.ts
+++ b/results-explorer/src/lib/__tests__/compareSummary.test.ts
@@ -33,6 +33,7 @@ function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: null,
     execution_mode: null,
     tuning_mode: null,

--- a/results-explorer/src/lib/__tests__/displayLabels.test.ts
+++ b/results-explorer/src/lib/__tests__/displayLabels.test.ts
@@ -3,6 +3,7 @@ import {
   formatBenchmarkLabel,
   formatCostStatus,
   formatEnumLabel,
+  formatFunding,
   formatTrustLabel,
   formatValidationStatus,
   formatVisibility,
@@ -23,6 +24,31 @@ describe("formatTrustLabel", () => {
   it("falls back to underscore/dash humanization for unknown values", () => {
     expect(formatTrustLabel("future_tier")).toBe("future tier");
     expect(formatTrustLabel("some-new-tier")).toBe("some new tier");
+  });
+});
+
+describe("formatFunding", () => {
+  it("humanizes every canonical funding source", () => {
+    expect(formatFunding("employer")).toBe("employer funded");
+    expect(formatFunding("personal")).toBe("personally funded");
+    expect(formatFunding("free-trial")).toBe("free trial");
+    expect(formatFunding("vendor-sponsored")).toBe("vendor sponsored");
+    expect(formatFunding("grant")).toBe("grant funded");
+    expect(formatFunding("unspecified")).toBe("unspecified");
+  });
+
+  // Unlike formatTrustLabel, a missing value maps to "unspecified" rather than
+  // "unknown": `unspecified` is the producer default, so absent and declared
+  // carry the same meaning.
+  it("returns 'unspecified' for null/empty values", () => {
+    expect(formatFunding(null)).toBe("unspecified");
+    expect(formatFunding("")).toBe("unspecified");
+    expect(formatFunding(undefined)).toBe("unspecified");
+  });
+
+  it("falls back to underscore/dash humanization for unknown values", () => {
+    expect(formatFunding("crowd_funded")).toBe("crowd funded");
+    expect(formatFunding("some-new-source")).toBe("some new source");
   });
 });
 

--- a/results-explorer/src/lib/displayLabels.ts
+++ b/results-explorer/src/lib/displayLabels.ts
@@ -27,6 +27,19 @@ const VISIBILITY_LABELS: Record<string, string> = {
   internal: "internal",
 };
 
+// Source of truth: benchbox/core/results/provenance.py::FUNDING_SOURCES.
+// Mirrored here (rather than generated) because the explorer ships as a static
+// bundle with no Python build step; add a label here when that tuple grows.
+// Unrecognised values fall through to `formatEnumLabel`.
+const FUNDING_LABELS: Record<string, string> = {
+  employer: "employer funded",
+  personal: "personally funded",
+  "free-trial": "free trial",
+  "vendor-sponsored": "vendor sponsored",
+  grant: "grant funded",
+  unspecified: "unspecified",
+};
+
 const COST_STATUS_LABELS: Record<string, string> = {
   normalized: "normalized",
   not_applicable: "not applicable",
@@ -37,6 +50,17 @@ const COST_STATUS_LABELS: Record<string, string> = {
 export function formatTrustLabel(raw: string | null | undefined): string {
   if (raw === null || raw === undefined || raw === "") return "unknown";
   return TRUST_LABEL_LABELS[raw] ?? formatEnumLabel(raw);
+}
+
+/**
+ * Humanize a funding disclosure. A missing/empty value is treated as
+ * `unspecified` rather than "unknown": `funding` is NOT NULL in the snapshot
+ * schema and the producer default is literally `unspecified`, so an absent
+ * value carries the same meaning as a declared one.
+ */
+export function formatFunding(raw: string | null | undefined): string {
+  if (raw === null || raw === undefined || raw === "") return "unspecified";
+  return FUNDING_LABELS[raw] ?? formatEnumLabel(raw);
 }
 
 export function formatValidationStatus(raw: string | null | undefined): string {

--- a/results-explorer/src/lib/duckdbQueries.ts
+++ b/results-explorer/src/lib/duckdbQueries.ts
@@ -69,6 +69,9 @@ export interface ResultRow extends CostDeploymentFields {
 
 export interface ResultDetailMetricsRow extends Omit<ResultRow, "is_ranking_eligible" | "visibility"> {
   visibility: string;
+  // NOT NULL in the snapshot schema; "unspecified" when the bundle declares
+  // no funding. Orthogonal to trust_label - a disclosure, not a rank signal.
+  funding: string;
   os: string | null;
   arch: string | null;
   cpu_count: number | null;
@@ -319,6 +322,7 @@ const RESULT_DETAIL_METRICS_COLUMNS = [
   "ranking_exclusion_reason",
   "trust_label",
   "visibility",
+  "funding",
   "platform_version",
   "execution_mode",
   "tuning_mode",
@@ -599,6 +603,7 @@ export async function getDetailResult(resultId: string): Promise<DetailResult | 
     bundle_download_url: wide.bundle_download_url,
     trust_label: wide.trust_label,
     visibility: wide.visibility,
+    funding: wide.funding,
     platform_version: wide.platform_version,
     execution_mode: wide.execution_mode,
     tuning_mode: wide.tuning_mode,

--- a/results-explorer/src/pages/Query.tsx
+++ b/results-explorer/src/pages/Query.tsx
@@ -35,6 +35,7 @@ import { formatPlainNumber } from "@/lib/metricFormatters";
 import {
   formatBenchmarkLabel,
   formatCostStatus,
+  formatFunding,
   formatTrustLabel,
   formatValidationStatus,
   formatVisibility,
@@ -1135,6 +1136,7 @@ function projectVisibleRow(row: ResultRow, visibleColumns: string[]): ResultRow 
 function formatQueryRowCell(column: string, value: unknown): string {
   if (typeof value === "string" && value !== "") {
     if (column === "trust_label") return formatTrustLabel(value);
+    if (column === "funding") return formatFunding(value);
     if (column === "validation_status") return formatValidationStatus(value);
     if (column === "visibility") return formatVisibility(value);
     if (column === "cost_status") return formatCostStatus(value);

--- a/results-explorer/src/pages/ResultDetail.tsx
+++ b/results-explorer/src/pages/ResultDetail.tsx
@@ -8,6 +8,8 @@ import { LoadingSpinner } from "@/components/LoadingSpinner";
 import { ErrorMessage } from "@/components/ErrorMessage";
 import { Breadcrumb } from "@/components/Breadcrumb";
 import { TrustBadge, ValidationBadge } from "@/components/TrustBadge";
+import { FundingChip } from "@/components/FundingChip";
+import { ProvenanceLegend } from "@/components/ProvenanceLegend";
 import { TableScrollHint } from "@/components/TableScrollHint";
 import { TuningBadge } from "@/components/TuningBadge";
 import { StatusBadge } from "@/components/StatusBadge";
@@ -224,6 +226,7 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
                 {benchmarkLabel} - {detail.platform}
               </h1>
               <TrustBadge trustLabel={detail.trust_label} />
+              <FundingChip funding={detail.funding} />
               <ValidationBadge validationStatus={detail.validation_status} showMissing />
               {detail.tuning_mode && <TuningBadge tuningMode={detail.tuning_mode} />}
               {detail.visibility === "public-curated" && (
@@ -444,6 +447,8 @@ export function ResultDetail({ resultId = "" }: ResultDetailProps) {
           </section>
 
           <MethodologyDisclosure detail={detail} />
+
+          <ProvenanceLegend />
         </div>
       </div>
     </div>

--- a/results-explorer/src/pages/__tests__/Compare.a11y.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.a11y.test.tsx
@@ -94,6 +94,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: "0.10",
     execution_mode: "sql",
     tuning_mode: "default",

--- a/results-explorer/src/pages/__tests__/Compare.test.tsx
+++ b/results-explorer/src/pages/__tests__/Compare.test.tsx
@@ -80,6 +80,7 @@ function makeResult(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: null,
     execution_mode: null,
     tuning_mode: null,

--- a/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
+++ b/results-explorer/src/pages/__tests__/ResultDetail.test.tsx
@@ -66,6 +66,7 @@ function makeDetail(overrides: Partial<DetailResult> = {}): DetailResult {
     bundle_download_url: "https://example.test/download/r1.json",
     trust_label: "maintainer-run",
     visibility: "public-curated",
+    funding: "unspecified",
     platform_version: null,
     execution_mode: null,
     tuning_mode: null,
@@ -210,5 +211,40 @@ describe("ResultDetail - median-first contract", () => {
     await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
 
     expect(screen.queryAllByRole("link", { name: "Download plans" })).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Funding disclosure (chip + legend)
+  // -------------------------------------------------------------------------
+
+  it("renders the funding chip alongside the trust badge when funding is disclosed", async () => {
+    vi.mocked(getDetailResult).mockResolvedValue(
+      makeDetail({ funding: "employer", trust_label: "vendor-supplied" }),
+    );
+
+    render(<ResultDetail resultId="r1" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    // Orthogonal axes: a vendor-supplied result can still be employer-funded,
+    // and each renders its own independent element.
+    expect(document.querySelector('[data-role="funding"]')?.textContent).toBe("Employer funded");
+    expect(document.querySelector('[data-role="trust"]')?.textContent).toBe("Vendor");
+  });
+
+  it("omits the funding chip when funding is unspecified, leaving the trust badge intact", async () => {
+    vi.mocked(getDetailResult).mockResolvedValue(makeDetail({ funding: "unspecified" }));
+
+    render(<ResultDetail resultId="r1" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    expect(document.querySelector('[data-role="funding"]')).toBeNull();
+    expect(document.querySelector('[data-role="trust"]')).not.toBeNull();
+  });
+
+  it("exposes the provenance legend explaining the badges it renders", async () => {
+    render(<ResultDetail resultId="r1" />);
+    await waitFor(() => expect(screen.queryByText("Loading result...")).toBeNull());
+
+    expect(screen.getByRole("button", { name: /What do these labels mean\?/i })).toBeTruthy();
   });
 });

--- a/results-explorer/src/types.ts
+++ b/results-explorer/src/types.ts
@@ -84,6 +84,10 @@ export interface DetailResult extends CostDeploymentFields {
   bundle_download_url: string;
   trust_label: string;
   visibility: string;
+  // How the run was paid for. "unspecified" when the bundle declares no
+  // funding. Orthogonal to trust_label: a vendor-supplied result can be
+  // employer-funded, and a community submission can be vendor-sponsored.
+  funding: string;
   // Extended fields (null for bundles predating these fields)
   platform_version: string | null;
   execution_mode: string | null;


### PR DESCRIPTION
# Pull Request

## Description

Renders the `funding` disclosure axis on the results-explorer **result detail page**.

The data has been in place for a while: `results.funding` landed in PR #1021, and
PR #1080 projected `r.funding` into the `result_detail_metrics` view. Nothing read
it. This PR is the read surface — chip, legend, and the query-layer wiring between
them. **No pipeline, DDL, or `read_model_version` change is needed or made.**

Completes work units **w3** (chip + legend) and **w4** (e2e) of
`_project/TODO/results-labels-funding/planning/explorer-pipeline-frontend-handoff.yaml`.

### What's here

- **Query layer** — `funding` added to `RESULT_DETAIL_METRICS_COLUMNS`, to
  `ResultDetailMetricsRow`, to the `DetailResult` mapping, and to the
  `DetailResult` type.
- **`FundingChip.tsx`** (new) — built on the `StatusBadge` primitive with a new
  `StatusRole` `"funding"`. Every funding value renders with the **same `neutral`
  tone, deliberately**: a tone gradient (e.g. `vendor-sponsored` → warning) would
  re-encode *who paid* as *how much to trust this*. Funding is a disclosure, not a
  verdict. `unspecified` (the producer default, and every pre-funding bundle)
  renders **no chip**; an unrecognised token renders verbatim so vocabulary drift
  surfaces in the UI rather than silently swallowing a producer's claim.
- **`ProvenanceLegend.tsx`** (new) — satisfies the `hosted-results-contract.md`
  § *Trust label rendering rules* requirement that "a legend explaining all trust
  labels is accessible from every page that displays them". None existed anywhere;
  this is the minimal one. Its rows render the *real* `TrustBadge` / `FundingChip`
  components and pull prose from `trustLabelDescription()` / `fundingDescription()`,
  so the legend cannot drift from the badges it explains.
- **`formatFunding()`** in `displayLabels.ts`, mirroring `formatTrustLabel()`, and
  wired into the two places that already humanize `trust_label`: the `RunReceipt`
  provenance block and the Query workbench cell formatter (which was rendering the
  raw `funding` enum — `results.funding` is already a selectable column there).
- **Fixture corpus** — the `community` variant now declares
  `provenance.funding=employer`. `community-submission` + `employer-funded` is the
  corpus's standing proof that the two axes are independent.

`TrustBadge` rendering is unchanged. The chip is purely additive.

### Scope decision (deliberate)

**Detail page only.** The index / leaderboard / compare cards
(`BenchmarkIndex`, `PlatformIndex`, `MetaLeaderboard`, `Compare`, `RankTable`) read
`platform_index_rows` / `benchmark_rankings` / `benchmark_matrix_cells`, and **none
of those views project `funding`**. A card-level chip needs its own view projection
first. That is now tracked as **w5** on the TODO item, with the exact steps mirroring
what #1080 did for `result_detail_metrics`: bare `r.funding` column reference in
`duckdb_builder.py` (no computed expression — G-11), mirrored in
`browser-duckdb-schema.sql`, plus the `EXPECTED_VIEWS` entry in
`test_duckdb_browser_contract.py`. No `read_model_version` bump — the base table
already has the column.

Extending `ProvenanceLegend` to those pages belongs with w5, since the contract's
legend rule applies to every page that shows the badges.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Testing

All run locally against the real toolchain (node v26):

| Gate | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `npx vitest run` | 756 passed / 67 files |
| `npx playwright test --project=chromium` (full suite) | 109 passed, 10 skipped, **0 failed** — includes 6 new funding specs |
| `pytest tests/unit/scripts/explorer_pipeline/ test_scan_explorer_tokens.py test_explorer_build_contract.py` | 291 passed |
| `make lint` (ruff + explorer/site token scans) | clean |

New tests: `FundingChip.test.tsx`, `ProvenanceLegend.test.tsx`,
`e2e/routes/funding-disclosure.spec.ts` (chip renders, chip omitted on
`unspecified`, neutral tone, trust/funding orthogonality, legend reachable +
expands), plus funding cases in `displayLabels.test.ts`, `ResultDetail.test.tsx`,
and `RunReceipt.test.tsx`.

I verified the token-scan gate actually inspects the new components by
temporarily introducing an ad-hoc `text-gray-700` literal and confirming
`scan_explorer_tokens.py` failed on `FundingChip.tsx` before removing it. The chip
uses no colors of its own — only the existing `tone-*` badge classes.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces.
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact.
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative.

No schema, DDL, or `read_model_version` change — the read model already exposed
`funding`. This PR only reads it.

## Documentation

- [x] I updated the relevant user-facing docs.
- [x] I added regression notes for behavior changes.
- [x] I confirmed API contract wording remains accurate.

The legend *is* the user-facing documentation for this surface; it satisfies an
existing, previously-unmet `hosted-results-contract.md` requirement.

## Code Quality

- [x] I ran formatting and lint/type checks.
- [x] I reviewed impacted modules for backwards compatibility and migration impact.
- [x] I added/updated tests for behavior changes and error paths.
- [x] I confirmed public contracts and release checklists are still valid.

## Artifact Hygiene

- [x] I did not commit raw screenshots, browser reports, generated logs,
      benchmark outputs, or temporary binary artifacts.
- [x] Any committed binary/raw evidence file has durable repo value and is
      justified here with its consumer and size: **n/a — none committed.**

`test-fixtures/.generated/` is gitignored; only the generator's variant definition
is committed.

## Notes

**Reviewers may want to focus on:**

1. **The uniform `neutral` tone.** This is the load-bearing design decision. It is
   easy to "improve" by tinting `vendor-sponsored` amber — please don't; that would
   silently make funding a second trust ranking, which is exactly the anti-pattern
   the TODO calls out (a vendor-supplied result can be employer-funded, and vice
   versa).

2. **`unspecified` → no chip.** Chosen over a muted chip. Unlike `trust_label`
   (where a missing badge would read as "no opinion"), an absent funding disclosure
   *is* the baseline, and ~every existing bundle would otherwise carry a noise chip.
   The `RunReceipt` row still states "unspecified" explicitly, so the information is
   never lost — just not repeated as a header chip.

3. **Fixture `result_id` churn.** Adding `provenance.funding` to the `community`
   variant changes that bundle's bytes, and `result_id` is a sha8 of the raw bundle,
   so its id moved. I confirmed no e2e spec referenced the old id (I extracted every
   hardcoded `result_id` in `e2e/` and checked each against the regenerated corpus —
   0 dangling). Row counts and rankings are unaffected.

**Deferred:** w5 (card-level view projection + card chips + legend on those pages).

**One latent issue spotted, not fixed here (pre-existing, low severity):** #1080
added `funding` to `result_detail_metrics` *without* bumping `read_model_version`
(correct — no base-table column changed). That means a snapshot built at v2 *before*
#1080 passes the frontend's version guard but lacks the column, so this PR — the
first consumer — would make such a snapshot throw a Binder Error on the detail page.
This is **not reachable in production**: `docs.yml` rebuilds `public/data/` from
`results-data/` on every deploy and the snapshot is not committed. It can only bite a
developer holding a stale local snapshot, and `ensure-dev-snapshot` rebuilds on any
version mismatch. Flagging it because the read-model version can no longer
distinguish pre/post-#1080 v2 snapshots; if that ever matters, view changes need
their own contract signal.

**Test-suite flake observed (not caused by this PR):** on one full e2e run,
`responsive.spec.ts:138` (heatmap header) and `compare-entrypoints.spec.ts:97`
(empty Compare builder) failed with timeout-shaped durations (11.2s / 31.6s). Both
pass in isolation and both pass on a clean full re-run (109/109). I did not chase
them further; noting them in case they recur in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
