### PR TITLE
chore(release): enforce v* tag-ruleset drift check (flip TAG_RULESET_ENFORCED)

### DIFF
--- a/_project/scripts/ruleset_review_enforcement.py
+++ b/_project/scripts/ruleset_review_enforcement.py
@@ -119,16 +119,15 @@ def is_review_enforced(rules: list[dict[str, Any]]) -> bool:
 # v* tag-creation protection (tag-and-pypi-environment-admin-hardening w3)
 # ---------------------------------------------------------------------------
 
-# WARN-until-applied flag, mirroring ruleset_drift_check.DEVELOP_REVIEW_RULE_ENFORCED.
-# The v* tag-creation ruleset is a pending admin action (see
-# docs/operations/repo-admin-settings.md, "Tag creation restricted to release
-# flow"): the develop-PR GITHUB_TOKEN has no ``administration`` scope to POST a
-# ruleset. While this is False, ``tag_protection_findings`` are surfaced as
-# non-blocking warnings so the check can land BEFORE the admin acts without
-# turning the (eventual) canary red. Flip to True once the runbook's live-state
-# note records the applied ruleset id + conditions, exactly as
-# DEVELOP_REVIEW_RULE_ENFORCED is flipped for the develop review rule.
-TAG_RULESET_ENFORCED = False
+# Enforcement flag, mirroring ruleset_drift_check.DEVELOP_REVIEW_RULE_ENFORCED.
+# The v* tag-creation ruleset was applied by admin on 2026-07-10 (ruleset id
+# 18774756 ``v-tag-restricted``; see docs/operations/repo-admin-settings.md,
+# "Tag creation restricted to release flow"), so this is flipped to True:
+# ``tag_protection_findings`` for a missing/incomplete tag ruleset are now a
+# BLOCKING drift finding rather than a non-blocking warning. The bypass list
+# was confirmed to be the release-finalize identity only (User:57046) before
+# flipping, per the runbook's "CONFIRM before enforcing" gate.
+TAG_RULESET_ENFORCED = True
 
 # The ref pattern the release flow tags with (make release-finalize pushes v*).
 TAG_REF_PATTERN = "refs/tags/v*"

--- a/docs/operations/repo-admin-settings.md
+++ b/docs/operations/repo-admin-settings.md
@@ -385,10 +385,20 @@ Live-state note (fill in after applying — do not leave blank):
 
 ```text
 # Tag-creation ruleset live state
-# checked: <YYYY-MM-DD>  by: <admin>
-# ruleset id: <id>  enforcement: <active?>  conditions.ref_name.include: <...>
-# rules: <creation, ...>  bypass_actors: <...>
+# checked: 2026-07-10  by: joeharris76 (admin)
+# ruleset id: 18774756  enforcement: active  conditions.ref_name.include: [refs/tags/v*]
+# rules: [creation]  bypass_actors: [User:57046 (always)]
 ```
+
+Applied 2026-07-10: `v-tag-restricted` (id 18774756) is live and active. The
+bypass list is a single `User` actor (57046, the release-finalize identity) —
+confirmed to be the release identity only, not a broad Write/Admin role, which
+is what `release-finalize`'s `git push origin v$(VERSION)` needs to still
+succeed. With this confirmed, `TAG_RULESET_ENFORCED` in
+`_project/scripts/ruleset_review_enforcement.py` is flipped to `True`, so a
+future regression (ruleset deleted, made inactive, ref narrowed, creation rule
+dropped, or bypass emptied) becomes a blocking drift finding instead of a
+warning.
 
 ### `pypi` environment required-reviewers gate (verify/pending admin action)
 

--- a/tests/unit/release/test_ruleset_drift_review_coverage.py
+++ b/tests/unit/release/test_ruleset_drift_review_coverage.py
@@ -224,20 +224,35 @@ def test_tag_protection_summary_only_payload_does_not_pass():
     assert findings, "summary-only ruleset lacks a creation rule and must be flagged"
 
 
-def test_tag_check_is_warn_until_applied_by_default():
-    # Mirror DEVELOP_REVIEW_RULE_ENFORCED: the flag is False until the admin
-    # POST lands, so the check lands non-blocking.
-    assert _rre.TAG_RULESET_ENFORCED is False
+def test_tag_check_is_enforced_now_that_ruleset_is_applied():
+    # The v* tag ruleset was applied 2026-07-10 (see repo-admin-settings.md
+    # live-state note), so the flag is flipped: a regression is now blocking.
+    assert _rre.TAG_RULESET_ENFORCED is True
 
 
-def test_tag_check_main_warns_non_blocking_when_missing(tmp_path, capsys):
+def test_tag_check_main_fails_when_missing_now_that_enforced(tmp_path, capsys):
     import json as _json
 
     payload = tmp_path / "rulesets.json"
     payload.write_text(_json.dumps([]), encoding="utf-8")
     rc = _rre.main(["--rulesets-file", str(payload)])
     out = capsys.readouterr().out
-    assert rc == 0, "missing tag ruleset must be non-blocking while WARN-until-applied"
+    assert rc == 1, "missing tag ruleset must block now that TAG_RULESET_ENFORCED is True"
+    assert "Tag-creation ruleset - FAILED" in out
+    assert "target='tag'" in out
+
+
+def test_tag_check_main_warns_non_blocking_when_flag_off(tmp_path, capsys, monkeypatch):
+    # Preserve coverage of the WARN-until-applied path the flag used to give by
+    # default: with the flag forced off, a missing ruleset is non-blocking.
+    import json as _json
+
+    monkeypatch.setattr(_rre, "TAG_RULESET_ENFORCED", False)
+    payload = tmp_path / "rulesets.json"
+    payload.write_text(_json.dumps([]), encoding="utf-8")
+    rc = _rre.main(["--rulesets-file", str(payload)])
+    out = capsys.readouterr().out
+    assert rc == 0
     assert "WARNING (non-blocking):" in out
     assert "target='tag'" in out
 
