### PR TITLE
fix(make): stop pr-conflict-scan false-positiving on clean merges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1359,8 +1359,16 @@ pr-refresh:
 	$(MAKE) -s pr-open
 
 # Pure-git pairwise textual-conflict probe. Caller passes BRANCH=<current>;
-# we compare HEAD against every other open PR head via `git merge-tree` and
-# print warnings. Warn-only; does not exit non-zero. Used internally by pr-open.
+# we compare HEAD against every other open PR head via `git merge-tree
+# --write-tree` and print warnings. Warn-only; does not exit non-zero. Used
+# internally by pr-open.
+#
+# Exit status is the signal: 0 clean, 1 conflict, >1 error (e.g. unrelated
+# histories). Bad refs also exit 1, hence the rev-parse guard above the probe.
+# Do not parse the deprecated three-arg `git merge-tree <base> <a> <b>`: its
+# `changed in both` / `added in both` / `removed in {local,remote}` lines are
+# informational trivial-merge headers, not conflicts, and its real conflict
+# markers are diff-prefixed (`+<<<<<<< .our`), so `^<<<<<<<` never matches.
 pr-conflict-scan:
 	@CURRENT="$(BRANCH)"; \
 	[ -n "$$CURRENT" ] || CURRENT=$$(git branch --show-current); \
@@ -1369,11 +1377,11 @@ pr-conflict-scan:
 	while read num branch; do \
 		[ "$$branch" = "$$CURRENT" ] && continue; \
 		git fetch origin "$$branch" --quiet 2>/dev/null || continue; \
-		base=$$(git merge-base HEAD "origin/$$branch" 2>/dev/null) || continue; \
-		out=$$(git merge-tree "$$base" HEAD "origin/$$branch" 2>/dev/null); \
-		if echo "$$out" | grep -qE '^(<<<<<<<|changed in both|added in both|removed in local|removed in remote|CONFLICT )'; then \
-			echo "  ⚠ textual conflict with PR #$$num ($$branch) — coordinate before landing"; \
-		fi; \
+		git rev-parse --verify --quiet "origin/$$branch^{commit}" >/dev/null || continue; \
+		out=$$(git merge-tree --write-tree --name-only HEAD "origin/$$branch" 2>/dev/null); \
+		[ $$? -eq 1 ] || continue; \
+		files=$$(printf '%s\n' "$$out" | awk 'NR>1 && NF==0{exit} NR>1{printf "%s%s", sep, $$0; sep=", "}'); \
+		echo "  ⚠ textual conflict with PR #$$num ($$branch) in $$files — coordinate before landing"; \
 	done; true
 
 # Show open PRs against develop and their CI + auto-merge state.

