### PR TITLE
docs(todo): mark the -s ours alignment merge as folded into release-cut

### DIFF
--- a/_project/TODO/main/active/release-recovery-v0-3-1.yaml
+++ b/_project/TODO/main/active/release-recovery-v0-3-1.yaml
@@ -97,8 +97,8 @@ work:
         GitHub could not compute a merge ref and no CI ran at all. Needs
         `git merge -s ours --allow-unrelated-histories origin/main` on the
         release branch ("align release histories") -- tree-preserving, and
-        what every prior aborted cut had done by hand. `release-cut` does not
-        do this.
+        what every prior aborted cut had done by hand. `release-cut` did not
+        do this at the time; it was folded into the target by PR #1089.
       - `validate-base` bootstrap restored `ruleset_review_enforcement.py`
         from develop but not its sibling import `auto_merge_soundness_paths`,
         so the ruleset-drift step died with ModuleNotFoundError. Prior cuts
@@ -186,11 +186,11 @@ work:
         the old `automate_release.py` long gone. A second post-migration
         release would re-run an already-passed exercise.
       - The two release-infrastructure gaps this release exposed (the
-        `-s ours` history alignment that `release-cut` does not perform, and
+        `-s ours` history alignment that `release-cut` did not perform, and
         the missing `auto_merge_soundness_paths` restore in the `validate-base`
         bootstrap) are recorded in the decision-doc amendment. The bootstrap
         restore is fixed and regression-tested in this PR; the alignment merge
-        remains a documented manual step.
+        was folded into `release-cut` afterwards by PR #1089.
 
 verification:
 - description: "Recovery release workflow succeeded"

--- a/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
+++ b/_project/TODO/main/planning/single-repo-migration-phase-8-first-post-migration-release.yaml
@@ -79,10 +79,11 @@ work:
 
     The exercise did surface two real gaps, both recorded in
     _project/decisions/single-repo-migration.md (2026-07-09 amendment):
-    `release-cut` does not perform the `-s ours` history alignment that a
+    `release-cut` did not perform the `-s ours` history alignment that a
     `vX.Y.Z -> main` PR needs, and the `validate-base` bootstrap failed to
-    restore `auto_merge_soundness_paths`. The latter is fixed and
-    regression-tested; the former remains a documented manual step.
+    restore `auto_merge_soundness_paths`. Both are now fixed and
+    regression-tested — the alignment merge was folded into `release-cut`
+    itself (PR #1089), so a future cut no longer performs it by hand.
     Recorded in _project/decisions/single-repo-migration.md, not left implicit.
 
 - id: w1


### PR DESCRIPTION
PR #1089 folded the `git merge -s ours --allow-unrelated-histories
origin/main` history-alignment step into the `release-cut` Makefile target.
Three passages across two TODO items still told the reader it was a manual
step.

The most consequential was in the Phase 8 item under planning/, which is
forward-looking guidance: it instructed a future release cutter to perform
the merge by hand. That is now wrong and would have produced a redundant
second merge.

The two passages in release-recovery-v0-3-1 are historical records of the
v0.3.1 cut, so they keep the past tense ("release-cut did not do this at the
time") and gain a pointer to #1089 rather than being rewritten as if the
target always had the merge.

Incidentally makes the pre-existing "(both fixed, see w7)" line in
release-recovery-v0-3-1 true: at the time it was written only one of the two
gaps was actually fixed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
