### PR TITLE
chore(todo): capture DuckLake post-merge review follow-ups

### DIFF
--- a/_project/TODO/ducklake-review-followups/planning/ducklake-post-merge-review-followups.yaml
+++ b/_project/TODO/ducklake-review-followups/planning/ducklake-post-merge-review-followups.yaml
@@ -1,0 +1,201 @@
+id: "ducklake-post-merge-review-followups"
+title: "DuckLake platform: post-merge review follow-ups (CI coverage, live-test execution, reuse/force, docs, governance)"
+worktree: "ducklake-review-followups"
+priority: "Medium-High"
+status: "Not Started"
+description: |
+  Follow-ups from a deep post-merge review of the shipped DuckLake adapter
+  (#1082 core adapter, #1096 catalog backends + S3; both in _project/DONE/).
+  The confirmed credential leak is tracked separately and gates this item
+  (see deps.needs: ducklake-postgres-credential-leak-redaction).
+
+  Headline risk is COVERAGE, not code: the adapter's core live behavior runs in
+  ZERO CI lanes. tests/integration/test_ducklake_integration.py is module-marked
+  `slow`; the core in-process ATTACH class (TestDuckLakeLiveConnection) and the
+  Postgres/S3 classes additionally carry `live_integration`. Every default lane
+  selects `not (slow or ... or live_integration)`; the `-m slow` PR jobs are
+  file-scoped to OTHER files; release-canary/validate-main-pr exclude
+  live_integration. Net: classes 1/3/4 run in no lane; the SQLite class runs only
+  at the main-release gate -- never on the develop PR that merged it. Both feature
+  PRs squash-auto-merged with no human review (platforms/ is not a CODEOWNERS
+  path). The Postgres and S3 classes have never executed anywhere.
+
+  Two related process blind spots are recorded under _project/blind-spots/
+  (auto-revert blame heuristic; slow+live_integration coverage theater).
+
+category: "Testing and Quality Assurance"
+
+prior_art:
+- "tests/unit/test_marker_strategy.py + `make lint-markers` (CI-only marker gate) — EXTEND with a lane-coverage meta-check (w4)"
+- "tests/integration/platforms/test_postgresql_live.py skip_unless_docker_service + the nightly live_postgresql job — REUSE the docker-service bring-up pattern for the PG class (w1)"
+- "benchbox/platforms/ducklake.py:527-544 handle_existing_database local metadata_path reuse detection — SUPERSEDE for postgres with a server-side probe (w6)"
+- "benchbox/core/platform_registry.py:128 ducklake deployment_modes (two orthogonal axes encoded as three pseudo-modes) — SUPERSEDE/annotate (w10)"
+
+work:
+# --- Untested live paths (highest value: run them for real) ---
+- id: w1
+  summary: "Bring up live PostgreSQL, pre-create the catalog DB, and run the DuckLake PG live_integration class; fix what breaks"
+  status: pending
+  notes: |
+    Find the make docker-postgres target (e.g. make test-docker-up-postgresql).
+    Pre-create the ducklake_catalog database (adapter does NOT CREATE DATABASE).
+    Run: uv run -- python -m pytest tests/integration/test_ducklake_integration.py -m live_integration -n 0 -k Postgres
+    Report and fix every failure. This class has never executed against a real server.
+
+- id: w2
+  summary: "Run the DuckLake S3 data_path live_integration class against a real bucket; fix what breaks"
+  status: pending
+  notes: |
+    Set BENCHBOX_S3_TEST_BUCKET + AWS creds and run the S3 class
+    (-m live_integration -k S3). Never executed. Exercise both credential_chain
+    and explicit KEY_ID/SECRET paths, and force-recreate leaving orphaned Parquet (see w7).
+
+# --- CI coverage gaps ---
+- id: w3
+  summary: "Give the extension-only in-process ATTACH class a marker a real lane runs, so core adapter behavior is gated in CI"
+  status: pending
+  notes: |
+    TestDuckLakeLiveConnection needs only the ducklake extension (no external
+    service) yet is live_integration -> runs nowhere. Re-marker it (or add a
+    lane) so core ATTACH/cursor-scoping/force-recreate/platform_info is exercised
+    on develop PRs. Keep PG/S3 classes live_integration.
+
+- id: w4
+  summary: "Add a CI meta-check that fails when an integration test module is selected by zero configured lanes"
+  status: pending
+  notes: |
+    Resolve each test module's module+class markers against every workflow/Makefile
+    `-m` expression; fail if any module matches no lane. Prevents future
+    coverage-theater. Model on test_marker_strategy.py / lint-markers.
+
+- id: w5
+  summary: "Make _probe_extension's cached-False outcome loud instead of a silent session-wide skip"
+  status: pending
+  notes: |
+    tests/integration/test_ducklake_integration.py: DUCKLAKE_AVAILABLE =
+    @cache _probe_extension('ducklake') runs at import/collection; a transient
+    extension-repo blip caches False and silently skips even the SQLite class that
+    gates release-canary. Emit a warning/xfail (not a silent skip) at the release gate.
+
+# --- Correctness / operational ---
+- id: w6
+  summary: "Postgres catalog reuse/force: server-side detection so reruns don't crash and --force works"
+  status: pending
+  notes: |
+    handle_existing_database keys off local metadata_path.exists(), never true for
+    a server-side PG catalog -> database_was_reused stays False -> second run hits
+    inherited plain CREATE TABLE -> 'table already exists' crash; --force is a no-op.
+    Probe the PG catalog server-side (ducklake metadata tables) for reuse; honor
+    --force by dropping/recreating the catalog schema. NOTE: current behavior
+    crashes (safe) rather than silently misreporting cold-load timings -- confirmed.
+
+- id: w7
+  summary: "--force with cloud (s3) DATA_PATH leaves orphaned Parquet; clear the prefix or document"
+  status: pending
+  notes: |
+    _reset_ducklake_catalog correctly guards rmtree with `not _data_path_is_cloud`
+    (no dangerous deletion -- verified), but cloud data is never reset; new catalog
+    only references new files (results stay correct) yet storage leaks. Clear the
+    prefix via the cloud client on force, or document the leak.
+
+- id: w8
+  summary: "Express the duckdb>=1.3 floor installably (ducklake extra) or document the requirement"
+  status: pending
+  notes: |
+    pyproject pins duckdb>=1.0.0,<2.0.0; uv sync can resolve 1.2 which cannot load
+    ducklake. Mitigated by a clean runtime guard (ducklake.py:606) so it's not a
+    confusing failure -- but an optional-dependency extra `ducklake=["duckdb>=1.3,<2.0"]`
+    or a documented requirement would prevent a broken environment.
+
+# --- Docs / registry ---
+- id: w9
+  summary: "Correct CHANGELOG.md to reflect the shipped feature (sqlite/postgres catalogs + S3), not just the #1082 MVP"
+  status: pending
+  notes: |
+    #1096's scope_limit forbade the CHANGELOG edit and no follow-up corrected it;
+    the unreleased notes still say 'DuckDB-file catalog + local Parquet storage'.
+
+- id: w10
+  summary: "Fix the deployment_modes modeling: two orthogonal axes (catalog backend x storage location) presented as three exclusive pseudo-modes"
+  status: pending
+  notes: |
+    platform_registry.py:128 encodes catalog(duckdb/sqlite/postgres) x storage(local/s3)
+    as local/postgres_catalog/cloud_storage. Consequence: `ducklake:postgres_catalog`
+    validates (adapter_factory.py:190) but does nothing (adapter reads only
+    catalog=), and docs/platforms/comparison-matrix.md:81 lists them beside real
+    :mode platforms as mutually exclusive. Collapse to one mode or mark the entries
+    descriptive-only; correct the matrix row.
+
+# --- Governance / open decisions ---
+- id: w11
+  summary: "Define the concrete experimental -> beta exit criterion for the ducklake platform"
+  status: pending
+  notes: "None exists (registry only records support_status: experimental). Write measurable criteria."
+
+- id: w12
+  summary: "Decide the publishability policy for remote-backed (PG catalog / S3 storage) DuckLake results"
+  status: pending
+  notes: |
+    Network variance sits inside every timed phase (per-query S3 GET in
+    execute_query; PG catalog round-trips in ATTACH/commit). No annotation flags
+    remote-backed runs. Decide: quarantine/annotate vs allow to published-results.
+
+- id: w13
+  summary: "Decide whether platform adapters that produce publishable numbers should be a CODEOWNERS owner-review path"
+  status: pending
+  notes: |
+    #1082/#1096 merged via squash auto-merge, no human review; platforms/ is not a
+    soundness path. Decide whether to add benchbox/platforms/** (or new adapters)
+    to .github/CODEOWNERS + auto_merge_soundness_paths.py.
+
+- id: w14
+  summary: "Decide whether absence of DuckLake compaction/inlining biases cross-engine comparisons; instrument or document"
+  status: pending
+  notes: |
+    The adapter runs no compaction/merge/inlining between load and query; a
+    multi-batch load leaves many small Parquet files. If a competitor auto-compacts
+    and DuckLake doesn't, scan-time comparisons are unfair. Settle with a
+    load->compact->query vs load->query timing delta, then instrument or annotate.
+
+deferred:
+- summary: "Fine-grained attribution of catalog-metadata ops vs Parquet-scan vs engine time"
+  reason: "Requires new phase instrumentation; the coarse ducklake-vs-duckdb comparison is available today. Track only if w11/w12 conclude attribution is required for beta."
+
+deps:
+  needs:
+    - "ducklake-postgres-credential-leak-redaction"
+
+verification:
+- description: "PG and S3 live classes execute (not skip) against real infra and pass"
+  command: "uv run -- python -m pytest tests/integration/test_ducklake_integration.py -m live_integration -n 0"
+  expected_output: "PG + S3 classes run and pass (or reveal fixable failures), not silently skipped"
+- description: "Lane-coverage meta-check flags any zero-lane integration module"
+  command: "<new check added in w4>"
+  expected_output: "test_ducklake_integration.py is selected by at least one lane after w3"
+
+open_questions:
+- question: "Should remote-backed (PG/S3) DuckLake results be publishable to published-results at all, given network variance in timed phases?"
+  gating: true
+  affects: ["w12"]
+  default: "Quarantine/annotate remote-backed runs until an isolation story exists."
+- "Is a separate `ducklake` platform the right shape, or should it be a deployment mode of `duckdb`? (Current separate-platform choice is defensible; revisit only if w10 collapses the modes.)"
+
+metadata:
+  tags:
+    - "ducklake"
+    - "ci-coverage"
+    - "post-merge-review"
+  estimated_effort: "Large"
+  created_date: "2026-07-10"
+
+impact:
+  technical_debt: |
+    Closes the gap between 'tests exist' and 'tests run in CI' for the adapter,
+    executes never-run PG/S3 paths, and resolves the reuse/force, docs, and
+    governance loose ends from the review.
+
+success_metrics:
+  - "Core DuckLake live behavior (in-process ATTACH) is exercised by at least one CI lane"
+  - "PG and S3 integration classes have been executed against real infra at least once, with failures fixed or filed"
+  - "A CI meta-check prevents any integration module from running in zero lanes"
+  - "experimental->beta exit criterion and remote-result publishability policy are documented decisions"

--- a/_project/TODO/ducklake-review-followups/planning/ducklake-postgres-credential-leak-redaction.yaml
+++ b/_project/TODO/ducklake-review-followups/planning/ducklake-postgres-credential-leak-redaction.yaml
@@ -1,0 +1,111 @@
+id: "ducklake-postgres-credential-leak-redaction"
+title: "DuckLake postgres catalog: redact DB password from ATTACH-failure exception (confirmed leak)"
+worktree: "ducklake-review-followups"
+priority: "Critical"
+status: "Not Started"
+description: |
+  CONFIRMED credential leak found in a post-merge review of the shipped DuckLake
+  adapter (#1082, #1096; both in _project/DONE/).
+
+  When catalog=postgres and the ATTACH fails (server unreachable OR wrong
+  password -- the *normal* first-run case), DuckDB raises an IOException whose
+  message echoes the full libpq connection string, INCLUDING the plaintext
+  password, twice. benchbox/platforms/ducklake.py create_connection() catches
+  this and re-raises it verbatim via `... Underlying error: {e}` (around
+  ducklake.py:684-695), so the password propagates to:
+    - stderr / console / --verbose output
+    - the runner's serialized error list (benchbox/core/runner/runner.py:209,253
+      stringify exceptions into errors=[...]), which for this tool can be
+      exported to result JSON and potentially published.
+
+  Reproduced live (bogus PG target, connection refused):
+    ATTACH 'ducklake:postgres:dbname=cat host=127.0.0.1 user=bob password=SuperSecretPw123 port=5432' AS lake (DATA_PATH ...)
+    -> IOException: "... password=SuperSecretPw123 port=5432 ... Unable to connect
+       to Postgres at dbname=cat host=127.0.0.1 user=bob password=SuperSecretPw123 ..."
+    -> `SuperSecretPw123` present in str(e): True
+
+  Asymmetry that makes this clearly a miss (not a design choice): the S3 secret
+  path in the SAME function already redacts (ducklake.py:669-678 catches the
+  CREATE SECRET failure and suppresses key/secret material). The postgres ATTACH
+  path was not given the same treatment.
+
+category: "Security and Correctness"
+
+prior_art:
+- "benchbox/platforms/ducklake.py:669-678 S3 CREATE SECRET redaction (suppresses key/secret in the raised RuntimeError, raise ... from None) — REUSE the same shape for the postgres ATTACH failure"
+- "benchbox/platforms/ducklake.py:717-735 get_platform_info already excludes pg_user/pg_password from serialized platform config — EXTEND the same no-secret discipline to the exception path"
+
+work:
+- id: w1
+  summary: "Redact the postgres connection string (password) from the ATTACH-failure RuntimeError in create_connection()"
+  status: pending
+  notes: |
+    In ducklake.py create_connection()'s `except Exception as e:` around
+    lines 684-695: when self.catalog == 'postgres', do NOT interpolate raw {e}
+    and do NOT echo metadata_path/attach_target that embed the connstring.
+    Prefer emitting `type(e).__name__` plus host/port/database (already
+    non-secret), OR run the message through a scrubber that strips
+    `password=\S+` / `password='...'`. Keep the non-postgres branches informative.
+    Also confirm the version-guard reject path (ducklake.py:605-618) and the
+    outer wrap do not re-expand a redacted message.
+
+- id: w2
+  summary: "Regression test: assert no password/secret ever appears in a DuckLake postgres ATTACH-failure message"
+  needs: [w1]
+  status: pending
+  notes: |
+    Add a hermetic unit test (tests/unit/platforms/test_ducklake_adapter.py) that
+    drives create_connection() with catalog=postgres and a stubbed setup_conn
+    whose .execute('ATTACH ...') raises an IOException carrying a sentinel
+    password (e.g. 'PW_SENTINEL_do_not_leak'); assert the sentinel is absent from
+    str(raised) and from any log record. Mutation-check: reverting w1 must make
+    the test fail. This is hermetic (no live PG) so it runs in the fast lane.
+
+- id: w3
+  summary: "Sweep every other secret egress (pg_password, s3_secret) for the same raw-interpolation pattern"
+  needs: [w1]
+  status: pending
+  notes: |
+    grep ducklake.py (and any log.* / raise with {e}/{self.metadata_path}) for
+    paths that could embed pg_password or the connstring: verbose logging
+    (654-658 logs host/port/db only -- confirm), the _reset/handle paths, and the
+    outer create_connection wrap. Extract a small `_redact_pg_connstring()` helper
+    if reused in more than one place. Confirm s3_secret has no un-redacted egress.
+
+must_preserve:
+- "Non-postgres (duckdb/sqlite) ATTACH failures keep their informative metadata_path/data_path context"
+- "The S3 CREATE SECRET redaction at ducklake.py:669-678 stays intact"
+- "get_platform_info() continues to omit pg_user/pg_password"
+
+verification:
+- description: "New redaction regression test passes and is mutation-sensitive"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_ducklake_adapter.py -q"
+  expected_output: "all pass; reverting w1 flips the new test to red"
+- description: "No plaintext password reaches the raised message for a failed postgres ATTACH"
+  command: "uv run -- python -m pytest tests/unit/platforms/test_ducklake_adapter.py -k credential -q"
+  expected_output: "sentinel password absent from exception text"
+
+scope_limit:
+  only_modify:
+    - "benchbox/platforms/ducklake.py"
+    - "tests/unit/platforms/test_ducklake_adapter.py"
+
+metadata:
+  tags:
+    - "security"
+    - "ducklake"
+    - "credential-leak"
+  estimated_effort: "Small"
+  created_date: "2026-07-10"
+
+impact:
+  user_impact: |
+    A benchmarking tool that publishes results must never emit a catalog
+    password. Today the common failure path (unreachable/misconfigured PG
+    catalog) leaks it to logs and possibly exported JSON.
+  technical_debt: |
+    Closes the redaction asymmetry between the S3 and postgres paths in the
+    same function.
+
+success_metrics:
+  - "No DuckLake code path can surface pg_password in an exception, log line, or serialized result field"


### PR DESCRIPTION
Open TODOs for actions and testing surfaced by a deep post-merge review of
the shipped DuckLake adapter (#1082, #1096) that could not be completed in the
review turn, so they are not dropped:

- ducklake-postgres-credential-leak-redaction (Critical): confirmed plaintext
  password leak via the catalog=postgres ATTACH-failure exception
  (ducklake.py:684-695); redact like the existing S3 path + regression test.
- ducklake-post-merge-review-followups (Medium-High): core live behavior runs
  in zero CI lanes (slow+live_integration); PG/S3 classes never executed; a
  lane-coverage meta-check; postgres reuse/force server-side detection; cloud
  --force orphaned Parquet; duckdb>=1.3 floor; CHANGELOG/registry docs drift;
  experimental->beta criterion; remote-result publishability; CODEOWNERS and
  compaction-fairness decisions. Gated on the credential-leak fix.

Two related process blind spots recorded locally under _project/blind-spots/.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