--- a/tests/unit/test_release_infrastructure.py
+++ b/tests/unit/test_release_infrastructure.py
@@ -8,6 +8,7 @@ Copyright 2026 Joe Harris / BenchBox Project
 Licensed under the MIT License. See LICENSE file in the project root for details.
 """
 
+import itertools
 import re
 import subprocess
 import sys
@@ -1118,3 +1119,189 @@ class TestBetaReleaseSurface:
             "ty check reported diagnostics on Beta-critical entrypoints.\n"
             "Fix the diagnostics before releasing Beta:\n" + result.stdout + result.stderr
         )
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+def _init_repo(root: Path) -> None:
+    """Init a scratch repo insulated from the developer's ambient git config."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", ".", cwd=root)
+    # A global commit.gpgsign or core.hooksPath would otherwise break _commit_all.
+    for key, value in (
+        ("user.email", "test@benchbox.invalid"),
+        ("user.name", "BenchBox Test"),
+        ("commit.gpgsign", "false"),
+        ("tag.gpgsign", "false"),
+        ("core.hooksPath", str(root / ".no-hooks")),
+    ):
+        _git("config", key, value, cwd=root)
+
+
+def _commit_all(root: Path, message: str) -> None:
+    _git("add", "-A", cwd=root)
+    result = _git("commit", "-q", "--no-verify", "-m", message, cwd=root)
+    assert result.returncode == 0, f"scratch commit failed: {result.stdout}{result.stderr}"
+
+
+def _default_branch(root: Path) -> str:
+    return _git("symbolic-ref", "--short", "HEAD", cwd=root).stdout.strip()
+
+
+def _probe(root: Path, theirs: str) -> subprocess.CompletedProcess:
+    """Run the exact merge probe `pr-conflict-scan` uses, HEAD vs `theirs`."""
+    return _git("merge-tree", "--write-tree", "--name-only", "HEAD", theirs, cwd=root)
+
+
+def _git_version() -> tuple[int, ...]:
+    out = subprocess.run(["git", "--version"], capture_output=True, text=True, check=True).stdout
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", out)
+    assert match is not None, f"unparseable git version: {out!r}"
+    return tuple(int(part) for part in match.groups())
+
+
+# `git merge-tree --write-tree` landed in git 2.38.
+requires_modern_merge_tree = pytest.mark.skipif(
+    _git_version() < (2, 38, 0),
+    reason="pr-conflict-scan requires git >= 2.38 for `merge-tree --write-tree`",
+)
+
+
+class TestPrConflictScan:
+    """`pr-conflict-scan` must warn on real conflicts and stay silent otherwise.
+
+    Regression guard for the false-positive storm caused by parsing the
+    deprecated three-arg `git merge-tree <base> <ours> <theirs>` output: its
+    `changed in both` / `added in both` / `removed in {local,remote}` lines are
+    informational trivial-merge headers emitted for any file both sides touched,
+    not conflicts. Because nearly every PR edits CHANGELOG.md, the old probe
+    warned on almost every pair.
+    """
+
+    def test_probe_uses_modern_write_tree_form(self):
+        """The recipe must use the modern form and gate on a verified ref."""
+        recipe = _make_target_recipe("pr-conflict-scan")
+
+        assert 'git merge-tree --write-tree --name-only HEAD "origin/$$branch"' in recipe
+        # A bad ref also exits 1, indistinguishable from a conflict, so the ref
+        # must be verified before the probe runs.
+        assert 'git rev-parse --verify --quiet "origin/$$branch^{commit}"' in recipe
+        assert recipe.index("rev-parse --verify") < recipe.index("merge-tree")
+        # Only exit status 1 means conflict; >1 is an error and must not warn.
+        assert "[ $$? -eq 1 ] || continue" in recipe
+
+    def test_probe_does_not_parse_legacy_informational_headers(self):
+        """The legacy trivial-merge headers must never be treated as conflicts."""
+        # _make_target_recipe returns recipe lines only, so the explanatory
+        # comment above the target -- which names these headers -- is excluded.
+        recipe = _make_target_recipe("pr-conflict-scan")
+
+        for header in ("changed in both", "added in both", "removed in local", "removed in remote"):
+            assert header not in recipe, f"{header!r} is an informational header, not a conflict"
+        # The legacy three-arg form takes an explicit merge base as $1.
+        assert 'git merge-tree "$$base"' not in recipe
+
+    def test_scan_is_warn_only(self):
+        """The probe reports; it must never fail the caller's `pr-open`."""
+        recipe = _make_target_recipe("pr-conflict-scan")
+        assert recipe.rstrip().endswith("done; true")
+
+    @requires_modern_merge_tree
+    def test_probe_is_silent_when_sides_touch_disjoint_files(self, tmp_path: Path):
+        repo = tmp_path / "disjoint"
+        _init_repo(repo)
+        (repo / "ours.txt").write_text("a\n")
+        (repo / "theirs.txt").write_text("b\n")
+        _commit_all(repo, "base")
+        base = _default_branch(repo)
+
+        _git("checkout", "-q", "-b", "feature", cwd=repo)
+        (repo / "theirs.txt").write_text("theirs edit\n")
+        _commit_all(repo, "feature")
+
+        _git("checkout", "-q", base, cwd=repo)
+        (repo / "ours.txt").write_text("ours edit\n")
+        _commit_all(repo, "ours")
+
+        assert _probe(repo, "feature").returncode == 0
+
+    @requires_modern_merge_tree
+    def test_probe_is_silent_when_both_sides_edit_one_file_cleanly(self, tmp_path: Path):
+        """The exact false positive: both sides edit one file, far-apart hunks."""
+        repo = tmp_path / "same_file_clean"
+        _init_repo(repo)
+        (repo / "CHANGELOG.md").write_text("".join(f"line{i}\n" for i in range(1, 21)))
+        _commit_all(repo, "base")
+        base = _default_branch(repo)
+
+        _git("checkout", "-q", "-b", "feature", cwd=repo)
+        lines = (repo / "CHANGELOG.md").read_text().splitlines(keepends=True)
+        lines[-1] = "feature entry\n"
+        (repo / "CHANGELOG.md").write_text("".join(lines))
+        _commit_all(repo, "feature")
+
+        _git("checkout", "-q", base, cwd=repo)
+        lines = (repo / "CHANGELOG.md").read_text().splitlines(keepends=True)
+        lines[0] = "ours entry\n"
+        (repo / "CHANGELOG.md").write_text("".join(lines))
+        _commit_all(repo, "ours")
+
+        assert _probe(repo, "feature").returncode == 0, "clean auto-merge must not warn"
+
+        # The legacy probe the recipe used to run would have warned here.
+        merge_base = _git("merge-base", "HEAD", "feature", cwd=repo).stdout.strip()
+        legacy = _git("merge-tree", merge_base, "HEAD", "feature", cwd=repo).stdout
+        assert "changed in both" in legacy, "the legacy false-positive trigger is still reproducible"
+
+    @requires_modern_merge_tree
+    def test_probe_warns_on_a_true_conflict(self, tmp_path: Path):
+        repo = tmp_path / "conflict"
+        _init_repo(repo)
+        (repo / "Makefile").write_text("target:\n\techo base\n")
+        _commit_all(repo, "base")
+        base = _default_branch(repo)
+
+        _git("checkout", "-q", "-b", "feature", cwd=repo)
+        (repo / "Makefile").write_text("target:\n\techo feature\n")
+        _commit_all(repo, "feature")
+
+        _git("checkout", "-q", base, cwd=repo)
+        (repo / "Makefile").write_text("target:\n\techo ours\n")
+        _commit_all(repo, "ours")
+
+        result = _probe(repo, "feature")
+        assert result.returncode == 1, "a same-line conflict must be detected"
+        # Line 1 is the tree OID; conflicted names follow, terminated by a blank line.
+        conflicted = list(itertools.takewhile(bool, result.stdout.splitlines()[1:]))
+        assert conflicted == ["Makefile"]
+
+    @requires_modern_merge_tree
+    def test_legacy_conflict_marker_is_diff_prefixed(self, tmp_path: Path):
+        """`^<<<<<<<` can never match legacy output, so that fallback is unsafe.
+
+        Guards against "just anchor the grep to `<<<<<<<`" — in the legacy
+        format the marker is emitted inside a diff body as `+<<<<<<< .our`,
+        so an anchored grep matches nothing and the scan goes permanently
+        silent: a false negative on every real conflict.
+        """
+        repo = tmp_path / "legacy_marker"
+        _init_repo(repo)
+        (repo / "f.txt").write_text("base\nkeep\n")
+        _commit_all(repo, "base")
+        base = _default_branch(repo)
+
+        _git("checkout", "-q", "-b", "feature", cwd=repo)
+        (repo / "f.txt").write_text("feature\nkeep\n")
+        _commit_all(repo, "feature")
+
+        _git("checkout", "-q", base, cwd=repo)
+        (repo / "f.txt").write_text("ours\nkeep\n")
+        _commit_all(repo, "ours")
+
+        merge_base = _git("merge-base", "HEAD", "feature", cwd=repo).stdout.strip()
+        legacy = _git("merge-tree", merge_base, "HEAD", "feature", cwd=repo).stdout
+
+        assert "<<<<<<<" in legacy
+        assert not any(line.startswith("<<<<<<<") for line in legacy.splitlines())


### PR DESCRIPTION
pr-conflict-scan parsed the deprecated three-arg
`git merge-tree <base> <ours> <theirs>` and grepped for
`changed in both`, `added in both`, `removed in local`, and
`removed in remote`. Those are informational trivial-merge headers
emitted for any path both sides touched -- not conflicts. Because
nearly every PR edits CHANGELOG.md, the probe warned on almost every
pair: 4 of 5 warnings against open PRs were false.

Switch to `git merge-tree --write-tree --name-only` and branch on its
exit status (0 clean, 1 conflict, >1 error). Verify the remote ref
first: a bad ref also exits 1 and would otherwise read as a conflict.
The warning now names the conflicting files.

Anchoring the old grep to `^<<<<<<<` is not a fix -- the legacy format
emits the marker inside a diff body as `+<<<<<<< .our`, so an anchored
grep matches nothing and the scan would go silent on every real
conflict. A test pins that.

Verified against live PRs: silent on the four clean pairs, warns only
on #1090 (fix/release-cut-nested-claude, Makefile), which GitHub
independently reports as CONFLICTING.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