@@ -358,15 +373,26 @@ def test_tag_protection_narrower_exclude_does_not_negate_coverage():
 # ---------------------------------------------------------------------------
 
 
-def test_tag_creation_findings_warns_non_blocking_when_no_tag_ruleset_exists():
-    # Live state: only develop/main-release rulesets exist, no target='tag'
-    # ruleset yet -- must surface as a non-blocking warning by default
-    # (TAG_RULESET_ENFORCED is False), same WARN-until-applied pattern as the
-    # develop review rule.
+def test_tag_creation_findings_blocks_by_default_when_no_tag_ruleset_exists():
+    # Live state after 2026-07-10: the v* tag ruleset is applied and
+    # TAG_RULESET_ENFORCED is True, so a missing target='tag' ruleset is a
+    # BLOCKING drift finding by default (no longer WARN-until-applied).
     all_live = [
         _live_develop_ruleset(review_count=0, code_owner_review=False),
     ]
     findings = tag_creation_findings(all_live)
+    assert findings and blocking_findings(findings) == findings
+    assert not any(f.startswith(WARNING_PREFIX) for f in findings)
+    assert any("target='tag'" in f for f in findings)
+
+
+def test_tag_creation_findings_warns_when_enforcement_forced_off():
+    # Preserve the pre-2026-07-10 WARN-until-applied coverage via an explicit
+    # enforce_tag_rule=False override.
+    all_live = [
+        _live_develop_ruleset(review_count=0, code_owner_review=False),
+    ]
+    findings = tag_creation_findings(all_live, enforce_tag_rule=False)
     assert findings and all(f.startswith(WARNING_PREFIX) for f in findings)
     assert blocking_findings(findings) == []
     assert any("target='tag'" in f for f in findings)


### PR DESCRIPTION
# Pull Request

## Description

Flip `TAG_RULESET_ENFORCED` `False`→`True` now that the `v*` tag-creation
ruleset is live. Admin applied `v-tag-restricted` (id `18774756`) on
2026-07-10: `active`, `conditions.ref_name.include=[refs/tags/v*]`, a
`creation` rule, and `bypass_actors=[User:57046 (always)]` — the
release-finalize identity only, confirmed not a broad Write/Admin role (so
`make release-finalize`'s `git push origin v$(VERSION)` still succeeds).

The single constant in `_project/scripts/ruleset_review_enforcement.py` drives
both consumers: the standalone predicate `main()` and
`scripts/ruleset_drift_check.py:tag_creation_findings()`, which imports it as
the `enforce_tag_rule` default. Flipping it turns a missing/incomplete `v*`
tag ruleset from a non-blocking `WARNING` into a **blocking** finding in
`release-canary.yml`'s ruleset-drift job — so a future regression (ruleset
deleted, made inactive, ref narrowed, `creation` rule dropped, or bypass
emptied) fails CI instead of merely warning.

This does not change enforcement of the tag ruleset itself (GitHub already
enforces it); it arms the *drift detector* to treat a regression as blocking.

## Type of Change

- [x] Refactor / chore

## Testing

- `pytest tests/unit/release/ tests/unit/test_ruleset_drift.py tests/unit/test_release_infrastructure.py` — 104 passed.
- Ran the runbook's live predicate against the **actual** rulesets with the
  flag flipped: `Tag-creation ruleset - OK`, exit 0 — confirms the canary
  stays green and enforcement only arms on a future regression.

## Public Contract Check

- [x] I updated `docs/reference/public-contracts.md`, or this PR does not change
      public, beta-public, deprecated, generated, experimental, or repo-only
      contract surfaces. (No contract surface changed — internal release-tooling flag.)
- [x] I checked result schema fields, MCP tool parameters, platform support
      status, wrapper facades, adapter subclassing hooks, and generated docs for
      contract-map impact. (None affected.)
- [x] Any platform/benchmark count claim in docs is generated/checked from
      registry metadata, or explicitly marked editorial/non-authoritative. (N/A.)

## Documentation

- [x] I updated the relevant user-facing docs. (Filled the runbook's tag
      live-state note in `docs/operations/repo-admin-settings.md` — the
      precondition the flag comment requires before flipping.)
- [x] I added regression notes for behavior changes. (Runbook note + commit body.)
- [x] I confirmed API contract wording remains accurate.

## Code Quality

- [x] I ran formatting and lint/type checks. (pre-commit ran on commit.)
- [x] I reviewed impacted modules for backwards compatibility and migration impact.

## Notes for reviewer

- Coupling with #1027 (the `main`→`release` rename): none. #1027 edits
  `scripts/ruleset_drift_check.py` and the branch-rename prose in
  `repo-admin-settings.md`; this PR edits `_project/scripts/ruleset_review_enforcement.py`,
  the test file, and the *tag live-state note* block (lines are disjoint from
  #1027's runbook hunks), so no overlapping conflict.
- The sibling `DEVELOP_REVIEW_RULE_ENFORCED` flip is intentionally **not**
  included here — it lives in `scripts/ruleset_drift_check.py`, which #1027
  also edits, so it should ride #1027 or land after it to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
