### PR TITLE
fix(test): de-flake uat throughput mtime-boundary resolver tests

### DIFF
--- a/tests/uat/test_throughput.py
+++ b/tests/uat/test_throughput.py
@@ -24,6 +24,18 @@ from tests.uat.throughput import (
 pytestmark = pytest.mark.fast
 
 
+# ``resolve_official_result_path`` filters candidates by ``st_mtime >=
+# started_after``. Capturing ``started_after = datetime.now()`` immediately
+# before writing the fixture file is racy: filesystem mtime granularity (or a
+# small backward NTP step between the two calls) can floor the written file's
+# mtime just *below* ``started_after``, dropping the file and returning None
+# (observed as a one-off CI flake). Backdating ``started_after`` by a slack
+# margin makes the boundary robust without weakening any test's intent -- the
+# "ignores older files" case backdates its stale file by a full hour, well
+# outside this margin.
+_MTIME_SLACK = _dt.timedelta(seconds=2)
+
+
 # ---------------------------------------------------------------------------
 # resolve_official_result_path
 # ---------------------------------------------------------------------------
@@ -50,7 +62,7 @@ def test_resolve_official_result_path_returns_none_when_no_candidates(tmp_path: 
 def test_resolve_official_result_path_matches_platform_and_benchmark(tmp_path: Path):
     results_dir = tmp_path / "results"
     results_dir.mkdir()
-    started = _dt.datetime.now()
+    started = _dt.datetime.now() - _MTIME_SLACK
     match = results_dir / "tpch_sf1_duckdb_sql_20260709_223304_0865bb91.json"
     match.write_text("{}", encoding="utf-8")
     # A same-timestamp but different-platform file must not match.
@@ -78,7 +90,7 @@ def test_resolve_official_result_path_ignores_files_older_than_started_after(tmp
 def test_resolve_official_result_path_picks_newest_of_multiple_candidates(tmp_path: Path):
     results_dir = tmp_path / "results"
     results_dir.mkdir()
-    started = _dt.datetime.now()
+    started = _dt.datetime.now() - _MTIME_SLACK
     older = results_dir / "tpch_sf1_duckdb_sql_older.json"
     newer = results_dir / "tpch_sf1_duckdb_sql_newer.json"
     older.write_text("{}", encoding="utf-8")
@@ -97,7 +109,7 @@ def test_resolve_official_result_path_is_case_and_dash_insensitive(tmp_path: Pat
     """Platform tokens with dashes (e.g. `pg-duckdb`) normalize like the CLI's own output filenames."""
     results_dir = tmp_path / "results"
     results_dir.mkdir()
-    started = _dt.datetime.now()
+    started = _dt.datetime.now() - _MTIME_SLACK
     match = results_dir / "tpch_sf1_pg_duckdb_sql_20260709.json"
     match.write_text("{}", encoding="utf-8")
     out = resolve_official_result_path(results_dir, platform="pg-duckdb", benchmark="tpch", started_after=started)


### PR DESCRIPTION
## Summary

De-flakes three `tests/uat/test_throughput.py` tests that captured `started_after = datetime.now()` microseconds before writing a fixture file which must satisfy `st_mtime >= started_after`. Filesystem mtime granularity — or a small backward NTP step between the two calls — can floor the freshly-written file's mtime just below the mark, so `resolve_official_result_path` filters it out and returns `None`.

Observed once in CI as:
```
assert None == PosixPath('.../results/tpch_sf1_pg_duckdb_sql_20260709.json')
```
The embedded date token (`20260709`) is a red herring — resolution is purely mtime-based.

## Fix

Backdate `started_after` by a 2s slack margin (`_MTIME_SLACK`). The "ignores older files" test backdates its stale fixture by a full hour, well outside the margin, so its boundary semantics are unaffected.

## Incident context

This failure was one of three distinct test breaks that the post-#1096 **auto-revert storm** (#1099, #1107–#1112, #1115) surfaced and repeatedly **misattributed** to unrelated commits (the bot blames the most recent merge, but the ~26min `medium-test` tier means the real culprit landed several PRs earlier). The three, disentangled by pulling each run's CI logs:

| failure | root cause | status |
|---|---|---|
| `test_query_generation_preflight` | #1093 (dsqgen `-STREAMS` reroute) | fixed — #1113 (merged) |
| `test_throughput_session_isolation` | #1100 (`_extract_rows` dropped `first_row`) | fixed — #1117 |
| `test_resolve_official_result_path...` (this PR) | pre-existing mtime-boundary flake | **this PR** |

## Verification

All 18 tests in the file pass; the fix targets the exact `st_mtime >= started_after` boundary that produced the CI `None`.