### PR TITLE
fix(test): align tpcds throughput preflight test with dsqgen -STREAMS path

### DIFF
--- a/tests/unit/test_query_generation_preflight.py
+++ b/tests/unit/test_query_generation_preflight.py
@@ -60,26 +60,62 @@ def test_tpch_power_preflight_detects_generation_failures():
     assert "preflight failed" in str(ei.value).lower()
 
 
-def test_tpcds_throughput_preflight_detects_generation_failures():
+def _mk_tpcds_throughput(num_streams=2):
     from benchbox.core.tpcds.benchmark import TPCDSBenchmark
     from benchbox.core.tpcds.throughput_test import TPCDSThroughputTest
 
     bench = TPCDSBenchmark(scale_factor=1.0, verbose=False)
-
-    def _get_query(query_id, **kwargs):
-        # Fail one query to trigger preflight error
-        if query_id == 7:
-            raise RuntimeError("Template substitution error for q7")
-        return f"SELECT {query_id}"
-
-    bench.get_query = _get_query  # type: ignore[attr-defined]
-    thr = TPCDSThroughputTest(
+    return TPCDSThroughputTest(
         benchmark=bench,
         connection_factory=lambda: Mock(),
         scale_factor=0.01,
-        num_streams=2,
+        num_streams=num_streams,
     )
+
+
+def _fake_dsqgen_streams(num_streams, query_ids=(3, 7, 17)):
+    """Stand in for one `dsqgen -STREAMS` batch pass."""
+    from benchbox.core.tpcds.streams import StreamQuery
+
+    return {
+        stream_id: [
+            StreamQuery(stream_id=stream_id, position=position, query_id=qid, sql=f"SELECT {qid}")
+            for position, qid in enumerate(query_ids)
+        ]
+        for stream_id in range(num_streams)
+    }
+
+
+def test_tpcds_throughput_preflight_detects_dsqgen_batch_failure(monkeypatch):
+    """A failed `dsqgen -STREAMS` pass must fail fast, before the timed window."""
+    from benchbox.core.tpcds import streams
+
+    def _boom(**kwargs):
+        raise streams.DSQGenStreamsError("dsqgen exited 1")
+
+    monkeypatch.setattr(streams, "generate_dsqgen_streams", _boom)
+
+    with pytest.raises(RuntimeError) as ei:
+        _mk_tpcds_throughput().run()
+    assert "dsqgen -streams generation failed" in str(ei.value).lower()
+
+
+def test_tpcds_throughput_preflight_detects_generation_failures(monkeypatch):
+    """A per-query translation failure must fail fast, before the timed window."""
+    from benchbox.core.tpcds import streams
+
+    monkeypatch.setattr(streams, "generate_dsqgen_streams", lambda **kw: _fake_dsqgen_streams(kw["num_streams"]))
+
+    thr = _mk_tpcds_throughput()
+
+    def _translate(sql, source, target):
+        if sql == "SELECT 7":
+            raise RuntimeError("Template substitution error for q7")
+        return sql
+
+    thr.benchmark.translate_query_text = _translate  # type: ignore[attr-defined]
 
     with pytest.raises(RuntimeError) as ei:
         thr.run()
     assert "preflight failed" in str(ei.value).lower()
+    assert "q7" in str(ei.value)


### PR DESCRIPTION
PR #1093 rerouted TPC-DS throughput preflight from per-query
benchmark.get_query() calls to a single batch `dsqgen -STREAMS` pass
(generate_dsqgen_streams) plus per-query dialect translation. The
existing test still injected a failure by patching benchmark.get_query,
which the new path never calls -- so preflight no longer raised and the
test began failing DID NOT RAISE on develop.

This failure landed with #1093, 17 minutes before the ducklake PR #1096
that the auto-revert bot (PR #1104) blamed; reverting #1096 would leave
develop red. Fix forward by exercising the two real preflight seams:

- batch dsqgen failure (DSQGenStreamsError) -> fail fast
- per-query translation failure -> fail fast, before the timed window

Both assertions mutation-verified: neutering the fail-fast contract in
throughput_test.py makes each test go red.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
