### PR TITLE
chore(todo): seed SCD2 audit-followup TODOs (validation gating, soundness, portability coverage)

### DIFF
--- a/_project/TODO/scd2-audit-followup/planning/duckdb-merge-token-gate-hardening.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/duckdb-merge-token-gate-hardening.yaml
@@ -1,0 +1,140 @@
+id: "duckdb-merge-token-gate-hardening"
+title: "Harden DuckDB MERGE INTO token gate and reconcile its dead REGISTRY/comments"
+worktree: "scd2-audit-followup"
+priority: "Medium"
+status: "Not Started"
+category: "Core Functionality"
+description: |
+  SCD2 adversarial audit findings N6 and N7.
+
+  N6 - benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py:
+  40-42 tests "MERGE INTO" in write_sql.upper(). Verified (scratchpad repro3.py)
+  false positives and false negatives, both real against DuckDB 1.3.2:
+    - false positive: token only in a comment ('-- ... MERGE INTO ...') -> gate
+      skips an op DuckDB would run fine.
+    - false positive: token only in a string literal ('MERGE INTO staging')
+      -> same.
+    - false negatives: 'MERGE  INTO' (two spaces), 'MERGE\nINTO', and MERGE
+      reached via a CTE -> gate does NOT skip, and DuckDB 1.3.2 raises
+      ParserException on all three (confirmed).
+  No live instance today (all 21 catalog ops with the token use the exact
+  single-space form), so this is a regression trap for the next MERGE op added:
+  it would run and hard-error instead of skipping cleanly. The gate also reads
+  operation.write_sql (benchmark.py:422) and runs BEFORE platform_overrides
+  resolution (benchmark.py:428-432), so it does not see the effective SQL.
+
+  N7 - the gate's own metadata is wrong and its REGISTRY is write-only:
+    - duckdb_write_primitives.py:10-19 says "20 legacy MERGE INTO ops"; the
+      actual count of catalog ops whose write_sql contains MERGE INTO is 21 (the
+      20 merge-category ops + bulk_load_upsert_mode).
+    - :27 says DUCKDB_WRITE_PRIMITIVES_OPERATION_SKIPS holds "gaps that cannot be
+      detected from the write_sql token", but its only entry
+      (bulk_load_upsert_mode) IS token-detectable (verified), so that entry and
+      the operation_id lookup at :43-45 are dead code.
+    - the REGISTRY.register loop at :49-66 registers 1 duckdb execution-filter
+      rule while the runtime skips 21. Nothing resolves Phase.EXECUTION_FILTER:
+      benchmark.py:42-45 imports the dicts directly, so the registry is
+      decorative today - but a future consumer (coverage matrix, compat report)
+      would get a wrong DuckDB answer. postgres_write_primitives.py:97-114 has
+      the same write-only-registry shape.
+    - tests/integration/test_write_primitives_duckdb.py:515 repeats the
+      "112 - 20 failing MERGE INTO" arithmetic.
+impact:
+  business_value: "Prevents a future MERGE op from silently hard-erroring on DuckDB instead of skipping, and removes a registry that would mislead any future consumer."
+  user_impact: "New MERGE-family ops will be gated correctly regardless of whitespace/comments; DuckDB skip counts stay honest."
+  technical_debt: "Dead operation-skip dict, write-only registry, and stale comments in both duckdb and postgres execution-filter rules."
+prior_art:
+- "benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py:33-46 the token gate function - harden"
+- "benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py:49-66 write-only REGISTRY.register loop - decide populate vs delete"
+- "benchbox/sql_compat/rules/execution_filter/postgres_write_primitives.py:97-114 same write-only-registry shape - reconcile consistently"
+- "benchbox/core/write_primitives/benchmark.py:421-424 the token-gate call site (before platform_overrides resolution)"
+- "benchbox/sql_compat/context.py:17 Phase.EXECUTION_FILTER - resolved by nothing today"
+
+work:
+- id: w1
+  summary: "Replace substring test with a whitespace-tolerant regex over comment- and string-literal-stripped SQL (MERGE\\s+INTO)."
+  status: pending
+  notes: |
+    Strip line comments (--...), block comments (/*...*/), and single-quoted
+    string literals before matching, then apply re.search(r'\bMERGE\s+INTO\b').
+    Cover the exact cases in scratchpad repro3.py ATTACK 6.
+- id: w2
+  summary: "Evaluate the gate against the effective SQL (after platform_overrides), not operation.write_sql, so an override that swaps MERGE in/out is gated correctly."
+  needs: [w1]
+  status: pending
+  notes: |
+    Requires moving the gate call after override resolution in
+    benchmark.py:428-432, or passing the resolved SQL into the gate. Keep the
+    change minimal and covered by a test with a duckdb override. This edits the
+    SAME _get_effective_write_sql control flow as
+    write-primitives-sql-override-skip-order; land AFTER that TODO (see
+    deps.needs) and rebase on its reordering to avoid a benchmark.py conflict.
+- id: w3
+  summary: "Fix stale comments: :10-19 '20' -> 21 (incl bulk_load_upsert_mode); remove/justify the dead OPERATION_SKIPS entry + :43-45 lookup."
+  needs: [w1]
+  status: pending
+- id: w4
+  summary: "Reconcile the write-only REGISTRY: populate token-derived skips or delete the decorative register loop (duckdb + postgres)."
+  needs: [w3]
+  status: pending
+  notes: |
+    Pick ONE source of truth. The runtime reads the dicts directly, so either
+    wire the registry to the same derivation or drop the register loop entirely
+    in both duckdb_write_primitives.py and postgres_write_primitives.py.
+    Document the choice so no future consumer re-diverges (1 rule vs 21 skips).
+- id: w5
+  summary: "Correct the arithmetic comment at tests/integration/test_write_primitives_duckdb.py:515."
+  needs: [w3]
+  status: pending
+
+must_preserve:
+- "All 3 portable SCD2 ops (UPDATE+INSERT) continue to RUN on DuckDB (not skipped)."
+- "All 21 genuine MERGE INTO ops continue to skip cleanly on DuckDB."
+- "bulk_load_upsert_mode still skips on DuckDB (whether via token or an explicit rule)."
+- "postgres_write_primitives skip behavior is unchanged for the SCD2 and merge ops."
+
+approach: |
+  Harden the single gate function, then reconcile its metadata and registry.
+  Prefer a small comment/literal stripper + regex over a full SQL parser
+  (no parser dependency on this hot path). For the registry, pick one source of
+  truth: the runtime already reads the dicts directly, so either wire the
+  registry to the same derivation or drop the register loop entirely - do not
+  leave two mechanisms that can diverge. Apply the same decision symmetrically
+  to the postgres rule.
+
+anti_patterns:
+- "DO NOT pull in a SQL parser for the gate - because it is on the per-op resolution path - use a targeted comment/literal-stripped regex."
+- "DO NOT leave both a decorative registry and direct dict imports - because they can silently disagree (1 vs 21) - collapse to one source of truth."
+- "DO NOT widen the gate to the whole merge category - because portable SCD2 ops are merge-category and must keep running on DuckDB - gate on the MERGE INTO token only."
+
+verification:
+- description: "SCD2 ops still run (not skipped) on DuckDB; all MERGE INTO ops still skip."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  expected_output: "all pass"
+- description: "New gate unit test covers comment/literal false positives and whitespace/CTE false negatives."
+  command: "uv run -- python -m pytest tests/unit/sql_compat -n 0 -q -k merge_token_gate"
+  expected_output: "new test passes"
+
+scope_limit:
+  only_modify:
+  - "benchbox/sql_compat/rules/execution_filter/duckdb_write_primitives.py"
+  - "benchbox/sql_compat/rules/execution_filter/postgres_write_primitives.py"
+  - "benchbox/core/write_primitives/benchmark.py"
+  - "tests/integration/test_write_primitives_duckdb.py"
+  - "tests/unit/sql_compat"
+  do_not_modify:
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+
+deps:
+  needs: ["write-primitives-sql-override-skip-order"]
+
+success_metrics:
+- "Comment-only and string-literal MERGE INTO no longer trigger a false skip."
+- "Whitespace/newline/CTE MERGE INTO variants are correctly skipped on DuckDB."
+- "The execution-filter registry and the runtime skip set cannot disagree (one source of truth)."
+- "Stale '20' comment and test arithmetic corrected to 21."
+
+metadata:
+  tags: ["write-primitives", "duckdb", "sql-compat", "execution-filter", "audit-followup"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/scd2-basic-idempotency-and-cleanup-scoping.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/scd2-basic-idempotency-and-cleanup-scoping.yaml
@@ -1,0 +1,132 @@
+id: "scd2-basic-idempotency-and-cleanup-scoping"
+title: "Make merge_scd_type2_basic idempotent and scope SCD2 cleanups by change_type"
+worktree: "scd2-audit-followup"
+priority: "Medium"
+status: "Not Started"
+category: "Core Functionality"
+description: |
+  SCD2 adversarial audit finding N4. merge_scd_type2_basic's INSERT fires for
+  change_type='new' OR (changed AND EXISTS <closed row with valid_to =
+  s.effective_ts>), with NO NOT EXISTS guard on the current dimension - unlike
+  merge_scd_type2_new_keys_only, which has
+  AND NOT EXISTS (SELECT 1 FROM dim d WHERE d.c_custkey = s.c_custkey).
+
+  Reproduced (scratchpad repro2.py ATTACK 2): run basic's write_sql twice with
+  no cleanup between ->
+    after #1: total=1540 cur=1520 closed=20 dup_current_key=0
+    after #2: total=1580 cur=1560 closed=20 dup_current_key=40
+  Both the 'new' and 'changed' branches duplicate. The 'changed' branch
+  re-fires because the row closed in run 1 still carries
+  valid_to = DATE '2026-01-01' = s.effective_ts.
+
+  Reachability is real but narrow: execute_operation runs cleanup after every
+  successful write (benchmark.py:1207); _run_operation_cleanup swallows a
+  cleanup failure into a warning and the harness continues (benchmark.py:
+  1328-1337); the warmup+measurement loop re-runs every op with NO reset()
+  between iterations (execution.py:213-225). One swallowed cleanup therefore
+  produces the duplicate state on the next iteration - and per finding N1 it
+  reports green until the gating TODO lands.
+
+  Second half: the cleanup for basic and no_change is
+  DELETE FROM dim WHERE valid_from IN (SELECT effective_ts FROM stage),
+  unqualified by change_type. Reproduced (repro2.py ATTACK 3b): running basic's
+  cleanup after new_keys_only's write deletes all 20 of new_keys_only's rows.
+  The ops are safe today only because the catalog orders them basic ->
+  no_change -> new_keys_only with an immediate cleanup after each.
+
+  IMPORTANT downstream: adding the NOT EXISTS guard changes basic's measured
+  write path, which the blog publishes (2.517 ms SF0.01 / 4.360 ms SF0.1). Per
+  the user decision, re-measure with the same protocol and update the draft +
+  research note ONLY if the change exceeds run-to-run variance.
+impact:
+  business_value: "The canonical SCD2 op becomes idempotent (the correct SCD2 semantics), removing a latent double-write corruption."
+  user_impact: "A retried or re-run basic op no longer silently doubles current versions per key."
+  technical_debt: "Removes an implicit dependency on catalog op ordering + immediate cleanup for correctness."
+prior_art:
+- "benchbox/core/write_primitives/catalog/operations.yaml merge_scd_type2_new_keys_only - reuse its NOT EXISTS (dim d WHERE d.c_custkey = s.c_custkey) guard shape"
+- "benchbox/core/write_primitives/catalog/operations.yaml merge_scd_type2_basic / _no_change cleanup_sql - the unscoped DELETE to qualify by change_type"
+- "benchbox/core/write_primitives/benchmark.py:1207,1328-1337 cleanup-runs-then-swallows-failure path that makes the double-write reachable"
+- "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:195-207 published basic median (must re-check if the op changes)"
+
+work:
+- id: w1
+  summary: "Add NOT EXISTS (SELECT 1 FROM scd2_ops_dim_customer d WHERE d.c_custkey = s.c_custkey) to merge_scd_type2_basic's INSERT, mirroring new_keys_only."
+  status: pending
+  notes: |
+    This makes basic idempotent - the correct SCD2 semantic, not just a guard.
+    Confirm the 'changed' branch still inserts the new version on a clean run
+    (the closed old row is not 'current', so the guard must key on
+    d.c_custkey existence among CURRENT rows only, or the changed-key new
+    version would be blocked). Verify against repro2.py's clean-run expectations
+    before/after.
+- id: w2
+  summary: "Scope basic and no_change cleanup_sql by change_type so one op's cleanup cannot delete another op's inserted rows."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Test: basic's write_sql run twice with no cleanup is a no-op (no 40 duplicate current versions); cross-op cleanup no longer deletes foreign rows."
+  needs: [w1, w2]
+  status: pending
+- id: w4
+  summary: "Re-measure basic (30 runs SF0.01, 15 runs SF0.1) with the audit protocol; update blog draft table + research note C3 only if outside run-to-run variance."
+  needs: [w1]
+  status: pending
+  notes: |
+    Audit re-derivation (scratchpad scale.py) for reference:
+    SF0.01 basic median 2.09 ms, SF0.1 3.65 ms, SF1.0 13.34 ms (all validations
+    green). If the guard shifts these beyond noise, update
+    _blog/.../drafts/apply-changes-into-vs-standard-sql.md:195-207 AND the
+    research note's C3 entry, with a dated note that the op changed. Otherwise
+    leave the numbers and record 'within noise' in the PR body. While editing
+    the draft table here, also fold in the SF1 basic row deferred from
+    scd2-docs-and-count-hygiene-followup (SF1.0 basic median ~13.3 ms) so the
+    scale discussion is balanced - this TODO owns all blog-draft edits.
+
+must_preserve:
+- "A clean single run of basic still closes 20 changed keys, inserts 20 changed-key new versions + 20 new keys (closed=20, current=70, total=90 at the 50-customer fixture)."
+- "basic's own cleanup still restores the pristine seed exactly (0 rows deviating)."
+- "no_change and new_keys_only behavior unchanged except for cleanup change_type scoping."
+- "Blog SF0.01/SF0.1 basic medians stay accurate: either unchanged within noise, or updated in draft + research note."
+
+approach: |
+  Two small operations.yaml edits (basic INSERT guard, basic+no_change cleanup
+  scoping) plus a re-measurement pass. Reuse new_keys_only's existing NOT EXISTS
+  shape. The guard must not block the legitimate changed-key new version - key
+  it on current-row existence, matching SCD2 semantics (a changed key has no
+  current row at insert time because the UPDATE already closed it). Validate the
+  clean-run row counts against the integration fixture before committing.
+
+anti_patterns:
+- "DO NOT guard on bare c_custkey existence across ALL dim rows - because the just-closed old version would block the changed-key new version - guard on current-version existence."
+- "DO NOT land the SQL change without re-measuring - because the blog publishes basic's median and the write path changes - re-run the protocol first."
+- "DO NOT reorder the catalog ops as a 'fix' - because relying on order is the bug - make each op self-consistent instead."
+
+verification:
+- description: "SCD2 integration green; clean-run row counts unchanged."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  expected_output: "all pass"
+- description: "New idempotency test: basic run twice (no cleanup) yields no duplicate current versions."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -n 0 -q -k basic_idempotent"
+  expected_output: "new test passes"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+  - "tests/integration/test_write_primitives_duckdb.py"
+  - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+  - "_blog/platform-deep-dives/research/apply-changes-into-vs-merge-verification-2026-06-27.md"
+  do_not_modify:
+  - "benchbox/core/write_primitives/benchmark.py"
+
+deps:
+  needs: ["scd2-validation-coverage-hardening"]
+
+success_metrics:
+- "merge_scd_type2_basic is idempotent: running it twice without cleanup does not create duplicate current versions."
+- "SCD2 cleanups are change_type-scoped; no cross-op row deletion."
+- "Blog basic medians are re-measured and either confirmed within noise or updated in draft + research note."
+
+metadata:
+  tags: ["scd2", "write-primitives", "idempotency", "cleanup", "blog", "audit-followup"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/scd2-docs-and-count-hygiene-followup.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/scd2-docs-and-count-hygiene-followup.yaml
@@ -1,0 +1,121 @@
+id: "scd2-docs-and-count-hygiene-followup"
+title: "Fix residual SCD2 doc overclaim, README count contradictions, and op-vs-setup portability note"
+worktree: "scd2-audit-followup"
+priority: "Low"
+status: "Not Started"
+category: "Documentation"
+description: |
+  SCD2 adversarial audit findings N9, N10, N12 - tracked-file doc defects the
+  prior remediation (#1057/#1061/#923) left behind.
+
+  N9 - the blog OUTLINE still carries the pre-#1061 ClickHouse overclaim.
+  _blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md:57-58
+  states the portable form "runs unchanged across DuckDB, PostgreSQL, Snowflake,
+  BigQuery, ClickHouse." This contradicts the corrected draft (drafts/...:104-117,
+  169-170) and docs/benchmarks/write-primitives.md:132-136. The Completed TODO
+  _project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml
+  lists only the draft + docs under files_affected and never touched the outline.
+
+  N10 - README internal count contradictions (#923 incomplete).
+  benchbox/core/write_primitives/README.md:59 says "DELETE Operations (12)" but
+  :28 says "DELETE 14"; :112 still documents a "TRANSACTION Operations (8)"
+  category that :27 says was moved to transaction_primitives (no transaction
+  category exists in the catalog). CRITICAL: do NOT touch the "112" figure -
+  verified get_all_operations()=112 (user-facing), raw catalog=136, the 24
+  hidden ops are all category 'sketch'. docs' "112 operations" is CORRECT.
+
+  N12 (optional) - the blog scale claim (draft:209-213) is measured on its two
+  most favorable points: growth is 1.74x then 3.66x per decade (SF0.01->0.1->1),
+  6.4x for 100x data. The hedge is honest; optionally add the SF1 row for
+  balance. Audit re-derivation: SF0.01 basic 2.09 ms, SF0.1 3.65 ms, SF1.0
+  13.34 ms (all validations green).
+
+  Also: add the operation-vs-setup SQL portability distinction to
+  docs/benchmarks/write-primitives.md:132-136 - the draft has it (:112-117,
+  noting the setup population SQL's || / CAST(AS VARCHAR) floor), the docs do
+  not.
+
+  NOTE per audit finding D: docs/_build/ is gitignored/untracked - do not touch
+  built HTML; tracked files only. House rule: no em-dash/en-dash in _blog/
+  content (currently 0; keep it 0).
+impact:
+  business_value: "Removes the last surviving pre-#1061 ClickHouse overclaim and the self-contradicting README counts, keeping the published honesty story consistent."
+  user_impact: "Readers of the outline/README no longer see contradictory portability and count claims."
+  technical_debt: "Closes the incomplete edges of two prior Completed remediations (#1057/#1061 outline miss, #923 README counts)."
+prior_art:
+- "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md:104-117,169-170 - the corrected wording to mirror into the outline"
+- "docs/benchmarks/write-primitives.md:129-136 SCD2 paragraph - add the op-vs-setup distinction from draft:112-117"
+- "benchbox/core/write_primitives/README.md:27-28 correct totals (136 = 112 user-facing + 24 sketch) - reconcile :59 and :112 against these"
+- "_project/DONE/write-primitives-scd2-followup/scd2-portability-claim-accuracy.yaml - the Completed TODO that missed the outline"
+
+work:
+- id: w1
+  summary: "N9: rescope outline:57-58 to standard-DML engines with the ClickHouse mutation-rewrite caveat, matching the draft and docs."
+  status: pending
+- id: w2
+  summary: "N10: fix README:59 'DELETE (12)' -> 14 and remove/annotate the stale TRANSACTION (8) section at :112. Do NOT change the 112 figure."
+  status: pending
+  notes: |
+    Confirm the section sum reconciles to 136 raw / 112 user-facing after the
+    edit. The 24 sketch ops are user-hidden; docs' 112 is correct.
+- id: w3
+  summary: "Add the operation-vs-setup SQL portability distinction to docs/benchmarks/write-primitives.md:132-136 (setup population SQL's ||/CAST floor)."
+  status: pending
+- id: w4
+  summary: "Re-grep: 0 em/en-dashes in _blog/ SCD2 files; no remaining 'runs unchanged ... ClickHouse' overclaim in any tracked file."
+  needs: [w1, w2, w3]
+  status: pending
+
+deferred:
+- summary: "N12: add the SF1 basic row to the blog scale discussion (draft table) for balance."
+  reason: "The blog draft is owned by scd2-basic-idempotency-and-cleanup-scoping, which re-measures and may rewrite that table. Editing the draft here would collide. Fold the SF1 row into that TODO's w4 re-measurement instead."
+
+must_preserve:
+- "The '112 operations' figure in docs and README stays (it is correct for user-facing ops)."
+- "The corrected draft and docs portability wording is unchanged (already accurate)."
+- "Zero em-dash/en-dash in _blog/ content."
+- "No edits under docs/_build/ (untracked build artifacts)."
+
+approach: |
+  Wording-only edits across the outline, README, and the docs SCD2 paragraph.
+  Mirror the already-correct draft language into the outline. Reconcile the
+  README section counts against the verified 136-raw / 112-user-facing / 24-
+  sketch breakdown without touching the 112. Coordinate the optional SF1 blog
+  edit with the idempotency TODO if that one re-measured the tables.
+
+anti_patterns:
+- "DO NOT 'correct' 112 to 136 - because 112 is the user-facing count (24 sketch ops are hidden) and is right - only fix the self-contradicting per-category numbers."
+- "DO NOT edit docs/_build/ - because it is untracked build output - tracked sources only."
+- "DO NOT introduce em/en-dashes into _blog/ - because the house rule forbids them - use hyphens/rewordings."
+
+verification:
+- description: "No em/en-dash in the SCD2 blog files."
+  command: "grep -rnP \"[\\x{2014}\\x{2013}]\" _blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md _blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md"
+  expected_output: "no matches (exit 1)"
+- description: "No 'runs unchanged ... ClickHouse' overclaim remains in tracked files."
+  command: "git grep -n \"unchanged\" -- _blog docs benchbox/core/write_primitives | grep -i clickhouse"
+  expected_output: "only the corrected caveat wording, no unqualified overclaim"
+- description: "Docs build still validates."
+  command: "make docs-validate"
+  expected_output: "passes"
+
+scope_limit:
+  only_modify:
+  - "_blog/platform-deep-dives/outlines/apply-changes-into-vs-standard-sql.md"
+  - "benchbox/core/write_primitives/README.md"
+  - "docs/benchmarks/write-primitives.md"
+  do_not_modify:
+  - "docs/_build"
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+  - "_blog/platform-deep-dives/drafts/apply-changes-into-vs-standard-sql.md"
+
+success_metrics:
+- "The outline no longer claims the portable form runs unchanged on ClickHouse."
+- "README DELETE/TRANSACTION section counts are internally consistent; 112 unchanged."
+- "docs SCD2 paragraph distinguishes operation-SQL from setup-SQL portability."
+- "Zero em/en-dashes in _blog/ SCD2 content."
+
+metadata:
+  tags: ["scd2", "docs", "blog", "readme", "hygiene", "audit-followup"]
+  estimated_effort: "Small"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/scd2-validation-coverage-hardening.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/scd2-validation-coverage-hardening.yaml
@@ -1,0 +1,137 @@
+id: "scd2-validation-coverage-hardening"
+title: "Close SCD2 validation coverage holes (no-op passes, missing bounds, unscoped checks)"
+worktree: "scd2-audit-followup"
+priority: "Medium-High"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+description: |
+  SCD2 adversarial audit findings N2, N3, N5, N11. The three SCD2 ops in
+  benchbox/core/write_primitives/catalog/operations.yaml ship validations that a
+  broken or no-op implementation can pass:
+
+  N2 - merge_scd_type2_no_change has NO positive assertion. Its three checks
+  (at_most_one_current_per_business_key, no_rows_closed_by_batch,
+  no_new_versions_inserted) are all zero-row "offending" queries. Reproduced
+  (scratchpad repro3.py): delete all 20 'unchanged' keys from the dimension, run
+  nothing -> validation_passed=True. This directly falsifies the premise in the
+  Completed TODO _project/DONE/write-primitives-scd2-followup/
+  scd2-validation-soundness-hardening.yaml, which states "each op already
+  backstops the existence side with a positive companion check" - true for
+  basic and new_keys_only, false for no_change.
+
+  N3 - no cardinality bounds. Reproduced: inject 50 junk current rows for unseen
+  keys, or run basic against an already-merged dimension doing nothing -> all
+  checks pass. No SCD2 validation uses the expected_rows_min/max or
+  expected_value_min/max modes that _check_validation_query already supports
+  (benchmark.py:145-151).
+
+  N5 - merge_scd_type2_new_keys_only's no_rows_closed asserts globally
+  (WHERE is_current = false, expected 0), only pristine-seed-safe. Reproduced:
+  basic write (no cleanup) then new_keys_only -> no_rows_closed FAILs at 20 rows
+  though new_keys_only behaved perfectly. Its sibling no_rows_closed_by_batch
+  scopes by effective_ts; this one should too.
+
+  N11 - every_changed_key_closed_with_stamp checks
+  valid_to < DATE '9999-12-31' (any closed row) instead of
+  valid_to = s.effective_ts (this batch's stamp).
+
+  Depends on write-primitives-validation-result-gating: until a failing
+  validation fails the run, these additions are unobservable.
+
+  Explicitly NOT in scope: changing no_change's UPDATE/INSERT SQL. Verified
+  (scratchpad repro2.py 5a) it is a live, correct defensive path (row_hash wins
+  over the change_type label), not dead code. Timings the blog cites are
+  unaffected: validations are excluded from the reported write duration.
+impact:
+  business_value: "Makes the SCD2 'portable AND validated' claim real by ensuring the validations can actually catch a broken op."
+  user_impact: "A no-op or partial SCD2 implementation on a new engine would be caught rather than reported passing."
+  technical_debt: "Removes the false 'collective exactly-one guarantee' premise recorded in a prior Completed TODO."
+prior_art:
+- "benchbox/core/write_primitives/catalog/operations.yaml:105-107 the three SCD2 ops and their validation_queries"
+- "benchbox/core/write_primitives/benchmark.py:133-151 _check_validation_query (expected_rows / expected_rows_min-max / expected_value_min-max modes) - reuse the unused range modes"
+- "operations.yaml merge_scd_type2_no_change no_rows_closed_by_batch - reuse its effective_ts scoping pattern for N5"
+- "operations.yaml merge_scd_type2_basic every_changed_key_has_current_staged_version - reuse this positive anti-join shape for N2"
+- "_project/DONE/write-primitives-scd2-followup/scd2-validation-soundness-hardening.yaml - the Completed TODO whose central premise N2 falsifies"
+
+work:
+- id: w0
+  summary: "Re-confirm per-op which SCD2 ops lack a positive existence check; record that no_change has none."
+  status: pending
+  notes: |
+    scratchpad repro3.py classified each validation positive/negative:
+    basic has 3 positive companions, new_keys_only has 1, no_change has 0.
+    Reopen scd2-validation-soundness-hardening's premise in the PR body.
+- id: w1
+  summary: "N2: add every_unchanged_key_has_current_version_with_matching_hash to no_change (anti-join stage->dim on is_current AND row_hash = s.row_hash, expected 0)."
+  needs: [w0]
+  status: pending
+- id: w2
+  summary: "N3: add dimension-cardinality bounds per op via expected_value_min/max (SELECT COUNT(*)): basic=seed+40, no_change=seed, new_keys_only=seed+20."
+  needs: [w0]
+  status: pending
+  notes: |
+    Use a scale-independent form: bound the DELTA against the seed count rather
+    than an absolute SF-specific number, or assert the exact post-op total via a
+    subquery. Must stay scale-independent (the ops run at any SF).
+- id: w3
+  summary: "N5: scope new_keys_only.no_rows_closed to the batch (valid_to IN (SELECT effective_ts ... WHERE change_type='new'))."
+  needs: [w0]
+  status: pending
+- id: w4
+  summary: "N11: change every_changed_key_closed_with_stamp to test d.valid_to = s.effective_ts instead of < DATE '9999-12-31'."
+  needs: [w0]
+  status: pending
+- id: w5
+  summary: "Tests: each reproduced broken state now fails validation (zero-current keys; 50 junk current rows; no-op no_change against a dimension missing its keys)."
+  needs: [w1, w2, w3, w4]
+  status: pending
+
+must_preserve:
+- "The happy-path SCD2 run stays green on DuckDB and PostgreSQL (0 rows deviating from the pristine seed)."
+- "no_change's UPDATE/INSERT SQL is unchanged - it is a verified live defensive path, not dead code."
+- "Ops remain scale-independent: no absolute, SF-specific magic numbers beyond the existing small range bounds."
+- "Reported write durations (blog SF0.01/SF0.1 numbers) are unaffected - only validation_queries change."
+
+approach: |
+  Edit only the validation_queries blocks of the three SCD2 ops in
+  operations.yaml. For N2 reuse the positive anti-join shape already present in
+  basic/new_keys_only. For N3 use the existing but unused expected_value_min/max
+  mode in _check_validation_query, bounding the delta against the seed so it
+  stays scale-independent. For N5 copy the effective_ts scoping from
+  no_change's own no_rows_closed_by_batch. For N11 tighten the predicate to the
+  batch stamp. Land after the gating TODO so failures are observable.
+
+anti_patterns:
+- "DO NOT touch no_change's write_sql - because its change_type-vs-row_hash UPDATE is a verified correct live path - only add/adjust validation_queries."
+- "DO NOT hardcode SF-specific counts - because the ops run at any scale - bound the delta against the seed count."
+- "DO NOT rely on run ordering for correctness - because the audit showed unscoped checks (N5) only pass against a pristine seed - scope each check to its own batch."
+
+verification:
+- description: "SCD2 unit + DuckDB integration green (single-threaded)."
+  command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  expected_output: "all pass, including the new broken-state regression tests"
+- description: "no-op no_change against a dimension missing its 'unchanged' keys now FAILS validation."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -n 0 -q -k no_change_noop"
+  expected_output: "new test passes (validation correctly fails for the no-op)"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+  - "tests/unit/benchmarks/test_write_primitives_core.py"
+  - "tests/integration/test_write_primitives_duckdb.py"
+  do_not_modify:
+  - "benchbox/core/write_primitives/benchmark.py"
+
+deps:
+  needs: ["write-primitives-validation-result-gating"]
+
+success_metrics:
+- "merge_scd_type2_no_change has at least one positive existence assertion."
+- "All three ops assert a dimension-cardinality bound."
+- "Each of the four reproduced broken states (N2/N3/N5) fails validation in a test."
+- "no-op and junk-row injections no longer pass."
+
+metadata:
+  tags: ["scd2", "write-primitives", "validation", "soundness", "audit-followup"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/write-primitives-postgres-execution-coverage.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/write-primitives-postgres-execution-coverage.yaml
@@ -1,0 +1,103 @@
+id: "write-primitives-postgres-execution-coverage"
+title: "Add PostgreSQL execution coverage for SCD2 write-primitives ops"
+worktree: "scd2-audit-followup"
+priority: "Medium"
+status: "Not Started"
+category: "Testing and Quality Assurance"
+description: |
+  SCD2 adversarial audit finding C (prior review's Postgres gate item, now
+  closed empirically). The three SCD2 ops are correctly NOT in the Postgres
+  per-operation skip list (postgres_write_primitives.py:15-25), but "not
+  skipped" was never "verified passing" - no test, no CI workflow, and no UAT
+  cell executes write_primitives on PostgreSQL at all.
+
+  During the audit I stood up PostgreSQL 16.14 (Apple container runtime) and ran
+  the full SCD2 surface via scratchpad/pg_scd2.py: the DDL, BOTH _get_population_
+  sql bodies (the 3-statement stage population runs in a single execute() -
+  psycopg3 falls to the simple query protocol when there are no params and TEXT
+  format, per Cursor._execute_send), all three ops' multi-statement write_sql,
+  all 10 validation queries, and all three cleanup_sql bodies ran GREEN. The
+  dimension came back byte-identical to the pristine seed (0 rows deviating);
+  dim/stage row_hash agree 20/20 for the 'unchanged' group. Cross-engine
+  fingerprint formatting (|| concat + CAST AS VARCHAR) was byte-identical between
+  DuckDB and Postgres for c_acctbal, c_acctbal+100, -999.99, and integer-valued
+  decimals.
+
+  So the SQL is genuinely portable; the gap is purely coverage. This TODO turns
+  the one-off manual verification into a durable test + UAT cell.
+impact:
+  business_value: "Locks in the portability claim with executable evidence on a second standard-DML engine, not just DuckDB."
+  user_impact: "Regressions in SCD2 portability to PostgreSQL would be caught by CI/UAT rather than a manual audit."
+  technical_debt: "Removes a correct-but-unverified surface (ops that only avoid the skip list)."
+prior_art:
+- "tests/integration/test_write_primitives_duckdb.py:983 TestWritePrimitivesSCD2DuckDB - mirror this fixture for postgres"
+- "benchbox/platforms/postgresql.py PostgreSQLAdapter / PsycopgConnectionMixin - the adapter under test"
+- "benchbox/platforms/base/psycopg2_mixin.py:39 execute_query - psycopg connection path"
+- "tests/uat/test_phases.py:165-199 UAT benchmark/platform enumeration - add a postgresql x write_primitives cell"
+- "scratchpad/pg_scd2.py (audit) - the manual verification to convert into a fixture"
+
+work:
+- id: w0
+  summary: "Re-validate the audit evidence: re-run the SCD2 surface on a fresh PostgreSQL 16 container and confirm 0 rows deviating from seed."
+  status: pending
+  notes: |
+    Audit result to reproduce: setup DDL + both population bodies + 3 ops + 10
+    validations + 3 cleanups all green; final dim identical to pristine seed.
+    Capture stdout to /tmp; summarize PG version, per-op pass/fail, and the
+    deviation count here and in the PR body. Container runtime: Apple
+    `container` (docker shim hangs on this host - see MEMORY mocker gotchas).
+- id: w1
+  summary: "Add a postgres SCD2 integration test mirroring TestWritePrimitivesSCD2DuckDB, gated on a container fixture (skip if no PG available)."
+  needs: [w0]
+  status: pending
+- id: w2
+  summary: "Add a postgresql x write_primitives UAT cell so the surface is enumerated and executed in the matrix."
+  needs: [w0]
+  status: pending
+- id: w3
+  summary: "Document in the test that psycopg3's simple query protocol (no params + TEXT format) is what lets the multi-statement write_sql run in one execute()."
+  needs: [w1]
+  status: pending
+
+must_preserve:
+- "The DuckDB SCD2 integration tests are unchanged and still green."
+- "The new postgres test SKIPS cleanly (not fails) when no PostgreSQL container is available, so local fast-test runs are unaffected."
+- "No change to operation SQL or population SQL - this TODO is coverage only."
+
+approach: |
+  Reuse the DuckDB SCD2 fixture shape (seed 50 customers, run each op, assert
+  close/insert counts + seed restoration). Parameterize the connection over a
+  container-backed psycopg fixture, skipping when unavailable. Add the UAT cell
+  via the existing enumeration config. Keep runtime notes (container CLI,
+  simple-protocol) in the test so the next maintainer does not re-derive them.
+
+anti_patterns:
+- "DO NOT hard-require a live PostgreSQL for the default/fast test run - because most local runs have none - skip when the container/DSN is absent."
+- "DO NOT use the docker CLI on this host - because it hangs (mocker shim) - use the Apple `container` runtime or a CI service container."
+- "DO NOT modify operation/population SQL to 'help' Postgres - because it already passes verbatim - coverage only."
+
+verification:
+- description: "New postgres SCD2 test passes when a PG container is present, skips otherwise."
+  command: "uv run -- python -m pytest tests/integration -n 0 -q -k scd2_postgres"
+  expected_output: "passes with PG available; skipped (not failed) without"
+- description: "DuckDB SCD2 tests unchanged and green."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "tests/integration"
+  - "tests/uat"
+  do_not_modify:
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+  - "benchbox/core/write_primitives/benchmark.py"
+
+success_metrics:
+- "A PostgreSQL SCD2 integration test exists and passes against PG 16."
+- "A postgresql x write_primitives UAT cell is enumerated."
+- "The multi-statement / simple-protocol dependency is documented in-test."
+
+metadata:
+  tags: ["scd2", "write-primitives", "postgresql", "coverage", "uat", "audit-followup"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/write-primitives-sql-override-skip-order.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/write-primitives-sql-override-skip-order.yaml
@@ -1,0 +1,99 @@
+id: "write-primitives-sql-override-skip-order"
+title: "Apply write-primitives skip checks before sql_override short-circuit"
+worktree: "scd2-audit-followup"
+priority: "Medium"
+status: "Not Started"
+category: "Core Functionality"
+description: |
+  SCD2 adversarial audit finding N8 (live defect, broader than SCD2).
+  benchbox/core/write_primitives/benchmark.py:398-399 returns sql_override
+  before EVERY skip check: the aggregate-state check, the Postgres skips, the
+  DuckDB MERGE token gate, the platform_overrides null check, the bulk-load file
+  check, AND the staging-population guard.
+
+  Consequence verified (scratchpad repro3.py ATTACK 6c + a direct check):
+  bulk_load_upsert_mode carries platform_overrides: {datafusion: null,
+  starrocks: null}, yet DataFusionAdapter.preprocess_operation_sql
+  (benchbox/platforms/datafusion.py:170-178) returns rewritten SQL for every
+  bulk_load op. That rewritten SQL is threaded in as sql_override
+  (execution.py:1052-1055), so _get_effective_write_sql returns it at :398-399
+  and the datafusion:null override is never consulted - an op explicitly marked
+  unsupported on DataFusion RUNS there.
+
+  This also answers the audit's question about the SCD2 datafusion:null
+  overrides: they are honored today only BY ACCIDENT of category. The three SCD2
+  ops are category 'merge', so preprocess_operation_sql returns None
+  (datafusion.py:179) and no sql_override is set, so the null override is
+  respected. Nothing structural protects them - a future SCD2 preprocess hook
+  would silently bypass the override.
+impact:
+  business_value: "An operation marked unsupported on a platform must not execute there via a preprocessing side-channel."
+  user_impact: "DataFusion (and any platform with a preprocess hook) no longer runs ops the catalog marks unsupported."
+  technical_debt: "Removes an ordering hazard where adapter preprocessing outranks the entire skip policy."
+prior_art:
+- "benchbox/core/write_primitives/benchmark.py:372-442 _get_effective_write_sql - the ordering to fix (:398-399 early return vs :408-440 skip checks)"
+- "benchbox/platforms/datafusion.py:170-179 preprocess_operation_sql (returns rewritten SQL for every bulk_load op)"
+- "benchbox/platforms/base/execution.py:1048-1055 where preprocessed SQL becomes sql_override"
+- "benchbox/core/write_primitives/catalog/operations.yaml bulk_load_upsert_mode platform_overrides {datafusion: null, starrocks: null} - the override being bypassed"
+
+work:
+- id: w1
+  summary: "Reorder _get_effective_write_sql so all skip checks run before the sql_override short-circuit."
+  status: pending
+  notes: |
+    Affected checks that currently sit AFTER the :398-399 early return:
+    aggregate-state, Postgres skips, DuckDB token gate, platform_overrides null,
+    bulk-load file check, staging-population guard. The skip decision depends on
+    (operation, platform_key), not on the preprocessed SQL text, so compute it
+    first and apply the override only if the op is not skipped. Keep
+    adapter-preprocessing priority for the SQL body once the op is runnable.
+- id: w2
+  summary: "Regression test: bulk_load_upsert_mode (datafusion:null) is SKIPPED on datafusion even though preprocess_operation_sql returns rewritten SQL."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Document that the SCD2 datafusion:null overrides are honored only because category='merge' yields no preprocess override; note the ordering now enforces it structurally."
+  needs: [w1]
+  status: pending
+
+must_preserve:
+- "Legitimate adapter preprocessing (e.g. DataFusion bulk_load COPY -> CREATE EXTERNAL TABLE rewrite) still applies for ops that are NOT skipped."
+- "The staging-population guard, bulk-load file check, and Postgres/DuckDB skips still fire for their ops."
+- "SCD2 ops on DuckDB/Postgres remain runnable and unaffected (they set no sql_override)."
+
+approach: |
+  Compute the skip decision from (operation, platform_key) first; only if the op
+  is runnable, apply sql_override (or the platform override, or the base SQL).
+  This preserves adapter-rewrite priority for the SQL body while making the
+  skip policy authoritative. Minimal reorder inside _get_effective_write_sql;
+  no call-site changes needed.
+
+anti_patterns:
+- "DO NOT drop adapter preprocessing - because DataFusion bulk_load genuinely needs the CREATE EXTERNAL TABLE rewrite - only make skip checks outrank it."
+- "DO NOT special-case bulk_load_upsert_mode - because the ordering bug is general (any preprocess hook + any null override) - fix the ordering."
+
+verification:
+- description: "Write-primitives unit + DuckDB integration green."
+  command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py -n 0 -q"
+  expected_output: "all pass"
+- description: "New test: datafusion:null op skips despite a returned sql_override."
+  command: "uv run -- python -m pytest tests/unit/core/write_primitives -n 0 -q -k override_skip_order"
+  expected_output: "new test passes"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/write_primitives/benchmark.py"
+  - "tests/unit/core/write_primitives"
+  do_not_modify:
+  - "benchbox/platforms/datafusion.py"
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+
+success_metrics:
+- "An operation with platform_overrides {<platform>: null} is skipped on that platform even when a preprocess hook returns rewritten SQL."
+- "Adapter preprocessing still applies to runnable ops."
+- "SCD2 datafusion:null enforcement is now structural, not category-accidental."
+
+metadata:
+  tags: ["write-primitives", "datafusion", "platform-overrides", "skip-policy", "audit-followup"]
+  estimated_effort: "Small"
+  created_date: "2026-07-10"

--- a/_project/TODO/scd2-audit-followup/planning/write-primitives-validation-result-gating.yaml
+++ b/_project/TODO/scd2-audit-followup/planning/write-primitives-validation-result-gating.yaml
@@ -1,0 +1,128 @@
+id: "write-primitives-validation-result-gating"
+title: "Gate write/transaction-primitives run status on validation_passed"
+worktree: "scd2-audit-followup"
+priority: "High"
+status: "Not Started"
+category: "Core Functionality"
+description: |
+  SCD2 adversarial audit finding N1 (keystone). An operation whose validation
+  queries FAIL still reports success. OperationResult is built with a hardcoded
+  success=True / status="SUCCESS" regardless of validation_passed
+  (benchbox/core/write_primitives/benchmark.py:1211-1224), and the same shape
+  exists in benchbox/core/transaction_primitives/benchmark.py:809-816. The
+  adapter copies validation_passed into the result dict at
+  benchbox/platforms/base/execution.py:1087, but NOTHING in benchbox/ ever reads
+  it: _log_query_result (execution.py:1103-1126) keys its console line off
+  row_count_validation_status, which _execute_operation_query never sets, so a
+  SUCCESS op with validation_passed=False renders a green check; and
+  _log_execution_summary (execution.py:1128-1140) counts only
+  SUCCESS/SKIPPED/FAILED. Net effect: a SCD2 op that corrupts the dimension
+  (e.g. after a swallowed cleanup on the next warmup/measurement iteration, which
+  never resets between runs - execution.py:213-225) prints a passing result.
+
+  Reproduced (scratchpad repro4.py): seed the dirty state a swallowed cleanup
+  leaves, re-run merge_scd_type2_basic -> success=True, status=SUCCESS,
+  validation_passed=False, at_most_one_current_per_business_key returns 40
+  offending rows. The blog's "validation | passed" column happens to be correct
+  only because it reads the operation API directly, not the runner.
+
+  This is the keystone: hardening the SCD2 validations (sibling TODOs) is
+  unobservable until a failing validation actually fails the run.
+impact:
+  business_value: "A benchmark tool that silently reports incorrect writes as passing is unsound as a measurement instrument."
+  user_impact: "Corrupting or no-op operations surface as green; results and the honesty story depend on this being fixed first."
+  technical_debt: "Dead validation-status plumbing (row_count_validation_status) that operations never populate."
+prior_art:
+- "benchbox/core/write_primitives/benchmark.py:1211-1224 OperationResult construction (hardcoded success=True)"
+- "benchbox/core/transaction_primitives/benchmark.py:809-816 identical construction in sibling benchmark"
+- "benchbox/platforms/base/execution.py:1080-1094 _execute_operation_query result dict (writes validation_passed, read by nothing)"
+- "benchbox/platforms/base/execution.py:1103-1126 _log_query_result (keys off unset row_count_validation_status) - extend / supersede"
+- "benchbox/core/write_primitives/benchmark.py:126-130 OperationResult.status field already exists (SUCCESS/SKIPPED/FAILED) - reuse"
+
+work:
+- id: w0
+  summary: "Re-validate blast radius on write + transaction primitives and a second engine before flipping status."
+  status: pending
+  notes: |
+    Measured on DuckDB SF0.01 (scratchpad blast.py): write_primitives
+    SUCCESS=56 SKIPPED=56 FAILED=0, with ZERO ops SUCCESS-but-validation_failed.
+    So no op currently relies on validation failure being ignored -> the flip is
+    non-breaking today. Re-run for transaction_primitives and one non-DuckDB
+    engine (sqlite is local, no container). Capture stdout to /tmp, summarize
+    counts here. If any op legitimately returns validation_passed=False on the
+    happy path, STOP and reclassify - that op has a bad validation, not a
+    gating gap.
+- id: w1
+  summary: "Decision gate: reuse status=FAILED vs add a distinct VALIDATION_FAILED status."
+  needs: [w0]
+  status: pending
+  notes: |
+    Recommend a distinct VALIDATION_FAILED: it separates 'the SQL raised' from
+    'the SQL ran and the post-condition is wrong', which matters for a
+    benchmarking tool's reporting and for not conflating infra errors with
+    correctness errors. Record the decision before touching call sites.
+- id: w2
+  summary: "Derive success/status from validation_passed in both benchmark.py OperationResult constructions."
+  needs: [w1]
+  status: pending
+- id: w3
+  summary: "Propagate status through _execute_operation_query; make _log_query_result and _log_execution_summary reflect validation failure."
+  needs: [w2]
+  status: pending
+  notes: |
+    _log_query_result currently reads result['row_count_validation_status'],
+    never set for operations. Either populate it from validation_passed in
+    _execute_operation_query, or branch on validation_passed directly. Ensure
+    the summary line counts a validation failure as not-passed.
+- id: w4
+  summary: "Regression test: an op with a deliberately failing validation must not report SUCCESS/green."
+  needs: [w3]
+  status: pending
+
+must_preserve:
+- "All 56 currently-passing write_primitives ops on DuckDB SF0.01 keep reporting success (w0 confirms zero rely on ignored validation failure)."
+- "SKIPPED semantics unchanged: a skipped op still reports success with status=SKIPPED (skip means not-applicable, not failure)."
+- "transaction_primitives operation reporting stays behaviorally consistent with write_primitives after the change."
+
+approach: |
+  Single semantic change threaded through two layers. In each benchmark.py,
+  compute status/success from validation_passed at the OperationResult return.
+  In execution.py, thread the resulting status into the result dict and the two
+  logging helpers. Prefer reusing the existing status field over inventing new
+  plumbing; only add VALIDATION_FAILED if w1 chooses it. Keep the change
+  mechanical and symmetric across write + transaction primitives.
+
+anti_patterns:
+- "DO NOT gate only write_primitives - because transaction_primitives shares the identical hardcoded success=True (benchmark.py:809-816) - fix both."
+- "DO NOT resurrect row_count_validation_status as a second source of truth - because it is unset dead plumbing - drive the console off validation_passed / status instead."
+- "DO NOT change what counts as SKIPPED - because skip is not failure - only SUCCESS-with-failed-validation changes."
+
+verification:
+- description: "SCD2 unit + DuckDB integration still green (single-threaded to respect the shared test lock)."
+  command: "uv run -- python -m pytest tests/unit/benchmarks/test_write_primitives_core.py tests/integration/test_write_primitives_duckdb.py -k scd2 -n 0 -q"
+  expected_output: "all pass"
+- description: "New regression: a failing validation flips status away from SUCCESS/green."
+  command: "uv run -- python -m pytest tests/integration/test_write_primitives_duckdb.py -n 0 -q -k validation_fail"
+  expected_output: "new test passes; op reports validation failure, not SUCCESS"
+- description: "transaction_primitives operation tests still green."
+  command: "uv run -- python -m pytest tests/unit/core/transaction_primitives -n 0 -q"
+  expected_output: "all pass"
+
+scope_limit:
+  only_modify:
+  - "benchbox/core/write_primitives/benchmark.py"
+  - "benchbox/core/transaction_primitives/benchmark.py"
+  - "benchbox/platforms/base/execution.py"
+  - "tests/integration/test_write_primitives_duckdb.py"
+  do_not_modify:
+  - "benchbox/core/write_primitives/catalog/operations.yaml"
+
+success_metrics:
+- "An operation with a failing validation query no longer reports SUCCESS or a green console line."
+- "Both write_primitives and transaction_primitives gate on validation_passed."
+- "Zero regressions across the 56 currently-passing DuckDB SF0.01 write_primitives ops."
+
+metadata:
+  tags: ["scd2", "write-primitives", "transaction-primitives", "validation", "correctness", "audit-followup"]
+  estimated_effort: "Medium"
+  created_date: "2026-07-10"


### PR DESCRIPTION
Seven planning TODOs on worktree scd2-audit-followup capturing the defects
from the adversarial SCD2 audit, sequenced create > review > fix > PR:

- write-primitives-validation-result-gating (High): validation_passed is
  computed and never read; a corrupting op reports SUCCESS/green. Fix both
  write_primitives and transaction_primitives. Keystone for the rest.
- scd2-validation-coverage-hardening (Medium-High): no_change has no positive
  assertion; no cardinality bounds; new_keys_only.no_rows_closed unscoped;
  stamp check too loose. Depends on the gating TODO.
- scd2-basic-idempotency-and-cleanup-scoping (Medium): basic lacks a NOT EXISTS
  guard (double-writes on re-run); cleanups not change_type-scoped; re-measure
  blog numbers. Depends on the coverage TODO.
- duckdb-merge-token-gate-hardening (Medium): MERGE INTO substring gate has
  comment/literal false positives and whitespace/CTE false negatives; dead
  OPERATION_SKIPS entry; write-only registry. Depends on skip-order TODO.
- write-primitives-sql-override-skip-order (Medium): sql_override short-circuits
  all skip checks, so datafusion:null ops run via a preprocess side-channel.
- write-primitives-postgres-execution-coverage (Medium): SCD2 verified green on
  PostgreSQL 16.14 during the audit but no test/CI/UAT exercises it.
- scd2-docs-and-count-hygiene-followup (Low): outline still carries the pre-#1061
  ClickHouse overclaim; README DELETE/TRANSACTION count contradictions.

Dependency graph validated (no cycles, no dangling refs). Reviewed against the
todo rubric; fixed two undeclared couplings (token-gate->skip-order on
benchmark.py; blog-draft ownership moved wholly to the idempotency TODO).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
